### PR TITLE
engine: charge and discharge MemoryBudget at every node_buffers mutation site (#121)

### DIFF
--- a/crates/clinker-core/src/executor/commit/dispatch.rs
+++ b/crates/clinker-core/src/executor/commit/dispatch.rs
@@ -44,7 +44,7 @@ use petgraph::visit::{EdgeRef, Topo};
 use super::DlqEvent;
 use super::detect::RetractScope;
 use crate::error::PipelineError;
-use crate::executor::dispatch::{ExecutorContext, dispatch_plan_node};
+use crate::executor::dispatch::{ExecutorContext, charge_node_buffer_admit, dispatch_plan_node};
 use crate::executor::node_buffer::NodeBuffer;
 use crate::plan::CompositionBodyId;
 use crate::plan::deferred_region::{DeferredRegion, ParentContinuation};
@@ -228,10 +228,16 @@ async fn dispatch_one_region(
     // — `recompute_aggregates` populates it with the post-recompute
     // narrow rows.
     for &m in &region.members {
-        ctx.node_buffers.remove(&m);
+        if let Some(nb) = ctx.node_buffers.remove(&m) {
+            ctx.memory_budget
+                .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+        }
     }
     for &o in &region.outputs {
-        ctx.node_buffers.remove(&o);
+        if let Some(nb) = ctx.node_buffers.remove(&o) {
+            ctx.memory_budget
+                .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+        }
     }
 
     let active_body = ctx.window_runtime.active_stack.last().copied();
@@ -325,6 +331,14 @@ fn seed_cross_region_inputs_for(
         let Some(parked) = ctx.region_input_buffers.remove(&key) else {
             continue;
         };
+        // Charge the NodeBuffer counter for the rows about to enter
+        // `node_buffers[source_idx]`. The same rows were Arena-charged
+        // at forward-pass cross-region tee admission; that ledger
+        // tracks `region_input_buffers` and is independent of this
+        // node-buffer-category surface. The consumer's predecessor-walk
+        // remove discharges this charge once the records leave the slot.
+        let producer_name = current_dag.graph[source_idx].name().to_string();
+        charge_node_buffer_admit(ctx, &producer_name, &parked)?;
         // Append onto the source node's buffer so the consumer's
         // existing predecessor-walk logic resolves them.
         let slot = ctx
@@ -476,6 +490,8 @@ async fn recurse_into_body(
         let mut harvested: Vec<(Record, u64)> = Vec::new();
         for body_out_idx in bound_body.output_port_to_node_idx.values() {
             if let Some(nb) = ctx.node_buffers.remove(body_out_idx) {
+                ctx.memory_budget
+                    .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
                 for pair in nb.drain() {
                     harvested.push(pair?);
                 }
@@ -484,6 +500,21 @@ async fn recurse_into_body(
         Ok::<Vec<(Record, u64)>, PipelineError>(harvested)
     }
     .await;
+
+    // Body exit cleanup mirroring the forward-pass executor: discharge
+    // any body-local `node_buffers` charges that the body walk left
+    // behind (early-return on error, sink-only bodies that never
+    // consume their seeded inputs, etc.) so the NodeBuffer ledger does
+    // not leak across the body / parent boundary when `saved_buffers`
+    // overwrites the field below.
+    let leaked_bytes: u64 = ctx
+        .node_buffers
+        .values()
+        .map(NodeBuffer::estimated_memory_bytes)
+        .sum();
+    if leaked_bytes > 0 {
+        ctx.memory_budget.discharge_node_buffer_bytes(leaked_bytes);
+    }
 
     // Restore parent scope on every exit. The window-runtime body
     // overlay is popped first so subsequent parent-scope walks route
@@ -502,11 +533,15 @@ async fn recurse_into_body(
         // the forward-pass `tee_emit_to_region_input_buffers` applies,
         // so a runaway body cannot evade the per-pipeline budget by
         // routing its output through the harvest path instead.
-        crate::executor::dispatch::charge_harvest_admission(
-            ctx,
-            &harvested,
-            parent_dag.graph[composition_idx].name(),
-        )?;
+        let composition_name = parent_dag.graph[composition_idx].name().to_string();
+        crate::executor::dispatch::charge_harvest_admission(ctx, &harvested, &composition_name)?;
+        // NodeBuffer-category charge for the rows about to enter the
+        // parent's `node_buffers[composition_idx]` slot. Attributed to
+        // the parent composition's user-visible name (not the body's
+        // output port) so an overflow diagnostic points at the operator
+        // the user wrote. Discharge fires when the parent's continuation
+        // consumes the slot.
+        charge_node_buffer_admit(ctx, &composition_name, &harvested)?;
         let slot = ctx
             .node_buffers
             .entry(composition_idx)
@@ -570,10 +605,16 @@ async fn dispatch_continuation(
     // not re-read. The Composition seed's slot is preserved — it
     // carries the harvest.
     for &m in &continuation.members {
-        ctx.node_buffers.remove(&m);
+        if let Some(nb) = ctx.node_buffers.remove(&m) {
+            ctx.memory_budget
+                .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+        }
     }
     for &o in &continuation.outputs {
-        ctx.node_buffers.remove(&o);
+        if let Some(nb) = ctx.node_buffers.remove(&o) {
+            ctx.memory_budget
+                .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+        }
     }
 
     for idx in topo {

--- a/crates/clinker-core/src/executor/commit/recompute_agg.rs
+++ b/crates/clinker-core/src/executor/commit/recompute_agg.rs
@@ -18,7 +18,8 @@ use super::detect::RetractScope;
 use crate::aggregation::HashAggError;
 use crate::error::PipelineError;
 use crate::executor::dispatch::{
-    ExecutorContext, finalize_node_rooted_windows, project_rows_to_buffer_schema,
+    ExecutorContext, charge_node_buffer_admit, finalize_node_rooted_windows,
+    project_rows_to_buffer_schema,
 };
 use crate::executor::node_buffer::NodeBuffer;
 use crate::plan::execution::ExecutionPlanDag;
@@ -67,14 +68,20 @@ pub(crate) fn recompute_aggregates(
                 // (degrade path) or was never instantiated. Mark for
                 // degrade-fallback collateral handling in flush.
                 degraded.push(agg_idx);
-                ctx.node_buffers.remove(&agg_idx);
+                if let Some(nb) = ctx.node_buffers.remove(&agg_idx) {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                }
                 continue;
             };
             retract_and_refinalize(retained, new_retract_rows).is_ok()
         };
         if !retract_ok {
             degraded.push(agg_idx);
-            ctx.node_buffers.remove(&agg_idx);
+            if let Some(nb) = ctx.node_buffers.remove(&agg_idx) {
+                ctx.memory_budget
+                    .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+            }
             ctx.relaxed_aggregator_states.remove(&agg_idx);
             continue;
         }
@@ -85,7 +92,10 @@ pub(crate) fn recompute_aggregates(
             }
             Err(_) => {
                 degraded.push(agg_idx);
-                ctx.node_buffers.remove(&agg_idx);
+                if let Some(nb) = ctx.node_buffers.remove(&agg_idx) {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                }
                 ctx.relaxed_aggregator_states.remove(&agg_idx);
             }
         }
@@ -204,6 +214,25 @@ pub(crate) fn emit_post_recompute(
             "node-rooted window rebuild during commit-pass recompute: {e}"
         )));
     }
+    // The forward-pass Aggregate arm previously charged this slot;
+    // the post-retract emit replaces it with a narrower projection.
+    // Discharge the existing slot's bytes (if any) before the new
+    // charge so the ledger does not double-count across the swap.
+    if let Some(prev) = ctx.node_buffers.get(&agg_idx) {
+        let prev_bytes = prev.estimated_memory_bytes();
+        ctx.memory_budget.discharge_node_buffer_bytes(prev_bytes);
+    }
+    let agg_name = current_dag.graph[agg_idx].name().to_string();
+    charge_node_buffer_admit(ctx, &agg_name, &projected).map_err(|e| {
+        // Mapping budget exceeded into `HashAggError::Spill` lets the
+        // caller's degrade-fallback handle commit-pass admission
+        // overflow consistently with the rest of the post-retract
+        // emit path — the post-retract narrow projection is supplementary
+        // to the forward-pass Aggregate arm's primary charge, and a
+        // run-fatal bail there is the canonical surface for runaway
+        // aggregate output.
+        HashAggError::Spill(format!("post-recompute node-buffer admission: {e}"))
+    })?;
     ctx.node_buffers
         .insert(agg_idx, NodeBuffer::Memory(projected));
     Ok(emitted)

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -1137,6 +1137,46 @@ pub(crate) fn charge_harvest_admission(
     Ok(())
 }
 
+/// Per-row charge against `ctx.memory_budget.charge_node_buffer_bytes`
+/// for a `Vec<(Record, u64)>` about to be inserted, extended into, or
+/// cloned out of `ctx.node_buffers`. Returns the total bytes charged
+/// so the discharge site (consumer's `node_buffers.remove` or local
+/// `Drop`) can release the same amount; on hard-limit breach, returns
+/// a `MemoryBudgetExceeded` tagged `BudgetCategory::NodeBuffer` so
+/// diagnostics distinguish the inter-stage handoff layer from the
+/// arena-tracked surfaces.
+///
+/// The per-row formula matches `NodeBuffer::estimated_memory_bytes` and
+/// `charge_harvest_admission`: each row contributes `size_of::<Value>()
+/// * column_count + size_of::<(Record, u64)>()` bytes. The two budget
+/// surfaces share the `MemoryBudget::hard_limit` envelope via
+/// `total_charged`, so a runaway producer trips on the combined sum.
+pub(crate) fn charge_node_buffer_admit(
+    ctx: &mut ExecutorContext<'_>,
+    node_name: &str,
+    rows: &[(Record, u64)],
+) -> Result<u64, PipelineError> {
+    let Some((first, _)) = rows.first() else {
+        return Ok(0);
+    };
+    let row_bytes = std::mem::size_of::<Value>() * first.schema().column_count()
+        + std::mem::size_of::<(Record, u64)>();
+    let bytes = (row_bytes as u64).saturating_mul(rows.len() as u64);
+    if bytes == 0 {
+        return Ok(0);
+    }
+    if ctx.memory_budget.charge_node_buffer_bytes(bytes) {
+        return Err(PipelineError::MemoryBudgetExceeded {
+            node: node_name.to_string(),
+            used: ctx.memory_budget.total_charged(),
+            limit: ctx.memory_budget.hard_limit(),
+            source: BudgetCategory::NodeBuffer,
+            detail: Some("node_buffer admission".to_string()),
+        });
+    }
+    Ok(bytes)
+}
+
 /// Build the engine-stamped tail mapping for a Source's plan-time
 /// target schema: `(target_index, source_field_name)` per
 /// `$ck.<field>` shadow column. Resolved once per Source so the
@@ -1818,6 +1858,7 @@ pub(crate) async fn transform_fused_consume(
 
     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+    charge_node_buffer_admit(ctx, name, &output_records)?;
     ctx.node_buffers
         .insert(node_idx, NodeBuffer::Memory(output_records));
     Ok(())
@@ -1905,6 +1946,8 @@ pub(crate) async fn dispatch_plan_node(
                     // consumers run. Apply per-record seeding for body-
                     // declared record_vars (parent's writes survive via
                     // `seed_record_vars`'s preserve-existing semantics).
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(seeded.estimated_memory_bytes());
                     let mut out: Vec<(Record, u64)> = Vec::with_capacity(seeded.len_hint());
                     let has_record_seed = !ctx.record_var_seed.is_empty();
                     for pair in seeded.drain() {
@@ -2003,6 +2046,7 @@ pub(crate) async fn dispatch_plan_node(
             // now anchors here.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &records)?;
+            charge_node_buffer_admit(ctx, name, &records)?;
             ctx.node_buffers
                 .insert(node_idx, NodeBuffer::Memory(records));
         }
@@ -2027,6 +2071,8 @@ pub(crate) async fn dispatch_plan_node(
             // node for branch dispatch), then fall back to predecessor.
             let input_records: Vec<(Record, u64)> =
                 if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(own_buf.estimated_memory_bytes());
                     own_buf.drain().collect::<Result<Vec<_>, _>>()?
                 } else {
                     let predecessors: Vec<NodeIndex> = current_dag
@@ -2039,7 +2085,11 @@ pub(crate) async fn dispatch_plan_node(
                         predecessors.iter().find_map(|p| ctx.node_buffers.remove(p))
                     };
                     match pred_buf {
-                        Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                        Some(nb) => {
+                            ctx.memory_budget
+                                .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                            nb.drain().collect::<Result<Vec<_>, _>>()?
+                        }
                         None => Vec::new(),
                     }
                 };
@@ -2050,6 +2100,7 @@ pub(crate) async fn dispatch_plan_node(
                 None => {
                     // No transform found — pass through
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &input_records)?;
+                    charge_node_buffer_admit(ctx, name.as_str(), &input_records)?;
                     ctx.node_buffers
                         .insert(node_idx, NodeBuffer::Memory(input_records));
                     return Ok(());
@@ -2231,6 +2282,7 @@ pub(crate) async fn dispatch_plan_node(
             // matching runtime; otherwise the helper is a no-op.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+            charge_node_buffer_admit(ctx, name, &output_records)?;
             ctx.node_buffers
                 .insert(node_idx, NodeBuffer::Memory(output_records));
         }
@@ -2252,10 +2304,16 @@ pub(crate) async fn dispatch_plan_node(
                 .collect();
             let input_records: Vec<(Record, u64)> =
                 if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(own_buf.estimated_memory_bytes());
                     own_buf.drain().collect::<Result<Vec<_>, _>>()?
                 } else {
                     match predecessors.iter().find_map(|p| ctx.node_buffers.remove(p)) {
-                        Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                        Some(nb) => {
+                            ctx.memory_budget
+                                .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                            nb.drain().collect::<Result<Vec<_>, _>>()?
+                        }
                         None => Vec::new(),
                     }
                 };
@@ -2516,6 +2574,7 @@ pub(crate) async fn dispatch_plan_node(
                             .push((record.clone(), *rn));
                     }
                 }
+                charge_node_buffer_admit(ctx, name, &buf)?;
                 ctx.node_buffers.insert(succ_idx, NodeBuffer::Memory(buf));
             }
         }
@@ -2653,6 +2712,8 @@ pub(crate) async fn dispatch_plan_node(
                         for pred in &sorted_preds {
                             let upstream_name = current_dag.graph[*pred].name().to_string();
                             if let Some(buf) = ctx.node_buffers.remove(pred) {
+                                ctx.memory_budget
+                                    .discharge_node_buffer_bytes(buf.estimated_memory_bytes());
                                 for pair in buf.drain() {
                                     let (record, rn) = pair?;
                                     emit(&mut merged, &upstream_name, record, rn)?;
@@ -2676,6 +2737,9 @@ pub(crate) async fn dispatch_plan_node(
                             .map(|pred| -> Result<VecDeque<(Record, u64)>, PipelineError> {
                                 match ctx.node_buffers.remove(pred) {
                                     Some(nb) => {
+                                        ctx.memory_budget.discharge_node_buffer_bytes(
+                                            nb.estimated_memory_bytes(),
+                                        );
                                         let v: Vec<_> =
                                             nb.drain().collect::<Result<Vec<_>, _>>()?;
                                         Ok(VecDeque::from(v))
@@ -2727,6 +2791,7 @@ pub(crate) async fn dispatch_plan_node(
             // nothing because no spec roots at a Merge NodeIndex.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &merged)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &merged)?;
+            charge_node_buffer_admit(ctx, name, &merged)?;
             ctx.node_buffers
                 .insert(node_idx, NodeBuffer::Memory(merged));
         }
@@ -2749,12 +2814,20 @@ pub(crate) async fn dispatch_plan_node(
                 .collect();
             let input_records: Vec<(Record, u64)> =
                 match predecessors.iter().find_map(|p| ctx.node_buffers.remove(p)) {
-                    Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                    Some(nb) => {
+                        ctx.memory_budget
+                            .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                        nb.drain().collect::<Result<Vec<_>, _>>()?
+                    }
                     None => Vec::new(),
                 };
 
             if input_records.is_empty() {
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &[])?;
+                // Empty Vec heuristic charges zero bytes — admit helper
+                // is still called for symmetry with the non-empty path,
+                // so the ledger surface treats every Sort insert uniformly.
+                charge_node_buffer_admit(ctx, name, &[])?;
                 ctx.node_buffers
                     .insert(node_idx, NodeBuffer::Memory(Vec::new()));
                 return Ok(());
@@ -2836,6 +2909,7 @@ pub(crate) async fn dispatch_plan_node(
             ctx.collector
                 .record(sort_timer.finish(sort_count, sort_count));
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out)?;
+            charge_node_buffer_admit(ctx, name, &out)?;
             ctx.node_buffers.insert(node_idx, NodeBuffer::Memory(out));
         }
 
@@ -2874,7 +2948,11 @@ pub(crate) async fn dispatch_plan_node(
             let pred =
                 crate::executor::single_predecessor(current_dag, node_idx, "aggregation", name)?;
             let input: Vec<(Record, u64)> = match ctx.node_buffers.remove(&pred) {
-                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                Some(nb) => {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                    nb.drain().collect::<Result<Vec<_>, _>>()?
+                }
                 None => Vec::new(),
             };
 
@@ -3227,6 +3305,7 @@ pub(crate) async fn dispatch_plan_node(
                 let projected = project_rows_to_buffer_schema(out_rows, &buffer_schema);
                 finalize_node_rooted_windows(ctx, current_dag, node_idx, &projected)?;
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &projected)?;
+                charge_node_buffer_admit(ctx, name, &projected)?;
                 ctx.node_buffers
                     .insert(node_idx, NodeBuffer::Memory(projected));
             } else {
@@ -3239,6 +3318,7 @@ pub(crate) async fn dispatch_plan_node(
                 // `out_rows` here, not from the source stream.
                 finalize_node_rooted_windows(ctx, current_dag, node_idx, &out_rows)?;
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out_rows)?;
+                charge_node_buffer_admit(ctx, name, &out_rows)?;
                 ctx.node_buffers
                     .insert(node_idx, NodeBuffer::Memory(out_rows));
             }
@@ -3260,8 +3340,17 @@ pub(crate) async fn dispatch_plan_node(
             // Get input records: check own buffer first (Route
             // nodes store records at the successor's index), then
             // fall back to predecessor buffers.
+            //
+            // `multi_consumer_clone_bytes` tracks the NodeBuffer-category
+            // charge admitted on the get-and-clone fan-out path so the
+            // discharge fires once the clone is consumed below. The own-
+            // buffer and last-consumer-remove paths discharge inline
+            // since those bytes were already charged by the producer.
+            let mut multi_consumer_clone_bytes: u64 = 0;
             let input_records: Vec<(Record, u64)> =
                 if let Some(own_buf) = ctx.node_buffers.remove(&node_idx) {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(own_buf.estimated_memory_bytes());
                     own_buf.drain().collect::<Result<Vec<_>, _>>()?
                 } else {
                     let predecessors: Vec<NodeIndex> = current_dag
@@ -3280,14 +3369,43 @@ pub(crate) async fn dispatch_plan_node(
                             .count();
                         if remaining_consumers == 0 {
                             if let Some(nb) = ctx.node_buffers.remove(&p) {
+                                ctx.memory_budget
+                                    .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
                                 found = Some(nb.drain().collect::<Result<Vec<_>, _>>()?);
                                 break;
                             }
-                        } else if let Some(nb) = ctx.node_buffers.get(&p) {
+                        } else {
                             // Multi-consumer fanout: keep the producer's
-                            // buffer alive for remaining siblings.
-                            found = Some(nb.clone_memory_only());
-                            break;
+                            // buffer alive for remaining siblings. The
+                            // clone is a heap copy and a transient RSS
+                            // bump under this Output's identity; the
+                            // discharge fires after `input_records` is
+                            // split into the writer-side buffered /
+                            // unbuffered locals below.
+                            //
+                            // Borrow shape: read the bytes estimate and
+                            // perform the heap clone while only the
+                            // immutable `node_buffers.get` borrow is
+                            // live, then drop it so the charge path can
+                            // take `&mut ctx.memory_budget`.
+                            let cloned_with_bytes = ctx
+                                .node_buffers
+                                .get(&p)
+                                .map(|nb| (nb.clone_memory_only(), nb.estimated_memory_bytes()));
+                            if let Some((cloned, bytes)) = cloned_with_bytes {
+                                if bytes > 0 && ctx.memory_budget.charge_node_buffer_bytes(bytes) {
+                                    return Err(PipelineError::MemoryBudgetExceeded {
+                                        node: name.to_string(),
+                                        used: ctx.memory_budget.total_charged(),
+                                        limit: ctx.memory_budget.hard_limit(),
+                                        source: BudgetCategory::NodeBuffer,
+                                        detail: Some("Output fan-out clone admission".to_string()),
+                                    });
+                                }
+                                multi_consumer_clone_bytes = bytes;
+                                found = Some(cloned);
+                                break;
+                            }
                         }
                     }
                     found.unwrap_or_default()
@@ -3329,6 +3447,14 @@ pub(crate) async fn dispatch_plan_node(
             } else {
                 buffered = Vec::new();
                 unbuffered = input_records;
+            }
+            // input_records has been destructured into buffered /
+            // unbuffered; the fan-out clone's transient bytes are no
+            // longer in scope as a node_buffers-shaped Vec, so release
+            // the NodeBuffer counter charge admitted at clone time.
+            if multi_consumer_clone_bytes > 0 {
+                ctx.memory_budget
+                    .discharge_node_buffer_bytes(multi_consumer_clone_bytes);
             }
 
             // Counter semantics:
@@ -3572,6 +3698,11 @@ pub(crate) async fn dispatch_plan_node(
             // popped, so the install lands on `top` (parent scope).
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+            // Attribution rule: the body harvest's bytes are charged
+            // under the parent composition's name so a budget-exceeded
+            // diagnostic points the user at the user-visible operator,
+            // not at the body's internal output port node name.
+            charge_node_buffer_admit(ctx, &composition_name, &output_records)?;
             ctx.node_buffers
                 .insert(node_idx, NodeBuffer::Memory(output_records));
         }
@@ -3751,11 +3882,19 @@ pub(crate) async fn dispatch_plan_node(
                 })?;
 
             let driver_buf: Vec<(Record, u64)> = match ctx.node_buffers.remove(&driver_pred) {
-                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                Some(nb) => {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                    nb.drain().collect::<Result<Vec<_>, _>>()?
+                }
                 None => Vec::new(),
             };
             let build_buf: Vec<(Record, u64)> = match ctx.node_buffers.remove(&build_pred) {
-                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                Some(nb) => {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                    nb.drain().collect::<Result<Vec<_>, _>>()?
+                }
                 None => Vec::new(),
             };
 
@@ -3949,6 +4088,7 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+                    charge_node_buffer_admit(ctx, name, &output_records)?;
                     ctx.node_buffers
                         .insert(node_idx, NodeBuffer::Memory(output_records));
                     // Combine arm clean-exit: drop the per-fold cursor
@@ -4028,6 +4168,7 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+                    charge_node_buffer_admit(ctx, name, &output_records)?;
                     ctx.node_buffers
                         .insert(node_idx, NodeBuffer::Memory(output_records));
                     // Combine arm clean-exit: drop the per-fold cursor
@@ -4113,6 +4254,7 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+                    charge_node_buffer_admit(ctx, name, &output_records)?;
                     ctx.node_buffers
                         .insert(node_idx, NodeBuffer::Memory(output_records));
                     // Combine arm clean-exit: drop the per-fold cursor
@@ -4602,6 +4744,7 @@ pub(crate) async fn dispatch_plan_node(
                 .record(probe_timer.finish(probe_records_in, probe_records_out));
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+            charge_node_buffer_admit(ctx, name, &output_records)?;
             ctx.node_buffers
                 .insert(node_idx, NodeBuffer::Memory(output_records));
             // Drop the per-fold cursor snapshot: every emitted record
@@ -5065,7 +5208,7 @@ fn flush_clean_records_to_writers(
 /// intact for any sibling consumer the parent walk has not yet reached;
 /// fan-out from a single producer to multiple ports is a normal case.
 fn collect_port_records(
-    ctx: &ExecutorContext<'_>,
+    ctx: &mut ExecutorContext<'_>,
     parent_dag: &ExecutionPlanDag,
     composition_node_idx: NodeIndex,
     composition_name: &str,
@@ -5092,11 +5235,33 @@ fn collect_port_records(
                 ),
             });
         };
-        let records: Vec<(Record, u64)> = ctx
+        // Compute the heap-clone footprint while the immutable borrow
+        // of `node_buffers` is live, then release it so the charge
+        // path can take `&mut ctx.memory_budget`. The cloned records
+        // are about to be seeded into the body-local `node_buffers`
+        // namespace inside `execute_composition_body`; the body's
+        // port-source Source arm discharges the slot when it claims
+        // the seeded buffer, and the body-exit leak-discharge cleans
+        // up any unconsumed remainder if a body operator errored.
+        let cloned_with_bytes = ctx
             .node_buffers
             .get(&edge.source())
-            .map(|nb| nb.clone_memory_only())
-            .unwrap_or_default();
+            .map(|nb| (nb.clone_memory_only(), nb.estimated_memory_bytes()));
+        let records: Vec<(Record, u64)> = match cloned_with_bytes {
+            Some((cloned, bytes)) => {
+                if bytes > 0 && ctx.memory_budget.charge_node_buffer_bytes(bytes) {
+                    return Err(PipelineError::MemoryBudgetExceeded {
+                        node: composition_name.to_string(),
+                        used: ctx.memory_budget.total_charged(),
+                        limit: ctx.memory_budget.hard_limit(),
+                        source: BudgetCategory::NodeBuffer,
+                        detail: Some("composition port-records clone admission".to_string()),
+                    });
+                }
+                cloned
+            }
+            None => Vec::new(),
+        };
         // Two parallel edges to the same port (e.g. `inputs: { p: a,
         // p: a }` — currently rejected at parse, but the runtime is
         // defensive) would overwrite; the wiring pass guarantees
@@ -5238,7 +5403,11 @@ async fn execute_composition_body(
     let output_records: Vec<(Record, u64)> = match (&walk_result, output_idx) {
         (Ok(()), Some(idx)) => {
             let drained: Vec<(Record, u64)> = match ctx.node_buffers.remove(&idx) {
-                Some(nb) => nb.drain().collect::<Result<Vec<_>, _>>()?,
+                Some(nb) => {
+                    ctx.memory_budget
+                        .discharge_node_buffer_bytes(nb.estimated_memory_bytes());
+                    nb.drain().collect::<Result<Vec<_>, _>>()?
+                }
                 None => Vec::new(),
             };
             if body_dag.deferred_region_at_producer(idx).is_some() {
@@ -5249,6 +5418,23 @@ async fn execute_composition_body(
         }
         _ => Vec::new(),
     };
+
+    // Body exit cleanup: any slots still alive in the body-local
+    // `node_buffers` map are about to be dropped when `saved_buffers`
+    // overwrites the field below. Discharge their NodeBuffer-category
+    // charges so the ledger does not leak across the body / parent
+    // boundary — both the early-error path (a body operator returned
+    // `Err`, leaving partially-consumed intermediates) and the
+    // sink-only body case (no output port, seeded inputs never
+    // claimed) hit this path.
+    let leaked_bytes: u64 = ctx
+        .node_buffers
+        .values()
+        .map(NodeBuffer::estimated_memory_bytes)
+        .sum();
+    if leaked_bytes > 0 {
+        ctx.memory_budget.discharge_node_buffer_bytes(leaked_bytes);
+    }
 
     // Decrement depth and restore parent scope. `saturating_sub`
     // is defensive over the invariant; the inc/dec pairs are kept in

--- a/crates/clinker-core/src/executor/node_buffer.rs
+++ b/crates/clinker-core/src/executor/node_buffer.rs
@@ -412,8 +412,8 @@ mod tests {
     #[test]
     fn estimated_memory_bytes_scales_with_row_count_and_columns() {
         let s = schema();
-        let row_bytes_each = std::mem::size_of::<Value>() * s.column_count()
-            + std::mem::size_of::<(Record, u64)>();
+        let row_bytes_each =
+            std::mem::size_of::<Value>() * s.column_count() + std::mem::size_of::<(Record, u64)>();
 
         // Memory: row count × per-row formula.
         let mem = NodeBuffer::Memory(vec![

--- a/crates/clinker-core/src/executor/node_buffer.rs
+++ b/crates/clinker-core/src/executor/node_buffer.rs
@@ -16,7 +16,7 @@
 
 use std::vec::IntoIter as VecIntoIter;
 
-use clinker_record::Record;
+use clinker_record::{Record, Value};
 
 use crate::error::PipelineError;
 use crate::pipeline::spill::{SpillFile, SpillReader};
@@ -120,6 +120,26 @@ impl NodeBuffer {
                 );
             }
         }
+    }
+
+    /// Heuristic in-memory footprint of the slot, paired with the
+    /// `MemoryBudget::charge_node_buffer_bytes` /
+    /// `discharge_node_buffer_bytes` ledger. The estimate matches
+    /// `charge_harvest_admission`'s per-row formula so the executor's
+    /// two budget surfaces (`Arena` for parked region tee, `NodeBuffer`
+    /// for inter-stage handoff) use the same per-row size.
+    ///
+    /// Returns `0` on an empty memory tail. Spill-resident chunks are
+    /// accounted via `MemoryBudget::cumulative_spill_bytes` (the disk
+    /// quota), not this counter, so a `Spilled` slot reports `0` here.
+    pub(crate) fn estimated_memory_bytes(&self) -> u64 {
+        let mem = self.peek_mem();
+        let Some((first, _)) = mem.first() else {
+            return 0;
+        };
+        let row_bytes = std::mem::size_of::<Value>() * first.schema().column_count()
+            + std::mem::size_of::<(Record, u64)>();
+        (row_bytes as u64).saturating_mul(mem.len() as u64)
     }
 
     /// Consume the buffer, returning an iterator that yields memory
@@ -387,5 +407,44 @@ mod tests {
             0
         );
         assert_eq!(NodeBuffer::Memory(vec![(rec(&s, 1, "a"), 1)]).len_hint(), 1);
+    }
+
+    #[test]
+    fn estimated_memory_bytes_scales_with_row_count_and_columns() {
+        let s = schema();
+        let row_bytes_each = std::mem::size_of::<Value>() * s.column_count()
+            + std::mem::size_of::<(Record, u64)>();
+
+        // Memory: row count × per-row formula.
+        let mem = NodeBuffer::Memory(vec![
+            (rec(&s, 1, "a"), 1),
+            (rec(&s, 2, "b"), 2),
+            (rec(&s, 3, "c"), 3),
+        ]);
+        assert_eq!(mem.estimated_memory_bytes(), (row_bytes_each * 3) as u64);
+
+        // Spilled: zero bytes here — the disk surface tracks them
+        // separately through `MemoryBudget::cumulative_spill_bytes`.
+        let spilled = NodeBuffer::Spilled(vec![spill_chunk(vec![(rec(&s, 1, "a"), 1)])]);
+        assert_eq!(spilled.estimated_memory_bytes(), 0);
+
+        // Mixed: only the in-memory tail counts.
+        let mixed = NodeBuffer::Mixed {
+            mem: vec![(rec(&s, 1, "m"), 1), (rec(&s, 2, "n"), 2)],
+            spills: vec![spill_chunk(vec![(rec(&s, 3, "s"), 3)])],
+        };
+        assert_eq!(mixed.estimated_memory_bytes(), (row_bytes_each * 2) as u64);
+
+        // Empty variants report zero.
+        assert_eq!(NodeBuffer::Memory(Vec::new()).estimated_memory_bytes(), 0);
+        assert_eq!(NodeBuffer::Spilled(Vec::new()).estimated_memory_bytes(), 0);
+        assert_eq!(
+            NodeBuffer::Mixed {
+                mem: Vec::new(),
+                spills: Vec::new(),
+            }
+            .estimated_memory_bytes(),
+            0
+        );
     }
 }

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -3585,24 +3585,22 @@ nodes:
         .expect_err("1-byte memory_limit must abort combine");
         match &err {
             CombineFixtureError::Run(
-                clinker_core::error::PipelineError::MemoryBudgetExceeded {
-                    node,
-                    source,
-                    detail,
-                    ..
-                },
+                clinker_core::error::PipelineError::MemoryBudgetExceeded { node, source, .. },
             ) => {
-                assert_eq!(node, "enriched");
-                assert_eq!(
-                    *source,
-                    clinker_core::pipeline::memory::BudgetCategory::Arena
-                );
-                let detail = detail.as_deref().unwrap_or("");
+                use clinker_core::pipeline::memory::BudgetCategory;
+                // Either the per-row Arena charge inside the Combine
+                // build/probe path or the per-Vec NodeBuffer admission
+                // charge at any upstream insert can be the first surface
+                // to trip the 1-byte ceiling. Both report the producing
+                // operator's name and the BudgetCategory tag — the
+                // architectural guarantee this regression test pins.
                 assert!(
-                    detail.contains("combine build")
-                        || detail.contains("combine probe")
-                        || detail.contains("grace hash"),
-                    "detail must mention the combine memory abort; got {detail:?}"
+                    matches!(*source, BudgetCategory::Arena | BudgetCategory::NodeBuffer),
+                    "memory abort must carry a BudgetCategory; got {source:?}"
+                );
+                assert!(
+                    !node.is_empty(),
+                    "memory abort must name the producing operator; got empty string"
                 );
             }
             other => panic!("memory abort must surface MemoryBudgetExceeded; got: {other:?}"),


### PR DESCRIPTION
Closes #121. Sub-issue of #108.

## Summary

Wires the `MemoryBudget::charge_node_buffer_bytes` / `discharge_node_buffer_bytes` API (added in #148) into every executor site that mutates `ctx.node_buffers`. Before this PR, bytes alive in node-buffer slots between non-fused operators were invisible to the budget — a Route fan-out holding 1.5 GB of in-memory clones would OOM the process rather than trip a structured `E310` bail. After this PR, every insert / extend / push / clone-into-local is charged and every remove or terminal drain is discharged, so the per-pipeline budget sees both the arena-tracked surfaces and the node-buffer handoff surface against a single shared `hard_limit` envelope via `total_charged`.

## Helpers added

- **`NodeBuffer::estimated_memory_bytes`** (`pub(crate)`) — heuristic in-memory footprint matching the per-row formula used elsewhere: `size_of::<Value>() * column_count + size_of::<(Record, u64)>()`. Returns 0 on `Spilled` (disk-resident chunks are tracked via `cumulative_spill_bytes`) and on the empty tail.
- **`charge_node_buffer_admit(ctx, node_name, rows)`** (`pub(crate)`) — sibling to `charge_harvest_admission`. Charges the heuristic estimate and returns the bytes admitted so the discharge site can release the matching amount. On hard-limit breach, returns `PipelineError::MemoryBudgetExceeded` tagged `BudgetCategory::NodeBuffer` so diagnostics distinguish the inter-stage handoff layer from the arena-tracked surfaces.

## Sites wired

- **15 insert sites**: Source, fused Transform tail, Transform pass-through and main, Route fork into each successor, Merge, Sort empty + emit, Aggregate deferred and non-deferred, Composition harvest, four Combine arms (IEJoin / Grace / SortMerge / outer).
- **15 remove / drain sites**: mirror the inserts; discharge fires before the drain consumes the slot.
- **2 get-and-clone sites**: Output multi-consumer fan-out (clone owns arm-scope bytes; discharge at the buffered/unbuffered split) and `collect_port_records` (clone enters the body's `node_buffers` namespace and is consumed via the body's port-source Source arm).
- **Composition body harvest**: attribution flows through the parent composition's name on re-charge into `node_buffers[composition_idx]`, so a budget-exceeded diagnostic at the harvest reports the user-visible operator instead of the body's internal output port.
- **Forward-pass and commit-pass body executors** both add a leak-discharge step before restoring parent-scope buffers — covers early-return error paths and sink-only bodies that never consume their seeded inputs.
- **Commit-pass deferred-region clears** (member/output stale-buffer discards), continuation clears, recompute-aggregate degrade-fallback removes, and the post-recompute emit insert (which also discharges the pre-recompute slot's bytes before the swap).

Cross-region tee admission (`region_input_buffers` Arena charge at `dispatch.rs:2493-2517` and `tee_emit_to_region_input_buffers`) is left as Arena — those track a separate parking buffer; the new NodeBuffer charges supplement rather than replace.

## Out of scope

Soft-threshold spill: hitting `should_spill()` on a tight budget still falls through to the hard-fail path. The next sub-issue under #108 wires the spill branch. No runtime path constructs `NodeBuffer::Spilled` / `Mixed` yet, so the `#[allow(dead_code)]` on `Spilled` stays.

## Tests

- `combine_test::test_combine_exec_e310_memory_abort` relaxed: the 1-byte budget now trips at the first upstream insert (NodeBuffer category) rather than reaching the Combine build/probe (Arena category). The architectural guarantee the test pins — that `MemoryBudgetExceeded` carries a non-empty operator name and a `BudgetCategory` tag — still holds; the specific node and category move earlier in the pipeline as expected.
- New unit test `NodeBuffer::estimated_memory_bytes_scales_with_row_count_and_columns` covers the new method across Memory / Spilled / Mixed and the empty case.
- Audit grep: every line under `crates/clinker-core/src/executor/` that matches `node_buffers\.` is paired with `charge_node_buffer_*` / `discharge_node_buffer_bytes` (or is a documented peek-only read).

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check --benches --workspace`
- [x] `cargo check --features bench-alloc -p clinker-benchmarks`
- [x] `cargo test --benches -p clinker-benchmarks`
- [x] `cargo deny check`

All seven green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)