### PR TITLE
clinker-core: introduce AggregatorConfig to drop too_many_arguments in aggregation

### DIFF
--- a/crates/clinker-core/src/aggregation/hash.rs
+++ b/crates/clinker-core/src/aggregation/hash.rs
@@ -187,23 +187,59 @@ pub struct HashAggregator {
     consumer_handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
 }
 
+/// Construction parameters shared by [`HashAggregator::new`] and
+/// [`AggregateStream::for_node`].
+///
+/// Groups the compiled plan, its evaluator, the output and spill
+/// schemas, the memory budget, the spill directory, the node's
+/// transform name, and the arbitrator-facing consumer handle into one
+/// value so neither constructor carries a long positional argument list.
+/// `spill_schema` and `spill_dir` feed the spill path; the hot loop
+/// only consults them through the `value_heap_bytes` budget check.
+///
+/// [`AggregateStream::for_node`]: super::AggregateStream::for_node
+pub struct AggregatorConfig {
+    /// Compiled aggregate plan — bindings, group-by projection, and
+    /// retraction-strategy flags.
+    pub compiled: Arc<CompiledAggregate>,
+    /// Evaluator for pre-aggregation filters and expression bindings.
+    pub evaluator: ProgramEvaluator,
+    /// Schema of finalized output rows.
+    pub output_schema: Arc<Schema>,
+    /// Schema of spilled partition rows (group-by columns ++
+    /// `__acc_state`).
+    pub spill_schema: Arc<Schema>,
+    /// RSS budget in bytes that gates the spill trigger. Zero disables
+    /// the group-count cap (`max_groups` becomes `usize::MAX`).
+    pub memory_budget: usize,
+    /// Directory for spill files; `None` keeps the aggregator
+    /// in-memory-only.
+    pub spill_dir: Option<PathBuf>,
+    /// Node name, used for diagnostics and the synthetic
+    /// `$ck.aggregate.<name>` lineage column.
+    pub transform_name: String,
+    /// Shared handle mirroring `value_heap_bytes` into the
+    /// pipeline-scoped arbitrator's pull-mode accounting.
+    pub consumer_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
+}
+
 impl HashAggregator {
-    /// Construct a new aggregator from a compiled aggregate plan.
+    /// Construct a new aggregator from an [`AggregatorConfig`].
     ///
-    /// `spill_schema` and `spill_dir` are wired for the spill path that
-    /// lands in 16.3.10. The 16.3.8 hot loop only touches them through
-    /// the `value_heap_bytes` budget check.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        compiled: Arc<CompiledAggregate>,
-        evaluator: ProgramEvaluator,
-        output_schema: Arc<Schema>,
-        spill_schema: Arc<Schema>,
-        memory_budget: usize,
-        spill_dir: Option<PathBuf>,
-        transform_name: impl Into<String>,
-        consumer_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
-    ) -> Self {
+    /// `spill_schema` and `spill_dir` are wired for the spill path; the
+    /// hot loop only touches them through the `value_heap_bytes` budget
+    /// check.
+    pub fn new(config: AggregatorConfig) -> Self {
+        let AggregatorConfig {
+            compiled,
+            evaluator,
+            output_schema,
+            spill_schema,
+            memory_budget,
+            spill_dir,
+            transform_name,
+            consumer_handle,
+        } = config;
         let group_by_indices = compiled.group_by_indices.clone();
         let group_by_fields = compiled.group_by_fields.clone();
         let pre_agg_filter = compiled.pre_agg_filter.clone();
@@ -249,7 +285,7 @@ impl HashAggregator {
             spill_schema,
             spill_dir,
             output_schema,
-            transform_name: transform_name.into(),
+            transform_name,
             evaluator,
             rows_seen: 0,
             max_groups,
@@ -1536,16 +1572,16 @@ mod spill_trigger_tests {
 
         let evaluator = ProgramEvaluator::new(Arc::new(typed), false);
 
-        HashAggregator::new(
-            Arc::new(compiled),
+        HashAggregator::new(AggregatorConfig {
+            compiled: Arc::new(compiled),
             evaluator,
             output_schema,
             spill_schema,
             memory_budget,
             spill_dir,
-            "test_agg",
-            crate::pipeline::memory::ConsumerHandle::new(),
-        )
+            transform_name: "test_agg".to_string(),
+            consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+        })
     }
 
     fn ctx_for<'a>(stable: &'a StableEvalContext, file: &'a Arc<str>, row: u64) -> EvalContext<'a> {
@@ -2805,16 +2841,16 @@ mod spill_trigger_tests {
 
         let evaluator = ProgramEvaluator::new(Arc::new(typed), false);
 
-        HashAggregator::new(
-            Arc::new(compiled),
+        HashAggregator::new(AggregatorConfig {
+            compiled: Arc::new(compiled),
             evaluator,
             output_schema,
             spill_schema,
             memory_budget,
             spill_dir,
-            transform_name,
-            crate::pipeline::memory::ConsumerHandle::new(),
-        )
+            transform_name: transform_name.to_string(),
+            consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+        })
     }
 
     #[test]

--- a/crates/clinker-core/src/aggregation/mod.rs
+++ b/crates/clinker-core/src/aggregation/mod.rs
@@ -38,14 +38,13 @@ mod hash;
 mod spill;
 
 pub use error::{AggregateEvalError, AggregateStrategy, HashAggError};
-pub use hash::{AccumulatorFactory, AggregateConsumer, HashAggregator};
+pub use hash::{AccumulatorFactory, AggregateConsumer, AggregatorConfig, HashAggregator};
 pub use spill::{AggSpillFile, SpillState};
 
 use hash::NullStorage;
 pub(crate) use hash::{empty_global_fold_row, finalize_group_inner, group_by_sort_fields};
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -395,31 +394,25 @@ impl AggregateStream {
     /// `PipelineError::Internal` (NOT `todo!()` / `unreachable!()`) per
     /// the DataFusion #12086 lesson on unreachable arms in long-lived
     /// executor dispatch tables.
-    #[allow(clippy::too_many_arguments)]
     pub fn for_node(
-        compiled: Arc<CompiledAggregate>,
-        evaluator: ProgramEvaluator,
         strategy: AggregateStrategy,
-        output_schema: Arc<Schema>,
-        spill_schema: Arc<Schema>,
-        memory_budget: usize,
-        spill_dir: Option<PathBuf>,
-        transform_name: String,
-        consumer_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
+        config: AggregatorConfig,
     ) -> Result<Self, PipelineError> {
-        let _ = (&spill_schema, memory_budget, &spill_dir);
         match strategy {
-            AggregateStrategy::Hash => Ok(Self::Hash(Box::new(HashAggregator::new(
-                compiled,
-                evaluator,
-                output_schema,
-                spill_schema,
-                memory_budget,
-                spill_dir,
-                transform_name,
-                consumer_handle,
-            )))),
+            AggregateStrategy::Hash => Ok(Self::Hash(Box::new(HashAggregator::new(config)))),
             AggregateStrategy::Streaming => {
+                // The streaming path ignores the spill schema, memory
+                // budget, spill directory, and consumer handle: it folds
+                // a pre-sorted upstream key-by-key without accumulating an
+                // in-memory hash table, so there is nothing to spill or
+                // charge into the arbitrator.
+                let AggregatorConfig {
+                    compiled,
+                    evaluator,
+                    output_schema,
+                    transform_name,
+                    ..
+                } = config;
                 Ok(Self::Streaming(Box::new(StreamingAggregator::new_for_raw(
                     compiled,
                     evaluator,

--- a/crates/clinker-core/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-core/src/executor/aggregate_dispatch.rs
@@ -192,15 +192,17 @@ pub(crate) fn dispatch_aggregation(
             crate::aggregation::AggregateConsumer::new(agg_consumer_handle.clone()),
         ));
         let mut stream = crate::aggregation::AggregateStream::for_node(
-            Arc::clone(compiled),
-            evaluator,
             agg_strategy,
-            Arc::clone(output_schema),
-            spill_schema,
-            mem_limit,
-            Some(ctx.spill_root_path.to_path_buf()),
-            name.clone(),
-            agg_consumer_handle,
+            crate::aggregation::AggregatorConfig {
+                compiled: Arc::clone(compiled),
+                evaluator,
+                output_schema: Arc::clone(output_schema),
+                spill_schema,
+                memory_budget: mem_limit,
+                spill_dir: Some(ctx.spill_root_path.to_path_buf()),
+                transform_name: name.clone(),
+                consumer_handle: agg_consumer_handle,
+            },
         )?;
 
         // Per-record accumulator updates + spill I/O. The loop
@@ -666,15 +668,17 @@ fn run_time_windowed_aggregate(
             crate::aggregation::AggregateConsumer::new(agg_consumer_handle.clone()),
         ));
         let stream = AggregateStream::for_node(
-            Arc::clone(compiled),
-            evaluator,
             strategy,
-            Arc::clone(&output_schema),
-            Arc::clone(&spill_schema),
-            mem_limit,
-            Some(ctx.spill_root_path.to_path_buf()),
-            name.to_string(),
-            agg_consumer_handle,
+            crate::aggregation::AggregatorConfig {
+                compiled: Arc::clone(compiled),
+                evaluator,
+                output_schema: Arc::clone(&output_schema),
+                spill_schema: Arc::clone(&spill_schema),
+                memory_budget: mem_limit,
+                spill_dir: Some(ctx.spill_root_path.to_path_buf()),
+                transform_name: name.to_string(),
+                consumer_handle: agg_consumer_handle,
+            },
         )?;
         Ok((stream, agg_consumer_id))
     };

--- a/crates/clinker-core/src/executor/tests/aggregation.rs
+++ b/crates/clinker-core/src/executor/tests/aggregation.rs
@@ -21,7 +21,7 @@ mod dispatch {
     use cxl::typecheck::types::Type;
     use indexmap::IndexMap;
 
-    use crate::aggregation::{AggregatorGroupState, HashAggregator};
+    use crate::aggregation::{AggregatorConfig, AggregatorGroupState, HashAggregator};
     use crate::config::ErrorStrategy;
     use crate::error::PipelineError;
     use crate::executor::tests::run_test;
@@ -89,16 +89,16 @@ mod dispatch {
 
         let evaluator = ProgramEvaluator::new(Arc::new(typed), false);
 
-        HashAggregator::new(
-            Arc::new(compiled),
+        HashAggregator::new(AggregatorConfig {
+            compiled: Arc::new(compiled),
             evaluator,
             output_schema,
             spill_schema,
             memory_budget,
             spill_dir,
-            transform_name.to_string(),
-            crate::pipeline::memory::ConsumerHandle::new(),
-        )
+            transform_name: transform_name.to_string(),
+            consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+        })
     }
 
     fn ctx_for<'a>(stable: &'a StableEvalContext, file: &'a Arc<str>, row: u64) -> EvalContext<'a> {
@@ -1411,7 +1411,7 @@ mod two_phase_bytes_spill {
     use cxl::typecheck::types::Type;
     use indexmap::IndexMap;
 
-    use crate::aggregation::{HashAggregator, group_by_sort_fields};
+    use crate::aggregation::{AggregatorConfig, HashAggregator, group_by_sort_fields};
     use crate::pipeline::sort_key::SortKeyEncoder;
 
     /// Compile a CXL aggregate snippet with a configurable memory budget
@@ -1464,16 +1464,16 @@ mod two_phase_bytes_spill {
 
         let evaluator = ProgramEvaluator::new(Arc::new(typed), false);
 
-        HashAggregator::new(
-            Arc::new(compiled),
+        HashAggregator::new(AggregatorConfig {
+            compiled: Arc::new(compiled),
             evaluator,
             output_schema,
             spill_schema,
             memory_budget,
-            None,
-            transform_name.to_string(),
-            crate::pipeline::memory::ConsumerHandle::new(),
-        )
+            spill_dir: None,
+            transform_name: transform_name.to_string(),
+            consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+        })
     }
 
     fn make_input_schema() -> Arc<Schema> {


### PR DESCRIPTION
## Intent

Two constructors in the hash-aggregation engine — `HashAggregator::new` and `AggregateStream::for_node` — each carried a `#[allow(clippy::too_many_arguments)]` suppression to silence Clippy over an eight-parameter argument list. This collapses that shared parameter cluster into a named struct and removes both suppressions.

## What changed

- Introduce `AggregatorConfig`, a struct that groups the construction parameters shared by both constructors: the compiled aggregate plan, its evaluator, the output and spill schemas, the memory budget, the spill directory, the node's transform name, and the arbitrator-facing consumer handle.
- `HashAggregator::new(config: AggregatorConfig)` destructures the struct; `AggregateStream::for_node(strategy, config)` keeps the strategy selector as its only positional argument and forwards the config (the Hash arm hands it straight to `HashAggregator::new`; the Streaming arm destructures the fields its constructor needs).
- Update the two aggregate-dispatch call sites and the four test call sites to build the struct.
- Delete both `#[allow(clippy::too_many_arguments)]` annotations.

`AggregatorConfig` has multiple consumers (both constructors plus both dispatch call sites), so it is not a speculative single-use wrapper. The change is pure argument grouping — behavior is identical and tests pass unmodified in their logic.

## Verification

`cargo fmt`, `cargo clippy --workspace -- -D warnings`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check --benches --workspace`, and `cargo deny check` all pass.

Closes #271