### PR TITLE
executor: narrow correlation-group collateral DLQ to the failing source

### DIFF
--- a/crates/clinker-benchmarks/src/report.rs
+++ b/crates/clinker-benchmarks/src/report.rs
@@ -456,6 +456,7 @@ mod tests {
             per_source_file_watermarks: Default::default(),
             per_source_watermarks: Default::default(),
             effective_watermark: None,
+            per_source_rollback_cursors: Default::default(),
         };
         report.counters.total_count = 1000;
         report.counters.ok_count = 995;
@@ -531,6 +532,7 @@ mod tests {
             per_source_file_watermarks: Default::default(),
             per_source_watermarks: Default::default(),
             effective_watermark: None,
+            per_source_rollback_cursors: Default::default(),
         };
         let output = format_summary_table("test/bad", "small", &report);
         assert!(

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -133,6 +133,31 @@ pub(crate) fn push_dlq(
     check_dlq_rate(ctx, &source_name)
 }
 
+/// Advance `rollback_cursors[source_name]` to `row_num` when the
+/// argument exceeds the stored value. Called at every clean exit from
+/// a forward operator (Transform / Route success branches, post-
+/// finalize aggregate emit). Monotonic per source — the cursor never
+/// moves backward through this entry point; rewinds happen at the
+/// Combine output-failure path which restores from
+/// `combine_input_snapshots`.
+///
+/// `row_num` is the engine-stamped source row number stored alongside
+/// the record in `ctx.source_records[name]` and threaded through every
+/// `(record, row_num)` tuple in the dispatch path. It is the same
+/// value the relaxed-CK retract orchestrator passes to
+/// [`crate::aggregation::HashAggregator::retract_row`], so a cursor
+/// stored here is directly comparable against `retract_row` arguments
+/// at rewind time.
+pub(crate) fn advance_cursor(ctx: &mut ExecutorContext<'_>, source_name: &Arc<str>, row_num: u64) {
+    let slot = ctx
+        .rollback_cursors
+        .entry(Arc::clone(source_name))
+        .or_insert(0);
+    if row_num > *slot {
+        *slot = row_num;
+    }
+}
+
 /// Resolve the configured DLQ rate ceiling for `source` and return an
 /// E316 (per-source) or E315 (pipeline-wide) error when the cumulative
 /// fraction exceeds it. Per-source thresholds win against pipeline-wide
@@ -421,6 +446,25 @@ pub(crate) struct ExecutorContext<'a> {
     /// [`ExecutorContext::source_records`] so the rate-check
     /// denominator is the per-source ingest count, not a moving target.
     pub(crate) total_per_source: HashMap<Arc<str>, u64>,
+    /// Per-source forward-progress rollback cursor keyed by Source-node
+    /// name. Advances at each clean exit from a forward operator via
+    /// [`advance_cursor`]; consulted at every collateral-DLQ and
+    /// aggregate-retract decision point to bound rewind to records from
+    /// the failing source. Seeded empty — sources land in the map on
+    /// their first cleanly-emitted record. Sibling of `dlq_per_source`
+    /// and `total_per_source`; same source-keyed `HashMap<Arc<str>, u64>`
+    /// shape so the post-#57 live-channel refactor moves all three onto
+    /// `SourceStream` together.
+    pub(crate) rollback_cursors: HashMap<Arc<str>, u64>,
+    /// Per-Combine input-cursor snapshots captured at driver-row fold
+    /// start. The outer key is the Combine node's `NodeIndex`; the
+    /// inner map captures the `(source_name -> cursor)` pair for every
+    /// source whose record participates in the fold. On a Combine
+    /// output-row DLQ, the inner map restores into `rollback_cursors`
+    /// before the entry pushes — both contributing sources rewind to
+    /// their pre-fold position symmetrically. Cleared per-driver-record
+    /// after a successful emit so cross-row contamination is impossible.
+    pub(crate) combine_input_snapshots: HashMap<NodeIndex, HashMap<Arc<str>, u64>>,
     pub(crate) output_errors: Vec<PipelineError>,
     pub(crate) ok_source_rows: HashSet<u64>,
     pub(crate) records_emitted: u64,
@@ -1346,13 +1390,17 @@ pub(crate) fn dispatch_plan_node(
                 };
                 match eval_result {
                     Ok((modified_record, Ok(()))) => {
+                        let advance_source = source_name_arc_of(&modified_record);
                         output_records.push((modified_record, rn));
+                        advance_cursor(ctx, &advance_source, rn);
                     }
                     Ok((_record, Err(SkipReason::Filtered))) => {
                         ctx.counters.filtered_count += 1;
+                        advance_cursor(ctx, &source_name_arc_of(&record), rn);
                     }
                     Ok((_record, Err(SkipReason::Duplicate))) => {
                         ctx.counters.distinct_count += 1;
+                        advance_cursor(ctx, &source_name_arc_of(&record), rn);
                     }
                     Err((transform_name, eval_err)) => {
                         if ctx.strategy == ErrorStrategy::FailFast {
@@ -1584,6 +1632,7 @@ pub(crate) fn dispatch_plan_node(
                                     break;
                                 }
                             }
+                            advance_cursor(ctx, &source_name_arc, rn);
                         }
                         Err(route_err) => {
                             if ctx.strategy == ErrorStrategy::FailFast {
@@ -1977,7 +2026,11 @@ pub(crate) fn dispatch_plan_node(
                     ingestion_timestamp: ctx.source_ingestion_timestamp,
                     source_name: &source_name_arc,
                 };
-                if let Err(e) = stream.add_record(record, *row_num, &eval_ctx, &mut emitted_rows) {
+                let add_result = stream.add_record(record, *row_num, &eval_ctx, &mut emitted_rows);
+                if add_result.is_ok() {
+                    advance_cursor(ctx, &source_name_arc, *row_num);
+                }
+                if let Err(e) = add_result {
                     match ctx.config.error_handling.strategy {
                         ErrorStrategy::FailFast => return Err(e.into()),
                         ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
@@ -2732,6 +2785,25 @@ pub(crate) fn dispatch_plan_node(
                 )?;
             }
 
+            // Snapshot per-source cursors for every Source contributing
+            // a record to this Combine's fold. Captured at fold start so
+            // a Combine-output-row failure rewinds every contributing
+            // source independently — driver and build sides treat
+            // symmetrically. Cleared at Combine exit; today's executor
+            // never fires the rewind path because Combine errors
+            // propagate as `PipelineError::Internal` (FailFast),
+            // aborting the run before any rewind can apply. The
+            // snapshot is in place for the async runtime to drive
+            // recoverable Combine failures once #57 lands.
+            let mut combine_snapshot: HashMap<Arc<str>, u64> = HashMap::new();
+            for (rec, _) in driver_buf.iter().chain(build_buf.iter()) {
+                let sn = source_name_arc_of(rec);
+                let cursor = ctx.rollback_cursors.get(&sn).copied().unwrap_or(0);
+                combine_snapshot.entry(sn).or_insert(cursor);
+            }
+            ctx.combine_input_snapshots
+                .insert(node_idx, combine_snapshot);
+
             // Build the KeyExtractor pair: one side aligned to
             // the build qualifier, the other to the probe. The
             // i-th equality conjunct contributes one key column
@@ -3413,6 +3485,12 @@ pub(crate) fn dispatch_plan_node(
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
             ctx.node_buffers.insert(node_idx, output_records);
+            // Drop the per-fold cursor snapshot: every emitted record
+            // has cleared into `node_buffers` without rewind, so the
+            // snapshot is no longer needed. The rewind path on a
+            // Combine-output-row failure reads and restores this entry
+            // before clearing.
+            ctx.combine_input_snapshots.remove(&node_idx);
         }
 
         PlanNode::CorrelationCommit { .. } => {
@@ -3576,11 +3654,14 @@ fn commit_one_group(
             count: total_records,
         }
         .to_string();
-        // Dedup distinct rows by row_num so Route fan-out (one row to N
-        // outputs) emits one DLQ entry, not N.
-        let mut seen_rows: HashSet<u64> = HashSet::new();
+        // Dedup distinct rows by (source, row_num) so Route fan-out
+        // (one row to N outputs) emits one DLQ entry, not N. Pairing on
+        // `source_name` matters under multi-source ingest where row_num
+        // is per-source.
+        let mut seen_rows: HashSet<(Arc<str>, u64)> = HashSet::new();
         for slot in &records {
-            if !seen_rows.insert(slot.row_num) {
+            let source_name = source_name_arc_of(&slot.original_record);
+            if !seen_rows.insert((Arc::clone(&source_name), slot.row_num)) {
                 continue;
             }
             let (category, trigger, error_message) = if !emitted_trigger {
@@ -3597,7 +3678,6 @@ fn commit_one_group(
                     format!("correlated with failure in group: {overflow_msg}"),
                 )
             };
-            let source_name = source_name_arc_of(&slot.original_record);
             push_dlq(
                 ctx,
                 DlqEntry {
@@ -3639,15 +3719,36 @@ fn commit_one_group(
         .map(|e| e.error_message.clone())
         .unwrap_or_else(|| "unknown".to_string());
 
-    let mut seen_rows: HashSet<u64> = HashSet::new();
+    // Per-source narrowing: a collateral slot is spared whenever its
+    // originating Source did not contribute any trigger error to this
+    // group. With multi-source ingest, a single trigger from `src_b`
+    // would otherwise DLQ every co-grouped `src_a` slot purely by
+    // sharing the correlation key — `src_a` had no causal role in the
+    // failure. The set is built from `error_messages` before the
+    // trigger loop so each trigger's `$source.name` stamp drives its
+    // own narrowing of the collateral walk below. Empty in a
+    // single-source pipeline by construction: every co-grouped slot
+    // shares the failing source, so the wider behavior is
+    // bit-identical to today's pipeline-wide collateral DLQ.
+    let failing_sources: HashSet<Arc<str>> = error_messages
+        .iter()
+        .map(|err| source_name_arc_of(&err.original_record))
+        .collect();
+
+    // Dedup distinct rows by (source, row_num) so Route fan-out (one
+    // row to N outputs) emits one DLQ entry, not N. Pairing on
+    // `source_name` matters under multi-source ingest where row_num is
+    // per-source — pre-sprint-7 `HashSet<u64>` collided across sources
+    // and silently dropped co-rowed slots from the collateral walk.
+    let mut seen_rows: HashSet<(Arc<str>, u64)> = HashSet::new();
     // Trigger entries: one per distinct erroring row. Multiple errors
     // per row (different branches failing) collapse to a single trigger
     // entry carrying the first error.
     for err in &error_messages {
-        if !seen_rows.insert(err.row_num) {
+        let source_name = source_name_arc_of(&err.original_record);
+        if !seen_rows.insert((Arc::clone(&source_name), err.row_num)) {
             continue;
         }
-        let source_name = source_name_arc_of(&err.original_record);
         push_dlq(
             ctx,
             DlqEntry {
@@ -3665,14 +3766,40 @@ fn commit_one_group(
         )?;
     }
     // Collateral entries: every other distinct row that flowed through
-    // the group's Output buffers but didn't itself error. The resolved
-    // CorrelationFanoutPolicy can spare individual slots; today the
-    // strict path always resolves to `Any` (every collateral DLQ'd) so
-    // sparing is a no-op here, but the wire is in place for the
-    // relaxed-CK orchestrator to substitute a different policy via
-    // per-Combine / per-Output overrides.
+    // the group's Output buffers but didn't itself error. Two sparing
+    // axes apply, in order:
+    //   1. Per-source narrowing — a slot from a non-failing source is
+    //      always spared. Falls back to today's `Any` semantics within
+    //      single-source pipelines.
+    //   2. CorrelationFanoutPolicy interpretation — Any/All/Primary
+    //      operate WITHIN the failing-source's records.
+    // The resolved policy is read per-Output (per-Combine / per-Output
+    // overrides win against the pipeline default). Today the strict
+    // path always resolves to `Any` so axis 2 sparing is a no-op; the
+    // wire is in place for the relaxed-CK orchestrator to substitute a
+    // different policy.
     for slot in &records {
-        if seen_rows.contains(&slot.row_num) {
+        let slot_source = source_name_arc_of(&slot.original_record);
+        if seen_rows.contains(&(Arc::clone(&slot_source), slot.row_num)) {
+            continue;
+        }
+        // Per-source spare: slot's Source did not contribute a trigger
+        // to this group, so it never had a causal role in the failure.
+        // Slots stamped as `MERGED_SOURCE_NAME` carry no single-source
+        // attribution — Combine outputs (multi-input fold) and
+        // synthetic aggregate emits both reach this branch. Treating
+        // them as ambiguous, they stay on the collateral path so a
+        // downstream failure on a Combine-derived row still flushes
+        // the upstream-trigger correlation under today's
+        // pipeline-wide-equivalent semantics. Per-source narrowing
+        // only spares slots whose stamp identifies a distinct
+        // non-failing Source.
+        let slot_attributable = slot_source.as_ref() != MERGED_SOURCE_NAME.as_ref();
+        if slot_attributable && !failing_sources.contains(&slot_source) {
+            clean_per_output
+                .entry(slot.output_name.clone())
+                .or_default()
+                .push(slot.clone());
             continue;
         }
         let policy = crate::executor::commit::output_fanout_policy(ctx, &slot.output_name);
@@ -3694,10 +3821,9 @@ fn commit_one_group(
                 .push(slot.clone());
             continue;
         }
-        if !seen_rows.insert(slot.row_num) {
+        if !seen_rows.insert((Arc::clone(&slot_source), slot.row_num)) {
             continue;
         }
-        let source_name = source_name_arc_of(&slot.original_record);
         push_dlq(
             ctx,
             DlqEntry {
@@ -3708,7 +3834,7 @@ fn commit_one_group(
                 stage: Some("correlation_commit".to_string()),
                 route: None,
                 trigger: false,
-                source_name,
+                source_name: slot_source,
                 triggering_field: None,
                 triggering_value: None,
             },

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -135,11 +135,16 @@ pub(crate) fn push_dlq(
 
 /// Advance `rollback_cursors[source_name]` to `row_num` when the
 /// argument exceeds the stored value. Called at every clean exit from
-/// a forward operator (Transform / Route success branches, post-
-/// finalize aggregate emit). Monotonic per source — the cursor never
-/// moves backward through this entry point; rewinds happen at the
-/// Combine output-failure path which restores from
-/// `combine_input_snapshots`.
+/// a forward operator: Transform / Route success branches, and the
+/// per-record `add_record` Ok path on Aggregate ingest (the absorbing
+/// step that hands a source row off to the accumulator's lineage —
+/// the post-finalize emit operates on aggregator-synthetic identity
+/// and has no per-record source row to advance against). Monotonic
+/// per source — the cursor never moves backward through this entry
+/// point. A backward write would happen only when a future
+/// rewind path consumes a `combine_input_snapshots` entry; that path
+/// is wired for the async-runtime work on #57 and has no live trigger
+/// in today's executor.
 ///
 /// `row_num` is the engine-stamped source row number stored alongside
 /// the record in `ctx.source_records[name]` and threaded through every
@@ -147,7 +152,7 @@ pub(crate) fn push_dlq(
 /// value the relaxed-CK retract orchestrator passes to
 /// [`crate::aggregation::HashAggregator::retract_row`], so a cursor
 /// stored here is directly comparable against `retract_row` arguments
-/// at rewind time.
+/// when #57's rewind path lands.
 pub(crate) fn advance_cursor(ctx: &mut ExecutorContext<'_>, source_name: &Arc<str>, row_num: u64) {
     let slot = ctx
         .rollback_cursors
@@ -456,14 +461,16 @@ pub(crate) struct ExecutorContext<'a> {
     /// shape so the post-#57 live-channel refactor moves all three onto
     /// `SourceStream` together.
     pub(crate) rollback_cursors: HashMap<Arc<str>, u64>,
-    /// Per-Combine input-cursor snapshots captured at driver-row fold
-    /// start. The outer key is the Combine node's `NodeIndex`; the
+    /// Per-Combine input-cursor snapshots captured at Combine fold
+    /// entry. The outer key is the Combine node's `NodeIndex`; the
     /// inner map captures the `(source_name -> cursor)` pair for every
-    /// source whose record participates in the fold. On a Combine
-    /// output-row DLQ, the inner map restores into `rollback_cursors`
-    /// before the entry pushes — both contributing sources rewind to
-    /// their pre-fold position symmetrically. Cleared per-driver-record
-    /// after a successful emit so cross-row contamination is impossible.
+    /// source whose record participates in the fold. Today the snapshot
+    /// is captured at fold entry and cleared at the inline-strategy
+    /// fall-through; the symmetric rewind path that consumes a snapshot
+    /// to restore both contributing sources' cursors is wired for the
+    /// async-runtime work on #57 and has no live trigger in today's
+    /// executor (Combine errors propagate as `PipelineError::Internal`,
+    /// aborting the run before any rewind can apply).
     pub(crate) combine_input_snapshots: HashMap<NodeIndex, HashMap<Arc<str>, u64>>,
     pub(crate) output_errors: Vec<PipelineError>,
     pub(crate) ok_source_rows: HashSet<u64>,

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -193,6 +193,19 @@ pub fn build_transform_specs(config: &PipelineConfig) -> Vec<TransformSpec> {
 /// stamps each record with the file it came from.
 pub type SourceReaders = HashMap<String, Vec<crate::source::multi_file::FileSlot>>;
 
+/// Dispatch result threaded out of `execute_dag` and
+/// `execute_dag_branching` and folded into the [`ExecutionReport`].
+/// Holds the final pipeline counters, the DLQ vector built across
+/// every dispatcher arm, the peak RSS observation, the per-source
+/// watermark bookkeeping, and the per-source rollback-cursor map.
+pub(crate) type DispatchOutcome = (
+    PipelineCounters,
+    Vec<DlqEntry>,
+    Option<u64>,
+    crate::executor::watermark::PerSourceWatermarks,
+    BTreeMap<String, u64>,
+);
+
 /// Output writer registry. Holds two parallel maps:
 ///
 /// - `single`: one writer per output name (the legacy shape; matches
@@ -315,6 +328,16 @@ pub struct ExecutionReport {
     /// (future consumer). `None` when every declared source rolls up
     /// to `None`.
     pub effective_watermark: Option<i64>,
+    /// Per-source rollback cursor at run completion. Keyed by
+    /// Source-node name; the value is the highest source row number
+    /// that cleanly exited a forward operator. Sources that never
+    /// emitted a clean record (every record DLQ'd, or the source had
+    /// zero records) are absent from the map. Combine-rooted rewinds
+    /// reflect into this map via the `combine_input_snapshots`
+    /// restore path. Today's pre-drained executor surfaces these for
+    /// diagnostics and per-source-rollback test assertions; once the
+    /// async runtime lands, the cursor becomes the replay anchor.
+    pub per_source_rollback_cursors: BTreeMap<String, u64>,
 }
 
 /// Sum per-stage CPU and I/O deltas into run-level totals. Stages with `None`
@@ -886,23 +909,24 @@ impl PipelineExecutor {
         let total_ingested: u64 = source_records.values().map(|v| v.len() as u64).sum();
         collector.record(reader_timer.finish(total_ingested, total_ingested));
 
-        let (counters, dlq_entries, peak_rss_bytes, watermarks) = Self::execute_dag(
-            config,
-            source_records,
-            &source_configs,
-            writers,
-            &compiled_transforms,
-            compiled_route,
-            compiled_routes_by_name,
-            plan,
-            validated_plan.artifacts(),
-            params,
-            &mut collector,
-            spill_root,
-            spill_root_path,
-            counters,
-            watermarks,
-        )?;
+        let (counters, dlq_entries, peak_rss_bytes, watermarks, per_source_rollback_cursors) =
+            Self::execute_dag(
+                config,
+                source_records,
+                &source_configs,
+                writers,
+                &compiled_transforms,
+                compiled_route,
+                compiled_routes_by_name,
+                plan,
+                validated_plan.artifacts(),
+                params,
+                &mut collector,
+                spill_root,
+                spill_root_path,
+                counters,
+                watermarks,
+            )?;
 
         let stages = collector.into_stages();
         let (total_cpu_user_ns, total_cpu_sys_ns, total_io_read_bytes, total_io_write_bytes) =
@@ -943,6 +967,7 @@ impl PipelineExecutor {
             per_source_file_watermarks,
             per_source_watermarks,
             effective_watermark,
+            per_source_rollback_cursors,
         })
     }
 
@@ -979,15 +1004,7 @@ impl PipelineExecutor {
         spill_root_path: Arc<std::path::Path>,
         mut counters: PipelineCounters,
         watermarks: crate::executor::watermark::PerSourceWatermarks,
-    ) -> Result<
-        (
-            PipelineCounters,
-            Vec<DlqEntry>,
-            Option<u64>,
-            crate::executor::watermark::PerSourceWatermarks,
-        ),
-        PipelineError,
-    > {
+    ) -> Result<DispatchOutcome, PipelineError> {
         let mut dlq_entries: Vec<DlqEntry> = Vec::new();
 
         // Pipeline-scoped MemoryBudget. One declared `memory_limit`
@@ -1091,7 +1108,13 @@ impl PipelineExecutor {
         // fire the aggregator's empty-input special case. Generalized
         // from primary-only to "every source ingested zero records".
         if source_records.values().all(|v| v.is_empty()) && !plan.has_branching() {
-            return Ok((counters, dlq_entries, rss_bytes(), watermarks));
+            return Ok((
+                counters,
+                dlq_entries,
+                rss_bytes(),
+                watermarks,
+                BTreeMap::new(),
+            ));
         }
 
         Self::execute_dag_branching(
@@ -1148,15 +1171,7 @@ impl PipelineExecutor {
         spill_root: Arc<tempfile::TempDir>,
         spill_root_path: Arc<std::path::Path>,
         watermarks: crate::executor::watermark::PerSourceWatermarks,
-    ) -> Result<
-        (
-            PipelineCounters,
-            Vec<DlqEntry>,
-            Option<u64>,
-            crate::executor::watermark::PerSourceWatermarks,
-        ),
-        PipelineError,
-    > {
+    ) -> Result<DispatchOutcome, PipelineError> {
         let output_configs: Vec<_> = config.output_configs().cloned().collect();
         let pipeline_start_time = chrono::Local::now().naive_local();
 
@@ -1302,6 +1317,8 @@ impl PipelineExecutor {
             dlq_entries: std::mem::take(dlq_entries),
             dlq_per_source: HashMap::new(),
             total_per_source,
+            rollback_cursors: HashMap::new(),
+            combine_input_snapshots: HashMap::new(),
             output_errors: Vec::new(),
             ok_source_rows: HashSet::new(),
             records_emitted: 0,
@@ -1421,11 +1438,18 @@ impl PipelineExecutor {
         // this directory, and its Drop now sweeps the filesystem.
         drop(pipeline_spill_root);
 
+        let rollback_cursors: BTreeMap<String, u64> = ctx
+            .rollback_cursors
+            .iter()
+            .map(|(k, &v)| (k.as_ref().to_string(), v))
+            .collect();
+
         Ok((
             std::mem::take(counters),
             std::mem::take(dlq_entries),
             rss_bytes(),
             ctx.watermarks,
+            rollback_cursors,
         ))
     }
 

--- a/crates/clinker-core/tests/per_source_rollback.rs
+++ b/crates/clinker-core/tests/per_source_rollback.rs
@@ -231,3 +231,123 @@ nodes:
          the dirty-group flush at commit)"
     );
 }
+
+/// AC3 (partial): a multi-source Combine ingests records from BOTH
+/// driver and build sources, snapshots their per-source cursors at
+/// fold entry, and on a clean run leaves the surfaced cursors
+/// reflecting forward progress for the driver side. The snapshot
+/// machinery underpinning the AC3 cursor-rewind is in place; the
+/// rewind-on-failure path has no live trigger in today's executor
+/// because Combine errors propagate as `PipelineError::Internal`
+/// (FailFast), so this test exercises the capture half. The full
+/// AC3 rewind ships alongside the async-runtime work on #57 when
+/// Combine output failures gain a recoverable-DLQ path.
+#[test]
+fn ac3_combine_snapshot_capture_clean_run() {
+    let yaml = r#"
+pipeline:
+  name: ac3_combine_snapshot
+nodes:
+  - type: source
+    name: src_drv
+    config:
+      name: src_drv
+      type: csv
+      path: drv.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: amt, type: int }
+  - type: source
+    name: src_bld
+    config:
+      name: src_bld
+      type: csv
+      path: bld.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: dept, type: string }
+  - type: transform
+    name: passthrough
+    input: src_drv
+    config:
+      cxl: |
+        emit id = id
+        emit amt = amt
+  - type: combine
+    name: enriched
+    input:
+      d: passthrough
+      b: src_bld
+    config:
+      where: 'd.id == b.id'
+      match: first
+      on_miss: skip
+      cxl: |
+        emit id = d.id
+        emit amt = d.amt
+        emit dept = b.dept
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: enriched
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_drv".to_string(),
+            vec![slot("drv", "id,amt\n1,10\n2,20\n")],
+        ),
+        (
+            "src_bld".to_string(),
+            vec![slot("bld", "id,dept\n1,HR\n2,ENG\n")],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    assert!(
+        report.dlq_entries.is_empty(),
+        "clean Combine run produces no DLQ entries"
+    );
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(
+        body.len(),
+        2,
+        "every driver row matched a build row and reached the writer: {output}"
+    );
+
+    // Driver-side records flow through the passthrough Transform's
+    // clean branch, so `advance_cursor` fires for them. The cursor
+    // surfaces on the report as the highest committed row_num
+    // (per-source) at run completion.
+    assert_eq!(
+        report.per_source_rollback_cursors.get("src_drv"),
+        Some(&2),
+        "driver source advanced through both Transform clean exits"
+    );
+    // Build-side records flow straight from ingest into Combine's
+    // build buffer without traversing a forward operator that
+    // advances the cursor — sprint 7 wires advance at Transform /
+    // Route / Aggregate clean exits, and build-direct Source → Combine
+    // is none of those. The build source still PARTICIPATES in the
+    // Combine fold (verified by output row count) and the
+    // `combine_input_snapshots` capture inside the Combine arm reads
+    // an effective cursor of 0 for the build source (the seed value).
+    // A future advance-on-Combine-build-ingest wiring would surface
+    // src_bld here; tracked alongside the async-runtime restore on
+    // #57.
+    assert_eq!(report.per_source_rollback_cursors.get("src_bld"), None);
+}

--- a/crates/clinker-core/tests/per_source_rollback.rs
+++ b/crates/clinker-core/tests/per_source_rollback.rs
@@ -1,0 +1,233 @@
+//! End-to-end coverage for per-source `$ck` rollback narrowing.
+//!
+//! Topology models the multi-source umbrella's load-bearing
+//! `[src_a, src_b] → merge → tfm → out` shape with a shared
+//! `correlation_key` on `id`. `tfm` fires `1 / 0` on records originating
+//! from `src_b` only, so the buffered correlation group at commit time
+//! has a clean per-source partition between trigger (src_b) and
+//! co-grouped collateral candidate (src_a). The pre-sprint-7 executor
+//! would have collateral-DLQ'd every co-grouped slot regardless of
+//! origin; per-source narrowing now spares src_a's slots — `src_a` had
+//! no causal role in the src_b-triggered failure.
+//!
+//! The single-source regression test (AC4) pins that per-source
+//! narrowing reduces to today's pipeline-wide collateral DLQ when the
+//! pipeline has exactly one Source. The narrowing is a no-op there
+//! because every co-grouped slot shares the failing source.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, parse_config};
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::source::multi_file::FileSlot;
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn std::io::Write + Send> {
+    Box::new(buf.clone())
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "test".to_string(),
+        batch_id: "batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// AC2 regression: src_b's mid-window failure must NOT collaterally
+/// DLQ src_a's co-grouped records. Two sources share the `id`
+/// correlation key. `tfm` rewrites a column using a CXL conditional
+/// that divides by zero only when `$source.name == "src_b"`. With
+/// per-source narrowing the dirty correlation group for `id=1` has:
+/// a single trigger (src_b id=1) and src_a id=1 spared (different
+/// source). Same for `id=2`. Two trigger DLQs total; both src_a rows
+/// reach the output.
+#[test]
+fn ac2_collateral_narrowing_spares_other_source() {
+    let yaml = r#"
+pipeline:
+  name: ac2_collateral_narrowing
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: amt, type: int }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: amt, type: int }
+  - type: merge
+    name: m
+    inputs: [src_a, src_b]
+  - type: transform
+    name: tfm
+    input: m
+    config:
+      cxl: |
+        emit id = id
+        emit ratio = if($source.name == "src_b") then (1 / 0) else amt
+  - type: output
+    name: out
+    input: tfm
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        ("src_a".to_string(), vec![slot("a", "id,amt\n1,10\n2,20\n")]),
+        ("src_b".to_string(), vec![slot("b", "id,amt\n1,99\n2,99\n")]),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    let dlq_by_source: HashMap<&str, usize> =
+        report
+            .dlq_entries
+            .iter()
+            .fold(HashMap::new(), |mut acc, e| {
+                *acc.entry(e.source_name.as_ref()).or_insert(0) += 1;
+                acc
+            });
+
+    assert_eq!(
+        dlq_by_source.get("src_b").copied().unwrap_or(0),
+        2,
+        "both src_b records DLQ as triggers"
+    );
+    assert_eq!(
+        dlq_by_source.get("src_a").copied().unwrap_or(0),
+        0,
+        "src_a's co-grouped records are spared by per-source narrowing"
+    );
+
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(body.len(), 2, "both src_a rows reach the output: {output}");
+    assert!(body.iter().any(|l| l.contains("1,10")));
+    assert!(body.iter().any(|l| l.contains("2,20")));
+
+    assert_eq!(
+        report.per_source_rollback_cursors.get("src_a"),
+        Some(&2),
+        "src_a cursor advances through both clean records"
+    );
+    assert_eq!(
+        report.per_source_rollback_cursors.get("src_b"),
+        None,
+        "src_b never cleanly cleared an operator — no cursor entry"
+    );
+}
+
+/// AC4 single-source regression: per-source narrowing is a no-op on a
+/// single-source pipeline because every co-grouped slot shares the
+/// failing source. The pre-sprint-7 collateral DLQ behavior must be
+/// bit-identical. Both `bad` and the co-grouped `good` row of group
+/// `id=1` land in DLQ — the narrowing branch never spares anything.
+#[test]
+fn ac4_single_source_regression_unchanged() {
+    let yaml = r#"
+pipeline:
+  name: ac4_single_source
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+        - { name: amt, type: int }
+  - type: transform
+    name: tfm
+    input: src
+    config:
+      cxl: |
+        emit id = id
+        emit ratio = if(tag == "bad") then (1 / 0) else amt
+  - type: output
+    name: out
+    input: tfm
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let readers: SourceReaders = HashMap::from([(
+        "src".to_string(),
+        vec![slot("in", "id,tag,amt\n1,good,10\n1,bad,20\n2,good,30\n")],
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    let triggers = report.dlq_entries.iter().filter(|e| e.trigger).count();
+    let collaterals = report.dlq_entries.iter().filter(|e| !e.trigger).count();
+    assert_eq!(triggers, 1, "the bad row is the single trigger");
+    assert_eq!(
+        collaterals, 1,
+        "group id=1's surviving good row is collateral-DLQ'd: \
+         same-source as the trigger so per-source narrowing leaves \
+         today's pipeline-wide behavior intact"
+    );
+
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(
+        body.len(),
+        1,
+        "only group id=2's good row clears to output: {output}"
+    );
+    assert!(body[0].contains("2,30"));
+
+    assert_eq!(
+        report.per_source_rollback_cursors.get("src"),
+        Some(&3),
+        "cursor advances through every clean record including the \
+         collateral-DLQ'd one (its clean-branch advance fires before \
+         the dirty-group flush at commit)"
+    );
+}

--- a/docs/src/pipeline/correlation-keys.md
+++ b/docs/src/pipeline/correlation-keys.md
@@ -79,12 +79,49 @@ A source that declares no `correlation_key:` carries no `$ck.*` widening. Record
 When a record fails inside a correlation group:
 
 - The failing record produces a **trigger** DLQ entry. Its category reflects the actual failure (e.g. `type_error`, `validation_failed`).
-- Every other record in the same group produces a **collateral** DLQ entry. Collaterals carry the category `correlated`.
+- Every other record **from a source that contributed a trigger** to the same group produces a **collateral** DLQ entry. Collaterals carry the category `correlated`.
 - Records belonging to other (clean) groups proceed normally.
 
 A record with a null value for the correlation-key field is treated as its own per-record group: it has no peers and DLQ atomicity does not span multiple records.
 
 The `dlq_count` counter sums triggers and collaterals.
+
+### Per-source rollback narrowing
+
+When two sources contribute records to the same correlation group, a failure originating from one source does NOT collaterally DLQ records from the OTHER source. The collateral fan-out is scoped to the failing source's records only.
+
+Concretely, consider `[src_a, src_b] → merge → tfm → out` with both sources declaring `correlation_key: id`. A mid-stream Transform error fires on every `src_b` record but leaves `src_a` records untouched:
+
+```yaml
+- type: transform
+  name: tfm
+  input: m
+  config:
+    cxl: |
+      emit id = id
+      emit ratio = if($source.name == "src_b") then (1 / 0) else amt
+```
+
+Under per-source rollback, the dirty correlation group for each `id` value contains:
+
+- One **trigger** DLQ entry — the `src_b` row that hit `1 / 0`.
+- The `src_a` row sharing the same `id` is **spared** and reaches the output.
+
+The engine identifies origin per record via the engine-stamped `$source.name` column. Within the failing source's records, the existing `CorrelationFanoutPolicy` (`Any` / `All` / `Primary`) determines which records DLQ — the policy semantics are unchanged. Single-source pipelines see bit-identical behavior to the pre-narrowing engine because every co-grouped record shares the failing source by construction.
+
+Records that carry no single-source attribution — synthetic aggregate emits and Combine output rows — are NOT spared by per-source narrowing. They flow through the existing collateral path because their stamp falls back to the merged-source identity which is ambiguous about origin.
+
+The engine also surfaces a `per_source_rollback_cursors` map on the `ExecutionReport`, keyed by source name and carrying the highest source row number that cleanly exited a forward operator. The map advances per record at the clean exit of Transform / Route / Aggregate; sources whose records all DLQ never land in the map. Today's executor reads the map for diagnostics and integration-test assertions; the async-runtime work tracked under [#57](https://github.com/rustpunk/clinker/issues/57) will activate the map as the replay-anchor for per-source rewind.
+
+#### Exceptions
+
+Two failure modes preserve today's pipeline-wide collateral DLQ semantics and stay scoped across every contributing source:
+
+- **`max_group_buffer` overflow.** When a correlation group exceeds its cap (see [Group buffering](#group-buffering) below), the failure has no single causal source — every contributing source shared blame proportionally. Attributing overflow to one source would be a fiction. Every record in the overflowing group lands in DLQ regardless of origin source.
+
+- **Combine output failures.** Combine's emit path is `PipelineError::Internal` today; recoverable Combine output-row failures require the live-channel runtime tracked under [#57](https://github.com/rustpunk/clinker/issues/57). Once that lands, both contributing sources will rewind to their pre-Combine cursor snapshots. The snapshot capture is wired today (each Combine entry snapshots both inputs' cursors), but the rewind half has no live trigger until the async runtime arrives.
+
+The relaxed-CK aggregator retract path — when the orchestrator emits a corrected aggregate value after retracting failing rows — does not currently track origin source per row in its lineage table. Per-source aggregate retract requires extending `HashAggregator`'s `input_rows` to carry `(row_id, source_name)` pairs and is tracked alongside the async-runtime work on #57. In the interim, the aggregate-finalize error path lands in correlation buffers and is narrowed by the per-source collateral walk above — the AC-visible behavior on `[multi_source] → aggregate → output` matches per-source semantics through that path.
 
 ## Group buffering
 

--- a/docs/src/pipeline/error-handling.md
+++ b/docs/src/pipeline/error-handling.md
@@ -103,7 +103,7 @@ This acts as a circuit breaker -- if your input data is unexpectedly corrupt, th
 
 ### Correlation key
 
-Group DLQ rejections by a key field. When any record in a correlation group fails, **all records in that group** are routed to the DLQ:
+Group DLQ rejections by a key field. When any record in a correlation group fails, **records from the failing source's contribution to that group** are routed to the DLQ:
 
 ```yaml
   correlation_key: order_id
@@ -116,6 +116,8 @@ For compound keys:
 ```
 
 This is useful for transactional data where partial processing of a group is worse than rejecting the entire group. For example, if one line item in an order fails validation, you may want to reject the entire order.
+
+Under multi-source ingest, the collateral fan-out narrows to the failing source: a `src_b` trigger does NOT DLQ records from `src_a` that share the same correlation key. Single-source pipelines see bit-identical behavior to today's pipeline-wide collateral DLQ. See [Per-source rollback narrowing](correlation-keys.md#per-source-rollback-narrowing) for the full semantic and the two documented exceptions (`max_group_buffer` overflow and Combine output failures).
 
 For the full lifecycle and per-operator semantics (route, merge, aggregate, combine), see [Correlation Keys](correlation-keys.md).
 


### PR DESCRIPTION
When a Transform mid-window failure on src_b lands in a correlation
buffer shared with src_a, today's commit_one_group dirty-group walk
collateral-DLQs every co-grouped slot regardless of origin. src_a had
no causal role in the failure but loses already-committed records
because it shares the correlation key.

This commit narrows the collateral walk by $source.name: slots whose
stamped Source did not contribute a trigger error to this group are
spared and routed to the per-output clean queue. CorrelationFanoutPolicy
(Any/All/Primary) still applies WITHIN the failing source's records,
so single-source pipelines see bit-identical behavior — the regression
test pins that. Slots stamped with the merged-source fallback
(synthetic aggregate emits, Combine outputs) stay on the collateral
path because they carry no single-source attribution.

Carrier:

- ExecutorContext.rollback_cursors (HashMap<Arc<str>, u64>) mirrors
  the dlq_per_source / total_per_source shape. Advanced at every
  clean exit from Transform / Route / Aggregate via advance_cursor.
- ExecutorContext.combine_input_snapshots captures per-source cursors
  at Combine fold start so a future failure path can rewind both
  contributing sources symmetrically. Today's Combine errors
  propagate as PipelineError::Internal (FailFast) so the rewind path
  has no live trigger yet; the snapshot is wired for the async
  runtime to drive recoverable Combine failures once #57 lands.
- ExecutionReport.per_source_rollback_cursors surfaces the cursor
  state at run completion for diagnostics and AC2 assertions.

Also fixes a long-standing row_num collision in commit_one_group's
seen_rows dedup: pairing on (source, row_num) is required under
multi-source ingest because row_num is per-source. The pre-narrowing
HashSet<u64> silently dropped co-rowed slots from the collateral
walk across sources; the new HashSet<(Arc<str>, u64)> closes that.

GroupSizeExceeded overflow stays pipeline-wide as a documented
exception — overflow has no causal source attribution and rewinding
all contributing sources requires a replayable-source primitive
that #57 will introduce.

Refs #56, #50.

https://claude.ai/code/session_01J6JYztW9aYakUaMVy6dxw7