### PR TITLE
docs: strengthen the bounded-memory promise and fix the memory-tuning page

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -17,14 +17,16 @@ lightweight, and easy to reason about.
 long-running stream processor.** A pipeline run is a job: Sources read until
 EOF, the DAG drains, the process exits. Within a run, stateless operators
 (Transform, Route, most Combine probe-side work, Output) evaluate records one
-at a time without accumulating per-record state. The DAG executor does
-materialize intermediate buffers between non-fused stages, so memory footprint
-scales with the largest intermediate stage's output rather than total input
-size; fused streaming paths (Source → Transform → Output without fan-out)
-avoid intermediate materialization entirely. Blocking operators (Aggregate,
-sort, grace-hash Combine) accumulate state inside the configured RSS budget
-and **spill to disk** when soft and hard memory thresholds trip, rather than
-OOM-killing the process.
+at a time without accumulating per-record state. Every stage is charged
+against the configured RSS budget. Fused Source → Transform → Output paths
+run streaming with no per-stage materialization; non-fused boundaries
+(Route fan-out, Merge fan-in, Composition bodies, diamond DAGs) materialize
+records into per-stage buffers that charge against the same envelope. The
+engine spills buffers to disk at 80% of the limit and fails fast with
+`E310 MemoryBudgetExceeded` at the hard limit, naming the offending
+producer. Blocking operators (Aggregate, sort, grace-hash Combine)
+accumulate state inside that same budget and **spill to disk** when soft
+and hard memory thresholds trip, rather than OOM-killing the process.
 
 If you have used Flink, Kafka Streams, or Beam in unbounded mode: Clinker is
 not that. There are no watermarks against wall-clock time, no infinite-source

--- a/docs/src/getting-started/concepts.md
+++ b/docs/src/getting-started/concepts.md
@@ -110,15 +110,23 @@ finite batch job, not Flink-style unbounded stream processing.
 
 Per-record evaluation keeps **per-row** memory usage bounded for the
 stateless parts of the graph (Transform, Route, Merge, most Combine
-probe-side work, Output). The DAG executor itself materializes intermediate
-buffers between non-fused stages, so the overall memory footprint scales with
-the largest live intermediate stage's output -- not with total input size.
-For a fused streaming path (Source → Transform → Output, no branching, no
-fan-out), no intermediate buffer materializes and a 100 GB CSV passes through
-with the same footprint as a 100 KB CSV. For general DAG shapes (diamonds,
-Route fan-out, Merge fan-in, Composition bodies), the predecessor's output
-stays in `node_buffers` until every consumer has read it -- and that buffer
-size grows with input size unless an upstream blocking operator caps it.
+probe-side work, Output). Every stage is charged against the configured
+RSS budget. Fused Source → Transform → Output paths run streaming, with
+no per-stage materialization, so a 100 GB CSV passes through with the
+same footprint as a 100 KB CSV. Non-fused boundaries -- Route fan-out,
+Merge fan-in, Composition bodies, diamond DAGs -- materialize records
+into per-stage buffers that charge against the same budget envelope.
+When a buffer would push cumulative usage past the soft threshold (80%
+of the limit), the engine spills the buffer to disk; when it would
+exceed the hard limit, the engine fails fast with a structured
+`E310 MemoryBudgetExceeded` diagnostic that names the offending
+producer.
+
+Use `clinker run --explain` to see which nodes will materialize
+(`buffer: materialized`) versus which will stream (`buffer: streaming`)
+before runtime -- that label is the canonical "which stages charge the
+budget" signal. See [the `--explain` reference](../ops/explain.md) and
+[the memory-tuning page](../ops/memory.md).
 
 **Stateful operators must accumulate.** Aggregate, sort, and grace-hash
 Combine cannot emit until they have seen enough input -- sums need every

--- a/docs/src/ops/memory.md
+++ b/docs/src/ops/memory.md
@@ -17,17 +17,27 @@ pipeline:
 
 The CLI flag overrides the YAML value. Accepted suffixes: `K` (kilobytes), `M` (megabytes), `G` (gigabytes).
 
-**Default:** 256M
+**Default:** 512M
 
 ## How it works
 
-Clinker uses a custom accounting allocator to track memory usage across all pipeline nodes. When memory pressure rises toward the configured limit, aggregation operations spill intermediate state to temporary files on disk. The pipeline continues with degraded throughput rather than crashing with an out-of-memory error.
+Clinker tracks memory in two layers. RSS (resident set size) is sampled at chunk boundaries and supplies the primary spill / abort signal. In parallel, the engine maintains a byte counter that charges every arena build site and every inter-stage `node_buffers` materialization against the same limit envelope -- so a pipeline declaring a 512 MB budget cannot multiply that limit across many operators. When memory pressure rises toward the configured limit, aggregation operations and inter-stage buffers spill to temporary files on disk. The pipeline continues with degraded throughput rather than crashing with an out-of-memory error.
 
 This means:
 
 - Pipelines always complete if disk space is available, regardless of input size.
 - Performance degrades gracefully under memory pressure -- you will see slower execution, not failures.
 - The memory limit is a soft ceiling, not a hard wall. Momentary spikes may briefly exceed the limit before spill kicks in.
+
+## Bounded-memory contract for non-fused stages
+
+Fused chains (Source → Transform → Output, Merge.interleave fed by Sources) run streaming with no per-stage materialization. Non-fused boundaries -- Route fan-out, Merge fan-in, Composition bodies, diamond DAGs -- materialize records into per-stage `node_buffers` that charge against the budget.
+
+When a buffer crosses the soft threshold (80% of the limit), the engine spills that buffer to disk using the same LZ4 + postcard frame format as grace-hash sort partitions. When a buffer crosses the hard limit, the engine fails fast with `E310 MemoryBudgetExceeded { node }` naming the producer that overran. See [error E310](../explain/E310.html) for the full diagnostic model, including the [composition-involved](../explain/E310.html#composition-involvement) two-shape error model.
+
+Spill fires at the producer side of the first slot whose downstream topology permits it -- single-consumer, port-less. For a Source feeding a Route, that's the Source's own slot, not the Route's per-branch slots, because the Source has the one outgoing edge that satisfies the topology rule. Per-branch slots can still spill independently when their own row-distribution drives them past the soft threshold, but the canonical case lands at the producer.
+
+Use `clinker run --explain` to predict which stages will dominate the budget before runtime -- each node carries a `buffer: streaming | materialized` annotation, and the materialized nodes are exactly the ones that charge `pipeline.memory_limit` and are spill-eligible.
 
 ## Sizing guidelines
 


### PR DESCRIPTION
Closes #125. Part of #108.

## Summary

Three user-facing docs files described Clinker's memory model with hedged prose and one factual error. After the node_buffers RSS accounting work landed (PRs #149/#150/#151/#152), the engine's runtime guarantees outran the docs. This PR strengthens the prose and fixes the drift.

- `docs/src/getting-started/concepts.md` — replaces the "memory scales with the largest live intermediate stage's output" hedge with the stronger budget contract: every stage charges the configured RSS budget; fused chains stream; non-fused boundaries materialize per-stage buffers that spill at 80% and fail fast with `E310 MemoryBudgetExceeded` at the hard limit. Adds a cross-reference to `clinker run --explain` and its `buffer: streaming | materialized` label.
- `docs/src/README.md` — same prose upgrade in the front-page "What Clinker is, plainly" summary, kept tighter (no `--explain` follow-up; that belongs on the deeper pages).
- `docs/src/ops/memory.md` — three targeted edits, no section reorder:
  - **Default value fix:** `256M` → `512M` (verified against `parse_memory_limit_bytes` in `crates/clinker-core/src/pipeline/memory.rs:328`).
  - **"Custom accounting allocator" sentence removed.** Replaced with a two-layer description: RSS sampling at chunk boundaries plus a per-charge-site byte counter that charges every arena build and every inter-stage `node_buffers` materialization against the same envelope.
  - **New "Bounded-memory contract for non-fused stages" subsection** between `## How it works` and `## Sizing guidelines`. Covers soft/hard thresholds, the LZ4 + postcard spill frame format (same as grace-hash sort partitions), producer-side spill topology (Source-feeding-Route example: spill fires at the Source's own slot, not the Route's per-branch slots), and the \`--explain\` \`buffer:\` annotation as the predictive memory-cost signal.

The \`## Compositions\` section added by #165 stays in place; the new subsection slots in earlier and links to \`E310#composition-involvement\` rather than duplicating the shared-budget framing.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace -- -D warnings\`
- [x] \`cargo test --workspace\`
- [x] \`cargo check --benches --workspace\`
- [x] \`cargo check --features bench-alloc -p clinker-benchmarks\`
- [x] \`cargo test --benches -p clinker-benchmarks\`
- [x] \`cargo deny check\` — \`advisories ok, bans ok, licenses ok, sources ok\`
- [x] \`mdbook build docs/\` — clean