### PR TITLE
docs: match em-dash in E319 example to runtime Display

### DIFF
--- a/docs/explain/E319.md
+++ b/docs/explain/E319.md
@@ -11,7 +11,7 @@ The runtime diagnostic identifies the combine node and the driver row
 number that missed:
 
 ```
-E319 combine 'enrich_orders': on_miss: error - no matching build row for driver row 42
+E319 combine 'enrich_orders': on_miss: error — no matching build row for driver row 42
 ```
 
 ## Example


### PR DESCRIPTION
## Summary
Follow-up to #161. The example runtime diagnostic in `docs/explain/E319.md` used an ASCII hyphen (`-`) between `on_miss: error` and `no matching build row`, but the actual `PipelineError::CombineMissingMatch` `Display` impl in `crates/clinker-core/src/error.rs:522` emits an em-dash (`—`). A user copying the doc example into `grep` would not match real log output.

This PR is a one-character fix to align the doc example with the emitted diagnostic.

## Test plan
- [ ] `cargo run --quiet -p clinker -- explain --code E319 | rg 'no matching build row'` still matches
- [ ] Trigger E319 in a small pipeline and confirm the emitted line and the doc example agree character-for-character

🤖 Generated with [Claude Code](https://claude.ai/code)