### PR TITLE
executor: engine-stamp $source.name on every Source-ingested record (closes #54)

### DIFF
--- a/crates/clinker-core/src/aggregation.rs
+++ b/crates/clinker-core/src/aggregation.rs
@@ -1534,14 +1534,21 @@ impl HashAggregator {
         let encoder = crate::pipeline::sort_key::SortKeyEncoder::new(sort_fields);
 
         let gb_count = self.group_by_indices.len();
+        let schema_cols = self.spill_schema.column_count();
         let mut prepared: Vec<(Vec<u8>, usize)> = Vec::with_capacity(drained.len());
         for (idx, (key, _state)) in drained.iter().enumerate() {
-            let mut values: Vec<Value> = Vec::with_capacity(gb_count + 1);
+            let mut values: Vec<Value> = Vec::with_capacity(schema_cols);
             for gk in key {
                 values.push(gk.to_value());
             }
-            // Pad to match spill_schema column count for SortKeyEncoder.
-            values.push(Value::Null);
+            // Pad the non-group-by tail (`__acc_state`, `__meta_tracker`) with
+            // Null so the synth record matches the spill schema's column count.
+            // `SortKeyEncoder` only reads the group-by prefix; everything past
+            // it is encoder-irrelevant but must be present to satisfy
+            // `Record::new`'s schema/values length invariant.
+            for _ in gb_count..schema_cols {
+                values.push(Value::Null);
+            }
             let synth = Record::new(Arc::clone(&self.spill_schema), values);
             let mut buf = Vec::new();
             encoder.encode_into(&synth, &mut buf);

--- a/crates/clinker-core/src/config/mod.rs
+++ b/crates/clinker-core/src/config/mod.rs
@@ -3045,6 +3045,8 @@ pub(crate) fn lower_node_to_plan_node(
                         builder.with_field_meta(col, FieldMetadata::widened_sidecar())
                     } else if col == crate::config::pipeline_node::SOURCE_FILE_COLUMN {
                         builder.with_field_meta(col, FieldMetadata::source_file())
+                    } else if col == crate::config::pipeline_node::SOURCE_NAME_COLUMN {
+                        builder.with_field_meta(col, FieldMetadata::source_name())
                     } else {
                         builder.with_field(col)
                     };

--- a/crates/clinker-core/src/config/pipeline_node.rs
+++ b/crates/clinker-core/src/config/pipeline_node.rs
@@ -796,6 +796,14 @@ pub const WIDENED_SIDECAR_COLUMN: &str = "$widened";
 /// merges instead of via an external row-keyed array.
 pub const SOURCE_FILE_COLUMN: &str = "$source.file";
 
+/// Stable column name for the per-record Source-node identity stamp.
+/// Every Source's bound schema carries one such tail-appended slot;
+/// ingest stamps a shared `Arc<str>` of the originating Source's name
+/// so `$source.name` resolves per-record through merges — the case
+/// schema identity alone cannot answer when peer Sources share a
+/// column shape (the silent-corruption topology at the root of #47).
+pub const SOURCE_NAME_COLUMN: &str = "$source.name";
+
 /// Transform variant body. The new shape: a mandatory `cxl:` field
 /// carrying the CXL source as a `CxlSource` (so it captures its YAML
 /// span where serde-saphyr can deliver one), plus the row-level

--- a/crates/clinker-core/src/dlq.rs
+++ b/crates/clinker-core/src/dlq.rs
@@ -98,6 +98,7 @@ pub fn write_dlq<W: Write>(
         "_cxl_dlq_id",
         "_cxl_dlq_timestamp",
         "_cxl_dlq_source_file",
+        "_cxl_dlq_source_name",
         "_cxl_dlq_source_row",
     ];
     if include_reason {
@@ -123,6 +124,7 @@ pub fn write_dlq<W: Write>(
             id,
             timestamp,
             source_file.to_string(),
+            entry.source_name.as_ref().to_string(),
             entry.source_row.to_string(),
         ];
 
@@ -163,7 +165,9 @@ fn dlq_user_columns(schema: &Schema) -> impl Iterator<Item = (usize, &str)> {
         .iter()
         .enumerate()
         .filter_map(|(i, c)| match schema.field_metadata(i) {
-            Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) => None,
+            Some(FieldMetadata::WidenedSidecar)
+            | Some(FieldMetadata::SourceFile)
+            | Some(FieldMetadata::SourceName) => None,
             Some(FieldMetadata::SourceCorrelation { .. })
             | Some(FieldMetadata::AggregateGroupIndex { .. })
             | None => Some((i, c.as_ref())),
@@ -222,6 +226,7 @@ mod tests {
             stage: None,
             route: None,
             trigger: true,
+            source_name: Arc::from("test_source"),
         }
     }
 
@@ -244,14 +249,15 @@ mod tests {
         assert_eq!(columns[0], "_cxl_dlq_id");
         assert_eq!(columns[1], "_cxl_dlq_timestamp");
         assert_eq!(columns[2], "_cxl_dlq_source_file");
-        assert_eq!(columns[3], "_cxl_dlq_source_row");
-        assert_eq!(columns[4], "_cxl_dlq_error_category");
-        assert_eq!(columns[5], "_cxl_dlq_error_detail");
-        assert_eq!(columns[6], "_cxl_dlq_stage");
-        assert_eq!(columns[7], "_cxl_dlq_route");
-        assert_eq!(columns[8], "_cxl_dlq_trigger");
-        assert_eq!(columns[9], "name");
-        assert_eq!(columns[10], "value");
+        assert_eq!(columns[3], "_cxl_dlq_source_name");
+        assert_eq!(columns[4], "_cxl_dlq_source_row");
+        assert_eq!(columns[5], "_cxl_dlq_error_category");
+        assert_eq!(columns[6], "_cxl_dlq_error_detail");
+        assert_eq!(columns[7], "_cxl_dlq_stage");
+        assert_eq!(columns[8], "_cxl_dlq_route");
+        assert_eq!(columns[9], "_cxl_dlq_trigger");
+        assert_eq!(columns[10], "name");
+        assert_eq!(columns[11], "value");
     }
 
     #[test]
@@ -470,6 +476,7 @@ mod tests {
             stage: None,
             route: None,
             trigger: true,
+            source_name: Arc::from("test_source"),
         }];
         let mut buf = Vec::new();
         write_dlq(&mut buf, &entries, &schema, "input.csv", true, true).unwrap();
@@ -477,11 +484,13 @@ mod tests {
 
         let header_line = output.lines().next().unwrap();
         let columns: Vec<&str> = header_line.split(',').collect();
-        // Source fields in schema order (zulu, alpha, mike), not alphabetical
-        // Columns 6-8 are _cxl_dlq_stage, _cxl_dlq_route, _cxl_dlq_trigger
-        assert_eq!(columns[9], "zulu");
-        assert_eq!(columns[10], "alpha");
-        assert_eq!(columns[11], "mike");
+        // Source fields in schema order (zulu, alpha, mike), not alphabetical.
+        // Columns 0-4 are the prelude (_cxl_dlq_id / timestamp / source_file /
+        // source_name / source_row); 5-6 are error category/detail; 7-9 are
+        // stage/route/trigger.
+        assert_eq!(columns[10], "zulu");
+        assert_eq!(columns[11], "alpha");
+        assert_eq!(columns[12], "mike");
     }
 
     #[test]
@@ -576,6 +585,7 @@ mod tests {
             stage: None,
             route: None,
             trigger: true,
+            source_name: Arc::from("test_source"),
         };
         let mut buf = Vec::new();
         write_dlq(&mut buf, &[entry], &schema, "input.csv", true, true).unwrap();

--- a/crates/clinker-core/src/executor/commit/detect.rs
+++ b/crates/clinker-core/src/executor/commit/detect.rs
@@ -204,12 +204,15 @@ pub(crate) fn detect_retract_scope(
                             }
                         }
                     }
-                    Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) => {
+                    Some(FieldMetadata::WidenedSidecar)
+                    | Some(FieldMetadata::SourceFile)
+                    | Some(FieldMetadata::SourceName) => {
                         // The `auto_widen` sidecar and the
-                        // `$source.file` lineage stamp carry no
-                        // correlation linkage — they ride alongside
-                        // the CK lattice but the retract walk routes
-                        // through `$ck.*` columns only.
+                        // `$source.file` / `$source.name` lineage
+                        // stamps carry no correlation linkage — they
+                        // ride alongside the CK lattice but the
+                        // retract walk routes through `$ck.*` columns
+                        // only.
                     }
                     None => {}
                 }

--- a/crates/clinker-core/src/executor/commit/recompute_agg.rs
+++ b/crates/clinker-core/src/executor/commit/recompute_agg.rs
@@ -146,6 +146,7 @@ pub(crate) fn emit_post_recompute(
         source_count: ctx.source_count,
         source_batch: ctx.source_batch_arc,
         ingestion_timestamp: ctx.source_ingestion_timestamp,
+        source_name: &crate::executor::dispatch::MERGED_SOURCE_NAME,
     };
     let emits_synthetic = retained.aggregator.emits_synthetic_ck();
     retained

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -36,6 +36,11 @@ use crate::error::PipelineError;
 /// Used when [`source_file_of`] returns `None`.
 pub(crate) static MERGED_SOURCE_FILE: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from("<merged>"));
 
+/// Stand-in `$source.name` value for the same synthetic-emit sites that
+/// [`MERGED_SOURCE_FILE`] covers — Combine / post-aggregate finalize and
+/// composition-body emits that lost lineage at fan-in.
+pub(crate) static MERGED_SOURCE_NAME: LazyLock<Arc<str>> = LazyLock::new(|| Arc::from("<merged>"));
+
 /// Read the per-record source-file path from the record's
 /// [`FieldMetadata::SourceFile`] engine-stamped column. Returns `None`
 /// when the record carries no such column (typical for Combine /
@@ -66,6 +71,35 @@ pub(crate) fn source_file_arc_of(record: &Record) -> Arc<str> {
     match source_file_path_of(record) {
         Some(s) => Arc::from(s),
         None => Arc::clone(&MERGED_SOURCE_FILE),
+    }
+}
+
+/// Read the per-record Source-node name from the record's
+/// [`FieldMetadata::SourceName`] engine-stamped column. Returns `None`
+/// when the column is absent (synthetic emits) or non-String.
+pub(crate) fn source_name_of(record: &Record) -> Option<&str> {
+    let schema = record.schema();
+    for idx in 0..schema.column_count() {
+        if matches!(schema.field_metadata(idx), Some(FieldMetadata::SourceName))
+            && let Some(Value::String(s)) = record.values().get(idx)
+        {
+            return Some(s.as_ref());
+        }
+    }
+    None
+}
+
+/// Read the per-record Source-node `Arc<str>` from the record's
+/// [`FieldMetadata::SourceName`] engine-stamped column, materializing
+/// a fresh `Arc<str>` per call. Falls back to a clone of
+/// [`MERGED_SOURCE_NAME`] when the stamp is absent. Same trade-off as
+/// [`source_file_arc_of`]: localized O(N) per-record Arc construction
+/// in exchange for post-merge correctness — peer Sources with shared
+/// column shape still resolve to their originating Source by name.
+pub(crate) fn source_name_arc_of(record: &Record) -> Arc<str> {
+    match source_name_of(record) {
+        Some(s) => Arc::from(s),
+        None => Arc::clone(&MERGED_SOURCE_NAME),
     }
 }
 
@@ -130,7 +164,10 @@ fn buffer_key_for_record(record: &Record, row_num: u64) -> Vec<GroupByKey> {
                 let idx = key.len();
                 key.push(value_to_correlation_key(&record.values()[i], idx));
             }
-            Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) | None => {}
+            Some(FieldMetadata::WidenedSidecar)
+            | Some(FieldMetadata::SourceFile)
+            | Some(FieldMetadata::SourceName)
+            | None => {}
         }
     }
     if key.is_empty() || key_is_null(&key) {
@@ -935,13 +972,15 @@ pub(crate) fn dispatch_plan_node(
                             // ingest. The `$widened` sidecar is filled by
                             // CoercingReader from input-record keys, not
                             // by name-based mapping from the reader.
-                            // `$source.file` is stamped at ingest into the
-                            // record's value vector directly, so it flows
-                            // through canonicalize via the per-name copy
-                            // loop above rather than this engine-stamp tail.
+                            // `$source.file` and `$source.name` are
+                            // stamped at ingest into the record's value
+                            // vector directly, so they flow through
+                            // canonicalize via the per-name copy loop
+                            // above rather than this engine-stamp tail.
                             Some(clinker_record::FieldMetadata::AggregateGroupIndex { .. })
                             | Some(clinker_record::FieldMetadata::WidenedSidecar)
                             | Some(clinker_record::FieldMetadata::SourceFile)
+                            | Some(clinker_record::FieldMetadata::SourceName)
                             | None => None,
                         })
                         .collect()
@@ -1134,6 +1173,7 @@ pub(crate) fn dispatch_plan_node(
                     check_input_schema(exp, record.schema(), name, "transform", &upstream_name)?;
                 }
                 let source_file_arc = source_file_arc_of(&record);
+                let source_name_arc = source_name_arc_of(&record);
                 let eval_ctx = EvalContext {
                     stable: ctx.stable,
                     source_file: &source_file_arc,
@@ -1142,6 +1182,7 @@ pub(crate) fn dispatch_plan_node(
                     source_count: ctx.source_count,
                     source_batch: ctx.source_batch_arc,
                     ingestion_timestamp: ctx.source_ingestion_timestamp,
+                    source_name: &source_name_arc,
                 };
 
                 let target_schema = output_schema
@@ -1234,6 +1275,7 @@ pub(crate) fn dispatch_plan_node(
                         );
                         if !routed {
                             ctx.counters.dlq_count += 1;
+                            let source_name = source_name_arc_of(&record);
                             ctx.dlq_entries.push(DlqEntry {
                                 source_row: rn,
                                 category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
@@ -1242,6 +1284,7 @@ pub(crate) fn dispatch_plan_node(
                                 stage,
                                 route: None,
                                 trigger: true,
+                                source_name,
                             });
                         }
                     }
@@ -1410,6 +1453,7 @@ pub(crate) fn dispatch_plan_node(
             if let Some(ref mut route) = route_handle {
                 for (record, rn) in input_records {
                     let source_file_arc = source_file_arc_of(&record);
+                    let source_name_arc = source_name_arc_of(&record);
                     let eval_ctx = EvalContext {
                         stable: ctx.stable,
                         source_file: &source_file_arc,
@@ -1418,6 +1462,7 @@ pub(crate) fn dispatch_plan_node(
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
+                        source_name: &source_name_arc,
                     };
 
                     let route_result = {
@@ -1455,6 +1500,7 @@ pub(crate) fn dispatch_plan_node(
                             );
                             if !routed {
                                 ctx.counters.dlq_count += 1;
+                                let source_name = source_name_arc_of(&record);
                                 ctx.dlq_entries.push(DlqEntry {
                                     source_row: rn,
                                     category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
@@ -1463,6 +1509,7 @@ pub(crate) fn dispatch_plan_node(
                                     stage,
                                     route: None,
                                     trigger: true,
+                                    source_name,
                                 });
                             }
                         }
@@ -1812,6 +1859,7 @@ pub(crate) fn dispatch_plan_node(
             let mut emitted_rows: Vec<AggSortRow> = Vec::with_capacity(64);
             for (record, row_num) in &input {
                 let source_file_arc = source_file_arc_of(record);
+                let source_name_arc = source_name_arc_of(record);
                 let eval_ctx = EvalContext {
                     stable: ctx.stable,
                     source_file: &source_file_arc,
@@ -1820,6 +1868,7 @@ pub(crate) fn dispatch_plan_node(
                     source_count: ctx.source_count,
                     source_batch: ctx.source_batch_arc,
                     ingestion_timestamp: ctx.source_ingestion_timestamp,
+                    source_name: &source_name_arc,
                 };
                 if let Err(e) = stream.add_record(record, *row_num, &eval_ctx, &mut emitted_rows) {
                     match ctx.config.error_handling.strategy {
@@ -1837,6 +1886,7 @@ pub(crate) fn dispatch_plan_node(
                             );
                             if !routed {
                                 ctx.counters.dlq_count += 1;
+                                let source_name = source_name_arc_of(record);
                                 ctx.dlq_entries.push(DlqEntry {
                                     source_row: *row_num,
                                     category: crate::dlq::DlqErrorCategory::AggregateFinalize,
@@ -1845,6 +1895,7 @@ pub(crate) fn dispatch_plan_node(
                                     stage,
                                     route: None,
                                     trigger: true,
+                                    source_name,
                                 });
                             }
                         }
@@ -1874,6 +1925,7 @@ pub(crate) fn dispatch_plan_node(
                 source_count: ctx.source_count,
                 source_batch: ctx.source_batch_arc,
                 ingestion_timestamp: ctx.source_ingestion_timestamp,
+                source_name: &MERGED_SOURCE_NAME,
             };
             let out_rows: Vec<AggSortRow> = if is_relaxed {
                 let mut hash_box = match stream.into_retained_hash() {
@@ -1926,6 +1978,7 @@ pub(crate) fn dispatch_plan_node(
                             } else {
                                 Record::new(Arc::clone(output_schema), Vec::new())
                             };
+                            let source_name = source_name_arc_of(&synthetic);
                             ctx.dlq_entries.push(DlqEntry {
                                 source_row: 0,
                                 category: crate::dlq::DlqErrorCategory::AggregateFinalize,
@@ -1936,6 +1989,7 @@ pub(crate) fn dispatch_plan_node(
                                 stage: Some(crate::dlq::stage_aggregate(name)),
                                 route: None,
                                 trigger: true,
+                                source_name,
                             });
                             Vec::new()
                         }
@@ -1964,6 +2018,7 @@ pub(crate) fn dispatch_plan_node(
                             } else {
                                 Record::new(Arc::clone(output_schema), Vec::new())
                             };
+                            let source_name = source_name_arc_of(&synthetic);
                             ctx.dlq_entries.push(DlqEntry {
                                 source_row: 0,
                                 category: crate::dlq::DlqErrorCategory::AggregateFinalize,
@@ -1974,6 +2029,7 @@ pub(crate) fn dispatch_plan_node(
                                 stage: Some(crate::dlq::stage_aggregate(name)),
                                 route: None,
                                 trigger: true,
+                                source_name,
                             });
                             Vec::new()
                         }
@@ -2631,6 +2687,7 @@ pub(crate) fn dispatch_plan_node(
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
+                        source_name: &MERGED_SOURCE_NAME,
                     };
                     let output_records = execute_combine_iejoin(IEJoinExec {
                         name,
@@ -2684,6 +2741,7 @@ pub(crate) fn dispatch_plan_node(
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
+                        source_name: &MERGED_SOURCE_NAME,
                     };
                     let output_records = execute_combine_grace_hash(GraceHashExec {
                         name,
@@ -2745,6 +2803,7 @@ pub(crate) fn dispatch_plan_node(
                         source_count: ctx.source_count,
                         source_batch: ctx.source_batch_arc,
                         ingestion_timestamp: ctx.source_ingestion_timestamp,
+                        source_name: &MERGED_SOURCE_NAME,
                     };
                     let output_records = execute_combine_sort_merge(SortMergeExec {
                         name,
@@ -2792,6 +2851,7 @@ pub(crate) fn dispatch_plan_node(
                 source_count: ctx.source_count,
                 source_batch: ctx.source_batch_arc,
                 ingestion_timestamp: ctx.source_ingestion_timestamp,
+                source_name: &MERGED_SOURCE_NAME,
             };
             let build_timer =
                 stage_metrics::StageTimer::new(stage_metrics::StageName::CombineBuild {
@@ -2837,6 +2897,7 @@ pub(crate) fn dispatch_plan_node(
 
             for (probe_record, rn) in driver_buf {
                 let source_file_arc = source_file_arc_of(&probe_record);
+                let source_name_arc = source_name_arc_of(&probe_record);
                 let eval_ctx = EvalContext {
                     stable: ctx.stable,
                     source_file: &source_file_arc,
@@ -2845,6 +2906,7 @@ pub(crate) fn dispatch_plan_node(
                     source_count: ctx.source_count,
                     source_batch: ctx.source_batch_arc,
                     ingestion_timestamp: ctx.source_ingestion_timestamp,
+                    source_name: &source_name_arc,
                 };
 
                 // Probe-side key extraction routes through the
@@ -3395,6 +3457,7 @@ fn commit_one_group(
                 )
             };
             ctx.counters.dlq_count += 1;
+            let source_name = source_name_arc_of(&slot.original_record);
             ctx.dlq_entries.push(DlqEntry {
                 source_row: slot.row_num,
                 category,
@@ -3403,6 +3466,7 @@ fn commit_one_group(
                 stage: Some("correlation_commit".to_string()),
                 route: None,
                 trigger,
+                source_name,
             });
         }
         return Ok(());
@@ -3439,6 +3503,7 @@ fn commit_one_group(
             continue;
         }
         ctx.counters.dlq_count += 1;
+        let source_name = source_name_arc_of(&err.original_record);
         ctx.dlq_entries.push(DlqEntry {
             source_row: err.row_num,
             category: err.category,
@@ -3447,6 +3512,7 @@ fn commit_one_group(
             stage: err.stage.clone(),
             route: err.route.clone(),
             trigger: true,
+            source_name,
         });
     }
     // Collateral entries: every other distinct row that flowed through
@@ -3483,6 +3549,7 @@ fn commit_one_group(
             continue;
         }
         ctx.counters.dlq_count += 1;
+        let source_name = source_name_arc_of(&slot.original_record);
         ctx.dlq_entries.push(DlqEntry {
             source_row: slot.row_num,
             category: crate::dlq::DlqErrorCategory::Correlated,
@@ -3491,6 +3558,7 @@ fn commit_one_group(
             stage: Some("correlation_commit".to_string()),
             route: None,
             trigger: false,
+            source_name,
         });
     }
 

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -453,6 +453,13 @@ pub struct DlqEntry {
     /// `true` if this record's own evaluation caused the DLQ entry.
     /// Serialized as `_cxl_dlq_trigger` column in DLQ CSV.
     pub trigger: bool,
+    /// Originating Source-node name. Read from the failing record's
+    /// `FieldMetadata::SourceName` engine-stamp at the push site so a
+    /// post-Merge / post-Combine DLQ entry still identifies which
+    /// upstream Source produced the record. Serialized as
+    /// `_cxl_dlq_source_name` in DLQ CSV. Unblocks per-source DLQ
+    /// thresholds (#55).
+    pub source_name: Arc<str>,
 }
 
 impl DlqEntry {
@@ -1674,14 +1681,22 @@ fn value_to_event_time_nanos(value: &clinker_record::Value) -> Option<i64> {
 /// to the read-side handle. Used uniformly by every declared Source —
 /// no primary asymmetry.
 ///
-/// Each ingested record is widened with a tail `$source.file`
-/// engine-stamped column (`FieldMetadata::SourceFile`) carrying the
-/// per-record file `Arc<str>` from
-/// `MultiFileFormatReader::current_source_file()`. Stamping at ingest
-/// lets `$source.file` / `$source.path` resolution survive Merge /
-/// Combine downstream without an external row-keyed array.
-/// `counters.total_count` increments per record so every source
-/// contributes to the pipeline-wide total.
+/// Each ingested record is widened with two tail engine-stamped
+/// columns:
+///
+/// - `$source.file` (`FieldMetadata::SourceFile`) — per-record
+///   originating file `Arc<str>` from
+///   `MultiFileFormatReader::current_source_file()`.
+/// - `$source.name` (`FieldMetadata::SourceName`) — per-record
+///   originating Source-node name as a shared `Arc<str>`. One Arc per
+///   Source, cloned by every record from that Source — the runtime
+///   cost is one Arc bump per ingested row.
+///
+/// Stamping at ingest lets `$source.file` / `$source.path` /
+/// `$source.name` resolution survive Merge / Combine downstream
+/// without external row-keyed arrays. `counters.total_count`
+/// increments per record so every source contributes to the
+/// pipeline-wide total.
 fn ingest_source_into_stream(
     src_cfg: &crate::config::SourceConfig,
     files: Vec<crate::source::multi_file::FileSlot>,
@@ -1702,13 +1717,16 @@ fn ingest_source_into_stream(
     let mut src_reader = wrap_with_schema_coercion(raw_reader, config, &src_cfg.name)?;
     let reader_schema = src_reader.schema()?;
 
-    // Widen the reader schema with a $source.file SourceFile-marked
-    // tail column. The stamp travels with every record so downstream
-    // operators resolve `$source.file` per-record via the column read
-    // (see `dispatch::source_file_arc_of`) instead of indexing an
-    // external row-keyed Vec.
+    // Widen the reader schema with `$source.file` and `$source.name`
+    // engine-stamped tail columns. The stamps travel with every record
+    // so downstream operators resolve `$source.file` / `$source.name`
+    // per-record via column reads (see `dispatch::source_file_arc_of`
+    // and `dispatch::source_name_arc_of`) instead of indexing external
+    // row-keyed Vecs. Tail order is load-bearing — see
+    // `bind_schema::columns_from_decl`: `$ck.<field>` shadows first,
+    // then `$widened`, then `$source.file`, then `$source.name` last.
     let mut widened_builder =
-        clinker_record::SchemaBuilder::with_capacity(reader_schema.column_count() + 1);
+        clinker_record::SchemaBuilder::with_capacity(reader_schema.column_count() + 2);
     for (idx, col) in reader_schema.columns().iter().enumerate() {
         widened_builder = match reader_schema.field_metadata(idx) {
             Some(meta) => widened_builder.with_field_meta(col.as_ref(), meta.clone()),
@@ -1720,6 +1738,10 @@ fn ingest_source_into_stream(
             crate::config::pipeline_node::SOURCE_FILE_COLUMN,
             clinker_record::FieldMetadata::source_file(),
         )
+        .with_field_meta(
+            crate::config::pipeline_node::SOURCE_NAME_COLUMN,
+            clinker_record::FieldMetadata::source_name(),
+        )
         .build();
 
     let static_source_file: Arc<str> = if src_cfg.path_str().is_empty() {
@@ -1727,6 +1749,9 @@ fn ingest_source_into_stream(
     } else {
         Arc::from(src_cfg.path_str())
     };
+    // One shared Arc per Source — every record stamps a clone, so the
+    // per-record cost is one Arc bump rather than a fresh allocation.
+    let source_name_arc: Arc<str> = Arc::from(src_cfg.name.as_str());
 
     // Resolve the watermark column to a position on the widened
     // schema once per source; the per-record observation below is then
@@ -1782,6 +1807,9 @@ fn ingest_source_into_stream(
                 }
                 values.push(clinker_record::Value::String(
                     file_arc.as_ref().to_string().into_boxed_str(),
+                ));
+                values.push(clinker_record::Value::String(
+                    source_name_arc.as_ref().to_string().into_boxed_str(),
                 ));
                 let widened_record =
                     clinker_record::Record::new(Arc::clone(&widened_schema), values);

--- a/crates/clinker-core/src/executor/tests/multi_output.rs
+++ b/crates/clinker-core/src/executor/tests/multi_output.rs
@@ -1290,6 +1290,7 @@ fn test_dlq_stage_source() {
         stage: Some(DlqEntry::stage_source()),
         route: None,
         trigger: true,
+        source_name: std::sync::Arc::from("test_source"),
     };
     assert_eq!(entry.stage, Some("source".to_string()));
     assert_eq!(entry.route, None);
@@ -1448,6 +1449,7 @@ fn test_dlq_stage_output() {
         stage: Some(DlqEntry::stage_output("results")),
         route: Some("high_value".to_string()),
         trigger: true,
+        source_name: std::sync::Arc::from("test_source"),
     };
     assert_eq!(entry.stage, Some("output:results".to_string()));
     assert_eq!(entry.route, Some("high_value".to_string()));
@@ -1533,6 +1535,7 @@ fn test_dlq_columns_in_csv() {
         stage: Some(DlqEntry::stage_transform("my_transform")),
         route: None,
         trigger: true,
+        source_name: std::sync::Arc::from("test_source"),
     }];
 
     let mut buf = Vec::new();

--- a/crates/clinker-core/src/pipeline/grace_hash.rs
+++ b/crates/clinker-core/src/pipeline/grace_hash.rs
@@ -910,6 +910,7 @@ pub(crate) fn execute_combine_grace_hash(
             source_count: ctx.source_count,
             source_batch: ctx.source_batch,
             ingestion_timestamp: ctx.ingestion_timestamp,
+            source_name: ctx.source_name,
         };
         let probe_resolver = CombineResolver::new(resolver_mapping, &probe_record, None);
         probe_keys_buf.clear();
@@ -1350,6 +1351,7 @@ fn process_spilled_partition(
                 source_count: ctx.source_count,
                 source_batch: ctx.source_batch,
                 ingestion_timestamp: ctx.ingestion_timestamp,
+                source_name: ctx.source_name,
             };
             let resolver = CombineResolver::new(rc.emit.resolver_mapping, &probe_record, None);
             probe_keys_buf.clear();
@@ -1559,6 +1561,7 @@ fn bnl_fallback(
                     source_count: rc.ctx.source_count,
                     source_batch: rc.ctx.source_batch,
                     ingestion_timestamp: rc.ctx.ingestion_timestamp,
+                    source_name: rc.ctx.source_name,
                 };
                 let resolver = CombineResolver::new(rc.emit.resolver_mapping, &probe_record, None);
                 probe_keys_buf.clear();

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -486,7 +486,7 @@ fn validate_post_merge_source_reads(
 fn is_builtin_source_member(field: &str) -> bool {
     matches!(
         field,
-        "file" | "row" | "path" | "count" | "batch" | "ingestion_timestamp"
+        "file" | "row" | "path" | "count" | "batch" | "ingestion_timestamp" | "name"
     )
 }
 
@@ -2148,7 +2148,8 @@ fn build_input_port_rows(
         for (qf, ty) in upstream_row.fields() {
             let is_engine_stamped = qf.name.starts_with("$ck.")
                 || qf.name.as_ref() == crate::config::pipeline_node::WIDENED_SIDECAR_COLUMN
-                || qf.name.as_ref() == crate::config::pipeline_node::SOURCE_FILE_COLUMN;
+                || qf.name.as_ref() == crate::config::pipeline_node::SOURCE_FILE_COLUMN
+                || qf.name.as_ref() == crate::config::pipeline_node::SOURCE_NAME_COLUMN;
             if is_engine_stamped && !declared_columns.contains_key(qf) {
                 declared_columns.insert(qf.clone(), ty.clone());
             }
@@ -2381,6 +2382,8 @@ fn normalize_path(path: &Path) -> PathBuf {
 ///   [`FieldMetadata::WidenedSidecar`].
 /// - `$source.file` — per-record source-file lineage stamp. Stamped
 ///   [`FieldMetadata::SourceFile`].
+/// - `$source.name` — per-record Source-node identity stamp. Stamped
+///   [`FieldMetadata::SourceName`].
 ///
 /// The aggregate prefix is checked first because `$ck.aggregate.x`
 /// also matches the generic `$ck.` prefix; misordering would mis-
@@ -2404,6 +2407,8 @@ where
             builder.with_field_meta(name, FieldMetadata::widened_sidecar())
         } else if name == crate::config::pipeline_node::SOURCE_FILE_COLUMN {
             builder.with_field_meta(name, FieldMetadata::source_file())
+        } else if name == crate::config::pipeline_node::SOURCE_NAME_COLUMN {
+            builder.with_field_meta(name, FieldMetadata::source_name())
         } else {
             builder.with_field(name)
         };
@@ -2439,13 +2444,17 @@ fn columns_from_decl(
         .map(|c| (QualifiedField::bare(c.name.as_str()), c.ty.clone()))
         .collect();
     // Engine-stamped tail order: `$ck.<field>` shadow columns first,
-    // then the `$widened` sidecar, then `$source.file` last. The order
-    // is load-bearing — CK-aligned aggregate / combine propagation
-    // walks the schema expecting `$ck.*` immediately after declared
-    // columns; pushing `$widened` between them would break that
-    // propagation. Sources with `auto_widen` get `$widened` after
-    // every `$ck.<field>` slot; `$source.file` lives outside the CK
-    // lattice and tail-appends after `$widened`.
+    // then the `$widened` sidecar, then `$source.file`, then
+    // `$source.name` last. The order is load-bearing — CK-aligned
+    // aggregate / combine propagation walks the schema expecting
+    // `$ck.*` immediately after declared columns; pushing `$widened`
+    // between them would break that propagation. Sources with
+    // `auto_widen` get `$widened` after every `$ck.<field>` slot;
+    // `$source.file` and `$source.name` live outside the CK lattice
+    // and tail-append after `$widened`. The same order is replayed by
+    // `executor::mod::ingest_source_into_stream` when it widens the
+    // runtime reader schema, so the planner's view stays positionally
+    // aligned with the actual records flowing through dispatch.
     let mut missing: Vec<String> = Vec::new();
     if let Some(ck) = correlation_key {
         for field in ck.fields() {
@@ -2471,6 +2480,10 @@ fn columns_from_decl(
     }
     cols.insert(
         QualifiedField::bare(crate::config::pipeline_node::SOURCE_FILE_COLUMN),
+        Type::String,
+    );
+    cols.insert(
+        QualifiedField::bare(crate::config::pipeline_node::SOURCE_NAME_COLUMN),
         Type::String,
     );
     (cols, missing)

--- a/crates/clinker-core/tests/bind_schema_test.rs
+++ b/crates/clinker-core/tests/bind_schema_test.rs
@@ -58,15 +58,20 @@ nodes:
         .expect("source1 must have a bound row");
     // Schema includes the user-declared `a` + `b`, the `$widened`
     // engine-stamped sidecar (auto_widen is the default `OnUnmapped`
-    // policy), and the `$source.file` per-record source-file lineage
-    // stamp (every Source unconditionally tail-appends this).
-    assert_eq!(row.field_count(), 4);
+    // policy), the `$source.file` per-record source-file lineage stamp,
+    // and the `$source.name` per-record Source-node identity stamp
+    // (every Source unconditionally tail-appends both lineage columns).
+    assert_eq!(row.field_count(), 5);
     assert!(row.has_field("a"), "expected column 'a'");
     assert!(row.has_field("b"), "expected column 'b'");
     assert!(row.has_field("$widened"), "expected $widened sidecar");
     assert!(
         row.has_field("$source.file"),
         "expected $source.file lineage stamp"
+    );
+    assert!(
+        row.has_field("$source.name"),
+        "expected $source.name lineage stamp"
     );
     assert_eq!(
         row.tail,
@@ -234,13 +239,15 @@ nodes:
     let plan = compile_yaml(yaml);
     let schema = source_output_schema(&plan, "src");
     // User-declared columns + `$widened` engine-stamped sidecar
-    // (auto_widen is the default `OnUnmapped` policy) + the
-    // `$source.file` per-record lineage stamp every Source carries.
-    assert_eq!(schema.column_count(), 4);
+    // (auto_widen is the default `OnUnmapped` policy) + per-record
+    // lineage stamps every Source carries: `$source.file` then
+    // `$source.name`.
+    assert_eq!(schema.column_count(), 5);
     assert_eq!(&*schema.columns()[0], "employee_id");
     assert_eq!(&*schema.columns()[1], "salary");
     assert_eq!(&*schema.columns()[2], "$widened");
     assert_eq!(&*schema.columns()[3], "$source.file");
+    assert_eq!(&*schema.columns()[4], "$source.name");
     assert!(
         schema.field_metadata_by_name("employee_id").is_none(),
         "user-declared column must not carry engine-stamp metadata"
@@ -256,6 +263,10 @@ nodes:
     assert!(
         schema.field_metadata_by_name("$source.file").is_some(),
         "$source.file must carry engine-stamp metadata"
+    );
+    assert!(
+        schema.field_metadata_by_name("$source.name").is_some(),
+        "$source.name must carry engine-stamp metadata"
     );
 }
 
@@ -293,8 +304,9 @@ nodes:
 
     // User-declared columns stay at their declared positions, then
     // engine-stamped tail: `$ck.<field>` shadow columns first, then
-    // the `$widened` sidecar (auto_widen default), then `$source.file`.
-    assert_eq!(schema.column_count(), 5);
+    // the `$widened` sidecar (auto_widen default), then `$source.file`,
+    // then `$source.name`.
+    assert_eq!(schema.column_count(), 6);
     assert_eq!(&*schema.columns()[0], "employee_id");
     assert_eq!(&*schema.columns()[1], "salary");
     assert_eq!(
@@ -304,6 +316,7 @@ nodes:
     );
     assert_eq!(&*schema.columns()[3], "$widened");
     assert_eq!(&*schema.columns()[4], "$source.file");
+    assert_eq!(&*schema.columns()[5], "$source.name");
     assert_eq!(schema.index("$ck.employee_id"), Some(2));
 
     // Engine-stamp metadata points back at the user-declared field.
@@ -355,14 +368,17 @@ nodes:
     let plan = compile_yaml(yaml);
     let schema = source_output_schema(&plan, "src");
 
-    // 3 declared + 2 `$ck.*` shadows + `$widened` sidecar + `$source.file` = 7 columns.
-    assert_eq!(schema.column_count(), 7);
+    // 3 declared + 2 `$ck.*` shadows + `$widened` sidecar + `$source.file`
+    // + `$source.name` = 8 columns.
+    assert_eq!(schema.column_count(), 8);
     // Tail-append order matches `correlation_key.fields()` order, then sidecar,
-    // then the per-record `$source.file` lineage stamp.
+    // then the per-record `$source.file` lineage stamp, then the per-record
+    // `$source.name` Source-node identity stamp.
     assert_eq!(&*schema.columns()[3], "$ck.tenant");
     assert_eq!(&*schema.columns()[4], "$ck.employee_id");
     assert_eq!(&*schema.columns()[5], "$widened");
     assert_eq!(&*schema.columns()[6], "$source.file");
+    assert_eq!(&*schema.columns()[7], "$source.name");
 
     assert_eq!(
         source_correlation_field(schema.field_metadata_by_name("$ck.tenant")),

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -581,9 +581,11 @@ mod tests {
 
         // Driver = orders (default first-in-IndexMap, no `drive:` hint).
         // Driver fields: order_id, product_id, amount, plus the
-        // `$widened` engine-stamped sidecar (auto_widen default) and
-        // the `$source.file` per-record lineage stamp every Source
-        // carries. Then the auto-added `products` field of Type::Array.
+        // `$widened` engine-stamped sidecar (auto_widen default), the
+        // `$source.file` per-record lineage stamp, and the
+        // `$source.name` per-record Source-node identity stamp that
+        // every Source carries. Then the auto-added `products` field
+        // of Type::Array.
         let names: Vec<String> = row.field_names().map(|qf| qf.to_string()).collect();
         assert_eq!(
             names,
@@ -593,6 +595,7 @@ mod tests {
                 "amount".to_string(),
                 "$widened".to_string(),
                 "$source.file".to_string(),
+                "$source.name".to_string(),
                 "products".to_string(),
             ],
             "auto-derived row = driver fields + (build_qualifier: Array)"

--- a/crates/clinker-core/tests/multi_source_ingestion.rs
+++ b/crates/clinker-core/tests/multi_source_ingestion.rs
@@ -136,6 +136,118 @@ nodes:
     }
 }
 
+/// Engine-stamped `$source.name` survives a Merge: every record
+/// emitted from `[src_a, src_b] → merge → tfm → out` carries the
+/// originating Source-node's name, even though both Sources share the
+/// same column shape and downstream operators cannot distinguish them
+/// by schema identity alone. Closes the lineage gap that schema-match
+/// peer Sources left open at the silent-corruption root of #47.
+#[test]
+fn merge_preserves_source_name_per_record() {
+    let yaml = r#"
+pipeline:
+  name: merge_source_name
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b]
+  - type: transform
+    name: stamp
+    input: merged
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+        emit origin = $source.name
+  - type: output
+    name: out
+    input: stamp
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot("a", "id,tag\n1,a-one\n2,a-two\n")],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot("b", "id,tag\n10,b-ten\n11,b-eleven\n")],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("merge_preserves_source_name pipeline must execute");
+    assert_eq!(report.counters.total_count, 4);
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let header = output.lines().next().expect("header line");
+    let columns: Vec<&str> = header.split(',').collect();
+    let id_col = columns.iter().position(|c| *c == "id").expect("id col");
+    let origin_col = columns
+        .iter()
+        .position(|c| *c == "origin")
+        .expect("origin col");
+    // Default Output projection strips engine-stamped columns; the
+    // `$source.name` value only reaches the writer because the
+    // Transform's `emit origin = $source.name` materialized it into
+    // the user-facing `origin` column.
+    assert!(
+        !columns.contains(&"$source.name"),
+        "$source.name must be filtered from default Output projection; columns: {columns:?}"
+    );
+
+    let body: Vec<Vec<&str>> = output
+        .lines()
+        .skip(1)
+        .map(|line| line.split(',').collect())
+        .collect();
+    assert_eq!(body.len(), 4, "expected 4 records, got:\n{output}");
+    for row in &body {
+        let id: i64 = row[id_col].parse().expect("id parses");
+        let origin = row[origin_col];
+        if (1..=2).contains(&id) {
+            assert_eq!(
+                origin, "src_a",
+                "id={id} originated from src_a; got origin={origin}"
+            );
+        } else if (10..=11).contains(&id) {
+            assert_eq!(
+                origin, "src_b",
+                "id={id} originated from src_b; got origin={origin}"
+            );
+        } else {
+            panic!("unexpected id {id} in output:\n{output}");
+        }
+    }
+}
+
 /// Topology 2 — `src_a → tfm_a → out_a`, `src_b → tfm_b → out_b`. The
 /// two chains are wholly disjoint at the DAG level; the bug pre-fix
 /// was that `src_b`'s dispatch silently emitted `src_a`'s records,

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -236,7 +236,9 @@ impl Record {
             .iter()
             .enumerate()
             .filter(|(i, _)| match self.schema.field_metadata(*i) {
-                Some(FieldMetadata::WidenedSidecar) | Some(FieldMetadata::SourceFile) => false,
+                Some(FieldMetadata::WidenedSidecar)
+                | Some(FieldMetadata::SourceFile)
+                | Some(FieldMetadata::SourceName) => false,
                 Some(FieldMetadata::SourceCorrelation { .. })
                 | Some(FieldMetadata::AggregateGroupIndex { .. })
                 | None => true,

--- a/crates/clinker-record/src/schema.rs
+++ b/crates/clinker-record/src/schema.rs
@@ -40,6 +40,13 @@ use std::sync::Arc;
 ///   per-source row numbers collide. Filtered out of default Output
 ///   projection like the other engine-stamped variants; users opt in
 ///   by projecting `emit source_file = $source.file` explicitly.
+/// - [`FieldMetadata::SourceName`] — per-record Source-node identity
+///   column. Named `$source.name`; stamped at Source ingest with the
+///   originating Source node's name as a shared `Arc<str>`. Survives
+///   Merge / Combine so post-fan-in records still resolve to their
+///   originating Source by node name (the case schema identity alone
+///   cannot answer when peer Sources share a column shape — the
+///   silent-corruption topology at the root of #47).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FieldMetadata {
     /// Source-CK shadow column. `source_field` is the user-declared
@@ -61,6 +68,13 @@ pub enum FieldMetadata {
     /// sites; survives merge so post-fan-in records still resolve to
     /// their actual file rather than an external row-keyed lookup.
     SourceFile,
+    /// Per-record Source-node identity column. Named `$source.name`,
+    /// stamped at Source ingest with the originating Source node's
+    /// name as a shared `Arc<str>` (one Arc per Source, cloned per
+    /// record). Read by `$source.name` resolution at dispatch sites;
+    /// survives merge so post-fan-in records still report origin even
+    /// when peer Sources share a column shape.
+    SourceName,
 }
 
 impl FieldMetadata {
@@ -91,6 +105,13 @@ impl FieldMetadata {
     /// wrapping the originating file path Arc.
     pub fn source_file() -> Self {
         Self::SourceFile
+    }
+
+    /// Marks this column as the per-record Source-node identity stamp.
+    /// Always named `$source.name`; the value is a `Value::String`
+    /// wrapping the originating Source node's name Arc.
+    pub fn source_name() -> Self {
+        Self::SourceName
     }
 
     /// True for every variant. The presence of [`FieldMetadata`] on a
@@ -380,6 +401,24 @@ mod tests {
         match schema.field_metadata_by_name("$source.file") {
             Some(FieldMetadata::SourceFile) => {}
             other => panic!("expected SourceFile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_schema_with_metadata_attaches_source_name() {
+        let cols: Vec<Box<str>> = vec!["id".into(), "$source.name".into()];
+        let meta = vec![None, Some(FieldMetadata::source_name())];
+        let schema = Schema::with_metadata(cols, meta);
+        assert!(schema.field_metadata(0).is_none());
+        let stamp = schema.field_metadata(1).expect("metadata attached");
+        match stamp {
+            FieldMetadata::SourceName => {}
+            other => panic!("expected SourceName, got {other:?}"),
+        }
+        assert!(stamp.is_engine_stamped());
+        match schema.field_metadata_by_name("$source.name") {
+            Some(FieldMetadata::SourceName) => {}
+            other => panic!("expected SourceName, got {other:?}"),
         }
     }
 

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -287,6 +287,11 @@ fn cmd_eval(file: Option<&str>, expr: Option<&str>, record_json: Option<&str>, f
         static_vars: std::sync::Arc::new(indexmap::IndexMap::new()),
     };
     let source_file_arc: std::sync::Arc<str> = std::sync::Arc::from(source_name);
+    // REPL has no Source-node context, but `$source.name` is a stable
+    // per-record namespace; surface the parameter as the originating
+    // name so `emit n = $source.name` echoes back the same string the
+    // caller passed in.
+    let source_name_arc: std::sync::Arc<str> = std::sync::Arc::from(source_name);
     // REPL has no real batch context — use the same placeholder as the
     // stable execution_id so `$source.batch` is at least non-empty.
     let source_batch_arc: std::sync::Arc<str> = std::sync::Arc::clone(&stable.pipeline_batch_id);
@@ -298,6 +303,7 @@ fn cmd_eval(file: Option<&str>, expr: Option<&str>, record_json: Option<&str>, f
         source_count: 1,
         source_batch: &source_batch_arc,
         ingestion_timestamp: stable.pipeline_start_time,
+        source_name: &source_name_arc,
     };
 
     let resolver = HashMapResolver::new(record_map);
@@ -705,6 +711,7 @@ mod tests {
             static_vars: std::sync::Arc::new(indexmap::IndexMap::new()),
         };
         let source_file_arc: std::sync::Arc<str> = std::sync::Arc::from("test");
+        let source_name_arc: std::sync::Arc<str> = std::sync::Arc::from("test");
         let source_batch_arc: std::sync::Arc<str> =
             std::sync::Arc::clone(&stable.pipeline_batch_id);
         let ctx = EvalContext {
@@ -715,6 +722,7 @@ mod tests {
             source_count: 1,
             source_batch: &source_batch_arc,
             ingestion_timestamp: stable.pipeline_start_time,
+            source_name: &source_name_arc,
         };
 
         let resolver = HashMapResolver::new(HashMap::new());
@@ -758,6 +766,7 @@ mod tests {
             static_vars: std::sync::Arc::new(indexmap::IndexMap::new()),
         };
         let source_file_arc: std::sync::Arc<str> = std::sync::Arc::from("test");
+        let source_name_arc: std::sync::Arc<str> = std::sync::Arc::from("test");
         let source_batch_arc: std::sync::Arc<str> =
             std::sync::Arc::clone(&stable.pipeline_batch_id);
         let ctx = EvalContext {
@@ -768,6 +777,7 @@ mod tests {
             source_count: 1,
             source_batch: &source_batch_arc,
             ingestion_timestamp: stable.pipeline_start_time,
+            source_name: &source_name_arc,
         };
 
         let resolver = HashMapResolver::new(fields);

--- a/crates/cxl/src/eval/context.rs
+++ b/crates/cxl/src/eval/context.rs
@@ -212,6 +212,10 @@ pub struct EvalContext<'a> {
     /// `$source.ingestion_timestamp` — wall-clock time when ingestion of
     /// this source began.
     pub ingestion_timestamp: NaiveDateTime,
+    /// `$source.name` — originating Source node's name. Stable across
+    /// every record from the same Source; survives Merge / Combine via
+    /// the per-record `FieldMetadata::SourceName` engine-stamp.
+    pub source_name: &'a Arc<str>,
 }
 
 impl<'a> EvalContext<'a> {
@@ -233,6 +237,7 @@ impl<'a> EvalContext<'a> {
             "count" => Some(Value::Integer(self.source_count as i64)),
             "batch" => Some(Value::String(self.source_batch.to_string().into())),
             "ingestion_timestamp" => Some(Value::DateTime(self.ingestion_timestamp)),
+            "name" => Some(Value::String(self.source_name.to_string().into())),
             other => self.stable.resolve_source_var(self.source_file, other),
         }
     }
@@ -255,6 +260,7 @@ impl<'a> EvalContext<'a> {
                 .unwrap()
                 .and_hms_opt(12, 0, 0)
                 .unwrap(),
+            source_name: test_default_source_name(),
         }
     }
 
@@ -279,6 +285,7 @@ impl<'a> EvalContext<'a> {
                 .unwrap()
                 .and_hms_opt(12, 0, 0)
                 .unwrap(),
+            source_name: test_default_source_name(),
         }
     }
 }
@@ -297,6 +304,15 @@ fn test_default_source_batch() -> &'static Arc<str> {
     use std::sync::OnceLock;
     static BATCH: OnceLock<Arc<str>> = OnceLock::new();
     BATCH.get_or_init(|| Arc::from("test-batch-000"))
+}
+
+/// Like `test_default_source_file` but for `$source.name`. Defaulted
+/// to `"test_source"` for test contexts that don't care about the
+/// originating Source's name.
+fn test_default_source_name() -> &'static Arc<str> {
+    use std::sync::OnceLock;
+    static NAME: OnceLock<Arc<str>> = OnceLock::new();
+    NAME.get_or_init(|| Arc::from("test_source"))
 }
 
 #[cfg(test)]
@@ -422,6 +438,7 @@ mod tests {
                 .unwrap()
                 .and_hms_opt(0, 0, 0)
                 .unwrap(),
+            source_name: test_default_source_name(),
         }
     }
 
@@ -465,6 +482,10 @@ mod tests {
             ctx.resolve_source("ingestion_timestamp"),
             Some(Value::DateTime(_))
         ));
+        match ctx.resolve_source("name").unwrap() {
+            Value::String(s) => assert_eq!(&*s, "test_source"),
+            other => panic!("expected String, got {:?}", other),
+        }
         assert!(ctx.resolve_source("nonexistent").is_none());
     }
 

--- a/crates/cxl/src/resolve/pass.rs
+++ b/crates/cxl/src/resolve/pass.rs
@@ -77,6 +77,7 @@ const SOURCE_MEMBERS: &[&str] = &[
     "count",
     "batch",
     "ingestion_timestamp",
+    "name",
 ];
 
 /// Run Phase B: resolve all identifiers in the program.
@@ -823,6 +824,16 @@ mod tests {
             .iter()
             .any(|b| matches!(b, Some(ResolvedBinding::PipelineMember)));
         assert!(has_binding, "Expected binding for $source.file");
+    }
+
+    #[test]
+    fn test_resolve_source_name() {
+        let resolved = resolve_ok("emit n = $source.name", &[]);
+        let has_binding = resolved
+            .bindings
+            .iter()
+            .any(|b| matches!(b, Some(ResolvedBinding::PipelineMember)));
+        assert!(has_binding, "Expected builtin binding for $source.name");
     }
 
     #[test]

--- a/crates/cxl/src/resolve/scoped_vars.rs
+++ b/crates/cxl/src/resolve/scoped_vars.rs
@@ -16,7 +16,7 @@
 //!   `execution_id`, `batch_id`, counter set).
 //! - [`ScopedVarsRegistry::source`] — read via `$source.<key>`, alongside
 //!   builtin provenance (`file`, `row`, `path`, `count`, `batch`,
-//!   `ingestion_timestamp`).
+//!   `ingestion_timestamp`, `name`).
 //! - [`ScopedVarsRegistry::record`] — read via `$record.<key>`. No
 //!   builtins. Per-record scratch state, multi-writer across nodes
 //!   within a record's lifetime. Written by Transforms whose

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -453,7 +453,7 @@ impl<'a> TypeChecker<'a> {
 
             Expr::SourceAccess { node_id, field, .. } => {
                 let ty = match &**field {
-                    "file" | "path" | "batch" => Type::String,
+                    "file" | "path" | "batch" | "name" => Type::String,
                     "row" | "count" => Type::Int,
                     "ingestion_timestamp" => Type::DateTime,
                     other => self


### PR DESCRIPTION
Add a per-record `$source.name` engine-stamped column, sibling of the
`$source.file` lineage stamp shipped by #51. Every record ingested
through `SourceStream` carries a shared `Arc<str>` of its originating
Source node's name — one Arc per Source, cloned per record — so peer
Sources with identical column shape can still be told apart by name
after Merge / Combine downstream. Schema identity alone could not
answer this question before (it is the silent-corruption topology at
the root of #47, fixed at the dispatch arm but never made readable
to user CXL or DLQ attribution).

Surface:

- `$source.name` resolves at CXL eval through `EvalContext.source_name`,
  joining the existing `$source.{file,row,path,count,batch,
  ingestion_timestamp}` builtin set. Type::String at typecheck;
  exempt from the post-Merge E172 ambiguity rule (it is a per-record
  read by design).
- `FieldMetadata::SourceName` joins the engine-stamped variant set,
  with the same projection-skip / canonicalize-skip semantics as
  `SourceFile` and `WidenedSidecar`. The 24-byte size assertion still
  passes.
- `DlqEntry.source_name: Arc<str>` is populated from the failing
  record's stamp at every push site, and surfaces as the
  `_cxl_dlq_source_name` column in DLQ CSV output. Unblocks
  per-source DLQ thresholds (#55) and per-source `$ck` rollback
  granularity (#56).
- Integration test on the `[src_a, src_b] -> merge -> tfm -> out`
  topology proves every output row reports the right origin via
  `emit origin = $source.name`.

Sprint reallocation: the slot originally budgeted for #53
(`merge.mode: interleave`) pivoted to #54 after a prior-art survey
across Postgres / Trino / Spark SQL / DuckDB / DataFusion / Polars /
Flink / Beam / Vector / Kafka Streams. The literal #53 framing
(concurrent receivers via `crossbeam::select!`) cannot deliver its
load-bearing AC5 acceptance criterion (back-pressure under a slow
upstream) on today's sync executor — every `SourceStream` is drained
into `ctx.source_records` before dispatch runs, so the merge arm
reads already-resident vectors with no live receivers to select
over. No mature streaming system exposes a `mode: interleave` knob
whose runtime is a no-op semantic dress-up; #53's surface (YAML
MergeMode + Merge-arm branch + back-pressure test) has been folded
into #57's body to land alongside the runtime change it depends on.
#50's umbrella table now marks #53 as blocked on #57.

Drive-by: pad the synthetic record built inside `HashAggregator::spill`
to its `spill_schema.column_count()` rather than `gb_count + 1`. The
record is encoder input only (every value past the group-by prefix is
ignored by `SortKeyEncoder`), but `Record::new`'s debug_assert
enforces a schema/values length match. Larger per-record payloads
from the added `$source.name` stamp made the spill threshold trip
sooner in the e2e bench harness and surfaced the latent mismatch.