### PR TITLE
docs: wire E319 into explain diagnostics

### DIFF
--- a/crates/clinker-core/src/plan/explain_provenance.rs
+++ b/crates/clinker-core/src/plan/explain_provenance.rs
@@ -217,6 +217,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E310" => Some(include_str!("../../../../docs/explain/E310.md")),
         "E311" => Some(include_str!("../../../../docs/explain/E311.md")),
         "E313" => Some(include_str!("../../../../docs/explain/E313.md")),
+        "E319" => Some(include_str!("../../../../docs/explain/E319.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
         "E150d" => Some(include_str!("../../../../docs/explain/E150d.md")),
@@ -309,6 +310,14 @@ mod tests {
     }
 
     #[test]
+    fn test_explain_code_e319() {
+        let doc = explain_code("E319").unwrap();
+        assert!(doc.contains("E319"));
+        assert!(doc.contains("on_miss: error"));
+        assert!(doc.contains("no matching build row"));
+    }
+
+    #[test]
     fn test_explain_code_unknown() {
         assert!(explain_code("E999").is_none());
     }
@@ -318,7 +327,7 @@ mod tests {
         let codes = [
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
-            "E309", "E310", "E311", "E313", "E15Y", "W101", "W302", "W305", "W306",
+            "E309", "E310", "E311", "E313", "E319", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -92,7 +92,7 @@ Inspect field-level provenance chains or look up error/warning code documentatio
 Use --field to trace where a composition config value comes from across all \
 configuration layers (composition defaults, channel defaults, channel fixed). \
 Use --code to look up the documentation for a diagnostic code (composition codes \
-E101–E108, combine codes E300–E313 and W302/W305/W306, and W101).",
+E101–E108, combine codes E300-E319 and W302/W305/W306, and W101).",
         after_long_help = "\
 EXAMPLES:
   # Show provenance for a composition config field
@@ -1333,7 +1333,8 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             }
             None => {
                 return Err(format!(
-                    "unknown diagnostic code '{code}'. Valid codes: E101-E108, E110, E15Y, W101"
+                    "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
+                     E15Y, E300/E301/E303-E311/E313/E319, W101/W302/W305/W306"
                 )
                 .into());
             }

--- a/crates/clinker/tests/explain_provenance_test.rs
+++ b/crates/clinker/tests/explain_provenance_test.rs
@@ -134,6 +134,53 @@ fn test_explain_error_code_e105_outputs_doc_content() {
 }
 
 #[test]
+fn test_explain_error_code_e319_outputs_doc_content() {
+    let output = Command::new(clinker_bin())
+        .arg("explain")
+        .arg("--code")
+        .arg("E319")
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "clinker explain --code E319 must succeed.\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("E319"),
+        "output must contain E319.\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("on_miss: error"),
+        "output must describe the on_miss policy.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn test_explain_help_shows_e319_range() {
+    let output = Command::new(clinker_bin())
+        .arg("explain")
+        .arg("--help")
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        output.status.success(),
+        "clinker explain --help must succeed.\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("E300-E319"),
+        "help output must advertise the E319 combine range.\nstdout: {stdout}"
+    );
+}
+
+#[test]
 fn test_explain_error_code_e15y_streaming_help() {
     let output = Command::new(clinker_bin())
         .arg("explain")

--- a/docs/explain/E319.md
+++ b/docs/explain/E319.md
@@ -1,0 +1,96 @@
+# Error E319: Combine `on_miss: error` found no match
+
+## What it means
+
+A combine node ran with `on_miss: error`, and one driver-side record
+found no matching build-side record. Clinker stops the pipeline because
+that setting means an unmatched driver row is a referential-integrity
+failure, not a row that should be filled with nulls or skipped.
+
+The runtime diagnostic identifies the combine node and the driver row
+number that missed:
+
+```
+E319 combine 'enrich_orders': on_miss: error - no matching build row for driver row 42
+```
+
+## Example
+
+```yaml
+# Invalid for strict enrichment: order 42 references a product id that is
+# absent from products.csv.
+nodes:
+  - type: combine
+    name: enrich_orders
+    input:
+      orders: orders
+      products: products
+    where: "orders.product_id == products.id"
+    on_miss: error
+    cxl: |
+      emit orders.order_id, products.sku
+```
+
+```yaml
+# Corrected when missing products should halt before the run:
+# fix or load the missing product record so every order product_id has
+# a matching products.id value.
+nodes:
+  - type: combine
+    name: enrich_orders
+    input:
+      orders: orders
+      products: products
+    where: "orders.product_id == products.id"
+    on_miss: error
+    cxl: |
+      emit orders.order_id, products.sku
+```
+
+If unmatched driver rows are expected, use an explicit non-failing
+policy instead:
+
+```yaml
+on_miss: null_fields   # left-join shape
+# or
+on_miss: skip          # inner-join shape
+```
+
+## How to fix
+
+Pick the fix that matches the data contract:
+
+1. **Repair the reference data** so every driver key has a build-side
+   match. This is the right fix when `on_miss: error` is enforcing
+   required dimensions or lookup tables.
+
+2. **Normalize the join keys** before the combine. Trim whitespace,
+   cast types consistently, and align case if the two inputs encode the
+   same business key differently.
+
+3. **Change the miss policy** to `on_miss: null_fields` when a missing
+   build row should still emit the driver row with null build fields.
+
+4. **Change the miss policy** to `on_miss: skip` when unmatched driver
+   rows should be dropped.
+
+## Technical context
+
+E319 is a runtime diagnostic emitted after combine matching has already
+evaluated the `where:` predicate for a driver row. It is distinct from
+compile-time combine predicate errors such as E303/E305/E313 and from
+E310 memory-budget aborts.
+
+The error can be raised by the in-memory, grace-hash, or sort-merge
+combine paths. All of them apply the same `on_miss` contract after they
+determine that the driver row has zero matches. With `on_miss: error`,
+the executor returns `PipelineError::CombineMissingMatch` and the CLI
+exits as a configuration/runtime failure instead of silently emitting a
+partial record.
+
+## See also
+
+- E303 (combine where-clause does not evaluate to Bool)
+- E305 (where-clause has no cross-input comparisons)
+- E310 (combine runtime exceeded hard memory limit)
+- E313 (combine has no equality conjuncts)


### PR DESCRIPTION
Fixes #155.

## Summary
- registers E319 in the explain-code lookup and docs coverage list
- adds `docs/explain/E319.md` for the `on_miss: error` missing-match runtime diagnostic
- updates `clinker explain --help` and the unknown-code valid list to include E319
- adds focused core and CLI regression coverage for E319

## Proof
- `cargo test -p clinker-core test_explain_code_e319`
- `cargo test -p clinker-core test_explain_docs_all_have_required_sections`
- `cargo test -p clinker --test explain_provenance_test e319`
- `cargo run --quiet -p clinker -- explain --code E319`
- `cargo run --quiet -p clinker -- explain --help | rg "E300-E319"`
- `cargo run --quiet -p clinker -- explain --code E999 2>&1 | rg "E319"`
- `git diff --check`

Optional direct-fix settlement: https://nicdunz.gumroad.com/l/tiny-codex-teardown-direct?wanted=true
