### PR TITLE
Forward-pass deferral for deferred-region operators

### DIFF
--- a/crates/clinker-core/src/config/mod.rs
+++ b/crates/clinker-core/src/config/mod.rs
@@ -2156,11 +2156,16 @@ impl PipelineConfig {
 
         // Deferred-region detection. Runs after retraction flags and
         // window-buffer-recompute flags so each relaxed-CK Aggregate is
-        // already classified. The walk produces one `DeferredRegion`
-        // per producer; we flatten the list into a NodeIndex-keyed map
-        // so dispatcher arms can do O(1) lookup at every participating
-        // node (producer, members, outputs).
-        let regions = crate::plan::deferred_region::detect_deferred_regions(
+        // already classified. The walk returns top-level regions
+        // (producer in `dag.graph`) separately from body-internal
+        // regions (producer in some `BoundBody.graph`); we flatten each
+        // bucket into a NodeIndex-keyed map at the right scope so
+        // dispatcher arms can do O(1) lookup at every participating
+        // node (producer, members, outputs). The two index spaces are
+        // disjoint by scope — body-local NodeIndex values can
+        // numerically collide with parent-graph indices, so they live
+        // on `BoundBody.deferred_regions`, not on the parent map.
+        let (top_regions, body_regions) = crate::plan::deferred_region::detect_deferred_regions(
             &dag.graph,
             &dag.node_properties,
             &artifacts,
@@ -2169,7 +2174,7 @@ impl PipelineConfig {
             petgraph::graph::NodeIndex,
             crate::plan::deferred_region::DeferredRegion,
         > = HashMap::new();
-        for region in regions {
+        for region in top_regions {
             let producer = region.producer;
             let members = region.members.clone();
             let outputs = region.outputs.clone();
@@ -2178,6 +2183,20 @@ impl PipelineConfig {
             }
         }
         dag.deferred_regions = region_map;
+
+        for (body_id, regions) in body_regions {
+            let Some(body) = artifacts.composition_bodies.get_mut(&body_id) else {
+                continue;
+            };
+            for region in regions {
+                let producer = region.producer;
+                let members = region.members.clone();
+                let outputs = region.outputs.clone();
+                for k in std::iter::once(producer).chain(members).chain(outputs) {
+                    body.deferred_regions.insert(k, region.clone());
+                }
+            }
+        }
 
         // E15Y: an aggregate whose `group_by` omits any correlation-key
         // field cannot also use `strategy: streaming`. Streaming

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -313,7 +313,32 @@ pub(crate) struct ExecutorContext<'a> {
     /// the zero-overhead-on-strict-pipeline test so the assertion
     /// proves the short-circuit is taken on every strict workload.
     pub(crate) commit_step_path: CommitStepPath,
+
+    /// Per-edge buffer parking records that cross from a non-deferred
+    /// upstream into a deferred-region member (typically Combine's
+    /// build-side input). Populated by the upstream operator's arm at
+    /// emit time; drained by the commit-time deferred dispatcher in a
+    /// later phase. Keyed by `(active body, EdgeIndex)` because
+    /// top-level and body graphs maintain disjoint EdgeIndex namespaces
+    /// — the body id disambiguates collisions.
+    ///
+    /// Charges against `ctx.memory_budget` via `charge_arena_bytes` per
+    /// admission, mirroring the per-row accounting the windowed
+    /// Transform arm uses for buffer-recompute mode.
+    pub(crate) region_input_buffers: RegionInputBuffers,
 }
+
+/// Map keying (active composition body, outgoing edge id) to the rows
+/// that crossed from a non-deferred upstream into a deferred-region
+/// consumer along that edge. The body id is `None` for top-level edges;
+/// each composition body has its own EdgeIndex namespace.
+pub(crate) type RegionInputBuffers = HashMap<
+    (
+        Option<crate::plan::CompositionBodyId>,
+        petgraph::graph::EdgeIndex,
+    ),
+    Vec<(Record, u64)>,
+>;
 
 /// Which commit-step body the orchestrator selected for the current
 /// pipeline. `FastPath` short-circuits to the strict body and is the
@@ -402,6 +427,125 @@ impl ExecutorContext<'_> {
     pub(crate) fn spill_root(&self) -> &Arc<tempfile::TempDir> {
         &self.spill_root
     }
+}
+
+/// Project every record in `rows` onto the column set in
+/// `buffer_schema`, returning narrow `Record` instances on a fresh,
+/// per-call `Arc<Schema>` shared by every emitted Record.
+///
+/// Mirrors the column-pruning pattern at
+/// `pipeline::arena::project_records_into_minimal`. Invoked once at the
+/// deferred-region producer (a relaxed-CK Aggregate) so the emit buffer
+/// retains exactly the columns the deferred operators reach via
+/// `Expr::support_into`. Source row numbers carry through unchanged.
+fn project_rows_to_buffer_schema(
+    rows: Vec<(Record, u64)>,
+    buffer_schema: &[String],
+) -> Vec<(Record, u64)> {
+    let narrow_schema: Arc<clinker_record::Schema> = buffer_schema
+        .iter()
+        .map(|s| Box::<str>::from(s.as_str()))
+        .collect::<SchemaBuilder>()
+        .build();
+    rows.into_iter()
+        .map(|(record, rn)| {
+            let wide_schema = record.schema();
+            let mut values = Vec::with_capacity(buffer_schema.len());
+            for col in buffer_schema {
+                let v = wide_schema
+                    .index(col)
+                    .and_then(|i| record.values().get(i).cloned())
+                    .unwrap_or(Value::Null);
+                values.push(v);
+            }
+            let mut narrow = Record::new(Arc::clone(&narrow_schema), values);
+            for (k, v) in record.iter_meta() {
+                let _ = narrow.set_meta(k, v.clone());
+            }
+            (narrow, rn)
+        })
+        .collect()
+}
+
+/// Tee `emit_rows` into `region_input_buffers` for every outgoing edge
+/// from `producer_idx` whose target is a deferred-region member or
+/// output AND whose source (`producer_idx`) is NOT in the same region.
+/// Internal-region edges are skipped — they live in `node_buffers`
+/// already. Edges leaving the region's producer toward a member are
+/// also skipped because the producer's own `node_buffers[producer_idx]`
+/// is the canonical entry point the commit-time deferred dispatcher
+/// reads from.
+///
+/// Charges per-row size against `ctx.memory_budget.charge_arena_bytes`;
+/// returns the same `E310`-shape `PipelineError::Compilation` the
+/// windowed Transform's buffer-recompute path raises on overflow so
+/// downstream callers see a uniform admission failure mode.
+fn tee_emit_to_region_input_buffers(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    producer_idx: NodeIndex,
+    emit_rows: &[(Record, u64)],
+) -> Result<(), PipelineError> {
+    use petgraph::visit::EdgeRef;
+    let producer_region_producer = current_dag
+        .deferred_region_at(producer_idx)
+        .map(|r| r.producer);
+    let active_body = ctx.window_runtime.active_stack.last().copied();
+    let mut crossing_edges: Vec<petgraph::graph::EdgeIndex> = Vec::new();
+    for edge_ref in current_dag
+        .graph
+        .edges_directed(producer_idx, petgraph::Direction::Outgoing)
+    {
+        let target = edge_ref.target();
+        let target_region_producer = current_dag.deferred_region_at(target).map(|r| r.producer);
+        let crosses = match (producer_region_producer, target_region_producer) {
+            // Non-deferred source feeding a deferred consumer: park
+            // narrow rows so the commit-time dispatcher can re-feed
+            // the deferred member without losing the upstream emit.
+            (None, Some(_)) => true,
+            // Distinct deferred regions abutting at this edge.
+            (Some(p), Some(t)) if p != t => true,
+            // Same region (internal edge) or both non-deferred: no
+            // cross-region tee needed; node_buffers carries the
+            // payload already.
+            _ => false,
+        };
+        if crosses {
+            crossing_edges.push(edge_ref.id());
+        }
+    }
+    if crossing_edges.is_empty() {
+        return Ok(());
+    }
+    // Approximate per-row cost: per-Value payload + tuple overhead.
+    // Mirrors the windowed Transform's per-row charge to keep both
+    // admission paths consistent against a single shared budget.
+    let row_bytes_each: u64 = emit_rows
+        .first()
+        .map(|(rec, _)| {
+            (std::mem::size_of::<Value>() * rec.schema().column_count()
+                + std::mem::size_of::<(Record, u64)>()) as u64
+        })
+        .unwrap_or(0);
+    for edge_id in crossing_edges {
+        for (record, rn) in emit_rows {
+            if row_bytes_each > 0 && ctx.memory_budget.charge_arena_bytes(row_bytes_each) {
+                return Err(PipelineError::Compilation {
+                    transform_name: String::new(),
+                    messages: vec![format!(
+                        "E310 deferred-region buffer admission exceeded \
+                         memory limit: hard limit {}",
+                        ctx.memory_budget.hard_limit()
+                    )],
+                });
+            }
+            ctx.region_input_buffers
+                .entry((active_body, edge_id))
+                .or_default()
+                .push((record.clone(), *rn));
+        }
+    }
+    Ok(())
 }
 
 /// Build node-rooted window runtimes for every IndexSpec rooted at
@@ -646,6 +790,7 @@ pub(crate) fn dispatch_plan_node(
                     .map(|(r, rn)| (canonicalize(r), *rn))
                     .collect()
             };
+            tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &records)?;
             ctx.node_buffers.insert(node_idx, records);
         }
 
@@ -654,6 +799,14 @@ pub(crate) fn dispatch_plan_node(
             window_index,
             ..
         } => {
+            // Deferred-region member: skip the per-record evaluation
+            // on the forward pass. The commit-time deferred dispatcher
+            // re-runs this Transform on post-recompute upstream emits;
+            // draining the predecessor's buffer here would leak the
+            // pre-recompute snapshot to the writer ahead of recompute.
+            if current_dag.is_deferred_consumer(node_idx) {
+                return Ok(());
+            }
             // Get input records: first check own buffer (set by Route
             // node for branch dispatch), then fall back to predecessor.
             let input_records = if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
@@ -680,6 +833,7 @@ pub(crate) fn dispatch_plan_node(
                 Some(&idx) => idx,
                 None => {
                     // No transform found — pass through
+                    tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &input_records)?;
                     ctx.node_buffers.insert(node_idx, input_records);
                     return Ok(());
                 }
@@ -970,6 +1124,7 @@ pub(crate) fn dispatch_plan_node(
             // this Transform's `NodeIndex`, the call below installs the
             // matching runtime; otherwise the helper is a no-op.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+            tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
             ctx.node_buffers.insert(node_idx, output_records);
         }
 
@@ -980,6 +1135,14 @@ pub(crate) fn dispatch_plan_node(
             default: _,
             ..
         } => {
+            // Deferred-region member: skip branching dispatch on the
+            // forward pass — the commit-time deferred dispatcher re-runs
+            // this Route on post-recompute upstream emits. Draining
+            // predecessors here would commit branch decisions to a
+            // pre-recompute view of the records.
+            if current_dag.is_deferred_consumer(node_idx) {
+                return Ok(());
+            }
             // Body-context Routes that consume an input port have no
             // predecessor in the body's mini-DAG — the records are
             // seeded into this node's own buffer at composition entry.
@@ -1184,13 +1347,64 @@ pub(crate) fn dispatch_plan_node(
                 }
             }
 
-            // Put branch buffers into node_buffers keyed by successor
+            // Put branch buffers into node_buffers keyed by successor.
+            // For successors that fall inside a deferred region while
+            // this Route does not, also park the per-branch records on
+            // the matching outgoing edge so the commit-time deferred
+            // dispatcher receives the same records the forward branch
+            // assignment selected. Internal-region edges and edges
+            // between two non-deferred operators skip the tee — the
+            // node_buffers entry already covers them.
+            let route_region_producer =
+                current_dag.deferred_region_at(node_idx).map(|r| r.producer);
+            let active_body = ctx.window_runtime.active_stack.last().copied();
             for (succ_idx, buf) in branch_buffers {
+                let succ_region_producer =
+                    current_dag.deferred_region_at(succ_idx).map(|r| r.producer);
+                let crosses = match (route_region_producer, succ_region_producer) {
+                    (None, Some(_)) => true,
+                    (Some(p), Some(t)) if p != t => true,
+                    _ => false,
+                };
+                if crosses && let Some(edge) = current_dag.graph.find_edge(node_idx, succ_idx) {
+                    let row_bytes_each: u64 = buf
+                        .first()
+                        .map(|(rec, _)| {
+                            (std::mem::size_of::<Value>() * rec.schema().column_count()
+                                + std::mem::size_of::<(Record, u64)>())
+                                as u64
+                        })
+                        .unwrap_or(0);
+                    for (record, rn) in &buf {
+                        if row_bytes_each > 0
+                            && ctx.memory_budget.charge_arena_bytes(row_bytes_each)
+                        {
+                            return Err(PipelineError::Compilation {
+                                transform_name: String::new(),
+                                messages: vec![format!(
+                                    "E310 deferred-region buffer admission exceeded \
+                                     memory limit: hard limit {}",
+                                    ctx.memory_budget.hard_limit()
+                                )],
+                            });
+                        }
+                        ctx.region_input_buffers
+                            .entry((active_body, edge))
+                            .or_default()
+                            .push((record.clone(), *rn));
+                    }
+                }
                 ctx.node_buffers.insert(succ_idx, buf);
             }
         }
 
         PlanNode::Merge { ref name, .. } => {
+            // Deferred-region member: skip concatenation on the forward
+            // pass. The commit-time deferred dispatcher re-runs this
+            // Merge on post-recompute upstream emits.
+            if current_dag.is_deferred_consumer(node_idx) {
+                return Ok(());
+            }
             // Concatenate predecessor buffers in declaration order —
             // the order appearing in the Merge's `inputs:` YAML
             // array, which is stable across compile runs. Under
@@ -1277,6 +1491,7 @@ pub(crate) fn dispatch_plan_node(
             // the helper iterates plan.indices_to_build and matches
             // nothing because no spec roots at a Merge NodeIndex.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &merged)?;
+            tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &merged)?;
             ctx.node_buffers.insert(node_idx, merged);
         }
 
@@ -1285,6 +1500,13 @@ pub(crate) fn dispatch_plan_node(
             ref sort_fields,
             ..
         } => {
+            // Deferred-region member: skip sort on the forward pass.
+            // The commit-time deferred dispatcher re-runs this Sort on
+            // post-recompute upstream emits, so admitting records to a
+            // SortBuffer here would double-charge the sort.
+            if current_dag.is_deferred_consumer(node_idx) {
+                return Ok(());
+            }
             // Enforcer-sort dispatch. Carries `row_num` through
             // the sort permutation as the `SortBuffer<u64>`
             // payload — the Record itself carries every field
@@ -1302,6 +1524,7 @@ pub(crate) fn dispatch_plan_node(
                 .unwrap_or_default();
 
             if input_records.is_empty() {
+                tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &[])?;
                 ctx.node_buffers.insert(node_idx, Vec::new());
                 return Ok(());
             }
@@ -1373,6 +1596,7 @@ pub(crate) fn dispatch_plan_node(
             }
             ctx.collector
                 .record(sort_timer.finish(sort_count, sort_count));
+            tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out)?;
             ctx.node_buffers.insert(node_idx, out);
         }
 
@@ -1641,18 +1865,47 @@ pub(crate) fn dispatch_plan_node(
 
             ctx.collector
                 .record(agg_timer.finish(input_count, out_rows.len() as u64));
-            // Materialize node-rooted window runtimes for any IndexSpec
-            // rooted at this aggregate. The aggregate emits columns the
-            // source arena cannot project (e.g. `total = sum(amount)`,
-            // `$ck.aggregate.<name>`); a downstream window's IndexSpec
-            // pins its `arena_fields` against the aggregate's
-            // `output_schema`, so the arena materializes from
-            // `out_rows` here, not from the source stream.
-            finalize_node_rooted_windows(ctx, current_dag, node_idx, &out_rows)?;
-            ctx.node_buffers.insert(node_idx, out_rows);
+            if let Some(region) = current_dag.deferred_region_at_producer(node_idx) {
+                // Deferred-region producer. Project emits to the region's
+                // buffer schema (the planner already pruned this to the
+                // minimum columns the deferred operators reach via
+                // `Expr::support_into`), park narrow rows in
+                // `node_buffers[node_idx]`, and skip
+                // `finalize_node_rooted_windows`: every IndexSpec rooted
+                // here is consumed by a downstream operator INSIDE the
+                // same region, which does not run on the forward pass.
+                // The wide pre-retract rows held on
+                // `RetainedAggregatorState.pre_retract_output_rows`
+                // already cover the recompute-aggregates phase, so the
+                // narrow projection here costs nothing the recompute
+                // path needs.
+                let buffer_schema = region.buffer_schema.clone();
+                let projected = project_rows_to_buffer_schema(out_rows, &buffer_schema);
+                tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &projected)?;
+                ctx.node_buffers.insert(node_idx, projected);
+            } else {
+                // Materialize node-rooted window runtimes for any IndexSpec
+                // rooted at this aggregate. The aggregate emits columns the
+                // source arena cannot project (e.g. `total = sum(amount)`,
+                // `$ck.aggregate.<name>`); a downstream window's IndexSpec
+                // pins its `arena_fields` against the aggregate's
+                // `output_schema`, so the arena materializes from
+                // `out_rows` here, not from the source stream.
+                finalize_node_rooted_windows(ctx, current_dag, node_idx, &out_rows)?;
+                tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out_rows)?;
+                ctx.node_buffers.insert(node_idx, out_rows);
+            }
         }
 
         PlanNode::Output { ref name, .. } => {
+            // Deferred-region exit: skip writer admission on the forward
+            // pass. The commit-time deferred dispatcher routes
+            // post-recompute records into this Output, so any record
+            // dropped here on a stale upstream buffer would be a
+            // pre-recompute leak.
+            if current_dag.is_deferred_consumer(node_idx) {
+                return Ok(());
+            }
             // Get input records: check own buffer first (Route
             // nodes store records at the successor's index), then
             // fall back to predecessor buffers.
@@ -1860,6 +2113,13 @@ pub(crate) fn dispatch_plan_node(
         }
 
         PlanNode::Composition { ref name, body, .. } => {
+            // Deferred-region member: skip recursive body execution on
+            // the forward pass. The commit-time deferred dispatcher
+            // re-enters this Composition on post-recompute upstream
+            // emits.
+            if current_dag.is_deferred_consumer(node_idx) {
+                return Ok(());
+            }
             // Recursive body execution: collect parent-scope records
             // per declared input port, swap `current_dag` to the body's
             // mini-DAG, walk the body's topo, then collect the body's
@@ -1938,6 +2198,7 @@ pub(crate) fn dispatch_plan_node(
             // body executor returned with `active_stack` already
             // popped, so the install lands on `top` (parent scope).
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+            tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
             ctx.node_buffers.insert(node_idx, output_records);
         }
 
@@ -1951,6 +2212,13 @@ pub(crate) fn dispatch_plan_node(
             ref propagate_ck,
             ..
         } => {
+            // Deferred-region member: skip the join on the forward pass.
+            // The commit-time deferred dispatcher will re-run this
+            // Combine against the post-recompute upstream emits parked
+            // in `region_input_buffers` for its cross-region edges.
+            if current_dag.is_deferred_consumer(node_idx) {
+                return Ok(());
+            }
             use crate::config::pipeline_node::{MatchMode, OnMiss};
             use crate::executor::combine::{CombineResolver, CombineResolverMapping};
             use crate::pipeline::combine::{CombineHashTable, KeyExtractor};
@@ -2261,6 +2529,7 @@ pub(crate) fn dispatch_plan_node(
                     ctx.collector
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+                    tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
                     ctx.node_buffers.insert(node_idx, output_records);
                     return Ok(());
                 }
@@ -2310,6 +2579,7 @@ pub(crate) fn dispatch_plan_node(
                     ctx.collector
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+                    tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
                     ctx.node_buffers.insert(node_idx, output_records);
                     return Ok(());
                 }
@@ -2366,6 +2636,7 @@ pub(crate) fn dispatch_plan_node(
                     ctx.collector
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+                    tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
                     ctx.node_buffers.insert(node_idx, output_records);
                     return Ok(());
                 }
@@ -2790,6 +3061,7 @@ pub(crate) fn dispatch_plan_node(
             ctx.collector
                 .record(probe_timer.finish(probe_records_in, probe_records_out));
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+            tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
             ctx.node_buffers.insert(node_idx, output_records);
         }
 

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -1354,6 +1354,7 @@ impl PipelineExecutor {
             relaxed_aggregator_degrade: Vec::new(),
             relaxed_window_states: HashMap::new(),
             commit_step_path: dispatch::CommitStepPath::NotSelected,
+            region_input_buffers: HashMap::new(),
         };
 
         // Walk DAG in topological order. `topo_order` is cloned so
@@ -2431,6 +2432,7 @@ mod tests {
     mod correlated_window_after_aggregate_retract;
     mod correlated_window_retract;
     mod cross_source_window_topology;
+    mod deferred_dispatch;
     mod format_dispatch;
     mod multi_output;
     mod post_aggregate_lag_lead;

--- a/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
@@ -1,0 +1,218 @@
+//! Forward-pass deferred-dispatch wiring smoke test.
+//!
+//! Exercises the operator-arm short-circuit and the producer-projection
+//! split landed alongside this module: a relaxed-CK Aggregate with
+//! downstream Transform + Output forms a deferred region whose member
+//! and exit operators must NOT execute on the forward pass. The
+//! commit-time deferred dispatcher (a later phase) is the only legal
+//! caller of those arms; the forward pass observes the producer's
+//! buffer projected to the region's `buffer_schema` and nothing flowing
+//! into the writer.
+//!
+//! The downstream retraction tests
+//! (`correlated_post_aggregate_retract`,
+//! `correlated_window_after_aggregate_retract`,
+//! `correlated_dlq_retract`, `window_recompute_correctness`) are
+//! expected to be CI-red until the commit-time deferred dispatcher
+//! lands; they assert end-to-end values that depend on the deferred
+//! arms running, which they will once a follow-up commit wires the
+//! post-recompute re-dispatch.
+
+use super::*;
+use clinker_bench_support::io::SharedBuffer;
+use std::collections::{BTreeSet, HashMap};
+
+/// Source(`order_id` CK) → Aggregate(`group_by: [department]`, relaxed
+/// because `group_by` omits the source CK) → Transform → Output. The
+/// Aggregate seeds a deferred region whose member is the Transform and
+/// whose exit is the Output.
+const DEFERRED_PIPELINE: &str = r#"
+pipeline:
+  name: deferred_smoke
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    path: input.csv
+    correlation_key: order_id
+    type: csv
+    schema:
+      - { name: order_id, type: string }
+      - { name: department, type: string }
+      - { name: amount, type: int }
+- type: aggregate
+  name: dept_totals
+  input: src
+  config:
+    group_by: [department]
+    cxl: |
+      emit department = department
+      emit total = sum(amount)
+- type: transform
+  name: scaled
+  input: dept_totals
+  config:
+    cxl: |
+      emit department = department
+      emit total = total
+      emit scaled = total * 2
+- type: output
+  name: out
+  input: scaled
+  config:
+    name: out
+    path: out.csv
+    type: csv
+    include_unmapped: true
+"#;
+
+/// Plan-side: the planner registers a deferred region whose producer is
+/// the relaxed Aggregate and whose `buffer_schema` covers exactly the
+/// columns the deferred Transform reaches via `Expr::support_into`.
+/// `members` includes the Transform; `outputs` includes the
+/// correlation-buffered Output. The region's NodeIndex membership
+/// is reachable from `dag.deferred_region_at` for every participant.
+#[test]
+fn relaxed_aggregate_seeds_a_deferred_region_with_downstream_members() {
+    use crate::config::{CompileContext, parse_config};
+    use crate::plan::execution::PlanNode;
+
+    let config = parse_config(DEFERRED_PIPELINE).expect("parse");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile must succeed for the deferred-region smoke pipeline")
+        .dag()
+        .clone();
+
+    let agg_idx = plan
+        .graph
+        .node_indices()
+        .find(|&i| matches!(&plan.graph[i], PlanNode::Aggregation { .. }))
+        .expect("Aggregate node must be present");
+    let transform_idx = plan
+        .graph
+        .node_indices()
+        .find(|&i| matches!(&plan.graph[i], PlanNode::Transform { name, .. } if name == "scaled"))
+        .expect("Transform 'scaled' must be present");
+    let output_idx = plan
+        .graph
+        .node_indices()
+        .find(|&i| matches!(&plan.graph[i], PlanNode::Output { name, .. } if name == "out"))
+        .expect("Output 'out' must be present");
+
+    let region = plan
+        .deferred_region_at_producer(agg_idx)
+        .expect("Aggregate must seed a deferred region");
+    assert!(
+        region.members.contains(&transform_idx),
+        "deferred region members must include the downstream Transform"
+    );
+    assert!(
+        region.outputs.contains(&output_idx),
+        "deferred region outputs must include the correlation-buffered Output"
+    );
+
+    // `is_deferred_consumer` flips true for member + output (so their
+    // arms short-circuit) but stays false for the producer (which still
+    // runs its aggregation kernel, then projects to buffer_schema).
+    assert!(
+        plan.is_deferred_consumer(transform_idx),
+        "Transform should be flagged as deferred consumer"
+    );
+    assert!(
+        plan.is_deferred_consumer(output_idx),
+        "Output should be flagged as deferred consumer"
+    );
+    assert!(
+        !plan.is_deferred_consumer(agg_idx),
+        "Aggregate (the producer) must NOT be flagged as deferred consumer"
+    );
+
+    // The buffer_schema is the column-pruned union the deferred
+    // operators reach. The Transform reads `department` and `total`,
+    // so both must appear — and the schema is sorted alphabetically
+    // for deterministic --explain rendering.
+    let schema_set: BTreeSet<&str> = region.buffer_schema.iter().map(String::as_str).collect();
+    assert!(
+        schema_set.contains("department"),
+        "buffer_schema must retain 'department': {:?}",
+        region.buffer_schema
+    );
+    assert!(
+        schema_set.contains("total"),
+        "buffer_schema must retain 'total': {:?}",
+        region.buffer_schema
+    );
+    let mut sorted = region.buffer_schema.clone();
+    sorted.sort();
+    assert_eq!(
+        region.buffer_schema, sorted,
+        "buffer_schema must be sorted alphabetically"
+    );
+}
+
+/// Runtime side: with the deferred-dispatch short-circuit in place,
+/// running the pipeline end-to-end produces an empty writer payload —
+/// the deferred Transform and Output arms return without admitting any
+/// row. A follow-up commit's commit-time deferred dispatcher will
+/// re-run the deferred arms and land records in the writer; this test
+/// locks the forward-pass intermediate.
+///
+/// Counters reflect the same: no DLQ entries (no errors fired), no
+/// records written by the strict commit body (correlation_buffers are
+/// empty because the Output arm short-circuited before admitting
+/// anything).
+#[test]
+fn deferred_consumers_emit_nothing_on_the_forward_pass() {
+    let config = crate::config::parse_config(DEFERRED_PIPELINE).expect("parse");
+    let primary = "src".to_string();
+    let csv = "\
+order_id,department,amount
+o1,HR,10
+o2,HR,20
+o3,ENG,100
+";
+    let readers: HashMap<String, Box<dyn std::io::Read + Send>> = HashMap::from([(
+        primary.clone(),
+        Box::new(std::io::Cursor::new(csv.as_bytes().to_vec())) as Box<dyn std::io::Read + Send>,
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: Default::default(),
+        shutdown_token: None,
+    };
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, &primary, readers, writers, &params)
+            .expect("pipeline must run without error");
+
+    let written = buf.as_string();
+    // The deferred Output's arm short-circuited — no projected rows
+    // landed in `correlation_buffers`, so the strict-commit flush has
+    // nothing to drain. The body is empty (the writer never opened
+    // because no record reached `build_format_writer`).
+    let body_lines: Vec<&str> = written.lines().collect();
+    assert!(
+        body_lines.is_empty(),
+        "deferred-dispatch forward pass must not write to the output sink \
+         (commit-time re-dispatch lands in a follow-up commit); got {body_lines:?}"
+    );
+    assert_eq!(
+        report.counters.records_written, 0,
+        "deferred Output writes zero rows on the forward pass; got {}",
+        report.counters.records_written
+    );
+    assert_eq!(
+        report.counters.dlq_count, 0,
+        "no upstream errors expected in the smoke fixture; got {}",
+        report.counters.dlq_count
+    );
+}

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -955,6 +955,7 @@ fn bind_composition(
         nested_body_ids,
         body_indices_to_build: Vec::new(),
         body_window_configs,
+        deferred_regions: HashMap::new(),
     };
     artifacts.insert_body(body_id, bound_body);
     artifacts

--- a/crates/clinker-core/src/plan/composition_body.rs
+++ b/crates/clinker-core/src/plan/composition_body.rs
@@ -8,6 +8,7 @@ use cxl::typecheck::Row;
 use indexmap::IndexMap;
 use petgraph::graph::{DiGraph, NodeIndex};
 
+use super::deferred_region::DeferredRegion;
 use super::execution::{PlanEdge, PlanNode};
 
 /// Opaque handle into `CompileArtifacts.composition_bodies`. Each
@@ -148,4 +149,22 @@ pub struct BoundBody {
     /// pass to construct `body_indices_to_build` and backfill
     /// `window_index` onto each body Transform.
     pub body_window_configs: HashMap<String, crate::plan::index::LocalWindowConfig>,
+
+    /// Deferred-region metadata for relaxed-CK Aggregates that live
+    /// inside this body. Keys are NodeIndex values in this body's
+    /// local mini-DAG (`graph`), distinct from
+    /// `ExecutionPlanDag.deferred_regions` whose keys live in the
+    /// parent graph's NodeIndex space — the two spaces collide
+    /// numerically because each graph numbers from zero, so the
+    /// dispatcher consults the right map by which scope it is
+    /// currently executing.
+    ///
+    /// Every NodeIndex participating in a body-internal region
+    /// (producer + members + outputs) is keyed to a clone of the
+    /// region so dispatcher arms get O(1) lookup. Empty for bodies
+    /// without a relaxed-CK Aggregate. The field is `pub` for the
+    /// same reason `ExecutionPlanDag.deferred_regions` is — out-of-
+    /// crate test code struct-literal-constructs `BoundBody`, which
+    /// forces field visibility to match the type's visibility.
+    pub deferred_regions: HashMap<NodeIndex, DeferredRegion>,
 }

--- a/crates/clinker-core/src/plan/deferred_region.rs
+++ b/crates/clinker-core/src/plan/deferred_region.rs
@@ -29,7 +29,7 @@ use petgraph::Direction;
 use petgraph::graph::{DiGraph, NodeIndex};
 
 use crate::plan::bind_schema::CompileArtifacts;
-use crate::plan::composition_body::BoundBody;
+use crate::plan::composition_body::{BoundBody, CompositionBodyId};
 use crate::plan::execution::{PlanEdge, PlanNode, group_by_omits_any_ck_field};
 use crate::plan::properties::NodeProperties;
 
@@ -62,14 +62,28 @@ pub struct DeferredRegion {
 /// through composition bodies via `artifacts.composition_bodies`) and
 /// return one `DeferredRegion` per producer.
 ///
-/// Body-internal Aggregates produce regions whose indices are body-
-/// local; the caller is responsible for keying them appropriately.
+/// Returns a tuple `(top_level, per_body)`:
+///
+/// - `top_level` — regions whose `producer` is a parent-graph
+///   `NodeIndex`. The caller flattens these into
+///   `ExecutionPlanDag.deferred_regions`.
+/// - `per_body` — regions seeded by body-internal Aggregates, keyed by
+///   the body that owns them. The caller flattens each entry into the
+///   matching `BoundBody.deferred_regions`. The two index spaces are
+///   separated because a body-local NodeIndex can numerically collide
+///   with a parent-graph NodeIndex (each graph numbers from zero); the
+///   dispatcher consults the right map by which scope it is currently
+///   executing.
 pub(crate) fn detect_deferred_regions(
     graph: &DiGraph<PlanNode, PlanEdge>,
     node_properties: &HashMap<NodeIndex, NodeProperties>,
     artifacts: &CompileArtifacts,
-) -> Vec<DeferredRegion> {
-    let mut regions = Vec::new();
+) -> (
+    Vec<DeferredRegion>,
+    HashMap<CompositionBodyId, Vec<DeferredRegion>>,
+) {
+    let mut top_level = Vec::new();
+    let mut per_body: HashMap<CompositionBodyId, Vec<DeferredRegion>> = HashMap::new();
 
     // Top-level relaxed-CK aggregates.
     for idx in graph.node_indices() {
@@ -81,7 +95,7 @@ pub(crate) fn detect_deferred_regions(
             continue;
         }
         if let Some(region) = build_region(graph, artifacts, idx) {
-            regions.push(region);
+            top_level.push(region);
         }
     }
 
@@ -89,7 +103,7 @@ pub(crate) fn detect_deferred_regions(
     // body's parent-CK at each Aggregate from the upstream stored
     // schema (mirrors `apply_retraction_flags_in_body`), and seed a
     // region inside the body's mini-DAG.
-    for body in artifacts.composition_bodies.values() {
+    for (body_id, body) in &artifacts.composition_bodies {
         for idx in body.graph.node_indices() {
             let PlanNode::Aggregation { config, .. } = &body.graph[idx] else {
                 continue;
@@ -99,12 +113,12 @@ pub(crate) fn detect_deferred_regions(
                 continue;
             }
             if let Some(region) = build_body_region(body, idx) {
-                regions.push(region);
+                per_body.entry(*body_id).or_default().push(region);
             }
         }
     }
 
-    regions
+    (top_level, per_body)
 }
 
 /// Resolve the upstream node's CK set from `node_properties` for a

--- a/crates/clinker-core/src/plan/execution.rs
+++ b/crates/clinker-core/src/plan/execution.rs
@@ -897,8 +897,46 @@ impl ExecutionPlanDag {
                 worker_threads: 1,
             },
             node_properties: HashMap::new(),
-            deferred_regions: HashMap::new(),
+            // Body-local deferred regions ride along on the transient
+            // DAG so dispatcher arms reading `current_dag.deferred_regions`
+            // see body-internal producers without any arm-side branching.
+            // Body NodeIndex space matches `body.graph`, so the keys
+            // remain valid against the cloned graph above.
+            deferred_regions: body.deferred_regions.clone(),
         }
+    }
+
+    /// `Some(region)` iff `idx` participates in any deferred region on
+    /// this DAG (producer, member, or output). Dispatcher arms call
+    /// this at the top of every operator branch to decide whether to
+    /// short-circuit to the deferred buffer.
+    pub(crate) fn deferred_region_at(
+        &self,
+        idx: NodeIndex,
+    ) -> Option<&crate::plan::deferred_region::DeferredRegion> {
+        self.deferred_regions.get(&idx)
+    }
+
+    /// `true` iff `idx` is a non-producer participant in some deferred
+    /// region (member or output). Operator arms use this to skip work
+    /// on the forward pass — the deferred dispatch at commit will run
+    /// the operator on post-recompute aggregate emits.
+    pub(crate) fn is_deferred_consumer(&self, idx: NodeIndex) -> bool {
+        self.deferred_regions
+            .get(&idx)
+            .is_some_and(|r| r.producer != idx)
+    }
+
+    /// `Some(region)` iff `idx` is the producer of a deferred region.
+    /// The Aggregation arm uses this to project emits to
+    /// `region.buffer_schema` before parking them in `node_buffers`.
+    pub(crate) fn deferred_region_at_producer(
+        &self,
+        idx: NodeIndex,
+    ) -> Option<&crate::plan::deferred_region::DeferredRegion> {
+        self.deferred_regions
+            .get(&idx)
+            .filter(|r| r.producer == idx)
     }
 
     /// Whether any node requires arena allocation (window functions).
@@ -4625,6 +4663,7 @@ mod port_tag_guard_tests {
             nested_body_ids: Vec::new(),
             body_indices_to_build: Vec::new(),
             body_window_configs: HashMap::new(),
+            deferred_regions: HashMap::new(),
         };
         artifacts.insert_body(body_id, body);
         let diags = diagnose_untagged_composition_edges(&dag, &artifacts);

--- a/crates/clinker-core/src/plan/tests/deferred_region.rs
+++ b/crates/clinker-core/src/plan/tests/deferred_region.rs
@@ -14,21 +14,22 @@ use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::config::{CompileContext, PipelineConfig, parse_config};
+use crate::plan::CompiledPlan;
 use crate::plan::execution::ExecutionPlanDag;
 
 fn compile(yaml: &str) -> ExecutionPlanDag {
-    let config: PipelineConfig = parse_config(yaml).expect("parse");
-    config
-        .compile(&CompileContext::default())
-        .expect("compile")
-        .dag()
-        .clone()
+    compile_full(yaml).dag().clone()
 }
 
-fn compile_with_dir(yaml: &str, workspace_root: &std::path::Path) -> ExecutionPlanDag {
+fn compile_full(yaml: &str) -> CompiledPlan {
+    let config: PipelineConfig = parse_config(yaml).expect("parse");
+    config.compile(&CompileContext::default()).expect("compile")
+}
+
+fn compile_with_dir_full(yaml: &str, workspace_root: &std::path::Path) -> CompiledPlan {
     let config: PipelineConfig = parse_config(yaml).expect("parse");
     let ctx = CompileContext::with_pipeline_dir(workspace_root, PathBuf::from("pipelines"));
-    config.compile(&ctx).expect("compile").dag().clone()
+    config.compile(&ctx).expect("compile")
 }
 
 fn node_idx_for(plan: &ExecutionPlanDag, node_name: &str) -> NodeIndex {
@@ -36,6 +37,16 @@ fn node_idx_for(plan: &ExecutionPlanDag, node_name: &str) -> NodeIndex {
         .node_indices()
         .find(|&i| plan.graph[i].name() == node_name)
         .unwrap_or_else(|| panic!("node {node_name:?} not found in plan"))
+}
+
+fn body_node_idx_for(
+    body: &crate::plan::composition_body::BoundBody,
+    node_name: &str,
+) -> NodeIndex {
+    body.graph
+        .node_indices()
+        .find(|&i| body.graph[i].name() == node_name)
+        .unwrap_or_else(|| panic!("body node {node_name:?} not found"))
 }
 
 /// Test 1: Simple region — Source(CK=order_id) → Aggregate(group_by=dept,
@@ -415,8 +426,14 @@ nodes:
 }
 
 /// Test 5: Composition body containing a relaxed-CK Aggregate. The
-/// region must cross the body↔parent boundary: the body's internal
-/// Transform AND the parent's downstream Transform are members.
+/// body-internal Aggregate seeds a region inside the body's mini-DAG;
+/// the body-local map (`BoundBody.deferred_regions`) keys the
+/// body-internal Aggregate as producer and its downstream body
+/// Transform as a member, with O(1) lookup at every body NodeIndex
+/// participating in the region. Parent-graph continuation through the
+/// Composition node is not propagated by the detector today (the parent
+/// walker only seeds from top-level Aggregates); per-body keying is the
+/// load-bearing dispatcher contract Phase 2 asserts on.
 #[test]
 fn composition_body_relaxed_aggregate_crosses_boundary() {
     let workspace = tempfile::tempdir().expect("tempdir");
@@ -497,34 +514,56 @@ nodes:
       path: out.csv
       include_unmapped: true
 "#;
-    let plan = compile_with_dir(yaml, workspace.path());
+    let compiled = compile_with_dir_full(yaml, workspace.path());
+    let plan = compiled.dag();
 
-    // The body-internal Aggregate seeds a region in the body's
-    // mini-DAG; the flatten in config/mod.rs writes both parent-graph
-    // and body-local NodeIndex values into the same flat HashMap.
-    // Body-local indices can collide with parent indices because each
-    // graph numbers nodes from 0, so we cannot assert directly on
-    // `plan.deferred_regions[&parent_idx]` for body-local entries.
-    // The contract this test verifies: at least one region exists
-    // touching parent-graph nodes downstream of the composition
-    // boundary. Body-aware keying (e.g. `(CompositionBodyId,
-    // NodeIndex)`) lands when a runtime consumer needs to disambiguate.
-    let comp_idx = node_idx_for(&plan, "body");
-    let parent_t_idx = node_idx_for(&plan, "parent_t");
-    let out_idx = node_idx_for(&plan, "out");
+    // Parent-graph indices for the composition call site and the
+    // downstream chain. The body-internal Aggregate seeds a region
+    // whose body-local NodeIndex space is disjoint from the parent
+    // graph; the dispatcher consults the right map by which scope it
+    // is currently executing.
+    let comp_idx = node_idx_for(plan, "body");
+    let parent_t_idx = node_idx_for(plan, "parent_t");
+    let out_idx = node_idx_for(plan, "out");
 
-    // The body-internal relaxed Aggregate produces a body-local
-    // region; the parent-graph walk does NOT see body internals as
-    // relaxed because the parent walker only inspects top-level
-    // Aggregates. What we assert here is that the body-local region
-    // detection ran and produced at least one region covering the
-    // body-internal Aggregate. The load-bearing invariant: the
-    // detector reaches body-internal Aggregates at all.
-    let saw_any_region = !plan.deferred_regions.is_empty();
+    // Body-local regions: look up the bound body via the composition's
+    // name → body-id assignment, then assert the body-internal
+    // Aggregate is the producer, the body's Transform is a member, and
+    // both NodeIndex slots are keyed for O(1) dispatcher lookup.
+    let artifacts = compiled.artifacts();
+    let body_id = artifacts
+        .composition_body_assignments
+        .get("body")
+        .copied()
+        .expect("composition 'body' must be assigned a CompositionBodyId");
+    let bound = compiled
+        .body_of(body_id)
+        .expect("body_id must resolve to a BoundBody");
+    let body_agg_idx = body_node_idx_for(bound, "dept_totals");
+    let body_xform_idx = body_node_idx_for(bound, "agg_emit");
+
+    let body_region = bound
+        .deferred_regions
+        .get(&body_agg_idx)
+        .expect("body-internal Aggregate keys its body-local region");
+    assert_eq!(body_region.producer, body_agg_idx);
     assert!(
-        saw_any_region,
-        "composition body containing a relaxed Aggregate must produce at least \
-         one region (body-local or parent-flow)"
+        body_region.members.contains(&body_xform_idx),
+        "body Transform agg_emit is a member of the body-local region"
+    );
+    assert!(
+        bound.deferred_regions.contains_key(&body_xform_idx),
+        "body Transform agg_emit is keyed in the body-local map for O(1) dispatch"
+    );
+
+    // The parent-flat map carries no entries seeded by body-internal
+    // Aggregates today — the parent walker only seeds from top-level
+    // Aggregates, and there are none in this fixture.
+    assert!(
+        plan.deferred_regions.is_empty(),
+        "parent-graph map carries only top-level-Aggregate regions; \
+         body-internal regions live on BoundBody.deferred_regions; got {:?}",
+        plan.deferred_regions.keys().collect::<Vec<_>>()
     );
 
     // Sanity: the parent-side downstream chain (parent_t, out) is reachable
@@ -644,15 +683,77 @@ nodes:
       path: out.csv
       include_unmapped: true
 "#;
-    let plan = compile_with_dir(yaml, workspace.path());
+    let compiled = compile_with_dir_full(yaml, workspace.path());
+    let plan = compiled.dag();
 
-    // Detector must walk the nested-body chain and produce at least
-    // one region covering the inner body's relaxed Aggregate.
+    let outer_idx = node_idx_for(plan, "outer");
+    let out_idx = node_idx_for(plan, "out");
+
+    // Body-local: the inner body owns the relaxed Aggregate; the outer
+    // body owns no relaxed Aggregate of its own and thus has no body-
+    // local region keyed on its mini-DAG. Walk the assignments to
+    // locate both bodies and verify the load-bearing one carries the
+    // expected producer.
+    let artifacts = compiled.artifacts();
+    let outer_body_id = artifacts
+        .composition_body_assignments
+        .get("outer")
+        .copied()
+        .expect("outer composition assignment");
+    let outer_body = compiled
+        .body_of(outer_body_id)
+        .expect("outer BoundBody resolves");
     assert!(
-        !plan.deferred_regions.is_empty(),
-        "nested composition body containing a relaxed Aggregate must produce \
-         at least one region"
+        outer_body.deferred_regions.is_empty(),
+        "outer body has no relaxed Aggregate of its own; its body-local map stays empty",
     );
+
+    // Inner body assignment lives under the body-internal Composition
+    // node `inner_call` inside `outer_wrap.comp.yaml`.
+    let inner_body_id = artifacts
+        .composition_body_assignments
+        .get("inner_call")
+        .copied()
+        .expect("inner_call composition assignment");
+    let inner_body = compiled
+        .body_of(inner_body_id)
+        .expect("inner BoundBody resolves");
+    let inner_agg_idx = body_node_idx_for(inner_body, "dept_totals");
+    let inner_region = inner_body
+        .deferred_regions
+        .get(&inner_agg_idx)
+        .expect("inner body-internal Aggregate keys its body-local region");
+    assert_eq!(inner_region.producer, inner_agg_idx);
+    assert!(
+        inner_body.deferred_regions.contains_key(&inner_agg_idx),
+        "inner body-local map carries the producer NodeIndex for O(1) dispatch"
+    );
+
+    // Parent-flat map carries no body-internal regions today (the
+    // parent walker only seeds from top-level Aggregates).
+    assert!(
+        plan.deferred_regions.is_empty(),
+        "parent-graph map stays empty for nested-body fixtures with no \
+         top-level Aggregate; got {:?}",
+        plan.deferred_regions.keys().collect::<Vec<_>>()
+    );
+
+    // Sanity: the parent's downstream (`out`) is reachable from the
+    // outer Composition via outgoing edges.
+    let mut downstream: std::collections::HashSet<NodeIndex> = std::collections::HashSet::new();
+    let mut stack: Vec<NodeIndex> = plan
+        .graph
+        .neighbors_directed(outer_idx, Direction::Outgoing)
+        .collect();
+    while let Some(n) = stack.pop() {
+        if !downstream.insert(n) {
+            continue;
+        }
+        for s in plan.graph.neighbors_directed(n, Direction::Outgoing) {
+            stack.push(s);
+        }
+    }
+    assert!(downstream.contains(&out_idx));
 }
 
 /// Test 7: Output fan-out via Route — Source → Aggregate(relaxed) →

--- a/crates/clinker-core/tests/composition_binding_test.rs
+++ b/crates/clinker-core/tests/composition_binding_test.rs
@@ -60,6 +60,7 @@ fn test_compile_artifacts_insert_body_and_lookup() {
         nested_body_ids: vec![],
         body_indices_to_build: Vec::new(),
         body_window_configs: std::collections::HashMap::new(),
+        deferred_regions: std::collections::HashMap::new(),
     };
 
     artifacts.insert_body(id, body.clone());


### PR DESCRIPTION
## Summary
- Stops running deferred-region operators on the streaming forward pass: every Transform/Route/Merge/Sort/Output/Composition/Combine arm gains a top-of-arm `is_deferred_consumer` early-return; the producing relaxed-CK Aggregate projects its emit to the region's `buffer_schema` before parking; cross-region edges (Combine build-side input) tee upstream emits into a new `region_input_buffers` keyed by `(active body, EdgeIndex)` so top-level and body graph EdgeIndex namespaces don't collide.
- Body-internal regions move from the colliding flat `dag.deferred_regions` map to a new `BoundBody.deferred_regions` field; `detect_deferred_regions` now returns `(Vec<DeferredRegion>, HashMap<CompositionBodyId, Vec<DeferredRegion>>)` and the planner flattens each per-body vec into the matching body's field.
- Adds three accessors on `ExecutionPlanDag` (`deferred_region_at`, `is_deferred_consumer`, `deferred_region_at_producer`) and two helpers in `dispatch.rs` (`project_rows_to_buffer_schema`, `tee_emit_to_region_input_buffers`).
- Re-strengthens plan-time tests 5 and 6 in `plan/tests/deferred_region.rs` to per-NodeIndex membership inside the body's `deferred_regions` (the NodeIndex collision flagged in the previous PR's findings is now resolved).
- New smoke tests in `executor/tests/deferred_dispatch.rs`: plan-side wiring + runtime forward-pass empty-output observability.

Builds on the previous PR #28 (Plan-time deferred-region detection + `Expr::support_into` visitor), which has merged. The `ab99b60` commit on this branch is the same content that was squash-merged to main as `7d0511c`; the diff against `main` shows only the new `8d6279f` Phase 2 changes.

## CI status — expected red

This is an intermediate commit in a multi-commit sprint per the project's atomicity-at-sprint-not-commit policy (CLAUDE.md § Refactoring policy). Twenty tests across the relaxed-CK retraction surface fail because the forward pass no longer populates `correlation_buffers` for deferred Outputs and the existing five-phase replay path patches an empty buffer:

- `correlated_dlq_retract` (9 failures)
- `correlated_post_aggregate_retract` (2 failures)
- `correlated_window_after_aggregate_retract` (2 failures)
- `window_recompute_correctness::post_aggregate_window_recompute_corrects_running_total`
- `ck_aligned_partition_runtime::ck_aligned_partition_failure_does_not_engage_partition_recompute`
- `combine_propagate_ck_test::runtime_synthetic_ck_carries_through_driver_side_combine`
- `combine_propagate_ck_test::runtime_propagate_ck_driver_drops_source_ck_keeps_synthetic`
- `retract_demo_smoke::demo_dlq_contains_upstream_and_post_aggregate_triggers`
- `retract_demo_smoke::demo_retraction_counters_fire_in_the_expected_direction`
- `retraction_metrics_test::retraction_counters_fire_under_relaxed_dlq_trigger`

None of these tests were modified, ignored, or deleted. A follow-up commit collapses the orchestrator to the three-phase `detect → recompute → dispatch_deferred_subdag` protocol on top of these primitives and brings every failure back green. The closing commit of the sprint will pass all seven CI checks.

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo check --workspace` — clean (no errors, no new warnings)
- [x] Strict-pipeline tests still green: `correlated_dlq` (18), `aggregation` (76), `branching` (12), `multi_output` (33), `format_dispatch` (10), `cross_source_window_topology` (2)
- [x] 7 plan-time region detection tests still pass (with re-strengthened tests 5/6)
- [x] 2 new `deferred_dispatch` smoke tests pass
- [x] 766 total tests pass; 20 documented retraction tests fail intentionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)