### PR TITLE
engine: uniform Combine output-row dead-letter recovery across all join kernels

### DIFF
--- a/crates/clinker-core/src/dlq.rs
+++ b/crates/clinker-core/src/dlq.rs
@@ -55,10 +55,10 @@ pub enum DlqErrorCategory {
     /// rollback cursor to the captured pre-fold floor so a downstream
     /// resume reprocesses both the driver and the matched build row.
     /// Routed only under `Continue` / `BestEffort`; `FailFast` propagates
-    /// the eval error unchanged. Recovery is implemented for the hash
-    /// build-probe (inline) Combine arm; the IEJoin, grace-hash, and
-    /// sort-merge kernels propagate an output-eval failure as fail-fast
-    /// regardless of strategy.
+    /// the eval error unchanged. Recovery is uniform across every Combine
+    /// join mode — the inline hash build-probe arm and the IEJoin,
+    /// grace-hash, and sort-merge kernels all route an output-eval failure
+    /// here under `Continue` / `BestEffort`.
     CombineOutputRow,
 }
 

--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -5139,7 +5139,7 @@ pub(crate) fn dispatch_plan_node(
                     // it runs on the shared Rayon pool. Row order is
                     // determined by the kernel's deterministic
                     // partition-then-merge, not by pool scheduling.
-                    let output_records = ctx.kernel_pool.install(|| {
+                    let kernel_out = ctx.kernel_pool.install(|| {
                         execute_combine_iejoin(IEJoinExec {
                             name,
                             build_qualifier: &build_qualifier,
@@ -5155,8 +5155,30 @@ pub(crate) fn dispatch_plan_node(
                             propagate_ck,
                             ctx: &iejoin_ctx,
                             budget: &ctx.memory_budget,
+                            strategy: ctx.strategy,
                         })
                     })?;
+                    let crate::pipeline::combine::CombineKernelOutput {
+                        records: output_records,
+                        output_eval_failures,
+                    } = kernel_out;
+                    // Route each deferred output-stage eval failure through
+                    // the same `combine_output_row` path the inline arm
+                    // uses. This MUST run before the snapshot is dropped
+                    // below — `dispatch_combine_output_error` reads the
+                    // installed pre-fold snapshot to rewind each
+                    // contributing source's rollback cursor.
+                    for f in output_eval_failures {
+                        dispatch_combine_output_error(
+                            ctx,
+                            node_idx,
+                            &f.probe_record,
+                            f.row,
+                            f.matched_build.as_ref(),
+                            name,
+                            f.error,
+                        )?;
+                    }
                     let probe_records_out = output_records.len() as u64;
                     ctx.collector
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
@@ -5237,7 +5259,7 @@ pub(crate) fn dispatch_plan_node(
                     // `grace_ctx`, and the spill dir, so it runs on the
                     // shared Rayon pool. Emitted-row order is fixed by the
                     // kernel's deterministic partition-then-probe walk.
-                    let output_records = ctx.kernel_pool.install(|| {
+                    let kernel_out = ctx.kernel_pool.install(|| {
                         execute_combine_grace_hash(GraceHashExec {
                             name,
                             build_qualifier: &build_qualifier,
@@ -5255,8 +5277,27 @@ pub(crate) fn dispatch_plan_node(
                             budget: &ctx.memory_budget,
                             spill_dir: ctx.spill_root_path.as_ref(),
                             consumer_handle: grace_consumer_handle,
+                            strategy: ctx.strategy,
                         })
                     })?;
+                    let crate::pipeline::combine::CombineKernelOutput {
+                        records: output_records,
+                        output_eval_failures,
+                    } = kernel_out;
+                    // Route each deferred output-stage eval failure through
+                    // the `combine_output_row` path while the pre-fold
+                    // snapshot is still installed (the rewind reads it).
+                    for f in output_eval_failures {
+                        dispatch_combine_output_error(
+                            ctx,
+                            node_idx,
+                            &f.probe_record,
+                            f.row,
+                            f.matched_build.as_ref(),
+                            name,
+                            f.error,
+                        )?;
+                    }
                     let probe_records_out = output_records.len() as u64;
                     ctx.collector
                         .record(probe_timer.finish(probe_records_in, probe_records_out));
@@ -5344,7 +5385,7 @@ pub(crate) fn dispatch_plan_node(
                     // `sm_ctx`, and the spill dir, so it runs on the
                     // shared Rayon pool. The two-cursor merge emits in a
                     // deterministic order independent of pool scheduling.
-                    let output_records = ctx.kernel_pool.install(|| {
+                    let kernel_out = ctx.kernel_pool.install(|| {
                         execute_combine_sort_merge(SortMergeExec {
                             name,
                             build_qualifier: &build_qualifier,
@@ -5362,8 +5403,27 @@ pub(crate) fn dispatch_plan_node(
                             budget: &ctx.memory_budget,
                             spill_dir: ctx.spill_root_path.as_ref(),
                             consumer_handle: sm_consumer_handle,
+                            strategy: ctx.strategy,
                         })
                     })?;
+                    let crate::pipeline::combine::CombineKernelOutput {
+                        records: output_records,
+                        output_eval_failures,
+                    } = kernel_out;
+                    // Route each deferred output-stage eval failure through
+                    // the `combine_output_row` path while the pre-fold
+                    // snapshot is still installed (the rewind reads it).
+                    for f in output_eval_failures {
+                        dispatch_combine_output_error(
+                            ctx,
+                            node_idx,
+                            &f.probe_record,
+                            f.row,
+                            f.matched_build.as_ref(),
+                            name,
+                            f.error,
+                        )?;
+                    }
                     let probe_records_out = output_records.len() as u64;
                     ctx.collector
                         .record(probe_timer.finish(probe_records_in, probe_records_out));

--- a/crates/clinker-core/src/pipeline/combine.rs
+++ b/crates/clinker-core/src/pipeline/combine.rs
@@ -341,6 +341,57 @@ impl std::error::Error for CombineError {
 }
 
 // ──────────────────────────────────────────────────────────────────────────
+// CombineKernelOutput
+// ──────────────────────────────────────────────────────────────────────────
+
+/// One recoverable output-stage eval failure surfaced by a combine kernel.
+///
+/// Kernels run inside the Rayon pool with only a `&MemoryArbitrator` and a
+/// local `EvalContext` — they hold no `&mut ExecutorContext`, so they cannot
+/// route a failing row to the dead-letter queue or rewind a source's
+/// rollback cursor themselves. Instead a recoverable failure is captured
+/// here and handed back to the dispatcher, which drains it through the same
+/// `combine_output_row` path the inline hash build-probe arm uses while the
+/// pre-fold input snapshot is still installed. Only output-stage CXL eval
+/// errors (residual filter and matched / `on_miss: null_fields` body) are
+/// recoverable; structural invariants and memory aborts stay fail-fast.
+#[derive(Debug)]
+pub(crate) struct CombineOutputEvalFailure {
+    /// The driver/probe record whose output-stage eval failed. Carries the
+    /// real `$source.name` / `$ck.*` lineage the dispatcher attributes the
+    /// dead-letter entry to.
+    pub probe_record: Record,
+    /// The driver record's source row number, used as the dead-letter
+    /// entry's source row.
+    pub row: u64,
+    /// The matched build record when the failure occurred on a matched pair
+    /// (residual or matched body); `None` for an `on_miss: null_fields`
+    /// failure where no build row contributed.
+    pub matched_build: Option<Record>,
+    /// The captured eval error. `EvalError` is `Clone`, so stashing the
+    /// failing error per row and replaying it from the dispatcher is sound.
+    pub error: EvalError,
+}
+
+/// A combine kernel's emitted rows plus any recoverable output-stage eval
+/// failures it deferred to the dispatcher.
+///
+/// Returned by the IEJoin, grace-hash, and sort-merge kernels in place of a
+/// bare `Vec<(Record, u64)>`. Under `FailFast` the failures vector is always
+/// empty because those errors propagate immediately; under
+/// `Continue` / `BestEffort` each deferred failure is drained by the
+/// dispatcher into the `combine_output_row` dead-letter path.
+#[derive(Debug)]
+pub(crate) struct CombineKernelOutput {
+    /// Emitted `(record, source-row-order)` pairs, identical in shape to the
+    /// pre-change kernel return.
+    pub records: Vec<(Record, u64)>,
+    /// Recoverable output-stage eval failures the dispatcher must route.
+    /// Empty under `FailFast`.
+    pub output_eval_failures: Vec<CombineOutputEvalFailure>,
+}
+
+// ──────────────────────────────────────────────────────────────────────────
 // KeyExtractor
 // ──────────────────────────────────────────────────────────────────────────
 

--- a/crates/clinker-core/src/pipeline/grace_hash.rs
+++ b/crates/clinker-core/src/pipeline/grace_hash.rs
@@ -62,7 +62,10 @@ use crate::config::pipeline_node::{MatchMode, OnMiss};
 use crate::error::PipelineError;
 use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
-use crate::pipeline::combine::{CombineHashTable, KeyExtractor, hash_composite_key};
+use crate::pipeline::combine::{
+    CombineHashTable, CombineKernelOutput, CombineOutputEvalFailure, KeyExtractor,
+    hash_composite_key,
+};
 use crate::pipeline::grace_spill::{GraceSpillReader, GraceSpillWriter, SpillFilePath};
 #[cfg(test)]
 use crate::pipeline::memory::NoOpPolicy;
@@ -369,6 +372,11 @@ pub(crate) struct GraceHashExec<'a> {
     /// partition bytes mirror into the arbitrator's pull-mode
     /// `current_usage` surface.
     pub consumer_handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
+    /// Error strategy governing output-stage eval failures. Under
+    /// `FailFast` a residual / body eval error propagates immediately;
+    /// under `Continue` / `BestEffort` the failing row is deferred to the
+    /// dispatcher via [`CombineKernelOutput::output_eval_failures`].
+    pub strategy: crate::config::ErrorStrategy,
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -800,7 +808,7 @@ fn estimated_record_bytes(record: &Record) -> usize {
 /// is the caller's responsibility (matches the IEJoin contract).
 pub(crate) fn execute_combine_grace_hash(
     args: GraceHashExec<'_>,
-) -> Result<Vec<(Record, RecordOrder)>, PipelineError> {
+) -> Result<CombineKernelOutput, PipelineError> {
     let GraceHashExec {
         name,
         build_qualifier,
@@ -818,6 +826,7 @@ pub(crate) fn execute_combine_grace_hash(
         budget,
         spill_dir,
         consumer_handle,
+        strategy,
     } = args;
 
     if decomposed.equalities.is_empty() {
@@ -941,6 +950,11 @@ pub(crate) fn execute_combine_grace_hash(
 
     // ── Probe phase ───────────────────────────────────────────────────
     let mut output_records: Vec<(Record, RecordOrder)> = Vec::new();
+    // Recoverable output-stage eval failures deferred to the dispatcher.
+    // Threaded by `&mut` through every emit path (in-memory, spilled
+    // reload, and BNL fallback) so a failure on any path is routed
+    // uniformly. Always empty under `FailFast`.
+    let mut output_eval_failures: Vec<CombineOutputEvalFailure> = Vec::new();
     let mut body_evaluator = body_program.map(|bp| ProgramEvaluator::new(Arc::clone(bp), false));
     let mut probe_keys_buf: Vec<Value> = Vec::with_capacity(driver_extractor.len());
     let mut emitted_since_check = 0usize;
@@ -954,6 +968,7 @@ pub(crate) fn execute_combine_grace_hash(
         on_miss,
         build_qualifier,
         propagate_ck,
+        strategy,
     };
 
     for (probe_record, rn) in driver_records {
@@ -995,7 +1010,10 @@ pub(crate) fn execute_combine_grace_hash(
                     probe_iter,
                     body_evaluator.as_mut(),
                     &row_ctx,
-                    &mut output_records,
+                    &mut GraceEmitSink {
+                        records: &mut output_records,
+                        failures: &mut output_eval_failures,
+                    },
                 )?;
             }
             ProbeOutcome::Spilled => {
@@ -1057,14 +1075,26 @@ pub(crate) fn execute_combine_grace_hash(
         hash_state: &hash_state,
     };
     for sp in spilled {
-        process_spilled_partition(&rc, sp, &mut body_evaluator, budget, &mut output_records)?;
+        process_spilled_partition(
+            &rc,
+            sp,
+            &mut body_evaluator,
+            budget,
+            &mut GraceEmitSink {
+                records: &mut output_records,
+                failures: &mut output_eval_failures,
+            },
+        )?;
     }
 
     // Keep the executor alive until reload finishes — its TempDir owns
     // every spill file path threaded through the reload loop.
     drop(executor);
 
-    Ok(output_records)
+    Ok(CombineKernelOutput {
+        records: output_records,
+        output_eval_failures,
+    })
 }
 
 /// Bundle of reload-phase context shared across recursive
@@ -1092,7 +1122,7 @@ fn process_spilled_partition(
     sp: SpilledPartition,
     body_evaluator: &mut Option<ProgramEvaluator>,
     budget: &MemoryArbitrator,
-    output: &mut Vec<(Record, RecordOrder)>,
+    sink: &mut GraceEmitSink<'_>,
 ) -> Result<(), PipelineError> {
     let name = rc.name;
     let build_extractor = rc.build_extractor;
@@ -1225,7 +1255,7 @@ fn process_spilled_partition(
                 combined,
                 body_evaluator,
                 budget,
-                output,
+                sink,
                 &mut BnlStats::default(),
             );
         }
@@ -1347,7 +1377,7 @@ fn process_spilled_partition(
                 hash_bits: child_assigner.hash_bits(),
                 distinct_sketch: child_sketch,
             };
-            process_spilled_partition(rc, child_sp, body_evaluator, budget, output)?;
+            process_spilled_partition(rc, child_sp, body_evaluator, budget, sink)?;
         }
         return Ok(());
     }
@@ -1363,7 +1393,7 @@ fn process_spilled_partition(
             build_records,
             body_evaluator,
             budget,
-            output,
+            sink,
             &mut BnlStats::default(),
         );
     }
@@ -1428,7 +1458,7 @@ fn process_spilled_partition(
                 probe_iter,
                 body_evaluator.as_mut(),
                 &row_ctx,
-                output,
+                sink,
             )?;
             row_seq += 1;
         }
@@ -1542,7 +1572,7 @@ fn bnl_fallback(
     build_records: Vec<Record>,
     body_evaluator: &mut Option<ProgramEvaluator>,
     budget: &MemoryArbitrator,
-    output: &mut Vec<(Record, RecordOrder)>,
+    sink: &mut GraceEmitSink<'_>,
     stats: &mut BnlStats,
 ) -> Result<(), PipelineError> {
     let name = rc.name;
@@ -1636,7 +1666,7 @@ fn bnl_fallback(
                         messages: vec![format!("grace hash bnl probe key eval: {e}")],
                     })?;
                 let probe_iter = table.probe(&probe_keys_buf);
-                let pre = output.len();
+                let pre = sink.records.len();
                 emit_for_probe(
                     rc.emit,
                     &probe_record,
@@ -1644,9 +1674,9 @@ fn bnl_fallback(
                     probe_iter,
                     body_evaluator.as_mut(),
                     &row_ctx,
-                    output,
+                    sink,
                 )?;
-                let added = output.len() - pre;
+                let added = sink.records.len() - pre;
                 emitted_in_batch += added;
                 row_seq += 1;
 
@@ -1706,6 +1736,16 @@ fn combine_e310_partition_aborted(
     }
 }
 
+/// Mutable emission targets threaded through every grace-hash emit path
+/// (in-memory probe, spilled reload, BNL fallback). `records` accumulates
+/// emitted output rows; `failures` accumulates recoverable output-stage
+/// eval failures the dispatcher routes to the dead-letter queue. Bundled
+/// so the emit helpers stay under clippy's too-many-arguments cap.
+struct GraceEmitSink<'a> {
+    records: &'a mut Vec<(Record, RecordOrder)>,
+    failures: &'a mut Vec<CombineOutputEvalFailure>,
+}
+
 /// Shape-stable bundle for [`emit_for_probe`]. Bundling the per-call
 /// arguments keeps the function signature under clippy's
 /// too-many-arguments cap and lets call sites update one field
@@ -1719,6 +1759,7 @@ struct EmitArgs<'a> {
     on_miss: OnMiss,
     build_qualifier: &'a str,
     propagate_ck: &'a crate::config::pipeline_node::PropagateCkSpec,
+    strategy: crate::config::ErrorStrategy,
 }
 
 /// Per-probe emission. Walks the probe iterator, applies the residual
@@ -1732,7 +1773,7 @@ fn emit_for_probe<'a>(
     probe_iter: crate::pipeline::combine::ProbeIter<'a>,
     body_evaluator: Option<&mut ProgramEvaluator>,
     ctx: &EvalContext<'_>,
-    output: &mut Vec<(Record, RecordOrder)>,
+    sink: &mut GraceEmitSink<'_>,
 ) -> Result<(), PipelineError> {
     let EmitArgs {
         name,
@@ -1743,6 +1784,7 @@ fn emit_for_probe<'a>(
         on_miss,
         build_qualifier,
         propagate_ck,
+        strategy,
     } = *args;
     match match_mode {
         MatchMode::Collect => {
@@ -1764,7 +1806,18 @@ fn emit_for_probe<'a>(
                                 detail: "emit_each fan-out is not supported in a combine residual filter".into(),
                             });
                         }
-                        Err(e) => return Err(PipelineError::from(e)),
+                        Err(e) => {
+                            if strategy == crate::config::ErrorStrategy::FailFast {
+                                return Err(PipelineError::from(e));
+                            }
+                            sink.failures.push(CombineOutputEvalFailure {
+                                probe_record: probe_record.clone(),
+                                row: rn,
+                                matched_build: Some(cand.record.clone()),
+                                error: e,
+                            });
+                            continue;
+                        }
                     }
                 }
                 if arr.len() >= COLLECT_PER_GROUP_CAP {
@@ -1807,7 +1860,7 @@ fn emit_for_probe<'a>(
                 crate::executor::copy_build_ck_columns(&mut rec, b, propagate_ck);
             }
             rec.set(build_qualifier, Value::Array(arr));
-            output.push((rec, rn));
+            sink.records.push((rec, rn));
         }
         MatchMode::First | MatchMode::All => {
             let matched: Vec<Record> = {
@@ -1827,7 +1880,18 @@ fn emit_for_probe<'a>(
                                     detail: "emit_each fan-out is not supported in a combine residual filter".into(),
                                 });
                             }
-                            Err(e) => return Err(PipelineError::from(e)),
+                            Err(e) => {
+                                if strategy == crate::config::ErrorStrategy::FailFast {
+                                    return Err(PipelineError::from(e));
+                                }
+                                sink.failures.push(CombineOutputEvalFailure {
+                                    probe_record: probe_record.clone(),
+                                    row: rn,
+                                    matched_build: Some(cand.record.clone()),
+                                    error: e,
+                                });
+                                continue;
+                            }
                         }
                     }
                     acc.push(cand.record.clone());
@@ -1870,7 +1934,7 @@ fn emit_for_probe<'a>(
                                 for (k, v) in *record_vars {
                                     let _ = rec.set_record_var(&k, v);
                                 }
-                                output.push((rec, rn));
+                                sink.records.push((rec, rn));
                             }
                             Ok(EvalResult::Skip(SkipReason::Filtered)) => {}
                             Ok(EvalResult::Skip(SkipReason::Duplicate)) => {}
@@ -1882,7 +1946,17 @@ fn emit_for_probe<'a>(
                                         .into(),
                                 });
                             }
-                            Err(e) => return Err(PipelineError::from(e)),
+                            Err(e) => {
+                                if strategy == crate::config::ErrorStrategy::FailFast {
+                                    return Err(PipelineError::from(e));
+                                }
+                                sink.failures.push(CombineOutputEvalFailure {
+                                    probe_record: probe_record.clone(),
+                                    row: rn,
+                                    matched_build: None,
+                                    error: e,
+                                });
+                            }
                         }
                     }
                 }
@@ -1906,7 +1980,7 @@ fn emit_for_probe<'a>(
                                 let _ = rec.set_record_var(&k, v);
                             }
                             crate::executor::copy_build_ck_columns(&mut rec, m, propagate_ck);
-                            output.push((rec, rn));
+                            sink.records.push((rec, rn));
                         }
                         Ok(EvalResult::Skip(_)) => {}
                         Ok(EvalResult::EmitMany { .. }) => {
@@ -1917,7 +1991,18 @@ fn emit_for_probe<'a>(
                                     .into(),
                             });
                         }
-                        Err(e) => return Err(PipelineError::from(e)),
+                        Err(e) => {
+                            if strategy == crate::config::ErrorStrategy::FailFast {
+                                return Err(PipelineError::from(e));
+                            }
+                            sink.failures.push(CombineOutputEvalFailure {
+                                probe_record: probe_record.clone(),
+                                row: rn,
+                                matched_build: Some(m.clone()),
+                                error: e,
+                            });
+                            continue;
+                        }
                     }
                 }
             } else {
@@ -1946,7 +2031,7 @@ fn emit_for_probe<'a>(
                         });
                     }
                     let rec = Record::new(Arc::clone(target_schema), values);
-                    output.push((rec, rn));
+                    sink.records.push((rec, rn));
                 }
             }
         }
@@ -2450,8 +2535,10 @@ mod tests {
             budget: &budget,
             spill_dir: dir.path(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            strategy: crate::config::ErrorStrategy::FailFast,
         })
-        .expect("grace hash E2E");
+        .expect("grace hash E2E")
+        .records;
 
         assert_eq!(result.len(), 10, "every driver matches one build by k");
         // Verify membership: each (k, v, k, name) tuple is present.
@@ -2637,8 +2724,10 @@ mod tests {
             budget: &budget,
             spill_dir: dir.path(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            strategy: crate::config::ErrorStrategy::FailFast,
         })
-        .expect("grace hash spill E2E");
+        .expect("grace hash spill E2E")
+        .records;
 
         assert_eq!(
             result.len(),
@@ -2817,6 +2906,7 @@ mod tests {
             budget: &budget,
             spill_dir: dir.path(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            strategy: crate::config::ErrorStrategy::FailFast,
         });
 
         let err = result.expect_err("disk quota must abort the combine");
@@ -3085,6 +3175,7 @@ mod tests {
             on_miss: h.emit.on_miss,
             build_qualifier: &h.emit.build_qualifier,
             propagate_ck: &crate::config::pipeline_node::PropagateCkSpec::Driver,
+            strategy: crate::config::ErrorStrategy::FailFast,
         };
         let eval_ctx = EvalContext::test_with_file(&h.stable, &h.source_file, 0);
         let rc = ReloadContext {
@@ -3222,7 +3313,10 @@ mod tests {
                 builds,
                 &mut body_eval,
                 &budget,
-                &mut output,
+                &mut GraceEmitSink {
+                    records: &mut output,
+                    failures: &mut Vec::new(),
+                },
                 &mut stats,
             )
             .expect("BNL fallback must run on irreducible partition");
@@ -3277,7 +3371,10 @@ mod tests {
                 builds,
                 &mut body_eval,
                 &budget,
-                &mut output,
+                &mut GraceEmitSink {
+                    records: &mut output,
+                    failures: &mut Vec::new(),
+                },
                 &mut stats,
             )
             .expect("BNL must succeed on non-skewed input");
@@ -3362,7 +3459,10 @@ mod tests {
                 builds,
                 &mut body_eval,
                 &budget,
-                &mut output,
+                &mut GraceEmitSink {
+                    records: &mut output,
+                    failures: &mut Vec::new(),
+                },
                 &mut stats,
             )
             .expect("BNL must succeed with bounded chunks");
@@ -3426,7 +3526,10 @@ mod tests {
                 builds2,
                 &mut body_eval2,
                 &big_budget,
-                &mut output2,
+                &mut GraceEmitSink {
+                    records: &mut output2,
+                    failures: &mut Vec::new(),
+                },
                 &mut stats2,
             )
             .unwrap();
@@ -3488,7 +3591,10 @@ mod tests {
                 builds,
                 &mut body_eval,
                 &budget,
-                &mut output,
+                &mut GraceEmitSink {
+                    records: &mut output,
+                    failures: &mut Vec::new(),
+                },
                 &mut stats,
             )
             .expect("BNL must produce output for hot-key test");
@@ -3550,7 +3656,10 @@ mod tests {
                 builds,
                 &mut body_eval,
                 &budget,
-                &mut output,
+                &mut GraceEmitSink {
+                    records: &mut output,
+                    failures: &mut Vec::new(),
+                },
                 &mut stats,
             )
             .expect_err("1-byte hard limit must abort BNL")

--- a/crates/clinker-core/src/pipeline/iejoin.rs
+++ b/crates/clinker-core/src/pipeline/iejoin.rs
@@ -53,7 +53,10 @@ use crate::config::pipeline_node::{MatchMode, OnMiss};
 use crate::error::PipelineError;
 use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
-use crate::pipeline::combine::{KeyExtractor, hash_composite_key, keys_equal_canonicalized};
+use crate::pipeline::combine::{
+    CombineKernelOutput, CombineOutputEvalFailure, KeyExtractor, hash_composite_key,
+    keys_equal_canonicalized,
+};
 use crate::pipeline::memory::{BudgetCategory, MemoryArbitrator};
 use crate::plan::combine::{DecomposedPredicate, RangeOp};
 
@@ -425,11 +428,16 @@ pub(crate) struct IEJoinExec<'a> {
     pub propagate_ck: &'a crate::config::pipeline_node::PropagateCkSpec,
     pub ctx: &'a EvalContext<'a>,
     pub budget: &'a MemoryArbitrator,
+    /// Error strategy governing output-stage eval failures. Under
+    /// `FailFast` a residual / body eval error propagates immediately;
+    /// under `Continue` / `BestEffort` the failing row is deferred to the
+    /// dispatcher via [`CombineKernelOutput::output_eval_failures`].
+    pub strategy: crate::config::ErrorStrategy,
 }
 
 pub(crate) fn execute_combine_iejoin(
     args: IEJoinExec<'_>,
-) -> Result<Vec<(Record, RecordOrder)>, PipelineError> {
+) -> Result<CombineKernelOutput, PipelineError> {
     let IEJoinExec {
         name,
         build_qualifier,
@@ -445,7 +453,11 @@ pub(crate) fn execute_combine_iejoin(
         propagate_ck,
         ctx,
         budget,
+        strategy,
     } = args;
+    // Recoverable output-stage eval failures deferred to the dispatcher.
+    // Always empty under `FailFast` (those errors return immediately).
+    let mut output_eval_failures: Vec<CombineOutputEvalFailure> = Vec::new();
     if decomposed.ranges.is_empty() {
         return Err(PipelineError::Internal {
             op: "combine",
@@ -756,7 +768,18 @@ pub(crate) fn execute_combine_iejoin(
                                 detail: "emit_each fan-out is not supported in a combine residual filter".into(),
                             });
                         }
-                        Err(e) => return Err(PipelineError::from(e)),
+                        Err(e) => {
+                            if strategy == crate::config::ErrorStrategy::FailFast {
+                                return Err(PipelineError::from(e));
+                            }
+                            output_eval_failures.push(CombineOutputEvalFailure {
+                                probe_record: driver_record.clone(),
+                                row: driver_order,
+                                matched_build: Some(build_record.clone()),
+                                error: e,
+                            });
+                            continue;
+                        }
                     }
                 }
 
@@ -856,7 +879,18 @@ pub(crate) fn execute_combine_iejoin(
                                                 .into(),
                                     });
                                 }
-                                Err(e) => return Err(PipelineError::from(e)),
+                                Err(e) => {
+                                    if strategy == crate::config::ErrorStrategy::FailFast {
+                                        return Err(PipelineError::from(e));
+                                    }
+                                    output_eval_failures.push(CombineOutputEvalFailure {
+                                        probe_record: driver_record.clone(),
+                                        row: driver_order,
+                                        matched_build: Some(build_record.clone()),
+                                        error: e,
+                                    });
+                                    continue;
+                                }
                             }
                         } else {
                             // Body-less synthetic intermediate step
@@ -937,7 +971,12 @@ pub(crate) fn execute_combine_iejoin(
             rec.set(build_qualifier, Value::Array(arr));
             output_records.push((rec, *driver_order));
         }
-        return Ok(output_records);
+        // Collect mode never runs the body eval, so no recoverable
+        // output-stage failure can accrue on this path.
+        return Ok(CombineKernelOutput {
+            records: output_records,
+            output_eval_failures,
+        });
     }
 
     // First/All on_miss dispatch — every driver that saw zero matches
@@ -1009,13 +1048,27 @@ pub(crate) fn execute_combine_iejoin(
                             detail: "emit_each fan-out is not supported in a combine body".into(),
                         });
                     }
-                    Err(e) => return Err(PipelineError::from(e)),
+                    Err(e) => {
+                        if strategy == crate::config::ErrorStrategy::FailFast {
+                            return Err(PipelineError::from(e));
+                        }
+                        output_eval_failures.push(CombineOutputEvalFailure {
+                            probe_record: driver_record.clone(),
+                            row: driver_order,
+                            matched_build: None,
+                            error: e,
+                        });
+                        continue;
+                    }
                 }
             }
         }
     }
 
-    Ok(output_records)
+    Ok(CombineKernelOutput {
+        records: output_records,
+        output_eval_failures,
+    })
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/crates/clinker-core/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-core/src/pipeline/sort_merge_join.rs
@@ -49,7 +49,7 @@ use crate::config::pipeline_node::{MatchMode, OnMiss};
 use crate::error::PipelineError;
 use crate::executor::combine::{CombineResolver, CombineResolverMapping};
 use crate::executor::widen_record_to_schema;
-use crate::pipeline::combine::KeyExtractor;
+use crate::pipeline::combine::{CombineKernelOutput, CombineOutputEvalFailure, KeyExtractor};
 use crate::pipeline::grace_spill::{GraceSpillReader, GraceSpillWriter, SpillFilePath};
 #[cfg(test)]
 use crate::pipeline::memory::NoOpPolicy;
@@ -364,6 +364,11 @@ pub(crate) struct SortMergeExec<'a> {
     /// so the arbitrator's pull-mode `current_usage` reads the
     /// operator's live in-memory state.
     pub consumer_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
+    /// Error strategy governing output-stage eval failures. Under
+    /// `FailFast` a residual / body eval error propagates immediately;
+    /// under `Continue` / `BestEffort` the failing row is deferred to the
+    /// dispatcher via [`CombineKernelOutput::output_eval_failures`].
+    pub strategy: crate::config::ErrorStrategy,
 }
 
 /// Snapshot of which phases ran during a sort-merge execution. Used by
@@ -398,9 +403,9 @@ struct SortMergeStats {
 /// (e.g. invocation with no range conjuncts) and on spill I/O failures.
 pub(crate) fn execute_combine_sort_merge(
     args: SortMergeExec<'_>,
-) -> Result<Vec<(Record, RecordOrder)>, PipelineError> {
-    let (records, _stats) = execute_combine_sort_merge_with_stats(args)?;
-    Ok(records)
+) -> Result<CombineKernelOutput, PipelineError> {
+    let (output, _stats) = execute_combine_sort_merge_with_stats(args)?;
+    Ok(output)
 }
 
 /// Variant of [`execute_combine_sort_merge`] that also returns
@@ -410,7 +415,7 @@ pub(crate) fn execute_combine_sort_merge(
 /// [`execute_combine_sort_merge`].
 fn execute_combine_sort_merge_with_stats(
     args: SortMergeExec<'_>,
-) -> Result<(Vec<(Record, RecordOrder)>, SortMergeStats), PipelineError> {
+) -> Result<(CombineKernelOutput, SortMergeStats), PipelineError> {
     let SortMergeExec {
         name,
         build_qualifier,
@@ -428,9 +433,14 @@ fn execute_combine_sort_merge_with_stats(
         budget,
         spill_dir,
         consumer_handle,
+        strategy,
     } = args;
 
     let mut stats = SortMergeStats::default();
+    // Recoverable output-stage eval failures deferred to the dispatcher.
+    // Threaded by `&mut` through `walk_two_cursors` / `emit_for_run` and
+    // the on_miss path below. Always empty under `FailFast`.
+    let mut output_eval_failures: Vec<CombineOutputEvalFailure> = Vec::new();
 
     if decomposed.ranges.is_empty() {
         return Err(PipelineError::Internal {
@@ -677,6 +687,8 @@ fn execute_combine_sort_merge_with_stats(
         emitted_since_check: &mut emitted_since_check,
         budget,
         consumer_handle: &consumer_handle,
+        strategy,
+        failures: &mut output_eval_failures,
     })?;
 
     // ── on_miss / collect-mode flush ─────────────────────────────────
@@ -755,14 +767,31 @@ fn execute_combine_sort_merge_with_stats(
                                     .into(),
                             });
                         }
-                        Err(e) => return Err(PipelineError::from(e)),
+                        Err(e) => {
+                            if strategy == crate::config::ErrorStrategy::FailFast {
+                                return Err(PipelineError::from(e));
+                            }
+                            output_eval_failures.push(CombineOutputEvalFailure {
+                                probe_record: driver_record.clone(),
+                                row: driver_order,
+                                matched_build: None,
+                                error: e,
+                            });
+                            continue;
+                        }
                     }
                 }
             }
         }
     }
 
-    Ok((output_records, stats))
+    Ok((
+        CombineKernelOutput {
+            records: output_records,
+            output_eval_failures,
+        },
+        stats,
+    ))
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -1034,6 +1063,8 @@ struct WalkArgs<'a, 'b, 'c> {
     emitted_since_check: &'b mut usize,
     budget: &'c MemoryArbitrator,
     consumer_handle: &'a Arc<crate::pipeline::memory::ConsumerHandle>,
+    strategy: crate::config::ErrorStrategy,
+    failures: &'b mut Vec<CombineOutputEvalFailure>,
 }
 
 /// Walk the two pre-sorted cursors, emitting cross-product matches per
@@ -1071,6 +1102,8 @@ fn walk_two_cursors(args: WalkArgs<'_, '_, '_>) -> Result<(), PipelineError> {
         emitted_since_check,
         budget,
         consumer_handle,
+        strategy,
+        failures,
     } = args;
 
     let mut di = 0usize;
@@ -1146,6 +1179,8 @@ fn walk_two_cursors(args: WalkArgs<'_, '_, '_>) -> Result<(), PipelineError> {
             matched_driver_orders,
             emitted_since_check,
             budget,
+            strategy,
+            failures,
         })?;
 
         // Discharge any in-memory residue still held by the
@@ -1189,6 +1224,8 @@ struct EmitForRunArgs<'a, 'b> {
     matched_driver_orders: &'b mut std::collections::HashSet<RecordOrder>,
     emitted_since_check: &'b mut usize,
     budget: &'b MemoryArbitrator,
+    strategy: crate::config::ErrorStrategy,
+    failures: &'b mut Vec<CombineOutputEvalFailure>,
 }
 
 /// Emit cross-product records for one driver row against the buffered
@@ -1235,7 +1272,18 @@ fn emit_for_run(args: &mut EmitForRunArgs<'_, '_>) -> Result<(), PipelineError> 
                                 detail: "emit_each fan-out is not supported in a combine residual filter".into(),
                             });
                         }
-                        Err(e) => return Err(PipelineError::from(e)),
+                        Err(e) => {
+                            if args.strategy == crate::config::ErrorStrategy::FailFast {
+                                return Err(PipelineError::from(e));
+                            }
+                            args.failures.push(CombineOutputEvalFailure {
+                                probe_record: driver_record.clone(),
+                                row: driver_order,
+                                matched_build: Some(inner.clone()),
+                                error: e,
+                            });
+                            continue;
+                        }
                     }
                 }
                 if arr.len() >= COLLECT_PER_GROUP_CAP {
@@ -1309,7 +1357,18 @@ fn emit_for_run(args: &mut EmitForRunArgs<'_, '_>) -> Result<(), PipelineError> 
                                 detail: "emit_each fan-out is not supported in a combine residual filter".into(),
                             });
                         }
-                        Err(e) => return Err(PipelineError::from(e)),
+                        Err(e) => {
+                            if args.strategy == crate::config::ErrorStrategy::FailFast {
+                                return Err(PipelineError::from(e));
+                            }
+                            args.failures.push(CombineOutputEvalFailure {
+                                probe_record: driver_record.clone(),
+                                row: driver_order,
+                                matched_build: Some(inner.clone()),
+                                error: e,
+                            });
+                            continue;
+                        }
                     }
                 }
 
@@ -1368,7 +1427,18 @@ fn emit_for_run(args: &mut EmitForRunArgs<'_, '_>) -> Result<(), PipelineError> 
                                     .into(),
                             });
                         }
-                        Err(e) => return Err(PipelineError::from(e)),
+                        Err(e) => {
+                            if args.strategy == crate::config::ErrorStrategy::FailFast {
+                                return Err(PipelineError::from(e));
+                            }
+                            args.failures.push(CombineOutputEvalFailure {
+                                probe_record: driver_record.clone(),
+                                row: driver_order,
+                                matched_build: Some(inner.clone()),
+                                error: e,
+                            });
+                            continue;
+                        }
                     }
                 } else if let Some(target_schema) = output_schema {
                     // Body-less synthetic chain step: concatenate driver
@@ -1742,14 +1812,15 @@ mod tests {
             budget: &mut budget,
             spill_dir: dir.path(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            strategy: crate::config::ErrorStrategy::FailFast,
         };
-        let result = execute_combine_sort_merge_with_stats(args)
+        let (output, stats) = execute_combine_sort_merge_with_stats(args)
             .expect("sort-merge kernel execution failed");
         // Hold the TempDir until the kernel has consumed every spill
         // segment; segments carry `Arc<Path>` references back into
         // this directory.
         drop(dir);
-        result
+        (output.records, stats)
     }
 
     /// Pure-range correctness gate: products vs tax brackets.

--- a/crates/clinker-core/tests/combine_grouped_output_row_dlq.rs
+++ b/crates/clinker-core/tests/combine_grouped_output_row_dlq.rs
@@ -1,0 +1,225 @@
+//! Grouped (correlation-key) coverage for the recoverable Combine
+//! output-row dead-letter path.
+//!
+//! The existing `combine_output_row` recovery tests declare no
+//! `correlation_key`, so a recoverable output-stage eval failure takes
+//! the ungrouped direct-push branch. This test declares `correlation_key`
+//! on both Combine sources, so the failure parks under its `$ck` group
+//! cell and surfaces through group-commit — exercising that the parked
+//! failure's category (`combine_output_row`) and stage (`combine:<name>`)
+//! survive group-commit verbatim rather than being rewritten to the
+//! generic correlation-commit disposition, and that the failing group
+//! flushes atomically while clean groups still reach the writer.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_core::config::{CompileContext, parse_config};
+use clinker_core::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_core::source::multi_file::FileSlot;
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn std::io::Write + Send> {
+    Box::new(buf.clone())
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "test".to_string(),
+        batch_id: "batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// A recoverable Combine output-row eval failure parks under its
+/// correlation group cell and surfaces through group-commit with its
+/// original category and stage preserved.
+///
+/// Both Combine sources declare `correlation_key: id` and the Combine
+/// equijoins on `id`, so the driver row and its matched build row share
+/// one `$ck` group cell per id. The matched-body `d.amt / b.factor` eval
+/// divides by zero on `id=2` (build factor=0), so that group's cell goes
+/// dirty; ids 1 and 3 land in their own clean cells. At group-commit the
+/// dirty cell re-emits its parked failures as `combine_output_row`
+/// triggers (category and `combine:enriched` stage copied verbatim from
+/// the parked records — NOT rewritten to the generic correlation-commit
+/// disposition), while the two clean cells flush their surviving rows to
+/// the writer. The failing group is a self-contained single-member group,
+/// so no clean survivor is co-grouped with the failure and DLQ'd as
+/// collateral.
+#[test]
+fn grouped_combine_output_row_parks_under_group_cell_and_flushes_atomically() {
+    let yaml = r#"
+pipeline:
+  name: grouped_combine_output_row
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_drv
+    config:
+      name: src_drv
+      type: csv
+      path: drv.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: amt, type: int }
+  - type: source
+    name: src_bld
+    config:
+      name: src_bld
+      type: csv
+      path: bld.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: int }
+        - { name: factor, type: int }
+  - type: combine
+    name: enriched
+    input:
+      d: src_drv
+      b: src_bld
+    config:
+      where: 'd.id == b.id'
+      match: first
+      on_miss: skip
+      cxl: |
+        emit id = d.id
+        emit ratio = d.amt / b.factor
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: enriched
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    // Build row id=2 carries factor=0, so the matched-body
+    // `d.amt / b.factor` eval divides by zero for driver row id=2 only;
+    // ids 1 and 3 evaluate cleanly into their own group cells.
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_drv".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot(
+                "drv",
+                "id,amt\n1,10\n2,20\n3,30\n",
+            )]),
+        ),
+        (
+            "src_bld".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot(
+                "bld",
+                "id,factor\n1,2\n2,0\n3,5\n",
+            )]),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    // (a) The parked failure surfaces through group-commit as
+    // `combine_output_row` — category and stage preserved verbatim, not
+    // rewritten to the generic correlation-commit disposition.
+    let combine_dlq: Vec<&clinker_core::executor::DlqEntry> = report
+        .dlq_entries
+        .iter()
+        .filter(|e| e.category == clinker_core::dlq::DlqErrorCategory::CombineOutputRow)
+        .collect();
+    assert_eq!(
+        combine_dlq.len(),
+        2,
+        "the failing group parks the driver row and its matched build row, \
+         both surfacing as combine_output_row through group-commit: {:?}",
+        report
+            .dlq_entries
+            .iter()
+            .map(|e| (e.source_name.as_ref(), e.category.as_str(), e.trigger))
+            .collect::<Vec<_>>()
+    );
+
+    let driver_entry = combine_dlq
+        .iter()
+        .find(|e| e.source_name.as_ref() == "src_drv")
+        .expect("driver row of the failing group is attributed to src_drv");
+    assert!(
+        driver_entry.trigger,
+        "the driver row is the group's trigger after group-commit"
+    );
+    assert_eq!(
+        driver_entry.stage.as_deref(),
+        Some("combine:enriched"),
+        "the parked Combine stage survives group-commit, not rewritten to \
+         the generic correlation-commit stage"
+    );
+    assert_eq!(
+        driver_entry.source_row, 2,
+        "the failing driver source row is id=2's 1-based source row"
+    );
+
+    let build_entry = combine_dlq
+        .iter()
+        .find(|e| e.source_name.as_ref() == "src_bld")
+        .expect("matched build row is attributed to src_bld, not the merged source");
+    assert_eq!(
+        build_entry.stage.as_deref(),
+        Some("combine:enriched"),
+        "the parked build-side Combine stage also survives group-commit"
+    );
+
+    // (b) The failing group is a self-contained single-member dirty cell,
+    // so no co-grouped survivor is collaterally DLQ'd: no `correlated`
+    // entry is produced for id=2's group.
+    assert!(
+        !report
+            .dlq_entries
+            .iter()
+            .any(|e| e.category == clinker_core::dlq::DlqErrorCategory::Correlated),
+        "id=2 is the only member of its dirty group, so no collateral \
+         (Correlated) entry is produced: {:?}",
+        report
+            .dlq_entries
+            .iter()
+            .map(|e| (e.source_name.as_ref(), e.category.as_str()))
+            .collect::<Vec<_>>()
+    );
+
+    // The clean id=1 and id=3 groups flush their surviving rows; the
+    // failing id=2 output is dropped.
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(
+        body.len(),
+        2,
+        "the clean id=1 and id=3 groups each flush one surviving row: {output}"
+    );
+    assert!(
+        body.iter().any(|line| line.starts_with("1,")),
+        "the id=1 survivor reaches the output: {output}"
+    );
+    assert!(
+        body.iter().any(|line| line.starts_with("3,")),
+        "the id=3 survivor reaches the output: {output}"
+    );
+    assert!(
+        !body.iter().any(|line| line.starts_with("2,")),
+        "the failing id=2 row is dropped from the output: {output}"
+    );
+}

--- a/crates/clinker-core/tests/per_source_rollback.rs
+++ b/crates/clinker-core/tests/per_source_rollback.rs
@@ -508,3 +508,371 @@ nodes:
         "the surviving row is id=1: {output}"
     );
 }
+
+/// Asserts the standard `combine_output_row` recovery shape: a clean run
+/// (no abort), exactly the driver + matched-build DLQ pair attributed to
+/// the contributing sources, both contributing sources rewound to their
+/// pre-fold floor of 0, and exactly the clean `id=1` row at the output.
+fn assert_combine_output_row_recovered(
+    report: &clinker_core::executor::ExecutionReport,
+    buf: &SharedBuffer,
+) {
+    let combine_dlq: Vec<&clinker_core::executor::DlqEntry> = report
+        .dlq_entries
+        .iter()
+        .filter(|e| e.category == clinker_core::dlq::DlqErrorCategory::CombineOutputRow)
+        .collect();
+    assert_eq!(
+        combine_dlq.len(),
+        2,
+        "one trigger (driver) + one build-side entry for the failing row: {:?}",
+        report
+            .dlq_entries
+            .iter()
+            .map(|e| (e.source_name.as_ref(), e.category.as_str(), e.trigger))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        combine_dlq
+            .iter()
+            .any(|e| e.source_name.as_ref() == "src_drv" && e.trigger),
+        "driver row is the attributed trigger on src_drv: {:?}",
+        combine_dlq
+            .iter()
+            .map(|e| (e.source_name.as_ref(), e.trigger))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        combine_dlq
+            .iter()
+            .any(|e| e.source_name.as_ref() == "src_bld" && !e.trigger),
+        "matched build row is attributed to src_bld, not the merged source"
+    );
+
+    assert_eq!(
+        report.per_source_rollback_cursors.get("src_drv"),
+        Some(&0),
+        "driver source rewinds to its pre-fold snapshot floor of 0"
+    );
+    assert_eq!(
+        report.per_source_rollback_cursors.get("src_bld"),
+        Some(&0),
+        "build source rewinds to its pre-fold snapshot floor of 0"
+    );
+
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(
+        body.len(),
+        1,
+        "only the clean id=1 row reaches the output: {output}"
+    );
+    assert!(
+        body[0].starts_with("1,"),
+        "the surviving row is id=1: {output}"
+    );
+}
+
+/// A recoverable Combine output-row eval failure under `strategy: continue`
+/// recovers the same way through the IEJoin kernel as through the inline
+/// hash build-probe arm: the failing driver row routes to the DLQ with
+/// category `combine_output_row`, attributes to the contributing sources,
+/// and rewinds both their cursors to the pre-fold floor.
+///
+/// A pure-range two-conjunct predicate (`d.lo <= b.x AND d.hi >= b.x`,
+/// no equality) routes the combine through the IEJoin kernel. The
+/// matched-body `d.amt / b.factor` eval divides by zero for the row whose
+/// matched build carries `factor=0`. Inputs are kept tiny so no spill
+/// occurs and the driver row number is exact.
+#[test]
+fn iejoin_combine_output_row_recoverable_dlq() {
+    let yaml = r#"
+pipeline:
+  name: iejoin_combine_output_row_recoverable
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_drv
+    config:
+      name: src_drv
+      type: csv
+      path: drv.csv
+      schema:
+        - { name: lo, type: int }
+        - { name: hi, type: int }
+        - { name: amt, type: int }
+  - type: source
+    name: src_bld
+    config:
+      name: src_bld
+      type: csv
+      path: bld.csv
+      schema:
+        - { name: x, type: int }
+        - { name: factor, type: int }
+  - type: combine
+    name: enriched
+    input:
+      d: src_drv
+      b: src_bld
+    config:
+      where: 'd.lo <= b.x and d.hi >= b.x'
+      match: first
+      on_miss: skip
+      cxl: |
+        emit x = b.x
+        emit ratio = d.amt / b.factor
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: enriched
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    // Driver row 1 (lo=1,hi=5) brackets build x=1 (factor=2) → clean.
+    // Driver row 2 (lo=6,hi=10) brackets build x=8 (factor=0) → the
+    // matched-body division by zero fires for that driver row only.
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_drv".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot(
+                "drv",
+                "lo,hi,amt\n1,5,10\n6,10,20\n",
+            )]),
+        ),
+        (
+            "src_bld".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot("bld", "x,factor\n1,2\n8,0\n")]),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    assert_combine_output_row_recovered(&report, &buf);
+    // The surviving IEJoin row carries the matched build x=1.
+    assert!(
+        buf.as_string()
+            .lines()
+            .nth(1)
+            .is_some_and(|l| l.starts_with("1,")),
+        "surviving row carries the clean matched build x=1: {}",
+        buf.as_string()
+    );
+}
+
+/// A recoverable Combine output-row eval failure recovers the same way
+/// through the grace-hash kernel as through the inline arm.
+///
+/// An equality predicate with the `strategy: grace_hash` hint routes the
+/// combine through the grace-hash kernel. Inputs are tiny so the failing
+/// probe stays in the in-memory partition (no spill), keeping the
+/// driver's row number exact for attribution. The matched-body
+/// `d.amt / b.factor` divides by zero where the matched build carries
+/// `factor=0`.
+#[test]
+fn grace_hash_combine_output_row_recoverable_dlq() {
+    let yaml = r#"
+pipeline:
+  name: grace_hash_combine_output_row_recoverable
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_drv
+    config:
+      name: src_drv
+      type: csv
+      path: drv.csv
+      schema:
+        - { name: id, type: int }
+        - { name: amt, type: int }
+  - type: source
+    name: src_bld
+    config:
+      name: src_bld
+      type: csv
+      path: bld.csv
+      schema:
+        - { name: id, type: int }
+        - { name: factor, type: int }
+  - type: combine
+    name: enriched
+    input:
+      d: src_drv
+      b: src_bld
+    config:
+      where: 'd.id == b.id'
+      match: first
+      on_miss: skip
+      strategy: grace_hash
+      cxl: |
+        emit id = d.id
+        emit ratio = d.amt / b.factor
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: enriched
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    // Build row id=2 carries factor=0, so the matched-body
+    // `d.amt / b.factor` eval divides by zero for driver row id=2 only.
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_drv".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot("drv", "id,amt\n1,10\n2,20\n")]),
+        ),
+        (
+            "src_bld".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot("bld", "id,factor\n1,2\n2,0\n")]),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    assert_combine_output_row_recovered(&report, &buf);
+}
+
+/// A recoverable Combine output-row eval failure recovers the same way
+/// through the sort-merge kernel as through the inline arm.
+///
+/// A single pure-range inequality (`d.k <= b.k`) with both sources
+/// declaring `sort_order` on the range key routes the combine through the
+/// sort-merge kernel (single range conjunct, presorted inputs). The
+/// matched-body `d.amt / b.factor` divides by zero where the matched
+/// build carries `factor=0`.
+#[test]
+fn sort_merge_combine_output_row_recoverable_dlq() {
+    let yaml = r#"
+pipeline:
+  name: sort_merge_combine_output_row_recoverable
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_drv
+    config:
+      name: src_drv
+      type: csv
+      path: drv.csv
+      sort_order:
+        - field: k
+      schema:
+        - { name: k, type: int }
+        - { name: amt, type: int }
+  - type: source
+    name: src_bld
+    config:
+      name: src_bld
+      type: csv
+      path: bld.csv
+      sort_order:
+        - field: k
+      schema:
+        - { name: k, type: int }
+        - { name: factor, type: int }
+  - type: combine
+    name: enriched
+    input:
+      src_drv: src_drv
+      src_bld: src_bld
+    config:
+      where: 'src_drv.k <= src_bld.k'
+      match: first
+      on_miss: skip
+      cxl: |
+        emit k = src_drv.k
+        emit ratio = src_drv.amt / src_bld.factor
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: enriched
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    // Driver row k=1 (amt=10) matches the first build (k=5, factor=2)
+    // under `match: first` → clean. Driver row k=6 (amt=20) matches the
+    // first build with k>=6 (k=8, factor=0) → division by zero fires for
+    // that driver row only. Both inputs are ascending on `k`.
+    let readers: SourceReaders = HashMap::from([
+        (
+            "src_drv".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot("drv", "k,amt\n1,10\n6,20\n")]),
+        ),
+        (
+            "src_bld".to_string(),
+            clinker_core::executor::SourceInput::Files(vec![slot("bld", "k,factor\n5,2\n8,0\n")]),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    // The clean driver row k=1 reaches the output; the failing k=6 row is
+    // routed to the DLQ with both contributing sources rewound.
+    let combine_dlq: Vec<&clinker_core::executor::DlqEntry> = report
+        .dlq_entries
+        .iter()
+        .filter(|e| e.category == clinker_core::dlq::DlqErrorCategory::CombineOutputRow)
+        .collect();
+    assert_eq!(
+        combine_dlq.len(),
+        2,
+        "one trigger (driver) + one build-side entry for the failing row: {:?}",
+        report
+            .dlq_entries
+            .iter()
+            .map(|e| (e.source_name.as_ref(), e.category.as_str(), e.trigger))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        combine_dlq
+            .iter()
+            .any(|e| e.source_name.as_ref() == "src_drv" && e.trigger),
+        "driver row is the attributed trigger on src_drv"
+    );
+    assert!(
+        combine_dlq
+            .iter()
+            .any(|e| e.source_name.as_ref() == "src_bld" && !e.trigger),
+        "matched build row is attributed to src_bld, not the merged source"
+    );
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert_eq!(
+        body.len(),
+        1,
+        "only the clean k=1 row reaches the output: {output}"
+    );
+    assert!(
+        body[0].starts_with("1,"),
+        "the surviving row is k=1: {output}"
+    );
+}

--- a/docs/src/pipeline/error-handling.md
+++ b/docs/src/pipeline/error-handling.md
@@ -88,6 +88,10 @@ The `_cxl_dlq_error_category` column contains one of these values:
 | `aggregate_type_error` | An aggregate function received an incompatible type |
 | `validation_failure` | A declarative validation check failed |
 | `aggregate_finalize` | An aggregate function failed during finalization |
+| `correlated` | A non-failing record was DLQ'd as collateral because another record in its correlation group failed |
+| `group_size_exceeded` | A correlation-key group exceeded the configured `max_group_buffer` limit |
+| `late_record` | A record arrived at a time-windowed aggregate after its event-time window had already closed |
+| `expansion_limit_exceeded` | A transform's `emit each` fan-out produced more output records than its `max_expansion` ceiling allows |
 | `combine_output_row` | A Combine output-stage eval failed for one driver row (probe-key, residual, or matched / `on_miss: null_fields` body); the entry carries the contributing-build lineage and rewinds both the driver and matched build source's rollback cursor. Recovery applies to the hash build-probe (inline) Combine arm only; IEJoin, grace-hash, and sort-merge output-eval failures stay fail-fast |
 
 ## Advanced options

--- a/docs/src/pipeline/error-handling.md
+++ b/docs/src/pipeline/error-handling.md
@@ -92,7 +92,7 @@ The `_cxl_dlq_error_category` column contains one of these values:
 | `group_size_exceeded` | A correlation-key group exceeded the configured `max_group_buffer` limit |
 | `late_record` | A record arrived at a time-windowed aggregate after its event-time window had already closed |
 | `expansion_limit_exceeded` | A transform's `emit each` fan-out produced more output records than its `max_expansion` ceiling allows |
-| `combine_output_row` | A Combine output-stage eval failed for one driver row (probe-key, residual, or matched / `on_miss: null_fields` body); the entry carries the contributing-build lineage and rewinds both the driver and matched build source's rollback cursor. Recovery applies to the hash build-probe (inline) Combine arm only; IEJoin, grace-hash, and sort-merge output-eval failures stay fail-fast |
+| `combine_output_row` | A Combine output-stage eval failed for one driver row (probe-key, residual, or matched / `on_miss: null_fields` body); the entry carries the contributing-build lineage and rewinds both the driver and matched build source's rollback cursor. Routed to the DLQ under `continue` / `best_effort` across every Combine join mode; `fail_fast` propagates the eval error |
 
 ## Advanced options
 


### PR DESCRIPTION
## Summary

When a Combine operator's output-stage expression fails on a matched row (the
residual filter, the matched body, or the `on_miss: null_fields` body), the
engine can route that record to the `combine_output_row` dead-letter category
and rewind the contributing sources instead of aborting the whole run — but
until now that recovery worked only in the inline hash build-probe join arm.
The other three join kernels (IEJoin, grace-hash, sort-merge) propagated an
output-stage evaluation failure as a hard error regardless of the configured
error strategy.

This PR makes the configured error strategy (`continue` / `best_effort` vs
`fail_fast`) govern Combine output-stage failures **uniformly across all four
join modes**, adds the missing coverage for the grouped (correlation-key)
recovery path, and completes the dead-letter category table in the user docs.

## Changes

### Uniform output-row recovery across all join kernels (closes #218)

The three non-inline kernels execute inside a Rayon pool scope without mutable
access to the executor context, so they cannot route to the dead-letter queue
directly. Each kernel now carries the configured error strategy and, under a
recovering strategy, defers a recoverable output-stage evaluation failure into a
new `CombineKernelOutput { records, output_eval_failures }` rather than
returning early; `fail_fast` behaviour is unchanged. The dispatcher drains those
deferred failures through the existing recovery path — rewinding each
contributing source to its captured pre-fold cursor before admitting the
dead-letter entry — exactly as the inline arm does. Structural, memory-budget,
and spill-I/O failures remain fail-fast. One recovery test is added per kernel.

### Grouped output-row dead-letter gate test (closes #219)

When a pipeline declares a correlation key, a recoverable Combine output failure
is parked under its group cell and flushed atomically with the rest of the group
through group-commit, with its `combine_output_row` category preserved. This
path was wired but only the ungrouped path had direct coverage. This adds an
end-to-end test that fails a Combine output expression on one member of a
correlation group and asserts the row is parked under the correct group cell and
the group flushes atomically, category preserved, with the surviving rows
emitted.

### Complete the dead-letter category table (closes #220)

The category table in the error-handling guide listed 8 of the 12 dead-letter
categories. This adds the four missing rows — `correlated`,
`group_size_exceeded`, `late_record`, `expansion_limit_exceeded` — each with its
trigger condition, and updates the `combine_output_row` row to reflect the now
uniform recovery.

## Testing

- 4 new tests: one per join kernel for output-row recovery, plus the grouped
  correlation-key path.
- Full workspace test suite green; clippy clean with and without
  `--all-targets`; `cargo deny check` clean; no new dependencies.

Closes #218
Closes #219
Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
