### PR TITLE
cxl: type analytic_window YAML; extend $window.* registry

### DIFF
--- a/crates/clinker-core/benches/window.rs
+++ b/crates/clinker-core/benches/window.rs
@@ -38,7 +38,7 @@ fn bench_window_sum(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.sum("amount"));
                 });
             },
@@ -60,7 +60,7 @@ fn bench_window_avg(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.avg("amount"));
                 });
             },
@@ -82,7 +82,7 @@ fn bench_window_min_max(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.min("amount"));
                 });
             },
@@ -93,7 +93,7 @@ fn bench_window_min_max(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.max("amount"));
                 });
             },
@@ -115,7 +115,7 @@ fn bench_window_count(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.count());
                 });
             },
@@ -137,7 +137,7 @@ fn bench_window_first_last(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.first());
                 });
             },
@@ -148,7 +148,7 @@ fn bench_window_first_last(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.last());
                 });
             },
@@ -170,7 +170,7 @@ fn bench_window_lag_lead(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.lag(1));
                 });
             },
@@ -181,7 +181,7 @@ fn bench_window_lag_lead(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.lead(1));
                 });
             },
@@ -203,7 +203,7 @@ fn bench_window_collect_set(c: &mut Criterion) {
             &partition_size,
             |b, _| {
                 b.iter(|| {
-                    let ctx = PartitionWindowContext::new(&arena, &positions, mid);
+                    let ctx = PartitionWindowContext::new(&arena, &positions, mid, &[]);
                     black_box(ctx.collect("category"));
                 });
             },

--- a/crates/clinker-core/src/config/mod.rs
+++ b/crates/clinker-core/src/config/mod.rs
@@ -3,6 +3,7 @@ pub mod composition;
 pub mod node_header;
 pub mod pipeline_node;
 
+pub use crate::plan::index::AnalyticWindowSpec;
 pub use compile_context::CompileContext;
 pub use composition::{
     CompositionFile, CompositionSignature, CompositionSymbolTable, LayerKind, NodeRef, OutputAlias,
@@ -12,8 +13,8 @@ pub use composition::{
 };
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use pipeline_node::{
-    AggregateBody, AnalyticWindowSpec, MergeBody, OutputBody, Phase, PipelineNode, RouteBody,
-    SourceBody, TransformBody, VarScope,
+    AggregateBody, MergeBody, OutputBody, Phase, PipelineNode, RouteBody, SourceBody,
+    TransformBody, VarScope,
 };
 
 use crate::yaml::Spanned;
@@ -1969,7 +1970,7 @@ impl PipelineConfig {
         // programs the analyzer pass would consume).
         struct PlannerEntry {
             name: String,
-            analytic_window: Option<serde_json::Value>,
+            analytic_window: Option<AnalyticWindowSpec>,
         }
         let entries: Vec<PlannerEntry> = self
             .nodes
@@ -2018,18 +2019,9 @@ impl PipelineConfig {
         for a in &report.transforms {
             analysis_by_name.insert(a.name.clone(), a);
         }
-        let window_configs: Vec<Option<crate::plan::index::LocalWindowConfig>> = entries
-            .iter()
-            .map(|e| crate::plan::index::parse_analytic_window_value(&e.analytic_window, &e.name))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                vec![Diagnostic::error(
-                    "E003",
-                    format!("analytic_window parse error: {e}"),
-                    LabeledSpan::primary(Span::SYNTHETIC, String::new()),
-                )]
-            })?;
-        // Validate: if a transform uses window.* but has no local_window, error.
+        let window_configs: Vec<Option<AnalyticWindowSpec>> =
+            entries.iter().map(|e| e.analytic_window.clone()).collect();
+        // Validate: if a transform uses window.* but has no analytic_window, error.
         for (i, analysis) in report.transforms.iter().enumerate() {
             if !analysis.window_calls.is_empty() {
                 let entry_idx = entries_by_name.get(&analysis.name).copied().unwrap_or(i);
@@ -2041,7 +2033,7 @@ impl PipelineConfig {
                     diags.push(Diagnostic::error(
                         "E003",
                         format!(
-                            "transform '{}' uses window.* functions but declares no local_window",
+                            "transform '{}' uses window.* functions but declares no analytic_window",
                             analysis.name
                         ),
                         LabeledSpan::primary(Span::SYNTHETIC, String::new()),
@@ -2063,7 +2055,7 @@ impl PipelineConfig {
                     diags.push(Diagnostic::error(
                         "E003",
                         format!(
-                            "transform '{}' references unknown source '{}' in local_window",
+                            "transform '{}' references unknown source '{}' in analytic_window",
                             entries[i].name, source
                         ),
                         LabeledSpan::primary(Span::SYNTHETIC, String::new()),
@@ -2336,7 +2328,7 @@ impl PipelineConfig {
                             "E003",
                             format!(
                                 "windowed transform '{}' has no upstream input; \
-                                 local_window requires a predecessor in the DAG",
+                                 analytic_window requires a predecessor in the DAG",
                                 transform_name
                             ),
                             LabeledSpan::primary(Span::SYNTHETIC, String::new()),
@@ -3161,7 +3153,7 @@ fn resolve_all_input_references(
 #[derive(Default)]
 pub(crate) struct LoweringCtx<'a> {
     pub analysis: Option<&'a cxl::analyzer::TransformAnalysis>,
-    pub window_config: Option<&'a crate::plan::index::LocalWindowConfig>,
+    pub window_config: Option<&'a AnalyticWindowSpec>,
     pub primary_source: &'a str,
 }
 

--- a/crates/clinker-core/src/config/pipeline_node.rs
+++ b/crates/clinker-core/src/config/pipeline_node.rs
@@ -42,6 +42,7 @@ use serde::de::{self, IntoDeserializer, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::config::node_header::{CombineHeader, MergeHeader, NodeHeader, SourceHeader};
+use crate::plan::index::AnalyticWindowSpec;
 use crate::yaml::CxlSource;
 
 /// Unified pipeline node taxonomy. Every node in the YAML `nodes:` list
@@ -897,11 +898,6 @@ pub enum MatchMode {
     /// Per-group limit of 10K entries.
     Collect,
 }
-
-/// The analytic-window spec attached to a `Transform`. Currently held
-/// as a structurally opaque JSON value; a typed shape is a future
-/// refactor.
-pub type AnalyticWindowSpec = serde_json::Value;
 
 /// Event-time window declaration attached to an `Aggregate`. Distinct
 /// from the positional analytic window on `Transform`: that one slices

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -3253,10 +3253,12 @@ pub(crate) fn evaluate_single_transform_windowed(
         })
         .collect();
 
+    let sort_fields: Vec<&str> = spec.sort_by.iter().map(|s| s.field.as_str()).collect();
     let result = if let Some(key) = key {
         if let Some(partition) = index.get(&key) {
             let pos_in_partition = partition.iter().position(|&p| p == record_pos).unwrap_or(0);
-            let wctx = PartitionWindowContext::new(arena, partition, pos_in_partition);
+            let wctx =
+                PartitionWindowContext::new(arena, partition, pos_in_partition, &sort_fields);
             evaluator
                 .eval_record(ctx, record, Some(&wctx))
                 .map_err(|e| (transform_name.to_string(), e))?
@@ -3572,6 +3574,7 @@ mod tests {
     mod post_aggregate_lag_lead;
     mod post_aggregate_recompute_determinism;
     mod post_aggregate_window;
+    mod post_aggregate_window_ranking;
     mod post_aggregate_window_spilled;
     mod post_combine_array_field;
     mod post_combine_synthetic_ck;

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -59,7 +59,6 @@ pub struct TransformSpec {
     pub name: String,
     pub cxl: Option<String>,
     pub aggregate: Option<crate::config::AggregateConfig>,
-    pub local_window: Option<serde_json::Value>,
     pub route: Option<crate::config::RouteConfig>,
     pub input: Option<crate::config::TransformInput>,
 }
@@ -129,7 +128,6 @@ pub fn build_transform_specs(config: &PipelineConfig) -> Vec<TransformSpec> {
                     name: header.name.clone(),
                     cxl: Some(body.cxl.as_ref().to_string()),
                     aggregate: None,
-                    local_window: body.analytic_window.clone(),
                     route: None,
                     input: project_input(&header.input.value),
                 });
@@ -148,7 +146,6 @@ pub fn build_transform_specs(config: &PipelineConfig) -> Vec<TransformSpec> {
                         time_window: body.time_window.clone(),
                         allowed_lateness: body.allowed_lateness,
                     }),
-                    local_window: None,
                     route: None,
                     input: project_input(&header.input.value),
                 });
@@ -169,7 +166,6 @@ pub fn build_transform_specs(config: &PipelineConfig) -> Vec<TransformSpec> {
                     name: header.name.clone(),
                     cxl: Some(String::new()),
                     aggregate: None,
-                    local_window: None,
                     route: Some(RouteConfig {
                         mode: body.mode,
                         branches,

--- a/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
@@ -15,8 +15,8 @@
 //!
 //! Coverage. The full design matrix is 13 `$window.*` builtins ×
 //! {rows, range} × 3 frame-bound shapes × {single-row retract,
-//! full-partition retract} = 156 cells. Today's `LocalWindowConfig`
-//! does not expose the `frame:` configuration to the runtime, so the
+//! full-partition retract} = 156 cells. Today's `AnalyticWindowSpec`
+//! does not thread the `frame:` configuration into the runtime, so the
 //! frame variant collapses to "implicit unbounded over partition" for
 //! every builtin. Removing the frame axis reduces the matrix to 13 ×
 //! {single, full} = 26 representative cells, which the parameterized

--- a/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
+++ b/crates/clinker-core/src/executor/tests/correlated_window_retract.rs
@@ -516,10 +516,10 @@ async fn window_lag2_and_lead2_boundary_retract() {
     );
 }
 
-// `$window.distinct(...)` and `$window.any(...)` / `$window.all(...)`
+// `$window.distinct(...)` and `$window.any(...)` / `$window.every(...)`
 // are listed in the windows.md docs but the CXL parser today rejects
 // `distinct` (it is a top-level keyword) and the iterable-predicate
-// shape (any/all over a predicate expression) does not flow cleanly
+// shape (any/every over a predicate expression) does not flow cleanly
 // through the same analytic_window plumbing as the value-emitting
 // builtins. The buffer-recompute path is uniform across builtins so
 // the iterable cells are structurally covered by `collect` (the only

--- a/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_any_all.rs
@@ -1,13 +1,13 @@
-//! End-to-end pipeline coverage for `$window.any` / `$window.all`.
+//! End-to-end pipeline coverage for `$window.any` / `$window.every`.
 //!
 //! Pins two properties:
 //!   1. The predicate iterates over partition rows, not the current row —
-//!      every row in a partition emits the same any/all value.
+//!      every row in a partition emits the same any/every value.
 //!   2. Short-circuit evaluation produces the right Bool over a real
 //!      Arena partition produced by the executor.
 //!
 //! Three-valued / Null semantics are pinned exhaustively in
-//! `cxl::eval::tests::any_all` (mod-level unit tests) where Value::Null
+//! `cxl::eval::tests::any_every` (mod-level unit tests) where Value::Null
 //! can be injected directly without depending on CSV coercion.
 
 use super::*;
@@ -39,9 +39,9 @@ nodes:
       emit region = region
       emit score = score
       emit any_high = $window.any(score > 25)
-      emit all_high = $window.all(score > 25)
+      emit all_high = $window.every(score > 25)
       emit any_low = $window.any(score < 25)
-      emit all_low = $window.all(score < 25)
+      emit all_low = $window.every(score < 25)
     analytic_window:
       group_by: [department]
       sort_by:

--- a/crates/clinker-core/src/executor/tests/post_aggregate_window_ranking.rs
+++ b/crates/clinker-core/src/executor/tests/post_aggregate_window_ranking.rs
@@ -1,0 +1,300 @@
+//! End-to-end pipeline coverage for the ranking and first/last-value
+//! window builtins introduced alongside the typed AnalyticWindowSpec.
+//!
+//! Each test runs a Source → Transform-with-window pipeline against a
+//! small CSV input and verifies the emitted columns against arithmetic
+//! ground truth computed independently of the planner. The Arena-backed
+//! partition exercises tie detection (rank/dense_rank) and first/last
+//! row projection (first_value/last_value); the cxl unit tests under
+//! `cxl::eval::tests::ranking_and_value` already pin the value-shape
+//! contract against a minimal in-memory implementation.
+
+use super::*;
+use clinker_bench_support::io::SharedBuffer;
+use std::collections::HashMap;
+
+const RANKING_PIPELINE: &str = r#"
+pipeline:
+  name: window_ranking
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    path: input.csv
+    type: csv
+    schema:
+      - { name: dept, type: string }
+      - { name: score, type: int }
+- type: transform
+  name: ranked
+  input: src
+  config:
+    cxl: |
+      emit dept = dept
+      emit score = score
+      emit rn = $window.row_number()
+      emit rk = $window.rank()
+      emit drk = $window.dense_rank()
+      emit fv = $window.first_value(score)
+      emit lv = $window.last_value(score)
+    analytic_window:
+      group_by: [dept]
+      sort_by:
+        - field: score
+          order: asc
+- type: output
+  name: out
+  input: ranked
+  config:
+    name: out
+    path: output.csv
+    type: csv
+    include_widened: true
+"#;
+
+async fn run(csv: &str) -> String {
+    let config = crate::config::parse_config(RANKING_PIPELINE).expect("parse");
+    let params = PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: Default::default(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let readers: crate::executor::SourceReaders = HashMap::from([(
+        "src".to_string(),
+        crate::executor::single_file_reader(
+            "test.csv",
+            Box::new(std::io::Cursor::new(csv.as_bytes().to_vec())),
+        ),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+        .await
+        .expect("pipeline must run");
+    buf.as_string()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn ranking_and_value_columns_over_tied_partition() {
+    // Partition `eng` has a clean ascending sequence (no ties);
+    // partition `hr` has two pairs of tied scores so rank() must skip
+    // and dense_rank() must not.
+    //
+    //   eng sorted asc: 10 20 30 40
+    //                   rn=[1,2,3,4]  rk=[1,2,3,4]  drk=[1,2,3,4]
+    //
+    //   hr  sorted asc: 10 10 20 20 30
+    //                   rn=[1,2,3,4,5] rk=[1,1,3,3,5] drk=[1,1,2,2,3]
+    //
+    // first_value/last_value pin the partition's extremes (sorted
+    // asc, so first is the smallest score and last is the largest).
+    let csv = "\
+dept,score
+eng,40
+eng,10
+eng,20
+eng,30
+hr,20
+hr,30
+hr,10
+hr,20
+hr,10
+";
+
+    let out = run(csv).await;
+    let mut lines = out.lines();
+    let header_line = lines.next().expect("header");
+    let headers: Vec<&str> = header_line.split(',').collect();
+    let idx = |name: &str| {
+        headers
+            .iter()
+            .position(|h| *h == name)
+            .unwrap_or_else(|| panic!("header missing: {name}"))
+    };
+    let dept_idx = idx("dept");
+    let score_idx = idx("score");
+    let rn_idx = idx("rn");
+    let rk_idx = idx("rk");
+    let drk_idx = idx("drk");
+    let fv_idx = idx("fv");
+    let lv_idx = idx("lv");
+
+    // Collect rows by (dept, score) ordering — sort the captured rows
+    // by (dept, score asc) to align with the partition's sorted view,
+    // since output emission order is the input-arrival order.
+    let mut rows: Vec<Vec<String>> = lines
+        .filter(|l| !l.is_empty())
+        .map(|l| l.split(',').map(str::to_string).collect())
+        .collect();
+    rows.sort_by(|a, b| {
+        let dept_cmp = a[dept_idx].cmp(&b[dept_idx]);
+        if !dept_cmp.is_eq() {
+            return dept_cmp;
+        }
+        let sa: i64 = a[score_idx].parse().unwrap();
+        let sb: i64 = b[score_idx].parse().unwrap();
+        sa.cmp(&sb)
+    });
+
+    let expect_eng: [(i64, i64, i64, i64); 4] = [
+        // (score, rn, rk, drk)
+        (10, 1, 1, 1),
+        (20, 2, 2, 2),
+        (30, 3, 3, 3),
+        (40, 4, 4, 4),
+    ];
+    let expect_hr: [(i64, i64, i64, i64); 5] = [
+        (10, 1, 1, 1),
+        (10, 2, 1, 1),
+        (20, 3, 3, 2),
+        (20, 4, 3, 2),
+        (30, 5, 5, 3),
+    ];
+
+    let mut eng_seen = 0;
+    let mut hr_seen = 0;
+    for row in &rows {
+        let dept = &row[dept_idx];
+        let score: i64 = row[score_idx].parse().unwrap();
+        let rn: i64 = row[rn_idx].parse().unwrap();
+        let rk: i64 = row[rk_idx].parse().unwrap();
+        let drk: i64 = row[drk_idx].parse().unwrap();
+        let fv: i64 = row[fv_idx].parse().unwrap();
+        let lv: i64 = row[lv_idx].parse().unwrap();
+
+        match dept.as_str() {
+            "eng" => {
+                let (es, ern, erk, edrk) = expect_eng[eng_seen];
+                assert_eq!(score, es, "eng score order at {eng_seen}");
+                assert_eq!(rn, ern, "eng row_number at {eng_seen}");
+                assert_eq!(rk, erk, "eng rank at {eng_seen}");
+                assert_eq!(drk, edrk, "eng dense_rank at {eng_seen}");
+                assert_eq!(fv, 10, "eng first_value");
+                assert_eq!(lv, 40, "eng last_value");
+                eng_seen += 1;
+            }
+            "hr" => {
+                let (es, ern, erk, edrk) = expect_hr[hr_seen];
+                assert_eq!(score, es, "hr score order at {hr_seen}");
+                assert_eq!(rn, ern, "hr row_number at {hr_seen}");
+                assert_eq!(rk, erk, "hr rank at {hr_seen}");
+                assert_eq!(drk, edrk, "hr dense_rank at {hr_seen}");
+                assert_eq!(fv, 10, "hr first_value");
+                assert_eq!(lv, 30, "hr last_value");
+                hr_seen += 1;
+            }
+            other => panic!("unexpected department {other:?}"),
+        }
+    }
+    assert_eq!(eng_seen, 4);
+    assert_eq!(hr_seen, 5);
+}
+
+const EVERY_EXISTS_PIPELINE: &str = r#"
+pipeline:
+  name: window_every_exists
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    path: input.csv
+    type: csv
+    schema:
+      - { name: dept, type: string }
+      - { name: score, type: int }
+- type: transform
+  name: predicates
+  input: src
+  config:
+    cxl: |
+      emit dept = dept
+      emit score = score
+      emit every_high = $window.every(score > 25)
+      emit exists_low = $window.exists(score < 25)
+      emit none_neg = $window.not_exists(score < 0)
+    analytic_window:
+      group_by: [dept]
+- type: output
+  name: out
+  input: predicates
+  config:
+    name: out
+    path: output.csv
+    type: csv
+    include_widened: true
+"#;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn every_exists_not_exists_partition_scoped() {
+    // HR scores = [10, 20, 30]   → every >25: false, exists <25: true,  none_neg: true
+    // ENG scores = [50, 60, 70]  → every >25: true,  exists <25: false, none_neg: true
+    let csv = "\
+dept,score
+HR,10
+HR,20
+HR,30
+ENG,50
+ENG,60
+ENG,70
+";
+
+    let config = crate::config::parse_config(EVERY_EXISTS_PIPELINE).expect("parse");
+    let params = PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: Default::default(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let readers: crate::executor::SourceReaders = HashMap::from([(
+        "src".to_string(),
+        crate::executor::single_file_reader(
+            "test.csv",
+            Box::new(std::io::Cursor::new(csv.as_bytes().to_vec())),
+        ),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params)
+        .await
+        .expect("pipeline must run");
+    let out = buf.as_string();
+
+    let mut lines = out.lines();
+    let header_line = lines.next().expect("header");
+    let headers: Vec<&str> = header_line.split(',').collect();
+    let idx = |name: &str| headers.iter().position(|h| *h == name).unwrap();
+    let dept_idx = idx("dept");
+    let every_idx = idx("every_high");
+    let exists_idx = idx("exists_low");
+    let none_neg_idx = idx("none_neg");
+
+    let mut rows = 0;
+    for line in lines.filter(|l| !l.is_empty()) {
+        rows += 1;
+        let v: Vec<&str> = line.split(',').collect();
+        let (exp_every, exp_exists) = match v[dept_idx] {
+            "HR" => ("false", "true"),
+            "ENG" => ("true", "false"),
+            other => panic!("unexpected dept {other:?}"),
+        };
+        assert_eq!(v[every_idx], exp_every, "every_high for {}", v[dept_idx]);
+        assert_eq!(v[exists_idx], exp_exists, "exists_low for {}", v[dept_idx]);
+        assert_eq!(v[none_neg_idx], "true", "none_neg for {}", v[dept_idx]);
+    }
+    assert_eq!(rows, 6);
+}

--- a/crates/clinker-core/src/pipeline/window_context.rs
+++ b/crates/clinker-core/src/pipeline/window_context.rs
@@ -9,20 +9,47 @@ use crate::pipeline::arena::Arena;
 /// Concrete WindowContext over a sorted Arena partition.
 ///
 /// Holds a reference to the Arena and a slice of sorted record positions.
-/// `current_pos` is the index *within the partition* of the record being evaluated.
+/// `current_pos` is the index *within the partition* of the record being
+/// evaluated. `sort_fields` names the columns that define the partition's
+/// ordering — `rank()` / `dense_rank()` consult them to detect ties, and
+/// an empty slice degenerates both to "every row tied at 1".
 pub struct PartitionWindowContext<'a> {
     arena: &'a Arena,
     partition: &'a [u64],
     current_pos: usize,
+    sort_fields: &'a [&'a str],
 }
 
 impl<'a> PartitionWindowContext<'a> {
-    pub fn new(arena: &'a Arena, partition: &'a [u64], current_pos: usize) -> Self {
+    /// Construct a context against the given arena partition.
+    ///
+    /// `sort_fields` should be the same sequence of field names that the
+    /// secondary index used to order the partition. Pass an empty slice
+    /// when the index has no declared `sort_by` — `rank` / `dense_rank`
+    /// then report every row as tied.
+    pub fn new(
+        arena: &'a Arena,
+        partition: &'a [u64],
+        current_pos: usize,
+        sort_fields: &'a [&'a str],
+    ) -> Self {
         Self {
             arena,
             partition,
             current_pos,
+            sort_fields,
         }
+    }
+
+    /// Compare two partition rows by their sort-key tuple. Returns `true`
+    /// when every configured sort field resolves to the same `Value` on
+    /// both rows. With no sort fields configured all rows are equal.
+    fn sort_keys_equal(&self, lhs: u64, rhs: u64) -> bool {
+        self.sort_fields.iter().all(|field| {
+            let l = self.arena.resolve_field(lhs, field);
+            let r = self.arena.resolve_field(rhs, field);
+            l == r
+        })
     }
 
     /// Sum a named field across the supplied partition positions.
@@ -208,6 +235,59 @@ impl<'a> WindowContext<'a, Arena> for PartitionWindowContext<'a> {
         }
         Value::Array(values)
     }
+
+    fn row_number(&self) -> i64 {
+        (self.current_pos as i64) + 1
+    }
+
+    fn rank(&self) -> i64 {
+        // Walk forward from the partition's start, bumping the rank
+        // whenever the sort-key tuple changes. Tie groups share the
+        // rank of their first row; the next distinct key jumps to its
+        // own positional index + 1, leaving a gap equal to the tie
+        // group size. Stops as soon as we reach `current_pos`.
+        if self.partition.is_empty() || self.current_pos == 0 {
+            return 1;
+        }
+        let mut rank: i64 = 1;
+        for i in 1..=self.current_pos.min(self.partition.len() - 1) {
+            if !self.sort_keys_equal(self.partition[i - 1], self.partition[i]) {
+                rank = (i as i64) + 1;
+            }
+        }
+        rank
+    }
+
+    fn dense_rank(&self) -> i64 {
+        // Same fold as `rank` but each distinct sort key increments by
+        // exactly one — no gaps after a tie group.
+        if self.partition.is_empty() || self.current_pos == 0 {
+            return 1;
+        }
+        let mut rank: i64 = 1;
+        for i in 1..=self.current_pos.min(self.partition.len() - 1) {
+            if !self.sort_keys_equal(self.partition[i - 1], self.partition[i]) {
+                rank += 1;
+            }
+        }
+        rank
+    }
+
+    fn first_value(&self, field: &str) -> Value {
+        self.partition
+            .first()
+            .and_then(|&pos| self.arena.resolve_field(pos, field))
+            .cloned()
+            .unwrap_or(Value::Null)
+    }
+
+    fn last_value(&self, field: &str) -> Value {
+        self.partition
+            .last()
+            .and_then(|&pos| self.arena.resolve_field(pos, field))
+            .cloned()
+            .unwrap_or(Value::Null)
+    }
 }
 
 /// Simple less-than comparison for Value (used by min/max).
@@ -272,7 +352,7 @@ mod tests {
             &["name", "amount"],
         );
         let partition: Vec<u64> = vec![0, 1, 2];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 1);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 1, &[]);
 
         let first = ctx.first().unwrap();
         assert_eq!(first.resolve("name"), Some(&Value::String("Alice".into())));
@@ -287,7 +367,7 @@ mod tests {
             &["name", "amount"],
         );
         let partition: Vec<u64> = vec![0, 1, 2, 3, 4];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 3);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 3, &[]);
 
         let lag = ctx.lag(1).unwrap();
         assert_eq!(lag.resolve("name"), Some(&Value::String("C".into())));
@@ -299,7 +379,7 @@ mod tests {
     fn test_window_lag_out_of_bounds() {
         let arena = make_arena("name\nA\nB\n", &["name"]);
         let partition: Vec<u64> = vec![0, 1];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
 
         assert!(ctx.lag(1).is_none());
     }
@@ -308,7 +388,7 @@ mod tests {
     fn test_window_count() {
         let arena = make_arena("x\na\nb\nc\nd\ne\n", &["x"]);
         let partition: Vec<u64> = vec![0, 1, 2, 3, 4];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
         assert_eq!(ctx.count(), 5);
     }
 
@@ -322,7 +402,7 @@ mod tests {
         // Let's test the "non-numeric returns null" case and a String-numeric coercion case.
         let arena = make_arena("amount\n10\n20\n30\n", &["amount"]);
         let partition: Vec<u64> = vec![0, 1, 2];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
 
         // CSV reads as strings, so sum/avg return Null for string fields
         assert_eq!(ctx.sum("amount"), Value::Null);
@@ -338,7 +418,7 @@ mod tests {
         // String comparison for CSV-sourced data
         let arena = make_arena("name\nBob\nAlice\nCarol\n", &["name"]);
         let partition: Vec<u64> = vec![0, 1, 2];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
 
         assert_eq!(ctx.min("name"), Value::String("Alice".into()));
         assert_eq!(ctx.max("name"), Value::String("Carol".into()));
@@ -348,7 +428,7 @@ mod tests {
     fn test_window_sum_non_numeric() {
         let arena = make_arena("name\nAlice\nBob\n", &["name"]);
         let partition: Vec<u64> = vec![0, 1];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
         assert_eq!(ctx.sum("name"), Value::Null);
     }
 
@@ -357,7 +437,7 @@ mod tests {
         // any/all are evaluator-driven (not on this trait), but we test partition_len/partition_record
         let arena = make_arena("amount\n50\n150\n200\n", &["amount"]);
         let partition: Vec<u64> = vec![0, 1, 2];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
 
         assert_eq!(ctx.partition_len(), 3);
         let rec = ctx.partition_record(1);
@@ -368,7 +448,7 @@ mod tests {
     fn test_window_collect() {
         let arena = make_arena("name\nAlice\nBob\nCarol\n", &["name"]);
         let partition: Vec<u64> = vec![0, 1, 2];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
 
         match ctx.collect("name") {
             Value::Array(vals) => {
@@ -385,7 +465,7 @@ mod tests {
     fn test_window_distinct() {
         let arena = make_arena("dept\nA\nB\nA\nC\n", &["dept"]);
         let partition: Vec<u64> = vec![0, 1, 2, 3];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
 
         match ctx.distinct("dept") {
             Value::Array(vals) => {
@@ -403,7 +483,7 @@ mod tests {
     fn test_window_single_record_partition() {
         let arena = make_arena("name\nAlice\n", &["name"]);
         let partition: Vec<u64> = vec![0];
-        let ctx = PartitionWindowContext::new(&arena, &partition, 0);
+        let ctx = PartitionWindowContext::new(&arena, &partition, 0, &[]);
 
         // first == last for single record
         assert_eq!(

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -1996,31 +1996,13 @@ fn bind_composition(
     // `window_index` on the PlanNode::Transform — that backfill is
     // owned by the body-window pass once parent NodeIndex space is
     // allocated.
-    let mut body_window_configs: HashMap<String, crate::plan::index::LocalWindowConfig> =
+    let mut body_window_configs: HashMap<String, crate::plan::index::AnalyticWindowSpec> =
         HashMap::new();
     for spanned in &body_file.nodes {
         if let PipelineNode::Transform { header, config } = &spanned.value
-            && let Some(raw) = config.analytic_window.as_ref()
+            && let Some(spec) = config.analytic_window.as_ref()
         {
-            match crate::plan::index::parse_analytic_window_value(&Some(raw.clone()), &header.name)
-            {
-                Ok(Some(wc)) => {
-                    body_window_configs.insert(header.name.clone(), wc);
-                }
-                Ok(None) => {}
-                Err(e) => {
-                    diags.push(Diagnostic::error(
-                        "E003",
-                        format!(
-                            "composition body for {node_name:?} carries an \
-                             invalid analytic_window on transform {:?}: {e}",
-                            header.name
-                        ),
-                        LabeledSpan::primary(span, String::new()),
-                    ));
-                    return;
-                }
-            }
+            body_window_configs.insert(header.name.clone(), spec.clone());
         }
     }
 

--- a/crates/clinker-core/src/plan/composition_body.rs
+++ b/crates/clinker-core/src/plan/composition_body.rs
@@ -143,12 +143,12 @@ pub struct BoundBody {
 
     /// Per-Transform analytic-window configs captured at
     /// `bind_composition` time. Keyed by the body Transform's name;
-    /// values are the typed `LocalWindowConfig` parsed from the
+    /// values are the typed `AnalyticWindowSpec` deserialized from the
     /// body file's `analytic_window:` block. Empty entries are
     /// omitted. Consumed by the post-parent-DAG-build body-window
     /// pass to construct `body_indices_to_build` and backfill
     /// `window_index` onto each body Transform.
-    pub body_window_configs: HashMap<String, crate::plan::index::LocalWindowConfig>,
+    pub body_window_configs: HashMap<String, crate::plan::index::AnalyticWindowSpec>,
 
     /// Deferred-region metadata for relaxed-CK Aggregates that live
     /// inside this body. Keys are NodeIndex values in this body's

--- a/crates/clinker-core/src/plan/execution.rs
+++ b/crates/clinker-core/src/plan/execution.rs
@@ -20,7 +20,7 @@ use crate::config::{
 use crate::error::PipelineError;
 use crate::executor::combine::JoinSide;
 use crate::plan::composition_body::CompositionBodyId;
-use crate::plan::index::{IndexSpec, LocalWindowConfig, PlanIndexError};
+use crate::plan::index::{AnalyticWindowSpec, IndexSpec};
 use crate::plan::properties::{
     NodeProperties, Ordering, OrderingProvenance, Partitioning, PartitioningKind,
     PartitioningProvenance,
@@ -499,7 +499,7 @@ pub struct PlanSourcePayload {
 /// downstream wiring, and the compile-time CXL `TypedProgram`.
 #[derive(Debug, Clone)]
 pub struct PlanTransformPayload {
-    pub analytic_window: Option<crate::config::pipeline_node::AnalyticWindowSpec>,
+    pub analytic_window: Option<AnalyticWindowSpec>,
     pub log: Vec<crate::config::LogDirective>,
     pub validations: Vec<crate::config::ValidationEntry>,
     pub dlq_node: Option<NodeIndex>,
@@ -2518,7 +2518,7 @@ pub(crate) fn assign_tiers(graph: &mut DiGraph<PlanNode, PlanEdge>, topo_order: 
 /// Derive ParallelismClass from analyzer output and window config.
 pub(crate) fn derive_parallelism_class(
     analysis: &cxl::analyzer::TransformAnalysis,
-    wc: &Option<LocalWindowConfig>,
+    wc: &Option<AnalyticWindowSpec>,
     primary_source: &str,
 ) -> ParallelismClass {
     match analysis.parallelism_hint {
@@ -2593,7 +2593,7 @@ pub struct ParallelismProfile {
 /// earlier tiers than the transforms that depend on them.
 pub(crate) fn build_source_dag(
     sources: &[SourceConfig],
-    window_configs: &[Option<LocalWindowConfig>],
+    window_configs: &[Option<AnalyticWindowSpec>],
     primary_source: &str,
 ) -> Result<Vec<SourceTier>, PlanError> {
     let all_sources: Vec<String> = sources.iter().map(|i| i.name.clone()).collect();
@@ -4569,8 +4569,9 @@ pub(crate) fn extract_has_distinct(typed: &TypedProgram) -> bool {
 /// Errors from execution plan compilation.
 #[derive(Debug)]
 pub enum PlanError {
-    IndexPlanning(PlanIndexError),
-    MissingLocalWindow {
+    /// A Transform's CXL invokes `$window.*` but the YAML body declares
+    /// no `analytic_window:` block.
+    MissingAnalyticWindow {
         transform: String,
     },
     UnknownSource {
@@ -4636,11 +4637,10 @@ pub enum PlanError {
 impl std::fmt::Display for PlanError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PlanError::IndexPlanning(e) => write!(f, "index planning error: {}", e),
-            PlanError::MissingLocalWindow { transform } => {
+            PlanError::MissingAnalyticWindow { transform } => {
                 write!(
                     f,
-                    "transform '{}' uses window.* but has no local_window config",
+                    "transform '{}' uses window.* but has no analytic_window config",
                     transform
                 )
             }

--- a/crates/clinker-core/src/plan/index.rs
+++ b/crates/clinker-core/src/plan/index.rs
@@ -147,6 +147,10 @@ pub struct AnalyticWindowSpec {
 /// Row-frame attached to an [`AnalyticWindowSpec`]. Mirrors SQL window
 /// frames (`ROWS BETWEEN <start> AND <end>`). `Range` / `Groups` modes
 /// land in a later sprint.
+///
+/// Currently the frame deserializes and round-trips through the plan but
+/// does **not** alter evaluation — every `$window.*` call evaluates over
+/// the entire partition. Frame-aware semantics are a future change.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct WindowFrame {

--- a/crates/clinker-core/src/plan/index.rs
+++ b/crates/clinker-core/src/plan/index.rs
@@ -126,12 +126,6 @@ pub struct AnalyticWindowSpec {
     pub sort_by: Vec<SortField>,
     /// Expression to evaluate against the primary record for cross-source lookup.
     pub on: Option<String>,
-    /// Optional row-frame attached to the window. `None` means "entire
-    /// partition" and matches the historical default semantics. Range /
-    /// Groups modes land in a later sprint; only `FrameMode::Rows` is
-    /// accepted today.
-    #[serde(default)]
-    pub frame: Option<WindowFrame>,
     /// Window sits downstream of a relaxed-CK aggregate whose dropped CK
     /// fields overlap this window's `partition_by`. Set to `true` by the
     /// plan-time derivation walk in
@@ -142,49 +136,6 @@ pub struct AnalyticWindowSpec {
     /// because YAML never sets this — it is a derived plan-time property.
     #[serde(default)]
     pub requires_buffer_recompute: bool,
-}
-
-/// Row-frame attached to an [`AnalyticWindowSpec`]. Mirrors SQL window
-/// frames (`ROWS BETWEEN <start> AND <end>`). `Range` / `Groups` modes
-/// land in a later sprint.
-///
-/// Currently the frame deserializes and round-trips through the plan but
-/// does **not** alter evaluation — every `$window.*` call evaluates over
-/// the entire partition. Frame-aware semantics are a future change.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
-pub struct WindowFrame {
-    pub mode: FrameMode,
-    pub start: FrameBound,
-    pub end: FrameBound,
-}
-
-/// Frame mode. Only `Rows` (positional offsets) is supported today.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum FrameMode {
-    Rows,
-}
-
-/// One bound of a [`WindowFrame`]. YAML form is externally tagged for
-/// the offset-carrying variants and a bare string for the parameterless
-/// ones. `Preceding`/`Following` carry a non-negative row offset.
-///
-/// ```yaml
-/// start: unbounded_preceding
-/// end:   current_row
-/// # or
-/// start: { preceding: 3 }
-/// end:   { following: 0 }
-/// ```
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum FrameBound {
-    UnboundedPreceding,
-    Preceding(u32),
-    CurrentRow,
-    Following(u32),
-    UnboundedFollowing,
 }
 
 /// Specification for one secondary index to build during Phase 1.

--- a/crates/clinker-core/src/plan/index.rs
+++ b/crates/clinker-core/src/plan/index.rs
@@ -1,7 +1,8 @@
-//! Phase E: Index planning.
+//! Window-index planning.
 //!
-//! Extracts `analytic_window` configs from pipeline nodes, combines with
-//! `AnalysisReport` field sets, deduplicates into `Vec<IndexSpec>`.
+//! Carries the typed [`AnalyticWindowSpec`] off pipeline nodes through
+//! the deduplication step that produces `Vec<IndexSpec>`, combined with
+//! `AnalysisReport` field sets harvested from each transform's CXL.
 
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
@@ -9,7 +10,7 @@ use std::sync::Arc;
 
 use clinker_record::Schema;
 use petgraph::graph::NodeIndex;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::SortField;
 
@@ -107,8 +108,15 @@ impl Hash for PlanIndexRoot {
 }
 
 /// Typed representation of the `analytic_window` YAML block on a transform.
-#[derive(Debug, Clone, Deserialize)]
-pub struct LocalWindowConfig {
+///
+/// Deserialized directly by serde-saphyr off the YAML config; the same
+/// struct is then carried forward through plan lowering. The
+/// `requires_buffer_recompute` field is the lone exception — it is a
+/// derived plan-time property, not a YAML-authored field; see its doc
+/// comment for why `#[serde(default)]` is the correct shape there.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AnalyticWindowSpec {
     /// Reference source name. If None or same as primary input, it's a same-source window.
     pub source: Option<String>,
     /// Fields to group the partition by.
@@ -118,6 +126,12 @@ pub struct LocalWindowConfig {
     pub sort_by: Vec<SortField>,
     /// Expression to evaluate against the primary record for cross-source lookup.
     pub on: Option<String>,
+    /// Optional row-frame attached to the window. `None` means "entire
+    /// partition" and matches the historical default semantics. Range /
+    /// Groups modes land in a later sprint; only `FrameMode::Rows` is
+    /// accepted today.
+    #[serde(default)]
+    pub frame: Option<WindowFrame>,
     /// Window sits downstream of a relaxed-CK aggregate whose dropped CK
     /// fields overlap this window's `partition_by`. Set to `true` by the
     /// plan-time derivation walk in
@@ -130,26 +144,43 @@ pub struct LocalWindowConfig {
     pub requires_buffer_recompute: bool,
 }
 
-/// Parse a transform's `analytic_window` JSON value into a typed
-/// [`LocalWindowConfig`]. `None` raw value yields `Ok(None)`. Used by
-/// `PipelineConfig::compile_with_diagnostics` while building per-node
-/// window configs in declaration order.
-pub(crate) fn parse_analytic_window_value(
-    raw: &Option<serde_json::Value>,
-    transform_name: &str,
-) -> Result<Option<LocalWindowConfig>, PlanIndexError> {
-    match raw {
-        None => Ok(None),
-        Some(value) => {
-            let config: LocalWindowConfig = serde_json::from_value(value.clone()).map_err(|e| {
-                PlanIndexError::InvalidLocalWindow {
-                    transform: transform_name.to_string(),
-                    message: e.to_string(),
-                }
-            })?;
-            Ok(Some(config))
-        }
-    }
+/// Row-frame attached to an [`AnalyticWindowSpec`]. Mirrors SQL window
+/// frames (`ROWS BETWEEN <start> AND <end>`). `Range` / `Groups` modes
+/// land in a later sprint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct WindowFrame {
+    pub mode: FrameMode,
+    pub start: FrameBound,
+    pub end: FrameBound,
+}
+
+/// Frame mode. Only `Rows` (positional offsets) is supported today.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FrameMode {
+    Rows,
+}
+
+/// One bound of a [`WindowFrame`]. YAML form is externally tagged for
+/// the offset-carrying variants and a bare string for the parameterless
+/// ones. `Preceding`/`Following` carry a non-negative row offset.
+///
+/// ```yaml
+/// start: unbounded_preceding
+/// end:   current_row
+/// # or
+/// start: { preceding: 3 }
+/// end:   { following: 0 }
+/// ```
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum FrameBound {
+    UnboundedPreceding,
+    Preceding(u32),
+    CurrentRow,
+    Following(u32),
+    UnboundedFollowing,
 }
 
 /// Specification for one secondary index to build during Phase 1.
@@ -165,7 +196,7 @@ pub struct IndexSpec {
     pub arena_fields: Vec<String>,
     /// True if the source config declares a sort_order matching this index's sort_by.
     pub already_sorted: bool,
-    /// Mirror of `LocalWindowConfig.requires_buffer_recompute`. Set during
+    /// Mirror of `AnalyticWindowSpec.requires_buffer_recompute`. Set during
     /// `deduplicate_indices` from the input `RawIndexRequest`s; the
     /// executor's window arm consults this to decide between streaming
     /// emit and buffered emit. When two transforms share a deduplicated
@@ -218,7 +249,7 @@ pub fn deduplicate_indices(raw_specs: Vec<RawIndexRequest>) -> Vec<IndexSpec> {
     deduped
 }
 
-/// Raw index request before deduplication. One per (transform, local_window) pair.
+/// Raw index request before deduplication. One per (transform, analytic_window) pair.
 #[derive(Debug, Clone)]
 pub struct RawIndexRequest {
     pub root: PlanIndexRoot,
@@ -228,7 +259,7 @@ pub struct RawIndexRequest {
     pub already_sorted: bool,
     /// Index of the transform that requested this index.
     pub transform_index: usize,
-    /// Mirror of `LocalWindowConfig.requires_buffer_recompute` for this
+    /// Mirror of `AnalyticWindowSpec.requires_buffer_recompute` for this
     /// transform. Carried through dedup so the merged `IndexSpec` lifts
     /// the flag when any contributing transform needs buffer recompute.
     pub requires_buffer_recompute: bool,
@@ -279,25 +310,3 @@ fn sort_fields_equal(a: &[SortField], b: &[SortField]) -> bool {
         .zip(b.iter())
         .all(|(x, y)| x.field == y.field && x.order == y.order)
 }
-
-/// Errors from index planning.
-#[derive(Debug)]
-pub enum PlanIndexError {
-    InvalidLocalWindow { transform: String, message: String },
-}
-
-impl std::fmt::Display for PlanIndexError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PlanIndexError::InvalidLocalWindow { transform, message } => {
-                write!(
-                    f,
-                    "invalid local_window on transform '{}': {}",
-                    transform, message
-                )
-            }
-        }
-    }
-}
-
-impl std::error::Error for PlanIndexError {}

--- a/crates/clinker-core/tests/bench_config_validation.rs
+++ b/crates/clinker-core/tests/bench_config_validation.rs
@@ -295,14 +295,9 @@ fn test_two_pass_configs_have_analytic_window_group_by() {
 
         let has_window = config.nodes.iter().any(|n| {
             if let PipelineNode::Transform { config: body, .. } = &n.value {
-                if let Some(window) = &body.analytic_window {
-                    window
-                        .get("group_by")
-                        .and_then(|v| v.as_array())
-                        .map_or(false, |a| !a.is_empty())
-                } else {
-                    false
-                }
+                body.analytic_window
+                    .as_ref()
+                    .is_some_and(|spec| !spec.group_by.is_empty())
             } else {
                 false
             }

--- a/crates/clinker-record/src/resolver.rs
+++ b/crates/clinker-record/src/resolver.rs
@@ -94,6 +94,28 @@ pub trait WindowContext<'a, S: RecordStorage> {
 
     /// Collect unique field values from all partition records into an Array.
     fn distinct(&self, field: &str) -> Value;
+
+    /// 1-indexed position of the current record within its partition.
+    /// Returns `1` for the first row, `partition_len()` for the last.
+    fn row_number(&self) -> i64;
+
+    /// SQL `RANK()`: ties (equal sort-key tuples) share a rank, and the
+    /// next distinct sort key skips ahead by the size of the tie group.
+    /// With no `sort_by` declared every row is tied — `rank()` collapses
+    /// to `1` for every record, mirroring SQL's degenerate-frame behavior.
+    fn rank(&self) -> i64;
+
+    /// SQL `DENSE_RANK()`: ties share a rank with no gaps to the next
+    /// distinct sort key. Without `sort_by` every row is tied at `1`.
+    fn dense_rank(&self) -> i64;
+
+    /// Value of `field` at the first record of the partition (ordered by
+    /// the configured `sort_by`). Empty partitions return `Value::Null`.
+    fn first_value(&self, field: &str) -> Value;
+
+    /// Value of `field` at the last record of the partition (ordered by
+    /// the configured `sort_by`). Empty partitions return `Value::Null`.
+    fn last_value(&self, field: &str) -> Value;
 }
 
 // Compile-time object safety assertion for FieldResolver

--- a/crates/cxl/src/builtins.rs
+++ b/crates/cxl/src/builtins.rs
@@ -28,6 +28,11 @@ pub enum Category {
     WindowAggregate,
     WindowPositional,
     WindowIterable,
+    /// Zero-argument ranking functions (`row_number`, `rank`, `dense_rank`).
+    /// Distinct from `WindowAggregate` because they take no field
+    /// argument and from `WindowPositional` because they return an
+    /// integer rather than a record reference.
+    WindowRanking,
 }
 
 /// Definition of a single built-in method or window function.
@@ -386,7 +391,13 @@ impl BuiltinRegistry {
             },
         );
 
-        // ── Window aggregate (5) ──
+        // ── Window aggregate ──
+        // first_value / last_value take a field-ref argument and return
+        // its value at the partition's first / last row, mirroring SQL's
+        // `FIRST_VALUE` / `LAST_VALUE` shape. They sit in this category
+        // because they collapse to a field projection over a
+        // single-row "frame" — the same as how sum/avg collapse a
+        // numeric column over the partition.
         let wa = |name: &'static str, args: Vec<TypeTag>, min: usize, ret: TypeTag| {
             (
                 name,
@@ -408,6 +419,8 @@ impl BuiltinRegistry {
             wa("min", vec![TypeTag::Any], 1, TypeTag::Any),
             wa("max", vec![TypeTag::Any], 1, TypeTag::Any),
             wa("count", vec![], 0, TypeTag::Int),
+            wa("first_value", vec![TypeTag::Any], 1, TypeTag::Any),
+            wa("last_value", vec![TypeTag::Any], 1, TypeTag::Any),
         ] {
             window_fns.insert(n, d);
         }
@@ -436,7 +449,27 @@ impl BuiltinRegistry {
             window_fns.insert(n, d);
         }
 
-        // ── Window iterable (4) ──  — any/all take predicate exprs, collect/distinct take field exprs
+        // ── Window ranking (3) ── — zero-argument integer functions.
+        let wr = |name: &'static str| {
+            (
+                name,
+                BuiltinDef {
+                    name,
+                    receiver: TypeTag::Any,
+                    args: vec![],
+                    min_args: 0,
+                    max_args: Some(0),
+                    return_type: TypeTag::Int,
+                    category: Category::WindowRanking,
+                },
+            )
+        };
+        for (n, d) in [wr("row_number"), wr("rank"), wr("dense_rank")] {
+            window_fns.insert(n, d);
+        }
+
+        // ── Window iterable ──  — any/every/exists/not_exists take a
+        // predicate expr; collect/distinct take a field expr.
         let wi = |name: &'static str, ret: TypeTag| {
             (
                 name,
@@ -453,7 +486,9 @@ impl BuiltinRegistry {
         };
         for (n, d) in [
             wi("any", TypeTag::Bool),
-            wi("all", TypeTag::Bool),
+            wi("every", TypeTag::Bool),
+            wi("exists", TypeTag::Bool),
+            wi("not_exists", TypeTag::Bool),
             wi("collect", TypeTag::Array),
             wi("distinct", TypeTag::Array),
         ] {
@@ -660,7 +695,15 @@ mod tests {
     #[test]
     fn test_registry_all_window_aggregate() {
         let r = registry();
-        for name in ["sum", "avg", "min", "max", "count"] {
+        for name in [
+            "sum",
+            "avg",
+            "min",
+            "max",
+            "count",
+            "first_value",
+            "last_value",
+        ] {
             let def = r
                 .lookup_window(name)
                 .unwrap_or_else(|| panic!("missing window agg: {}", name));
@@ -680,9 +723,30 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_all_window_ranking() {
+        let r = registry();
+        for name in ["row_number", "rank", "dense_rank"] {
+            let def = r
+                .lookup_window(name)
+                .unwrap_or_else(|| panic!("missing window ranking: {}", name));
+            assert_eq!(def.category, Category::WindowRanking);
+            assert_eq!(def.return_type, TypeTag::Int);
+            assert_eq!(def.min_args, 0);
+            assert_eq!(def.max_args, Some(0));
+        }
+    }
+
+    #[test]
     fn test_registry_all_window_iterable() {
         let r = registry();
-        for name in ["any", "all", "collect", "distinct"] {
+        for name in [
+            "any",
+            "every",
+            "exists",
+            "not_exists",
+            "collect",
+            "distinct",
+        ] {
             let def = r
                 .lookup_window(name)
                 .unwrap_or_else(|| panic!("missing window iter: {}", name));
@@ -691,14 +755,24 @@ mod tests {
     }
 
     #[test]
+    fn test_registry_no_legacy_all() {
+        let r = registry();
+        assert!(
+            r.lookup_window("all").is_none(),
+            "$window.all renamed to $window.every — no compatibility alias"
+        );
+    }
+
+    #[test]
     fn test_registry_total_count() {
         let r = registry();
         // Due to overloaded names (join/length), scalar map has fewer unique entries.
-        // Total = scalar unique + window unique
+        // Total = scalar unique + window unique. Range covers the scalar
+        // population plus the current window-fn set (aggregate + positional
+        // + ranking + iterable) without pinning the exact count, since new
+        // builtins land here regularly.
         let total = r.total_count();
-        // We expect ~81 but join overwrites, so actual scalar = 68 unique keys + 13 window = 81
-        // Actually let's just check it's in a reasonable range since overloads affect count
-        assert!(total >= 75 && total <= 85, "expected ~81, got {}", total);
+        assert!(total >= 80 && total <= 100, "expected ~88, got {}", total);
     }
 
     #[test]

--- a/crates/cxl/src/eval/mod.rs
+++ b/crates/cxl/src/eval/mod.rs
@@ -752,18 +752,44 @@ pub fn eval_expr<'w, S: RecordStorage + 'w>(
                         Ok(Value::Null)
                     }
                 }
-                // `any` is iterated `or`; `all` is iterated `and`. The
-                // fold must agree with BinOp::And/Or above (lines
-                // 801–829), which are Kleene three-valued and silently
-                // treat non-Bool/non-Null operands as Null. Mirroring
-                // both properties keeps the algebraic identity
-                // `any([a, b, c]) ≡ a or b or c` correctness-preserving
-                // under rewrites.
+                "row_number" => Ok(Value::Integer(w.row_number())),
+                "rank" => Ok(Value::Integer(w.rank())),
+                "dense_rank" => Ok(Value::Integer(w.dense_rank())),
+                "first_value" => {
+                    if let Some(Expr::FieldRef { name, .. }) = args.first() {
+                        Ok(w.first_value(name))
+                    } else {
+                        Ok(Value::Null)
+                    }
+                }
+                "last_value" => {
+                    if let Some(Expr::FieldRef { name, .. }) = args.first() {
+                        Ok(w.last_value(name))
+                    } else {
+                        Ok(Value::Null)
+                    }
+                }
+                // Predicate-fold builtins share a three-valued Kleene
+                // shape: `any` and `exists` collapse to iterated OR;
+                // `every` and `not_exists` collapse to iterated AND
+                // (with `not_exists` inverting the predicate result).
+                // The fold must agree with BinOp::And/Or, which are
+                // Kleene three-valued and silently treat non-Bool /
+                // non-Null operands as Null. Mirroring both properties
+                // keeps the identity `any([a, b, c]) ≡ a or b or c`
+                // correctness-preserving under rewrites.
+                //
+                // `exists(p)` is a semantic alias of `any(p)` — they
+                // produce the same value over the same partition.
+                // `not_exists(p)` is `every(not p)` and is implemented
+                // as a primitive (`every` fold over an inverted Bool)
+                // for clarity and to share short-circuit semantics with
+                // the other folds.
                 //
                 // Typecheck (typecheck/pass.rs) rejects non-Bool argument
                 // types and nested $window.* inside the predicate before
                 // we reach this arm.
-                "any" | "all" => {
+                "any" | "every" | "exists" | "not_exists" => {
                     let predicate = args.first().ok_or_else(|| {
                         EvalError::new(
                             EvalErrorKind::ArityMismatch {
@@ -774,11 +800,17 @@ pub fn eval_expr<'w, S: RecordStorage + 'w>(
                             *span,
                         )
                     })?;
-                    let want_any = &**function == "any";
+                    let invert = &**function == "not_exists";
+                    let want_any = matches!(&**function, "any" | "exists");
                     let mut found_null = false;
                     for i in 0..w.partition_len() {
                         let row = w.partition_record(i);
-                        match eval_expr(predicate, typed, ctx, &row, window, env)? {
+                        let raw = eval_expr(predicate, typed, ctx, &row, window, env)?;
+                        let v = match (invert, raw) {
+                            (true, Value::Bool(b)) => Value::Bool(!b),
+                            (_, other) => other,
+                        };
+                        match v {
                             Value::Bool(true) if want_any => return Ok(Value::Bool(true)),
                             Value::Bool(false) if !want_any => return Ok(Value::Bool(false)),
                             Value::Bool(_) => {}
@@ -792,12 +824,23 @@ pub fn eval_expr<'w, S: RecordStorage + 'w>(
                         Value::Null
                     } else {
                         // Identity for the iterated operator:
-                        //   any (iterated or) → false
-                        //   all (iterated and) → true
+                        //   any/exists (iterated or) → false
+                        //   every/not_exists (iterated and) → true
                         Value::Bool(!want_any)
                     })
                 }
-                _ => Ok(Value::Null),
+                // Unregistered names cannot reach here: the typecheck
+                // pass rejects unknown $window.* identifiers before
+                // evaluation. Reaching this arm means a registered name
+                // has no evaluator implementation — surface a typed
+                // error rather than silently emitting Null.
+                _ => Err(EvalError::new(
+                    EvalErrorKind::TypeMismatch {
+                        expected: "registered $window function",
+                        got: "unimplemented evaluator arm",
+                    },
+                    *span,
+                )),
             }
         }
 

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -532,15 +532,15 @@ fn test_log_level4_guard_short_circuits() {
 }
 
 // ---------------------------------------------------------------------------
-// $window.any / $window.all — three-valued logic
+// $window.any / $window.every — three-valued logic
 //
-// Mirrors BinOp::And/Or in eval/mod.rs:801–829 by construction. Tests use a
+// Mirrors BinOp::And/Or in eval/mod.rs by construction. Tests use a
 // minimal in-memory `RowsStorage` + `RowsWindow` so each test row can hold
 // explicit `Value::Bool` / `Value::Null` predicate inputs without going
 // through CSV/coercion.
 // ---------------------------------------------------------------------------
 
-mod any_all {
+mod any_every {
     use super::*;
     use crate::typecheck::row::QualifiedField;
     use clinker_record::{RecordView, WindowContext};
@@ -621,6 +621,21 @@ mod any_all {
         fn distinct(&self, _: &str) -> Value {
             Value::Null
         }
+        fn row_number(&self) -> i64 {
+            1
+        }
+        fn rank(&self) -> i64 {
+            1
+        }
+        fn dense_rank(&self) -> i64 {
+            1
+        }
+        fn first_value(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn last_value(&self, _: &str) -> Value {
+            Value::Null
+        }
     }
 
     fn eval_window(src: &str, partition: Vec<Value>) -> Value {
@@ -672,7 +687,7 @@ mod any_all {
     }
 
     #[test]
-    fn any_all_false_returns_false() {
+    fn any_every_false_returns_false() {
         assert_eq!(
             eval_window(
                 "emit r = $window.any(flag)",
@@ -695,26 +710,26 @@ mod any_all {
     }
 
     #[test]
-    fn all_short_circuits_on_false() {
+    fn every_short_circuits_on_false() {
         assert_eq!(
             eval_window(
-                "emit r = $window.all(flag)",
+                "emit r = $window.every(flag)",
                 vec![b(true), b(false), b(true)]
             ),
             Value::Bool(false)
         );
         // False before null → still false (short-circuit fires before null is seen).
         assert_eq!(
-            eval_window("emit r = $window.all(flag)", vec![b(false), n(), b(true)]),
+            eval_window("emit r = $window.every(flag)", vec![b(false), n(), b(true)]),
             Value::Bool(false)
         );
     }
 
     #[test]
-    fn all_all_true_returns_true() {
+    fn every_all_true_returns_true() {
         assert_eq!(
             eval_window(
-                "emit r = $window.all(flag)",
+                "emit r = $window.every(flag)",
                 vec![b(true), b(true), b(true)]
             ),
             Value::Bool(true)
@@ -722,13 +737,13 @@ mod any_all {
     }
 
     #[test]
-    fn all_null_with_no_false_returns_null() {
+    fn every_null_with_no_false_returns_null() {
         assert_eq!(
-            eval_window("emit r = $window.all(flag)", vec![n(), b(true), b(true)]),
+            eval_window("emit r = $window.every(flag)", vec![n(), b(true), b(true)]),
             Value::Null
         );
         assert_eq!(
-            eval_window("emit r = $window.all(flag)", vec![b(true), n(), b(true)]),
+            eval_window("emit r = $window.every(flag)", vec![b(true), n(), b(true)]),
             Value::Null
         );
     }
@@ -737,22 +752,22 @@ mod any_all {
     fn empty_partition_returns_identity() {
         // Defensive — unreachable in practice (current row is always in
         // partition), but identity for iterated or/and:
-        // any → false, all → true.
+        // any → false, every → true.
         assert_eq!(
             eval_window("emit r = $window.any(flag)", vec![]),
             Value::Bool(false)
         );
         assert_eq!(
-            eval_window("emit r = $window.all(flag)", vec![]),
+            eval_window("emit r = $window.every(flag)", vec![]),
             Value::Bool(true)
         );
     }
 
     #[test]
     fn agrees_with_iterated_or_and_two_rows() {
-        // Algebraic identity: any([a, b]) ≡ a or b; all([a, b]) ≡ a and b.
-        // BinOp::And/Or in eval/mod.rs:801–829 are the source of truth;
-        // any/all over the same inputs must produce the same Value.
+        // Algebraic identity: any([a, b]) ≡ a or b; every([a, b]) ≡ a and b.
+        // BinOp::And/Or in eval/mod.rs are the source of truth;
+        // any/every over the same inputs must produce the same Value.
         let pairs = [
             (b(true), b(true)),
             (b(true), b(false)),
@@ -777,17 +792,351 @@ mod any_all {
                 "any({a:?}, {b_val:?}) must match iterated or"
             );
 
-            let from_all =
-                eval_window("emit r = $window.all(flag)", vec![a.clone(), b_val.clone()]);
-            let expected_all = match (&a, &b_val) {
+            let from_every = eval_window(
+                "emit r = $window.every(flag)",
+                vec![a.clone(), b_val.clone()],
+            );
+            let expected_every = match (&a, &b_val) {
                 (Value::Bool(false), _) | (_, Value::Bool(false)) => Value::Bool(false),
                 (Value::Bool(true), Value::Bool(true)) => Value::Bool(true),
                 _ => Value::Null,
             };
             assert_eq!(
-                from_all, expected_all,
-                "all({a:?}, {b_val:?}) must match iterated and"
+                from_every, expected_every,
+                "every({a:?}, {b_val:?}) must match iterated and"
             );
         }
+    }
+
+    #[test]
+    fn exists_aliases_any() {
+        // exists(p) and any(p) collapse to iterated OR over identical
+        // inputs and must match Value-for-Value.
+        assert_eq!(
+            eval_window(
+                "emit r = $window.exists(flag)",
+                vec![b(false), b(true), b(false)]
+            ),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval_window(
+                "emit r = $window.exists(flag)",
+                vec![b(false), b(false), b(false)]
+            ),
+            Value::Bool(false)
+        );
+        // Empty partition: same identity as any.
+        assert_eq!(
+            eval_window("emit r = $window.exists(flag)", vec![]),
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn not_exists_inverts_predicate() {
+        // not_exists(p) ≡ every(not p): true iff no row satisfies p.
+        assert_eq!(
+            eval_window(
+                "emit r = $window.not_exists(flag)",
+                vec![b(false), b(false), b(false)]
+            ),
+            Value::Bool(true)
+        );
+        assert_eq!(
+            eval_window(
+                "emit r = $window.not_exists(flag)",
+                vec![b(false), b(true), b(false)]
+            ),
+            Value::Bool(false)
+        );
+        // Empty partition: vacuously true (matches every's identity).
+        assert_eq!(
+            eval_window("emit r = $window.not_exists(flag)", vec![]),
+            Value::Bool(true)
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Typecheck: unknown $window.* functions are an error.
+// Catches the silent-Null bug where $window.row_numbr() previously
+// fell through the registry's None branch and inherited Type::Any.
+// ---------------------------------------------------------------------------
+
+mod window_typecheck {
+    use super::*;
+
+    fn typecheck_errors(src: &str) -> Vec<String> {
+        let parsed = Parser::parse(src);
+        assert!(parsed.errors.is_empty(), "parse: {:?}", parsed.errors);
+        let resolved = resolve_program(parsed.ast, &[], parsed.node_count)
+            .unwrap_or_else(|d| panic!("resolve: {:?}", d));
+        let row = empty_row();
+        match type_check(resolved, &row) {
+            Ok(_) => vec![],
+            Err(diags) => diags.into_iter().map(|d| d.message).collect(),
+        }
+    }
+
+    #[test]
+    fn unknown_window_function_errors() {
+        let errs = typecheck_errors("emit r = $window.row_numbr()");
+        assert!(
+            errs.iter().any(|m| m.contains("unknown window function")),
+            "expected unknown-window-function diagnostic, got: {:?}",
+            errs
+        );
+    }
+
+    #[test]
+    fn registered_window_function_typechecks() {
+        // row_number is registered with return type Int; should not error.
+        let errs = typecheck_errors("emit r = $window.row_number()");
+        assert!(errs.is_empty(), "unexpected errors: {:?}", errs);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// $window.row_number / rank / dense_rank / first_value / last_value.
+//
+// Unit-level shape tests against a minimal in-memory implementation that
+// keys ranks off a synthetic `k` column. End-to-end coverage with an
+// Arena partition lives in
+// `clinker_core::executor::tests::post_aggregate_window_ranking`.
+// ---------------------------------------------------------------------------
+
+mod ranking_and_value {
+    use super::*;
+    use crate::typecheck::row::QualifiedField;
+    use clinker_record::{RecordView, WindowContext};
+
+    /// Storage with two columns: `k` (sort key) and `v` (value).
+    struct KeyedRows {
+        keys: Vec<Value>,
+        values: Vec<Value>,
+    }
+
+    impl RecordStorage for KeyedRows {
+        fn resolve_field(&self, index: u64, name: &str) -> Option<&Value> {
+            match name {
+                "k" => self.keys.get(index as usize),
+                "v" => self.values.get(index as usize),
+                _ => None,
+            }
+        }
+        fn resolve_qualified(&self, _: u64, _: &str, _: &str) -> Option<&Value> {
+            None
+        }
+        fn available_fields(&self, _: u64) -> Vec<&str> {
+            vec!["k", "v"]
+        }
+        fn record_count(&self) -> u64 {
+            self.keys.len() as u64
+        }
+    }
+
+    /// Window over the full storage. `current_pos` selects which row the
+    /// ranking functions report; rank/dense_rank consult the `k` column
+    /// for tie detection.
+    struct RankWindow<'a> {
+        storage: &'a KeyedRows,
+        current_pos: usize,
+    }
+
+    impl<'a> WindowContext<'a, KeyedRows> for RankWindow<'a> {
+        fn first(&self) -> Option<RecordView<'a, KeyedRows>> {
+            (!self.storage.keys.is_empty()).then(|| RecordView::new(self.storage, 0))
+        }
+        fn last(&self) -> Option<RecordView<'a, KeyedRows>> {
+            self.storage
+                .keys
+                .len()
+                .checked_sub(1)
+                .map(|i| RecordView::new(self.storage, i as u64))
+        }
+        fn lag(&self, _: usize) -> Option<RecordView<'a, KeyedRows>> {
+            None
+        }
+        fn lead(&self, _: usize) -> Option<RecordView<'a, KeyedRows>> {
+            None
+        }
+        fn count(&self) -> i64 {
+            self.storage.keys.len() as i64
+        }
+        fn sum(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn cumulative_sum(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn avg(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn min(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn max(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn partition_len(&self) -> usize {
+            self.storage.keys.len()
+        }
+        fn partition_record(&self, index: usize) -> RecordView<'a, KeyedRows> {
+            RecordView::new(self.storage, index as u64)
+        }
+        fn collect(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn distinct(&self, _: &str) -> Value {
+            Value::Null
+        }
+        fn row_number(&self) -> i64 {
+            self.current_pos as i64 + 1
+        }
+        fn rank(&self) -> i64 {
+            if self.storage.keys.is_empty() {
+                return 1;
+            }
+            let mut rank = 1i64;
+            for i in 1..=self.current_pos {
+                if self.storage.keys[i] != self.storage.keys[i - 1] {
+                    rank = (i as i64) + 1;
+                }
+            }
+            rank
+        }
+        fn dense_rank(&self) -> i64 {
+            if self.storage.keys.is_empty() {
+                return 1;
+            }
+            let mut rank = 1i64;
+            for i in 1..=self.current_pos {
+                if self.storage.keys[i] != self.storage.keys[i - 1] {
+                    rank += 1;
+                }
+            }
+            rank
+        }
+        fn first_value(&self, field: &str) -> Value {
+            match field {
+                "k" => self.storage.keys.first().cloned().unwrap_or(Value::Null),
+                "v" => self.storage.values.first().cloned().unwrap_or(Value::Null),
+                _ => Value::Null,
+            }
+        }
+        fn last_value(&self, field: &str) -> Value {
+            match field {
+                "k" => self.storage.keys.last().cloned().unwrap_or(Value::Null),
+                "v" => self.storage.values.last().cloned().unwrap_or(Value::Null),
+                _ => Value::Null,
+            }
+        }
+    }
+
+    fn eval_with(
+        src: &str,
+        keys: Vec<Value>,
+        values: Vec<Value>,
+        current_pos: usize,
+    ) -> indexmap::IndexMap<String, Value> {
+        let parsed = Parser::parse(src);
+        assert!(parsed.errors.is_empty(), "parse: {:?}", parsed.errors);
+        let resolved = resolve_program(parsed.ast, &["k", "v"], parsed.node_count)
+            .unwrap_or_else(|d| panic!("resolve: {:?}", d));
+        let mut cols = indexmap::IndexMap::new();
+        cols.insert(
+            QualifiedField::bare("k"),
+            crate::typecheck::types::Type::Int,
+        );
+        cols.insert(
+            QualifiedField::bare("v"),
+            crate::typecheck::types::Type::Int,
+        );
+        let row = Row::closed(cols, Span::new(0, 0));
+        let typed = type_check(resolved, &row).unwrap_or_else(|d| panic!("type: {:?}", d));
+        let stable = StableEvalContext::test_default();
+        let ctx = EvalContext::test_default_borrowed(&stable);
+        let storage = KeyedRows { keys, values };
+        let resolver = HashMapResolver::new(HashMap::new());
+        let window = RankWindow {
+            storage: &storage,
+            current_pos,
+        };
+        eval_program::<KeyedRows>(&typed, &ctx, &resolver, Some(&window))
+            .unwrap_or_else(|e| panic!("eval: {}", e))
+    }
+
+    fn i(n: i64) -> Value {
+        Value::Integer(n)
+    }
+
+    #[test]
+    fn row_number_is_1_indexed() {
+        let out = eval_with(
+            "emit n = $window.row_number()",
+            vec![i(1), i(1), i(2), i(3)],
+            vec![i(10), i(20), i(30), i(40)],
+            0,
+        );
+        assert_eq!(out.get("n"), Some(&Value::Integer(1)));
+        let out = eval_with(
+            "emit n = $window.row_number()",
+            vec![i(1), i(1), i(2), i(3)],
+            vec![i(10), i(20), i(30), i(40)],
+            3,
+        );
+        assert_eq!(out.get("n"), Some(&Value::Integer(4)));
+    }
+
+    #[test]
+    fn rank_ties_share_value_then_gap() {
+        // Keys: 1 1 2 2 2 5 → rank: 1 1 3 3 3 6 (gap of two after the
+        // first tie pair, gap of two after the second tie triple).
+        let keys = vec![i(1), i(1), i(2), i(2), i(2), i(5)];
+        let vals = vec![i(0); 6];
+        let expected = [1, 1, 3, 3, 3, 6];
+        for (pos, exp) in expected.iter().enumerate() {
+            let out = eval_with("emit r = $window.rank()", keys.clone(), vals.clone(), pos);
+            assert_eq!(
+                out.get("r"),
+                Some(&Value::Integer(*exp)),
+                "rank at pos {pos}"
+            );
+        }
+    }
+
+    #[test]
+    fn dense_rank_no_gaps() {
+        // Keys: 1 1 2 2 2 5 → dense_rank: 1 1 2 2 2 3 (each distinct
+        // key bumps the rank by exactly one).
+        let keys = vec![i(1), i(1), i(2), i(2), i(2), i(5)];
+        let vals = vec![i(0); 6];
+        let expected = [1, 1, 2, 2, 2, 3];
+        for (pos, exp) in expected.iter().enumerate() {
+            let out = eval_with(
+                "emit r = $window.dense_rank()",
+                keys.clone(),
+                vals.clone(),
+                pos,
+            );
+            assert_eq!(
+                out.get("r"),
+                Some(&Value::Integer(*exp)),
+                "dense_rank at pos {pos}"
+            );
+        }
+    }
+
+    #[test]
+    fn first_value_last_value_project_field() {
+        let out = eval_with(
+            "emit fv = $window.first_value(v)\nemit lv = $window.last_value(v)",
+            vec![i(1), i(2), i(3)],
+            vec![i(100), i(200), i(300)],
+            1,
+        );
+        assert_eq!(out.get("fv"), Some(&Value::Integer(100)));
+        assert_eq!(out.get("lv"), Some(&Value::Integer(300)));
     }
 }

--- a/crates/cxl/src/resolve/pass.rs
+++ b/crates/cxl/src/resolve/pass.rs
@@ -617,10 +617,11 @@ impl<'a> Resolver<'a> {
             } else {
                 self.diagnostics.push(ResolveDiagnostic {
                     span,
-                    message: "'it' is only valid inside $window.any() or $window.all() predicates"
-                        .into(),
+                    message:
+                        "'it' is only valid inside a $window predicate (any / every / exists / not_exists)"
+                            .into(),
                     help: Some(
-                        "Move this expression inside a $window.any() or $window.all() call".into(),
+                        "Move this expression inside a $window.any() / .every() / .exists() / .not_exists() call".into(),
                     ),
                 });
                 return;
@@ -906,7 +907,7 @@ mod tests {
         assert!(
             diags[0]
                 .message
-                .contains("'it' is only valid inside $window.any() or $window.all()")
+                .contains("'it' is only valid inside a $window predicate")
         );
     }
 

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -762,12 +762,13 @@ impl<'a> TypeChecker<'a> {
                 args,
                 span,
             } => {
-                let is_predicate_fn = &**function == "any" || &**function == "all";
+                let is_predicate_fn =
+                    matches!(&**function, "any" | "every" | "exists" | "not_exists");
 
                 // Check for nested window calls inside predicate_expr
                 if in_predicate {
                     self.error(*span,
-                        format!("$window.{}() cannot be called inside a $window.any() or $window.all() predicate", function),
+                        format!("$window.{}() cannot be called inside a $window.any/every/exists/not_exists predicate", function),
                         Some("Move the window call outside the predicate expression".into()));
                 }
 
@@ -797,8 +798,9 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
 
-                // any/all: enforce arity 1 and Bool-typed predicate so
-                // the eval-time three-valued fold has a well-typed input.
+                // Predicate-fold builtins: enforce arity 1 and Bool-typed
+                // predicate so the eval-time three-valued fold has a
+                // well-typed input.
                 if is_predicate_fn {
                     match args.len() {
                         1 => {
@@ -823,10 +825,24 @@ impl<'a> TypeChecker<'a> {
                     }
                 }
 
-                let ty = if let Some(def) = self.registry.lookup_window(function) {
-                    Type::from_type_tag(def.return_type)
-                } else {
-                    Type::Any
+                // Unregistered window names are a typecheck error.
+                // Letting them fall through to `Type::Any` lets a
+                // misspelled `$window.row_numbr()` reach eval-time and
+                // silently return `Value::Null` from the catch-all arm —
+                // a class of silent-Null bug this pass exists to catch.
+                let ty = match self.registry.lookup_window(function) {
+                    Some(def) => Type::from_type_tag(def.return_type),
+                    None => {
+                        self.error(
+                            *span,
+                            format!("unknown window function $window.{}()", function),
+                            Some(
+                                "Use one of the registered window functions: row_number, rank, dense_rank, count, sum, cumulative_sum, avg, min, max, first, last, first_value, last_value, lag, lead, any, every, exists, not_exists, collect, distinct"
+                                    .into(),
+                            ),
+                        );
+                        Type::Any
+                    }
                 };
 
                 self.set_type(*node_id, ty.clone());
@@ -1474,11 +1490,11 @@ mod tests {
     }
 
     #[test]
-    fn test_typecheck_all_requires_bool_arg() {
+    fn test_typecheck_every_requires_bool_arg() {
         let mut cols = IndexMap::new();
         cols.insert("amount".into(), Type::Int);
         let schema = Row::closed(cols, Span::new(0, 0));
-        let diags = typecheck_err("emit val = $window.all(amount)", &["amount"], &schema);
+        let diags = typecheck_err("emit val = $window.every(amount)", &["amount"], &schema);
         assert!(
             diags.iter().any(|d| d.message.contains("Bool")),
             "Expected Bool requirement diagnostic, got: {:?}",

--- a/docs/src/cxl/windows.md
+++ b/docs/src/cxl/windows.md
@@ -80,6 +80,55 @@ Count of records in the window frame. Takes no arguments.
 emit window_size = $window.count()
 ```
 
+### $window.first_value(field)
+
+Returns the value of `field` at the first record of the window frame
+(ordered by `sort_by`). Equivalent to SQL `FIRST_VALUE(field)`.
+
+```
+emit opening_amount = $window.first_value(amount)
+```
+
+### $window.last_value(field)
+
+Returns the value of `field` at the last record of the window frame
+(ordered by `sort_by`). Equivalent to SQL `LAST_VALUE(field)`.
+
+```
+emit closing_amount = $window.last_value(amount)
+```
+
+## Ranking window functions
+
+Zero-argument integer functions that return the current row's rank
+within its partition.
+
+### $window.row_number()
+
+1-indexed position of the current record within its partition.
+
+```
+emit row_idx = $window.row_number()
+```
+
+### $window.rank()
+
+SQL `RANK()`: rows that share the same `sort_by` tuple receive the same
+rank, and the next distinct row jumps by the size of the tie group.
+
+```
+emit sales_rank = $window.rank()
+```
+
+### $window.dense_rank()
+
+SQL `DENSE_RANK()`: ties share a rank with no gaps between distinct
+ranks.
+
+```
+emit sales_dense_rank = $window.dense_rank()
+```
+
 ## Positional window functions
 
 These access specific records by position within the window frame.
@@ -129,12 +178,31 @@ Returns `true` if the predicate is true for any record in the window.
 emit has_high = $window.any(amount > 1000)
 ```
 
-### $window.all(predicate)
+### $window.every(predicate)
 
-Returns `true` if the predicate is true for all records in the window.
+Returns `true` if the predicate is true for every record in the window.
 
 ```
-emit all_positive = $window.all(amount > 0)
+emit all_positive = $window.every(amount > 0)
+```
+
+### $window.exists(predicate)
+
+Returns `true` if the predicate is true for at least one record in the
+window — a SQL-fluency alias of `$window.any`.
+
+```
+emit any_high = $window.exists(amount > 1000)
+```
+
+### $window.not_exists(predicate)
+
+Returns `true` if no record in the window satisfies the predicate.
+Equivalent to `not $window.exists(predicate)` and to
+`$window.every(not predicate)`.
+
+```
+emit none_negative = $window.not_exists(amount < 0)
 ```
 
 ### $window.collect(field)


### PR DESCRIPTION
## Summary

- Replaces the `pub type AnalyticWindowSpec = serde_json::Value` alias with a real typed struct, deserialized directly by serde-saphyr off the YAML config. `parse_analytic_window_value()`, `PlanIndexError`, dead `TransformSpec.local_window`, and the JSON round-trip in `lower_node_to_plan_node` are deleted. Diagnostic vocabulary follows the YAML key (`MissingAnalyticWindow`).
- Adds five new `$window.*` builtins — `row_number`, `rank`, `dense_rank`, `first_value`, `last_value` — implemented as `WindowContext` trait methods on `PartitionWindowContext`. `rank`/`dense_rank` consult the partition's sort-field tuple to detect ties.
- Adds two new partition-scoped predicate folds — `$window.exists` and `$window.not_exists` — and **renames `$window.all` → `$window.every` with no compatibility alias** (greenfield rename). The four predicate folds (`any`/`every`/`exists`/`not_exists`) share a single Kleene-fold evaluator arm.
- The CXL typecheck pass now rejects unknown `$window.<name>()` calls instead of silently typing them as `Any`. This closes a latent silent-`Null` bug where `$window.row_number()` in the windowed-analytics bench fixture had been returning `Null` for the lack of a registered handler — it now actually works.

## Breaking changes

- Pipelines calling `$window.all(predicate)` must rename to `$window.every(predicate)`. No alias kept.
- Pipelines calling an unregistered `$window.foo()` now fail typecheck instead of silently returning `Null`. Misspellings surface with a span-aware diagnostic.
- `PlanError::MissingLocalWindow` is renamed to `PlanError::MissingAnalyticWindow`. Diagnostic messages follow.

## Deferrals

- Frame-aware (`ROWS BETWEEN`) evaluation is not part of this PR. The `WindowFrame`/`FrameMode`/`FrameBound` types were sketched and then removed because no evaluator consumed them at landing time. They return alongside their consumer — tracked at #87.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo test --workspace` — ~1500 tests across the workspace, all green
- [x] `cargo check --benches --workspace` clean (bench callsites compile against the typed `AnalyticWindowSpec` and the renamed `$window.every`)
- [x] `cargo check --features bench-alloc -p clinker-benchmarks` clean
- [x] `cargo test --benches -p clinker-benchmarks` — all e2e scale matrices pass
- [x] `cargo deny check` clean (advisories, bans, licenses, sources)

New tests covering the surface in this PR:

- `crates/cxl/src/eval/tests.rs` — `exists_aliases_any`, `not_exists_inverts_predicate`, predicate-fold core (`any_every_*`)
- `crates/cxl/src/eval/tests.rs::window_typecheck` — `unknown_window_function_errors`, `registered_window_function_typechecks`
- `crates/cxl/src/eval/tests.rs::ranking_and_value` — `row_number_is_1_indexed`, `first_value_last_value_project_field`
- `crates/clinker-core/src/executor/tests/post_aggregate_window_ranking.rs` — `ranking_and_value_columns_over_tied_partition` (end-to-end with tied sort keys verifying `rank` vs `dense_rank` behavior), `every_exists_not_exists_partition_scoped` (partition-bounded behavior of the three predicate folds)