### PR TITLE
executor: per-(source, file) event-time watermark plumbing (closes #52)

### DIFF
--- a/crates/clinker-benchmarks/src/report.rs
+++ b/crates/clinker-benchmarks/src/report.rs
@@ -453,6 +453,9 @@ mod tests {
                     heap_alloc_count: None,
                 },
             ],
+            per_source_file_watermarks: Default::default(),
+            per_source_watermarks: Default::default(),
+            effective_watermark: None,
         };
         report.counters.total_count = 1000;
         report.counters.ok_count = 995;
@@ -525,6 +528,9 @@ mod tests {
                     heap_alloc_count: None,
                 },
             ],
+            per_source_file_watermarks: Default::default(),
+            per_source_watermarks: Default::default(),
+            effective_watermark: None,
         };
         let output = format_summary_table("test/bad", "small", &report);
         assert!(

--- a/crates/clinker-core/src/config/mod.rs
+++ b/crates/clinker-core/src/config/mod.rs
@@ -247,6 +247,16 @@ pub struct SourceConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files: Option<FileListingControls>,
 
+    /// Event-time watermark declaration. Names the column whose value
+    /// is observed at ingest and folded into a per-(source, file)
+    /// max-event-time stamp; rolled up at the read side by
+    /// `PerSourceWatermarks::min_across_sources`. Mirrors Flink SQL's
+    /// `WATERMARK FOR <col> AS <col> - INTERVAL` declaration site
+    /// (delay column deferred to the time-window operator sprint,
+    /// https://github.com/rustpunk/clinker/issues/61).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub watermark: Option<WatermarkConfig>,
+
     /// Format-layer schema pointer (e.g. fixed-width field layouts).
     /// Distinct from the CXL-type-level `SourceBody.schema` declared
     /// at the parent `SourceBody` scope — this one points at on-disk
@@ -268,6 +278,22 @@ pub struct SourceConfig {
     /// Kiln IDE metadata: stage notes + field annotations. Ignored by the engine.
     #[serde(default, rename = "_notes", skip_serializing_if = "Option::is_none")]
     pub notes: Option<serde_json::Value>,
+}
+
+/// Event-time watermark declaration on a `SourceConfig`.
+///
+/// `column` names a record field whose value is the source's event-
+/// time axis. At ingest, each record's value at this column is
+/// converted to an i64 nanosecond stamp and folded into a per-(source,
+/// file) max via [`crate::executor::watermark::PerSourceWatermarks`].
+/// The column type must coerce to [`clinker_record::Value::Timestamp`]
+/// or [`clinker_record::Value::Date`] (validated at plan time, see
+/// `crate::plan::bind_schema`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WatermarkConfig {
+    /// Name of the event-time column on the source's declared schema.
+    pub column: String,
 }
 
 /// File-listing controls — file-set ordering, take-N, recursion,

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -343,6 +343,21 @@ pub(crate) struct ExecutorContext<'a> {
     /// aggregate emitted columns the source arena could not project.
     pub(crate) window_runtime: crate::executor::window_runtime::WindowRuntimeRegistry,
 
+    /// Per-(source, file) event-time watermark bookkeeping. Populated
+    /// at ingest from each `SourceConfig.watermark.column` declaration;
+    /// keyed by `(source_name, $source.file Arc)` so glob/regex/paths
+    /// sources keep per-file isolation matching the
+    /// `fan_out_per_source_file` 1:1 source-file → sink invariant.
+    /// Today's only consumer is the [`ExecutionReport`]; future time-
+    /// windowed aggregates will read
+    /// [`PerSourceWatermarks::min_across_sources`] at the
+    /// window-close decision.
+    ///
+    /// [`ExecutionReport`]: crate::executor::ExecutionReport
+    /// [`PerSourceWatermarks::min_across_sources`]:
+    ///   crate::executor::watermark::PerSourceWatermarks::min_across_sources
+    pub(crate) watermarks: crate::executor::watermark::PerSourceWatermarks,
+
     /// Pipeline-scoped memory budget shared across the source-rooted
     /// Phase-0 arena and every node-rooted arena materialized at an
     /// upstream operator's dispatch-arm exit. One declared

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -5,9 +5,10 @@ pub(crate) mod commit;
 pub(crate) mod dispatch;
 mod schema_check;
 pub(crate) mod source_stream;
+pub(crate) mod watermark;
 pub(crate) mod window_runtime;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::{BufWriter, Read, Write};
 use std::sync::atomic::AtomicU32;
 use std::sync::{Arc, Mutex};
@@ -295,6 +296,25 @@ pub struct ExecutionReport {
     pub finished_at: DateTime<Utc>,
     /// Per-stage instrumentation metrics, ordered by execution sequence.
     pub stages: Vec<stage_metrics::StageMetrics>,
+    /// Per-(source, file) event-time watermarks observed at ingest,
+    /// keyed by `(source_name, source_file_path)`. The max event-time
+    /// seen for that pair in i64 nanoseconds, or `None` when the
+    /// partition had no observations. Finest granularity; drives the
+    /// `fan_out_per_source_file` 1:1 source-file → sink case where
+    /// each file's watermark is independently meaningful.
+    pub per_source_file_watermarks: BTreeMap<(String, String), Option<i64>>,
+    /// Per-source rollup = `min` across the source's per-file
+    /// watermarks. One entry per declared source (sources whose
+    /// `SourceConfig.watermark.column` is set). A glob source with one
+    /// lagging file holds its source-level watermark back to that
+    /// file's max — matching the Flink/Arroyo per-partition + min
+    /// reducer pattern.
+    pub per_source_watermarks: BTreeMap<String, Option<i64>>,
+    /// Cross-source rollup = `min` across rolled-up source values.
+    /// The reducer a time-windowed aggregate's close decision reads
+    /// (future consumer). `None` when every declared source rolls up
+    /// to `None`.
+    pub effective_watermark: Option<i64>,
 }
 
 /// Sum per-stage CPU and I/O deltas into run-level totals. Stages with `None`
@@ -815,7 +835,14 @@ impl PipelineExecutor {
         let reader_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::ReaderInit);
         let mut counters = PipelineCounters::default();
         let mut source_records: HashMap<String, Vec<(Record, u64)>> = HashMap::new();
+        let mut watermarks = crate::executor::watermark::PerSourceWatermarks::new();
         for src_cfg in &source_configs {
+            // Pre-declare so the report's `iter_declared_sources` view
+            // emits a per-source rollup entry even when ingest produces
+            // zero observable records (e.g. empty input file).
+            if src_cfg.watermark.is_some() {
+                watermarks.declare(&src_cfg.name);
+            }
             let files = readers.remove(&src_cfg.name).ok_or_else(|| {
                 PipelineError::Config(crate::config::ConfigError::Validation(format!(
                     "no reader registered for source '{}'",
@@ -828,6 +855,7 @@ impl PipelineExecutor {
                 config,
                 Some(Arc::clone(&spill_root_path)),
                 &mut counters,
+                &mut watermarks,
             )?;
             let records = drained
                 .into_records()
@@ -841,7 +869,7 @@ impl PipelineExecutor {
         let total_ingested: u64 = source_records.values().map(|v| v.len() as u64).sum();
         collector.record(reader_timer.finish(total_ingested, total_ingested));
 
-        let (counters, dlq_entries, peak_rss_bytes) = Self::execute_dag(
+        let (counters, dlq_entries, peak_rss_bytes, watermarks) = Self::execute_dag(
             config,
             source_records,
             &source_configs,
@@ -856,11 +884,31 @@ impl PipelineExecutor {
             spill_root,
             spill_root_path,
             counters,
+            watermarks,
         )?;
 
         let stages = collector.into_stages();
         let (total_cpu_user_ns, total_cpu_sys_ns, total_io_read_bytes, total_io_write_bytes) =
             sum_cpu_io_totals(&stages);
+
+        // Roll the per-(source, file) watermark map into the report's
+        // three granularities. BTreeMap keys are owned `String`s so the
+        // report is `'static`-clonable for snapshot testing.
+        let per_source_file_watermarks: BTreeMap<(String, String), Option<i64>> = watermarks
+            .iter_partitions()
+            .map(|(src, file, w)| {
+                (
+                    (src.to_string(), file.as_ref().to_string()),
+                    w.max_event_time_nanos,
+                )
+            })
+            .collect();
+        let per_source_watermarks: BTreeMap<String, Option<i64>> = watermarks
+            .iter_declared_sources()
+            .map(|name| (name.to_string(), watermarks.source_min(name)))
+            .collect();
+        let declared_source_names: Vec<&str> = watermarks.iter_declared_sources().collect();
+        let effective_watermark = watermarks.min_across_sources(&declared_source_names);
 
         Ok(ExecutionReport {
             counters,
@@ -875,6 +923,9 @@ impl PipelineExecutor {
             started_at,
             finished_at: Utc::now(),
             stages,
+            per_source_file_watermarks,
+            per_source_watermarks,
+            effective_watermark,
         })
     }
 
@@ -910,7 +961,16 @@ impl PipelineExecutor {
         spill_root: Arc<tempfile::TempDir>,
         spill_root_path: Arc<std::path::Path>,
         mut counters: PipelineCounters,
-    ) -> Result<(PipelineCounters, Vec<DlqEntry>, Option<u64>), PipelineError> {
+        watermarks: crate::executor::watermark::PerSourceWatermarks,
+    ) -> Result<
+        (
+            PipelineCounters,
+            Vec<DlqEntry>,
+            Option<u64>,
+            crate::executor::watermark::PerSourceWatermarks,
+        ),
+        PipelineError,
+    > {
         let mut dlq_entries: Vec<DlqEntry> = Vec::new();
 
         // Pipeline-scoped MemoryBudget. One declared `memory_limit`
@@ -1014,7 +1074,7 @@ impl PipelineExecutor {
         // fire the aggregator's empty-input special case. Generalized
         // from primary-only to "every source ingested zero records".
         if source_records.values().all(|v| v.is_empty()) && !plan.has_branching() {
-            return Ok((counters, dlq_entries, rss_bytes()));
+            return Ok((counters, dlq_entries, rss_bytes(), watermarks));
         }
 
         Self::execute_dag_branching(
@@ -1035,6 +1095,7 @@ impl PipelineExecutor {
             memory_budget,
             spill_root,
             spill_root_path,
+            watermarks,
         )
     }
 
@@ -1069,7 +1130,16 @@ impl PipelineExecutor {
         memory_budget: crate::pipeline::memory::MemoryBudget,
         spill_root: Arc<tempfile::TempDir>,
         spill_root_path: Arc<std::path::Path>,
-    ) -> Result<(PipelineCounters, Vec<DlqEntry>, Option<u64>), PipelineError> {
+        watermarks: crate::executor::watermark::PerSourceWatermarks,
+    ) -> Result<
+        (
+            PipelineCounters,
+            Vec<DlqEntry>,
+            Option<u64>,
+            crate::executor::watermark::PerSourceWatermarks,
+        ),
+        PipelineError,
+    > {
         let output_configs: Vec<_> = config.output_configs().cloned().collect();
         let pipeline_start_time = chrono::Local::now().naive_local();
 
@@ -1222,6 +1292,7 @@ impl PipelineExecutor {
             spill_root,
             spill_root_path,
             window_runtime,
+            watermarks,
             memory_budget,
             correlation_buffers,
             correlation_max_group_buffer,
@@ -1330,6 +1401,7 @@ impl PipelineExecutor {
             std::mem::take(counters),
             std::mem::take(dlq_entries),
             rss_bytes(),
+            ctx.watermarks,
         ))
     }
 
@@ -1577,6 +1649,27 @@ fn wrap_with_schema_coercion(
     }
 }
 
+/// Convert a record value at a declared watermark column into the
+/// canonical i64-nanoseconds event-time stamp folded into
+/// [`crate::executor::watermark::PerSourceWatermarks`].
+///
+/// Accepts [`clinker_record::Value::DateTime`] (preserved at nano
+/// resolution via `and_utc().timestamp_nanos_opt()`) and
+/// [`clinker_record::Value::Date`] (anchored at 00:00:00 UTC). Null,
+/// non-temporal, or out-of-`i64`-nanos-range values return `None`
+/// and are silently skipped — late-record dropping is the time-window
+/// operator's job.
+fn value_to_event_time_nanos(value: &clinker_record::Value) -> Option<i64> {
+    use clinker_record::Value;
+    match value {
+        Value::DateTime(nd) => nd.and_utc().timestamp_nanos_opt(),
+        Value::Date(d) => d
+            .and_hms_opt(0, 0, 0)
+            .and_then(|nd| nd.and_utc().timestamp_nanos_opt()),
+        _ => None,
+    }
+}
+
 /// Ingest a Source's records into a bounded `SourceStream` and drain
 /// to the read-side handle. Used uniformly by every declared Source —
 /// no primary asymmetry.
@@ -1595,6 +1688,7 @@ fn ingest_source_into_stream(
     config: &PipelineConfig,
     spill_dir: Option<Arc<std::path::Path>>,
     counters: &mut PipelineCounters,
+    watermarks: &mut crate::executor::watermark::PerSourceWatermarks,
 ) -> Result<source_stream::DrainedSourceStream, PipelineError> {
     if files.is_empty() {
         return Err(PipelineError::Config(
@@ -1634,6 +1728,30 @@ fn ingest_source_into_stream(
         Arc::from(src_cfg.path_str())
     };
 
+    // Resolve the watermark column to a position on the widened
+    // schema once per source; the per-record observation below is then
+    // a positional read with no name lookup. Resolution failure here
+    // means the planner (`crate::plan::bind_schema`) admitted a
+    // declaration that doesn't match the runtime schema — defense in
+    // depth surfaces as a config error rather than silent skip.
+    let watermark_column_idx: Option<usize> = match src_cfg.watermark.as_ref() {
+        None => None,
+        Some(wm) => match widened_schema.index(wm.column.as_str()) {
+            Some(i) => Some(i),
+            None => {
+                return Err(PipelineError::Config(
+                    crate::config::ConfigError::Validation(format!(
+                        "source '{}' declares watermark.column = '{}' but no such column \
+                         exists on the runtime schema (declared columns: {:?})",
+                        src_cfg.name,
+                        wm.column,
+                        widened_schema.columns(),
+                    )),
+                ));
+            }
+        },
+    };
+
     let mut stream = source_stream::SourceStream::new(
         Arc::clone(&widened_schema),
         source_stream::DEFAULT_SOURCE_STREAM_CAPACITY,
@@ -1650,6 +1768,18 @@ fn ingest_source_into_stream(
                     .cloned()
                     .unwrap_or_else(|| Arc::clone(&static_source_file));
                 let mut values: Vec<clinker_record::Value> = record.values().to_vec();
+                // Observe the watermark column BEFORE widening: read
+                // the value at its position, convert Timestamp / Date
+                // to i64 nanoseconds, and fold into the per-(source,
+                // file) max. Null / non-temporal / unparseable values
+                // are silently skipped — late-record dropping is the
+                // time-window operator's job, not ingest's.
+                if let Some(idx) = watermark_column_idx
+                    && let Some(value) = values.get(idx)
+                    && let Some(ts_nanos) = value_to_event_time_nanos(value)
+                {
+                    watermarks.observe(&src_cfg.name, &file_arc, ts_nanos);
+                }
                 values.push(clinker_record::Value::String(
                     file_arc.as_ref().to_string().into_boxed_str(),
                 ));

--- a/crates/clinker-core/src/executor/watermark.rs
+++ b/crates/clinker-core/src/executor/watermark.rs
@@ -1,0 +1,294 @@
+//! Per-(source, file) event-time watermark bookkeeping.
+//!
+//! [`ExecutorContext`] owns one [`PerSourceWatermarks`] for the
+//! pipeline run. State is keyed by `(source_name, Arc<source_file>)` —
+//! the same `$source.file` Arc that travels on every record's
+//! engine-stamped lineage column — so a glob/regex/paths source that
+//! pulls N files keeps N independent watermarks. Collapsing N files
+//! into one watermark would cross-gate file A's windows against file
+//! B's record stream, breaking the 1:1 source-file → sink invariant
+//! that `fan_out_per_source_file` outputs rely on.
+//!
+//! Sources declare their event-time column via `watermark:` on
+//! [`crate::config::SourceConfig`] (column applies to every file the
+//! source pulls in). `ingest_source_into_stream` observes per record
+//! using the reader's `current_source_file()` as the file key and
+//! folds the column value into an i64-nanos max for that pair.
+//!
+//! Read-side rollup methods serve every consumer granularity:
+//! - [`file_max`](PerSourceWatermarks::file_max) — exactly one
+//!   `(source, file)` pair.
+//! - [`source_min`](PerSourceWatermarks::source_min) — min across all
+//!   files of one source (per-file watermarks compose at the source
+//!   level via min, so a glob source with one lagging file holds the
+//!   source-level watermark back, matching the Flink/Arroyo
+//!   per-partition + operator-level reducer pattern).
+//! - [`min_across_sources`](PerSourceWatermarks::min_across_sources) —
+//!   min across rolled-up source values; the cross-source operator-
+//!   level reducer a time-windowed close decision reads.
+//!
+//! `None` semantics at every level mirror Spark Structured Streaming:
+//! a partition / source with no observations contributes `None` and
+//! is excluded from the min reducer. A min reducer over an all-`None`
+//! input returns `None`. Idle-source flagging (Flink's
+//! `WatermarkStatus.IDLE`) is deferred to the async migration sprint
+//! where concurrent ingest can leave a source genuinely quiet while
+//! peers advance; see https://github.com/rustpunk/clinker/issues/57.
+//!
+//! Reset on `$ck` rollback (https://github.com/rustpunk/clinker/issues/56)
+//! is not wired here — pipeline-wide rollback rebuilds
+//! [`ExecutorContext`] from scratch, so monotonicity within a run is
+//! preserved by construction. When per-source rollback lands, the
+//! reset method lives in that sprint alongside its caller (LD-011:
+//! no unwired `pub(crate)` APIs).
+//!
+//! [`ExecutorContext`]: crate::executor::dispatch::ExecutorContext
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+/// Max event-time observed for one (source, file) partition, in
+/// nanoseconds since the Unix epoch. `None` means the partition has
+/// no observations — either zero records, or every record's
+/// watermark column was Null / unparseable.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct SourcePartitionWatermark {
+    pub(crate) max_event_time_nanos: Option<i64>,
+}
+
+/// Per-source / per-file event-time watermark map.
+///
+/// Two tables kept in sync at the executor boundary:
+///
+/// - `declared`: set of source names that declared
+///   [`crate::config::SourceConfig::watermark`]. The
+///   [`ExecutionReport`] uses this to emit a per-source rollup entry
+///   even when ingest observed zero records for that source.
+/// - `by_source`: per-(source, file) max-event-time. Populated by
+///   ingest [`observe`](Self::observe) calls. A source declared but
+///   with zero observed records is absent from this table; rollups
+///   treat the missing entry as `None`.
+///
+/// [`ExecutionReport`]: crate::executor::ExecutionReport
+#[derive(Debug, Default)]
+pub(crate) struct PerSourceWatermarks {
+    declared: HashSet<String>,
+    by_source: HashMap<String, HashMap<Arc<str>, SourcePartitionWatermark>>,
+}
+
+impl PerSourceWatermarks {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record that a source declared `watermark:` in its config.
+    /// Idempotent. Called once per declared source at executor start,
+    /// before any `observe` calls.
+    pub(crate) fn declare(&mut self, source: &str) {
+        self.declared.insert(source.to_string());
+    }
+
+    /// Fold one observation into the running max for `(source, file)`.
+    /// The `Arc<str>` for the file is cloned only when a new partition
+    /// entry materializes — the steady-state hot path reuses the
+    /// caller's existing Arc identity (the same one that lands on the
+    /// record's `$source.file` engine-stamped column).
+    pub(crate) fn observe(&mut self, source: &str, file: &Arc<str>, ts_nanos: i64) {
+        let partition = self
+            .by_source
+            .entry(source.to_string())
+            .or_default()
+            .entry(Arc::clone(file))
+            .or_default();
+        partition.max_event_time_nanos = Some(match partition.max_event_time_nanos {
+            Some(prev) => prev.max(ts_nanos),
+            None => ts_nanos,
+        });
+    }
+
+    /// Min across all files of one source — the source-level rollup
+    /// that holds back a glob source's effective watermark when one
+    /// file lags. Returns `None` when the source has no populated
+    /// partitions (no records observed yet, or no `watermark:`
+    /// declared).
+    pub(crate) fn source_min(&self, source: &str) -> Option<i64> {
+        self.by_source
+            .get(source)?
+            .values()
+            .filter_map(|p| p.max_event_time_nanos)
+            .min()
+    }
+
+    /// Min across the rolled-up source-level values for the supplied
+    /// names. The reducer a time-windowed aggregate's close decision
+    /// reads (future consumer; today only [`ExecutionReport`] reads
+    /// this). Sources whose [`source_min`](Self::source_min) is `None`
+    /// are excluded from the min; an all-`None` input set returns
+    /// `None`.
+    ///
+    /// [`ExecutionReport`]: crate::executor::ExecutionReport
+    pub(crate) fn min_across_sources(&self, sources: &[&str]) -> Option<i64> {
+        sources.iter().filter_map(|s| self.source_min(s)).min()
+    }
+
+    /// Iterate every populated (source, file, watermark) triple.
+    /// Order is unspecified; the report layer collects into a
+    /// [`std::collections::BTreeMap`] for deterministic snapshot
+    /// ordering.
+    pub(crate) fn iter_partitions(
+        &self,
+    ) -> impl Iterator<Item = (&str, &Arc<str>, &SourcePartitionWatermark)> + '_ {
+        self.by_source
+            .iter()
+            .flat_map(|(src, files)| files.iter().map(move |(file, w)| (src.as_str(), file, w)))
+    }
+
+    /// Iterate every declared source name (regardless of whether it
+    /// has any populated partitions yet). The report layer uses this
+    /// to emit a per-source rollup entry for declared-but-zero-record
+    /// sources.
+    pub(crate) fn iter_declared_sources(&self) -> impl Iterator<Item = &str> + '_ {
+        self.declared.iter().map(|s| s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn arc(s: &str) -> Arc<str> {
+        Arc::from(s)
+    }
+
+    fn file_max_from_iter(w: &PerSourceWatermarks, src: &str, file: &str) -> Option<i64> {
+        w.iter_partitions()
+            .find(|(s, f, _)| *s == src && f.as_ref() == file)
+            .and_then(|(_, _, p)| p.max_event_time_nanos)
+    }
+
+    #[test]
+    fn observe_is_max_per_partition() {
+        let mut w = PerSourceWatermarks::new();
+        let a = arc("a.csv");
+        w.observe("src", &a, 100);
+        w.observe("src", &a, 50);
+        w.observe("src", &a, 200);
+        w.observe("src", &a, 150);
+        assert_eq!(file_max_from_iter(&w, "src", "a.csv"), Some(200));
+    }
+
+    #[test]
+    fn observe_keeps_files_independent() {
+        let mut w = PerSourceWatermarks::new();
+        let a = arc("a.csv");
+        let b = arc("b.csv");
+        w.observe("src", &a, 100);
+        w.observe("src", &b, 999);
+        assert_eq!(file_max_from_iter(&w, "src", "a.csv"), Some(100));
+        assert_eq!(file_max_from_iter(&w, "src", "b.csv"), Some(999));
+    }
+
+    #[test]
+    fn source_min_rolls_files_via_min() {
+        let mut w = PerSourceWatermarks::new();
+        let a = arc("a.csv");
+        let b = arc("b.csv");
+        w.observe("src", &a, 100);
+        w.observe("src", &b, 999);
+        // The lagging file holds the source-level watermark back —
+        // file b's high mark cannot finalize file a's data
+        // unilaterally.
+        assert_eq!(w.source_min("src"), Some(100));
+    }
+
+    #[test]
+    fn source_min_returns_none_for_unobserved_source() {
+        let w = PerSourceWatermarks::new();
+        assert_eq!(w.source_min("src"), None);
+    }
+
+    #[test]
+    fn min_across_sources_skips_none_and_returns_min() {
+        let mut w = PerSourceWatermarks::new();
+        w.observe("src_a", &arc("a.csv"), 100);
+        w.observe("src_b", &arc("b.csv"), 200);
+        assert_eq!(w.min_across_sources(&["src_a", "src_b"]), Some(100));
+        // An unobserved source is skipped, not treated as zero.
+        assert_eq!(
+            w.min_across_sources(&["src_a", "src_b", "src_unobs"]),
+            Some(100),
+        );
+    }
+
+    #[test]
+    fn min_across_sources_returns_none_when_all_unobserved() {
+        let w = PerSourceWatermarks::new();
+        assert_eq!(w.min_across_sources(&["src_a", "src_b"]), None);
+    }
+
+    #[test]
+    fn declare_alone_leaves_rollups_none() {
+        let mut w = PerSourceWatermarks::new();
+        w.declare("src");
+        // Declaration alone does not populate by_source; rollups
+        // still return None until `observe` runs.
+        assert_eq!(w.source_min("src"), None);
+        assert_eq!(file_max_from_iter(&w, "src", "any.csv"), None);
+        let declared: Vec<&str> = w.iter_declared_sources().collect();
+        assert_eq!(declared, vec!["src"]);
+    }
+
+    #[test]
+    fn iter_declared_sources_lists_zero_record_sources() {
+        let mut w = PerSourceWatermarks::new();
+        w.declare("src_a");
+        w.declare("src_b");
+        let mut declared: Vec<&str> = w.iter_declared_sources().collect();
+        declared.sort();
+        assert_eq!(declared, vec!["src_a", "src_b"]);
+    }
+
+    #[test]
+    fn iter_partitions_yields_every_populated_pair() {
+        let mut w = PerSourceWatermarks::new();
+        w.observe("src_a", &arc("a.csv"), 100);
+        w.observe("src_a", &arc("b.csv"), 200);
+        w.observe("src_b", &arc("c.csv"), 300);
+        let mut triples: Vec<(String, String, Option<i64>)> = w
+            .iter_partitions()
+            .map(|(s, f, w)| {
+                (
+                    s.to_string(),
+                    f.as_ref().to_string(),
+                    w.max_event_time_nanos,
+                )
+            })
+            .collect();
+        triples.sort();
+        assert_eq!(
+            triples,
+            vec![
+                ("src_a".to_string(), "a.csv".to_string(), Some(100)),
+                ("src_a".to_string(), "b.csv".to_string(), Some(200)),
+                ("src_b".to_string(), "c.csv".to_string(), Some(300)),
+            ],
+        );
+    }
+
+    #[test]
+    fn observe_reuses_existing_arc_for_repeat_files() {
+        // The steady-state hot path (every record from the same file
+        // through the same source) must not clone the Arc on each
+        // observation — it should reuse the Arc identity recorded on
+        // first contact.
+        let mut w = PerSourceWatermarks::new();
+        let file = arc("a.csv");
+        let initial_strong = Arc::strong_count(&file);
+        for ts in 0..1000 {
+            w.observe("src", &file, ts);
+        }
+        // One additional strong reference: the one stored in the map.
+        // 1000 observations did not 1000-x the count.
+        assert_eq!(Arc::strong_count(&file), initial_strong + 1);
+    }
+}

--- a/crates/clinker-core/src/executor/watermark.rs
+++ b/crates/clinker-core/src/executor/watermark.rs
@@ -16,8 +16,6 @@
 //! folds the column value into an i64-nanos max for that pair.
 //!
 //! Read-side rollup methods serve every consumer granularity:
-//! - [`file_max`](PerSourceWatermarks::file_max) — exactly one
-//!   `(source, file)` pair.
 //! - [`source_min`](PerSourceWatermarks::source_min) — min across all
 //!   files of one source (per-file watermarks compose at the source
 //!   level via min, so a glob source with one lagging file holds the
@@ -39,8 +37,9 @@
 //! is not wired here — pipeline-wide rollback rebuilds
 //! [`ExecutorContext`] from scratch, so monotonicity within a run is
 //! preserved by construction. When per-source rollback lands, the
-//! reset method lives in that sprint alongside its caller (LD-011:
-//! no unwired `pub(crate)` APIs).
+//! reset method ships in that sprint alongside its caller — the rule
+//! the project applies sprint-wide is that every `pub(crate)` API has
+//! an intra-crate caller at the closing commit.
 //!
 //! [`ExecutorContext`]: crate::executor::dispatch::ExecutorContext
 

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -1032,6 +1032,56 @@ fn bind_schema_inner(
                         LabeledSpan::primary(span, String::new()),
                     ));
                 }
+                // Watermark declaration: column must exist on the
+                // source's declared schema AND have an event-time-
+                // coercible CXL type (DateTime or Date).
+                if let Some(wm) = config.source.watermark.as_ref() {
+                    let declared = schema_decl.columns.iter().find(|c| c.name == wm.column);
+                    match declared {
+                        None => diags.push(
+                            Diagnostic::error(
+                                "E154",
+                                format!(
+                                    "source {name:?} declares watermark.column = {col:?} \
+                                     but the column is not present in this source's \
+                                     `schema:` block.",
+                                    col = wm.column,
+                                ),
+                                LabeledSpan::primary(span, String::new()),
+                            )
+                            .with_help(
+                                "add the watermark column to the source's `schema:` \
+                                 block, or remove the `watermark:` declaration",
+                            ),
+                        ),
+                        Some(col)
+                            if !matches!(
+                                col.ty,
+                                cxl::typecheck::Type::DateTime | cxl::typecheck::Type::Date,
+                            ) =>
+                        {
+                            diags.push(
+                                Diagnostic::error(
+                                    "E155",
+                                    format!(
+                                        "source {name:?} declares watermark.column = {col_name:?} \
+                                         but its declared type {ty:?} is not event-time-coercible; \
+                                         watermark columns must be `date_time` or `date`.",
+                                        col_name = wm.column,
+                                        ty = col.ty.display_name(),
+                                    ),
+                                    LabeledSpan::primary(span, String::new()),
+                                )
+                                .with_help(
+                                    "change the column's declared `type:` to `date_time` \
+                                     or `date`, or point `watermark.column` at a column \
+                                     that already has one of those types",
+                                ),
+                            );
+                        }
+                        Some(_) => {}
+                    }
+                }
                 let cxl_span = cxl::lexer::Span::new(span.start as usize, span.start as usize);
                 let row = Row::closed(columns, cxl_span);
                 schema_by_name.insert(name.clone(), row.clone());

--- a/crates/clinker-core/src/plan/tests/mod.rs
+++ b/crates/clinker-core/src/plan/tests/mod.rs
@@ -5,3 +5,4 @@ mod dedup_node_rooted;
 mod deferred_region;
 mod explain_polish;
 mod plan_time_window_root;
+mod watermark_validation;

--- a/crates/clinker-core/src/plan/tests/watermark_validation.rs
+++ b/crates/clinker-core/src/plan/tests/watermark_validation.rs
@@ -1,0 +1,154 @@
+//! Plan-time validation for `SourceConfig.watermark`.
+//!
+//! Two negative paths surface as compile-time diagnostics:
+//! - E154 — the named watermark column is not present in the source's
+//!   declared `schema:` block.
+//! - E155 — the named watermark column exists but its declared CXL
+//!   type is not `date_time` or `date` (not event-time-coercible).
+
+use crate::config::{CompileContext, parse_config};
+
+fn compile_diagnostics(yaml: &str) -> Vec<(String, String)> {
+    let config = parse_config(yaml).expect("parse_config");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("compile should fail");
+    diags
+        .iter()
+        .map(|d| (d.code.clone(), d.message.clone()))
+        .collect()
+}
+
+#[test]
+fn watermark_column_not_in_schema_emits_e154() {
+    let yaml = r#"
+pipeline:
+  name: watermark_missing_column
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: a.csv
+    watermark:
+      column: nonexistent_column
+    schema:
+      - { name: id, type: int }
+      - { name: event_time, type: date_time }
+- type: output
+  name: out
+  input: src
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    let diags = compile_diagnostics(yaml);
+    let hit = diags
+        .iter()
+        .find(|(code, _)| code == "E154")
+        .unwrap_or_else(|| panic!("expected E154, got {diags:?}"));
+    assert!(
+        hit.1.contains("nonexistent_column"),
+        "E154 message should name the missing column: {}",
+        hit.1
+    );
+}
+
+#[test]
+fn watermark_column_wrong_type_emits_e155() {
+    let yaml = r#"
+pipeline:
+  name: watermark_wrong_type
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: a.csv
+    watermark:
+      column: id
+    schema:
+      - { name: id, type: int }
+      - { name: event_time, type: date_time }
+- type: output
+  name: out
+  input: src
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    let diags = compile_diagnostics(yaml);
+    let hit = diags
+        .iter()
+        .find(|(code, _)| code == "E155")
+        .unwrap_or_else(|| panic!("expected E155, got {diags:?}"));
+    assert!(
+        hit.1.contains("id"),
+        "E155 message should name the column: {}",
+        hit.1
+    );
+}
+
+#[test]
+fn watermark_on_date_column_compiles_clean() {
+    let yaml = r#"
+pipeline:
+  name: watermark_date_ok
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: a.csv
+    watermark:
+      column: day
+    schema:
+      - { name: id, type: int }
+      - { name: day, type: date }
+- type: output
+  name: out
+  input: src
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    config
+        .compile(&CompileContext::default())
+        .expect("Date-typed watermark column compiles clean");
+}
+
+#[test]
+fn watermark_absent_compiles_clean() {
+    let yaml = r#"
+pipeline:
+  name: no_watermark
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: a.csv
+    schema:
+      - { name: id, type: int }
+      - { name: event_time, type: date_time }
+- type: output
+  name: out
+  input: src
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    config
+        .compile(&CompileContext::default())
+        .expect("absent watermark compiles clean");
+}

--- a/crates/clinker-core/src/source/discovery.rs
+++ b/crates/clinker-core/src/source/discovery.rs
@@ -449,6 +449,7 @@ mod tests {
             min_size: None,
             max_size: None,
             files: None,
+            watermark: None,
             schema: None,
             schema_overrides: None,
             array_paths: None,

--- a/crates/clinker-core/tests/per_source_watermarks.rs
+++ b/crates/clinker-core/tests/per_source_watermarks.rs
@@ -1,0 +1,450 @@
+//! Integration tests for per-source / per-file event-time watermark
+//! propagation. Covers the four-granularity contract:
+//!
+//! - `per_source_file_watermarks` — finest granularity, one entry per
+//!   `(source_name, source_file_path)` pair.
+//! - `per_source_watermarks` — `min` rollup across each source's
+//!   files.
+//! - `effective_watermark` — `min` rollup across declared sources.
+//! - Sources without `watermark:` declared contribute nothing at any
+//!   level; sources declared but with zero observed records appear
+//!   in the per-source map with `None`.
+//!
+//! Acceptance criterion 1 of https://github.com/rustpunk/clinker/issues/52
+//! ("aggregate waits for src_b to advance past each window's end")
+//! is exercised structurally here — the engine has no time-windowed
+//! aggregate operator today (tracked in
+//! https://github.com/rustpunk/clinker/issues/61), so this suite
+//! pins the carrier and rollup contract that operator will read.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, parse_config};
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::source::multi_file::FileSlot;
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn std::io::Write + Send> {
+    Box::new(buf.clone())
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// ISO 8601 second-precision datetime parsed by Clinker's default
+/// coercion chain (`DEFAULT_DATETIME_FORMATS`). Returns the i64
+/// nanoseconds-since-epoch the watermark map folds into its max.
+fn iso_dt_nanos(s: &str) -> i64 {
+    let nd =
+        chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S").expect("parse ISO datetime");
+    nd.and_utc().timestamp_nanos_opt().expect("nanos in range")
+}
+
+/// Two sources of differing event-time density. Pins per-source +
+/// effective-watermark rollups. Acceptance criterion 2 of
+/// https://github.com/rustpunk/clinker/issues/52.
+#[test]
+fn two_sources_differing_density() {
+    let yaml = r#"
+pipeline:
+  name: per_source_watermarks
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      watermark:
+        column: event_time
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      watermark:
+        column: event_time
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b]
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot(
+                "a",
+                "id,event_time\n1,2026-01-01T00:00:00\n2,2026-01-01T00:01:00\n3,2026-01-01T00:02:00\n",
+            )],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot(
+                "b",
+                "id,event_time\n10,2026-01-01T00:00:30\n11,2026-01-01T00:00:45\n",
+            )],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("execute multi-source watermarked pipeline");
+
+    let a_max = iso_dt_nanos("2026-01-01T00:02:00");
+    let b_max = iso_dt_nanos("2026-01-01T00:00:45");
+    assert_eq!(
+        report.per_source_watermarks.get("src_a"),
+        Some(&Some(a_max))
+    );
+    assert_eq!(
+        report.per_source_watermarks.get("src_b"),
+        Some(&Some(b_max))
+    );
+    assert_eq!(report.effective_watermark, Some(a_max.min(b_max)));
+
+    // Per-file map mirrors the source-level rollup for the single-
+    // file-per-source case.
+    let a_file_key = ("src_a".to_string(), "a.csv".to_string());
+    let b_file_key = ("src_b".to_string(), "b.csv".to_string());
+    assert_eq!(
+        report.per_source_file_watermarks.get(&a_file_key),
+        Some(&Some(a_max)),
+    );
+    assert_eq!(
+        report.per_source_file_watermarks.get(&b_file_key),
+        Some(&Some(b_max)),
+    );
+
+    // Merge correctness regression — both sources' records survive.
+    assert_eq!(report.counters.total_count, 5);
+}
+
+/// One source pulling two files. The file with the trailing watermark
+/// holds the source-level rollup back to its max — matching the
+/// Flink/Arroyo per-partition + min reducer pattern. This is the
+/// invariant the `fan_out_per_source_file` 1:1 source-file → sink
+/// topology relies on.
+#[test]
+fn glob_source_multi_file_per_partition() {
+    let yaml = r#"
+pipeline:
+  name: glob_source_watermark
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      paths: [a.csv, b.csv]
+      watermark:
+        column: event_time
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([(
+        "src".to_string(),
+        vec![
+            slot(
+                "a",
+                "id,event_time\n1,2026-01-01T00:00:01\n2,2026-01-01T00:00:02\n3,2026-01-01T00:00:03\n",
+            ),
+            slot(
+                "b",
+                "id,event_time\n10,2026-01-01T01:00:00\n11,2026-01-01T02:00:00\n12,2026-01-01T03:00:00\n",
+            ),
+        ],
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("execute glob source");
+
+    let a_max = iso_dt_nanos("2026-01-01T00:00:03");
+    let b_max = iso_dt_nanos("2026-01-01T03:00:00");
+    let a_key = ("src".to_string(), "a.csv".to_string());
+    let b_key = ("src".to_string(), "b.csv".to_string());
+    assert_eq!(
+        report.per_source_file_watermarks.get(&a_key),
+        Some(&Some(a_max))
+    );
+    assert_eq!(
+        report.per_source_file_watermarks.get(&b_key),
+        Some(&Some(b_max))
+    );
+    // Source-level rollup = min across files — file b's late watermark
+    // cannot finalize file a's data unilaterally.
+    assert_eq!(report.per_source_watermarks.get("src"), Some(&Some(a_max)));
+    assert_eq!(report.effective_watermark, Some(a_max));
+}
+
+/// Acceptance criterion 4: single-source pipelines still produce a
+/// per-source-watermarks report entry equal to `max(event_time)`,
+/// with no regression in pipeline output.
+#[test]
+fn single_source_unaffected() {
+    let yaml = r#"
+pipeline:
+  name: single_source_watermark
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: a.csv
+      watermark:
+        column: event_time
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([(
+        "src".to_string(),
+        vec![slot(
+            "a",
+            "id,event_time\n1,2026-01-01T00:00:01\n2,2026-01-01T00:00:02\n",
+        )],
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("execute single-source watermarked pipeline");
+
+    let expected = iso_dt_nanos("2026-01-01T00:00:02");
+    assert_eq!(
+        report.per_source_watermarks.get("src"),
+        Some(&Some(expected))
+    );
+    assert_eq!(report.effective_watermark, Some(expected));
+    assert_eq!(report.counters.total_count, 2);
+}
+
+/// A source without `watermark:` declared contributes nothing to any
+/// rollup. The `effective_watermark` then equals the declared source's
+/// rollup alone — the undeclared source does not pull the min toward
+/// `None`.
+#[test]
+fn undeclared_source_skipped_at_min() {
+    let yaml = r#"
+pipeline:
+  name: undeclared_skipped
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      watermark:
+        column: event_time
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b]
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot(
+                "a",
+                "id,event_time\n1,2026-01-01T00:00:01\n2,2026-01-01T00:00:02\n",
+            )],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot(
+                "b",
+                "id,event_time\n100,2030-01-01T00:00:00\n200,2030-01-01T00:00:01\n",
+            )],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("execute mixed-watermark pipeline");
+
+    let a_max = iso_dt_nanos("2026-01-01T00:00:02");
+    assert_eq!(
+        report.per_source_watermarks.get("src_a"),
+        Some(&Some(a_max))
+    );
+    // src_b is undeclared — does not appear in per_source_watermarks.
+    assert!(!report.per_source_watermarks.contains_key("src_b"));
+    // Cross-source min = the only declared source's rollup.
+    assert_eq!(report.effective_watermark, Some(a_max));
+}
+
+/// Pipeline with zero `watermark:` declarations: report is well-formed
+/// (empty maps, `None` effective watermark), pipeline output is
+/// unchanged from a pre-sprint baseline.
+#[test]
+fn no_watermarks_anywhere() {
+    let yaml = r#"
+pipeline:
+  name: no_watermarks
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders =
+        HashMap::from([("src".to_string(), vec![slot("a", "id,tag\n1,foo\n2,bar\n")])]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("execute no-watermark pipeline");
+
+    assert!(report.per_source_watermarks.is_empty());
+    assert!(report.per_source_file_watermarks.is_empty());
+    assert_eq!(report.effective_watermark, None);
+    assert_eq!(report.counters.total_count, 2);
+}
+
+/// A source with `watermark:` declared but zero matching records (the
+/// file is empty / contains only headers): the declared-source list
+/// still surfaces the entry with `None`, and rollups gracefully
+/// degrade.
+#[test]
+fn zero_records_keeps_declared_entry_with_none() {
+    let yaml = r#"
+pipeline:
+  name: zero_records_watermark
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: a.csv
+      watermark:
+        column: event_time
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders =
+        HashMap::from([("src".to_string(), vec![slot("a", "id,event_time\n")])]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("execute empty-input watermarked pipeline");
+
+    // Declared, but with no observations: source entry exists with
+    // None. Per-file map is empty because no record was observed.
+    assert_eq!(report.per_source_watermarks.get("src"), Some(&None));
+    assert!(report.per_source_file_watermarks.is_empty());
+    // min across {None} = None (Spark-style skip-`None` semantics).
+    assert_eq!(report.effective_watermark, None);
+}

--- a/crates/clinker-core/tests/per_source_watermarks.rs
+++ b/crates/clinker-core/tests/per_source_watermarks.rs
@@ -20,10 +20,11 @@
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use clinker_bench_support::io::SharedBuffer;
 use clinker_core::config::{CompileContext, parse_config};
-use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders, WriterRegistry};
 use clinker_core::source::multi_file::FileSlot;
 
 fn slot(name: &str, csv: &str) -> FileSlot {
@@ -447,4 +448,133 @@ nodes:
     assert!(report.per_source_file_watermarks.is_empty());
     // min across {None} = None (Spark-style skip-`None` semantics).
     assert_eq!(report.effective_watermark, None);
+}
+
+/// End-to-end: a glob source feeding a `fan_out_per_source_file`
+/// output. Per-file watermarks must remain separate in the report
+/// AND each output file must contain only its own source-file's
+/// records. Exercises the 1:1 source-file → sink invariant the
+/// granularity decision is designed to preserve.
+#[test]
+fn fan_out_per_source_file_watermark_isolation() {
+    let yaml = r#"
+pipeline:
+  name: fan_out_watermark_isolation
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      paths: [a.csv, b.csv]
+      watermark:
+        column: event_time
+      schema:
+        - { name: id, type: int }
+        - { name: event_time, type: date_time }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out_{source_file}.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+
+    // The reader builds its own Arc<str> for `$source.file` from the
+    // FileSlot path. Matching by string value (Arc<str> compares by
+    // contents via HashMap's Borrow<str> impl).
+    let arc_a: Arc<str> = Arc::from("a.csv");
+    let arc_b: Arc<str> = Arc::from("b.csv");
+    let readers: SourceReaders = HashMap::from([(
+        "src".to_string(),
+        vec![
+            FileSlot::new(
+                PathBuf::from(arc_a.as_ref()),
+                Box::new(Cursor::new(
+                    "id,event_time\n1,2026-01-01T00:00:01\n2,2026-01-01T00:00:02\n3,2026-01-01T00:00:03\n"
+                        .as_bytes()
+                        .to_vec(),
+                )),
+            ),
+            FileSlot::new(
+                PathBuf::from(arc_b.as_ref()),
+                Box::new(Cursor::new(
+                    "id,event_time\n10,2026-01-01T05:00:00\n11,2026-01-01T06:00:00\n"
+                        .as_bytes()
+                        .to_vec(),
+                )),
+            ),
+        ],
+    )]);
+
+    let buf_a = SharedBuffer::new();
+    let buf_b = SharedBuffer::new();
+    let mut per_file: HashMap<Arc<str>, Box<dyn std::io::Write + Send>> = HashMap::new();
+    per_file.insert(
+        Arc::clone(&arc_a),
+        Box::new(buf_a.clone()) as Box<dyn std::io::Write + Send>,
+    );
+    per_file.insert(
+        Arc::clone(&arc_b),
+        Box::new(buf_b.clone()) as Box<dyn std::io::Write + Send>,
+    );
+    let mut fan_out: HashMap<String, HashMap<Arc<str>, Box<dyn std::io::Write + Send>>> =
+        HashMap::new();
+    fan_out.insert("out".to_string(), per_file);
+    let writers = WriterRegistry {
+        single: HashMap::new(),
+        fan_out,
+    };
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("run fan-out watermark pipeline");
+
+    // Per-file watermarks reported independently — the early file's
+    // max watermark does not creep into the late file's slot, and
+    // vice versa.
+    let a_key = ("src".to_string(), "a.csv".to_string());
+    let b_key = ("src".to_string(), "b.csv".to_string());
+    let a_max = iso_dt_nanos("2026-01-01T00:00:03");
+    let b_max = iso_dt_nanos("2026-01-01T06:00:00");
+    assert_eq!(
+        report.per_source_file_watermarks.get(&a_key),
+        Some(&Some(a_max))
+    );
+    assert_eq!(
+        report.per_source_file_watermarks.get(&b_key),
+        Some(&Some(b_max))
+    );
+    // Source-level rollup = min over files (file a's max).
+    assert_eq!(report.per_source_watermarks.get("src"), Some(&Some(a_max)));
+
+    // The 1:1 source-file → sink invariant: each output file's buffer
+    // contains exactly that source file's records, no leakage in
+    // either direction.
+    let out_a = buf_a.as_string();
+    let out_b = buf_b.as_string();
+    for early_id in ["1", "2", "3"] {
+        assert!(
+            out_a.contains(&format!(",{early_id},")) || out_a.contains(&format!("\n{early_id},")),
+            "buf_a missing id {early_id}: {out_a}"
+        );
+        assert!(
+            !(out_b.contains(&format!(",{early_id},"))
+                || out_b.contains(&format!("\n{early_id},"))),
+            "buf_b leaked id {early_id}: {out_b}"
+        );
+    }
+    for late_id in ["10", "11"] {
+        assert!(
+            out_b.contains(&format!(",{late_id},")) || out_b.contains(&format!("\n{late_id},")),
+            "buf_b missing id {late_id}: {out_b}"
+        );
+        assert!(
+            !(out_a.contains(&format!(",{late_id},")) || out_a.contains(&format!("\n{late_id},"))),
+            "buf_a leaked id {late_id}: {out_a}"
+        );
+    }
 }


### PR DESCRIPTION
Adds `PerSourceWatermarks` bookkeeping keyed by `(source_name, $source.file Arc)` — the granularity sprint 2's engine-stamped SourceFile lineage column already preserves through Merge. A glob / regex / paths source keeps N independent watermarks, one per file, so downstream operators that fan out 1:1 per source-file (`fan_out_per_source_file`) keep their isolation invariant.

Read-side rollups: `source_min` (Flink-style min over a source's per-file watermarks) → `min_across_sources` (the cross-source operator-level reducer a time-windowed close decision reads).

The carrier and rollup contract are the load-bearing artifact this sprint produces. The engine has no time-windowed aggregate operator today; per-source min-watermark is trivially the final per-source max in the batch model, so semantic gating belongs to the time-window operator sprint that will read `min_across_sources` from `ExecutionReport`. Tracked: #61 (time-window primitive + lateness / delay policy), #57 (async runtime brings the idle-source flag), #56 (per-source rollback brings the reset hook).

YAML surface mirrors Flink SQL's `WATERMARK FOR ts AS ts - INTERVAL` — declared per-source on `SourceConfig`:

```yaml
watermark:
  column: event_time
```

Plan-time validation surfaces **E154** (column not in schema) and **E155** (column type not coercible to event-time). Late-record dropping, `allowed_lateness`, and the delay column are deferred to #61 where the operator that consumes them lands.

`ExecutionReport` exposes `per_source_file_watermarks` (finest), `per_source_watermarks` (source-level min rollup), and `effective_watermark` (cross-source min). Integration coverage in `crates/clinker-core/tests/per_source_watermarks.rs` pins seven cases: two-source differing density, glob multi-file per-partition isolation, fan-out-per-source-file end-to-end isolation, single-source regression, undeclared-source skip-at-min, no-watermarks-anywhere, and zero-records-keeps-declared-entry-with-none. Plan-time negative tests in `src/plan/tests/watermark_validation.rs` cover the E154 / E155 paths plus the Date-typed and absent-watermark happy paths.
