### PR TITLE
channel: overlay $vars / $pipeline / $source / $record overrides + adds (#45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,8 @@ dependencies = [
  "clinker-channel",
  "clinker-core",
  "clinker-format",
+ "clinker-record",
+ "indexmap",
  "miette",
  "num_cpus",
  "serde-saphyr",

--- a/crates/clinker-benchmarks/src/runner.rs
+++ b/crates/clinker-benchmarks/src/runner.rs
@@ -107,6 +107,7 @@ impl BenchPipelineRunner {
             batch_id: "bench-batch".to_string(),
             pipeline_vars: IndexMap::new(),
             shutdown_token: None,
+            ..Default::default()
         };
 
         PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)

--- a/crates/clinker-channel/benches/channel_merge.rs
+++ b/crates/clinker-channel/benches/channel_merge.rs
@@ -58,10 +58,10 @@ fn bench_channel_merge(c: &mut Criterion) {
                         ),
                     );
                 }
-                plan
+                (config, plan)
             },
-            |mut plan| {
-                apply_channel_overlay(&mut plan, &binding);
+            |(config, mut plan)| {
+                apply_channel_overlay(&mut plan, &binding, &config);
             },
             criterion::BatchSize::SmallInput,
         );

--- a/crates/clinker-channel/src/binding.rs
+++ b/crates/clinker-channel/src/binding.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
+use clinker_core::config::ScopedVarDecl;
 use clinker_core::config::composition::CompositionSymbolTable;
 use clinker_core::error::{Diagnostic, LabeledSpan};
 use clinker_core::span::Span;
@@ -116,6 +117,22 @@ pub struct ChannelBinding {
     pub config_fixed: IndexMap<DottedPath, serde_json::Value>,
     pub resources_default: IndexMap<DottedPath, serde_json::Value>,
     pub resources_fixed: IndexMap<DottedPath, serde_json::Value>,
+    /// Channel-supplied overrides/adds for the pipeline-level `vars:`
+    /// block (read via `$vars.<key>`). Each entry mirrors the pipeline
+    /// declaration shape: `{ type, default }`. Override-existing matches
+    /// the declared type; add-new becomes the new declaration.
+    pub vars_static: IndexMap<String, ScopedVarDecl>,
+    /// Channel-supplied overrides/adds for `$pipeline.<key>` declared
+    /// on Transforms via `declares: { scope: pipeline }`.
+    pub vars_pipeline: IndexMap<String, ScopedVarDecl>,
+    /// Channel-supplied overrides/adds for `$source.<key>` declared
+    /// on Transforms via `declares: { scope: source }`. Outer key is
+    /// the source-node name; inner key is the var name.
+    pub vars_source: IndexMap<String, IndexMap<String, ScopedVarDecl>>,
+    /// Channel-supplied overrides/adds for `$record.<key>` declared
+    /// on Transforms via `declares: { scope: record }`. Channel-wide
+    /// (every record sees the same channel-supplied default).
+    pub vars_record: IndexMap<String, ScopedVarDecl>,
     pub source_path: PathBuf,
     /// BLAKE3 hash of the raw file bytes, used as cache-invalidation identity.
     pub channel_hash: [u8; 32],
@@ -144,6 +161,14 @@ impl ChannelBinding {
         let resources_default = validate_dotted_keys(raw.resources.default)?;
         let resources_fixed = validate_dotted_keys(raw.resources.fixed)?;
 
+        validate_var_names(raw.vars.static_block.keys())?;
+        validate_var_names(raw.vars.pipeline.keys())?;
+        validate_var_names(raw.vars.record.keys())?;
+        for (src_name, inner) in &raw.vars.source {
+            validate_var_name(src_name)?;
+            validate_var_names(inner.keys())?;
+        }
+
         Ok(ChannelBinding {
             name: raw.channel.name,
             target,
@@ -151,6 +176,10 @@ impl ChannelBinding {
             config_fixed,
             resources_default,
             resources_fixed,
+            vars_static: raw.vars.static_block,
+            vars_pipeline: raw.vars.pipeline,
+            vars_source: raw.vars.source,
+            vars_record: raw.vars.record,
             source_path,
             channel_hash,
         })
@@ -172,6 +201,8 @@ struct RawChannelFile {
     config: RawChannelConfig,
     #[serde(default)]
     resources: RawChannelConfig,
+    #[serde(default)]
+    vars: RawChannelVars,
 }
 
 #[derive(Deserialize)]
@@ -186,6 +217,18 @@ struct RawChannelConfig {
     default: IndexMap<String, serde_json::Value>,
     #[serde(default)]
     fixed: IndexMap<String, serde_json::Value>,
+}
+
+#[derive(Deserialize, Default)]
+struct RawChannelVars {
+    #[serde(default, rename = "static")]
+    static_block: IndexMap<String, ScopedVarDecl>,
+    #[serde(default)]
+    pipeline: IndexMap<String, ScopedVarDecl>,
+    #[serde(default)]
+    source: IndexMap<String, IndexMap<String, ScopedVarDecl>>,
+    #[serde(default)]
+    record: IndexMap<String, ScopedVarDecl>,
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────────
@@ -207,6 +250,46 @@ fn validate_dotted_keys(
             Ok((path, v))
         })
         .collect()
+}
+
+/// Channel `vars:` keys are flat names — accept the same character set
+/// CXL identifiers use. Reject empties, dotted forms (declarations are
+/// per-scope and per-source-name; nesting under `vars.<scope>` already
+/// resolves the scope), and leading-digit names.
+fn validate_var_name(name: &str) -> Result<(), ChannelError> {
+    if name.is_empty() {
+        return Err(ChannelError::InvalidVarName {
+            name: name.to_string(),
+            reason: "name is empty".to_string(),
+        });
+    }
+    if name.contains('.') {
+        return Err(ChannelError::InvalidVarName {
+            name: name.to_string(),
+            reason: "dots are not allowed in flat var names".to_string(),
+        });
+    }
+    let first = name.as_bytes()[0];
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return Err(ChannelError::InvalidVarName {
+            name: name.to_string(),
+            reason: "name must start with a letter or '_'".to_string(),
+        });
+    }
+    if !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_') {
+        return Err(ChannelError::InvalidVarName {
+            name: name.to_string(),
+            reason: "only [a-zA-Z0-9_] characters are allowed".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_var_names<'a>(names: impl IntoIterator<Item = &'a String>) -> Result<(), ChannelError> {
+    for n in names {
+        validate_var_name(n)?;
+    }
+    Ok(())
 }
 
 // ── Channel validation ─────────────────────────────────────────────────

--- a/crates/clinker-channel/src/error.rs
+++ b/crates/clinker-channel/src/error.rs
@@ -17,4 +17,6 @@ pub enum ChannelError {
     },
     #[error("invalid dotted path `{path}`: {reason}")]
     InvalidDottedPath { path: String, reason: String },
+    #[error("invalid var name `{name}`: {reason}")]
+    InvalidVarName { name: String, reason: String },
 }

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -59,4 +59,4 @@ pub use binding::{
     ChannelBinding, ChannelTarget, DottedPath, scan_workspace_channels, validate_channel_bindings,
 };
 pub use error::ChannelError;
-pub use overlay::apply_channel_overlay;
+pub use overlay::{ChannelOverlayResult, apply_channel_overlay};

--- a/crates/clinker-channel/src/overlay.rs
+++ b/crates/clinker-channel/src/overlay.rs
@@ -2,52 +2,139 @@
 //!
 //! Applies a [`ChannelBinding`] to a [`CompiledPlan`], overlaying config
 //! values as `ChannelDefault` or `ChannelFixed` provenance layers on the
-//! plan's [`ProvenanceDb`]. Stamps a [`ChannelIdentity`] for cache-keying.
+//! plan's [`ProvenanceDb`], and resolving channel-supplied var
+//! overrides/adds for the four scoped registries (`$vars.*`,
+//! `$pipeline.*`, `$source.*`, `$record.*`) against the pipeline's
+//! declarations. Stamps a [`ChannelIdentity`] for cache-keying.
+
+use indexmap::IndexMap;
 
 use clinker_core::config::composition::LayerKind;
+use clinker_core::config::pipeline_node::{PipelineNode, VarScope};
+use clinker_core::config::{
+    PipelineConfig, ScopedVarDecl, ScopedVarType, check_scoped_var_default,
+    coerce_scoped_var_default, reserved_names_for,
+};
 use clinker_core::error::{Diagnostic, LabeledSpan};
 use clinker_core::plan::{ChannelIdentity, CompiledPlan};
 use clinker_core::span::Span;
+use clinker_record::Value;
 
-use crate::binding::{ChannelBinding, DottedPath};
+use crate::binding::{ChannelBinding, ChannelTarget, DottedPath};
 
-/// Apply a channel binding's config overlays to a compiled plan.
+/// Resolved channel overlay output: typed var maps and any diagnostics
+/// raised during validation.
+#[derive(Debug, Default)]
+pub struct ChannelOverlayResult {
+    /// Channel overrides/adds for `$vars.*`. Keyed by var name.
+    pub static_vars: IndexMap<String, Value>,
+    /// Channel overrides/adds for `$pipeline.*`. Keyed by var name.
+    pub pipeline_vars: IndexMap<String, Value>,
+    /// Channel overrides/adds for `$source.<src>.<var>`. Outer key is
+    /// the source-node name, inner key is the var name.
+    pub source_vars: IndexMap<String, IndexMap<String, Value>>,
+    /// Channel overrides/adds for `$record.*`. Channel-wide pre-seed
+    /// applied to every record at materialization.
+    pub record_vars: IndexMap<String, Value>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+/// Apply a channel binding to a compiled plan.
 ///
-/// For each key in `config_default`, applies a `ChannelDefault` provenance
-/// layer. For each key in `config_fixed`, applies a `ChannelFixed` layer.
-/// Returns diagnostics for bindings that reference nodes/params not present
-/// in the plan's provenance DB.
+/// Performs three things:
 ///
-/// Stamps `ChannelIdentity` on the plan after overlay.
-pub fn apply_channel_overlay(plan: &mut CompiledPlan, binding: &ChannelBinding) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+/// 1. Overlays `config.default` / `config.fixed` onto the plan's
+///    [`ProvenanceDb`] as `ChannelDefault` / `ChannelFixed` layers
+///    (W103 for keys not matched in the plan).
+/// 2. Resolves the channel's `vars:` block against the pipeline's
+///    declared registries — typecheck on override (E107), reserved
+///    name guard (E110), unknown source-node guard (E111),
+///    composition-target guard (E109).
+/// 3. Stamps `ChannelIdentity` on the plan.
+///
+/// Returns the typed var maps even when diagnostics include warnings;
+/// callers should refuse to execute if any `Severity::Error` is present.
+pub fn apply_channel_overlay(
+    plan: &mut CompiledPlan,
+    binding: &ChannelBinding,
+    config: &PipelineConfig,
+) -> ChannelOverlayResult {
+    let mut result = ChannelOverlayResult::default();
 
     apply_config_layer(
         plan,
         &binding.config_default,
         LayerKind::ChannelDefault,
         &binding.name,
-        &mut diagnostics,
+        &mut result.diagnostics,
     );
     apply_config_layer(
         plan,
         &binding.config_fixed,
         LayerKind::ChannelFixed,
         &binding.name,
-        &mut diagnostics,
+        &mut result.diagnostics,
     );
+
+    let composition_target = matches!(binding.target, ChannelTarget::Composition(_));
+    let has_var_overrides = !binding.vars_static.is_empty()
+        || !binding.vars_pipeline.is_empty()
+        || !binding.vars_source.is_empty()
+        || !binding.vars_record.is_empty();
+
+    if composition_target && has_var_overrides {
+        let target_path = match &binding.target {
+            ChannelTarget::Composition(p) => p.display().to_string(),
+            ChannelTarget::Pipeline(_) => unreachable!(),
+        };
+        result.diagnostics.push(Diagnostic::error(
+            "E109",
+            format!(
+                "channel {:?}: var overrides not supported on composition channels (target: {})",
+                binding.name, target_path,
+            ),
+            LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+        ));
+    } else {
+        result.static_vars = resolve_static_overrides(
+            &binding.name,
+            &binding.vars_static,
+            config,
+            &mut result.diagnostics,
+        );
+        result.pipeline_vars = resolve_scoped_overrides(
+            &binding.name,
+            &binding.vars_pipeline,
+            config,
+            VarScope::Pipeline,
+            &mut result.diagnostics,
+        );
+        result.record_vars = resolve_scoped_overrides(
+            &binding.name,
+            &binding.vars_record,
+            config,
+            VarScope::Record,
+            &mut result.diagnostics,
+        );
+        result.source_vars = resolve_source_overrides(
+            &binding.name,
+            &binding.vars_source,
+            config,
+            &mut result.diagnostics,
+        );
+    }
 
     plan.set_channel_identity(ChannelIdentity {
         name: binding.name.clone(),
         content_hash: binding.channel_hash,
     });
 
-    diagnostics
+    result
 }
 
 fn apply_config_layer(
     plan: &mut CompiledPlan,
-    config: &indexmap::IndexMap<DottedPath, serde_json::Value>,
+    config: &IndexMap<DottedPath, serde_json::Value>,
     kind: LayerKind,
     channel_name: &str,
     diagnostics: &mut Vec<Diagnostic>,
@@ -78,4 +165,212 @@ fn apply_config_layer(
             }
         }
     }
+}
+
+// ── Var overlay resolvers ──────────────────────────────────────────────
+
+/// View of the pipeline's declared `$vars.*` registry.
+fn declared_static_vars(config: &PipelineConfig) -> IndexMap<String, ScopedVarType> {
+    config
+        .pipeline
+        .vars
+        .as_ref()
+        .map(|m| m.iter().map(|(k, d)| (k.clone(), d.var_type)).collect())
+        .unwrap_or_default()
+}
+
+/// View of the pipeline's declared `$<scope>.*` registry built from
+/// every Transform's `declares:` filtered to `wanted` scope.
+fn declared_scoped_vars(
+    config: &PipelineConfig,
+    wanted: VarScope,
+) -> IndexMap<String, ScopedVarType> {
+    let mut out = IndexMap::new();
+    for spanned in &config.nodes {
+        if let PipelineNode::Transform { config: body, .. } = &spanned.value {
+            for entry in &body.declares {
+                if entry.scope == wanted {
+                    out.insert(entry.name.clone(), entry.var_type);
+                }
+            }
+        }
+    }
+    out
+}
+
+fn declared_source_node_names(config: &PipelineConfig) -> Vec<String> {
+    config
+        .nodes
+        .iter()
+        .filter_map(|n| match &n.value {
+            PipelineNode::Source { header, .. } => Some(header.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Resolve `$vars.*` channel overrides. `$vars.*` has no reserved
+/// subset and no scope label — handled separately from
+/// [`resolve_scoped_overrides`].
+fn resolve_static_overrides(
+    channel_name: &str,
+    overrides: &IndexMap<String, ScopedVarDecl>,
+    config: &PipelineConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> IndexMap<String, Value> {
+    let declared = declared_static_vars(config);
+    let mut out = IndexMap::new();
+    for (name, decl) in overrides {
+        if let Some(value) = validate_and_coerce(
+            channel_name,
+            "static",
+            name,
+            decl,
+            declared.get(name).copied(),
+            None,
+            diagnostics,
+        ) {
+            out.insert(name.clone(), value);
+        }
+    }
+    out
+}
+
+/// Resolve `$pipeline.*` or `$record.*` channel overrides — flat
+/// shared namespaces with reserved-name guards.
+fn resolve_scoped_overrides(
+    channel_name: &str,
+    overrides: &IndexMap<String, ScopedVarDecl>,
+    config: &PipelineConfig,
+    scope: VarScope,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> IndexMap<String, Value> {
+    let declared = declared_scoped_vars(config, scope);
+    let scope_label = match scope {
+        VarScope::Pipeline => "pipeline",
+        VarScope::Source => "source",
+        VarScope::Record => "record",
+    };
+    let mut out = IndexMap::new();
+    for (name, decl) in overrides {
+        if let Some(value) = validate_and_coerce(
+            channel_name,
+            scope_label,
+            name,
+            decl,
+            declared.get(name).copied(),
+            Some(scope),
+            diagnostics,
+        ) {
+            out.insert(name.clone(), value);
+        }
+    }
+    out
+}
+
+/// Resolve `$source.<src>.<var>` channel overrides. Outer dimension is
+/// the source-node name (must exist in the pipeline; E111 otherwise);
+/// inner dimension follows the same rules as
+/// [`resolve_scoped_overrides`] for `Source` scope.
+fn resolve_source_overrides(
+    channel_name: &str,
+    overrides: &IndexMap<String, IndexMap<String, ScopedVarDecl>>,
+    config: &PipelineConfig,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> IndexMap<String, IndexMap<String, Value>> {
+    let declared_sources = declared_source_node_names(config);
+    let declared = declared_scoped_vars(config, VarScope::Source);
+    let mut out: IndexMap<String, IndexMap<String, Value>> = IndexMap::new();
+    for (src_name, inner) in overrides {
+        if !declared_sources.iter().any(|n| n == src_name) {
+            diagnostics.push(Diagnostic::error(
+                "E111",
+                format!(
+                    "channel {:?}: source {:?} not declared in pipeline (known: {})",
+                    channel_name,
+                    src_name,
+                    declared_sources.join(", "),
+                ),
+                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+            continue;
+        }
+        let mut resolved_inner = IndexMap::new();
+        for (var_name, decl) in inner {
+            if let Some(value) = validate_and_coerce(
+                channel_name,
+                "source",
+                var_name,
+                decl,
+                declared.get(var_name).copied(),
+                Some(VarScope::Source),
+                diagnostics,
+            ) {
+                resolved_inner.insert(var_name.clone(), value);
+            }
+        }
+        if !resolved_inner.is_empty() {
+            out.insert(src_name.clone(), resolved_inner);
+        }
+    }
+    out
+}
+
+/// Single per-entry validator: reserved-name guard (when
+/// `reserved_scope` is `Some`), type-equality check on override
+/// (E107), default coercion. Push diagnostics on failure; return
+/// `None` so the caller skips the entry.
+fn validate_and_coerce(
+    channel_name: &str,
+    scope_label: &str,
+    var_name: &str,
+    decl: &ScopedVarDecl,
+    declared_type: Option<ScopedVarType>,
+    reserved_scope: Option<VarScope>,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Value> {
+    if let Some(scope) = reserved_scope
+        && reserved_names_for(scope).contains(&var_name)
+    {
+        diagnostics.push(Diagnostic::error(
+            "E110",
+            format!(
+                "channel {:?}: var ${}.{} shadows reserved system field",
+                channel_name, scope_label, var_name,
+            ),
+            LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+        ));
+        return None;
+    }
+
+    if let Some(declared) = declared_type
+        && declared != decl.var_type
+    {
+        diagnostics.push(Diagnostic::error(
+            "E107",
+            format!(
+                "channel {:?}: var ${}.{} override type mismatch — declared {:?}, override declared {:?}",
+                channel_name, scope_label, var_name, declared, decl.var_type,
+            ),
+            LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+        ));
+        return None;
+    }
+
+    let default = decl.default.as_ref()?;
+
+    let where_label = format!("channel {channel_name:?} vars.{scope_label}");
+    if let Err(e) = check_scoped_var_default(&where_label, var_name, decl.var_type, default) {
+        diagnostics.push(Diagnostic::error(
+            "E107",
+            format!(
+                "channel {:?}: var ${}.{} default does not match type {:?}: {e}",
+                channel_name, scope_label, var_name, decl.var_type,
+            ),
+            LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+        ));
+        return None;
+    }
+
+    Some(coerce_scoped_var_default(decl.var_type, default))
 }

--- a/crates/clinker-channel/tests/channel_merge_test.rs
+++ b/crates/clinker-channel/tests/channel_merge_test.rs
@@ -15,8 +15,13 @@ fn channel_fixtures_dir() -> PathBuf {
     fixtures_dir().join("channels")
 }
 
-/// Compile a pipeline fixture into a CompiledPlan for overlay testing.
-fn compile_fixture(rel_pipeline_path: &str) -> clinker_core::plan::CompiledPlan {
+/// Compile a pipeline fixture into (config, plan) for overlay testing.
+fn compile_fixture(
+    rel_pipeline_path: &str,
+) -> (
+    clinker_core::config::PipelineConfig,
+    clinker_core::plan::CompiledPlan,
+) {
     let root = fixtures_dir();
     let yaml_path = root.join(rel_pipeline_path);
     let yaml = std::fs::read_to_string(&yaml_path)
@@ -28,7 +33,9 @@ fn compile_fixture(rel_pipeline_path: &str) -> clinker_core::plan::CompiledPlan 
         .unwrap_or(std::path::Path::new(""))
         .to_path_buf();
     let ctx = clinker_core::config::CompileContext::with_pipeline_dir(&root, pipeline_dir);
-    clinker_core::config::PipelineConfig::compile(&config, &ctx).expect("compile fixture")
+    let plan =
+        clinker_core::config::PipelineConfig::compile(&config, &ctx).expect("compile fixture");
+    (config, plan)
 }
 
 // ── Channel overlay merge tests ─────────────────────────────────────────
@@ -37,7 +44,7 @@ fn compile_fixture(rel_pipeline_path: &str) -> clinker_core::plan::CompiledPlan 
 fn test_channel_overlay_applies_fixed_binding_wins() {
     // nested_composition_pipeline has composition `nested_process` with
     // `strict_mode: false` at the call site (CompositionDefault).
-    let mut plan = compile_fixture("pipelines/nested_composition_pipeline.yaml");
+    let (config, mut plan) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
 
     // Verify provenance exists before overlay
     assert!(
@@ -58,7 +65,7 @@ config:
     let binding =
         ChannelBinding::from_yaml_bytes(yaml, PathBuf::from("test.channel.yaml")).unwrap();
 
-    let _diags = apply_channel_overlay(&mut plan, &binding);
+    let _result = apply_channel_overlay(&mut plan, &binding, &config);
 
     let resolved = plan
         .provenance()
@@ -80,7 +87,7 @@ config:
 
 #[test]
 fn test_channel_overlay_default_does_not_override_fixed() {
-    let mut plan = compile_fixture("pipelines/nested_composition_pipeline.yaml");
+    let (config, mut plan) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
 
     // First apply a ChannelFixed layer
     let fixed_yaml = br#"
@@ -93,7 +100,7 @@ config:
 "#;
     let fixed_binding =
         ChannelBinding::from_yaml_bytes(fixed_yaml, PathBuf::from("fixed.channel.yaml")).unwrap();
-    apply_channel_overlay(&mut plan, &fixed_binding);
+    apply_channel_overlay(&mut plan, &fixed_binding, &config);
 
     // Now apply a ChannelDefault layer — it should NOT override the fixed winner
     let default_yaml = br#"
@@ -107,7 +114,7 @@ config:
     let default_binding =
         ChannelBinding::from_yaml_bytes(default_yaml, PathBuf::from("default.channel.yaml"))
             .unwrap();
-    apply_channel_overlay(&mut plan, &default_binding);
+    apply_channel_overlay(&mut plan, &default_binding, &config);
 
     let resolved = plan
         .provenance()
@@ -129,8 +136,8 @@ config:
 
 #[test]
 fn test_channel_identity_stable_across_reruns() {
-    let mut plan1 = compile_fixture("pipelines/nested_composition_pipeline.yaml");
-    let mut plan2 = compile_fixture("pipelines/nested_composition_pipeline.yaml");
+    let (config, mut plan1) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
+    let (_, mut plan2) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
 
     let yaml = br#"
 channel:
@@ -143,8 +150,8 @@ config:
     let binding1 = ChannelBinding::from_yaml_bytes(yaml, PathBuf::from("a.channel.yaml")).unwrap();
     let binding2 = ChannelBinding::from_yaml_bytes(yaml, PathBuf::from("b.channel.yaml")).unwrap();
 
-    apply_channel_overlay(&mut plan1, &binding1);
-    apply_channel_overlay(&mut plan2, &binding2);
+    apply_channel_overlay(&mut plan1, &binding1, &config);
+    apply_channel_overlay(&mut plan2, &binding2, &config);
 
     let id1 = plan1
         .channel_identity()
@@ -188,8 +195,8 @@ fn test_channel_overlay_applies_all_six_fixtures_without_errors() {
         let binding = ChannelBinding::load(&channel_path)
             .unwrap_or_else(|e| panic!("load {channel_name}: {e}"));
 
-        let mut plan = compile_fixture("pipelines/nested_composition_pipeline.yaml");
-        let diags = apply_channel_overlay(&mut plan, &binding);
+        let (config, mut plan) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
+        let result = apply_channel_overlay(&mut plan, &binding, &config);
 
         // Channel identity should be stamped
         assert!(
@@ -198,7 +205,8 @@ fn test_channel_overlay_applies_all_six_fixtures_without_errors() {
         );
 
         // No error-severity diagnostics
-        let errors: Vec<_> = diags
+        let errors: Vec<_> = result
+            .diagnostics
             .iter()
             .filter(|d| matches!(d.severity, clinker_core::error::Severity::Error))
             .collect();
@@ -213,7 +221,7 @@ fn test_channel_overlay_applies_all_six_fixtures_without_errors() {
 
 #[test]
 fn test_channel_identity_is_none_before_overlay() {
-    let plan = compile_fixture("pipelines/nested_composition_pipeline.yaml");
+    let (_, plan) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
     assert!(
         plan.channel_identity().is_none(),
         "channel_identity should be None for base compiled plan"

--- a/crates/clinker-channel/tests/channel_var_overlay_test.rs
+++ b/crates/clinker-channel/tests/channel_var_overlay_test.rs
@@ -1,0 +1,467 @@
+//! Channel-overlay var resolution tests for issue #45.
+//!
+//! Covers the four registries (`$vars.*`, `$pipeline.*`, `$source.*`,
+//! `$record.*`) crossed with override + add semantics, plus the
+//! reserved-name guard, the unknown-source guard, the type-mismatch
+//! check, and the composition-target guard.
+
+use std::path::PathBuf;
+
+use clinker_channel::binding::ChannelBinding;
+use clinker_channel::overlay::apply_channel_overlay;
+use clinker_core::error::Severity;
+use clinker_record::Value;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("clinker-core/tests/fixtures")
+}
+
+/// Compile the var-overlay fixture pipeline into (config, plan).
+fn compile_vars_fixture() -> (
+    clinker_core::config::PipelineConfig,
+    clinker_core::plan::CompiledPlan,
+) {
+    let root = fixtures_dir();
+    let yaml_path = root.join("pipelines/channel_vars_pipeline.yaml");
+    let yaml = std::fs::read_to_string(&yaml_path).unwrap();
+    let config: clinker_core::config::PipelineConfig =
+        clinker_core::yaml::from_str(&yaml).expect("parse vars fixture");
+    let ctx =
+        clinker_core::config::CompileContext::with_pipeline_dir(&root, PathBuf::from("pipelines"));
+    let plan = clinker_core::config::PipelineConfig::compile(&config, &ctx).expect("compile");
+    (config, plan)
+}
+
+fn binding(yaml: &[u8]) -> ChannelBinding {
+    ChannelBinding::from_yaml_bytes(yaml, PathBuf::from("test.channel.yaml"))
+        .expect("channel YAML parses")
+}
+
+fn errors_with_code<'a>(
+    diags: &'a [clinker_core::error::Diagnostic],
+    code: &str,
+) -> Vec<&'a clinker_core::error::Diagnostic> {
+    diags
+        .iter()
+        .filter(|d| matches!(d.severity, Severity::Error) && d.code == code)
+        .collect()
+}
+
+// ── $vars (static) ─────────────────────────────────────────────────────
+
+#[test]
+fn static_var_override_applied() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  static:
+    fuzzy_threshold:
+      type: float
+      default: 0.92
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    assert_eq!(
+        result.static_vars.get("fuzzy_threshold"),
+        Some(&Value::Float(0.92)),
+    );
+}
+
+#[test]
+fn static_var_add_applied() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  static:
+    new_static_knob:
+      type: int
+      default: 7
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    assert_eq!(
+        result.static_vars.get("new_static_knob"),
+        Some(&Value::Integer(7)),
+    );
+}
+
+#[test]
+fn static_var_type_mismatch_emits_e107() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  static:
+    fuzzy_threshold:
+      type: string
+      default: "wrong"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    let errs = errors_with_code(&result.diagnostics, "E107");
+    assert_eq!(
+        errs.len(),
+        1,
+        "expected one E107, got {:?}",
+        result.diagnostics
+    );
+}
+
+// ── $pipeline ──────────────────────────────────────────────────────────
+
+#[test]
+fn pipeline_var_override_applied() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  pipeline:
+    cutoff_date:
+      type: date
+      default: "2026-01-01"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    assert_eq!(
+        result.pipeline_vars.get("cutoff_date"),
+        Some(&Value::String("2026-01-01".to_string().into_boxed_str())),
+    );
+}
+
+#[test]
+fn pipeline_var_add_applied() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  pipeline:
+    extra_pipeline_var:
+      type: bool
+      default: true
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    assert_eq!(
+        result.pipeline_vars.get("extra_pipeline_var"),
+        Some(&Value::Bool(true)),
+    );
+}
+
+#[test]
+fn pipeline_reserved_name_emits_e110() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  pipeline:
+    execution_id:
+      type: string
+      default: "x"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    let errs = errors_with_code(&result.diagnostics, "E110");
+    assert_eq!(errs.len(), 1);
+}
+
+// ── $source ────────────────────────────────────────────────────────────
+
+#[test]
+fn source_var_override_applied_per_source_name() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  source:
+    orders:
+      ingest_label:
+        type: string
+        default: "staging"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    let inner = result
+        .source_vars
+        .get("orders")
+        .expect("orders source has overrides");
+    assert_eq!(
+        inner.get("ingest_label"),
+        Some(&Value::String("staging".to_string().into_boxed_str())),
+    );
+}
+
+#[test]
+fn source_var_add_applied_per_source_name() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  source:
+    orders:
+      added_per_src:
+        type: int
+        default: 99
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    let inner = result.source_vars.get("orders").unwrap();
+    assert_eq!(inner.get("added_per_src"), Some(&Value::Integer(99)));
+}
+
+#[test]
+fn source_unknown_name_emits_e111() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  source:
+    not_a_source:
+      x:
+        type: int
+        default: 1
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    let errs = errors_with_code(&result.diagnostics, "E111");
+    assert_eq!(errs.len(), 1);
+}
+
+#[test]
+fn source_reserved_name_emits_e110() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  source:
+    orders:
+      path:
+        type: string
+        default: "/tmp/x"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    let errs = errors_with_code(&result.diagnostics, "E110");
+    assert_eq!(errs.len(), 1);
+}
+
+// ── $record ────────────────────────────────────────────────────────────
+
+#[test]
+fn record_var_override_applied() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  record:
+    tier:
+      type: string
+      default: "platinum"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    assert_eq!(
+        result.record_vars.get("tier"),
+        Some(&Value::String("platinum".to_string().into_boxed_str())),
+    );
+}
+
+#[test]
+fn record_var_add_applied() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: ch
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  record:
+    region:
+      type: string
+      default: "west"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    assert_eq!(
+        result.record_vars.get("region"),
+        Some(&Value::String("west".to_string().into_boxed_str())),
+    );
+}
+
+// ── Cross-cutting ──────────────────────────────────────────────────────
+
+#[test]
+fn missing_channel_falls_back_to_declared_defaults() {
+    // Without a channel binding, no overlay runs; static_vars/pipeline_vars
+    // /source_vars/record_vars come purely from declared defaults via the
+    // collect_*_var_defaults helpers (covered by executor seeding tests).
+    // Here we assert the apply_channel_overlay shape: without a channel
+    // binding, the function isn't called and the result type stays empty
+    // by definition. Confirm that an empty channel produces empty maps.
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: empty
+  target: ./pipelines/channel_vars_pipeline.yaml
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(result.static_vars.is_empty());
+    assert!(result.pipeline_vars.is_empty());
+    assert!(result.source_vars.is_empty());
+    assert!(result.record_vars.is_empty());
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+}
+
+#[test]
+fn multiple_overrides_in_one_channel() {
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: kitchen_sink
+  target: ./pipelines/channel_vars_pipeline.yaml
+vars:
+  static:
+    fuzzy_threshold:
+      type: float
+      default: 0.99
+  pipeline:
+    cutoff_date:
+      type: date
+      default: "2030-01-01"
+  source:
+    orders:
+      ingest_label:
+        type: string
+        default: "yolo"
+  record:
+    tier:
+      type: string
+      default: "diamond"
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|d| !matches!(d.severity, Severity::Error))
+    );
+    assert_eq!(result.static_vars.len(), 1);
+    assert_eq!(result.pipeline_vars.len(), 1);
+    assert_eq!(result.source_vars.get("orders").unwrap().len(), 1);
+    assert_eq!(result.record_vars.len(), 1);
+}
+
+#[test]
+fn composition_target_with_vars_emits_e109() {
+    // Use an existing composition fixture as the target.
+    let (config, mut plan) = compile_vars_fixture();
+    let b = binding(
+        br#"
+channel:
+  name: comp_with_vars
+  target: ./compositions/customer_enrich.comp.yaml
+vars:
+  static:
+    foo:
+      type: int
+      default: 1
+"#,
+    );
+    let result = apply_channel_overlay(&mut plan, &b, &config);
+    let errs = errors_with_code(&result.diagnostics, "E109");
+    assert_eq!(errs.len(), 1);
+}

--- a/crates/clinker-core/benches/combine.rs
+++ b/crates/clinker-core/benches/combine.rs
@@ -56,6 +56,7 @@ fn bench_params() -> PipelineRunParams {
         batch_id: "combine-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/benches/combine_grace_hash.rs
+++ b/crates/clinker-core/benches/combine_grace_hash.rs
@@ -206,6 +206,7 @@ fn bench_params() -> PipelineRunParams {
         batch_id: "grace-hash-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/benches/combine_iejoin.rs
+++ b/crates/clinker-core/benches/combine_iejoin.rs
@@ -283,6 +283,7 @@ fn bench_params() -> PipelineRunParams {
         batch_id: "iejoin-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/benches/combine_nary_3input.rs
+++ b/crates/clinker-core/benches/combine_nary_3input.rs
@@ -210,6 +210,7 @@ fn bench_params() -> PipelineRunParams {
         batch_id: "nary-3input-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/benches/parallel.rs
+++ b/crates/clinker-core/benches/parallel.rs
@@ -32,6 +32,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "bench-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/benches/pipeline.rs
+++ b/crates/clinker-core/benches/pipeline.rs
@@ -32,6 +32,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "bench-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/benches/window.rs
+++ b/crates/clinker-core/benches/window.rs
@@ -286,6 +286,7 @@ nodes:
         batch_id: "bench-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let mut group = c.benchmark_group("node_rooted_window");
@@ -398,6 +399,7 @@ nodes:
         batch_id: "bench-batch".to_string(),
         pipeline_vars: IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     // Build dept lookup once.

--- a/crates/clinker-core/src/config/mod.rs
+++ b/crates/clinker-core/src/config/mod.rs
@@ -3591,7 +3591,7 @@ pub fn parse_config(yaml: &str) -> Result<PipelineConfig, ConfigError> {
 /// Reserved `$pipeline.*` member names that cannot be used as
 /// `declares:` entry names with `scope: pipeline`. Mirrors
 /// `crates/cxl/src/resolve/pass.rs::PIPELINE_MEMBERS`.
-const RESERVED_PIPELINE_NAMES: &[&str] = &[
+pub const RESERVED_PIPELINE_NAMES: &[&str] = &[
     "start_time",
     "name",
     "execution_id",
@@ -3605,7 +3605,7 @@ const RESERVED_PIPELINE_NAMES: &[&str] = &[
 
 /// Reserved `$source.*` member names. Mirrors
 /// `crates/cxl/src/resolve/pass.rs::SOURCE_MEMBERS`.
-const RESERVED_SOURCE_NAMES: &[&str] = &[
+pub const RESERVED_SOURCE_NAMES: &[&str] = &[
     "file",
     "row",
     "path",
@@ -3618,7 +3618,17 @@ const RESERVED_SOURCE_NAMES: &[&str] = &[
 /// `index` (record's positional index in its source) and `source` (a
 /// back-reference to the originating source-node name) as builtin
 /// members.
-const RESERVED_RECORD_NAMES: &[&str] = &[];
+pub const RESERVED_RECORD_NAMES: &[&str] = &[];
+
+/// Single source of truth for the reserved-name lookup by scope.
+/// Used by `declares:` validation and channel-overlay validation.
+pub fn reserved_names_for(scope: pipeline_node::VarScope) -> &'static [&'static str] {
+    match scope {
+        pipeline_node::VarScope::Pipeline => RESERVED_PIPELINE_NAMES,
+        pipeline_node::VarScope::Source => RESERVED_SOURCE_NAMES,
+        pipeline_node::VarScope::Record => RESERVED_RECORD_NAMES,
+    }
+}
 
 /// Post-deserialization validation.
 fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError> {
@@ -3640,7 +3650,7 @@ fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError> {
     if let Some(ref vars) = config.pipeline.vars {
         for (name, decl) in vars {
             if let Some(default) = &decl.default {
-                check_default_type("vars", name, decl.var_type, default)?;
+                check_scoped_var_default("vars", name, decl.var_type, default)?;
             }
         }
     }
@@ -3656,19 +3666,19 @@ fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError> {
             continue;
         };
         for entry in &body.declares {
-            let (scope_label, reserved) = match entry.scope {
-                pipeline_node::VarScope::Pipeline => ("pipeline", RESERVED_PIPELINE_NAMES),
-                pipeline_node::VarScope::Source => ("source", RESERVED_SOURCE_NAMES),
-                pipeline_node::VarScope::Record => ("record", RESERVED_RECORD_NAMES),
+            let scope_label = match entry.scope {
+                pipeline_node::VarScope::Pipeline => "pipeline",
+                pipeline_node::VarScope::Source => "source",
+                pipeline_node::VarScope::Record => "record",
             };
-            if reserved.contains(&entry.name.as_str()) {
+            if reserved_names_for(entry.scope).contains(&entry.name.as_str()) {
                 return Err(ConfigError::Validation(format!(
                     "transform '{}': declares: '{}' is a reserved ${} member name and cannot be used as a variable",
                     header.name, entry.name, scope_label,
                 )));
             }
             if let Some(default) = &entry.default {
-                check_default_type(
+                check_scoped_var_default(
                     &format!("transform '{}' declares", header.name),
                     &entry.name,
                     entry.var_type,
@@ -3677,6 +3687,8 @@ fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError> {
             }
         }
     }
+
+    validate_unique_scoped_declarations(config)?;
 
     // Validate log directives on Transform nodes.
     for spanned in &config.nodes {
@@ -3710,7 +3722,11 @@ fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError> {
     Ok(())
 }
 
-fn check_default_type(
+/// Typecheck a serde-json default value against a declared scoped-var
+/// type. Used at config-load time for pipeline `vars:` and Transform
+/// `declares:` defaults, and at channel-bind time for channel var
+/// overrides — same invariant in every caller.
+pub fn check_scoped_var_default(
     where_label: &str,
     name: &str,
     var_type: ScopedVarType,
@@ -3745,9 +3761,12 @@ pub fn convert_vars(
 ) -> IndexMap<String, clinker_record::Value> {
     vars.iter()
         .filter_map(|(name, decl)| {
-            decl.default
-                .as_ref()
-                .map(|default| (name.clone(), default_to_value(decl.var_type, default)))
+            decl.default.as_ref().map(|default| {
+                (
+                    name.clone(),
+                    coerce_scoped_var_default(decl.var_type, default),
+                )
+            })
         })
         .collect()
 }
@@ -3761,20 +3780,33 @@ pub fn convert_vars(
 pub fn collect_pipeline_var_defaults(
     nodes: &[crate::yaml::Spanned<crate::config::pipeline_node::PipelineNode>],
 ) -> IndexMap<String, clinker_record::Value> {
-    use crate::config::pipeline_node::{PipelineNode, VarScope};
+    collect_scoped_var_defaults(nodes, pipeline_node::VarScope::Pipeline)
+}
+
+/// Walk every Transform's `declares:` entries and collect declared
+/// defaults for variables whose scope matches `wanted`. Pipeline,
+/// Source, and Record scopes share the same shape — pull them through
+/// the same helper rather than duplicating the loop body. Source and
+/// record defaults use this map as their pre-seed at executor init
+/// when channel-supplied overrides are absent.
+fn collect_scoped_var_defaults(
+    nodes: &[crate::yaml::Spanned<crate::config::pipeline_node::PipelineNode>],
+    wanted: pipeline_node::VarScope,
+) -> IndexMap<String, clinker_record::Value> {
+    use crate::config::pipeline_node::PipelineNode;
     let mut out = IndexMap::new();
     for spanned in nodes {
         let PipelineNode::Transform { config, .. } = &spanned.value else {
             continue;
         };
         for entry in &config.declares {
-            if entry.scope != VarScope::Pipeline {
+            if entry.scope != wanted {
                 continue;
             }
             if let Some(default) = &entry.default {
                 out.insert(
                     entry.name.clone(),
-                    default_to_value(entry.var_type, default),
+                    coerce_scoped_var_default(entry.var_type, default),
                 );
             }
         }
@@ -3782,7 +3814,81 @@ pub fn collect_pipeline_var_defaults(
     out
 }
 
-fn default_to_value(var_type: ScopedVarType, default: &serde_json::Value) -> clinker_record::Value {
+/// Walk every Transform's `declares:` entries and collect declared
+/// defaults for variables whose `scope: source`. Channels overlay
+/// per-source-name overrides on top of this baseline.
+pub fn collect_source_var_defaults(
+    nodes: &[crate::yaml::Spanned<crate::config::pipeline_node::PipelineNode>],
+) -> IndexMap<String, clinker_record::Value> {
+    collect_scoped_var_defaults(nodes, pipeline_node::VarScope::Source)
+}
+
+/// Walk every Transform's `declares:` entries and collect declared
+/// defaults for variables whose `scope: record`. Channels overlay
+/// channel-wide defaults on top; the executor pre-seeds these into
+/// each record's `record_vars` map at materialization.
+pub fn collect_record_var_defaults(
+    nodes: &[crate::yaml::Spanned<crate::config::pipeline_node::PipelineNode>],
+) -> IndexMap<String, clinker_record::Value> {
+    collect_scoped_var_defaults(nodes, pipeline_node::VarScope::Record)
+}
+
+/// Walk the config's declared scopes ({Pipeline, Source, Record}) and
+/// reject duplicate names within each flat shared registry. Source-scope
+/// uniqueness applies globally (the runtime keys source-scope state by
+/// `Arc<str>` source-file but the declared-name namespace is shared).
+///
+/// A duplicate name implies ambiguity for downstream channel-overlay
+/// resolution and for the runtime read namespace itself — flat shared
+/// namespaces fail-fast (Beam, Flink, Kafka Streams, Dagster, Cargo,
+/// Rust statics, post-fix dbt). Authors who want shared state declare
+/// once and reference everywhere; clinker has no nested-scope construct
+/// for `$pipeline.*`/`$source.*`/`$record.*` that would justify
+/// shadowing semantics.
+fn validate_unique_scoped_declarations(config: &PipelineConfig) -> Result<(), ConfigError> {
+    use crate::config::pipeline_node::{PipelineNode, VarScope};
+    for scope in [VarScope::Pipeline, VarScope::Source, VarScope::Record] {
+        let mut first_seen: HashMap<&str, &str> = HashMap::new();
+        for spanned in &config.nodes {
+            let PipelineNode::Transform {
+                header,
+                config: body,
+            } = &spanned.value
+            else {
+                continue;
+            };
+            for entry in &body.declares {
+                if entry.scope != scope {
+                    continue;
+                }
+                if let Some(prior) = first_seen.insert(entry.name.as_str(), header.name.as_str())
+                    && prior != header.name.as_str()
+                {
+                    let scope_label = match scope {
+                        VarScope::Pipeline => "pipeline",
+                        VarScope::Source => "source",
+                        VarScope::Record => "record",
+                    };
+                    return Err(ConfigError::Validation(format!(
+                        "duplicate ${scope_label} declaration: '{name}' is declared in transforms '{prior}' and '{current}' — the {scope_label}-scope namespace is flat and shared, declare once and reference",
+                        name = entry.name,
+                        current = header.name,
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Coerce a serde-json default value into a typed `clinker_record::Value`
+/// according to the declared scoped-var type. Caller MUST have run
+/// [`check_scoped_var_default`] first; this function panics on any
+/// (type, value) combo that validator would have rejected.
+pub fn coerce_scoped_var_default(
+    var_type: ScopedVarType,
+    default: &serde_json::Value,
+) -> clinker_record::Value {
     use clinker_record::Value;
     match (var_type, default) {
         (ScopedVarType::Bool, serde_json::Value::Bool(b)) => Value::Bool(*b),
@@ -3796,8 +3902,7 @@ fn default_to_value(var_type: ScopedVarType, default: &serde_json::Value) -> cli
             ScopedVarType::String | ScopedVarType::Date | ScopedVarType::DateTime,
             serde_json::Value::String(s),
         ) => Value::String(s.clone().into_boxed_str()),
-        // check_default_type rejects every other (type, default) combo.
-        _ => unreachable!("check_default_type should reject mismatched defaults"),
+        _ => unreachable!("check_scoped_var_default should reject mismatched defaults"),
     }
 }
 

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -1411,8 +1411,7 @@ impl PipelineExecutor {
         if (!declared_source_defaults.is_empty() || channel_for_primary.is_some())
             && let Ok(mut map) = stable.source_vars.write()
         {
-            let mut seen: std::collections::HashSet<&Arc<str>> =
-                std::collections::HashSet::new();
+            let mut seen: std::collections::HashSet<&Arc<str>> = std::collections::HashSet::new();
             for file_arc in &per_record_source_files {
                 if !seen.insert(file_arc) {
                     continue;

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -231,13 +231,26 @@ pub fn single_file_reader(
 }
 
 /// Runtime parameters for a pipeline execution (not derived from config YAML).
+#[derive(Default)]
 pub struct PipelineRunParams {
     /// UUID v7 execution ID, unique per run.
     pub execution_id: String,
     /// Batch ID from --batch-id CLI flag or auto UUID v7.
     pub batch_id: String,
-    /// Converted pipeline.vars (already validated and converted from serde_json).
+    /// Channel-supplied overrides/adds for `$pipeline.*`. Layered atop
+    /// `collect_pipeline_var_defaults` at executor init; channel wins.
     pub pipeline_vars: IndexMap<String, Value>,
+    /// Channel-supplied overrides/adds for `$vars.*`. Layered atop
+    /// `convert_vars(config.pipeline.vars)`; channel wins.
+    pub static_vars: IndexMap<String, Value>,
+    /// Channel-supplied overrides/adds for `$source.<src>.<var>`. Outer
+    /// key is source-node name; inner key is var name. Layered atop
+    /// `collect_source_var_defaults` per file Arc at materialization.
+    pub source_vars: IndexMap<String, IndexMap<String, Value>>,
+    /// Channel-supplied overrides/adds for `$record.*`. Pre-seeded into
+    /// every Record's `record_vars` map at materialization, layered
+    /// atop `collect_record_var_defaults`.
+    pub record_vars: IndexMap<String, Value>,
     /// Per-run shutdown handle. The executor checks this at chunk boundaries
     /// and inside `Arena::build`. `None` disables shutdown signaling for this
     /// run; production callers typically construct one via
@@ -1354,9 +1367,9 @@ impl PipelineExecutor {
     fn execute_dag_branching(
         config: &PipelineConfig,
         input: &crate::config::SourceConfig,
-        all_records: Vec<(Record, u64)>,
+        mut all_records: Vec<(Record, u64)>,
         per_record_source_files: Vec<Arc<str>>,
-        preloaded_source_records: HashMap<String, Vec<(Record, u64)>>,
+        mut preloaded_source_records: HashMap<String, Vec<(Record, u64)>>,
         writers: WriterRegistry,
         transforms: &[CompiledTransform],
         compiled_route: Option<CompiledRoute>,
@@ -1381,7 +1394,63 @@ impl PipelineExecutor {
             &params.execution_id,
             &params.batch_id,
             &params.pipeline_vars,
+            &params.static_vars,
         );
+
+        // Seed source-scope vars on every distinct primary-source file
+        // Arc. Channel overrides (per source-node name) layer atop
+        // Transform-`declares: scope: source` defaults; the per-file
+        // inner map uses `or_insert` for declared defaults (so any
+        // source-scope writer that planted earlier wins) and `insert`
+        // for channel values (channel always wins). Combine
+        // build-side preloaded sources are not seeded from this point;
+        // their channel overrides apply when those sources flow
+        // through their own primary `execute_dag` call.
+        let declared_source_defaults = crate::config::collect_source_var_defaults(&config.nodes);
+        let channel_for_primary = params.source_vars.get(&input.name);
+        if (!declared_source_defaults.is_empty() || channel_for_primary.is_some())
+            && let Ok(mut map) = stable.source_vars.write()
+        {
+            let mut seen: std::collections::HashSet<&Arc<str>> =
+                std::collections::HashSet::new();
+            for file_arc in &per_record_source_files {
+                if !seen.insert(file_arc) {
+                    continue;
+                }
+                let entry = map.entry(Arc::clone(file_arc)).or_default();
+                for (k, v) in &declared_source_defaults {
+                    entry.entry(k.clone()).or_insert_with(|| v.clone());
+                }
+                if let Some(ch) = channel_for_primary {
+                    for (k, v) in ch {
+                        entry.insert(k.clone(), v.clone());
+                    }
+                }
+            }
+        }
+
+        // Pre-seed `$record.<key>` defaults into every materialized
+        // record so init-phase reads observe the declared/channel
+        // default before any per-record `state` writer fires. Channel
+        // record-vars layer atop Transform-`declares: scope: record`
+        // defaults; existing per-record entries (if any) are preserved.
+        let record_var_seed: IndexMap<String, Value> = {
+            let mut seed = crate::config::collect_record_var_defaults(&config.nodes);
+            for (k, v) in &params.record_vars {
+                seed.insert(k.clone(), v.clone());
+            }
+            seed
+        };
+        if !record_var_seed.is_empty() {
+            for (record, _) in &mut all_records {
+                record.seed_record_vars(&record_var_seed);
+            }
+            for (_, recs) in preloaded_source_records.iter_mut() {
+                for (record, _) in recs {
+                    record.seed_record_vars(&record_var_seed);
+                }
+            }
+        }
         // Synthetic source-file placeholder used by dispatch sites that
         // have no live record (combine/finalize/post-aggregate emits
         // with `source_row: 0`). For multi-file sources `input.path` is
@@ -2324,6 +2393,7 @@ fn build_stable_eval_context(
     execution_id: &str,
     batch_id: &str,
     pipeline_vars: &IndexMap<String, Value>,
+    static_vars_overrides: &IndexMap<String, Value>,
 ) -> StableEvalContext {
     // Seed pipeline-scope vars with declared defaults from every
     // Transform's `declares:` entries; runtime injections (channel
@@ -2342,20 +2412,27 @@ fn build_stable_eval_context(
         pipeline_vars: Arc::new(std::sync::RwLock::new(seeded)),
         source_vars: Arc::new(std::sync::RwLock::new(std::collections::HashMap::new())),
         source_input_arcs: Arc::new(compute_source_input_arcs(config)),
-        static_vars: Arc::new(build_static_vars(config)),
+        static_vars: Arc::new(build_static_vars(config, static_vars_overrides)),
     }
 }
 
 /// Build the `$vars.*` runtime value map from the pipeline's `vars:`
-/// block. Each entry's `default` field (post-validation, already
-/// coerced to the declared type) becomes the frozen runtime value.
-/// Stage 7 will overlay channel `pipeline.vars.<key>` overrides on
-/// top of this before the pipeline starts.
-fn build_static_vars(config: &PipelineConfig) -> IndexMap<String, Value> {
-    let Some(decls) = config.pipeline.vars.as_ref() else {
-        return IndexMap::new();
-    };
-    crate::config::convert_vars(decls)
+/// block, with `overrides` (channel-supplied) layered on top. Channel
+/// adds extend the map; channel overrides replace.
+fn build_static_vars(
+    config: &PipelineConfig,
+    overrides: &IndexMap<String, Value>,
+) -> IndexMap<String, Value> {
+    let mut out = config
+        .pipeline
+        .vars
+        .as_ref()
+        .map(crate::config::convert_vars)
+        .unwrap_or_default();
+    for (k, v) in overrides {
+        out.insert(k.clone(), v.clone());
+    }
+    out
 }
 
 /// Walk the YAML config to map every `Merge` / `Combine` named input to
@@ -2837,6 +2914,7 @@ mod tests {
             batch_id: "test-batch-id".to_string(),
             pipeline_vars: IndexMap::new(),
             shutdown_token: None,
+            ..Default::default()
         };
 
         let report = PipelineExecutor::run_with_readers_writers(

--- a/crates/clinker-core/src/executor/tests/branching.rs
+++ b/crates/clinker-core/src/executor/tests/branching.rs
@@ -32,6 +32,7 @@ fn run_branch_test(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     };
 
     let report = PipelineExecutor::run_with_readers_writers(

--- a/crates/clinker-core/src/executor/tests/ck_aligned_partition_runtime.rs
+++ b/crates/clinker-core/src/executor/tests/ck_aligned_partition_runtime.rs
@@ -83,6 +83,7 @@ o6,ENG,300
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_with_readers_writers(
         &config,

--- a/crates/clinker-core/src/executor/tests/correlated_dlq.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_dlq.rs
@@ -20,6 +20,7 @@ fn run_correlated_pipeline(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = config.source_configs().next().unwrap().name.clone();
@@ -384,6 +385,7 @@ nodes:
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let primary = config.source_configs().next().unwrap().name.clone();
     let readers: crate::executor::SourceReaders = HashMap::from([(
@@ -890,6 +892,7 @@ nodes:
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = "orders".to_string();
@@ -1076,6 +1079,7 @@ nodes:
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = "orders".to_string();
@@ -1306,6 +1310,7 @@ nodes:
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = "orders".to_string();

--- a/crates/clinker-core/src/executor/tests/correlated_dlq_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_dlq_retract.rs
@@ -36,6 +36,7 @@ fn run_pipeline(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = config.source_configs().next().unwrap().name.clone();

--- a/crates/clinker-core/src/executor/tests/correlated_post_aggregate_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_post_aggregate_retract.rs
@@ -32,6 +32,7 @@ fn run_pipeline(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = config.source_configs().next().unwrap().name.clone();

--- a/crates/clinker-core/src/executor/tests/correlated_window_after_aggregate_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_window_after_aggregate_retract.rs
@@ -31,6 +31,7 @@ fn run_pipeline(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = config.source_configs().next().unwrap().name.clone();

--- a/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
@@ -56,6 +56,7 @@ fn run_pipeline(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = config.source_configs().next().unwrap().name.clone();

--- a/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
@@ -203,6 +203,7 @@ o3,ENG,100
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_with_readers_writers(
         &config,
@@ -330,6 +331,7 @@ nodes:
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let config = crate::config::parse_config(yaml).expect("parse");
     // The pipeline either errors at the producer's region tee (E310 from
@@ -461,6 +463,7 @@ o3,HR,30
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let config = crate::config::parse_config(yaml).expect("parse");
     with_test_loop_cap(0, || {
@@ -618,6 +621,7 @@ ENG,500
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_with_readers_writers(
         &config,
@@ -810,6 +814,7 @@ o6,ENG,300
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     // Run via the standard `run_with_readers_writers` entry point;
     // composition resolution flows through the same `_compose:` loader
@@ -1054,6 +1059,7 @@ o6,ENG,300
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
@@ -1284,6 +1290,7 @@ o6,ENG,300
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
@@ -1487,6 +1494,7 @@ o6,ENG,300
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
@@ -1672,6 +1680,7 @@ o6,ENG,300
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
@@ -1829,6 +1838,7 @@ o6,ENG,300
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let config = crate::config::parse_config(yaml).expect("parse");
     let report = PipelineExecutor::run_with_readers_writers(
@@ -2020,6 +2030,7 @@ nodes:
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let config = crate::config::parse_config(yaml).expect("parse");
     let result = PipelineExecutor::run_with_readers_writers(

--- a/crates/clinker-core/src/executor/tests/format_dispatch.rs
+++ b/crates/clinker-core/src/executor/tests/format_dispatch.rs
@@ -44,6 +44,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "test-batch-001".into(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/src/executor/tests/multi_output.rs
+++ b/crates/clinker-core/src/executor/tests/multi_output.rs
@@ -31,6 +31,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "test-batch-id".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
@@ -64,6 +64,7 @@ fn run(csv: &str) -> String {
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let primary = "src".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([(

--- a/crates/clinker-core/src/executor/tests/post_aggregate_lag_lead.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_lag_lead.rs
@@ -69,6 +69,7 @@ fn run_once(csv: &str) -> String {
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let primary = "src".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([(

--- a/crates/clinker-core/src/executor/tests/post_aggregate_recompute_determinism.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_recompute_determinism.rs
@@ -76,6 +76,7 @@ fn run_once() -> u64 {
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
     let primary = config.source_configs().next().unwrap().name.clone();
     let readers: crate::executor::SourceReaders = HashMap::from([(

--- a/crates/clinker-core/src/executor/tests/post_aggregate_window.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_window.rs
@@ -24,6 +24,7 @@ fn run_pipeline(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = config.source_configs().next().unwrap().name.clone();

--- a/crates/clinker-core/src/executor/tests/post_aggregate_window_spilled.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_window_spilled.rs
@@ -80,6 +80,7 @@ nodes:
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let primary = "src".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([(

--- a/crates/clinker-core/src/executor/tests/post_combine_window_strategies.rs
+++ b/crates/clinker-core/src/executor/tests/post_combine_window_strategies.rs
@@ -132,6 +132,7 @@ ENG,5000
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     PipelineExecutor::run_plan_with_readers_writers_with_primary(
         &plan, &primary, readers, writers, &params,
@@ -258,6 +259,7 @@ ENG,5000
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     PipelineExecutor::run_plan_with_readers_writers_with_primary(
         &plan, &primary, readers, writers, &params,

--- a/crates/clinker-core/src/executor/tests/strict_pipeline_zero_overhead.rs
+++ b/crates/clinker-core/src/executor/tests/strict_pipeline_zero_overhead.rs
@@ -96,6 +96,7 @@ o3,ENG,100
         batch_id: "test-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let config = crate::config::parse_config(STRICT_PIPELINE).expect("parse");
     let report = PipelineExecutor::run_with_readers_writers(

--- a/crates/clinker-core/src/executor/tests/window_recompute_correctness.rs
+++ b/crates/clinker-core/src/executor/tests/window_recompute_correctness.rs
@@ -63,6 +63,7 @@ fn run_pipeline(
         batch_id: "test-batch-id".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let primary = config.source_configs().next().unwrap().name.clone();

--- a/crates/clinker-core/src/integration_tests.rs
+++ b/crates/clinker-core/src/integration_tests.rs
@@ -35,6 +35,7 @@ mod tests {
             batch_id: "test-batch-id".to_string(),
             pipeline_vars,
             shutdown_token: None,
+            ..Default::default()
         };
 
         let report = PipelineExecutor::run_with_readers_writers(
@@ -854,6 +855,7 @@ nodes:
             batch_id: "test-batch-id".to_string(),
             pipeline_vars: Default::default(),
             shutdown_token: None,
+            ..Default::default()
         };
 
         let result = PipelineExecutor::run_with_readers_writers(
@@ -921,6 +923,7 @@ nodes:
             batch_id: "test-batch-id".to_string(),
             pipeline_vars: Default::default(),
             shutdown_token: None,
+            ..Default::default()
         };
 
         let result = PipelineExecutor::run_with_readers_writers(
@@ -1044,6 +1047,7 @@ nodes:
             batch_id: "test-batch-id".to_string(),
             pipeline_vars: Default::default(),
             shutdown_token: None,
+            ..Default::default()
         };
 
         let report = PipelineExecutor::run_with_readers_writers(

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -211,7 +211,10 @@ pub fn bind_schema(
         &mut schema_by_name,
     );
 
-    validate_producer_writers(nodes, diags);
+    // Cross-Transform duplicate `declares:` (the only path that
+    // produced multi-writer for a `(scope, var)` pair) is now caught at
+    // config-validation time by `validate_unique_scoped_declarations`,
+    // so the previous compile-time E170 multi-writer check is dead.
     validate_init_phase_terminals(nodes, diags);
     validate_read_after_write(nodes, &artifacts, diags);
     validate_post_merge_source_reads(nodes, &artifacts, diags);
@@ -231,7 +234,7 @@ pub fn bind_schema(
 /// (declaration default is the intended value). Only the
 /// init-reads-runtime-only case is flagged.
 ///
-/// Reuses `validate_producer_writers`'s writer-map shape and
+/// Reuses `iter_writers` for the writer-map shape and
 /// `validate_read_after_write`'s AST walker (`collect_scope_reads_*`).
 /// Iterate every (scope, var) writer in the pipeline. Each writer is
 /// a Transform with one or more `config.declares:` entries; one
@@ -240,21 +243,18 @@ struct WriterInfo<'a> {
     scope: crate::config::VarScope,
     var: &'a str,
     node_name: &'a str,
-    span: Span,
     phase: crate::config::Phase,
 }
 
 fn iter_writers<'a>(nodes: &'a [Spanned<PipelineNode>]) -> Vec<WriterInfo<'a>> {
     let mut out = Vec::new();
     for spanned in nodes {
-        let span = span_for_node(spanned);
         if let PipelineNode::Transform { header, config } = &spanned.value {
             for entry in &config.declares {
                 out.push(WriterInfo {
                     scope: entry.scope,
                     var: &entry.name,
                     node_name: &header.name,
-                    span,
                     phase: config.phase,
                 });
             }
@@ -965,56 +965,6 @@ fn validate_init_phase_terminals(nodes: &[Spanned<PipelineNode>], diags: &mut Ve
                     )),
                 );
             }
-        }
-    }
-}
-
-/// Compile-time check: at most one Transform writes any given
-/// `(scope, var)` pair via `declares:`. Multiple writers produce
-/// non-deterministic last-write-wins behavior — the locked-decision
-/// design forbids it and demands the user collapse the writes into a
-/// single Transform (Hop / Talend canonical anti-pattern).
-///
-/// Init-phase and runtime-phase writers are tracked together; a
-/// converging-init writer is architecturally distinct from a
-/// converging-runtime writer (init runs to completion first), but the
-/// single-writer rule applies to both pools uniformly here.
-///
-/// Emits E170 with primary span on the second writer and secondary
-/// span on the first (the chronologically-first span in declaration
-/// order is the "canonical" writer; downstream nodes are duplicates).
-fn validate_producer_writers(nodes: &[Spanned<PipelineNode>], diags: &mut Vec<Diagnostic>) {
-    let mut seen: std::collections::HashMap<(crate::config::VarScope, String), (Span, String)> =
-        std::collections::HashMap::new();
-    let scope_str = |scope: crate::config::VarScope| match scope {
-        crate::config::VarScope::Pipeline => "$pipeline",
-        crate::config::VarScope::Source => "$source",
-        crate::config::VarScope::Record => "$record",
-    };
-    for w in iter_writers(nodes) {
-        let key = (w.scope, w.var.to_string());
-        if let Some((first_span, first_node)) = seen.get(&key) {
-            diags.push(
-                Diagnostic::error(
-                    "E170",
-                    format!(
-                        "scoped variable '{}.{}' has multiple writers: \
-                         {:?} duplicates the write from earlier writer {:?} — \
-                         collapse into a single producer",
-                        scope_str(w.scope),
-                        w.var,
-                        w.node_name,
-                        first_node
-                    ),
-                    LabeledSpan::primary(w.span, "second writer".to_string()),
-                )
-                .with_secondary(LabeledSpan::new(
-                    *first_span,
-                    Some("first writer".to_string()),
-                )),
-            );
-        } else {
-            seen.insert(key, (w.span, w.node_name.to_string()));
         }
     }
 }

--- a/crates/clinker-core/tests/aggregate_integration.rs
+++ b/crates/clinker-core/tests/aggregate_integration.rs
@@ -43,6 +43,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch-001".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/tests/auto_widen_integration.rs
+++ b/crates/clinker-core/tests/auto_widen_integration.rs
@@ -41,6 +41,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch-001".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/tests/combine_propagate_ck_test.rs
+++ b/crates/clinker-core/tests/combine_propagate_ck_test.rs
@@ -57,6 +57,7 @@ fn run_with_output(
         batch_id: "propagate-ck-batch".to_string(),
         pipeline_vars: Default::default(),
         shutdown_token: None,
+        ..Default::default()
     };
     let report = PipelineExecutor::run_plan_with_readers_writers_with_primary(
         &plan, primary, readers, writers, &params,

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -2143,6 +2143,7 @@ nodes:
             batch_id: "combine-test-batch".to_string(),
             pipeline_vars,
             shutdown_token: None,
+            ..Default::default()
         };
 
         let report = PipelineExecutor::run_plan_with_readers_writers_with_primary(

--- a/crates/clinker-core/tests/composition_body_window.rs
+++ b/crates/clinker-core/tests/composition_body_window.rs
@@ -56,6 +56,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/tests/composition_combine_test.rs
+++ b/crates/clinker-core/tests/composition_combine_test.rs
@@ -52,6 +52,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch-001".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/tests/composition_executor_test.rs
+++ b/crates/clinker-core/tests/composition_executor_test.rs
@@ -52,6 +52,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch-001".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/tests/correlation_composition_test.rs
+++ b/crates/clinker-core/tests/correlation_composition_test.rs
@@ -61,6 +61,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch-001".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 

--- a/crates/clinker-core/tests/fan_out_writers_test.rs
+++ b/crates/clinker-core/tests/fan_out_writers_test.rs
@@ -100,6 +100,7 @@ fn dispatch_routes_records_to_per_file_writers() {
         batch_id: "b".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)

--- a/crates/clinker-core/tests/fixtures/pipelines/channel_vars_pipeline.yaml
+++ b/crates/clinker-core/tests/fixtures/pipelines/channel_vars_pipeline.yaml
@@ -1,0 +1,42 @@
+# Fixture pipeline used by `channel_var_overlay_test`. Declares one
+# `$vars.*` and one `$pipeline.*` / `$source.*` / `$record.*` to exercise
+# every channel-overlay path.
+pipeline:
+  name: channel_vars_pipeline
+  vars:
+    fuzzy_threshold:
+      type: float
+      default: 0.85
+    cohort_label:
+      type: string
+      default: "baseline"
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: data/orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: numeric }
+
+  - type: transform
+    name: enrich
+    input: orders
+    config:
+      declares:
+        - { name: cutoff_date, scope: pipeline, type: date, default: "2024-01-01" }
+        - { name: ingest_label, scope: source, type: string, default: "prod" }
+        - { name: tier, scope: record, type: string, default: "bronze" }
+      cxl: |
+        emit order_id = order_id
+        emit amount = amount
+
+  - type: output
+    name: sink
+    input: enrich
+    config:
+      name: sink
+      type: csv
+      path: data/channel_vars_output.csv

--- a/crates/clinker-core/tests/multi_file_source_test.rs
+++ b/crates/clinker-core/tests/multi_file_source_test.rs
@@ -84,6 +84,7 @@ fn multi_file_glob_concatenates_and_stamps_source_provenance() {
         batch_id: "b".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)

--- a/crates/clinker-core/tests/pre_lift_baselines.rs
+++ b/crates/clinker-core/tests/pre_lift_baselines.rs
@@ -213,6 +213,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch-001".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 
@@ -758,7 +759,7 @@ config:
     )
     .expect("parse channel");
 
-    let _diags = apply_channel_overlay(&mut plan, &binding);
+    let _result = apply_channel_overlay(&mut plan, &binding, &config);
 
     // Verify the provenance chain contains a ChannelFixed layer
     let resolved = plan

--- a/crates/clinker-core/tests/retract_demo_smoke.rs
+++ b/crates/clinker-core/tests/retract_demo_smoke.rs
@@ -144,6 +144,7 @@ fn run_demo(orders_csv: &str, audit_events_csv: &str) -> (ExecutionReport, Strin
         batch_id: "smoke-001".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
 
     let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)

--- a/crates/clinker-core/tests/retraction_metrics_test.rs
+++ b/crates/clinker-core/tests/retraction_metrics_test.rs
@@ -25,6 +25,7 @@ fn run_pipeline(yaml: &str, csv_input: &str) -> PipelineCounters {
         batch_id: "test-batch".to_string(),
         pipeline_vars: indexmap::IndexMap::new(),
         shutdown_token: None,
+        ..Default::default()
     };
     let primary = config.source_configs().next().unwrap().name.clone();
     let readers = HashMap::from([(

--- a/crates/clinker-core/tests/snapshots/state_node_diagnostics__snapshot_duplicate_pipeline_declaration_rejected_at_parse.snap
+++ b/crates/clinker-core/tests/snapshots/state_node_diagnostics__snapshot_duplicate_pipeline_declaration_rejected_at_parse.snap
@@ -1,0 +1,6 @@
+---
+source: crates/clinker-core/tests/state_node_diagnostics.rs
+assertion_line: 145
+expression: err.to_string()
+---
+config validation error: duplicate $pipeline declaration: 'x' is declared in transforms 'w1' and 'w2' — the pipeline-scope namespace is flat and shared, declare once and reference

--- a/crates/clinker-core/tests/snapshots/state_node_diagnostics__snapshot_e170_multi_writer.snap
+++ b/crates/clinker-core/tests/snapshots/state_node_diagnostics__snapshot_e170_multi_writer.snap
@@ -1,5 +1,0 @@
----
-source: crates/clinker-core/tests/state_node_diagnostics.rs
-expression: render_diags(&diags)
----
-E170: scoped variable '$pipeline.x' has multiple writers: "w2" duplicates the write from earlier writer "w1" — collapse into a single producer

--- a/crates/clinker-core/tests/state_node_diagnostics.rs
+++ b/crates/clinker-core/tests/state_node_diagnostics.rs
@@ -96,10 +96,16 @@ nodes:
 }
 
 #[test]
-fn snapshot_e170_multi_writer() {
+fn snapshot_duplicate_pipeline_declaration_rejected_at_parse() {
+    // Two transforms declare the same `$pipeline.x` — flat shared
+    // namespaces fail-fast (Beam, Flink, Kafka Streams, Dagster, post-fix
+    // dbt, Cargo, Rust statics). The earlier compile-time E170 multi-
+    // writer rule was unreachable in this exact form because both
+    // writers had to declare to write; the cross-Transform uniqueness
+    // check at parse time supersedes it.
     let yaml = r#"
 pipeline:
-  name: e170_multi_writer
+  name: dup_pipeline_decl
 nodes:
   - type: source
     name: src
@@ -135,8 +141,8 @@ nodes:
       type: csv
       path: out.csv
 "#;
-    let diags = compile_err_diags(yaml);
-    insta::assert_snapshot!(render_diags(&diags));
+    let err = parse_config(yaml).expect_err("expected parse-time validation error");
+    insta::assert_snapshot!(err.to_string());
 }
 
 #[test]

--- a/crates/clinker-core/tests/state_node_integration.rs
+++ b/crates/clinker-core/tests/state_node_integration.rs
@@ -38,6 +38,7 @@ fn test_params() -> PipelineRunParams {
         batch_id: "batch-h-001".to_string(),
         pipeline_vars,
         shutdown_token: None,
+        ..Default::default()
     }
 }
 
@@ -609,6 +610,76 @@ nodes:
 // ─────────────────────────────────────────────────────────────────
 // Fixture 8 — $vars.<key> static config, frozen at pipeline start
 // ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn channel_static_var_override_flows_into_static_vars() {
+    // Same fixture as `static_vars_visible_in_transform_cxl`, but the
+    // executor receives a channel-resolved override for `$vars.cutoff`
+    // via PipelineRunParams. The pipeline's declared default is 100;
+    // the channel raises it to 175, so only records with amount > 175
+    // should survive the filter.
+    let yaml = r#"
+pipeline:
+  name: channel_static_smoke
+  vars:
+    cutoff: { type: int, default: 100 }
+    label: { type: string, default: "tier-A" }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: int }
+        - { name: amount, type: int }
+  - type: transform
+    name: filter_and_tag
+    input: src
+    config:
+      cxl: |
+        filter amount > $vars.cutoff
+        emit id = id
+        emit tier = $vars.label
+        emit threshold = $vars.cutoff
+  - type: output
+    name: out
+    input: filter_and_tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let csv = "id,amount\n1,50\n2,150\n3,200\n";
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = clinker_core::config::PipelineConfig::compile(&config, &CompileContext::default())
+        .expect("compile");
+    let readers = HashMap::from([(
+        config.source_configs().next().unwrap().name.clone(),
+        clinker_core::executor::single_file_reader(
+            "test.csv",
+            Box::new(Cursor::new(csv.as_bytes().to_vec())),
+        ),
+    )]);
+    let buf = SharedBuffer::default();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        config.output_configs().next().unwrap().name.clone(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+    let mut static_vars = indexmap::IndexMap::new();
+    static_vars.insert("cutoff".to_string(), clinker_record::Value::Integer(175));
+    let params = PipelineRunParams {
+        execution_id: "ch-static".to_string(),
+        batch_id: "ch-static-001".to_string(),
+        static_vars,
+        ..Default::default()
+    };
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("pipeline run");
+    let lines = body_lines_sorted(&buf.as_string());
+    assert_eq!(lines, vec!["3,tier-A,175"]);
+}
 
 #[test]
 fn static_vars_visible_in_transform_cxl() {

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -163,6 +163,27 @@ impl Record {
         }
     }
 
+    /// Pre-seed `$record.<key>` defaults into this record before any
+    /// per-record writer fires. Used at materialization to plant
+    /// channel-supplied and Transform-declared `scope: record` defaults
+    /// so init-phase reads observe the right value when the writer
+    /// hasn't run yet. Existing entries are preserved (writers that
+    /// fired earlier in the materialization path win).
+    pub fn seed_record_vars(&mut self, seed: &IndexMap<String, Value>) {
+        if seed.is_empty() {
+            return;
+        }
+        let map = self
+            .record_vars
+            .get_or_insert_with(|| Box::new(IndexMap::new()));
+        for (k, v) in seed {
+            if map.len() >= MAX_RECORD_VARS && !map.contains_key(k.as_str()) {
+                break;
+            }
+            map.entry(k.as_str().into()).or_insert_with(|| v.clone());
+        }
+    }
+
     // ── Fields ─────────────────────────────────────────────────────
 
     /// Iterator over every schema field in schema order.

--- a/crates/clinker/Cargo.toml
+++ b/crates/clinker/Cargo.toml
@@ -9,7 +9,9 @@ description = "CLI for the Clinker ETL engine"
 clinker-core = { workspace = true }
 clinker-channel = { workspace = true }
 clinker-format = { workspace = true }
+clinker-record = { workspace = true }
 clap = { workspace = true }
+indexmap = { workspace = true }
 serde_json = { workspace = true }
 serde-saphyr = { workspace = true }
 chrono = { workspace = true }

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -195,6 +195,13 @@ pub struct RunArgs {
     /// Overrides CLINKER_METRICS_SPOOL_DIR env var and pipeline.metrics.spool_dir in YAML.
     #[arg(long, help_heading = "Metrics")]
     pub metrics_spool_dir: Option<PathBuf>,
+
+    /// Channel YAML file to overlay before execution.
+    /// The channel can override or add `$vars.*` / `$pipeline.*` /
+    /// `$source.*` / `$record.*` defaults. Reserved system field names
+    /// are rejected.
+    #[arg(long, help_heading = "Configuration")]
+    pub channel: Option<PathBuf>,
 }
 
 impl RunArgs {
@@ -411,6 +418,36 @@ fn render_pipeline_error(err: &PipelineError, config_path: &std::path::Path) {
     eprintln!("{report:?}");
 }
 
+/// Print every diagnostic from a channel-overlay result and convert
+/// any error-severity entry into a `PipelineError::Compilation` so
+/// the run aborts before executor init.
+fn abort_on_overlay_errors(
+    overlay: &clinker_channel::ChannelOverlayResult,
+) -> Result<(), PipelineError> {
+    use clinker_core::error::Severity;
+    let mut had_error = false;
+    let mut messages: Vec<String> = Vec::new();
+    for d in &overlay.diagnostics {
+        let severity_label = match d.severity {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Note => "note",
+        };
+        eprintln!("{}: [{}] {}", severity_label, d.code, d.message);
+        if matches!(d.severity, Severity::Error) {
+            had_error = true;
+            messages.push(format!("[{}] {}", d.code, d.message));
+        }
+    }
+    if had_error {
+        return Err(PipelineError::Compilation {
+            transform_name: String::from("<channel overlay>"),
+            messages,
+        });
+    }
+    Ok(())
+}
+
 fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // Resolve CLINKER_ENV
     if let Some(env_name) = args
@@ -421,10 +458,39 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         unsafe { std::env::set_var("CLINKER_ENV", env_name) };
     }
 
-    // Load pipeline YAML directly — single-model scan, no composition or
-    // channel overlay at this entry point.
     let mut pipeline_config = clinker_core::config::load_config_with_vars(&args.config, &[])
         .map_err(PipelineError::Config)?;
+
+    // Load the channel binding once if `--channel` was supplied. The
+    // overlay itself runs against each `compile()` result below; the
+    // binding is borrowed by the `--explain` arm and the main run.
+    let channel_binding = match args.channel.as_deref() {
+        Some(path) => Some(clinker_channel::ChannelBinding::load(path).map_err(|e| {
+            PipelineError::Config(clinker_core::config::ConfigError::Validation(format!(
+                "channel '{}': {e}",
+                path.display(),
+            )))
+        })?),
+        None => None,
+    };
+    if let Some(b) = &channel_binding {
+        let target = match &b.target {
+            clinker_channel::ChannelTarget::Pipeline(p) => p,
+            clinker_channel::ChannelTarget::Composition(p) => p,
+        };
+        let canon_target = std::fs::canonicalize(target).ok();
+        let canon_config = std::fs::canonicalize(&args.config).ok();
+        if let (Some(t), Some(c)) = (canon_target.as_ref(), canon_config.as_ref())
+            && t != c
+        {
+            eprintln!(
+                "W104: channel {:?} targets {:?} but run loaded {:?}; proceeding",
+                b.name,
+                target.display(),
+                args.config.display(),
+            );
+        }
+    }
 
     // Resolve workspace_root ONCE at the entry point.
     // Production CLI path — never call env::current_dir() inside compile().
@@ -464,7 +530,7 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     let template_ctx = clinker_core::output::path_template::TemplateContext {
         source_name_default: source_name_default.as_deref(),
         source_name_by_node: source_name_by_node.clone(),
-        channel: None,
+        channel: channel_binding.as_ref().map(|b| b.name.as_str()),
         pipeline_hash,
         timestamp: Some(&timestamp_str),
         execution_id: Some(&execution_id),
@@ -483,13 +549,21 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     }
 
     if let Some(format) = args.explain {
-        let compiled_plan =
+        let mut compiled_plan =
             pipeline_config
                 .compile(&compile_ctx)
                 .map_err(|diags| PipelineError::Compilation {
                     transform_name: String::new(),
                     messages: diags.iter().map(|d| d.message.clone()).collect(),
                 })?;
+        if let Some(binding) = &channel_binding {
+            let overlay = clinker_channel::apply_channel_overlay(
+                &mut compiled_plan,
+                binding,
+                &pipeline_config,
+            );
+            abort_on_overlay_errors(&overlay)?;
+        }
         let dag = compiled_plan.dag();
         let artifacts = compiled_plan.artifacts();
         match format {
@@ -543,17 +617,19 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         .and_then(|m| m.spool_dir.as_deref());
     let spool_dir = metrics::resolve_spool_dir(args.metrics_spool_dir.as_deref(), yaml_spool);
 
-    // Build runtime parameters. execution_id/batch_id were generated
-    // earlier so the path-template context could embed them. Channel
-    // overlay (Stage 7) will eventually populate `pipeline_vars` from
-    // the active channel's overrides; for now it stays empty and the
-    // executor seeds defaults from each Transform's `declares:` block.
-    let run_params = clinker_core::executor::PipelineRunParams {
-        execution_id: execution_id.clone(),
-        batch_id: batch_id.clone(),
-        pipeline_vars: Default::default(),
-        shutdown_token: None,
-    };
+    // Channel-resolved var overrides land here when --channel is set.
+    // Populated below from `apply_channel_overlay` after compile; the
+    // executor layers them atop Transform-declared defaults at init.
+    let mut channel_static_vars: indexmap::IndexMap<String, clinker_record::Value> =
+        Default::default();
+    let mut channel_pipeline_vars: indexmap::IndexMap<String, clinker_record::Value> =
+        Default::default();
+    let mut channel_source_vars: indexmap::IndexMap<
+        String,
+        indexmap::IndexMap<String, clinker_record::Value>,
+    > = Default::default();
+    let mut channel_record_vars: indexmap::IndexMap<String, clinker_record::Value> =
+        Default::default();
 
     // Run the pipeline using file-based I/O — open readers for ALL sources
     // (primary + lookup references) and writers for ALL outputs.
@@ -651,7 +727,16 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // Compile the plan up front so output-side fan-out detection
     // (§5) can read `fan_out_per_source_file` flags before the writer
     // setup decides whether to open one writer or N.
-    let compiled_plan = pipeline_config.compile(&compile_ctx).expect("compile");
+    let mut compiled_plan = pipeline_config.compile(&compile_ctx).expect("compile");
+    if let Some(binding) = &channel_binding {
+        let overlay =
+            clinker_channel::apply_channel_overlay(&mut compiled_plan, binding, &pipeline_config);
+        abort_on_overlay_errors(&overlay)?;
+        channel_static_vars = overlay.static_vars;
+        channel_pipeline_vars = overlay.pipeline_vars;
+        channel_source_vars = overlay.source_vars;
+        channel_record_vars = overlay.record_vars;
+    }
     let mut fan_out_writers: std::collections::HashMap<
         String,
         std::collections::HashMap<std::sync::Arc<str>, Box<dyn std::io::Write + Send>>,
@@ -754,6 +839,15 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     let registry = clinker_core::executor::WriterRegistry {
         single: writers,
         fan_out: fan_out_writers,
+    };
+    let run_params = clinker_core::executor::PipelineRunParams {
+        execution_id: execution_id.clone(),
+        batch_id: batch_id.clone(),
+        pipeline_vars: channel_pipeline_vars,
+        static_vars: channel_static_vars,
+        source_vars: channel_source_vars,
+        record_vars: channel_record_vars,
+        shutdown_token: None,
     };
     let report = match PipelineExecutor::run_plan_with_readers_writers(
         &compiled_plan,

--- a/docs/src/pipeline/channels.md
+++ b/docs/src/pipeline/channels.md
@@ -2,106 +2,104 @@
 
 Channels enable multi-tenant pipeline customization. A single pipeline definition can be run with different configurations per client, environment, or business unit -- without duplicating or modifying the base YAML.
 
-## Channel structure
-
-Each channel lives in its own directory under a `channels/` folder, with a `channel.yaml` manifest:
-
-```
-project/
-  pipeline.yaml
-  channels/
-    acme-corp/
-      channel.yaml
-    globex/
-      channel.yaml
-```
+A `.channel.yaml` file declares a target pipeline (or composition), composition-level config knobs, and overrides/adds for the four scoped-variable registries the pipeline reads.
 
 ## Channel manifest
 
 ```yaml
-# channels/acme-corp/channel.yaml
-_channel:
-  id: acme-corp
-  name: "Acme Corporation"
-  description: "Custom config for Acme Corp"
-  contact: "ops@acme.example.com"
-  active: true
-  tags: [enterprise, priority]
-  tier: gold
+# channels/staging.channel.yaml
+channel:
+  name: staging
+  target: ./pipelines/my_pipeline.yaml
 
-variables:
-  EXPRESS_SURCHARGE: "8.99"
-  TAX_RATE: "0.095"
-  OUTPUT_DIR: "/data/acme/output"
+# Composition-level config knobs (DottedPath keys: alias.param)
+config:
+  default:
+    enrich1.fuzzy_threshold: 0.85
+  fixed:
+    enrich1.lookup_table: "s3://acme/lookups/staging.csv"
+
+# Variable overrides / adds (issue #45)
+vars:
+  static:                          # overrides + adds for $vars.*
+    fuzzy_threshold:
+      type: float
+      default: 0.92
+  pipeline:                        # overrides + adds for $pipeline.*
+    cutoff_date:
+      type: date
+      default: "2026-01-01"
+  source:                          # per-source-name overrides + adds for $source.*
+    orders:
+      ingest_label:
+        type: string
+        default: "staging"
+  record:                          # overrides + adds for $record.*
+    tier:
+      type: string
+      default: "bronze"
 ```
 
-### Channel metadata fields
+### Top-level fields
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `id` | Yes | Unique channel identifier (used in CLI and logs) |
-| `name` | Yes | Human-readable display name |
-| `description` | No | Channel purpose and notes |
-| `contact` | No | Responsible team or person |
-| `active` | No | Whether the channel is enabled (default: `true`) |
-| `tags` | No | Arbitrary tags for filtering and grouping |
-| `tier` | No | Service tier classification |
+| `channel.name` | Yes | Channel identifier; used in `--channel`, path templates, and the channel-identity stamp on the compiled plan. |
+| `channel.target` | Yes | Path to the target pipeline (`*.yaml`) or composition (`*.comp.yaml`). |
+| `config.default` / `config.fixed` | No | Composition-config overlays. `default` can be overridden by a higher layer; `fixed` cannot. |
+| `vars.*` | No | See **Variable overrides** below. |
 
 ## Running with a channel
 
-Use the `--channel` flag to run a pipeline with a specific channel's configuration:
-
 ```
-clinker run pipeline.yaml --channel acme-corp
+clinker run pipeline.yaml --channel ./channels/staging.channel.yaml
 ```
 
-Clinker looks for the channel manifest in the workspace's `channels/` directory, loads the variable overrides, and applies them before pipeline execution begins.
+`--channel` loads the binding once, validates it against the compiled plan, applies the overlay, and seeds the executor's eval context before any record-stream-phase node runs. The channel name is also available as the `{channel}` token in output path templates.
+
+If `channel.target` does not match the loaded `<config>` path, clinker emits **W104** and proceeds — the operator may have a legitimate reason to run a sibling pipeline against the same channel.
 
 ## Variable overrides
 
-The `variables:` section in a channel manifest provides values that override pipeline-level `vars:` defaults. This lets each tenant customize thresholds, paths, labels, and other parameters:
+A pipeline exposes four scoped-variable registries:
 
-```yaml
-# Pipeline defaults
-pipeline:
-  name: invoice_processing
-  vars:
-    late_fee: 25.00
-    output_path: "./output/"
+| Read syntax | Lifetime | Pipeline declaration site |
+|---|---|---|
+| `$vars.<key>` | Frozen at pipeline start | Top-level `vars: { key: { type, default } }` |
+| `$pipeline.<key>` | Pipeline-wide, mutable | Transform `declares: [{ name, scope: pipeline, type, default? }]` |
+| `$source.<key>` | Per-source-file, mutable | Transform `declares: [{ name, scope: source, type, default? }]` |
+| `$record.<key>` | Per-record, mutable | Transform `declares: [{ name, scope: record, type, default? }]` |
 
-# Channel override
-variables:
-  LATE_FEE: "50.00"
-  OUTPUT_PATH: "/data/acme/invoices/"
-```
+Each registry has a corresponding sub-block under `vars:` on a channel YAML. Every entry uses the same `{ type, default }` shape the pipeline declarations use:
 
-Channel variables support `${ENV_VAR}` syntax for referencing system environment variables -- these are resolved at channel load time.
+- **Override** — entry name already exists in the registry. The channel-supplied `type` MUST equal the declared type (mismatch → **E107**). The channel `default` replaces the declared default after passing the same typecheck pipeline declarations use.
+- **Add** — entry name not yet declared. The full `{ type, default }` becomes the new declaration in that registry.
+
+Source overrides are keyed by source-node name (`vars.source.<src>.<var>`). Adds and overrides on `$source` apply to every file the named source ingests; an unknown source name produces **E111**.
+
+### Reserved-system fields
+
+Each scope has a small set of reserved field names that the engine populates (e.g. `$pipeline.execution_id`, `$source.path`, `$source.row`, `$pipeline.start_time`). Channels cannot shadow these — attempting it produces **E110**, naming the offending scope and field. The full lists live in `crates/clinker-core/src/config/mod.rs` (`RESERVED_PIPELINE_NAMES`, `RESERVED_SOURCE_NAMES`, `RESERVED_RECORD_NAMES`); `$vars.*` has no reserved subset.
+
+### Composition-target channels
+
+Channels that target a `.comp.yaml` may not carry a `vars:` block (composition var overlay is out of scope today) — the binding emits **E109** if `vars:` is non-empty. Channel-config knobs (`config:` block) on composition targets continue to work as before.
+
+### Diagnostic codes
+
+| Code | Meaning |
+|------|---------|
+| **E107** | Var override type mismatch (declared `T`, override declared `U`). |
+| **E109** | Var overrides not supported on composition channels. |
+| **E110** | Channel var shadows reserved system field for that scope. |
+| **E111** | `vars.source.<src>` references a source-node name not declared in the pipeline. |
+| **W103** | Channel `config.*` key did not match any composition parameter in the compiled plan. |
+| **W104** | `channel.target` does not match the `<config>` argument passed to `clinker run`. |
+
+### Cross-Transform declaration uniqueness
+
+`$pipeline`, `$source`, and `$record` are flat shared namespaces. The same name declared on more than one Transform's `declares:` is a config-validation error — clinker mirrors the fail-fast posture of Beam, Flink, Kafka Streams, Dagster, and post-fix dbt for shared-namespace key collisions. Authors who want shared state declare it once and reference everywhere.
 
 ## Workspace discovery
 
 Channels are part of the broader workspace system. Clinker discovers workspaces via `clinker.toml` files, which can define the channel directory layout and other workspace-level settings.
-
-## Current status
-
-> **Note:** The channel system is being rebuilt in Phase 16c. The current implementation supports variable overrides. Full channel documentation -- including path overrides, schema overrides, and channel inheritance -- will be expanded when the rebuild is complete.
-
-## Complete example
-
-```yaml
-# channels/globex/channel.yaml
-_channel:
-  id: globex
-  name: "Globex Industries"
-  active: true
-  tier: standard
-
-variables:
-  COMMISSION_RATE: "0.15"
-  MIN_ORDER: "250"
-  REPORT_LABEL: "Globex Monthly"
-```
-
-```
-# Run the pipeline with Globex's configuration
-clinker run sales_pipeline.yaml --channel globex
-```

--- a/docs/src/pipeline/variables.md
+++ b/docs/src/pipeline/variables.md
@@ -161,14 +161,22 @@ registry, and every cross-DAG flow is verified against the topology.
 
 | Code | What it catches                                                        |
 | ---- | ---------------------------------------------------------------------- |
+| E107 | Channel var override declares a different type than the pipeline.      |
+| E109 | Channel targets a composition but carries `vars:` overrides.           |
+| E110 | Channel var name shadows a reserved system field for that scope.       |
+| E111 | Channel `vars.source.<src>` references an unknown source-node name.    |
 | E164 | An init-phase state node has a runtime descendant.                     |
-| E170 | Two state nodes write the same `(scope, var)` in runtime phase.        |
 | E171 | A reader is not a transitive DAG descendant of its writer.             |
 | E172 | Bare `$source.<custom>` read downstream of a Merge or Combine.         |
 | E173 | Composition body reads a parent scoped var without opting in.          |
 | E174 | Composition `_compose.scoped_vars` declares a different type than the parent. |
 | E175 | An init-phase node reads a runtime-only writer's variable.             |
 | E200 | A reference to an undeclared scoped variable (resolver-level failure). |
+
+Cross-Transform duplicate `declares:` (the same `(scope, name)` declared
+on two Transforms) is rejected at config-validation time, ahead of
+compilation. `$pipeline`, `$source`, and `$record` are flat shared
+namespaces; declare each name once and reference it from every consumer.
 
 Each diagnostic carries the offending span plus secondary spans
 pointing at the conflicting writer or the parent declaration, so
@@ -248,24 +256,58 @@ These are intentional non-features:
 
 ## Channel overrides
 
-Channels still override declaration defaults for `pipeline`-scope
-variables (the original use case):
+A channel can both override a pipeline's declaration defaults and add
+new entries across all four registries (`$vars.*`, `$pipeline.*`,
+`$source.*`, `$record.*`). Each registry has its own sub-block under
+`vars:` on a `.channel.yaml`, and each entry uses the same
+`{ type, default }` shape that pipeline-side declarations use:
 
 ```yaml
-# Pipeline
+# Pipeline declarations
 pipeline:
+  name: orders
   vars:
-    pipeline:
-      express_surcharge:
-        type: float
-        default: 5.99
+    fuzzy_threshold: { type: float, default: 0.85 }   # $vars.*
+nodes:
+  - type: source
+    name: orders_src
+    config: { name: orders_src, type: csv, path: in.csv,
+              schema: [{ name: id, type: int }] }
+  - type: transform
+    name: enrich
+    input: orders_src
+    config:
+      declares:
+        - { name: cutoff_date,  scope: pipeline, type: date,   default: "2024-01-01" }
+        - { name: ingest_label, scope: source,   type: string, default: "prod" }
+        - { name: tier,         scope: record,   type: string, default: "bronze" }
+      cxl: |
+        emit id = id
 
-# channels/acme-corp/channel.yaml
-_channel:
-  id: acme-corp
-variables:
-  express_surcharge: 8.99
+# channels/acme-prod.channel.yaml
+channel:
+  name: acme-prod
+  target: ./pipelines/orders.yaml
+vars:
+  static:
+    fuzzy_threshold: { type: float, default: 0.95 }
+  pipeline:
+    cutoff_date: { type: date, default: "2026-01-01" }
+  source:
+    orders_src:
+      ingest_label: { type: string, default: "acme-prod" }
+  record:
+    tier: { type: string, default: "platinum" }
 ```
 
-Channel overrides currently apply only to the `pipeline` scope.
-Override surface for `source` and `record` scopes is a follow-up.
+Override semantics (entry name already declared) require the channel's
+`type` to match the declared type — mismatches produce **E107**. Add
+semantics (entry name not yet declared) extend the registry with a new
+declaration. `$source` overrides are keyed by source-node name; an
+unknown source name produces **E111**. The reserved-name guard
+(**E110**) blocks channels from shadowing system fields like
+`$pipeline.execution_id` or `$source.path`. Channels that target a
+`.comp.yaml` may not carry `vars:` (**E109** if they do).
+
+See [Channels](channels.md) for the full overlay rules and the channel
+manifest reference.


### PR DESCRIPTION
Channels gain a top-level `vars:` block with `static`/`pipeline`/`source`
/`record` sub-blocks; each entry mirrors the pipeline's declaration shape
`{ type, default }` and either overrides an existing declared default or
adds a new one. Validation typechecks against the pipeline's declared
registry, rejects reserved system field names, refuses unknown
source-node names, and refuses var overrides on composition-target
channels. The CLI's `clinker run --channel <path>` loads the binding,
applies the overlay, and seeds the executor's `$vars.*` map plus the
per-source-file `$source.*` and per-record `$record.*` registries before
any record-stream-phase node runs.

Same-name `declares:` collisions across Transforms now error at
config-parse time (the flat-shared-namespace cluster — Beam, Flink,
Kafka Streams, Dagster, Cargo, Rust statics, post-fix dbt — fail-fast
on these). The earlier compile-time E170 multi-writer rule is dead
because both writers must declare to write; deleted along with the now-
unreachable validate_producer_writers helper.