### PR TITLE
Return CoercionError instead of panicking on Date→DateTime promotion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -757,6 +757,7 @@ dependencies = [
  "num_cpus",
  "serde-saphyr",
  "serde_json",
+ "tempfile",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/clinker-core/benches/arena.rs
+++ b/crates/clinker-core/benches/arena.rs
@@ -54,7 +54,7 @@ fn bench_arena_field_access(c: &mut Criterion) {
             &record_count,
             |b, _| {
                 b.iter(|| {
-                    for pos in 0..record_count as u32 {
+                    for pos in 0..record_count as u64 {
                         black_box(arena.resolve_field(pos, "f4"));
                     }
                 });

--- a/crates/clinker-core/benches/sort.rs
+++ b/crates/clinker-core/benches/sort.rs
@@ -34,7 +34,7 @@ fn bench_sort_single_field(c: &mut Criterion) {
 
     for count in [SMALL, MEDIUM, LARGE] {
         let arena = build_arena(count, 10, 0.0);
-        let positions_template: Vec<u32> = (0..count as u32).collect();
+        let positions_template: Vec<u64> = (0..count as u64).collect();
 
         group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
@@ -60,7 +60,7 @@ fn bench_sort_multi_field(c: &mut Criterion) {
 
     for count in [SMALL, MEDIUM, LARGE] {
         let arena = build_arena(count, 10, 0.0);
-        let positions_template: Vec<u32> = (0..count as u32).collect();
+        let positions_template: Vec<u64> = (0..count as u64).collect();
 
         group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
@@ -83,7 +83,7 @@ fn bench_sort_with_nulls(c: &mut Criterion) {
     for null_pct in [0, 10, 50] {
         let null_ratio = null_pct as f64 / 100.0;
         let arena = build_arena(MEDIUM, 10, null_ratio);
-        let positions_template: Vec<u32> = (0..MEDIUM as u32).collect();
+        let positions_template: Vec<u64> = (0..MEDIUM as u64).collect();
 
         group.throughput(Throughput::Elements(MEDIUM as u64));
         group.bench_with_input(BenchmarkId::new("null_pct", null_pct), &null_pct, |b, _| {
@@ -110,7 +110,7 @@ fn bench_sort_presorted(c: &mut Criterion) {
             .map(|i| MinimalRecord::new(vec![Value::Integer(i as i64), Value::Null]))
             .collect();
         let arena = Arena::from_parts(schema, minimals);
-        let positions_template: Vec<u32> = (0..count as u32).collect();
+        let positions_template: Vec<u64> = (0..count as u64).collect();
 
         group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {
@@ -137,7 +137,7 @@ fn bench_sort_reverse(c: &mut Criterion) {
             .map(|i| MinimalRecord::new(vec![Value::Integer(i as i64), Value::Null]))
             .collect();
         let arena = Arena::from_parts(schema, minimals);
-        let positions_template: Vec<u32> = (0..count as u32).collect();
+        let positions_template: Vec<u64> = (0..count as u64).collect();
 
         group.throughput(Throughput::Elements(count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), &count, |b, _| {

--- a/crates/clinker-core/benches/window.rs
+++ b/crates/clinker-core/benches/window.rs
@@ -10,7 +10,7 @@ use std::io::{Cursor, Write};
 use std::sync::{Arc, Mutex};
 
 /// Build an Arena with numeric fields for window benchmarks.
-fn build_numeric_arena(partition_size: usize) -> (Arena, Vec<u32>) {
+fn build_numeric_arena(partition_size: usize) -> (Arena, Vec<u64>) {
     let schema = Arc::new(Schema::new(vec!["amount".into(), "category".into()]));
     let mut rng = fastrand::Rng::with_seed(42);
     let mut minimals = Vec::with_capacity(partition_size);
@@ -20,7 +20,7 @@ fn build_numeric_arena(partition_size: usize) -> (Arena, Vec<u32>) {
             Value::String(format!("cat_{}", i % 50).into_boxed_str()),
         ]));
     }
-    let positions: Vec<u32> = (0..partition_size as u32).collect();
+    let positions: Vec<u64> = (0..partition_size as u64).collect();
     (Arena::from_parts(schema, minimals), positions)
 }
 

--- a/crates/clinker-core/src/aggregation.rs
+++ b/crates/clinker-core/src/aggregation.rs
@@ -46,16 +46,16 @@ use crate::pipeline::loser_tree::LoserTree;
 /// implements `FieldResolver`); the storage parameter is unused.
 struct NullStorage;
 impl RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         Vec::new()
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }
@@ -684,7 +684,7 @@ pub struct AggregatorGroupState {
     /// alongside accumulator state so the post-merge `AggregatorGroupState`
     /// preserves which input rows folded into each group across the
     /// round trip.
-    pub input_rows: Vec<u32>,
+    pub input_rows: Vec<u64>,
     /// Per-row evaluated binding values, parallel to `input_rows`.
     /// `retract_values[i]` is the per-binding `Vec<Value>` produced by
     /// the i-th ingested row (in `CompiledAggregate.bindings[]` order),
@@ -747,7 +747,7 @@ pub struct BufferedGroupState {
     /// Per-group input-row-number list. Mirrors
     /// `AggregatorGroupState.input_rows` so the spill-merge concat
     /// round-trips through the same shape on both retraction strategies.
-    pub input_rows: Vec<u32>,
+    pub input_rows: Vec<u64>,
     /// Per-row evaluated binding values. `contributions[i][slot]`
     /// holds the value the binding at slot `slot` produced for the
     /// i-th ingested row, in `CompiledAggregate.bindings[]` order.
@@ -787,7 +787,7 @@ pub enum HashAggError {
     /// in the executor dispatch path.
     GroupKey {
         field: String,
-        row: u32,
+        row: u64,
         message: String,
     },
     /// Spill path raised an I/O error. Stub until 16.3.10 lands the
@@ -1082,7 +1082,7 @@ pub struct HashAggregator {
     /// call: post-spill the per-group `AggregatorGroupState.input_rows`
     /// holds the canonical lineage shape, and the flat vec is rebuilt
     /// from there during finalize when callers need the dense form.
-    lineage: Option<Vec<(u32, u32)>>,
+    lineage: Option<Vec<(u64, u32)>>,
     /// Buffer-mode per-group state, populated only when
     /// `compiled.requires_buffer_mode` is true. Mutually exclusive with
     /// `groups` at the dispatch level — `add_record` consults
@@ -1202,7 +1202,7 @@ impl HashAggregator {
     /// is an obvious future optimization but not warranted at current
     /// call frequencies (one walk per detect-phase synthetic-CK
     /// trigger column).
-    pub(crate) fn input_rows_by_group_index(&self, group_index: u32) -> Option<&[u32]> {
+    pub(crate) fn input_rows_by_group_index(&self, group_index: u32) -> Option<&[u64]> {
         if self.buffer_mode {
             self.buffered_groups
                 .values()
@@ -1313,13 +1313,13 @@ impl HashAggregator {
                 .get(*idx as usize)
                 .cloned()
                 .unwrap_or(Value::Null);
-            match value_to_group_key(&val, field_name, None, ctx.source_row as u32) {
+            match value_to_group_key(&val, field_name, None, ctx.source_row) {
                 Ok(Some(gk)) => key.push(gk),
                 Ok(None) => key.push(GroupByKey::Null),
                 Err(e) => {
                     return Err(HashAggError::GroupKey {
                         field: field_name.to_string(),
-                        row: ctx.source_row as u32,
+                        row: ctx.source_row,
                         message: e.to_string(),
                     });
                 }
@@ -1361,13 +1361,13 @@ impl HashAggregator {
             // lineage entry will sit alongside the full-precision
             // `min_row_num`, which is what downstream sort-stable
             // ordering uses.
-            let row_u32 = row_num as u32;
+            let row_u64 = row_num;
             let group_idx = group_state.group_index;
-            lin.push((row_u32, group_idx));
-            group_state.input_rows.push(row_u32);
+            lin.push((row_u64, group_idx));
+            group_state.input_rows.push(row_u64);
             self.value_heap_bytes = self
                 .value_heap_bytes
-                .saturating_add(std::mem::size_of::<(u32, u32)>() + std::mem::size_of::<u32>());
+                .saturating_add(std::mem::size_of::<(u64, u32)>() + std::mem::size_of::<u64>());
         }
 
         // 5. BindingArg dispatch hot loop (D1).
@@ -1570,13 +1570,13 @@ impl HashAggregator {
                 .get(*idx as usize)
                 .cloned()
                 .unwrap_or(Value::Null);
-            match value_to_group_key(&val, field_name, None, ctx.source_row as u32) {
+            match value_to_group_key(&val, field_name, None, ctx.source_row) {
                 Ok(Some(gk)) => key.push(gk),
                 Ok(None) => key.push(GroupByKey::Null),
                 Err(e) => {
                     return Err(HashAggError::GroupKey {
                         field: field_name.to_string(),
-                        row: ctx.source_row as u32,
+                        row: ctx.source_row,
                         message: e.to_string(),
                     });
                 }
@@ -1604,7 +1604,7 @@ impl HashAggregator {
         //    two-Value inner vec so the rollback step can replay the
         //    exact same `(value, weight)` pair through `add_weighted`.
         let bindings = self.factory.compiled().bindings.clone();
-        let row_u32 = row_num as u32;
+        let row_u64 = row_num;
         let mut row_values: Vec<Value> = Vec::with_capacity(bindings.len());
         let mut row_heap_bytes: usize = 0;
         for binding in bindings.iter() {
@@ -1634,7 +1634,7 @@ impl HashAggregator {
         let row_charge = std::mem::size_of::<Value>().saturating_mul(row_value_count)
             + row_heap_bytes
             + std::mem::size_of::<Vec<Value>>()
-            + std::mem::size_of::<u32>();
+            + std::mem::size_of::<u64>();
         // Hard-limit guard. A single record whose contributions alone
         // exceed the entire memory budget cannot be held in memory and
         // cannot be salvaged by spilling — the very next add of the same
@@ -1652,7 +1652,7 @@ impl HashAggregator {
             );
         }
         group_state.contributions.push(row_values);
-        group_state.input_rows.push(row_u32);
+        group_state.input_rows.push(row_u64);
         self.value_heap_bytes = self.value_heap_bytes.saturating_add(row_charge);
 
         // 6. Metadata common-only propagation, identical shape to
@@ -1740,7 +1740,7 @@ impl HashAggregator {
     /// state. The orchestrator's degrade-fallback surface catches that
     /// case and routes the affected groups through strict-collateral DLQ
     /// per the relaxed-CK fallback contract.
-    pub(crate) fn retract_row(&mut self, input_row_id: u32) -> Result<(), HashAggError> {
+    pub(crate) fn retract_row(&mut self, input_row_id: u64) -> Result<(), HashAggError> {
         if !self.spill_files.is_empty() {
             return Err(HashAggError::Spill(format!(
                 "retract_row {input_row_id} called on aggregator with spilled groups; \
@@ -1756,7 +1756,7 @@ impl HashAggregator {
                     let row_charge = std::mem::size_of::<Value>().saturating_mul(removed.len())
                         + removed.iter().map(Value::heap_size).sum::<usize>()
                         + std::mem::size_of::<Vec<Value>>()
-                        + std::mem::size_of::<u32>();
+                        + std::mem::size_of::<u64>();
                     self.value_heap_bytes = self.value_heap_bytes.saturating_sub(row_charge);
                     return Ok(());
                 }
@@ -1800,7 +1800,7 @@ impl HashAggregator {
             let removed_row_charge = std::mem::size_of::<Value>().saturating_mul(values.len())
                 + values.iter().map(Value::heap_size).sum::<usize>()
                 + std::mem::size_of::<Vec<Value>>()
-                + std::mem::size_of::<u32>();
+                + std::mem::size_of::<u64>();
             self.value_heap_bytes = self.value_heap_bytes.saturating_sub(removed_row_charge);
             // Negative `total_delta` is a shrink; saturating-sub clamps
             // at zero against the running total.
@@ -2878,13 +2878,13 @@ impl StreamingAggregator<AddRaw> {
                 .get(*idx as usize)
                 .cloned()
                 .unwrap_or(Value::Null);
-            match value_to_group_key(&val, field_name, None, ctx.source_row as u32) {
+            match value_to_group_key(&val, field_name, None, ctx.source_row) {
                 Ok(Some(gk)) => key.push(gk),
                 Ok(None) => key.push(GroupByKey::Null),
                 Err(e) => {
                     return Err(HashAggError::GroupKey {
                         field: field_name.to_string(),
-                        row: ctx.source_row as u32,
+                        row: ctx.source_row,
                         message: e.to_string(),
                     });
                 }
@@ -2942,7 +2942,7 @@ impl StreamingAggregator<AddRaw> {
         let transform_name = self.transform_name.clone();
         let group_by_indices = self.group_by_indices.clone();
         let group_by_fields = self.group_by_fields.clone();
-        let source_row = ctx.source_row as u32;
+        let source_row = ctx.source_row;
         let finalize_closure =
             |rec: &Record, s: &AggregatorGroupState| -> Result<Record, HashAggError> {
                 let mut k: Vec<GroupByKey> = Vec::with_capacity(group_by_indices.len());
@@ -3941,7 +3941,7 @@ mod spill_trigger_tests {
         let lineage = agg.lineage.as_ref().expect("lineage allocated");
         assert_eq!(lineage.len(), 5, "every record must produce one entry");
         // Row numbers must be the input order 0..5.
-        let rows: Vec<u32> = lineage.iter().map(|(r, _)| *r).collect();
+        let rows: Vec<u64> = lineage.iter().map(|(r, _)| *r).collect();
         assert_eq!(rows, vec![0, 1, 2, 3, 4]);
         // Two distinct group indices, alternating with the input keys.
         let g0 = lineage[0].1;
@@ -3957,7 +3957,7 @@ mod spill_trigger_tests {
         // Per-group input_rows mirror the flat lineage partition.
         let groups = agg.groups();
         assert_eq!(groups.len(), 2);
-        let mut input_row_lists: Vec<Vec<u32>> =
+        let mut input_row_lists: Vec<Vec<u64>> =
             groups.values().map(|s| s.input_rows.clone()).collect();
         input_row_lists.sort();
         assert_eq!(input_row_lists, vec![vec![0, 2, 4], vec![1, 3]]);
@@ -3995,7 +3995,7 @@ mod spill_trigger_tests {
 
         // Walk every spill file's entries directly, verifying that
         // `input_rows` round-trips byte-for-byte through postcard+LZ4.
-        let mut by_key: std::collections::HashMap<String, Vec<u32>> =
+        let mut by_key: std::collections::HashMap<String, Vec<u64>> =
             std::collections::HashMap::new();
         for f in agg.spill_files() {
             let mut reader = f.reader().expect("open spill reader");
@@ -4034,7 +4034,7 @@ mod spill_trigger_tests {
             // Recover the expected row indices for this key from the
             // input pattern: positions where `keys[i % 4] == k`.
             let key_idx = keys.iter().position(|kk| *kk == k).expect("known key");
-            let expected: Vec<u32> = (0..32u32)
+            let expected: Vec<u64> = (0..32u64)
                 .filter(|i| (*i as usize) % 4 == key_idx)
                 .collect();
             assert_eq!(
@@ -4199,7 +4199,7 @@ mod spill_trigger_tests {
         );
         // Per-group input_rows mirror the lineage path's shape so
         // the rollback step indexes into `contributions` by row.
-        let mut a_rows: Vec<u32> = agg
+        let mut a_rows: Vec<u64> = agg
             .buffered_groups
             .iter()
             .find(|(k, _)| matches!(&k[0], GroupByKey::Str(s) if s.as_ref() == "a"))
@@ -4281,7 +4281,7 @@ mod spill_trigger_tests {
         // Reassemble per-group contributions from every spill file plus
         // any in-memory remainder, then compare to the deterministic
         // input pattern.
-        let mut by_key: std::collections::HashMap<String, Vec<(u32, i64)>> =
+        let mut by_key: std::collections::HashMap<String, Vec<(u64, i64)>> =
             std::collections::HashMap::new();
         for f in agg.spill_files() {
             let mut reader = f.reader().expect("open spill reader");
@@ -4328,7 +4328,7 @@ mod spill_trigger_tests {
         for (k, mut rows) in by_key.into_iter() {
             rows.sort_by_key(|(r, _)| *r);
             let key_idx = keys.iter().position(|kk| *kk == k).expect("known key");
-            let expected: Vec<(u32, i64)> = (0..32u32)
+            let expected: Vec<(u64, i64)> = (0..32u64)
                 .filter(|i| (*i as usize) % 4 == key_idx)
                 .map(|i| (i, i as i64))
                 .collect();
@@ -4455,7 +4455,7 @@ mod spill_trigger_tests {
         input_fields: &[(&str, Type)],
         group_by: &[&str],
         rows: &[(Vec<Value>, u64)],
-        retract: &[u32],
+        retract: &[u64],
         feed_subset: F,
     ) -> (Vec<Record>, Vec<Record>)
     where

--- a/crates/clinker-core/src/executor/commit/detect.rs
+++ b/crates/clinker-core/src/executor/commit/detect.rs
@@ -21,7 +21,7 @@ pub(crate) struct RetractScope {
     /// Affected aggregate node + group keys that need rerun. Each
     /// entry's `Vec<u32>` carries the runtime-DLQ-triggered input row
     /// IDs to retract from that aggregate's per-group state.
-    pub(crate) aggregates: Vec<(NodeIndex, Vec<u32>)>,
+    pub(crate) aggregates: Vec<(NodeIndex, Vec<u64>)>,
     /// Trigger group keys (correlation-buffer keys) that drove the
     /// scope expansion. Used by `flush` to format DLQ trigger messages
     /// against the same group identifier the strict path emits. `Vec`
@@ -37,7 +37,7 @@ pub(crate) struct RetractScope {
     /// directly: source rows are bounded, so a strictly-monotone set
     /// caps the loop at `|source_rows|` iterations regardless of how
     /// many DLQ events each iteration produces.
-    pub(crate) seen_source_rows: BTreeSet<u32>,
+    pub(crate) seen_source_rows: BTreeSet<u64>,
 }
 
 /// Compute the retract scope from `ctx.correlation_buffers` plus the
@@ -108,7 +108,7 @@ pub(crate) fn detect_retract_scope(
     // instantiated), the synthetic-CK lookup misses and the existing
     // degrade-fallback in `recompute_agg.rs` routes the affected group
     // through strict-collateral DLQ.
-    let mut affected_row_ids: BTreeSet<u32> = BTreeSet::new();
+    let mut affected_row_ids: BTreeSet<u64> = BTreeSet::new();
     // Accumulate counter deltas locally so the immutable borrow of
     // `ctx.correlation_buffers` (and the immutable hand to
     // `ctx.relaxed_aggregator_states`) does not collide with the
@@ -219,7 +219,7 @@ pub(crate) fn detect_retract_scope(
         // silently no-opping. Skip the raw union in that case.
         if has_source_ck || !had_synthetic_lookup {
             for &row in &group.error_rows {
-                affected_row_ids.insert(row as u32);
+                affected_row_ids.insert(row);
             }
         }
     }
@@ -286,17 +286,14 @@ impl RetractScope {
     /// tolerance for aggregates whose lineage doesn't include it, so
     /// the wide-fanout shape (every relaxed-CK aggregate sees every
     /// new row id) stays correct without per-aggregate filtering.
-    pub(crate) fn expand_with_dlq_events(&mut self, events: &[DlqEvent]) -> Vec<u32> {
-        let mut new_rows: Vec<u32> = Vec::new();
+    pub(crate) fn expand_with_dlq_events(&mut self, events: &[DlqEvent]) -> Vec<u64> {
+        let mut new_rows: Vec<u64> = Vec::new();
         for event in events {
-            let row_u32 = match u32::try_from(event.source_row) {
-                Ok(r) => r,
-                Err(_) => continue,
-            };
-            if !self.seen_source_rows.insert(row_u32) {
+            let row = event.source_row;
+            if !self.seen_source_rows.insert(row) {
                 continue;
             }
-            new_rows.push(row_u32);
+            new_rows.push(row);
         }
         if !new_rows.is_empty() {
             for (_, retract_ids) in &mut self.aggregates {

--- a/crates/clinker-core/src/executor/commit/dispatch.rs
+++ b/crates/clinker-core/src/executor/commit/dispatch.rs
@@ -406,7 +406,7 @@ fn recurse_into_body(
         // re-runs the body detect against the updated
         // `correlation_buffers`.
         let body_scope = super::detect::detect_retract_scope(ctx, &body_dag);
-        let body_initial_rows: Vec<u32> = body_scope.seen_source_rows.iter().copied().collect();
+        let body_initial_rows: Vec<u64> = body_scope.seen_source_rows.iter().copied().collect();
         super::recompute_agg::recompute_aggregates(
             ctx,
             &body_dag,

--- a/crates/clinker-core/src/executor/commit/mod.rs
+++ b/crates/clinker-core/src/executor/commit/mod.rs
@@ -122,7 +122,7 @@ pub(crate) fn orchestrate(
     // the per-iteration delta returned by `expand_with_dlq_events`,
     // because `retract_row` is not idempotent on a row already taken
     // out of the aggregator's contributions.
-    let initial_rows: Vec<u32> = scope.seen_source_rows.iter().copied().collect();
+    let initial_rows: Vec<u64> = scope.seen_source_rows.iter().copied().collect();
 
     // Snapshot the forward-pass baseline buffer state. The strict-Output
     // records and forward-pass error events captured here are stable
@@ -168,7 +168,7 @@ pub(crate) fn orchestrate(
     // records.
     let mut error_archive: HashMap<Vec<GroupByKey>, CorrelationGroupBuffer> = HashMap::new();
 
-    let mut iteration_rows: Vec<u32> = initial_rows;
+    let mut iteration_rows: Vec<u64> = initial_rows;
     loop {
         if iter >= cap {
             panic!(
@@ -198,9 +198,7 @@ pub(crate) fn orchestrate(
         archive_iteration_errors(&mut error_archive, ctx.correlation_buffers.as_ref());
         let mut new_events: Vec<DlqEvent> = direct_events;
         for row in &post_dispatch_scope.seen_source_rows {
-            new_events.push(DlqEvent {
-                source_row: *row as u64,
-            });
+            new_events.push(DlqEvent { source_row: *row });
         }
         let new_triggers = scope.expand_with_dlq_events(&new_events);
         if new_triggers.is_empty() {

--- a/crates/clinker-core/src/executor/commit/recompute_agg.rs
+++ b/crates/clinker-core/src/executor/commit/recompute_agg.rs
@@ -44,7 +44,7 @@ pub(crate) fn recompute_aggregates(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     scope: &RetractScope,
-    new_retract_rows: &[u32],
+    new_retract_rows: &[u64],
 ) -> Result<(), PipelineError> {
     if scope.aggregates.is_empty() || new_retract_rows.is_empty() {
         return Ok(());
@@ -100,7 +100,7 @@ pub(crate) fn recompute_aggregates(
 /// "row not in this aggregator's lineage" case (treated as no-op).
 fn retract_and_refinalize(
     retained: &mut crate::executor::dispatch::RetainedAggregatorState,
-    retract_ids: &[u32],
+    retract_ids: &[u64],
 ) -> Result<(), HashAggError> {
     for &row_id in retract_ids {
         if let Err(e) = retained.aggregator.retract_row(row_id) {

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -40,7 +40,7 @@ fn value_to_correlation_key(v: &Value, idx: usize) -> GroupByKey {
     if v.is_null() {
         return GroupByKey::Null;
     }
-    value_to_group_key(v, "__correlation_key", None, idx as u32)
+    value_to_group_key(v, "__correlation_key", None, idx as u64)
         .ok()
         .flatten()
         .unwrap_or(GroupByKey::Null)
@@ -622,7 +622,7 @@ pub(crate) fn finalize_node_rooted_windows(
             transform_name: String::new(),
             messages: vec![format!("E310 node-rooted arena build: {e}")],
         })?;
-        let arena_len = arena.record_count() as u64;
+        let arena_len = arena.record_count();
         ctx.collector
             .record(arena_timer.finish(arena_len, arena_len));
 
@@ -953,7 +953,7 @@ pub(crate) fn dispatch_plan_node(
                                     ),
                                 })?;
                         // record_pos semantics:
-                        // - Source(_)  → (rn - 1) as u32. Phase-0 materializes
+                        // - Source(_)  → rn - 1. Phase-0 materializes
                         //   records in arena order, source row numbers
                         //   start at 1, so the position is always `rn - 1`.
                         // - Node{..} / ParentNode{..} → enumerate index `i`.
@@ -964,9 +964,9 @@ pub(crate) fn dispatch_plan_node(
                         //   position by construction.
                         let record_pos =
                             if matches!(spec.root, crate::plan::index::PlanIndexRoot::Source(_)) {
-                                (rn - 1) as u32
+                                rn - 1
                             } else {
-                                i as u32
+                                i as u64
                             };
                         evaluate_single_transform_windowed(
                             &record,

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -260,16 +260,16 @@ fn sum_cpu_io_totals(
 /// Used to satisfy the `S: RecordStorage` type parameter when `window` is `None`.
 pub(crate) struct NullStorage;
 impl RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }
@@ -930,7 +930,7 @@ impl PipelineExecutor {
                     transform_name: String::new(),
                     messages: vec![format!("E310 source-arena build: {e}")],
                 })?;
-                let arena_len = arena.record_count() as u64;
+                let arena_len = arena.record_count();
                 collector.record(arena_timer.finish(arena_len, arena_len));
 
                 let index_name = format!("{}:{}", source_name, spec.group_by.join(","));
@@ -2121,7 +2121,7 @@ pub(crate) fn evaluate_single_transform_windowed(
     plan: &ExecutionPlanDag,
     window_index: usize,
     runtime: &crate::executor::window_runtime::WindowRuntime,
-    record_pos: u32,
+    record_pos: u64,
 ) -> Result<(Record, Result<(), SkipReason>), (String, cxl::eval::EvalError)> {
     let spec = &plan.indices_to_build[window_index];
     let arena = runtime.arena.as_ref();

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -2458,6 +2458,7 @@ mod tests {
     mod deferred_dispatch;
     mod format_dispatch;
     mod multi_output;
+    mod post_aggregate_any_all;
     mod post_aggregate_lag_lead;
     mod post_aggregate_recompute_determinism;
     mod post_aggregate_window;

--- a/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
@@ -1,0 +1,139 @@
+//! End-to-end pipeline coverage for `$window.any` / `$window.all`.
+//!
+//! Pins two properties:
+//!   1. The predicate iterates over partition rows, not the current row —
+//!      every row in a partition emits the same any/all value.
+//!   2. Short-circuit evaluation produces the right Bool over a real
+//!      Arena partition produced by the executor.
+//!
+//! Three-valued / Null semantics are pinned exhaustively in
+//! `cxl::eval::tests::any_all` (mod-level unit tests) where Value::Null
+//! can be injected directly without depending on CSV coercion.
+
+use super::*;
+use clinker_bench_support::io::SharedBuffer;
+use std::collections::HashMap;
+
+const ANY_ALL_PIPELINE: &str = r#"
+pipeline:
+  name: post_agg_any_all
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    path: input.csv
+    type: csv
+    schema:
+      - { name: department, type: string }
+      - { name: region, type: string }
+      - { name: score, type: int }
+- type: transform
+  name: predicates
+  input: src
+  config:
+    cxl: |
+      emit department = department
+      emit region = region
+      emit score = score
+      emit any_high = $window.any(score > 25)
+      emit all_high = $window.all(score > 25)
+      emit any_low = $window.any(score < 25)
+      emit all_low = $window.all(score < 25)
+    analytic_window:
+      group_by: [department]
+      sort_by:
+        - field: region
+          order: asc
+- type: output
+  name: out
+  input: predicates
+  config:
+    name: out
+    path: output.csv
+    type: csv
+    include_unmapped: true
+"#;
+
+fn run(csv: &str) -> String {
+    let config = crate::config::parse_config(ANY_ALL_PIPELINE).expect("parse");
+    let params = PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: Default::default(),
+        shutdown_token: None,
+    };
+    let primary = "src".to_string();
+    let readers: HashMap<String, Box<dyn std::io::Read + Send>> = HashMap::from([(
+        "src".to_string(),
+        Box::new(std::io::Cursor::new(csv.as_bytes().to_vec())) as Box<dyn std::io::Read + Send>,
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    PipelineExecutor::run_with_readers_writers(&config, &primary, readers, writers, &params)
+        .expect("pipeline must run");
+    buf.as_string()
+}
+
+#[test]
+fn any_all_window_predicates_partition_scoped() {
+    // Two partitions:
+    //   HR  scores = [10, 20, 30]   → > 25: [F, F, T] → any=T, all=F
+    //                                  < 25: [T, T, F] → any=T, all=F
+    //   ENG scores = [50, 60, 70]   → > 25: [T, T, T] → any=T, all=T
+    //                                  < 25: [F, F, F] → any=F, all=F
+    let csv = "\
+department,region,score
+HR,a,10
+HR,b,20
+HR,c,30
+ENG,a,50
+ENG,b,60
+ENG,c,70
+";
+
+    let out = run(csv);
+    let mut lines = out.lines();
+    let header_line = lines.next().expect("header");
+    let headers: Vec<&str> = header_line.split(',').collect();
+    let dept_idx = headers.iter().position(|h| *h == "department").unwrap();
+    let region_idx = headers.iter().position(|h| *h == "region").unwrap();
+    let any_high_idx = headers.iter().position(|h| *h == "any_high").unwrap();
+    let all_high_idx = headers.iter().position(|h| *h == "all_high").unwrap();
+    let any_low_idx = headers.iter().position(|h| *h == "any_low").unwrap();
+    let all_low_idx = headers.iter().position(|h| *h == "all_low").unwrap();
+
+    let mut row_count = 0;
+    for line in lines {
+        if line.is_empty() {
+            continue;
+        }
+        row_count += 1;
+        let v: Vec<&str> = line.split(',').collect();
+        let dept = v[dept_idx];
+        let region = v[region_idx];
+        let any_high = v[any_high_idx];
+        let all_high = v[all_high_idx];
+        let any_low = v[any_low_idx];
+        let all_low = v[all_low_idx];
+
+        // Same any/all values must appear on every row of the partition —
+        // confirms predicate iterates the partition, not the current row.
+        let (exp_ah, exp_lh, exp_al, exp_ll) = match dept {
+            "HR" => ("true", "false", "true", "false"),
+            "ENG" => ("true", "true", "false", "false"),
+            other => panic!("unexpected department {other:?}"),
+        };
+
+        assert_eq!(any_high, exp_ah, "any_high for ({dept}, {region})");
+        assert_eq!(all_high, exp_lh, "all_high for ({dept}, {region})");
+        assert_eq!(any_low, exp_al, "any_low for ({dept}, {region})");
+        assert_eq!(all_low, exp_ll, "all_low for ({dept}, {region})");
+    }
+    assert_eq!(row_count, 6, "all 6 source rows fan through transform");
+}

--- a/crates/clinker-core/src/pipeline/arena.rs
+++ b/crates/clinker-core/src/pipeline/arena.rs
@@ -174,21 +174,21 @@ impl Arena {
 }
 
 impl RecordStorage for Arena {
-    fn resolve_field(&self, index: u32, name: &str) -> Option<&Value> {
+    fn resolve_field(&self, index: u64, name: &str) -> Option<&Value> {
         let col = self.schema.index(name)?;
         self.records.get(index as usize)?.get(col)
     }
 
-    fn resolve_qualified(&self, _index: u32, _source: &str, _field: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _index: u64, _source: &str, _field: &str) -> Option<&Value> {
         None // Arena is single-source; qualified lookups go through PartitionLookup
     }
 
-    fn available_fields(&self, _index: u32) -> Vec<&str> {
+    fn available_fields(&self, _index: u64) -> Vec<&str> {
         self.schema.columns().iter().map(|s| &**s).collect()
     }
 
-    fn record_count(&self) -> u32 {
-        u32::try_from(self.records.len()).expect("Arena exceeds u32::MAX records")
+    fn record_count(&self) -> u64 {
+        self.records.len() as u64
     }
 }
 

--- a/crates/clinker-core/src/pipeline/combine.rs
+++ b/crates/clinker-core/src/pipeline/combine.rs
@@ -469,16 +469,16 @@ impl KeyExtractor {
 struct NullStorage;
 
 impl RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }

--- a/crates/clinker-core/src/pipeline/grace_hash.rs
+++ b/crates/clinker-core/src/pipeline/grace_hash.rs
@@ -1841,16 +1841,16 @@ fn emit_for_probe<'a>(
 struct NullStorage;
 
 impl clinker_record::RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }

--- a/crates/clinker-core/src/pipeline/iejoin.rs
+++ b/crates/clinker-core/src/pipeline/iejoin.rs
@@ -1063,16 +1063,16 @@ fn key_eval_error(name: &str, side: &'static str, err: EvalError) -> PipelineErr
 struct NullStorage;
 
 impl clinker_record::RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }

--- a/crates/clinker-core/src/pipeline/index.rs
+++ b/crates/clinker-core/src/pipeline/index.rs
@@ -18,7 +18,7 @@ pub use clinker_record::{GroupByKey, GroupKeyError, value_to_group_key};
 /// Secondary index: maps composite group keys to Arena record positions.
 #[derive(Debug)]
 pub struct SecondaryIndex {
-    pub groups: HashMap<Vec<GroupByKey>, Vec<u32>>,
+    pub groups: HashMap<Vec<GroupByKey>, Vec<u64>>,
 }
 
 impl SecondaryIndex {
@@ -34,7 +34,7 @@ impl SecondaryIndex {
         group_by: &[String],
         schema_pins: &HashMap<String, FieldDef>,
     ) -> Result<Self, GroupKeyError> {
-        let mut groups: HashMap<Vec<GroupByKey>, Vec<u32>> = HashMap::new();
+        let mut groups: HashMap<Vec<GroupByKey>, Vec<u64>> = HashMap::new();
         let record_count = storage.record_count();
 
         for pos in 0..record_count {
@@ -66,7 +66,7 @@ impl SecondaryIndex {
     }
 
     /// Look up a partition by its composite group key. Returns the position list.
-    pub fn get(&self, key: &[GroupByKey]) -> Option<&[u32]> {
+    pub fn get(&self, key: &[GroupByKey]) -> Option<&[u64]> {
         self.groups.get(key).map(|v| v.as_slice())
     }
 
@@ -103,18 +103,18 @@ mod tests {
     }
 
     impl RecordStorage for TestStorage {
-        fn resolve_field(&self, index: u32, name: &str) -> Option<&Value> {
+        fn resolve_field(&self, index: u64, name: &str) -> Option<&Value> {
             let col = self.schema.index(name)?;
             self.records.get(index as usize)?.get(col)
         }
-        fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+        fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
             None
         }
-        fn available_fields(&self, _: u32) -> Vec<&str> {
+        fn available_fields(&self, _: u64) -> Vec<&str> {
             self.schema.columns().iter().map(|s| &**s).collect()
         }
-        fn record_count(&self) -> u32 {
-            self.records.len() as u32
+        fn record_count(&self) -> u64 {
+            self.records.len() as u64
         }
     }
 

--- a/crates/clinker-core/src/pipeline/sort.rs
+++ b/crates/clinker-core/src/pipeline/sort.rs
@@ -15,7 +15,7 @@ use crate::config::{NullOrder, SortField, SortOrder};
 /// Null handling applied per-field via `NullOrder`.
 pub fn sort_partition<S: RecordStorage>(
     storage: &S,
-    positions: &mut Vec<u32>,
+    positions: &mut Vec<u64>,
     sort_by: &[SortField],
 ) {
     // First pass: drop nulls for any field with NullOrder::Drop
@@ -35,7 +35,7 @@ pub fn sort_partition<S: RecordStorage>(
 /// Check if a partition is already sorted (linear scan).
 ///
 /// Returns true if all consecutive pairs are in the correct order.
-pub fn is_sorted<S: RecordStorage>(storage: &S, positions: &[u32], sort_by: &[SortField]) -> bool {
+pub fn is_sorted<S: RecordStorage>(storage: &S, positions: &[u64], sort_by: &[SortField]) -> bool {
     positions
         .windows(2)
         .all(|pair| compare_records(storage, pair[0], pair[1], sort_by) != Ordering::Greater)
@@ -44,8 +44,8 @@ pub fn is_sorted<S: RecordStorage>(storage: &S, positions: &[u32], sort_by: &[So
 /// Compare two records by sort_by fields.
 fn compare_records<S: RecordStorage>(
     storage: &S,
-    a: u32,
-    b: u32,
+    a: u64,
+    b: u64,
     sort_by: &[SortField],
 ) -> Ordering {
     for sf in sort_by {
@@ -148,18 +148,18 @@ mod tests {
     }
 
     impl RecordStorage for TestStorage {
-        fn resolve_field(&self, index: u32, name: &str) -> Option<&Value> {
+        fn resolve_field(&self, index: u64, name: &str) -> Option<&Value> {
             let col = self.schema.index(name)?;
             self.records.get(index as usize)?.get(col)
         }
-        fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+        fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
             None
         }
-        fn available_fields(&self, _: u32) -> Vec<&str> {
+        fn available_fields(&self, _: u64) -> Vec<&str> {
             self.schema.columns().iter().map(|s| &**s).collect()
         }
-        fn record_count(&self) -> u32 {
-            self.records.len() as u32
+        fn record_count(&self) -> u64 {
+            self.records.len() as u64
         }
     }
 
@@ -183,7 +183,7 @@ mod tests {
                 vec![Value::Integer(40)],
             ],
         );
-        let mut positions: Vec<u32> = vec![0, 1, 2, 3, 4];
+        let mut positions: Vec<u64> = vec![0, 1, 2, 3, 4];
         sort_partition(
             &storage,
             &mut positions,
@@ -204,7 +204,7 @@ mod tests {
                 vec![Value::Integer(40)],
             ],
         );
-        let mut positions: Vec<u32> = vec![0, 1, 2, 3, 4];
+        let mut positions: Vec<u64> = vec![0, 1, 2, 3, 4];
         sort_partition(
             &storage,
             &mut positions,
@@ -223,7 +223,7 @@ mod tests {
                 vec![Value::Integer(10)],
             ],
         );
-        let mut positions: Vec<u32> = vec![0, 1, 2];
+        let mut positions: Vec<u64> = vec![0, 1, 2];
         sort_partition(
             &storage,
             &mut positions,
@@ -244,7 +244,7 @@ mod tests {
                 vec![Value::Integer(10)],
             ],
         );
-        let mut positions: Vec<u32> = vec![0, 1, 2];
+        let mut positions: Vec<u64> = vec![0, 1, 2];
         sort_partition(
             &storage,
             &mut positions,
@@ -265,7 +265,7 @@ mod tests {
                 vec![Value::Integer(10)],
             ],
         );
-        let mut positions: Vec<u32> = vec![0, 1, 2];
+        let mut positions: Vec<u64> = vec![0, 1, 2];
         sort_partition(
             &storage,
             &mut positions,
@@ -285,7 +285,7 @@ mod tests {
                 vec![Value::Integer(30)],
             ],
         );
-        let positions: Vec<u32> = vec![0, 1, 2];
+        let positions: Vec<u64> = vec![0, 1, 2];
         assert!(is_sorted(
             &storage,
             &positions,
@@ -304,7 +304,7 @@ mod tests {
                 vec![Value::String("B".into()), Value::Integer(100)],
             ],
         );
-        let mut positions: Vec<u32> = vec![0, 1, 2, 3];
+        let mut positions: Vec<u64> = vec![0, 1, 2, 3];
         sort_partition(
             &storage,
             &mut positions,

--- a/crates/clinker-core/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-core/src/pipeline/sort_merge_join.rs
@@ -1276,16 +1276,16 @@ fn key_eval_error(name: &str, side: &'static str, err: EvalError) -> PipelineErr
 struct NullStorage;
 
 impl clinker_record::RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }

--- a/crates/clinker-core/src/pipeline/window_context.rs
+++ b/crates/clinker-core/src/pipeline/window_context.rs
@@ -12,12 +12,12 @@ use crate::pipeline::arena::Arena;
 /// `current_pos` is the index *within the partition* of the record being evaluated.
 pub struct PartitionWindowContext<'a> {
     arena: &'a Arena,
-    partition: &'a [u32],
+    partition: &'a [u64],
     current_pos: usize,
 }
 
 impl<'a> PartitionWindowContext<'a> {
-    pub fn new(arena: &'a Arena, partition: &'a [u32], current_pos: usize) -> Self {
+    pub fn new(arena: &'a Arena, partition: &'a [u64], current_pos: usize) -> Self {
         Self {
             arena,
             partition,
@@ -33,7 +33,7 @@ impl<'a> PartitionWindowContext<'a> {
     /// Float values participate, every other resolved Value (including
     /// String, Date, Null) is silently skipped, and a slice with no
     /// numeric values returns Null rather than 0.
-    fn sum_slice(&self, field: &str, positions: &[u32]) -> Value {
+    fn sum_slice(&self, field: &str, positions: &[u64]) -> Value {
         let mut total = 0.0f64;
         let mut has_numeric = false;
         for &pos in positions {
@@ -271,7 +271,7 @@ mod tests {
             "name,amount\nAlice,100\nBob,200\nCarol,300\n",
             &["name", "amount"],
         );
-        let partition: Vec<u32> = vec![0, 1, 2];
+        let partition: Vec<u64> = vec![0, 1, 2];
         let ctx = PartitionWindowContext::new(&arena, &partition, 1);
 
         let first = ctx.first().unwrap();
@@ -286,7 +286,7 @@ mod tests {
             "name,amount\nA,10\nB,20\nC,30\nD,40\nE,50\n",
             &["name", "amount"],
         );
-        let partition: Vec<u32> = vec![0, 1, 2, 3, 4];
+        let partition: Vec<u64> = vec![0, 1, 2, 3, 4];
         let ctx = PartitionWindowContext::new(&arena, &partition, 3);
 
         let lag = ctx.lag(1).unwrap();
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_window_lag_out_of_bounds() {
         let arena = make_arena("name\nA\nB\n", &["name"]);
-        let partition: Vec<u32> = vec![0, 1];
+        let partition: Vec<u64> = vec![0, 1];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
 
         assert!(ctx.lag(1).is_none());
@@ -307,7 +307,7 @@ mod tests {
     #[test]
     fn test_window_count() {
         let arena = make_arena("x\na\nb\nc\nd\ne\n", &["x"]);
-        let partition: Vec<u32> = vec![0, 1, 2, 3, 4];
+        let partition: Vec<u64> = vec![0, 1, 2, 3, 4];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
         assert_eq!(ctx.count(), 5);
     }
@@ -321,7 +321,7 @@ mod tests {
         // For a proper numeric test, we'd need non-CSV input or post-coercion.
         // Let's test the "non-numeric returns null" case and a String-numeric coercion case.
         let arena = make_arena("amount\n10\n20\n30\n", &["amount"]);
-        let partition: Vec<u32> = vec![0, 1, 2];
+        let partition: Vec<u64> = vec![0, 1, 2];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
 
         // CSV reads as strings, so sum/avg return Null for string fields
@@ -337,7 +337,7 @@ mod tests {
     fn test_window_min_max() {
         // String comparison for CSV-sourced data
         let arena = make_arena("name\nBob\nAlice\nCarol\n", &["name"]);
-        let partition: Vec<u32> = vec![0, 1, 2];
+        let partition: Vec<u64> = vec![0, 1, 2];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
 
         assert_eq!(ctx.min("name"), Value::String("Alice".into()));
@@ -347,7 +347,7 @@ mod tests {
     #[test]
     fn test_window_sum_non_numeric() {
         let arena = make_arena("name\nAlice\nBob\n", &["name"]);
-        let partition: Vec<u32> = vec![0, 1];
+        let partition: Vec<u64> = vec![0, 1];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
         assert_eq!(ctx.sum("name"), Value::Null);
     }
@@ -356,7 +356,7 @@ mod tests {
     fn test_window_any_all() {
         // any/all are evaluator-driven (not on this trait), but we test partition_len/partition_record
         let arena = make_arena("amount\n50\n150\n200\n", &["amount"]);
-        let partition: Vec<u32> = vec![0, 1, 2];
+        let partition: Vec<u64> = vec![0, 1, 2];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
 
         assert_eq!(ctx.partition_len(), 3);
@@ -367,7 +367,7 @@ mod tests {
     #[test]
     fn test_window_collect() {
         let arena = make_arena("name\nAlice\nBob\nCarol\n", &["name"]);
-        let partition: Vec<u32> = vec![0, 1, 2];
+        let partition: Vec<u64> = vec![0, 1, 2];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
 
         match ctx.collect("name") {
@@ -384,7 +384,7 @@ mod tests {
     #[test]
     fn test_window_distinct() {
         let arena = make_arena("dept\nA\nB\nA\nC\n", &["dept"]);
-        let partition: Vec<u32> = vec![0, 1, 2, 3];
+        let partition: Vec<u64> = vec![0, 1, 2, 3];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
 
         match ctx.distinct("dept") {
@@ -402,7 +402,7 @@ mod tests {
     #[test]
     fn test_window_single_record_partition() {
         let arena = make_arena("name\nAlice\n", &["name"]);
-        let partition: Vec<u32> = vec![0];
+        let partition: Vec<u64> = vec![0];
         let ctx = PartitionWindowContext::new(&arena, &partition, 0);
 
         // first == last for single record

--- a/crates/clinker-record/src/coercion.rs
+++ b/crates/clinker-record/src/coercion.rs
@@ -177,7 +177,14 @@ pub fn coerce_to_datetime(value: &Value, formats: &[&str]) -> Result<Value, Coer
     match value {
         Value::Null => Ok(Value::Null),
         Value::DateTime(_) => Ok(value.clone()),
-        Value::Date(d) => Ok(Value::DateTime(d.and_hms_opt(0, 0, 0).unwrap())),
+        Value::Date(d) => {
+            d.and_hms_opt(0, 0, 0)
+                .map(Value::DateTime)
+                .ok_or_else(|| CoercionError::ParseFailure {
+                    input: d.to_string(),
+                    target: "DateTime",
+                })
+        }
         Value::String(s) => {
             let chain = if formats.is_empty() {
                 DEFAULT_DATETIME_FORMATS
@@ -274,6 +281,25 @@ mod tests {
         // US datetime format
         let v = Value::String("01/15/2024 10:30:00".into());
         assert_eq!(coerce_to_datetime(&v, &[]).unwrap(), expected);
+    }
+
+    #[test]
+    fn test_coerce_date_to_datetime_promotes_at_midnight() {
+        let d = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+        let expected = Value::DateTime(d.and_hms_opt(0, 0, 0).unwrap());
+        assert_eq!(coerce_to_datetime(&Value::Date(d), &[]).unwrap(), expected);
+
+        // Boundary dates: midnight must be representable across chrono's
+        // entire NaiveDate range, so the (now Result-returning) error
+        // path is unreachable for valid Dates.
+        for d in [
+            NaiveDate::MIN,
+            NaiveDate::MAX,
+            NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(2000, 2, 29).unwrap(),
+        ] {
+            assert!(coerce_to_datetime(&Value::Date(d), &[]).is_ok());
+        }
     }
 
     #[test]

--- a/crates/clinker-record/src/group_key.rs
+++ b/crates/clinker-record/src/group_key.rs
@@ -52,19 +52,19 @@ impl GroupByKey {
 #[derive(Debug)]
 pub enum GroupKeyError {
     /// NaN value in a group_by / distinct field.
-    NanInGroupBy { field: String, row: u32 },
+    NanInGroupBy { field: String, row: u64 },
     /// Float value in an integer-pinned field.
     TypeMismatch {
         field: String,
         expected: &'static str,
         got: &'static str,
-        row: u32,
+        row: u64,
     },
     /// Unsupported type (e.g. Array) used as group key.
     UnsupportedType {
         field: String,
         type_name: &'static str,
-        row: u32,
+        row: u64,
     },
 }
 
@@ -119,7 +119,7 @@ pub fn value_to_group_key(
     val: &Value,
     field: &str,
     schema_pin: Option<&FieldDef>,
-    row: u32,
+    row: u64,
 ) -> Result<Option<GroupByKey>, GroupKeyError> {
     match val {
         Value::Null => Ok(None),

--- a/crates/clinker-record/src/record_view.rs
+++ b/crates/clinker-record/src/record_view.rs
@@ -6,22 +6,22 @@ use crate::storage::RecordStorage;
 
 /// Zero-allocation view into an arena-backed record.
 ///
-/// 16 bytes: pointer + u32 index + padding. `Copy` and stack-allocated.
+/// 16 bytes: pointer + u64 index. `Copy` and stack-allocated.
 /// Implements `FieldResolver` by delegating to the underlying `RecordStorage`.
 #[derive(Clone, Copy)]
 pub struct RecordView<'a, S: RecordStorage + ?Sized> {
     storage: &'a S,
-    index: u32,
+    index: u64,
 }
 
 impl<'a, S: RecordStorage + ?Sized> RecordView<'a, S> {
     /// Create a new view into the storage at the given record index.
-    pub fn new(storage: &'a S, index: u32) -> Self {
+    pub fn new(storage: &'a S, index: u64) -> Self {
         Self { storage, index }
     }
 
     /// The record index this view points to.
-    pub fn index(&self) -> u32 {
+    pub fn index(&self) -> u64 {
         self.index
     }
 }

--- a/crates/clinker-record/src/resolver.rs
+++ b/crates/clinker-record/src/resolver.rs
@@ -156,16 +156,16 @@ mod tests {
     struct DummyStorage;
 
     impl RecordStorage for DummyStorage {
-        fn resolve_field(&self, _index: u32, _name: &str) -> Option<&Value> {
+        fn resolve_field(&self, _index: u64, _name: &str) -> Option<&Value> {
             None
         }
-        fn resolve_qualified(&self, _index: u32, _source: &str, _field: &str) -> Option<&Value> {
+        fn resolve_qualified(&self, _index: u64, _source: &str, _field: &str) -> Option<&Value> {
             None
         }
-        fn available_fields(&self, _index: u32) -> Vec<&str> {
+        fn available_fields(&self, _index: u64) -> Vec<&str> {
             vec![]
         }
-        fn record_count(&self) -> u32 {
+        fn record_count(&self) -> u64 {
             0
         }
     }

--- a/crates/clinker-record/src/storage.rs
+++ b/crates/clinker-record/src/storage.rs
@@ -17,14 +17,14 @@ use crate::Value;
 /// `Value::String(Box<str>)`.
 pub trait RecordStorage: Send + Sync {
     /// Resolve a field by name from the record at the given index.
-    fn resolve_field(&self, index: u32, name: &str) -> Option<&Value>;
+    fn resolve_field(&self, index: u64, name: &str) -> Option<&Value>;
 
     /// Resolve a qualified field (source.field) from the record at the given index.
-    fn resolve_qualified(&self, index: u32, source: &str, field: &str) -> Option<&Value>;
+    fn resolve_qualified(&self, index: u64, source: &str, field: &str) -> Option<&Value>;
 
     /// List all available field names for the record at the given index.
-    fn available_fields(&self, index: u32) -> Vec<&str>;
+    fn available_fields(&self, index: u64) -> Vec<&str>;
 
     /// Total number of records in this storage.
-    fn record_count(&self) -> u32;
+    fn record_count(&self) -> u64;
 }

--- a/crates/clinker/Cargo.toml
+++ b/crates/clinker/Cargo.toml
@@ -18,3 +18,7 @@ tracing = { workspace = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi"] }
 uuid = { version = "1", features = ["v7"] }
 miette = { workspace = true }
+tempfile = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -532,25 +532,77 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         readers.insert(source.name.clone(), reader);
     }
 
+    // Outputs are written atomically: each output writes to a sibling
+    // tempfile, then renames into place after the pipeline completes
+    // successfully. On crash or pipeline error, the tempfile is left in
+    // place (and its path logged) so an operator can inspect partial
+    // output without the final path showing a truncated file.
     let mut writers: std::collections::HashMap<String, Box<dyn std::io::Write + Send>> =
         std::collections::HashMap::new();
+    let mut output_temps: Vec<(String, std::path::PathBuf, tempfile::NamedTempFile)> = Vec::new();
     for output in pipeline_config.output_configs() {
-        let writer: Box<dyn std::io::Write + Send> = Box::new(std::fs::File::create(&output.path)?);
+        let final_path: std::path::PathBuf = output.path.clone().into();
+        let parent = final_path.parent().filter(|p| !p.as_os_str().is_empty());
+        let temp = match parent {
+            Some(dir) => {
+                if !dir.exists() {
+                    std::fs::create_dir_all(dir)?;
+                }
+                tempfile::NamedTempFile::new_in(dir)?
+            }
+            None => tempfile::NamedTempFile::new_in(".")?,
+        };
+        let handle = temp.reopen()?;
+        let writer: Box<dyn std::io::Write + Send> = Box::new(handle);
         writers.insert(output.name.clone(), writer);
+        output_temps.push((output.name.clone(), final_path, temp));
     }
 
     let compiled_plan = pipeline_config.compile(&compile_ctx).expect("compile");
-    let report = PipelineExecutor::run_plan_with_readers_writers(
+    let report = match PipelineExecutor::run_plan_with_readers_writers(
         &compiled_plan,
         readers,
         writers,
         &run_params,
-    )?;
+    ) {
+        Ok(report) => report,
+        Err(e) => {
+            for (name, final_path, temp) in output_temps {
+                let kept = temp.into_temp_path().keep().ok();
+                tracing::warn!(
+                    output = %name,
+                    final_path = %final_path.display(),
+                    partial_path = ?kept,
+                    "pipeline failed; partial output preserved at temp path",
+                );
+            }
+            return Err(e);
+        }
+    };
+
+    // Pipeline succeeded — atomically promote each tempfile to its
+    // final path. Failure here aborts the run with the temp file still
+    // on disk under its tempfile name.
+    for (_name, final_path, temp) in output_temps {
+        temp.persist(&final_path).map_err(|e| {
+            tracing::error!(
+                final_path = %final_path.display(),
+                "failed to atomically rename output into place; temp file preserved",
+            );
+            std::io::Error::other(format!(
+                "atomic output rename failed for {}: {}",
+                final_path.display(),
+                e.error
+            ))
+        })?;
+    }
 
     let counters = &report.counters;
     let dlq_entries = &report.dlq_entries;
 
-    // Write DLQ if there are entries and DLQ path is configured
+    // Write DLQ if there are entries and DLQ path is configured.
+    // Same atomic temp+rename discipline as primary outputs above —
+    // operators inspecting DLQ output should never see a truncated file.
     if !dlq_entries.is_empty()
         && let Some(ref dlq_config) = pipeline_config.error_handling.dlq
         && let Some(ref dlq_path) = dlq_config.path
@@ -563,11 +615,21 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
             );
             r.schema().map_err(PipelineError::Format)?
         };
-        let dlq_writer = std::fs::File::create(dlq_path)?;
+        let dlq_path_buf: std::path::PathBuf = dlq_path.clone().into();
+        let dlq_dir = dlq_path_buf
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        if !dlq_dir.exists() {
+            std::fs::create_dir_all(&dlq_dir)?;
+        }
+        let dlq_temp = tempfile::NamedTempFile::new_in(&dlq_dir)?;
+        let dlq_temp_handle = dlq_temp.reopen()?;
         let include_reason = dlq_config.include_reason.unwrap_or(true);
         let include_source_row = dlq_config.include_source_row.unwrap_or(true);
         clinker_core::dlq::write_dlq(
-            dlq_writer,
+            dlq_temp_handle,
             dlq_entries,
             &input_schema,
             &input_path,
@@ -575,6 +637,17 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
             include_source_row,
         )
         .map_err(PipelineError::Format)?;
+        dlq_temp.persist(&dlq_path_buf).map_err(|e| {
+            tracing::error!(
+                final_path = %dlq_path_buf.display(),
+                "failed to atomically rename DLQ output into place; temp file preserved",
+            );
+            PipelineError::Io(std::io::Error::other(format!(
+                "atomic DLQ rename failed for {}: {}",
+                dlq_path_buf.display(),
+                e.error
+            )))
+        })?;
     }
 
     tracing::info!(

--- a/crates/clinker/tests/atomic_output_test.rs
+++ b/crates/clinker/tests/atomic_output_test.rs
@@ -1,0 +1,212 @@
+//! Atomic output: outputs land via tempfile + atomic rename so a
+//! pipeline failure cannot leave a truncated final file behind.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+#[test]
+fn successful_run_leaves_final_path_only() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    std::fs::write(dir.path().join("input.csv"), "id,name\n1,Alice\n2,Bob\n").expect("write input");
+
+    let output_path = dir.path().join("out.csv");
+    let pipeline_path = dir.path().join("pipeline.yaml");
+    let pipeline = r#"pipeline:
+  name: atomic_output_smoke
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    path: input.csv
+    type: csv
+    schema:
+      - { name: id, type: int }
+      - { name: name, type: string }
+- type: output
+  name: out
+  input: src
+  config:
+    name: out
+    path: out.csv
+    type: csv
+    include_unmapped: true
+"#;
+    std::fs::write(&pipeline_path, pipeline).expect("write pipeline");
+
+    let output = Command::new(clinker_bin())
+        .current_dir(dir.path())
+        .arg("run")
+        .arg(&pipeline_path)
+        .output()
+        .expect("spawn clinker");
+    assert!(
+        output.status.success(),
+        "clinker run must succeed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    assert!(
+        output_path.exists(),
+        "final output path must exist after success"
+    );
+    let body = std::fs::read_to_string(&output_path).expect("read output");
+    assert!(
+        body.contains("Alice") && body.contains("Bob"),
+        "rows: {body}"
+    );
+
+    // Sweep the dir for any leftover .tmp files — none should remain.
+    let tmp_leftovers: Vec<PathBuf> = std::fs::read_dir(dir.path())
+        .expect("readdir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(".tmp"))
+        })
+        .collect();
+    assert!(
+        tmp_leftovers.is_empty(),
+        "no temp files should remain after success: {tmp_leftovers:?}"
+    );
+}
+
+#[test]
+fn missing_input_run_does_not_create_final_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // Reader-creation failure: the CLI fails opening the input file
+    // BEFORE writers / temp files are constructed, so no temp file
+    // appears either. Critical contract: the final output path must
+    // not exist.
+    let output_path = dir.path().join("out.csv");
+    let pipeline_path = dir.path().join("pipeline.yaml");
+    let pipeline = r#"pipeline:
+  name: atomic_output_failure_smoke
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    path: does-not-exist.csv
+    type: csv
+    schema:
+      - { name: id, type: int }
+- type: output
+  name: out
+  input: src
+  config:
+    name: out
+    path: out.csv
+    type: csv
+    include_unmapped: true
+"#;
+    std::fs::write(&pipeline_path, pipeline).expect("write pipeline");
+
+    let status = Command::new(clinker_bin())
+        .current_dir(dir.path())
+        .arg("run")
+        .arg(&pipeline_path)
+        .status()
+        .expect("spawn clinker");
+    assert!(
+        !status.success(),
+        "missing-input run must fail with a non-zero exit"
+    );
+
+    // Final output must NOT exist — atomic rename was never performed.
+    assert!(
+        !output_path.exists(),
+        "final output path must not exist after failure"
+    );
+}
+
+#[test]
+fn executor_failure_preserves_partial_tempfile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+
+    // Input present; CXL `1 / 0` triggers a runtime DivisionByZero on
+    // the first record, and `strategy: fail_fast` aborts the executor
+    // immediately. This exercises the post-writer-construction failure
+    // path, which is where the CLI must preserve the temp file with a
+    // WARN log so an operator can inspect partial output.
+    std::fs::write(dir.path().join("input.csv"), "id,name\n1,Alice\n2,Bob\n").expect("write input");
+    let output_path = dir.path().join("out.csv");
+    let pipeline_path = dir.path().join("pipeline.yaml");
+    let pipeline = r#"pipeline:
+  name: atomic_output_runtime_failure
+error_handling:
+  strategy: fail_fast
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    path: input.csv
+    type: csv
+    schema:
+      - { name: id, type: int }
+      - { name: name, type: string }
+- type: transform
+  name: divzero
+  input: src
+  config:
+    cxl: |
+      emit id = id
+      emit boom = id / 0
+- type: output
+  name: out
+  input: divzero
+  config:
+    name: out
+    path: out.csv
+    type: csv
+    include_unmapped: true
+"#;
+    std::fs::write(&pipeline_path, pipeline).expect("write pipeline");
+
+    let status = Command::new(clinker_bin())
+        .current_dir(dir.path())
+        .arg("run")
+        .arg(&pipeline_path)
+        .status()
+        .expect("spawn clinker");
+    assert!(
+        !status.success(),
+        "divzero pipeline must abort with non-zero exit"
+    );
+
+    // The final output must not exist — atomic rename never ran.
+    assert!(
+        !output_path.exists(),
+        "final output path must not exist after runtime failure"
+    );
+
+    // A temp file must remain on disk so an operator can inspect
+    // partial output. tempfile::NamedTempFile names begin with `.tmp`
+    // by default on Linux.
+    let leftovers: Vec<_> = std::fs::read_dir(dir.path())
+        .expect("readdir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with(".tmp"))
+        })
+        .collect();
+    assert!(
+        !leftovers.is_empty(),
+        "temp file must be preserved after runtime failure"
+    );
+}

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -7,16 +7,16 @@ use clinker_record::{RecordStorage, Value};
 /// Dummy storage for no-window evaluation.
 struct NullStorage;
 impl RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }

--- a/crates/cxl/benches/eval.rs
+++ b/crates/cxl/benches/eval.rs
@@ -14,16 +14,16 @@ use std::sync::Arc;
 struct NullStorage;
 
 impl RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }

--- a/crates/cxl/src/eval/mod.rs
+++ b/crates/cxl/src/eval/mod.rs
@@ -700,7 +700,51 @@ pub fn eval_expr<'w, S: RecordStorage + 'w>(
                         Ok(Value::Null)
                     }
                 }
-                "any" | "all" => Ok(Value::Null), // Evaluator-driven: implemented in Task 5.4
+                // `any` is iterated `or`; `all` is iterated `and`. The
+                // fold must agree with BinOp::And/Or above (lines
+                // 801–829), which are Kleene three-valued and silently
+                // treat non-Bool/non-Null operands as Null. Mirroring
+                // both properties keeps the algebraic identity
+                // `any([a, b, c]) ≡ a or b or c` correctness-preserving
+                // under rewrites.
+                //
+                // Typecheck (typecheck/pass.rs) rejects non-Bool argument
+                // types and nested $window.* inside the predicate before
+                // we reach this arm.
+                "any" | "all" => {
+                    let predicate = args.first().ok_or_else(|| {
+                        EvalError::new(
+                            EvalErrorKind::ArityMismatch {
+                                name: function.to_string(),
+                                expected: 1,
+                                got: 0,
+                            },
+                            *span,
+                        )
+                    })?;
+                    let want_any = &**function == "any";
+                    let mut found_null = false;
+                    for i in 0..w.partition_len() {
+                        let row = w.partition_record(i);
+                        match eval_expr(predicate, typed, ctx, &row, window, env, meta_state)? {
+                            Value::Bool(true) if want_any => return Ok(Value::Bool(true)),
+                            Value::Bool(false) if !want_any => return Ok(Value::Bool(false)),
+                            Value::Bool(_) => {}
+                            // Null and non-Bool runtime values both
+                            // collapse to "null seen" — same catch-all
+                            // as BinOp::And/Or.
+                            _ => found_null = true,
+                        }
+                    }
+                    Ok(if found_null {
+                        Value::Null
+                    } else {
+                        // Identity for the iterated operator:
+                        //   any (iterated or) → false
+                        //   all (iterated and) → true
+                        Value::Bool(!want_any)
+                    })
+                }
                 _ => Ok(Value::Null),
             }
         }

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -530,3 +530,264 @@ fn test_log_level4_guard_short_circuits() {
     );
     assert_eq!(output.get("val"), Some(&Value::Integer(42)));
 }
+
+// ---------------------------------------------------------------------------
+// $window.any / $window.all — three-valued logic
+//
+// Mirrors BinOp::And/Or in eval/mod.rs:801–829 by construction. Tests use a
+// minimal in-memory `RowsStorage` + `RowsWindow` so each test row can hold
+// explicit `Value::Bool` / `Value::Null` predicate inputs without going
+// through CSV/coercion.
+// ---------------------------------------------------------------------------
+
+mod any_all {
+    use super::*;
+    use crate::typecheck::row::QualifiedField;
+    use clinker_record::{RecordView, WindowContext};
+
+    /// Storage that returns the i-th row's `flag` field by index.
+    struct RowsStorage {
+        rows: Vec<Value>,
+    }
+
+    impl RecordStorage for RowsStorage {
+        fn resolve_field(&self, index: u32, name: &str) -> Option<&Value> {
+            if name == "flag" {
+                self.rows.get(index as usize)
+            } else {
+                None
+            }
+        }
+        fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+            None
+        }
+        fn available_fields(&self, _: u32) -> Vec<&str> {
+            vec!["flag"]
+        }
+        fn record_count(&self) -> u32 {
+            self.rows.len() as u32
+        }
+    }
+
+    /// Window over the entire RowsStorage — every row is in the partition.
+    struct RowsWindow<'a> {
+        storage: &'a RowsStorage,
+    }
+
+    impl<'a> WindowContext<'a, RowsStorage> for RowsWindow<'a> {
+        fn first(&self) -> Option<RecordView<'a, RowsStorage>> {
+            (!self.storage.rows.is_empty()).then(|| RecordView::new(self.storage, 0))
+        }
+        fn last(&self) -> Option<RecordView<'a, RowsStorage>> {
+            self.storage
+                .rows
+                .len()
+                .checked_sub(1)
+                .map(|i| RecordView::new(self.storage, i as u32))
+        }
+        fn lag(&self, _: usize) -> Option<RecordView<'a, RowsStorage>> {
+            None
+        }
+        fn lead(&self, _: usize) -> Option<RecordView<'a, RowsStorage>> {
+            None
+        }
+        fn count(&self) -> i64 {
+            self.storage.rows.len() as i64
+        }
+        fn sum(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn cumulative_sum(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn avg(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn min(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn max(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn partition_len(&self) -> usize {
+            self.storage.rows.len()
+        }
+        fn partition_record(&self, index: usize) -> RecordView<'a, RowsStorage> {
+            RecordView::new(self.storage, index as u32)
+        }
+        fn collect(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn distinct(&self, _: &str) -> Value {
+            Value::Null
+        }
+    }
+
+    fn eval_window(src: &str, partition: Vec<Value>) -> Value {
+        let parsed = Parser::parse(src);
+        assert!(parsed.errors.is_empty(), "parse: {:?}", parsed.errors);
+        let resolved = resolve_program(parsed.ast, &["flag"], parsed.node_count)
+            .unwrap_or_else(|d| panic!("resolve: {:?}", d));
+        let row = Row::closed(
+            indexmap::IndexMap::from([(
+                QualifiedField::bare("flag"),
+                crate::typecheck::types::Type::Bool,
+            )]),
+            Span::new(0, 0),
+        );
+        let typed = type_check(resolved, &row).unwrap_or_else(|d| panic!("type: {:?}", d));
+        let stable = StableEvalContext::test_default();
+        let ctx = EvalContext::test_default_borrowed(&stable);
+        let storage = RowsStorage { rows: partition };
+        let resolver = HashMapResolver::new(HashMap::new());
+        let window = RowsWindow { storage: &storage };
+        eval_program::<RowsStorage>(&typed, &ctx, &resolver, Some(&window))
+            .unwrap_or_else(|e| panic!("eval: {}", e))
+            .into_values()
+            .next()
+            .unwrap_or(Value::Null)
+    }
+
+    fn b(v: bool) -> Value {
+        Value::Bool(v)
+    }
+    fn n() -> Value {
+        Value::Null
+    }
+
+    #[test]
+    fn any_short_circuits_on_true() {
+        assert_eq!(
+            eval_window(
+                "emit r = $window.any(flag)",
+                vec![b(true), b(false), b(false)]
+            ),
+            Value::Bool(true)
+        );
+        // True before null → still true (short-circuit fires before null is seen).
+        assert_eq!(
+            eval_window("emit r = $window.any(flag)", vec![b(true), n(), b(false)]),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn any_all_false_returns_false() {
+        assert_eq!(
+            eval_window(
+                "emit r = $window.any(flag)",
+                vec![b(false), b(false), b(false)]
+            ),
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn any_null_with_no_true_returns_null() {
+        assert_eq!(
+            eval_window("emit r = $window.any(flag)", vec![n(), b(false), b(false)]),
+            Value::Null
+        );
+        assert_eq!(
+            eval_window("emit r = $window.any(flag)", vec![b(false), n(), b(false)]),
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn all_short_circuits_on_false() {
+        assert_eq!(
+            eval_window(
+                "emit r = $window.all(flag)",
+                vec![b(true), b(false), b(true)]
+            ),
+            Value::Bool(false)
+        );
+        // False before null → still false (short-circuit fires before null is seen).
+        assert_eq!(
+            eval_window("emit r = $window.all(flag)", vec![b(false), n(), b(true)]),
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn all_all_true_returns_true() {
+        assert_eq!(
+            eval_window(
+                "emit r = $window.all(flag)",
+                vec![b(true), b(true), b(true)]
+            ),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn all_null_with_no_false_returns_null() {
+        assert_eq!(
+            eval_window("emit r = $window.all(flag)", vec![n(), b(true), b(true)]),
+            Value::Null
+        );
+        assert_eq!(
+            eval_window("emit r = $window.all(flag)", vec![b(true), n(), b(true)]),
+            Value::Null
+        );
+    }
+
+    #[test]
+    fn empty_partition_returns_identity() {
+        // Defensive — unreachable in practice (current row is always in
+        // partition), but identity for iterated or/and:
+        // any → false, all → true.
+        assert_eq!(
+            eval_window("emit r = $window.any(flag)", vec![]),
+            Value::Bool(false)
+        );
+        assert_eq!(
+            eval_window("emit r = $window.all(flag)", vec![]),
+            Value::Bool(true)
+        );
+    }
+
+    #[test]
+    fn agrees_with_iterated_or_and_two_rows() {
+        // Algebraic identity: any([a, b]) ≡ a or b; all([a, b]) ≡ a and b.
+        // BinOp::And/Or in eval/mod.rs:801–829 are the source of truth;
+        // any/all over the same inputs must produce the same Value.
+        let pairs = [
+            (b(true), b(true)),
+            (b(true), b(false)),
+            (b(false), b(true)),
+            (b(false), b(false)),
+            (b(true), n()),
+            (n(), b(true)),
+            (b(false), n()),
+            (n(), b(false)),
+            (n(), n()),
+        ];
+        for (a, b_val) in pairs {
+            let from_any =
+                eval_window("emit r = $window.any(flag)", vec![a.clone(), b_val.clone()]);
+            let expected_any = match (&a, &b_val) {
+                (Value::Bool(true), _) | (_, Value::Bool(true)) => Value::Bool(true),
+                (Value::Bool(false), Value::Bool(false)) => Value::Bool(false),
+                _ => Value::Null,
+            };
+            assert_eq!(
+                from_any, expected_any,
+                "any({a:?}, {b_val:?}) must match iterated or"
+            );
+
+            let from_all =
+                eval_window("emit r = $window.all(flag)", vec![a.clone(), b_val.clone()]);
+            let expected_all = match (&a, &b_val) {
+                (Value::Bool(false), _) | (_, Value::Bool(false)) => Value::Bool(false),
+                (Value::Bool(true), Value::Bool(true)) => Value::Bool(true),
+                _ => Value::Null,
+            };
+            assert_eq!(
+                from_all, expected_all,
+                "all({a:?}, {b_val:?}) must match iterated and"
+            );
+        }
+    }
+}

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -18,16 +18,16 @@ fn empty_row() -> Row {
 /// Dummy storage for no-window evaluation tests.
 struct NullStorage;
 impl RecordStorage for NullStorage {
-    fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+    fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
         None
     }
-    fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+    fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
         None
     }
-    fn available_fields(&self, _: u32) -> Vec<&str> {
+    fn available_fields(&self, _: u64) -> Vec<&str> {
         vec![]
     }
-    fn record_count(&self) -> u32 {
+    fn record_count(&self) -> u64 {
         0
     }
 }
@@ -551,21 +551,21 @@ mod any_all {
     }
 
     impl RecordStorage for RowsStorage {
-        fn resolve_field(&self, index: u32, name: &str) -> Option<&Value> {
+        fn resolve_field(&self, index: u64, name: &str) -> Option<&Value> {
             if name == "flag" {
                 self.rows.get(index as usize)
             } else {
                 None
             }
         }
-        fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+        fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
             None
         }
-        fn available_fields(&self, _: u32) -> Vec<&str> {
+        fn available_fields(&self, _: u64) -> Vec<&str> {
             vec!["flag"]
         }
-        fn record_count(&self) -> u32 {
-            self.rows.len() as u32
+        fn record_count(&self) -> u64 {
+            self.rows.len() as u64
         }
     }
 
@@ -583,7 +583,7 @@ mod any_all {
                 .rows
                 .len()
                 .checked_sub(1)
-                .map(|i| RecordView::new(self.storage, i as u32))
+                .map(|i| RecordView::new(self.storage, i as u64))
         }
         fn lag(&self, _: usize) -> Option<RecordView<'a, RowsStorage>> {
             None
@@ -613,7 +613,7 @@ mod any_all {
             self.storage.rows.len()
         }
         fn partition_record(&self, index: usize) -> RecordView<'a, RowsStorage> {
-            RecordView::new(self.storage, index as u32)
+            RecordView::new(self.storage, index as u64)
         }
         fn collect(&self, _: &str) -> Value {
             Value::Null

--- a/crates/cxl/src/resolve/test_double.rs
+++ b/crates/cxl/src/resolve/test_double.rs
@@ -29,16 +29,16 @@ mod tests {
         #[allow(dead_code)]
         struct DummyStorage;
         impl RecordStorage for DummyStorage {
-            fn resolve_field(&self, _: u32, _: &str) -> Option<&Value> {
+            fn resolve_field(&self, _: u64, _: &str) -> Option<&Value> {
                 None
             }
-            fn resolve_qualified(&self, _: u32, _: &str, _: &str) -> Option<&Value> {
+            fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
                 None
             }
-            fn available_fields(&self, _: u32) -> Vec<&str> {
+            fn available_fields(&self, _: u64) -> Vec<&str> {
                 vec![]
             }
-            fn record_count(&self) -> u32 {
+            fn record_count(&self) -> u64 {
                 0
             }
         }

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -675,6 +675,32 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
 
+                // any/all: enforce arity 1 and Bool-typed predicate so
+                // the eval-time three-valued fold has a well-typed input.
+                if is_predicate_fn {
+                    match args.len() {
+                        1 => {
+                            let arg_ty = self.get_type(args[0].node_id());
+                            let inner = arg_ty.unwrap_nullable();
+                            if !matches!(inner, Type::Bool | Type::Any) {
+                                self.error(
+                                    args[0].span(),
+                                    format!(
+                                        "window.{}() requires a Bool argument, got {}",
+                                        function, arg_ty
+                                    ),
+                                    Some("Use a boolean expression like `amount > 100`".into()),
+                                );
+                            }
+                        }
+                        n => self.error(
+                            *span,
+                            format!("window.{}() takes exactly 1 argument, got {}", function, n),
+                            None,
+                        ),
+                    }
+                }
+
                 let ty = if let Some(def) = self.registry.lookup_window(function) {
                     Type::from_type_tag(def.return_type)
                 } else {
@@ -1307,6 +1333,44 @@ mod tests {
                 .iter()
                 .any(|d| d.message.contains("cannot be called inside")),
             "Expected nested window diagnostic, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_typecheck_any_requires_bool_arg() {
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Int);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let diags = typecheck_err("emit val = $window.any(amount)", &["amount"], &schema);
+        assert!(
+            diags.iter().any(|d| d.message.contains("Bool")),
+            "Expected Bool requirement diagnostic, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_typecheck_all_requires_bool_arg() {
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Int);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let diags = typecheck_err("emit val = $window.all(amount)", &["amount"], &schema);
+        assert!(
+            diags.iter().any(|d| d.message.contains("Bool")),
+            "Expected Bool requirement diagnostic, got: {:?}",
+            diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_typecheck_any_arity_rejected() {
+        let diags = typecheck_err("emit val = $window.any()", &[], &empty_row());
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.message.contains("takes exactly 1 argument")),
+            "Expected arity diagnostic, got: {:?}",
             diags.iter().map(|d| &d.message).collect::<Vec<_>>()
         );
     }


### PR DESCRIPTION
coerce_to_datetime promoted Value::Date to Value::DateTime via
and_hms_opt(0, 0, 0).unwrap(). Midnight is representable for every
in-range NaiveDate, but unwrap is panic-capable in a coercion path
that the rest of the API treats as Result-returning, and panics abort
the entire pipeline run with no actionable diagnostic.

Replace the unwrap with a CoercionError::ParseFailure carrying the
date as the input string. Add a boundary test asserting midnight is
representable for NaiveDate::MIN, NaiveDate::MAX, and a couple of
common dates so a regression in chrono's representable range surfaces
as a test failure rather than a runtime panic.