### PR TITLE
clinker-core: move JoinSide and AggregateStrategy into the plan layer

### DIFF
--- a/crates/clinker-core/src/aggregation/error.rs
+++ b/crates/clinker-core/src/aggregation/error.rs
@@ -1,7 +1,6 @@
-//! Plan-time aggregation strategy and the aggregation error taxonomy.
+//! The aggregation error taxonomy.
 //!
-//! Holds the lowest layer of the aggregation engine: the
-//! [`AggregateStrategy`] plan enum, the finalize-time
+//! Holds the lowest layer of the aggregation engine: the finalize-time
 //! [`AggregateEvalError`], the hot-loop [`HashAggError`], and the
 //! `HashAggError → PipelineError` mapping consumed by the executor
 //! dispatch arm. Every other aggregation submodule depends on these
@@ -9,21 +8,8 @@
 
 use clinker_record::accumulator::AccumulatorError;
 use cxl::eval::EvalError;
-use serde::{Deserialize, Serialize};
 
 use crate::error::PipelineError;
-
-/// Aggregation strategy selected at plan-compile time.
-///
-/// `Hash` is the universal default. `Streaming` is used when the input
-/// is provably sorted on the full group-by prefix — allowing a
-/// one-group-at-a-time fold that never materializes a hash table.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum AggregateStrategy {
-    Hash,
-    Streaming,
-}
 
 /// Errors that can arise while evaluating a residual in aggregate
 /// scope.

--- a/crates/clinker-core/src/aggregation/mod.rs
+++ b/crates/clinker-core/src/aggregation/mod.rs
@@ -2,9 +2,8 @@
 //!
 //! This module is split into focused submodules:
 //!
-//! * [`error`] — the plan-time [`AggregateStrategy`] enum and the
-//!   [`AggregateEvalError`] / [`HashAggError`] taxonomy plus its
-//!   `PipelineError` mapping.
+//! * [`error`] — the finalize-time [`AggregateEvalError`] /
+//!   [`HashAggError`] taxonomy plus its `PipelineError` mapping.
 //! * [`hash`] — the [`HashAggregator`] per-group hash table, the
 //!   [`AccumulatorFactory`] prototype clone factory, the
 //!   [`AggregateConsumer`] arbitrator hook, and the shared group
@@ -20,9 +19,9 @@
 //!
 //! Runtime types referenced by `PlanNode::Aggregation`'s executor dispatch:
 //!
-//! * [`AggregateStrategy`] — plan-time enum (also surfaced on the plan
-//!   node) selecting the per-group hash table or the streaming
-//!   single-group fold.
+//! * [`crate::plan::types::AggregateStrategy`] — plan-time enum (also
+//!   surfaced on the plan node) selecting the per-group hash table or
+//!   the streaming single-group fold.
 //! * [`AggregateInput`] — dual input mode: a freshly read input record
 //!   or a previously spilled per-group state being recovered.
 //! * [`AccumulatorFactory`] — clones a per-group prototype
@@ -37,7 +36,7 @@ mod error;
 mod hash;
 mod spill;
 
-pub use error::{AggregateEvalError, AggregateStrategy, HashAggError};
+pub use error::{AggregateEvalError, HashAggError};
 pub use hash::{AccumulatorFactory, AggregateConsumer, AggregatorConfig, HashAggregator};
 pub use spill::{AggSpillFile, SpillState};
 
@@ -59,6 +58,7 @@ use cxl::plan::{AggregateBinding, BindingArg, CompiledAggregate};
 
 use crate::config::SortField;
 use crate::error::PipelineError;
+use crate::plan::types::AggregateStrategy;
 
 /// Input to an aggregator's `add` path. Live input records and
 /// recovered spilled state both flow through the same dispatch so the

--- a/crates/clinker-core/src/config/pipeline.rs
+++ b/crates/clinker-core/src/config/pipeline.rs
@@ -1895,7 +1895,6 @@ pub(crate) fn lower_node_to_plan_node(
     ctx: &LoweringCtx<'_>,
     diags: &mut Vec<crate::error::Diagnostic>,
 ) -> Option<crate::plan::execution::PlanNode> {
-    use crate::aggregation::AggregateStrategy;
     use crate::error::{Diagnostic, LabeledSpan};
     use crate::plan::composition_body::CompositionBodyId;
     use crate::plan::execution::{
@@ -1903,6 +1902,7 @@ pub(crate) fn lower_node_to_plan_node(
         PlanSourcePayload, PlanTransformPayload, derive_parallelism_class, extract_has_distinct,
         extract_write_set,
     };
+    use crate::plan::types::AggregateStrategy;
     use clinker_record::{FieldMetadata, SchemaBuilder};
     use std::sync::Arc;
 

--- a/crates/clinker-core/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-core/src/executor/aggregate_dispatch.rs
@@ -15,7 +15,6 @@ use clinker_record::{GroupByKey, Record, Schema, SchemaBuilder, Value};
 use cxl::eval::ProgramEvaluator;
 use petgraph::graph::NodeIndex;
 
-use crate::aggregation::AggregateStrategy;
 use crate::config::ErrorStrategy;
 use crate::error::PipelineError;
 use crate::executor::dispatch::{
@@ -27,6 +26,7 @@ use crate::executor::dispatch::{
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::{DlqEntry, parse_memory_limit, stage_metrics};
 use crate::plan::execution::{ExecutionPlanDag, PlanNode};
+use crate::plan::types::AggregateStrategy;
 
 /// Execute the `Aggregation` arm for `node_idx`: select hash or streaming
 /// strategy, ingest the predecessor's records (per-record for hash, sorted

--- a/crates/clinker-core/src/executor/combine.rs
+++ b/crates/clinker-core/src/executor/combine.rs
@@ -29,19 +29,7 @@ use indexmap::IndexMap;
 
 use crate::plan::combine::CombineInput;
 use crate::plan::row_type::QualifiedField;
-
-/// Which side of a combine a matched record came from.
-///
-/// `Probe` is the driver (streaming) side; `Build` is the materialized
-/// hash-table side. A combine has exactly one probe qualifier and one
-/// build qualifier — N-ary user-authored combines are rewritten by the
-/// plan-time decomposition pass into a chain of binary combines, so by
-/// the time this enum is consulted every combine in the DAG is binary.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum JoinSide {
-    Build,
-    Probe,
-}
+use crate::plan::types::JoinSide;
 
 /// Compile-time resolution table built once per combine node.
 ///

--- a/crates/clinker-core/src/executor/streaming.rs
+++ b/crates/clinker-core/src/executor/streaming.rs
@@ -361,7 +361,7 @@ pub(crate) fn classify_stream_nodes(
 ///
 /// Producer = streaming-strategy `Aggregate`:
 ///
-/// - The aggregate resolved to [`AggregateStrategy::Streaming`] (the
+/// - The aggregate resolved to [`crate::plan::types::AggregateStrategy::Streaming`] (the
 ///   planner certified pre-sorted input), feeds only this Output, and
 ///   roots no window arena. Hash aggregation stays blocking: it must
 ///   accumulate every group before emitting, so it cannot stream.
@@ -389,9 +389,9 @@ fn streaming_output_producer(
     fused_transforms: &HashSet<petgraph::graph::NodeIndex>,
     init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
 ) -> Option<petgraph::graph::NodeIndex> {
-    use crate::aggregation::AggregateStrategy;
     use crate::plan::combine::CombineStrategy;
     use crate::plan::execution::PlanNode;
+    use crate::plan::types::AggregateStrategy;
 
     let PlanNode::Output { resolved, .. } = &plan.graph[output_idx] else {
         return None;

--- a/crates/clinker-core/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-core/src/pipeline/grace_hash/tests.rs
@@ -270,8 +270,9 @@ fn lazy_probe_spill_routes_to_partition_file() {
 /// of which partitions get spilled.
 #[test]
 fn execute_grace_hash_partition_pair_correct() {
-    use crate::executor::combine::{CombineResolverMapping, JoinSide};
+    use crate::executor::combine::CombineResolverMapping;
     use crate::plan::combine::{DecomposedPredicate, EqualityConjunct};
+    use crate::plan::types::JoinSide;
     use cxl::eval::{EvalContext, StableEvalContext};
 
     // Driver and build schemas use distinct bare names for the
@@ -467,8 +468,9 @@ fn execute_grace_hash_partition_pair_correct() {
 /// emits the same join membership the in-memory path would.
 #[test]
 fn execute_grace_hash_spill_then_reload_correct() {
-    use crate::executor::combine::{CombineResolverMapping, JoinSide};
+    use crate::executor::combine::CombineResolverMapping;
     use crate::plan::combine::{DecomposedPredicate, EqualityConjunct};
+    use crate::plan::types::JoinSide;
     use cxl::eval::{EvalContext, StableEvalContext};
 
     let driver_schema = schema_with(&["dk", "v"]);
@@ -644,8 +646,9 @@ fn execute_grace_hash_spill_then_reload_correct() {
 /// cause this combine to fail.
 #[test]
 fn execute_grace_hash_aborts_on_disk_quota_overflow() {
-    use crate::executor::combine::{CombineResolverMapping, JoinSide};
+    use crate::executor::combine::CombineResolverMapping;
     use crate::plan::combine::{DecomposedPredicate, EqualityConjunct};
+    use crate::plan::types::JoinSide;
     use cxl::eval::{EvalContext, StableEvalContext};
 
     let driver_schema = schema_with(&["dk", "v"]);
@@ -928,8 +931,9 @@ struct EmitArgsOwned {
 }
 
 fn build_bnl_harness() -> BnlHarness {
-    use crate::executor::combine::{CombineResolverMapping, JoinSide};
+    use crate::executor::combine::CombineResolverMapping;
     use crate::plan::combine::{DecomposedPredicate, EqualityConjunct};
+    use crate::plan::types::JoinSide;
     use cxl::eval::StableEvalContext;
 
     let driver_schema = schema_with(&["dk", "v"]);

--- a/crates/clinker-core/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-core/src/pipeline/sort_merge_join.rs
@@ -1587,8 +1587,9 @@ impl crate::pipeline::memory::MemoryConsumer for SortMergeConsumer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::executor::combine::{CombineResolverMapping, JoinSide};
+    use crate::executor::combine::CombineResolverMapping;
     use crate::plan::combine::{CombineInput, RangeConjunct};
+    use crate::plan::types::JoinSide;
     use clinker_record::SchemaBuilder;
     use cxl::ast::Statement;
     use cxl::lexer::Span as CxlSpan;

--- a/crates/clinker-core/src/plan/bind_schema.rs
+++ b/crates/clinker-core/src/plan/bind_schema.rs
@@ -40,6 +40,7 @@ use crate::plan::combine::{
     CombineInput, DecomposedPredicate, decompose_predicate, select_driving_input,
 };
 use crate::plan::composition_body::{BoundBody, CompositionBodyId};
+use crate::plan::types::JoinSide;
 use crate::span::{FileId, Span};
 use crate::yaml::Spanned;
 
@@ -3066,8 +3067,7 @@ fn bind_combine(
         // where-clause — collect mode has no body, but the residual
         // predicate (if any) still drives a `CombineResolver` at
         // probe time.
-        let mut resolved_map: HashMap<QualifiedField, (crate::executor::combine::JoinSide, u32)> =
-            HashMap::new();
+        let mut resolved_map: HashMap<QualifiedField, (JoinSide, u32)> = HashMap::new();
         for stmt in &typed_where.program.statements {
             for sub in statement_exprs(stmt) {
                 walk_expr_for_qualified_refs(Some(sub), inputs, Some(&driving), &mut resolved_map);
@@ -3246,9 +3246,7 @@ fn resolve_combine_body_columns(
     typed: &TypedProgram,
     inputs: &IndexMap<String, crate::plan::combine::CombineInput>,
     driver_qualifier: Option<&str>,
-) -> HashMap<QualifiedField, (crate::executor::combine::JoinSide, u32)> {
-    use crate::executor::combine::JoinSide;
-
+) -> HashMap<QualifiedField, (JoinSide, u32)> {
     let mut out: HashMap<QualifiedField, (JoinSide, u32)> = HashMap::new();
     for stmt in &typed.program.statements {
         for sub in statement_exprs(stmt) {
@@ -3299,10 +3297,8 @@ fn walk_expr_for_qualified_refs(
     expr: Option<&Expr>,
     inputs: &IndexMap<String, crate::plan::combine::CombineInput>,
     driver_qualifier: Option<&str>,
-    out: &mut HashMap<QualifiedField, (crate::executor::combine::JoinSide, u32)>,
+    out: &mut HashMap<QualifiedField, (JoinSide, u32)>,
 ) {
-    use crate::executor::combine::JoinSide;
-
     let Some(expr) = expr else {
         return;
     };

--- a/crates/clinker-core/src/plan/combine.rs
+++ b/crates/clinker-core/src/plan/combine.rs
@@ -27,6 +27,7 @@ use serde::Serialize;
 use crate::error::{Diagnostic, LabeledSpan};
 use crate::plan::execution::DependencyType;
 use crate::plan::row_type::{QualifiedField, Row};
+use crate::plan::types::JoinSide;
 use crate::span::Span;
 use cxl::ast::{BinOp, Expr, NodeId, Program, Statement};
 use cxl::typecheck::Type;
@@ -1837,12 +1838,10 @@ pub(crate) fn decompose_nary_combines(
         // input's source schema. The `CombineResolver` consumes this
         // map at runtime via
         // `CombineResolverMapping::from_pre_resolved`.
-        let mut step_resolved_maps: Vec<
-            HashMap<QualifiedField, (crate::executor::combine::JoinSide, u32)>,
-        > = Vec::with_capacity(steps.len());
+        let mut step_resolved_maps: Vec<HashMap<QualifiedField, (JoinSide, u32)>> =
+            Vec::with_capacity(steps.len());
         for (i, step) in steps.iter().enumerate() {
-            let mut step_map: HashMap<QualifiedField, (crate::executor::combine::JoinSide, u32)> =
-                HashMap::new();
+            let mut step_map: HashMap<QualifiedField, (JoinSide, u32)> = HashMap::new();
             // Probe-side qualifiers: every original qualifier that's
             // already in the joined chain at the start of this step.
             // For step 0 the chain has only the original driving
@@ -1859,7 +1858,7 @@ pub(crate) fn decompose_nary_combines(
                 for (idx, (qf, _ty)) in driver_input.row.fields().enumerate() {
                     let resolve_qual = qf.qualifier.as_deref().unwrap_or(driving.as_str());
                     let key = QualifiedField::qualified(resolve_qual, qf.name.clone());
-                    step_map.insert(key, (crate::executor::combine::JoinSide::Probe, idx as u32));
+                    step_map.insert(key, (JoinSide::Probe, idx as u32));
                 }
             } else {
                 let prev_intermediate = &steps[i - 1].intermediate_row;
@@ -1869,7 +1868,7 @@ pub(crate) fn decompose_nary_combines(
                         .as_deref()
                         .expect("intermediate_row fields are qualified by construction");
                     let key = QualifiedField::qualified(resolve_qual, qf.name.clone());
-                    step_map.insert(key, (crate::executor::combine::JoinSide::Probe, idx as u32));
+                    step_map.insert(key, (JoinSide::Probe, idx as u32));
                 }
             }
             // Build-side qualifier: the single input newly joined at
@@ -1882,7 +1881,7 @@ pub(crate) fn decompose_nary_combines(
                 .expect("step.build_input qualifier was selected from inputs.keys()");
             for (idx, (qf, _ty)) in build_input_meta.row.fields().enumerate() {
                 let key = QualifiedField::qualified(step.build_input.as_str(), qf.name.clone());
-                step_map.insert(key, (crate::executor::combine::JoinSide::Build, idx as u32));
+                step_map.insert(key, (JoinSide::Build, idx as u32));
             }
             step_resolved_maps.push(step_map);
         }

--- a/crates/clinker-core/src/plan/execution/mod.rs
+++ b/crates/clinker-core/src/plan/execution/mod.rs
@@ -25,12 +25,11 @@ use serde::Serialize;
 
 use std::sync::Arc;
 
-use crate::aggregation::AggregateStrategy;
 use crate::config::{AggregateConfig, OutputConfig, RouteMode, SortField, SourceConfig};
-use crate::executor::combine::JoinSide;
 use crate::plan::composition_body::CompositionBodyId;
 use crate::plan::index::{AnalyticWindowSpec, IndexSpec};
 use crate::plan::row_type::QualifiedField;
+use crate::plan::types::{AggregateStrategy, JoinSide};
 use crate::span::Span;
 use clinker_record::Schema;
 use cxl::plan::CompiledAggregate;

--- a/crates/clinker-core/src/plan/execution/scheduling.rs
+++ b/crates/clinker-core/src/plan/execution/scheduling.rs
@@ -347,11 +347,10 @@ impl ExecutionPlanDag {
     /// input, via the rustc-shaped walker
     /// `render_unordered_streaming_error`.
     pub(crate) fn select_aggregation_strategies(&mut self) -> Result<(), PipelineError> {
-        use crate::aggregation::{
-            AggregateStrategy, StreamingEligibility, qualifies_for_streaming,
-        };
+        use crate::aggregation::{StreamingEligibility, qualifies_for_streaming};
         use crate::config::AggregateStrategyHint;
         use crate::plan::properties::{Confidence, render_unordered_streaming_error};
+        use crate::plan::types::AggregateStrategy;
 
         // Collect target indices first to avoid holding a borrow on `graph`
         // while mutating `node_properties`.
@@ -553,7 +552,7 @@ impl crate::pipeline::memory::SchedulingHint for ExecutionPlanDag {
 
 /// Internal carrier for `select_aggregation_strategies` resolution result.
 struct ResolvedStrategy {
-    strategy: crate::aggregation::AggregateStrategy,
+    strategy: crate::plan::types::AggregateStrategy,
     fallback_reason: Option<String>,
     skipped_streaming_available: bool,
     qualified_sort_order: Option<Vec<SortField>>,

--- a/crates/clinker-core/src/plan/mod.rs
+++ b/crates/clinker-core/src/plan/mod.rs
@@ -9,10 +9,12 @@ pub mod extraction;
 pub mod index;
 pub mod properties;
 pub mod row_type;
+pub mod types;
 
 pub use compiled::{ChannelIdentity, CompiledPlan};
 pub use composition_body::{BoundBody, CompositionBodyId};
 pub use row_type::{ColumnLookup, QualifiedField, Row, RowTail, TailVarId};
+pub use types::{AggregateStrategy, JoinSide};
 
 pub use properties::{
     NodeProperties, Ordering, OrderingProvenance, Partitioning, PartitioningKind,

--- a/crates/clinker-core/src/plan/types.rs
+++ b/crates/clinker-core/src/plan/types.rs
@@ -1,0 +1,37 @@
+//! Plan-layer enums shared across the planner, executor, and
+//! aggregation engine.
+//!
+//! These are compile-time selections baked into the execution plan: the
+//! side a combine match came from ([`JoinSide`]) and the aggregation
+//! algorithm chosen for a grouped reduction ([`AggregateStrategy`]).
+//! They live in the plan layer because the planner produces them and the
+//! lower runtime layers merely consume them — keeping the definitions
+//! here lets `plan/` stay free of any upward import from `executor/` or
+//! `aggregation/`.
+
+use serde::{Deserialize, Serialize};
+
+/// Which side of a combine a matched record came from.
+///
+/// `Probe` is the driver (streaming) side; `Build` is the materialized
+/// hash-table side. A combine has exactly one probe qualifier and one
+/// build qualifier — N-ary user-authored combines are rewritten by the
+/// plan-time decomposition pass into a chain of binary combines, so by
+/// the time this enum is consulted every combine in the DAG is binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JoinSide {
+    Build,
+    Probe,
+}
+
+/// Aggregation strategy selected at plan-compile time.
+///
+/// `Hash` is the universal default. `Streaming` is used when the input
+/// is provably sorted on the full group-by prefix — allowing a
+/// one-group-at-a-time fold that never materializes a hash table.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AggregateStrategy {
+    Hash,
+    Streaming,
+}

--- a/crates/clinker-core/tests/combine_test.rs
+++ b/crates/clinker-core/tests/combine_test.rs
@@ -509,7 +509,7 @@ mod tests {
     /// the field's position within its declared input row.
     #[test]
     fn test_typecheck_combine_resolves_qualified_field_refs_to_indices() {
-        use clinker_core::executor::combine::JoinSide;
+        use clinker_core::plan::types::JoinSide;
         use cxl::typecheck::QualifiedField;
 
         let (artifacts, diags) = compile_combine_fixture("match_all");


### PR DESCRIPTION
## What

Moves two plan-produced enums up into a new `plan::types` module so the
planning layer no longer reaches upward into the executor or aggregation
modules to name types it actually owns:

- `JoinSide` — which side of a binary combine a matched record came from.
  Previously defined in `executor::combine`.
- `AggregateStrategy` — the hash-vs-streaming choice baked into an
  `Aggregate` plan node. Previously defined in `aggregation::error`.

Both are compile-time selections the planner emits and the lower runtime
layers merely consume, so their natural home is the plan layer.

## Why

With the definitions sitting below the planner, `plan/` had to import
`crate::executor::combine::JoinSide` and
`crate::aggregation::AggregateStrategy` — an upward dependency that reads
like a cycle and stands in the way of splitting these layers into
separate crates later. Relocating the enums removes that edge.

## How

- New `plan/types.rs` holds both enums, carried over verbatim with their
  derives. `JoinSide` keeps `Copy`/`Hash`/`Eq`; `AggregateStrategy` keeps
  its `snake_case` serde representation. Only the module path changed.
- Every caller is repointed at the new location: the planner
  (`plan::execution`, `plan::combine`, `plan::bind_schema`), the combine
  and aggregate executor arms, the aggregation engine's strategy
  dispatch, the node-lowering pass, and the join-resolution unit and
  integration tests.
- No re-export shim is left behind in the old locations; the old import
  paths are gone.

Scope is limited to these two enums by design. Other cross-layer
references from `plan/` into the executor and aggregation modules
(streaming-eligibility helpers, stream classification, transform-spec
builders) are unrelated symbols and are left for their own follow-up
decoupling work.

## Verification

- `cargo fmt --all`
- `cargo check -p clinker-core`
- `cargo clippy -p clinker-core -- -D warnings`
- `cargo clippy -p clinker-core --all-targets -- -D warnings`

Closes #264