### PR TITLE
docs(source): document watermark block on Source nodes

### DIFF
--- a/docs/src/cookbook/aggregation.md
+++ b/docs/src/cookbook/aggregation.md
@@ -202,3 +202,239 @@ Omit `group_by` to aggregate all records into a single output row:
         emit record_count = count(*)
         emit average_amount = avg(amount)
 ```
+
+## Time-windowed rollups
+
+When the grouping dimension is *event-time bucket*, declare a
+[`watermark:`](../pipeline/source.md#watermarks) on every source
+and a [`time_window:`](../pipeline/aggregate.md#time-windowed-aggregates)
+on the aggregate. Three patterns cover the common shapes; all three
+ship as runnable pipelines under `examples/pipelines/`.
+
+### Tumbling: hourly click counts
+
+Non-overlapping one-hour buckets per user. Use when each record
+should contribute to exactly one reporting bucket.
+
+`examples/pipelines/tumbling_clicks.yaml`:
+
+```yaml
+pipeline:
+  name: tumbling_clicks
+
+nodes:
+  - type: source
+    name: clicks
+    description: Per-user click stream with an event-time column.
+    config:
+      name: clicks
+      type: csv
+      path: ./data/tumbling_clicks.csv
+      options:
+        has_header: true
+      watermark:
+        column: event_ts
+      schema:
+        - { name: user_id, type: string }
+        - { name: event_ts, type: date_time }
+        - { name: kind, type: string }
+
+  - type: aggregate
+    name: hourly_clicks
+    description: Per-user click count, bucketed by event-time hour.
+    input: clicks
+    config:
+      group_by: [user_id]
+      time_window:
+        tumbling: { size: 1h }
+      cxl: |
+        emit user_id = user_id
+        emit n = count(*)
+
+  - type: output
+    name: results
+    input: hourly_clicks
+    config:
+      name: results
+      type: csv
+      path: ./output/tumbling_clicks.csv
+
+error_handling:
+  strategy: fail_fast
+```
+
+Run:
+
+```bash
+cargo run -p clinker -- run examples/pipelines/tumbling_clicks.yaml
+```
+
+The source's watermark advances with each record's `event_ts`; each
+hour-aligned bucket emits one row per `user_id` as soon as the
+watermark crosses `bucket_end`. Records observed out-of-order land
+in the DLQ as `late_record` — add `delay:` on the source or
+`allowed_lateness:` on the aggregate if the input has a known
+out-of-order tail.
+
+### Hopping: 1-hour sums advanced every 5 minutes
+
+Overlapping one-hour windows that move forward every 5 minutes. Use
+for moving averages and rolling sums where one record should
+contribute to multiple overlapping reports.
+
+`examples/pipelines/hopping_sliding_5m_1h.yaml`:
+
+```yaml
+pipeline:
+  name: hopping_sliding_5m_1h
+
+nodes:
+  - type: source
+    name: clicks
+    config:
+      name: clicks
+      type: csv
+      path: ./data/hopping_clicks.csv
+      options:
+        has_header: true
+      watermark:
+        column: event_ts
+        delay: 5s
+      schema:
+        - { name: user_id, type: string }
+        - { name: event_ts, type: date_time }
+        - { name: amount, type: int }
+
+  - type: aggregate
+    name: sliding_amount
+    input: clicks
+    config:
+      group_by: [user_id]
+      time_window:
+        hopping:
+          size: 1h
+          slide: 5m
+      allowed_lateness: 30s
+      cxl: |
+        emit user_id = user_id
+        emit total = sum(amount)
+        emit n = count(*)
+
+  - type: output
+    name: results
+    input: sliding_amount
+    config:
+      name: results
+      type: csv
+      path: ./output/hopping_sliding_5m_1h.csv
+
+error_handling:
+  strategy: fail_fast
+```
+
+Run:
+
+```bash
+cargo run -p clinker -- run examples/pipelines/hopping_sliding_5m_1h.yaml
+```
+
+Each record fans into `ceil(size / slide) = 12` overlapping
+windows, so the output row count is roughly 12× the active-window
+record count. The source's `delay: 5s` plus the aggregate's
+`allowed_lateness: 30s` give the pipeline 35 seconds of total grace
+beyond strict event-time order before a record drops to the DLQ.
+
+### Session: per-user multi-source login sessions
+
+Variable-duration windows bounded by inactivity, computed across
+two independent sources. Use for activity grouping where the
+window length is data-driven rather than clock-aligned.
+
+`examples/pipelines/multi_source_session.yaml`:
+
+```yaml
+pipeline:
+  name: multi_source_session
+
+nodes:
+  - type: source
+    name: src_web
+    description: Web login events.
+    config:
+      name: src_web
+      type: csv
+      path: ./data/session_logins.csv
+      options:
+        has_header: true
+      watermark:
+        column: event_ts
+      schema:
+        - { name: user_id, type: string }
+        - { name: event_ts, type: date_time }
+        - { name: source, type: string }
+
+  - type: source
+    name: src_mobile
+    description: Mobile login events.
+    config:
+      name: src_mobile
+      type: csv
+      path: ./data/session_mobile.csv
+      options:
+        has_header: true
+      watermark:
+        column: event_ts
+      schema:
+        - { name: user_id, type: string }
+        - { name: event_ts, type: date_time }
+        - { name: source, type: string }
+
+  - type: merge
+    name: all_logins
+    inputs: [src_web, src_mobile]
+
+  - type: aggregate
+    name: user_sessions
+    input: all_logins
+    config:
+      group_by: [user_id]
+      time_window:
+        session: { gap: 5m }
+      allowed_lateness: 30s
+      cxl: |
+        emit user_id = user_id
+        emit logins = count(*)
+
+  - type: output
+    name: results
+    input: user_sessions
+    config:
+      name: results
+      type: csv
+      path: ./output/multi_source_session.csv
+
+error_handling:
+  strategy: fail_fast
+```
+
+Run:
+
+```bash
+cargo run -p clinker -- run examples/pipelines/multi_source_session.yaml
+```
+
+Each source declares its own `watermark.column` independently. The
+aggregate's close decision reads `min_across_sources` across both
+sources' partitions: a session can't emit until both `src_web` and
+`src_mobile` have advanced past `session_end + allowed_lateness`.
+Drop the `watermark:` block on either source and the planner
+rejects the pipeline with
+[**E156**](../ops/exit-codes.md#plan-time-diagnostic-codes).
+
+### When to pick each
+
+| Kind | Bucket shape | Typical use |
+|------|--------------|-------------|
+| `tumbling` | Disjoint, clock-aligned, fixed width | Hourly metrics, daily rollups, billing periods. |
+| `hopping` | Overlapping, clock-aligned, fixed width | Moving averages, sliding sums, anomaly detection where each record should affect multiple reports. |
+| `session` | Variable width, gap-bounded, per-key | User sessions, telemetry burst grouping, activity envelopes where the window length is data-driven. |

--- a/docs/src/cxl/system-variables.md
+++ b/docs/src/cxl/system-variables.md
@@ -27,20 +27,6 @@ $ cxl eval -e 'emit name = $pipeline.name' \
 }
 ```
 
-### Per-record provenance
-
-| Variable | Type | Description |
-|----------|------|-------------|
-| `$pipeline.source_file` | String | Path of the source file for the current record |
-| `$pipeline.source_row` | Int | Row number within the source file |
-
-These change per record, tracking where each record originated. Useful for diagnostics and auditing.
-
-```
-emit meta audit_source = $pipeline.source_file
-emit meta audit_row = $pipeline.source_row
-```
-
 ### Counters
 
 | Variable | Type | Description |
@@ -54,6 +40,35 @@ emit meta audit_row = $pipeline.source_row
 ```
 trace info if $pipeline.total_count % 10000 == 0 then "processed " + $pipeline.total_count.to_string() + " records"
 ```
+
+## $source.* -- Per-record source lineage
+
+`$source.*` exposes engine-stamped columns that travel with every
+record from its origin Source node downstream through merges,
+combines, and transforms. They identify *where the record came
+from* and *when in event-time it happened*. All three columns are
+filtered out of default Output projections — reference them
+explicitly with `emit` if you need them in your output schema.
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `$source.file` | String | Path of the input file the current record was read from. |
+| `$source.name` | String | Name of the Source node that produced the current record. Survives through `merge` / `combine` so downstream nodes can branch on origin. |
+| `$source.event_time` | DateTime | Engine-stamped event time, delay-corrected by the source's `watermark.delay`. `Null` when the source has no `watermark:` block, or when the per-record value did not parse. |
+
+```
+filter $source.name == "src_web"
+emit origin = $source.name
+emit ingest_file = $source.file
+emit ts = $source.event_time
+```
+
+`$source.event_time` is the column a
+[time-windowed aggregate](../pipeline/aggregate.md#time-windowed-aggregates)
+reads to assign records to windows. It is only populated for
+records from a source that declares
+[`watermark:`](../pipeline/source.md#watermarks) — otherwise it
+holds `Null`.
 
 ## $vars.* -- User-defined variables
 
@@ -151,7 +166,7 @@ pipeline:
         emit tax = amount * $vars.tax_rate
         emit total = amount * (1 - discount) + tax
         emit processed_at = now
-        emit meta source_row = $pipeline.source_row
+        emit meta source_file = $source.file
         emit pipeline_run = $pipeline.execution_id
 
     - name: output

--- a/docs/src/ops/exit-codes.md
+++ b/docs/src/ops/exit-codes.md
@@ -97,6 +97,51 @@ Common causes:
 
 **Action:** Fix file paths, permissions, or disk space, then re-run.
 
+## Plan-time diagnostic codes
+
+The process exit codes above tell a scheduler whether the run
+succeeded. The `E###` codes below appear inside the structured
+`Error:` messages a configuration error (exit code 1) prints, and
+identify the specific compile-time check that rejected the
+pipeline. The codes below cover the event-time watermark and
+time-windowed aggregate surface
+([issue #61](https://github.com/rustpunk/clinker/issues/61));
+related code sets live in
+[Pipeline Variables](../pipeline/variables.md),
+[Channels](../pipeline/channels.md), and
+[Correlation Keys](../pipeline/correlation-keys.md).
+
+| Code | Trigger | Remediation |
+|------|---------|-------------|
+| **E154** | A source declares `watermark.column: <col>` but `<col>` is not present in that source's `schema:` block. | Add the column to `schema:`, or remove the `watermark:` block. |
+| **E155** | A source declares `watermark.column: <col>` and the column exists, but its declared CXL type is not `date_time` or `date`. | Change the column's `type:` to `date_time` or `date`, or point `watermark.column` at a column that already has one of those types. |
+| **E156** | An aggregate declares `time_window:` but at least one upstream-reachable source does not declare `watermark.column`. | Add `watermark: { column: <event-time-column> }` to each listed source, or remove `time_window:` from the aggregate. Without a watermark on every upstream source, `min_across_sources` never advances past `None` and the window can never close. |
+
+See [Source Nodes → Watermarks](../pipeline/source.md#watermarks)
+and [Aggregate Nodes → Time-windowed aggregates](../pipeline/aggregate.md#time-windowed-aggregates)
+for the field semantics each code is enforcing.
+
+### DLQ category: LateRecord
+
+When a time-windowed aggregate sees a record whose event time falls
+inside an already-closed window
+(`window_end + allowed_lateness < min_across_sources`), the engine
+routes the record to the DLQ instead of attempting to fold it into
+a finalized accumulator. Mirrors Flink's
+[`sideOutputLateData`](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/datastream/operators/windows/#getting-late-data-as-a-side-output)
+and Spark Structured Streaming's late-data drop.
+
+The DLQ row carries:
+
+- `_cxl_dlq_error_category` = `late_record`
+- `_cxl_dlq_stage` = `time_window:<aggregate-name>`
+- `_cxl_dlq_error_detail` — the closed window's `[start, end)`
+  bounds as i64 nanoseconds since the Unix epoch
+
+Tune `watermark.delay` (source-side, applies before any aggregate)
+or `allowed_lateness` (operator-side, applies per aggregate) to
+absorb expected out-of-order tails before they reach this path.
+
 ## Scheduler integration
 
 ### Cron script

--- a/docs/src/pipeline/aggregate.md
+++ b/docs/src/pipeline/aggregate.md
@@ -103,6 +103,261 @@ A retraction-mode aggregate emits one engine-managed `$ck.aggregate.<name>` shad
 
 The retraction protocol carries a per-aggregate cost — Reversible accumulators use a per-row lineage map, BufferRequired accumulators hold raw contributions until commit. Both paths additionally pay ~16 bytes per output row for the synthetic-CK shadow column. The [operator-by-operator retraction cost reference](correlation-keys.md#operator-by-operator-retraction-cost-reference) has the per-operator breakdown; `clinker run --explain` reports the live per-aggregate detail including the synthetic-CK line.
 
+## Time-windowed aggregates
+
+When `time_window:` is set on the aggregate body, the operator
+groups records not just by `group_by` but also by *event-time
+window*. Each record is assigned to one or more windows by the
+engine-stamped [`$source.event_time`](../cxl/system-variables.md)
+column; state accumulates per `(group_by, window)`; a window closes
+once `min_across_sources >= window_end + allowed_lateness` and emits
+one row per group it saw. The shape parallels Flink SQL
+[Window TVFs](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/table/sql/queries/window-tvf/),
+Spark Structured Streaming
+[window / session_window](https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html#window-operations-on-event-time),
+and Beam
+[windowing](https://beam.apache.org/documentation/programming-guide/#windowing).
+
+Every upstream-reachable source must declare a
+[`watermark:`](source.md#watermarks). Otherwise `min_across_sources`
+stays at `None`, no window ever closes, and the planner rejects the
+pipeline with
+[**E156**](../ops/exit-codes.md#plan-time-diagnostic-codes).
+
+The engine emits user-declared columns only — window bounds do not
+appear in the output unless you compute and emit them yourself. The
+emit order is ascending `window_start` (deterministic), so output
+rows naturally group by window.
+
+### Tumbling windows
+
+Non-overlapping fixed-size buckets. Each record lands in exactly one
+window `[floor(t / size) * size, floor(t / size) * size + size)`.
+
+```yaml
+time_window:
+  tumbling: { size: 1h }
+```
+
+**Input** (`tumbling_demo.csv`):
+
+```csv
+user_id,event_ts,kind
+u1,2026-05-14T10:05:00,click
+u2,2026-05-14T10:30:00,click
+u1,2026-05-14T10:42:00,click
+u1,2026-05-14T11:03:00,click
+u2,2026-05-14T11:15:00,click
+u2,2026-05-14T11:50:00,click
+```
+
+**Output** with `tumbling: { size: 1h }`, `group_by: [user_id]`,
+`emit n = count(*)`:
+
+```csv
+user_id,n
+u1,2
+u2,1
+u1,1
+u2,2
+```
+
+Reading top-to-bottom: the first two rows are the `[10:00, 11:00)`
+bucket (u1's 10:05 and 10:42, then u2's 10:30); the next two are
+the `[11:00, 12:00)` bucket (u1's 11:03, then u2's 11:15 and 11:50).
+Each input record contributes to exactly one window.
+
+### Hopping windows
+
+Overlapping fixed-size buckets advanced by `slide`. Each record
+lands in `ceil(size / slide)` windows: `slide < size` produces
+overlap, `slide == size` degenerates to tumbling, `slide > size`
+produces gaps where some records fall in zero windows.
+
+```yaml
+time_window:
+  hopping: { size: 1h, slide: 30m }
+```
+
+**Input** (`hopping_demo.csv`):
+
+```csv
+user_id,event_ts,amount
+u1,2026-05-14T10:05:00,10
+u1,2026-05-14T10:42:00,20
+u1,2026-05-14T11:10:00,15
+```
+
+**Output** with `group_by: [user_id]`, `emit total = sum(amount)`,
+`emit n = count(*)`:
+
+```csv
+user_id,total,n
+u1,10,1
+u1,30,2
+u1,35,2
+u1,15,1
+```
+
+Three input records, four output rows — each record fans into two
+overlapping `size: 1h, slide: 30m` windows:
+
+- `[09:30, 10:30)` — just 10:05 → `total=10, n=1`
+- `[10:00, 11:00)` — 10:05 + 10:42 → `total=30, n=2`
+- `[10:30, 11:30)` — 10:42 + 11:10 → `total=35, n=2`
+- `[11:00, 12:00)` — just 11:10 → `total=15, n=1`
+
+### Session windows
+
+Per-key gap-bounded sessions. A new record extends its key's current
+session if its event time is within `gap` of the session's last
+event time; otherwise it starts a new session. The boundary is
+data-driven, not clock-aligned.
+
+```yaml
+time_window:
+  session: { gap: 10m }
+```
+
+**Input** (`session_demo.csv`):
+
+```csv
+user_id,event_ts,action
+u1,2026-05-14T10:00:00,login
+u1,2026-05-14T10:07:00,click
+u1,2026-05-14T10:13:00,click
+u1,2026-05-14T10:50:00,login
+u1,2026-05-14T10:55:00,click
+```
+
+**Output** with `group_by: [user_id]`, `emit n = count(*)`:
+
+```csv
+user_id,n
+u1,3
+u1,2
+```
+
+`u1`'s first three rows form one session (10:00 → 10:07 → 10:13,
+consecutive gaps ≤ 10m). The 37-minute idle stretch exceeds `gap`,
+so 10:50 starts a fresh session that runs through 10:55. Two
+sessions, two output rows.
+
+### Allowed lateness
+
+`allowed_lateness` is an operator-side knob, distinct from the
+source-side `watermark.delay`. A window with `time_window:` closes
+when `min_across_sources >= window_end + allowed_lateness`. Records
+arriving after a window's `end + allowed_lateness` route to the DLQ
+as `LateRecord` with stage label `time_window:<aggregate-name>`.
+See [DLQ category: LateRecord](../ops/exit-codes.md#dlq-category-laterecord)
+for the DLQ row layout.
+
+```yaml
+- type: aggregate
+  name: hourly
+  input: clicks
+  config:
+    group_by: [user_id]
+    time_window:
+      tumbling: { size: 1h }
+    allowed_lateness: 30s
+    cxl: |
+      emit n = count(*)
+```
+
+Default (unset) means no grace beyond the watermark — windows close
+the instant `min_across_sources` crosses `window_end`. Set
+`allowed_lateness` when the source's `watermark.delay` alone is too
+small to absorb the observed out-of-order tail.
+
+### Worked example: multi-source session window
+
+This pipeline merges two independent login feeds and groups per-user
+events into gap-bounded sessions. Issue
+[#61](https://github.com/rustpunk/clinker/issues/61) tracks the
+multi-source synchronisation contract: a window cannot close until
+**every** upstream source has advanced its watermark past
+`window_end + allowed_lateness`.
+
+```yaml
+pipeline:
+  name: multi_source_session
+
+nodes:
+  - type: source
+    name: src_web
+    description: Web login events.
+    config:
+      name: src_web
+      type: csv
+      path: ./data/session_logins.csv
+      options:
+        has_header: true
+      watermark:
+        column: event_ts
+      schema:
+        - { name: user_id, type: string }
+        - { name: event_ts, type: date_time }
+        - { name: source, type: string }
+
+  - type: source
+    name: src_mobile
+    description: Mobile login events.
+    config:
+      name: src_mobile
+      type: csv
+      path: ./data/session_mobile.csv
+      options:
+        has_header: true
+      watermark:
+        column: event_ts
+      schema:
+        - { name: user_id, type: string }
+        - { name: event_ts, type: date_time }
+        - { name: source, type: string }
+
+  - type: merge
+    name: all_logins
+    inputs: [src_web, src_mobile]
+
+  - type: aggregate
+    name: user_sessions
+    input: all_logins
+    config:
+      group_by: [user_id]
+      time_window:
+        session: { gap: 5m }
+      allowed_lateness: 30s
+      cxl: |
+        emit user_id = user_id
+        emit logins = count(*)
+
+  - type: output
+    name: results
+    input: user_sessions
+    config:
+      name: results
+      type: csv
+      path: ./output/multi_source_session.csv
+```
+
+Both sources declare their own `watermark.column` independently. At
+ingest, each record gets the engine-stamped `$source.event_time`
+column, so the aggregate is column-name-agnostic about which source
+delivered any given record. The aggregate's close decision reads
+`min_across_sources` across **both** sources' partitions: a session
+cannot emit until both `src_web` and `src_mobile` have advanced past
+the session's `end + allowed_lateness`. Drop the `watermark:` block
+on either source and the planner rejects the pipeline with
+[**E156**](../ops/exit-codes.md#plan-time-diagnostic-codes).
+
+Run it from the repo:
+
+```bash
+cargo run -p clinker -- run examples/pipelines/multi_source_session.yaml
+```
+
 ## Complete example
 
 ```yaml

--- a/docs/src/pipeline/source.md
+++ b/docs/src/pipeline/source.md
@@ -194,6 +194,71 @@ The shorthand form is also accepted -- a bare string defaults to ascending:
       - { field: "txn_date", order: desc }
 ```
 
+## Watermarks
+
+An event-time watermark declares which column on the source carries
+each record's *event time* — the wall-clock instant the event
+happened, distinct from when Clinker read the row. When set, the
+engine reads the column on every record, subtracts the source's
+`delay`, and folds the result into a per-source monotonic watermark.
+The delay-corrected value is also stamped on every record as
+[`$source.event_time`](../cxl/system-variables.md), the column a
+downstream [time-windowed aggregate](aggregate.md#time-windowed-aggregates)
+uses to assign records to windows.
+
+```yaml
+- type: source
+  name: clicks
+  config:
+    name: clicks
+    type: csv
+    path: "./data/clicks.csv"
+    options:
+      has_header: true
+    watermark:
+      column: event_ts       # must be date_time or date
+      delay: 5s              # bounded out-of-order tolerance
+      idle_timeout: 30s      # flip partitions to idle if quiet
+    schema:
+      - { name: user_id, type: string }
+      - { name: event_ts, type: date_time }
+      - { name: amount, type: int }
+```
+
+Fields:
+
+- `column` (required) — the schema column whose value is each
+  record's event time. The column's declared type must be `date_time`
+  or `date`. A `column:` that names a field absent from `schema:`
+  raises [**E154**](../ops/exit-codes.md#plan-time-diagnostic-codes);
+  a `column:` whose declared type is neither raises **E155**.
+
+- `delay` (optional duration, default unset) — bounded out-of-order
+  tolerance. Each record's event time is shifted earlier by `delay`
+  before being folded into the watermark, so the source's effective
+  watermark trails its observed max event time by this amount.
+  Mirrors Flink's
+  [`BoundedOutOfOrdernessWatermarks`](https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/datastream/event-time/built_in/#fixed-amount-of-lateness).
+  Without `delay`, the watermark advances strictly to the observed
+  max — a single late record routes to the DLQ.
+
+- `idle_timeout` (optional duration, default unset) — if a live
+  source's receiver stays quiet longer than this, its partitions
+  flip to idle and stop holding back `min_across_sources`. Lets
+  downstream windows keep closing when one source pauses. `None`
+  means never go idle, preserving the prior behaviour for pipelines
+  without a window-close consumer.
+
+Durations use the suffixes `ms`, `s`, `m`, `h`, `d`. `ms` is
+matched before the single-character `s`, so `500ms` reads as 500
+milliseconds, not 500 seconds with a stray `m`.
+
+A pipeline whose aggregate declares `time_window:` **must** have a
+`watermark.column` on every upstream-reachable source. Without it,
+`min_across_sources` over the source set stays at `None` and the
+window can never close — the planner rejects this with
+[**E156**](../ops/exit-codes.md#plan-time-diagnostic-codes).
+
 ## Array paths
 
 For nested data (JSON/XML sources with embedded arrays), `array_paths` controls how nested arrays are handled:


### PR DESCRIPTION
Cover the `watermark.column` / `delay` / `idle_timeout` fields the
Source surface gained for event-time ordering. The block is required
on every upstream source whenever a downstream aggregate declares a
`time_window:`; without it the planner emits E156 and the pipeline
never runs. Closes the Source-side gap for issue #61.

https://claude.ai/code/session_01622f5VvGmsL55VVQyhKzd7