### PR TITLE
clinker-core: add PipelineNode accessor methods for recurring variant groups

### DIFF
--- a/crates/clinker-core/src/config/pipeline.rs
+++ b/crates/clinker-core/src/config/pipeline.rs
@@ -419,34 +419,7 @@ impl PipelineConfig {
         for spanned in &self.nodes {
             let node = &spanned.value;
             let name = node.name();
-            let mut self_ref = false;
-            match node {
-                PipelineNode::Source { .. } => {}
-                PipelineNode::Transform { header, .. }
-                | PipelineNode::Aggregate { header, .. }
-                | PipelineNode::Route { header, .. }
-                | PipelineNode::Output { header, .. }
-                | PipelineNode::Composition { header, .. } => {
-                    if input_target(&header.input.value) == name {
-                        self_ref = true;
-                    }
-                }
-                PipelineNode::Merge { header, .. } => {
-                    if header.inputs.iter().any(|i| input_target(&i.value) == name) {
-                        self_ref = true;
-                    }
-                }
-                PipelineNode::Combine { header, .. } => {
-                    if header
-                        .input
-                        .values()
-                        .any(|i| input_target(&i.value) == name)
-                    {
-                        self_ref = true;
-                    }
-                }
-            }
-            if self_ref {
+            if node.direct_input_names().contains(&name) {
                 diags.push(Diagnostic::error(
                     "E002",
                     format!("node {name:?} lists itself as an input"),
@@ -463,33 +436,9 @@ impl PipelineConfig {
         for spanned in &self.nodes {
             let node = &spanned.value;
             let consumer = node.name();
-            match node {
-                PipelineNode::Source { .. } => {}
-                PipelineNode::Transform { header, .. }
-                | PipelineNode::Aggregate { header, .. }
-                | PipelineNode::Route { header, .. }
-                | PipelineNode::Output { header, .. }
-                | PipelineNode::Composition { header, .. } => {
-                    let producer = input_target(&header.input.value);
-                    if producer != consumer && graph.index_of(producer).is_some() {
-                        graph.add_edge(producer, consumer);
-                    }
-                }
-                PipelineNode::Merge { header, .. } => {
-                    for i in &header.inputs {
-                        let producer = input_target(&i.value);
-                        if producer != consumer && graph.index_of(producer).is_some() {
-                            graph.add_edge(producer, consumer);
-                        }
-                    }
-                }
-                PipelineNode::Combine { header, .. } => {
-                    for i in header.input.values() {
-                        let producer = input_target(&i.value);
-                        if producer != consumer && graph.index_of(producer).is_some() {
-                            graph.add_edge(producer, consumer);
-                        }
-                    }
+            for producer in node.direct_input_names() {
+                if producer != consumer && graph.index_of(producer).is_some() {
+                    graph.add_edge(producer, consumer);
                 }
             }
         }
@@ -1811,13 +1760,6 @@ impl PipelineConfig {
 
         let plan = CompiledPlan::new(dag, self.clone(), artifacts);
         Ok((plan, diags))
-    }
-}
-
-fn input_target(input: &node_header::NodeInput) -> &str {
-    match input {
-        node_header::NodeInput::Single(s) => s.as_str(),
-        node_header::NodeInput::Port { node, .. } => node.as_str(),
     }
 }
 

--- a/crates/clinker-core/src/config/pipeline_node.rs
+++ b/crates/clinker-core/src/config/pipeline_node.rs
@@ -646,6 +646,58 @@ impl PipelineNode {
         }
     }
 
+    /// Names of every node this variant declares as a direct upstream
+    /// input, in declaration order. Each entry is the producer's node
+    /// name with any `.port` suffix stripped (the connectivity target,
+    /// not the branch qualifier).
+    ///
+    /// `Source` has no inputs and yields an empty vector. The
+    /// single-input consumer variants (`Transform`, `Aggregate`,
+    /// `Route`, `Output`, `Composition`) yield their one `input:`. The
+    /// multi-input variants yield each entry of their input collection:
+    /// `Merge` walks its ordered `inputs:` list, `Combine` walks its
+    /// named `input:` map in insertion order.
+    ///
+    /// This is the connectivity view shared by the DAG-edge, cycle,
+    /// self-loop, and source-reachability walks; it intentionally drops
+    /// the per-input span and the Combine qualifier — callers needing
+    /// those match the variant directly.
+    pub fn direct_input_names(&self) -> Vec<&str> {
+        match self {
+            PipelineNode::Source { .. } => Vec::new(),
+            PipelineNode::Transform { header, .. }
+            | PipelineNode::Aggregate { header, .. }
+            | PipelineNode::Route { header, .. }
+            | PipelineNode::Output { header, .. }
+            | PipelineNode::Composition { header, .. } => vec![header.input.value.name()],
+            PipelineNode::Merge { header, .. } => {
+                header.inputs.iter().map(|i| i.value.name()).collect()
+            }
+            PipelineNode::Combine { header, .. } => {
+                header.input.values().map(|i| i.value.name()).collect()
+            }
+        }
+    }
+
+    /// Whether this variant carries a user-authored CXL body whose
+    /// statements can read scoped variables (`$pipeline.*` / `$source.*`
+    /// / `$record.*`). True for `Transform`, `Aggregate`, and `Combine`
+    /// — the three variants whose `cxl:` source the read-after-write and
+    /// post-merge-source-read validators walk for scope reads.
+    ///
+    /// `Route` and `Source` carry typed programs too, but those are
+    /// engine-synthesized (an empty Route predicate program, a synthetic
+    /// Source schema program) and never hold author scope reads, so they
+    /// are excluded.
+    pub fn reads_scope_vars_in_cxl(&self) -> bool {
+        matches!(
+            self,
+            PipelineNode::Transform { .. }
+                | PipelineNode::Aggregate { .. }
+                | PipelineNode::Combine { .. }
+        )
+    }
+
     /// String tag of the variant for display.
     pub fn type_tag(&self) -> &'static str {
         match self {

--- a/crates/clinker-core/src/output/path_template.rs
+++ b/crates/clinker-core/src/output/path_template.rs
@@ -304,7 +304,6 @@ fn source_ancestors_of(
     output_name: &str,
 ) -> Vec<SourceAncestor> {
     use crate::config::PipelineNode;
-    use crate::config::node_header::NodeInput;
     use std::collections::{HashSet, VecDeque};
 
     let by_name: HashMap<&str, &PipelineNode> = config
@@ -316,13 +315,6 @@ fn source_ancestors_of(
     let mut visited: HashSet<String> = HashSet::new();
     let mut sources: Vec<SourceAncestor> = Vec::new();
     let mut queue: VecDeque<String> = VecDeque::from([output_name.to_string()]);
-
-    let target_name_of = |inp: &NodeInput| -> String {
-        match inp {
-            NodeInput::Single(s) => s.clone(),
-            NodeInput::Port { node, .. } => node.clone(),
-        }
-    };
 
     while let Some(name) = queue.pop_front() {
         if !visited.insert(name.clone()) {
@@ -343,21 +335,11 @@ fn source_ancestors_of(
                     stem,
                 });
             }
-            PipelineNode::Transform { header, .. }
-            | PipelineNode::Aggregate { header, .. }
-            | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
-            | PipelineNode::Composition { header, .. } => {
-                queue.push_back(target_name_of(&header.input.value));
-            }
-            PipelineNode::Merge { header, .. } => {
-                for inp in &header.inputs {
-                    queue.push_back(target_name_of(&inp.value));
-                }
-            }
-            PipelineNode::Combine { header, .. } => {
-                for inp in header.input.values() {
-                    queue.push_back(target_name_of(&inp.value));
+            // Every non-Source ancestor enqueues each of its direct
+            // upstream inputs (port suffix stripped to the node name).
+            other => {
+                for input in other.direct_input_names() {
+                    queue.push_back(input.to_string());
                 }
             }
         }

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -384,29 +384,12 @@ fn validate_post_merge_source_reads(
     for spanned in nodes {
         let name = spanned.value.name().to_string();
         let span = span_for_node(spanned);
-        let direct_inputs: Vec<String> = match &spanned.value {
-            PipelineNode::Source { .. } => Vec::new(),
-            PipelineNode::Transform { header, .. }
-            | PipelineNode::Aggregate { header, .. }
-            | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
-            | PipelineNode::Composition { header, .. } => upstream_target_name(&header.input.value)
-                .into_iter()
-                .map(String::from)
-                .collect(),
-            PipelineNode::Merge { header, .. } => header
-                .inputs
-                .iter()
-                .filter_map(|i| upstream_target_name(&i.value))
-                .map(String::from)
-                .collect(),
-            PipelineNode::Combine { header, .. } => header
-                .input
-                .values()
-                .filter_map(|i| upstream_target_name(&i.value))
-                .map(String::from)
-                .collect(),
-        };
+        let direct_inputs: Vec<String> = spanned
+            .value
+            .direct_input_names()
+            .into_iter()
+            .map(String::from)
+            .collect();
         // A Merge or Combine node IS the merge ancestor for everything
         // downstream — including itself in the lookup so its own
         // direct descendants pick it up.
@@ -433,15 +416,8 @@ fn validate_post_merge_source_reads(
             continue;
         };
         let mut typed_keys: Vec<String> = Vec::new();
-        match &spanned.value {
-            PipelineNode::Transform { .. }
-            | PipelineNode::Aggregate { .. }
-            | PipelineNode::Combine { .. } => {
-                if artifacts.typed.contains_key(&reader_name) {
-                    typed_keys.push(reader_name.clone());
-                }
-            }
-            _ => {}
+        if spanned.value.reads_scope_vars_in_cxl() && artifacts.typed.contains_key(&reader_name) {
+            typed_keys.push(reader_name.clone());
         }
         let span = span_for_node(spanned);
         for key in typed_keys {
@@ -541,29 +517,12 @@ fn validate_read_after_write(
     for spanned in nodes {
         let name = spanned.value.name().to_string();
         let mut anc: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let direct: Vec<String> = match &spanned.value {
-            PipelineNode::Source { .. } => Vec::new(),
-            PipelineNode::Transform { header, .. }
-            | PipelineNode::Aggregate { header, .. }
-            | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
-            | PipelineNode::Composition { header, .. } => upstream_target_name(&header.input.value)
-                .into_iter()
-                .map(String::from)
-                .collect(),
-            PipelineNode::Merge { header, .. } => header
-                .inputs
-                .iter()
-                .filter_map(|i| upstream_target_name(&i.value))
-                .map(String::from)
-                .collect(),
-            PipelineNode::Combine { header, .. } => header
-                .input
-                .values()
-                .filter_map(|i| upstream_target_name(&i.value))
-                .map(String::from)
-                .collect(),
-        };
+        let direct: Vec<String> = spanned
+            .value
+            .direct_input_names()
+            .into_iter()
+            .map(String::from)
+            .collect();
         for parent in direct {
             anc.insert(parent.clone());
             if let Some(parent_anc) = ancestors.get(&parent) {
@@ -579,15 +538,8 @@ fn validate_read_after_write(
     for spanned in nodes {
         let reader_name = spanned.value.name().to_string();
         let mut typed_keys: Vec<String> = Vec::new();
-        match &spanned.value {
-            PipelineNode::Transform { .. }
-            | PipelineNode::Aggregate { .. }
-            | PipelineNode::Combine { .. } => {
-                if artifacts.typed.contains_key(&reader_name) {
-                    typed_keys.push(reader_name.clone());
-                }
-            }
-            _ => {}
+        if spanned.value.reads_scope_vars_in_cxl() && artifacts.typed.contains_key(&reader_name) {
+            typed_keys.push(reader_name.clone());
         }
         let span = span_for_node(spanned);
         for key in typed_keys {
@@ -923,26 +875,7 @@ fn validate_init_phase_terminals(nodes: &[Spanned<PipelineNode>], diags: &mut Ve
         // set. Each input declared on a node implies a downstream
         // dependency on that input, so an init node showing up as an
         // input means it has a non-init descendant.
-        let inputs: Vec<&str> = match &spanned.value {
-            PipelineNode::Source { .. } => Vec::new(),
-            PipelineNode::Transform { header, .. }
-            | PipelineNode::Aggregate { header, .. }
-            | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
-            | PipelineNode::Composition { header, .. } => {
-                vec![upstream_target_name(&header.input.value).unwrap_or("")]
-            }
-            PipelineNode::Merge { header, .. } => header
-                .inputs
-                .iter()
-                .filter_map(|i| upstream_target_name(&i.value))
-                .collect(),
-            PipelineNode::Combine { header, .. } => header
-                .input
-                .values()
-                .filter_map(|i| upstream_target_name(&i.value))
-                .collect(),
-        };
+        let inputs: Vec<&str> = spanned.value.direct_input_names();
         let consumer_name = spanned.value.name();
         let consumer_span = span_for(spanned);
         // Init-phase consumers (State or Transform) are fine — the
@@ -1142,24 +1075,11 @@ fn bind_schema_inner(
                 s.insert(name.clone());
                 s
             }
-            PipelineNode::Transform { header, .. }
-            | PipelineNode::Aggregate { header, .. }
-            | PipelineNode::Route { header, .. }
-            | PipelineNode::Output { header, .. }
-            | PipelineNode::Composition { header, .. } => upstream_target_name(&header.input.value)
-                .and_then(|n| upstream_sources.get(n).cloned())
-                .unwrap_or_default(),
-            PipelineNode::Merge { header, .. } => header
-                .inputs
-                .iter()
-                .filter_map(|i| upstream_target_name(&i.value))
-                .filter_map(|n| upstream_sources.get(n))
-                .flat_map(|s| s.iter().cloned())
-                .collect(),
-            PipelineNode::Combine { header, .. } => header
-                .input
-                .values()
-                .filter_map(|i| upstream_target_name(&i.value))
+            // Every non-Source variant inherits the union of its direct
+            // inputs' upstream-source sets.
+            _ => node
+                .direct_input_names()
+                .into_iter()
                 .filter_map(|n| upstream_sources.get(n))
                 .flat_map(|s| s.iter().cloned())
                 .collect(),


### PR DESCRIPTION
## Intent

Several validation, planning, and output-path walks over the `PipelineNode` enum classified variants by enumerating the same `|`-joined match-arm groups repeatedly. Two of those groups recurred verbatim across multiple call sites. This adds a named accessor method for each recurring group so consumers ask the question by name instead of re-listing the variant set, and retrofits the call sites.

## Accessors added

Each accessor matches the **exact same variant set** as every inline group it replaces, with the same boolean / data sense — so behavior is identical at every retrofitted site.

- **`direct_input_names(&self) -> Vec<&str>`** — the connectivity view shared by the DAG-edge, cycle, self-loop, init-descendant, and source-reachability walks. Variant handling:
  - `Source` → no inputs (empty)
  - `Transform` | `Aggregate` | `Route` | `Output` | `Composition` → their single `input:`
  - `Merge` → each entry of the ordered `inputs:` list
  - `Combine` → each value of the named `input:` map (insertion order)

  Each returned name has any `.port` suffix stripped — identical to the `input_target` / `upstream_target_name` / `target_name_of` helpers the call sites previously used. Retrofitted 7 call sites across `plan/bind_schema.rs`, `config/pipeline.rs`, and `output/path_template.rs`. The now-unused private `input_target` helper in `config/pipeline.rs` is deleted.

- **`reads_scope_vars_in_cxl(&self) -> bool`** — true for `Transform`, `Aggregate`, and `Combine`: the three variants whose author-written `cxl:` body the read-after-write and post-merge-source-read validators walk for scoped-variable reads. `Route` and `Source` carry only engine-synthesized typed programs (an empty Route predicate program, a synthetic Source schema program) and are excluded — matching the prior inline group exactly. Retrofitted 2 call sites in `plan/bind_schema.rs`.

The existing `input_node_name()` accessor was reused where applicable.

## Behavior preserved

The change is purely a refactor — no diagnostic, plan, or output behavior changes. Where a prior site used `.unwrap_or("")` to placeholder a missing single input, that empty string could never match a real (non-empty) node name, so dropping it is equivalent. Call sites whose variant set genuinely differs (groups needing the full port-qualified input reference, or that handle `Composition` with separate edge logic) are intentionally left inline rather than forced onto a shared accessor.

Net change: roughly 100 fewer lines, with the recurring variant enumeration collapsed to two well-documented accessors.

## Verification

`cargo fmt --all`, `cargo clippy --workspace -- -D warnings`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check --benches --workspace`, the bench-feature checks, and `cargo deny check` all pass.

Closes #139