### PR TITLE
executor: route non-primary Sources through SourceStream (closes #47)

### DIFF
--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -226,6 +226,14 @@ pub(crate) struct ExecutorContext<'a> {
     /// time when ingestion of this source began.
     pub(crate) source_ingestion_timestamp: chrono::NaiveDateTime,
     pub(crate) strategy: ErrorStrategy,
+    /// Name of the primary Source (first declared in `source_configs`).
+    /// Records for this Source live in `all_records`; every other Source
+    /// has its records in `preloaded_source_records`. The Source dispatch
+    /// arm uses this to distinguish "fallthrough is correct because this
+    /// IS the primary" from "fallthrough is a defense-in-depth bug
+    /// signal because a non-primary Source somehow wasn't preloaded" —
+    /// the silent-corruption surface at the root of #47.
+    pub(crate) primary_input_name: &'a str,
 
     // Owned mutable per-walk state.
     pub(crate) node_buffers: HashMap<NodeIndex, Vec<(Record, u64)>>,
@@ -964,11 +972,33 @@ pub(crate) fn dispatch_plan_node(
                     .iter()
                     .map(|(r, rn)| (canonicalize(r), *rn))
                     .collect()
-            } else {
+            } else if name.as_str() == ctx.primary_input_name {
                 ctx.all_records
                     .iter()
                     .map(|(r, rn)| (canonicalize(r), *rn))
                     .collect()
+            } else {
+                // Defense-in-depth: a non-primary Source reaching this
+                // arm means its records were never ingested into
+                // `preloaded_source_records` by the executor's preload
+                // pass. Before sprint 1 (umbrella #50) this branch
+                // silently emitted the primary's records — see #47.
+                // The third preload loop in
+                // `run_with_readers_writers` now covers every
+                // non-primary top-level Source, so any future
+                // regression that bypasses it surfaces here as a loud
+                // internal error rather than corrupted output.
+                return Err(PipelineError::Internal {
+                    op: "executor",
+                    node: name.clone(),
+                    detail: format!(
+                        "non-primary Source '{name}' has no preloaded records; \
+                         primary is '{primary}'. Preload pass missed this Source — \
+                         likely a planner regression introducing a Source topology \
+                         the preload doesn't enumerate.",
+                        primary = ctx.primary_input_name,
+                    ),
+                });
             };
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &records)?;
             ctx.node_buffers.insert(node_idx, records);

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -4,6 +4,7 @@ pub mod combine;
 pub(crate) mod commit;
 pub(crate) mod dispatch;
 mod schema_check;
+pub(crate) mod source_stream;
 pub(crate) mod window_runtime;
 
 use std::collections::{HashMap, HashSet};
@@ -1220,7 +1221,17 @@ impl PipelineExecutor {
             }
         };
 
-        let mut preloaded_source_records: HashMap<String, Vec<(Record, u64)>> = HashMap::new();
+        // Per-non-primary-source ingest buffers, populated by three
+        // preload passes below. Each pass ingests its scope of
+        // non-primary Sources through `preload_source_into_stream`,
+        // which writes to a bounded-capacity in-memory buffer with
+        // disk-spill overflow. `execute_dag_branching` drains each
+        // stream into `preloaded_source_records` (the in-memory Vec
+        // map the dispatcher still consumes) before walking the DAG.
+        // Sprint-1 scope per umbrella #50; sub-issue #51 will collapse
+        // the primary onto `SourceStream` too.
+        let mut source_streams: HashMap<String, source_stream::DrainedSourceStream> =
+            HashMap::new();
         for (combine_name, combine_inputs) in &artifacts.combine_inputs {
             let owning_body_id = combine_owning_body.get(combine_name.as_str()).copied();
             for combine_input in combine_inputs.values() {
@@ -1235,40 +1246,14 @@ impl PipelineExecutor {
                     // `all_records`.
                     continue;
                 }
-                if preloaded_source_records.contains_key(upstream) {
+                if source_streams.contains_key(upstream) {
                     continue;
                 }
-                let Some(files) = readers.remove(upstream) else {
-                    // Another combine already drained the reader (safe —
-                    // the map is shared across all combine inputs).
-                    continue;
-                };
-                if files.is_empty() {
-                    continue;
+                if let Some(drained) =
+                    preload_source_into_stream(upstream, readers, source_configs, config)?
+                {
+                    source_streams.insert(upstream.to_string(), drained);
                 }
-                let src_cfg = source_configs
-                    .iter()
-                    .find(|s| s.name == upstream)
-                    .ok_or_else(|| {
-                        PipelineError::Config(crate::config::ConfigError::Validation(format!(
-                            "combine build-side source '{upstream}' not declared in the pipeline",
-                        )))
-                    })?;
-                let raw_reader = build_multi_file_reader(src_cfg, files)?;
-                let mut src_reader = wrap_with_schema_coercion(raw_reader, config, upstream)?;
-                let mut recs: Vec<(Record, u64)> = Vec::new();
-                let mut rn: u64 = 0;
-                loop {
-                    match src_reader.next_record() {
-                        Ok(Some(record)) => {
-                            rn += 1;
-                            recs.push((record, rn));
-                        }
-                        Ok(None) => break,
-                        Err(other) => return Err(other.into()),
-                    }
-                }
-                preloaded_source_records.insert(upstream.to_string(), recs);
             }
         }
 
@@ -1296,38 +1281,44 @@ impl PipelineExecutor {
                 // Records already in `all_records`.
                 continue;
             }
-            if preloaded_source_records.contains_key(upstream) {
+            if source_streams.contains_key(upstream) {
                 continue;
             }
-            let Some(files) = readers.remove(upstream.as_str()) else {
-                continue;
-            };
-            if files.is_empty() {
+            if let Some(drained) =
+                preload_source_into_stream(upstream, readers, source_configs, config)?
+            {
+                source_streams.insert(upstream.clone(), drained);
+            }
+        }
+
+        // ── Pre-load every remaining non-primary top-level Source ─────
+        // Catch-all for Source nodes the combine-input and init-phase
+        // passes above don't cover — concretely: Merge inputs,
+        // disjoint parallel chains (`src_b → tfm → out_b` alongside a
+        // primary `src_a` chain), and any non-primary chain whose
+        // downstream operators are neither Combine build-side inputs
+        // nor init-phase ancestors. Without this pass those Sources
+        // would silently fall through the dispatch arm's
+        // `else { ctx.all_records.iter() ... }` branch and emit the
+        // primary's records — the silent data-corruption surface at
+        // the root of #47 and umbrella #50. The new branch in
+        // `dispatch::PlanNode::Source` (added in this sprint) treats
+        // a missing-stream non-primary as `PipelineError::Internal`
+        // so any future regression is loud, not silent.
+        let non_primary_top_level_sources: Vec<String> = source_configs
+            .iter()
+            .map(|s| s.name.clone())
+            .filter(|name| name.as_str() != input.name)
+            .collect();
+        for upstream in &non_primary_top_level_sources {
+            if source_streams.contains_key(upstream) {
                 continue;
             }
-            let src_cfg = source_configs
-                .iter()
-                .find(|s| s.name == *upstream)
-                .ok_or_else(|| {
-                    PipelineError::Config(crate::config::ConfigError::Validation(format!(
-                        "init-phase source '{upstream}' not declared in the pipeline",
-                    )))
-                })?;
-            let raw_reader = build_multi_file_reader(src_cfg, files)?;
-            let mut src_reader = wrap_with_schema_coercion(raw_reader, config, upstream)?;
-            let mut recs: Vec<(Record, u64)> = Vec::new();
-            let mut rn: u64 = 0;
-            loop {
-                match src_reader.next_record() {
-                    Ok(Some(record)) => {
-                        rn += 1;
-                        recs.push((record, rn));
-                    }
-                    Ok(None) => break,
-                    Err(other) => return Err(other.into()),
-                }
+            if let Some(drained) =
+                preload_source_into_stream(upstream, readers, source_configs, config)?
+            {
+                source_streams.insert(upstream.clone(), drained);
             }
-            preloaded_source_records.insert(upstream.clone(), recs);
         }
 
         Self::execute_dag_branching(
@@ -1335,7 +1326,7 @@ impl PipelineExecutor {
             input,
             all_records,
             per_record_source_files,
-            preloaded_source_records,
+            source_streams,
             writers,
             transforms,
             compiled_route,
@@ -1369,7 +1360,7 @@ impl PipelineExecutor {
         input: &crate::config::SourceConfig,
         mut all_records: Vec<(Record, u64)>,
         per_record_source_files: Vec<Arc<str>>,
-        mut preloaded_source_records: HashMap<String, Vec<(Record, u64)>>,
+        source_streams: HashMap<String, source_stream::DrainedSourceStream>,
         writers: WriterRegistry,
         transforms: &[CompiledTransform],
         compiled_route: Option<CompiledRoute>,
@@ -1383,6 +1374,23 @@ impl PipelineExecutor {
         window_runtime: crate::executor::window_runtime::WindowRuntimeRegistry,
         memory_budget: crate::pipeline::memory::MemoryBudget,
     ) -> Result<(PipelineCounters, Vec<DlqEntry>, Option<u64>), PipelineError> {
+        // Drain each non-primary Source's bounded ingest stream into
+        // the in-memory `preloaded_source_records` map the dispatcher
+        // consumes. Spill files (if any) read sequentially here and
+        // delete themselves via `tempfile::TempPath` Drop after the
+        // reader iterator exhausts. Sprint-2 work (sub-issue #51)
+        // pushes this drain down into per-Source dispatch so we don't
+        // re-materialize spilled records into RAM at all.
+        let mut preloaded_source_records: HashMap<String, Vec<(Record, u64)>> =
+            HashMap::with_capacity(source_streams.len());
+        for (name, stream) in source_streams {
+            let records = stream.into_records().map_err(|e| PipelineError::Internal {
+                op: "source-stream-drain",
+                node: name.clone(),
+                detail: e.to_string(),
+            })?;
+            preloaded_source_records.insert(name, records);
+        }
         let output_configs: Vec<_> = config.output_configs().cloned().collect();
         let pipeline_start_time = chrono::Local::now().naive_local();
 
@@ -1541,6 +1549,7 @@ impl PipelineExecutor {
             source_count,
             source_ingestion_timestamp,
             strategy,
+            primary_input_name: input.name.as_str(),
 
             node_buffers: HashMap::new(),
             preloaded_source_records,
@@ -1917,6 +1926,78 @@ fn wrap_with_schema_coercion(
         }
         _ => Ok(reader),
     }
+}
+
+/// Ingest one non-primary Source's records into a [`SourceStream`].
+///
+/// Returns `Ok(None)` when `upstream`'s files are missing from `readers`
+/// (already drained by an earlier preload step) or empty. Returns
+/// `Ok(Some(stream))` otherwise. The caller inserts the drained stream
+/// into the per-source map; reusing this helper across the
+/// combine-input, init-phase, and merge/disjoint preload passes keeps
+/// the ingest logic single-sourced.
+///
+/// Errors map `SpillError` to `PipelineError::Internal` because the
+/// preload pass has no recoverable strategy for a corrupted spill
+/// temp file or out-of-disk condition — the pipeline cannot make
+/// progress without the source's records.
+fn preload_source_into_stream(
+    upstream: &str,
+    readers: &mut SourceReaders,
+    source_configs: &[crate::config::SourceConfig],
+    config: &PipelineConfig,
+) -> Result<Option<source_stream::DrainedSourceStream>, PipelineError> {
+    let Some(files) = readers.remove(upstream) else {
+        return Ok(None);
+    };
+    if files.is_empty() {
+        return Ok(None);
+    }
+    let src_cfg = source_configs
+        .iter()
+        .find(|s| s.name == upstream)
+        .ok_or_else(|| {
+            PipelineError::Config(crate::config::ConfigError::Validation(format!(
+                "source '{upstream}' not declared in the pipeline",
+            )))
+        })?;
+    let raw_reader = build_multi_file_reader(src_cfg, files)?;
+    let mut src_reader = wrap_with_schema_coercion(raw_reader, config, upstream)?;
+    let schema = src_reader.schema()?;
+    // `spill_dir = None` lets `SpillWriter` fall back to the system
+    // tempdir; per-file cleanup is handled by `tempfile::TempPath` Drop
+    // on `SpillFile<u64>`. Hoisting the pipeline-scoped TempDir up
+    // from `execute_dag_branching` so preload spill files share the
+    // secondary panic-recovery sweep is a sprint-2 follow-up tracked
+    // under umbrella #50.
+    let mut stream = source_stream::SourceStream::new(
+        schema,
+        source_stream::DEFAULT_SOURCE_STREAM_CAPACITY,
+        None,
+    );
+    let mut rn: u64 = 0;
+    loop {
+        match src_reader.next_record() {
+            Ok(Some(record)) => {
+                rn += 1;
+                stream
+                    .push(record, rn)
+                    .map_err(|e| PipelineError::Internal {
+                        op: "source-stream-spill",
+                        node: upstream.to_string(),
+                        detail: e.to_string(),
+                    })?;
+            }
+            Ok(None) => break,
+            Err(other) => return Err(other.into()),
+        }
+    }
+    let drained = stream.finish().map_err(|e| PipelineError::Internal {
+        op: "source-stream-finish",
+        node: upstream.to_string(),
+        detail: e.to_string(),
+    })?;
+    Ok(Some(drained))
 }
 
 /// Extract `Vec<FieldDef>` from `SourceConfig.schema` for fixed-width format.

--- a/crates/clinker-core/src/executor/source_stream.rs
+++ b/crates/clinker-core/src/executor/source_stream.rs
@@ -1,0 +1,228 @@
+//! Bounded source-ingest buffer with disk-spill overflow.
+//!
+//! `SourceStream` ingests records from a non-primary Source into an
+//! in-memory buffer keyed by source row number. When the buffer exceeds
+//! `capacity`, subsequent records spill to a temp file via
+//! `pipeline::spill::SpillFile<u64>` (payload = source row number,
+//! preserving FIFO order across the in-memory / on-disk boundary).
+//!
+//! `finish()` finalizes any open spill writer and returns a
+//! `DrainedSourceStream` whose `into_records()` materializes every
+//! record back into a `Vec<(Record, u64)>` in FIFO order — in-memory
+//! portion first, then any spilled records read sequentially from disk.
+//!
+//! Sprint-1 scope: single-threaded ingest in the executor's preload
+//! pass, drained back into `ExecutorContext.preloaded_source_records`
+//! before dispatch runs. The peak-RSS win versus today's
+//! `HashMap<String, Vec<(Record, u64)>>` preload is that each
+//! non-primary Source's overflow can spill before the next source's
+//! ingest begins, so only one source's in-memory portion is resident
+//! at a time. Sub-issue #51 collapses the primary-source path onto
+//! `SourceStream` too; #57 swaps the impl for a concurrent
+//! channel-backed ingest under tokio.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema};
+
+use crate::pipeline::spill::{SpillError, SpillFile, SpillWriter};
+
+/// Default in-memory capacity threshold before overflow records spill
+/// to disk. Sized to cover most real-world non-primary feeds without
+/// spilling while still bounding peak RSS for vendor-feed-scale inputs.
+pub(crate) const DEFAULT_SOURCE_STREAM_CAPACITY: usize = 64 * 1024;
+
+/// Write-side buffer for ingesting a non-primary Source's records.
+///
+/// Records are appended via [`push`]. The first `capacity` records
+/// land in memory; the rest are streamed to a `SpillWriter<u64>`. Once
+/// every record is pushed, [`finish`] hands back a [`DrainedSourceStream`]
+/// that can be consumed exactly once.
+pub(crate) struct SourceStream {
+    schema: Arc<Schema>,
+    capacity: usize,
+    in_memory: Vec<(Record, u64)>,
+    spill_dir: Option<Arc<Path>>,
+    /// Lazy-allocated on first overflow; `None` if every record fit in
+    /// the in-memory portion.
+    spill_writer: Option<SpillWriter<u64>>,
+}
+
+impl SourceStream {
+    /// Construct a fresh stream. `spill_dir` is the temp-directory
+    /// override forwarded to `SpillWriter::new`; `None` falls back to
+    /// the system tempdir (per-file cleanup via `tempfile::TempPath`
+    /// Drop still applies).
+    pub(crate) fn new(schema: Arc<Schema>, capacity: usize, spill_dir: Option<Arc<Path>>) -> Self {
+        Self {
+            schema,
+            capacity,
+            in_memory: Vec::new(),
+            spill_dir,
+            spill_writer: None,
+        }
+    }
+
+    /// Append one record + source row number. Overflow records past
+    /// `capacity` go to disk.
+    pub(crate) fn push(&mut self, record: Record, row_num: u64) -> Result<(), SpillError> {
+        if self.in_memory.len() < self.capacity {
+            self.in_memory.push((record, row_num));
+            return Ok(());
+        }
+        let writer = match self.spill_writer.as_mut() {
+            Some(w) => w,
+            None => {
+                let w =
+                    SpillWriter::<u64>::new(Arc::clone(&self.schema), self.spill_dir.as_deref())?;
+                self.spill_writer = Some(w);
+                self.spill_writer.as_mut().expect("just inserted")
+            }
+        };
+        writer.write_pair(&record, &row_num)
+    }
+
+    /// Finalize the stream. Closes the spill writer (if any) and
+    /// returns the read-side handle.
+    pub(crate) fn finish(self) -> Result<DrainedSourceStream, SpillError> {
+        let SourceStream {
+            in_memory,
+            spill_writer,
+            ..
+        } = self;
+        let spill_file = match spill_writer {
+            Some(w) => Some(w.finish()?),
+            None => None,
+        };
+        Ok(DrainedSourceStream {
+            in_memory,
+            spill_file,
+        })
+    }
+}
+
+/// Read-side handle for a finalized [`SourceStream`]. Single-consume —
+/// `into_records` drains both the in-memory buffer and the spill file.
+pub(crate) struct DrainedSourceStream {
+    in_memory: Vec<(Record, u64)>,
+    spill_file: Option<SpillFile<u64>>,
+}
+
+impl DrainedSourceStream {
+    /// Materialize every record in FIFO order. The in-memory portion
+    /// is returned first; spilled records follow, read sequentially
+    /// from the temp file. The `SpillFile` is dropped at end of scope
+    /// so the temp file deletes itself via `TempPath` Drop.
+    pub(crate) fn into_records(self) -> Result<Vec<(Record, u64)>, SpillError> {
+        let DrainedSourceStream {
+            mut in_memory,
+            spill_file,
+        } = self;
+        if let Some(spill) = spill_file {
+            let reader = spill.reader()?;
+            for item in reader {
+                let (record, row_num) = item?;
+                in_memory.push((record, row_num));
+            }
+        }
+        Ok(in_memory)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::Value;
+
+    fn schema_id_payload() -> Arc<Schema> {
+        Arc::new(Schema::new(vec!["id".into(), "payload".into()]))
+    }
+
+    fn record(schema: &Arc<Schema>, id: i64, payload: &str) -> Record {
+        Record::new(
+            Arc::clone(schema),
+            vec![Value::Integer(id), Value::String(payload.into())],
+        )
+    }
+
+    #[test]
+    fn in_memory_only_preserves_fifo() {
+        let schema = schema_id_payload();
+        let mut stream = SourceStream::new(Arc::clone(&schema), 1024, None);
+        for i in 0..50 {
+            stream
+                .push(record(&schema, i, &format!("r{i}")), (i + 1) as u64)
+                .unwrap();
+        }
+        let drained = stream.finish().unwrap();
+        let records = drained.into_records().unwrap();
+        assert_eq!(records.len(), 50);
+        for (i, (rec, row_num)) in records.iter().enumerate() {
+            assert_eq!(*row_num, (i + 1) as u64);
+            assert_eq!(rec.get("id"), Some(&Value::Integer(i as i64)));
+            assert_eq!(
+                rec.get("payload"),
+                Some(&Value::String(format!("r{i}").into())),
+            );
+        }
+    }
+
+    #[test]
+    fn overflow_spills_and_drains_in_order() {
+        let schema = schema_id_payload();
+        // Capacity = 4 so records 5..20 spill.
+        let mut stream = SourceStream::new(Arc::clone(&schema), 4, None);
+        for i in 0..20 {
+            stream
+                .push(record(&schema, i, &format!("r{i}")), (i + 1) as u64)
+                .unwrap();
+        }
+        let drained = stream.finish().unwrap();
+        let records = drained.into_records().unwrap();
+        assert_eq!(records.len(), 20);
+        // FIFO across the in-memory / disk boundary.
+        for (i, (rec, row_num)) in records.iter().enumerate() {
+            assert_eq!(*row_num, (i + 1) as u64);
+            assert_eq!(rec.get("id"), Some(&Value::Integer(i as i64)));
+        }
+    }
+
+    #[test]
+    fn empty_stream_yields_empty_vec() {
+        let schema = schema_id_payload();
+        let stream = SourceStream::new(schema, 1024, None);
+        let records = stream.finish().unwrap().into_records().unwrap();
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn capacity_zero_spills_every_record() {
+        let schema = schema_id_payload();
+        let mut stream = SourceStream::new(Arc::clone(&schema), 0, None);
+        for i in 0..5 {
+            stream
+                .push(record(&schema, i, "x"), (i + 1) as u64)
+                .unwrap();
+        }
+        let records = stream.finish().unwrap().into_records().unwrap();
+        assert_eq!(records.len(), 5);
+        for (i, (_, rn)) in records.iter().enumerate() {
+            assert_eq!(*rn, (i + 1) as u64);
+        }
+    }
+
+    #[test]
+    fn spill_dir_override_is_honored() {
+        let custom = tempfile::tempdir().unwrap();
+        let custom_arc: Arc<Path> = Arc::from(custom.path());
+        let schema = schema_id_payload();
+        let mut stream = SourceStream::new(Arc::clone(&schema), 0, Some(Arc::clone(&custom_arc)));
+        stream.push(record(&schema, 1, "x"), 1).unwrap();
+        let drained = stream.finish().unwrap();
+        // The drain itself confirms the spill file is readable from
+        // the custom dir; assertion here exercises that path.
+        let records = drained.into_records().unwrap();
+        assert_eq!(records.len(), 1);
+    }
+}

--- a/crates/clinker-core/tests/auto_widen_integration.rs
+++ b/crates/clinker-core/tests/auto_widen_integration.rs
@@ -334,12 +334,11 @@ nodes:
 /// success case: two sources both on auto_widen (the engine-wide
 /// default) compile cleanly, and the merge's typed output Row
 /// carries the `$widened` engine-stamped sidecar column inherited
-/// from the first input. The runtime side of multi-source merge
-/// (each source's reader populating `node_buffers`) is exercised by
-/// `route → branches → merge` topologies in
-/// `executor::tests::branching` and is independent of the auto_widen
-/// sidecar machinery — the sidecar follows whatever upstream-row
-/// shape the merge inherits, by construction.
+/// from the first input. The runtime side of multi-source Merge —
+/// each Source's records actually flowing into the Merge's input
+/// buffers — is exercised end-to-end in
+/// `tests/multi_source_ingestion.rs`, which covers the
+/// silent-corruption topology matrix from #47 / umbrella #50.
 #[test]
 fn h3_merge_same_policy_auto_widen_carries_sidecar() {
     use clinker_core::plan::execution::PlanNode;

--- a/crates/clinker-core/tests/multi_source_ingestion.rs
+++ b/crates/clinker-core/tests/multi_source_ingestion.rs
@@ -1,0 +1,442 @@
+//! End-to-end coverage for the silent-corruption topologies fixed by
+//! the multi-source `SourceStream` rewiring in sprint 1 of umbrella #50
+//! (closes #47). Each topology constructs two CSV sources with
+//! non-overlapping `id` ranges so that any leak of one source's records
+//! into the other's chain is immediately visible in the output.
+//!
+//! Pre-fix surface (the bug, schema-match across sources):
+//!
+//! | Topology | Symptom |
+//! |---|---|
+//! | `[src_a, src_b] → merge → out` | `src_b` emits `src_a`'s records (#47) |
+//! | `src_a → tfm → out_a`, `src_b → tfm → out_b` | `src_b`'s chain reads `src_a`'s records |
+//! | `src_a → tfm → merge`, `src_b → tfm → merge` | same fallthrough at the Source dispatcher |
+//! | `src_a → out_a`, `src_b → tfm → out_b` | non-primary single-output chain reads primary |
+//!
+//! The fix wires every non-primary Source through `SourceStream` in the
+//! executor's preload pass, removing the silent fallthrough to
+//! `ctx.all_records`. The Source dispatcher's third arm is now a
+//! defense-in-depth `PipelineError::Internal` (loud, not silent) when
+//! a non-primary Source somehow lacks preloaded records.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, parse_config};
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::source::multi_file::FileSlot;
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn std::io::Write + Send> {
+    Box::new(buf.clone())
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// Topology 1 — `[src_a, src_b] → merge → out`. This is the canonical
+/// shape from #47. Pre-fix, the output silently contained `src_a`'s
+/// records twice; post-fix it carries the union of both sources.
+#[test]
+fn merge_direct_two_sources_yields_union() {
+    let yaml = r#"
+pipeline:
+  name: merge_direct_two_sources
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b]
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot("a", "id,tag\n1,a-one\n2,a-two\n3,a-three\n")],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot("b", "id,tag\n10,b-ten\n11,b-eleven\n12,b-twelve\n")],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("multi-source merge must execute");
+    // `report.counters.total_count` only tracks the primary stream
+    // (a sub-#51 accounting gap that closes when the primary moves
+    // onto `SourceStream` too); the output buffer is the
+    // authoritative check.
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(body.len(), 6, "expected 6 records, got:\n{output}");
+    // src_a's ids 1,2,3 each appear exactly once with their original tags.
+    for (id, tag) in [(1, "a-one"), (2, "a-two"), (3, "a-three")] {
+        let needle = format!("{id},{tag}");
+        let hits = body.iter().filter(|row| row.contains(&needle)).count();
+        assert_eq!(
+            hits, 1,
+            "row `{needle}` should appear exactly once; got: {output}"
+        );
+    }
+    // src_b's ids 10,11,12 each appear exactly once with their original tags.
+    for (id, tag) in [(10, "b-ten"), (11, "b-eleven"), (12, "b-twelve")] {
+        let needle = format!("{id},{tag}");
+        let hits = body.iter().filter(|row| row.contains(&needle)).count();
+        assert_eq!(
+            hits, 1,
+            "row `{needle}` should appear exactly once; got: {output}"
+        );
+    }
+}
+
+/// Topology 2 — `src_a → tfm_a → out_a`, `src_b → tfm_b → out_b`. The
+/// two chains are wholly disjoint at the DAG level; the bug pre-fix
+/// was that `src_b`'s dispatch silently emitted `src_a`'s records,
+/// so `out_b` carried `src_a`'s data instead of `src_b`'s.
+#[test]
+fn disjoint_parallel_chains_dont_cross_streams() {
+    let yaml = r#"
+pipeline:
+  name: disjoint_parallel
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: transform
+    name: tfm_a
+    input: src_a
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+  - type: transform
+    name: tfm_b
+    input: src_b
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+  - type: output
+    name: out_a
+    input: tfm_a
+    config:
+      name: out_a
+      type: csv
+      path: out_a.csv
+  - type: output
+    name: out_b
+    input: tfm_b
+    config:
+      name: out_b
+      type: csv
+      path: out_b.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot("a", "id,tag\n1,a-one\n2,a-two\n3,a-three\n")],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot("b", "id,tag\n10,b-ten\n11,b-eleven\n12,b-twelve\n")],
+        ),
+    ]);
+    let buf_a = SharedBuffer::new();
+    let buf_b = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        ("out_a".to_string(), writer(&buf_a)),
+        ("out_b".to_string(), writer(&buf_b)),
+    ]);
+
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+        .expect("disjoint parallel chains must execute");
+
+    let out_a = buf_a.as_string();
+    let out_b = buf_b.as_string();
+    let body_a: Vec<&str> = out_a.lines().skip(1).collect();
+    let body_b: Vec<&str> = out_b.lines().skip(1).collect();
+    assert_eq!(body_a.len(), 3, "out_a expected 3 records, got:\n{out_a}");
+    assert_eq!(body_b.len(), 3, "out_b expected 3 records, got:\n{out_b}");
+    for needle in ["a-one", "a-two", "a-three"] {
+        assert!(out_a.contains(needle), "out_a missing `{needle}`: {out_a}");
+        assert!(
+            !out_b.contains(needle),
+            "out_b leaked src_a tag `{needle}` — silent corruption!\n{out_b}"
+        );
+    }
+    for needle in ["b-ten", "b-eleven", "b-twelve"] {
+        assert!(out_b.contains(needle), "out_b missing `{needle}`: {out_b}");
+        assert!(
+            !out_a.contains(needle),
+            "out_a leaked src_b tag `{needle}` — silent corruption!\n{out_a}"
+        );
+    }
+}
+
+/// Topology 3 — `src_a → tfm_a → merge`, `src_b → tfm_b → merge`.
+/// Each source flows through its own transform before fan-in. The
+/// bug surface pre-fix was identical to topology 1: the second
+/// Source's dispatch silently emitted the primary's records, so the
+/// merge collapsed to two copies of `src_a`-derived rows. The
+/// transforms also stamp an `origin` field so a regression would be
+/// visible even if the ids overlap.
+#[test]
+fn chained_into_merge_preserves_per_source_data() {
+    let yaml = r#"
+pipeline:
+  name: chained_into_merge
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: transform
+    name: tfm_a
+    input: src_a
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+        emit origin = "A"
+  - type: transform
+    name: tfm_b
+    input: src_b
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+        emit origin = "B"
+  - type: merge
+    name: merged
+    inputs: [tfm_a, tfm_b]
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot("a", "id,tag\n1,a-one\n2,a-two\n3,a-three\n")],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot("b", "id,tag\n10,b-ten\n11,b-eleven\n12,b-twelve\n")],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("chained-into-merge must execute");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    // Output buffer is authoritative; `total_count` is primary-only
+    // (sub-#51 accounting gap).
+    assert_eq!(
+        output.lines().skip(1).count(),
+        6,
+        "expected 6 merged records, got:\n{output}"
+    );
+    // Every row stamped origin=A should carry an `a-*` tag; every B
+    // row should carry `b-*`. A silent leak would have a B-stamped
+    // row paired with an `a-*` tag (or vice versa).
+    for line in output.lines().skip(1) {
+        if line.contains(",A,") || line.ends_with(",A") {
+            assert!(
+                line.contains("a-"),
+                "origin=A row carries non-A tag — silent corruption: `{line}`\n{output}"
+            );
+        }
+        if line.contains(",B,") || line.ends_with(",B") {
+            assert!(
+                line.contains("b-"),
+                "origin=B row carries non-B tag — silent corruption: `{line}`\n{output}"
+            );
+        }
+    }
+    assert_eq!(
+        output.matches("a-").count(),
+        3,
+        "expected 3 src_a-derived rows: {output}"
+    );
+    assert_eq!(
+        output.matches("b-").count(),
+        3,
+        "expected 3 src_b-derived rows: {output}"
+    );
+}
+
+/// Topology 4 — `src_a → out_a` (primary, identity passthrough),
+/// `src_b → tfm → out_b` (non-primary single-output chain). Pre-fix,
+/// `src_b`'s chain silently read the primary's records; post-fix the
+/// preload's third pass ingests src_b and the dispatcher reads from
+/// its own stream.
+#[test]
+fn non_primary_single_output_reads_own_records() {
+    let yaml = r#"
+pipeline:
+  name: non_primary_single_output
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: transform
+    name: stamp_b
+    input: src_b
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+  - type: output
+    name: out_a
+    input: src_a
+    config:
+      name: out_a
+      type: csv
+      path: out_a.csv
+  - type: output
+    name: out_b
+    input: stamp_b
+    config:
+      name: out_b
+      type: csv
+      path: out_b.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot("a", "id,tag\n1,a-one\n2,a-two\n3,a-three\n")],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot("b", "id,tag\n10,b-ten\n11,b-eleven\n12,b-twelve\n")],
+        ),
+    ]);
+    let buf_a = SharedBuffer::new();
+    let buf_b = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        ("out_a".to_string(), writer(&buf_a)),
+        ("out_b".to_string(), writer(&buf_b)),
+    ]);
+
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+        .expect("non-primary chain must execute");
+
+    let out_a = buf_a.as_string();
+    let out_b = buf_b.as_string();
+    let body_b: Vec<&str> = out_b.lines().skip(1).collect();
+    assert_eq!(body_b.len(), 3, "out_b expected 3 records, got:\n{out_b}");
+    for needle in ["b-ten", "b-eleven", "b-twelve"] {
+        assert!(out_b.contains(needle), "out_b missing `{needle}`: {out_b}");
+    }
+    for needle in ["a-one", "a-two", "a-three"] {
+        assert!(
+            !out_b.contains(needle),
+            "out_b leaked src_a tag `{needle}` — silent corruption!\n{out_b}"
+        );
+        assert!(out_a.contains(needle), "out_a missing `{needle}`: {out_a}");
+    }
+}


### PR DESCRIPTION
Pipelines with two physical Sources feeding a Merge silently emitted the
primary's records twice instead of merging two streams. Root cause: the
Source dispatcher's third arm fell through to `ctx.all_records` (the
primary) whenever a Source wasn't preloaded — and the preload pass only
enumerated combine build-side inputs and init-phase ancestors. Every
other non-primary topology (Merge inputs, disjoint parallel chains,
non-primary single-output chains) hit the silent fallthrough and emitted
the primary's records.

Introduces `SourceStream` (in-memory buffer + `SpillFile<u64>` overflow)
in `crates/clinker-core/src/executor/source_stream.rs` and wires every
non-primary Source through it. The executor's preload pass now has three
loops — combine-input, init-phase, and a new catch-all that walks every
remaining non-primary top-level Source — each calling
`preload_source_into_stream` so the ingest logic is single-sourced. The
Source dispatcher's fallthrough is now a defense-in-depth
`PipelineError::Internal` when a non-primary Source somehow lacks
preloaded records, replacing the silent corruption with a loud signal.

Memory-budget win during ingest: each non-primary Source's records can
spill to disk before the next source's ingest begins. Sprint-1 scope
materializes everything back into `preloaded_source_records: Vec` at
the start of `execute_dag_branching` so the dispatcher and seeding loop
stay unchanged; truly streaming dispatch is a follow-up sprint.

Integration coverage in `tests/multi_source_ingestion.rs` covers the
four silent-corruption topologies from the issue's matrix:
`[src_a, src_b] → merge`; disjoint parallel `src_a → out_a, src_b →
out_b`; chained-into-merge; non-primary single-output. Each uses
non-overlapping `id` ranges so any cross-stream leak surfaces in the
output assertions. The `auto_widen_integration::h3_*` deferral comment
that pointed at `executor::tests::branching` for runtime coverage is
replaced with a pointer to the new file — runtime coverage now lives
where it can actually exercise multi-source Merge.

The primary source still uses `all_records` after this commit (a
single-feature-scope retention of the old path, not a parallel
architecture). Subsequent sprints in umbrella #50 collapse the primary
onto `SourceStream` (#51), add per-source watermarks (#52), the
`merge.mode: interleave` opt-in (#53), engine-stamped `$source.name`
(#54), DLQ source-name attribution (#55), per-source `$ck` rollback
(#56), and the async runtime migration that unblocks #11 (#57).

The existing `pipeline::spill::SpillFile<P>` primitive already had the
generic shape the umbrella's "extract a SpillBuffer primitive"
deliverable described, so no extraction was needed — `SourceStream`
consumes it directly.

Closes #47.

https://claude.ai/code/session_013yPH7Comq8W39GRB3uCVBD