### PR TITLE
clinker-core: deduplicate inline YAML fixtures in executor integration tests

### DIFF
--- a/crates/clinker-core/tests/branching.rs
+++ b/crates/clinker-core/tests/branching.rs
@@ -3,6 +3,8 @@
 //! Tests in this module exercise the DAG executor's branch dispatch,
 //! merge semantics, record conservation, and per-node execution strategy.
 
+#[path = "common/branch_fixtures.rs"]
+mod branch_fixtures;
 mod common;
 
 use std::collections::HashMap;
@@ -50,28 +52,9 @@ fn run_branch_test(
 /// Diamond DAG: fork -> 2 branches -> merge: all records present in output.
 #[test]
 fn test_branch_diamond_dag() {
-    let yaml = r#"
-pipeline:
-  name: diamond
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "diamond",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -104,18 +87,11 @@ nodes:
     cxl: 'emit final = tag
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,200\n2,50\n3,300\n4,10\n";
-    let (counters, dlq, output) = run_branch_test(yaml, csv).unwrap();
+    let (counters, dlq, output) = run_branch_test(&yaml, csv).unwrap();
 
     assert_eq!(counters.ok_count, 4, "all 4 records should be in output");
     assert!(dlq.is_empty(), "no DLQ entries expected");
@@ -134,28 +110,9 @@ nodes:
 /// Exclusive mode: input count = output count (no duplication, no loss).
 #[test]
 fn test_branch_exclusive_conservation() {
-    let yaml = r#"
-pipeline:
-  name: exclusive_conservation
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "exclusive_conservation",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -189,18 +146,11 @@ nodes:
     cxl: 'emit final = tag
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,200\n2,50\n3,300\n4,10\n5,150\n";
-    let (counters, _, _) = run_branch_test(yaml, csv).unwrap();
+    let (counters, _, _) = run_branch_test(&yaml, csv).unwrap();
 
     // Exclusive mode: no duplication, no loss
     assert_eq!(
@@ -212,28 +162,9 @@ nodes:
 /// Inclusive mode: records in multiple branches, merge has more than input.
 #[test]
 fn test_branch_inclusive_duplication() {
-    let yaml = r#"
-pipeline:
-  name: inclusive_dup
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "inclusive_dup",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -276,18 +207,11 @@ nodes:
     cxl: 'emit final = tag
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,200\n2,50\n3,75\n";
-    let (counters, _, output) = run_branch_test(yaml, csv).unwrap();
+    let (counters, _, output) = run_branch_test(&yaml, csv).unwrap();
 
     // id=1 (200): matches over_50 AND over_100 -> 2 writes
     // id=2 (50): matches nothing -> default (low) -> 1 write
@@ -308,28 +232,9 @@ nodes:
 /// Records within each branch maintain input order.
 #[test]
 fn test_branch_order_within_branch() {
-    let yaml = r#"
-pipeline:
-  name: order_test
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "order_test",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -362,19 +267,12 @@ nodes:
     cxl: 'emit final = tag
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     // High records: 1(200), 3(300), 5(500) -- should maintain order
     let csv = "id,amount\n1,200\n2,50\n3,300\n4,10\n5,500\n";
-    let (counters, _, output) = run_branch_test(yaml, csv).unwrap();
+    let (counters, _, output) = run_branch_test(&yaml, csv).unwrap();
 
     assert_eq!(counters.ok_count, 5, "all records should be in output");
 
@@ -402,28 +300,9 @@ nodes:
 /// Merge output: branch A records, then branch B records (declaration order).
 #[test]
 fn test_branch_merge_concatenation_order() {
-    let yaml = r#"
-pipeline:
-  name: merge_order
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "merge_order",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -456,18 +335,11 @@ nodes:
     cxl: 'emit final = tag
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,200\n2,50\n3,300\n4,10\n";
-    let (_, _, output) = run_branch_test(yaml, csv).unwrap();
+    let (_, _, output) = run_branch_test(&yaml, csv).unwrap();
 
     // enrich_high is declared first in the merge input, so high records come first
     let lines: Vec<&str> = output.lines().collect();
@@ -488,28 +360,9 @@ nodes:
 /// Route condition that never matches -> empty branch -> no error.
 #[test]
 fn test_branch_empty_branch_no_error() {
-    let yaml = r#"
-pipeline:
-  name: empty_branch
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "empty_branch",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -542,18 +395,11 @@ nodes:
     cxl: 'emit final = tag
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,100\n2,200\n3,300\n";
-    let (counters, dlq, output) = run_branch_test(yaml, csv).unwrap();
+    let (counters, dlq, output) = run_branch_test(&yaml, csv).unwrap();
 
     // All records go to 'normal' branch, 'impossible' is empty
     assert_eq!(counters.ok_count, 3);
@@ -565,28 +411,9 @@ nodes:
 /// 3 branches, each with different transforms.
 #[test]
 fn test_branch_three_way_fork() {
-    let yaml = r#"
-pipeline:
-  name: three_way
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "three_way",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -628,18 +455,11 @@ nodes:
     cxl: 'emit final = tier
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,300\n2,100\n3,10\n4,500\n5,75\n6,5\n";
-    let (counters, _, output) = run_branch_test(yaml, csv).unwrap();
+    let (counters, _, output) = run_branch_test(&yaml, csv).unwrap();
 
     assert_eq!(counters.ok_count, 6, "all 6 records in output");
     assert!(output.contains("HIGH"));
@@ -650,28 +470,9 @@ nodes:
 /// Branch A: enrichment, Branch B: filtering -- different transforms per branch.
 #[test]
 fn test_branch_different_transforms_per_branch() {
-    let yaml = r#"
-pipeline:
-  name: different_transforms
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "different_transforms",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -704,18 +505,11 @@ nodes:
     cxl: 'emit final = enriched
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,200\n2,50\n3,300\n";
-    let (counters, _, output) = run_branch_test(yaml, csv).unwrap();
+    let (counters, _, output) = run_branch_test(&yaml, csv).unwrap();
 
     assert_eq!(counters.ok_count, 3);
     assert!(
@@ -844,28 +638,9 @@ nodes:
 #[test]
 fn test_branch_rayon_scope_deterministic_order() {
     // Run the three-way fork multiple times and verify deterministic output
-    let yaml = r#"
-pipeline:
-  name: deterministic
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "deterministic",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -907,22 +682,15 @@ nodes:
     cxl: 'emit final = tier
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,300\n2,100\n3,10\n4,500\n5,75\n";
 
     // Run multiple times and check deterministic output
-    let (_, _, output1) = run_branch_test(yaml, csv).unwrap();
-    let (_, _, output2) = run_branch_test(yaml, csv).unwrap();
-    let (_, _, output3) = run_branch_test(yaml, csv).unwrap();
+    let (_, _, output1) = run_branch_test(&yaml, csv).unwrap();
+    let (_, _, output2) = run_branch_test(&yaml, csv).unwrap();
+    let (_, _, output3) = run_branch_test(&yaml, csv).unwrap();
 
     assert_eq!(output1, output2, "output must be deterministic");
     assert_eq!(output2, output3, "output must be deterministic");
@@ -931,28 +699,9 @@ nodes:
 /// Inclusive mode clones records -- mutations in one branch don't affect another.
 #[test]
 fn test_branch_inclusive_isolation() {
-    let yaml = r#"
-pipeline:
-  name: inclusive_isolation
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    type: csv
-    path: input.csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = branch_fixtures::branch_pipeline(
+        "inclusive_isolation",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -987,18 +736,11 @@ nodes:
     cxl: 'emit final = marker
 
       '
-- type: output
-  name: dest
-  input: combine
-  config:
-    name: dest
-    type: csv
-    path: output.csv
-    include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,100\n";
-    let (counters, _, output) = run_branch_test(yaml, csv).unwrap();
+    let (counters, _, output) = run_branch_test(&yaml, csv).unwrap();
 
     // id=1 matches both branches (inclusive) -> 2 writes from 1 input record.
     // Dual counters:

--- a/crates/clinker-core/tests/common/branch_fixtures.rs
+++ b/crates/clinker-core/tests/common/branch_fixtures.rs
@@ -1,0 +1,31 @@
+//! Fixture builder for the branch-dispatch integration tests.
+//!
+//! Every route/merge pipeline in `branching.rs` shares one byte-identical
+//! scaffold: a single CSV `src` over `{ id, amount }`, a `classify_emit`
+//! transform that lifts `amount` to an int, and a terminal `combine`
+//! transform feeding the `dest` output. Only the middle — the `classify`
+//! route, the per-branch transforms, and the `combine__merge` inputs —
+//! distinguishes one test from another.
+//!
+//! [`branch_pipeline`] emits that fixed head and `dest` tail and splices
+//! the caller's `body` (the route through the final `combine` transform)
+//! between them, so each test keeps only its distinctive routing logic
+//! inline. The assembled string is byte-for-byte identical to the
+//! hand-written YAML it replaces.
+
+/// Build a branch-dispatch pipeline named `name` whose routing middle is
+/// `body`.
+///
+/// `body` must be the YAML from the `classify` route node through the
+/// terminal `combine` transform — exactly the span that varies between
+/// branch tests. The shared `src`/`classify_emit` head and the `dest`
+/// output tail are supplied here.
+pub fn branch_pipeline(name: &str, body: &str) -> String {
+    format!(
+        "\npipeline:\n  name: {name}\nnodes:\n\
+- type: source\n  name: src\n  config:\n    name: src\n    type: csv\n    path: input.csv\n    schema:\n      - {{ name: id, type: string }}\n      - {{ name: amount, type: string }}\n\n\
+- type: transform\n  name: classify_emit\n  input: src\n  config:\n    cxl: 'emit amount_val = amount.to_int()\n\n      '\n\
+{body}\
+- type: output\n  name: dest\n  input: combine\n  config:\n    name: dest\n    type: csv\n    path: output.csv\n    include_unmapped: true\n"
+    )
+}

--- a/crates/clinker-core/tests/common/dlq_fixtures.rs
+++ b/crates/clinker-core/tests/common/dlq_fixtures.rs
@@ -1,0 +1,32 @@
+//! Fixture builder shared by the correlation-key DLQ integration tests
+//! (`correlated_dlq.rs` and its retract-path sibling
+//! `correlated_dlq_retract.rs`).
+//!
+//! Both suites lean on one recurring shape: a CSV `src` carrying a
+//! `correlation_key`, a `validate` transform that echoes the employee id
+//! and coerces `value` to an int (so a non-numeric cell triggers a
+//! per-group DLQ), and a single `out` sink — all under the `continue`
+//! error strategy. Only the pipeline name, the correlation key, and the
+//! source schema vary between callers.
+//!
+//! [`dlq_validate_pipeline`] emits that shape. The schema rows are passed
+//! verbatim (including their trailing newline) so a caller can append the
+//! blank line some fixtures place before the first node; the assembled
+//! string is byte-for-byte identical to the hand-written YAML it replaces.
+
+/// Build a correlation-key DLQ pipeline named `name`, keyed on
+/// `correlation_key`, whose source schema rows are `schema`.
+///
+/// `schema` is the indented YAML for the source `schema:` list — each row
+/// like `"      - { name: employee_id, type: string }\n"` — and carries
+/// its own trailing whitespace so callers reproduce the exact spacing
+/// before the `validate` transform.
+pub fn dlq_validate_pipeline(name: &str, correlation_key: &str, schema: &str) -> String {
+    format!(
+        "\npipeline:\n  name: {name}\nerror_handling:\n  strategy: continue\nnodes:\n\
+- type: source\n  name: src\n  config:\n    name: src\n    path: input.csv\n    correlation_key: {correlation_key}\n    type: csv\n    schema:\n\
+{schema}\
+- type: transform\n  name: validate\n  input: src\n  config:\n    cxl: 'emit emp_id = employee_id\n\n      emit val = value.to_int()\n\n      '\n\
+- type: output\n  name: out\n  input: validate\n  config:\n    name: out\n    path: output.csv\n    type: csv\n    include_unmapped: true\n"
+    )
+}

--- a/crates/clinker-core/tests/common/multi_output_fixtures.rs
+++ b/crates/clinker-core/tests/common/multi_output_fixtures.rs
@@ -1,0 +1,30 @@
+//! Fixture builder for the multi-output integration tests.
+//!
+//! Most pipelines in `multi_output.rs` open with one byte-identical
+//! preamble: a single CSV `src` over `{ id, amount }` feeding a
+//! `classify_emit` transform that lifts `amount` to an int. What differs
+//! per test is everything downstream — the `classify` route and the fan
+//! of `output` sinks (two-way, three-way, inclusive, error-injecting,
+//! and so on).
+//!
+//! [`multi_output_pipeline`] emits that fixed head and splices the
+//! caller's `body` (the route through the output sinks) after it. The
+//! assembled string is byte-for-byte identical to the hand-written YAML
+//! it replaces. Fixtures that diverge in the head itself (a custom
+//! schema, an `error_handling` block, a non-`classify_emit` transform)
+//! stay written out in full.
+
+/// Build a multi-output pipeline named `name` whose route-and-sink tail
+/// is `body`.
+///
+/// `body` must be the YAML from the first node after `classify_emit`
+/// (typically the `classify` route) through the final `output` node. The
+/// shared `src`/`classify_emit` head is supplied here.
+pub fn multi_output_pipeline(name: &str, body: &str) -> String {
+    format!(
+        "\npipeline:\n  name: {name}\nnodes:\n\
+- type: source\n  name: src\n  config:\n    name: src\n    path: input.csv\n    type: csv\n    schema:\n      - {{ name: id, type: string }}\n      - {{ name: amount, type: string }}\n\n\
+- type: transform\n  name: classify_emit\n  input: src\n  config:\n    cxl: 'emit amount_val = amount.to_int()\n\n      '\n\
+{body}"
+    )
+}

--- a/crates/clinker-core/tests/correlated_dlq.rs
+++ b/crates/clinker-core/tests/correlated_dlq.rs
@@ -7,6 +7,8 @@
 //! preservation (F.1, F.2) cases that motivated the redesign.
 
 mod common;
+#[path = "common/dlq_fixtures.rs"]
+mod dlq_fixtures;
 
 use clinker_bench_support::io::SharedBuffer;
 use clinker_core::error::PipelineError;
@@ -47,44 +49,10 @@ fn run_correlated_pipeline(
 }
 
 fn base_yaml(correlation_key: &str) -> String {
-    format!(
-        r#"
-pipeline:
-  name: correlated_test
-error_handling:
-  strategy: continue
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    correlation_key: {0}
-    type: csv
-    schema:
-      - {{ name: employee_id, type: string }}
-      - {{ name: value, type: string }}
-      - {{ name: dept, type: string }}
-
-- type: transform
-  name: validate
-  input: src
-  config:
-    cxl: 'emit emp_id = employee_id
-
-      emit val = value.to_int()
-
-      '
-- type: output
-  name: out
-  input: validate
-  config:
-    name: out
-    path: output.csv
-    type: csv
-    include_unmapped: true
-"#,
-        correlation_key
+    dlq_fixtures::dlq_validate_pipeline(
+        "correlated_test",
+        correlation_key,
+        "      - { name: employee_id, type: string }\n      - { name: value, type: string }\n      - { name: dept, type: string }\n\n",
     )
 }
 

--- a/crates/clinker-core/tests/correlated_dlq_retract.rs
+++ b/crates/clinker-core/tests/correlated_dlq_retract.rs
@@ -23,6 +23,8 @@
 //!   tests.
 
 mod common;
+#[path = "common/dlq_fixtures.rs"]
+mod dlq_fixtures;
 
 use clinker_bench_support::io::SharedBuffer;
 use clinker_core::error::PipelineError;
@@ -69,42 +71,13 @@ fn run_pipeline(yaml: &str, csv_input: &str) -> Result<RunOutput, PipelineError>
 /// branch so the strict body emits the same DLQ shape as before.
 #[test]
 fn strict_pipeline_zero_overhead_short_circuits_to_fast_path() {
-    let yaml = r#"
-pipeline:
-  name: strict_test
-error_handling:
-  strategy: continue
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    correlation_key: employee_id
-    type: csv
-    schema:
-      - { name: employee_id, type: string }
-      - { name: value, type: string }
-- type: transform
-  name: validate
-  input: src
-  config:
-    cxl: 'emit emp_id = employee_id
-
-      emit val = value.to_int()
-
-      '
-- type: output
-  name: out
-  input: validate
-  config:
-    name: out
-    path: output.csv
-    type: csv
-    include_unmapped: true
-"#;
+    let yaml = dlq_fixtures::dlq_validate_pipeline(
+        "strict_test",
+        "employee_id",
+        "      - { name: employee_id, type: string }\n      - { name: value, type: string }\n",
+    );
     let csv = "employee_id,value\nA,100\nA,bad\nB,200\n";
-    let (counters, dlq_entries, output) = run_pipeline(yaml, csv).unwrap();
+    let (counters, dlq_entries, output) = run_pipeline(&yaml, csv).unwrap();
 
     // Group A is dirty (one bad record); group B is clean.
     assert_eq!(counters.dlq_count, 2, "group A DLQ'd as a unit (2 records)");

--- a/crates/clinker-core/tests/multi_output.rs
+++ b/crates/clinker-core/tests/multi_output.rs
@@ -7,6 +7,8 @@
 //! seam) stay inline in `executor/tests/multi_output.rs`.
 
 mod common;
+#[path = "common/multi_output_fixtures.rs"]
+mod multi_output_fixtures;
 
 use std::collections::HashMap;
 
@@ -86,28 +88,9 @@ fn run_multi_output(yaml: &str, csv_input: &str) -> MultiOutputResult {
 
 #[test]
 fn test_multi_output_two_writers() {
-    let yaml = r#"
-pipeline:
-  name: test_two_outputs
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_two_outputs",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -130,10 +113,11 @@ nodes:
     path: low.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,200\n2,50\n3,300\n4,10\n";
-    let (counters, _, outputs) = run_multi_output(yaml, csv).unwrap();
+    let (counters, _, outputs) = run_multi_output(&yaml, csv).unwrap();
 
     assert_eq!(counters.ok_count, 4);
     let high = &outputs["high"];
@@ -155,28 +139,9 @@ nodes:
 
 #[test]
 fn test_multi_output_three_writers() {
-    let yaml = r#"
-pipeline:
-  name: test_three_outputs
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_three_outputs",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -208,10 +173,11 @@ nodes:
     path: low.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,5000\n2,500\n3,50\n";
-    let (counters, _, outputs) = run_multi_output(yaml, csv).unwrap();
+    let (counters, _, outputs) = run_multi_output(&yaml, csv).unwrap();
 
     assert_eq!(counters.ok_count, 3);
     assert!(outputs["high"].contains("1,5000"));
@@ -221,28 +187,9 @@ nodes:
 
 #[test]
 fn test_multi_output_record_counts() {
-    let yaml = r#"
-pipeline:
-  name: test_record_counts
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_record_counts",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -265,10 +212,11 @@ nodes:
     path: small.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
     let csv = "id,amount\n1,100\n2,10\n3,200\n4,20\n5,300\n";
-    let (counters, _, outputs) = run_multi_output(yaml, csv).unwrap();
+    let (counters, _, outputs) = run_multi_output(&yaml, csv).unwrap();
 
     assert_eq!(counters.ok_count, 5);
     assert_eq!(counters.total_count, 5);
@@ -283,28 +231,9 @@ nodes:
 
 #[test]
 fn test_multi_output_order_preserved() {
-    let yaml = r#"
-pipeline:
-  name: test_order
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_order",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -327,11 +256,12 @@ nodes:
     path: small.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
     // All go to "big" — order must match input order
     let csv = "id,amount\n1,100\n2,200\n3,300\n4,400\n5,500\n";
-    let (_, _, outputs) = run_multi_output(yaml, csv).unwrap();
+    let (_, _, outputs) = run_multi_output(&yaml, csv).unwrap();
 
     let big_lines: Vec<&str> = outputs["big"].lines().skip(1).collect();
     assert_eq!(big_lines.len(), 5);
@@ -377,28 +307,9 @@ fn test_multi_output_writer_error_propagated() {
         }
     }
 
-    let yaml = r#"
-pipeline:
-  name: test_writer_error
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_writer_error",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -421,9 +332,10 @@ nodes:
     path: bad.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
-    let config = clinker_core::config::parse_config(yaml).unwrap();
+    let config = clinker_core::config::parse_config(&yaml).unwrap();
     let params = test_params();
 
     let csv = "id,amount\n1,100\n2,10\n3,200\n";
@@ -453,28 +365,9 @@ nodes:
 
 #[test]
 fn test_multi_output_inclusive_duplicate() {
-    let yaml = r#"
-pipeline:
-  name: test_inclusive
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_inclusive",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -507,11 +400,12 @@ nodes:
     path: standard.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
     // amount=500 matches both audit (>100) and report (>50)
     let csv = "id,amount\n1,500\n2,30\n";
-    let (counters, _, outputs) = run_multi_output(yaml, csv).unwrap();
+    let (counters, _, outputs) = run_multi_output(&yaml, csv).unwrap();
 
     // Dual counters:
     //   ok_count = 2 (both input records reached at least one Output)
@@ -577,28 +471,9 @@ nodes:
 
 #[test]
 fn test_multi_output_empty_route() {
-    let yaml = r#"
-pipeline:
-  name: test_empty_route
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_empty_route",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -621,11 +496,12 @@ nodes:
     path: normal.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
     // No records match "special" (all < 99999)
     let csv = "id,amount\n1,100\n2,200\n";
-    let (_, _, outputs) = run_multi_output(yaml, csv).unwrap();
+    let (_, _, outputs) = run_multi_output(&yaml, csv).unwrap();
 
     // Special output should have just a header (or be empty)
     let special_lines: Vec<&str> = outputs["special"]
@@ -667,28 +543,9 @@ fn test_multi_output_writer_panic_propagated() {
         }
     }
 
-    let yaml = r#"
-pipeline:
-  name: test_panic
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_panic",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -711,9 +568,10 @@ nodes:
     path: bad.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
-    let config = clinker_core::config::parse_config(yaml).unwrap();
+    let config = clinker_core::config::parse_config(&yaml).unwrap();
     let params = test_params();
 
     let csv = "id,amount\n1,100\n2,10\n";
@@ -845,28 +703,9 @@ fn test_multi_output_send_error_disconnected() {
         }
     }
 
-    let yaml = r#"
-pipeline:
-  name: test_disconnected
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_disconnected",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -889,9 +728,10 @@ nodes:
     path: b.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
-    let config = clinker_core::config::parse_config(yaml).unwrap();
+    let config = clinker_core::config::parse_config(&yaml).unwrap();
     let params = test_params();
 
     // Enough records that "b" gets traffic and will error
@@ -937,28 +777,9 @@ fn test_multi_output_multiple_errors_collected() {
         }
     }
 
-    let yaml = r#"
-pipeline:
-  name: test_multiple_errors
-nodes:
-- type: source
-  name: src
-  config:
-    name: src
-    path: input.csv
-    type: csv
-    schema:
-      - { name: id, type: string }
-      - { name: amount, type: string }
-
-- type: transform
-  name: classify_emit
-  input: src
-  config:
-    cxl: 'emit amount_val = amount.to_int()
-
-      '
-- type: route
+    let yaml = multi_output_fixtures::multi_output_pipeline(
+        "test_multiple_errors",
+        r#"- type: route
   name: classify
   input: classify_emit
   config:
@@ -981,9 +802,10 @@ nodes:
     path: b.csv
     type: csv
     include_unmapped: true
-"#;
+"#,
+    );
 
-    let config = clinker_core::config::parse_config(yaml).unwrap();
+    let config = clinker_core::config::parse_config(&yaml).unwrap();
     let params = test_params();
 
     let csv = "id,amount\n1,100\n2,10\n";


### PR DESCRIPTION
## What

Several relocated executor integration tests embed large inline YAML
pipeline fixtures as raw strings, repeating the same boilerplate verbatim
across many tests. A change to the fixture shape (for example, adding a new
required schema field) currently means editing every literal independently.

This change extracts three parameterized fixture builders. Each lives under
`crates/clinker-core/tests/common/` and is included only by the files that
use it (via `#[path]`), so no test binary carries an unused helper:

- `branch_pipeline(name, body)` — the branch-dispatch skeleton in
  `branching.rs`: a CSV `src` over `{ id, amount }`, a `classify_emit`
  transform, and the terminal `combine` → `dest` output. Each test now
  supplies only its distinctive route/branch/merge middle.
- `multi_output_pipeline(name, body)` — the multi-output preamble in
  `multi_output.rs`: the same `src` + `classify_emit` head, with the
  per-test route-and-sink fan supplied as the body.
- `dlq_validate_pipeline(name, correlation_key, schema)` — the
  correlation-key DLQ skeleton shared by `correlated_dlq.rs` and
  `correlated_dlq_retract.rs`: a keyed source, a `validate` transform that
  coerces `value` to an int, and a single sink under the `continue` error
  strategy.

## Semantics are unchanged

Each builder reproduces the YAML it replaces byte-for-byte, so every test
exercises the exact same pipeline and asserts the exact same things as
before. Fixtures whose shape genuinely differs (a custom schema, an
`error_handling` block, extra nodes) are left written out in full rather
than forced through a builder. No test was added, removed, or ignored, and
no assertion was changed; the full workspace test count is unchanged
(`cargo test --workspace`: 2194 passed, 0 failed, 4 ignored — identical to
before).

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`,
`cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace`, `cargo check --benches --workspace`, and
`cargo deny check` all pass.

Closes #138