### PR TITLE
engine: document the two-path composition node_buffers admission model + cover the bare port-admission path

### DIFF
--- a/crates/clinker-core/src/error.rs
+++ b/crates/clinker-core/src/error.rs
@@ -344,6 +344,30 @@ pub enum PipelineError {
     /// recursive walk so the rendered diagnostic carries the
     /// composition's name. Lets users see "in composition '<name>'"
     /// in failure messages instead of an opaque inner error.
+    ///
+    /// # Two-path model for composition-involved errors
+    ///
+    /// This wrapper is applied **only** to errors that bubble up
+    /// from a body operator whose `node` field names a body-internal
+    /// identifier the user never wrote (e.g. a body-internal Transform
+    /// named `stage_split`). The outer `composition_name` field
+    /// supplies the user-visible call-site name so the rendered
+    /// diagnostic can attribute the failure to the operator the
+    /// user actually authored.
+    ///
+    /// Errors emitted at the **composition boundary** — when records
+    /// are cloned into a body input port, or when the body's output
+    /// is harvested back into the parent's `node_buffers` slot — are
+    /// **not** wrapped. Their `node` field already carries the
+    /// call-site composition name, so an outer wrapper would just
+    /// duplicate the same identifier in two places. Consumers that
+    /// want to catch every composition-involved failure must match
+    /// both this variant and the bare inner-variant form.
+    ///
+    /// The wrapper is purely diagnostic attribution, not a separate
+    /// enforcement path: body operators share the same `MemoryBudget`
+    /// instance as the parent pipeline and admit through the same
+    /// site-level primitives.
     CompositionBodyError {
         composition_name: String,
         inner: Box<PipelineError>,
@@ -364,6 +388,22 @@ pub enum PipelineError {
     /// site-specific context the rendered message previously inlined
     /// (e.g. partition id, distinct-count estimate, disk-spill quota
     /// figures). Always aborts the run.
+    ///
+    /// # Composition involvement
+    ///
+    /// When a composition is in play, this variant can reach the
+    /// user in two shapes — see [`CompositionBodyError`] for the
+    /// full two-path model. In summary: budget exceedances at a
+    /// composition boundary (records flowing into a body input port
+    /// or back out of the body) surface as a **bare**
+    /// `MemoryBudgetExceeded` with `node` set to the call-site
+    /// composition name; exceedances inside the body surface
+    /// **wrapped** in `CompositionBodyError`, with `node` then
+    /// pointing at a body-internal operator. The budget itself is
+    /// shared across the whole run — body operators charge the same
+    /// `MemoryBudget` instance the parent pipeline uses.
+    ///
+    /// [`CompositionBodyError`]: PipelineError::CompositionBodyError
     MemoryBudgetExceeded {
         node: String,
         used: u64,
@@ -574,7 +614,11 @@ impl PipelineError {
     }
 
     /// Wrap an inner error from a composition body walk so the
-    /// rendered diagnostic carries the composition's name.
+    /// rendered diagnostic carries the composition's name. Apply
+    /// only to body-interior errors whose inner `node` would
+    /// otherwise be opaque to the user; boundary admits already
+    /// carry the call-site composition name and should stay
+    /// unwrapped — see [`PipelineError::CompositionBodyError`].
     pub fn compose_body_error(composition_name: String, inner: Box<PipelineError>) -> Self {
         Self::CompositionBodyError {
             composition_name,

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -3865,6 +3865,15 @@ pub(crate) async fn dispatch_plan_node(
             // under the parent composition's name so a budget-exceeded
             // diagnostic points the user at the user-visible operator,
             // not at the body's internal output port node name.
+            //
+            // Boundary admit (post-body): same two-path model as the
+            // pre-body port-records clone in `collect_port_records`.
+            // If `admit_node_buffer` returns `MemoryBudgetExceeded`
+            // here, it surfaces bare with `node = composition_name` —
+            // not wrapped in `CompositionBodyError`. The wrapper at
+            // `execute_composition_body`'s topo walk has already
+            // returned with `Ok` by the time we reach this admit;
+            // only errors from inside that walk get the wrapper.
             let nb = admit_node_buffer(
                 ctx,
                 &composition_name,
@@ -5426,6 +5435,15 @@ fn collect_port_records(
         // port-source Source arm discharges the slot when it claims
         // the seeded buffer, and the body-exit leak-discharge cleans
         // up any unconsumed remainder if a body operator errored.
+        //
+        // Boundary admit: the budget exceedance surfaces as a bare
+        // `MemoryBudgetExceeded` with `node = composition_name`
+        // (the user-visible call-site identifier). The body has not
+        // executed yet, so there is no body-internal operator name
+        // to disambiguate via `CompositionBodyError` — only inner
+        // errors that bubble out of `execute_composition_body`'s
+        // topo walk get that wrapper. Detail string discriminates
+        // this site from the generic admit in `admit_node_buffer`.
         let cloned_with_bytes = ctx
             .node_buffers
             .get(&edge.source())
@@ -5560,6 +5578,18 @@ async fn execute_composition_body(
     // composition's name for diagnosability — the user sees
     // "in composition '<name>': <inner>" instead of an opaque
     // inner-only message.
+    //
+    // Body-interior path of the two-path admission model: the inner
+    // error's `node` field names a body-internal operator (e.g.
+    // `stage_split`) the user never wrote in their YAML, so the
+    // wrapper supplies the user-visible call-site name on top. The
+    // boundary admits in `collect_port_records` (pre-body input
+    // clone) and the parent's Composition arm (post-body output
+    // harvest) stay unwrapped because their `node` is already the
+    // call-site composition name — wrapping them would duplicate
+    // the same identifier in both layers with no information gain.
+    // Consumers that want to catch every composition-involved
+    // budget exceedance must match both shapes.
     let topo: Vec<NodeIndex> = body_dag.topo_order.clone();
     let mut walk_result: Result<(), PipelineError> = Ok(());
     for node_idx in topo {

--- a/crates/clinker-core/tests/composition_port_admission_hard_fail.rs
+++ b/crates/clinker-core/tests/composition_port_admission_hard_fail.rs
@@ -1,0 +1,165 @@
+//! Composition port-admission diagnostic surfacing.
+//!
+//! Counterpart to `nested_composition_hard_fail.rs`. Where that test
+//! pins the body-interior shape (wrapped in
+//! `PipelineError::CompositionBodyError`), this one pins the
+//! boundary-admit shape: when the engine clones records from the
+//! parent producer's `node_buffers` slot into the composition
+//! body's input port, the clone admission charges the **shared**
+//! `MemoryBudget` (compositions do not get their own budget — body
+//! operators share the parent pipeline's instance). If the doubled
+//! charge crosses the hard limit, the dispatcher returns a bare
+//! `PipelineError::MemoryBudgetExceeded` whose `node` field carries
+//! the call-site composition name and whose `detail` discriminates
+//! the site from the generic `node_buffer admission` string used by
+//! `admit_node_buffer`.
+//!
+//! The two-path split between this shape and `CompositionBodyError`
+//! is documented on the variants in `crates/clinker-core/src/error.rs`
+//! and at the admit sites in `crates/clinker-core/src/executor/
+//! dispatch.rs` — it is a *diagnostic* split (which name the user
+//! sees), not an enforcement split. The explicit
+//! `CompositionBodyError` arm in this test's assertion defends the
+//! split against drift: future readers who silently wrap the
+//! boundary admit will see this test fail with a pointed message.
+//!
+//! Per-row admission cost is `size_of::<Value>() * cols +
+//! size_of::<(Record, u64)>()` (see `estimate_node_buffer_bytes` in
+//! `executor/dispatch.rs`); cols=1 for the single-column passthrough
+//! schema yields ~168 B/row. 5_000 rows give an upstream admission
+//! charge of ~840 KiB (under the 1 MiB hard limit) and a clone
+//! charge of another ~840 KiB on top, placing the hard-fail at the
+//! `collect_port_records` clone admission before the body's first
+//! operator runs.
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, PipelineConfig};
+use clinker_core::error::PipelineError;
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_core::pipeline::memory::BudgetCategory;
+use std::collections::HashMap;
+use std::io::Write;
+use std::path::PathBuf;
+
+const PIPELINE_YAML: &str = r#"
+pipeline:
+  name: composition_port_admission_hard_fail
+  memory_limit: "1M"
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - { name: id, type: string }
+  - type: composition
+    name: port_enrich_call
+    input: src
+    use: ../compositions/passthrough_check.comp.yaml
+    inputs:
+      data: src
+  - type: output
+    name: out
+    input: port_enrich_call
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+const TOTAL_ROWS: usize = 5_000;
+
+fn build_src_csv() -> String {
+    let mut s = String::with_capacity(TOTAL_ROWS * 16);
+    s.push_str("id\n");
+    for i in 1..=TOTAL_ROWS as u64 {
+        s.push_str(&format!("id_{i}\n"));
+    }
+    s
+}
+
+fn fixture_workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn port_admission_hard_fail_is_bare_with_call_site_name() {
+    let csv = build_src_csv();
+    let config: PipelineConfig =
+        clinker_core::yaml::from_str(PIPELINE_YAML).expect("parse pipeline YAML");
+    let ctx =
+        CompileContext::with_pipeline_dir(fixture_workspace_root(), PathBuf::from("pipelines"));
+    let plan = config.compile(&ctx).expect("compile pipeline");
+
+    let mut readers: clinker_core::executor::SourceReaders = HashMap::new();
+    readers.insert(
+        "src".to_string(),
+        clinker_core::executor::single_file_reader(
+            "src.csv",
+            Box::new(std::io::Cursor::new(csv.into_bytes())),
+        ),
+    );
+
+    let out = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(out.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "composition-port-admission-hard-fail".to_string(),
+        batch_id: "batch-0".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let err = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .await
+        .expect_err("1 MiB budget must abort the port-records clone admission");
+
+    match err {
+        PipelineError::MemoryBudgetExceeded {
+            node,
+            source,
+            used,
+            limit,
+            detail,
+        } => {
+            assert_eq!(
+                node, "port_enrich_call",
+                "boundary admit must name the user-visible composition call-site, \
+                 not a body-internal operator",
+            );
+            assert!(
+                matches!(source, BudgetCategory::NodeBuffer),
+                "port admission must surface under NodeBuffer category; got {source:?}",
+            );
+            assert_eq!(
+                detail.as_deref(),
+                Some("composition port-records clone admission"),
+                "detail string must discriminate the port-clone site from \
+                 the generic `node_buffer admission` used by admit_node_buffer",
+            );
+            assert!(
+                used > limit,
+                "reported used ({used}) must exceed limit ({limit}) at hard-fail",
+            );
+        }
+        PipelineError::CompositionBodyError { .. } => {
+            panic!(
+                "port-admission path must NOT be wrapped in CompositionBodyError — \
+                 the two-path diagnostic model documents this split (see \
+                 error.rs::CompositionBodyError doc-comment and \
+                 executor/dispatch.rs::collect_port_records). Wrapping the \
+                 boundary admit would put the call-site name in both the \
+                 wrapper and the inner `node` field with no information gain.",
+            );
+        }
+        other => panic!("expected bare MemoryBudgetExceeded; got: {other:?}"),
+    }
+}

--- a/docs/explain/E310.md
+++ b/docs/explain/E310.md
@@ -65,6 +65,41 @@ RSS exceeds the hard limit even after spill. Soft-limit crossings
 trigger spill, not E310; a well-tuned pipeline never sees E310
 because spill absorbs the overflow before hard-limit is crossed.
 
+## Composition involvement
+
+A composition (a reusable sub-pipeline included via `use:`) shares
+the **same** `MemoryBudget` instance as the parent pipeline — there
+is one budget per run, body operators charge it via the same admit
+and spill paths every other node uses. The two-path split described
+below is purely about *which name* appears in the diagnostic, not
+about asymmetric enforcement.
+
+When the budget trips with a composition in play, the error reaches
+the user in one of two shapes depending on where the admit failed:
+
+1. **Boundary admit (bare error).** Records flowing into a body
+   input port (the engine's port-records clone) or back out of the
+   body (the post-body harvest into the parent's `node_buffers`
+   slot) admit under the composition's **call-site name**. A budget
+   exceedance at either site surfaces as a bare
+   `MemoryBudgetExceeded` whose `node` field already carries the
+   user-visible call-site identifier (e.g. `enrich_call`). The
+   pre-body site sets the `detail` string to `"composition
+   port-records clone admission"` so it can be distinguished from
+   the generic admit.
+2. **Body-interior admit (wrapped error).** An admit failure inside
+   a body operator surfaces wrapped in
+   `CompositionBodyError { composition_name, inner }`. The inner
+   `MemoryBudgetExceeded.node` names a body-internal operator the
+   user never wrote in their YAML (e.g. an internal `stage_split`
+   Transform), so the wrapper supplies the call-site name on top
+   for attribution.
+
+Consumers pattern-matching on `MemoryBudgetExceeded` directly will
+catch shape (1) but miss shape (2); consumers matching only on
+`CompositionBodyError` will catch (2) but miss (1). Match both to
+catch every composition-involved failure.
+
 ## See also
 
 - E300 (fewer than 2 inputs — compile-time)

--- a/docs/src/ops/memory.md
+++ b/docs/src/ops/memory.md
@@ -65,6 +65,30 @@ To influence strategy selection:
 
 Only force `streaming` when you are certain the input is sorted by the group-by keys. If the data is not sorted, results will be incorrect. Use `auto` when in doubt.
 
+## Compositions
+
+A composition (a reusable sub-pipeline included via `use:`) does
+not get its own memory budget. Body operators charge the same
+budget as the parent pipeline, admit through the same paths, and
+spill to the same temporary directory. The recursion is purely
+structural.
+
+When a budget exceedance involves a composition, the error message
+arrives in one of two shapes:
+
+- **At the composition boundary** (records flowing into the body
+  via an input port, or back out into the parent) — the error
+  names the composition's call-site directly (e.g.
+  `enrich_call`).
+- **Inside the body** — the error is wrapped so the user-visible
+  call-site name surfaces alongside the body-internal operator
+  that tripped. The rendered message reads
+  `in composition 'enrich_call': ...` followed by the inner
+  detail.
+
+See [error E310](../explain/E310.html) for the full diagnostic
+model.
+
 ## Monitoring memory usage
 
 Use the [metrics system](metrics.md) to track `peak_rss_bytes` across runs:


### PR DESCRIPTION
Closes #153. Part of #108.

## Summary

`MemoryBudgetExceeded` from a `node_buffers` admission involving a composition reaches the user through two distinct error shapes depending on where the admit failed, and the rule was undocumented. PR #152 covered one shape; the other had zero integration coverage. This PR documents the model, adds the missing test, and pins both shapes against future drift.

## The two-path model

Composition body operators share the **same** `MemoryBudget` instance as the parent pipeline — there is one budget per run, body operators charge it via the same admit and spill paths every other node uses. The two-path split is about *which name* surfaces in the diagnostic, not about asymmetric enforcement.

1. **Boundary admit (bare error).** Records cloned into a body input port (the pre-body port-records clone in `collect_port_records`) or harvested back out of the body (the post-body admit in the Composition dispatch arm) admit under the composition's **call-site name**. A budget exceedance at either site surfaces as a bare `MemoryBudgetExceeded` whose `node` field already carries the user-visible call-site identifier (e.g. `enrich_call`). The pre-body site uses `detail = \"composition port-records clone admission\"` to discriminate it from the generic admit.
2. **Body-interior admit (wrapped error).** An admit failure inside a body operator surfaces wrapped in `CompositionBodyError { composition_name, inner }`. The inner `MemoryBudgetExceeded.node` names a body-internal operator the user never wrote in their YAML (e.g. an internal `stage_split` Transform), so the wrapper supplies the call-site name on top for attribution.

## Decision: split-and-document (not unify)

Wrapping the boundary admits would put the call-site composition name in both the wrapper and the inner `node` field with no information gain — three boundary sites would all have to learn to wrap, and the wrapper variant would lose its specific meaning (\"the inner `node` would be opaque without me\"). The split is principled because boundary admits do not have a body-internal operator name that needs disambiguation.

## Changes

- `crates/clinker-core/src/error.rs` — extended doc comments on `PipelineError::CompositionBodyError`, `PipelineError::MemoryBudgetExceeded`, and the `compose_body_error` constructor describing the two-path model and the shared-budget invariant.
- `crates/clinker-core/src/executor/dispatch.rs` — extended comments at the three boundary admit sites (`collect_port_records`, the post-body output harvest in the Composition arm) and the body-interior wrapper in `execute_composition_body`, each stating the rule and referencing its counterpart.
- `docs/explain/E310.md` — new \"Composition involvement\" section describing both shapes for end users, the discriminating `detail` string, and consumer-matching guidance.
- `docs/src/ops/memory.md` — new \"Compositions\" section pointing back to E310 and stating the shared-budget invariant in user language.
- `crates/clinker-core/tests/composition_port_admission_hard_fail.rs` — new integration test that sizes a single-column passthrough composition so the upstream source admit fits but the port-records clone admit trips on doubling, with destructured assertions on every field plus an explicit panic arm on `CompositionBodyError` to defend the split against future drift. Reuses the existing `passthrough_check.comp.yaml` fixture as-is.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — new test passes; existing `nested_composition_hard_fail` test still passes
- [x] `cargo check --benches --workspace`
- [x] `cargo check --features bench-alloc -p clinker-benchmarks`
- [x] `cargo test --benches -p clinker-benchmarks`
- [x] `cargo deny check`