### PR TITLE
executor: per-source DLQ thresholds, sidecar routing, and EvalError row/expr context (closes #55, closes #9)

### DIFF
--- a/crates/clinker-core/src/aggregation.rs
+++ b/crates/clinker-core/src/aggregation.rs
@@ -2113,13 +2113,13 @@ fn eval_binding_arg_value(
                 &env,
             )?)
         }
-        BindingArg::Pair(_, _) => Err(HashAggError::EvalFailed(EvalError {
-            kind: cxl::eval::EvalErrorKind::TypeMismatch {
+        BindingArg::Pair(_, _) => Err(HashAggError::EvalFailed(EvalError::new(
+            cxl::eval::EvalErrorKind::TypeMismatch {
                 expected: "scalar binding arg",
                 got: "nested Pair",
             },
-            span: cxl::lexer::Span::new(0, 0),
-        })),
+            cxl::lexer::Span::new(0, 0),
+        ))),
     }
 }
 

--- a/crates/clinker-core/src/config/mod.rs
+++ b/crates/clinker-core/src/config/mod.rs
@@ -1796,13 +1796,20 @@ impl PipelineConfig {
             &ctx.pipeline_dir,
             scoped_vars_registry,
         );
+
+        crate::plan::bind_schema::validate_dlq_per_source(
+            self.error_handling.dlq.as_ref(),
+            &self.nodes,
+            &mut diags,
+        );
+
         // Only abort on non-composition CXL errors (E200/E201) and
         // source-CK validation errors (E153). Composition binding
         // errors (E102–E109) are non-fatal for the rest of the pipeline
         // — the composition node is omitted from the DAG.
         let has_cxl_errors = diags.iter().any(|d| {
             matches!(d.severity, crate::error::Severity::Error)
-                && (d.code == "E200" || d.code == "E201" || d.code == "E153")
+                && matches!(d.code.as_str(), "E200" | "E201" | "E153" | "E317" | "E318")
         });
         if has_cxl_errors {
             return Err(diags);
@@ -3471,6 +3478,16 @@ fn default_strategy() -> ErrorStrategy {
 }
 
 /// Dead-letter queue configuration.
+///
+/// `max_rate` is a cumulative fraction in `[0.0, 1.0]`. When set, the
+/// pipeline halts once `dlq_count / total_count >= max_rate` AND
+/// `total_count >= min_records`. `min_records` defaults to 100 to avoid
+/// 1/1 = 100% false positives on the first failure.
+///
+/// `per_source` overrides keyed by Source-node name win against the
+/// pipeline-wide `max_rate` / `min_records`. A per-source `path`, if
+/// set, reroutes that source's DLQ entries to a separate sidecar file —
+/// those entries do not appear in the pipeline-wide file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DlqConfig {
@@ -3480,7 +3497,33 @@ pub struct DlqConfig {
     pub include_reason: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub include_source_row: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_records: Option<u64>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub per_source: std::collections::BTreeMap<String, DlqPerSourceConfig>,
 }
+
+/// Per-source overrides for [`DlqConfig`].
+///
+/// Operators consulting `path` should grep both the pipeline-wide DLQ
+/// file and every per-source sidecar — entries with a `per_source` path
+/// override do not duplicate into the pipeline-wide file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DlqPerSourceConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_records: Option<u64>,
+}
+
+/// Default `min_records` floor used when neither pipeline-wide nor per-source
+/// override is supplied.
+pub const DEFAULT_DLQ_MIN_RECORDS: u64 = 100;
 
 /// Errors during config loading and parsing.
 #[derive(Debug)]

--- a/crates/clinker-core/src/dlq.rs
+++ b/crates/clinker-core/src/dlq.rs
@@ -1,8 +1,10 @@
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use clinker_record::{FieldMetadata, Schema, Value};
 
+use crate::config::DlqConfig;
 use crate::executor::DlqEntry;
 
 /// All 6 DLQ error categories per spec §10.4.
@@ -54,19 +56,6 @@ pub fn stage_aggregate(transform: &str) -> String {
     format!("aggregate:{transform}")
 }
 
-/// DLQ column names per spec §10.4.
-pub const DLQ_COLUMNS: &[&str] = &[
-    "_cxl_dlq_id",
-    "_cxl_dlq_timestamp",
-    "_cxl_dlq_source_file",
-    "_cxl_dlq_source_row",
-    "_cxl_dlq_error_category",
-    "_cxl_dlq_error_detail",
-    "_cxl_dlq_stage",
-    "_cxl_dlq_route",
-    "_cxl_dlq_trigger",
-];
-
 /// Write DLQ entries to a CSV writer (DLQ is always CSV per spec §10.4).
 ///
 /// Column layout:
@@ -100,6 +89,8 @@ pub fn write_dlq<W: Write>(
         "_cxl_dlq_source_file",
         "_cxl_dlq_source_name",
         "_cxl_dlq_source_row",
+        "_cxl_dlq_triggering_field",
+        "_cxl_dlq_triggering_value",
     ];
     if include_reason {
         header.push("_cxl_dlq_error_category");
@@ -126,6 +117,12 @@ pub fn write_dlq<W: Write>(
             source_file.to_string(),
             entry.source_name.as_ref().to_string(),
             entry.source_row.to_string(),
+            entry.triggering_field.as_deref().unwrap_or("").to_string(),
+            entry
+                .triggering_value
+                .as_ref()
+                .map(value_to_string)
+                .unwrap_or_default(),
         ];
 
         if include_reason {
@@ -150,6 +147,59 @@ pub fn write_dlq<W: Write>(
 
     csv_writer.flush()?;
     Ok(())
+}
+
+/// Partition DLQ entries by configured per-source `path:` override.
+///
+/// Returns `(path, entries)` pairs. Entries whose `source_name` has a
+/// per-source `path` override land in their own bucket; the remainder
+/// fall through to `DlqConfig.path` (the pipeline-wide sidecar). When
+/// `dlq_config.path` is `None` and no per-source override matches, an
+/// entry has no destination and is dropped from the result — the CLI
+/// emits nothing for it. Insertion order is preserved within each
+/// bucket; bucket ordering is deterministic via the BTreeMap traversal
+/// over `per_source`.
+pub fn partition_dlq_entries<'a>(
+    entries: &'a [DlqEntry],
+    dlq_config: &DlqConfig,
+) -> Vec<(PathBuf, Vec<&'a DlqEntry>)> {
+    let mut per_source_paths: std::collections::BTreeMap<&str, PathBuf> =
+        std::collections::BTreeMap::new();
+    for (src, per) in &dlq_config.per_source {
+        if let Some(p) = per.path.as_deref() {
+            per_source_paths.insert(src.as_str(), PathBuf::from(p));
+        }
+    }
+
+    // Deterministic output order: pipeline-wide path first (if set),
+    // then per-source paths in BTreeMap order.
+    let mut buckets: Vec<(PathBuf, Vec<&'a DlqEntry>)> = Vec::new();
+    let mut index_of: std::collections::HashMap<PathBuf, usize> = std::collections::HashMap::new();
+    if let Some(p) = dlq_config.path.as_deref() {
+        let pb = PathBuf::from(p);
+        index_of.insert(pb.clone(), 0);
+        buckets.push((pb, Vec::new()));
+    }
+    for path in per_source_paths.values() {
+        if !index_of.contains_key(path) {
+            index_of.insert(path.clone(), buckets.len());
+            buckets.push((path.clone(), Vec::new()));
+        }
+    }
+
+    for entry in entries {
+        let target = per_source_paths
+            .get(entry.source_name.as_ref())
+            .cloned()
+            .or_else(|| dlq_config.path.as_deref().map(PathBuf::from));
+        if let Some(target) = target
+            && let Some(&i) = index_of.get(&target)
+        {
+            buckets[i].1.push(entry);
+        }
+    }
+
+    buckets
 }
 
 /// Iterator over schema columns that should appear in DLQ output:
@@ -227,6 +277,8 @@ mod tests {
             route: None,
             trigger: true,
             source_name: Arc::from("test_source"),
+            triggering_field: None,
+            triggering_value: None,
         }
     }
 
@@ -251,13 +303,15 @@ mod tests {
         assert_eq!(columns[2], "_cxl_dlq_source_file");
         assert_eq!(columns[3], "_cxl_dlq_source_name");
         assert_eq!(columns[4], "_cxl_dlq_source_row");
-        assert_eq!(columns[5], "_cxl_dlq_error_category");
-        assert_eq!(columns[6], "_cxl_dlq_error_detail");
-        assert_eq!(columns[7], "_cxl_dlq_stage");
-        assert_eq!(columns[8], "_cxl_dlq_route");
-        assert_eq!(columns[9], "_cxl_dlq_trigger");
-        assert_eq!(columns[10], "name");
-        assert_eq!(columns[11], "value");
+        assert_eq!(columns[5], "_cxl_dlq_triggering_field");
+        assert_eq!(columns[6], "_cxl_dlq_triggering_value");
+        assert_eq!(columns[7], "_cxl_dlq_error_category");
+        assert_eq!(columns[8], "_cxl_dlq_error_detail");
+        assert_eq!(columns[9], "_cxl_dlq_stage");
+        assert_eq!(columns[10], "_cxl_dlq_route");
+        assert_eq!(columns[11], "_cxl_dlq_trigger");
+        assert_eq!(columns[12], "name");
+        assert_eq!(columns[13], "value");
     }
 
     #[test]
@@ -477,6 +531,8 @@ mod tests {
             route: None,
             trigger: true,
             source_name: Arc::from("test_source"),
+            triggering_field: None,
+            triggering_value: None,
         }];
         let mut buf = Vec::new();
         write_dlq(&mut buf, &entries, &schema, "input.csv", true, true).unwrap();
@@ -485,12 +541,12 @@ mod tests {
         let header_line = output.lines().next().unwrap();
         let columns: Vec<&str> = header_line.split(',').collect();
         // Source fields in schema order (zulu, alpha, mike), not alphabetical.
-        // Columns 0-4 are the prelude (_cxl_dlq_id / timestamp / source_file /
-        // source_name / source_row); 5-6 are error category/detail; 7-9 are
+        // Columns 0-4 are the identity prelude; 5-6 are triggering_field/
+        // triggering_value; 7-8 are error category/detail; 9-11 are
         // stage/route/trigger.
-        assert_eq!(columns[10], "zulu");
-        assert_eq!(columns[11], "alpha");
-        assert_eq!(columns[12], "mike");
+        assert_eq!(columns[12], "zulu");
+        assert_eq!(columns[13], "alpha");
+        assert_eq!(columns[14], "mike");
     }
 
     #[test]
@@ -586,6 +642,8 @@ mod tests {
             route: None,
             trigger: true,
             source_name: Arc::from("test_source"),
+            triggering_field: None,
+            triggering_value: None,
         };
         let mut buf = Vec::new();
         write_dlq(&mut buf, &[entry], &schema, "input.csv", true, true).unwrap();
@@ -622,5 +680,87 @@ mod tests {
             "sidecar map's `region` key must not appear in any DLQ body cell; \
              got body: {body}"
         );
+    }
+
+    #[test]
+    fn test_dlq_triggering_field_and_value_columns() {
+        let schema = make_schema();
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::String("Alice".into()), Value::String("oops".into())],
+        );
+        let entry = DlqEntry {
+            source_row: 7,
+            category: DlqErrorCategory::TypeCoercionFailure,
+            error_message: "cannot convert".to_string(),
+            original_record: record,
+            stage: None,
+            route: None,
+            trigger: true,
+            source_name: Arc::from("test_source"),
+            triggering_field: Some(Arc::from("amount")),
+            triggering_value: Some(Value::String("not-a-number".into())),
+        };
+        let mut buf = Vec::new();
+        write_dlq(&mut buf, &[entry], &schema, "input.csv", true, true).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let body = output.lines().nth(1).expect("body line");
+        let cells: Vec<&str> = body.split(',').collect();
+        assert_eq!(cells[5], "amount");
+        assert_eq!(cells[6], "not-a-number");
+    }
+
+    #[test]
+    fn test_partition_dlq_entries_splits_by_source_path() {
+        let schema = make_schema();
+        let mk = |src: &str| {
+            let rec = Record::new(
+                Arc::clone(&schema),
+                vec![Value::String("n".into()), Value::String("v".into())],
+            );
+            DlqEntry {
+                source_row: 0,
+                category: DlqErrorCategory::TypeCoercionFailure,
+                error_message: String::new(),
+                original_record: rec,
+                stage: None,
+                route: None,
+                trigger: true,
+                source_name: Arc::from(src),
+                triggering_field: None,
+                triggering_value: None,
+            }
+        };
+        let entries = vec![mk("src_a"), mk("src_b"), mk("src_a"), mk("src_c")];
+
+        let mut per_source = std::collections::BTreeMap::new();
+        per_source.insert(
+            "src_b".to_string(),
+            crate::config::DlqPerSourceConfig {
+                path: Some("dlq_b.csv".to_string()),
+                max_rate: None,
+                min_records: None,
+            },
+        );
+        let cfg = crate::config::DlqConfig {
+            path: Some("dlq.csv".to_string()),
+            include_reason: None,
+            include_source_row: None,
+            max_rate: None,
+            min_records: None,
+            per_source,
+        };
+
+        let buckets = partition_dlq_entries(&entries, &cfg);
+        assert_eq!(buckets.len(), 2);
+        assert_eq!(buckets[0].0, PathBuf::from("dlq.csv"));
+        assert_eq!(
+            buckets[0].1.len(),
+            3,
+            "src_a + src_a + src_c land in default"
+        );
+        assert_eq!(buckets[1].0, PathBuf::from("dlq_b.csv"));
+        assert_eq!(buckets[1].1.len(), 1);
+        assert_eq!(buckets[1].1[0].source_name.as_ref(), "src_b");
     }
 }

--- a/crates/clinker-core/src/error.rs
+++ b/crates/clinker-core/src/error.rs
@@ -64,6 +64,15 @@
 //! | `W302`      | warning  | Pure-equi combine with all small inputs — consider InMemoryHash |
 //! | `W305`      | warning  | Combine where-clause has no equality conjuncts       |
 //! | `W306`      | warning  | Combine planner cannot determine optimal driving input |
+//!
+//! DLQ threshold + per-source routing diagnostics:
+//!
+//! | Code        | Severity | Meaning                                              |
+//! |-------------|----------|------------------------------------------------------|
+//! | `E315`      | error    | Pipeline-wide DLQ rate exceeded `error_handling.dlq.max_rate` |
+//! | `E316`      | error    | Per-source DLQ rate exceeded `error_handling.dlq.per_source.<name>.max_rate` |
+//! | `E317`      | error    | `error_handling.dlq.per_source` key does not name a declared Source |
+//! | `E318`      | error    | `error_handling.dlq.*.max_rate` out of `[0.0, 1.0]` or DLQ path collides |
 
 use std::fmt;
 
@@ -342,6 +351,19 @@ pub enum PipelineError {
         group_key: String,
         count: u64,
     },
+    /// E315 (pipeline-wide, `source: None`) or E316 (per-source,
+    /// `source: Some(name)`) — the cumulative DLQ fraction crossed
+    /// the configured `max_rate` after at least `min_records` rows
+    /// from the relevant scope had been observed. ALWAYS aborts the
+    /// run regardless of `ErrorStrategy::Continue`; this is a halt
+    /// directive, not a per-record error.
+    DlqRateExceeded {
+        source: Option<std::sync::Arc<str>>,
+        observed_rate: f64,
+        max_rate: f64,
+        observed_count: u64,
+        total_count: u64,
+    },
 }
 
 impl fmt::Display for PipelineError {
@@ -451,6 +473,25 @@ impl fmt::Display for PipelineError {
                  after {count} records — remaining records of the group are \
                  DLQ'd as collateral"
             ),
+            Self::DlqRateExceeded {
+                source,
+                observed_rate,
+                max_rate,
+                observed_count,
+                total_count,
+            } => match source {
+                Some(name) => write!(
+                    f,
+                    "E316 source {name:?} DLQ rate {observed_rate:.4} exceeds \
+                     per_source.{name}.max_rate {max_rate:.4} \
+                     ({observed_count}/{total_count} records)"
+                ),
+                None => write!(
+                    f,
+                    "E315 pipeline DLQ rate {observed_rate:.4} exceeds \
+                     max_rate {max_rate:.4} ({observed_count}/{total_count} records)"
+                ),
+            },
         }
     }
 }
@@ -593,7 +634,7 @@ mod diagnostic_tests {
         // explicit entry both here and in the registry table above.
         for code in [
             "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308", "E309", "E310", "E311",
-            "E313", "E314",
+            "E313", "E314", "E315", "E316", "E317", "E318",
         ] {
             let pattern = format!("`{code}`");
             assert!(

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -103,6 +103,92 @@ pub(crate) fn source_name_arc_of(record: &Record) -> Arc<str> {
     }
 }
 
+/// Push a [`DlqEntry`] to the run-scoped DLQ vector, increment both the
+/// pipeline-wide and per-source DLQ counters, then check the configured
+/// rate ceilings. Returns [`PipelineError::DlqRateExceeded`] (E315 or
+/// E316) when the per-source ratio crosses
+/// `error_handling.dlq.per_source.<name>.max_rate` or the pipeline-wide
+/// ratio crosses `error_handling.dlq.max_rate`. Per-source > pipeline-wide
+/// precedence so the offending source surfaces in the rendered diagnostic.
+///
+/// The rate denominator is the full per-source ingest count, seeded
+/// once at executor entry from
+/// [`ExecutorContext::total_per_source`] — not a moving "records
+/// processed so far" counter. This is consistent with today's
+/// pre-ingested-into-`source_records` executor model where every
+/// declared Source is fully drained before dispatch runs. When the
+/// async streaming runtime swaps `SourceStream` for a live
+/// channel-driven ingest, the denominator becomes a moving target
+/// that needs to be re-keyed off the per-source receive count instead.
+pub(crate) fn push_dlq(
+    ctx: &mut ExecutorContext<'_>,
+    entry: DlqEntry,
+) -> Result<(), PipelineError> {
+    let source_name = Arc::clone(&entry.source_name);
+    ctx.counters.dlq_count += 1;
+    *ctx.dlq_per_source
+        .entry(Arc::clone(&source_name))
+        .or_insert(0) += 1;
+    ctx.dlq_entries.push(entry);
+    check_dlq_rate(ctx, &source_name)
+}
+
+/// Resolve the configured DLQ rate ceiling for `source` and return an
+/// E316 (per-source) or E315 (pipeline-wide) error when the cumulative
+/// fraction exceeds it. Per-source thresholds win against pipeline-wide
+/// when set. Both branches honor `min_records` to avoid 1/1 = 100%
+/// false positives on the very first failure.
+pub(crate) fn check_dlq_rate(
+    ctx: &ExecutorContext<'_>,
+    source: &Arc<str>,
+) -> Result<(), PipelineError> {
+    let Some(dlq) = ctx.config.error_handling.dlq.as_ref() else {
+        return Ok(());
+    };
+    let pipeline_min = dlq
+        .min_records
+        .unwrap_or(crate::config::DEFAULT_DLQ_MIN_RECORDS);
+
+    if let Some(per) = dlq.per_source.get(source.as_ref())
+        && let Some(max) = per.max_rate
+    {
+        let total = ctx.total_per_source.get(source).copied().unwrap_or(0);
+        let observed = ctx.dlq_per_source.get(source).copied().unwrap_or(0);
+        let min = per.min_records.unwrap_or(pipeline_min);
+        if total >= min && total > 0 {
+            let rate = observed as f64 / total as f64;
+            if rate >= max {
+                return Err(PipelineError::DlqRateExceeded {
+                    source: Some(Arc::clone(source)),
+                    observed_rate: rate,
+                    max_rate: max,
+                    observed_count: observed,
+                    total_count: total,
+                });
+            }
+        }
+    }
+
+    if let Some(max) = dlq.max_rate {
+        let total: u64 = ctx.total_per_source.values().sum();
+        let observed = ctx.counters.dlq_count;
+        if total >= pipeline_min && total > 0 {
+            let rate = observed as f64 / total as f64;
+            if rate >= max {
+                return Err(PipelineError::DlqRateExceeded {
+                    source: None,
+                    observed_rate: rate,
+                    max_rate: max,
+                    observed_count: observed,
+                    total_count: total,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 fn value_to_correlation_key(v: &Value, idx: usize) -> GroupByKey {
     use clinker_record::value_to_group_key;
     if let Value::String(s) = v
@@ -326,6 +412,15 @@ pub(crate) struct ExecutorContext<'a> {
     pub(crate) current_body_node_input_refs: Option<HashMap<String, Vec<String>>>,
     pub(crate) counters: PipelineCounters,
     pub(crate) dlq_entries: Vec<DlqEntry>,
+    /// Per-source DLQ counters keyed by Source-node name. Incremented
+    /// alongside `counters.dlq_count` at the [`push_dlq`] funnel so
+    /// per-source `max_rate` thresholds can fire with attribution.
+    pub(crate) dlq_per_source: HashMap<Arc<str>, u64>,
+    /// Per-source total record counters keyed by Source-node name.
+    /// Seeded once at executor entry from
+    /// [`ExecutorContext::source_records`] so the rate-check
+    /// denominator is the per-source ingest count, not a moving target.
+    pub(crate) total_per_source: HashMap<Arc<str>, u64>,
     pub(crate) output_errors: Vec<PipelineError>,
     pub(crate) ok_source_rows: HashSet<u64>,
     pub(crate) records_emitted: u64,
@@ -1274,18 +1369,24 @@ pub(crate) fn dispatch_plan_node(
                             None,
                         );
                         if !routed {
-                            ctx.counters.dlq_count += 1;
                             let source_name = source_name_arc_of(&record);
-                            ctx.dlq_entries.push(DlqEntry {
-                                source_row: rn,
-                                category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
-                                error_message: eval_err.to_string(),
-                                original_record: record,
-                                stage,
-                                route: None,
-                                trigger: true,
-                                source_name,
-                            });
+                            let triggering_field = eval_err.triggering_field.clone();
+                            let triggering_value = eval_err.triggering_value();
+                            push_dlq(
+                                ctx,
+                                DlqEntry {
+                                    source_row: rn,
+                                    category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
+                                    error_message: eval_err.to_string(),
+                                    original_record: record,
+                                    stage,
+                                    route: None,
+                                    trigger: true,
+                                    source_name,
+                                    triggering_field,
+                                    triggering_value,
+                                },
+                            )?;
                         }
                     }
                 }
@@ -1499,18 +1600,24 @@ pub(crate) fn dispatch_plan_node(
                                 None,
                             );
                             if !routed {
-                                ctx.counters.dlq_count += 1;
                                 let source_name = source_name_arc_of(&record);
-                                ctx.dlq_entries.push(DlqEntry {
-                                    source_row: rn,
-                                    category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
-                                    error_message: route_err.to_string(),
-                                    original_record: record,
-                                    stage,
-                                    route: None,
-                                    trigger: true,
-                                    source_name,
-                                });
+                                let triggering_field = route_err.triggering_field.clone();
+                                let triggering_value = route_err.triggering_value();
+                                push_dlq(
+                                    ctx,
+                                    DlqEntry {
+                                        source_row: rn,
+                                        category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
+                                        error_message: route_err.to_string(),
+                                        original_record: record,
+                                        stage,
+                                        route: None,
+                                        trigger: true,
+                                        source_name,
+                                        triggering_field,
+                                        triggering_value,
+                                    },
+                                )?;
                             }
                         }
                     }
@@ -1885,18 +1992,22 @@ pub(crate) fn dispatch_plan_node(
                                 None,
                             );
                             if !routed {
-                                ctx.counters.dlq_count += 1;
                                 let source_name = source_name_arc_of(record);
-                                ctx.dlq_entries.push(DlqEntry {
-                                    source_row: *row_num,
-                                    category: crate::dlq::DlqErrorCategory::AggregateFinalize,
-                                    error_message: format!("aggregate {name}: {e}"),
-                                    original_record: record.clone(),
-                                    stage,
-                                    route: None,
-                                    trigger: true,
-                                    source_name,
-                                });
+                                push_dlq(
+                                    ctx,
+                                    DlqEntry {
+                                        source_row: *row_num,
+                                        category: crate::dlq::DlqErrorCategory::AggregateFinalize,
+                                        error_message: format!("aggregate {name}: {e}"),
+                                        original_record: record.clone(),
+                                        stage,
+                                        route: None,
+                                        trigger: true,
+                                        source_name,
+                                        triggering_field: None,
+                                        triggering_value: None,
+                                    },
+                                )?;
                             }
                         }
                     }
@@ -1972,25 +2083,40 @@ pub(crate) fn dispatch_plan_node(
                             });
                         }
                         ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
-                            ctx.counters.dlq_count += 1;
-                            let synthetic = if let Some((rec, _)) = input.first() {
-                                rec.clone()
+                            // Empty-input finalize failures have no real
+                            // record to attribute to a Source, so stamp
+                            // the aggregate node's own name as the
+                            // source label. The DLQ reader sees a
+                            // specific aggregate identifier instead of
+                            // the generic `<merged>` fallthrough
+                            // `source_name_arc_of` would yield for a
+                            // schema-only synthetic record.
+                            let (synthetic, source_name) = if let Some((rec, _)) = input.first() {
+                                let sn = source_name_arc_of(rec);
+                                (rec.clone(), sn)
                             } else {
-                                Record::new(Arc::clone(output_schema), Vec::new())
+                                (
+                                    Record::new(Arc::clone(output_schema), Vec::new()),
+                                    Arc::from(name.as_str()),
+                                )
                             };
-                            let source_name = source_name_arc_of(&synthetic);
-                            ctx.dlq_entries.push(DlqEntry {
-                                source_row: 0,
-                                category: crate::dlq::DlqErrorCategory::AggregateFinalize,
-                                error_message: format!(
-                                    "aggregate {transform}.{binding}: {source:?}"
-                                ),
-                                original_record: synthetic,
-                                stage: Some(crate::dlq::stage_aggregate(name)),
-                                route: None,
-                                trigger: true,
-                                source_name,
-                            });
+                            push_dlq(
+                                ctx,
+                                DlqEntry {
+                                    source_row: 0,
+                                    category: crate::dlq::DlqErrorCategory::AggregateFinalize,
+                                    error_message: format!(
+                                        "aggregate {transform}.{binding}: {source:?}"
+                                    ),
+                                    original_record: synthetic,
+                                    stage: Some(crate::dlq::stage_aggregate(name)),
+                                    route: None,
+                                    trigger: true,
+                                    source_name,
+                                    triggering_field: None,
+                                    triggering_value: None,
+                                },
+                            )?;
                             Vec::new()
                         }
                     },
@@ -2012,25 +2138,40 @@ pub(crate) fn dispatch_plan_node(
                             });
                         }
                         ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
-                            ctx.counters.dlq_count += 1;
-                            let synthetic = if let Some((rec, _)) = input.first() {
-                                rec.clone()
+                            // Empty-input finalize failures have no real
+                            // record to attribute to a Source, so stamp
+                            // the aggregate node's own name as the
+                            // source label. The DLQ reader sees a
+                            // specific aggregate identifier instead of
+                            // the generic `<merged>` fallthrough
+                            // `source_name_arc_of` would yield for a
+                            // schema-only synthetic record.
+                            let (synthetic, source_name) = if let Some((rec, _)) = input.first() {
+                                let sn = source_name_arc_of(rec);
+                                (rec.clone(), sn)
                             } else {
-                                Record::new(Arc::clone(output_schema), Vec::new())
+                                (
+                                    Record::new(Arc::clone(output_schema), Vec::new()),
+                                    Arc::from(name.as_str()),
+                                )
                             };
-                            let source_name = source_name_arc_of(&synthetic);
-                            ctx.dlq_entries.push(DlqEntry {
-                                source_row: 0,
-                                category: crate::dlq::DlqErrorCategory::AggregateFinalize,
-                                error_message: format!(
-                                    "aggregate {transform}.{binding}: {source:?}"
-                                ),
-                                original_record: synthetic,
-                                stage: Some(crate::dlq::stage_aggregate(name)),
-                                route: None,
-                                trigger: true,
-                                source_name,
-                            });
+                            push_dlq(
+                                ctx,
+                                DlqEntry {
+                                    source_row: 0,
+                                    category: crate::dlq::DlqErrorCategory::AggregateFinalize,
+                                    error_message: format!(
+                                        "aggregate {transform}.{binding}: {source:?}"
+                                    ),
+                                    original_record: synthetic,
+                                    stage: Some(crate::dlq::stage_aggregate(name)),
+                                    route: None,
+                                    trigger: true,
+                                    source_name,
+                                    triggering_field: None,
+                                    triggering_value: None,
+                                },
+                            )?;
                             Vec::new()
                         }
                     },
@@ -3456,18 +3597,22 @@ fn commit_one_group(
                     format!("correlated with failure in group: {overflow_msg}"),
                 )
             };
-            ctx.counters.dlq_count += 1;
             let source_name = source_name_arc_of(&slot.original_record);
-            ctx.dlq_entries.push(DlqEntry {
-                source_row: slot.row_num,
-                category,
-                error_message,
-                original_record: slot.original_record.clone(),
-                stage: Some("correlation_commit".to_string()),
-                route: None,
-                trigger,
-                source_name,
-            });
+            push_dlq(
+                ctx,
+                DlqEntry {
+                    source_row: slot.row_num,
+                    category,
+                    error_message,
+                    original_record: slot.original_record.clone(),
+                    stage: Some("correlation_commit".to_string()),
+                    route: None,
+                    trigger,
+                    source_name,
+                    triggering_field: None,
+                    triggering_value: None,
+                },
+            )?;
         }
         return Ok(());
     }
@@ -3502,18 +3647,22 @@ fn commit_one_group(
         if !seen_rows.insert(err.row_num) {
             continue;
         }
-        ctx.counters.dlq_count += 1;
         let source_name = source_name_arc_of(&err.original_record);
-        ctx.dlq_entries.push(DlqEntry {
-            source_row: err.row_num,
-            category: err.category,
-            error_message: err.error_message.clone(),
-            original_record: err.original_record.clone(),
-            stage: err.stage.clone(),
-            route: err.route.clone(),
-            trigger: true,
-            source_name,
-        });
+        push_dlq(
+            ctx,
+            DlqEntry {
+                source_row: err.row_num,
+                category: err.category,
+                error_message: err.error_message.clone(),
+                original_record: err.original_record.clone(),
+                stage: err.stage.clone(),
+                route: err.route.clone(),
+                trigger: true,
+                source_name,
+                triggering_field: None,
+                triggering_value: None,
+            },
+        )?;
     }
     // Collateral entries: every other distinct row that flowed through
     // the group's Output buffers but didn't itself error. The resolved
@@ -3548,18 +3697,22 @@ fn commit_one_group(
         if !seen_rows.insert(slot.row_num) {
             continue;
         }
-        ctx.counters.dlq_count += 1;
         let source_name = source_name_arc_of(&slot.original_record);
-        ctx.dlq_entries.push(DlqEntry {
-            source_row: slot.row_num,
-            category: crate::dlq::DlqErrorCategory::Correlated,
-            error_message: format!("correlated with failure in group: {first_err_message}"),
-            original_record: slot.original_record.clone(),
-            stage: Some("correlation_commit".to_string()),
-            route: None,
-            trigger: false,
-            source_name,
-        });
+        push_dlq(
+            ctx,
+            DlqEntry {
+                source_row: slot.row_num,
+                category: crate::dlq::DlqErrorCategory::Correlated,
+                error_message: format!("correlated with failure in group: {first_err_message}"),
+                original_record: slot.original_record.clone(),
+                stage: Some("correlation_commit".to_string()),
+                route: None,
+                trigger: false,
+                source_name,
+                triggering_field: None,
+                triggering_value: None,
+            },
+        )?;
     }
 
     Ok(())

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -457,9 +457,19 @@ pub struct DlqEntry {
     /// `FieldMetadata::SourceName` engine-stamp at the push site so a
     /// post-Merge / post-Combine DLQ entry still identifies which
     /// upstream Source produced the record. Serialized as
-    /// `_cxl_dlq_source_name` in DLQ CSV. Unblocks per-source DLQ
-    /// thresholds (#55).
+    /// `_cxl_dlq_source_name` in DLQ CSV.
     pub source_name: Arc<str>,
+    /// Output field the evaluator was computing when the error fired,
+    /// captured at the emit-statement boundary. `None` for collateral
+    /// entries that were not directly eval-triggered (correlation
+    /// fan-out, group-size overflow, etc.). Serialized as
+    /// `_cxl_dlq_triggering_field`.
+    pub triggering_field: Option<Arc<str>>,
+    /// Value carried by the failing `EvalErrorKind` payload, when the
+    /// variant exposes one (conversion source string, out-of-bounds
+    /// index, mismatched arity). `None` otherwise. Serialized as
+    /// `_cxl_dlq_triggering_value`.
+    pub triggering_value: Option<clinker_record::Value>,
 }
 
 impl DlqEntry {
@@ -1265,6 +1275,11 @@ impl PipelineExecutor {
         // `counters` and `dlq_entries` are taken out of their `&mut`
         // borrows here, mutated through the dispatcher, and written
         // back at the end of the walk.
+        let total_per_source: HashMap<Arc<str>, u64> = source_records
+            .iter()
+            .map(|(name, records)| (Arc::from(name.as_str()), records.len() as u64))
+            .collect();
+
         let mut ctx = dispatch::ExecutorContext {
             config,
             artifacts,
@@ -1285,6 +1300,8 @@ impl PipelineExecutor {
             compiled_route,
             counters: std::mem::take(counters),
             dlq_entries: std::mem::take(dlq_entries),
+            dlq_per_source: HashMap::new(),
+            total_per_source,
             output_errors: Vec::new(),
             ok_source_rows: HashSet::new(),
             records_emitted: 0,
@@ -2455,6 +2472,7 @@ fn arcs_reachable_from(
 /// Returns `Ok((modified_record, Ok(())))` on emit,
 /// `Ok((record, Err(SkipReason)))` on skip. On error, returns
 /// `(transform_name, EvalError)`.
+#[allow(clippy::result_large_err)]
 pub(crate) fn evaluate_single_transform(
     record: &Record,
     transform_name: &str,
@@ -2508,7 +2526,7 @@ pub(crate) fn evaluate_single_transform(
 /// in any group key, or no matching partition), the evaluator runs
 /// without a window context — matching the legacy inline arena path's
 /// behavior.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::result_large_err)]
 pub(crate) fn evaluate_single_transform_windowed(
     record: &Record,
     transform_name: &str,

--- a/crates/clinker-core/src/executor/tests/correlated_window_after_aggregate_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_window_after_aggregate_retract.rs
@@ -330,7 +330,11 @@ O6,ENG,300
             .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "HR")),
         "trigger record must be the HR aggregate output row"
     );
-    assert_eq!(trigger.error_message, "division by zero");
+    assert!(
+        trigger.error_message.ends_with("division by zero"),
+        "trigger error must end with the eval-kind text; got: {}",
+        trigger.error_message
+    );
     assert!(
         trigger
             .original_record

--- a/crates/clinker-core/src/executor/tests/multi_output.rs
+++ b/crates/clinker-core/src/executor/tests/multi_output.rs
@@ -1291,6 +1291,8 @@ fn test_dlq_stage_source() {
         route: None,
         trigger: true,
         source_name: std::sync::Arc::from("test_source"),
+        triggering_field: None,
+        triggering_value: None,
     };
     assert_eq!(entry.stage, Some("source".to_string()));
     assert_eq!(entry.route, None);
@@ -1450,6 +1452,8 @@ fn test_dlq_stage_output() {
         route: Some("high_value".to_string()),
         trigger: true,
         source_name: std::sync::Arc::from("test_source"),
+        triggering_field: None,
+        triggering_value: None,
     };
     assert_eq!(entry.stage, Some("output:results".to_string()));
     assert_eq!(entry.route, Some("high_value".to_string()));
@@ -1536,6 +1540,8 @@ fn test_dlq_columns_in_csv() {
         route: None,
         trigger: true,
         source_name: std::sync::Arc::from("test_source"),
+        triggering_field: None,
+        triggering_value: None,
     }];
 
     let mut buf = Vec::new();

--- a/crates/clinker-core/src/executor/tests/window_recompute_correctness.rs
+++ b/crates/clinker-core/src/executor/tests/window_recompute_correctness.rs
@@ -237,7 +237,11 @@ fn post_aggregate_window_recompute_corrects_running_total() {
 
     let trigger = &dlq[0];
     assert!(trigger.trigger, "the single DLQ entry is the trigger");
-    assert_eq!(trigger.error_message, "division by zero");
+    assert!(
+        trigger.error_message.ends_with("division by zero"),
+        "trigger error must end with the eval-kind text; got: {}",
+        trigger.error_message
+    );
     assert!(
         trigger
             .original_record

--- a/crates/clinker-core/src/integration_tests.rs
+++ b/crates/clinker-core/src/integration_tests.rs
@@ -70,7 +70,11 @@ mod tests {
                 | PipelineError::CompositionUnknownPort { .. }
                 | PipelineError::CompositionBodyError { .. },
             ) => 1,
-            Err(PipelineError::Eval(_) | PipelineError::Accumulator { .. }) => 3,
+            Err(
+                PipelineError::Eval(_)
+                | PipelineError::Accumulator { .. }
+                | PipelineError::DlqRateExceeded { .. },
+            ) => 3,
             Err(
                 PipelineError::Io(_)
                 | PipelineError::Format(_)

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -971,6 +971,100 @@ fn validate_init_phase_terminals(nodes: &[Spanned<PipelineNode>], diags: &mut Ve
 
 /// Build a placeholder `TypedProgram` carrying only `output_row`, for
 /// node variants without a CXL body (Source/Merge/Output/Composition).
+/// Validate `error_handling.dlq.per_source` against the declared Source
+/// nodes and the DLQ-routing path set. Emits E317 when a `per_source`
+/// key does not name a declared Source node, and E318 when a configured
+/// `max_rate` is outside `(0.0, 1.0]` (zero is rejected because a
+/// `max_rate: 0.0` config halts on the very first failure — a
+/// `min_records`-bypassing footgun that should be expressed via a
+/// dedicated halt-on-any-DLQ surface instead) or a configured DLQ
+/// output path collides with another DLQ path (pipeline-wide or
+/// per-source).
+pub(crate) fn validate_dlq_per_source(
+    dlq: Option<&crate::config::DlqConfig>,
+    nodes: &[Spanned<PipelineNode>],
+    diags: &mut Vec<Diagnostic>,
+) {
+    /// Accepts the half-open interval `(0.0, 1.0]` — see the function-
+    /// level docstring for why zero is rejected.
+    fn is_valid_max_rate(r: f64) -> bool {
+        r > 0.0 && r <= 1.0 && r.is_finite()
+    }
+
+    let Some(dlq) = dlq else {
+        return;
+    };
+
+    // Range-check the pipeline-wide max_rate. Accepts the half-open
+    // interval `(0.0, 1.0]`: zero is rejected as an unintended
+    // halt-on-first-failure footgun (the `min_records` floor would also
+    // be bypassed when the numerator and denominator both start at 0).
+    if let Some(r) = dlq.max_rate
+        && !is_valid_max_rate(r)
+    {
+        diags.push(Diagnostic::error(
+            "E318",
+            format!("error_handling.dlq.max_rate {r} is out of range; must be in (0.0, 1.0]"),
+            LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+        ));
+    }
+
+    // Collect declared Source-node names so unknown per_source keys
+    // can be flagged with a precise message.
+    let source_names: HashSet<&str> = nodes
+        .iter()
+        .filter_map(|n| match &n.value {
+            PipelineNode::Source { header, .. } => Some(header.name.as_ref()),
+            _ => None,
+        })
+        .collect();
+
+    // Track path collisions across the pipeline-wide + every per-source
+    // entry. First insertion wins; subsequent insertions emit E318.
+    let mut paths: HashMap<&str, String> = HashMap::new();
+    if let Some(p) = dlq.path.as_deref() {
+        paths.insert(p, "error_handling.dlq.path".to_string());
+    }
+
+    for (src_name, per) in &dlq.per_source {
+        if !source_names.contains(src_name.as_str()) {
+            diags.push(Diagnostic::error(
+                "E317",
+                format!(
+                    "error_handling.dlq.per_source key {src_name:?} does not match \
+                     any declared Source node"
+                ),
+                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+        }
+        if let Some(r) = per.max_rate
+            && !is_valid_max_rate(r)
+        {
+            diags.push(Diagnostic::error(
+                "E318",
+                format!(
+                    "error_handling.dlq.per_source.{src_name}.max_rate {r} \
+                     is out of range; must be in (0.0, 1.0]"
+                ),
+                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+        }
+        if let Some(p) = per.path.as_deref()
+            && let Some(prev) =
+                paths.insert(p, format!("error_handling.dlq.per_source.{src_name}.path"))
+        {
+            diags.push(Diagnostic::error(
+                "E318",
+                format!(
+                    "error_handling.dlq.per_source.{src_name}.path {p:?} collides \
+                     with {prev}"
+                ),
+                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+        }
+    }
+}
+
 fn synthetic_typed_program(output_row: Row) -> TypedProgram {
     TypedProgram {
         program: cxl::ast::Program {
@@ -983,6 +1077,7 @@ fn synthetic_typed_program(output_row: Row) -> TypedProgram {
         regexes: Vec::new(),
         node_count: 0,
         output_row,
+        source: None,
     }
 }
 
@@ -2559,6 +2654,7 @@ fn typecheck_cxl(
         )
     })?;
     cxl::typecheck::pass::type_check_with_mode_and_vars(resolved, schema, mode, scoped_vars)
+        .map(|typed| typed.with_source(std::sync::Arc::from(source)))
         .map_err(|diags| {
             let errors: Vec<String> = diags
                 .iter()
@@ -3281,7 +3377,7 @@ fn typecheck_combine_where(
         cxl::typecheck::pass::AggregateMode::Row,
         scoped_vars,
     ) {
-        Ok(typed) => Ok(typed),
+        Ok(typed) => Ok(typed.with_source(std::sync::Arc::from(wrapped.as_str()))),
         Err(type_diags) => {
             let mut out = Vec::new();
             for td in type_diags.into_iter().filter(|d| !d.is_warning) {

--- a/crates/clinker-core/src/plan/combine.rs
+++ b/crates/clinker-core/src/plan/combine.rs
@@ -2290,6 +2290,7 @@ mod tests {
             regexes: Vec::new(),
             node_count: 0,
             output_row: cxl::typecheck::row::Row::closed(IndexMap::new(), CxlSpan::new(0, 0)),
+            source: None,
         });
         let mk_eq = || EqualityConjunct {
             left_expr: dummy_lit(),
@@ -2602,6 +2603,7 @@ mod tests {
             regexes: Vec::new(),
             node_count: 0,
             output_row: cxl::typecheck::row::Row::closed(IndexMap::new(), CxlSpan::new(0, 0)),
+            source: None,
         });
         let equalities: Vec<EqualityConjunct> = edges
             .iter()
@@ -2884,6 +2886,7 @@ mod tests {
                 IndexMap::new(),
                 cxl::lexer::Span::new(0, 0),
             ),
+            source: None,
         });
         let predicate = DecomposedPredicate {
             equalities: vec![
@@ -2981,6 +2984,7 @@ mod tests {
                 IndexMap::new(),
                 cxl::lexer::Span::new(0, 0),
             ),
+            source: None,
         });
         let predicate = DecomposedPredicate {
             equalities: vec![

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -4274,6 +4274,7 @@ nodes:
             regexes: Vec::new(),
             node_count: 0,
             output_row: cxl::typecheck::row::Row::closed(IndexMap::new(), CxlSpan::new(0, 0)),
+            source: None,
         });
         let predicate = DecomposedPredicate {
             equalities: vec![EqualityConjunct {

--- a/crates/clinker-core/tests/dlq_rate_threshold.rs
+++ b/crates/clinker-core/tests/dlq_rate_threshold.rs
@@ -1,0 +1,532 @@
+//! End-to-end coverage for per-source and pipeline-wide DLQ rate
+//! thresholds, per-source DLQ sidecar routing, and the source-name
+//! attribution that flows through the entire stack.
+//!
+//! Topology is the canonical multi-source merge-attribution shape:
+//! `[src_a, src_b] → merge → tfm → out`. `tfm` raises a divide-by-zero
+//! on records from `src_b` only, so the DLQ stream has clean source
+//! attribution and the per-source threshold can be exercised in
+//! isolation against `src_b`'s denominator.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, parse_config};
+use clinker_core::error::PipelineError;
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::source::multi_file::FileSlot;
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn std::io::Write + Send> {
+    Box::new(buf.clone())
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// Pipeline that fails every record originating from `src_b`. `src_a`
+/// records pass through; `src_b` records hit `1 / 0`. Returns the
+/// parsed config + the canned reader registry so each test can layer
+/// its own `error_handling` block on top.
+fn fail_src_b_yaml(error_handling: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: dlq_rate_threshold
+{error_handling}
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - {{ name: id, type: int }}
+        - {{ name: amt, type: int }}
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - {{ name: id, type: int }}
+        - {{ name: amt, type: int }}
+  - type: merge
+    name: m
+    inputs: [src_a, src_b]
+  - type: transform
+    name: tfm
+    input: m
+    config:
+      cxl: |
+        emit id = id
+        emit ratio = if($source.name == "src_b") then (1 / 0) else amt
+  - type: output
+    name: out
+    input: tfm
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+fn five_each_readers() -> SourceReaders {
+    HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot("a", "id,amt\n1,10\n2,20\n3,30\n4,40\n5,50\n")],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot("b", "id,amt\n10,10\n11,11\n12,12\n13,13\n14,14\n")],
+        ),
+    ])
+}
+
+/// AC1 reinforcement: every DLQ entry carries the originating Source
+/// name through Merge. With `tfm` failing 100% of `src_b` records and
+/// no per-source override, every entry in the in-memory DLQ vector
+/// must report `source_name == "src_b"`. CSV column ordering is
+/// validated separately in `dlq.rs` unit tests; this asserts the
+/// in-memory plumbing through the full executor walk.
+#[test]
+fn dlq_entries_carry_source_b_attribution_under_merge() {
+    let yaml = fail_src_b_yaml(
+        r#"
+error_handling:
+  strategy: continue
+"#,
+    );
+    let config = parse_config(&yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        five_each_readers(),
+        writers,
+        &run_params(),
+    )
+    .expect("pipeline must complete under Continue strategy");
+    assert_eq!(report.counters.dlq_count, 5, "5 src_b rows fail");
+    assert!(
+        report
+            .dlq_entries
+            .iter()
+            .all(|e| e.source_name.as_ref() == "src_b"),
+        "every DLQ entry must attribute to src_b; got: {:?}",
+        report
+            .dlq_entries
+            .iter()
+            .map(|e| e.source_name.as_ref())
+            .collect::<Vec<_>>()
+    );
+    // The eval failed inside `emit ratio = ...`. The emit-statement
+    // boundary in `cxl::eval::ProgramEvaluator::eval_record_inner`
+    // attaches the target field name to `EvalError.triggering_field`,
+    // so every DLQ entry derived from an emit-statement subexpression
+    // names the offending column.
+    assert!(
+        report
+            .dlq_entries
+            .iter()
+            .all(|e| e.triggering_field.as_deref() == Some("ratio")),
+        "every DLQ entry must name 'ratio' as the triggering field"
+    );
+}
+
+/// AC2/AC3/AC5: per-source `max_rate: 0.1` on `src_b` halts the
+/// pipeline once `dlq_count_for_src_b / total_per_src_b` crosses 10%
+/// (and the `min_records` floor has been met). `tfm` fails every src_b
+/// record so the first failure past the floor trips the threshold; the
+/// resulting error is `DlqRateExceeded { source: Some("src_b"), .. }`
+/// — AC3's "names the offending source" requirement.
+#[test]
+fn per_source_threshold_halts_with_attributed_error() {
+    let yaml = fail_src_b_yaml(
+        r#"
+error_handling:
+  strategy: continue
+  dlq:
+    path: dlq.csv
+    min_records: 2
+    per_source:
+      src_b:
+        max_rate: 0.1
+"#,
+    );
+    let config = parse_config(&yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let err = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        five_each_readers(),
+        writers,
+        &run_params(),
+    )
+    .expect_err("per-source threshold of 0.1 must halt the run on the first src_b failure");
+    match err {
+        PipelineError::DlqRateExceeded {
+            source,
+            observed_rate,
+            max_rate,
+            ..
+        } => {
+            let name = source.expect("E316 must name the offending source");
+            assert_eq!(name.as_ref(), "src_b");
+            assert!(observed_rate >= 0.1);
+            assert_eq!(max_rate, 0.1);
+        }
+        other => panic!("expected E316 DlqRateExceeded(src_b), got: {other:?}"),
+    }
+}
+
+/// Pipeline-wide threshold halts the run when the cumulative DLQ
+/// fraction crosses `max_rate`. The `source: None` variant of
+/// `DlqRateExceeded` carries E315 and reports the aggregate rate
+/// rather than blaming a specific source.
+#[test]
+fn pipeline_wide_threshold_halts_with_e315() {
+    let yaml = fail_src_b_yaml(
+        r#"
+error_handling:
+  strategy: continue
+  dlq:
+    path: dlq.csv
+    min_records: 4
+    max_rate: 0.4
+"#,
+    );
+    let config = parse_config(&yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let err = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        five_each_readers(),
+        writers,
+        &run_params(),
+    )
+    .expect_err("pipeline-wide max_rate 0.4 must halt the run once 5/10 records DLQ");
+    match err {
+        PipelineError::DlqRateExceeded {
+            source,
+            observed_rate,
+            max_rate,
+            ..
+        } => {
+            assert!(source.is_none(), "E315 carries source: None");
+            assert!(observed_rate >= 0.4);
+            assert_eq!(max_rate, 0.4);
+        }
+        other => panic!("expected E315 DlqRateExceeded(pipeline-wide), got: {other:?}"),
+    }
+}
+
+/// `min_records` floor suppresses early halts even when the rate
+/// exceeds `max_rate`. Without the floor, a 1/1 first failure would
+/// trip a 0.5 threshold; with `min_records: 100` the floor is never
+/// reached and the run completes normally despite a 50% DLQ rate.
+#[test]
+fn min_records_floor_suppresses_early_halt() {
+    let yaml = fail_src_b_yaml(
+        r#"
+error_handling:
+  strategy: continue
+  dlq:
+    path: dlq.csv
+    min_records: 100
+    max_rate: 0.01
+"#,
+    );
+    let config = parse_config(&yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        five_each_readers(),
+        writers,
+        &run_params(),
+    )
+    .expect("min_records floor (100) is above this run's total (10); no halt expected");
+    assert_eq!(report.counters.dlq_count, 5);
+}
+
+/// AC4: per-source `path:` partitions DLQ entries into their own
+/// sidecar file. The `partition_dlq_entries` helper drives the CLI
+/// flush loop; this test exercises the partitioner directly so the
+/// routing semantics are pinned independent of the I/O layer.
+#[test]
+fn per_source_path_partitions_dlq_entries() {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use clinker_core::config::{DlqConfig, DlqPerSourceConfig};
+    use clinker_core::dlq::{DlqErrorCategory, partition_dlq_entries};
+    use clinker_core::executor::DlqEntry;
+    use clinker_record::{Record, Schema, Value};
+
+    let schema = Arc::new(Schema::new(vec!["id".into()]));
+    let mk = |src: &str| DlqEntry {
+        source_row: 0,
+        category: DlqErrorCategory::TypeCoercionFailure,
+        error_message: String::new(),
+        original_record: Record::new(Arc::clone(&schema), vec![Value::Integer(0)]),
+        stage: None,
+        route: None,
+        trigger: true,
+        source_name: Arc::from(src),
+        triggering_field: None,
+        triggering_value: None,
+    };
+    let entries = vec![mk("src_a"), mk("src_b"), mk("src_a"), mk("src_b")];
+
+    let mut per_source = std::collections::BTreeMap::new();
+    per_source.insert(
+        "src_b".to_string(),
+        DlqPerSourceConfig {
+            path: Some("dlq_b.csv".to_string()),
+            max_rate: None,
+            min_records: None,
+        },
+    );
+    let cfg = DlqConfig {
+        path: Some("dlq.csv".to_string()),
+        include_reason: None,
+        include_source_row: None,
+        max_rate: None,
+        min_records: None,
+        per_source,
+    };
+
+    let buckets = partition_dlq_entries(&entries, &cfg);
+    let dlq_bucket = buckets
+        .iter()
+        .find(|(p, _)| p == &PathBuf::from("dlq.csv"))
+        .expect("default bucket must exist");
+    assert_eq!(dlq_bucket.1.len(), 2);
+    assert!(
+        dlq_bucket
+            .1
+            .iter()
+            .all(|e| e.source_name.as_ref() == "src_a")
+    );
+
+    let b_bucket = buckets
+        .iter()
+        .find(|(p, _)| p == &PathBuf::from("dlq_b.csv"))
+        .expect("per-source bucket must exist");
+    assert_eq!(b_bucket.1.len(), 2);
+    assert!(b_bucket.1.iter().all(|e| e.source_name.as_ref() == "src_b"));
+}
+
+/// E317: `per_source` map key that does not name a declared Source
+/// surfaces at compile time. The compile result is `Err(Vec<Diagnostic>)`
+/// because the diagnostic is `Severity::Error`.
+#[test]
+fn unknown_per_source_key_emits_e317() {
+    let yaml = r#"
+pipeline:
+  name: e317_unknown_per_source
+error_handling:
+  strategy: continue
+  dlq:
+    path: dlq.csv
+    per_source:
+      ghost:
+        max_rate: 0.5
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src_a
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("ghost per_source key must produce E317 at compile time");
+    let combined = diags
+        .iter()
+        .map(|d| format!("{}: {}", d.code, d.message))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        combined.contains("E317") && combined.contains("ghost"),
+        "expected E317 naming 'ghost', got:\n{combined}"
+    );
+}
+
+/// E318: out-of-range `max_rate` (both pipeline-wide and per-source).
+/// The accepted interval is the half-open `(0.0, 1.0]` — zero is
+/// rejected as a footgun, see [`crate::plan::bind_schema::validate_dlq_per_source`].
+#[test]
+fn zero_max_rate_emits_e318() {
+    let yaml = r#"
+pipeline:
+  name: e318_zero_max_rate
+error_handling:
+  strategy: continue
+  dlq:
+    path: dlq.csv
+    max_rate: 0.0
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src_a
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    let diags = config.compile(&CompileContext::default()).expect_err(
+        "max_rate: 0.0 must produce E318 (halt-on-first-failure is not a supported config)",
+    );
+    let e318_count = diags.iter().filter(|d| d.code == "E318").count();
+    assert!(
+        e318_count >= 1,
+        "expected at least one E318 diagnostic for zero max_rate; got: {:?}",
+        diags
+            .iter()
+            .map(|d| format!("{}: {}", d.code, d.message))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn out_of_range_max_rate_emits_e318() {
+    let yaml = r#"
+pipeline:
+  name: e318_out_of_range
+error_handling:
+  strategy: continue
+  dlq:
+    path: dlq.csv
+    max_rate: 1.5
+    per_source:
+      src_a:
+        max_rate: -0.2
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src_a
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("out-of-range max_rate values must produce E318");
+    let e318_count = diags.iter().filter(|d| d.code == "E318").count();
+    assert!(
+        e318_count >= 2,
+        "expected at least two E318 diagnostics (pipeline-wide + src_a); got: {:?}",
+        diags
+            .iter()
+            .map(|d| format!("{}: {}", d.code, d.message))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// E318: per-source DLQ `path:` collides with the pipeline-wide path.
+#[test]
+fn duplicate_dlq_path_emits_e318() {
+    let yaml = r#"
+pipeline:
+  name: e318_path_collision
+error_handling:
+  strategy: continue
+  dlq:
+    path: dlq.csv
+    per_source:
+      src_a:
+        path: dlq.csv
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src_a
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("duplicate DLQ path must produce E318");
+    let combined = diags
+        .iter()
+        .map(|d| format!("{}: {}", d.code, d.message))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        combined.contains("E318") && combined.contains("collides"),
+        "expected E318 path collision, got:\n{combined}"
+    );
+}

--- a/crates/clinker-core/tests/multi_source_ingestion.rs
+++ b/crates/clinker-core/tests/multi_source_ingestion.rs
@@ -248,6 +248,115 @@ nodes:
     }
 }
 
+/// `_cxl_dlq_source_name` column round-trips through the CSV sidecar
+/// writer for every failing record produced by a Merge-fed Transform.
+/// The pipeline maps src_a records cleanly and fails 100% of src_b
+/// records via `1 / 0`; the resulting sidecar must contain three rows,
+/// all attributed to `src_b` in the `_cxl_dlq_source_name` column.
+#[test]
+fn dlq_csv_sidecar_attributes_every_row_to_originating_source() {
+    use std::sync::Arc;
+
+    use clinker_record::{Schema, SchemaBuilder};
+
+    let yaml = r#"
+pipeline:
+  name: dlq_attribution_sidecar
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b]
+  - type: transform
+    name: tfm
+    input: merged
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+        emit safe_ratio = if($source.name == "src_b") then (1 / 0) else 1
+  - type: output
+    name: out
+    input: tfm
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slot("a", "id,tag\n1,a-one\n2,a-two\n3,a-three\n")],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slot("b", "id,tag\n10,b-ten\n11,b-eleven\n12,b-twelve\n")],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("pipeline must complete under Continue strategy");
+    assert_eq!(report.counters.dlq_count, 3);
+
+    // Round-trip the DLQ vector through the CSV writer and read the
+    // header + body back to assert column-level attribution.
+    let dlq_schema: Arc<Schema> = SchemaBuilder::new()
+        .with_field("id")
+        .with_field("tag")
+        .build();
+    let mut buf = Vec::new();
+    clinker_core::dlq::write_dlq(
+        &mut buf,
+        &report.dlq_entries,
+        &dlq_schema,
+        "input.csv",
+        true,
+        true,
+    )
+    .expect("write_dlq must succeed");
+    let csv = String::from_utf8(buf).unwrap();
+    let mut lines = csv.lines();
+    let header: Vec<&str> = lines.next().unwrap().split(',').collect();
+    let name_col = header
+        .iter()
+        .position(|c| *c == "_cxl_dlq_source_name")
+        .expect("DLQ header must carry _cxl_dlq_source_name");
+    let rows: Vec<&str> = lines.collect();
+    assert_eq!(rows.len(), 3);
+    for row in rows {
+        let cells: Vec<&str> = row.split(',').collect();
+        assert_eq!(
+            cells[name_col], "src_b",
+            "every DLQ row must attribute to src_b; got row: {row}"
+        );
+    }
+}
+
 /// Topology 2 — `src_a → tfm_a → out_a`, `src_b → tfm_b → out_b`. The
 /// two chains are wholly disjoint at the DAG level; the bug pre-fix
 /// was that `src_b`'s dispatch silently emitted `src_a`'s records,

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -321,6 +321,10 @@ fn main() -> ExitCode {
                         // emission site. Treat as exit 4 defensively
                         // in case a future caller surfaces it.
                         PipelineError::CorrelationGroupOverflow { .. } => ExitCode::from(4),
+                        // Configured DLQ rate ceiling tripped (E315 /
+                        // E316). Treat as a data-quality halt — exit 3
+                        // sits between config (1) and infrastructure (4).
+                        PipelineError::DlqRateExceeded { .. } => ExitCode::from(3),
                     }
                 }
             }
@@ -919,54 +923,66 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     let counters = &report.counters;
     let dlq_entries = &report.dlq_entries;
 
-    // Write DLQ if there are entries and DLQ path is configured.
-    // Same atomic temp+rename discipline as primary outputs above —
-    // operators inspecting DLQ output should never see a truncated file.
+    // Write DLQ if there are entries and at least one DLQ path is
+    // configured (pipeline-wide or per-source). Same atomic
+    // temp+rename discipline as primary outputs above — operators
+    // inspecting DLQ output should never see a truncated file.
+    // Per-source `path:` overrides partition entries into separate
+    // sidecar files; entries from sources without an override fall
+    // through to `dlq_config.path` (the pipeline-wide sink).
     if !dlq_entries.is_empty()
         && let Some(ref dlq_config) = pipeline_config.error_handling.dlq
-        && let Some(ref dlq_path) = dlq_config.path
     {
-        let input_schema = {
-            let f = std::fs::File::open(&input_path)?;
-            let mut r = clinker_format::csv::reader::CsvReader::from_reader(
-                f,
-                clinker_format::csv::reader::CsvReaderConfig::default(),
-            );
-            r.schema().map_err(PipelineError::Format)?
-        };
-        let dlq_path_buf: std::path::PathBuf = dlq_path.clone().into();
-        let dlq_dir = dlq_path_buf
-            .parent()
-            .filter(|p| !p.as_os_str().is_empty())
-            .map(|p| p.to_path_buf())
-            .unwrap_or_else(|| std::path::PathBuf::from("."));
-        if !dlq_dir.exists() {
-            std::fs::create_dir_all(&dlq_dir)?;
+        let buckets = clinker_core::dlq::partition_dlq_entries(dlq_entries, dlq_config);
+        if !buckets.is_empty() {
+            let input_schema = {
+                let f = std::fs::File::open(&input_path)?;
+                let mut r = clinker_format::csv::reader::CsvReader::from_reader(
+                    f,
+                    clinker_format::csv::reader::CsvReaderConfig::default(),
+                );
+                r.schema().map_err(PipelineError::Format)?
+            };
+            let include_reason = dlq_config.include_reason.unwrap_or(true);
+            let include_source_row = dlq_config.include_source_row.unwrap_or(true);
+            for (target_path, bucket_entries) in &buckets {
+                if bucket_entries.is_empty() {
+                    continue;
+                }
+                let target_dir = target_path
+                    .parent()
+                    .filter(|p| !p.as_os_str().is_empty())
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| std::path::PathBuf::from("."));
+                if !target_dir.exists() {
+                    std::fs::create_dir_all(&target_dir)?;
+                }
+                let dlq_temp = tempfile::NamedTempFile::new_in(&target_dir)?;
+                let dlq_temp_handle = dlq_temp.reopen()?;
+                let owned: Vec<clinker_core::executor::DlqEntry> =
+                    bucket_entries.iter().map(|e| (*e).clone()).collect();
+                clinker_core::dlq::write_dlq(
+                    dlq_temp_handle,
+                    &owned,
+                    &input_schema,
+                    &input_path,
+                    include_reason,
+                    include_source_row,
+                )
+                .map_err(PipelineError::Format)?;
+                dlq_temp.persist(target_path).map_err(|e| {
+                    tracing::error!(
+                        final_path = %target_path.display(),
+                        "failed to atomically rename DLQ output into place; temp file preserved",
+                    );
+                    PipelineError::Io(std::io::Error::other(format!(
+                        "atomic DLQ rename failed for {}: {}",
+                        target_path.display(),
+                        e.error
+                    )))
+                })?;
+            }
         }
-        let dlq_temp = tempfile::NamedTempFile::new_in(&dlq_dir)?;
-        let dlq_temp_handle = dlq_temp.reopen()?;
-        let include_reason = dlq_config.include_reason.unwrap_or(true);
-        let include_source_row = dlq_config.include_source_row.unwrap_or(true);
-        clinker_core::dlq::write_dlq(
-            dlq_temp_handle,
-            dlq_entries,
-            &input_schema,
-            &input_path,
-            include_reason,
-            include_source_row,
-        )
-        .map_err(PipelineError::Format)?;
-        dlq_temp.persist(&dlq_path_buf).map_err(|e| {
-            tracing::error!(
-                final_path = %dlq_path_buf.display(),
-                "failed to atomically rename DLQ output into place; temp file preserved",
-            );
-            PipelineError::Io(std::io::Error::other(format!(
-                "atomic DLQ rename failed for {}: {}",
-                dlq_path_buf.display(),
-                e.error
-            )))
-        })?;
     }
 
     // Provenance sidecars for outputs that opted in via `write_meta`.

--- a/crates/cxl/src/eval/error.rs
+++ b/crates/cxl/src/eval/error.rs
@@ -1,11 +1,34 @@
+use std::sync::Arc;
+
+use clinker_record::Value;
+
 use crate::lexer::Span;
 
 /// Runtime evaluation error with diagnostic metadata.
-/// Follows the Boa/Starlark convention: struct with kind enum + shared span.
+///
+/// Follows the Boa/Starlark convention: struct with kind enum + shared
+/// span. Span byte offsets are relative to [`Self::source_expr`] when
+/// that field is populated, which is how the miette `Diagnostic` impl
+/// renders the offending subexpression with a caret.
+///
+/// `source_row`, `source_expr`, and `triggering_field` are attached at
+/// the outermost eval boundary (`map_err` wrapper at record-level
+/// evaluation entry) so the 14 internal constructors stay cheap on the
+/// hot path. `triggering_value` is extracted on demand from the
+/// `EvalErrorKind` payload via [`extract_triggering_value`].
 #[derive(Debug, Clone)]
 pub struct EvalError {
     pub kind: EvalErrorKind,
     pub span: Span,
+    /// Input row index that was being evaluated when the error fired.
+    pub source_row: Option<u64>,
+    /// CXL source text the program was parsed from. Drives miette's
+    /// underlined-expression rendering at `source_code()`.
+    pub source_expr: Option<Arc<str>>,
+    /// Output field the evaluator was computing when the error fired.
+    /// Set at the emit-statement boundary; absent for filter / non-emit
+    /// failure paths.
+    pub triggering_field: Option<Arc<str>>,
 }
 
 /// Error categories. `#[non_exhaustive]` allows future growth.
@@ -82,7 +105,14 @@ impl std::fmt::Display for EvalErrorKind {
 
 impl std::fmt::Display for EvalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.kind)
+        match (self.source_row, self.triggering_field.as_deref()) {
+            (Some(row), Some(field)) => {
+                write!(f, "row {row}: field '{field}': {}", self.kind)
+            }
+            (Some(row), None) => write!(f, "row {row}: {}", self.kind),
+            (None, Some(field)) => write!(f, "field '{field}': {}", self.kind),
+            (None, None) => write!(f, "{}", self.kind),
+        }
     }
 }
 
@@ -90,7 +120,13 @@ impl std::error::Error for EvalError {}
 
 impl EvalError {
     pub fn new(kind: EvalErrorKind, span: Span) -> Self {
-        Self { kind, span }
+        Self {
+            kind,
+            span,
+            source_row: None,
+            source_expr: None,
+            triggering_field: None,
+        }
     }
 
     pub fn type_mismatch(expected: &'static str, got: &'static str, span: Span) -> Self {
@@ -117,5 +153,173 @@ impl EvalError {
 
     pub fn string_too_large(size: usize, limit: usize, span: Span) -> Self {
         Self::new(EvalErrorKind::StringTooLarge { size, limit }, span)
+    }
+
+    /// Attach the source row currently being evaluated. Called by the
+    /// boundary wrapper at record-level eval entry, so every error
+    /// surfaced past that boundary carries the row that triggered it.
+    pub fn with_source_row(mut self, row: u64) -> Self {
+        self.source_row = Some(row);
+        self
+    }
+
+    /// Attach the original CXL source text for miette rendering.
+    pub fn with_source_expr(mut self, expr: Arc<str>) -> Self {
+        self.source_expr = Some(expr);
+        self
+    }
+
+    /// Attach the output field name the evaluator was computing.
+    /// Set at the emit-statement boundary.
+    pub fn with_triggering_field(mut self, field: Arc<str>) -> Self {
+        self.triggering_field = Some(field);
+        self
+    }
+
+    /// Extract the value carried by the underlying [`EvalErrorKind`]
+    /// payload, when the variant exposes one. Best-effort: variants
+    /// that describe a shape (`TypeMismatch`, `DivisionByZero`, etc.)
+    /// return `None`; variants whose payload is a concrete value or
+    /// integer (`ConversionFailed`, `IndexOutOfBounds`, `ArityMismatch`)
+    /// surface that value so DLQ consumers see what failed without
+    /// re-running the pipeline.
+    pub fn triggering_value(&self) -> Option<Value> {
+        extract_triggering_value(&self.kind)
+    }
+}
+
+/// Extract the value carried by an [`EvalErrorKind`] payload, when the
+/// variant exposes one. Symmetric with the runtime DLQ writer's
+/// `triggering_value` column.
+pub fn extract_triggering_value(kind: &EvalErrorKind) -> Option<Value> {
+    match kind {
+        EvalErrorKind::ConversionFailed { value, .. } => {
+            Some(Value::String(Box::<str>::from(value.as_str())))
+        }
+        EvalErrorKind::IndexOutOfBounds { index, .. } => Some(Value::Integer(*index)),
+        EvalErrorKind::ArityMismatch { got, .. } => Some(Value::Integer(*got as i64)),
+        EvalErrorKind::TypeMismatch { .. }
+        | EvalErrorKind::DivisionByZero
+        | EvalErrorKind::RegexCompile { .. }
+        | EvalErrorKind::IntegerOverflow { .. }
+        | EvalErrorKind::StringTooLarge { .. } => None,
+    }
+}
+
+impl miette::Diagnostic for EvalError {
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        let s: &'static str = match &self.kind {
+            EvalErrorKind::TypeMismatch { .. } => "cxl::eval::type_mismatch",
+            EvalErrorKind::DivisionByZero => "cxl::eval::division_by_zero",
+            EvalErrorKind::ConversionFailed { .. } => "cxl::eval::conversion_failed",
+            EvalErrorKind::RegexCompile { .. } => "cxl::eval::regex_compile",
+            EvalErrorKind::IndexOutOfBounds { .. } => "cxl::eval::index_out_of_bounds",
+            EvalErrorKind::ArityMismatch { .. } => "cxl::eval::arity_mismatch",
+            EvalErrorKind::IntegerOverflow { .. } => "cxl::eval::integer_overflow",
+            EvalErrorKind::StringTooLarge { .. } => "cxl::eval::string_too_large",
+        };
+        Some(Box::new(s))
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        Some(miette::Severity::Error)
+    }
+
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        self.source_expr
+            .as_ref()
+            .map(|s| s as &dyn miette::SourceCode)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        let start = self.span.start as usize;
+        let len = self.span.end.saturating_sub(self.span.start) as usize;
+        let s = miette::SourceSpan::new(start.into(), len);
+        Some(Box::new(std::iter::once(
+            miette::LabeledSpan::new_with_span(Some(self.kind.to_string()), s),
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Span;
+
+    fn s(start: u32, end: u32) -> Span {
+        Span { start, end }
+    }
+
+    #[test]
+    fn source_row_appears_in_display() {
+        let err = EvalError::division_by_zero(s(0, 1)).with_source_row(42);
+        let rendered = err.to_string();
+        assert!(rendered.contains("row 42"), "got: {rendered}");
+        assert!(rendered.contains("division by zero"), "got: {rendered}");
+    }
+
+    #[test]
+    fn triggering_field_appears_in_display() {
+        let err = EvalError::division_by_zero(s(0, 1))
+            .with_source_row(7)
+            .with_triggering_field(Arc::from("total"));
+        let rendered = err.to_string();
+        assert!(rendered.contains("field 'total'"), "got: {rendered}");
+    }
+
+    #[test]
+    fn miette_source_code_returns_attached_expr() {
+        let expr: Arc<str> = Arc::from("emit total = a / b");
+        let err = EvalError::division_by_zero(s(13, 18)).with_source_expr(Arc::clone(&expr));
+        let report = miette::Report::new(err);
+        let rendered = format!("{:?}", report.with_source_code(expr.to_string()));
+        // The fancy formatter underlines the failing subexpression.
+        // We assert on the expression text and the per-error code arm.
+        assert!(rendered.contains("a / b"), "got: {rendered}");
+        assert!(
+            rendered.contains("cxl::eval::division_by_zero"),
+            "got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn extract_triggering_value_table() {
+        assert_eq!(
+            extract_triggering_value(&EvalErrorKind::ConversionFailed {
+                value: "not-a-number".to_string(),
+                target: "int",
+            }),
+            Some(Value::String(Box::<str>::from("not-a-number")))
+        );
+        assert_eq!(
+            extract_triggering_value(&EvalErrorKind::IndexOutOfBounds {
+                index: 12,
+                length: 3,
+            }),
+            Some(Value::Integer(12))
+        );
+        assert_eq!(
+            extract_triggering_value(&EvalErrorKind::ArityMismatch {
+                name: "round".to_string(),
+                expected: 2,
+                got: 5,
+            }),
+            Some(Value::Integer(5))
+        );
+        assert_eq!(
+            extract_triggering_value(&EvalErrorKind::DivisionByZero),
+            None
+        );
+        assert_eq!(
+            extract_triggering_value(&EvalErrorKind::TypeMismatch {
+                expected: "Int",
+                got: "String",
+            }),
+            None
+        );
+        assert_eq!(
+            extract_triggering_value(&EvalErrorKind::IntegerOverflow { op: "+" }),
+            None
+        );
     }
 }

--- a/crates/cxl/src/eval/mod.rs
+++ b/crates/cxl/src/eval/mod.rs
@@ -16,7 +16,7 @@ use crate::resolve::traits::{FieldResolver, RecordStorage, WindowContext};
 use crate::typecheck::pass::TypedProgram;
 
 pub use context::{Clock, EvalContext, FixedClock, StableEvalContext, WallClock};
-pub use error::{EvalError, EvalErrorKind};
+pub use error::{EvalError, EvalErrorKind, extract_triggering_value};
 
 /// Row disposition signal from CXL evaluation.
 ///
@@ -123,7 +123,36 @@ impl ProgramEvaluator {
     }
 
     /// Evaluate a record through the full program, returning Emit or Skip.
+    ///
+    /// Wraps the inner walk in a boundary `map_err` that attaches the
+    /// current `source_row` and the program's `source` text to any
+    /// [`EvalError`] surfaced from a subexpression, so DLQ entries and
+    /// miette diagnostics downstream carry "row N: ..." context and an
+    /// underlined source span without every internal constructor having
+    /// to thread those fields manually.
     pub fn eval_record<'w, S: RecordStorage + 'w>(
+        &mut self,
+        ctx: &EvalContext<'_>,
+        resolver: &dyn FieldResolver,
+        window: Option<&dyn WindowContext<'w, S>>,
+    ) -> Result<EvalResult, EvalError> {
+        let source_row = ctx.source_row;
+        let source_expr = self.typed.source.clone();
+        self.eval_record_inner(ctx, resolver, window)
+            .map_err(move |mut e| {
+                if e.source_row.is_none() {
+                    e.source_row = Some(source_row);
+                }
+                if e.source_expr.is_none()
+                    && let Some(s) = source_expr
+                {
+                    e.source_expr = Some(s);
+                }
+                e
+            })
+    }
+
+    fn eval_record_inner<'w, S: RecordStorage + 'w>(
         &mut self,
         ctx: &EvalContext<'_>,
         resolver: &dyn FieldResolver,
@@ -158,7 +187,14 @@ impl ProgramEvaluator {
                 Statement::Emit {
                     name, expr, target, ..
                 } => {
-                    let val = eval_expr(expr, &self.typed, ctx, resolver, window, &env)?;
+                    let val = eval_expr(expr, &self.typed, ctx, resolver, window, &env).map_err(
+                        |mut e| {
+                            if e.triggering_field.is_none() {
+                                e.triggering_field = Some(Arc::from(&**name));
+                            }
+                            e
+                        },
+                    )?;
                     match target {
                         EmitTarget::Field => {
                             output.insert(name.to_string(), val);

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 use regex::Regex;
@@ -107,6 +108,23 @@ pub struct TypedProgram {
     /// value is `Row::closed(IndexMap::new(), Span::default())`;
     /// consumers observe the populated row after `bind_schema` completes.
     pub output_row: Row,
+    /// Original CXL source text this program was parsed from. Populated
+    /// by production callers (the pipeline compiler) so runtime
+    /// [`crate::eval::EvalError`] diagnostics can render the offending
+    /// expression with a caret on the failing span. `None` for synthetic
+    /// programs and standalone tests that do not exercise the diagnostic
+    /// renderer.
+    pub source: Option<Arc<str>>,
+}
+
+impl TypedProgram {
+    /// Attach the original CXL source text. Production pipeline-compile
+    /// callers set this so [`crate::eval::EvalError`] miette rendering
+    /// can underline the offending subexpression.
+    pub fn with_source(mut self, source: Arc<str>) -> Self {
+        self.source = Some(source);
+        self
+    }
 }
 
 /// Run Phase C: type-check a resolved program in row-level mode (the
@@ -202,6 +220,7 @@ pub fn type_check_with_mode_and_vars(
         regexes,
         node_count,
         output_row: Row::closed(IndexMap::new(), Span::default()),
+        source: None,
     })
 }
 


### PR DESCRIPTION
Builds on the engine-stamped $source.name plumbing from PR #63 to
deliver per-source DLQ thresholds with halt-on-attribution, optional
per-source DLQ sidecar routing, and the EvalError diagnostic richness
that issue #9 has been asking for.

DlqConfig grows three opt-in surfaces, all with serde-default
semantics so today's `dlq: { path: ... }` configs keep parsing:

- max_rate: f64 in (0.0, 1.0] — pipeline-wide cumulative DLQ fraction
  ceiling. Halts the run as E315 once
  `dlq_count / total_count >= max_rate` AND
  `total_count >= min_records`. Zero is rejected at compile time as
  E318 — a `max_rate: 0.0` config would halt on the very first
  failure and would also bypass `min_records` (numerator and
  denominator both start at 0), an unintended halt-on-any-DLQ
  footgun.
- min_records: u64 — floor guarding the rate check so a 1/1 = 100%
  first failure does not trip a sub-1.0 threshold. Defaults to 100.
- per_source: BTreeMap<String, DlqPerSourceConfig> — keyed by
  Source-node name. Each entry overrides max_rate/min_records and
  optionally re-routes that source's DLQ entries to a separate sidecar
  via `path:`. Per-source > pipeline-wide precedence; the offending
  source surfaces in the rendered E316 diagnostic.

Routing follows the compositional pattern every mature streaming
system (Vector .dropped, Benthos switch, Kafka Connect per-connector
DLQ) converges on: a filtered separate sink, never co-opting a
downstream Output node. `partition_dlq_entries` in clinker_core::dlq
splits the run-scoped `Vec<DlqEntry>` into one bucket per configured
path; the CLI's end-of-run flush loop writes each bucket through the
unchanged `write_dlq` with the same atomic temp+rename discipline as
single-sink runs.

Runtime delta is a single funnel — `push_dlq` in
executor::dispatch — that every one of the existing eight DlqEntry
push sites now routes through. The funnel increments
`counters.dlq_count`, increments the per-source counter, appends the
entry, then runs `check_dlq_rate` against the resolved per-source and
pipeline-wide ceilings. The rate denominator is the full per-source
ingest count, seeded once at executor entry from
`total_per_source` — not a moving "records processed so far" counter.
This is consistent with today's pre-ingested-into-source_records
executor model. When the async streaming runtime swaps SourceStream
for a live channel-driven ingest, the denominator becomes a moving
target that needs to be re-keyed off the per-source receive count.

PipelineError::DlqRateExceeded { source, observed_rate, max_rate,
observed_count, total_count } joins the error enum and always aborts
regardless of ErrorStrategy — the rate ceiling is a halt directive,
not a per-record failure (the same shape SortOrderViolation
already uses). The Display arm renders E315 (source: None) or E316
(source: Some(name)) so the offending source surfaces in stderr.

Four new diagnostic codes (E315–E318) are documented in
crates/clinker-core/src/error.rs's code registry and exercised by
the new bind-schema validator `validate_dlq_per_source`:

- E315 — pipeline-wide DLQ rate exceeded max_rate (runtime).
- E316 — per-source DLQ rate exceeded per_source.<name>.max_rate
  (runtime, names the source).
- E317 — `per_source` map key does not name a declared Source
  (compile-time).
- E318 — out-of-range max_rate (interval `(0.0, 1.0]`) or DLQ path
  collision (compile-time).

EvalError gains source_row, source_expr, and triggering_field — all
attached at the outermost eval boundary so the 14 internal
constructors stay cheap on the hot path. A `map_err` wrapper at
`ProgramEvaluator::eval_record` snapshots `ctx.source_row` and the
program's source text; the emit-statement evaluator attaches the
target field name on its own subexpression error. EvalError gains a
miette::Diagnostic impl that renders the underlined offending
subexpression via NamedSource — the long-asked-for diagnostic in #9.
`extract_triggering_value` projects the EvalErrorKind payload into a
Value when the variant exposes one (ConversionFailed.value,
IndexOutOfBounds.index, ArityMismatch.got); the eight DLQ push sites
read it alongside `triggering_field` so the new CSV columns carry
both pieces of context for every eval-derived entry.

TypedProgram threads an optional `source: Arc<str>` field; the two
production typecheck call sites in plan::bind_schema populate it
(`typecheck_cxl` and `typecheck_combine_where`), test helpers and
synthetic programs leave it None. CompiledTransform reads through
the existing TypedProgram clone so no executor-signature changes
were needed.

Aggregate-finalize DLQ entries built from an empty input vector
stamp `source_name = aggregate_node_name` instead of falling
through to `<merged>`, so the DLQ reader sees a specific aggregate
identifier when finalize fails on zero records.

DLQ CSV column layout adds two new columns immediately after
`_cxl_dlq_source_row`:

  _cxl_dlq_id, _cxl_dlq_timestamp, _cxl_dlq_source_file,
  _cxl_dlq_source_name, _cxl_dlq_source_row,
  _cxl_dlq_triggering_field, _cxl_dlq_triggering_value,
  [_cxl_dlq_error_category, _cxl_dlq_error_detail,]
  _cxl_dlq_stage, _cxl_dlq_route, _cxl_dlq_trigger,
  [<user-declared columns>]

Drive-by: deleted the stale `DLQ_COLUMNS` constant in
crates/clinker-core/src/dlq.rs. PR #63 added `_cxl_dlq_source_name`
to the runtime header but left the constant out of sync; the
constant had no consumers anywhere in the workspace so the right fix
was deletion rather than re-synchronization.

Integration coverage (crates/clinker-core/tests/dlq_rate_threshold.rs,
+ extension to multi_source_ingestion.rs):

- DLQ entries carry src_b attribution end-to-end through
  Merge → Transform.
- DLQ CSV sidecar round-trip pins `_cxl_dlq_source_name` per row.
- Per-source max_rate halts with attributed E316.
- Pipeline-wide max_rate halts with E315.
- min_records floor suppresses early halts.
- `partition_dlq_entries` splits entries by per-source path.
- E317 fires when a per_source key names a missing Source.
- E318 fires on zero, on out-of-range max_rate, and on path
  collisions.

Pre-commit gauntlet: fmt clean, clippy --workspace clean, full test
suite green (clinker-kiln excluded — gdk-3.0 not installed in this
sandbox), benches compile and run. cargo-deny not installed in this
sandbox — CI runs it on every PR.