### PR TITLE
clinker-core: pre-decomposition cleanups (dead code, fixture count, spill helper, redundant clone)

### DIFF
--- a/crates/clinker-core/src/executor/dispatch.rs
+++ b/crates/clinker-core/src/executor/dispatch.rs
@@ -2319,7 +2319,6 @@ pub(crate) fn transform_fused_consume(
         .expected_input_schema_in(current_dag)
         .cloned();
     let output_schema = current_dag.graph[node_idx].stored_output_schema().cloned();
-    let upstream_name = source_name_owned.clone();
     // Per-Transform-resolved streaming batch size. The fused loop drives
     // emitted records through an `EventBatcher` of this size, bounding the
     // in-flight working set to one batch before each flush. Resolved
@@ -2498,7 +2497,7 @@ pub(crate) fn transform_fused_consume(
             }
 
             if let Some(exp) = expected_input.as_ref() {
-                check_input_schema(exp, rec.schema(), name, "transform", &upstream_name)?;
+                check_input_schema(exp, rec.schema(), name, "transform", &source_name_owned)?;
             }
 
             if let Some(evaluator) = evaluator_opt.as_mut() {

--- a/crates/clinker-core/src/log_rules.rs
+++ b/crates/clinker-core/src/log_rules.rs
@@ -77,19 +77,6 @@ pub fn resolve_log_rules(
 mod tests {
     use super::*;
 
-    #[allow(dead_code)]
-    fn make_directive(level: LogLevel, when: LogTiming, message: &str) -> LogDirective {
-        LogDirective {
-            level,
-            when,
-            condition: None,
-            message: message.to_string(),
-            fields: None,
-            every: None,
-            log_rule: None,
-        }
-    }
-
     fn make_rule() -> LogRule {
         LogRule {
             level: Some(LogLevel::Info),

--- a/crates/clinker-core/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-core/src/pipeline/sort_merge_join.rs
@@ -67,6 +67,13 @@ const COLLECT_PER_GROUP_CAP: usize = 10_000;
 /// polls during the merge walk.
 const MEMORY_CHECK_INTERVAL: usize = 10_000;
 
+/// Per-side external-sort spill threshold in bytes: half the soft RSS limit,
+/// floored at 16 KiB so tests with tiny budgets still exercise the spill path.
+/// Shared by both the driver- and build-side external sorts.
+fn spill_threshold_bytes(budget: &MemoryArbitrator) -> usize {
+    std::cmp::max(16 * 1024, budget.soft_limit() as usize / 2)
+}
+
 /// Order-tracking sidecar carried alongside every record in the
 /// executor's `node_buffers`. Same alias the IEJoin and grace-hash
 /// kernels expose; spelled out here so the public exec entry point's
@@ -828,7 +835,7 @@ fn sort_driver_pairs_externally(
         });
     };
     let schema = Arc::clone(pairs[0].0.schema());
-    let spill_threshold = std::cmp::max(16 * 1024, budget.soft_limit() as usize / 2);
+    let spill_threshold = spill_threshold_bytes(budget);
     let sort_field = crate::config::SortField {
         field: field.clone(),
         order: crate::config::SortOrder::Asc,
@@ -950,7 +957,7 @@ fn sort_build_pairs_externally(
         });
     };
     let schema = Arc::clone(pairs[0].0.schema());
-    let spill_threshold = std::cmp::max(16 * 1024, budget.soft_limit() as usize / 2);
+    let spill_threshold = spill_threshold_bytes(budget);
     let sort_field = crate::config::SortField {
         field: field.clone(),
         order: crate::config::SortOrder::Asc,

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -4093,19 +4093,6 @@ fn combine_e309(combine_name: &str, span: Span) -> Diagnostic {
     )
 }
 
-/// E201 diagnostic for a Source with no `schema:` field.
-#[allow(dead_code)]
-pub fn e201_missing_schema(source_name: &str, span: Span) -> Diagnostic {
-    Diagnostic::error(
-        "E201",
-        format!("source {source_name:?} is missing required `schema:` field"),
-        LabeledSpan::primary(span, String::new()),
-    )
-    .with_help(
-        "declare the source columns inline:\n  schema:\n    - { name: col1, type: string }\n    - { name: col2, type: int }",
-    )
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/clinker-core/tests/composition_loader_test.rs
+++ b/crates/clinker-core/tests/composition_loader_test.rs
@@ -13,6 +13,27 @@ fn manifest_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+/// Counts `.comp.yaml` files under `dir`, recursing into subdirectories —
+/// mirrors the directory walk `scan_workspace_signatures` performs, so the
+/// loaded-table length can be checked against the on-disk corpus without
+/// hard-coding a count that every new fixture would force a test edit on.
+fn count_comp_fixtures(dir: &std::path::Path) -> usize {
+    let mut count = 0;
+    for entry in std::fs::read_dir(dir).expect("read fixture dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            count += count_comp_fixtures(&path);
+        } else if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(".comp.yaml"))
+        {
+            count += 1;
+        }
+    }
+    count
+}
+
 /// Path to the committed 5-fixture corpus.
 fn fixture_workspace_root() -> PathBuf {
     manifest_dir().join("tests").join("fixtures")
@@ -39,10 +60,14 @@ fn test_phase1_scanner_loads_all_fixtures() {
     let table = scan_workspace_signatures(&root)
         .expect("composition fixture corpus must load without errors");
 
+    // The scanner must find one signature per on-disk `.comp.yaml`; counting
+    // the corpus dynamically keeps this from breaking every time a fixture is
+    // added.
+    let expected = count_comp_fixtures(&root);
     assert_eq!(
         table.len(),
-        23,
-        "expected 23 composition signatures, got {}: {:?}",
+        expected,
+        "expected {expected} composition signatures (one per `.comp.yaml`), got {}: {:?}",
         table.len(),
         table.keys().collect::<Vec<_>>()
     );

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -1483,11 +1483,6 @@ mod tests {
         type_check(resolved, schema).expect_err("Expected type errors but got Ok")
     }
 
-    #[allow(dead_code)]
-    fn node_type(typed: &TypedProgram, idx: usize) -> &Type {
-        typed.types[idx].as_ref().unwrap_or(&Type::Any)
-    }
-
     // Find the type of the first expression in the first emit statement
     fn first_emit_expr_type(typed: &TypedProgram) -> Type {
         for stmt in &typed.program.statements {


### PR DESCRIPTION
Four small, independent, behavior-preserving cleanups in `clinker-core` (and one in `cxl`), landed ahead of the larger `clinker-core` decomposition work so the modules that will be split are already tidy. Each is its own commit.

- **Remove dead code** — Delete three unused functions that each carried an `#[allow(dead_code)]` suppression: `e201_missing_schema` (a duplicate of an E201 diagnostic emitted inline elsewhere) and two test helpers (`make_directive`, `node_type`) that no test ever called. Removing them clears the suppressions so the dead-code lint covers these modules again.
- **Dynamic composition-fixture count** — The scanner integration test hard-coded `table.len() == 23`, forcing a one-line bump every time a fixture was added. It now counts the `.comp.yaml` files in the fixture tree the scanner walks and asserts the loaded-table length matches. The canonical-name presence checks are unchanged.
- **Deduplicate spill threshold** — The per-side external-sort spill threshold in the sort-merge join (`max(16 KiB, soft_limit / 2)`) was computed by an identical inline expression at two sites. Extracted into one private `spill_threshold_bytes` helper.
- **Drop a redundant clone** — The fused Transform dispatch path cloned the upstream source name a second time only to pass it as a diagnostic label. The original owned string outlives every use, so the schema check now borrows it directly, removing an allocation on the Transform hot path.

No behavioral change in any commit. The full CI gauntlet (fmt, both clippy passes, workspace tests, bench checks, dependency audit) is green.

Closes #141
Closes #154
Closes #140
Closes #143
