### PR TITLE
engine: MemoryArbitrator skeleton + MemoryConsumer / ArbitrationPolicy traits (117a)

### DIFF
--- a/CROSS_RECORD_TRANSFORMS_PLAN.md
+++ b/CROSS_RECORD_TRANSFORMS_PLAN.md
@@ -215,7 +215,7 @@ skip its *stats* (not its index).
 
 ### 4.4 Hysteresis on spill thresholds
 
-The existing `MemoryBudget::should_spill()` flips on at the soft threshold
+The existing `MemoryArbitrator::should_spill()` flips on at the soft threshold
 (80% of hard limit). Cross-record operators trigger this much more often
 than per-record transforms; without hysteresis, the pipeline ping-pongs
 in/out of spill at every batch. Generalization adds a sticky 20% raise:

--- a/crates/clinker-core/benches/combine_grace_hash.rs
+++ b/crates/clinker-core/benches/combine_grace_hash.rs
@@ -28,7 +28,7 @@
 //! Two paths are measured:
 //!   - **In-memory baseline**: pipeline `memory_limit: 16G`. Process
 //!     RSS stays well below 0.8 × 16G = 12.8G on every conceivable CI
-//!     host, so [`MemoryBudget::should_spill`] never returns true and
+//!     host, so [`MemoryArbitrator::should_spill`] never returns true and
 //!     the grace executor stays in its no-spill fast path.
 //!   - **Forced spill**: pipeline `memory_limit: 1G`. Soft limit is
 //!     ~820M; the bench process's RSS during probe runs ~800M-1G after
@@ -37,7 +37,7 @@
 //!     partition transitions to OnDisk. The 1G hard limit gives a 200M
 //!     headroom band over the 820M soft limit so `should_abort` does
 //!     not trigger before the spill kernel can drop residency.
-//!     `MemoryBudget::from_config` hardcodes `spill_threshold_pct = 0.80`
+//!     `MemoryArbitrator::from_config` hardcodes `spill_threshold_pct = 0.80`
 //!     — the YAML knob does not let the bench tune the soft/hard
 //!     ratio independently, so the limit is sized to the natural band.
 //!
@@ -71,7 +71,7 @@ use indexmap::IndexMap;
 // `strategy: grace_hash` on a pure-equi combine forces the planner to
 // pick `CombineStrategy::GraceHash` regardless of cardinality
 // estimates. The two `memory_limit:` knobs (`SPILL` vs `IN_MEMORY`)
-// drive the [`MemoryBudget::should_spill`] threshold; the YAML body is
+// drive the [`MemoryArbitrator::should_spill`] threshold; the YAML body is
 // otherwise identical so any timing delta is attributable to the
 // spill-vs-no-spill execution mode.
 const COMBINE_GRACE_HASH_SPILL_YAML: &str = r#"

--- a/crates/clinker-core/benches/deferred_buffer_pruning.rs
+++ b/crates/clinker-core/benches/deferred_buffer_pruning.rs
@@ -18,7 +18,7 @@
 //! charge formula surfaces in CI.
 
 use clinker_core::pipeline::arena::Arena;
-use clinker_core::pipeline::memory::MemoryBudget;
+use clinker_core::pipeline::memory::MemoryArbitrator;
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use std::sync::Arc;
@@ -49,7 +49,7 @@ fn build_wide_rows() -> Vec<(Record, u64)> {
 
 fn measure_arena_bytes(rows: &[(Record, u64)], fields: &[String]) -> u64 {
     let schema = rows[0].0.schema().clone();
-    let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+    let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
     let _arena = Arena::from_records(rows, fields, &schema, &mut budget)
         .expect("u64::MAX budget never overflows");
     budget.arena_bytes_charged()

--- a/crates/clinker-core/src/error.rs
+++ b/crates/clinker-core/src/error.rs
@@ -365,7 +365,7 @@ pub enum PipelineError {
     /// both this variant and the bare inner-variant form.
     ///
     /// The wrapper is purely diagnostic attribution, not a separate
-    /// enforcement path: body operators share the same `MemoryBudget`
+    /// enforcement path: body operators share the same `MemoryArbitrator`
     /// instance as the parent pipeline and admit through the same
     /// site-level primitives.
     CompositionBodyError {
@@ -401,7 +401,7 @@ pub enum PipelineError {
     /// **wrapped** in `CompositionBodyError`, with `node` then
     /// pointing at a body-internal operator. The budget itself is
     /// shared across the whole run — body operators charge the same
-    /// `MemoryBudget` instance the parent pipeline uses.
+    /// `MemoryArbitrator` instance the parent pipeline uses.
     ///
     /// [`CompositionBodyError`]: PipelineError::CompositionBodyError
     MemoryBudgetExceeded {

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -412,7 +412,7 @@ use crate::executor::{
     evaluate_single_transform, evaluate_single_transform_windowed, parse_memory_limit,
     stage_metrics, widen_record_to_schema,
 };
-use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
+use crate::pipeline::memory::{BudgetCategory, MemoryArbitrator};
 use crate::plan::bind_schema::CompileArtifacts;
 use crate::plan::execution::{ExecutionPlanDag, PlanNode};
 use crate::projection::project_output_from_record;
@@ -683,7 +683,7 @@ pub(crate) struct ExecutorContext<'a> {
     /// accumulate against this budget so a relaxed pipeline cannot
     /// multiply its declared limit across N upstream operators by
     /// accident.
-    pub(crate) memory_budget: crate::pipeline::memory::MemoryBudget,
+    pub(crate) memory_budget: crate::pipeline::memory::MemoryArbitrator,
 
     /// Per-correlation-group buffer holding deferred output writes
     /// and per-record error events. `Some` iff the plan carries a
@@ -1149,7 +1149,7 @@ pub(crate) fn charge_harvest_admission(
 /// The per-row formula matches `NodeBuffer::estimated_memory_bytes` and
 /// `charge_harvest_admission`: each row contributes `size_of::<Value>()
 /// * column_count + size_of::<(Record, u64)>()` bytes. The two budget
-/// surfaces share the `MemoryBudget::hard_limit` envelope via
+/// surfaces share the `MemoryArbitrator::hard_limit` envelope via
 /// `total_charged`, so a runaway producer trips on the combined sum.
 ///
 /// Used today only by the commit-pass body-harvest re-charge in
@@ -1235,11 +1235,11 @@ pub(crate) fn node_buffer_spill_allowed(
 /// in-memory and on-disk variants based on the live RSS reading.
 ///
 /// 1. Empty input returns `NodeBuffer::Memory(Vec::new())`.
-/// 2. The per-row byte cost is charged against `MemoryBudget` via
+/// 2. The per-row byte cost is charged against `MemoryArbitrator` via
 ///    [`charge_node_buffer_admit`]'s shared formula. A hard-limit
 ///    breach surfaces as
 ///    `MemoryBudgetExceeded { source: BudgetCategory::NodeBuffer, .. }`.
-/// 3. When `spill_allowed` is `true` and `MemoryBudget::should_spill()`
+/// 3. When `spill_allowed` is `true` and `MemoryArbitrator::should_spill()`
 ///    reports the RSS soft threshold tripped, the rows flush to a
 ///    `SpillFile<u64>` via [`node_buffer_spill::spill_node_buffer`].
 ///    The in-memory charge is discharged immediately and the file size
@@ -4192,7 +4192,7 @@ pub(crate) async fn dispatch_plan_node(
             match dispatch {
                 Dispatch::IEJoin(partition_bits) => {
                     let mut budget =
-                        MemoryBudget::from_config(ctx.config.pipeline.memory_limit.as_deref());
+                        MemoryArbitrator::from_config(ctx.config.pipeline.memory_limit.as_deref());
                     // Advance per-source `rollback_cursors` for every
                     // build-side record before its `row_num` is dropped
                     // in the `(r, _)` map. Source→Combine direct paths
@@ -4281,7 +4281,7 @@ pub(crate) async fn dispatch_plan_node(
                 }
                 Dispatch::Grace(partition_bits) => {
                     let mut budget =
-                        MemoryBudget::from_config(ctx.config.pipeline.memory_limit.as_deref());
+                        MemoryArbitrator::from_config(ctx.config.pipeline.memory_limit.as_deref());
                     // Same per-source cursor advance the IEJoin arm
                     // performs; Source→Combine direct paths on either
                     // side need the explicit walk because the build /
@@ -4371,7 +4371,7 @@ pub(crate) async fn dispatch_plan_node(
                     // the inputs in place via the two-cursor
                     // merge.
                     let mut budget =
-                        MemoryBudget::from_config(ctx.config.pipeline.memory_limit.as_deref());
+                        MemoryArbitrator::from_config(ctx.config.pipeline.memory_limit.as_deref());
                     // Same per-source cursor advance the IEJoin /
                     // Grace arms perform; Source→Combine direct paths
                     // on either side need the explicit walk because
@@ -4455,12 +4455,13 @@ pub(crate) async fn dispatch_plan_node(
             }
 
             // Hash-build phase — drain the build buffer into a
-            // fresh MemoryBudget-governed CombineHashTable. The
+            // fresh MemoryArbitrator-governed CombineHashTable. The
             // stage timer covers the full build walk; on a
             // budget abort the timer is dropped without
             // recording (matches the `StageTimer` "no report on
             // error" contract documented at its definition).
-            let mut budget = MemoryBudget::from_config(ctx.config.pipeline.memory_limit.as_deref());
+            let mut budget =
+                MemoryArbitrator::from_config(ctx.config.pipeline.memory_limit.as_deref());
             // Per-source cursor advance for both build and driver.
             // Source→Combine direct paths bypass the Transform /
             // Aggregate advance points so the cursor never moved off

--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -240,7 +240,7 @@ pub(crate) struct DispatchOutcome {
     pub(crate) per_source_dlq_counts: BTreeMap<String, u64>,
     /// Saturating sum of bytes the run committed to spill files across
     /// every spill site (node_buffer admission, grace-hash partition
-    /// flush, sort-merge external sort). Read from `MemoryBudget`'s
+    /// flush, sort-merge external sort). Read from `MemoryArbitrator`'s
     /// running total at dispatch close so an aborted run still
     /// reports the last committed value.
     pub(crate) cumulative_spill_bytes: u64,
@@ -398,7 +398,7 @@ pub struct ExecutionReport {
     /// Saturating sum of bytes committed to spill files across every
     /// spill site (`node_buffers` admission, grace-hash partition
     /// flush, sort-merge external sort). Sourced from
-    /// `MemoryBudget`'s running total at dispatch close; an aborted
+    /// `MemoryArbitrator`'s running total at dispatch close; an aborted
     /// run still surfaces the last committed value.
     pub cumulative_spill_bytes: u64,
 }
@@ -1134,12 +1134,12 @@ impl PipelineExecutor {
     ) -> Result<DispatchOutcome, PipelineError> {
         let mut dlq_entries: Vec<DlqEntry> = Vec::new();
 
-        // Pipeline-scoped MemoryBudget. One declared `memory_limit`
+        // Pipeline-scoped MemoryArbitrator. One declared `memory_limit`
         // envelopes every node-rooted arena finalize — including the
         // arenas built at Source dispatch-arm exits. Promoted to
         // ctx-owned so a relaxed pipeline cannot multiply its declared
         // limit across N upstream operators by accident.
-        let memory_budget = crate::pipeline::memory::MemoryBudget::from_config(
+        let memory_budget = crate::pipeline::memory::MemoryArbitrator::from_config(
             config.pipeline.memory_limit.as_deref(),
         );
 
@@ -1212,7 +1212,7 @@ impl PipelineExecutor {
         dlq_entries: &mut Vec<DlqEntry>,
         collector: &mut stage_metrics::StageCollector,
         window_runtime: crate::executor::window_runtime::WindowRuntimeRegistry,
-        memory_budget: crate::pipeline::memory::MemoryBudget,
+        memory_budget: crate::pipeline::memory::MemoryArbitrator,
         spill_root: Arc<tempfile::TempDir>,
         spill_root_path: Arc<std::path::Path>,
         watermarks: crate::executor::watermark::PerSourceWatermarks,

--- a/crates/clinker-core/src/executor/node_buffer.rs
+++ b/crates/clinker-core/src/executor/node_buffer.rs
@@ -11,7 +11,7 @@
 //! returns an iterator that streams memory rows first, then per-spill
 //! rows via `SpillReader` without materializing the spill into RAM.
 //! Producer-side spill is wired in `executor/node_buffer_spill.rs` and
-//! gated on `MemoryBudget::should_spill()` at every bulk admission site
+//! gated on `MemoryArbitrator::should_spill()` at every bulk admission site
 //! via `admit_node_buffer`.
 
 use std::vec::IntoIter as VecIntoIter;
@@ -124,14 +124,14 @@ impl NodeBuffer {
     }
 
     /// Heuristic in-memory footprint of the slot, paired with the
-    /// `MemoryBudget::charge_node_buffer_bytes` /
+    /// `MemoryArbitrator::charge_node_buffer_bytes` /
     /// `discharge_node_buffer_bytes` ledger. The estimate matches
     /// `charge_harvest_admission`'s per-row formula so the executor's
     /// two budget surfaces (`Arena` for parked region tee, `NodeBuffer`
     /// for inter-stage handoff) use the same per-row size.
     ///
     /// Returns `0` on an empty memory tail. Spill-resident chunks are
-    /// accounted via `MemoryBudget::cumulative_spill_bytes` (the disk
+    /// accounted via `MemoryArbitrator::cumulative_spill_bytes` (the disk
     /// quota), not this counter, so a `Spilled` slot reports `0` here.
     pub(crate) fn estimated_memory_bytes(&self) -> u64 {
         let mem = self.peek_mem();
@@ -425,7 +425,7 @@ mod tests {
         assert_eq!(mem.estimated_memory_bytes(), (row_bytes_each * 3) as u64);
 
         // Spilled: zero bytes here — the disk surface tracks them
-        // separately through `MemoryBudget::cumulative_spill_bytes`.
+        // separately through `MemoryArbitrator::cumulative_spill_bytes`.
         let spilled = NodeBuffer::Spilled(vec![spill_chunk(vec![(rec(&s, 1, "a"), 1)])]);
         assert_eq!(spilled.estimated_memory_bytes(), 0);
 

--- a/crates/clinker-core/src/executor/node_buffer_spill.rs
+++ b/crates/clinker-core/src/executor/node_buffer_spill.rs
@@ -1,6 +1,6 @@
 //! Producer-side spill helper for `ctx.node_buffers`.
 //!
-//! When `MemoryBudget::should_spill()` trips at admission time, the
+//! When `MemoryArbitrator::should_spill()` trips at admission time, the
 //! producer flushes the in-memory `Vec<(Record, u64)>` to disk through
 //! `SpillWriter<u64>` and stores the resulting `(SpillFile<u64>, u64)`
 //! pair inside `NodeBuffer::Spilled`. Consumer-side streaming is

--- a/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-core/src/executor/tests/deferred_dispatch.rs
@@ -1906,7 +1906,7 @@ o6,ENG,300
     );
 }
 
-/// MemoryBudget overflow on the region-input-buffer surfaces with the
+/// MemoryArbitrator overflow on the region-input-buffer surfaces with the
 /// E310 admission failure shape. Pipeline: a Combine inside a deferred
 /// region with a non-deferred build-side Source whose forward-pass tee
 /// lands records into `region_input_buffers`. A tight pipeline-level
@@ -2028,7 +2028,7 @@ nodes:
 
     // The pipeline either errors at the build-side cross-region tee
     // (`tee_emit_to_region_input_buffers` raising MemoryBudgetExceeded
-    // from `MemoryBudget::charge_arena_bytes`) or at the source-rooted
+    // from `MemoryArbitrator::charge_arena_bytes`) or at the source-rooted
     // arena build for the build-side reader (same shape). Both
     // surfaces carry the same admission-failure error type; the test
     // pins the failure-shape contract regardless of which boundary

--- a/crates/clinker-core/src/pipeline/arena.rs
+++ b/crates/clinker-core/src/pipeline/arena.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use clinker_format::traits::FormatReader;
 use clinker_record::{MinimalRecord, RecordStorage, Schema, SchemaBuilder, Value};
 
-use super::memory::MemoryBudget;
+use super::memory::MemoryArbitrator;
 
 /// Columnar-projected record storage for Phase 1 indexing.
 /// Stores only the fields needed by window expressions.
@@ -40,7 +40,7 @@ impl Arena {
     /// `fields`: field names to project into the Arena (from `IndexSpec.arena_fields`).
     /// `memory_limit`: hard byte limit threaded through this call only — the
     /// caller's per-arena cap, distinct from the cumulative budget tracked
-    /// on `MemoryBudget`. Each admitted record's projected size charges
+    /// on `MemoryArbitrator`. Each admitted record's projected size charges
     /// the cumulative `arena_bytes_charged` counter via `budget`. If
     /// either the per-call `memory_limit` or the cumulative budget tips,
     /// returns `ArenaError::MemoryBudgetExceeded`.
@@ -49,7 +49,7 @@ impl Arena {
         fields: &[String],
         memory_limit: usize,
         shutdown: Option<&super::shutdown::ShutdownToken>,
-        budget: &mut MemoryBudget,
+        budget: &mut MemoryArbitrator,
     ) -> Result<Self, ArenaError> {
         let source_schema = reader.schema()?;
 
@@ -133,7 +133,7 @@ impl Arena {
     /// `anchor_schema`; missing fields produce `Value::Null` (mirroring
     /// the source-rooted path's behavior).
     ///
-    /// `budget` is the executor's ctx-owned `MemoryBudget`. Each
+    /// `budget` is the executor's ctx-owned `MemoryArbitrator`. Each
     /// admitted record's projected `MinimalRecord` size is charged to
     /// the cumulative arena counter; on overflow the call returns
     /// `ArenaError::MemoryBudgetExceeded` with the totals at the
@@ -143,7 +143,7 @@ impl Arena {
         rows: &[(clinker_record::Record, u64)],
         fields: &[String],
         anchor_schema: &Arc<Schema>,
-        budget: &mut MemoryBudget,
+        budget: &mut MemoryArbitrator,
     ) -> Result<Self, ArenaError> {
         let schema: Arc<Schema> = fields
             .iter()
@@ -197,7 +197,7 @@ impl RecordStorage for Arena {
 /// Project a stream of `Record`-shaped inputs onto `field_indices`
 /// (one entry per output column, or `None` for a missing column),
 /// charging each admitted `MinimalRecord` against the shared
-/// `MemoryBudget`. Used by both `Arena::from_records` (post-operator
+/// `MemoryArbitrator`. Used by both `Arena::from_records` (post-operator
 /// node-rooted arenas) and any caller that already holds materialized
 /// records and wants the same projection + budget-charge contract
 /// `Arena::build` provides at the source-stream boundary.
@@ -207,7 +207,7 @@ impl RecordStorage for Arena {
 fn project_records_into_minimal<'a, I>(
     records: I,
     field_indices: &[Option<usize>],
-    budget: &mut MemoryBudget,
+    budget: &mut MemoryArbitrator,
 ) -> Result<Vec<MinimalRecord>, ArenaError>
 where
     I: IntoIterator<Item = &'a clinker_record::Record>,
@@ -377,7 +377,7 @@ mod tests {
             big_csv.push_str(&format!("D{},{},Name{}\n", i % 3, i * 10, i));
         }
         let mut reader = make_csv_reader(&big_csv);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -393,7 +393,7 @@ mod tests {
     fn test_arena_field_projection() {
         let csv = "dept,amount,name,extra\nA,100,Alice,X\nB,200,Bob,Y\n";
         let mut reader = make_csv_reader(csv);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -423,7 +423,7 @@ mod tests {
     fn test_arena_record_view_resolve() {
         let csv = "dept,amount\nA,100\nB,200\nC,300\nD,400\nE,500\nF,600\n";
         let mut reader = make_csv_reader(csv);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -442,7 +442,7 @@ mod tests {
     fn test_arena_record_view_missing_field() {
         let csv = "dept,amount\nA,100\n";
         let mut reader = make_csv_reader(csv);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -475,7 +475,7 @@ mod tests {
     fn test_arena_empty_input() {
         let csv = "dept,amount\n";
         let mut reader = make_csv_reader(csv);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -495,7 +495,7 @@ mod tests {
             csv.push_str(&format!("Department_{},{}00\n", i, i));
         }
         let mut reader = make_csv_reader(&csv);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let result = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -574,7 +574,7 @@ mod tests {
             second_schema: Arc::clone(&second_schema),
             emitted: 0,
         };
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let result = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -594,7 +594,7 @@ mod tests {
         }
     }
 
-    /// Shared `MemoryBudget` across a source-stream `Arena::build` and
+    /// Shared `MemoryArbitrator` across a source-stream `Arena::build` and
     /// a downstream `Arena::from_records`: when their combined byte
     /// charge crosses the cumulative limit, the second build raises
     /// `MemoryBudgetExceeded` even though its own per-call
@@ -615,7 +615,7 @@ mod tests {
         // first build admits 100 records and the second build's
         // node-rooted projection trips on the cumulative ceiling.
         let cumulative_limit = 12_000u64;
-        let mut shared_budget = MemoryBudget::new(cumulative_limit, 0.80);
+        let mut shared_budget = MemoryArbitrator::new(cumulative_limit, 0.80);
         let src_arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -687,7 +687,7 @@ mod tests {
                 (Record::new(Arc::clone(&schema), v), i as u64)
             })
             .collect();
-        let mut budget = MemoryBudget::new(u64::MAX, 1.0);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 1.0);
         let arena = Arena::from_records(&rows, &["id".into(), "name".into()], &schema, &mut budget)
             .expect("uniform-variant arena builds");
         assert_eq!(arena.record_count(), 50);

--- a/crates/clinker-core/src/pipeline/combine.rs
+++ b/crates/clinker-core/src/pipeline/combine.rs
@@ -38,10 +38,10 @@ use std::collections::HashMap;
 use std::hash::{BuildHasher, Hasher};
 use std::sync::Arc;
 
-use crate::pipeline::memory::MemoryBudget;
+use crate::pipeline::memory::MemoryArbitrator;
 
 /// Period (measured in records processed) between
-/// [`crate::pipeline::memory::MemoryBudget::should_abort`] checks during
+/// [`crate::pipeline::memory::MemoryArbitrator::should_abort`] checks during
 /// `CombineHashTable::build` AND during probe-side fan-out emission.
 ///
 /// Matches ClickHouse per-block cadence and is the same order of
@@ -290,7 +290,7 @@ pub enum CombineError {
     /// Memory budget was exhausted while building or probing. `used` is
     /// the hash table's self-reported footprint at the moment of the
     /// check; `limit` is the configured budget. Emitted after
-    /// `MemoryBudget::should_abort` returns true (checked every
+    /// `MemoryArbitrator::should_abort` returns true (checked every
     /// [`MEMORY_CHECK_INTERVAL`] records to amortize the cost).
     MemoryLimitExceeded { used: u64, limit: u64 },
 
@@ -557,7 +557,7 @@ impl CombineHashTable {
         records: Vec<Record>,
         extractor: &KeyExtractor,
         ctx: &EvalContext<'_>,
-        budget: &mut MemoryBudget,
+        budget: &mut MemoryArbitrator,
         estimated_rows: Option<usize>,
     ) -> Result<Self, CombineError> {
         let expected = estimated_rows.unwrap_or(records.len());
@@ -691,7 +691,7 @@ impl CombineHashTable {
     /// Total bytes of owned memory. Sums all four allocation sources —
     /// missing any one was the DataFusion #14222/#5490/#6170 failure class.
     /// Stable pub API: the executor uses this both for the periodic
-    /// `MemoryBudget` check and for the `--explain` RSS reporting.
+    /// `MemoryArbitrator` check and for the `--explain` RSS reporting.
     pub fn memory_bytes(&self) -> usize {
         self.index.allocation_size()
             + self.chain.capacity() * std::mem::size_of::<u32>()
@@ -1269,8 +1269,8 @@ mod tests {
         Record::new(Arc::clone(schema), values)
     }
 
-    fn test_budget(limit_bytes: u64) -> MemoryBudget {
-        MemoryBudget::new(limit_bytes, 0.80)
+    fn test_budget(limit_bytes: u64) -> MemoryArbitrator {
+        MemoryArbitrator::new(limit_bytes, 0.80)
     }
 
     /// Build a single-column integer-key KeyExtractor that extracts field `name`.

--- a/crates/clinker-core/src/pipeline/grace_hash.rs
+++ b/crates/clinker-core/src/pipeline/grace_hash.rs
@@ -26,7 +26,7 @@
 //!
 //! ## Spill victim policy
 //!
-//! When the [`MemoryBudget`] reports `should_spill`, the largest
+//! When the [`MemoryArbitrator`] reports `should_spill`, the largest
 //! `Building` partition (by accumulated bytes) transitions to `OnDisk`.
 //! AsterixDB's "Largest-Size" policy: maximizes bytes evicted per
 //! spill cycle, minimizes how often we cross the budget threshold.
@@ -63,7 +63,7 @@ use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
 use crate::pipeline::combine::{CombineHashTable, KeyExtractor, hash_composite_key};
 use crate::pipeline::grace_spill::{GraceSpillReader, GraceSpillWriter, SpillFilePath};
-use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
+use crate::pipeline::memory::{BudgetCategory, MemoryArbitrator};
 use crate::plan::combine::DecomposedPredicate;
 
 /// Cap on matches collected per driver under [`MatchMode::Collect`].
@@ -71,7 +71,7 @@ use crate::plan::combine::DecomposedPredicate;
 /// every code path truncates at the same threshold.
 const COLLECT_PER_GROUP_CAP: usize = 10_000;
 
-/// Period (matches emitted) between [`MemoryBudget::should_abort`] polls
+/// Period (matches emitted) between [`MemoryArbitrator::should_abort`] polls
 /// during the probe loop. Same cadence as the inline hash probe.
 const MEMORY_CHECK_INTERVAL: usize = 10_000;
 
@@ -93,7 +93,7 @@ pub(crate) const GRACE_RECORD_BYTES_ESTIMATE: u64 = 1024;
 pub(crate) type RecordOrder = u64;
 
 /// Number of result records the BNL fallback emits per output batch
-/// before polling [`MemoryBudget::should_abort`]. Output amplification
+/// before polling [`MemoryArbitrator::should_abort`]. Output amplification
 /// from a hot key joining against many probe-side records can produce
 /// `M * N` rows for a single equivalence class; periodic polling at the
 /// 10 K boundary keeps the abort signal responsive without paying an
@@ -354,7 +354,7 @@ pub(crate) struct GraceHashExec<'a> {
     /// `copy_build_ck_columns` at each emit site.
     pub propagate_ck: &'a crate::config::pipeline_node::PropagateCkSpec,
     pub ctx: &'a EvalContext<'a>,
-    pub budget: &'a mut MemoryBudget,
+    pub budget: &'a mut MemoryArbitrator,
     /// Pipeline-scoped spill directory. Owned by the executor's
     /// `Arc<TempDir>` on `ExecutorContext`; this borrow lives for one
     /// combine invocation. Cleanup of individual spill files runs on
@@ -381,7 +381,7 @@ pub(crate) struct GraceHashExecutor {
     hash_state: RandomState,
     /// Bytes written across every spill commit this executor has
     /// performed. Drained by [`Self::take_spilled_bytes`] so the
-    /// caller can fold the delta into [`MemoryBudget::record_spill_bytes`]
+    /// caller can fold the delta into [`MemoryArbitrator::record_spill_bytes`]
     /// and surface E310 on disk-quota overflow.
     spilled_bytes: u64,
 }
@@ -420,7 +420,7 @@ impl GraceHashExecutor {
 
     /// Drain the cumulative spill-bytes counter and return it. The
     /// caller folds the result into
-    /// [`MemoryBudget::record_spill_bytes`] after each operation that
+    /// [`MemoryArbitrator::record_spill_bytes`] after each operation that
     /// may have spilled (build, probe finalize, repartition).
     pub(crate) fn take_spilled_bytes(&mut self) -> u64 {
         std::mem::take(&mut self.spilled_bytes)
@@ -446,7 +446,7 @@ impl GraceHashExecutor {
         &mut self,
         record: Record,
         hash: u64,
-        budget: &mut MemoryBudget,
+        budget: &mut MemoryArbitrator,
     ) -> std::io::Result<()> {
         let p = self.assigner.partition_for(hash) as usize;
         let bytes = estimated_record_bytes(&record);
@@ -508,7 +508,7 @@ impl GraceHashExecutor {
 
     /// Force-spill the largest Building partition. Returns Ok(()) when
     /// no Building partition remains (everything is already on disk).
-    fn spill_largest_building(&mut self, budget: &mut MemoryBudget) -> std::io::Result<()> {
+    fn spill_largest_building(&mut self, budget: &mut MemoryArbitrator) -> std::io::Result<()> {
         // Iterate until RSS drops below soft limit OR no Building
         // partition is left to evict. The soft limit is checked through
         // `should_spill` rather than `should_abort`: we want to catch
@@ -582,7 +582,7 @@ impl GraceHashExecutor {
         &mut self,
         extractor: &KeyExtractor,
         ctx: &EvalContext<'_>,
-        budget: &mut MemoryBudget,
+        budget: &mut MemoryArbitrator,
         combine_name: &str,
     ) -> Result<(), PipelineError> {
         for i in 0..self.partitions.len() {
@@ -1041,7 +1041,7 @@ fn process_spilled_partition(
     rc: &ReloadContext<'_>,
     sp: SpilledPartition,
     body_evaluator: &mut Option<ProgramEvaluator>,
-    budget: &mut MemoryBudget,
+    budget: &mut MemoryArbitrator,
     output: &mut Vec<(Record, RecordOrder)>,
 ) -> Result<(), PipelineError> {
     let name = rc.name;
@@ -1402,7 +1402,7 @@ pub(crate) struct BnlStats {
     /// [`CombineHashTable::memory_bytes`].
     pub peak_chunk_table_bytes: usize,
     /// Number of times the fallback hit a 10 K-record output batch
-    /// boundary and polled [`MemoryBudget::should_abort`].
+    /// boundary and polled [`MemoryArbitrator::should_abort`].
     pub batches_emitted: usize,
     /// Largest single-chunk record count.
     pub peak_chunk_records: usize,
@@ -1481,7 +1481,7 @@ impl Iterator for BuildChunkIter {
 ///     chunk it's `M * chunk_keys`, so the result-batch poll happens
 ///     between every 10 K matches.
 ///
-/// On [`MemoryBudget::should_abort`] returning true at any tier
+/// On [`MemoryArbitrator::should_abort`] returning true at any tier
 /// (chunk-table construction, between batches), the function returns
 /// an E310 [`PipelineError::Compilation`] carrying the partition_id
 /// and the HLL-derived approximate distinct-key count.
@@ -1490,7 +1490,7 @@ fn bnl_fallback(
     sp: &SpilledPartition,
     build_records: Vec<Record>,
     body_evaluator: &mut Option<ProgramEvaluator>,
-    budget: &mut MemoryBudget,
+    budget: &mut MemoryArbitrator,
     output: &mut Vec<(Record, RecordOrder)>,
     stats: &mut BnlStats,
 ) -> Result<(), PipelineError> {
@@ -1640,7 +1640,7 @@ fn combine_e310_partition_aborted(
     transform: &str,
     partition_id: u16,
     approx_distinct: u64,
-    budget: &MemoryBudget,
+    budget: &MemoryArbitrator,
 ) -> PipelineError {
     PipelineError::MemoryBudgetExceeded {
         node: transform.to_string(),
@@ -1977,8 +1977,8 @@ mod tests {
     /// `limit` is 10 GiB so RSS-vs-hard-limit always falls inside;
     /// `spill_threshold_pct` is set so soft limit = 1 KiB, well below
     /// any host's resident set.
-    fn tiny_budget() -> MemoryBudget {
-        MemoryBudget::new(10 * 1024 * 1024 * 1024, 0.000_001)
+    fn tiny_budget() -> MemoryArbitrator {
+        MemoryArbitrator::new(10 * 1024 * 1024 * 1024, 0.000_001)
     }
 
     #[test]
@@ -2033,7 +2033,7 @@ mod tests {
         let schema = schema_with(&["k"]);
         // Deposit a record and force a spill so a file actually exists.
         let rec = record_for(&schema, vec![Value::Integer(7)]);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         exec.add_build_record(rec, 0, &mut budget).unwrap();
         exec.spill_partition(0).unwrap();
         let spilled_inside = std::fs::read_dir(&pipeline_path).unwrap().count();
@@ -2065,7 +2065,7 @@ mod tests {
             let mut exec = GraceHashExecutor::new(4, pipeline_dir.path()).unwrap();
             let schema = schema_with(&["k"]);
             let rec = record_for(&schema, vec![Value::Integer(99)]);
-            let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+            let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
             exec.add_build_record(rec, 0, &mut budget).unwrap();
             exec.spill_partition(0).unwrap();
             panic!("simulated mid-spill panic");
@@ -2288,7 +2288,7 @@ mod tests {
         let stable = StableEvalContext::test_default();
         let source_file: Arc<str> = Arc::from("test.csv");
         let ctx = EvalContext::test_with_file(&stable, &source_file, 0);
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
 
         // Drive everything through grace hash. body_program=None so
         // the synthetic-step concatenation path is exercised; that's
@@ -2477,7 +2477,7 @@ mod tests {
         // threshold so should_spill fires immediately (process RSS
         // far exceeds 1 KiB on any host). This decouples spill
         // activation from build abort.
-        let mut budget = MemoryBudget::new(10 * 1024 * 1024 * 1024, 0.000_001);
+        let mut budget = MemoryArbitrator::new(10 * 1024 * 1024 * 1024, 0.000_001);
 
         let mut combined_schema_builder = clinker_record::SchemaBuilder::new();
         combined_schema_builder = combined_schema_builder.with_field("dk");
@@ -2654,7 +2654,7 @@ mod tests {
         // Memory hard limit huge so should_abort never fires; spill
         // threshold tiny so spills happen; disk quota tight so the
         // first partition flush trips it.
-        let mut budget = MemoryBudget::new(10 * 1024 * 1024 * 1024, 0.000_001);
+        let mut budget = MemoryArbitrator::new(10 * 1024 * 1024 * 1024, 0.000_001);
         budget.max_spill_bytes = 64;
 
         let combined_schema = clinker_record::SchemaBuilder::new()
@@ -2721,7 +2721,7 @@ mod tests {
             .tempdir()
             .unwrap();
         let mut exec = GraceHashExecutor::new(2, dir.path()).unwrap();
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80); // never spills via budget
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80); // never spills via budget
         let originals: Vec<Record> = (0..16i64)
             .map(|i| {
                 record_for(
@@ -3075,7 +3075,7 @@ mod tests {
         // Now drive BNL directly and confirm it produces the expected
         // 5 driver × 200 build = 1000 join rows.
         let mut output: Vec<(Record, RecordOrder)> = Vec::new();
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let mut stats = BnlStats::default();
         let mut body_eval: Option<ProgramEvaluator> = None;
         with_reload_context(&h, |rc| {
@@ -3129,7 +3129,7 @@ mod tests {
 
         // Force a small chunk budget so the chunked path actually
         // splits the build into pieces (not a single chunk).
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let mut output: Vec<(Record, RecordOrder)> = Vec::new();
         let mut stats = BnlStats::default();
         let mut body_eval: Option<ProgramEvaluator> = None;
@@ -3209,7 +3209,7 @@ mod tests {
         // floor kicks in). spill_threshold_pct expresses soft as a
         // fraction of hard.
         let target_soft = (PROBE_BUFFER_RESERVATION as f64) / 2.0; // ~2 MB < reservation
-        let mut budget = MemoryBudget::new(u64::MAX, target_soft / (u64::MAX as f64));
+        let mut budget = MemoryArbitrator::new(u64::MAX, target_soft / (u64::MAX as f64));
         let mut output: Vec<(Record, RecordOrder)> = Vec::new();
         let mut stats = BnlStats::default();
         let mut body_eval: Option<ProgramEvaluator> = None;
@@ -3248,7 +3248,7 @@ mod tests {
         // (soft - reservation) / 2 value. hard_limit stays at u64::MAX
         // so should_abort cannot fire on RSS.
         let big_soft = (PROBE_BUFFER_RESERVATION as u64) * 8;
-        let mut big_budget = MemoryBudget::new(u64::MAX, (big_soft as f64) / (u64::MAX as f64));
+        let mut big_budget = MemoryArbitrator::new(u64::MAX, (big_soft as f64) / (u64::MAX as f64));
         let sp2 = spill_for_bnl(
             &h,
             &(0..10i64)
@@ -3332,7 +3332,7 @@ mod tests {
             .collect();
         let sp = spill_for_bnl(&h, &builds, &probes, 0, 2);
 
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = MemoryArbitrator::new(u64::MAX, 0.80);
         let mut output: Vec<(Record, RecordOrder)> = Vec::new();
         let mut stats = BnlStats::default();
         let mut body_eval: Option<ProgramEvaluator> = None;
@@ -3394,7 +3394,7 @@ mod tests {
         let sp = spill_for_bnl(&h, &builds, &probes, 7, 2);
 
         // 1-byte hard limit → should_abort fires immediately.
-        let mut budget = MemoryBudget::new(1, 1.0);
+        let mut budget = MemoryArbitrator::new(1, 1.0);
         let mut output: Vec<(Record, RecordOrder)> = Vec::new();
         let mut stats = BnlStats::default();
         let mut body_eval: Option<ProgramEvaluator> = None;

--- a/crates/clinker-core/src/pipeline/grace_spill.rs
+++ b/crates/clinker-core/src/pipeline/grace_spill.rs
@@ -120,7 +120,7 @@ impl GraceSpillWriter {
     /// Finalize the LZ4 frame, append the footer, return the file
     /// path along with the byte length of the finished file.
     ///
-    /// The byte length feeds [`crate::pipeline::memory::MemoryBudget::record_spill_bytes`]
+    /// The byte length feeds [`crate::pipeline::memory::MemoryArbitrator::record_spill_bytes`]
     /// so the disk-quota poll can tally cumulative on-disk usage
     /// without re-stat'ing each finalized file.
     pub(crate) fn finish(self) -> std::io::Result<(SpillFilePath, u64)> {

--- a/crates/clinker-core/src/pipeline/iejoin.rs
+++ b/crates/clinker-core/src/pipeline/iejoin.rs
@@ -32,7 +32,7 @@
 //!
 //! **Memory model:** the IEJoin scan materializes both partition sides,
 //! the L1/L2 vectors (`signed_idx, op1_key, op2_key` triples), the
-//! permutation P, and the bit array. The caller's [`MemoryBudget`] is
+//! permutation P, and the bit array. The caller's [`MemoryArbitrator`] is
 //! polled every 10K emitted matched pairs; abort returns a typed
 //! `PipelineError::MemoryBudgetExceeded` carrying the combine node's
 //! name and `BudgetCategory::Arena` — the same shape every other
@@ -53,7 +53,7 @@ use crate::error::PipelineError;
 use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
 use crate::pipeline::combine::{KeyExtractor, hash_composite_key, keys_equal_canonicalized};
-use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
+use crate::pipeline::memory::{BudgetCategory, MemoryArbitrator};
 use crate::plan::combine::{DecomposedPredicate, RangeOp};
 
 /// Cap on matches collected per driver under [`MatchMode::Collect`].
@@ -61,7 +61,7 @@ use crate::plan::combine::{DecomposedPredicate, RangeOp};
 /// truncate at the same threshold.
 const COLLECT_PER_GROUP_CAP: usize = 10_000;
 
-/// Period (matched pairs emitted) between [`MemoryBudget::should_abort`]
+/// Period (matched pairs emitted) between [`MemoryArbitrator::should_abort`]
 /// polls during the IEJoin scan. Same cadence as the hash probe loop.
 const MEMORY_CHECK_INTERVAL: usize = 10_000;
 
@@ -423,7 +423,7 @@ pub(crate) struct IEJoinExec<'a> {
     /// the shared `copy_build_ck_columns` helper at every emit site.
     pub propagate_ck: &'a crate::config::pipeline_node::PropagateCkSpec,
     pub ctx: &'a EvalContext<'a>,
-    pub budget: &'a mut MemoryBudget,
+    pub budget: &'a mut MemoryArbitrator,
 }
 
 pub(crate) fn execute_combine_iejoin(

--- a/crates/clinker-core/src/pipeline/memory.rs
+++ b/crates/clinker-core/src/pipeline/memory.rs
@@ -1,4 +1,4 @@
-//! Cross-platform RSS tracking and memory budget for spill decisions.
+//! Cross-platform RSS tracking and the central memory arbitrator.
 //!
 //! `rss_bytes()` returns the current process RSS via platform-native APIs:
 //! - Linux: `/proc/self/statm` (resident pages × page size)
@@ -6,9 +6,17 @@
 //! - Windows: `K32GetProcessMemoryInfo` via `windows-sys` (pure Rust FFI)
 //! - Unsupported: returns `None`
 //!
-//! `MemoryBudget` governs spill decisions: `should_spill()` returns true when
-//! RSS exceeds `limit * spill_threshold_pct`. Polled once per chunk at the
-//! start of Phase 2 processing.
+//! `MemoryArbitrator` is the single seat that governs every spill / abort
+//! decision in the executor. Each spill-capable operator (Aggregate, sort,
+//! grace-hash, sort-merge join, IEJoin, inter-stage `node_buffers`) polls
+//! the same arbitrator instance and trusts its `should_spill` /
+//! `should_abort` answer. The trait surface (`MemoryConsumer`,
+//! `ArbitrationPolicy`) lets later work plug in policies that pick a
+//! victim across operators instead of reacting independently. Until a
+//! real policy is installed, the arbitrator ships with `NoOpPolicy`,
+//! which preserves the pre-existing react-only behavior byte-for-byte.
+
+use std::collections::HashMap;
 
 /// Cross-platform RSS measurement. Returns `None` on unsupported platforms.
 pub fn rss_bytes() -> Option<u64> {
@@ -88,7 +96,7 @@ fn rss_bytes_impl() -> Option<u64> {
     None
 }
 
-/// Discriminant tag carried on every `MemoryBudget` charge so a budget
+/// Discriminant tag carried on every arbitrator charge so a budget
 /// overflow can name which surface tripped the hard limit. Sources are
 /// summed against the single `limit` counter; the tag is for
 /// diagnostics and downstream routing only.
@@ -97,14 +105,15 @@ fn rss_bytes_impl() -> Option<u64> {
 /// `MemoryBudgetExceeded` consumer that destructures `source`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum BudgetCategory {
-    /// Source-rooted Phase-0 arena, node-rooted arenas, deferred-region
+    /// Source-rooted arenas, node-rooted arenas, deferred-region
     /// admission buffers, grace-hash build/probe accounting, and the
     /// disk-spill quota counter. Every budget-tracked allocation that
     /// is not `ctx.node_buffers` falls under this tag.
     Arena,
     /// `ctx.node_buffers` — the inter-stage handoff layer between
-    /// non-fused operators. Not wired to the budget today; reserved
-    /// for the upcoming sub-issues that charge node-buffer mutations.
+    /// non-fused operators. Charged at producer admission, discharged
+    /// at consumer drain; shares the same `limit` envelope as
+    /// `BudgetCategory::Arena` through `total_charged()`.
     NodeBuffer,
 }
 
@@ -117,47 +126,179 @@ impl std::fmt::Display for BudgetCategory {
     }
 }
 
-/// Memory budget governing spill decisions.
+/// Stable identifier for a memory consumer registered with the
+/// arbitrator. Assigned by `MemoryArbitrator` at registration time and
+/// referenced by every subsequent arbitration decision.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ConsumerId(u32);
+
+/// Reason a `MemoryConsumer::try_spill` call could not free the
+/// requested number of bytes.
 ///
-/// Polled once per chunk at the start of Phase 2 processing.
-/// Streaming: RSS is the only signal. Blocking stage spill triggers
-/// (sort, distinct) are implemented in Phase 8.
+/// Distinct from `crate::pipeline::spill::SpillError`, which models
+/// disk-write and serialization failures. `ConsumerSpillError` is the
+/// arbitrator-facing signal that a victim either failed to write or
+/// could not free enough state to satisfy the target.
+#[derive(Debug)]
+pub enum ConsumerSpillError {
+    /// Underlying spill medium (disk, OS) returned an I/O error.
+    Io(std::io::Error),
+    /// Consumer ran spill to completion but freed fewer bytes than the
+    /// arbitrator requested — the caller may need to select another
+    /// victim or escalate to a hard abort.
+    BelowTarget { target: u64, freed: u64 },
+}
+
+impl std::fmt::Display for ConsumerSpillError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "consumer spill I/O failure: {e}"),
+            Self::BelowTarget { target, freed } => write!(
+                f,
+                "consumer freed {freed} bytes; arbitrator requested {target}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ConsumerSpillError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::BelowTarget { .. } => None,
+        }
+    }
+}
+
+/// Memory-consuming operator that the arbitrator can interrogate and,
+/// when a policy elects it, ask to give up memory.
 ///
-/// `max_spill_bytes` adds an optional disk-spill quota distinct from
-/// the RSS hard limit: even when memory pressure is fine, an unbounded
-/// stream of spill files can still exhaust local disk. Operators that
-/// already poll `should_spill()` poll `record_spill_bytes()` after each
-/// spill commit; on overflow the operator surfaces E310 with a partition
-/// + spill-bytes diagnostic rather than continuing to fill the disk.
-pub struct MemoryBudget {
+/// Implementations live with their operator (Aggregate, sort,
+/// grace-hash, sort-merge join, IEJoin, inter-stage buffers). The
+/// arbitrator stores them as `Box<dyn MemoryConsumer>` and reads
+/// `current_usage` / `spill_priority` / `can_back_pressure` on every
+/// arbitration round; `pause` / `resume` / `try_spill` fire only when
+/// a policy selects the consumer as a victim.
+///
+/// `Send + Sync` so the arbitrator can be shared across worker threads
+/// without compromising the existing pipeline-context concurrency
+/// posture.
+pub trait MemoryConsumer: Send + Sync {
+    /// Live bytes the consumer currently holds against the arbitrator's
+    /// `limit` envelope. Read every arbitration round; must be cheap.
+    fn current_usage(&self) -> u64;
+
+    /// Relative spill cost. Lower = spill first. The arbitrator's
+    /// policy uses this when comparing victims of similar size.
+    /// Convention: `0` for cheap-to-spill consumers
+    /// (`ctx.node_buffers`), `10` for grace-hash, `20` for sort,
+    /// `30` for Aggregate.
+    fn spill_priority(&self) -> i32;
+
+    /// Best-effort attempt to release `target_bytes` of live state to
+    /// disk. Returns the actual number of bytes freed, which may be
+    /// less than `target_bytes` (the policy then re-selects).
+    fn try_spill(&mut self, target_bytes: u64) -> Result<u64, ConsumerSpillError>;
+
+    /// Whether the consumer can be paused at its inbound channel
+    /// instead of forced to spill. True for Sources and inter-stage
+    /// buffers fronted by a bounded channel; false for blocking
+    /// operators that have no upstream to gate.
+    fn can_back_pressure(&self) -> bool;
+
+    /// Pause the consumer's inbound channel. No-op for consumers that
+    /// return `false` from `can_back_pressure`.
+    fn pause(&mut self);
+
+    /// Resume a previously paused consumer.
+    fn resume(&mut self);
+}
+
+/// Policy that selects which `MemoryConsumer` gives up memory when
+/// the arbitrator reports pressure.
+///
+/// Returning `None` is a vote to take no action (e.g. `NoOpPolicy`,
+/// or a real policy that decides current pressure is transient).
+pub trait ArbitrationPolicy: Send + Sync {
+    /// Pick a victim from the candidates the arbitrator currently
+    /// has registered. `pressure_bytes` is the gap between observed
+    /// RSS and the soft limit at the moment the arbitrator polled.
+    fn select_victim(
+        &self,
+        consumers: &[(ConsumerId, &dyn MemoryConsumer)],
+        pressure_bytes: u64,
+    ) -> Option<ConsumerId>;
+}
+
+/// Policy that selects no victim under any pressure.
+///
+/// Default policy on every freshly constructed arbitrator. Preserves
+/// pre-arbitrator react-only behavior: every operator continues to
+/// poll `should_spill` / `should_abort` and decides for itself.
+/// Replaced at runtime once a real `ArbitrationPolicy` is installed.
+pub struct NoOpPolicy;
+
+impl ArbitrationPolicy for NoOpPolicy {
+    fn select_victim(
+        &self,
+        _consumers: &[(ConsumerId, &dyn MemoryConsumer)],
+        _pressure_bytes: u64,
+    ) -> Option<ConsumerId> {
+        None
+    }
+}
+
+/// Central memory arbitrator. Owns the RSS hard / soft limits, the
+/// per-category byte counters (arena, node-buffer, disk spill), and
+/// the policy + consumer registry used to elect spill victims.
+///
+/// `should_spill` is the single polling entry used by every spill-
+/// capable operator. It updates `peak_rss`, consults the registered
+/// `ArbitrationPolicy`, and reports whether the soft threshold has
+/// been crossed. `should_abort` mirrors the same check against the
+/// hard `limit`.
+///
+/// `max_spill_bytes` is a disk-spill quota distinct from the RSS
+/// envelope: even when RSS is fine, an unbounded stream of spill
+/// files can still exhaust local disk. Operators poll
+/// `record_spill_bytes` after each commit; on overflow the operator
+/// surfaces E310 with a partition + spill-bytes diagnostic instead
+/// of continuing to fill the disk.
+pub struct MemoryArbitrator {
     /// Total memory limit in bytes (the hard limit). Default: 512MB.
     pub limit: u64,
-    /// Fraction of limit at which proactive spill triggers (the soft limit).
-    /// Default: 0.80. Dual-threshold model: 80% soft / 100% hard / 20% spike
-    /// allowance — OTel Memory Limiter consensus.
+    /// Fraction of limit at which proactive spill triggers (the soft
+    /// limit). Default: 0.80. Dual-threshold model: 80% soft / 100%
+    /// hard / 20% spike allowance — OTel Memory Limiter consensus.
     pub spill_threshold_pct: f64,
-    /// Peak RSS observed across all `observe()` / `should_spill()` calls.
-    /// `None` on platforms where RSS measurement is unavailable.
+    /// Peak RSS observed across all `observe()` / `should_spill()`
+    /// calls. `None` on platforms where RSS measurement is
+    /// unavailable.
     pub peak_rss: Option<u64>,
     /// Optional disk-spill quota in bytes. `u64::MAX` = unlimited.
     /// Polled by spill operators alongside `should_spill()`. When
-    /// cumulative spill bytes exceed this value, the operator emits
+    /// cumulative spill bytes exceed this value the operator emits
     /// E310 with a partition + spill-bytes diagnostic.
     pub max_spill_bytes: u64,
     cumulative_spill_bytes: u64,
-    /// Cumulative bytes charged across every Arena build site sharing this
-    /// budget. Source arena + N node-rooted arenas share one cumulative
-    /// counter so a pipeline declaring a 512MB limit cannot multiply that
-    /// limit across operators.
+    /// Cumulative bytes charged across every Arena build site sharing
+    /// this arbitrator. The source-rooted arena and every node-rooted
+    /// arena share one counter so a pipeline declaring a 512MB limit
+    /// cannot multiply that limit across operators.
     arena_bytes_charged: u64,
     /// Cumulative bytes alive in the inter-stage handoff layer between
-    /// non-fused DAG operators. Counted toward the same `limit` envelope
-    /// as `arena_bytes_charged` via `total_charged()` — the declared
-    /// memory limit is a pipeline-wide ceiling, not per-surface.
+    /// non-fused DAG operators. Summed with `arena_bytes_charged` via
+    /// `total_charged()` — the declared memory limit is a
+    /// pipeline-wide ceiling, not per-surface.
     node_buffer_bytes_charged: u64,
+    consumers: HashMap<ConsumerId, Box<dyn MemoryConsumer>>,
+    policy: Box<dyn ArbitrationPolicy>,
 }
 
-impl MemoryBudget {
+impl MemoryArbitrator {
+    /// Build an arbitrator with `limit` bytes hard ceiling and
+    /// `spill_threshold_pct` soft-limit fraction. Ships with
+    /// `NoOpPolicy` and no registered consumers.
     pub fn new(limit: u64, spill_threshold_pct: f64) -> Self {
         Self {
             limit,
@@ -167,45 +308,57 @@ impl MemoryBudget {
             cumulative_spill_bytes: 0,
             arena_bytes_charged: 0,
             node_buffer_bytes_charged: 0,
+            consumers: HashMap::new(),
+            policy: Box::new(NoOpPolicy),
         }
     }
 
-    /// Build from config memory_limit string ("512M", "2G", raw bytes).
-    ///
-    /// Uses the 0.80 default for `spill_threshold_pct` (dual-threshold model:
-    /// 80% soft / 100% hard / 20% spike allowance). `max_spill_bytes`
-    /// defaults to `u64::MAX` (unlimited disk quota); the surface is
-    /// not yet wired to a config field — callers that want a quota
-    /// set it directly on the constructed budget.
+    /// Build from config `memory_limit` string ("512M", "2G", raw
+    /// bytes). Uses the 0.80 default for `spill_threshold_pct`
+    /// (80% soft / 100% hard / 20% spike allowance).
+    /// `max_spill_bytes` defaults to `u64::MAX` (unlimited disk
+    /// quota); callers that want a quota set it directly on the
+    /// constructed arbitrator.
     pub fn from_config(memory_limit: Option<&str>) -> Self {
         let limit = parse_memory_limit_bytes(memory_limit);
         Self::new(limit, 0.80)
     }
 
-    /// Poll current RSS and update `peak_rss` if it exceeds the recorded peak.
-    /// Called at chunk boundaries during Phase 2; also called by `should_spill()`.
+    /// Poll current RSS and update `peak_rss` if it exceeds the
+    /// recorded peak. Called at chunk boundaries by every spill-
+    /// capable operator; also called from `should_spill()` and
+    /// `should_abort()`.
     pub fn observe(&mut self) {
         if let Some(rss) = rss_bytes() {
             self.peak_rss = Some(self.peak_rss.map_or(rss, |prev| prev.max(rss)));
         }
     }
 
-    /// Returns true when current RSS exceeds the spill threshold.
-    /// Also updates `peak_rss` as a side-effect.
-    /// Returns false if RSS cannot be measured (unsupported platform).
+    /// True when current RSS exceeds the soft spill threshold. Also
+    /// updates `peak_rss` as a side-effect and runs one arbitration
+    /// round (the round is a no-op under `NoOpPolicy`). False when
+    /// RSS cannot be measured.
     pub fn should_spill(&mut self) -> bool {
         self.observe();
-        self.peak_rss
-            .is_some_and(|rss| rss > (self.limit as f64 * self.spill_threshold_pct) as u64)
+        let tripped = self.peak_rss.is_some_and(|rss| rss > self.soft_limit());
+        if tripped {
+            // The result is intentionally discarded: real
+            // victim selection lands once non-trivial policies and
+            // consumer registrations exist. `NoOpPolicy` always
+            // returns `None`, so behavior is byte-for-byte identical
+            // to the pre-arbitrator code path.
+            let _ = self.poll_arbitration();
+        }
+        tripped
     }
 
-    /// Spill threshold in absolute bytes.
+    /// Soft spill threshold in absolute bytes.
     pub fn spill_threshold_bytes(&self) -> u64 {
-        (self.limit as f64 * self.spill_threshold_pct) as u64
+        self.soft_limit()
     }
 
-    /// Soft limit: point at which proactive spill begins.
-    /// Equals limit * spill_threshold_pct (default 0.80).
+    /// Soft limit: point at which proactive spill begins. Equals
+    /// `limit * spill_threshold_pct` (default 0.80).
     pub fn soft_limit(&self) -> u64 {
         (self.limit as f64 * self.spill_threshold_pct) as u64
     }
@@ -220,20 +373,21 @@ impl MemoryBudget {
         self.hard_limit() - self.soft_limit()
     }
 
-    /// True when RSS exceeds hard limit. Check periodically in probe loops
-    /// (every 10K output records) to prevent unbounded fan-out.
+    /// True when RSS exceeds the hard limit. Check periodically in
+    /// probe loops (every 10K output records) to prevent unbounded
+    /// fan-out from blowing the ceiling between spill polls.
     pub fn should_abort(&mut self) -> bool {
         self.observe();
         self.peak_rss.is_some_and(|rss| rss > self.limit)
     }
 
-    /// Disk-spill quota in bytes. `u64::MAX` indicates unlimited.
+    /// Disk-spill quota in bytes. `u64::MAX` = unlimited.
     pub fn disk_quota(&self) -> u64 {
         self.max_spill_bytes
     }
 
     /// Cumulative spill bytes recorded so far across every spill
-    /// operator polling this budget.
+    /// operator polling this arbitrator.
     pub fn cumulative_spill_bytes(&self) -> u64 {
         self.cumulative_spill_bytes
     }
@@ -255,17 +409,17 @@ impl MemoryBudget {
     /// overflowing accumulation cannot wrap below the limit and
     /// silently disable the gate.
     ///
-    /// One shared counter across the source-rooted Phase-0 arena and
-    /// every node-rooted arena built at an upstream operator's
-    /// dispatch-arm exit: the pipeline's declared memory limit is a
-    /// pipeline-wide envelope, not a per-arena one.
+    /// One shared counter across the source-rooted arena and every
+    /// node-rooted arena built at an upstream operator's dispatch-arm
+    /// exit: the pipeline's declared memory limit is a pipeline-wide
+    /// envelope, not a per-arena one.
     pub fn charge_arena_bytes(&mut self, n: u64) -> bool {
         self.arena_bytes_charged = self.arena_bytes_charged.saturating_add(n);
         self.arena_bytes_charged > self.limit
     }
 
     /// Cumulative arena bytes charged so far across every Arena build
-    /// site polling this budget.
+    /// site polling this arbitrator.
     pub fn arena_bytes_charged(&self) -> u64 {
         self.arena_bytes_charged
     }
@@ -292,7 +446,7 @@ impl MemoryBudget {
     }
 
     /// Cumulative node-buffer bytes currently alive across every
-    /// `ctx.node_buffers` slot polling this budget.
+    /// `ctx.node_buffers` slot polling this arbitrator.
     pub fn node_buffer_bytes_charged(&self) -> u64 {
         self.node_buffer_bytes_charged
     }
@@ -308,10 +462,26 @@ impl MemoryBudget {
         self.arena_bytes_charged
             .saturating_add(self.node_buffer_bytes_charged)
     }
+
+    /// Run one arbitration round and return the elected victim, if
+    /// any. Used internally by `should_spill`; real callers will
+    /// land once policies and consumer registrations exist. With
+    /// `NoOpPolicy` and an empty consumer registry the call is a
+    /// cheap loop over zero entries and always returns `None`.
+    fn poll_arbitration(&mut self) -> Option<ConsumerId> {
+        let pressure = self.peak_rss.unwrap_or(0).saturating_sub(self.soft_limit());
+        let snapshot: Vec<(ConsumerId, &dyn MemoryConsumer)> = self
+            .consumers
+            .iter()
+            .map(|(id, consumer)| (*id, consumer.as_ref()))
+            .collect();
+        self.policy.select_victim(&snapshot, pressure)
+    }
 }
 
-/// Parse memory limit string to bytes. Supports "512M", "2G", "512m", "2g",
-/// raw integer string. Returns 512MB default if None or unparseable.
+/// Parse memory limit string to bytes. Supports "512M", "2G",
+/// "512m", "2g", raw integer string. Returns 512MB default if
+/// `None` or unparseable.
 pub fn parse_memory_limit_bytes(s: Option<&str>) -> u64 {
     s.and_then(|s| {
         let s = s.trim();
@@ -361,71 +531,71 @@ mod tests {
     }
 
     #[test]
-    fn test_memory_budget_below_threshold() {
-        let mut budget = MemoryBudget::new(512 * 1024 * 1024, 0.80);
+    fn test_memory_arbitrator_below_threshold() {
+        let mut arbitrator = MemoryArbitrator::new(512 * 1024 * 1024, 0.80);
         // Test process RSS should be well under 410MB (80% of 512MB)
         if rss_bytes().is_some() {
-            assert!(!budget.should_spill());
+            assert!(!arbitrator.should_spill());
         }
     }
 
     #[test]
-    fn test_memory_budget_above_threshold() {
-        // Budget of 1MB — any running process exceeds this
-        let mut budget = MemoryBudget::new(1024 * 1024, 0.80);
+    fn test_memory_arbitrator_above_threshold() {
+        // Limit of 1MB — any running process exceeds this
+        let mut arbitrator = MemoryArbitrator::new(1024 * 1024, 0.80);
         if rss_bytes().is_some() {
-            assert!(budget.should_spill());
+            assert!(arbitrator.should_spill());
         }
     }
 
     #[test]
-    fn test_memory_budget_peak_rss_tracked() {
-        let mut budget = MemoryBudget::new(512 * 1024 * 1024, 0.80);
+    fn test_memory_arbitrator_peak_rss_tracked() {
+        let mut arbitrator = MemoryArbitrator::new(512 * 1024 * 1024, 0.80);
         if rss_bytes().is_none() {
             return; // Skip on unsupported platforms
         }
-        budget.observe();
+        arbitrator.observe();
         assert!(
-            budget.peak_rss.is_some(),
+            arbitrator.peak_rss.is_some(),
             "peak_rss should be set after observe()"
         );
-        let first_peak = budget.peak_rss.unwrap();
-        budget.observe();
+        let first_peak = arbitrator.peak_rss.unwrap();
+        arbitrator.observe();
         // Peak must be non-decreasing
-        assert!(budget.peak_rss.unwrap() >= first_peak);
+        assert!(arbitrator.peak_rss.unwrap() >= first_peak);
     }
 
     #[test]
-    fn test_memory_budget_default_values() {
-        let budget = MemoryBudget::from_config(None);
-        assert_eq!(budget.limit, 512 * 1024 * 1024);
-        assert!((budget.spill_threshold_pct - 0.80).abs() < f64::EPSILON);
+    fn test_memory_arbitrator_default_values() {
+        let arbitrator = MemoryArbitrator::from_config(None);
+        assert_eq!(arbitrator.limit, 512 * 1024 * 1024);
+        assert!((arbitrator.spill_threshold_pct - 0.80).abs() < f64::EPSILON);
     }
 
     #[test]
     fn test_disk_quota_default_unlimited() {
-        let budget = MemoryBudget::new(512 * 1024 * 1024, 0.80);
-        assert_eq!(budget.disk_quota(), u64::MAX);
-        assert_eq!(budget.cumulative_spill_bytes(), 0);
+        let arbitrator = MemoryArbitrator::new(512 * 1024 * 1024, 0.80);
+        assert_eq!(arbitrator.disk_quota(), u64::MAX);
+        assert_eq!(arbitrator.cumulative_spill_bytes(), 0);
     }
 
     #[test]
     fn test_record_spill_bytes_under_quota() {
-        let mut budget = MemoryBudget::new(512 * 1024 * 1024, 0.80);
-        budget.max_spill_bytes = 1024;
-        assert!(!budget.record_spill_bytes(256));
-        assert_eq!(budget.cumulative_spill_bytes(), 256);
-        assert!(!budget.record_spill_bytes(512));
-        assert_eq!(budget.cumulative_spill_bytes(), 768);
+        let mut arbitrator = MemoryArbitrator::new(512 * 1024 * 1024, 0.80);
+        arbitrator.max_spill_bytes = 1024;
+        assert!(!arbitrator.record_spill_bytes(256));
+        assert_eq!(arbitrator.cumulative_spill_bytes(), 256);
+        assert!(!arbitrator.record_spill_bytes(512));
+        assert_eq!(arbitrator.cumulative_spill_bytes(), 768);
     }
 
     #[test]
     fn test_record_spill_bytes_overflows_quota() {
-        let mut budget = MemoryBudget::new(512 * 1024 * 1024, 0.80);
-        budget.max_spill_bytes = 1024;
-        assert!(!budget.record_spill_bytes(1024));
-        assert!(budget.record_spill_bytes(1));
-        assert_eq!(budget.cumulative_spill_bytes(), 1025);
+        let mut arbitrator = MemoryArbitrator::new(512 * 1024 * 1024, 0.80);
+        arbitrator.max_spill_bytes = 1024;
+        assert!(!arbitrator.record_spill_bytes(1024));
+        assert!(arbitrator.record_spill_bytes(1));
+        assert_eq!(arbitrator.cumulative_spill_bytes(), 1025);
     }
 
     #[test]
@@ -433,11 +603,11 @@ mod tests {
         // Saturating-add on a u64 counter: even an absurdly large
         // accumulation cannot wrap below the configured quota and
         // silently disable the gate.
-        let mut budget = MemoryBudget::new(512 * 1024 * 1024, 0.80);
-        budget.max_spill_bytes = 1024;
-        budget.cumulative_spill_bytes = u64::MAX - 10;
-        assert!(budget.record_spill_bytes(100));
-        assert_eq!(budget.cumulative_spill_bytes(), u64::MAX);
+        let mut arbitrator = MemoryArbitrator::new(512 * 1024 * 1024, 0.80);
+        arbitrator.max_spill_bytes = 1024;
+        arbitrator.cumulative_spill_bytes = u64::MAX - 10;
+        assert!(arbitrator.record_spill_bytes(100));
+        assert_eq!(arbitrator.cumulative_spill_bytes(), u64::MAX);
     }
 
     #[test]
@@ -460,19 +630,19 @@ mod tests {
 
     #[test]
     fn test_charge_node_buffer_bytes_increases_counter() {
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
-        assert!(!budget.charge_node_buffer_bytes(256));
-        assert_eq!(budget.node_buffer_bytes_charged(), 256);
-        assert!(!budget.charge_node_buffer_bytes(512));
-        assert_eq!(budget.node_buffer_bytes_charged(), 768);
+        let mut arbitrator = MemoryArbitrator::new(u64::MAX, 0.80);
+        assert!(!arbitrator.charge_node_buffer_bytes(256));
+        assert_eq!(arbitrator.node_buffer_bytes_charged(), 256);
+        assert!(!arbitrator.charge_node_buffer_bytes(512));
+        assert_eq!(arbitrator.node_buffer_bytes_charged(), 768);
     }
 
     #[test]
     fn test_discharge_node_buffer_bytes_decreases_counter() {
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
-        budget.charge_node_buffer_bytes(1024);
-        budget.discharge_node_buffer_bytes(256);
-        assert_eq!(budget.node_buffer_bytes_charged(), 768);
+        let mut arbitrator = MemoryArbitrator::new(u64::MAX, 0.80);
+        arbitrator.charge_node_buffer_bytes(1024);
+        arbitrator.discharge_node_buffer_bytes(256);
+        assert_eq!(arbitrator.node_buffer_bytes_charged(), 768);
     }
 
     #[test]
@@ -480,16 +650,16 @@ mod tests {
         // Estimate drift between producer's charge and consumer's
         // discharge must not wrap the counter to a huge positive
         // value and silently disable the gate downstream.
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
-        budget.charge_node_buffer_bytes(100);
-        budget.discharge_node_buffer_bytes(200);
-        assert_eq!(budget.node_buffer_bytes_charged(), 0);
+        let mut arbitrator = MemoryArbitrator::new(u64::MAX, 0.80);
+        arbitrator.charge_node_buffer_bytes(100);
+        arbitrator.discharge_node_buffer_bytes(200);
+        assert_eq!(arbitrator.node_buffer_bytes_charged(), 0);
     }
 
     #[test]
     fn test_charge_node_buffer_bytes_under_limit_returns_false() {
-        let mut budget = MemoryBudget::new(1024, 0.80);
-        assert!(!budget.charge_node_buffer_bytes(256));
+        let mut arbitrator = MemoryArbitrator::new(1024, 0.80);
+        assert!(!arbitrator.charge_node_buffer_bytes(256));
     }
 
     #[test]
@@ -497,17 +667,17 @@ mod tests {
         // Strict `>` semantics: exactly at the limit is NOT an
         // overflow, matching `record_spill_bytes` and
         // `charge_arena_bytes`. Only the byte that crosses trips.
-        let mut budget = MemoryBudget::new(1024, 0.80);
-        assert!(!budget.charge_node_buffer_bytes(1024));
-        assert_eq!(budget.node_buffer_bytes_charged(), 1024);
+        let mut arbitrator = MemoryArbitrator::new(1024, 0.80);
+        assert!(!arbitrator.charge_node_buffer_bytes(1024));
+        assert_eq!(arbitrator.node_buffer_bytes_charged(), 1024);
     }
 
     #[test]
     fn test_charge_node_buffer_bytes_over_limit_returns_true() {
-        let mut budget = MemoryBudget::new(1024, 0.80);
-        assert!(!budget.charge_node_buffer_bytes(1024));
-        assert!(budget.charge_node_buffer_bytes(1));
-        assert_eq!(budget.node_buffer_bytes_charged(), 1025);
+        let mut arbitrator = MemoryArbitrator::new(1024, 0.80);
+        assert!(!arbitrator.charge_node_buffer_bytes(1024));
+        assert!(arbitrator.charge_node_buffer_bytes(1));
+        assert_eq!(arbitrator.node_buffer_bytes_charged(), 1025);
     }
 
     #[test]
@@ -516,11 +686,11 @@ mod tests {
         // envelope with the arena counter. Neither one alone exceeds
         // the limit, but their sum does — and the node-buffer charge
         // must surface that.
-        let mut budget = MemoryBudget::new(1024, 0.80);
-        assert!(!budget.charge_arena_bytes(800));
-        assert!(!budget.charge_node_buffer_bytes(100));
-        assert!(budget.charge_node_buffer_bytes(200));
-        assert_eq!(budget.total_charged(), 1100);
+        let mut arbitrator = MemoryArbitrator::new(1024, 0.80);
+        assert!(!arbitrator.charge_arena_bytes(800));
+        assert!(!arbitrator.charge_node_buffer_bytes(100));
+        assert!(arbitrator.charge_node_buffer_bytes(200));
+        assert_eq!(arbitrator.total_charged(), 1100);
     }
 
     #[test]
@@ -528,18 +698,18 @@ mod tests {
         // Saturating-add on a u64 counter: even an absurdly large
         // accumulation cannot wrap below the configured limit and
         // silently disable the gate.
-        let mut budget = MemoryBudget::new(1024, 0.80);
-        budget.node_buffer_bytes_charged = u64::MAX - 10;
-        assert!(budget.charge_node_buffer_bytes(100));
-        assert_eq!(budget.node_buffer_bytes_charged(), u64::MAX);
+        let mut arbitrator = MemoryArbitrator::new(1024, 0.80);
+        arbitrator.node_buffer_bytes_charged = u64::MAX - 10;
+        assert!(arbitrator.charge_node_buffer_bytes(100));
+        assert_eq!(arbitrator.node_buffer_bytes_charged(), u64::MAX);
     }
 
     #[test]
     fn test_total_charged_sums_arena_and_node_buffer() {
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
-        budget.charge_arena_bytes(400);
-        budget.charge_node_buffer_bytes(600);
-        assert_eq!(budget.total_charged(), 1000);
+        let mut arbitrator = MemoryArbitrator::new(u64::MAX, 0.80);
+        arbitrator.charge_arena_bytes(400);
+        arbitrator.charge_node_buffer_bytes(600);
+        assert_eq!(arbitrator.total_charged(), 1000);
     }
 
     #[test]
@@ -548,19 +718,131 @@ mod tests {
         // in-memory `limit` envelope. Including spill bytes in
         // `total_charged()` would double-count the spilled work
         // against the RAM budget and force premature aborts.
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
-        budget.cumulative_spill_bytes = 9999;
-        budget.charge_arena_bytes(100);
-        assert_eq!(budget.total_charged(), 100);
+        let mut arbitrator = MemoryArbitrator::new(u64::MAX, 0.80);
+        arbitrator.cumulative_spill_bytes = 9999;
+        arbitrator.charge_arena_bytes(100);
+        assert_eq!(arbitrator.total_charged(), 100);
     }
 
     #[test]
     fn test_total_charged_saturates_on_overflow() {
         // Two near-`u64::MAX` counters must not wrap the sum and
         // silently pass the `total_charged() > limit` gate.
-        let mut budget = MemoryBudget::new(u64::MAX, 0.80);
-        budget.arena_bytes_charged = u64::MAX - 10;
-        budget.node_buffer_bytes_charged = 1000;
-        assert_eq!(budget.total_charged(), u64::MAX);
+        let mut arbitrator = MemoryArbitrator::new(u64::MAX, 0.80);
+        arbitrator.arena_bytes_charged = u64::MAX - 10;
+        arbitrator.node_buffer_bytes_charged = 1000;
+        assert_eq!(arbitrator.total_charged(), u64::MAX);
+    }
+
+    /// Minimal `MemoryConsumer` used to exercise the trait surface
+    /// from inside the crate — there are no production implementers
+    /// yet; real ones land alongside operator registration.
+    struct MockConsumer {
+        usage: u64,
+        priority: i32,
+        paused: bool,
+        spill_response: u64,
+    }
+
+    impl MemoryConsumer for MockConsumer {
+        fn current_usage(&self) -> u64 {
+            self.usage
+        }
+        fn spill_priority(&self) -> i32 {
+            self.priority
+        }
+        fn try_spill(&mut self, target_bytes: u64) -> Result<u64, ConsumerSpillError> {
+            let freed = self.spill_response.min(target_bytes);
+            self.usage = self.usage.saturating_sub(freed);
+            if freed == target_bytes {
+                Ok(freed)
+            } else {
+                Err(ConsumerSpillError::BelowTarget {
+                    target: target_bytes,
+                    freed,
+                })
+            }
+        }
+        fn can_back_pressure(&self) -> bool {
+            true
+        }
+        fn pause(&mut self) {
+            self.paused = true;
+        }
+        fn resume(&mut self) {
+            self.paused = false;
+        }
+    }
+
+    #[test]
+    fn test_noop_policy_select_victim_returns_none_empty() {
+        let policy = NoOpPolicy;
+        assert!(policy.select_victim(&[], 0).is_none());
+        assert!(policy.select_victim(&[], 4096).is_none());
+    }
+
+    #[test]
+    fn test_noop_policy_select_victim_returns_none_with_candidates() {
+        let policy = NoOpPolicy;
+        let mut consumer = MockConsumer {
+            usage: 4096,
+            priority: 0,
+            paused: false,
+            spill_response: 4096,
+        };
+        let id = ConsumerId(0);
+        let consumer_ref: &dyn MemoryConsumer = &consumer;
+        assert!(policy.select_victim(&[(id, consumer_ref)], 1024).is_none());
+        // Touch every other trait method so the mock is fully exercised
+        // — this is the in-crate non-test infrastructure that 117b/c
+        // will replace.
+        assert_eq!(consumer.current_usage(), 4096);
+        assert_eq!(consumer.spill_priority(), 0);
+        assert!(consumer.can_back_pressure());
+        consumer.pause();
+        assert!(consumer.paused);
+        consumer.resume();
+        assert!(!consumer.paused);
+        assert!(consumer.try_spill(4096).is_ok());
+        let mut short = MockConsumer {
+            usage: 1024,
+            priority: 10,
+            paused: false,
+            spill_response: 100,
+        };
+        assert!(matches!(
+            short.try_spill(500),
+            Err(ConsumerSpillError::BelowTarget {
+                target: 500,
+                freed: 100
+            })
+        ));
+    }
+
+    #[test]
+    fn test_memory_arbitrator_new_installs_noop_policy() {
+        let mut arbitrator = MemoryArbitrator::new(u64::MAX, 0.80);
+        // poll_arbitration is private — exercise it through the
+        // public `should_spill` path with a deliberately tiny
+        // limit so the soft-threshold gate trips.
+        arbitrator.limit = 1;
+        arbitrator.peak_rss = Some(100);
+        // NoOpPolicy yields no victim, so should_spill still returns
+        // true (RSS-based) and no consumer state changes.
+        assert!(arbitrator.should_spill());
+        assert!(arbitrator.consumers.is_empty());
+    }
+
+    #[test]
+    fn test_consumer_spill_error_displays_io_and_below_target() {
+        let io = ConsumerSpillError::Io(std::io::Error::other("disk full"));
+        assert!(format!("{io}").contains("disk full"));
+        let short = ConsumerSpillError::BelowTarget {
+            target: 1024,
+            freed: 256,
+        };
+        let msg = format!("{short}");
+        assert!(msg.contains("256"));
+        assert!(msg.contains("1024"));
     }
 }

--- a/crates/clinker-core/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-core/src/pipeline/sort_merge_join.rs
@@ -49,7 +49,7 @@ use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
 use crate::pipeline::combine::KeyExtractor;
 use crate::pipeline::grace_spill::{GraceSpillReader, GraceSpillWriter, SpillFilePath};
-use crate::pipeline::memory::{BudgetCategory, MemoryBudget};
+use crate::pipeline::memory::{BudgetCategory, MemoryArbitrator};
 use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
 use crate::plan::combine::{DecomposedPredicate, RangeOp};
 
@@ -59,7 +59,7 @@ use crate::plan::combine::{DecomposedPredicate, RangeOp};
 /// threshold.
 const COLLECT_PER_GROUP_CAP: usize = 10_000;
 
-/// Period (matched pairs emitted) between [`MemoryBudget::should_abort`]
+/// Period (matched pairs emitted) between [`MemoryArbitrator::should_abort`]
 /// polls during the merge walk.
 const MEMORY_CHECK_INTERVAL: usize = 10_000;
 
@@ -115,7 +115,7 @@ impl MatchingRunBuffer {
 ///
 /// Returns the byte length committed to disk during this call (zero
 /// when the record stayed in memory). Caller folds the result into
-/// [`crate::pipeline::memory::MemoryBudget::record_spill_bytes`] so
+/// [`crate::pipeline::memory::MemoryArbitrator::record_spill_bytes`] so
 /// the disk-quota gate can fire on overflow.
 fn push_to_buffer(
     buf: &mut MatchingRunBuffer,
@@ -179,7 +179,7 @@ fn push_to_buffer(
 /// [`GraceSpillWriter`]. The returned path lives inside `spill_dir`;
 /// the caller's `TempDir` owns its lifetime. The byte length is
 /// returned alongside the path so the caller can fold it into
-/// [`crate::pipeline::memory::MemoryBudget::record_spill_bytes`].
+/// [`crate::pipeline::memory::MemoryArbitrator::record_spill_bytes`].
 fn write_spill_segment(
     spill_dir: &std::path::Path,
     spill_seq: &mut u32,
@@ -336,7 +336,7 @@ pub(crate) struct SortMergeExec<'a> {
     /// `copy_build_ck_columns` at each emit site.
     pub propagate_ck: &'a crate::config::pipeline_node::PropagateCkSpec,
     pub ctx: &'a EvalContext<'a>,
-    pub budget: &'a mut MemoryBudget,
+    pub budget: &'a mut MemoryArbitrator,
     /// Pipeline-scoped spill directory borrowed from
     /// `ExecutorContext::spill_root_path`. Matching-run spill segments
     /// land inside it; the surrounding `Arc<TempDir>` Drop is the
@@ -719,7 +719,7 @@ fn sort_driver_pairs_externally(
     pairs: &mut Vec<(Record, RecordOrder, Value)>,
     name: &str,
     range_field: &Option<String>,
-    budget: &mut MemoryBudget,
+    budget: &mut MemoryArbitrator,
 ) -> Result<(), PipelineError> {
     if pairs.is_empty() {
         return Ok(());
@@ -820,7 +820,7 @@ fn sort_build_pairs_externally(
     pairs: &mut Vec<(Record, Value)>,
     name: &str,
     range_field: &Option<String>,
-    budget: &mut MemoryBudget,
+    budget: &mut MemoryArbitrator,
 ) -> Result<(), PipelineError> {
     if pairs.is_empty() {
         return Ok(());
@@ -934,7 +934,7 @@ struct WalkArgs<'a, 'b, 'c> {
     output: &'b mut Vec<(Record, RecordOrder)>,
     matched_driver_orders: &'b mut std::collections::HashSet<RecordOrder>,
     emitted_since_check: &'b mut usize,
-    budget: &'c mut MemoryBudget,
+    budget: &'c mut MemoryArbitrator,
 }
 
 /// Walk the two pre-sorted cursors, emitting cross-product matches per
@@ -1068,7 +1068,7 @@ struct EmitForRunArgs<'a, 'b> {
     output: &'b mut Vec<(Record, RecordOrder)>,
     matched_driver_orders: &'b mut std::collections::HashSet<RecordOrder>,
     emitted_since_check: &'b mut usize,
-    budget: &'b mut MemoryBudget,
+    budget: &'b mut MemoryArbitrator,
 }
 
 /// Emit cross-product records for one driver row against the buffered
@@ -1547,8 +1547,8 @@ mod tests {
         let source_file: Arc<str> = Arc::from("");
         let ctx = EvalContext::test_with_file(&stable, &source_file, 0);
         let mut budget = match rk.budget_bytes {
-            Some(b) => MemoryBudget::new(b, 0.80),
-            None => MemoryBudget::from_config(None),
+            Some(b) => MemoryArbitrator::new(b, 0.80),
+            None => MemoryArbitrator::from_config(None),
         };
         let dir = tempfile::Builder::new()
             .prefix("sm-test-")

--- a/crates/clinker-core/src/pipeline/window_context.rs
+++ b/crates/clinker-core/src/pipeline/window_context.rs
@@ -334,7 +334,7 @@ mod tests {
                 has_header: true,
             },
         );
-        let mut budget = crate::pipeline::memory::MemoryBudget::new(u64::MAX, 0.80);
+        let mut budget = crate::pipeline::memory::MemoryArbitrator::new(u64::MAX, 0.80);
         Arena::build(
             &mut reader,
             &fields.iter().map(|s| s.to_string()).collect::<Vec<_>>(),

--- a/crates/clinker-core/src/plan/combine.rs
+++ b/crates/clinker-core/src/plan/combine.rs
@@ -921,7 +921,7 @@ pub(crate) fn select_combine_strategies_in_graph(
 /// per-record byte estimate would breach the configured 80% soft
 /// limit. The pipeline's `memory_limit:` YAML knob is what binds
 /// the threshold; absent that, we fall back to the same default
-/// `MemoryBudget::from_config(None)` uses.
+/// `MemoryArbitrator::from_config(None)` uses.
 ///
 /// When estimates are missing on either side, returns false — there
 /// is no signal to override the default in-memory hash strategy, and

--- a/crates/clinker-core/src/plan/execution.rs
+++ b/crates/clinker-core/src/plan/execution.rs
@@ -167,7 +167,7 @@ fn format_bytes(n: u64) -> String {
 }
 
 /// Per-combine planned share of the pipeline-level memory limit. The
-/// runtime executor uses one shared `MemoryBudget`; the rendering
+/// runtime executor uses one shared `MemoryArbitrator`; the rendering
 /// divides the limit equally across the combine nodes visible in the
 /// DAG so a reader can predict a single combine's working-set
 /// allocation. `combine_count_total.max(1)` (V-8-1) guards against a
@@ -183,7 +183,7 @@ fn memory_budget_per_combine(total_limit_bytes: u64, combine_count_total: usize)
 /// per-operator ceiling — without it, users read the displayed budget
 /// as a hard cap and report it as a bug when one combine's working set
 /// consumes the full pipeline limit. Soft limit follows the dual-
-/// threshold model on `MemoryBudget` (default 80%).
+/// threshold model on `MemoryArbitrator` (default 80%).
 fn format_memory_budget_line(planned_bytes: u64) -> String {
     let soft_pct = 0.80_f64;
     let soft_bytes = (planned_bytes as f64 * soft_pct) as u64;
@@ -856,18 +856,18 @@ pub struct PlanEdge {
 /// Mirrors the runtime distinction visible in
 /// [`crate::executor::dispatch`]: nodes whose output bypasses
 /// `ctx.node_buffers` (fused Source / Transform chains and sink Outputs)
-/// charge no inter-stage memory against [`crate::pipeline::memory::MemoryBudget`];
+/// charge no inter-stage memory against [`crate::pipeline::memory::MemoryArbitrator`];
 /// every other node materializes an intermediate buffer and is spill-eligible.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BufferClass {
     /// No `ctx.node_buffers` slot is admitted for this stage's output —
-    /// no `MemoryBudget` charge for this stage, no spill eligibility.
+    /// no `MemoryArbitrator` charge for this stage, no spill eligibility.
     /// Today this covers fused Sources (their receiver is consumed
     /// directly by the downstream fused arm) and every Output (sinks
     /// write to their configured writer and never admit a buffer).
     Streaming,
     /// Records pass through a `ctx.node_buffers` slot between dispatch
-    /// arms. The producer charges `MemoryBudget` via
+    /// arms. The producer charges `MemoryArbitrator` via
     /// `charge_node_buffer_bytes` on admit, the consumer discharges on
     /// drain, and a soft-threshold trip spills the slot to disk.
     Materialized,
@@ -1194,7 +1194,7 @@ impl ExecutionPlanDag {
     /// `buffer_classes` carries the `streaming` / `materialized`
     /// verdict per node so the **Physical Properties** section can
     /// append a `buffer:` line — the pre-runtime signal that pipeline
-    /// authors use to see which stages will charge `MemoryBudget`.
+    /// authors use to see which stages will charge `MemoryArbitrator`.
     /// Build it with [`Self::classify_node_buffers`] when a
     /// `PipelineConfig` is in hand.
     fn explain(&self, buffer_classes: &HashMap<NodeIndex, BufferClass>) -> String {

--- a/crates/clinker-core/src/plan/tests/explain_buffer_class.rs
+++ b/crates/clinker-core/src/plan/tests/explain_buffer_class.rs
@@ -8,7 +8,7 @@
 //!   `ctx.node_buffers` slot at runtime (fused Source/Transform chain
 //!   or a sink Output).
 //! - `materialized` — the node's output is admitted into `node_buffers`
-//!   between dispatch arms and charges `MemoryBudget`.
+//!   between dispatch arms and charges `MemoryArbitrator`.
 //!
 //! These gates pin the annotation contract so it stays stable across
 //! future executor / planner refactors.

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -3509,8 +3509,8 @@ nodes:
         }
     }
 
-    /// MemoryBudget abort — a 1-byte hard limit forces
-    /// `MemoryBudget::should_abort` to return true on the first poll
+    /// MemoryArbitrator abort — a 1-byte hard limit forces
+    /// `MemoryArbitrator::should_abort` to return true on the first poll
     /// inside `CombineHashTable::build` (process RSS trivially exceeds
     /// 1 byte). The build's safety-net final check fires for the small
     /// build set, the executor wraps `CombineError::MemoryLimitExceeded`

--- a/crates/clinker-core/tests/composition_port_admission_hard_fail.rs
+++ b/crates/clinker-core/tests/composition_port_admission_hard_fail.rs
@@ -6,7 +6,7 @@
 //! boundary-admit shape: when the engine clones records from the
 //! parent producer's `node_buffers` slot into the composition
 //! body's input port, the clone admission charges the **shared**
-//! `MemoryBudget` (compositions do not get their own budget — body
+//! `MemoryArbitrator` (compositions do not get their own budget — body
 //! operators share the parent pipeline's instance). If the doubled
 //! charge crosses the hard limit, the dispatcher returns a bare
 //! `PipelineError::MemoryBudgetExceeded` whose `node` field carries

--- a/docs/explain/E310.md
+++ b/docs/explain/E310.md
@@ -5,7 +5,7 @@
 At runtime, a combine node's memory usage crossed the hard memory
 limit — either the probe-side fan-out blew past the soft budget,
 the in-memory hash table build grew beyond the spike allowance, or
-a cumulative spike triggered `MemoryBudget::should_abort`. The run
+a cumulative spike triggered `MemoryArbitrator::should_abort`. The run
 is aborted to prevent OOM-kill of the entire process.
 
 ## Example
@@ -60,7 +60,7 @@ Combine uses a dual-threshold memory budget (RESOLUTION B-6, D57/D58):
 `soft_limit()` (0.80 of total) triggers spill-to-disk for the
 GraceHash strategy, `hard_limit()` aborts the run, and a separate
 `spike_allowance()` tolerates brief fan-out bursts. E310 fires only
-from `MemoryBudget::should_abort()` — the hard-stop that triggers when
+from `MemoryArbitrator::should_abort()` — the hard-stop that triggers when
 RSS exceeds the hard limit even after spill. Soft-limit crossings
 trigger spill, not E310; a well-tuned pipeline never sees E310
 because spill absorbs the overflow before hard-limit is crossed.
@@ -68,7 +68,7 @@ because spill absorbs the overflow before hard-limit is crossed.
 ## Composition involvement
 
 A composition (a reusable sub-pipeline included via `use:`) shares
-the **same** `MemoryBudget` instance as the parent pipeline — there
+the **same** `MemoryArbitrator` instance as the parent pipeline — there
 is one budget per run, body operators charge it via the same admit
 and spill paths every other node uses. The two-path split described
 below is purely about *which name* appears in the diagnostic, not


### PR DESCRIPTION
## Summary
- Renames `MemoryBudget` to `MemoryArbitrator` across `clinker-core` (21 files) and adds the trait skeleton (`MemoryConsumer`, `ArbitrationPolicy`, `NoOpPolicy`, `ConsumerId`, `ConsumerSpillError`) that later sub-issues plug into.
- Runtime behavior is unchanged — the arbitrator ships with `NoOpPolicy` and an empty consumer registry, so every spill / abort decision still follows the same RSS-driven per-operator polling.
- Catches two tracked markdown files (`docs/explain/E310.md`, `CROSS_RECORD_TRANSFORMS_PLAN.md`) the Rust-only rename missed.

Closes #156. Sub-issue of #117 (M7).

See the implementation note on #156 for the `SpillError` → `ConsumerSpillError` rename rationale (collision with the existing `pipeline::spill::SpillError`).

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo check --benches --workspace`
- [x] `cargo check --features bench-alloc -p clinker-benchmarks`
- [x] `cargo test --benches -p clinker-benchmarks`
- [x] `cargo deny check`
- [x] grep gate: zero `\bMemoryBudget\b` survivors workspace-wide