### PR TITLE
clinker-core: build arbitration policy in the memory subsystem, not config

### DIFF
--- a/crates/clinker-core/src/config/pipeline.rs
+++ b/crates/clinker-core/src/config/pipeline.rs
@@ -82,11 +82,10 @@ pub struct PipelineMeta {
 
 /// Memory-arbitrator tuning, nested under `pipeline.memory`.
 ///
-/// `limit` accepts the same suffix grammar as the pre-#157 flat
-/// `memory.limit` field: `"512M"`, `"2G"`, `"1024K"`, or a raw
-/// integer byte count. When omitted, the arbitrator falls back to
-/// a 512 MiB hard ceiling (resolved at construction time through
-/// `crate::pipeline::memory::parse_memory_limit_bytes`).
+/// `limit` accepts a byte-size suffix grammar: `"512M"`, `"2G"`,
+/// `"1024K"`, or a raw integer byte count. When omitted, the
+/// arbitrator falls back to a 512 MiB hard ceiling, resolved at
+/// construction time by the memory subsystem rather than here.
 ///
 /// `backpressure` selects the active arbitration policy. The
 /// default `pause` installs `BackPressurePreferred -> Priority`:
@@ -150,20 +149,6 @@ impl BackpressureKnob {
     /// rather than re-emitted as redundant noise.
     pub fn is_default(&self) -> bool {
         matches!(self, Self::Pause)
-    }
-
-    /// Construct the boxed `ArbitrationPolicy` this knob selects.
-    /// Called by every production callsite that builds a
-    /// `MemoryArbitrator` from parsed config.
-    pub fn build_policy(self) -> Box<dyn crate::pipeline::memory::ArbitrationPolicy> {
-        use crate::pipeline::memory::{
-            BackPressurePreferred, LargestFirst, MemoryArbitrator, Priority,
-        };
-        match self {
-            Self::Spill => Box::new(Priority),
-            Self::Pause => MemoryArbitrator::default_policy(),
-            Self::Both => Box::new(BackPressurePreferred::wrapping(LargestFirst)),
-        }
     }
 }
 

--- a/crates/clinker-core/src/executor/util.rs
+++ b/crates/clinker-core/src/executor/util.rs
@@ -354,9 +354,10 @@ pub(crate) fn parse_memory_limit(config: &PipelineConfig) -> usize {
 
 /// Build a `MemoryArbitrator` from the pipeline-level `memory:` block.
 /// Resolves `memory.limit` through `parse_memory_limit_bytes` (defaults
-/// to 512 MiB when omitted) and chooses the active policy via
-/// `BackpressureKnob::build_policy`. Used by both the pipeline-scoped
-/// arbitrator and every per-arm budget the dispatch path constructs.
+/// to 512 MiB when omitted) and chooses the active policy by mapping the
+/// `memory.backpressure` knob through `build_policy`. Used by both the
+/// pipeline-scoped arbitrator and every per-arm budget the dispatch path
+/// constructs.
 pub(crate) fn build_arbitrator_from_config(
     config: &PipelineConfig,
 ) -> crate::pipeline::memory::MemoryArbitrator {
@@ -365,6 +366,6 @@ pub(crate) fn build_arbitrator_from_config(
     crate::pipeline::memory::MemoryArbitrator::with_policy(
         limit,
         0.80,
-        mem.backpressure.build_policy(),
+        crate::pipeline::memory::build_policy(mem.backpressure),
     )
 }

--- a/crates/clinker-core/src/pipeline/memory.rs
+++ b/crates/clinker-core/src/pipeline/memory.rs
@@ -622,6 +622,31 @@ impl ArbitrationPolicy for BackPressurePreferred {
     }
 }
 
+/// Build the boxed [`ArbitrationPolicy`] a `pipeline.memory.backpressure`
+/// knob selects.
+///
+/// Keeps the concrete policy types ([`Priority`], [`LargestFirst`],
+/// [`BackPressurePreferred`]) and their wiring inside the memory
+/// subsystem: the config layer carries only the plain
+/// [`BackpressureKnob`](crate::config::BackpressureKnob) selector and
+/// never names a policy type. Called by every production path that turns
+/// parsed config into a live arbitrator.
+///
+/// - `spill` → bare [`Priority`]: react-only, cheapest-to-spill-first.
+/// - `pause` → [`MemoryArbitrator::default_policy`]
+///   (`BackPressurePreferred -> Priority`): prefer pausing a producer,
+///   otherwise spill cheapest first. This is the runtime default.
+/// - `both` → `BackPressurePreferred -> LargestFirst`: prefer pausing,
+///   otherwise force the largest holder regardless of priority.
+pub fn build_policy(knob: crate::config::BackpressureKnob) -> Box<dyn ArbitrationPolicy> {
+    use crate::config::BackpressureKnob;
+    match knob {
+        BackpressureKnob::Spill => Box::new(Priority),
+        BackpressureKnob::Pause => MemoryArbitrator::default_policy(),
+        BackpressureKnob::Both => Box::new(BackPressurePreferred::wrapping(LargestFirst)),
+    }
+}
+
 /// Central memory arbitrator. Owns the RSS hard / soft limits, the
 /// per-category byte counters (arena, node-buffer, disk spill), and
 /// the policy + consumer registry used to elect spill victims.
@@ -704,8 +729,7 @@ impl MemoryArbitrator {
     /// `ArbitrationPolicy`. Ships with no registered consumers.
     ///
     /// Production paths construct via this constructor with the
-    /// policy chosen by `memory.backpressure` (see
-    /// `BackpressureKnob::build_policy` in `crate::config`).
+    /// policy chosen by `memory.backpressure` (see [`build_policy`]).
     /// Tests that want pre-policy react-only behavior pass
     /// `Box::new(NoOpPolicy)`; tests that want the production
     /// default pass `Self::default_policy()`.

--- a/crates/clinker-core/src/plan/execution/explain.rs
+++ b/crates/clinker-core/src/plan/execution/explain.rs
@@ -671,7 +671,7 @@ impl ExecutionPlanDag {
         // every combine node when artifacts are absent — so the output
         // of `explain()` already has no combine block to dedupe.
         let classes = self.classify_node_buffers(config);
-        let policy = config.pipeline.memory.backpressure.build_policy();
+        let policy = crate::pipeline::memory::build_policy(config.pipeline.memory.backpressure);
         let policy_name = policy.policy_name();
         let mut out = self.explain(&classes, &policy_name);
         self.render_combine_section(&mut out, Some(artifacts), total_memory_limit_bytes);
@@ -1036,7 +1036,7 @@ impl ExecutionPlanDag {
     /// Full `--explain` output combining execution plan with config context.
     pub fn explain_full(&self, config: &PipelineConfig) -> String {
         let classes = self.classify_node_buffers(config);
-        let policy = config.pipeline.memory.backpressure.build_policy();
+        let policy = crate::pipeline::memory::build_policy(config.pipeline.memory.backpressure);
         let policy_name = policy.policy_name();
         let mut out = self.explain(&classes, &policy_name);
         if let Some(start) = out.find("=== Retraction ===\n") {


### PR DESCRIPTION
## Summary

Breaks the upward dependency edge from the config layer to the execution layer in `clinker-core`.

The `pipeline.memory.backpressure` knob carried a `build_policy` method that named the concrete arbitration-policy types (`Priority`, `LargestFirst`, `BackPressurePreferred`) and the `MemoryArbitrator` constructor. That pulled the config layer up into the execution layer it should sit beneath.

## Change

- Move policy construction into a free `build_policy` function alongside the policy types in the memory subsystem (`pipeline/memory.rs`). It takes the plain `BackpressureKnob` selector as input and returns a boxed `ArbitrationPolicy`.
- Config now carries only the knob enum and never names a policy type or the arbitrator.
- Repoint all three production callers — the per-run arbitrator builder and both `--explain` renderers — to the new function.
- Drop a stale doc reference to the qualified pipeline path from the config-side `MemoryConfig` comment.

## Result

The config module has no remaining imports from the `pipeline` or `aggregation` modules:

```
$ grep -rn "use crate::pipeline\|crate::pipeline::\|use crate::aggregation\|crate::aggregation::" crates/clinker-core/src/config/
(no output)
```

Behavior is unchanged; the `spill` / `pause` / `both` knob values still map to the same policies. Memory-module unit tests pass; `cargo fmt`, scoped `cargo check`, and `cargo clippy -- -D warnings` (with and without `--all-targets`) are clean on `clinker-core`.

Closes #265