### PR TITLE
executor: unify Source ingest through SourceStream; delete primary asymmetry (closes #51)

### DIFF
--- a/crates/clinker-core/benches/combine.rs
+++ b/crates/clinker-core/benches/combine.rs
@@ -132,9 +132,8 @@ nodes:
 
 /// End-to-end equi-combine bench at three sizes. Each iteration
 /// re-parses readers from cached CSV bytes, recompiles the plan, and
-/// drives `PipelineExecutor::run_plan_with_readers_writers_with_primary`
-/// with `orders` as the explicit driving source. This measures the
-/// same boundary-to-boundary path as the preserved
+/// drives `PipelineExecutor::run_plan_with_readers_writers`. This
+/// measures the same boundary-to-boundary path as the preserved
 /// `lookup_baseline/10k_x_100k/lookup-v1` saved baseline so a numeric
 /// delta against that estimates.json is meaningful.
 fn bench_combine_equi_2input(c: &mut Criterion) {
@@ -191,8 +190,8 @@ fn bench_combine_equi_2input(c: &mut Criterion) {
                     &clinker_core::config::CompileContext::default(),
                 )
                 .expect("combine equi_2input must compile");
-                let report = PipelineExecutor::run_plan_with_readers_writers_with_primary(
-                    &plan, "orders", readers, writers, &params,
+                let report = PipelineExecutor::run_plan_with_readers_writers(
+                    &plan, readers, writers, &params,
                 )
                 .expect("combine equi_2input must execute");
                 black_box(report);

--- a/crates/clinker-core/benches/combine_grace_hash.rs
+++ b/crates/clinker-core/benches/combine_grace_hash.rs
@@ -258,10 +258,8 @@ fn run_grace(
         "out".to_string(),
         Box::new(out_buf.clone()) as Box<dyn Write + Send>,
     )]);
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        plan, "probe", readers, writers, params,
-    )
-    .expect("grace hash pipeline must execute");
+    PipelineExecutor::run_plan_with_readers_writers(plan, readers, writers, params)
+        .expect("grace hash pipeline must execute");
     out_buf.0.lock().unwrap().clone()
 }
 

--- a/crates/clinker-core/benches/combine_iejoin.rs
+++ b/crates/clinker-core/benches/combine_iejoin.rs
@@ -318,14 +318,8 @@ fn run_iejoin_executor(
         "out".to_string(),
         Box::new(out_buf.clone()) as Box<dyn Write + Send>,
     )]);
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        plan,
-        "employees",
-        readers,
-        writers,
-        params,
-    )
-    .expect("iejoin pipeline must execute");
+    PipelineExecutor::run_plan_with_readers_writers(plan, readers, writers, params)
+        .expect("iejoin pipeline must execute");
     let bytes = out_buf.0.lock().unwrap().clone();
     let text = std::str::from_utf8(&bytes).expect("output is utf8");
     text.lines()

--- a/crates/clinker-core/benches/combine_nary_3input.rs
+++ b/crates/clinker-core/benches/combine_nary_3input.rs
@@ -253,10 +253,8 @@ fn run_3input(
         "out".to_string(),
         Box::new(out_buf.clone()) as Box<dyn Write + Send>,
     )]);
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        plan, "a", readers, writers, params,
-    )
-    .expect("3-input pipeline must execute");
+    PipelineExecutor::run_plan_with_readers_writers(plan, readers, writers, params)
+        .expect("3-input pipeline must execute");
     let bytes = out_buf.0.lock().unwrap().clone();
     let text = std::str::from_utf8(&bytes).expect("output is utf8");
     text.lines()
@@ -294,10 +292,8 @@ fn run_2input(
         "out".to_string(),
         Box::new(out_buf.clone()) as Box<dyn Write + Send>,
     )]);
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        plan, "a", readers, writers, params,
-    )
-    .expect("2-input baseline must execute");
+    PipelineExecutor::run_plan_with_readers_writers(plan, readers, writers, params)
+        .expect("2-input baseline must execute");
     let bytes = out_buf.0.lock().unwrap().clone();
     let text = std::str::from_utf8(&bytes).expect("output is utf8");
     text.lines()

--- a/crates/clinker-core/benches/window.rs
+++ b/crates/clinker-core/benches/window.rs
@@ -315,8 +315,8 @@ nodes:
                         "out".to_string(),
                         Box::new(buf.clone()) as Box<dyn Write + Send>,
                     )]);
-                    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-                        &plan, "src", readers, writers, &params,
+                    PipelineExecutor::run_plan_with_readers_writers(
+                        &plan, readers, writers, &params,
                     )
                     .expect("bench pipeline runs");
                     black_box(buf);
@@ -446,8 +446,8 @@ nodes:
                         "out".to_string(),
                         Box::new(buf.clone()) as Box<dyn Write + Send>,
                     )]);
-                    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-                        &plan, "orders", readers, writers, &params,
+                    PipelineExecutor::run_plan_with_readers_writers(
+                        &plan, readers, writers, &params,
                     )
                     .expect("bench pipeline runs");
                     black_box(buf);

--- a/crates/clinker-core/src/config/mod.rs
+++ b/crates/clinker-core/src/config/mod.rs
@@ -3017,6 +3017,8 @@ pub(crate) fn lower_node_to_plan_node(
                         builder.with_field_meta(col, FieldMetadata::source_correlation(field))
                     } else if col == crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN {
                         builder.with_field_meta(col, FieldMetadata::widened_sidecar())
+                    } else if col == crate::config::pipeline_node::SOURCE_FILE_COLUMN {
+                        builder.with_field_meta(col, FieldMetadata::source_file())
                     } else {
                         builder.with_field(col)
                     };

--- a/crates/clinker-core/src/config/pipeline_node.rs
+++ b/crates/clinker-core/src/config/pipeline_node.rs
@@ -789,6 +789,13 @@ impl OnUnmapped {
 /// Stable column name for the `auto_widen` sidecar absorber slot.
 pub const WIDENED_SIDECAR_COLUMN: &str = "$widened";
 
+/// Stable column name for the per-record source-file lineage stamp.
+/// Every Source's bound schema carries one such tail-appended slot;
+/// the dispatcher's Source arm stamps the originating file Arc at
+/// ingest so `$source.file` / `$source.path` resolve per-record through
+/// merges instead of via an external row-keyed array.
+pub const SOURCE_FILE_COLUMN: &str = "$source.file";
+
 /// Transform variant body. The new shape: a mandatory `cxl:` field
 /// carrying the CXL source as a `CxlSource` (so it captures its YAML
 /// span where serde-saphyr can deliver one), plus the row-level

--- a/crates/clinker-core/src/dlq.rs
+++ b/crates/clinker-core/src/dlq.rs
@@ -163,7 +163,7 @@ fn dlq_user_columns(schema: &Schema) -> impl Iterator<Item = (usize, &str)> {
         .iter()
         .enumerate()
         .filter_map(|(i, c)| match schema.field_metadata(i) {
-            Some(FieldMetadata::WidenedSidecar) => None,
+            Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) => None,
             Some(FieldMetadata::SourceCorrelation { .. })
             | Some(FieldMetadata::AggregateGroupIndex { .. })
             | None => Some((i, c.as_ref())),

--- a/crates/clinker-core/src/executor/commit/detect.rs
+++ b/crates/clinker-core/src/executor/commit/detect.rs
@@ -204,11 +204,12 @@ pub(crate) fn detect_retract_scope(
                             }
                         }
                     }
-                    Some(FieldMetadata::WidenedSidecar) => {
-                        // The `auto_widen` sidecar slot carries no
-                        // correlation lineage — it's a passthrough
-                        // map of input fields, not an engine-stamped
-                        // CK lattice column.
+                    Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) => {
+                        // The `auto_widen` sidecar and the
+                        // `$source.file` lineage stamp carry no
+                        // correlation linkage — they ride alongside
+                        // the CK lattice but the retract walk routes
+                        // through `$ck.*` columns only.
                     }
                     None => {}
                 }

--- a/crates/clinker-core/src/executor/commit/dispatch.rs
+++ b/crates/clinker-core/src/executor/commit/dispatch.rs
@@ -375,7 +375,7 @@ fn recurse_into_body(
     // collide numerically). Restore on every exit.
     let body_buffers: HashMap<NodeIndex, Vec<(Record, u64)>> = HashMap::new();
     let saved_buffers = std::mem::replace(&mut ctx.node_buffers, body_buffers);
-    let saved_combine = std::mem::take(&mut ctx.preloaded_source_records);
+    let saved_combine = std::mem::take(&mut ctx.source_records);
     let saved_body_refs = ctx
         .current_body_node_input_refs
         .replace(bound_body.node_input_refs.clone());
@@ -467,7 +467,7 @@ fn recurse_into_body(
     ctx.window_runtime.active_stack.pop();
     ctx.window_runtime.bodies.remove(&body_id);
     ctx.current_body_node_input_refs = saved_body_refs;
-    ctx.preloaded_source_records = saved_combine;
+    ctx.source_records = saved_combine;
     ctx.node_buffers = saved_buffers;
 
     let harvested = walk_and_harvest?;

--- a/crates/clinker-core/src/executor/commit/mod.rs
+++ b/crates/clinker-core/src/executor/commit/mod.rs
@@ -135,25 +135,27 @@ pub(crate) fn orchestrate(
 
     // Loop cap: each iteration must add ≥ 1 source row to the trigger
     // set (otherwise the loop exits via empty `expand_with_dlq_events`
-    // return), and source rows are bounded by `ctx.all_records.len()`.
-    // The `parent + body node_count + 1` slack accounts for the initial
-    // iteration (which retracts the initial trigger set, not new rows)
-    // plus defensive headroom against any non-source-row reason the
-    // scope could grow. Body node counts fold in because a body's
-    // continuation walk can surface fresh source-row triggers across
-    // iterations; the body sum is structural headroom, not a new
-    // termination contributor (termination is still |source_rows|-
-    // bounded). Test-only override (`TEST_LOOP_CAP_OVERRIDE`) lets the
-    // defensive panic-message contract be exercised with a synthetic
-    // small cap; production callers always see the structural value.
+    // return), and source rows are bounded by the union of every
+    // declared source's ingested record count. The `parent + body
+    // node_count + 1` slack accounts for the initial iteration (which
+    // retracts the initial trigger set, not new rows) plus defensive
+    // headroom against any non-source-row reason the scope could grow.
+    // Body node counts fold in because a body's continuation walk can
+    // surface fresh source-row triggers across iterations; the body sum
+    // is structural headroom, not a new termination contributor
+    // (termination is still |source_rows|-bounded). Test-only override
+    // (`TEST_LOOP_CAP_OVERRIDE`) lets the defensive panic-message
+    // contract be exercised with a synthetic small cap; production
+    // callers always see the structural value.
     let body_node_count: usize = ctx
         .artifacts
         .composition_bodies
         .values()
         .map(|b| b.graph.node_count())
         .sum();
+    let total_source_rows: usize = ctx.source_records.values().map(|v| v.len()).sum();
     let cap = test_cap_override()
-        .unwrap_or(current_dag.graph.node_count() + body_node_count + ctx.all_records.len() + 1);
+        .unwrap_or(current_dag.graph.node_count() + body_node_count + total_source_rows + 1);
     let mut iter = 0usize;
 
     // Cumulative error archive across iterations. Each iteration's

--- a/crates/clinker-core/src/executor/commit/recompute_agg.rs
+++ b/crates/clinker-core/src/executor/commit/recompute_agg.rs
@@ -140,9 +140,9 @@ pub(crate) fn emit_post_recompute(
     let mut new_rows: Vec<crate::aggregation::SortRow> = Vec::new();
     let finalize_ctx = EvalContext {
         stable: ctx.stable,
-        source_file: ctx.synthetic_source_file,
+        source_file: &crate::executor::dispatch::MERGED_SOURCE_FILE,
         source_row: 0,
-        source_path: ctx.synthetic_source_file,
+        source_path: &crate::executor::dispatch::MERGED_SOURCE_FILE,
         source_count: ctx.source_count,
         source_batch: ctx.source_batch_arc,
         ingestion_timestamp: ctx.source_ingestion_timestamp,

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -18,9 +18,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
-use clinker_record::{GroupByKey, PipelineCounters, Record, SchemaBuilder, Value};
+use clinker_record::{FieldMetadata, GroupByKey, PipelineCounters, Record, SchemaBuilder, Value};
 use cxl::eval::{EvalContext, EvalResult, ProgramEvaluator, SkipReason, StableEvalContext};
 use cxl::typecheck::TypedProgram;
 use indexmap::IndexMap;
@@ -29,6 +29,45 @@ use petgraph::graph::NodeIndex;
 
 use crate::config::{ErrorStrategy, OutputConfig, PipelineConfig};
 use crate::error::PipelineError;
+
+/// Stand-in `$source.file` value for dispatch sites that have no
+/// originating source record (Combine/finalize/post-aggregate emits with
+/// `source_row: 0`, body composition emits that lost lineage at fan-in).
+/// Used when [`source_file_of`] returns `None`.
+pub(crate) static MERGED_SOURCE_FILE: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from("<merged>"));
+
+/// Read the per-record source-file path from the record's
+/// [`FieldMetadata::SourceFile`] engine-stamped column. Returns `None`
+/// when the record carries no such column (typical for Combine /
+/// post-aggregate synthetic emits with `source_row: 0`) or when the
+/// column's value is non-String. Callers that need an owned `Arc<str>`
+/// for `RecordContext.source_file` use [`source_file_arc_of`].
+pub(crate) fn source_file_path_of(record: &Record) -> Option<&str> {
+    let schema = record.schema();
+    for idx in 0..schema.column_count() {
+        if matches!(schema.field_metadata(idx), Some(FieldMetadata::SourceFile))
+            && let Some(Value::String(s)) = record.values().get(idx)
+        {
+            return Some(s.as_ref());
+        }
+    }
+    None
+}
+
+/// Read the per-record source-file `Arc<str>` from the record's
+/// [`FieldMetadata::SourceFile`] engine-stamped column, materializing
+/// a fresh `Arc<str>` per call. Falls back to a clone of
+/// [`MERGED_SOURCE_FILE`] when the stamp is absent. The Arc
+/// construction is O(N) on the path length per call; per-record
+/// dispatch sites accept this as a localized cost in exchange for
+/// post-merge correctness — records flowing past a Merge still resolve
+/// to their actual origin file rather than a primary-only fallback.
+pub(crate) fn source_file_arc_of(record: &Record) -> Arc<str> {
+    match source_file_path_of(record) {
+        Some(s) => Arc::from(s),
+        None => Arc::clone(&MERGED_SOURCE_FILE),
+    }
+}
 
 fn value_to_correlation_key(v: &Value, idx: usize) -> GroupByKey {
     use clinker_record::value_to_group_key;
@@ -91,7 +130,7 @@ fn buffer_key_for_record(record: &Record, row_num: u64) -> Vec<GroupByKey> {
                 let idx = key.len();
                 key.push(value_to_correlation_key(&record.values()[i], idx));
             }
-            Some(FieldMetadata::WidenedSidecar) | None => {}
+            Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) | None => {}
         }
     }
     if key.is_empty() || key_is_null(&key) {
@@ -170,17 +209,16 @@ use crate::projection::project_output_from_record;
 /// * `transform_by_name` — name → index into `compiled_transforms`.
 /// * `compiled_transforms` — precompiled CXL programs for Transform and
 ///   Aggregation arms.
-/// * `stable` / `source_file_arc` / `strategy` — pipeline-stable scalars
+/// * `stable` / `source_batch_arc` / `strategy` — pipeline-stable scalars
 ///   reused at every per-record dispatch site.
 ///
 /// Owned (mutated across the walk):
 /// * `node_buffers` — `(Record, row_num)` queues threaded between arms.
-/// * `preloaded_source_records` — pre-loaded non-primary source streams
-///   the Source arm consults before falling back to `all_records`. Holds
-///   both combine build-side inputs and init-phase
-///   ancestor Sources. Renamed from `combine_source_records`
-///   when broadened the role.
-/// * `all_records` — primary driving stream materialized before the walk.
+/// * `source_records` — per-source ingested records keyed by Source node
+///   name. The Source dispatch arm reads its records from this map.
+///   Every declared Source is ingested through `SourceStream` in the
+///   executor's unified ingest pass; the `$source.file` per-record
+///   stamp travels on each record's engine-stamped column.
 /// * `writers` — output writer registry consumed lazily as Output arms fire.
 /// * `compiled_route` — cached evaluator for Route arms.
 /// * `counters` / `dlq_entries` — pipeline-wide accounting.
@@ -202,48 +240,34 @@ pub(crate) struct ExecutorContext<'a> {
     pub(crate) compiled_transforms: &'a [CompiledTransform],
     pub(crate) transform_by_name: HashMap<&'a str, usize>,
     pub(crate) stable: &'a StableEvalContext,
-    /// Per-record source-file `Arc<str>`s, indexed by `source_row - 1`
-    /// (since `source_row` is 1-based). For literal-`path:` sources
-    /// every entry is the same Arc; for `glob`/`regex`/`paths` sources
-    /// entries vary across the file boundaries set by
-    /// `MultiFileFormatReader::current_source_file()`. Doubles as the
-    /// `$source.path` storage today (full canonical path).
-    pub(crate) source_file_arcs: &'a [Arc<str>],
-    /// Stand-in `Arc<str>` for dispatch sites that have no live record
-    /// (combine/finalize/post-aggregate emits with `source_row: 0`).
-    /// Set to `Arc::from("<merged>")` for multi-file sources after
-    /// merge/combine consumed the partition; matches the first
-    /// per-record Arc otherwise.
-    pub(crate) synthetic_source_file: &'a Arc<str>,
-    /// Backing storage for `$source.batch` — per-source-run UUID v7,
-    /// shared across all records ingested from this source. Distinct from
-    /// `pipeline.batch_id` which is single-valued per pipeline run.
+    /// Backing storage for `$source.batch` — per-pipeline-run UUID v7
+    /// (per-source attribution is sub-issue #54). Distinct from
+    /// `pipeline.batch_id`.
     pub(crate) source_batch_arc: &'a Arc<str>,
     /// Backing storage for `$source.count` — the total record count
-    /// ingested from this source. Set after Phase-1 arena fill.
+    /// ingested across every declared Source. Set after the unified
+    /// ingest pass completes.
     pub(crate) source_count: u64,
     /// Backing storage for `$source.ingestion_timestamp` — wall-clock
-    /// time when ingestion of this source began.
+    /// time when the pipeline run began.
     pub(crate) source_ingestion_timestamp: chrono::NaiveDateTime,
     pub(crate) strategy: ErrorStrategy,
-    /// Name of the primary Source (first declared in `source_configs`).
-    /// Records for this Source live in `all_records`; every other Source
-    /// has its records in `preloaded_source_records`. The Source dispatch
-    /// arm uses this to distinguish "fallthrough is correct because this
-    /// IS the primary" from "fallthrough is a defense-in-depth bug
-    /// signal because a non-primary Source somehow wasn't preloaded" —
-    /// the silent-corruption surface at the root of #47.
-    pub(crate) primary_input_name: &'a str,
 
     // Owned mutable per-walk state.
     pub(crate) node_buffers: HashMap<NodeIndex, Vec<(Record, u64)>>,
-    pub(crate) preloaded_source_records: HashMap<String, Vec<(Record, u64)>>,
-    pub(crate) all_records: Vec<(Record, u64)>,
+    /// Per-source ingested records keyed by Source node name. Every
+    /// declared Source's records live here uniformly — there is no
+    /// "primary" asymmetry. The dispatch arm reads
+    /// `ctx.source_records[name]` for each Source node it walks; a
+    /// missing entry surfaces as a defense-in-depth Internal error
+    /// (loud, not silent).
+    pub(crate) source_records: HashMap<String, Vec<(Record, u64)>>,
     pub(crate) writers: HashMap<String, Box<dyn Write + Send>>,
     /// Per-source-file writers for outputs marked `fan_out_per_source_file`
     /// in the plan. Outer key is the output name; inner key is the
-    /// per-file `Arc<str>` (matching the Arc stored in `source_file_arcs`).
-    /// The CLI populates this for outputs whose path templates reference
+    /// per-file `Arc<str>` (matching the path returned by
+    /// [`source_file_path_of`] for records flowing through). The CLI
+    /// populates this for outputs whose path templates reference
     /// `{source_file}` / `{source_path}` AND whose input is
     /// `FilePartitioned`. Empty map means no fan-out outputs in this run.
     pub(crate) fan_out_writers: HashMap<String, HashMap<Arc<str>, Box<dyn Write + Send>>>,
@@ -470,7 +494,6 @@ fn emit_fan_out(
     cxl_emit_names_opt: Option<&[String]>,
     output_schema: &Arc<clinker_record::Schema>,
     unbuffered: &[(Record, u64)],
-    source_file_arcs: &[Arc<str>],
     per_file: HashMap<Arc<str>, Box<dyn Write + Send>>,
     output_errors: &mut Vec<PipelineError>,
     write_timer: &mut crate::executor::stage_metrics::CumulativeTimer,
@@ -495,19 +518,21 @@ fn emit_fan_out(
     collector.record(scan_timer.finish(1, 1));
 
     for (record, rn) in unbuffered {
-        let idx = (rn.saturating_sub(1)) as usize;
-        let Some(file_arc) = source_file_arcs.get(idx) else {
+        let Some(file_path) = source_file_path_of(record) else {
             output_errors.push(PipelineError::Internal {
                 op: "fan_out",
                 node: name.to_string(),
                 detail: format!(
-                    "row {rn} has no source-file Arc; source_file_arcs.len()={}",
-                    source_file_arcs.len()
+                    "row {rn} has no `$source.file` stamp; fan-out output requires per-record source-file lineage",
                 ),
             });
             continue;
         };
-        let Some(fw) = format_writers.get_mut(file_arc) else {
+        // Look up the writer by path; the registry keys by Arc<str>
+        // so we need to find by string equality. Build a probing Arc
+        // once per record (cheap relative to the write itself).
+        let file_arc: Arc<str> = Arc::from(file_path);
+        let Some(fw) = format_writers.get_mut(&file_arc) else {
             // Record's file isn't in the fan-out registry — typically
             // means the CLI's writer setup didn't pre-open one for
             // this file. Surface but keep going.
@@ -854,20 +879,22 @@ pub(crate) fn dispatch_plan_node(
     let node = current_dag.graph[node_idx].clone();
     match node {
         PlanNode::Source { ref name, .. } => {
-            // Three input paths feed a Source's buffer: (1) records
+            // Two input paths feed a Source's buffer: (1) records
             // already seeded into `ctx.node_buffers[node_idx]` by the
             // body executor at composition entry — composition input
             // ports surface as synthetic Source nodes in the body
             // graph, owning the records the parent scope harvested
-            // for that port; (2) combine build-side sources whose
-            // records were pre-loaded into `preloaded_source_records`
-            // before the DAG walk; (3) fall back to the primary
-            // driving reader's stream via `all_records`. Records are
-            // canonicalized onto the Source's plan-time `Arc<Schema>`
-            // so every downstream operator hits the `Arc::ptr_eq`
-            // fast path on the first record. Structural equality
-            // holds by construction: `CoercingReader` builds its Arc
-            // from the same declared `schema:` block that
+            // for that port; (2) the unified ingest pass's
+            // `source_records[name]` entry. A Source reaching this
+            // arm with neither path populated surfaces as a defense-
+            // in-depth `PipelineError::Internal` — silent fallthrough
+            // to a different source's records was the root cause of
+            // #47 and is no longer reachable. Records are canonicalized
+            // onto the Source's plan-time `Arc<Schema>` so every
+            // downstream operator hits the `Arc::ptr_eq` fast path on
+            // the first record. Structural equality holds by
+            // construction: the ingest helper builds its widened
+            // schema from the same declared `schema:` block that
             // `bind_schema` reads to populate
             // `PlanNode::Source.output_schema`, and synthetic port
             // sources adopt their parent source's column list at
@@ -893,8 +920,13 @@ pub(crate) fn dispatch_plan_node(
                             // ingest. The `$widened` sidecar is filled by
                             // CoercingReader from input-record keys, not
                             // by name-based mapping from the reader.
+                            // `$source.file` is stamped at ingest into the
+                            // record's value vector directly, so it flows
+                            // through canonicalize via the per-name copy
+                            // loop above rather than this engine-stamp tail.
                             Some(clinker_record::FieldMetadata::AggregateGroupIndex { .. })
                             | Some(clinker_record::FieldMetadata::WidenedSidecar)
+                            | Some(clinker_record::FieldMetadata::SourceFile)
                             | None => None,
                         })
                         .collect()
@@ -967,36 +999,28 @@ pub(crate) fn dispatch_plan_node(
                     .into_iter()
                     .map(|(r, rn)| (canonicalize(&r), rn))
                     .collect()
-            } else if let Some(src_recs) = ctx.preloaded_source_records.get(name.as_str()) {
+            } else if let Some(src_recs) = ctx.source_records.get(name.as_str()) {
                 src_recs
                     .iter()
                     .map(|(r, rn)| (canonicalize(r), *rn))
                     .collect()
-            } else if name.as_str() == ctx.primary_input_name {
-                ctx.all_records
-                    .iter()
-                    .map(|(r, rn)| (canonicalize(r), *rn))
-                    .collect()
             } else {
-                // Defense-in-depth: a non-primary Source reaching this
-                // arm means its records were never ingested into
-                // `preloaded_source_records` by the executor's preload
-                // pass. Before sprint 1 (umbrella #50) this branch
-                // silently emitted the primary's records — see #47.
-                // The third preload loop in
-                // `run_with_readers_writers` now covers every
-                // non-primary top-level Source, so any future
-                // regression that bypasses it surfaces here as a loud
-                // internal error rather than corrupted output.
+                // Defense-in-depth: a Source reaching this arm with
+                // neither a body-port seed nor an entry in
+                // `source_records` means the executor's unified
+                // ingest pass missed it. Now that every declared
+                // Source ingests through the same `source_records`
+                // map (no primary fallthrough), any miss surfaces
+                // here as a loud internal error rather than the
+                // silent-corruption surface at the root of #47.
                 return Err(PipelineError::Internal {
                     op: "executor",
                     node: name.clone(),
                     detail: format!(
-                        "non-primary Source '{name}' has no preloaded records; \
-                         primary is '{primary}'. Preload pass missed this Source — \
+                        "Source '{name}' has no ingested records; \
+                         the executor's source-ingest pass missed this Source — \
                          likely a planner regression introducing a Source topology \
-                         the preload doesn't enumerate.",
-                        primary = ctx.primary_input_name,
+                         the ingest pass doesn't enumerate.",
                     ),
                 });
             };
@@ -1094,11 +1118,12 @@ pub(crate) fn dispatch_plan_node(
                 if let Some(exp) = expected_input.as_ref() {
                     check_input_schema(exp, record.schema(), name, "transform", &upstream_name)?;
                 }
+                let source_file_arc = source_file_arc_of(&record);
                 let eval_ctx = EvalContext {
                     stable: ctx.stable,
-                    source_file: &ctx.source_file_arcs[(rn.saturating_sub(1)) as usize],
+                    source_file: &source_file_arc,
                     source_row: rn,
-                    source_path: &ctx.source_file_arcs[(rn.saturating_sub(1)) as usize],
+                    source_path: &source_file_arc,
                     source_count: ctx.source_count,
                     source_batch: ctx.source_batch_arc,
                     ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -1369,11 +1394,12 @@ pub(crate) fn dispatch_plan_node(
 
             if let Some(ref mut route) = route_handle {
                 for (record, rn) in input_records {
+                    let source_file_arc = source_file_arc_of(&record);
                     let eval_ctx = EvalContext {
                         stable: ctx.stable,
-                        source_file: &ctx.source_file_arcs[(rn.saturating_sub(1)) as usize],
+                        source_file: &source_file_arc,
                         source_row: rn,
-                        source_path: &ctx.source_file_arcs[(rn.saturating_sub(1)) as usize],
+                        source_path: &source_file_arc,
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -1770,11 +1796,12 @@ pub(crate) fn dispatch_plan_node(
 
             let mut emitted_rows: Vec<AggSortRow> = Vec::with_capacity(64);
             for (record, row_num) in &input {
+                let source_file_arc = source_file_arc_of(record);
                 let eval_ctx = EvalContext {
                     stable: ctx.stable,
-                    source_file: &ctx.source_file_arcs[(row_num.saturating_sub(1)) as usize],
+                    source_file: &source_file_arc,
                     source_row: *row_num,
-                    source_path: &ctx.source_file_arcs[(row_num.saturating_sub(1)) as usize],
+                    source_path: &source_file_arc,
                     source_count: ctx.source_count,
                     source_batch: ctx.source_batch_arc,
                     ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -1826,9 +1853,9 @@ pub(crate) fn dispatch_plan_node(
             // pipelines pay zero overhead.
             let finalize_ctx = EvalContext {
                 stable: ctx.stable,
-                source_file: ctx.synthetic_source_file,
+                source_file: &MERGED_SOURCE_FILE,
                 source_row: 0,
-                source_path: ctx.synthetic_source_file,
+                source_path: &MERGED_SOURCE_FILE,
                 source_count: ctx.source_count,
                 source_batch: ctx.source_batch_arc,
                 ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -2161,7 +2188,6 @@ pub(crate) fn dispatch_plan_node(
                     cxl_emit_names_opt,
                     &output_schema,
                     &unbuffered,
-                    ctx.source_file_arcs,
                     per_file,
                     &mut ctx.output_errors,
                     &mut ctx.write_timer,
@@ -2584,9 +2610,9 @@ pub(crate) fn dispatch_plan_node(
                     let combine_output_schema_arc = combine_output_schema.clone();
                     let iejoin_ctx = EvalContext {
                         stable: ctx.stable,
-                        source_file: ctx.synthetic_source_file,
+                        source_file: &MERGED_SOURCE_FILE,
                         source_row: 0,
-                        source_path: ctx.synthetic_source_file,
+                        source_path: &MERGED_SOURCE_FILE,
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -2637,9 +2663,9 @@ pub(crate) fn dispatch_plan_node(
                     let combine_output_schema_arc = combine_output_schema.clone();
                     let grace_ctx = EvalContext {
                         stable: ctx.stable,
-                        source_file: ctx.synthetic_source_file,
+                        source_file: &MERGED_SOURCE_FILE,
                         source_row: 0,
-                        source_path: ctx.synthetic_source_file,
+                        source_path: &MERGED_SOURCE_FILE,
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -2698,9 +2724,9 @@ pub(crate) fn dispatch_plan_node(
                     let combine_output_schema_arc = combine_output_schema.clone();
                     let sm_ctx = EvalContext {
                         stable: ctx.stable,
-                        source_file: ctx.synthetic_source_file,
+                        source_file: &MERGED_SOURCE_FILE,
                         source_row: 0,
-                        source_path: ctx.synthetic_source_file,
+                        source_path: &MERGED_SOURCE_FILE,
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -2745,9 +2771,9 @@ pub(crate) fn dispatch_plan_node(
             let estimated_rows = Some(build_records.len());
             let hash_table_ctx = EvalContext {
                 stable: ctx.stable,
-                source_file: ctx.synthetic_source_file,
+                source_file: &MERGED_SOURCE_FILE,
                 source_row: 0,
-                source_path: ctx.synthetic_source_file,
+                source_path: &MERGED_SOURCE_FILE,
                 source_count: ctx.source_count,
                 source_batch: ctx.source_batch_arc,
                 ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -2795,11 +2821,12 @@ pub(crate) fn dispatch_plan_node(
             let mut probe_keys_buf: Vec<Value> = Vec::with_capacity(probe_extractor.len());
 
             for (probe_record, rn) in driver_buf {
+                let source_file_arc = source_file_arc_of(&probe_record);
                 let eval_ctx = EvalContext {
                     stable: ctx.stable,
-                    source_file: &ctx.source_file_arcs[(rn.saturating_sub(1)) as usize],
+                    source_file: &source_file_arc,
                     source_row: rn,
-                    source_path: &ctx.source_file_arcs[(rn.saturating_sub(1)) as usize],
+                    source_path: &source_file_arc,
                     source_count: ctx.source_count,
                     source_batch: ctx.source_batch_arc,
                     ingestion_timestamp: ctx.source_ingestion_timestamp,
@@ -3642,12 +3669,14 @@ fn execute_composition_body(
     let output_idx = bound_body.output_port_to_node_idx.values().next().copied();
 
     // Swap node_buffers to a body-local namespace so body NodeIndices
-    // don't collide with the parent's. `preloaded_source_records` is
-    // also swapped to an empty map: the body's Source arms (if any
-    // — body-scope sources are unusual but legal) fall back to
-    // `all_records`, not parent-scope combine sources.
+    // don't collide with the parent's. `source_records` is also
+    // swapped to an empty map so body-scope Source nodes resolve
+    // through `node_buffers` (port seeding from parent scope), not
+    // through parent-scope source ingestion — bodies declare ports,
+    // not top-level sources. Any non-port-seeded body Source surfaces
+    // as the defense-in-depth `Internal` error from the Source arm.
     let saved_buffers = std::mem::replace(&mut ctx.node_buffers, body_buffers);
-    let saved_combine = std::mem::take(&mut ctx.preloaded_source_records);
+    let saved_combine = std::mem::take(&mut ctx.source_records);
     // Install the body's `input:` reference table so the Route arm
     // can resolve `<route>.<branch>` references against body
     // siblings. Restored on exit.
@@ -3719,7 +3748,7 @@ fn execute_composition_body(
     // sync by hand on every exit path through this function.
     ctx.recursion_depth = ctx.recursion_depth.saturating_sub(1);
     ctx.node_buffers = saved_buffers;
-    ctx.preloaded_source_records = saved_combine;
+    ctx.source_records = saved_combine;
     ctx.current_body_node_input_refs = saved_body_refs;
     // Pop the window-runtime overlay so subsequent windows in the
     // parent scope route through `top` again. Removing the body's

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -199,7 +199,8 @@ pub type SourceReaders = HashMap<String, Vec<crate::source::multi_file::FileSlot
 /// - `fan_out`: per-source-file writers for outputs flagged
 ///   `fan_out_per_source_file` in the plan. Outer key is the output
 ///   name; inner key is the source-file `Arc<str>` (matching the
-///   per-record Arcs in `ExecutorContext.source_file_arcs`).
+///   per-record path read from each record's `$source.file` engine-
+///   stamped column).
 ///
 /// Auto-converts from `HashMap<String, Box<dyn Write + Send>>` so
 /// existing callers that don't need fan-out keep the simpler shape.
@@ -467,15 +468,10 @@ impl PipelineExecutor {
     /// Accepts the typed `CompiledPlan` handle returned by
     /// [`crate::config::PipelineConfig::compile`] and forwards to
     /// [`Self::run_with_readers_writers`] using the plan's embedded
-    /// [`PipelineConfig`].
-    ///
-    /// The primary (driving) source is the first source node in
-    /// declaration order (`config.source_configs().next()`). Callers
-    /// that need to drive the pipeline from a non-first declared
-    /// source must use
-    /// [`Self::run_plan_with_readers_writers_with_primary`] instead —
-    /// declaration-order-as-primary is a convenience of this wrapper,
-    /// not a contract of the executor itself.
+    /// [`PipelineConfig`]. Every declared Source is ingested through
+    /// the same code path; there is no "primary" driving source. DAG
+    /// dispatch order is determined by topological walk of the plan,
+    /// not by source declaration order.
     ///
     /// Compile-fail guarantee — `&PipelineConfig` is NOT accepted:
     ///
@@ -498,38 +494,7 @@ impl PipelineExecutor {
         writers: W,
         params: &PipelineRunParams,
     ) -> Result<ExecutionReport, PipelineError> {
-        let config = plan.config();
-        let primary_name = config
-            .source_configs()
-            .next()
-            .map(|s| s.name.clone())
-            .ok_or_else(|| {
-                PipelineError::Config(crate::config::ConfigError::Validation(
-                    "pipeline declares no source nodes; cannot infer primary driving input"
-                        .to_string(),
-                ))
-            })?;
-        Self::run_with_readers_writers(config, &primary_name, readers, writers.into(), params)
-    }
-
-    /// Same as [`Self::run_plan_with_readers_writers`] but with an
-    /// explicit `primary` driving-source name. Use this when the
-    /// driving input is not the first-declared source — e.g., lookup
-    /// baselines that put the reference table earlier in YAML for
-    /// readability but drive the pipeline from the probe source.
-    ///
-    /// `primary` must match the `name` of one of the source nodes
-    /// declared in the pipeline config, and a reader for that name
-    /// must be present in `readers`. Violations surface as
-    /// `PipelineError::Config(ConfigError::Validation(..))`.
-    pub fn run_plan_with_readers_writers_with_primary<W: Into<WriterRegistry>>(
-        plan: &crate::plan::CompiledPlan,
-        primary: &str,
-        readers: SourceReaders,
-        writers: W,
-        params: &PipelineRunParams,
-    ) -> Result<ExecutionReport, PipelineError> {
-        Self::run_with_readers_writers(plan.config(), primary, readers, writers.into(), params)
+        Self::run_with_readers_writers(plan.config(), readers, writers.into(), params)
     }
 
     /// `&CompiledPlan`-consuming `--explain` text entry.
@@ -548,28 +513,19 @@ impl PipelineExecutor {
     ///
     /// `readers` and `writers` are keyed by the input/output `name` fields from
     /// the pipeline config. For single-input/output pipelines, pass single-entry
-    /// HashMaps.
-    ///
-    /// `primary` is the name of the source node that drives the
-    /// pipeline: its reader is consumed as the streaming input, and
-    /// every other entry in `readers` feeds combine-node build sides.
-    /// Source declaration order in YAML is irrelevant — `primary` is
-    /// chosen explicitly. If `primary` does not match a declared source
-    /// name, or no reader is registered under that name, the function
-    /// returns `PipelineError::Config(ConfigError::Validation(..))`.
+    /// HashMaps. Every declared Source must have a reader entry; missing
+    /// readers and empty file lists are hard errors.
     ///
     /// Returns an [`ExecutionReport`] containing record counts, DLQ entries,
     /// execution mode, peak RSS, and wall-clock start/finish timestamps.
     pub(crate) fn run_with_readers_writers(
         config: &PipelineConfig,
-        primary: &str,
         readers: SourceReaders,
         writers: WriterRegistry,
         params: &PipelineRunParams,
     ) -> Result<ExecutionReport, PipelineError> {
         Self::run_with_readers_writers_in_context(
             config,
-            primary,
             readers,
             writers,
             params,
@@ -585,7 +541,6 @@ impl PipelineExecutor {
     /// workspace roots.
     pub(crate) fn run_with_readers_writers_in_context(
         config: &PipelineConfig,
-        primary: &str,
         mut readers: SourceReaders,
         writers: WriterRegistry,
         params: &PipelineRunParams,
@@ -593,41 +548,16 @@ impl PipelineExecutor {
     ) -> Result<ExecutionReport, PipelineError> {
         let started_at = Utc::now();
 
-        // Resolve the primary source config by name. The driving
-        // input is chosen explicitly via `primary` — declaration
-        // order in `config.source_configs()` plays no role.
         let source_configs: Vec<_> = config.source_configs().cloned().collect();
         let output_configs: Vec<_> = config.output_configs().cloned().collect();
-        let primary_idx = source_configs
-            .iter()
-            .position(|s| s.name == primary)
-            .ok_or_else(|| {
-                PipelineError::Config(crate::config::ConfigError::Validation(format!(
-                    "primary source '{primary}' is not declared in the pipeline config",
-                )))
-            })?;
-        let input = &source_configs[primary_idx];
-        let files = readers.remove(&input.name).ok_or_else(|| {
-            PipelineError::Config(crate::config::ConfigError::Validation(format!(
-                "no reader registered for input '{}'",
-                input.name
-            )))
-        })?;
-        if files.is_empty() {
+        if source_configs.is_empty() {
             return Err(PipelineError::Config(
-                crate::config::ConfigError::Validation(format!(
-                    "source '{}' has empty file list",
-                    input.name
-                )),
+                crate::config::ConfigError::Validation(
+                    "pipeline declares no source nodes; nothing to execute".to_string(),
+                ),
             ));
         }
         let mut collector = stage_metrics::StageCollector::default();
-        let reader_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::ReaderInit);
-        let raw_reader = build_multi_file_reader(input, files)?;
-        // Wrap with schema-based type coercion if the source declares typed columns.
-        let mut format_reader = wrap_with_schema_coercion(raw_reader, config, &input.name)?;
-        let schema = format_reader.schema()?;
-        collector.record(reader_timer.finish(0, 0));
 
         // Single canonical compile path.
         //
@@ -717,8 +647,28 @@ impl PipelineExecutor {
                 .find_map(|t| t.route.as_ref());
             match route_config {
                 Some(rc) => {
-                    let mut emitted_fields: Vec<String> =
-                        schema.columns().iter().map(|c| c.to_string()).collect();
+                    // Union of user-declared fields across every Source's
+                    // bound output_row. Engine-stamped tail columns
+                    // ($ck.*, $widened, $source.file) are filtered: Route
+                    // conditions reference user-declared field names, not
+                    // engine sidecars. Previously this seeded only the
+                    // primary source's reader columns, which silently
+                    // dropped non-primary fields from Route resolution in
+                    // multi-source pipelines.
+                    let mut emitted_fields: Vec<String> = Vec::new();
+                    for src_cfg in &source_configs {
+                        if let Some(typed) = validated_plan.artifacts().typed.get(&src_cfg.name) {
+                            for (qf, _) in typed.output_row.fields() {
+                                let s = qf.name.to_string();
+                                if s.starts_with('$') {
+                                    continue;
+                                }
+                                if !emitted_fields.contains(&s) {
+                                    emitted_fields.push(s);
+                                }
+                            }
+                        }
+                    }
                     for ct in &compiled_transforms {
                         for stmt in &ct.typed.program.statements {
                             if let Statement::Emit { name, .. } = stmt
@@ -839,11 +789,61 @@ impl PipelineExecutor {
             }
         }
 
+        // Pipeline-scoped TempDir. Allocated here (not inside
+        // `execute_dag_branching`) so every source-ingest spill file
+        // lands under the same panic-recovery sweep as later operator
+        // spills. Primary cleanup is per-file `tempfile::TempPath`
+        // Drop; secondary sweep is this TempDir's recursive remove on
+        // panic unwind.
+        let spill_root = Arc::new(
+            tempfile::Builder::new()
+                .prefix("clinker-spill-")
+                .tempdir()
+                .map_err(|e| PipelineError::Internal {
+                    op: "executor",
+                    node: String::new(),
+                    detail: format!("failed to allocate pipeline spill root: {e}"),
+                })?,
+        );
+        let spill_root_path: Arc<std::path::Path> = Arc::from(spill_root.path());
+
+        // ── Unified source ingest pass ───────────────────────────────
+        // Every declared Source is ingested through `SourceStream` into
+        // its own bounded buffer with disk-spill overflow. No primary
+        // asymmetry; missing reader or empty file list is a hard error.
+        // `counters.total_count` accumulates across sources.
+        let reader_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::ReaderInit);
+        let mut counters = PipelineCounters::default();
+        let mut source_records: HashMap<String, Vec<(Record, u64)>> = HashMap::new();
+        for src_cfg in &source_configs {
+            let files = readers.remove(&src_cfg.name).ok_or_else(|| {
+                PipelineError::Config(crate::config::ConfigError::Validation(format!(
+                    "no reader registered for source '{}'",
+                    src_cfg.name
+                )))
+            })?;
+            let drained = ingest_source_into_stream(
+                src_cfg,
+                files,
+                config,
+                Some(Arc::clone(&spill_root_path)),
+                &mut counters,
+            )?;
+            let records = drained
+                .into_records()
+                .map_err(|e| PipelineError::Internal {
+                    op: "source-stream-drain",
+                    node: src_cfg.name.clone(),
+                    detail: e.to_string(),
+                })?;
+            source_records.insert(src_cfg.name.clone(), records);
+        }
+        let total_ingested: u64 = source_records.values().map(|v| v.len() as u64).sum();
+        collector.record(reader_timer.finish(total_ingested, total_ingested));
+
         let (counters, dlq_entries, peak_rss_bytes) = Self::execute_dag(
             config,
-            input,
-            format_reader,
-            &mut readers,
+            source_records,
             &source_configs,
             writers,
             &compiled_transforms,
@@ -853,6 +853,9 @@ impl PipelineExecutor {
             validated_plan.artifacts(),
             params,
             &mut collector,
+            spill_root,
+            spill_root_path,
+            counters,
         )?;
 
         let stages = collector.into_stages();
@@ -884,13 +887,17 @@ impl PipelineExecutor {
     /// 2. RequiresSortedInput → read all, sort, then walk DAG with group-boundary logic
     /// 3. Streaming → read all, walk DAG with per-record evaluation
     ///
+    /// `source_records` holds every declared Source's pre-ingested records,
+    /// each tuple carrying the source-file `Arc<str>` engine-stamped on
+    /// the `$source.file` column. The caller's unified ingest pass
+    /// populates this map; this function does not read from any
+    /// `FormatReader` directly.
+    ///
     /// Returns `(counters, dlq_entries, peak_rss_bytes)`.
     #[allow(clippy::too_many_arguments)]
     fn execute_dag(
         config: &PipelineConfig,
-        input: &crate::config::SourceConfig,
-        mut format_reader: Box<dyn FormatReader>,
-        readers: &mut SourceReaders,
+        source_records: HashMap<String, Vec<(Record, u64)>>,
         source_configs: &[crate::config::SourceConfig],
         writers: WriterRegistry,
         transforms: &[CompiledTransform],
@@ -900,8 +907,10 @@ impl PipelineExecutor {
         artifacts: &crate::plan::bind_schema::CompileArtifacts,
         params: &PipelineRunParams,
         collector: &mut stage_metrics::StageCollector,
+        spill_root: Arc<tempfile::TempDir>,
+        spill_root_path: Arc<std::path::Path>,
+        mut counters: PipelineCounters,
     ) -> Result<(PipelineCounters, Vec<DlqEntry>, Option<u64>), PipelineError> {
-        let mut counters = PipelineCounters::default();
         let mut dlq_entries: Vec<DlqEntry> = Vec::new();
 
         // Pipeline-scoped MemoryBudget. One declared `memory_limit`
@@ -913,420 +922,105 @@ impl PipelineExecutor {
             config.pipeline.memory_limit.as_deref(),
         );
 
-        // ── Phase 0: source materialization ──
-        // Drain the primary reader into `all_records` carrying the
-        // full source schema. Records flow through the dispatcher
-        // unchanged; the windowed Transform arm reads through arena
-        // (a projected columnar view) for `$window.*` lookups but
-        // the records themselves keep every source field for
-        // downstream transforms / outputs that reference them.
-        // `MetadataCapExceeded` is recoverable per-record (DLQ);
-        // every other reader error short-circuits.
-        let mut all_records: Vec<(Record, u64)> = Vec::new();
-        // Parallel vector of per-record source-file Arcs. Index by
-        // `row_num - 1` to recover the file each record came from. For
-        // single-file sources every entry is the same Arc; for
-        // multi-file sources entries vary across file boundaries set
-        // by `MultiFileFormatReader::current_source_file()`.
-        let mut per_record_source_files: Vec<Arc<str>> = Vec::new();
-        // Fallback when the format-reader chain doesn't expose a
-        // current-file (e.g. literal `path:` sources don't go through
-        // the multi-file wrapper). Falls back to the static config
-        // path; empty for matchers that don't carry one.
-        let static_source_file: Arc<str> = if input.path_str().is_empty() {
-            Arc::from("<source>")
-        } else {
-            Arc::from(input.path_str())
-        };
-        let mut row_num: u64 = 0;
-        loop {
-            match format_reader.next_record() {
-                Ok(Some(record)) => {
-                    row_num += 1;
-                    counters.total_count += 1;
-                    let file_arc = format_reader
-                        .current_source_file()
-                        .cloned()
-                        .unwrap_or_else(|| Arc::clone(&static_source_file));
-                    all_records.push((record, row_num));
-                    per_record_source_files.push(file_arc);
-                }
-                Ok(None) => break,
-                Err(other) => return Err(other.into()),
-            }
-        }
-
         // Build per-window arena+index runtimes for every source-rooted
-        // IndexSpec whose declared source matches this primary input.
-        // Other-source `Source(..)` slots are reserved for the multi-
-        // source ingestion path (`pipeline/ingestion.rs`); node-rooted
-        // (`Node`/`ParentNode`) slots populate later at their upstream
-        // operator's dispatch-arm exit through
-        // `finalize_node_rooted_windows`.
-        //
-        // Each IndexSpec gets its own arena projected to that spec's
-        // `arena_fields` set. Per-spec projection (rather than a single
-        // union arena) lets node-rooted slots sit alongside source-
-        // rooted slots without a shared index space — every slot
-        // carries its own anchor schema. Memory accounting is shared
-        // across every build site through `memory_budget`.
+        // IndexSpec — each spec's `root: Source(name)` resolves against
+        // `source_records[name]`. Source-rooted arenas are built up-
+        // front here because their input is the Source's full ingested
+        // record set, available once the executor's ingest pass
+        // completes. Node-rooted (`Node`/`ParentNode`) slots still
+        // populate at their upstream operator's dispatch-arm exit
+        // through `finalize_node_rooted_windows`.
         let mut window_runtime =
             crate::executor::window_runtime::WindowRuntimeRegistry::new(&plan.indices_to_build);
-        if !all_records.is_empty() {
-            let source_schema = Arc::clone(all_records[0].0.schema());
-            let schema_pins: HashMap<String, clinker_record::schema_def::FieldDef> = input
-                .schema_overrides
-                .as_ref()
-                .map(|overrides| {
-                    overrides
-                        .iter()
-                        .map(|o| (o.name.clone(), o.clone()))
-                        .collect()
-                })
-                .unwrap_or_default();
+        let schema_overrides_by_name: HashMap<
+            &str,
+            HashMap<String, clinker_record::schema_def::FieldDef>,
+        > = source_configs
+            .iter()
+            .map(|s| {
+                let overrides = s
+                    .schema_overrides
+                    .as_ref()
+                    .map(|overrides| {
+                        overrides
+                            .iter()
+                            .map(|o| (o.name.clone(), o.clone()))
+                            .collect::<HashMap<_, _>>()
+                    })
+                    .unwrap_or_default();
+                (s.name.as_str(), overrides)
+            })
+            .collect();
+        let empty_schema_pins: HashMap<String, clinker_record::schema_def::FieldDef> =
+            HashMap::new();
+        for (idx, spec) in plan.indices_to_build.iter().enumerate() {
+            let crate::plan::index::PlanIndexRoot::Source(source_name) = &spec.root else {
+                continue;
+            };
+            let Some(records) = source_records.get(source_name.as_str()) else {
+                continue;
+            };
+            if records.is_empty() {
+                continue;
+            }
+            let source_schema = Arc::clone(records[0].0.schema());
+            let schema_pins = schema_overrides_by_name
+                .get(source_name.as_str())
+                .unwrap_or(&empty_schema_pins);
 
-            for (idx, spec) in plan.indices_to_build.iter().enumerate() {
-                let crate::plan::index::PlanIndexRoot::Source(source_name) = &spec.root else {
-                    continue;
-                };
-                if source_name != &input.name {
-                    // Other-source rooted — owned by the multi-source
-                    // ingestion path or by a future top-level pre-walk
-                    // that materializes referenced sources up front.
-                    continue;
-                }
-                let arena_timer =
-                    stage_metrics::StageTimer::new(stage_metrics::StageName::ArenaBuild);
-                let arena = Arena::from_records(
-                    &all_records,
-                    &spec.arena_fields,
-                    &source_schema,
-                    &mut memory_budget,
-                )
+            let arena_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::ArenaBuild);
+            let arena = Arena::from_records(
+                records,
+                &spec.arena_fields,
+                &source_schema,
+                &mut memory_budget,
+            )
+            .map_err(|e| PipelineError::Compilation {
+                transform_name: String::new(),
+                messages: vec![format!("E310 source-arena build: {e}")],
+            })?;
+            let arena_len = arena.record_count();
+            collector.record(arena_timer.finish(arena_len, arena_len));
+
+            let index_name = format!("{}:{}", source_name, spec.group_by.join(","));
+            let index_timer =
+                stage_metrics::StageTimer::new(stage_metrics::StageName::IndexBuild {
+                    name: index_name,
+                });
+            let mut secondary_index = SecondaryIndex::build(&arena, &spec.group_by, schema_pins)
                 .map_err(|e| PipelineError::Compilation {
                     transform_name: String::new(),
-                    messages: vec![format!("E310 source-arena build: {e}")],
+                    messages: vec![e.to_string()],
                 })?;
-                let arena_len = arena.record_count();
-                collector.record(arena_timer.finish(arena_len, arena_len));
+            collector.record(index_timer.finish(arena_len, arena_len));
 
-                let index_name = format!("{}:{}", source_name, spec.group_by.join(","));
-                let index_timer =
-                    stage_metrics::StageTimer::new(stage_metrics::StageName::IndexBuild {
-                        name: index_name,
-                    });
-                let mut secondary_index =
-                    SecondaryIndex::build(&arena, &spec.group_by, &schema_pins).map_err(|e| {
-                        PipelineError::Compilation {
-                            transform_name: String::new(),
-                            messages: vec![e.to_string()],
-                        }
-                    })?;
-                collector.record(index_timer.finish(arena_len, arena_len));
-
-                if !spec.already_sorted {
-                    for partition in secondary_index.groups.values_mut() {
-                        if !sort::is_sorted(&arena, partition, &spec.sort_by) {
-                            sort::sort_partition(&arena, partition, &spec.sort_by);
-                        }
+            if !spec.already_sorted {
+                for partition in secondary_index.groups.values_mut() {
+                    if !sort::is_sorted(&arena, partition, &spec.sort_by) {
+                        sort::sort_partition(&arena, partition, &spec.sort_by);
                     }
                 }
-
-                window_runtime.top[idx] = Some(crate::executor::window_runtime::WindowRuntime {
-                    arena: Arc::new(arena),
-                    index: Arc::new(secondary_index),
-                });
             }
+
+            window_runtime.top[idx] = Some(crate::executor::window_runtime::WindowRuntime {
+                arena: Arc::new(arena),
+                index: Arc::new(secondary_index),
+            });
         }
 
-        // D12: a global-fold aggregate (group_by: []) must still emit one
-        // row over empty input, so we cannot early-return when the plan
-        // contains an Aggregation node — the DAG walk needs to fire the
-        // aggregator's empty-input special case.
-        if all_records.is_empty() && !plan.has_branching() {
+        // D12: a global-fold aggregate (group_by: []) must still emit
+        // one row over empty input, so we cannot early-return when the
+        // plan contains an Aggregation node — the DAG walk needs to
+        // fire the aggregator's empty-input special case. Generalized
+        // from primary-only to "every source ingested zero records".
+        if source_records.values().all(|v| v.is_empty()) && !plan.has_branching() {
             return Ok((counters, dlq_entries, rss_bytes()));
-        }
-
-        // ── Pre-load combine build-side sources ──
-        // Every combine input whose upstream source is NOT the primary
-        // driving reader needs its records materialized before the DAG
-        // walk. `execute_dag_branching`'s `PlanNode::Source` arm consults
-        // this map first; primary-sourced entries fall back to
-        // `all_records`.
-        //
-        // Scope: every source name referenced by `artifacts.combine_inputs`
-        // as a build-side upstream whose reader is still in the `readers`
-        // registry (primary was removed at function entry). Drained here
-        // so the readers are consumed exactly once.
-        //
-        // Body-context translation: `combine_input.upstream_name` is the
-        // raw value from the combine's `input:` map. For top-level
-        // combines that's a parent-scope source name. For combines
-        // inside a composition body that's a port name — resolved here
-        // by walking the live edge graph one composition layer at a
-        // time. Each step finds the parent scope's incoming edge to
-        // the current body's composition node tagged with the current
-        // port name, follows to the producer, and recurses if the
-        // producer is the parent body's own synthetic-port-source
-        // (i.e., the composition's input was itself a port in the
-        // enclosing scope). The walk terminates on a non-port producer
-        // and returns its name (typically a top-level Source). This
-        // keeps reader setup aligned with the dispatcher's port
-        // resolution: both consult the live edge graph, so any
-        // planner-pass rewrite that updates edges automatically flows
-        // through both paths without a parallel name snapshot.
-        //
-        // Two reverse lookups: combine-node-name → owning body, and
-        // body → (enclosing scope, composition NodeIndex in that scope).
-        // Top-level combines are absent from `combine_owning_body`;
-        // bodies whose composition node lives in the top-level pipeline
-        // have `parent_body_id = None` in `body_to_parent`.
-        use petgraph::Direction;
-        use petgraph::graph::NodeIndex;
-        use petgraph::visit::EdgeRef;
-        let mut combine_owning_body: HashMap<
-            &str,
-            crate::plan::composition_body::CompositionBodyId,
-        > = HashMap::new();
-        for (body_id, body) in &artifacts.composition_bodies {
-            for combine_name in body.name_to_idx.keys() {
-                if artifacts.combine_inputs.contains_key(combine_name) {
-                    combine_owning_body.insert(combine_name.as_str(), *body_id);
-                }
-            }
-        }
-
-        #[derive(Clone, Copy)]
-        struct BodyParentScope {
-            parent_body_id: Option<crate::plan::composition_body::CompositionBodyId>,
-            composition_node_idx: NodeIndex,
-        }
-        let mut body_to_parent: HashMap<
-            crate::plan::composition_body::CompositionBodyId,
-            BodyParentScope,
-        > = HashMap::new();
-        for idx in plan.graph.node_indices() {
-            if let crate::plan::execution::PlanNode::Composition { body, .. } = &plan.graph[idx] {
-                body_to_parent.insert(
-                    *body,
-                    BodyParentScope {
-                        parent_body_id: None,
-                        composition_node_idx: idx,
-                    },
-                );
-            }
-        }
-        for (parent_id, parent_body) in &artifacts.composition_bodies {
-            for idx in parent_body.graph.node_indices() {
-                if let crate::plan::execution::PlanNode::Composition { body, .. } =
-                    &parent_body.graph[idx]
-                {
-                    body_to_parent.insert(
-                        *body,
-                        BodyParentScope {
-                            parent_body_id: Some(*parent_id),
-                            composition_node_idx: idx,
-                        },
-                    );
-                }
-            }
-        }
-
-        // Edge-walk a body-context port reference to its terminal name
-        // in the topmost enclosing scope. At each step the current name
-        // must be a port in the current body (otherwise it's already
-        // body-internal, terminal). The corresponding parent scope's
-        // incoming edge to the body's composition node carries the port
-        // tag; the producer of that edge is either:
-        //   - the parent body's synthetic-port-source for one of its
-        //     own input ports → recurse one layer up, AND
-        //   - any other node → terminal (return its name).
-        // Distinguishes the synthetic-port-source case by exact
-        // NodeIndex match against the parent body's
-        // `port_name_to_node_idx`, not just by name, because port names
-        // can legally collide with body-internal node names.
-        let resolve_upstream = |start_body_id: crate::plan::composition_body::CompositionBodyId,
-                                start_name: &str|
-         -> String {
-            let mut current_body_id = start_body_id;
-            let mut current_name = start_name.to_string();
-            loop {
-                let Some(body) = artifacts.composition_bodies.get(&current_body_id) else {
-                    return current_name;
-                };
-                if !body.port_name_to_node_idx.contains_key(&current_name) {
-                    // Not a port in this body — body-internal node
-                    // name (Transform/Aggregate/Source declared in the
-                    // body); terminal.
-                    return current_name;
-                }
-                let Some(scope) = body_to_parent.get(&current_body_id).copied() else {
-                    return current_name;
-                };
-                let parent_graph = match scope.parent_body_id {
-                    None => &plan.graph,
-                    Some(pid) => match artifacts.composition_bodies.get(&pid) {
-                        Some(b) => &b.graph,
-                        None => return current_name,
-                    },
-                };
-                let mut producer_idx_opt: Option<NodeIndex> = None;
-                for edge in
-                    parent_graph.edges_directed(scope.composition_node_idx, Direction::Incoming)
-                {
-                    if edge.weight().port.as_deref() == Some(current_name.as_str()) {
-                        producer_idx_opt = Some(edge.source());
-                        break;
-                    }
-                }
-                let Some(producer_idx) = producer_idx_opt else {
-                    // No port-tagged incoming edge — planner-pass
-                    // invariant violation; the dispatcher would also
-                    // surface this as PipelineError::Internal at the
-                    // composition arm. Return current_name; the caller
-                    // (reader setup) will silently skip if no reader
-                    // matches, mirroring the existing fall-through.
-                    return current_name;
-                };
-                let producer_name = parent_graph[producer_idx].name().to_string();
-                match scope.parent_body_id {
-                    None => {
-                        // Parent is top-level; producer is a top-level
-                        // node (typically a Source).
-                        return producer_name;
-                    }
-                    Some(pid) => {
-                        let parent_body = match artifacts.composition_bodies.get(&pid) {
-                            Some(b) => b,
-                            None => return producer_name,
-                        };
-                        // Synthetic-port-source identification: the
-                        // producer's NodeIndex must match the parent
-                        // body's port_name_to_node_idx entry for that
-                        // name. Name-only check is unsafe — port and
-                        // body-internal namespaces can legally collide.
-                        if parent_body
-                            .port_name_to_node_idx
-                            .get(&producer_name)
-                            .copied()
-                            == Some(producer_idx)
-                        {
-                            current_body_id = pid;
-                            current_name = producer_name;
-                        } else {
-                            return producer_name;
-                        }
-                    }
-                }
-            }
-        };
-
-        // Per-non-primary-source ingest buffers, populated by three
-        // preload passes below. Each pass ingests its scope of
-        // non-primary Sources through `preload_source_into_stream`,
-        // which writes to a bounded-capacity in-memory buffer with
-        // disk-spill overflow. `execute_dag_branching` drains each
-        // stream into `preloaded_source_records` (the in-memory Vec
-        // map the dispatcher still consumes) before walking the DAG.
-        // Sprint-1 scope per umbrella #50; sub-issue #51 will collapse
-        // the primary onto `SourceStream` too.
-        let mut source_streams: HashMap<String, source_stream::DrainedSourceStream> =
-            HashMap::new();
-        for (combine_name, combine_inputs) in &artifacts.combine_inputs {
-            let owning_body_id = combine_owning_body.get(combine_name.as_str()).copied();
-            for combine_input in combine_inputs.values() {
-                let raw_upstream = combine_input.upstream_name.as_ref();
-                let resolved = match owning_body_id {
-                    Some(body_id) => resolve_upstream(body_id, raw_upstream),
-                    None => raw_upstream.to_string(),
-                };
-                let upstream: &str = resolved.as_str();
-                if upstream == input.name {
-                    // Primary source — records already live in
-                    // `all_records`.
-                    continue;
-                }
-                if source_streams.contains_key(upstream) {
-                    continue;
-                }
-                if let Some(drained) =
-                    preload_source_into_stream(upstream, readers, source_configs, config)?
-                {
-                    source_streams.insert(upstream.to_string(), drained);
-                }
-            }
-        }
-
-        // ── Pre-load init-phase Sources ─────────────
-        // Init-phase Transforms' ancestors include Sources. Those
-        // Sources need their records materialized before the
-        // two-pass walk runs, because the Source dispatcher arm
-        // reads from `preloaded_source_records` (or `all_records` for
-        // the primary). A standalone init Source isn't a combine
-        // input and isn't the primary, so without this pre-load it
-        // would have nothing to feed the init-phase Aggregate /
-        // Transform downstream.
-        let init_source_names: Vec<String> = {
-            let init_set = crate::executor::compute_init_phase_node_set(plan);
-            init_set
-                .into_iter()
-                .filter_map(|idx| match &plan.graph[idx] {
-                    crate::plan::execution::PlanNode::Source { name, .. } => Some(name.clone()),
-                    _ => None,
-                })
-                .collect()
-        };
-        for upstream in &init_source_names {
-            if upstream.as_str() == input.name {
-                // Records already in `all_records`.
-                continue;
-            }
-            if source_streams.contains_key(upstream) {
-                continue;
-            }
-            if let Some(drained) =
-                preload_source_into_stream(upstream, readers, source_configs, config)?
-            {
-                source_streams.insert(upstream.clone(), drained);
-            }
-        }
-
-        // ── Pre-load every remaining non-primary top-level Source ─────
-        // Catch-all for Source nodes the combine-input and init-phase
-        // passes above don't cover — concretely: Merge inputs,
-        // disjoint parallel chains (`src_b → tfm → out_b` alongside a
-        // primary `src_a` chain), and any non-primary chain whose
-        // downstream operators are neither Combine build-side inputs
-        // nor init-phase ancestors. Without this pass those Sources
-        // would silently fall through the dispatch arm's
-        // `else { ctx.all_records.iter() ... }` branch and emit the
-        // primary's records — the silent data-corruption surface at
-        // the root of #47 and umbrella #50. The new branch in
-        // `dispatch::PlanNode::Source` (added in this sprint) treats
-        // a missing-stream non-primary as `PipelineError::Internal`
-        // so any future regression is loud, not silent.
-        let non_primary_top_level_sources: Vec<String> = source_configs
-            .iter()
-            .map(|s| s.name.clone())
-            .filter(|name| name.as_str() != input.name)
-            .collect();
-        for upstream in &non_primary_top_level_sources {
-            if source_streams.contains_key(upstream) {
-                continue;
-            }
-            if let Some(drained) =
-                preload_source_into_stream(upstream, readers, source_configs, config)?
-            {
-                source_streams.insert(upstream.clone(), drained);
-            }
         }
 
         Self::execute_dag_branching(
             config,
-            input,
-            all_records,
-            per_record_source_files,
-            source_streams,
+            source_records,
+            source_configs,
             writers,
             transforms,
             compiled_route,
@@ -1339,6 +1033,8 @@ impl PipelineExecutor {
             collector,
             window_runtime,
             memory_budget,
+            spill_root,
+            spill_root_path,
         )
     }
 
@@ -1357,10 +1053,8 @@ impl PipelineExecutor {
     #[allow(clippy::too_many_arguments)]
     fn execute_dag_branching(
         config: &PipelineConfig,
-        input: &crate::config::SourceConfig,
-        mut all_records: Vec<(Record, u64)>,
-        per_record_source_files: Vec<Arc<str>>,
-        source_streams: HashMap<String, source_stream::DrainedSourceStream>,
+        mut source_records: HashMap<String, Vec<(Record, u64)>>,
+        source_configs: &[crate::config::SourceConfig],
         writers: WriterRegistry,
         transforms: &[CompiledTransform],
         compiled_route: Option<CompiledRoute>,
@@ -1373,24 +1067,9 @@ impl PipelineExecutor {
         collector: &mut stage_metrics::StageCollector,
         window_runtime: crate::executor::window_runtime::WindowRuntimeRegistry,
         memory_budget: crate::pipeline::memory::MemoryBudget,
+        spill_root: Arc<tempfile::TempDir>,
+        spill_root_path: Arc<std::path::Path>,
     ) -> Result<(PipelineCounters, Vec<DlqEntry>, Option<u64>), PipelineError> {
-        // Drain each non-primary Source's bounded ingest stream into
-        // the in-memory `preloaded_source_records` map the dispatcher
-        // consumes. Spill files (if any) read sequentially here and
-        // delete themselves via `tempfile::TempPath` Drop after the
-        // reader iterator exhausts. Sprint-2 work (sub-issue #51)
-        // pushes this drain down into per-Source dispatch so we don't
-        // re-materialize spilled records into RAM at all.
-        let mut preloaded_source_records: HashMap<String, Vec<(Record, u64)>> =
-            HashMap::with_capacity(source_streams.len());
-        for (name, stream) in source_streams {
-            let records = stream.into_records().map_err(|e| PipelineError::Internal {
-                op: "source-stream-drain",
-                node: name.clone(),
-                detail: e.to_string(),
-            })?;
-            preloaded_source_records.insert(name, records);
-        }
         let output_configs: Vec<_> = config.output_configs().cloned().collect();
         let pipeline_start_time = chrono::Local::now().naive_local();
 
@@ -1405,32 +1084,39 @@ impl PipelineExecutor {
             &params.static_vars,
         );
 
-        // Seed source-scope vars on every distinct primary-source file
-        // Arc. Channel overrides (per source-node name) layer atop
-        // Transform-`declares: scope: source` defaults; the per-file
-        // inner map uses `or_insert` for declared defaults (so any
-        // source-scope writer that planted earlier wins) and `insert`
-        // for channel values (channel always wins). Combine
-        // build-side preloaded sources are not seeded from this point;
-        // their channel overrides apply when those sources flow
-        // through their own primary `execute_dag` call.
+        // Seed source-scope vars on every distinct per-record file Arc
+        // across every declared source. Channel overrides (per source-
+        // node name) layer atop Transform-`declares: scope: source`
+        // defaults; the per-file inner map uses `or_insert` for
+        // declared defaults (so any source-scope writer that planted
+        // earlier wins) and `insert` for channel values (channel
+        // always wins). The per-record file path is read off the
+        // `$source.file` engine-stamped column on each record.
         let declared_source_defaults = crate::config::collect_source_var_defaults(&config.nodes);
-        let channel_for_primary = params.source_vars.get(&input.name);
-        if (!declared_source_defaults.is_empty() || channel_for_primary.is_some())
+        if (!declared_source_defaults.is_empty() || !params.source_vars.is_empty())
             && let Ok(mut map) = stable.source_vars.write()
         {
-            let mut seen: std::collections::HashSet<&Arc<str>> = std::collections::HashSet::new();
-            for file_arc in &per_record_source_files {
-                if !seen.insert(file_arc) {
+            for src_cfg in source_configs {
+                let Some(records) = source_records.get(&src_cfg.name) else {
                     continue;
-                }
-                let entry = map.entry(Arc::clone(file_arc)).or_default();
-                for (k, v) in &declared_source_defaults {
-                    entry.entry(k.clone()).or_insert_with(|| v.clone());
-                }
-                if let Some(ch) = channel_for_primary {
-                    for (k, v) in ch {
-                        entry.insert(k.clone(), v.clone());
+                };
+                let channel = params.source_vars.get(&src_cfg.name);
+                let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+                for (record, _) in records {
+                    let Some(file_path) = dispatch::source_file_path_of(record) else {
+                        continue;
+                    };
+                    if !seen.insert(file_path) {
+                        continue;
+                    }
+                    let entry = map.entry(Arc::from(file_path)).or_default();
+                    for (k, v) in &declared_source_defaults {
+                        entry.entry(k.clone()).or_insert_with(|| v.clone());
+                    }
+                    if let Some(ch) = channel {
+                        for (k, v) in ch {
+                            entry.insert(k.clone(), v.clone());
+                        }
                     }
                 }
             }
@@ -1449,34 +1135,21 @@ impl PipelineExecutor {
             seed
         };
         if !record_var_seed.is_empty() {
-            for (record, _) in &mut all_records {
-                record.seed_record_vars(&record_var_seed);
-            }
-            for (_, recs) in preloaded_source_records.iter_mut() {
+            for recs in source_records.values_mut() {
                 for (record, _) in recs {
                     record.seed_record_vars(&record_var_seed);
                 }
             }
         }
-        // Synthetic source-file placeholder used by dispatch sites that
-        // have no live record (combine/finalize/post-aggregate emits
-        // with `source_row: 0`). For multi-file sources `input.path` is
-        // empty; the placeholder string is distinguishable from a real
-        // file path so users see it clearly in `$source.file` if it
-        // ever leaks past a merge boundary.
-        let source_file_arc: Arc<str> = if input.path_str().is_empty() {
-            Arc::from("<source>")
-        } else {
-            Arc::from(input.path_str())
-        };
-        // `$source.batch` is per-source-run. Default to a fresh UUID v7
-        // that's distinct from `pipeline.batch_id` (per-pipeline-run).
+        // `$source.batch` is per-pipeline-run scalar today (sub-issue
+        // #54 introduces per-source attribution as a separate stamp).
         let source_batch_arc: Arc<str> = Arc::from(uuid::Uuid::now_v7().to_string());
         let source_ingestion_timestamp = pipeline_start_time;
 
         let strategy = config.error_handling.strategy;
-        let total_records = all_records.len() as u64;
-        // `$source.count` — total records ingested from this source.
+        // `$source.count` is the pipeline-wide total across every
+        // declared source. Per-source attribution is sub-issue #54.
+        let total_records: u64 = source_records.values().map(|v| v.len() as u64).sum();
         let source_count: u64 = total_records;
 
         // Name → index map for looking up `CompiledTransform` by node
@@ -1487,26 +1160,6 @@ impl PipelineExecutor {
             .enumerate()
             .map(|(i, t)| (t.name.as_str(), i))
             .collect();
-
-        // Pipeline-scoped spill directory. One TempDir per pipeline
-        // run; every spilling operator borrows its path. Drop runs at
-        // the end of the walk (normal exit) or during stack unwinding
-        // (panic), so any individual spill file an operator left
-        // behind mid-flight gets swept by the directory's recursive
-        // remove. This is the secondary cleanup sweep that closes the
-        // panic-leak hole; primary cleanup remains per-file via
-        // `tempfile::TempPath` Drop.
-        let spill_root = Arc::new(
-            tempfile::Builder::new()
-                .prefix("clinker-spill-")
-                .tempdir()
-                .map_err(|e| PipelineError::Internal {
-                    op: "executor",
-                    node: String::new(),
-                    detail: format!("failed to allocate pipeline spill root: {e}"),
-                })?,
-        );
-        let spill_root_path: Arc<std::path::Path> = Arc::from(spill_root.path());
 
         // Correlation grouping context. `Some(...)` iff at least one
         // source declares a `correlation_key:`; the planner's
@@ -1543,17 +1196,13 @@ impl PipelineExecutor {
             compiled_transforms: transforms,
             transform_by_name,
             stable: &stable,
-            source_file_arcs: &per_record_source_files,
-            synthetic_source_file: &source_file_arc,
             source_batch_arc: &source_batch_arc,
             source_count,
             source_ingestion_timestamp,
             strategy,
-            primary_input_name: input.name.as_str(),
 
             node_buffers: HashMap::new(),
-            preloaded_source_records,
-            all_records,
+            source_records,
             writers: writers.single,
             fan_out_writers: writers.fan_out,
             compiled_route,
@@ -1928,63 +1577,89 @@ fn wrap_with_schema_coercion(
     }
 }
 
-/// Ingest one non-primary Source's records into a [`SourceStream`].
+/// Ingest a Source's records into a bounded `SourceStream` and drain
+/// to the read-side handle. Used uniformly by every declared Source —
+/// no primary asymmetry.
 ///
-/// Returns `Ok(None)` when `upstream`'s files are missing from `readers`
-/// (already drained by an earlier preload step) or empty. Returns
-/// `Ok(Some(stream))` otherwise. The caller inserts the drained stream
-/// into the per-source map; reusing this helper across the
-/// combine-input, init-phase, and merge/disjoint preload passes keeps
-/// the ingest logic single-sourced.
-///
-/// Errors map `SpillError` to `PipelineError::Internal` because the
-/// preload pass has no recoverable strategy for a corrupted spill
-/// temp file or out-of-disk condition — the pipeline cannot make
-/// progress without the source's records.
-fn preload_source_into_stream(
-    upstream: &str,
-    readers: &mut SourceReaders,
-    source_configs: &[crate::config::SourceConfig],
+/// Each ingested record is widened with a tail `$source.file`
+/// engine-stamped column (`FieldMetadata::SourceFile`) carrying the
+/// per-record file `Arc<str>` from
+/// `MultiFileFormatReader::current_source_file()`. Stamping at ingest
+/// lets `$source.file` / `$source.path` resolution survive Merge /
+/// Combine downstream without an external row-keyed array.
+/// `counters.total_count` increments per record so every source
+/// contributes to the pipeline-wide total.
+fn ingest_source_into_stream(
+    src_cfg: &crate::config::SourceConfig,
+    files: Vec<crate::source::multi_file::FileSlot>,
     config: &PipelineConfig,
-) -> Result<Option<source_stream::DrainedSourceStream>, PipelineError> {
-    let Some(files) = readers.remove(upstream) else {
-        return Ok(None);
-    };
+    spill_dir: Option<Arc<std::path::Path>>,
+    counters: &mut PipelineCounters,
+) -> Result<source_stream::DrainedSourceStream, PipelineError> {
     if files.is_empty() {
-        return Ok(None);
+        return Err(PipelineError::Config(
+            crate::config::ConfigError::Validation(format!(
+                "source '{}' has empty file list",
+                src_cfg.name
+            )),
+        ));
     }
-    let src_cfg = source_configs
-        .iter()
-        .find(|s| s.name == upstream)
-        .ok_or_else(|| {
-            PipelineError::Config(crate::config::ConfigError::Validation(format!(
-                "source '{upstream}' not declared in the pipeline",
-            )))
-        })?;
     let raw_reader = build_multi_file_reader(src_cfg, files)?;
-    let mut src_reader = wrap_with_schema_coercion(raw_reader, config, upstream)?;
-    let schema = src_reader.schema()?;
-    // `spill_dir = None` lets `SpillWriter` fall back to the system
-    // tempdir; per-file cleanup is handled by `tempfile::TempPath` Drop
-    // on `SpillFile<u64>`. Hoisting the pipeline-scoped TempDir up
-    // from `execute_dag_branching` so preload spill files share the
-    // secondary panic-recovery sweep is a sprint-2 follow-up tracked
-    // under umbrella #50.
+    let mut src_reader = wrap_with_schema_coercion(raw_reader, config, &src_cfg.name)?;
+    let reader_schema = src_reader.schema()?;
+
+    // Widen the reader schema with a $source.file SourceFile-marked
+    // tail column. The stamp travels with every record so downstream
+    // operators resolve `$source.file` per-record via the column read
+    // (see `dispatch::source_file_arc_of`) instead of indexing an
+    // external row-keyed Vec.
+    let mut widened_builder =
+        clinker_record::SchemaBuilder::with_capacity(reader_schema.column_count() + 1);
+    for (idx, col) in reader_schema.columns().iter().enumerate() {
+        widened_builder = match reader_schema.field_metadata(idx) {
+            Some(meta) => widened_builder.with_field_meta(col.as_ref(), meta.clone()),
+            None => widened_builder.with_field(col.as_ref()),
+        };
+    }
+    let widened_schema = widened_builder
+        .with_field_meta(
+            crate::config::pipeline_node::SOURCE_FILE_COLUMN,
+            clinker_record::FieldMetadata::source_file(),
+        )
+        .build();
+
+    let static_source_file: Arc<str> = if src_cfg.path_str().is_empty() {
+        Arc::from("<source>")
+    } else {
+        Arc::from(src_cfg.path_str())
+    };
+
     let mut stream = source_stream::SourceStream::new(
-        schema,
+        Arc::clone(&widened_schema),
         source_stream::DEFAULT_SOURCE_STREAM_CAPACITY,
-        None,
+        spill_dir,
     );
     let mut rn: u64 = 0;
     loop {
         match src_reader.next_record() {
             Ok(Some(record)) => {
                 rn += 1;
+                counters.total_count += 1;
+                let file_arc = src_reader
+                    .current_source_file()
+                    .cloned()
+                    .unwrap_or_else(|| Arc::clone(&static_source_file));
+                let mut values: Vec<clinker_record::Value> = record.values().to_vec();
+                values.push(clinker_record::Value::String(
+                    file_arc.as_ref().to_string().into_boxed_str(),
+                ));
+                let widened_record =
+                    clinker_record::Record::new(Arc::clone(&widened_schema), values);
                 stream
-                    .push(record, rn)
+                    .push(widened_record, rn)
                     .map_err(|e| PipelineError::Internal {
                         op: "source-stream-spill",
-                        node: upstream.to_string(),
+                        node: src_cfg.name.clone(),
                         detail: e.to_string(),
                     })?;
             }
@@ -1992,12 +1667,11 @@ fn preload_source_into_stream(
             Err(other) => return Err(other.into()),
         }
     }
-    let drained = stream.finish().map_err(|e| PipelineError::Internal {
+    stream.finish().map_err(|e| PipelineError::Internal {
         op: "source-stream-finish",
-        node: upstream.to_string(),
+        node: src_cfg.name.clone(),
         detail: e.to_string(),
-    })?;
-    Ok(Some(drained))
+    })
 }
 
 /// Extract `Vec<FieldDef>` from `SourceConfig.schema` for fixed-width format.
@@ -2997,13 +2671,8 @@ mod tests {
             ..Default::default()
         };
 
-        let report = PipelineExecutor::run_with_readers_writers(
-            &config,
-            &primary,
-            readers,
-            writers.into(),
-            &params,
-        )?;
+        let report =
+            PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
 
         let output = output_buf.as_string();
         Ok((report.counters, report.dlq_entries, output))

--- a/crates/clinker-core/src/executor/source_stream.rs
+++ b/crates/clinker-core/src/executor/source_stream.rs
@@ -1,7 +1,7 @@
 //! Bounded source-ingest buffer with disk-spill overflow.
 //!
-//! `SourceStream` ingests records from a non-primary Source into an
-//! in-memory buffer keyed by source row number. When the buffer exceeds
+//! `SourceStream` ingests records from a Source into an in-memory
+//! buffer keyed by source row number. When the buffer exceeds
 //! `capacity`, subsequent records spill to a temp file via
 //! `pipeline::spill::SpillFile<u64>` (payload = source row number,
 //! preserving FIFO order across the in-memory / on-disk boundary).
@@ -11,15 +11,15 @@
 //! record back into a `Vec<(Record, u64)>` in FIFO order — in-memory
 //! portion first, then any spilled records read sequentially from disk.
 //!
-//! Sprint-1 scope: single-threaded ingest in the executor's preload
-//! pass, drained back into `ExecutorContext.preloaded_source_records`
-//! before dispatch runs. The peak-RSS win versus today's
-//! `HashMap<String, Vec<(Record, u64)>>` preload is that each
-//! non-primary Source's overflow can spill before the next source's
+//! Every declared Source ingests through this primitive — there is no
+//! "primary" asymmetry. Single-threaded ingest in the executor's
+//! unified ingest pass, drained back into
+//! `ExecutorContext.source_records` before dispatch runs. The peak-RSS
+//! win versus a flat `HashMap<String, Vec<(Record, u64)>>` preload is
+//! that each Source's overflow can spill before the next source's
 //! ingest begins, so only one source's in-memory portion is resident
-//! at a time. Sub-issue #51 collapses the primary-source path onto
-//! `SourceStream` too; #57 swaps the impl for a concurrent
-//! channel-backed ingest under tokio.
+//! at a time. Sub-issue #57 swaps the impl for a concurrent channel-
+//! backed ingest under tokio.
 
 use std::path::Path;
 use std::sync::Arc;

--- a/crates/clinker-core/src/executor/tests/branching.rs
+++ b/crates/clinker-core/src/executor/tests/branching.rs
@@ -35,13 +35,8 @@ fn run_branch_test(
         ..Default::default()
     };
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
 
     let output = output_buf.as_string();
     Ok((report.counters, report.dlq_entries, output))

--- a/crates/clinker-core/src/executor/tests/ck_aligned_partition_runtime.rs
+++ b/crates/clinker-core/src/executor/tests/ck_aligned_partition_runtime.rs
@@ -65,7 +65,6 @@ o5,ENG,200
 o6,ENG,300
 ";
     let config = crate::config::parse_config(yaml).expect("parse");
-    let primary = "src".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([(
         "src".to_string(),
         crate::executor::single_file_reader(
@@ -85,14 +84,9 @@ o6,ENG,300
         shutdown_token: None,
         ..Default::default()
     };
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .expect("pipeline must run");
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .expect("pipeline must run");
     let counters = report.counters;
 
     // o3 (HR, 30) hits divide-by-zero → 1 DLQ. Other rows reach the

--- a/crates/clinker-core/src/executor/tests/correlated_dlq.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_dlq.rs
@@ -38,13 +38,8 @@ fn run_correlated_pipeline(
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
     Ok((report.counters, report.dlq_entries, buf.as_string()))
 }
 
@@ -407,14 +402,9 @@ nodes:
             Box::new(buf_b.clone()) as Box<dyn std::io::Write + Send>,
         ),
     ]);
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .unwrap();
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .unwrap();
 
     let out_a = buf_a.as_string();
     let out_b = buf_b.as_string();
@@ -895,7 +885,7 @@ nodes:
         ..Default::default()
     };
 
-    let primary = "orders".to_string();
+    let _primary = "orders".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([
         (
             "orders".to_string(),
@@ -919,14 +909,9 @@ nodes:
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .unwrap();
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .unwrap();
     let output = buf.as_string();
 
     // Group A driver records: A,1 (clean) and A,3 (clean) survive
@@ -1082,7 +1067,7 @@ nodes:
         ..Default::default()
     };
 
-    let primary = "orders".to_string();
+    let _primary = "orders".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([
         (
             "orders".to_string(),
@@ -1113,14 +1098,9 @@ nodes:
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .unwrap();
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .unwrap();
     let output = buf.as_string();
 
     // Department A: O1 and O3 succeed validate; O2 fails (trigger).
@@ -1313,7 +1293,7 @@ nodes:
         ..Default::default()
     };
 
-    let primary = "orders".to_string();
+    let _primary = "orders".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([
         (
             "orders".to_string(),
@@ -1337,14 +1317,9 @@ nodes:
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .unwrap();
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .unwrap();
     let output = buf.as_string();
 
     assert_eq!(

--- a/crates/clinker-core/src/executor/tests/correlated_dlq_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_dlq_retract.rs
@@ -54,13 +54,8 @@ fn run_pipeline(
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
     Ok((report.counters, report.dlq_entries, buf.as_string()))
 }
 

--- a/crates/clinker-core/src/executor/tests/correlated_post_aggregate_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_post_aggregate_retract.rs
@@ -50,13 +50,8 @@ fn run_pipeline(
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
     Ok((report.counters, report.dlq_entries, buf.as_string()))
 }
 

--- a/crates/clinker-core/src/executor/tests/correlated_window_after_aggregate_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_window_after_aggregate_retract.rs
@@ -49,13 +49,8 @@ fn run_pipeline(
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
     Ok((report.counters, report.dlq_entries, buf.as_string()))
 }
 

--- a/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
@@ -74,13 +74,8 @@ fn run_pipeline(
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
     Ok((report.counters, report.dlq_entries, buf.as_string()))
 }
 

--- a/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
@@ -205,14 +205,9 @@ o3,ENG,100
         shutdown_token: None,
         ..Default::default()
     };
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .expect("pipeline must run without error");
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .expect("pipeline must run without error");
 
     let written = buf.as_string();
     let body_lines: Vec<&str> = written.lines().filter(|l| !l.is_empty()).collect();
@@ -339,13 +334,8 @@ nodes:
     // build (E310 from the source-rooted Phase-0 arena). Either path
     // surfaces the E310 admission failure shape; assert the err string
     // carries that signature.
-    let result = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    );
+    let result =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
     let err = result.expect_err(
         "tight memory limit must surface as a typed admission failure on the \
          deferred buffer's projection or upstream spill path",
@@ -467,13 +457,8 @@ o3,HR,30
     };
     let config = crate::config::parse_config(yaml).expect("parse");
     with_test_loop_cap(0, || {
-        let _ = PipelineExecutor::run_with_readers_writers(
-            &config,
-            &primary,
-            readers,
-            writers.into(),
-            &params,
-        );
+        let _ =
+            PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
     });
 }
 
@@ -498,8 +483,8 @@ o3,HR,30
 ///
 /// Build-side rows that hit DLQ during the forward pass require
 /// either a Transform-mediated build chain (which breaks
-/// `preloaded_source_records` lookup since Combine's build input must
-/// resolve to a Source directly) or source-level validation (not yet
+/// `source_records` lookup since Combine's build input must resolve
+/// to a Source directly) or source-level validation (not yet
 /// available on `Source` nodes). The contract that an at-commit
 /// Combine rebuild reads from the cross-region buffer rather than
 /// re-reading the source IS pinned indirectly: a per-iteration
@@ -594,7 +579,7 @@ ENG,500
 ";
 
     let config = crate::config::parse_config(yaml).expect("parse");
-    let primary = "orders".to_string();
+    let _primary = "orders".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([
         (
             "orders".to_string(),
@@ -623,14 +608,9 @@ ENG,500
         shutdown_token: None,
         ..Default::default()
     };
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .expect("combine-in-region pipeline must converge");
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .expect("combine-in-region pipeline must converge");
 
     let written = buf.as_string();
     let body_lines: Vec<&str> = written.lines().filter(|l| !l.is_empty()).collect();
@@ -827,7 +807,6 @@ o6,ENG,300
     // runner.
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
-        &primary,
         readers,
         writers.into(),
         &params,
@@ -1063,7 +1042,6 @@ o6,ENG,300
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
-        &primary,
         readers,
         writers.into(),
         &params,
@@ -1294,7 +1272,6 @@ o6,ENG,300
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
-        &primary,
         readers,
         writers.into(),
         &params,
@@ -1498,7 +1475,6 @@ o6,ENG,300
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
-        &primary,
         readers,
         writers.into(),
         &params,
@@ -1684,7 +1660,6 @@ o6,ENG,300
     };
     let report = PipelineExecutor::run_with_readers_writers_in_context(
         &config,
-        &primary,
         readers,
         writers.into(),
         &params,
@@ -1841,14 +1816,9 @@ o6,ENG,300
         ..Default::default()
     };
     let config = crate::config::parse_config(yaml).expect("parse");
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .expect("fan-out pipeline must converge");
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .expect("fan-out pipeline must converge");
 
     let big_out = big_buf.as_string();
     let small_out = small_buf.as_string();
@@ -2003,7 +1973,7 @@ nodes:
         lookup_csv.push_str(&format!("D{i},lookup_payload_{i}\n"));
     }
 
-    let primary = "orders".to_string();
+    let _primary = "orders".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([
         (
             "orders".to_string(),
@@ -2033,13 +2003,8 @@ nodes:
         ..Default::default()
     };
     let config = crate::config::parse_config(yaml).expect("parse");
-    let result = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    );
+    let result =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
 
     // The pipeline either errors at the build-side cross-region tee
     // (`tee_emit_to_region_input_buffers` raising E310 from

--- a/crates/clinker-core/src/executor/tests/format_dispatch.rs
+++ b/crates/clinker-core/src/executor/tests/format_dispatch.rs
@@ -68,13 +68,8 @@ fn run_format_test(
     )]);
 
     let params = test_params();
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        input_name,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
 
     let output = output_buf.as_string();
     Ok((report.counters, report.dlq_entries, output))

--- a/crates/clinker-core/src/executor/tests/multi_output.rs
+++ b/crates/clinker-core/src/executor/tests/multi_output.rs
@@ -313,13 +313,8 @@ fn run_multi_output(
         })
         .collect();
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
 
     let outputs: HashMap<String, String> = buffers
         .iter()
@@ -698,13 +693,8 @@ nodes:
         ),
     ]);
 
-    let result = PipelineExecutor::run_with_readers_writers(
-        &config,
-        "src",
-        readers,
-        writers.into(),
-        &params,
-    );
+    let result =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
     assert!(result.is_err(), "should propagate writer error");
 }
 
@@ -999,7 +989,7 @@ nodes:
 
     // Panic should be caught and propagated, not hang or abort
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        PipelineExecutor::run_with_readers_writers(&config, "src", readers, writers.into(), &params)
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
     }));
 
     // The panic is re-raised via resume_unwind, so catch_unwind catches it
@@ -1174,13 +1164,8 @@ nodes:
     ]);
 
     // Should not deadlock — producer handles SendError::Disconnected
-    let result = PipelineExecutor::run_with_readers_writers(
-        &config,
-        "src",
-        readers,
-        writers.into(),
-        &params,
-    );
+    let result =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
     // Either error (from the dying writer) or success if the writer survived long enough
     // The key assertion: no deadlock, no hang — the test completes
     let _ = result;
@@ -1271,13 +1256,8 @@ nodes:
         ),
     ]);
 
-    let result = PipelineExecutor::run_with_readers_writers(
-        &config,
-        "src",
-        readers,
-        writers.into(),
-        &params,
-    );
+    let result =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
     // The DAG-walk Output arm collects every Output's write/flush
     // failure across the topo walk before aggregating into
     // PipelineError::Multiple. With both writers failing on flush, the
@@ -1698,13 +1678,8 @@ nodes:
         })
         .collect();
 
-    let result = PipelineExecutor::run_with_readers_writers(
-        &config,
-        "src",
-        readers,
-        writers.into(),
-        &params,
-    );
+    let result =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
     assert!(
         result.is_ok(),
         "single-writer HashMap should work: {result:?}"
@@ -1770,13 +1745,8 @@ nodes:
         })
         .collect();
 
-    let result = PipelineExecutor::run_with_readers_writers(
-        &config,
-        "src",
-        readers,
-        writers.into(),
-        &params,
-    );
+    let result =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
     assert!(
         result.is_ok(),
         "single-reader HashMap should work: {result:?}"

--- a/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
@@ -66,7 +66,6 @@ fn run(csv: &str) -> String {
         shutdown_token: None,
         ..Default::default()
     };
-    let primary = "src".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([(
         "src".to_string(),
         crate::executor::single_file_reader(
@@ -79,7 +78,7 @@ fn run(csv: &str) -> String {
         "out".to_string(),
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
-    PipelineExecutor::run_with_readers_writers(&config, &primary, readers, writers.into(), &params)
+    PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
         .expect("pipeline must run");
     buf.as_string()
 }

--- a/crates/clinker-core/src/executor/tests/post_aggregate_lag_lead.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_lag_lead.rs
@@ -71,7 +71,6 @@ fn run_once(csv: &str) -> String {
         shutdown_token: None,
         ..Default::default()
     };
-    let primary = "src".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([(
         "src".to_string(),
         crate::executor::single_file_reader(
@@ -84,7 +83,7 @@ fn run_once(csv: &str) -> String {
         "out".to_string(),
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
-    PipelineExecutor::run_with_readers_writers(&config, &primary, readers, writers.into(), &params)
+    PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
         .expect("pipeline must run");
     buf.as_string()
 }

--- a/crates/clinker-core/src/executor/tests/post_aggregate_recompute_determinism.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_recompute_determinism.rs
@@ -91,14 +91,9 @@ fn run_once() -> u64 {
         config.output_configs().next().unwrap().name.clone(),
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .expect("buffer-recompute pipeline must execute");
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .expect("buffer-recompute pipeline must execute");
     report.counters.retraction.partitions_dispatched
 }
 

--- a/crates/clinker-core/src/executor/tests/post_aggregate_window.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_window.rs
@@ -42,13 +42,8 @@ fn run_pipeline(
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
     Ok((report.counters, report.dlq_entries, buf.as_string()))
 }
 

--- a/crates/clinker-core/src/executor/tests/post_aggregate_window_spilled.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_window_spilled.rs
@@ -82,7 +82,6 @@ nodes:
         shutdown_token: None,
         ..Default::default()
     };
-    let primary = "src".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([(
         "src".to_string(),
         crate::executor::single_file_reader(
@@ -95,7 +94,7 @@ nodes:
         "out".to_string(),
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
-    PipelineExecutor::run_with_readers_writers(&config, &primary, readers, writers.into(), &params)
+    PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
         .expect("pipeline must run under memory pressure");
     let output = buf.as_string();
 

--- a/crates/clinker-core/src/executor/tests/post_combine_window_strategies.rs
+++ b/crates/clinker-core/src/executor/tests/post_combine_window_strategies.rs
@@ -105,7 +105,6 @@ ENG,5000
     let plan = config
         .compile(&crate::config::CompileContext::default())
         .expect("compile");
-    let primary = "orders".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([
         (
             "orders".to_string(),
@@ -134,10 +133,8 @@ ENG,5000
         shutdown_token: None,
         ..Default::default()
     };
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        &plan, &primary, readers, writers, &params,
-    )
-    .expect("pipeline must run");
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("pipeline must run");
     let _output = buf.as_string();
     // The Output node above is wired to the combine `enriched`, so the
     // running window's emit columns aren't projected to the writer in
@@ -232,7 +229,6 @@ ENG,5000
     let plan = config
         .compile(&crate::config::CompileContext::default())
         .expect("compile");
-    let primary = "orders".to_string();
     let readers: crate::executor::SourceReaders = HashMap::from([
         (
             "orders".to_string(),
@@ -261,10 +257,8 @@ ENG,5000
         shutdown_token: None,
         ..Default::default()
     };
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        &plan, &primary, readers, writers, &params,
-    )
-    .expect("pipeline must run");
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("pipeline must run");
     let output = buf.as_string();
 
     // Per-department: HR rows (10+20+30=60), ENG rows (100+200=300).

--- a/crates/clinker-core/src/executor/tests/strict_pipeline_zero_overhead.rs
+++ b/crates/clinker-core/src/executor/tests/strict_pipeline_zero_overhead.rs
@@ -99,14 +99,9 @@ o3,ENG,100
         ..Default::default()
     };
     let config = crate::config::parse_config(STRICT_PIPELINE).expect("parse");
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )
-    .expect("strict pipeline must run on the FastPath without error");
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+            .expect("strict pipeline must run on the FastPath without error");
 
     // Strict pipelines emit every record through the strict commit
     // body — no deferred-Output speculation, no cascading-retraction

--- a/crates/clinker-core/src/executor/tests/window_recompute_correctness.rs
+++ b/crates/clinker-core/src/executor/tests/window_recompute_correctness.rs
@@ -81,13 +81,8 @@ fn run_pipeline(
         Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
     )]);
 
-    let report = PipelineExecutor::run_with_readers_writers(
-        &config,
-        &primary,
-        readers,
-        writers.into(),
-        &params,
-    )?;
+    let report =
+        PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
     Ok((report.counters, report.dlq_entries, buf.as_string()))
 }
 

--- a/crates/clinker-core/src/integration_tests.rs
+++ b/crates/clinker-core/src/integration_tests.rs
@@ -38,13 +38,8 @@ mod tests {
             ..Default::default()
         };
 
-        let report = PipelineExecutor::run_with_readers_writers(
-            &config,
-            &first_source,
-            readers,
-            writers.into(),
-            &params,
-        )?;
+        let report =
+            PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)?;
 
         let output = output_buf.as_string();
         Ok((report.counters, report.dlq_entries, output))
@@ -797,91 +792,17 @@ emit out_code = code"#,
     // ── Combine enrichment coverage lives in
     //     `crates/clinker-core/tests/combine_test.rs`. ──
 
-    // ── Explicit-primary contract tests ──
+    // ── Source-ingest contract tests ──
     //
-    // These three gate tests pin down the contract introduced when
-    // `PipelineExecutor::run_with_readers_writers` took an explicit
-    // `primary: &str` parameter (replacing the implicit
-    // `source_configs[0]`-as-primary convention). See
-    // `crates/clinker-core/src/executor/mod.rs`.
+    // These gate tests pin down the unified-ingest contract: every
+    // declared source must have a registered reader, and declaration
+    // order is irrelevant (no "primary" asymmetry).
 
-    /// Passing a `primary` name that does not match any declared
-    /// source in the pipeline config must surface as a
-    /// `Config(ConfigError::Validation(..))` error — no panic, no
-    /// silent coercion.
-    #[test]
-    fn test_run_with_readers_writers_rejects_unknown_primary() {
-        let yaml = r#"
-pipeline:
-  name: single_source
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-- type: transform
-  name: identity
-  input: src
-  config:
-    cxl: 'emit id = id'
-- type: output
-  name: dest
-  input: identity
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-"#;
-        let config = config::parse_config(yaml).unwrap();
-
-        // `src` is registered, but we pass "nonexistent" as primary.
-        let readers: crate::executor::SourceReaders = HashMap::from([(
-            "src".to_string(),
-            crate::executor::single_file_reader(
-                "test.csv",
-                Box::new(std::io::Cursor::new(b"id\n1\n".to_vec())),
-            ),
-        )]);
-        let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
-            "dest".to_string(),
-            Box::new(SharedBuffer::new()) as Box<dyn std::io::Write + Send>,
-        )]);
-        let params = PipelineRunParams {
-            execution_id: "test-exec-id".to_string(),
-            batch_id: "test-batch-id".to_string(),
-            pipeline_vars: Default::default(),
-            shutdown_token: None,
-            ..Default::default()
-        };
-
-        let result = PipelineExecutor::run_with_readers_writers(
-            &config,
-            "nonexistent",
-            readers,
-            writers.into(),
-            &params,
-        );
-
-        match result {
-            Err(PipelineError::Config(crate::config::ConfigError::Validation(msg))) => {
-                assert!(
-                    msg.contains("primary source 'nonexistent'") && msg.contains("not declared"),
-                    "expected 'primary source \\'nonexistent\\' not declared...' message, got: {msg}"
-                );
-            }
-            other => panic!("expected Config(Validation) for unknown primary, got: {other:?}"),
-        }
-    }
-
-    /// Passing a `primary` that IS declared in the pipeline config
-    /// but is missing from the `readers` HashMap must surface as a
-    /// `Config(ConfigError::Validation(..))` error — the same clear
-    /// error the old implementation already produced for the
-    /// positionally-selected primary.
+    /// A declared source missing from the `readers` HashMap must
+    /// surface as `Config(ConfigError::Validation(..))` — silent skip
+    /// would be a regression surface (the previous non-primary preload
+    /// passes returned `Ok(None)` on missing readers; with one
+    /// unified ingest pass that's no longer a defensible default).
     #[test]
     fn test_run_with_readers_writers_rejects_primary_missing_from_readers() {
         let yaml = r#"
@@ -926,18 +847,13 @@ nodes:
             ..Default::default()
         };
 
-        let result = PipelineExecutor::run_with_readers_writers(
-            &config,
-            "src",
-            readers,
-            writers.into(),
-            &params,
-        );
+        let result =
+            PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params);
 
         match result {
             Err(PipelineError::Config(crate::config::ConfigError::Validation(msg))) => {
                 assert!(
-                    msg.contains("no reader registered for input 'src'"),
+                    msg.contains("no reader registered for source 'src'"),
                     "expected missing-reader message, got: {msg}"
                 );
             }
@@ -945,18 +861,17 @@ nodes:
         }
     }
 
-    /// Key regression-proofing test: declare sources in the order
+    /// Regression-proofing test: declare sources in the order
     /// `[reference, driving]` (so `source_configs[0]` is the reference
-    /// table, not the driving input), pass `primary = "orders"`
-    /// explicitly, and verify the pipeline runs correctly end-to-end.
+    /// table, not the driving input), and verify the pipeline runs
+    /// correctly end-to-end.
     ///
     /// Under the old positional-primary convention this configuration
-    /// would have consumed the `products` reader as the driving input
-    /// and starved the combine build side. With the explicit-primary
-    /// contract, declaration order is irrelevant — not just for
-    /// reader extraction but also for downstream provenance
-    /// (`source_file` on every emitted record) and arena-field
-    /// scoping inside `execute_dag` / `execute_dag_branching`.
+    /// would have consumed `products` as the primary driving reader
+    /// and starved the combine build side. With unified ingest there
+    /// is no "primary" — every source is ingested through
+    /// `SourceStream` and dispatch order follows the plan topology,
+    /// so declaration order is irrelevant.
     #[test]
     fn test_run_with_readers_writers_primary_is_not_first_source() {
         let yaml = r#"
@@ -1050,18 +965,13 @@ nodes:
             ..Default::default()
         };
 
-        let report = PipelineExecutor::run_with_readers_writers(
-            &config,
-            "orders", // explicit primary — NOT the first-declared source
-            readers,
-            writers.into(),
-            &params,
-        )
-        .expect("pipeline must execute when primary is declared second");
+        let report =
+            PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+                .expect("pipeline must execute regardless of source declaration order");
 
         assert_eq!(
-            report.counters.total_count, 2,
-            "both orders rows must be read as the driving input"
+            report.counters.total_count, 4,
+            "every ingested record (2 orders + 2 products) contributes to total_count"
         );
         assert_eq!(
             report.counters.ok_count, 2,

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -2075,13 +2075,15 @@ fn build_input_port_rows(
         }
 
         // Append the parent's engine-stamped tail columns to the
-        // body's port declared set. Two engine-stamp shapes propagate
-        // from parent to body:
+        // body's port declared set. Three engine-stamp shapes
+        // propagate from parent to body:
         //
         // - `$ck.<field>` source-CK shadow columns from each parent
         //   source's `correlation_key:` widening.
         // - `$widened` sidecar absorber column from
         //   `on_unmapped: auto_widen`.
+        // - `$source.file` per-record source-file lineage stamp
+        //   every Source carries.
         //
         // The runtime port-synthetic Source built at body entry adopts
         // every parent column, so the body sees these at runtime;
@@ -2095,7 +2097,8 @@ fn build_input_port_rows(
         let mut declared_columns = declared_columns;
         for (qf, ty) in upstream_row.fields() {
             let is_engine_stamped = qf.name.starts_with("$ck.")
-                || qf.name.as_ref() == crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN;
+                || qf.name.as_ref() == crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN
+                || qf.name.as_ref() == crate::config::pipeline_node::SOURCE_FILE_COLUMN;
             if is_engine_stamped && !declared_columns.contains_key(qf) {
                 declared_columns.insert(qf.clone(), ty.clone());
             }
@@ -2326,6 +2329,8 @@ fn normalize_path(path: &Path) -> PathBuf {
 ///   [`FieldMetadata::SourceCorrelation`].
 /// - `$widened` — `auto_widen` sidecar absorber. Stamped
 ///   [`FieldMetadata::WidenedSidecar`].
+/// - `$source.file` — per-record source-file lineage stamp. Stamped
+///   [`FieldMetadata::SourceFile`].
 ///
 /// The aggregate prefix is checked first because `$ck.aggregate.x`
 /// also matches the generic `$ck.` prefix; misordering would mis-
@@ -2347,6 +2352,8 @@ where
             builder.with_field_meta(name, FieldMetadata::source_correlation(field))
         } else if name == crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN {
             builder.with_field_meta(name, FieldMetadata::widened_sidecar())
+        } else if name == crate::config::pipeline_node::SOURCE_FILE_COLUMN {
+            builder.with_field_meta(name, FieldMetadata::source_file())
         } else {
             builder.with_field(name)
         };
@@ -2382,11 +2389,13 @@ fn columns_from_decl(
         .map(|c| (QualifiedField::bare(c.name.as_str()), c.ty.clone()))
         .collect();
     // Engine-stamped tail order: `$ck.<field>` shadow columns first,
-    // then the `$widened` sidecar last. The order is load-bearing —
-    // CK-aligned aggregate / combine propagation walks the schema
-    // expecting `$ck.*` immediately after declared columns; pushing
-    // `$widened` between them would break that propagation. Sources
-    // with `auto_widen` get `$widened` after every `$ck.<field>` slot.
+    // then the `$widened` sidecar, then `$source.file` last. The order
+    // is load-bearing — CK-aligned aggregate / combine propagation
+    // walks the schema expecting `$ck.*` immediately after declared
+    // columns; pushing `$widened` between them would break that
+    // propagation. Sources with `auto_widen` get `$widened` after
+    // every `$ck.<field>` slot; `$source.file` lives outside the CK
+    // lattice and tail-appends after `$widened`.
     let mut missing: Vec<String> = Vec::new();
     if let Some(ck) = correlation_key {
         for field in ck.fields() {
@@ -2410,6 +2419,10 @@ fn columns_from_decl(
             Type::Any,
         );
     }
+    cols.insert(
+        QualifiedField::bare(crate::config::pipeline_node::SOURCE_FILE_COLUMN),
+        Type::String,
+    );
     (cols, missing)
 }
 

--- a/crates/clinker-core/tests/bind_schema_test.rs
+++ b/crates/clinker-core/tests/bind_schema_test.rs
@@ -56,13 +56,18 @@ nodes:
     let row = plan
         .typed_output_row("source1")
         .expect("source1 must have a bound row");
-    // Schema includes the user-declared `a` + `b` plus the
-    // `$widened` engine-stamped sidecar column (auto_widen is the
-    // default `OnUnmapped` policy).
-    assert_eq!(row.field_count(), 3);
+    // Schema includes the user-declared `a` + `b`, the `$widened`
+    // engine-stamped sidecar (auto_widen is the default `OnUnmapped`
+    // policy), and the `$source.file` per-record source-file lineage
+    // stamp (every Source unconditionally tail-appends this).
+    assert_eq!(row.field_count(), 4);
     assert!(row.has_field("a"), "expected column 'a'");
     assert!(row.has_field("b"), "expected column 'b'");
     assert!(row.has_field("$widened"), "expected $widened sidecar");
+    assert!(
+        row.has_field("$source.file"),
+        "expected $source.file lineage stamp"
+    );
     assert_eq!(
         row.tail,
         cxl::typecheck::row::RowTail::Closed,
@@ -229,11 +234,13 @@ nodes:
     let plan = compile_yaml(yaml);
     let schema = source_output_schema(&plan, "src");
     // User-declared columns + `$widened` engine-stamped sidecar
-    // (auto_widen is the default `OnUnmapped` policy).
-    assert_eq!(schema.column_count(), 3);
+    // (auto_widen is the default `OnUnmapped` policy) + the
+    // `$source.file` per-record lineage stamp every Source carries.
+    assert_eq!(schema.column_count(), 4);
     assert_eq!(&*schema.columns()[0], "employee_id");
     assert_eq!(&*schema.columns()[1], "salary");
     assert_eq!(&*schema.columns()[2], "$widened");
+    assert_eq!(&*schema.columns()[3], "$source.file");
     assert!(
         schema.field_metadata_by_name("employee_id").is_none(),
         "user-declared column must not carry engine-stamp metadata"
@@ -245,6 +252,10 @@ nodes:
     assert!(
         schema.field_metadata_by_name("$widened").is_some(),
         "$widened sidecar must carry engine-stamp metadata"
+    );
+    assert!(
+        schema.field_metadata_by_name("$source.file").is_some(),
+        "$source.file must carry engine-stamp metadata"
     );
 }
 
@@ -282,8 +293,8 @@ nodes:
 
     // User-declared columns stay at their declared positions, then
     // engine-stamped tail: `$ck.<field>` shadow columns first, then
-    // the `$widened` sidecar (auto_widen default).
-    assert_eq!(schema.column_count(), 4);
+    // the `$widened` sidecar (auto_widen default), then `$source.file`.
+    assert_eq!(schema.column_count(), 5);
     assert_eq!(&*schema.columns()[0], "employee_id");
     assert_eq!(&*schema.columns()[1], "salary");
     assert_eq!(
@@ -292,6 +303,7 @@ nodes:
         "CK shadow column tail-appended before sidecar"
     );
     assert_eq!(&*schema.columns()[3], "$widened");
+    assert_eq!(&*schema.columns()[4], "$source.file");
     assert_eq!(schema.index("$ck.employee_id"), Some(2));
 
     // Engine-stamp metadata points back at the user-declared field.
@@ -343,12 +355,14 @@ nodes:
     let plan = compile_yaml(yaml);
     let schema = source_output_schema(&plan, "src");
 
-    // 3 declared + 2 `$ck.*` shadows + `$widened` sidecar = 6 columns.
-    assert_eq!(schema.column_count(), 6);
-    // Tail-append order matches `correlation_key.fields()` order, then sidecar.
+    // 3 declared + 2 `$ck.*` shadows + `$widened` sidecar + `$source.file` = 7 columns.
+    assert_eq!(schema.column_count(), 7);
+    // Tail-append order matches `correlation_key.fields()` order, then sidecar,
+    // then the per-record `$source.file` lineage stamp.
     assert_eq!(&*schema.columns()[3], "$ck.tenant");
     assert_eq!(&*schema.columns()[4], "$ck.employee_id");
     assert_eq!(&*schema.columns()[5], "$widened");
+    assert_eq!(&*schema.columns()[6], "$source.file");
 
     assert_eq!(
         source_correlation_field(schema.field_metadata_by_name("$ck.tenant")),

--- a/crates/clinker-core/tests/combine_propagate_ck_test.rs
+++ b/crates/clinker-core/tests/combine_propagate_ck_test.rs
@@ -59,10 +59,8 @@ fn run_with_output(
         shutdown_token: None,
         ..Default::default()
     };
-    let report = PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        &plan, primary, readers, writers, &params,
-    )
-    .expect("pipeline must run cleanly");
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("pipeline must run cleanly");
     (report, buffer.as_string())
 }
 

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -581,8 +581,9 @@ mod tests {
 
         // Driver = orders (default first-in-IndexMap, no `drive:` hint).
         // Driver fields: order_id, product_id, amount, plus the
-        // `$widened` engine-stamped sidecar (auto_widen default).
-        // Then the auto-added `products` field of Type::Array.
+        // `$widened` engine-stamped sidecar (auto_widen default) and
+        // the `$source.file` per-record lineage stamp every Source
+        // carries. Then the auto-added `products` field of Type::Array.
         let names: Vec<String> = row.field_names().map(|qf| qf.to_string()).collect();
         assert_eq!(
             names,
@@ -591,6 +592,7 @@ mod tests {
                 "product_id".to_string(),
                 "amount".to_string(),
                 "$widened".to_string(),
+                "$source.file".to_string(),
                 "products".to_string(),
             ],
             "auto-derived row = driver fields + (build_qualifier: Array)"
@@ -1982,8 +1984,8 @@ nodes:
     //
     // `run_combine_fixture` is the canonical end-to-end executor entry for
     // combine (and lookup, during the C.2 migration) integration tests. It
-    // wraps the public
-    // `PipelineExecutor::run_plan_with_readers_writers_with_primary` entry.
+    // wraps the public `PipelineExecutor::run_plan_with_readers_writers`
+    // entry.
     //
     // Error handling: structured `CombineFixtureError` preserves parse,
     // compile, and run distinctions. Tests that assert on specific
@@ -2085,25 +2087,18 @@ nodes:
     fn run_combine_fixture(
         yaml: &str,
         inputs: &[(&str, &str)],
-        primary_override: Option<&str>,
+        _primary_override: Option<&str>,
     ) -> Result<CombineFixtureResult, CombineFixtureError> {
         let config: PipelineConfig = clinker_core::yaml::from_str(yaml)
             .map_err(|e| CombineFixtureError::Parse(e.to_string()))?;
         let ctx = CompileContext::default();
         let plan = config.compile(&ctx).map_err(CombineFixtureError::Compile)?;
 
-        let primary: String = match primary_override {
-            Some(name) => name.to_string(),
-            None => inputs
-                .first()
-                .map(|(n, _)| (*n).to_string())
-                .ok_or_else(|| {
-                    CombineFixtureError::Precondition(
-                        "run_combine_fixture: no inputs provided and no primary_override set"
-                            .to_string(),
-                    )
-                })?,
-        };
+        if inputs.is_empty() {
+            return Err(CombineFixtureError::Precondition(
+                "run_combine_fixture: no inputs provided".to_string(),
+            ));
+        }
 
         let mut readers: clinker_core::executor::SourceReaders = HashMap::new();
         for (name, data) in inputs {
@@ -2146,10 +2141,9 @@ nodes:
             ..Default::default()
         };
 
-        let report = PipelineExecutor::run_plan_with_readers_writers_with_primary(
-            &plan, &primary, readers, writers, &params,
-        )
-        .map_err(CombineFixtureError::Run)?;
+        let report =
+            PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+                .map_err(CombineFixtureError::Run)?;
 
         let outputs: HashMap<String, String> = output_buffers
             .into_iter()
@@ -2875,9 +2869,12 @@ nodes:
             Some("orders"),
         )
         .expect("combine enrichment baseline must execute");
+        // Unified ingest counts every declared source's records, so
+        // `total_count = orders (4) + products (2) = 6`. The driver-
+        // only count (4) was the historical primary-only accounting.
         assert_eq!(
-            result.report.counters.total_count, 4,
-            "expected 4 input records processed; counters: {:?}",
+            result.report.counters.total_count, 6,
+            "expected 6 input records processed (4 orders + 2 products); counters: {:?}",
             result.report.counters
         );
         let high = result

--- a/crates/clinker-core/tests/composition_body_window.rs
+++ b/crates/clinker-core/tests/composition_body_window.rs
@@ -248,9 +248,8 @@ ENG,300
     let ctx = CompileContext::with_pipeline_dir(&root, PathBuf::from("pipelines"));
     let plan = config.compile(&ctx).expect("compile");
 
-    let primary = "src".to_string();
     let readers = HashMap::from([(
-        primary.clone(),
+        config.source_configs().next().unwrap().name.clone(),
         clinker_core::executor::single_file_reader(
             "test.csv",
             Box::new(Cursor::new(csv.as_bytes().to_vec())),
@@ -261,14 +260,8 @@ ENG,300
         "out".to_string(),
         Box::new(buf.clone()) as Box<dyn Write + Send>,
     )]);
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        &plan,
-        &primary,
-        readers,
-        writers,
-        &test_params(),
-    )
-    .expect("pipeline must run");
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &test_params())
+        .expect("pipeline must run");
     let output = buf.as_string();
 
     // Body emits one row per dept; running_total over a 1-row partition

--- a/crates/clinker-core/tests/composition_combine_test.rs
+++ b/crates/clinker-core/tests/composition_combine_test.rs
@@ -92,14 +92,9 @@ fn run_pipeline_multi_source(
         .first()
         .map(|(n, _)| (*n).to_string())
         .expect("at least one input source required");
-    let report = PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        &plan,
-        &primary,
-        readers,
-        writers,
-        &test_params(),
-    )
-    .expect("pipeline run");
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &test_params())
+            .expect("pipeline run");
     (report, buf.as_string())
 }
 

--- a/crates/clinker-core/tests/multi_source_ingestion.rs
+++ b/crates/clinker-core/tests/multi_source_ingestion.rs
@@ -1,8 +1,8 @@
-//! End-to-end coverage for the silent-corruption topologies fixed by
-//! the multi-source `SourceStream` rewiring in sprint 1 of umbrella #50
-//! (closes #47). Each topology constructs two CSV sources with
-//! non-overlapping `id` ranges so that any leak of one source's records
-//! into the other's chain is immediately visible in the output.
+//! End-to-end coverage for the silent-corruption topologies that
+//! historically affected non-primary Sources (closes #47). Each
+//! topology constructs two CSV sources with non-overlapping `id`
+//! ranges so that any leak of one source's records into the other's
+//! chain is immediately visible in the output.
 //!
 //! Pre-fix surface (the bug, schema-match across sources):
 //!
@@ -13,11 +13,12 @@
 //! | `src_a → tfm → merge`, `src_b → tfm → merge` | same fallthrough at the Source dispatcher |
 //! | `src_a → out_a`, `src_b → tfm → out_b` | non-primary single-output chain reads primary |
 //!
-//! The fix wires every non-primary Source through `SourceStream` in the
-//! executor's preload pass, removing the silent fallthrough to
-//! `ctx.all_records`. The Source dispatcher's third arm is now a
-//! defense-in-depth `PipelineError::Internal` (loud, not silent) when
-//! a non-primary Source somehow lacks preloaded records.
+//! The fix wires every Source through `SourceStream` so dispatch
+//! reads from `ctx.source_records[name]` rather than falling through
+//! to a single primary record set. The Source dispatcher's catch-all
+//! arm is now a defense-in-depth `PipelineError::Internal` (loud,
+//! not silent) when an ingest regression leaves a declared Source
+//! without records.
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -106,10 +107,10 @@ nodes:
     let report =
         PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
             .expect("multi-source merge must execute");
-    // `report.counters.total_count` only tracks the primary stream
-    // (a sub-#51 accounting gap that closes when the primary moves
-    // onto `SourceStream` too); the output buffer is the
-    // authoritative check.
+    // Unified source ingest counts every source's records, so
+    // `total_count` reports the union (3 + 3 = 6) rather than the
+    // historical primary-only count.
+    assert_eq!(report.counters.total_count, 6);
     assert_eq!(report.counters.dlq_count, 0);
 
     let output = buf.as_string();
@@ -211,8 +212,10 @@ nodes:
         ("out_b".to_string(), writer(&buf_b)),
     ]);
 
-    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
-        .expect("disjoint parallel chains must execute");
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("disjoint parallel chains must execute");
+    assert_eq!(report.counters.total_count, 6);
 
     let out_a = buf_a.as_string();
     let out_b = buf_b.as_string();
@@ -314,10 +317,10 @@ nodes:
         PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
             .expect("chained-into-merge must execute");
     assert_eq!(report.counters.dlq_count, 0);
+    // Unified ingest counts every source's records — 3 + 3 = 6.
+    assert_eq!(report.counters.total_count, 6);
 
     let output = buf.as_string();
-    // Output buffer is authoritative; `total_count` is primary-only
-    // (sub-#51 accounting gap).
     assert_eq!(
         output.lines().skip(1).count(),
         6,
@@ -422,8 +425,10 @@ nodes:
         ("out_b".to_string(), writer(&buf_b)),
     ]);
 
-    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
-        .expect("non-primary chain must execute");
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("non-primary chain must execute");
+    assert_eq!(report.counters.total_count, 6);
 
     let out_a = buf_a.as_string();
     let out_b = buf_b.as_string();
@@ -439,4 +444,101 @@ nodes:
         );
         assert!(out_a.contains(needle), "out_a missing `{needle}`: {out_a}");
     }
+}
+
+/// Topology 5 — `[src_a, src_b] → merge → transform emits $source.file
+/// → out`. Verifies per-record source-file lineage survives the merge:
+/// the engine-stamped `$source.file` column tracks the originating
+/// file path per record, so records merged from src_a carry "a.csv"
+/// and records from src_b carry "b.csv". The engine-stamped column
+/// replaces an earlier external `source_file_arcs[rn-1]` array
+/// indexed by primary-only row numbers, which leaked the primary's
+/// file path to non-primary records (or panicked on out-of-range).
+#[test]
+fn post_merge_source_file_resolves_per_record() {
+    let yaml = r#"
+pipeline:
+  name: post_merge_source_file
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b]
+  - type: transform
+    name: stamp_source
+    input: merged
+    config:
+      cxl: |
+        emit id = id
+        emit origin_file = $source.file
+  - type: output
+    name: out
+    input: stamp_source
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        ("src_a".to_string(), vec![slot("a", "id\n1\n2\n")]),
+        ("src_b".to_string(), vec![slot("b", "id\n10\n11\n")]),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+        .expect("post-merge $source.file pipeline must execute");
+
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(body.len(), 4, "expected 4 records, got:\n{output}");
+    // src_a's ids carry "a.csv"; src_b's ids carry "b.csv". The
+    // previous external-array design (indexed by primary-only rn)
+    // would have leaked src_a's file path to src_b's rows.
+    let mut a_rows = 0;
+    let mut b_rows = 0;
+    for line in &body {
+        if line.starts_with("1,") || line.starts_with("2,") {
+            assert!(
+                line.contains("a.csv"),
+                "src_a row missing 'a.csv' origin: `{line}`"
+            );
+            assert!(
+                !line.contains("b.csv"),
+                "src_a row leaked 'b.csv' — post-merge $source.file regression: `{line}`"
+            );
+            a_rows += 1;
+        }
+        if line.starts_with("10,") || line.starts_with("11,") {
+            assert!(
+                line.contains("b.csv"),
+                "src_b row missing 'b.csv' origin: `{line}`"
+            );
+            assert!(
+                !line.contains("a.csv"),
+                "src_b row leaked 'a.csv' — post-merge $source.file regression: `{line}`"
+            );
+            b_rows += 1;
+        }
+    }
+    assert_eq!(a_rows, 2, "expected 2 src_a rows");
+    assert_eq!(b_rows, 2, "expected 2 src_b rows");
 }

--- a/crates/clinker-core/tests/retraction_metrics_test.rs
+++ b/crates/clinker-core/tests/retraction_metrics_test.rs
@@ -27,9 +27,8 @@ fn run_pipeline(yaml: &str, csv_input: &str) -> PipelineCounters {
         shutdown_token: None,
         ..Default::default()
     };
-    let primary = config.source_configs().next().unwrap().name.clone();
     let readers = HashMap::from([(
-        primary,
+        config.source_configs().next().unwrap().name.clone(),
         clinker_core::executor::single_file_reader(
             "test.csv",
             Box::new(std::io::Cursor::new(csv_input.as_bytes().to_vec())),

--- a/crates/clinker-core/tests/state_node_integration.rs
+++ b/crates/clinker-core/tests/state_node_integration.rs
@@ -82,14 +82,8 @@ fn run_multi(yaml: &str, primary: &str, inputs: &[(&str, &str)]) -> String {
         config.output_configs().next().unwrap().name.clone(),
         Box::new(buf.clone()) as Box<dyn Write + Send>,
     )]);
-    PipelineExecutor::run_plan_with_readers_writers_with_primary(
-        &plan,
-        primary,
-        readers,
-        writers,
-        &test_params(),
-    )
-    .expect("pipeline run");
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &test_params())
+        .expect("pipeline run");
     buf.as_string()
 }
 

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -236,7 +236,7 @@ impl Record {
             .iter()
             .enumerate()
             .filter(|(i, _)| match self.schema.field_metadata(*i) {
-                Some(FieldMetadata::WidenedSidecar) => false,
+                Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) => false,
                 Some(FieldMetadata::SourceCorrelation { .. })
                 | Some(FieldMetadata::AggregateGroupIndex { .. })
                 | None => true,

--- a/crates/clinker-record/src/schema.rs
+++ b/crates/clinker-record/src/schema.rs
@@ -31,6 +31,15 @@ use std::sync::Arc;
 ///   into top-level columns via `include_widened: true`. Pattern
 ///   precedent: Databricks Auto Loader's `_rescued_data` and
 ///   ClickHouse's `JSON` column type.
+/// - [`FieldMetadata::SourceFile`] — per-Source lineage column carrying
+///   the originating file path Arc per record. Named `$source.file`;
+///   stamped at ingest with the path the record was read from
+///   (`MultiFileFormatReader::current_source_file()`). Replaces the
+///   pre-multi-source `ctx.source_file_arcs` external Vec indexed by
+///   row number — required when peer Sources merge downstream and
+///   per-source row numbers collide. Filtered out of default Output
+///   projection like the other engine-stamped variants; users opt in
+///   by projecting `emit source_file = $source.file` explicitly.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FieldMetadata {
     /// Source-CK shadow column. `source_field` is the user-declared
@@ -46,6 +55,12 @@ pub enum FieldMetadata {
     /// column is named `$widened` and carries a `Value::Map` of every
     /// input-record key that was not in the user-declared schema.
     WidenedSidecar,
+    /// Per-record source-file lineage column. Named `$source.file`,
+    /// stamped at Source ingest with the originating file path Arc.
+    /// Read by `$source.file` / `$source.path` resolution at dispatch
+    /// sites; survives merge so post-fan-in records still resolve to
+    /// their actual file rather than an external row-keyed lookup.
+    SourceFile,
 }
 
 impl FieldMetadata {
@@ -69,6 +84,13 @@ impl FieldMetadata {
     /// payload.
     pub fn widened_sidecar() -> Self {
         Self::WidenedSidecar
+    }
+
+    /// Marks this column as the per-record source-file lineage stamp.
+    /// Always named `$source.file`; the value is a `Value::String`
+    /// wrapping the originating file path Arc.
+    pub fn source_file() -> Self {
+        Self::SourceFile
     }
 
     /// True for every variant. The presence of [`FieldMetadata`] on a
@@ -341,6 +363,24 @@ mod tests {
             other => panic!("expected AggregateGroupIndex, got {other:?}"),
         }
         assert!(stamp.is_engine_stamped());
+    }
+
+    #[test]
+    fn test_schema_with_metadata_attaches_source_file() {
+        let cols: Vec<Box<str>> = vec!["id".into(), "$source.file".into()];
+        let meta = vec![None, Some(FieldMetadata::source_file())];
+        let schema = Schema::with_metadata(cols, meta);
+        assert!(schema.field_metadata(0).is_none());
+        let stamp = schema.field_metadata(1).expect("metadata attached");
+        match stamp {
+            FieldMetadata::SourceFile => {}
+            other => panic!("expected SourceFile, got {other:?}"),
+        }
+        assert!(stamp.is_engine_stamped());
+        match schema.field_metadata_by_name("$source.file") {
+            Some(FieldMetadata::SourceFile) => {}
+            other => panic!("expected SourceFile, got {other:?}"),
+        }
     }
 
     /// Pins the in-memory size of [`FieldMetadata`] so a future variant


### PR DESCRIPTION
Every declared Source now ingests through a single bounded `SourceStream`
with disk-spill overflow. There is no "primary" driving source — DAG
dispatch order follows the plan topology, and source declaration order
is irrelevant. The dispatch arm has exactly one path (`source_records[name]`),
plus a body-port arm and a defense-in-depth `PipelineError::Internal`
for unknown sources.

Deletes:
- `ExecutorContext.primary_input_name`
- `ExecutorContext.all_records`
- `ExecutorContext.source_file_arcs`
- `ExecutorContext.synthetic_source_file`
- `PipelineExecutor::run_plan_with_readers_writers_with_primary`
- `primary: &str` parameter from internal `run_with_readers_writers(_in_context)`
- The 3 preload passes (combine-input, init-phase, catch-all) and the
  composition-body upstream resolver they used

Adds:
- `FieldMetadata::SourceFile` engine-stamped column. `bind_schema`
  widens every Source's output_row with a `$source.file` shadow column;
  the unified ingest helper stamps the per-record file path into it.
  Resolves `$source.file` / `$source.path` per-record post-Merge —
  pre-sprint this used an external `Vec<Arc<str>>` indexed by primary-
  only row numbers, which leaked the primary's file path to non-primary
  records or panicked on out-of-range.
- `dispatch::source_file_path_of` / `source_file_arc_of` / `MERGED_SOURCE_FILE`
  for dispatch sites reading the stamp.
- Generalized source-rooted window arena build: every source's
  `PlanIndexRoot::Source` spec gets its arena built, not just the
  primary's. Closes a latent gap where non-primary windowed pipelines
  had no source-rooted index.
- Pipeline-scoped TempDir hoisted up from `execute_dag_branching` to
  `run_with_readers_writers_in_context` so the source-ingest spill
  files share the panic-recovery sweep.

Behavioral changes:
- `counters.total_count` now reports the union across every declared
  source (previously primary-only — the sub-#51 inline notes in
  `tests/multi_source_ingestion.rs` are now real `assert_eq!`s).
- Missing reader for a declared source is a hard error (previously
  silent skip for non-primary, which was only defensible under three
  overlapping preload passes).
- `[empty primary, non-empty secondary] → merge → out` no longer
  incorrectly short-circuits via the empty-input early return.

Caller migration: every test / bench previously calling
`run_plan_with_readers_writers_with_primary(plan, "name", ...)` is
updated to `run_plan_with_readers_writers(plan, ...)`. ~14 sites
across 11 files.

New test `post_merge_source_file_resolves_per_record` verifies
post-Merge `$source.file` resolution: src_a records carry "a.csv",
src_b records carry "b.csv".

Closes #51. The transitional-state note in umbrella issue #50 is now
stale.

https://claude.ai/code/session_01YAZqpK9ktST2bmrEBfTAJU