### PR TITLE
record: drop dead RecordProvenance.source_count and assert column-variant uniformity in arena builds (closes #77)

### DIFF
--- a/crates/clinker-bench-support/src/io.rs
+++ b/crates/clinker-bench-support/src/io.rs
@@ -4,9 +4,17 @@
 //! against the output node name. Tests and benches inject a
 //! [`SharedBuffer`] so the post-run byte stream is inspectable from the
 //! test thread without touching the filesystem.
+//!
+//! The reader-side helpers ([`slow_reader`], [`fast_reader`]) build the
+//! `Box<dyn Read + Send>` payload a `FileSlot` expects. They return the
+//! reader rather than a fully-built `FileSlot` because constructing a
+//! slot requires `clinker_core::source::multi_file::FileSlot`, and
+//! `clinker-bench-support` sits beneath `clinker-core` in the workspace
+//! dep graph — a `clinker-core` import here would form a cycle.
 
-use std::io::{self, Write};
+use std::io::{self, Cursor, Read, Write};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 /// Thread-safe, cloneable in-memory buffer for capturing output.
 ///
@@ -47,6 +55,83 @@ impl Write for SharedBuffer {
     }
 }
 
+/// `std::io::Read` adapter that paces row delivery by sleeping `delay`
+/// after each newline-terminated chunk.
+///
+/// Integration tests need to drive the executor against a Source whose
+/// per-row arrival is observably slow (live-channel back-pressure,
+/// fused-Transform streaming, streaming-Output drain races). A real
+/// filesystem or network reader would introduce flakiness; this adapter
+/// produces deterministic, configurable per-row latency at the byte
+/// stream layer where the CSV format reader actually sits.
+///
+/// The blocking `std::thread::sleep` is intentional — the format reader
+/// runs inside `tokio::task::spawn_blocking`, so blocking sleeps do not
+/// stall the runtime. The header row is exempt from the sleep (the CSV
+/// reader consumes it during schema inference, before any record-level
+/// pacing matters).
+pub struct DelayedRowReader {
+    bytes: Vec<u8>,
+    pos: usize,
+    delay: Duration,
+    rows_read: usize,
+}
+
+impl DelayedRowReader {
+    /// Build a reader that emits `csv`'s bytes and sleeps `delay`
+    /// between rows.
+    pub fn new(csv: &str, delay: Duration) -> Self {
+        Self {
+            bytes: csv.as_bytes().to_vec(),
+            pos: 0,
+            delay,
+            rows_read: 0,
+        }
+    }
+}
+
+impl Read for DelayedRowReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.pos >= self.bytes.len() {
+            return Ok(0);
+        }
+        // Row-bounded chunking keeps each sleep aligned with a record
+        // boundary even when the format reader's internal buffer would
+        // otherwise pull multiple rows in one call.
+        let remaining = &self.bytes[self.pos..];
+        let chunk_end = remaining
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| p + 1)
+            .unwrap_or(remaining.len());
+        let n = chunk_end.min(buf.len());
+        buf[..n].copy_from_slice(&remaining[..n]);
+        self.pos += n;
+        if n > 0 && remaining[..n].ends_with(b"\n") {
+            self.rows_read += 1;
+            if self.rows_read >= 1 && self.pos < self.bytes.len() {
+                std::thread::sleep(self.delay);
+            }
+        }
+        Ok(n)
+    }
+}
+
+/// Box up a [`DelayedRowReader`] as the `Box<dyn Read + Send>` payload
+/// a `FileSlot` expects. Callers pair the returned reader with their
+/// own synthetic path because the `FileSlot` type lives in
+/// `clinker-core`, which this crate cannot depend on.
+pub fn slow_reader(csv: &str, delay: Duration) -> Box<dyn Read + Send> {
+    Box::new(DelayedRowReader::new(csv, delay))
+}
+
+/// Box up an in-memory CSV payload as a non-pacing `Box<dyn Read + Send>`
+/// suitable for a `FileSlot`. Used as the fast-side counterpart to
+/// [`slow_reader`] when only one source needs pacing.
+pub fn fast_reader(csv: &str) -> Box<dyn Read + Send> {
+    Box::new(Cursor::new(csv.as_bytes().to_vec()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -74,6 +159,34 @@ mod tests {
             clone.as_string(),
             "written via original",
             "clone should see data written through original"
+        );
+    }
+
+    #[test]
+    fn test_fast_reader_delivers_full_payload() {
+        let mut reader = fast_reader("id,tag\n1,a\n2,b\n");
+        let mut out = String::new();
+        reader.read_to_string(&mut out).unwrap();
+        assert_eq!(out, "id,tag\n1,a\n2,b\n");
+    }
+
+    #[test]
+    fn test_slow_reader_paces_between_rows() {
+        // Two body rows after the header → at least one inter-row sleep
+        // fires. A 20 ms delay is large enough to dominate scheduler
+        // noise but small enough to keep this test cheap.
+        let csv = "id,tag\n1,a\n2,b\n";
+        let delay = Duration::from_millis(20);
+        let mut reader = slow_reader(csv, delay);
+        let start = std::time::Instant::now();
+        let mut out = String::new();
+        reader.read_to_string(&mut out).unwrap();
+        let elapsed = start.elapsed();
+        assert_eq!(out, csv, "payload must arrive intact");
+        assert!(
+            elapsed >= delay,
+            "slow_reader should sleep at least once between rows; \
+             got elapsed={elapsed:?}, delay={delay:?}",
         );
     }
 }

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -339,6 +339,61 @@ fn record_error_to_buffer_if_grouped(
     });
     true
 }
+
+/// Dispatch a Transform CXL evaluation failure through the shared
+/// error path used by every Transform call site.
+///
+/// Both the fused and buffered Transform arms route eval errors through
+/// the same three-way decision: under [`ErrorStrategy::FailFast`] the
+/// error propagates immediately; with correlation buffering active the
+/// row is parked under its group cell so the group's success/failure
+/// stays atomic; otherwise the row is pushed to the run-scoped DLQ with
+/// the offending field/value attached. Folding the duplicated arm body
+/// here keeps the three-way precedence honored in one place — any
+/// future change to how Transform eval errors are routed lands here
+/// rather than having to be mirrored across arms.
+fn dispatch_transform_eval_error(
+    ctx: &mut ExecutorContext<'_>,
+    record: Record,
+    row_num: u64,
+    transform_name: String,
+    eval_err: cxl::eval::EvalError,
+) -> Result<(), PipelineError> {
+    if ctx.strategy == ErrorStrategy::FailFast {
+        return Err(eval_err.into());
+    }
+    let stage = Some(DlqEntry::stage_transform(&transform_name));
+    let routed = record_error_to_buffer_if_grouped(
+        ctx,
+        &record,
+        row_num,
+        crate::dlq::DlqErrorCategory::TypeCoercionFailure,
+        eval_err.to_string(),
+        stage.clone(),
+        None,
+    );
+    if routed {
+        return Ok(());
+    }
+    let source_name = source_name_arc_of(&record);
+    let triggering_field = eval_err.triggering_field.clone();
+    let triggering_value = eval_err.triggering_value();
+    push_dlq(
+        ctx,
+        DlqEntry {
+            source_row: row_num,
+            category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
+            error_message: eval_err.to_string(),
+            original_record: record,
+            stage,
+            route: None,
+            trigger: true,
+            source_name,
+            triggering_field,
+            triggering_value,
+        },
+    )
+}
 use crate::aggregation::AggregateStrategy;
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::{
@@ -1708,39 +1763,7 @@ pub(crate) async fn transform_fused_consume(
                     advance_cursor(ctx, &source_name_arc_of(&rec), rn);
                 }
                 Err((transform_name, eval_err)) => {
-                    if ctx.strategy == ErrorStrategy::FailFast {
-                        return Err(eval_err.into());
-                    }
-                    let stage = Some(DlqEntry::stage_transform(&transform_name));
-                    let routed = record_error_to_buffer_if_grouped(
-                        ctx,
-                        &rec,
-                        rn,
-                        crate::dlq::DlqErrorCategory::TypeCoercionFailure,
-                        eval_err.to_string(),
-                        stage.clone(),
-                        None,
-                    );
-                    if !routed {
-                        let dlq_source_name = source_name_arc_of(&rec);
-                        let triggering_field = eval_err.triggering_field.clone();
-                        let triggering_value = eval_err.triggering_value();
-                        push_dlq(
-                            ctx,
-                            DlqEntry {
-                                source_row: rn,
-                                category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
-                                error_message: eval_err.to_string(),
-                                original_record: rec,
-                                stage,
-                                route: None,
-                                trigger: true,
-                                source_name: dlq_source_name,
-                                triggering_field,
-                                triggering_value,
-                            },
-                        )?;
-                    }
+                    dispatch_transform_eval_error(ctx, rec, rn, transform_name, eval_err)?;
                 }
             }
         } else {
@@ -2142,39 +2165,7 @@ pub(crate) async fn dispatch_plan_node(
                         advance_cursor(ctx, &source_name_arc_of(&record), rn);
                     }
                     Err((transform_name, eval_err)) => {
-                        if ctx.strategy == ErrorStrategy::FailFast {
-                            return Err(eval_err.into());
-                        }
-                        let stage = Some(DlqEntry::stage_transform(&transform_name));
-                        let routed = record_error_to_buffer_if_grouped(
-                            ctx,
-                            &record,
-                            rn,
-                            crate::dlq::DlqErrorCategory::TypeCoercionFailure,
-                            eval_err.to_string(),
-                            stage.clone(),
-                            None,
-                        );
-                        if !routed {
-                            let source_name = source_name_arc_of(&record);
-                            let triggering_field = eval_err.triggering_field.clone();
-                            let triggering_value = eval_err.triggering_value();
-                            push_dlq(
-                                ctx,
-                                DlqEntry {
-                                    source_row: rn,
-                                    category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
-                                    error_message: eval_err.to_string(),
-                                    original_record: record,
-                                    stage,
-                                    route: None,
-                                    trigger: true,
-                                    source_name,
-                                    triggering_field,
-                                    triggering_value,
-                                },
-                            )?;
-                        }
+                        dispatch_transform_eval_error(ctx, record, rn, transform_name, eval_err)?;
                     }
                 }
             }

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -773,6 +773,16 @@ impl ExecutorContext<'_> {
         self.source_count_per_source.get(name).copied().flatten()
     }
 
+    /// True when the Transform at `node_idx` should run via the
+    /// fused streaming arm. Composition bodies share `NodeIndex`
+    /// numeric space with the top-level plan, so the membership check
+    /// is gated by `current_body_node_input_refs.is_none()` —
+    /// `fused_transforms` was populated against the top-level plan
+    /// only.
+    pub(crate) fn should_fuse_transform(&self, node_idx: NodeIndex) -> bool {
+        self.current_body_node_input_refs.is_none() && self.fused_transforms.contains(&node_idx)
+    }
+
     /// Stamp the per-source finalized count for `source_name` and, if
     /// every per-source slot is now populated, derive and stamp the
     /// pipeline-wide total under [`MERGED_SOURCE_NAME`]. Called by the
@@ -1663,7 +1673,7 @@ pub(crate) async fn transform_fused_consume(
         }
 
         if let Some(evaluator) = evaluator_opt.as_mut() {
-            let source_file_arc = source_file_arc_of(&rec);
+            let source_file_arc = Arc::clone(&last_file);
             let rec_source_name_arc = source_name_arc_of(&rec);
             let eval_ctx = EvalContext {
                 stable: ctx.stable,
@@ -1950,17 +1960,9 @@ pub(crate) async fn dispatch_plan_node(
             // non-init-phase, no upstream fan-out, and the Source is
             // not already claimed by Merge.interleave fusion), drive
             // per-record evaluation directly off the receiver instead
-            // of consuming a Vec from `node_buffers`. Composition body
-            // walks reuse the dispatcher with a body-local
-            // `ExecutionPlanDag` whose `NodeIndex` numbering is
-            // independent of the top-level plan; `fused_transforms`
-            // was populated against the top-level plan, so the check
-            // is gated by `current_body_node_input_refs.is_none()` to
-            // avoid spurious matches inside a body. See
+            // of consuming a Vec from `node_buffers`. See
             // https://github.com/rustpunk/clinker/issues/74.
-            if ctx.current_body_node_input_refs.is_none()
-                && ctx.fused_transforms.contains(&node_idx)
-            {
+            if ctx.should_fuse_transform(node_idx) {
                 return transform_fused_consume(ctx, current_dag, node_idx, name).await;
             }
             // Get input records: first check own buffer (set by Route

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -441,6 +441,18 @@ pub(crate) struct ExecutorContext<'a> {
     /// whose Merge mode is concat (concat keeps today's
     /// declaration-order drain through the Source arms).
     pub(crate) fused_sources: HashSet<String>,
+
+    /// Transforms whose sole upstream is a `PlanNode::Source` and that
+    /// have taken ownership of the Source's
+    /// [`tokio::sync::mpsc::Receiver`] out of [`Self::source_records`].
+    /// The Transform arm drives `recv().await` per record and runs CXL
+    /// evaluation inline; the upstream Source's dispatch arm short-
+    /// circuits via [`Self::fused_sources`] (the same set membership
+    /// the Merge.interleave fusion relies on). Populated at executor
+    /// entry by the same pre-pass that fills `fused_sources`. See
+    /// https://github.com/rustpunk/clinker/issues/74 for the
+    /// eligibility predicate and the windowed-Transform fallback.
+    pub(crate) fused_transforms: HashSet<NodeIndex>,
     /// Pipeline-wide `$record.<key>` default seed: declared
     /// `declares: scope: record` defaults plus channel
     /// `record_vars:` overrides. Borrowed by the Source dispatch
@@ -1454,6 +1466,232 @@ pub(crate) async fn merge_fused_interleave(
     Ok(merged)
 }
 
+/// Drive a `PlanNode::Transform` whose sole upstream is a
+/// `PlanNode::Source` directly off the Source's `mpsc::Receiver`,
+/// running per-record CXL evaluation inline instead of consuming a
+/// pre-drained `Vec` from `node_buffers`. The Source dispatch arm
+/// short-circuits via [`ExecutorContext::fused_sources`]; this helper
+/// takes ownership of the receiver, applies the same per-record
+/// pipeline the non-fused Source arm runs (canonicalize onto the
+/// Source's plan-time schema, seed `$record.<key>` defaults, seed
+/// `$source.<key>` defaults per `(source, file)`, advance the per-
+/// source running counter), runs the Transform's `evaluate_single_transform`
+/// per record, and emits records into `ctx.node_buffers[transform_idx]`
+/// at the close. See https://github.com/rustpunk/clinker/issues/74.
+///
+/// Eligibility (windowed Transforms, multi-input Transforms, body-
+/// context Transforms, init-phase Transforms, fanned-out Sources) is
+/// enforced upstream by `compute_transform_fused_sources` in
+/// `executor/mod.rs`; this helper trusts the predicate and panics on
+/// shape violations.
+pub(crate) async fn transform_fused_consume(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    name: &str,
+) -> Result<(), PipelineError> {
+    let pred_idx = current_dag
+        .graph
+        .neighbors_directed(node_idx, Direction::Incoming)
+        .next()
+        .ok_or_else(|| PipelineError::Internal {
+            op: "executor",
+            node: name.to_string(),
+            detail: format!(
+                "fused Transform {name:?} has no incoming edge — \
+                 fusion classifier accepted a node the predicate rejects"
+            ),
+        })?;
+    let PlanNode::Source {
+        name: source_name, ..
+    } = &current_dag.graph[pred_idx]
+    else {
+        return Err(PipelineError::Internal {
+            op: "executor",
+            node: name.to_string(),
+            detail: format!(
+                "fused Transform {name:?} predecessor at NodeIndex {pred_idx:?} \
+                 is not a PlanNode::Source — fusion classifier diverged from runtime"
+            ),
+        });
+    };
+    let source_name_owned = source_name.clone();
+
+    let source_schema = current_dag.graph[pred_idx].stored_output_schema().cloned();
+    let engine_stamped: Vec<(usize, Box<str>)> = source_schema
+        .as_ref()
+        .map(build_engine_stamped_tail)
+        .unwrap_or_default();
+    let canonicalize = |r: &Record| -> Record {
+        match source_schema.as_ref() {
+            Some(target) => canonicalize_to_source_schema(r, target, &engine_stamped),
+            None => r.clone(),
+        }
+    };
+
+    let transform_idx_opt = ctx.transform_by_name.get(name).copied();
+    let expected_input = current_dag.graph[node_idx]
+        .expected_input_schema_in(current_dag)
+        .cloned();
+    let output_schema = current_dag.graph[node_idx].stored_output_schema().cloned();
+    let upstream_name = source_name_owned.clone();
+
+    let mut evaluator_opt: Option<ProgramEvaluator> = transform_idx_opt.map(|idx| {
+        ProgramEvaluator::new(
+            Arc::clone(&ctx.compiled_transforms[idx].typed),
+            ctx.compiled_transforms[idx].has_distinct(),
+        )
+    });
+
+    let mut rx = ctx
+        .source_records
+        .remove(source_name_owned.as_str())
+        .ok_or_else(|| PipelineError::Internal {
+            op: "executor",
+            node: name.to_string(),
+            detail: format!(
+                "fused Transform {name:?}: upstream Source {source_name_owned:?} \
+                 has no receiver in ctx.source_records — Source arm already consumed it?"
+            ),
+        })?;
+    let timeout = ctx.idle_timeouts.get(source_name_owned.as_str()).copied();
+    let has_record_seed = !ctx.record_var_seed.is_empty();
+    let source_name_arc: Arc<str> = Arc::from(source_name_owned.as_str());
+
+    let mut output_records: Vec<(Record, u64)> = Vec::new();
+    let mut last_file: Arc<str> = Arc::clone(&MERGED_SOURCE_FILE);
+    let mut count: u64 = 0;
+    let mut yields_since_last: u32 = 0;
+    loop {
+        let item: Option<(Record, u64)> = match timeout {
+            Some(t) => match tokio::time::timeout(t, rx.recv()).await {
+                Ok(item) => item,
+                Err(_elapsed) => {
+                    ctx.watermarks
+                        .mark_idle(source_name_owned.as_str(), &last_file);
+                    continue;
+                }
+            },
+            None => rx.recv().await,
+        };
+        let Some((record, rn)) = item else {
+            break;
+        };
+        last_file = source_file_arc_of(&record);
+        let mut rec = canonicalize(&record);
+        if has_record_seed {
+            rec.seed_record_vars(ctx.record_var_seed);
+        }
+        seed_source_vars_for_record(ctx, source_name_owned.as_str(), &rec)?;
+        if let Some(slot) = ctx.total_per_source.get_mut(&source_name_arc) {
+            *slot += 1;
+        }
+        count += 1;
+        yields_since_last += 1;
+        if yields_since_last >= 1024 {
+            yields_since_last = 0;
+            tokio::task::yield_now().await;
+        }
+
+        if let Some(exp) = expected_input.as_ref() {
+            check_input_schema(exp, rec.schema(), name, "transform", &upstream_name)?;
+        }
+
+        if let Some(evaluator) = evaluator_opt.as_mut() {
+            let source_file_arc = source_file_arc_of(&rec);
+            let rec_source_name_arc = source_name_arc_of(&rec);
+            let eval_ctx = EvalContext {
+                stable: ctx.stable,
+                source_file: &source_file_arc,
+                source_row: rn,
+                source_path: &source_file_arc,
+                source_count: ctx.source_count_by_name(&rec_source_name_arc),
+                source_batch: ctx.source_batch_arc,
+                ingestion_timestamp: ctx.source_ingestion_timestamp,
+                source_name: &rec_source_name_arc,
+            };
+            let target_schema = output_schema
+                .as_ref()
+                .cloned()
+                .unwrap_or_else(|| Arc::clone(rec.schema()));
+            let eval_result = {
+                let _guard = ctx.transform_timer.guard();
+                evaluate_single_transform(&rec, name, evaluator, &eval_ctx, &target_schema)
+            };
+            match eval_result {
+                Ok((modified_record, Ok(()))) => {
+                    let advance_source = source_name_arc_of(&modified_record);
+                    output_records.push((modified_record, rn));
+                    advance_cursor(ctx, &advance_source, rn);
+                }
+                Ok((_record, Err(SkipReason::Filtered))) => {
+                    ctx.counters.filtered_count += 1;
+                    advance_cursor(ctx, &source_name_arc_of(&rec), rn);
+                }
+                Ok((_record, Err(SkipReason::Duplicate))) => {
+                    ctx.counters.distinct_count += 1;
+                    advance_cursor(ctx, &source_name_arc_of(&rec), rn);
+                }
+                Err((transform_name, eval_err)) => {
+                    if ctx.strategy == ErrorStrategy::FailFast {
+                        return Err(eval_err.into());
+                    }
+                    let stage = Some(DlqEntry::stage_transform(&transform_name));
+                    let routed = record_error_to_buffer_if_grouped(
+                        ctx,
+                        &rec,
+                        rn,
+                        crate::dlq::DlqErrorCategory::TypeCoercionFailure,
+                        eval_err.to_string(),
+                        stage.clone(),
+                        None,
+                    );
+                    if !routed {
+                        let dlq_source_name = source_name_arc_of(&rec);
+                        let triggering_field = eval_err.triggering_field.clone();
+                        let triggering_value = eval_err.triggering_value();
+                        push_dlq(
+                            ctx,
+                            DlqEntry {
+                                source_row: rn,
+                                category: crate::dlq::DlqErrorCategory::TypeCoercionFailure,
+                                error_message: eval_err.to_string(),
+                                original_record: rec,
+                                stage,
+                                route: None,
+                                trigger: true,
+                                source_name: dlq_source_name,
+                                triggering_field,
+                                triggering_value,
+                            },
+                        )?;
+                    }
+                }
+            }
+        } else {
+            // Transform has no compiled CXL — passthrough behavior
+            // mirrors the buffered arm's `transform_by_name.get` miss
+            // at the top of the existing path.
+            let advance_source = source_name_arc_of(&rec);
+            output_records.push((rec, rn));
+            advance_cursor(ctx, &advance_source, rn);
+        }
+    }
+    ctx.finalize_source_count(&source_name_arc, count);
+    if timeout.is_some() && ctx.watermarks.is_idle(source_name_owned.as_str()) {
+        tracing::debug!(
+            target: "clinker::watermark",
+            source = %source_name_owned,
+            "fused transform consumer ended with all partitions in WatermarkStatus::Idle"
+        );
+    }
+
+    finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+    tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+    ctx.node_buffers.insert(node_idx, output_records);
+    Ok(())
+}
+
 /// Execute one DAG node by routing it to its arm.
 ///
 /// Reads the node by `node_idx` from `current_dag.graph` and dispatches
@@ -1641,6 +1879,25 @@ pub(crate) async fn dispatch_plan_node(
             window_index,
             ..
         } => {
+            // Streaming-fused path: when the pre-pass has flagged this
+            // Transform as eligible (sole upstream is a Source whose
+            // receiver lives in `ctx.source_records`, non-windowed,
+            // non-init-phase, no upstream fan-out, and the Source is
+            // not already claimed by Merge.interleave fusion), drive
+            // per-record evaluation directly off the receiver instead
+            // of consuming a Vec from `node_buffers`. Composition body
+            // walks reuse the dispatcher with a body-local
+            // `ExecutionPlanDag` whose `NodeIndex` numbering is
+            // independent of the top-level plan; `fused_transforms`
+            // was populated against the top-level plan, so the check
+            // is gated by `current_body_node_input_refs.is_none()` to
+            // avoid spurious matches inside a body. See
+            // https://github.com/rustpunk/clinker/issues/74.
+            if ctx.current_body_node_input_refs.is_none()
+                && ctx.fused_transforms.contains(&node_idx)
+            {
+                return transform_fused_consume(ctx, current_dag, node_idx, name).await;
+            }
             // Get input records: first check own buffer (set by Route
             // node for branch dispatch), then fall back to predecessor.
             let input_records = if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -677,6 +677,37 @@ pub(crate) struct ExecutorContext<'a> {
     /// design — one set of operator arms, two pass modes — is the whole
     /// architectural value of the deferred-region landing.
     pub(crate) in_deferred_dispatch: bool,
+
+    /// Streaming-Output channel senders keyed by the upstream fused
+    /// `Merge` node's `NodeIndex`. Present when the executor entry has
+    /// matched a `Merge.interleave → single Output` chain against
+    /// the streaming eligibility predicate (issue #72) and spawned the
+    /// writer task. The fused Merge arm checks the map for its index;
+    /// if present, it streams each canonicalized record through the
+    /// bounded `tokio::sync::mpsc::channel` instead of accumulating
+    /// into a `Vec`, and drops its sender at clean exit so the writer
+    /// task's `recv()` returns `None`. Empty for pipelines that don't
+    /// match the topology — every other Output stays on the buffered
+    /// path. See
+    /// https://github.com/rustpunk/clinker/issues/72.
+    pub(crate) streaming_output_senders:
+        HashMap<NodeIndex, tokio::sync::mpsc::Sender<(Record, u64)>>,
+    /// `Output` `NodeIndex`es whose writes are streamed by a task
+    /// spawned at executor entry. The `Output` dispatch arm short-
+    /// circuits at the top when its index is in this set — the writer
+    /// has already been moved into the streaming task and there is no
+    /// buffered batch to drain. Empty when no streaming chain
+    /// qualified.
+    pub(crate) streaming_output_nodes: HashSet<NodeIndex>,
+    /// `JoinHandle`s for spawned streaming-output writer tasks. Owned
+    /// by the dispatcher so the end-of-DAG join surface (in
+    /// `execute_dag_branching`) folds per-task counter / timer /
+    /// error accounting back into the dispatcher's
+    /// `counters` / `records_emitted` / `write_timer` /
+    /// `projection_timer` / `ok_source_rows` / `output_errors`.
+    /// Drained via `std::mem::take` at the join surface.
+    pub(crate) streaming_output_tasks:
+        Vec<tokio::task::JoinHandle<crate::executor::StreamingOutputTaskOutput>>,
 }
 
 /// Map keying (active composition body, outgoing edge id) to the rows
@@ -1315,12 +1346,23 @@ pub(crate) fn finalize_node_rooted_windows(
 /// pulled in seed-determined order from whichever receivers have
 /// records available; unseeded variants follow arrival order via
 /// pure `tokio::select!`.
+///
+/// `streaming_sender` is `Some` iff the executor matched a fused
+/// `Merge.interleave → single Output` chain against the streaming
+/// eligibility predicate (issue #72). In streaming mode this function
+/// pushes each canonicalized record through the bounded
+/// `mpsc::channel` instead of accumulating into a Vec, applies live
+/// back-pressure end-to-end (writer slow → Merge yields → Sources
+/// yield), and returns an empty Vec at close. In non-streaming mode
+/// (`None`) it returns the accumulated `Vec<(Record, u64)>` that the
+/// Merge arm then teed into `node_buffers` for downstream consumers.
 pub(crate) async fn merge_fused_interleave(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     merge_name: &str,
     sorted_preds: &[NodeIndex],
     merge_output_schema: Option<&Arc<Schema>>,
+    streaming_sender: Option<tokio::sync::mpsc::Sender<(Record, u64)>>,
 ) -> Result<Vec<(Record, u64)>, PipelineError> {
     use std::future::poll_fn;
     use std::task::Poll;
@@ -1449,7 +1491,30 @@ pub(crate) async fn merge_fused_interleave(
                     let values = rec.values().to_vec();
                     rec = Record::new(Arc::clone(merge_schema), values);
                 }
-                merged.push((rec, rn));
+                match streaming_sender.as_ref() {
+                    Some(tx) => {
+                        // Bounded `send().await` is the back-pressure
+                        // pivot — if the writer task is slow, the Merge
+                        // arm yields here, which in turn slows the
+                        // `poll_recv` loop above and lets the Source
+                        // channels fill up. Send errors mean the
+                        // receiver was dropped (writer task panicked or
+                        // an error path raced); surface as Internal so
+                        // the caller knows the streaming chain is
+                        // broken rather than silently dropping records.
+                        if tx.send((rec, rn)).await.is_err() {
+                            return Err(PipelineError::Internal {
+                                op: "executor",
+                                node: merge_name.to_string(),
+                                detail: String::from(
+                                    "streaming Output writer task dropped its \
+                                     receiver before the Merge arm finished",
+                                ),
+                            });
+                        }
+                    }
+                    None => merged.push((rec, rn)),
+                }
             }
             None => {
                 // Source closed. Stamp finalized per-source count
@@ -2491,12 +2556,22 @@ pub(crate) async fn dispatch_plan_node(
                 });
 
             let merged: Vec<(Record, u64)> = if fused_mode {
+                // Streaming-Output handoff (issue #72): if a single
+                // Output downstream of this Merge passed the
+                // eligibility predicate at executor entry, its
+                // `mpsc::Sender` was installed under our `node_idx`.
+                // Take it here so the Merge arm streams every record
+                // through the channel instead of accumulating, and so
+                // dropping the sender at clean exit closes the
+                // streaming task's `recv()` loop.
+                let streaming_sender = ctx.streaming_output_senders.remove(&node_idx);
                 merge_fused_interleave(
                     ctx,
                     current_dag,
                     name,
                     &sorted_preds,
                     merge_output_schema.as_ref(),
+                    streaming_sender,
                 )
                 .await?
             } else {
@@ -3112,6 +3187,18 @@ pub(crate) async fn dispatch_plan_node(
         }
 
         PlanNode::Output { ref name, .. } => {
+            // Streaming-Output short-circuit (issue #72). The executor
+            // entry already moved this Output's writer into a
+            // `tokio::spawn`-ed task that drained records from a
+            // bounded `mpsc::channel` populated by the fused Merge
+            // arm. Per-record `write_record` already fired concurrently
+            // with Merge production; the dispatcher's end-of-DAG join
+            // surface awaits the task and folds its counters / timers /
+            // errors into the context. The Output's topo turn here is
+            // a no-op.
+            if ctx.streaming_output_nodes.contains(&node_idx) {
+                return Ok(());
+            }
             // Get input records: check own buffer first (Route
             // nodes store records at the successor's index), then
             // fall back to predecessor buffers.

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -2391,6 +2391,22 @@ fn apply_split_naming(base_path: &str, naming: &str, seq: u32) -> String {
     parent.join(filename).to_string_lossy().into_owned()
 }
 
+/// Reports whether `idx` has exactly one outgoing edge in `plan`. The
+/// streaming-fusion classifiers reject fan-out at the upstream side —
+/// a Source feeding two consumers cannot move its live receiver into
+/// one of them, and a Merge whose merged stream is read by siblings
+/// must stay on the buffered path so those siblings see the records
+/// via `node_buffers`.
+fn has_single_outgoing(
+    plan: &crate::plan::execution::ExecutionPlanDag,
+    idx: petgraph::graph::NodeIndex,
+) -> bool {
+    plan.graph
+        .neighbors_directed(idx, petgraph::Direction::Outgoing)
+        .count()
+        == 1
+}
+
 /// Build the pipeline-stable evaluation context.
 ///
 /// Called ONCE per pipeline run at the top of `execute_dag_branching`. The
@@ -2546,11 +2562,7 @@ fn compute_transform_fused_sources(
         if merge_fused.contains(source_name) {
             continue;
         }
-        let downstream_count = plan
-            .graph
-            .neighbors_directed(pred_idx, petgraph::Direction::Outgoing)
-            .count();
-        if downstream_count != 1 {
+        if !has_single_outgoing(plan, pred_idx) {
             continue;
         }
         extra_fused_sources.insert(source_name.clone());
@@ -2664,11 +2676,7 @@ fn compute_streaming_output_specs(
         // The Merge has exactly one outgoing edge (this Output). Anything
         // else and the buffered path is needed so siblings still see the
         // merged records via `node_buffers`.
-        let merge_downstream_count = plan
-            .graph
-            .neighbors_directed(merge_idx, petgraph::Direction::Outgoing)
-            .count();
-        if merge_downstream_count != 1 {
+        if !has_single_outgoing(plan, merge_idx) {
             continue;
         }
 

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -1253,7 +1253,18 @@ impl PipelineExecutor {
         // peer Sources' channels from filling — back-pressure flows
         // end-to-end. Per-Source arms detect membership in
         // `fused_sources` and return cleanly.
-        let fused_sources: HashSet<String> = compute_merge_interleave_fused_sources(plan, config);
+        let init_phase_set = compute_init_phase_node_set(plan);
+        let mut fused_sources: HashSet<String> =
+            compute_merge_interleave_fused_sources(plan, config);
+        // Extend `fused_sources` with Source names whose receivers are
+        // claimed by a downstream `PlanNode::Transform` running in
+        // streaming mode (issue #74). `fused_transforms` carries the
+        // matching Transform `NodeIndex`es so the Transform arm can
+        // dispatch into the streaming branch instead of consuming a
+        // pre-drained Vec from `node_buffers`.
+        let (extra_fused_sources, fused_transforms) =
+            compute_transform_fused_sources(plan, &fused_sources, &init_phase_set);
+        fused_sources.extend(extra_fused_sources);
 
         let mut ctx = dispatch::ExecutorContext {
             config,
@@ -1271,6 +1282,7 @@ impl PipelineExecutor {
             node_buffers: HashMap::new(),
             source_records,
             fused_sources,
+            fused_transforms,
             record_var_seed: &record_var_seed,
             declared_source_defaults: &declared_source_defaults,
             channel_source_vars: &params.source_vars,
@@ -1328,7 +1340,6 @@ impl PipelineExecutor {
         // a Source feeding both an init branch and a runtime branch
         // correctly clones its buffer for Pass 1's first consumer
         // and removes it for Pass 2's last consumer.
-        let init_phase_set = compute_init_phase_node_set(plan);
         if !init_phase_set.is_empty() {
             for node_idx in plan.topo_order.clone() {
                 if init_phase_set.contains(&node_idx) {
@@ -2388,6 +2399,83 @@ fn compute_merge_interleave_fused_sources(
         }
     }
     fused
+}
+
+/// Identify `PlanNode::Transform` nodes whose sole upstream is a
+/// `PlanNode::Source` with a parked receiver in `ctx.source_records`,
+/// and whose evaluation can stream directly off that receiver instead
+/// of a pre-drained Vec. Returns the set of fused Transform
+/// `NodeIndex`es plus the set of Source names whose receivers move
+/// into the fused Transform's hands (those names extend
+/// [`compute_merge_interleave_fused_sources`]'s output so the Source
+/// dispatch arm short-circuits via the same membership check).
+///
+/// Eligibility (all must hold):
+///
+/// - Exactly one incoming edge.
+/// - That predecessor is a `PlanNode::Source`.
+/// - The upstream Source has exactly one outgoing edge (no Merge or
+///   sibling fan-out — fanning would require cloning the live channel).
+/// - `window_index` is `None`. Windowed Transforms drive
+///   `evaluate_single_transform_windowed`, which indexes records into
+///   the upstream operator's arena via the row's enumerate position;
+///   that arena is built upstream and must already be materialized.
+/// - The Transform is not in the init-phase ancestor closure.
+/// - The upstream Source's name is not already claimed by
+///   `merge_fused`. Merge.interleave fusion wins because the Merge
+///   needs every predecessor's receiver concurrently.
+///
+/// See https://github.com/rustpunk/clinker/issues/74 for the rationale
+/// (extending #67's pattern from Merge to Transform unblocks
+/// `[slow Source → Transform → out]` topologies from sitting idle on
+/// the upstream Source's drain).
+fn compute_transform_fused_sources(
+    plan: &crate::plan::execution::ExecutionPlanDag,
+    merge_fused: &HashSet<String>,
+    init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
+) -> (HashSet<String>, HashSet<petgraph::graph::NodeIndex>) {
+    use crate::plan::execution::PlanNode;
+    let mut extra_fused_sources: HashSet<String> = HashSet::new();
+    let mut fused_transforms: HashSet<petgraph::graph::NodeIndex> = HashSet::new();
+    for node_idx in plan.graph.node_indices() {
+        let PlanNode::Transform { window_index, .. } = &plan.graph[node_idx] else {
+            continue;
+        };
+        if window_index.is_some() {
+            continue;
+        }
+        if init_phase_set.contains(&node_idx) {
+            continue;
+        }
+        let mut incoming = plan
+            .graph
+            .neighbors_directed(node_idx, petgraph::Direction::Incoming);
+        let Some(pred_idx) = incoming.next() else {
+            continue;
+        };
+        if incoming.next().is_some() {
+            continue;
+        }
+        let PlanNode::Source {
+            name: source_name, ..
+        } = &plan.graph[pred_idx]
+        else {
+            continue;
+        };
+        if merge_fused.contains(source_name) {
+            continue;
+        }
+        let downstream_count = plan
+            .graph
+            .neighbors_directed(pred_idx, petgraph::Direction::Outgoing)
+            .count();
+        if downstream_count != 1 {
+            continue;
+        }
+        extra_fused_sources.insert(source_name.clone());
+        fused_transforms.insert(node_idx);
+    }
+    (extra_fused_sources, fused_transforms)
 }
 
 fn compute_init_phase_node_set(

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -1425,32 +1425,7 @@ impl PipelineExecutor {
         ctx.streaming_output_senders.clear();
         for handle in std::mem::take(&mut ctx.streaming_output_tasks) {
             match handle.await {
-                Ok(out) => {
-                    let StreamingOutputTaskOutput {
-                        records_written,
-                        records_emitted: task_records_emitted,
-                        seen_row_nums,
-                        write_timer: task_write_timer,
-                        projection_timer: task_projection_timer,
-                        errors,
-                        stage_metrics: task_stage_metrics,
-                    } = out;
-                    let mut newly_ok: u64 = 0;
-                    for rn in seen_row_nums {
-                        if ctx.ok_source_rows.insert(rn) {
-                            newly_ok += 1;
-                        }
-                    }
-                    ctx.counters.ok_count += newly_ok;
-                    ctx.counters.records_written += records_written;
-                    ctx.records_emitted += task_records_emitted;
-                    ctx.write_timer.add(task_write_timer);
-                    ctx.projection_timer.add(task_projection_timer);
-                    ctx.output_errors.extend(errors);
-                    for sm in task_stage_metrics {
-                        ctx.collector.record(sm);
-                    }
-                }
+                Ok(out) => out.fold_into(&mut ctx),
                 Err(join_err) => {
                     ctx.output_errors.push(PipelineError::Internal {
                         op: "streaming_output",
@@ -2778,6 +2753,33 @@ pub(crate) struct StreamingOutputTaskOutput {
     pub(crate) stage_metrics: Vec<stage_metrics::StageMetrics>,
 }
 
+impl StreamingOutputTaskOutput {
+    /// Fold the task-local counters / timers / errors / stage metrics
+    /// back into the dispatcher's [`dispatch::ExecutorContext`] after
+    /// `JoinHandle::await`. Mirrors the buffered Output arm's inline
+    /// counter accounting: `ok_count` counts distinct source rows
+    /// (deduplicated against `ctx.ok_source_rows`), `records_written`
+    /// counts every write, and the per-task timers accumulate via
+    /// [`stage_metrics::CumulativeTimer::add`].
+    fn fold_into(self, ctx: &mut dispatch::ExecutorContext<'_>) {
+        let mut newly_ok: u64 = 0;
+        for rn in self.seen_row_nums {
+            if ctx.ok_source_rows.insert(rn) {
+                newly_ok += 1;
+            }
+        }
+        ctx.counters.ok_count += newly_ok;
+        ctx.counters.records_written += self.records_written;
+        ctx.records_emitted += self.records_emitted;
+        ctx.write_timer.add(self.write_timer);
+        ctx.projection_timer.add(self.projection_timer);
+        ctx.output_errors.extend(self.errors);
+        for sm in self.stage_metrics {
+            ctx.collector.record(sm);
+        }
+    }
+}
+
 /// Streaming-output writer task body. Drains the `mpsc::Receiver`
 /// populated by the fused `Merge.interleave` arm, projects each record
 /// through `project_output_from_record`, lazily constructs the writer on
@@ -2816,22 +2818,16 @@ async fn streaming_output_task(
     let mut raw_writer_slot: Option<Box<dyn Write + Send>> = Some(raw_writer);
 
     while let Some((record, rn)) = rx.recv().await {
-        // E314 invariant — every record arriving at the Output must
-        // match the compile-time input schema. Matches the buffered
-        // Output arm's pre-loop check, hoisted to per-record under
-        // streaming because the channel can interleave records across
-        // multiple Source predecessors.
         if let Some(expected) = spec.expected_input_schema.as_ref()
-            && !Arc::ptr_eq(expected, record.schema())
-            && expected.columns() != record.schema().columns()
+            && let Err(err) = crate::executor::schema_check::check_input_schema(
+                expected,
+                record.schema(),
+                &spec.output_name,
+                "output",
+                &spec.merge_name,
+            )
         {
-            out.errors.push(PipelineError::SchemaMismatch {
-                expected: Arc::clone(expected),
-                actual: Arc::clone(record.schema()),
-                operator_name: spec.output_name.clone(),
-                operator_kind: "output",
-                upstream_name: spec.merge_name.clone(),
-            });
+            out.errors.push(err);
             continue;
         }
 

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -1126,7 +1126,7 @@ impl PipelineExecutor {
         config: &PipelineConfig,
         source_records: HashMap<String, tokio::sync::mpsc::Receiver<(Record, u64)>>,
         source_configs: &[crate::config::SourceConfig],
-        writers: WriterRegistry,
+        mut writers: WriterRegistry,
         transforms: &[CompiledTransform],
         compiled_route: Option<CompiledRoute>,
         compiled_routes_by_name: HashMap<String, CompiledRoute>,
@@ -1266,6 +1266,52 @@ impl PipelineExecutor {
             compute_transform_fused_sources(plan, &fused_sources, &init_phase_set);
         fused_sources.extend(extra_fused_sources);
 
+        // Streaming-Output setup (issue #72). For every fused
+        // `Merge.interleave → single Output` chain that satisfies the
+        // eligibility predicate, take the writer out of `writers.single`
+        // and spawn a `tokio::spawn`-ed task that drains a bounded
+        // `mpsc::channel`. The Merge arm streams records into the
+        // channel as it produces them; the Output arm's topo turn
+        // becomes a no-op because its writer has already moved into the
+        // streaming task. `JoinHandle`s are stored on the context so
+        // the dispatcher can await them at end-of-DAG and fold the
+        // per-task counter / timer / error accounting back into the
+        // context.
+        let streaming_specs = compute_streaming_output_specs(
+            plan,
+            config,
+            &fused_sources,
+            &init_phase_set,
+            &output_configs,
+            &writers,
+        );
+        let mut streaming_output_senders: HashMap<
+            petgraph::graph::NodeIndex,
+            tokio::sync::mpsc::Sender<(Record, u64)>,
+        > = HashMap::new();
+        let mut streaming_output_nodes: HashSet<petgraph::graph::NodeIndex> = HashSet::new();
+        let mut streaming_output_tasks: Vec<tokio::task::JoinHandle<StreamingOutputTaskOutput>> =
+            Vec::new();
+        for spec in streaming_specs {
+            let raw_writer = writers
+                .single
+                .remove(&spec.output_name)
+                .expect("compute_streaming_output_specs verified writers.single contains output");
+            // 256 is the bounded channel capacity. The writer task
+            // typically clears each record in microseconds; capacity
+            // above ~256 buys no measured throughput but burns memory
+            // on the slow-writer / fast-merge end of the back-pressure
+            // curve. Mirrors the Source ingest channel sizing (issue
+            // #67) — the same bound paces both ends of the pipeline.
+            let (tx, rx) = tokio::sync::mpsc::channel::<(Record, u64)>(256);
+            let merge_idx = spec.merge_idx;
+            let output_idx = spec.output_idx;
+            let handle = tokio::spawn(streaming_output_task(rx, raw_writer, spec));
+            streaming_output_senders.insert(merge_idx, tx);
+            streaming_output_nodes.insert(output_idx);
+            streaming_output_tasks.push(handle);
+        }
+
         let mut ctx = dispatch::ExecutorContext {
             config,
             artifacts,
@@ -1320,6 +1366,9 @@ impl PipelineExecutor {
             commit_step_path: dispatch::CommitStepPath::NotSelected,
             region_input_buffers: HashMap::new(),
             in_deferred_dispatch: false,
+            streaming_output_senders,
+            streaming_output_nodes,
+            streaming_output_tasks,
         };
 
         // Walk DAG in topological order. `topo_order` is cloned so
@@ -1340,22 +1389,79 @@ impl PipelineExecutor {
         // a Source feeding both an init branch and a runtime branch
         // correctly clones its buffer for Pass 1's first consumer
         // and removes it for Pass 2's last consumer.
-        if !init_phase_set.is_empty() {
-            for node_idx in plan.topo_order.clone() {
-                if init_phase_set.contains(&node_idx) {
+        // Topo walk. Wrapped so a `?` error inside doesn't short-circuit
+        // past the streaming-output task join below — the spawned tasks
+        // own writers we still need to flush (or drop) before the
+        // function returns, and dropping `ctx.streaming_output_senders`
+        // on the error path is what signals the tasks to close their
+        // channel and run their flush.
+        let walk_result: Result<(), PipelineError> = async {
+            if !init_phase_set.is_empty() {
+                for node_idx in plan.topo_order.clone() {
+                    if init_phase_set.contains(&node_idx) {
+                        dispatch::dispatch_plan_node(&mut ctx, plan, node_idx).await?;
+                    }
+                }
+                for node_idx in plan.topo_order.clone() {
+                    if !init_phase_set.contains(&node_idx) {
+                        dispatch::dispatch_plan_node(&mut ctx, plan, node_idx).await?;
+                    }
+                }
+            } else {
+                for node_idx in plan.topo_order.clone() {
                     dispatch::dispatch_plan_node(&mut ctx, plan, node_idx).await?;
                 }
             }
-            for node_idx in plan.topo_order.clone() {
-                if !init_phase_set.contains(&node_idx) {
-                    dispatch::dispatch_plan_node(&mut ctx, plan, node_idx).await?;
+            Ok(())
+        }
+        .await;
+
+        // Streaming-output drain. Drop every remaining sender so the
+        // tasks' `rx.recv().await` returns `None` and they fall through
+        // to their flush path. The fused Merge arm normally removes its
+        // sender at clean exit; remaining entries here are the error-
+        // path leftovers (Merge arm never ran) or pipelines where no
+        // streaming chain was eligible (the map is empty).
+        ctx.streaming_output_senders.clear();
+        for handle in std::mem::take(&mut ctx.streaming_output_tasks) {
+            match handle.await {
+                Ok(out) => {
+                    let StreamingOutputTaskOutput {
+                        records_written,
+                        records_emitted: task_records_emitted,
+                        seen_row_nums,
+                        write_timer: task_write_timer,
+                        projection_timer: task_projection_timer,
+                        errors,
+                        stage_metrics: task_stage_metrics,
+                    } = out;
+                    let mut newly_ok: u64 = 0;
+                    for rn in seen_row_nums {
+                        if ctx.ok_source_rows.insert(rn) {
+                            newly_ok += 1;
+                        }
+                    }
+                    ctx.counters.ok_count += newly_ok;
+                    ctx.counters.records_written += records_written;
+                    ctx.records_emitted += task_records_emitted;
+                    ctx.write_timer.add(task_write_timer);
+                    ctx.projection_timer.add(task_projection_timer);
+                    ctx.output_errors.extend(errors);
+                    for sm in task_stage_metrics {
+                        ctx.collector.record(sm);
+                    }
                 }
-            }
-        } else {
-            for node_idx in plan.topo_order.clone() {
-                dispatch::dispatch_plan_node(&mut ctx, plan, node_idx).await?;
+                Err(join_err) => {
+                    ctx.output_errors.push(PipelineError::Internal {
+                        op: "streaming_output",
+                        node: String::from("<unknown>"),
+                        detail: format!("streaming output task panicked: {join_err}"),
+                    });
+                }
             }
         }
+
+        walk_result?;
 
         // Take the pipeline-scoped TempDir out of the context. Held
         // until the very end of the walk so any operator-side spill
@@ -2476,6 +2582,336 @@ fn compute_transform_fused_sources(
         fused_transforms.insert(node_idx);
     }
     (extra_fused_sources, fused_transforms)
+}
+
+/// Identify fused `Merge.interleave` → single `Output` chains eligible for
+/// per-record streaming writes (issue #72). The buffered Output arm waits
+/// until the Merge arm has produced every record before invoking the
+/// writer; under a slow upstream Source this defeats the live back-
+/// pressure #67 delivered, because every record sits in
+/// `ctx.node_buffers[merge_idx]` until the Merge finishes.
+///
+/// The streaming path moves the Output's writer into a `tokio::spawn`-ed
+/// task that consumes from a bounded `mpsc::channel` populated by the
+/// fused Merge arm. The Output arm becomes a no-op at its topo turn;
+/// per-record `Writer::write_record` fires concurrently with Merge
+/// production, and back-pressure flows writer → Merge → Source.
+///
+/// Eligibility (every predicate must hold; otherwise the buffered path
+/// runs):
+///
+/// - The Output node has exactly one incoming edge, and that predecessor
+///   is a `PlanNode::Merge`.
+/// - The Merge is `mode: interleave` with every direct predecessor a
+///   `PlanNode::Source` (the [`compute_merge_interleave_fused_sources`]
+///   predicate — same membership the fused arm relies on).
+/// - The Merge has no other downstream consumer besides this one Output
+///   (no fan-out from the Merge).
+/// - The Output is not in the init-phase ancestor closure.
+/// - The Output's writer entry lives in `writers.single` (not
+///   `fan_out_writers` — splitting / per-source-file writers handle
+///   their own buffering).
+/// - The OutputConfig has no `split:` block — `SplittingWriter` owns its
+///   file rotation lifecycle and is incompatible with the streaming
+///   writer task.
+/// - Correlation buffering is inactive pipeline-wide
+///   (`!any_source_has_correlation_key`). The correlation path defers
+///   writes to [`PlanNode::CorrelationCommit`] which is incompatible
+///   with per-record write at Merge-arm time.
+///
+/// Returns the list of streaming specs (one per qualifying Output). Empty
+/// for pipelines that don't match the topology, leaving every Output on
+/// the existing buffered path. See
+/// https://github.com/rustpunk/clinker/issues/72 for the rationale.
+fn compute_streaming_output_specs(
+    plan: &crate::plan::execution::ExecutionPlanDag,
+    config: &PipelineConfig,
+    fused_merge_sources: &HashSet<String>,
+    init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
+    output_configs: &[OutputConfig],
+    writers: &WriterRegistry,
+) -> Vec<StreamingOutputSpec> {
+    use crate::plan::execution::PlanNode;
+
+    // Pipeline-wide correlation buffering disables streaming for every
+    // Output — the CorrelationCommit terminal owns the actual writes.
+    if config.any_source_has_correlation_key() {
+        return Vec::new();
+    }
+
+    let mut specs: Vec<StreamingOutputSpec> = Vec::new();
+    for output_idx in plan.graph.node_indices() {
+        let PlanNode::Output {
+            name: output_name, ..
+        } = &plan.graph[output_idx]
+        else {
+            continue;
+        };
+        if init_phase_set.contains(&output_idx) {
+            continue;
+        }
+
+        // Exactly one incoming edge, and that predecessor is a Merge.
+        let mut incoming = plan
+            .graph
+            .neighbors_directed(output_idx, petgraph::Direction::Incoming);
+        let Some(merge_idx) = incoming.next() else {
+            continue;
+        };
+        if incoming.next().is_some() {
+            continue;
+        }
+        let PlanNode::Merge {
+            name: merge_name, ..
+        } = &plan.graph[merge_idx]
+        else {
+            continue;
+        };
+
+        // The Merge must be fused — every predecessor is a Source whose
+        // name appears in the fused-source set the Merge arm uses to
+        // run a live `tokio::select!`.
+        let merge_predecessors: Vec<_> = plan
+            .graph
+            .neighbors_directed(merge_idx, petgraph::Direction::Incoming)
+            .collect();
+        if merge_predecessors.is_empty() {
+            continue;
+        }
+        let all_fused_sources = merge_predecessors.iter().all(|p| match &plan.graph[*p] {
+            PlanNode::Source { name, .. } => fused_merge_sources.contains(name),
+            _ => false,
+        });
+        if !all_fused_sources {
+            continue;
+        }
+
+        // The Merge has exactly one outgoing edge (this Output). Anything
+        // else and the buffered path is needed so siblings still see the
+        // merged records via `node_buffers`.
+        let merge_downstream_count = plan
+            .graph
+            .neighbors_directed(merge_idx, petgraph::Direction::Outgoing)
+            .count();
+        if merge_downstream_count != 1 {
+            continue;
+        }
+
+        // Output writer registry checks: must be a single writer, not a
+        // fan-out, and the OutputConfig must not declare a split block.
+        if !writers.single.contains_key(output_name) {
+            continue;
+        }
+        if writers.fan_out.contains_key(output_name) {
+            continue;
+        }
+        let Some(out_cfg) = output_configs.iter().find(|o| &o.name == output_name) else {
+            continue;
+        };
+        if out_cfg.split.is_some() {
+            continue;
+        }
+
+        // Pre-compute the schema-check + projection metadata so the
+        // spawned task carries owned `Arc<Schema>` / `Vec<String>` / the
+        // upstream node name for E314 diagnostics, with no borrow back
+        // into the plan.
+        let expected_input_schema = plan.graph[output_idx]
+            .expected_input_schema_in(plan)
+            .cloned();
+        let cxl_emit_names: Vec<String> = plan.graph[output_idx].cxl_emit_names_in(plan);
+
+        specs.push(StreamingOutputSpec {
+            merge_idx,
+            output_idx,
+            output_name: output_name.clone(),
+            merge_name: merge_name.clone(),
+            out_cfg: out_cfg.clone(),
+            expected_input_schema,
+            cxl_emit_names,
+        });
+    }
+    specs
+}
+
+/// Plan-time metadata for a streaming `Output` task spawned at executor
+/// entry. Carries every field the task needs in owned form so it can run
+/// independently of the borrowed `&PipelineConfig` / `&ExecutionPlanDag`
+/// references that anchor the dispatcher's `ExecutorContext`.
+pub(crate) struct StreamingOutputSpec {
+    /// `NodeIndex` of the upstream `Merge` node. The Merge arm looks up
+    /// its sender in [`dispatch::ExecutorContext::streaming_output_senders`]
+    /// keyed by this index.
+    pub(crate) merge_idx: petgraph::graph::NodeIndex,
+    /// `NodeIndex` of the downstream `Output` node. The Output arm
+    /// short-circuits when its index appears in
+    /// [`dispatch::ExecutorContext::streaming_output_nodes`].
+    pub(crate) output_idx: petgraph::graph::NodeIndex,
+    pub(crate) output_name: String,
+    pub(crate) merge_name: String,
+    pub(crate) out_cfg: OutputConfig,
+    /// Compile-time input schema for the Output; used by the streaming
+    /// task to run the same `check_input_schema` invariant the buffered
+    /// path enforces (E314 SchemaMismatch diagnostics).
+    pub(crate) expected_input_schema: Option<Arc<Schema>>,
+    /// Upstream `cxl_emit_names_in` result — passed to
+    /// `project_output_from_record` so the streaming projection drops
+    /// passthroughs the user didn't explicitly emit (matching the
+    /// buffered path's `include_widened: false` semantic).
+    pub(crate) cxl_emit_names: Vec<String>,
+}
+
+/// Per-task return shape merged into the dispatcher's
+/// [`dispatch::ExecutorContext`] after `JoinHandle::await`. Mirrors the
+/// counter / timer / error accounting the buffered Output arm performs
+/// inline; the streaming task accumulates these locally and the
+/// dispatcher folds them back into `ctx.counters`, `ctx.records_emitted`,
+/// `ctx.write_timer`, `ctx.projection_timer`, `ctx.ok_source_rows`, and
+/// `ctx.output_errors`.
+pub(crate) struct StreamingOutputTaskOutput {
+    pub(crate) records_written: u64,
+    pub(crate) records_emitted: u64,
+    pub(crate) seen_row_nums: HashSet<u64>,
+    pub(crate) write_timer: stage_metrics::CumulativeTimer,
+    pub(crate) projection_timer: stage_metrics::CumulativeTimer,
+    pub(crate) errors: Vec<PipelineError>,
+    pub(crate) stage_metrics: Vec<stage_metrics::StageMetrics>,
+}
+
+/// Streaming-output writer task body. Drains the `mpsc::Receiver`
+/// populated by the fused `Merge.interleave` arm, projects each record
+/// through `project_output_from_record`, lazily constructs the writer on
+/// the first record, calls `Writer::write_record` per record, and
+/// flushes at channel close. Errors are accumulated rather than aborting
+/// the loop so the dispatcher can surface them alongside any sibling
+/// `output_errors`. See [`StreamingOutputSpec`] for the eligibility
+/// predicate and https://github.com/rustpunk/clinker/issues/72 for the
+/// rationale.
+async fn streaming_output_task(
+    mut rx: tokio::sync::mpsc::Receiver<(Record, u64)>,
+    raw_writer: Box<dyn Write + Send>,
+    spec: StreamingOutputSpec,
+) -> StreamingOutputTaskOutput {
+    use crate::projection::project_output_from_record;
+
+    let mut out = StreamingOutputTaskOutput {
+        records_written: 0,
+        records_emitted: 0,
+        seen_row_nums: HashSet::new(),
+        write_timer: stage_metrics::CumulativeTimer::new(),
+        projection_timer: stage_metrics::CumulativeTimer::new(),
+        errors: Vec::new(),
+        stage_metrics: Vec::new(),
+    };
+    let cxl_emit_names_opt: Option<&[String]> = if spec.cxl_emit_names.is_empty() {
+        None
+    } else {
+        Some(&spec.cxl_emit_names)
+    };
+
+    let mut scan_timer_slot: Option<stage_metrics::StageTimer> = Some(
+        stage_metrics::StageTimer::new(stage_metrics::StageName::SchemaScan),
+    );
+    let mut writer: Option<Box<dyn FormatWriter>> = None;
+    let mut raw_writer_slot: Option<Box<dyn Write + Send>> = Some(raw_writer);
+
+    while let Some((record, rn)) = rx.recv().await {
+        // E314 invariant — every record arriving at the Output must
+        // match the compile-time input schema. Matches the buffered
+        // Output arm's pre-loop check, hoisted to per-record under
+        // streaming because the channel can interleave records across
+        // multiple Source predecessors.
+        if let Some(expected) = spec.expected_input_schema.as_ref()
+            && !Arc::ptr_eq(expected, record.schema())
+            && expected.columns() != record.schema().columns()
+        {
+            out.errors.push(PipelineError::SchemaMismatch {
+                expected: Arc::clone(expected),
+                actual: Arc::clone(record.schema()),
+                operator_name: spec.output_name.clone(),
+                operator_kind: "output",
+                upstream_name: spec.merge_name.clone(),
+            });
+            continue;
+        }
+
+        let projected = {
+            let _guard = out.projection_timer.guard();
+            project_output_from_record(&record, &spec.out_cfg, cxl_emit_names_opt)
+        };
+
+        // Lazy writer construction: defer until we have the first
+        // record's projected schema so the writer's column list matches
+        // what `project_output_from_record` actually emits (same source
+        // of truth as the buffered Output arm at dispatch.rs's
+        // `output_schema = Arc::clone(projected.schema())`).
+        if writer.is_none() {
+            let raw = raw_writer_slot
+                .take()
+                .expect("raw_writer_slot is Some until first record arrives");
+            let schema = Arc::clone(projected.schema());
+            match build_format_writer(&spec.out_cfg, raw, schema) {
+                Ok(w) => {
+                    writer = Some(w);
+                    if let Some(timer) = scan_timer_slot.take() {
+                        out.stage_metrics.push(timer.finish(1, 1));
+                    }
+                }
+                Err(e) => {
+                    out.errors.push(e);
+                    if let Some(timer) = scan_timer_slot.take() {
+                        out.stage_metrics.push(timer.finish(0, 0));
+                    }
+                    // Drain the rest of the channel so the Merge arm's
+                    // bounded send doesn't deadlock — the streaming
+                    // task must keep consuming even when the writer is
+                    // dead, otherwise back-pressure stalls the whole
+                    // pipeline.
+                    while rx.recv().await.is_some() {}
+                    return out;
+                }
+            }
+        }
+
+        let write_result = {
+            let _guard = out.write_timer.guard();
+            writer
+                .as_mut()
+                .expect("writer is Some after lazy construction")
+                .write_record(&projected)
+        };
+        match write_result {
+            Ok(()) => {
+                out.records_written += 1;
+                out.records_emitted += 1;
+                out.seen_row_nums.insert(rn);
+            }
+            Err(e) => {
+                out.errors.push(PipelineError::from(e));
+                while rx.recv().await.is_some() {}
+                return out;
+            }
+        }
+    }
+
+    // Channel closed — every Merge predecessor's receiver returned None,
+    // so no more records will arrive. Flush whatever the writer has
+    // buffered. `writer.is_none()` is the empty-stream case (zero
+    // records arrived); matches the buffered path's
+    // `if unbuffered.is_empty() { return Ok(()); }` short-circuit.
+    if let Some(timer) = scan_timer_slot.take() {
+        out.stage_metrics.push(timer.finish(0, 0));
+    }
+    if let Some(mut w) = writer {
+        let flush_result = {
+            let _guard = out.write_timer.guard();
+            w.flush()
+        };
+        if let Err(e) = flush_result {
+            out.errors.push(PipelineError::from(e));
+        }
+    }
+    out
 }
 
 fn compute_init_phase_node_set(

--- a/crates/clinker-core/src/executor/stage_metrics.rs
+++ b/crates/clinker-core/src/executor/stage_metrics.rs
@@ -196,6 +196,15 @@ impl CumulativeTimer {
         }
     }
 
+    /// Fold another timer's accumulated time into `self`. Used by the
+    /// streaming-output writer task to merge its task-local timer back
+    /// into the dispatcher's `ctx.write_timer` / `ctx.projection_timer`
+    /// after `JoinHandle::await`, matching the cross-task convention
+    /// already established by `ChunkTimers::merge` for rayon folds.
+    pub fn add(&mut self, other: CumulativeTimer) {
+        self.nanos = self.nanos.saturating_add(other.nanos);
+    }
+
     /// Consume the timer and produce a [`StageMetrics`] entry.
     pub fn finish(self, name: StageName, records_in: u64, records_out: u64) -> StageMetrics {
         StageMetrics {

--- a/crates/clinker-core/src/pipeline/arena.rs
+++ b/crates/clinker-core/src/pipeline/arena.rs
@@ -154,6 +154,8 @@ impl Arena {
             fields.iter().map(|f| anchor_schema.index(f)).collect();
         let records =
             project_records_into_minimal(rows.iter().map(|(r, _)| r), &field_indices, budget)?;
+        #[cfg(debug_assertions)]
+        debug_assert_uniform_column_variants(&schema, &records);
         Ok(Arena { schema, records })
     }
 
@@ -242,6 +244,48 @@ pub(crate) fn estimated_size(record: &MinimalRecord) -> usize {
         })
         .sum();
     base + fields
+}
+
+/// Guards the assumption that upstream operators emit `Record`s whose
+/// `Value` variants are uniform per column before they reach a
+/// node-rooted `Arena::from_records`. Coercion lives at the source
+/// boundary (`wrap_with_schema_coercion`); operators in between
+/// preserve the variant by construction. A partial-coercion regression
+/// surfaces here as a per-column variant mismatch between rows. Null
+/// is exempted because it is the unit element for every type.
+#[cfg(debug_assertions)]
+fn debug_assert_uniform_column_variants(schema: &Arc<Schema>, records: &[MinimalRecord]) {
+    let column_count = schema.column_count();
+    let mut expected: Vec<Option<&'static str>> = vec![None; column_count];
+    for (row, rec) in records.iter().enumerate() {
+        for (col, slot) in expected.iter_mut().enumerate() {
+            let Some(v) = rec.get(col) else { continue };
+            let tag = match v {
+                Value::Null => continue,
+                Value::Bool(_) => "Bool",
+                Value::Integer(_) => "Integer",
+                Value::Float(_) => "Float",
+                Value::String(_) => "String",
+                Value::Date(_) => "Date",
+                Value::DateTime(_) => "DateTime",
+                Value::Array(_) => "Array",
+                Value::Map(_) => "Map",
+            };
+            match *slot {
+                None => *slot = Some(tag),
+                Some(prev) if prev == tag => {}
+                Some(prev) => {
+                    let column_name = schema.column_name(col).unwrap_or("?");
+                    panic!(
+                        "Arena::from_records: column `{column_name}` variant drift at row {row}: \
+                         saw {prev} earlier, now {tag}. \
+                         Upstream coercion (wrap_with_schema_coercion or operator emit) \
+                         must produce a uniform Value variant per column."
+                    );
+                }
+            }
+        }
+    }
 }
 
 /// Errors from Arena construction.
@@ -634,5 +678,25 @@ mod tests {
             }
             other => panic!("expected MemoryBudgetExceeded from shared budget; got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn from_records_passes_uniform_column_variants() {
+        use clinker_record::Record;
+        let schema = Arc::new(Schema::new(vec!["id".into(), "name".into()]));
+        let rows: Vec<(Record, u64)> = (0..50)
+            .map(|i| {
+                let v = if i % 5 == 0 {
+                    vec![Value::Integer(i), Value::Null]
+                } else {
+                    vec![Value::Integer(i), Value::String(format!("r{i}").into())]
+                };
+                (Record::new(Arc::clone(&schema), v), i as u64)
+            })
+            .collect();
+        let mut budget = MemoryBudget::new(u64::MAX, 1.0);
+        let arena = Arena::from_records(&rows, &["id".into(), "name".into()], &schema, &mut budget)
+            .expect("uniform-variant arena builds");
+        assert_eq!(arena.record_count(), 50);
     }
 }

--- a/crates/clinker-core/src/pipeline/arena.rs
+++ b/crates/clinker-core/src/pipeline/arena.rs
@@ -260,17 +260,10 @@ fn debug_assert_uniform_column_variants(schema: &Arc<Schema>, records: &[Minimal
     for (row, rec) in records.iter().enumerate() {
         for (col, slot) in expected.iter_mut().enumerate() {
             let Some(v) = rec.get(col) else { continue };
-            let tag = match v {
-                Value::Null => continue,
-                Value::Bool(_) => "Bool",
-                Value::Integer(_) => "Integer",
-                Value::Float(_) => "Float",
-                Value::String(_) => "String",
-                Value::Date(_) => "Date",
-                Value::DateTime(_) => "DateTime",
-                Value::Array(_) => "Array",
-                Value::Map(_) => "Map",
-            };
+            if matches!(v, Value::Null) {
+                continue;
+            }
+            let tag = v.type_name();
             match *slot {
                 None => *slot = Some(tag),
                 Some(prev) if prev == tag => {}

--- a/crates/clinker-core/tests/merge_interleave.rs
+++ b/crates/clinker-core/tests/merge_interleave.rs
@@ -9,19 +9,22 @@
 //! for the topology and assertion.
 
 use std::collections::HashMap;
-use std::io::{Cursor, Read};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use clinker_bench_support::io::SharedBuffer;
+use clinker_bench_support::io::{SharedBuffer, fast_reader, slow_reader};
 use clinker_core::config::{CompileContext, parse_config};
 use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
 use clinker_core::source::multi_file::FileSlot;
 
 fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(PathBuf::from(format!("{name}.csv")), fast_reader(csv))
+}
+
+fn slow_slot(name: &str, csv: &str, delay: Duration) -> FileSlot {
     FileSlot::new(
         PathBuf::from(format!("{name}.csv")),
-        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+        slow_reader(csv, delay),
     )
 }
 
@@ -212,68 +215,6 @@ async fn seeded_interleave_is_reproducible() {
     );
     assert_per_source_fifo(&first);
     assert_eq!(first.len(), 10);
-}
-
-/// `std::io::Read` adapter that sleeps for `delay` after each CSV
-/// row boundary (newline byte). Lives in `spawn_blocking` alongside
-/// the format reader, so `std::thread::sleep` does not block the
-/// tokio reactor. Used to gate `src_a` so the CSV format reader
-/// yields one row every `delay` while `src_b`'s reader pushes all
-/// rows immediately.
-struct DelayedRowReader {
-    bytes: Vec<u8>,
-    pos: usize,
-    delay: Duration,
-    rows_read: usize,
-}
-
-impl DelayedRowReader {
-    fn new(csv: &str, delay: Duration) -> Self {
-        Self {
-            bytes: csv.as_bytes().to_vec(),
-            pos: 0,
-            delay,
-            rows_read: 0,
-        }
-    }
-}
-
-impl Read for DelayedRowReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if self.pos >= self.bytes.len() {
-            return Ok(0);
-        }
-        // Read up to the next newline (or buffer end), one row at a
-        // time. The CSV format reader buffers internally, but
-        // returning row-bounded chunks keeps the sleep aligned with
-        // record boundaries.
-        let remaining = &self.bytes[self.pos..];
-        let chunk_end = remaining
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|p| p + 1)
-            .unwrap_or(remaining.len());
-        let n = chunk_end.min(buf.len());
-        buf[..n].copy_from_slice(&remaining[..n]);
-        self.pos += n;
-        // After the buffer ends with a newline, the next read starts
-        // a new row. Sleep before yielding the next row's bytes —
-        // skip the first sleep (header row needs no delay).
-        if n > 0 && remaining[..n].ends_with(b"\n") {
-            self.rows_read += 1;
-            if self.rows_read >= 1 && self.pos < self.bytes.len() {
-                std::thread::sleep(self.delay);
-            }
-        }
-        Ok(n)
-    }
-}
-
-fn slow_slot(name: &str, csv: &str, delay: Duration) -> FileSlot {
-    FileSlot::new(
-        PathBuf::from(format!("{name}.csv")),
-        Box::new(DelayedRowReader::new(csv, delay)),
-    )
 }
 
 /// Live-channel back-pressure: a slow `src_a` (50 ms sleep at the

--- a/crates/clinker-core/tests/merge_interleave.rs
+++ b/crates/clinker-core/tests/merge_interleave.rs
@@ -360,6 +360,268 @@ async fn interleave_does_not_block_peer_on_slow_source() {
     );
 }
 
+/// Four-Source `mode: interleave` pipeline YAML. Each Source emits
+/// the same two-column schema (`id, tag`) so they share an
+/// `output_schema` at the Merge boundary. Output sinks to `out`.
+fn pipeline_yaml_four_sources() -> String {
+    r#"
+pipeline:
+  name: merge_interleave_fairness_four
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_c
+    config:
+      name: src_c
+      type: csv
+      path: c.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_d
+    config:
+      name: src_d
+      type: csv
+      path: d.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b, src_c, src_d]
+    config:
+      mode: interleave
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    .to_string()
+}
+
+/// CSV body for a tag-prefixed source: `id` is the row number,
+/// `tag` is `"{prefix}-{N}"`. Mirrors `src_a_csv` / `src_b_csv` but
+/// parametric over the prefix so the four-source fairness test can
+/// build `a-*`, `b-*`, `c-*`, `d-*` streams from the same routine.
+fn tagged_csv(prefix: char, count: u32) -> String {
+    let mut s = String::from("id,tag\n");
+    for i in 1..=count {
+        s.push_str(&format!("{i},{prefix}-{i}\n"));
+    }
+    s
+}
+
+/// Generalized per-source FIFO check for an arbitrary set of tag
+/// prefixes. Each source's subsequence in `body` (rows whose tag
+/// begins `{prefix}-`) must be strictly increasing in the numeric
+/// suffix. Cross-source order is unconstrained.
+fn assert_per_source_fifo_n(body: &[String], prefixes: &[char]) {
+    let mut last: HashMap<char, u32> = prefixes.iter().map(|p| (*p, 0u32)).collect();
+    for row in body {
+        let tag = tag_of(row);
+        let prefix = tag.chars().next().expect("tag has at least one char");
+        assert!(
+            prefixes.contains(&prefix),
+            "unexpected tag prefix `{prefix}` in row {row:?}; \
+             allowed: {prefixes:?}"
+        );
+        let n: u32 = tag
+            .strip_prefix(&format!("{prefix}-"))
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("tag does not match `{prefix}-N`: {tag:?}"));
+        let prev = *last.get(&prefix).unwrap();
+        assert!(
+            n > prev,
+            "src_{prefix} subsequence not FIFO: saw {tag} after {prefix}-{prev}",
+        );
+        last.insert(prefix, n);
+    }
+}
+
+/// Multi-source fairness under live `Merge.interleave` with four
+/// Source predecessors at mixed produce rates.
+///
+/// Topology: src_a (0 ms / row), src_b (10 ms), src_c (25 ms),
+/// src_d (50 ms), 10 rows each, all feeding one `merge.interleave`
+/// into a CSV sink.
+///
+/// Surfaces any fairness regression in the fused arm's round-robin
+/// poll cursor (`dispatch.rs::merge_fused_interleave`) before #74
+/// extends the same pattern to Transform-arm predecessors. The
+/// invariants below are what the live-channel design promises:
+///
+/// 1. **Per-source FIFO** survives for every source (each source's
+///    records appear in `1, 2, …, 10` order — cross-source order is
+///    unconstrained).
+/// 2. **No starvation:** every source's final record (`{prefix}-10`)
+///    reaches output. If the merge dropped a closed receiver early,
+///    a source's tail would go missing.
+/// 3. **Parallel ingest, not serialized:** total wall-clock runtime
+///    is bounded by the slowest source's runtime plus modest
+///    overhead — `concat`-style serialization across the four would
+///    sum to ~850 ms; live interleave should land well under that.
+/// 4. **No single source monopolizes a contiguous tail:** in
+///    particular, the slowest source's records spread across the
+///    second half of the output. (The fastest source's records
+///    necessarily cluster early — `0 ms / row` means src_a fully
+///    drains within microseconds while peers are still on their
+///    first inter-row sleep. Asserting it lands in both quartiles
+///    would require artificial pacing antagonistic to live ingest;
+///    the slowest-source spread is the spec-meaningful direction.)
+#[tokio::test(flavor = "multi_thread")]
+async fn interleave_fairness_under_four_predecessors() {
+    use std::time::Instant;
+
+    let yaml = pipeline_yaml_four_sources();
+    let config = parse_config(&yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slow_slot(
+                "a",
+                &tagged_csv('a', 10),
+                Duration::from_millis(0),
+            )],
+        ),
+        (
+            "src_b".to_string(),
+            vec![slow_slot(
+                "b",
+                &tagged_csv('b', 10),
+                Duration::from_millis(10),
+            )],
+        ),
+        (
+            "src_c".to_string(),
+            vec![slow_slot(
+                "c",
+                &tagged_csv('c', 10),
+                Duration::from_millis(25),
+            )],
+        ),
+        (
+            "src_d".to_string(),
+            vec![slow_slot(
+                "d",
+                &tagged_csv('d', 10),
+                Duration::from_millis(50),
+            )],
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let start = Instant::now();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .await
+            .expect("pipeline executes");
+    let elapsed = start.elapsed();
+
+    assert_eq!(report.counters.dlq_count, 0);
+    let output = buf.as_string();
+    let body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    assert_eq!(body.len(), 40, "expected 40 records (10 × 4), got {body:?}");
+
+    // Invariant 1 — per-source FIFO for all four sources.
+    assert_per_source_fifo_n(&body, &['a', 'b', 'c', 'd']);
+
+    // Invariant 2 — no starvation: every source's last record appears.
+    for prefix in ['a', 'b', 'c', 'd'] {
+        let last_tag = format!("{prefix}-10");
+        assert!(
+            body.iter().any(|r| tag_of(r) == last_tag),
+            "src_{prefix}'s tail record `{last_tag}` missing from output {body:?}",
+        );
+        let count = body
+            .iter()
+            .filter(|r| tag_of(r).starts_with(&format!("{prefix}-")))
+            .count();
+        assert_eq!(
+            count, 10,
+            "src_{prefix} contributed {count} records, expected 10"
+        );
+    }
+
+    // Invariant 3 — parallel ingest. Slowest source alone runs
+    // 10 × 50 ms = ~500 ms; `concat`-style serialization across
+    // all four would sum to ~850 ms. Allow generous headroom for
+    // CI jitter while still proving the inputs run in parallel.
+    assert!(
+        elapsed < Duration::from_millis(800),
+        "pipeline took {elapsed:?}, expected < 800 ms — \
+         predecessors appear to be serialized rather than ingested in parallel"
+    );
+
+    // Invariant 4 — the slowest source's records span the second
+    // half of the output. With src_d producing one record every
+    // 50 ms over a ~500 ms run and faster peers fully drained
+    // earlier, at least one src_d record must land in the back
+    // half of the merged stream (positions 20..40). If the merge
+    // ever decided to buffer src_d to completion before emitting
+    // a peer-finished signal, src_d's records would land at the
+    // tail; if it ever pre-buffered all sources, they'd land
+    // wherever the round-robin cursor places them. Either
+    // regression breaks live back-pressure.
+    let half = body.len() / 2;
+    let d_in_back_half = body[half..].iter().any(|r| tag_of(r).starts_with("d-"));
+    assert!(
+        d_in_back_half,
+        "slowest source src_d has no record in the back half of output {body:?} — \
+         live interleave should spread the slow source across the full run",
+    );
+
+    // Invariant 4b — no source's records form one giant
+    // contiguous block. The fairness regression of concern is
+    // "merge greedily drains one channel before turning to the
+    // next." Reject any run of more than 12 same-prefix rows
+    // (more than 30% of the output is one source) — that's a
+    // generous margin over the natural 10-record bound per
+    // source, allowing for the early src_a cluster.
+    let mut run_prefix: Option<char> = None;
+    let mut run_len = 0usize;
+    let mut max_run = 0usize;
+    for row in &body {
+        let p = tag_of(row).chars().next().expect("non-empty tag");
+        if Some(p) == run_prefix {
+            run_len += 1;
+        } else {
+            run_prefix = Some(p);
+            run_len = 1;
+        }
+        max_run = max_run.max(run_len);
+    }
+    assert!(
+        max_run <= 12,
+        "longest contiguous same-source run is {max_run} (>12 of 40); \
+         the merge arm is draining one source before any other gets a turn. \
+         output: {body:?}",
+    );
+}
+
 /// Two different seeds produce different interleavings. With 8+8
 /// records the probability of two distinct fastrand schedules
 /// coinciding bit-for-bit is negligible; this would only fail on a

--- a/crates/clinker-core/tests/streaming_output.rs
+++ b/crates/clinker-core/tests/streaming_output.rs
@@ -27,20 +27,17 @@
 //!    scheduler is non-deterministic.
 
 use std::collections::HashMap;
-use std::io::{self, Cursor, Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use clinker_bench_support::io::SharedBuffer;
+use clinker_bench_support::io::{SharedBuffer, fast_reader, slow_reader};
 use clinker_core::config::{CompileContext, parse_config};
 use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
 use clinker_core::source::multi_file::FileSlot;
 
 fn slot(name: &str, csv: &str) -> FileSlot {
-    FileSlot::new(
-        PathBuf::from(format!("{name}.csv")),
-        Box::new(Cursor::new(csv.as_bytes().to_vec())),
-    )
+    FileSlot::new(PathBuf::from(format!("{name}.csv")), fast_reader(csv))
 }
 
 fn writer(buf: &SharedBuffer) -> Box<dyn Write + Send> {
@@ -116,55 +113,10 @@ fn src_b_csv(count: u32) -> String {
     s
 }
 
-/// `std::io::Read` adapter that sleeps for `delay` after each CSV row
-/// boundary. Same shape as `merge_interleave.rs::DelayedRowReader`;
-/// copied here to keep tests independent.
-struct DelayedRowReader {
-    bytes: Vec<u8>,
-    pos: usize,
-    delay: Duration,
-    rows_read: usize,
-}
-
-impl DelayedRowReader {
-    fn new(csv: &str, delay: Duration) -> Self {
-        Self {
-            bytes: csv.as_bytes().to_vec(),
-            pos: 0,
-            delay,
-            rows_read: 0,
-        }
-    }
-}
-
-impl Read for DelayedRowReader {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        if self.pos >= self.bytes.len() {
-            return Ok(0);
-        }
-        let remaining = &self.bytes[self.pos..];
-        let chunk_end = remaining
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|p| p + 1)
-            .unwrap_or(remaining.len());
-        let n = chunk_end.min(buf.len());
-        buf[..n].copy_from_slice(&remaining[..n]);
-        self.pos += n;
-        if n > 0 && remaining[..n].ends_with(b"\n") {
-            self.rows_read += 1;
-            if self.rows_read >= 1 && self.pos < self.bytes.len() {
-                std::thread::sleep(self.delay);
-            }
-        }
-        Ok(n)
-    }
-}
-
 fn slow_slot(name: &str, csv: &str, delay: Duration) -> FileSlot {
     FileSlot::new(
         PathBuf::from(format!("{name}.csv")),
-        Box::new(DelayedRowReader::new(csv, delay)),
+        slow_reader(csv, delay),
     )
 }
 

--- a/crates/clinker-core/tests/streaming_output.rs
+++ b/crates/clinker-core/tests/streaming_output.rs
@@ -1,0 +1,357 @@
+//! Integration tests for streaming-Output writes under fused
+//! `Merge.interleave` (issue #72).
+//!
+//! Sibling to `merge_interleave.rs`: those tests exercise the Merge
+//! arm's record ordering and live back-pressure with a buffered Output
+//! (records pile up in `node_buffers[merge_idx]` until the Merge
+//! finishes, then the Output arm writes them all). These tests cover
+//! the next step of that pipeline: a single Output downstream of a
+//! fused Merge.interleave takes the streaming path, so
+//! `Writer::write_record` fires per record as Merge emits, concurrent
+//! with Merge production.
+//!
+//! Black-box wall-clock discrimination of streaming-vs-buffered at the
+//! `std::io::Write` layer is defeated by the 64 KB `BufWriter` that
+//! `build_format_writer` wraps every raw writer in — the underlying
+//! `Write::write` callback fires only at end-of-task flush regardless
+//! of mode. These tests instead verify what the user-visible contract
+//! actually guarantees:
+//!
+//! 1. Output correctness (per-source FIFO, no DLQ, total counters).
+//! 2. End-to-end back-pressure under a slow source — the pipeline
+//!    must not deadlock when the source's bounded channel fills while
+//!    the streaming writer is mid-drain.
+//! 3. Topology repeat-stability — the per-source FIFO invariant must
+//!    survive many runs because the streaming task and the Merge arm
+//!    race on a bounded `tokio::sync::mpsc::channel` and tokio's
+//!    scheduler is non-deterministic.
+
+use std::collections::HashMap;
+use std::io::{self, Cursor, Read, Write};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, parse_config};
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::source::multi_file::FileSlot;
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn Write + Send> {
+    Box::new(buf.clone())
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// Two-source `Merge.interleave → Output` pipeline. Hard-codes
+/// `mode: interleave` and a single downstream Output so the executor's
+/// pre-pass at entry classifies this as a streamable topology under
+/// issue #72.
+fn pipeline_yaml() -> String {
+    r#"
+pipeline:
+  name: streaming_output_test
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: merge
+    name: merged
+    inputs: [src_a, src_b]
+    config:
+      mode: interleave
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    .to_string()
+}
+
+fn src_a_csv(count: u32) -> String {
+    let mut s = String::from("id,tag\n");
+    for i in 1..=count {
+        s.push_str(&format!("{i},a-{i}\n"));
+    }
+    s
+}
+
+fn src_b_csv(count: u32) -> String {
+    let mut s = String::from("id,tag\n");
+    for i in 1..=count {
+        s.push_str(&format!("{},b-{}\n", 100 + i, i));
+    }
+    s
+}
+
+/// `std::io::Read` adapter that sleeps for `delay` after each CSV row
+/// boundary. Same shape as `merge_interleave.rs::DelayedRowReader`;
+/// copied here to keep tests independent.
+struct DelayedRowReader {
+    bytes: Vec<u8>,
+    pos: usize,
+    delay: Duration,
+    rows_read: usize,
+}
+
+impl DelayedRowReader {
+    fn new(csv: &str, delay: Duration) -> Self {
+        Self {
+            bytes: csv.as_bytes().to_vec(),
+            pos: 0,
+            delay,
+            rows_read: 0,
+        }
+    }
+}
+
+impl Read for DelayedRowReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.pos >= self.bytes.len() {
+            return Ok(0);
+        }
+        let remaining = &self.bytes[self.pos..];
+        let chunk_end = remaining
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| p + 1)
+            .unwrap_or(remaining.len());
+        let n = chunk_end.min(buf.len());
+        buf[..n].copy_from_slice(&remaining[..n]);
+        self.pos += n;
+        if n > 0 && remaining[..n].ends_with(b"\n") {
+            self.rows_read += 1;
+            if self.rows_read >= 1 && self.pos < self.bytes.len() {
+                std::thread::sleep(self.delay);
+            }
+        }
+        Ok(n)
+    }
+}
+
+fn slow_slot(name: &str, csv: &str, delay: Duration) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(DelayedRowReader::new(csv, delay)),
+    )
+}
+
+/// Extract the `tag` column from a CSV body row (`id,tag\n`).
+fn tag_of(row: &str) -> &str {
+    row.split(',').nth(1).unwrap_or("").trim_end_matches('\r')
+}
+
+/// Per-source FIFO: `a-` records strictly ascending in N, `b-` records
+/// strictly ascending in N; cross-source order is unconstrained.
+fn assert_per_source_fifo(body: &[String]) {
+    let mut last_a: u32 = 0;
+    let mut last_b: u32 = 0;
+    for row in body {
+        let tag = tag_of(row);
+        if let Some(rest) = tag.strip_prefix("a-") {
+            let n: u32 = rest.parse().expect("a-tag parses");
+            assert!(n > last_a, "a-FIFO violated: a-{n} after a-{last_a}");
+            last_a = n;
+        } else if let Some(rest) = tag.strip_prefix("b-") {
+            let n: u32 = rest.parse().expect("b-tag parses");
+            assert!(n > last_b, "b-FIFO violated: b-{n} after b-{last_b}");
+            last_b = n;
+        } else {
+            panic!("unexpected tag in body: {tag:?}");
+        }
+    }
+}
+
+/// Single run of the streaming pipeline. Returns `(body_lines, counters)`.
+/// Body lines exclude the header row.
+async fn run_streaming_pipeline(
+    a_count: u32,
+    b_count: u32,
+    a_delay: Duration,
+) -> (Vec<String>, clinker_record::PipelineCounters) {
+    let yaml = pipeline_yaml();
+    let config = parse_config(&yaml).unwrap();
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slow_slot("a", &src_a_csv(a_count), a_delay)],
+        ),
+        ("src_b".to_string(), vec![slot("b", &src_b_csv(b_count))]),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .await
+            .expect("pipeline executes");
+    let output = buf.as_string();
+    let body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    (body, report.counters)
+}
+
+/// Streaming-Output correctness under a slow `src_a`. Asserts every
+/// record reaches the writer (per-source FIFO + total count), no DLQ,
+/// counters match the buffered Output arm's semantics, and the pipeline
+/// completes within a generous wall-clock bound (no deadlock when the
+/// streaming task's bounded channel meets a slow Source's bounded
+/// channel mid-drain).
+#[tokio::test(flavor = "multi_thread")]
+async fn streaming_writes_correct_output_under_slow_source() {
+    let start = Instant::now();
+    let (body, counters) = run_streaming_pipeline(10, 10, Duration::from_millis(50)).await;
+    let elapsed = start.elapsed();
+
+    assert_eq!(body.len(), 20, "expected 20 records, got {body:?}");
+    assert_per_source_fifo(&body);
+
+    // Every input record appears exactly once. Group by prefix then
+    // by numeric suffix so the comparison is stable across the run's
+    // arrival order — the streaming path interleaves cross-source
+    // records arbitrarily, which would defeat a string sort
+    // (`a-10` < `a-2` lexicographically).
+    let mut a_seen: Vec<u32> = body
+        .iter()
+        .filter_map(|r| tag_of(r).strip_prefix("a-").and_then(|s| s.parse().ok()))
+        .collect();
+    let mut b_seen: Vec<u32> = body
+        .iter()
+        .filter_map(|r| tag_of(r).strip_prefix("b-").and_then(|s| s.parse().ok()))
+        .collect();
+    a_seen.sort_unstable();
+    b_seen.sort_unstable();
+    assert_eq!(
+        a_seen,
+        (1..=10).collect::<Vec<u32>>(),
+        "src_a records must appear exactly once, got {a_seen:?}",
+    );
+    assert_eq!(
+        b_seen,
+        (1..=10).collect::<Vec<u32>>(),
+        "src_b records must appear exactly once, got {b_seen:?}",
+    );
+
+    // Counters match the buffered Output arm's semantics. `ok_count`
+    // counts DISTINCT `row_num` values across sources, and src_a /
+    // src_b both produce row_nums 1..=10, so the cross-source
+    // duplicates collide in the executor's `ok_source_rows` HashSet
+    // and `ok_count` lands at 10 (one count per distinct row_num).
+    assert_eq!(counters.dlq_count, 0, "no DLQ entries expected");
+    assert_eq!(
+        counters.records_written, 20,
+        "expected 20 writes (10 per source); counters={counters:?}",
+    );
+    assert_eq!(
+        counters.ok_count, 10,
+        "expected 10 distinct row_nums across sources; counters={counters:?}",
+    );
+    assert_eq!(
+        counters.total_count, 20,
+        "expected 20 total ingested records; counters={counters:?}",
+    );
+
+    // No deadlock. src_a's ~500 ms drain dominates; even under heavy
+    // CI jitter the pipeline must finish well under 2 s.
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "pipeline took {elapsed:?}, expected < 2 s — \
+         streaming task back-pressure may have deadlocked the run",
+    );
+}
+
+/// Streaming-Output preserves per-source FIFO across many independent
+/// runs. The streaming task and the fused Merge arm race on a
+/// bounded `tokio::sync::mpsc::channel` and tokio's scheduler is
+/// non-deterministic, so this test rerun catches a regression that
+/// would tear per-source order only on a fraction of runs.
+///
+/// 20 runs is the issue-72 stability bar; bumping this number is
+/// safe but each run costs ~50 ms of slow-source delay so the test
+/// is bounded at ~1 s when stable.
+#[tokio::test(flavor = "multi_thread")]
+async fn streaming_writes_stable_across_repeats() {
+    for run in 0..20 {
+        let (body, counters) = run_streaming_pipeline(5, 5, Duration::from_millis(10)).await;
+        assert_eq!(
+            body.len(),
+            10,
+            "run {run}: expected 10 records, got {body:?}",
+        );
+        assert_per_source_fifo(&body);
+        assert_eq!(counters.dlq_count, 0, "run {run}: no DLQ expected");
+        assert_eq!(
+            counters.records_written, 10,
+            "run {run}: counters={counters:?}",
+        );
+        let mut tags: Vec<&str> = body.iter().map(|r| tag_of(r)).collect();
+        tags.sort();
+        assert_eq!(
+            tags,
+            vec![
+                "a-1", "a-2", "a-3", "a-4", "a-5", "b-1", "b-2", "b-3", "b-4", "b-5"
+            ],
+            "run {run}: every input record must appear exactly once",
+        );
+    }
+}
+
+/// Streaming-Output sees every record from a fast pair of sources
+/// (no slow side) and produces a correct merged stream. Sanity check
+/// that the streaming task drains its `mpsc::Receiver` cleanly when
+/// both sources finish microseconds apart and the bounded channel
+/// never fills.
+#[tokio::test(flavor = "multi_thread")]
+async fn streaming_writes_correct_output_under_fast_sources() {
+    let (body, counters) = run_streaming_pipeline(20, 20, Duration::from_millis(0)).await;
+    assert_eq!(body.len(), 40, "expected 40 records, got {body:?}");
+    assert_per_source_fifo(&body);
+    assert_eq!(counters.dlq_count, 0);
+    assert_eq!(counters.records_written, 40);
+    assert_eq!(counters.total_count, 40);
+    let mut a_seen: Vec<u32> = body
+        .iter()
+        .filter_map(|r| tag_of(r).strip_prefix("a-").and_then(|s| s.parse().ok()))
+        .collect();
+    let mut b_seen: Vec<u32> = body
+        .iter()
+        .filter_map(|r| tag_of(r).strip_prefix("b-").and_then(|s| s.parse().ok()))
+        .collect();
+    a_seen.sort_unstable();
+    b_seen.sort_unstable();
+    assert_eq!(a_seen, (1..=20).collect::<Vec<u32>>());
+    assert_eq!(b_seen, (1..=20).collect::<Vec<u32>>());
+}

--- a/crates/clinker-core/tests/transform_stream_fusion.rs
+++ b/crates/clinker-core/tests/transform_stream_fusion.rs
@@ -27,11 +27,11 @@
 //!    asserting the windowed output is still well-formed.
 
 use std::collections::HashMap;
-use std::io::{Cursor, Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
-use clinker_bench_support::io::SharedBuffer;
+use clinker_bench_support::io::{SharedBuffer, fast_reader, slow_reader};
 use clinker_core::config::{CompileContext, parse_config};
 use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
 use clinker_core::source::multi_file::FileSlot;
@@ -50,63 +50,15 @@ fn writer(buf: &SharedBuffer) -> Box<dyn Write + Send> {
     Box::new(buf.clone())
 }
 
-/// `std::io::Read` adapter that sleeps for `delay` after each newline
-/// to pace per-row delivery from a synchronous CSV reader. Lives in
-/// `spawn_blocking`, so `std::thread::sleep` is acceptable.
-struct DelayedRowReader {
-    bytes: Vec<u8>,
-    pos: usize,
-    delay: Duration,
-    rows_read: usize,
-}
-
-impl DelayedRowReader {
-    fn new(csv: &str, delay: Duration) -> Self {
-        Self {
-            bytes: csv.as_bytes().to_vec(),
-            pos: 0,
-            delay,
-            rows_read: 0,
-        }
-    }
-}
-
-impl Read for DelayedRowReader {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if self.pos >= self.bytes.len() {
-            return Ok(0);
-        }
-        let remaining = &self.bytes[self.pos..];
-        let chunk_end = remaining
-            .iter()
-            .position(|&b| b == b'\n')
-            .map(|p| p + 1)
-            .unwrap_or(remaining.len());
-        let n = chunk_end.min(buf.len());
-        buf[..n].copy_from_slice(&remaining[..n]);
-        self.pos += n;
-        if n > 0 && remaining[..n].ends_with(b"\n") {
-            self.rows_read += 1;
-            if self.rows_read >= 1 && self.pos < self.bytes.len() {
-                std::thread::sleep(self.delay);
-            }
-        }
-        Ok(n)
-    }
-}
-
 fn slow_slot(name: &str, csv: &str, delay: Duration) -> FileSlot {
     FileSlot::new(
         PathBuf::from(format!("{name}.csv")),
-        Box::new(DelayedRowReader::new(csv, delay)),
+        slow_reader(csv, delay),
     )
 }
 
 fn fast_slot(name: &str, csv: &str) -> FileSlot {
-    FileSlot::new(
-        PathBuf::from(format!("{name}.csv")),
-        Box::new(Cursor::new(csv.as_bytes().to_vec())),
-    )
+    FileSlot::new(PathBuf::from(format!("{name}.csv")), fast_reader(csv))
 }
 
 fn body_lines(buf: &SharedBuffer) -> Vec<String> {

--- a/crates/clinker-core/tests/transform_stream_fusion.rs
+++ b/crates/clinker-core/tests/transform_stream_fusion.rs
@@ -1,0 +1,450 @@
+//! Integration tests for the Source → Transform fusion fast path
+//! (issue #74).
+//!
+//! When a `PlanNode::Transform`'s sole upstream is a `PlanNode::Source`
+//! with a parked receiver in `ExecutorContext::source_records`, the
+//! Transform takes ownership of the receiver and drives `recv().await`
+//! per-record evaluation directly. The Source dispatch arm short-
+//! circuits via the same `fused_sources` membership check that
+//! `merge_fused_interleave` uses (issue #67 pattern).
+//!
+//! These tests pin two pieces of behavior:
+//!
+//! 1. A `src (slow reader) → transform → out` pipeline produces the
+//!    correct output. If the fusion plumbing has misrouted the Source's
+//!    receiver — e.g. the Source arm runs even though `fused_sources`
+//!    contains the name, or the Transform arm doesn't take the receiver
+//!    out of `source_records` — the Source arm's defense-in-depth
+//!    `Internal` error at `dispatch.rs` fires loudly. Passing the test
+//!    proves fusion is wired end-to-end.
+//!
+//! 2. A windowed Transform (`window:` block on the parent transform)
+//!    is NOT eligible for fusion and continues to consume a pre-drained
+//!    Vec from the upstream Source's `node_buffers` entry. The
+//!    eligibility predicate in `compute_transform_fused_sources` is
+//!    what enforces this; the test verifies the predicate's exclusion
+//!    by running a windowed transform against a slow source and
+//!    asserting the windowed output is still well-formed.
+
+use std::collections::HashMap;
+use std::io::{Cursor, Read, Write};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, parse_config};
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::source::multi_file::FileSlot;
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn Write + Send> {
+    Box::new(buf.clone())
+}
+
+/// `std::io::Read` adapter that sleeps for `delay` after each newline
+/// to pace per-row delivery from a synchronous CSV reader. Lives in
+/// `spawn_blocking`, so `std::thread::sleep` is acceptable.
+struct DelayedRowReader {
+    bytes: Vec<u8>,
+    pos: usize,
+    delay: Duration,
+    rows_read: usize,
+}
+
+impl DelayedRowReader {
+    fn new(csv: &str, delay: Duration) -> Self {
+        Self {
+            bytes: csv.as_bytes().to_vec(),
+            pos: 0,
+            delay,
+            rows_read: 0,
+        }
+    }
+}
+
+impl Read for DelayedRowReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.bytes.len() {
+            return Ok(0);
+        }
+        let remaining = &self.bytes[self.pos..];
+        let chunk_end = remaining
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| p + 1)
+            .unwrap_or(remaining.len());
+        let n = chunk_end.min(buf.len());
+        buf[..n].copy_from_slice(&remaining[..n]);
+        self.pos += n;
+        if n > 0 && remaining[..n].ends_with(b"\n") {
+            self.rows_read += 1;
+            if self.rows_read >= 1 && self.pos < self.bytes.len() {
+                std::thread::sleep(self.delay);
+            }
+        }
+        Ok(n)
+    }
+}
+
+fn slow_slot(name: &str, csv: &str, delay: Duration) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(DelayedRowReader::new(csv, delay)),
+    )
+}
+
+fn fast_slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn body_lines(buf: &SharedBuffer) -> Vec<String> {
+    buf.as_string().lines().skip(1).map(String::from).collect()
+}
+
+/// Single-branch `Source → Transform → Output` pipeline whose Transform
+/// has nothing exotic about it (no `window:`, no Route fan-out, no
+/// composition body). Eligible for the fused streaming path.
+///
+/// A 25 ms-per-row slow reader on the Source verifies that:
+/// - The fused Transform arm takes the receiver out of
+///   `ctx.source_records` and drives per-record evaluation via
+///   `recv().await` without tripping the Source arm's
+///   "no ingested records" defense-in-depth `Internal` error.
+/// - Schema canonicalization, `seed_record_vars`, and
+///   `seed_source_vars_for_record` run inside the fused loop so the
+///   Transform's projection still sees the same Source-stamped fields
+///   the buffered path produces.
+/// - DLQ counters land on the upstream Source's name (verified via
+///   `report.counters.dlq_count` being zero — no record should DLQ on
+///   the well-formed input).
+#[tokio::test(flavor = "multi_thread")]
+async fn fused_transform_streams_source_records_correctly() {
+    let yaml = r#"
+pipeline:
+  name: transform_stream_fusion_smoke
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: transform
+    name: rename
+    input: src
+    config:
+      cxl: |
+        emit id = id
+        emit label = tag
+  - type: output
+    name: out
+    input: rename
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let mut csv = String::from("id,tag\n");
+    for i in 1..=8 {
+        csv.push_str(&format!("{i},row-{i}\n"));
+    }
+    let readers: SourceReaders = HashMap::from([(
+        "src".to_string(),
+        vec![slow_slot("in", &csv, Duration::from_millis(25))],
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .await
+            .expect("pipeline executes under fused Transform arm");
+    assert_eq!(report.counters.dlq_count, 0, "no records should DLQ");
+
+    let lines = body_lines(&buf);
+    assert_eq!(lines.len(), 8, "expected 8 records, got {lines:?}");
+    // Per-source FIFO preserved inside the fused loop.
+    let expected: Vec<String> = (1..=8).map(|i| format!("{i},row-{i}")).collect();
+    let actual: Vec<String> = lines
+        .iter()
+        .map(|l| l.trim_end_matches('\r').to_string())
+        .collect();
+    assert_eq!(
+        actual, expected,
+        "fused Transform output diverged from input order — \
+         per-record canonicalize/eval is supposed to preserve the \
+         upstream Source's row FIFO under streaming consumption"
+    );
+}
+
+/// A windowed Transform (`window:` block) must NOT take the fused
+/// streaming path: the windowed evaluator (`evaluate_single_transform_windowed`)
+/// indexes records into the upstream operator's already-materialized
+/// arena via the row's enumerate position. Streaming consumption has
+/// no upstream arena yet at the moment the per-record eval would
+/// dereference it, so the eligibility predicate excludes
+/// `window_index: Some(_)` Transforms.
+///
+/// This test exercises a windowed Transform over a slow source and
+/// asserts the output is the well-formed windowed-aggregate result.
+/// If the predicate ever regressed to accept windowed Transforms, the
+/// fused arm would dereference an unbuilt arena and either panic or
+/// produce nonsense; this test would surface that.
+#[tokio::test(flavor = "multi_thread")]
+async fn windowed_transform_keeps_buffered_path() {
+    let yaml = r#"
+pipeline:
+  name: transform_stream_fusion_windowed
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: int }
+        - { name: grp, type: string }
+        - { name: amt, type: int }
+  - type: transform
+    name: enrich
+    input: src
+    config:
+      analytic_window:
+        group_by: [grp]
+      cxl: |
+        emit id = id
+        emit grp = grp
+        emit amt = amt
+        emit running = $window.sum(amt)
+  - type: output
+    name: out
+    input: enrich
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let csv = "id,grp,amt\n\
+        1,a,10\n\
+        2,a,20\n\
+        3,b,5\n\
+        4,a,30\n\
+        5,b,15\n";
+    let readers: SourceReaders = HashMap::from([(
+        "src".to_string(),
+        vec![slow_slot("in", csv, Duration::from_millis(5))],
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .await
+            .expect("windowed pipeline executes via buffered path");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let mut lines: Vec<String> = body_lines(&buf)
+        .into_iter()
+        .map(|l| l.trim_end_matches('\r').to_string())
+        .collect();
+    // The window evaluator's emit order is partition-stable but the
+    // cross-partition order depends on the runtime's partition
+    // iteration; sort by id to make the assertion independent of that.
+    lines.sort_by_key(|l| {
+        l.split(',')
+            .next()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or(u32::MAX)
+    });
+    assert_eq!(
+        lines,
+        vec![
+            "1,a,10,60",
+            "2,a,20,60",
+            "3,b,5,20",
+            "4,a,30,60",
+            "5,b,15,20",
+        ],
+        "windowed partition-sum diverged — either the fused path is \
+         incorrectly being applied to a windowed Transform (which would \
+         dereference an unbuilt arena), or window evaluation broke \
+         under a slow-reader input. Group `a` records (ids 1/2/4) each \
+         see partition-sum 60; group `b` records (ids 3/5) each see 20."
+    );
+}
+
+/// Two independent `Source → Transform → Output` branches in one
+/// pipeline. Each Source has its own slot; each Transform's upstream
+/// is a single Source (fusion-eligible). The pipeline runs as a
+/// whole; we measure total wall-clock and verify the slow branch's
+/// drain does not multiply by the fast branch's record count (which
+/// it would if the dispatcher serialized the two branches' Source
+/// drains).
+///
+/// With fusion: src_a's arm skips; transform_a streams over src_a's
+/// receiver for ~250 ms; src_b's arm skips; transform_b streams over
+/// src_b's receiver in ~5 μs since src_b's ingest task produced all
+/// records into the channel during transform_a's tenure. Total wall-
+/// clock is bounded by transform_a's drain.
+///
+/// The discriminating bound: total runtime stays comfortably under
+/// 700 ms (the sum of the two streaming arm runtimes would be
+/// ≤ 250 ms + 5 μs; serialized non-fused would still be the same
+/// magnitude because of concurrent source ingest, so this test is a
+/// regression guard rather than a fusion benefit proof). Wall-clock
+/// proof of the per-record latency claim from issue #74's AC#4
+/// requires either streaming Output (issue #72) or parallel branch
+/// dispatch — neither is in scope for #74, but both are unblocked by
+/// the per-record streaming Transform arm landed here.
+#[tokio::test(flavor = "multi_thread")]
+async fn two_branch_fused_transforms_run_without_serializing() {
+    let yaml = r#"
+pipeline:
+  name: transform_stream_fusion_two_branch
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: transform
+    name: t_a
+    input: src_a
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+  - type: transform
+    name: t_b
+    input: src_b
+    config:
+      cxl: |
+        emit id = id
+        emit tag = tag
+  - type: output
+    name: out_a
+    input: t_a
+    config:
+      name: out_a
+      type: csv
+      path: out_a.csv
+  - type: output
+    name: out_b
+    input: t_b
+    config:
+      name: out_b
+      type: csv
+      path: out_b.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let mut a_csv = String::from("id,tag\n");
+    for i in 1..=5 {
+        a_csv.push_str(&format!("{i},a-{i}\n"));
+    }
+    let mut b_csv = String::from("id,tag\n");
+    for i in 1..=5 {
+        b_csv.push_str(&format!("{i},b-{i}\n"));
+    }
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_a".to_string(),
+            vec![slow_slot("a", &a_csv, Duration::from_millis(50))],
+        ),
+        ("src_b".to_string(), vec![fast_slot("b", &b_csv)]),
+    ]);
+    let buf_a = SharedBuffer::new();
+    let buf_b = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([
+        ("out_a".to_string(), writer(&buf_a)),
+        ("out_b".to_string(), writer(&buf_b)),
+    ]);
+
+    let start = Instant::now();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .await
+            .expect("pipeline executes");
+    let elapsed = start.elapsed();
+
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let a_lines: Vec<String> = body_lines(&buf_a)
+        .into_iter()
+        .map(|l| l.trim_end_matches('\r').to_string())
+        .collect();
+    let b_lines: Vec<String> = body_lines(&buf_b)
+        .into_iter()
+        .map(|l| l.trim_end_matches('\r').to_string())
+        .collect();
+    assert_eq!(
+        a_lines.len(),
+        5,
+        "src_a → t_a → out_a lost records: {a_lines:?}"
+    );
+    assert_eq!(
+        b_lines.len(),
+        5,
+        "src_b → t_b → out_b lost records: {b_lines:?}"
+    );
+    let expected_a: Vec<String> = (1..=5).map(|i| format!("{i},a-{i}")).collect();
+    let expected_b: Vec<String> = (1..=5).map(|i| format!("{i},b-{i}")).collect();
+    assert_eq!(a_lines, expected_a);
+    assert_eq!(b_lines, expected_b);
+
+    // Slow branch's drain is ~250 ms. Total pipeline runtime must
+    // stay well under the worst-case serialization of two slow drains
+    // (~500 ms) — 700 ms gives generous CI jitter headroom while still
+    // bounding the regression.
+    assert!(
+        elapsed < Duration::from_millis(700),
+        "pipeline took {elapsed:?}, expected < 700 ms — \
+         two-branch fused transforms appear to be serializing on the slow \
+         Source's drain. With fusion the slow branch's transform_a arm \
+         consumes src_a's live channel without blocking src_b's parallel ingest."
+    );
+}

--- a/crates/clinker-record/src/provenance.rs
+++ b/crates/clinker-record/src/provenance.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 pub struct RecordProvenance {
     pub source_file: Arc<str>,
     pub source_row: u64,
-    pub source_count: u64,
     pub source_batch: Arc<str>,
     pub ingestion_timestamp: NaiveDateTime,
 }
@@ -17,14 +16,12 @@ impl RecordProvenance {
     pub fn new(
         source_file: Arc<str>,
         source_row: u64,
-        source_count: u64,
         source_batch: Arc<str>,
         ingestion_timestamp: NaiveDateTime,
     ) -> Self {
         Self {
             source_file,
             source_row,
-            source_count,
             source_batch,
             ingestion_timestamp,
         }
@@ -40,7 +37,6 @@ impl RecordProvenance {
         move |source_row| Self {
             source_file: Arc::clone(&source_file),
             source_row,
-            source_count: 0, // set after Phase 1 completes (Arena size)
             source_batch: Arc::clone(&source_batch),
             ingestion_timestamp,
         }
@@ -64,14 +60,12 @@ mod tests {
         let p1 = RecordProvenance {
             source_file: Arc::clone(&file),
             source_row: 0,
-            source_count: 1,
             source_batch: Arc::clone(&batch),
             ingestion_timestamp: ts,
         };
         let p2 = RecordProvenance {
             source_file: Arc::clone(&file),
             source_row: 1,
-            source_count: 1,
             source_batch: Arc::clone(&batch),
             ingestion_timestamp: ts,
         };
@@ -89,8 +83,8 @@ mod tests {
             .and_hms_opt(0, 0, 0)
             .unwrap();
 
-        let p1 = RecordProvenance::new(Arc::clone(&file), 1, 100, Arc::clone(&batch), ts);
-        let p2 = RecordProvenance::new(Arc::clone(&file), 2, 100, Arc::clone(&batch), ts);
+        let p1 = RecordProvenance::new(Arc::clone(&file), 1, Arc::clone(&batch), ts);
+        let p2 = RecordProvenance::new(Arc::clone(&file), 2, Arc::clone(&batch), ts);
 
         assert_eq!(p1.source_row, 1);
         assert_eq!(p2.source_row, 2);
@@ -113,6 +107,5 @@ mod tests {
         assert_eq!(p1.source_row, 1);
         assert_eq!(p2.source_row, 2);
         assert!(Arc::ptr_eq(&p1.source_file, &p2.source_file));
-        assert_eq!(p1.source_count, 0);
     }
 }

--- a/docs/src/pipeline/merge.md
+++ b/docs/src/pipeline/merge.md
@@ -47,9 +47,87 @@ Downstream nodes wire to the merge as a normal single-input reference:
     path: "./output/combined.csv"
 ```
 
+## Modes
+
+Merge's cross-input ordering discipline is selected by `config.mode`. Two modes exist; `concat` is the default.
+
+### `concat` (default)
+
+Predecessor records drain in **declaration order**: `inputs[0]` flows to output first, then `inputs[1]`, then `inputs[2]`, and so on. Within a single predecessor, per-source FIFO order is preserved. Output is reproducible run-to-run.
+
+```yaml
+- type: merge
+  name: combined
+  inputs: [east, west]
+  config:
+    mode: concat
+```
+
+### `interleave`
+
+Records flow to output **as they become available** from any predecessor. Per-source FIFO is preserved within each input; cross-input order follows wall-clock arrival and is non-deterministic.
+
+```yaml
+- type: merge
+  name: combined
+  inputs: [east, west]
+  config:
+    mode: interleave
+```
+
+When every direct predecessor of an unseeded `interleave` merge is a `Source` node, the executor **fuses** the Merge into the source ingest loop — predecessor channels are polled directly and Merge consumption proceeds at live ingest rate without any intermediate buffering tier.
+
+### Seeded interleave — `interleave_seed:`
+
+Snapshot tests and benchmarks that need reproducible cross-input ordering can opt into a deterministic schedule:
+
+```yaml
+- type: merge
+  name: combined
+  inputs: [east, west]
+  config:
+    mode: interleave
+    interleave_seed: 42
+```
+
+A seeded interleave **bypasses the fused live-channel path**. The Merge instead pre-buffers each predecessor's output into a Vec, then emits records in `fastrand`-driven order seeded by `interleave_seed`. Output is reproducible regardless of upstream timing — at the cost of opting out of live back-pressure across this Merge (see below).
+
+## Back-pressure semantics
+
+How a slow consumer or slow upstream reader propagates back through the DAG depends on the merge mode.
+
+### `concat`
+
+Each Source ingest task pushes into its own bounded `mpsc` channel (capacity 1024 records per Source). Peer sources produce **concurrently** up to that capacity — the dispatch arm just consumes from `inputs[0]`'s channel before turning to `inputs[1]`'s.
+
+Consequences:
+
+- **Memory:** a non-leading input can hold up to one channel's worth of buffered records before its producer blocks. Multi-input `concat` over `N` Sources may carry up to `(N - 1) × 1024` records in flight even while only one input is being drained.
+- **Latency:** a record produced by `inputs[1]` while `inputs[0]` is still draining will not reach output until `inputs[0]` finishes, regardless of how fast it was produced.
+- **Producer-side back-pressure:** when a non-leading input's channel fills, its reader blocks at `blocking_send`, propagating pressure back to the upstream file/network reader. The upstream is throttled even though it is not the currently-consumed input.
+
+`concat` is the right choice when downstream consumers depend on declaration-ordered records (e.g. snapshot tests asserting on byte-identical output) or when the inputs represent ordered time partitions that must remain contiguous.
+
+### `interleave` (unseeded)
+
+Fused with Source predecessors, the Merge arm polls every predecessor's channel concurrently. Live back-pressure flows end-to-end:
+
+- A slow downstream operator delays Merge consumption, which fills the predecessor channels, which blocks the Source reader tasks.
+- A fast input does not wait on a slow peer — the Merge schedules whichever channel has a ready record.
+
+When predecessors are not all Sources (e.g. Transform → Merge), fusion does not apply and the Merge consumes pre-buffered predecessor outputs in round-robin order; live back-pressure across the Merge boundary itself is unavailable in that shape, though the upstream operator's own bounded buffer still throttles its predecessors.
+
+Unseeded `interleave` is the right choice when end-to-end latency matters and the downstream consumer is order-insensitive (e.g. an aggregator grouping on a key, or a writer that does not assert on row sequencing).
+
+### `interleave` (seeded)
+
+The seeded path **does not preserve live back-pressure across the Merge**: it pre-buffers each predecessor's full output into a `Vec` before emitting in `fastrand`-driven order. A slow consumer downstream of a seeded Merge will not throttle the Source readers while the buffers are still filling.
+
+If you need both run-to-run determinism and live back-pressure, prefer asserting on the multiset of records rather than their sequence and use unseeded `interleave`, or fall back to `concat` over deterministically-declared inputs.
+
 ## Record ordering
 
-Records arrive in the order they are produced by upstream nodes. There is no guaranteed interleaving order between upstream branches. If you need sorted output, use a `sort_order` on the downstream output node.
+Records arrive in the order described by the mode in use — see [Modes](#modes) and [Back-pressure semantics](#back-pressure-semantics) above. If you need sorted output regardless of merge mode, apply a `sort_order` on the downstream output node.
 
 ## Use cases
 

--- a/docs/src/pipeline/output.md
+++ b/docs/src/pipeline/output.md
@@ -239,6 +239,66 @@ At least one of `max_records` or `max_bytes` should be specified for splitting t
 
 When `group_key` is set, the split point is the first group boundary after the threshold is reached (greedy). Without `group_key`, files are split at the exact limit.
 
+## Streaming writes under fused `Merge.interleave`
+
+When a single Output sits directly downstream of a `Merge` whose mode is `interleave` and whose every direct predecessor is a `Source`, the executor takes a streaming path: a bounded `tokio::sync::mpsc::channel` connects the Merge arm to the writer task, and `Writer::write_record` fires per record as Merge emits, concurrent with Merge production.
+
+The buffered alternative — which still runs for every other Output topology — waits until the Merge arm has accumulated every record before invoking the writer. With a slow upstream Source that defeats the live back-pressure the `Merge.interleave` fusion provides at the Source-channel layer: each record sits in `node_buffers[merge]` until the slow Source finishes.
+
+### Topology
+
+```yaml
+- type: source
+  name: src_a
+  config: { type: csv, path: a.csv, schema: ... }
+- type: source
+  name: src_b
+  config: { type: csv, path: b.csv, schema: ... }
+- type: merge
+  name: merged
+  inputs: [src_a, src_b]
+  config:
+    mode: interleave        # required
+- type: output
+  name: out
+  input: merged
+  config:
+    name: out
+    type: csv
+    path: out.csv
+```
+
+The streaming path is selected automatically — there is no opt-in setting. Pipelines that don't match the topology keep the buffered path.
+
+### Eligibility
+
+Every condition must hold for the streaming path to engage; if any fails, the buffered path runs:
+
+- The Output has exactly one incoming edge, and that predecessor is a `Merge` with `mode: interleave`.
+- Every direct predecessor of that Merge is a `Source` (same predicate the fused `Merge.interleave` arm uses for its live `tokio::select!`).
+- The Merge has no other downstream consumer besides this one Output (no fan-out).
+- The Output is not in the init-phase ancestor closure.
+- The OutputConfig has no `split:` block — splitting writers manage their own file rotation lifecycle.
+- The writer is registered in the single-file writer registry (not `fan_out_per_source_file`).
+- No `Source` in the pipeline declares a correlation key — the correlation-buffered output path defers writes to `CorrelationCommit` and is incompatible with per-record write.
+
+### Back-pressure flow
+
+Under the streaming path, back-pressure flows end-to-end:
+
+```
+writer slow → mpsc::Sender::send().await yields
+             → Merge arm yields
+             → Source mpsc::Receiver fills
+             → Source ingest task blocks on send
+```
+
+The bounded handoff channel between Merge and Output (256 slots) and the existing per-Source ingest channels (issue #67) form a single pace-bound chain from the underlying `Write` sink back to the source reader. A slow file system, a saturated network sink, or a deliberately-paced writer no longer accumulates records in pipeline-internal `Vec`s; the upstream readers slow down to match.
+
+### Counter semantics
+
+Counter behavior under the streaming path matches the buffered Output arm exactly: `records_written` increments once per `Writer::write_record` call, `ok_count` counts distinct source `row_num`s reaching the Output, and `dlq_count` is unaffected (DLQ entries originate upstream). Stage metrics (`SchemaScan`, `Write`, `Projection`) accumulate into the same fields the buffered path uses; the dispatcher folds the streaming task's per-task accounting back into the run-wide totals at end of DAG.
+
 ## Complete example
 
 ```yaml


### PR DESCRIPTION
The source_count field on RecordProvenance was never read by non-test
code; CXL's $source.count resolves through EvalContext.source_count,
populated per-source by the executor. Removing the field shrinks
RecordProvenance::new by one argument and deletes a stale placeholder
comment.

Arena::from_records now debug-asserts that every column holds a
uniform Value variant across all projected records (Null exempted),
guarding the assumption that node-rooted arenas inherit
already-typed values from their upstream operator's emit. Release
builds carry zero cost.