### PR TITLE
engine: producer-side spill for node_buffer admission (#122)

### DIFF
--- a/crates/clinker-core/src/executor/commit/recompute_agg.rs
+++ b/crates/clinker-core/src/executor/commit/recompute_agg.rs
@@ -18,10 +18,9 @@ use super::detect::RetractScope;
 use crate::aggregation::HashAggError;
 use crate::error::PipelineError;
 use crate::executor::dispatch::{
-    ExecutorContext, charge_node_buffer_admit, finalize_node_rooted_windows,
+    ExecutorContext, admit_node_buffer, finalize_node_rooted_windows, node_buffer_spill_allowed,
     project_rows_to_buffer_schema,
 };
-use crate::executor::node_buffer::NodeBuffer;
 use crate::plan::execution::ExecutionPlanDag;
 
 /// Drive each affected aggregate through retract + refinalize, then
@@ -223,7 +222,13 @@ pub(crate) fn emit_post_recompute(
         ctx.memory_budget.discharge_node_buffer_bytes(prev_bytes);
     }
     let agg_name = current_dag.graph[agg_idx].name().to_string();
-    charge_node_buffer_admit(ctx, &agg_name, &projected).map_err(|e| {
+    let nb = admit_node_buffer(
+        ctx,
+        &agg_name,
+        projected,
+        node_buffer_spill_allowed(current_dag, agg_idx),
+    )
+    .map_err(|e| {
         // Mapping budget exceeded into `HashAggError::Spill` lets the
         // caller's degrade-fallback handle commit-pass admission
         // overflow consistently with the rest of the post-retract
@@ -233,7 +238,6 @@ pub(crate) fn emit_post_recompute(
         // aggregate output.
         HashAggError::Spill(format!("post-recompute node-buffer admission: {e}"))
     })?;
-    ctx.node_buffers
-        .insert(agg_idx, NodeBuffer::Memory(projected));
+    ctx.node_buffers.insert(agg_idx, nb);
     Ok(emitted)
 }

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -1151,17 +1151,19 @@ pub(crate) fn charge_harvest_admission(
 /// * column_count + size_of::<(Record, u64)>()` bytes. The two budget
 /// surfaces share the `MemoryBudget::hard_limit` envelope via
 /// `total_charged`, so a runaway producer trips on the combined sum.
+///
+/// Used today only by the commit-pass body-harvest re-charge in
+/// `executor/commit/dispatch.rs`, where records flow into an existing
+/// `node_buffers` slot via `NodeBuffer::push` rather than a bulk
+/// insert. Bulk insertion at every operator-arm emit goes through
+/// [`admit_node_buffer`] instead, which combines this charge with the
+/// soft-threshold spill decision.
 pub(crate) fn charge_node_buffer_admit(
     ctx: &mut ExecutorContext<'_>,
     node_name: &str,
     rows: &[(Record, u64)],
 ) -> Result<u64, PipelineError> {
-    let Some((first, _)) = rows.first() else {
-        return Ok(0);
-    };
-    let row_bytes = std::mem::size_of::<Value>() * first.schema().column_count()
-        + std::mem::size_of::<(Record, u64)>();
-    let bytes = (row_bytes as u64).saturating_mul(rows.len() as u64);
+    let bytes = estimate_node_buffer_bytes(rows);
     if bytes == 0 {
         return Ok(0);
     }
@@ -1175,6 +1177,125 @@ pub(crate) fn charge_node_buffer_admit(
         });
     }
     Ok(bytes)
+}
+
+/// Per-row heuristic byte cost. Returns `0` for an empty slice. The
+/// formula matches `NodeBuffer::estimated_memory_bytes` and
+/// `charge_harvest_admission` so the three admission surfaces agree on
+/// the same per-row size.
+fn estimate_node_buffer_bytes(rows: &[(Record, u64)]) -> u64 {
+    let Some((first, _)) = rows.first() else {
+        return 0;
+    };
+    let row_bytes = std::mem::size_of::<Value>() * first.schema().column_count()
+        + std::mem::size_of::<(Record, u64)>();
+    (row_bytes as u64).saturating_mul(rows.len() as u64)
+}
+
+/// Predicate: does the topology at `slot_key` permit a soft-threshold
+/// spill at admission time?
+///
+/// Returns `false` when the slot will be cloned by a downstream
+/// consumer rather than drained — multi-consumer fan-out
+/// (`Output` arms with more than one Output sharing a producer) and
+/// composition input-port edges both reach
+/// `NodeBuffer::clone_memory_only`, which panics on `Spilled`/`Mixed`
+/// because spill chunks cannot be cheap-cloned for parallel readers.
+/// Lifting that constraint requires sharing `Arc<SpillFile<u64>>` across
+/// readers and is tracked as a sibling sub-issue of #108 (back-pressure
+/// for fan-out spilling). Until that lands, producer-side spill is
+/// gated to slots with a single drain consumer.
+///
+/// Route's per-successor admission already pre-forks into per-branch
+/// slots keyed by the successor's `NodeIndex`; each such slot has
+/// exactly one outgoing consumer (the successor itself drives one
+/// chain), so this predicate returns `true` and spill applies — the
+/// canonical Route-fan-out scenario the issue body calls out.
+pub(crate) fn node_buffer_spill_allowed(
+    current_dag: &ExecutionPlanDag,
+    slot_key: NodeIndex,
+) -> bool {
+    let mut outgoing = 0usize;
+    for edge in current_dag
+        .graph
+        .edges_directed(slot_key, Direction::Outgoing)
+    {
+        outgoing += 1;
+        if outgoing > 1 {
+            return false;
+        }
+        if edge.weight().port.is_some() {
+            return false;
+        }
+    }
+    true
+}
+
+/// Admit `rows` into a `ctx.node_buffers` slot, choosing between the
+/// in-memory and on-disk variants based on the live RSS reading.
+///
+/// 1. Empty input returns `NodeBuffer::Memory(Vec::new())`.
+/// 2. The per-row byte cost is charged against `MemoryBudget` via
+///    [`charge_node_buffer_admit`]'s shared formula. A hard-limit
+///    breach surfaces as
+///    `MemoryBudgetExceeded { source: BudgetCategory::NodeBuffer, .. }`.
+/// 3. When `spill_allowed` is `true` and `MemoryBudget::should_spill()`
+///    reports the RSS soft threshold tripped, the rows flush to a
+///    `SpillFile<u64>` via [`node_buffer_spill::spill_node_buffer`].
+///    The in-memory charge is discharged immediately and the file size
+///    is added to `cumulative_spill_bytes`; an over-quota disk total
+///    surfaces the same structured `MemoryBudgetExceeded` shape with
+///    `detail: "spill quota exceeded"` so existing diagnostics tooling
+///    handles both surfaces uniformly.
+/// 4. Otherwise rows stay in memory as `NodeBuffer::Memory(rows)`.
+///
+/// `spill_allowed` should be computed via [`node_buffer_spill_allowed`]
+/// for the slot's `NodeIndex` so multi-consumer fan-out and
+/// composition input-port slots stay memory-bound (their consumers
+/// reach `NodeBuffer::clone_memory_only`, which panics on spill
+/// variants).
+pub(crate) fn admit_node_buffer(
+    ctx: &mut ExecutorContext<'_>,
+    node_name: &str,
+    rows: Vec<(Record, u64)>,
+    spill_allowed: bool,
+) -> Result<NodeBuffer, PipelineError> {
+    if rows.is_empty() {
+        return Ok(NodeBuffer::Memory(Vec::new()));
+    }
+    let bytes = estimate_node_buffer_bytes(&rows);
+    if bytes > 0 && ctx.memory_budget.charge_node_buffer_bytes(bytes) {
+        return Err(PipelineError::MemoryBudgetExceeded {
+            node: node_name.to_string(),
+            used: ctx.memory_budget.total_charged(),
+            limit: ctx.memory_budget.hard_limit(),
+            source: BudgetCategory::NodeBuffer,
+            detail: Some("node_buffer admission".to_string()),
+        });
+    }
+    if !spill_allowed || !ctx.memory_budget.should_spill() {
+        return Ok(NodeBuffer::Memory(rows));
+    }
+    match crate::executor::node_buffer_spill::spill_node_buffer(
+        rows,
+        Some(ctx.spill_root_path.as_ref()),
+    )? {
+        Some((file, count)) => {
+            ctx.memory_budget.discharge_node_buffer_bytes(bytes);
+            let file_bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
+            if ctx.memory_budget.record_spill_bytes(file_bytes) {
+                return Err(PipelineError::MemoryBudgetExceeded {
+                    node: node_name.to_string(),
+                    used: ctx.memory_budget.cumulative_spill_bytes(),
+                    limit: ctx.memory_budget.max_spill_bytes,
+                    source: BudgetCategory::NodeBuffer,
+                    detail: Some("spill quota exceeded".to_string()),
+                });
+            }
+            Ok(NodeBuffer::Spilled(vec![(file, count)]))
+        }
+        None => Ok(NodeBuffer::Memory(Vec::new())),
+    }
 }
 
 /// Build the engine-stamped tail mapping for a Source's plan-time
@@ -1858,9 +1979,13 @@ pub(crate) async fn transform_fused_consume(
 
     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-    charge_node_buffer_admit(ctx, name, &output_records)?;
-    ctx.node_buffers
-        .insert(node_idx, NodeBuffer::Memory(output_records));
+    let nb = admit_node_buffer(
+        ctx,
+        name,
+        output_records,
+        node_buffer_spill_allowed(current_dag, node_idx),
+    )?;
+    ctx.node_buffers.insert(node_idx, nb);
     Ok(())
 }
 
@@ -2046,9 +2171,13 @@ pub(crate) async fn dispatch_plan_node(
             // now anchors here.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &records)?;
-            charge_node_buffer_admit(ctx, name, &records)?;
-            ctx.node_buffers
-                .insert(node_idx, NodeBuffer::Memory(records));
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                records,
+                node_buffer_spill_allowed(current_dag, node_idx),
+            )?;
+            ctx.node_buffers.insert(node_idx, nb);
         }
 
         PlanNode::Transform {
@@ -2100,9 +2229,13 @@ pub(crate) async fn dispatch_plan_node(
                 None => {
                     // No transform found — pass through
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &input_records)?;
-                    charge_node_buffer_admit(ctx, name.as_str(), &input_records)?;
-                    ctx.node_buffers
-                        .insert(node_idx, NodeBuffer::Memory(input_records));
+                    let nb = admit_node_buffer(
+                        ctx,
+                        name.as_str(),
+                        input_records,
+                        node_buffer_spill_allowed(current_dag, node_idx),
+                    )?;
+                    ctx.node_buffers.insert(node_idx, nb);
                     return Ok(());
                 }
             };
@@ -2282,9 +2415,13 @@ pub(crate) async fn dispatch_plan_node(
             // matching runtime; otherwise the helper is a no-op.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-            charge_node_buffer_admit(ctx, name, &output_records)?;
-            ctx.node_buffers
-                .insert(node_idx, NodeBuffer::Memory(output_records));
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                output_records,
+                node_buffer_spill_allowed(current_dag, node_idx),
+            )?;
+            ctx.node_buffers.insert(node_idx, nb);
         }
 
         PlanNode::Route {
@@ -2574,8 +2711,13 @@ pub(crate) async fn dispatch_plan_node(
                             .push((record.clone(), *rn));
                     }
                 }
-                charge_node_buffer_admit(ctx, name, &buf)?;
-                ctx.node_buffers.insert(succ_idx, NodeBuffer::Memory(buf));
+                let nb = admit_node_buffer(
+                    ctx,
+                    name,
+                    buf,
+                    node_buffer_spill_allowed(current_dag, succ_idx),
+                )?;
+                ctx.node_buffers.insert(succ_idx, nb);
             }
         }
 
@@ -2791,9 +2933,13 @@ pub(crate) async fn dispatch_plan_node(
             // nothing because no spec roots at a Merge NodeIndex.
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &merged)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &merged)?;
-            charge_node_buffer_admit(ctx, name, &merged)?;
-            ctx.node_buffers
-                .insert(node_idx, NodeBuffer::Memory(merged));
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                merged,
+                node_buffer_spill_allowed(current_dag, node_idx),
+            )?;
+            ctx.node_buffers.insert(node_idx, nb);
         }
 
         PlanNode::Sort {
@@ -2827,9 +2973,13 @@ pub(crate) async fn dispatch_plan_node(
                 // Empty Vec heuristic charges zero bytes — admit helper
                 // is still called for symmetry with the non-empty path,
                 // so the ledger surface treats every Sort insert uniformly.
-                charge_node_buffer_admit(ctx, name, &[])?;
-                ctx.node_buffers
-                    .insert(node_idx, NodeBuffer::Memory(Vec::new()));
+                let nb = admit_node_buffer(
+                    ctx,
+                    name,
+                    Vec::new(),
+                    node_buffer_spill_allowed(current_dag, node_idx),
+                )?;
+                ctx.node_buffers.insert(node_idx, nb);
                 return Ok(());
             }
 
@@ -2909,8 +3059,13 @@ pub(crate) async fn dispatch_plan_node(
             ctx.collector
                 .record(sort_timer.finish(sort_count, sort_count));
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out)?;
-            charge_node_buffer_admit(ctx, name, &out)?;
-            ctx.node_buffers.insert(node_idx, NodeBuffer::Memory(out));
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                out,
+                node_buffer_spill_allowed(current_dag, node_idx),
+            )?;
+            ctx.node_buffers.insert(node_idx, nb);
         }
 
         PlanNode::Aggregation {
@@ -3305,9 +3460,13 @@ pub(crate) async fn dispatch_plan_node(
                 let projected = project_rows_to_buffer_schema(out_rows, &buffer_schema);
                 finalize_node_rooted_windows(ctx, current_dag, node_idx, &projected)?;
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &projected)?;
-                charge_node_buffer_admit(ctx, name, &projected)?;
-                ctx.node_buffers
-                    .insert(node_idx, NodeBuffer::Memory(projected));
+                let nb = admit_node_buffer(
+                    ctx,
+                    name,
+                    projected,
+                    node_buffer_spill_allowed(current_dag, node_idx),
+                )?;
+                ctx.node_buffers.insert(node_idx, nb);
             } else {
                 // Materialize node-rooted window runtimes for any IndexSpec
                 // rooted at this aggregate. The aggregate emits columns the
@@ -3318,9 +3477,13 @@ pub(crate) async fn dispatch_plan_node(
                 // `out_rows` here, not from the source stream.
                 finalize_node_rooted_windows(ctx, current_dag, node_idx, &out_rows)?;
                 tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out_rows)?;
-                charge_node_buffer_admit(ctx, name, &out_rows)?;
-                ctx.node_buffers
-                    .insert(node_idx, NodeBuffer::Memory(out_rows));
+                let nb = admit_node_buffer(
+                    ctx,
+                    name,
+                    out_rows,
+                    node_buffer_spill_allowed(current_dag, node_idx),
+                )?;
+                ctx.node_buffers.insert(node_idx, nb);
             }
         }
 
@@ -3702,9 +3865,13 @@ pub(crate) async fn dispatch_plan_node(
             // under the parent composition's name so a budget-exceeded
             // diagnostic points the user at the user-visible operator,
             // not at the body's internal output port node name.
-            charge_node_buffer_admit(ctx, &composition_name, &output_records)?;
-            ctx.node_buffers
-                .insert(node_idx, NodeBuffer::Memory(output_records));
+            let nb = admit_node_buffer(
+                ctx,
+                &composition_name,
+                output_records,
+                node_buffer_spill_allowed(current_dag, node_idx),
+            )?;
+            ctx.node_buffers.insert(node_idx, nb);
         }
 
         PlanNode::Combine {
@@ -4088,9 +4255,13 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-                    charge_node_buffer_admit(ctx, name, &output_records)?;
-                    ctx.node_buffers
-                        .insert(node_idx, NodeBuffer::Memory(output_records));
+                    let nb = admit_node_buffer(
+                        ctx,
+                        name,
+                        output_records,
+                        node_buffer_spill_allowed(current_dag, node_idx),
+                    )?;
+                    ctx.node_buffers.insert(node_idx, nb);
                     // Combine arm clean-exit: drop the per-fold cursor
                     // snapshot. Every emitted record has cleared into
                     // `node_buffers` without rewind, so the snapshot is
@@ -4168,9 +4339,13 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-                    charge_node_buffer_admit(ctx, name, &output_records)?;
-                    ctx.node_buffers
-                        .insert(node_idx, NodeBuffer::Memory(output_records));
+                    let nb = admit_node_buffer(
+                        ctx,
+                        name,
+                        output_records,
+                        node_buffer_spill_allowed(current_dag, node_idx),
+                    )?;
+                    ctx.node_buffers.insert(node_idx, nb);
                     // Combine arm clean-exit: drop the per-fold cursor
                     // snapshot. Mirrors the inline arm's post-emit
                     // clear so non-inline strategies do not leak
@@ -4254,9 +4429,13 @@ pub(crate) async fn dispatch_plan_node(
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
                     finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
                     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-                    charge_node_buffer_admit(ctx, name, &output_records)?;
-                    ctx.node_buffers
-                        .insert(node_idx, NodeBuffer::Memory(output_records));
+                    let nb = admit_node_buffer(
+                        ctx,
+                        name,
+                        output_records,
+                        node_buffer_spill_allowed(current_dag, node_idx),
+                    )?;
+                    ctx.node_buffers.insert(node_idx, nb);
                     // Combine arm clean-exit: drop the per-fold cursor
                     // snapshot. Mirrors the inline arm's post-emit
                     // clear.
@@ -4744,9 +4923,13 @@ pub(crate) async fn dispatch_plan_node(
                 .record(probe_timer.finish(probe_records_in, probe_records_out));
             finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-            charge_node_buffer_admit(ctx, name, &output_records)?;
-            ctx.node_buffers
-                .insert(node_idx, NodeBuffer::Memory(output_records));
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                output_records,
+                node_buffer_spill_allowed(current_dag, node_idx),
+            )?;
+            ctx.node_buffers.insert(node_idx, nb);
             // Drop the per-fold cursor snapshot: every emitted record
             // has cleared into `node_buffers` without rewind, so the
             // snapshot is no longer needed. The rewind path on a

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -4,6 +4,7 @@ pub mod combine;
 pub(crate) mod commit;
 pub(crate) mod dispatch;
 pub(crate) mod node_buffer;
+pub(crate) mod node_buffer_spill;
 mod schema_check;
 pub(crate) mod source_stream;
 pub(crate) mod time_window;

--- a/crates/clinker-core/src/executor/node_buffer.rs
+++ b/crates/clinker-core/src/executor/node_buffer.rs
@@ -10,9 +10,9 @@
 //! Every consumer drains a slot through [`NodeBuffer::drain`], which
 //! returns an iterator that streams memory rows first, then per-spill
 //! rows via `SpillReader` without materializing the spill into RAM.
-//! Spill construction is gated behind a future sub-issue of #108; at
-//! present no runtime producer emits `Spilled` or `Mixed`, but the
-//! type's shape is already the one the spill-trigger logic will use.
+//! Producer-side spill is wired in `executor/node_buffer_spill.rs` and
+//! gated on `MemoryBudget::should_spill()` at every bulk admission site
+//! via `admit_node_buffer`.
 
 use std::vec::IntoIter as VecIntoIter;
 
@@ -26,11 +26,9 @@ pub(crate) enum NodeBuffer {
     /// All rows live in memory.
     Memory(Vec<(Record, u64)>),
     /// Every row lives on disk. Each chunk pairs a spill file with the
-    /// number of rows that producer wrote to it (used by `len_hint`
-    /// and by the memory-charge accounting layer that the spill-wiring
-    /// sub-issue introduces). No runtime path constructs this variant
-    /// yet; tests cover the drain, promotion, and Drop semantics.
-    #[allow(dead_code)]
+    /// number of rows that producer wrote to it; the row count drives
+    /// `len_hint`'s O(1) total and the per-chunk discharge logic in the
+    /// drain iterator.
     Spilled(Vec<(SpillFile<u64>, u64)>),
     /// A mem tail accumulated after a partial spill. Drain order is
     /// memory rows first, then spill chunks in vector order.
@@ -104,11 +102,14 @@ impl NodeBuffer {
     ///
     /// Panics on `Spilled` and `Mixed`. Spill chunks cannot be
     /// cheap-cloned; the only legitimate multi-consumer access for a
-    /// spilled buffer is to drain it. The producer-side fan-out arm
-    /// in `dispatch.rs` uses this when there is at least one
-    /// remaining downstream consumer; today every reachable
-    /// `NodeBuffer` is `Memory`, so the panic path is unreachable at
-    /// runtime.
+    /// spilled buffer is to drain it. The producer-side admission
+    /// helper `dispatch::node_buffer_spill_allowed` returns `false`
+    /// for any slot whose outgoing topology will route through this
+    /// method (multi-consumer fan-out or a composition input-port
+    /// edge), so a `Spilled`/`Mixed` slot never reaches a caller of
+    /// this method. Lifting that constraint requires sharing
+    /// `Arc<SpillFile<u64>>` across readers and is a separate
+    /// follow-up under #108.
     pub(crate) fn clone_memory_only(&self) -> Vec<(Record, u64)> {
         match self {
             Self::Memory(v) => v.clone(),

--- a/crates/clinker-core/src/executor/node_buffer_spill.rs
+++ b/crates/clinker-core/src/executor/node_buffer_spill.rs
@@ -1,0 +1,136 @@
+//! Producer-side spill helper for `ctx.node_buffers`.
+//!
+//! When `MemoryBudget::should_spill()` trips at admission time, the
+//! producer flushes the in-memory `Vec<(Record, u64)>` to disk through
+//! `SpillWriter<u64>` and stores the resulting `(SpillFile<u64>, u64)`
+//! pair inside `NodeBuffer::Spilled`. Consumer-side streaming is
+//! already covered by [`NodeBuffer::drain`] (memory rows first, then
+//! per-spill rows via `SpillReader<u64>`), so this module exposes only
+//! the producer-side packaging.
+//!
+//! Goes through the same generic `pipeline/spill.rs` envelope (JSON
+//! schema header + length-prefixed postcard + LZ4 frame) that
+//! `sort_buffer.rs` writes today. `pipeline/grace_spill.rs` is a
+//! distinct, partition-aware format reserved for grace-hash combine
+//! and is intentionally not used here.
+//!
+//! Payload type `u64` carries the source row number alongside each
+//! record so the original lineage survives the round-trip — the
+//! consumer's drain re-emits the same `(Record, u64)` pairs the
+//! producer wrote.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use clinker_record::Record;
+
+use crate::error::PipelineError;
+use crate::pipeline::spill::{SpillFile, SpillWriter};
+
+/// Spill a `Vec<(Record, u64)>` to disk and return the resulting
+/// `(SpillFile<u64>, row_count)` pair. Schema is read from the first
+/// record; an empty input is a no-op (`Ok(None)`).
+///
+/// Errors from `SpillWriter::new` (temp-file creation), `write_pair`
+/// (postcard encode + LZ4 write), and `finish` (frame finalize) all
+/// surface as `PipelineError::Spill` via the existing
+/// `From<SpillError>` conversion.
+pub(crate) fn spill_node_buffer(
+    rows: Vec<(Record, u64)>,
+    spill_dir: Option<&Path>,
+) -> Result<Option<(SpillFile<u64>, u64)>, PipelineError> {
+    let Some((first, _)) = rows.first() else {
+        return Ok(None);
+    };
+    let schema = Arc::clone(first.schema());
+    let mut writer: SpillWriter<u64> = SpillWriter::new(schema, spill_dir)?;
+    let count = rows.len() as u64;
+    for (record, rn) in &rows {
+        writer.write_pair(record, rn)?;
+    }
+    let file = writer.finish()?;
+    Ok(Some((file, count)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::{Schema, Value};
+
+    use crate::executor::node_buffer::NodeBuffer;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec!["id".into(), "v".into()]))
+    }
+
+    fn rec(s: &Arc<Schema>, id: i64, v: &str) -> Record {
+        Record::new(
+            Arc::clone(s),
+            vec![Value::Integer(id), Value::String(v.into())],
+        )
+    }
+
+    #[test]
+    fn spill_node_buffer_roundtrip_preserves_rows_and_row_numbers() {
+        let s = schema();
+        let rows = vec![
+            (rec(&s, 1, "a"), 100),
+            (rec(&s, 2, "b"), 101),
+            (rec(&s, 3, "c"), 102),
+        ];
+
+        let (file, count) = spill_node_buffer(rows.clone(), None)
+            .expect("spill ok")
+            .expect("non-empty input produces a chunk");
+        assert_eq!(count, 3);
+
+        let nb = NodeBuffer::Spilled(vec![(file, count)]);
+        let drained: Vec<(Record, u64)> = nb.drain().collect::<Result<_, _>>().expect("drain ok");
+        assert_eq!(drained.len(), 3);
+        for (i, (orig, d)) in rows.iter().zip(drained.iter()).enumerate() {
+            assert_eq!(orig.1, d.1, "row_number mismatch at {i}");
+            assert_eq!(
+                orig.0.values(),
+                d.0.values(),
+                "record values mismatch at {i}",
+            );
+        }
+    }
+
+    #[test]
+    fn spill_node_buffer_empty_input_is_none() {
+        let result = spill_node_buffer(Vec::new(), None).expect("spill ok");
+        assert!(result.is_none(), "empty input must not create a spill file");
+    }
+
+    #[test]
+    fn multiple_spill_chunks_drain_in_order() {
+        let s = schema();
+        let chunk_a = spill_node_buffer(vec![(rec(&s, 1, "a"), 10), (rec(&s, 2, "b"), 11)], None)
+            .unwrap()
+            .unwrap();
+        let chunk_b = spill_node_buffer(vec![(rec(&s, 3, "c"), 12)], None)
+            .unwrap()
+            .unwrap();
+        let chunk_c = spill_node_buffer(vec![(rec(&s, 4, "d"), 13), (rec(&s, 5, "e"), 14)], None)
+            .unwrap()
+            .unwrap();
+
+        let nb = NodeBuffer::Spilled(vec![chunk_a, chunk_b, chunk_c]);
+        let drained: Vec<(Record, u64)> = nb.drain().collect::<Result<_, _>>().expect("drain ok");
+
+        assert_eq!(drained.len(), 5);
+        let row_numbers: Vec<u64> = drained.iter().map(|(_, rn)| *rn).collect();
+        assert_eq!(row_numbers, vec![10, 11, 12, 13, 14]);
+    }
+
+    #[test]
+    fn spilled_variant_len_hint_matches_written_rows() {
+        let s = schema();
+        let rows = vec![(rec(&s, 1, "a"), 1), (rec(&s, 2, "b"), 2)];
+        let (file, count) = spill_node_buffer(rows, None).unwrap().unwrap();
+
+        let nb = NodeBuffer::Spilled(vec![(file, count)]);
+        assert_eq!(nb.len_hint(), 2);
+    }
+}


### PR DESCRIPTION
## Summary

- Routes every admission into `ctx.node_buffers` through a single `admit_node_buffer` helper that charges `MemoryBudget`, then either keeps rows in memory or spills them to `NodeBuffer::Spilled` based on the live RSS reading and a per-slot spill-allowed predicate.
- Packages `Vec<(Record, u64)> → (SpillFile<u64>, u64)` through the existing `pipeline/spill` envelope (postcard + LZ4) in a new `executor::node_buffer_spill` module. `node_buffer_spill_allowed` gates spill off for multi-consumer fan-out and composition input-port edges — those reach `NodeBuffer::clone_memory_only`, which cannot share spill chunks across readers (Arc-shared spill files for fan-out are a follow-up under #108).
- Removes the `#[allow(dead_code)]` on `NodeBuffer::Spilled`. The slot is now reachable end-to-end through the admission path, including the relaxed-CK post-recompute emit in `executor::commit::recompute_agg`.

Closes #122. Sub-issue of #108.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` (full suite green; 4 new unit tests in `executor::node_buffer_spill::tests` covering empty input, single-chunk round-trip, multi-chunk drain order, and `len_hint` accuracy)
- [x] `cargo check --benches --workspace`
- [x] `cargo check --features bench-alloc -p clinker-benchmarks`
- [x] `cargo test --benches -p clinker-benchmarks`
- [x] `cargo deny check`
- [x] Architectural-rigor audit (working tree at HEAD): 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)