### PR TITLE
clinker-core: introduce context structs to drop too_many_arguments on execute_dag

### DIFF
--- a/crates/clinker-core/src/executor/mod.rs
+++ b/crates/clinker-core/src/executor/mod.rs
@@ -47,7 +47,9 @@ pub(crate) use streaming::{
 use streaming::{compute_streaming_output_specs, streaming_output};
 pub(crate) use transform::CompiledTransform;
 pub use transform::{TransformSpec, build_transform_specs};
-pub(crate) use transform::{evaluate_single_transform, evaluate_single_transform_windowed};
+pub(crate) use transform::{
+    WindowedEvalCtx, evaluate_single_transform, evaluate_single_transform_windowed,
+};
 use util::scheduled_pass_order;
 pub(crate) use util::{
     build_arbitrator_from_config, compute_init_phase_node_set, copy_build_ck_columns,
@@ -140,6 +142,64 @@ pub(crate) struct DispatchOutcome {
     /// walk unwound early. Carried up so the report surfaces the
     /// interrupted state to the CLI.
     pub(crate) interrupted: bool,
+}
+
+/// Borrowed, read-only inputs threaded through `execute_dag` and
+/// `execute_dag_branching`: the compiled program, the bound plan, and
+/// the per-run parameters. Grouped so both entry points share one
+/// `&` argument instead of six positional borrows, and so the owned
+/// run-scoped resources in [`DagExecResources`] stay visually distinct
+/// from the inputs that outlive the call.
+struct DagExecInputs<'a> {
+    /// Pipeline configuration: node list, error-handling policy,
+    /// concurrency knobs, output configs.
+    config: &'a PipelineConfig,
+    /// Declared Source configs in declaration order. Borrowed for
+    /// per-source seeding (watermark idle-timeouts, count slots).
+    source_configs: &'a [crate::config::SourceConfig],
+    /// Compiled per-node CXL transform programs, looked up by name at
+    /// each Transform / Aggregation dispatch arm.
+    transforms: &'a [CompiledTransform],
+    /// Topologically-sorted execution DAG walked by the dispatcher.
+    plan: &'a ExecutionPlanDag,
+    /// Compile artifacts (bound schemas, composition bodies) consulted
+    /// by the dispatcher while walking the plan.
+    artifacts: &'a crate::plan::bind_schema::CompileArtifacts,
+    /// Per-run parameters: execution / batch ids, channel variable
+    /// overrides, shutdown token.
+    params: &'a PipelineRunParams,
+}
+
+/// Owned, run-scoped resources moved through `execute_dag` into
+/// `execute_dag_branching`, where they are consumed when the dispatch
+/// [`dispatch::ExecutorContext`] is built. Distinct from
+/// [`DagExecInputs`] because every field here transfers ownership into
+/// the walk rather than being borrowed for its duration.
+struct DagExecResources {
+    /// One live crossbeam `Receiver` per declared Source, drained by
+    /// the Source dispatch arm.
+    source_records:
+        HashMap<String, crossbeam_channel::Receiver<crate::executor::stream_event::StreamEvent>>,
+    /// Single + fan-out output writers, split into the dispatcher's
+    /// `writers` / `fan_out_writers` maps at context construction.
+    writers: WriterRegistry,
+    /// Compiled top-level route, if the pipeline declares one Route node.
+    compiled_route: Option<CompiledRoute>,
+    /// Compiled routes keyed by node name, for nested / composition-body
+    /// Route nodes resolved during the walk.
+    compiled_routes_by_name: HashMap<String, CompiledRoute>,
+    /// Pipeline-scoped spill `TempDir`, held until the walk drains so
+    /// operator-side spill files survive the topo loop.
+    spill_root: Arc<tempfile::TempDir>,
+    /// Cached path of `spill_root`, handed to each spill site without
+    /// re-borrowing the `TempDir`.
+    spill_root_path: Arc<std::path::Path>,
+    /// Per-source / per-file event-time watermarks, carried through and
+    /// returned in the [`DispatchOutcome`] for report roll-up.
+    watermarks: crate::executor::watermark::PerSourceWatermarks,
+    /// Pipeline-scoped memory arbitrator that envelopes every spill /
+    /// back-pressure decision across the run.
+    memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
 }
 
 /// Helper for callers (mostly tests and benchmarks) that have a single
@@ -701,22 +761,26 @@ impl PipelineExecutor {
             peak_consumer_usage_bytes,
             interrupted,
         } = Self::execute_dag(
-            config,
-            source_records,
-            &source_configs,
-            writers,
-            &compiled_transforms,
-            compiled_route,
-            compiled_routes_by_name,
-            plan,
-            validated_plan.artifacts(),
-            params,
+            &DagExecInputs {
+                config,
+                source_configs: &source_configs,
+                transforms: &compiled_transforms,
+                plan,
+                artifacts: validated_plan.artifacts(),
+                params,
+            },
+            DagExecResources {
+                source_records,
+                writers,
+                compiled_route,
+                compiled_routes_by_name,
+                spill_root,
+                spill_root_path,
+                watermarks,
+                memory_budget,
+            },
             &mut collector,
-            spill_root,
-            spill_root_path,
             counters,
-            watermarks,
-            memory_budget,
         )?;
 
         // Collect ingest-task outcomes: per-source row counts and the
@@ -815,27 +879,11 @@ impl PipelineExecutor {
     /// directly.
     ///
     /// Returns `(counters, dlq_entries, peak_rss_bytes)`.
-    #[allow(clippy::too_many_arguments)]
     fn execute_dag(
-        config: &PipelineConfig,
-        source_records: HashMap<
-            String,
-            crossbeam_channel::Receiver<crate::executor::stream_event::StreamEvent>,
-        >,
-        source_configs: &[crate::config::SourceConfig],
-        writers: WriterRegistry,
-        transforms: &[CompiledTransform],
-        compiled_route: Option<CompiledRoute>,
-        compiled_routes_by_name: HashMap<String, CompiledRoute>,
-        plan: &ExecutionPlanDag,
-        artifacts: &crate::plan::bind_schema::CompileArtifacts,
-        params: &PipelineRunParams,
+        inputs: &DagExecInputs<'_>,
+        resources: DagExecResources,
         collector: &mut stage_metrics::StageCollector,
-        spill_root: Arc<tempfile::TempDir>,
-        spill_root_path: Arc<std::path::Path>,
         mut counters: PipelineCounters,
-        watermarks: crate::executor::watermark::PerSourceWatermarks,
-        memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
     ) -> Result<DispatchOutcome, PipelineError> {
         let mut dlq_entries: Vec<DlqEntry> = Vec::new();
 
@@ -855,28 +903,17 @@ impl PipelineExecutor {
         // dispatches the Aggregate node even when its upstream Source
         // produced zero records, so the special case still emits the
         // single global-fold row.
-        let window_runtime =
-            crate::executor::window_runtime::WindowRuntimeRegistry::new(&plan.indices_to_build);
+        let window_runtime = crate::executor::window_runtime::WindowRuntimeRegistry::new(
+            &inputs.plan.indices_to_build,
+        );
 
         Self::execute_dag_branching(
-            config,
-            source_records,
-            source_configs,
-            writers,
-            transforms,
-            compiled_route,
-            compiled_routes_by_name,
-            plan,
-            artifacts,
-            params,
+            inputs,
+            resources,
             &mut counters,
             &mut dlq_entries,
             collector,
             window_runtime,
-            memory_budget,
-            spill_root,
-            spill_root_path,
-            watermarks,
         )
     }
 
@@ -892,30 +929,33 @@ impl PipelineExecutor {
     /// is partition-level parallelism (par_iter_mut on chunks), not
     /// branch-level fork-join — scheduling overhead exceeds benefit at
     /// typical ETL branch sizes (2-4 branches, millisecond chains).
-    #[allow(clippy::too_many_arguments)]
     fn execute_dag_branching(
-        config: &PipelineConfig,
-        source_records: HashMap<
-            String,
-            crossbeam_channel::Receiver<crate::executor::stream_event::StreamEvent>,
-        >,
-        source_configs: &[crate::config::SourceConfig],
-        mut writers: WriterRegistry,
-        transforms: &[CompiledTransform],
-        compiled_route: Option<CompiledRoute>,
-        compiled_routes_by_name: HashMap<String, CompiledRoute>,
-        plan: &ExecutionPlanDag,
-        artifacts: &crate::plan::bind_schema::CompileArtifacts,
-        params: &PipelineRunParams,
+        inputs: &DagExecInputs<'_>,
+        resources: DagExecResources,
         counters: &mut PipelineCounters,
         dlq_entries: &mut Vec<DlqEntry>,
         collector: &mut stage_metrics::StageCollector,
         window_runtime: crate::executor::window_runtime::WindowRuntimeRegistry,
-        memory_budget: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
-        spill_root: Arc<tempfile::TempDir>,
-        spill_root_path: Arc<std::path::Path>,
-        watermarks: crate::executor::watermark::PerSourceWatermarks,
     ) -> Result<DispatchOutcome, PipelineError> {
+        let &DagExecInputs {
+            config,
+            source_configs,
+            transforms,
+            plan,
+            artifacts,
+            params,
+        } = inputs;
+        let DagExecResources {
+            source_records,
+            mut writers,
+            compiled_route,
+            compiled_routes_by_name,
+            spill_root,
+            spill_root_path,
+            watermarks,
+            memory_budget,
+        } = resources;
+
         let output_configs: Vec<_> = config.output_configs().cloned().collect();
         let pipeline_start_time = chrono::Local::now().naive_local();
 

--- a/crates/clinker-core/src/executor/transform.rs
+++ b/crates/clinker-core/src/executor/transform.rs
@@ -259,6 +259,28 @@ fn materialize_eval_result(input: &Record, result: EvalResult) -> Vec<TransformO
     }
 }
 
+/// Window-resolution inputs for [`evaluate_single_transform_windowed`]:
+/// the plan (for the analytic-window spec at `window_index`), the
+/// resolved per-window arena + partition index, and this record's
+/// position within that arena. Grouped so the windowed evaluator takes
+/// one `&` argument for the window context, keeping the per-record
+/// values (`record`, `transform_name`, `evaluator`, `ctx`) it shares
+/// with [`evaluate_single_transform`] in the same positions.
+pub(crate) struct WindowedEvalCtx<'a> {
+    /// Execution DAG, indexed by `window_index` to fetch the
+    /// transform's analytic-window spec (`group_by` / `sort_by`).
+    pub(crate) plan: &'a ExecutionPlanDag,
+    /// Index into `plan.indices_to_build` selecting this transform's
+    /// window spec.
+    pub(crate) window_index: usize,
+    /// Resolved window runtime: the materialized arena plus its
+    /// partition index, against which `$window.*` expressions evaluate.
+    pub(crate) runtime: &'a crate::executor::window_runtime::WindowRuntime,
+    /// This record's position within `runtime.arena`, used to locate
+    /// its slot inside the resolved partition.
+    pub(crate) record_pos: u64,
+}
+
 /// Same as [`evaluate_single_transform`] but threads a
 /// [`PartitionWindowContext`] derived from the resolved
 /// [`crate::executor::window_runtime::WindowRuntime`] so `$window.*`
@@ -282,17 +304,20 @@ fn materialize_eval_result(input: &Record, result: EvalResult) -> Vec<TransformO
 /// in any group key, or no matching partition), the evaluator runs
 /// without a window context — matching the legacy inline arena path's
 /// behavior.
-#[allow(clippy::too_many_arguments, clippy::result_large_err)]
+#[allow(clippy::result_large_err)]
 pub(crate) fn evaluate_single_transform_windowed(
     record: &Record,
     transform_name: &str,
     evaluator: &mut ProgramEvaluator,
     ctx: &EvalContext,
-    plan: &ExecutionPlanDag,
-    window_index: usize,
-    runtime: &crate::executor::window_runtime::WindowRuntime,
-    record_pos: u64,
+    window: &WindowedEvalCtx<'_>,
 ) -> Result<Vec<TransformOutput>, TransformEvalError> {
+    let &WindowedEvalCtx {
+        plan,
+        window_index,
+        runtime,
+        record_pos,
+    } = window;
     let spec = &plan.indices_to_build[window_index];
     let arena = runtime.arena.as_ref();
     let index = runtime.index.as_ref();

--- a/crates/clinker-core/src/executor/transform_dispatch.rs
+++ b/crates/clinker-core/src/executor/transform_dispatch.rs
@@ -21,7 +21,9 @@ use crate::executor::dispatch::{
     transform_fused_consume,
 };
 use crate::executor::schema_check::check_input_schema;
-use crate::executor::{evaluate_single_transform, evaluate_single_transform_windowed};
+use crate::executor::{
+    WindowedEvalCtx, evaluate_single_transform, evaluate_single_transform_windowed,
+};
 use crate::plan::execution::{ExecutionPlanDag, PlanNode};
 
 /// Execute the `Transform` arm for `node_idx`: drive per-record CXL
@@ -217,10 +219,12 @@ pub(crate) fn dispatch_transform(
                     name,
                     &mut evaluator,
                     &eval_ctx,
-                    current_dag,
-                    idx_num,
-                    runtime,
-                    record_pos,
+                    &WindowedEvalCtx {
+                        plan: current_dag,
+                        window_index: idx_num,
+                        runtime,
+                        record_pos,
+                    },
                 )
             } else {
                 evaluate_single_transform(&record, name, &mut evaluator, &eval_ctx, &target_schema)


### PR DESCRIPTION
## Intent

Three executor functions in `crates/clinker-core/src/executor` carried `#[allow(clippy::too_many_arguments)]` to suppress the long-parameter-list lint. This groups their shared positional parameters into named context structs so the signatures fall under the lint threshold and the suppressions are deleted outright rather than left in place.

## What changed

- **`DagExecInputs<'a>`** groups the six borrowed, read-only inputs threaded through both `execute_dag` and `execute_dag_branching`: pipeline config, source configs, compiled transforms, the execution plan, compile artifacts, and per-run parameters.
- **`DagExecResources`** groups the eight owned, run-scoped resources moved through both functions and consumed when the dispatch context is constructed: source receivers, output writers, compiled routes, the spill directory and its cached path, watermarks, and the memory arbitrator.
- **`WindowedEvalCtx<'a>`** groups the four window-resolution inputs to `evaluate_single_transform_windowed`: the plan, the window index, the resolved window runtime, and the record's arena position. The per-record evaluation arguments it shares with `evaluate_single_transform` keep their existing positions.

Each struct is destructured at the top of its consuming function into the same local bindings the parameters previously supplied, so every function body and all runtime behavior is unchanged. The two `execute_dag` structs are consumed by both entry points; the windowed struct is built in the Transform dispatch arm and consumed by the windowed evaluator.

The `clippy::result_large_err` suppression on the windowed evaluator is unrelated to this change and is preserved.

## Verification

Full gauntlet green: `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check --benches --workspace`, `cargo deny check`. No public API change; no tests modified.

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)