### PR TITLE
engine: spill disk cap with distinct cap-exceeded and disk-full error surfaces

### DIFF
--- a/crates/clinker-exec/src/executor/batch_handoff.rs
+++ b/crates/clinker-exec/src/executor/batch_handoff.rs
@@ -37,7 +37,6 @@ use std::sync::Arc;
 
 use crate::executor::stream_event::{Punctuation, StreamEvent};
 use crate::pipeline::memory::{ConsumerHandle, MemoryArbitrator};
-use clinker_plan::BudgetCategory;
 use clinker_plan::error::PipelineError;
 
 /// Default per-batch event count when no `pipeline.batch_size` knob and
@@ -348,7 +347,7 @@ impl StreamingChargeHandle {
     /// regardless of whether the batch round-tripped through disk. An
     /// empty run is a no-op (no spill file). Records the spilled file's
     /// on-disk size against the arbitrator's disk quota and surfaces
-    /// `MemoryBudgetExceeded` when the cumulative total exceeds the cap.
+    /// `SpillCapExceeded` (E320) when the cumulative total exceeds the cap.
     fn spill_and_forward_run(
         &self,
         run: Vec<(clinker_record::Record, u64)>,
@@ -363,13 +362,12 @@ impl StreamingChargeHandle {
         };
         let file_bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
         if self.arbitrator.record_spill_bytes(file_bytes) {
-            return Err(PipelineError::MemoryBudgetExceeded {
-                node: self.node_name.clone(),
-                used: self.arbitrator.cumulative_spill_bytes(),
-                limit: self.arbitrator.max_spill_bytes(),
-                source: BudgetCategory::NodeBuffer,
-                detail: Some("spill quota exceeded".to_string()),
-            });
+            return Err(PipelineError::spill_cap_exceeded(
+                self.node_name.clone(),
+                self.arbitrator.max_spill_bytes(),
+                file_bytes,
+                self.arbitrator.cumulative_spill_bytes(),
+            ));
         }
         for item in file.reader()? {
             let (record, rn) = item?;

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1308,9 +1308,9 @@ pub(crate) fn node_buffer_spill_allowed(
 ///    `SpillFile<u64>` via [`node_buffer_spill::spill_node_buffer`].
 ///    The in-memory charge is discharged immediately and the file size
 ///    is added to `cumulative_spill_bytes`; an over-quota disk total
-///    surfaces the same structured `MemoryBudgetExceeded` shape with
-///    `detail: "spill quota exceeded"` so existing diagnostics tooling
-///    handles both surfaces uniformly.
+///    surfaces `PipelineError::SpillCapExceeded` (E320) — a disk-cap
+///    surface deliberately distinct from the memory-budget E310 so a
+///    spilled-out volume never reads as an out-of-memory failure.
 /// 4. Otherwise rows stay in memory as `NodeBuffer::Memory(rows)`.
 ///
 /// `spill_allowed` should be computed via [`node_buffer_spill_allowed`]
@@ -1391,13 +1391,12 @@ pub(crate) fn admit_node_buffer(
             handle.set_bytes(0);
             let file_bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
             if ctx.memory_budget.record_spill_bytes(file_bytes) {
-                return Err(PipelineError::MemoryBudgetExceeded {
-                    node: node_name.to_string(),
-                    used: ctx.memory_budget.cumulative_spill_bytes(),
-                    limit: ctx.memory_budget.max_spill_bytes(),
-                    source: BudgetCategory::NodeBuffer,
-                    detail: Some("spill quota exceeded".to_string()),
-                });
+                return Err(PipelineError::spill_cap_exceeded(
+                    node_name,
+                    ctx.memory_budget.max_spill_bytes(),
+                    file_bytes,
+                    ctx.memory_budget.cumulative_spill_bytes(),
+                ));
             }
             Ok(NodeBuffer::Spilled {
                 chunks: vec![(file, count)],

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -370,7 +370,18 @@ impl PipelineExecutor {
         params: &PipelineRunParams,
         compile_ctx: clinker_plan::config::CompileContext,
     ) -> Result<ExecutionReport, PipelineError> {
-        let memory_budget = std::sync::Arc::new(build_arbitrator_from_config(config));
+        let arbitrator = build_arbitrator_from_config(config);
+        // Fold the workspace `storage.spill.disk_cap_bytes` quota into the
+        // arbitrator's disk-spill ceiling. Absent config leaves the cap at
+        // its `u64::MAX` (unlimited) default, so behavior is unchanged when
+        // no `clinker.toml` opts in. Set here — not inside
+        // `build_arbitrator_from_config` — because the cap lives in the
+        // workspace `clinker.toml` (a runtime parameter), not the per-pipeline
+        // `memory:` block the arbitrator builder reads.
+        if let Some(cap) = params.spill_disk_cap_bytes {
+            arbitrator.set_max_spill_bytes(cap);
+        }
+        let memory_budget = std::sync::Arc::new(arbitrator);
         Self::run_with_readers_writers_with_arbitrator(
             config,
             readers,

--- a/crates/clinker-exec/src/executor/params.rs
+++ b/crates/clinker-exec/src/executor/params.rs
@@ -44,6 +44,15 @@ pub struct PipelineRunParams {
     /// path: a failure to create the spill root under it is an internal error,
     /// not a config error.
     pub spill_root_dir: Option<std::path::PathBuf>,
+    /// Cumulative disk-spill quota for the run, in bytes, resolved from the
+    /// workspace `clinker.toml` `[storage.spill] disk_cap_bytes` setting.
+    /// `None` (no setting, or no `clinker.toml`) → unlimited spill, the
+    /// historical default. `Some(cap)` is folded into the run's memory
+    /// arbitrator as `max_spill_bytes`; once the cumulative on-disk size of
+    /// the run's spill files crosses it, the spilling operator aborts with
+    /// `PipelineError::SpillCapExceeded` (E320) — a disk-cap surface kept
+    /// distinct from both the RSS budget (E310) and a full volume (E321).
+    pub spill_disk_cap_bytes: Option<u64>,
 }
 
 /// Summary returned after a pipeline execution completes (success or partial).

--- a/crates/clinker-exec/src/executor/tests/composition_port_admission_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/composition_port_admission_overshoot.rs
@@ -146,32 +146,24 @@ fn port_admission_overshoot_is_wrapped_naming_the_port_source() {
                 "the wrapper must name the user-visible composition call-site",
             );
             match *inner {
-                PipelineError::MemoryBudgetExceeded {
+                PipelineError::SpillCapExceeded {
                     node,
-                    source,
-                    used,
-                    limit,
-                    detail,
+                    cap,
+                    attempted,
+                    current,
                 } => {
                     assert_eq!(
                         node, "data",
                         "the boundary overflow must name the body's port-source node",
                     );
+                    assert_eq!(cap, 1, "reported cap must equal the one-byte quota");
+                    assert!(attempted > 0, "the overflowing flush must report its size");
                     assert!(
-                        matches!(source, clinker_plan::BudgetCategory::NodeBuffer),
-                        "port admission must surface under NodeBuffer; got {source:?}",
-                    );
-                    assert_eq!(
-                        detail.as_deref(),
-                        Some("spill quota exceeded"),
-                        "the body admission uses the same disk-spill-quota gate as every slot",
-                    );
-                    assert!(
-                        used > limit,
-                        "reported used ({used}) must exceed the spill quota ({limit})",
+                        current > cap,
+                        "reported cumulative spilled ({current}) must exceed the cap ({cap})",
                     );
                 }
-                other => panic!("expected inner MemoryBudgetExceeded; got: {other:?}"),
+                other => panic!("expected inner SpillCapExceeded; got: {other:?}"),
             }
         }
         other => panic!("expected outer CompositionBodyError; got: {other:?}"),

--- a/crates/clinker-exec/src/executor/tests/diamond_node_buffer_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/diamond_node_buffer_overshoot.rs
@@ -1,18 +1,18 @@
 //! Hard-limit overshoot coverage for the `node_buffers` admission's
-//! disk-spill-quota gate, surfacing the bare
-//! `PipelineError::MemoryBudgetExceeded { source: BudgetCategory::NodeBuffer }`
-//! shape on a diamond topology.
+//! disk-spill-quota gate, surfacing the dedicated
+//! `PipelineError::SpillCapExceeded` (E320) shape on a diamond topology.
 //!
 //! Under the RSS-based arbitration model a `node_buffers` slot only
-//! raises E310 through the disk-spill-quota path in `admit_node_buffer`:
-//! when the soft limit has tripped (`should_spill()` true) the slot
-//! flushes to a spill file, and an over-quota cumulative disk total
-//! (`record_spill_bytes` past `max_spill_bytes`) returns the structured
-//! error with `detail: "spill quota exceeded"`. Producer-side spill is
-//! gated to single-consumer slots (`node_buffer_spill_allowed`), so the
-//! diamond's `stage_split` producer — which fans out to two branches —
-//! stays in memory; the spillable slot is a single-consumer branch
-//! feeding the Merge.
+//! raises the disk-cap error through the disk-spill-quota path in
+//! `admit_node_buffer`: when the soft limit has tripped (`should_spill()`
+//! true) the slot flushes to a spill file, and an over-quota cumulative
+//! disk total (`record_spill_bytes` past `max_spill_bytes`) returns the
+//! structured `SpillCapExceeded` error — deliberately distinct from the
+//! memory-budget E310 so a spilled-out volume never reads as OOM.
+//! Producer-side spill is gated to single-consumer slots
+//! (`node_buffer_spill_allowed`), so the diamond's `stage_split`
+//! producer — which fans out to two branches — stays in memory; the
+//! spillable slot is a single-consumer branch feeding the Merge.
 //!
 //! The arbitrator is seeded deterministically: `peak_rss` above the soft
 //! limit (so `should_spill` trips) but below the hard limit (so no
@@ -137,32 +137,24 @@ fn diamond_branch_admission_overshoots_spill_quota_as_node_buffer() {
     .expect_err("one-byte spill quota must abort the first branch flush");
 
     match err {
-        PipelineError::MemoryBudgetExceeded {
+        PipelineError::SpillCapExceeded {
             node,
-            source,
-            used,
-            limit,
-            detail,
+            cap,
+            attempted,
+            current,
         } => {
             assert!(
                 node == "branch_a" || node == "branch_b",
                 "the spillable slot is a single-consumer branch (stage_split fans out \
                  to two consumers and cannot spill); got node {node:?}",
             );
+            assert_eq!(cap, 1, "reported cap must equal the one-byte quota");
+            assert!(attempted > 0, "the overflowing flush must report its size");
             assert!(
-                matches!(source, clinker_plan::BudgetCategory::NodeBuffer),
-                "node_buffers admission must surface under NodeBuffer; got {source:?}",
-            );
-            assert_eq!(
-                detail.as_deref(),
-                Some("spill quota exceeded"),
-                "the disk-spill-quota path is the only node_buffers E310 surface",
-            );
-            assert!(
-                used > limit,
-                "reported used ({used}) must exceed the spill quota ({limit})",
+                current > cap,
+                "reported cumulative spilled ({current}) must exceed the cap ({cap})",
             );
         }
-        other => panic!("expected bare MemoryBudgetExceeded; got: {other:?}"),
+        other => panic!("expected SpillCapExceeded; got: {other:?}"),
     }
 }

--- a/crates/clinker-exec/src/executor/tests/nested_composition_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/nested_composition_overshoot.rs
@@ -10,8 +10,8 @@
 //! user-visible failure location is the `Composition` node they wrote,
 //! not a body-internal operator they never named in their YAML. The
 //! test destructures both layers: the wrapper carries the call-site
-//! name, the inner carries the body-internal node, the `NodeBuffer`
-//! category, and the `"spill quota exceeded"` detail.
+//! name, the inner carries the body-internal node and the dedicated
+//! `SpillCapExceeded` (E320) disk-cap surface.
 //!
 //! Reuses the multi-node body fixture
 //! `tests/fixtures/compositions/issue_123_nested_hard_fail.comp.yaml`,
@@ -129,32 +129,24 @@ fn body_interior_overshoot_is_wrapped_under_the_call_site() {
                 "the wrapper must name the call-site, not the body interior",
             );
             match *inner {
-                PipelineError::MemoryBudgetExceeded {
+                PipelineError::SpillCapExceeded {
                     node,
-                    source,
-                    used,
-                    limit,
-                    detail,
+                    cap,
+                    attempted,
+                    current,
                 } => {
                     assert!(
                         !node.is_empty(),
                         "the inner error must name the body-internal node that overflowed",
                     );
+                    assert_eq!(cap, 1, "reported cap must equal the one-byte quota");
+                    assert!(attempted > 0, "the overflowing flush must report its size");
                     assert!(
-                        matches!(source, clinker_plan::BudgetCategory::NodeBuffer),
-                        "the inner overflow must surface under NodeBuffer; got {source:?}",
-                    );
-                    assert_eq!(
-                        detail.as_deref(),
-                        Some("spill quota exceeded"),
-                        "the body admission uses the same disk-spill-quota gate as every slot",
-                    );
-                    assert!(
-                        used > limit,
-                        "reported used ({used}) must exceed the spill quota ({limit})",
+                        current > cap,
+                        "reported cumulative spilled ({current}) must exceed the cap ({cap})",
                     );
                 }
-                other => panic!("expected inner MemoryBudgetExceeded; got: {other:?}"),
+                other => panic!("expected inner SpillCapExceeded; got: {other:?}"),
             }
         }
         other => panic!("expected outer CompositionBodyError; got: {other:?}"),

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -80,6 +80,7 @@ mod tests {
             Err(
                 PipelineError::Io(_)
                 | PipelineError::Spill(_)
+                | PipelineError::SpillCapExceeded { .. }
                 | PipelineError::Format(_)
                 | PipelineError::ThreadPool(_)
                 | PipelineError::Multiple(_)

--- a/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
@@ -727,14 +727,14 @@ pub(crate) fn execute_combine_grace_hash(
             .map_err(|e| grace_spill_error(e, name, "build add failed"))?;
     }
     executor.finish_build(&build_extractor, ctx, budget, name)?;
-    if budget.record_spill_bytes(executor.take_spilled_bytes()) {
-        return Err(PipelineError::MemoryBudgetExceeded {
-            node: name.to_string(),
-            used: budget.cumulative_spill_bytes(),
-            limit: budget.disk_quota(),
-            source: BudgetCategory::Arena,
-            detail: Some("grace hash build exceeded disk-spill quota".to_string()),
-        });
+    let build_spilled = executor.take_spilled_bytes();
+    if budget.record_spill_bytes(build_spilled) {
+        return Err(PipelineError::spill_cap_exceeded(
+            name,
+            budget.disk_quota(),
+            build_spilled,
+            budget.cumulative_spill_bytes(),
+        ));
     }
 
     // ── Probe phase ───────────────────────────────────────────────────
@@ -817,14 +817,14 @@ pub(crate) fn execute_combine_grace_hash(
     executor
         .finalize_probe_spills()
         .map_err(|e| grace_spill_error(e, name, "probe finalize failed"))?;
-    if budget.record_spill_bytes(executor.take_spilled_bytes()) {
-        return Err(PipelineError::MemoryBudgetExceeded {
-            node: name.to_string(),
-            used: budget.cumulative_spill_bytes(),
-            limit: budget.disk_quota(),
-            source: BudgetCategory::Arena,
-            detail: Some("grace hash probe exceeded disk-spill quota".to_string()),
-        });
+    let probe_spilled = executor.take_spilled_bytes();
+    if budget.record_spill_bytes(probe_spilled) {
+        return Err(PipelineError::spill_cap_exceeded(
+            name,
+            budget.disk_quota(),
+            probe_spilled,
+            budget.cumulative_spill_bytes(),
+        ));
     }
 
     // ── Reload phase ──────────────────────────────────────────────────

--- a/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
@@ -274,16 +274,12 @@ pub(super) fn process_spilled_partition(
                 .finish()
                 .map_err(|e| grace_spill_error(e, name, "repartition build finalize"))?;
             if budget.record_spill_bytes(b_written) {
-                return Err(PipelineError::MemoryBudgetExceeded {
-                    node: name.to_string(),
-                    used: budget.cumulative_spill_bytes(),
-                    limit: budget.disk_quota(),
-                    source: BudgetCategory::Arena,
-                    detail: Some(format!(
-                        "grace hash repartition build exceeded disk-spill quota \
-                         (partition_id={child_id})"
-                    )),
-                });
+                return Err(PipelineError::spill_cap_exceeded(
+                    name,
+                    budget.disk_quota(),
+                    b_written,
+                    budget.cumulative_spill_bytes(),
+                ));
             }
             let mut probe_files: Vec<SpillFilePath> = Vec::new();
             if !child_probe.is_empty() {
@@ -301,16 +297,12 @@ pub(super) fn process_spilled_partition(
                     .finish()
                     .map_err(|e| grace_spill_error(e, name, "repartition probe finalize"))?;
                 if budget.record_spill_bytes(p_written) {
-                    return Err(PipelineError::MemoryBudgetExceeded {
-                        node: name.to_string(),
-                        used: budget.cumulative_spill_bytes(),
-                        limit: budget.disk_quota(),
-                        source: BudgetCategory::Arena,
-                        detail: Some(format!(
-                            "grace hash repartition probe exceeded disk-spill quota \
-                             (partition_id={child_id})"
-                        )),
-                    });
+                    return Err(PipelineError::spill_cap_exceeded(
+                        name,
+                        budget.disk_quota(),
+                        p_written,
+                        budget.cumulative_spill_bytes(),
+                    ));
                 }
                 probe_files.push(p);
             }

--- a/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
@@ -640,10 +640,12 @@ fn execute_grace_hash_spill_then_reload_correct() {
 }
 
 /// Disk-quota gate: a build phase that spills more than the
-/// configured `max_spill_bytes` aborts with E310 instead of
-/// continuing to fill the disk. The hard memory limit is large
-/// (so `should_abort` never fires); only the disk quota can
-/// cause this combine to fail.
+/// configured `max_spill_bytes` aborts with the dedicated
+/// `SpillCapExceeded` (E320) surface instead of continuing to fill
+/// the disk. The hard memory limit is large (so `should_abort`
+/// never fires); only the disk quota can cause this combine to
+/// fail, and the cap error must NOT masquerade as an out-of-memory
+/// E310.
 #[test]
 fn execute_grace_hash_aborts_on_disk_quota_overflow() {
     use crate::executor::combine::CombineResolverMapping;
@@ -806,21 +808,21 @@ fn execute_grace_hash_aborts_on_disk_quota_overflow() {
 
     let err = result.expect_err("disk quota must abort the combine");
     match &err {
-        PipelineError::MemoryBudgetExceeded {
+        PipelineError::SpillCapExceeded {
             node,
-            source,
-            detail,
-            ..
+            cap,
+            attempted,
+            current,
         } => {
             assert_eq!(node, "grace_quota_test");
-            assert_eq!(*source, BudgetCategory::Arena);
-            let detail = detail.as_deref().unwrap_or("");
+            assert_eq!(*cap, 64, "reported cap must equal the configured quota");
+            assert!(*attempted > 0, "the overflowing flush must report its size");
             assert!(
-                detail.contains("disk-spill quota"),
-                "detail must mention disk-spill quota; got {detail:?}"
+                *current > *cap,
+                "cumulative spilled ({current}) must exceed the cap ({cap})"
             );
         }
-        other => panic!("disk-quota overflow must surface MemoryBudgetExceeded; got {other:?}"),
+        other => panic!("disk-quota overflow must surface SpillCapExceeded; got {other:?}"),
     }
     assert!(
         budget.cumulative_spill_bytes() > 64,

--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -47,6 +47,11 @@ pub(crate) enum GraceSpillError {
     /// The spill root directory became unusable while creating a
     /// partition file. Carries the classified [`SpillError::DirUnavailable`].
     DirUnavailable(SpillError),
+    /// The spill volume ran out of space (`ENOSPC`) while creating, writing,
+    /// or finalizing a partition file. Carries the classified
+    /// [`SpillError::DiskFull`] so the combine path surfaces the same E321
+    /// disk-full diagnostic the node-buffer and sort spill paths do.
+    DiskFull(SpillError),
     /// A byte-stream fault during write/finalize, or an internal
     /// state-machine violation surfaced as an `io::Error`.
     Io(std::io::Error),
@@ -58,17 +63,37 @@ impl From<std::io::Error> for GraceSpillError {
     }
 }
 
+impl GraceSpillWriter {
+    /// Classify a write/finalize `io::Error` against the partition file's
+    /// parent directory: an `ENOSPC` becomes [`GraceSpillError::DiskFull`]
+    /// and a directory-level fault becomes [`GraceSpillError::DirUnavailable`],
+    /// matching the create-time classification so a disk filling mid-write
+    /// renders as E321 rather than an opaque internal error.
+    fn classify_io(&self, e: std::io::Error) -> GraceSpillError {
+        let dir = self.path.parent().unwrap_or(&self.path);
+        match SpillError::from_spill_dir_io(dir, e) {
+            dir_err @ SpillError::DirUnavailable { .. } => GraceSpillError::DirUnavailable(dir_err),
+            disk_err @ SpillError::DiskFull { .. } => GraceSpillError::DiskFull(disk_err),
+            SpillError::Io(io) => GraceSpillError::Io(io),
+            other => GraceSpillError::Io(std::io::Error::other(other.to_string())),
+        }
+    }
+}
+
 /// Map a [`GraceSpillError`] to a [`PipelineError`] for the combine node
 /// `node`, tagging the failing stage with `detail` (e.g. "build write",
 /// "probe writer").
 ///
-/// A mid-run directory fault becomes `PipelineError::Spill`, so it renders
-/// with the same `DirUnavailable` diagnostic the node-buffer, sort, and
-/// aggregate spill paths emit; a genuine byte fault or state-machine
-/// violation becomes `PipelineError::Internal`.
+/// A mid-run directory fault or a full-volume fault becomes
+/// `PipelineError::Spill`, so it renders with the same `DirUnavailable` /
+/// `DiskFull` diagnostic the node-buffer, sort, and aggregate spill paths
+/// emit; a genuine byte fault or state-machine violation becomes
+/// `PipelineError::Internal`.
 pub(crate) fn grace_spill_error(e: GraceSpillError, node: &str, detail: &str) -> PipelineError {
     match e {
-        GraceSpillError::DirUnavailable(spill) => PipelineError::Spill(spill),
+        GraceSpillError::DirUnavailable(spill) | GraceSpillError::DiskFull(spill) => {
+            PipelineError::Spill(spill)
+        }
         GraceSpillError::Io(io) => PipelineError::Internal {
             op: "combine",
             node: node.to_string(),
@@ -139,23 +164,22 @@ impl GraceSpillWriter {
             "grace-p{partition_id:05}-b{hash_bits:02}-s{seq:08}.spill"
         ));
         // A create failure in a spill dir the run validated at startup means
-        // the directory went bad mid-run. Classify it through the shared
-        // `from_spill_dir_io` helper so the grace path surfaces the same
-        // `DirUnavailable` diagnostic the node-buffer, sort, and aggregate
-        // spill paths do, rather than rendering as a generic internal error.
-        // `from_spill_dir_io` only lifts directory-kind faults (NotFound,
-        // PermissionDenied, ReadOnlyFilesystem); a genuine byte fault on
-        // create (e.g. ENOSPC) stays `SpillError::Io` and is re-narrowed to
-        // `GraceSpillError::Io` so only true directory faults carry the
-        // `DirUnavailable` diagnostic.
+        // the directory went bad mid-run (removed/unmounted/read-only) or the
+        // volume filled. Classify it through the shared `from_spill_dir_io`
+        // helper so the grace path surfaces the same `DirUnavailable` /
+        // `DiskFull` diagnostics the node-buffer, sort, and aggregate spill
+        // paths do, rather than rendering as a generic internal error. A
+        // genuine byte fault on create stays `SpillError::Io` and re-narrows
+        // to `GraceSpillError::Io`.
         let file =
             File::create(&path).map_err(|e| match SpillError::from_spill_dir_io(dir, e) {
                 dir_err @ SpillError::DirUnavailable { .. } => {
                     GraceSpillError::DirUnavailable(dir_err)
                 }
+                disk_err @ SpillError::DiskFull { .. } => GraceSpillError::DiskFull(disk_err),
                 SpillError::Io(io) => GraceSpillError::Io(io),
-                // `from_spill_dir_io` returns only `DirUnavailable` or `Io`; any
-                // other variant would be an unreachable classifier regression.
+                // `from_spill_dir_io` returns only `DirUnavailable`, `DiskFull`,
+                // or `Io`; any other variant would be a classifier regression.
                 other => GraceSpillError::Io(std::io::Error::other(other.to_string())),
             })?;
         let buf = BufWriter::new(file);
@@ -180,8 +204,14 @@ impl GraceSpillWriter {
             postcard::to_stdvec(&payload).map_err(|e| std::io::Error::other(e.to_string()))?;
         let len = u32::try_from(bytes.len())
             .map_err(|_| std::io::Error::other("grace spill: record exceeds u32 byte length"))?;
-        self.encoder.write_all(&len.to_le_bytes())?;
-        self.encoder.write_all(&bytes)?;
+        // Classify a write fault against the partition directory so an
+        // `ENOSPC` mid-stream surfaces as `DiskFull` (E321), not internal Io.
+        if let Err(e) = self.encoder.write_all(&len.to_le_bytes()) {
+            return Err(self.classify_io(e));
+        }
+        if let Err(e) = self.encoder.write_all(&bytes) {
+            return Err(self.classify_io(e));
+        }
         self.record_count += 1;
         Ok(())
     }
@@ -193,6 +223,23 @@ impl GraceSpillWriter {
     /// so the disk-quota poll can tally cumulative on-disk usage
     /// without re-stat'ing each finalized file.
     pub(crate) fn finish(self) -> Result<(SpillFilePath, u64), GraceSpillError> {
+        // Classify every finalize-time io fault against the partition's
+        // directory before `self` is consumed, so an `ENOSPC` flushing the
+        // last block or footer surfaces as `DiskFull` (E321) — the disk
+        // filling — rather than an opaque internal byte-stream error. The lz4
+        // frame error preserves its inner `io::Error` (and its `StorageFull`
+        // kind) through `Into<io::Error>`.
+        let dir = self.path.parent().unwrap_or(&self.path).to_path_buf();
+        let classify = |e: std::io::Error| -> GraceSpillError {
+            match SpillError::from_spill_dir_io(&dir, e) {
+                dir_err @ SpillError::DirUnavailable { .. } => {
+                    GraceSpillError::DirUnavailable(dir_err)
+                }
+                disk_err @ SpillError::DiskFull { .. } => GraceSpillError::DiskFull(disk_err),
+                SpillError::Io(io) => GraceSpillError::Io(io),
+                other => GraceSpillError::Io(std::io::Error::other(other.to_string())),
+            }
+        };
         let Self {
             encoder,
             path,
@@ -202,20 +249,18 @@ impl GraceSpillWriter {
         } = self;
         let buf = encoder
             .finish()
-            .map_err(|e| std::io::Error::other(e.to_string()))?;
-        let mut file = buf
-            .into_inner()
-            .map_err(|e| std::io::Error::other(e.into_error().to_string()))?;
+            .map_err(|e| classify(std::io::Error::from(e)))?;
+        let mut file = buf.into_inner().map_err(|e| classify(e.into_error()))?;
         // Seek to current end and append footer; LZ4 frame is closed.
-        let body_end = file.seek(SeekFrom::End(0))?;
+        let body_end = file.seek(SeekFrom::End(0)).map_err(&classify)?;
         let mut footer = [0u8; FOOTER_SIZE];
         footer[0..4].copy_from_slice(&GRACE_SPILL_MAGIC.to_le_bytes());
         footer[4..6].copy_from_slice(&GRACE_SPILL_VERSION.to_le_bytes());
         footer[6] = hash_bits;
         footer[7..9].copy_from_slice(&partition_id.to_le_bytes());
         footer[9..17].copy_from_slice(&record_count.to_le_bytes());
-        file.write_all(&footer)?;
-        file.flush()?;
+        file.write_all(&footer).map_err(&classify)?;
+        file.flush().map_err(&classify)?;
         let total_bytes = body_end + FOOTER_SIZE as u64;
         Ok((Arc::from(path.as_path()), total_bytes))
     }

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -1143,15 +1143,12 @@ fn walk_two_cursors(args: WalkArgs<'_, '_, '_>) -> Result<(), PipelineError> {
                 )
                 .map_err(|e| grace_spill_error(e, name, "sort-merge matching-run spill failed"))?;
                 if written > 0 && budget.record_spill_bytes(written) {
-                    return Err(PipelineError::MemoryBudgetExceeded {
-                        node: name.to_string(),
-                        used: budget.cumulative_spill_bytes(),
-                        limit: budget.disk_quota(),
-                        source: BudgetCategory::Arena,
-                        detail: Some(
-                            "sort-merge matching-run exceeded disk-spill quota".to_string(),
-                        ),
-                    });
+                    return Err(PipelineError::spill_cap_exceeded(
+                        name,
+                        budget.disk_quota(),
+                        written,
+                        budget.cumulative_spill_bytes(),
+                    ));
                 }
                 if was_inmemory && matches!(run, MatchingRunBuffer::Spilled { .. }) {
                     spilled_this_run = true;

--- a/crates/clinker-exec/src/pipeline/spill.rs
+++ b/crates/clinker-exec/src/pipeline/spill.rs
@@ -24,7 +24,7 @@
 
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::marker::PhantomData;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
@@ -43,6 +43,13 @@ use clinker_plan::SpillError;
 pub struct SpillWriter<P> {
     encoder: FrameEncoder<BufWriter<NamedTempFile>>,
     schema: Arc<Schema>,
+    /// Directory the spill file lives in, retained so a mid-stream write or
+    /// finalize fault can be classified against it: an `ENOSPC` becomes
+    /// `SpillError::DiskFull` and a directory-level fault becomes
+    /// `SpillError::DirUnavailable`, rather than both collapsing into the
+    /// generic `Io` variant. Holds the OS temp dir when no explicit spill
+    /// dir was configured, so the diagnostic still names a real path.
+    spill_dir: PathBuf,
     _payload: PhantomData<P>,
 }
 
@@ -52,12 +59,16 @@ impl<P: Serialize> SpillWriter<P> {
     pub fn new(schema: Arc<Schema>, spill_dir: Option<&Path>) -> Result<Self, SpillError> {
         // A create failure in a spill dir the run validated at startup means
         // the directory went bad mid-run (unmounted, removed, remounted
-        // read-only). `from_spill_dir_io` lifts those into the distinct
-        // `DirUnavailable` diagnostic rather than a generic spill I/O error.
+        // read-only) or the volume is full. `from_spill_dir_io` lifts those
+        // into the distinct `DirUnavailable` / `DiskFull` diagnostics rather
+        // than a generic spill I/O error.
+        let resolved_dir = spill_dir
+            .map(Path::to_path_buf)
+            .unwrap_or_else(std::env::temp_dir);
         let temp_file = if let Some(dir) = spill_dir {
             NamedTempFile::new_in(dir).map_err(|e| SpillError::from_spill_dir_io(dir, e))?
         } else {
-            NamedTempFile::new()?
+            NamedTempFile::new().map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?
         };
 
         let buf_writer = BufWriter::new(temp_file);
@@ -67,12 +78,17 @@ impl<P: Serialize> SpillWriter<P> {
         // Kept as JSON so the header is human-inspectable without a postcard decoder.
         let columns: Vec<&str> = schema.columns().iter().map(|c| &**c).collect();
         let schema_json = serde_json::to_string(&columns)?;
-        encoder.write_all(schema_json.as_bytes())?;
-        encoder.write_all(b"\n")?;
+        encoder
+            .write_all(schema_json.as_bytes())
+            .map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?;
+        encoder
+            .write_all(b"\n")
+            .map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?;
 
         Ok(SpillWriter {
             encoder,
             schema,
+            spill_dir: resolved_dir,
             _payload: PhantomData,
         })
     }
@@ -89,8 +105,14 @@ impl<P: Serialize> SpillWriter<P> {
         };
         let bytes = postcard::to_stdvec(&(&rec_payload, payload))?;
         let len = bytes.len() as u32;
-        self.encoder.write_all(&len.to_le_bytes())?;
-        self.encoder.write_all(&bytes)?;
+        // Classify a write fault against the spill directory so an `ENOSPC`
+        // mid-stream surfaces as `DiskFull` (E321), not a generic `Io`.
+        self.encoder
+            .write_all(&len.to_le_bytes())
+            .map_err(|e| SpillError::from_spill_dir_io(&self.spill_dir, e))?;
+        self.encoder
+            .write_all(&bytes)
+            .map_err(|e| SpillError::from_spill_dir_io(&self.spill_dir, e))?;
         Ok(())
     }
 
@@ -104,10 +126,19 @@ impl<P: Serialize> SpillWriter<P> {
 
     /// Flush, finalize LZ4 frame, return handle to the completed spill file.
     pub fn finish(self) -> Result<SpillFile<P>, SpillError> {
-        let buf_writer = self.encoder.finish()?;
+        let spill_dir = self.spill_dir;
+        // The encoder's buffered tail flushes here; an `ENOSPC` on that final
+        // flush is the disk filling, classified as `DiskFull` (E321). The lz4
+        // frame error preserves the underlying `io::Error` (and its
+        // `StorageFull` kind) through its `Into<io::Error>` conversion, so the
+        // classifier still sees the real cause rather than a flattened "other".
+        let buf_writer = self
+            .encoder
+            .finish()
+            .map_err(|e| SpillError::from_spill_dir_io(&spill_dir, std::io::Error::from(e)))?;
         let temp_file = buf_writer
             .into_inner()
-            .map_err(|e| SpillError::Io(e.into_error()))?;
+            .map_err(|e| SpillError::from_spill_dir_io(&spill_dir, e.into_error()))?;
         let path = temp_file.into_temp_path();
         Ok(SpillFile {
             path,

--- a/crates/clinker-plan/src/config/storage.rs
+++ b/crates/clinker-plan/src/config/storage.rs
@@ -13,6 +13,7 @@
 //! Parsing it now keeps `clinker.toml` files that opt into staging from
 //! tripping `deny_unknown_fields` before the feature exists.
 
+use crate::config::utils::ByteSize;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
@@ -94,6 +95,36 @@ pub struct SpillConfig {
     /// spill to a mounted volume are expected to give an absolute path.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dir: Option<PathBuf>,
+    /// Cumulative disk-spill quota for the run, in bytes. `None` (key
+    /// omitted) → unlimited, preserving the historical default. Accepts a
+    /// bare integer (bytes) or a human-readable string (`"500MB"`, `"2GB"`)
+    /// through the same [`ByteSize`] parser the source-filter size knobs use,
+    /// so a `clinker.toml` author writes one unit grammar across the file.
+    ///
+    /// When the summed on-disk size of every spill file a run writes crosses
+    /// this cap, the run aborts with a dedicated cap-exceeded diagnostic
+    /// rather than continuing to fill the volume. The cap is deliberately
+    /// distinct from the RSS `memory.limit`: a run can sit comfortably inside
+    /// its memory envelope yet still exhaust local disk through an unbounded
+    /// stream of spill files, and the operator needs to see "you hit the disk
+    /// cap" — not an out-of-memory message — when that happens (the confusing
+    /// surface DuckDB hit in duckdb/duckdb#14142, where a temp-dir cap
+    /// rendered as "OOM with 187 GiB available").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk_cap_bytes: Option<ByteSize>,
+}
+
+impl SpillConfig {
+    /// Cumulative spill-quota cap in bytes, or `None` when no
+    /// `disk_cap_bytes` was configured (unlimited spill).
+    ///
+    /// The executor folds `Some(cap)` into the run's memory arbitrator as
+    /// the disk-spill quota; `None` leaves the quota at its unlimited
+    /// default. Returns a plain `u64` so the executor stays free of the
+    /// `ByteSize` newtype.
+    pub fn disk_cap(&self) -> Option<u64> {
+        self.disk_cap_bytes.map(|ByteSize(n)| n)
+    }
 }
 
 impl SpillConfig {
@@ -267,6 +298,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let cfg = SpillConfig {
             dir: Some(dir.path().to_path_buf()),
+            ..Default::default()
         };
         let resolved = cfg.resolve().unwrap();
         assert_eq!(resolved.as_deref(), Some(dir.path()));
@@ -276,7 +308,10 @@ mod tests {
     fn resolve_errors_for_missing_dir() {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("does-not-exist");
-        let cfg = SpillConfig { dir: Some(missing) };
+        let cfg = SpillConfig {
+            dir: Some(missing),
+            ..Default::default()
+        };
         assert!(matches!(
             cfg.resolve().unwrap_err(),
             StorageConfigError::SpillDirMissing { .. }
@@ -288,10 +323,61 @@ mod tests {
         let file = tempfile::NamedTempFile::new().unwrap();
         let cfg = SpillConfig {
             dir: Some(file.path().to_path_buf()),
+            ..Default::default()
         };
         assert!(matches!(
             cfg.resolve().unwrap_err(),
             StorageConfigError::SpillDirNotADirectory { .. }
         ));
+    }
+
+    #[test]
+    fn disk_cap_absent_yields_none() {
+        let doc = ClinkerToml::parse(
+            r#"
+            [storage.spill]
+            dir = "/var/clinker/spill"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(doc.storage.spill.disk_cap(), None);
+    }
+
+    #[test]
+    fn disk_cap_parses_human_readable_string() {
+        let doc = ClinkerToml::parse(
+            r#"
+            [storage.spill]
+            disk_cap_bytes = "10GB"
+            "#,
+        )
+        .unwrap();
+        // Decimal units, matching the ByteSize grammar used elsewhere:
+        // 10 GB = 10_000_000_000 bytes.
+        assert_eq!(doc.storage.spill.disk_cap(), Some(10_000_000_000));
+    }
+
+    #[test]
+    fn disk_cap_parses_bare_integer_as_bytes() {
+        let doc = ClinkerToml::parse(
+            r#"
+            [storage.spill]
+            disk_cap_bytes = 1048576
+            "#,
+        )
+        .unwrap();
+        assert_eq!(doc.storage.spill.disk_cap(), Some(1_048_576));
+    }
+
+    #[test]
+    fn disk_cap_rejects_unparseable_size() {
+        let err = ClinkerToml::parse(
+            r#"
+            [storage.spill]
+            disk_cap_bytes = "ten gigabytes"
+            "#,
+        )
+        .unwrap_err();
+        assert!(matches!(err, StorageConfigError::Parse(_)));
     }
 }

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -176,6 +176,25 @@ pub enum PipelineError {
         combine: String,
         driver_row: u64,
     },
+    /// E320 — the cumulative on-disk size of the run's spill files crossed
+    /// the configured `storage.spill.disk_cap_bytes` quota. Deliberately
+    /// distinct from E310 (`MemoryBudgetExceeded`): a run can sit well
+    /// inside its RSS envelope yet still exhaust local disk through an
+    /// unbounded stream of spill files, and conflating the two reproduces
+    /// the duckdb/duckdb#14142 trap where a disk-cap hit rendered as an
+    /// out-of-memory message and operators wrongly concluded the engine was
+    /// broken. Also distinct from E321 (`SpillDiskFull`): the cap is a
+    /// configured policy ceiling the run chose to stop at, not the physical
+    /// volume running out of space. `node` names the spilling operator;
+    /// `cap` is the configured quota; `attempted` is the byte count of the
+    /// flush that would have crossed it; `current` is the cumulative total
+    /// after that flush. Always aborts the run.
+    SpillCapExceeded {
+        node: String,
+        cap: u64,
+        attempted: u64,
+        current: u64,
+    },
     /// E315 (pipeline-wide, `source: None`) or E316 (per-source,
     /// `source: Some(name)`) — the cumulative DLQ fraction crossed
     /// the configured `max_rate` after at least `min_records` rows
@@ -325,6 +344,20 @@ impl fmt::Display for PipelineError {
                 "E319 combine '{combine}': on_miss: error — no matching build row \
                  for driver row {driver_row}"
             ),
+            Self::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => write!(
+                f,
+                "E320 {node}: spill disk cap exceeded — the configured \
+                 storage.spill.disk_cap_bytes of {cap} bytes was crossed by a \
+                 {attempted}-byte flush ({current} bytes spilled in total). This \
+                 is a disk-cap stop, not an out-of-memory condition and not a \
+                 full volume; raise storage.spill.disk_cap_bytes, reduce input \
+                 size, or point storage.spill.dir at a larger volume."
+            ),
             Self::DlqRateExceeded {
                 source,
                 observed_rate,
@@ -389,6 +422,27 @@ impl PipelineError {
             inner,
         }
     }
+
+    /// E320 — the run crossed its configured `storage.spill.disk_cap_bytes`
+    /// quota. Built at every spill site the moment a flush would push the
+    /// cumulative spilled total past the cap, so the cap-exceeded surface
+    /// stays uniform across the node-buffer, streaming-handoff, grace-hash,
+    /// and sort-merge spill paths. Kept distinct from
+    /// [`PipelineError::MemoryBudgetExceeded`] (E310) on purpose — see the
+    /// variant docs.
+    pub fn spill_cap_exceeded(
+        node: impl Into<String>,
+        cap: u64,
+        attempted: u64,
+        current: u64,
+    ) -> Self {
+        Self::SpillCapExceeded {
+            node: node.into(),
+            cap,
+            attempted,
+            current,
+        }
+    }
 }
 
 impl std::error::Error for PipelineError {}
@@ -426,5 +480,44 @@ impl From<std::io::Error> for PipelineError {
 impl From<crate::runtime_error::SpillError> for PipelineError {
     fn from(e: crate::runtime_error::SpillError) -> Self {
         Self::Spill(e)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spill_cap_exceeded_renders_e320_distinct_from_oom() {
+        let e =
+            PipelineError::spill_cap_exceeded("sort_orders", 104_857_600, 8_388_608, 109_051_904);
+        let rendered = e.to_string();
+        assert!(rendered.contains("E320"), "{rendered}");
+        assert!(rendered.contains("spill disk cap exceeded"), "{rendered}");
+        assert!(rendered.contains("104857600"), "{rendered}");
+        assert!(rendered.contains("109051904"), "{rendered}");
+        // The message must steer the reader away from reading this as an OOM.
+        assert!(
+            rendered.contains("not an out-of-memory condition"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn spill_cap_exceeded_carries_structured_fields() {
+        match PipelineError::spill_cap_exceeded("n", 100, 200, 300) {
+            PipelineError::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => {
+                assert_eq!(node, "n");
+                assert_eq!(cap, 100);
+                assert_eq!(attempted, 200);
+                assert_eq!(current, 300);
+            }
+            other => panic!("constructor must build SpillCapExceeded; got {other:?}"),
+        }
     }
 }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -218,6 +218,8 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E311" => Some(include_str!("../../../../docs/explain/E311.md")),
         "E313" => Some(include_str!("../../../../docs/explain/E313.md")),
         "E319" => Some(include_str!("../../../../docs/explain/E319.md")),
+        "E320" => Some(include_str!("../../../../docs/explain/E320.md")),
+        "E321" => Some(include_str!("../../../../docs/explain/E321.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
         "E150d" => Some(include_str!("../../../../docs/explain/E150d.md")),
@@ -318,6 +320,23 @@ mod tests {
     }
 
     #[test]
+    fn test_explain_code_e320_disk_cap() {
+        let doc = explain_code("E320").unwrap();
+        assert!(doc.contains("E320"));
+        assert!(doc.contains("disk_cap_bytes"));
+        // The doc must keep E320 distinct from OOM and from a full disk.
+        assert!(doc.contains("not an out-of-memory"));
+    }
+
+    #[test]
+    fn test_explain_code_e321_disk_full() {
+        let doc = explain_code("E321").unwrap();
+        assert!(doc.contains("E321"));
+        assert!(doc.contains("out of space"));
+        assert!(doc.contains("not the configured spill cap"));
+    }
+
+    #[test]
     fn test_explain_code_unknown() {
         assert!(explain_code("E999").is_none());
     }
@@ -327,7 +346,8 @@ mod tests {
         let codes = [
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
-            "E309", "E310", "E311", "E313", "E319", "E15Y", "W101", "W302", "W305", "W306",
+            "E309", "E310", "E311", "E313", "E319", "E320", "E321", "E15Y", "W101", "W302", "W305",
+            "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/runtime_error.rs
+++ b/crates/clinker-plan/src/runtime_error.rs
@@ -29,6 +29,21 @@ pub enum SpillError {
         dir: String,
         source: String,
     },
+    /// E321 — a spill write failed because the spill volume ran out of
+    /// space (`std::io::ErrorKind::StorageFull`, i.e. `ENOSPC`). Distinct
+    /// from both [`SpillError::Io`] (so the rendered diagnostic names the
+    /// volume and the disk-full cause rather than reading as a generic
+    /// byte-stream fault) and from the cap-exceeded surface
+    /// (`PipelineError::SpillCapExceeded`): the disk physically filled,
+    /// the run did not merely cross its configured spill quota. Keeping
+    /// the two apart is the point of duckdb/duckdb#14142, where a cap hit
+    /// rendered as an out-of-memory message and operators inspected `df`
+    /// only to find free space. Carries the offending directory path and
+    /// the underlying OS message.
+    DiskFull {
+        dir: String,
+        source: String,
+    },
 }
 
 impl std::fmt::Display for SpillError {
@@ -44,6 +59,13 @@ impl std::fmt::Display for SpillError {
                  (the directory may have been unmounted, remounted read-only, \
                  deleted by an external cleaner, or had its permissions revoked)"
             ),
+            SpillError::DiskFull { dir, source } => write!(
+                f,
+                "E321 spill volume at {dir} is out of space: {source} \
+                 (the disk physically filled — this is not the configured \
+                 spill cap and not an out-of-memory condition; free space on \
+                 the volume or point storage.spill.dir at a larger one)"
+            ),
         }
     }
 }
@@ -52,13 +74,18 @@ impl SpillError {
     /// Classify an [`std::io::Error`] raised while creating a spill file in
     /// the spill root directory.
     ///
-    /// A failure to create a temp file in a directory the run validated as
-    /// writable at startup means the directory itself went bad mid-run
-    /// (`NotFound` → removed/unmounted, `PermissionDenied`/`ReadOnlyFilesystem`
-    /// → permissions revoked or read-only remount). Those map to the distinct
-    /// [`SpillError::DirUnavailable`] so the operator sees a directory-level
-    /// cause rather than a generic I/O error. Any other kind (a genuine
-    /// byte-stream fault, `ENOSPC`, etc.) stays [`SpillError::Io`].
+    /// A failure to create or write a spill file in a directory the run
+    /// validated as writable at startup falls into three buckets, each with
+    /// its own diagnostic so the operator's remediation is unambiguous:
+    ///
+    /// - The directory itself went bad mid-run (`NotFound` →
+    ///   removed/unmounted, `PermissionDenied`/`ReadOnlyFilesystem` →
+    ///   permissions revoked or read-only remount) → [`SpillError::DirUnavailable`].
+    /// - The volume ran out of space (`StorageFull`, i.e. `ENOSPC`) →
+    ///   [`SpillError::DiskFull`], kept distinct from the configured spill
+    ///   cap so a full disk never renders as a cap-exceeded or OOM message.
+    /// - Any other kind (a genuine byte-stream fault, a short write) stays
+    ///   [`SpillError::Io`].
     pub fn from_spill_dir_io(dir: &std::path::Path, e: std::io::Error) -> Self {
         use std::io::ErrorKind;
         match e.kind() {
@@ -68,6 +95,10 @@ impl SpillError {
                     source: e.to_string(),
                 }
             }
+            ErrorKind::StorageFull => SpillError::DiskFull {
+                dir: dir.display().to_string(),
+                source: e.to_string(),
+            },
             _ => SpillError::Io(e),
         }
     }
@@ -127,5 +158,67 @@ impl std::fmt::Display for BudgetCategory {
             Self::Arena => f.write_str("arena"),
             Self::NodeBuffer => f.write_str("node_buffer"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Error, ErrorKind};
+    use std::path::Path;
+
+    #[test]
+    fn storage_full_classifies_as_disk_full() {
+        let dir = Path::new("/mnt/spill");
+        let e = Error::new(ErrorKind::StorageFull, "No space left on device");
+        match SpillError::from_spill_dir_io(dir, e) {
+            SpillError::DiskFull { dir, .. } => assert_eq!(dir, "/mnt/spill"),
+            other => panic!("ENOSPC must classify as DiskFull; got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn disk_full_render_distinguishes_from_oom_and_cap() {
+        let e = SpillError::DiskFull {
+            dir: "/mnt/spill".to_string(),
+            source: "No space left on device (os error 28)".to_string(),
+        };
+        let rendered = e.to_string();
+        assert!(rendered.contains("E321"), "{rendered}");
+        assert!(rendered.contains("out of space"), "{rendered}");
+        // Must not read as an OOM or a cap stop.
+        assert!(rendered.contains("not an out-of-memory"), "{rendered}");
+        assert!(
+            rendered.contains("not the configured spill cap"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn directory_faults_still_classify_as_dir_unavailable() {
+        // The DiskFull addition must not steal the directory-level faults.
+        for kind in [
+            ErrorKind::NotFound,
+            ErrorKind::PermissionDenied,
+            ErrorKind::ReadOnlyFilesystem,
+        ] {
+            let e = Error::new(kind, "boom");
+            assert!(
+                matches!(
+                    SpillError::from_spill_dir_io(Path::new("/d"), e),
+                    SpillError::DirUnavailable { .. }
+                ),
+                "{kind:?} must stay DirUnavailable"
+            );
+        }
+    }
+
+    #[test]
+    fn generic_io_stays_io() {
+        let e = Error::new(ErrorKind::BrokenPipe, "pipe");
+        assert!(matches!(
+            SpillError::from_spill_dir_io(Path::new("/d"), e),
+            SpillError::Io(_)
+        ));
     }
 }

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -318,7 +318,15 @@ fn main() -> ExitCode {
                         | PipelineError::CompositionBodyError { .. }
                         | PipelineError::MemoryBudgetExceeded { .. }
                         | PipelineError::CombineMissingMatch { .. } => ExitCode::from(1),
-                        PipelineError::Io(_) | PipelineError::Spill(_) => ExitCode::from(4),
+                        // Disk-cap exceedance (E320) is a resource-exhaustion
+                        // halt — the run filled its configured spill budget.
+                        // Group it with the other infrastructure failures
+                        // (I/O, spill, full-volume) at exit 4 rather than the
+                        // config exit 1: the pipeline is valid, the host ran
+                        // out of the disk headroom the cap allotted.
+                        PipelineError::Io(_)
+                        | PipelineError::Spill(_)
+                        | PipelineError::SpillCapExceeded { .. } => ExitCode::from(4),
                         PipelineError::Eval(_) | PipelineError::Accumulator { .. } => {
                             ExitCode::from(3)
                         }
@@ -588,6 +596,12 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         .spill
         .resolve()
         .map_err(storage_config_error)?;
+    // Cumulative disk-spill quota (`storage.spill.disk_cap_bytes`). `None`
+    // leaves the run's spill budget unlimited, the historical default; a
+    // configured cap is folded into the arbitrator so a run that fills the
+    // spill volume aborts with a dedicated cap diagnostic instead of an
+    // out-of-memory message (the duckdb/duckdb#14142 trap).
+    let spill_disk_cap_bytes = storage_config.spill.disk_cap();
 
     let mut compile_ctx =
         clinker_plan::config::CompileContext::with_pipeline_dir(workspace_root, pipeline_dir);
@@ -689,6 +703,17 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                     spill_root_display.display(),
                     spill_root_source
                 );
+                // Resolved disk-spill cap: the cumulative on-disk spill budget
+                // (`storage.spill.disk_cap_bytes`), or unlimited when unset. An
+                // operator can confirm the cap before a run that might fill the
+                // spill volume — a cap hit aborts with E320, distinct from an
+                // out-of-memory (E310) or a full volume (E321).
+                match spill_disk_cap_bytes {
+                    Some(cap) => {
+                        println!("Spill disk cap: {cap} bytes [storage.spill.disk_cap_bytes]")
+                    }
+                    None => println!("Spill disk cap: unlimited (default)"),
+                }
             }
             ExplainFormat::Json => {
                 let view = clinker_plan::plan::execution::ExplainJson::new(dag, artifacts);
@@ -1004,6 +1029,7 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         record_vars: channel_record_vars,
         shutdown_token: Some(shutdown_token),
         spill_root_dir: spill_root_dir.clone(),
+        spill_disk_cap_bytes,
     };
     let report = match PipelineExecutor::run_plan_with_readers_writers_in_context(
         &compiled_plan,

--- a/crates/clinker/tests/storage_config_cli.rs
+++ b/crates/clinker/tests/storage_config_cli.rs
@@ -117,6 +117,71 @@ fn explain_surfaces_resolved_spill_root() {
 }
 
 #[test]
+fn explain_surfaces_resolved_disk_cap() {
+    let tmp = tempdir_path();
+    let pipeline = tmp.join("pipeline.yaml");
+    std::fs::write(&pipeline, PIPELINE_YAML).expect("write pipeline yaml");
+
+    // A configured disk cap is parsed via the shared ByteSize grammar and
+    // threaded into the run; --explain echoes the resolved byte count so an
+    // operator can confirm it before committing to a run that might spill.
+    std::fs::write(
+        tmp.join("clinker.toml"),
+        "[storage.spill]\ndisk_cap_bytes = \"10GB\"\n",
+    )
+    .expect("write clinker.toml");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        .arg("--explain")
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "explain with a valid disk cap must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        // 10GB in decimal ByteSize units = 10_000_000_000 bytes.
+        stdout.contains("Spill disk cap: 10000000000 bytes [storage.spill.disk_cap_bytes]"),
+        "explain must surface the resolved disk cap; got:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn explain_without_disk_cap_shows_unlimited() {
+    let tmp = tempdir_path();
+    let pipeline = tmp.join("pipeline.yaml");
+    std::fs::write(&pipeline, PIPELINE_YAML).expect("write pipeline yaml");
+    // No clinker.toml: the spill cap falls back to unlimited.
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        .arg("--explain")
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "explain with no disk cap must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Spill disk cap: unlimited (default)"),
+        "explain must label the default unlimited cap; got:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
 fn explain_without_storage_block_shows_default_spill_root() {
     let tmp = tempdir_path();
     let pipeline = tmp.join("pipeline.yaml");

--- a/docs/explain/E320.md
+++ b/docs/explain/E320.md
@@ -1,0 +1,86 @@
+# Error E320: Spill disk cap exceeded
+
+## What it means
+
+A blocking operator (Aggregate, external sort, grace-hash Combine, or an
+inter-stage buffer) spilled records to disk, and the cumulative on-disk
+size of every spill file the run has written crossed the configured
+`storage.spill.disk_cap_bytes` quota. Clinker stops the run rather than
+continuing to fill the spill volume.
+
+This is deliberately **not** an out-of-memory error and **not** a
+disk-full error. The run may be sitting comfortably inside its
+`memory.limit` RSS envelope, and the spill volume may still have free
+space — the run simply reached the disk budget you told it to stop at.
+
+The runtime diagnostic names the spilling operator, the configured cap,
+the size of the flush that crossed it, and the cumulative total:
+
+```
+E320 sort_orders: spill disk cap exceeded — the configured
+storage.spill.disk_cap_bytes of 104857600 bytes was crossed by a
+8388608-byte flush (109051904 bytes spilled in total). This is a
+disk-cap stop, not an out-of-memory condition and not a full volume;
+raise storage.spill.disk_cap_bytes, reduce input size, or point
+storage.spill.dir at a larger volume.
+```
+
+## Example
+
+```toml
+# clinker.toml — a 100 MiB spill budget on a job whose external sort
+# needs to spill ~200 MiB of intermediate runs.
+[storage.spill]
+dir = "/mnt/fast-ssd/clinker-spill"
+disk_cap_bytes = "100MB"
+```
+
+```toml
+# Corrected: raise the cap to fit the job's real spill footprint, or
+# remove it entirely to let the run spill until the volume itself fills
+# (which then surfaces as E321, not E320).
+[storage.spill]
+dir = "/mnt/fast-ssd/clinker-spill"
+disk_cap_bytes = "512MB"
+```
+
+## How to fix
+
+Pick the remediation that matches your intent:
+
+1. **Raise the cap.** If the job legitimately needs more spill room and
+   the volume has the space, increase `storage.spill.disk_cap_bytes`.
+
+2. **Give the run a larger spill volume.** Point `storage.spill.dir` at
+   a mount with more headroom; the cap is a policy ceiling independent of
+   the physical volume.
+
+3. **Reduce the spill footprint.** Shrink input size, partition the input
+   by key or file and run several `clinker` invocations, or raise
+   `memory.limit` so more state stays in RAM and less spills to disk.
+
+4. **Remove the cap** by omitting `disk_cap_bytes`. The run then spills
+   until the volume physically fills, which surfaces as E321 instead.
+
+## Technical context
+
+E320 is a runtime diagnostic. The run's memory arbitrator tracks the
+cumulative on-disk size of every spill file through a single quota
+counter; each spill site folds the size of a freshly finalized file into
+that counter immediately after writing it. When the running total crosses
+`storage.spill.disk_cap_bytes`, the spilling operator returns
+`PipelineError::SpillCapExceeded` and the CLI exits with the
+infrastructure status code.
+
+The cap exists because a run can exhaust local disk through an unbounded
+stream of spill files even while its RSS stays inside budget — the
+failure DataFusion shipped without a guard against (apache/datafusion
+issue #15358) until production runs filled volumes. Keeping E320 distinct
+from the memory-budget E310 avoids the trap DuckDB hit in
+duckdb/duckdb#14142, where a temp-dir cap rendered as an out-of-memory
+message and operators inspected `df` only to find free space.
+
+## See also
+
+- E310 (operator runtime exceeded the hard memory limit — a true OOM)
+- E321 (spill volume out of space — a full disk, not the configured cap)

--- a/docs/explain/E321.md
+++ b/docs/explain/E321.md
@@ -1,0 +1,79 @@
+# Error E321: Spill volume out of space
+
+## What it means
+
+A blocking operator tried to write a spill file and the operating system
+reported that the spill volume is out of space (`ENOSPC`). The physical
+disk filled. Clinker stops the run because it cannot make forward
+progress without writing the spilled state.
+
+This is distinct from both neighboring conditions:
+
+- It is **not** an out-of-memory error (E310) — RSS may be fine.
+- It is **not** the configured spill cap (E320) — you did not hit
+  `storage.spill.disk_cap_bytes`; the volume itself ran dry.
+
+The runtime diagnostic names the spill directory and the underlying OS
+message:
+
+```
+E321 spill volume at /mnt/fast-ssd/clinker-spill is out of space:
+No space left on device (os error 28) (the disk physically filled —
+this is not the configured spill cap and not an out-of-memory
+condition; free space on the volume or point storage.spill.dir at a
+larger one)
+```
+
+## Example
+
+```toml
+# clinker.toml — spill directed at a small volume that fills mid-run.
+[storage.spill]
+dir = "/mnt/tiny-tmp"
+```
+
+```toml
+# Corrected: direct spill at a volume with room for the job's
+# intermediate state, optionally pairing it with a disk cap so the run
+# stops at a known budget (E320) before the volume itself fills (E321).
+[storage.spill]
+dir = "/mnt/fast-ssd/clinker-spill"
+disk_cap_bytes = "50GB"
+```
+
+## How to fix
+
+1. **Free space on the spill volume.** Remove stale files, or evict an
+   over-eager temp-file consumer sharing the mount.
+
+2. **Point spill at a larger volume.** Set `storage.spill.dir` to a mount
+   with enough headroom for the job's intermediate state. Spilling to the
+   same small volume as `/tmp` is the common cause.
+
+3. **Reduce the spill footprint.** Shrink input size, raise
+   `memory.limit` so more state stays in RAM, or partition the input and
+   run several smaller `clinker` invocations.
+
+4. **Set a disk cap.** Adding `storage.spill.disk_cap_bytes` lets the run
+   stop at a chosen budget (E320) with a clear, attributable message
+   before it exhausts the whole volume and trips E321.
+
+## Technical context
+
+E321 is a runtime diagnostic raised when a spill write or finalize fails
+with `std::io::ErrorKind::StorageFull`. The spill writer classifies that
+error against the spill directory — distinguishing a full volume from a
+directory that went unavailable mid-run (unmounted, remounted read-only,
+deleted by an external cleaner) and from a generic byte-stream fault.
+
+The classification flows uniformly through every spill path: the
+node-buffer, streaming-handoff, grace-hash, and sort-merge writers all
+route their I/O faults through the same classifier, so a full disk renders
+as E321 regardless of which operator was spilling when the volume filled.
+The executor surfaces it as `PipelineError::Spill` and the CLI exits with
+the infrastructure status code.
+
+## See also
+
+- E310 (operator runtime exceeded the hard memory limit — a true OOM)
+- E320 (configured spill cap exceeded — a policy ceiling, not a full disk)

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -15,6 +15,7 @@ the per-pipeline YAML:
 ```toml
 [storage.spill]
 dir = "/var/clinker/spill"   # optional; default = OS temp dir
+disk_cap_bytes = "10GB"      # optional; default = unlimited
 
 [storage.staging]
 enabled = false              # parsed but inactive — staging is not yet implemented
@@ -68,6 +69,72 @@ Spill root: /var/clinker/spill [storage.spill.dir]
 Spill root: /tmp [OS temp dir (default)]
 ```
 
+The same `--explain` output reports the resolved disk cap on the next line:
+
+```text
+Spill disk cap: 10737418240 bytes [storage.spill.disk_cap_bytes]
+```
+
+…or, with no cap configured:
+
+```text
+Spill disk cap: unlimited (default)
+```
+
+## `storage.spill.disk_cap_bytes` — cap cumulative spill
+
+By default a run will spill as much as it needs, limited only by the physical
+space on the spill volume. `disk_cap_bytes` sets a **cumulative budget**: the
+total on-disk size of every spill file a run writes. When that running total
+would cross the cap, the run aborts with a dedicated diagnostic instead of
+continuing to fill the volume.
+
+```toml
+[storage.spill]
+dir = "/mnt/fast-ssd/clinker-spill"
+disk_cap_bytes = "50GB"
+```
+
+The value accepts the same human-readable byte-size grammar as the source
+size filters — a bare integer is bytes, and `KB`/`MB`/`GB` suffixes use
+decimal units (`1GB` = 1,000,000,000 bytes), matching `du`, `df`, and the AWS
+CLI. Omitting the key leaves spill unlimited, exactly as before.
+
+The cap is a **policy ceiling**, deliberately independent of both the memory
+budget and the physical volume size. A run can sit well inside its
+`memory.limit` and still exhaust local disk through an unbounded stream of
+spill files; the cap lets an operator bound that on a shared volume. It is the
+guard DataFusion shipped without ([apache/datafusion#15358]) until production
+runs filled volumes.
+
+## Distinguishing the four spill-related failure conditions
+
+Spill-related aborts are split into four distinct diagnostics so a single
+glance at the error tells you exactly what to fix — instead of every disk and
+memory problem rendering as one ambiguous "out of memory" message (the trap
+DuckDB hit in [duckdb/duckdb#14142], where a temp-dir cap was reported as
+"Out of Memory Error … 187.3 GiB/187.3 GiB used" and users inspected `df`
+only to find free space).
+
+| Condition | Code | What happened | What to do |
+| --- | --- | --- | --- |
+| **Out of memory** | E310 | An operator's in-RAM state crossed the hard `memory.limit` (a true RSS overrun). | Raise `memory.limit`, reduce input, or let the operator spill. |
+| **Spill cap exceeded** | E320 | Cumulative spill bytes crossed `storage.spill.disk_cap_bytes`. The volume may still have free space — you hit the configured budget. | Raise `disk_cap_bytes`, point `storage.spill.dir` at a larger volume, or reduce the spill footprint. |
+| **Spill volume full** | E321 | The OS reported the spill volume out of space (`ENOSPC`). The physical disk filled. | Free space on the volume, or move `storage.spill.dir` to a larger mount. |
+| **Spill directory unavailable** | (Spill) | The spill directory went bad mid-run — unmounted, remounted read-only, deleted by a cleaner, or permissions revoked. | Remount/restore the volume; stop the over-eager cleaner. |
+
+The key separations:
+
+- **E310 vs E320** — an OOM is an in-RAM overrun; a cap-exceeded is a
+  disk-budget stop. A run can hit E320 while comfortably inside its memory
+  envelope, so conflating the two would point you at the wrong knob.
+- **E320 vs E321** — E320 is the budget *you* set; E321 is the disk itself
+  running dry. If you removed `disk_cap_bytes`, an over-large run would no
+  longer trip E320 and would instead spill until the volume filled (E321).
+
+(A future per-operator memory-reservation surface will add a fifth,
+reservation-exhausted condition; it is not part of the engine yet.)
+
 ## Mid-run spill failures
 
 The startup check guarantees the spill directory is writable when the run
@@ -96,3 +163,5 @@ rejected as an unknown key.
 
 [`std::env::temp_dir`]: https://doc.rust-lang.org/std/env/fn.temp_dir.html
 [duckdb/duckdb#9401]: https://github.com/duckdb/duckdb/issues/9401
+[duckdb/duckdb#14142]: https://github.com/duckdb/duckdb/issues/14142
+[apache/datafusion#15358]: https://github.com/apache/datafusion/issues/15358


### PR DESCRIPTION
## Summary

Adds a configurable cumulative spill-disk quota and splits the runtime
diagnostics so a full or budgeted spill volume can no longer masquerade as an
out-of-memory failure. A run can sit comfortably inside its RSS envelope yet
still exhaust disk through unbounded spill files; before this change both
conditions surfaced as the same memory-budget error, reproducing the
confusing "OOM with free space" trap (duckdb/duckdb#14142).

## What changed

### Configurable disk cap (`storage.spill.disk_cap_bytes`)

- New optional field on the `[storage.spill]` block in `clinker.toml`, parsed
  through the existing `ByteSize` grammar so a single byte-size syntax is used
  across the whole file (bare integer = bytes; `KB`/`MB`/`GB` are decimal
  units). No second size parser is introduced.
- Threaded through to the run's memory arbitrator as `max_spill_bytes`. Absent
  config leaves spill unlimited, the historical default. `clinker run
  --explain` echoes the resolved cap.

### Distinct error surfaces

- The six spill-overflow sites (node-buffer admission, streaming handoff,
  grace-hash build/probe/repartition, sort-merge matching-run) now raise a
  dedicated **spill-cap-exceeded** diagnostic (E320) instead of the generic
  **memory-budget-exceeded** diagnostic (E310). The genuine RSS abort sites
  keep E310.
- An out-of-space (`ENOSPC`) failure on a spill write/create/finalize now
  classifies as a distinct **disk-full** diagnostic (E321) — the physical
  volume filling — kept separate from both the configured cap (E320) and an
  out-of-memory condition (E310). The grace-hash writer mirrors the same
  classification.

### Docs

- New explain pages for E320 and E321, registered in the explain index and
  covered by the section-completeness test.
- `docs/src/ops/storage.md` gains a `disk_cap_bytes` section and a table
  distinguishing all four spill-related failure conditions.

A fourth surface (per-operator reservation exhaustion) is intentionally
deferred until per-operator memory reservations exist; it is tracked
separately.

## Milestone

Part of **storage: configurable spill location + opt-in source staging**.

Closes #170, Closes #314
