### PR TITLE
engine: structured PipelineError::MemoryBudgetExceeded variant; migrate ad-hoc E310 emissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,14 @@ Clinker is a **bounded-memory batch DAG executor**. A pipeline run is a finite j
 
 Within a run, stateless operators (Transform, Route, most Combine probe-side work, Output) evaluate records **one at a time** without per-record state accumulation. The DAG executor materializes intermediate `node_buffers` between non-fused stages, so memory scales with the largest live intermediate stage's output, not total input size; fused Source → Transform → Output paths skip materialization entirely. Blocking operators (Aggregate, sort, grace-hash Combine) accumulate state inside the configured RSS budget (default 512 MB) and spill to disk when soft/hard thresholds trip rather than OOM the process.
 
+**Three architectural pillars** (committed to permanently — design decisions cascade from these):
+
+1. **Finite inputs only.** Files (CSV / JSON / XML / fixed-width) and finite-cursor network sources (paginated REST, SQL `SELECT` cursors) — both EOF after exhausting their cursor. Unbounded sources (Kafka, Kinesis, SSE, webhooks, `tail -f`) are out of scope permanently.
+2. **Finite jobs.** No daemon mode, no service surface, no infinite event loop. `clinker run` invokes, drains, exits with a status code.
+3. **Single process forever.** One invocation = one OS process. Parallelism happens inside the process via `std::thread` and Rayon. No worker-process pools, no multi-machine sharding, no network shuffle, no cluster manager. Scale by adding cores / RAM / disk to one host (DuckDB / Polars / Kettle model). If a host genuinely can't fit the work, partition the input by file or key and run multiple `clinker` invocations from a shell script.
+
+`docs/src/non-goals.md` is the user-facing version of this list; keep it in sync when these commitments change. Architectural proposals that violate any of the three pillars should be rejected at the design-review stage, not just at the implementation-review stage.
+
 ### Crate dependency layers (bottom → top)
 
 ```

--- a/crates/clinker-core/src/error.rs
+++ b/crates/clinker-core/src/error.rs
@@ -57,10 +57,11 @@
 //! | `E307`      | error    | Combine input references undeclared upstream         |
 //! | `E308`      | error    | Combine cxl body references unknown field            |
 //! | `E309`      | error    | Combine output schema is empty                       |
-//! | `E310`      | error    | Combine runtime exceeded hard memory limit           |
+//! | `E310`      | error    | Memory-budget surface exceeded the configured hard limit |
 //! | `E311`      | error    | Combine `match: collect` has a non-empty `cxl:` body |
 //! | `E313`      | error    | Combine has no equality conjuncts (HashBuildProbe needs ≥1) |
 //! | `E314`      | error    | Schema mismatch at operator entry (column list divergence) |
+//! | `E319`      | error    | Combine `on_miss: error` had no matching build row   |
 //! | `W302`      | warning  | Pure-equi combine with all small inputs — consider InMemoryHash |
 //! | `W305`      | warning  | Combine where-clause has no equality conjuncts       |
 //! | `W306`      | warning  | Combine planner cannot determine optimal driving input |
@@ -351,6 +352,27 @@ pub enum PipelineError {
         group_key: String,
         count: u64,
     },
+    /// E310 — a memory-budget surface (arena state, `node_buffers`,
+    /// or accumulated disk-spill bytes) exceeded the configured RSS
+    /// hard limit. `node` names the producing operator; `source`
+    /// distinguishes which surface tripped. `detail` carries any
+    /// site-specific context the rendered message previously inlined
+    /// (e.g. partition id, distinct-count estimate, disk-spill quota
+    /// figures). Always aborts the run.
+    MemoryBudgetExceeded {
+        node: String,
+        used: u64,
+        limit: u64,
+        source: crate::pipeline::memory::BudgetCategory,
+        detail: Option<String>,
+    },
+    /// E319 — a combine with `on_miss: error` saw a driver row that
+    /// matched no build row. Semantically distinct from E310 (which
+    /// is a memory-budget overflow). Always aborts the run.
+    CombineMissingMatch {
+        combine: String,
+        driver_row: u64,
+    },
     /// E315 (pipeline-wide, `source: None`) or E316 (per-source,
     /// `source: Some(name)`) — the cumulative DLQ fraction crossed
     /// the configured `max_rate` after at least `min_records` rows
@@ -472,6 +494,27 @@ impl fmt::Display for PipelineError {
                 "correlation-key group {group_key:?} exceeded max_group_buffer \
                  after {count} records — remaining records of the group are \
                  DLQ'd as collateral"
+            ),
+            Self::MemoryBudgetExceeded {
+                node,
+                used,
+                limit,
+                source,
+                detail,
+            } => match detail {
+                Some(d) => write!(
+                    f,
+                    "E310 {node}: {source} exceeded budget ({used}/{limit}) [{d}]"
+                ),
+                None => write!(f, "E310 {node}: {source} exceeded budget ({used}/{limit})"),
+            },
+            Self::CombineMissingMatch {
+                combine,
+                driver_row,
+            } => write!(
+                f,
+                "E319 combine '{combine}': on_miss: error — no matching build row \
+                 for driver row {driver_row}"
             ),
             Self::DlqRateExceeded {
                 source,
@@ -634,7 +677,7 @@ mod diagnostic_tests {
         // explicit entry both here and in the registry table above.
         for code in [
             "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308", "E309", "E310", "E311",
-            "E313", "E314", "E315", "E316", "E317", "E318",
+            "E313", "E314", "E315", "E316", "E317", "E318", "E319",
         ] {
             let pattern = format!("`{code}`");
             assert!(

--- a/crates/clinker-core/src/executor/commit/dispatch.rs
+++ b/crates/clinker-core/src/executor/commit/dispatch.rs
@@ -496,7 +496,11 @@ async fn recurse_into_body(
         // the forward-pass `tee_emit_to_region_input_buffers` applies,
         // so a runaway body cannot evade the per-pipeline budget by
         // routing its output through the harvest path instead.
-        crate::executor::dispatch::charge_harvest_admission(ctx, &harvested)?;
+        crate::executor::dispatch::charge_harvest_admission(
+            ctx,
+            &harvested,
+            parent_dag.graph[composition_idx].name(),
+        )?;
         ctx.node_buffers
             .entry(composition_idx)
             .or_default()

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -411,7 +411,7 @@ use crate::executor::{
     evaluate_single_transform, evaluate_single_transform_windowed, parse_memory_limit,
     stage_metrics, widen_record_to_schema,
 };
-use crate::pipeline::memory::MemoryBudget;
+use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
 use crate::plan::bind_schema::CompileArtifacts;
 use crate::plan::execution::{ExecutionPlanDag, PlanNode};
 use crate::projection::project_output_from_record;
@@ -1082,8 +1082,9 @@ fn tee_emit_to_region_input_buffers(
     if crossing_edges.is_empty() {
         return Ok(());
     }
+    let producer_name = current_dag.graph[producer_idx].name().to_string();
     for edge_id in crossing_edges {
-        charge_harvest_admission(ctx, emit_rows)?;
+        charge_harvest_admission(ctx, emit_rows, &producer_name)?;
         for (record, rn) in emit_rows {
             ctx.region_input_buffers
                 .entry((active_body, edge_id))
@@ -1097,9 +1098,10 @@ fn tee_emit_to_region_input_buffers(
 /// Per-row arena charge against `ctx.memory_budget` for records about
 /// to be admitted into a deferred-region buffer (cross-region tee on
 /// the forward pass, body→parent harvest on the commit pass). Returns
-/// the same `E310`-shape `PipelineError::Compilation` as the windowed
-/// Transform's buffer-recompute path so every admission site fails
-/// uniformly when the per-pipeline memory limit is exhausted.
+/// a typed `PipelineError::MemoryBudgetExceeded` when the per-pipeline
+/// memory limit is exhausted; the producer node's name is carried in
+/// `node` so downstream diagnostics and DLQ routing can identify the
+/// overflowing operator.
 ///
 /// Per-row size mirrors the per-Value-slot accounting the cross-region
 /// tee uses so a runaway body cannot evade the per-pipeline budget by
@@ -1108,6 +1110,7 @@ fn tee_emit_to_region_input_buffers(
 pub(crate) fn charge_harvest_admission(
     ctx: &mut ExecutorContext<'_>,
     rows: &[(Record, u64)],
+    node_name: &str,
 ) -> Result<(), PipelineError> {
     let row_bytes_each: u64 = rows
         .first()
@@ -1121,13 +1124,12 @@ pub(crate) fn charge_harvest_admission(
     }
     for _ in rows {
         if ctx.memory_budget.charge_arena_bytes(row_bytes_each) {
-            return Err(PipelineError::Compilation {
-                transform_name: String::new(),
-                messages: vec![format!(
-                    "E310 deferred-region buffer admission exceeded \
-                     memory limit: hard limit {}",
-                    ctx.memory_budget.hard_limit()
-                )],
+            return Err(PipelineError::MemoryBudgetExceeded {
+                node: node_name.to_string(),
+                used: ctx.memory_budget.arena_bytes_charged(),
+                limit: ctx.memory_budget.hard_limit(),
+                source: BudgetCategory::Arena,
+                detail: Some("deferred-region buffer admission".to_string()),
             });
         }
     }
@@ -1336,9 +1338,12 @@ pub(crate) fn finalize_node_rooted_windows(
             anchor_schema,
             &mut ctx.memory_budget,
         )
-        .map_err(|e| PipelineError::Compilation {
-            transform_name: String::new(),
-            messages: vec![format!("E310 node-rooted arena build: {e}")],
+        .map_err(|e| PipelineError::MemoryBudgetExceeded {
+            node: current_dag.graph[upstream_idx].name().to_string(),
+            used: ctx.memory_budget.arena_bytes_charged(),
+            limit: ctx.memory_budget.hard_limit(),
+            source: BudgetCategory::Arena,
+            detail: Some(format!("node-rooted arena build: {e}")),
         })?;
         let arena_len = arena.record_count();
         ctx.collector
@@ -2490,13 +2495,12 @@ pub(crate) async fn dispatch_plan_node(
                         if row_bytes_each > 0
                             && ctx.memory_budget.charge_arena_bytes(row_bytes_each)
                         {
-                            return Err(PipelineError::Compilation {
-                                transform_name: String::new(),
-                                messages: vec![format!(
-                                    "E310 deferred-region buffer admission exceeded \
-                                     memory limit: hard limit {}",
-                                    ctx.memory_budget.hard_limit()
-                                )],
+                            return Err(PipelineError::MemoryBudgetExceeded {
+                                node: name.to_string(),
+                                used: ctx.memory_budget.arena_bytes_charged(),
+                                limit: ctx.memory_budget.hard_limit(),
+                                source: BudgetCategory::Arena,
+                                detail: Some("Route cross-region tee admission".to_string()),
                             });
                         }
                         ctx.region_input_buffers
@@ -4128,9 +4132,12 @@ pub(crate) async fn dispatch_plan_node(
                 &mut budget,
                 estimated_rows,
             )
-            .map_err(|e| PipelineError::Compilation {
-                transform_name: name.clone(),
-                messages: vec![format!("E310 combine build: {e}")],
+            .map_err(|e| PipelineError::MemoryBudgetExceeded {
+                node: name.clone(),
+                used: budget.arena_bytes_charged(),
+                limit: budget.hard_limit(),
+                source: BudgetCategory::Arena,
+                detail: Some(format!("combine build: {e}")),
             })?;
             let build_records_out = hash_table.len() as u64;
             ctx.collector
@@ -4355,12 +4362,9 @@ pub(crate) async fn dispatch_plan_node(
                                     continue;
                                 }
                                 OnMiss::Error => {
-                                    return Err(PipelineError::Compilation {
-                                        transform_name: name.clone(),
-                                        messages: vec![format!(
-                                            "E310 combine on_miss: error — no \
-                                             matching build row for driver row {rn}"
-                                        )],
+                                    return Err(PipelineError::CombineMissingMatch {
+                                        combine: name.clone(),
+                                        driver_row: rn,
                                     });
                                 }
                                 OnMiss::NullFields => {
@@ -4544,13 +4548,12 @@ pub(crate) async fn dispatch_plan_node(
                 // build × large driver fan-out can blow RSS
                 // even though the table itself is bounded.
                 if emitted_since_check >= 10_000 && budget.should_abort() {
-                    return Err(PipelineError::Compilation {
-                        transform_name: name.clone(),
-                        messages: vec![format!(
-                            "E310 combine probe memory limit exceeded: \
-                             hard limit {}",
-                            budget.hard_limit()
-                        )],
+                    return Err(PipelineError::MemoryBudgetExceeded {
+                        node: name.clone(),
+                        used: budget.peak_rss.unwrap_or(budget.arena_bytes_charged()),
+                        limit: budget.hard_limit(),
+                        source: BudgetCategory::Arena,
+                        detail: Some("combine probe RSS abort".to_string()),
                     });
                 }
                 if emitted_since_check >= 10_000 {

--- a/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
@@ -341,22 +341,32 @@ nodes:
         "tight memory limit must surface as a typed admission failure on the \
          deferred buffer's projection or upstream spill path",
     );
-    let rendered = err.to_string();
-    // The deferred-buffer admission path raises E310 directly; an
-    // upstream sort enforcer that spilled past the budget surfaces a
-    // distinct "spill files" message but with the same "memory_limit
-    // too small" semantic. Either is an acceptable observation that
-    // memory accounting fired; the test pins the failure-shape
-    // contract for the deferred buffer specifically by asserting the
-    // E310 / MemoryBudgetExceeded substring when reachable, falling
-    // back to the spill message when the upstream ran out first.
-    assert!(
-        rendered.contains("E310")
-            || rendered.contains("MemoryBudgetExceeded")
-            || rendered.contains("memory_limit too small"),
-        "memory-overflow surface must carry E310 / MemoryBudgetExceeded \
-         or the spill-fallback admission message; got: {rendered}"
-    );
+    // The deferred-buffer admission path raises a typed
+    // MemoryBudgetExceeded directly; an upstream sort enforcer that
+    // spilled past the budget surfaces a distinct "spill files"
+    // Compilation message with the same "memory_limit too small"
+    // semantic. Either is an acceptable observation that memory
+    // accounting fired; the test pins the failure-shape contract for
+    // the deferred buffer by destructuring on MemoryBudgetExceeded
+    // when reachable and on the spill-fallback Compilation arm
+    // otherwise.
+    match &err {
+        crate::error::PipelineError::MemoryBudgetExceeded {
+            source: crate::pipeline::memory::BudgetCategory::Arena,
+            ..
+        } => {}
+        crate::error::PipelineError::Compilation { messages, .. }
+            if messages
+                .iter()
+                .any(|m| m.contains("memory_limit too small")) => {}
+        crate::error::PipelineError::Io(io_err)
+            if io_err.to_string().contains("memory_limit too small") => {}
+        other => panic!(
+            "memory-overflow surface must carry MemoryBudgetExceeded \
+             (BudgetCategory::Arena) or the spill-fallback admission \
+             message; got: {other:?}"
+        ),
+    }
     let _ = BTreeSet::<&str>::new();
 }
 
@@ -2017,20 +2027,21 @@ nodes:
         PipelineExecutor::run_with_readers_writers(&config, readers, writers.into(), &params).await;
 
     // The pipeline either errors at the build-side cross-region tee
-    // (`tee_emit_to_region_input_buffers` raising E310 from
-    // `MemoryBudget::charge_arena_bytes`) or at the source-rooted
-    // arena build for the build-side reader (also E310). Both surfaces
-    // carry the same admission-failure error code; the test pins the
-    // failure-shape contract regardless of which boundary fires first.
+    // (`tee_emit_to_region_input_buffers` raising MemoryBudgetExceeded
+    // from `MemoryBudget::charge_arena_bytes`) or at the source-rooted
+    // arena build for the build-side reader (same shape). Both
+    // surfaces carry the same admission-failure error type; the test
+    // pins the failure-shape contract regardless of which boundary
+    // fires first.
     match result {
-        Err(err) => {
-            let rendered = err.to_string();
-            assert!(
-                rendered.contains("E310") || rendered.contains("MemoryBudgetExceeded"),
-                "memory-overflow on the region-input-buffer admission \
-                 must carry E310 / MemoryBudgetExceeded; got: {rendered}"
-            );
-        }
+        Err(crate::error::PipelineError::MemoryBudgetExceeded {
+            source: crate::pipeline::memory::BudgetCategory::Arena,
+            ..
+        }) => {}
+        Err(other) => panic!(
+            "memory-overflow on the region-input-buffer admission must carry \
+             MemoryBudgetExceeded (BudgetCategory::Arena); got: {other:?}"
+        ),
         Ok(_) => {
             // 1KB is below the per-row charge for a 2KB payload, so
             // admission must overflow somewhere along the build-side
@@ -2038,8 +2049,8 @@ nodes:
             // silently absorbed the overflow — that would be the
             // architectural regression this test catches.
             panic!(
-                "expected E310 admission failure on the region-input-buffer \
-                 cross-region tee; got Ok"
+                "expected MemoryBudgetExceeded admission failure on the \
+                 region-input-buffer cross-region tee; got Ok"
             );
         }
     }

--- a/crates/clinker-core/src/integration_tests.rs
+++ b/crates/clinker-core/src/integration_tests.rs
@@ -69,7 +69,9 @@ mod tests {
                 | PipelineError::CompositionDepthExceeded { .. }
                 | PipelineError::CompositionBodyMissing { .. }
                 | PipelineError::CompositionUnknownPort { .. }
-                | PipelineError::CompositionBodyError { .. },
+                | PipelineError::CompositionBodyError { .. }
+                | PipelineError::MemoryBudgetExceeded { .. }
+                | PipelineError::CombineMissingMatch { .. },
             ) => 1,
             Err(
                 PipelineError::Eval(_)

--- a/crates/clinker-core/src/pipeline/grace_hash.rs
+++ b/crates/clinker-core/src/pipeline/grace_hash.rs
@@ -63,7 +63,7 @@ use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
 use crate::pipeline::combine::{CombineHashTable, KeyExtractor, hash_composite_key};
 use crate::pipeline::grace_spill::{GraceSpillReader, GraceSpillWriter, SpillFilePath};
-use crate::pipeline::memory::MemoryBudget;
+use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
 use crate::plan::combine::DecomposedPredicate;
 
 /// Cap on matches collected per driver under [`MatchMode::Collect`].
@@ -583,6 +583,7 @@ impl GraceHashExecutor {
         extractor: &KeyExtractor,
         ctx: &EvalContext<'_>,
         budget: &mut MemoryBudget,
+        combine_name: &str,
     ) -> Result<(), PipelineError> {
         for i in 0..self.partitions.len() {
             let prev = std::mem::replace(&mut self.partitions[i], PartitionState::Done);
@@ -594,18 +595,24 @@ impl GraceHashExecutor {
                         // Ready branch and emit zero matches uniformly.
                         let table =
                             CombineHashTable::build(records, extractor, ctx, budget, Some(0))
-                                .map_err(|e| PipelineError::Compilation {
-                                    transform_name: String::new(),
-                                    messages: vec![format!("E310 grace hash build: {e}")],
+                                .map_err(|e| PipelineError::MemoryBudgetExceeded {
+                                    node: combine_name.to_string(),
+                                    used: budget.arena_bytes_charged(),
+                                    limit: budget.hard_limit(),
+                                    source: BudgetCategory::Arena,
+                                    detail: Some(format!("grace hash build: {e}")),
                                 })?;
                         PartitionState::Ready { hash_table: table }
                     } else {
                         let estimated = Some(records.len());
                         let table =
                             CombineHashTable::build(records, extractor, ctx, budget, estimated)
-                                .map_err(|e| PipelineError::Compilation {
-                                    transform_name: String::new(),
-                                    messages: vec![format!("E310 grace hash build: {e}")],
+                                .map_err(|e| PipelineError::MemoryBudgetExceeded {
+                                    node: combine_name.to_string(),
+                                    used: budget.arena_bytes_charged(),
+                                    limit: budget.hard_limit(),
+                                    source: BudgetCategory::Arena,
+                                    detail: Some(format!("grace hash build: {e}")),
                                 })?;
                         PartitionState::Ready { hash_table: table }
                     }
@@ -872,15 +879,14 @@ pub(crate) fn execute_combine_grace_hash(
                 detail: format!("grace hash build add failed: {e}"),
             })?;
     }
-    executor.finish_build(&build_extractor, ctx, budget)?;
+    executor.finish_build(&build_extractor, ctx, budget, name)?;
     if budget.record_spill_bytes(executor.take_spilled_bytes()) {
-        return Err(PipelineError::Compilation {
-            transform_name: name.to_string(),
-            messages: vec![format!(
-                "E310 grace hash build exceeded disk-spill quota: {} > {}",
-                budget.cumulative_spill_bytes(),
-                budget.disk_quota()
-            )],
+        return Err(PipelineError::MemoryBudgetExceeded {
+            node: name.to_string(),
+            used: budget.cumulative_spill_bytes(),
+            limit: budget.disk_quota(),
+            source: BudgetCategory::Arena,
+            detail: Some("grace hash build exceeded disk-spill quota".to_string()),
         });
     }
 
@@ -954,12 +960,12 @@ pub(crate) fn execute_combine_grace_hash(
         if emitted_since_check >= MEMORY_CHECK_INTERVAL {
             emitted_since_check = 0;
             if budget.should_abort() {
-                return Err(PipelineError::Compilation {
-                    transform_name: name.to_string(),
-                    messages: vec![format!(
-                        "E310 grace hash probe memory limit exceeded: hard limit {}",
-                        budget.hard_limit()
-                    )],
+                return Err(PipelineError::MemoryBudgetExceeded {
+                    node: name.to_string(),
+                    used: budget.peak_rss.unwrap_or(budget.arena_bytes_charged()),
+                    limit: budget.hard_limit(),
+                    source: BudgetCategory::Arena,
+                    detail: Some("grace hash probe RSS abort".to_string()),
                 });
             }
         }
@@ -973,13 +979,12 @@ pub(crate) fn execute_combine_grace_hash(
             detail: format!("grace hash probe finalize failed: {e}"),
         })?;
     if budget.record_spill_bytes(executor.take_spilled_bytes()) {
-        return Err(PipelineError::Compilation {
-            transform_name: name.to_string(),
-            messages: vec![format!(
-                "E310 grace hash probe exceeded disk-spill quota: {} > {}",
-                budget.cumulative_spill_bytes(),
-                budget.disk_quota()
-            )],
+        return Err(PipelineError::MemoryBudgetExceeded {
+            node: name.to_string(),
+            used: budget.cumulative_spill_bytes(),
+            limit: budget.disk_quota(),
+            source: BudgetCategory::Arena,
+            detail: Some("grace hash probe exceeded disk-spill quota".to_string()),
         });
     }
 
@@ -1235,15 +1240,15 @@ fn process_spilled_partition(
                 detail: format!("grace hash repartition build finalize: {e}"),
             })?;
             if budget.record_spill_bytes(b_written) {
-                return Err(PipelineError::Compilation {
-                    transform_name: name.to_string(),
-                    messages: vec![format!(
-                        "E310 grace hash repartition build exceeded disk-spill quota \
-                         (partition_id={}): {} > {}",
-                        child_id,
-                        budget.cumulative_spill_bytes(),
-                        budget.disk_quota()
-                    )],
+                return Err(PipelineError::MemoryBudgetExceeded {
+                    node: name.to_string(),
+                    used: budget.cumulative_spill_bytes(),
+                    limit: budget.disk_quota(),
+                    source: BudgetCategory::Arena,
+                    detail: Some(format!(
+                        "grace hash repartition build exceeded disk-spill quota \
+                         (partition_id={child_id})"
+                    )),
                 });
             }
             let mut probe_files: Vec<SpillFilePath> = Vec::new();
@@ -1271,15 +1276,15 @@ fn process_spilled_partition(
                     detail: format!("grace hash repartition probe finalize: {e}"),
                 })?;
                 if budget.record_spill_bytes(p_written) {
-                    return Err(PipelineError::Compilation {
-                        transform_name: name.to_string(),
-                        messages: vec![format!(
-                            "E310 grace hash repartition probe exceeded disk-spill quota \
-                             (partition_id={}): {} > {}",
-                            child_id,
-                            budget.cumulative_spill_bytes(),
-                            budget.disk_quota()
-                        )],
+                    return Err(PipelineError::MemoryBudgetExceeded {
+                        node: name.to_string(),
+                        used: budget.cumulative_spill_bytes(),
+                        limit: budget.disk_quota(),
+                        source: BudgetCategory::Arena,
+                        detail: Some(format!(
+                            "grace hash repartition probe exceeded disk-spill quota \
+                             (partition_id={child_id})"
+                        )),
                     });
                 }
                 probe_files.push(p);
@@ -1321,9 +1326,12 @@ fn process_spilled_partition(
         budget,
         Some(sp.build_count as usize),
     )
-    .map_err(|e| PipelineError::Compilation {
-        transform_name: name.to_string(),
-        messages: vec![format!("E310 grace hash reload build: {e}")],
+    .map_err(|e| PipelineError::MemoryBudgetExceeded {
+        node: name.to_string(),
+        used: budget.arena_bytes_charged(),
+        limit: budget.hard_limit(),
+        source: BudgetCategory::Arena,
+        detail: Some(format!("grace hash reload build: {e}")),
     })?;
 
     // Walk every probe-side spill file and emit matches.
@@ -1508,6 +1516,7 @@ fn bnl_fallback(
             name,
             sp.partition_id,
             approx_distinct,
+            budget,
         ));
     }
 
@@ -1519,12 +1528,15 @@ fn bnl_fallback(
         let chunk_len = chunk.len();
         let table =
             CombineHashTable::build(chunk, rc.build_extractor, rc.ctx, budget, Some(chunk_len))
-                .map_err(|e| PipelineError::Compilation {
-                    transform_name: name.to_string(),
-                    messages: vec![format!(
-                        "E310 grace hash bnl chunk build (partition {}, ~{} distinct): {e}",
+                .map_err(|e| PipelineError::MemoryBudgetExceeded {
+                    node: name.to_string(),
+                    used: budget.arena_bytes_charged(),
+                    limit: budget.hard_limit(),
+                    source: BudgetCategory::Arena,
+                    detail: Some(format!(
+                        "grace hash bnl chunk build (partition {}, ~{} distinct): {e}",
                         sp.partition_id, approx_distinct
-                    )],
+                    )),
                 })?;
         stats.peak_chunk_table_bytes = stats.peak_chunk_table_bytes.max(table.memory_bytes());
 
@@ -1594,6 +1606,7 @@ fn bnl_fallback(
                             name,
                             sp.partition_id,
                             approx_distinct,
+                            budget,
                         ));
                     }
                 }
@@ -1611,6 +1624,7 @@ fn bnl_fallback(
                 name,
                 sp.partition_id,
                 approx_distinct,
+                budget,
             ));
         }
     }
@@ -1619,20 +1633,24 @@ fn bnl_fallback(
 
 /// E310 — runtime partition aborted because the chunked BNL fallback
 /// could not bring memory under the hard limit. Carries the partition
-/// index and an HLL-approximated distinct-key count so the operator
-/// can size `partition_bits` upstream or reroute the dominant key
-/// before retrying. See `crate::error` for the registry entry.
+/// index and an HLL-approximated distinct-key count in `detail` so the
+/// operator can size `partition_bits` upstream or reroute the dominant
+/// key before retrying.
 fn combine_e310_partition_aborted(
     transform: &str,
     partition_id: u16,
     approx_distinct: u64,
+    budget: &MemoryBudget,
 ) -> PipelineError {
-    PipelineError::Compilation {
-        transform_name: transform.to_string(),
-        messages: vec![format!(
-            "E310 combine grace hash exceeded memory limit on partition {partition_id}; \
+    PipelineError::MemoryBudgetExceeded {
+        node: transform.to_string(),
+        used: budget.peak_rss.unwrap_or(budget.arena_bytes_charged()),
+        limit: budget.hard_limit(),
+        source: BudgetCategory::Arena,
+        detail: Some(format!(
+            "combine grace hash exceeded memory limit on partition {partition_id}; \
              approximate distinct key count {approx_distinct}"
-        )],
+        )),
     }
 }
 
@@ -1771,11 +1789,9 @@ fn emit_for_probe<'a>(
                 match on_miss {
                     OnMiss::Skip => {}
                     OnMiss::Error => {
-                        return Err(PipelineError::Compilation {
-                            transform_name: name.to_string(),
-                            messages: vec![format!(
-                                "E310 combine on_miss: error — no matching build row for driver row {rn}"
-                            )],
+                        return Err(PipelineError::CombineMissingMatch {
+                            combine: name.to_string(),
+                            driver_row: rn,
                         });
                     }
                     OnMiss::NullFields => {
@@ -2671,15 +2687,23 @@ mod tests {
         });
 
         let err = result.expect_err("disk quota must abort the combine");
-        let rendered = format!("{err}");
-        assert!(
-            rendered.contains("E310"),
-            "error must surface E310 for disk-quota overflow; got {rendered}"
-        );
-        assert!(
-            rendered.contains("disk-spill quota"),
-            "error must mention disk-spill quota; got {rendered}"
-        );
+        match &err {
+            PipelineError::MemoryBudgetExceeded {
+                node,
+                source,
+                detail,
+                ..
+            } => {
+                assert_eq!(node, "grace_quota_test");
+                assert_eq!(*source, BudgetCategory::Arena);
+                let detail = detail.as_deref().unwrap_or("");
+                assert!(
+                    detail.contains("disk-spill quota"),
+                    "detail must mention disk-spill quota; got {detail:?}"
+                );
+            }
+            other => panic!("disk-quota overflow must surface MemoryBudgetExceeded; got {other:?}"),
+        }
         assert!(
             budget.cumulative_spill_bytes() > 64,
             "cumulative_spill_bytes must reflect the overflowing total"
@@ -3384,21 +3408,28 @@ mod tests {
                 &mut output,
                 &mut stats,
             )
-            .expect_err("1-byte hard limit must abort BNL with E310")
+            .expect_err("1-byte hard limit must abort BNL")
         });
 
-        let msg = format!("{err}");
-        assert!(msg.contains("E310"), "abort must surface E310; got: {msg}");
-        assert!(
-            msg.contains("partition 7"),
-            "E310 message must include partition_id; got: {msg}",
-        );
         let est = sp.distinct_sketch.estimate();
         assert!(est > 0, "HLL must report a positive distinct estimate");
-        assert!(
-            msg.contains(&est.to_string()),
-            "E310 message must include approx distinct count {est}; got: {msg}",
-        );
+        match &err {
+            PipelineError::MemoryBudgetExceeded { source, detail, .. } => {
+                assert_eq!(*source, BudgetCategory::Arena);
+                let detail = detail.as_deref().unwrap_or("");
+                assert!(
+                    detail.contains("partition 7"),
+                    "detail must include partition_id; got {detail:?}"
+                );
+                assert!(
+                    detail.contains(&est.to_string()),
+                    "detail must include approx distinct count {est}; got {detail:?}"
+                );
+            }
+            other => {
+                panic!("BNL hard-limit abort must surface MemoryBudgetExceeded; got {other:?}")
+            }
+        }
     }
 
     /// HLL sanity: 200 distinct hashes give an estimate within 50% of

--- a/crates/clinker-core/src/pipeline/iejoin.rs
+++ b/crates/clinker-core/src/pipeline/iejoin.rs
@@ -33,9 +33,10 @@
 //! **Memory model:** the IEJoin scan materializes both partition sides,
 //! the L1/L2 vectors (`signed_idx, op1_key, op2_key` triples), the
 //! permutation P, and the bit array. The caller's [`MemoryBudget`] is
-//! polled every 10K emitted matched pairs; abort returns
-//! `PipelineError::Compilation` with an E310-prefixed message — the
-//! same shape used by the C.2 hash build/probe path.
+//! polled every 10K emitted matched pairs; abort returns a typed
+//! `PipelineError::MemoryBudgetExceeded` carrying the combine node's
+//! name and `BudgetCategory::Arena` — the same shape every other
+//! budget-checked operator surface uses.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -52,7 +53,7 @@ use crate::error::PipelineError;
 use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
 use crate::pipeline::combine::{KeyExtractor, hash_composite_key, keys_equal_canonicalized};
-use crate::pipeline::memory::MemoryBudget;
+use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
 use crate::plan::combine::{DecomposedPredicate, RangeOp};
 
 /// Cap on matches collected per driver under [`MatchMode::Collect`].
@@ -822,13 +823,16 @@ pub(crate) fn execute_combine_iejoin(
                                     emitted_since_check += 1;
                                     if emitted_since_check >= MEMORY_CHECK_INTERVAL {
                                         if budget.should_abort() {
-                                            return Err(PipelineError::Compilation {
-                                                transform_name: name.to_string(),
-                                                messages: vec![format!(
-                                                    "E310 combine probe memory limit exceeded: \
-                                                     hard limit {}",
-                                                    budget.hard_limit()
-                                                )],
+                                            return Err(PipelineError::MemoryBudgetExceeded {
+                                                node: name.to_string(),
+                                                used: budget
+                                                    .peak_rss
+                                                    .unwrap_or(budget.arena_bytes_charged()),
+                                                limit: budget.hard_limit(),
+                                                source: BudgetCategory::Arena,
+                                                detail: Some(
+                                                    "iejoin combine probe RSS abort".to_string(),
+                                                ),
                                             });
                                         }
                                         emitted_since_check = 0;
@@ -886,13 +890,14 @@ pub(crate) fn execute_combine_iejoin(
                             emitted_since_check += 1;
                             if emitted_since_check >= MEMORY_CHECK_INTERVAL {
                                 if budget.should_abort() {
-                                    return Err(PipelineError::Compilation {
-                                        transform_name: name.to_string(),
-                                        messages: vec![format!(
-                                            "E310 combine probe memory limit exceeded: \
-                                             hard limit {}",
-                                            budget.hard_limit()
-                                        )],
+                                    return Err(PipelineError::MemoryBudgetExceeded {
+                                        node: name.to_string(),
+                                        used: budget
+                                            .peak_rss
+                                            .unwrap_or(budget.arena_bytes_charged()),
+                                        limit: budget.hard_limit(),
+                                        source: BudgetCategory::Arena,
+                                        detail: Some("iejoin combine probe RSS abort".to_string()),
                                     });
                                 }
                                 emitted_since_check = 0;
@@ -946,11 +951,9 @@ pub(crate) fn execute_combine_iejoin(
         match on_miss {
             OnMiss::Skip => continue,
             OnMiss::Error => {
-                return Err(PipelineError::Compilation {
-                    transform_name: name.to_string(),
-                    messages: vec![format!(
-                        "E310 combine on_miss: error — no matching build row for driver row {driver_order}"
-                    )],
+                return Err(PipelineError::CombineMissingMatch {
+                    combine: name.to_string(),
+                    driver_row: driver_order,
                 });
             }
             OnMiss::NullFields => {
@@ -981,13 +984,12 @@ pub(crate) fn execute_combine_iejoin(
                         emitted_since_check += 1;
                         if emitted_since_check >= MEMORY_CHECK_INTERVAL {
                             if budget.should_abort() {
-                                return Err(PipelineError::Compilation {
-                                    transform_name: name.to_string(),
-                                    messages: vec![format!(
-                                        "E310 combine probe memory limit exceeded: \
-                                         hard limit {}",
-                                        budget.hard_limit()
-                                    )],
+                                return Err(PipelineError::MemoryBudgetExceeded {
+                                    node: name.to_string(),
+                                    used: budget.peak_rss.unwrap_or(budget.arena_bytes_charged()),
+                                    limit: budget.hard_limit(),
+                                    source: BudgetCategory::Arena,
+                                    detail: Some("iejoin combine probe RSS abort".to_string()),
                                 });
                             }
                             emitted_since_check = 0;

--- a/crates/clinker-core/src/pipeline/memory.rs
+++ b/crates/clinker-core/src/pipeline/memory.rs
@@ -88,6 +88,35 @@ fn rss_bytes_impl() -> Option<u64> {
     None
 }
 
+/// Discriminant tag carried on every `MemoryBudget` charge so a budget
+/// overflow can name which surface tripped the hard limit. Sources are
+/// summed against the single `limit` counter; the tag is for
+/// diagnostics and downstream routing only.
+///
+/// Append-only. Removing a variant is a breaking change for any
+/// `MemoryBudgetExceeded` consumer that destructures `source`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum BudgetCategory {
+    /// Source-rooted Phase-0 arena, node-rooted arenas, deferred-region
+    /// admission buffers, grace-hash build/probe accounting, and the
+    /// disk-spill quota counter. Every budget-tracked allocation that
+    /// is not `ctx.node_buffers` falls under this tag.
+    Arena,
+    /// `ctx.node_buffers` — the inter-stage handoff layer between
+    /// non-fused operators. Not wired to the budget today; reserved
+    /// for the upcoming sub-issues that charge node-buffer mutations.
+    NodeBuffer,
+}
+
+impl std::fmt::Display for BudgetCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Arena => f.write_str("arena"),
+            Self::NodeBuffer => f.write_str("node_buffer"),
+        }
+    }
+}
+
 /// Memory budget governing spill decisions.
 ///
 /// Polled once per chunk at the start of Phase 2 processing.
@@ -371,6 +400,12 @@ mod tests {
         budget.cumulative_spill_bytes = u64::MAX - 10;
         assert!(budget.record_spill_bytes(100));
         assert_eq!(budget.cumulative_spill_bytes(), u64::MAX);
+    }
+
+    #[test]
+    fn test_budget_category_display_shape() {
+        assert_eq!(BudgetCategory::Arena.to_string(), "arena");
+        assert_eq!(BudgetCategory::NodeBuffer.to_string(), "node_buffer");
     }
 
     #[test]

--- a/crates/clinker-core/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-core/src/pipeline/sort_merge_join.rs
@@ -49,7 +49,7 @@ use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
 use crate::pipeline::combine::KeyExtractor;
 use crate::pipeline::grace_spill::{GraceSpillReader, GraceSpillWriter, SpillFilePath};
-use crate::pipeline::memory::MemoryBudget;
+use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
 use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
 use crate::plan::combine::{DecomposedPredicate, RangeOp};
 
@@ -656,12 +656,9 @@ fn execute_combine_sort_merge_with_stats(
             match on_miss {
                 OnMiss::Skip => continue,
                 OnMiss::Error => {
-                    return Err(PipelineError::Compilation {
-                        transform_name: name.to_string(),
-                        messages: vec![format!(
-                            "E310 combine on_miss: error — no matching build row for \
-                             driver row {driver_order}"
-                        )],
+                    return Err(PipelineError::CombineMissingMatch {
+                        combine: name.to_string(),
+                        driver_row: driver_order,
                     });
                 }
                 OnMiss::NullFields => {
@@ -1006,13 +1003,14 @@ fn walk_two_cursors(args: WalkArgs<'_, '_, '_>) -> Result<(), PipelineError> {
                     detail: format!("sort-merge matching-run spill failed: {e}"),
                 })?;
                 if written > 0 && budget.record_spill_bytes(written) {
-                    return Err(PipelineError::Compilation {
-                        transform_name: name.to_string(),
-                        messages: vec![format!(
-                            "E310 sort-merge matching-run exceeded disk-spill quota: {} > {}",
-                            budget.cumulative_spill_bytes(),
-                            budget.disk_quota()
-                        )],
+                    return Err(PipelineError::MemoryBudgetExceeded {
+                        node: name.to_string(),
+                        used: budget.cumulative_spill_bytes(),
+                        limit: budget.disk_quota(),
+                        source: BudgetCategory::Arena,
+                        detail: Some(
+                            "sort-merge matching-run exceeded disk-spill quota".to_string(),
+                        ),
                     });
                 }
                 if was_inmemory && matches!(run, MatchingRunBuffer::Spilled { .. }) {
@@ -1224,13 +1222,17 @@ fn emit_for_run(args: &mut EmitForRunArgs<'_, '_>) -> Result<(), PipelineError> 
                             *args.emitted_since_check = args.emitted_since_check.saturating_add(1);
                             if *args.emitted_since_check >= MEMORY_CHECK_INTERVAL {
                                 if args.budget.should_abort() {
-                                    return Err(PipelineError::Compilation {
-                                        transform_name: name.to_string(),
-                                        messages: vec![format!(
-                                            "E310 combine probe memory limit exceeded: \
-                                             hard limit {}",
-                                            args.budget.hard_limit()
-                                        )],
+                                    return Err(PipelineError::MemoryBudgetExceeded {
+                                        node: name.to_string(),
+                                        used: args
+                                            .budget
+                                            .peak_rss
+                                            .unwrap_or(args.budget.arena_bytes_charged()),
+                                        limit: args.budget.hard_limit(),
+                                        source: BudgetCategory::Arena,
+                                        detail: Some(
+                                            "sort-merge combine probe RSS abort".to_string(),
+                                        ),
                                     });
                                 }
                                 *args.emitted_since_check = 0;
@@ -1284,13 +1286,15 @@ fn emit_for_run(args: &mut EmitForRunArgs<'_, '_>) -> Result<(), PipelineError> 
                     *args.emitted_since_check = args.emitted_since_check.saturating_add(1);
                     if *args.emitted_since_check >= MEMORY_CHECK_INTERVAL {
                         if args.budget.should_abort() {
-                            return Err(PipelineError::Compilation {
-                                transform_name: name.to_string(),
-                                messages: vec![format!(
-                                    "E310 combine probe memory limit exceeded: \
-                                     hard limit {}",
-                                    args.budget.hard_limit()
-                                )],
+                            return Err(PipelineError::MemoryBudgetExceeded {
+                                node: name.to_string(),
+                                used: args
+                                    .budget
+                                    .peak_rss
+                                    .unwrap_or(args.budget.arena_bytes_charged()),
+                                limit: args.budget.hard_limit(),
+                                source: BudgetCategory::Arena,
+                                detail: Some("sort-merge combine probe RSS abort".to_string()),
                             });
                         }
                         *args.emitted_since_check = 0;

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -3487,7 +3487,7 @@ nodes:
     }
 
     /// on_miss: error — the pipeline fails on the first unmatched row.
-    /// Verify an E310-coded error surfaces.
+    /// Verify a structured CombineMissingMatch error surfaces.
     #[tokio::test(flavor = "multi_thread")]
     async fn test_combine_exec_on_miss_error() {
         let yaml = combine_exec_yaml("first", "error");
@@ -3498,11 +3498,15 @@ nodes:
         )
         .await
         .expect_err("on_miss:error must fail the pipeline on first unmatched row");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("E310"),
-            "on_miss:error must surface E310; got: {msg}",
-        );
+        match &err {
+            CombineFixtureError::Run(clinker_core::error::PipelineError::CombineMissingMatch {
+                combine,
+                ..
+            }) => {
+                assert_eq!(combine, "enriched");
+            }
+            other => panic!("on_miss:error must surface CombineMissingMatch; got: {other:?}"),
+        }
     }
 
     /// MemoryBudget abort — a 1-byte hard limit forces
@@ -3510,14 +3514,13 @@ nodes:
     /// inside `CombineHashTable::build` (process RSS trivially exceeds
     /// 1 byte). The build's safety-net final check fires for the small
     /// build set, the executor wraps `CombineError::MemoryLimitExceeded`
-    /// as `PipelineError::Compilation` with an `E310 combine build:
-    /// ...` message, and that surfaces in the run error string.
+    /// as a typed `MemoryBudgetExceeded` carrying the combine node's
+    /// name and the budget source, and that surfaces in the run error.
     ///
     /// Mirrors the build-side regression test in
     /// `pipeline/combine.rs::test_combine_hash_table_oom_aborts_during_build`,
     /// but exercised end-to-end through the combine executor arm so a
-    /// regression in the arm's error mapping (E310 → generic message)
-    /// is caught here.
+    /// regression in the arm's error mapping is caught here.
     ///
     /// Skipped silently when `rss_bytes()` is unavailable on the host
     /// platform — the same gate the unit test uses, applied via
@@ -3579,16 +3582,29 @@ nodes:
             Some("orders"),
         )
         .await
-        .expect_err("1-byte memory_limit must abort combine with E310");
-        let msg = format!("{err}");
-        assert!(
-            msg.contains("E310"),
-            "memory abort must surface E310; got: {msg}",
-        );
-        assert!(
-            msg.contains("memory limit exceeded") || msg.contains("combine build"),
-            "E310 message must mention the combine memory abort; got: {msg}",
-        );
+        .expect_err("1-byte memory_limit must abort combine");
+        match &err {
+            CombineFixtureError::Run(clinker_core::error::PipelineError::MemoryBudgetExceeded {
+                node,
+                source,
+                detail,
+                ..
+            }) => {
+                assert_eq!(node, "enriched");
+                assert_eq!(
+                    *source,
+                    clinker_core::pipeline::memory::BudgetCategory::Arena
+                );
+                let detail = detail.as_deref().unwrap_or("");
+                assert!(
+                    detail.contains("combine build")
+                        || detail.contains("combine probe")
+                        || detail.contains("grace hash"),
+                    "detail must mention the combine memory abort; got {detail:?}"
+                );
+            }
+            other => panic!("memory abort must surface MemoryBudgetExceeded; got: {other:?}"),
+        }
     }
 
     /// Residual predicate — equi predicate + a range residual. The

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -3584,12 +3584,14 @@ nodes:
         .await
         .expect_err("1-byte memory_limit must abort combine");
         match &err {
-            CombineFixtureError::Run(clinker_core::error::PipelineError::MemoryBudgetExceeded {
-                node,
-                source,
-                detail,
-                ..
-            }) => {
+            CombineFixtureError::Run(
+                clinker_core::error::PipelineError::MemoryBudgetExceeded {
+                    node,
+                    source,
+                    detail,
+                    ..
+                },
+            ) => {
                 assert_eq!(node, "enriched");
                 assert_eq!(
                     *source,

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -321,7 +321,9 @@ fn main() -> ExitCode {
                         | PipelineError::CompositionDepthExceeded { .. }
                         | PipelineError::CompositionBodyMissing { .. }
                         | PipelineError::CompositionUnknownPort { .. }
-                        | PipelineError::CompositionBodyError { .. } => ExitCode::from(1),
+                        | PipelineError::CompositionBodyError { .. }
+                        | PipelineError::MemoryBudgetExceeded { .. }
+                        | PipelineError::CombineMissingMatch { .. } => ExitCode::from(1),
                         PipelineError::Io(_) => ExitCode::from(4),
                         PipelineError::Eval(_) | PipelineError::Accumulator { .. } => {
                             ExitCode::from(3)

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -33,6 +33,27 @@ Pentaho Kettle / Apache Hop, Embulk, Singer, Benthos in batch mode, and Vector
 running file-to-file -- finite ETL jobs with per-record evaluation and a hard
 memory ceiling.
 
+**Three pillars of what Clinker is:**
+
+1. **Finite inputs.** Files (CSV, JSON, XML, fixed-width) are the canonical
+   shape. Finite-cursor network sources (paginated REST APIs, SQL `SELECT`
+   cursors) fit the same model -- they exhaust their cursor and EOF.
+   Unbounded sources (Kafka topics, Kinesis streams, Server-Sent Events,
+   webhooks, `tail -f`-style file followers) are out of scope and will
+   remain so.
+2. **Finite jobs.** A pipeline run begins when you invoke `clinker run`,
+   drains the DAG, and exits with a status code. No long-running daemon,
+   no service surface, no infinite event loop.
+3. **Single process.** One `clinker` binary invocation is one operating-
+   system process. Parallelism happens *inside* the process via threads
+   (`std::thread`, Rayon). Clinker does not spawn worker processes, does
+   not coordinate a cluster, and does not shuffle data between machines.
+   Scale by giving the host more cores, more RAM, and more disk -- the
+   DuckDB / Polars / Kettle model. If a single host genuinely can't fit
+   the work, partition the input by file or by key and run multiple
+   `clinker` invocations from a shell script; that's a five-line bash
+   script, not an architectural addition.
+
 ## Why Clinker?
 
 **Single binary, zero dependencies.** Download it, run it. No JVM, no Python,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 [Introduction](README.md)
+[Non-Goals](non-goals.md)
 
 # Getting Started
 

--- a/docs/src/getting-started/concepts.md
+++ b/docs/src/getting-started/concepts.md
@@ -22,6 +22,28 @@ long-running stream-processor semantics. Internal identifiers in the codebase
 row-by-row sense; if you see it in a stack trace, it is not Flink leaking
 through.
 
+### Finite inputs only
+
+Clinker reads sources that have an end. Files are the canonical shape, and
+finite-cursor network sources (paginated REST APIs, SQL `SELECT` cursors)
+fit the same model -- they exhaust their cursor and EOF. Unbounded sources
+(Kafka, Kinesis, Server-Sent Events, webhooks, `tail -f`-style file
+followers) are explicitly **out of scope** and will remain so.
+
+### Single process, ever
+
+One `clinker run` invocation is one OS process. Parallelism happens *inside*
+that process via threads. Clinker does not spawn worker processes, does not
+coordinate a cluster, and does not shuffle data between machines. Scale by
+giving the host more cores, more RAM, more disk -- the DuckDB / Polars /
+Kettle model. If a single host genuinely can't fit the work, partition the
+input by file or by key and run multiple `clinker` invocations from a shell
+script; that's a five-line script, not an architectural addition to
+Clinker.
+
+For the full list of what Clinker deliberately does not do, see
+[Non-Goals](../non-goals.md).
+
 ## Pipelines are DAGs
 
 A pipeline is a directed acyclic graph of nodes. Data flows from sources,

--- a/docs/src/non-goals.md
+++ b/docs/src/non-goals.md
@@ -1,0 +1,146 @@
+# Non-Goals
+
+This page lists what Clinker is deliberately **not**. These are
+architectural commitments — design surfaces Clinker will not grow into,
+not just features that haven't been built yet.
+
+If you arrived here because you were considering Clinker for one of the
+scenarios below, the answer is "a different tool is the right fit." Each
+non-goal is paired with the kind of tool that is the right fit.
+
+## Not an unbounded stream processor
+
+Clinker reads sources that have an end. A pipeline run is a **finite
+job**: Sources read until EOF, the DAG drains, the process exits.
+
+**Out of scope:**
+
+- Kafka topics, Kinesis streams, Pub/Sub subscriptions (long-running
+  consumers without a natural end).
+- Server-Sent Events, WebSocket subscriptions, webhooks-as-input.
+- `tail -f`-style file followers.
+- Watermarking against wall-clock time.
+- Exactly-once delivery across process restarts.
+- Stateful infinite-stream windowing (tumbling / sliding / session
+  windows over event time without a finite boundary).
+
+**Right fit instead:** Apache Flink, Kafka Streams, Apache Beam in
+unbounded mode, Vector with streaming sources, Benthos with streaming
+inputs, Apache NiFi.
+
+## Not a multi-process or distributed engine
+
+One `clinker run` invocation is one operating-system process. Clinker
+does not spawn worker processes, does not coordinate a cluster, and does
+not shuffle data between machines.
+
+**Out of scope:**
+
+- Worker-process pools on a single machine.
+- Multi-machine sharded execution.
+- Network shuffle between executors.
+- Cluster managers (Kubernetes operators, YARN, Mesos integrations).
+- Distributed memory accounting.
+- Partial-failure recovery across worker boundaries.
+
+**Right fit instead:** Apache Spark, Trino / Presto, Apache Flink in
+cluster mode, Apache Beam on Dataflow, Hadoop MapReduce.
+
+**Scaling Clinker:** give the host more cores, more RAM, more disk — the
+DuckDB / Polars / Kettle / Hop model. If a single host genuinely can't
+fit the work, partition the input by file or by key and run multiple
+`clinker` invocations from a shell script. That's a five-line script,
+not an architectural addition.
+
+## Not a long-running service
+
+Clinker is a **CLI binary**, not a server. There is no daemon mode, no
+HTTP control plane, no JDBC/ODBC listener, no UI server, no scheduled
+job runner inside Clinker itself.
+
+**Out of scope:**
+
+- HTTP API exposing pipeline execution.
+- Built-in cron / scheduler / orchestrator.
+- Persistent connection pool living across pipeline runs.
+- A long-lived process accepting new pipeline submissions over a socket.
+
+**Right fit instead:**
+
+- For scheduling: cron, systemd timers, Airflow, Dagster, Prefect,
+  Temporal.
+- For HTTP-fronted ETL: any of the above orchestrators wrapping
+  `clinker run` invocations.
+- For interactive queries against finite data: DuckDB, Polars, or any
+  embedded query engine.
+
+## Not an OLAP / SQL query engine
+
+Clinker is a **per-record expression engine** with explicit `nodes:` in
+a DAG. It does not parse SQL, does not optimize joins via cost-based
+optimization across the whole pipeline, and does not present a relational
+table model.
+
+**Out of scope:**
+
+- SQL parsing (the CXL language is the surface; no `SELECT ... FROM` is
+  accepted).
+- Cost-based join reordering across more than the local Combine node.
+- Materialized views or query caching.
+- Interactive query latencies under a second.
+- ANSI-SQL semantics for NULL, type coercion, or aggregate behavior.
+
+**Right fit instead:** DuckDB, ClickHouse, DataFusion, Trino, Postgres,
+or any RDBMS. If you want SQL-driven transformation over files, DuckDB
+is the closest single-binary alternative to Clinker for the cases where
+SQL is the right surface.
+
+## Not a connector marketplace
+
+Clinker ships with a deliberately small set of source and sink types:
+CSV, JSON, XML, fixed-width files in the current release; finite-cursor
+REST and SQL sources on the roadmap. There is no plugin registry, no
+third-party connector store, no SaaS-API catalog.
+
+**Out of scope:**
+
+- Hundreds of pre-built SaaS integrations (Salesforce, HubSpot,
+  Stripe, etc.).
+- A central registry of community-maintained connectors.
+- Schema discovery against arbitrary external APIs.
+- Change-data-capture (CDC) sources.
+
+**Right fit instead:** Airbyte, Fivetran, Stitch, Singer with its tap
+ecosystem, dlt (data load tool).
+
+## Not a streaming-CDC engine
+
+Clinker treats each pipeline run as a **fresh, finite pass** over the
+input. It does not maintain a persistent log of source changes, does
+not replicate row-level changes from a database, and does not produce
+an append-only stream of inserts / updates / deletes.
+
+**Out of scope:**
+
+- Postgres logical replication subscriptions.
+- MySQL binlog tailing.
+- Debezium-style CDC stream production.
+- Maintaining a target database in continuous sync with a source.
+
+**Right fit instead:** Debezium, Maxwell, AWS DMS, Striim, Estuary Flow,
+or vendor-native CDC like Snowflake Streams.
+
+## What Clinker **is**
+
+For the positive framing, see the [Introduction](README.md) and
+[Key Concepts](getting-started/concepts.md). The short version:
+
+- A pure-Rust, single-binary, **bounded-memory batch DAG executor** for
+  finite file and finite-cursor inputs.
+- Per-record evaluation through a directed acyclic graph of Source,
+  Transform, Aggregate, Route, Merge, Combine, Output, and Composition
+  nodes.
+- Pipelines declared in YAML, transformation logic written in CXL (a
+  custom per-record expression language).
+- One process, finite job, EOF-then-exit. Disk spill under memory
+  pressure rather than OOM.


### PR DESCRIPTION
## Summary

Replaces every ad-hoc `PipelineError::Compilation { messages: vec![format!("E310 ...")] }` emission in the executor with a typed `PipelineError::MemoryBudgetExceeded { node, used, limit, source, detail }` variant carrying a new `BudgetCategory { Arena, NodeBuffer }` tag. Combine `on_miss: error` paths — semantically distinct from memory-budget overflow — move to a separate `PipelineError::CombineMissingMatch { combine, driver_row }` variant under a new diagnostic code, **E319**.

The producer node's identity is now pinned in the typed error, so diagnostics and downstream DLQ routing can name the operator that overflowed. Test suites destructure the variants directly instead of grepping rendered substrings.

## Why

Before this change:

- Substring matches (`rendered.contains("E310")`) couldn't verify which node produced the failure or which budget surface tripped.
- The `transform_name` slot was empty at most call sites, conflating the operator name with the producer node ID.
- The umbrella refactor adding `node_buffers` accounting (issue #108) needs a structured error so the engine can name the overflowing node and so downstream consumers can distinguish arena vs node-buffer overflow.

This sub-issue lays the error-type foundation that every later sub-issue (#119 through #126) depends on. It also takes the opportunity to honour the diagnostic registry: E310 is now consistently a budget-overflow code; the missing-match path gets its own E319 entry instead of co-opting E310's slot.

## What changed

- `crates/clinker-core/src/pipeline/memory.rs` — new `pub enum BudgetCategory { Arena, NodeBuffer }` with `Display`. Unit test covering the rendered shape.
- `crates/clinker-core/src/error.rs` — new `MemoryBudgetExceeded` and `CombineMissingMatch` variants on `PipelineError` with `Display` impls rendering the E310 / E319 codes. Registry header updated; E319 added to the documented-codes test.
- `crates/clinker-core/src/executor/dispatch.rs` — 6 sites migrated. `charge_harvest_admission` grows a `node_name: &str` parameter; threaded through `tee_emit_to_region_input_buffers` and the body-harvest admission caller in `executor/commit/dispatch.rs`.
- `crates/clinker-core/src/pipeline/sort_merge_join.rs` — 4 sites (matching-run disk quota, two combine probe RSS aborts, one `on_miss: error`).
- `crates/clinker-core/src/pipeline/iejoin.rs` — 4 sites across all three IEJoin axes.
- `crates/clinker-core/src/pipeline/grace_hash.rs` — 14 sites covering build, probe, repartition, reload, BNL chunk build, and the partition hard-limit helper (`combine_e310_partition_aborted` now takes `&MemoryBudget` so it captures live used/limit; partition_id and approx-distinct context move to the variant's `detail` field).
- Tests: substring assertions in `executor/tests/deferred_dispatch.rs` (2 cases), `pipeline/grace_hash.rs` (2 cases), and `tests/combine_test.rs` (2 cases) are now destructured pattern matches asserting node, source, and detail content.
- Exit-code dispatchers in `crates/clinker-core/src/integration_tests.rs` and `crates/clinker/src/main.rs` extended to cover both new variants (exit 1, matching the existing user-data-error bucket).

After the migration both grep gates are empty:

```
$ git grep -n 'format!("E310 ' crates/clinker-core/src/
$ git grep -n '\.contains("E310")\|\.contains("MemoryBudgetExceeded")' crates/clinker-core/
```

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check --benches --workspace`
- [x] `cargo check --features bench-alloc -p clinker-benchmarks`
- [x] `cargo test --benches -p clinker-benchmarks`
- [x] `cargo deny check`
- [x] Both grep gates return zero results.

Closes #118.
Refs #108.