### PR TITLE
engine: NodeBuffer enum for inter-stage handoff (#120)

### DIFF
--- a/crates/clinker-core/src/error.rs
+++ b/crates/clinker-core/src/error.rs
@@ -262,6 +262,11 @@ pub enum PipelineError {
         messages: Vec<String>,
     },
     Io(std::io::Error),
+    /// Spill-format I/O or decode failure surfaced by
+    /// `crate::pipeline::spill::SpillReader`. Distinct from `Io` so the
+    /// rendered diagnostic preserves postcard and JSON-schema decode
+    /// context that bare `std::io::Error` would lose.
+    Spill(crate::pipeline::spill::SpillError),
     ThreadPool(String),
     /// Multiple errors collected from parallel writer threads.
     /// DataFusion `Collection` pattern (PR #14439).
@@ -409,6 +414,7 @@ impl fmt::Display for PipelineError {
                 Ok(())
             }
             Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Spill(e) => write!(f, "{e}"),
             Self::ThreadPool(e) => write!(f, "thread pool error: {e}"),
             Self::Multiple(errors) => {
                 write!(f, "{} errors:", errors.len())?;
@@ -606,6 +612,12 @@ impl From<crate::schema::SchemaError> for PipelineError {
 impl From<std::io::Error> for PipelineError {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
+    }
+}
+
+impl From<crate::pipeline::spill::SpillError> for PipelineError {
+    fn from(e: crate::pipeline::spill::SpillError) -> Self {
+        Self::Spill(e)
     }
 }
 

--- a/crates/clinker-core/src/executor/commit/dispatch.rs
+++ b/crates/clinker-core/src/executor/commit/dispatch.rs
@@ -45,6 +45,7 @@ use super::DlqEvent;
 use super::detect::RetractScope;
 use crate::error::PipelineError;
 use crate::executor::dispatch::{ExecutorContext, dispatch_plan_node};
+use crate::executor::node_buffer::NodeBuffer;
 use crate::plan::CompositionBodyId;
 use crate::plan::deferred_region::{DeferredRegion, ParentContinuation};
 use crate::plan::execution::{ExecutionPlanDag, PlanNode};
@@ -326,10 +327,13 @@ fn seed_cross_region_inputs_for(
         };
         // Append onto the source node's buffer so the consumer's
         // existing predecessor-walk logic resolves them.
-        ctx.node_buffers
+        let slot = ctx
+            .node_buffers
             .entry(source_idx)
-            .or_default()
-            .extend(parked);
+            .or_insert_with(|| NodeBuffer::Memory(Vec::new()));
+        for (record, rn) in parked {
+            slot.push(record, rn);
+        }
     }
 
     Ok(())
@@ -381,7 +385,7 @@ async fn recurse_into_body(
     // Swap to body-scope buffers so body NodeIndices index a fresh
     // namespace (parent-scope NodeIndex 0 and body-scope NodeIndex 0
     // collide numerically). Restore on every exit.
-    let body_buffers: HashMap<NodeIndex, Vec<(Record, u64)>> = HashMap::new();
+    let body_buffers: HashMap<NodeIndex, NodeBuffer> = HashMap::new();
     let saved_buffers = std::mem::replace(&mut ctx.node_buffers, body_buffers);
     let saved_combine = std::mem::take(&mut ctx.source_records);
     let saved_body_refs = ctx
@@ -471,8 +475,10 @@ async fn recurse_into_body(
         // body covered without an extra code path.
         let mut harvested: Vec<(Record, u64)> = Vec::new();
         for body_out_idx in bound_body.output_port_to_node_idx.values() {
-            if let Some(rows) = ctx.node_buffers.remove(body_out_idx) {
-                harvested.extend(rows);
+            if let Some(nb) = ctx.node_buffers.remove(body_out_idx) {
+                for pair in nb.drain() {
+                    harvested.push(pair?);
+                }
             }
         }
         Ok::<Vec<(Record, u64)>, PipelineError>(harvested)
@@ -501,10 +507,13 @@ async fn recurse_into_body(
             &harvested,
             parent_dag.graph[composition_idx].name(),
         )?;
-        ctx.node_buffers
+        let slot = ctx
+            .node_buffers
             .entry(composition_idx)
-            .or_default()
-            .extend(harvested);
+            .or_insert_with(|| NodeBuffer::Memory(Vec::new()));
+        for (record, rn) in harvested {
+            slot.push(record, rn);
+        }
     }
 
     if let Some(continuation) = parent_dag

--- a/crates/clinker-core/src/executor/commit/recompute_agg.rs
+++ b/crates/clinker-core/src/executor/commit/recompute_agg.rs
@@ -20,6 +20,7 @@ use crate::error::PipelineError;
 use crate::executor::dispatch::{
     ExecutorContext, finalize_node_rooted_windows, project_rows_to_buffer_schema,
 };
+use crate::executor::node_buffer::NodeBuffer;
 use crate::plan::execution::ExecutionPlanDag;
 
 /// Drive each affected aggregate through retract + refinalize, then
@@ -203,6 +204,7 @@ pub(crate) fn emit_post_recompute(
             "node-rooted window rebuild during commit-pass recompute: {e}"
         )));
     }
-    ctx.node_buffers.insert(agg_idx, projected);
+    ctx.node_buffers
+        .insert(agg_idx, NodeBuffer::Memory(projected));
     Ok(emitted)
 }

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -405,6 +405,7 @@ fn dispatch_transform_eval_error(
     )
 }
 use crate::aggregation::AggregateStrategy;
+use crate::executor::node_buffer::NodeBuffer;
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::{
     CompiledRoute, CompiledTransform, DlqEntry, NullStorage, build_format_writer,
@@ -486,7 +487,7 @@ pub(crate) struct ExecutorContext<'a> {
     pub(crate) strategy: ErrorStrategy,
 
     // Owned mutable per-walk state.
-    pub(crate) node_buffers: HashMap<NodeIndex, Vec<(Record, u64)>>,
+    pub(crate) node_buffers: HashMap<NodeIndex, NodeBuffer>,
     /// Per-source live ingest channels keyed by Source node name. Each
     /// declared Source has one `tokio::spawn`-ed task pushing records
     /// through a `TokioSourceStream`; this map holds the paired
@@ -1817,7 +1818,8 @@ pub(crate) async fn transform_fused_consume(
 
     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-    ctx.node_buffers.insert(node_idx, output_records);
+    ctx.node_buffers
+        .insert(node_idx, NodeBuffer::Memory(output_records));
     Ok(())
 }
 
@@ -1903,9 +1905,10 @@ pub(crate) async fn dispatch_plan_node(
                     // consumers run. Apply per-record seeding for body-
                     // declared record_vars (parent's writes survive via
                     // `seed_record_vars`'s preserve-existing semantics).
-                    let mut out: Vec<(Record, u64)> = Vec::with_capacity(seeded.len());
+                    let mut out: Vec<(Record, u64)> = Vec::with_capacity(seeded.len_hint());
                     let has_record_seed = !ctx.record_var_seed.is_empty();
-                    for (r, rn) in seeded {
+                    for pair in seeded.drain() {
+                        let (r, rn) = pair?;
                         let mut rec = canonicalize(&r);
                         if has_record_seed {
                             rec.seed_record_vars(ctx.record_var_seed);
@@ -2000,7 +2003,8 @@ pub(crate) async fn dispatch_plan_node(
             // now anchors here.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &records)?;
-            ctx.node_buffers.insert(node_idx, records);
+            ctx.node_buffers
+                .insert(node_idx, NodeBuffer::Memory(records));
         }
 
         PlanNode::Transform {
@@ -2021,24 +2025,24 @@ pub(crate) async fn dispatch_plan_node(
             }
             // Get input records: first check own buffer (set by Route
             // node for branch dispatch), then fall back to predecessor.
-            let input_records = if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
-                own_buf
-            } else {
-                let predecessors: Vec<NodeIndex> = current_dag
-                    .graph
-                    .neighbors_directed(node_idx, Direction::Incoming)
-                    .collect();
-                if predecessors.len() == 1 {
-                    ctx.node_buffers
-                        .remove(&predecessors[0])
-                        .unwrap_or_default()
+            let input_records: Vec<(Record, u64)> =
+                if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
+                    own_buf.drain().collect::<Result<Vec<_>, _>>()?
                 } else {
-                    predecessors
-                        .iter()
-                        .find_map(|p| ctx.node_buffers.remove(p))
-                        .unwrap_or_default()
-                }
-            };
+                    let predecessors: Vec<NodeIndex> = current_dag
+                        .graph
+                        .neighbors_directed(node_idx, Direction::Incoming)
+                        .collect();
+                    let pred_buf = if predecessors.len() == 1 {
+                        ctx.node_buffers.remove(&predecessors[0])
+                    } else {
+                        predecessors.iter().find_map(|p| ctx.node_buffers.remove(p))
+                    };
+                    match pred_buf {
+                        Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                        None => Vec::new(),
+                    }
+                };
 
             // Find the CompiledTransform for this node
             let transform_idx = match ctx.transform_by_name.get(name.as_str()) {
@@ -2046,7 +2050,8 @@ pub(crate) async fn dispatch_plan_node(
                 None => {
                     // No transform found — pass through
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &input_records)?;
-                    ctx.node_buffers.insert(node_idx, input_records);
+                    ctx.node_buffers
+                        .insert(node_idx, NodeBuffer::Memory(input_records));
                     return Ok(());
                 }
             };
@@ -2226,7 +2231,8 @@ pub(crate) async fn dispatch_plan_node(
             // matching runtime; otherwise the helper is a no-op.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-            ctx.node_buffers.insert(node_idx, output_records);
+            ctx.node_buffers
+                .insert(node_idx, NodeBuffer::Memory(output_records));
         }
 
         PlanNode::Route {
@@ -2244,14 +2250,15 @@ pub(crate) async fn dispatch_plan_node(
                 .graph
                 .neighbors_directed(node_idx, Direction::Incoming)
                 .collect();
-            let input_records = if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
-                own_buf
-            } else {
-                predecessors
-                    .iter()
-                    .find_map(|p| ctx.node_buffers.remove(p))
-                    .unwrap_or_default()
-            };
+            let input_records: Vec<(Record, u64)> =
+                if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
+                    own_buf.drain().collect::<Result<Vec<_>, _>>()?
+                } else {
+                    match predecessors.iter().find_map(|p| ctx.node_buffers.remove(p)) {
+                        Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                        None => Vec::new(),
+                    }
+                };
 
             if let Some(expected) = current_dag.graph[node_idx]
                 .expected_input_schema_in(current_dag)
@@ -2509,7 +2516,7 @@ pub(crate) async fn dispatch_plan_node(
                             .push((record.clone(), *rn));
                     }
                 }
-                ctx.node_buffers.insert(succ_idx, buf);
+                ctx.node_buffers.insert(succ_idx, NodeBuffer::Memory(buf));
             }
         }
 
@@ -2614,7 +2621,7 @@ pub(crate) async fn dispatch_plan_node(
             } else {
                 let total: usize = sorted_preds
                     .iter()
-                    .map(|p| ctx.node_buffers.get(p).map_or(0, |b| b.len()))
+                    .map(|p| ctx.node_buffers.get(p).map_or(0, |b| b.len_hint()))
                     .sum();
                 let mut merged = Vec::with_capacity(total);
                 let emit = |merged: &mut Vec<(Record, u64)>,
@@ -2646,7 +2653,8 @@ pub(crate) async fn dispatch_plan_node(
                         for pred in &sorted_preds {
                             let upstream_name = current_dag.graph[*pred].name().to_string();
                             if let Some(buf) = ctx.node_buffers.remove(pred) {
-                                for (record, rn) in buf {
+                                for pair in buf.drain() {
+                                    let (record, rn) = pair?;
                                     emit(&mut merged, &upstream_name, record, rn)?;
                                 }
                             }
@@ -2665,13 +2673,17 @@ pub(crate) async fn dispatch_plan_node(
                             .collect();
                         let mut deques: Vec<VecDeque<(Record, u64)>> = sorted_preds
                             .iter()
-                            .map(|pred| {
-                                ctx.node_buffers
-                                    .remove(pred)
-                                    .map(VecDeque::from)
-                                    .unwrap_or_default()
+                            .map(|pred| -> Result<VecDeque<(Record, u64)>, PipelineError> {
+                                match ctx.node_buffers.remove(pred) {
+                                    Some(nb) => {
+                                        let v: Vec<_> =
+                                            nb.drain().collect::<Result<Vec<_>, _>>()?;
+                                        Ok(VecDeque::from(v))
+                                    }
+                                    None => Ok(VecDeque::new()),
+                                }
                             })
-                            .collect();
+                            .collect::<Result<Vec<_>, _>>()?;
                         let mut rng = interleave_seed.map(fastrand::Rng::with_seed);
                         let mut cursor = 0usize;
                         loop {
@@ -2715,7 +2727,8 @@ pub(crate) async fn dispatch_plan_node(
             // nothing because no spec roots at a Merge NodeIndex.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &merged)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &merged)?;
-            ctx.node_buffers.insert(node_idx, merged);
+            ctx.node_buffers
+                .insert(node_idx, NodeBuffer::Memory(merged));
         }
 
         PlanNode::Sort {
@@ -2734,14 +2747,16 @@ pub(crate) async fn dispatch_plan_node(
                 .graph
                 .neighbors_directed(node_idx, Direction::Incoming)
                 .collect();
-            let input_records: Vec<_> = predecessors
-                .iter()
-                .find_map(|p| ctx.node_buffers.remove(p))
-                .unwrap_or_default();
+            let input_records: Vec<(Record, u64)> =
+                match predecessors.iter().find_map(|p| ctx.node_buffers.remove(p)) {
+                    Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                    None => Vec::new(),
+                };
 
             if input_records.is_empty() {
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &[])?;
-                ctx.node_buffers.insert(node_idx, Vec::new());
+                ctx.node_buffers
+                    .insert(node_idx, NodeBuffer::Memory(Vec::new()));
                 return Ok(());
             }
 
@@ -2821,7 +2836,7 @@ pub(crate) async fn dispatch_plan_node(
             ctx.collector
                 .record(sort_timer.finish(sort_count, sort_count));
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out)?;
-            ctx.node_buffers.insert(node_idx, out);
+            ctx.node_buffers.insert(node_idx, NodeBuffer::Memory(out));
         }
 
         PlanNode::Aggregation {
@@ -2858,7 +2873,10 @@ pub(crate) async fn dispatch_plan_node(
 
             let pred =
                 crate::executor::single_predecessor(current_dag, node_idx, "aggregation", name)?;
-            let input = ctx.node_buffers.remove(&pred).unwrap_or_default();
+            let input: Vec<(Record, u64)> = match ctx.node_buffers.remove(&pred) {
+                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                None => Vec::new(),
+            };
 
             if let Some(expected) = current_dag.graph[node_idx]
                 .expected_input_schema_in(current_dag)
@@ -3209,7 +3227,8 @@ pub(crate) async fn dispatch_plan_node(
                 let projected = project_rows_to_buffer_schema(out_rows, &buffer_schema);
                 finalize_node_rooted_windows(ctx, current_dag, node_idx, &projected)?;
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &projected)?;
-                ctx.node_buffers.insert(node_idx, projected);
+                ctx.node_buffers
+                    .insert(node_idx, NodeBuffer::Memory(projected));
             } else {
                 // Materialize node-rooted window runtimes for any IndexSpec
                 // rooted at this aggregate. The aggregate emits columns the
@@ -3220,7 +3239,8 @@ pub(crate) async fn dispatch_plan_node(
                 // `out_rows` here, not from the source stream.
                 finalize_node_rooted_windows(ctx, current_dag, node_idx, &out_rows)?;
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out_rows)?;
-                ctx.node_buffers.insert(node_idx, out_rows);
+                ctx.node_buffers
+                    .insert(node_idx, NodeBuffer::Memory(out_rows));
             }
         }
 
@@ -3240,16 +3260,16 @@ pub(crate) async fn dispatch_plan_node(
             // Get input records: check own buffer first (Route
             // nodes store records at the successor's index), then
             // fall back to predecessor buffers.
-            let input_records = if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
-                own_buf
-            } else {
-                let predecessors: Vec<NodeIndex> = current_dag
-                    .graph
-                    .neighbors_directed(node_idx, Direction::Incoming)
-                    .collect();
-                predecessors
-                    .iter()
-                    .find_map(|&p| {
+            let input_records: Vec<(Record, u64)> =
+                if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
+                    own_buf.drain().collect::<Result<Vec<_>, _>>()?
+                } else {
+                    let predecessors: Vec<NodeIndex> = current_dag
+                        .graph
+                        .neighbors_directed(node_idx, Direction::Incoming)
+                        .collect();
+                    let mut found: Option<Vec<(Record, u64)>> = None;
+                    for &p in &predecessors {
                         // When multiple outputs share a predecessor,
                         // clone the buffer for all but the last
                         // consumer to avoid starving siblings.
@@ -3259,13 +3279,19 @@ pub(crate) async fn dispatch_plan_node(
                             .filter(|&succ| succ > node_idx)
                             .count();
                         if remaining_consumers == 0 {
-                            ctx.node_buffers.remove(&p)
-                        } else {
-                            ctx.node_buffers.get(&p).cloned()
+                            if let Some(nb) = ctx.node_buffers.remove(&p) {
+                                found = Some(nb.drain().collect::<Result<Vec<_>, _>>()?);
+                                break;
+                            }
+                        } else if let Some(nb) = ctx.node_buffers.get(&p) {
+                            // Multi-consumer fanout: keep the producer's
+                            // buffer alive for remaining siblings.
+                            found = Some(nb.clone_memory_only());
+                            break;
                         }
-                    })
-                    .unwrap_or_default()
-            };
+                    }
+                    found.unwrap_or_default()
+                };
 
             if let Some(expected) = current_dag.graph[node_idx]
                 .expected_input_schema_in(current_dag)
@@ -3509,7 +3535,7 @@ pub(crate) async fn dispatch_plan_node(
                 if let Some(&first_pred) = predecessors.first()
                     && let Some(records) = ctx.node_buffers.get(&first_pred)
                 {
-                    for (record, _) in records {
+                    for (record, _) in records.peek_mem() {
                         check_input_schema(
                             &expected,
                             record.schema(),
@@ -3546,7 +3572,8 @@ pub(crate) async fn dispatch_plan_node(
             // popped, so the install lands on `top` (parent scope).
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-            ctx.node_buffers.insert(node_idx, output_records);
+            ctx.node_buffers
+                .insert(node_idx, NodeBuffer::Memory(output_records));
         }
 
         PlanNode::Combine {
@@ -3723,8 +3750,14 @@ pub(crate) async fn dispatch_plan_node(
                     ),
                 })?;
 
-            let driver_buf = ctx.node_buffers.remove(&driver_pred).unwrap_or_default();
-            let build_buf = ctx.node_buffers.remove(&build_pred).unwrap_or_default();
+            let driver_buf: Vec<(Record, u64)> = match ctx.node_buffers.remove(&driver_pred) {
+                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                None => Vec::new(),
+            };
+            let build_buf: Vec<(Record, u64)> = match ctx.node_buffers.remove(&build_pred) {
+                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                None => Vec::new(),
+            };
 
             // Operator-entry schema check per D4: every record
             // arriving on the probe and build channels is
@@ -3916,7 +3949,8 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-                    ctx.node_buffers.insert(node_idx, output_records);
+                    ctx.node_buffers
+                        .insert(node_idx, NodeBuffer::Memory(output_records));
                     // Combine arm clean-exit: drop the per-fold cursor
                     // snapshot. Every emitted record has cleared into
                     // `node_buffers` without rewind, so the snapshot is
@@ -3994,7 +4028,8 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-                    ctx.node_buffers.insert(node_idx, output_records);
+                    ctx.node_buffers
+                        .insert(node_idx, NodeBuffer::Memory(output_records));
                     // Combine arm clean-exit: drop the per-fold cursor
                     // snapshot. Mirrors the inline arm's post-emit
                     // clear so non-inline strategies do not leak
@@ -4078,7 +4113,8 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-                    ctx.node_buffers.insert(node_idx, output_records);
+                    ctx.node_buffers
+                        .insert(node_idx, NodeBuffer::Memory(output_records));
                     // Combine arm clean-exit: drop the per-fold cursor
                     // snapshot. Mirrors the inline arm's post-emit
                     // clear.
@@ -4566,7 +4602,8 @@ pub(crate) async fn dispatch_plan_node(
                 .record(probe_timer.finish(probe_records_in, probe_records_out));
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-            ctx.node_buffers.insert(node_idx, output_records);
+            ctx.node_buffers
+                .insert(node_idx, NodeBuffer::Memory(output_records));
             // Drop the per-fold cursor snapshot: every emitted record
             // has cleared into `node_buffers` without rewind, so the
             // snapshot is no longer needed. The rewind path on a
@@ -5055,10 +5092,10 @@ fn collect_port_records(
                 ),
             });
         };
-        let records = ctx
+        let records: Vec<(Record, u64)> = ctx
             .node_buffers
             .get(&edge.source())
-            .cloned()
+            .map(|nb| nb.clone_memory_only())
             .unwrap_or_default();
         // Two parallel edges to the same port (e.g. `inputs: { p: a,
         // p: a }` — currently rejected at parse, but the runtime is
@@ -5119,13 +5156,13 @@ async fn execute_composition_body(
     }
 
     // Seed body-scope buffers from parent records keyed by port.
-    let mut body_buffers: HashMap<NodeIndex, Vec<(clinker_record::Record, u64)>> = HashMap::new();
+    let mut body_buffers: HashMap<NodeIndex, NodeBuffer> = HashMap::new();
     for (port_name, records) in port_records {
         let body_idx = bound_body
             .port_name_to_node_idx
             .get(port_name.as_str())
             .ok_or_else(|| PipelineError::compose_unknown_port(composition_name, &port_name))?;
-        body_buffers.insert(*body_idx, records);
+        body_buffers.insert(*body_idx, NodeBuffer::Memory(records));
     }
 
     // Pick the body's terminal output node. The bind-time alias
@@ -5198,9 +5235,12 @@ async fn execute_composition_body(
     // again when `recurse_into_body` extends the slot with the
     // commit-pass harvest. Drop the forward emit so the commit pass
     // is the single source of records for that slot.
-    let output_records = match (&walk_result, output_idx) {
+    let output_records: Vec<(Record, u64)> = match (&walk_result, output_idx) {
         (Ok(()), Some(idx)) => {
-            let drained = ctx.node_buffers.remove(&idx).unwrap_or_default();
+            let drained: Vec<(Record, u64)> = match ctx.node_buffers.remove(&idx) {
+                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                None => Vec::new(),
+            };
             if body_dag.deferred_region_at_producer(idx).is_some() {
                 Vec::new()
             } else {

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -3,6 +3,7 @@ pub mod stage_metrics;
 pub mod combine;
 pub(crate) mod commit;
 pub(crate) mod dispatch;
+pub(crate) mod node_buffer;
 mod schema_check;
 pub(crate) mod source_stream;
 pub(crate) mod time_window;

--- a/crates/clinker-core/src/executor/node_buffer.rs
+++ b/crates/clinker-core/src/executor/node_buffer.rs
@@ -1,0 +1,391 @@
+//! Inter-stage handoff storage for `ExecutorContext::node_buffers`.
+//!
+//! A single `NodeBuffer` slot can hold:
+//!
+//! - `Memory`: rows accumulated entirely in RAM.
+//! - `Spilled`: zero or more on-disk spill files, each paired with its
+//!   recorded row count.
+//! - `Mixed`: a mem tail accumulated after a partial spill.
+//!
+//! Every consumer drains a slot through [`NodeBuffer::drain`], which
+//! returns an iterator that streams memory rows first, then per-spill
+//! rows via `SpillReader` without materializing the spill into RAM.
+//! Spill construction is gated behind a future sub-issue of #108; at
+//! present no runtime producer emits `Spilled` or `Mixed`, but the
+//! type's shape is already the one the spill-trigger logic will use.
+
+use std::vec::IntoIter as VecIntoIter;
+
+use clinker_record::Record;
+
+use crate::error::PipelineError;
+use crate::pipeline::spill::{SpillFile, SpillReader};
+
+/// One slot inside `ExecutorContext::node_buffers`.
+pub(crate) enum NodeBuffer {
+    /// All rows live in memory.
+    Memory(Vec<(Record, u64)>),
+    /// Every row lives on disk. Each chunk pairs a spill file with the
+    /// number of rows that producer wrote to it (used by `len_hint`
+    /// and by the memory-charge accounting layer that the spill-wiring
+    /// sub-issue introduces). No runtime path constructs this variant
+    /// yet; tests cover the drain, promotion, and Drop semantics.
+    #[allow(dead_code)]
+    Spilled(Vec<(SpillFile<u64>, u64)>),
+    /// A mem tail accumulated after a partial spill. Drain order is
+    /// memory rows first, then spill chunks in vector order.
+    Mixed {
+        mem: Vec<(Record, u64)>,
+        spills: Vec<(SpillFile<u64>, u64)>,
+    },
+}
+
+impl NodeBuffer {
+    /// Total record count across memory and recorded spill chunks.
+    ///
+    /// Used by consumer call-sites that want a `Vec::with_capacity`
+    /// pre-allocation hint without consuming the buffer. Cheap on
+    /// every variant — spill chunks carry their row count alongside
+    /// the file handle, so no disk scan is required.
+    pub(crate) fn len_hint(&self) -> usize {
+        match self {
+            Self::Memory(v) => v.len(),
+            Self::Spilled(chunks) => chunks.iter().map(|(_, c)| *c as usize).sum(),
+            Self::Mixed { mem, spills } => {
+                mem.len() + spills.iter().map(|(_, c)| *c as usize).sum::<usize>()
+            }
+        }
+    }
+
+    /// Append a single `(record, row_number)` pair to the in-memory tail.
+    ///
+    /// On `Memory` and `Mixed`, the pair is pushed onto the existing
+    /// mem `Vec`. On `Spilled`, the variant is promoted to `Mixed`
+    /// with the new pair as the sole mem tail. Producers that already
+    /// accumulate a `Vec` and then insert via `NodeBuffer::Memory(vec)`
+    /// remain the dominant pattern; `push` exists so spill-trigger
+    /// logic can resume in-memory accumulation after a partial spill.
+    pub(crate) fn push(&mut self, record: Record, rn: u64) {
+        match self {
+            Self::Memory(v) => v.push((record, rn)),
+            Self::Mixed { mem, .. } => mem.push((record, rn)),
+            Self::Spilled(_) => {
+                let chunks = match std::mem::replace(self, Self::Memory(Vec::new())) {
+                    Self::Spilled(c) => c,
+                    _ => unreachable!(),
+                };
+                *self = Self::Mixed {
+                    mem: vec![(record, rn)],
+                    spills: chunks,
+                };
+            }
+        }
+    }
+
+    /// Non-consuming borrow of the in-memory rows.
+    ///
+    /// Returns `&[]` on a pure `Spilled` slot — callers that need
+    /// schema-style validation of every row in a spilled buffer must
+    /// instead drain through [`Self::drain`]. The schema-check
+    /// call-site this is wired into today operates only on memory-
+    /// resident rows; spill-aware pre-flight validation is part of
+    /// the spill-wiring sub-issue.
+    pub(crate) fn peek_mem(&self) -> &[(Record, u64)] {
+        match self {
+            Self::Memory(v) => v.as_slice(),
+            Self::Mixed { mem, .. } => mem.as_slice(),
+            Self::Spilled(_) => &[],
+        }
+    }
+
+    /// Deep-clone the in-memory rows for a multi-consumer fan-out site.
+    ///
+    /// # Panics
+    ///
+    /// Panics on `Spilled` and `Mixed`. Spill chunks cannot be
+    /// cheap-cloned; the only legitimate multi-consumer access for a
+    /// spilled buffer is to drain it. The producer-side fan-out arm
+    /// in `dispatch.rs` uses this when there is at least one
+    /// remaining downstream consumer; today every reachable
+    /// `NodeBuffer` is `Memory`, so the panic path is unreachable at
+    /// runtime.
+    pub(crate) fn clone_memory_only(&self) -> Vec<(Record, u64)> {
+        match self {
+            Self::Memory(v) => v.clone(),
+            Self::Spilled(_) | Self::Mixed { .. } => {
+                panic!(
+                    "NodeBuffer::clone_memory_only called on a spill-backed \
+                     variant; spilled rows cannot be cloned for multi-consumer \
+                     fanout. Drain through NodeBuffer::drain instead.",
+                );
+            }
+        }
+    }
+
+    /// Consume the buffer, returning an iterator that yields memory
+    /// rows first and then per-spill-file rows in vector order.
+    ///
+    /// Spill rows stream from disk via `SpillReader<u64>` without
+    /// materializing the spill. Spill-open and per-row decode failures
+    /// surface as `PipelineError::Spill` items so the executor's
+    /// existing `?`-bubble path applies unchanged.
+    pub(crate) fn drain(self) -> NodeBufferDrain {
+        let (mem, spills) = match self {
+            Self::Memory(v) => (v, Vec::new()),
+            Self::Spilled(s) => (Vec::new(), s),
+            Self::Mixed { mem, spills } => (mem, spills),
+        };
+        NodeBufferDrain {
+            mem: mem.into_iter(),
+            remaining_spills: spills.into_iter(),
+            current: None,
+        }
+    }
+}
+
+/// Iterator returned by [`NodeBuffer::drain`].
+///
+/// Owns the spill chunks so each chunk's `TempPath` stays alive until
+/// the iterator advances past it, even if the producer dropped its
+/// handle. Fields drop in declaration order: the active reader closes
+/// its file handle before the chunk it was opened from is unlinked.
+pub(crate) struct NodeBufferDrain {
+    mem: VecIntoIter<(Record, u64)>,
+    remaining_spills: VecIntoIter<(SpillFile<u64>, u64)>,
+    current: Option<ActiveSpill>,
+}
+
+struct ActiveSpill {
+    reader: SpillReader<u64>,
+    // Holds the file alive while `reader` streams it.
+    _file: SpillFile<u64>,
+}
+
+impl Iterator for NodeBufferDrain {
+    type Item = Result<(Record, u64), PipelineError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(pair) = self.mem.next() {
+            return Some(Ok(pair));
+        }
+        loop {
+            if let Some(curr) = self.current.as_mut() {
+                match curr.reader.next() {
+                    Some(Ok(pair)) => return Some(Ok(pair)),
+                    Some(Err(e)) => return Some(Err(PipelineError::from(e))),
+                    None => self.current = None,
+                }
+            }
+            let (file, _count) = self.remaining_spills.next()?;
+            let reader = match file.reader() {
+                Ok(r) => r,
+                Err(e) => return Some(Err(PipelineError::from(e))),
+            };
+            self.current = Some(ActiveSpill {
+                reader,
+                _file: file,
+            });
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    use clinker_record::{Schema, Value};
+
+    use crate::pipeline::spill::SpillWriter;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec!["id".into(), "v".into()]))
+    }
+
+    fn rec(s: &Arc<Schema>, id: i64, v: &str) -> Record {
+        Record::new(
+            Arc::clone(s),
+            vec![Value::Integer(id), Value::String(v.into())],
+        )
+    }
+
+    fn spill_chunk(rows: Vec<(Record, u64)>) -> (SpillFile<u64>, u64) {
+        let s = if let Some(first) = rows.first() {
+            Arc::clone(first.0.schema())
+        } else {
+            schema()
+        };
+        let mut w: SpillWriter<u64> = SpillWriter::new(s, None).unwrap();
+        let count = rows.len() as u64;
+        for (r, rn) in &rows {
+            w.write_pair(r, rn).unwrap();
+        }
+        (w.finish().unwrap(), count)
+    }
+
+    #[test]
+    fn memory_push_drain_round_trip() {
+        let s = schema();
+        let mut nb = NodeBuffer::Memory(Vec::new());
+        nb.push(rec(&s, 1, "a"), 10);
+        nb.push(rec(&s, 2, "b"), 11);
+
+        assert_eq!(nb.len_hint(), 2);
+
+        let drained: Vec<_> = nb.drain().collect::<Result<_, _>>().unwrap();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].1, 10);
+        assert_eq!(drained[1].1, 11);
+    }
+
+    #[test]
+    fn spilled_drains_in_file_order() {
+        let s = schema();
+        let chunk_a = spill_chunk(vec![(rec(&s, 1, "a"), 1), (rec(&s, 2, "b"), 2)]);
+        let chunk_b = spill_chunk(vec![(rec(&s, 3, "c"), 3)]);
+        let nb = NodeBuffer::Spilled(vec![chunk_a, chunk_b]);
+
+        assert_eq!(nb.len_hint(), 3);
+
+        let drained: Vec<_> = nb.drain().collect::<Result<_, _>>().unwrap();
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].1, 1);
+        assert_eq!(drained[1].1, 2);
+        assert_eq!(drained[2].1, 3);
+    }
+
+    #[test]
+    fn mixed_drains_memory_before_spills() {
+        let s = schema();
+        let chunk = spill_chunk(vec![(rec(&s, 100, "spill-row"), 100)]);
+        let nb = NodeBuffer::Mixed {
+            mem: vec![(rec(&s, 1, "mem-a"), 1), (rec(&s, 2, "mem-b"), 2)],
+            spills: vec![chunk],
+        };
+
+        assert_eq!(nb.len_hint(), 3);
+
+        let drained: Vec<_> = nb.drain().collect::<Result<_, _>>().unwrap();
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0].1, 1);
+        assert_eq!(drained[1].1, 2);
+        assert_eq!(drained[2].1, 100);
+    }
+
+    #[test]
+    fn len_hint_matches_drained_count_on_each_variant() {
+        let s = schema();
+        let mem = NodeBuffer::Memory(vec![
+            (rec(&s, 1, "a"), 1),
+            (rec(&s, 2, "b"), 2),
+            (rec(&s, 3, "c"), 3),
+        ]);
+        assert_eq!(mem.len_hint(), 3);
+        assert_eq!(mem.drain().count(), 3);
+
+        let spilled = NodeBuffer::Spilled(vec![spill_chunk(vec![
+            (rec(&s, 1, "a"), 1),
+            (rec(&s, 2, "b"), 2),
+        ])]);
+        assert_eq!(spilled.len_hint(), 2);
+        assert_eq!(spilled.drain().count(), 2);
+
+        let mixed = NodeBuffer::Mixed {
+            mem: vec![(rec(&s, 1, "m"), 1)],
+            spills: vec![spill_chunk(vec![(rec(&s, 2, "s"), 2)])],
+        };
+        assert_eq!(mixed.len_hint(), 2);
+        assert_eq!(mixed.drain().count(), 2);
+    }
+
+    #[test]
+    fn peek_mem_returns_mem_slice_or_empty() {
+        let s = schema();
+        let mem = NodeBuffer::Memory(vec![(rec(&s, 1, "a"), 1)]);
+        assert_eq!(mem.peek_mem().len(), 1);
+
+        let spilled = NodeBuffer::Spilled(vec![spill_chunk(vec![(rec(&s, 1, "a"), 1)])]);
+        assert!(spilled.peek_mem().is_empty());
+
+        let mixed = NodeBuffer::Mixed {
+            mem: vec![(rec(&s, 1, "m"), 1)],
+            spills: vec![spill_chunk(vec![(rec(&s, 2, "s"), 2)])],
+        };
+        assert_eq!(mixed.peek_mem().len(), 1);
+        assert_eq!(mixed.peek_mem()[0].1, 1);
+    }
+
+    #[test]
+    fn clone_memory_only_returns_memory_clone() {
+        let s = schema();
+        let nb = NodeBuffer::Memory(vec![(rec(&s, 1, "a"), 1), (rec(&s, 2, "b"), 2)]);
+        let cloned = nb.clone_memory_only();
+        assert_eq!(cloned.len(), 2);
+        assert_eq!(cloned[1].1, 2);
+        // Original still drains its rows.
+        assert_eq!(nb.drain().count(), 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "spill-backed variant")]
+    fn clone_memory_only_panics_on_spilled() {
+        let s = schema();
+        let nb = NodeBuffer::Spilled(vec![spill_chunk(vec![(rec(&s, 1, "a"), 1)])]);
+        let _ = nb.clone_memory_only();
+    }
+
+    #[test]
+    #[should_panic(expected = "spill-backed variant")]
+    fn clone_memory_only_panics_on_mixed() {
+        let s = schema();
+        let nb = NodeBuffer::Mixed {
+            mem: vec![(rec(&s, 1, "m"), 1)],
+            spills: vec![spill_chunk(vec![(rec(&s, 2, "s"), 2)])],
+        };
+        let _ = nb.clone_memory_only();
+    }
+
+    #[test]
+    fn push_on_spilled_promotes_to_mixed() {
+        let s = schema();
+        let mut nb = NodeBuffer::Spilled(vec![spill_chunk(vec![(rec(&s, 100, "s"), 100)])]);
+        nb.push(rec(&s, 1, "after-spill"), 200);
+
+        assert!(matches!(nb, NodeBuffer::Mixed { .. }));
+        assert_eq!(nb.len_hint(), 2);
+
+        let drained: Vec<_> = nb.drain().collect::<Result<_, _>>().unwrap();
+        // mem tail drains first per the documented order.
+        assert_eq!(drained[0].1, 200);
+        assert_eq!(drained[1].1, 100);
+    }
+
+    #[test]
+    fn spilled_drop_unlinks_temp_files() {
+        let s = schema();
+        let (file, _) = spill_chunk(vec![(rec(&s, 1, "a"), 1)]);
+        let path = file.path().to_path_buf();
+        assert!(path.exists());
+
+        let nb = NodeBuffer::Spilled(vec![(file, 1)]);
+        drop(nb);
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn empty_variants_have_zero_len_hint() {
+        let s = schema();
+        assert_eq!(NodeBuffer::Memory(Vec::new()).len_hint(), 0);
+        assert_eq!(NodeBuffer::Spilled(Vec::new()).len_hint(), 0);
+        assert_eq!(
+            NodeBuffer::Mixed {
+                mem: Vec::new(),
+                spills: Vec::new(),
+            }
+            .len_hint(),
+            0
+        );
+        assert_eq!(NodeBuffer::Memory(vec![(rec(&s, 1, "a"), 1)]).len_hint(), 1);
+    }
+}

--- a/crates/clinker-core/src/integration_tests.rs
+++ b/crates/clinker-core/src/integration_tests.rs
@@ -80,6 +80,7 @@ mod tests {
             ) => 3,
             Err(
                 PipelineError::Io(_)
+                | PipelineError::Spill(_)
                 | PipelineError::Format(_)
                 | PipelineError::ThreadPool(_)
                 | PipelineError::Multiple(_)

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -324,7 +324,7 @@ fn main() -> ExitCode {
                         | PipelineError::CompositionBodyError { .. }
                         | PipelineError::MemoryBudgetExceeded { .. }
                         | PipelineError::CombineMissingMatch { .. } => ExitCode::from(1),
-                        PipelineError::Io(_) => ExitCode::from(4),
+                        PipelineError::Io(_) | PipelineError::Spill(_) => ExitCode::from(4),
                         PipelineError::Eval(_) | PipelineError::Accumulator { .. } => {
                             ExitCode::from(3)
                         }


### PR DESCRIPTION
Closes #120. Sub-issue of #108.

## Summary

- Replaces `ExecutorContext::node_buffers` storage from `HashMap<NodeIndex, Vec<(Record, u64)>>` to `HashMap<NodeIndex, NodeBuffer>` where `NodeBuffer` is `Memory | Spilled | Mixed`. Every consumer drains through `NodeBuffer::drain` so the upcoming spill-trigger work can produce `Spilled` / `Mixed` slots without parallel-map drift between in-memory rows and on-disk chunks.
- Adds `PipelineError::Spill(SpillError)` so spill-decode failures (postcard, JSON schema header, LZ4 frame I/O) keep their context rather than collapsing into a bare `std::io::Error`. Mapped to exit code 4 in `clinker/src/main.rs` and `clinker-core/src/integration_tests.rs`.
- 41 dispatch sites migrated across `executor/dispatch.rs`, `executor/commit/dispatch.rs`, and `executor/commit/recompute_agg.rs`. The three peek/clone/length sites use the new `len_hint`, `peek_mem`, `clone_memory_only` methods on `NodeBuffer`; every producer wraps its accumulated `Vec` in `NodeBuffer::Memory(vec)` before insert.

## Out of scope

This sub-issue is the type flip only. The follow-up sub-issue of #108 wires:

- Real production of `Spilled` / `Mixed` chunks when `MemoryBudget::should_spill` trips.
- Calls to `charge_node_buffer_bytes` / `discharge_node_buffer_bytes` (already landed via #119) at insert / drain time.
- The integration test that exercises a Route fan-out under the default budget and asserts the spill counter increments rather than RSS overshooting.

## Spilled variant attribute

At this commit's closing state, no runtime path constructs `NodeBuffer::Spilled` (the spill-trigger logic lives in the follow-up sub-issue). The variant carries `#[allow(dead_code)]` with an inline doc comment explaining the pending producer; the follow-up removes the attribute the same commit it adds the producer. `NodeBuffer::Mixed` is constructed at runtime via the `push()` Spilled-to-Mixed promotion path called from `commit/dispatch.rs`, so it passes dead-code lint cleanly.

## Test plan

- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `cargo test --workspace`
- [ ] `cargo check --benches --workspace`
- [ ] `cargo check --features bench-alloc -p clinker-benchmarks`
- [ ] `cargo test --benches -p clinker-benchmarks` (e2e scale matrix)
- [ ] `cargo deny check`
- [ ] Confirm Route fan-out, Merge fan-in, and Composition body fixture pipelines produce identical output to pre-flip behaviour (covered by the existing fixture tests in `crates/clinker-core/tests/`)
- [ ] Inspect `NodeBuffer::Spilled` / `Mixed` unit tests in `crates/clinker-core/src/executor/node_buffer.rs` (drain order, `len_hint` accuracy, `peek_mem` slicing, `clone_memory_only` panic on spill-backed variants, `Drop` cleans up tempfiles, push promotion of Spilled to Mixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)