### PR TITLE
engine: spill compression knob (auto|off|on) with small-row heuristic

### DIFF
--- a/crates/clinker-exec/Cargo.toml
+++ b/crates/clinker-exec/Cargo.toml
@@ -122,3 +122,7 @@ harness = false
 name = "arbitration_poll"
 harness = false
 
+[[bench]]
+name = "spill_compression"
+harness = false
+

--- a/crates/clinker-exec/benches/spill_compression.rs
+++ b/crates/clinker-exec/benches/spill_compression.rs
@@ -1,0 +1,85 @@
+//! Spill write+drain throughput across batch sizes for each compression mode.
+//!
+//! Measures the round-trip cost (postcard encode + optional LZ4 frame, then
+//! decode) of one spilled batch through `SpillWriter` / `SpillReader` at a
+//! range of per-batch byte sizes. The issue motivating the `compress` knob is
+//! that LZ4's per-frame fixed cost dominates on small batches; this bench
+//! validates that empirically by sweeping `compress = on` against `off` so the
+//! crossover where compression starts paying off is observable, and confirms
+//! `auto` tracks the better of the two across the range.
+//!
+//! Batch sizes target ~256 B, 1 KiB, 4 KiB, 16 KiB, and 64 KiB of payload —
+//! the threshold the `auto` heuristic keys on lives at 4 KiB.
+
+use clinker_bench_support::RecordFactory;
+use clinker_exec::pipeline::spill::{SpillReader, SpillWriter};
+use clinker_plan::config::CompressMode;
+use clinker_record::Record;
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+/// Approximate on-the-wire bytes one generated record contributes: each field
+/// is a `string_len`-byte string plus a few bytes of postcard framing. Used
+/// only to size each batch to a target byte budget; the bench measures the
+/// real spilled file, not this estimate.
+const APPROX_BYTES_PER_RECORD: usize = 24;
+
+/// Target per-batch payload sizes the bench sweeps. 4 KiB is the `auto`
+/// heuristic's byte threshold, so the sweep brackets it on both sides.
+const TARGET_BATCH_BYTES: [usize; 5] = [256, 1024, 4096, 16 * 1024, 64 * 1024];
+
+/// Generate one batch of records sized to roughly `target_bytes` of payload.
+fn make_batch(target_bytes: usize) -> Vec<Record> {
+    let row_count = (target_bytes / APPROX_BYTES_PER_RECORD).max(1);
+    // One narrow string field keeps per-record bytes predictable so the batch
+    // lands near its target size.
+    let mut factory = RecordFactory::new(1, 16, 0.0, 42);
+    factory.generate(row_count)
+}
+
+/// Write the batch to a spill file in `compress` mode, then drain it back,
+/// returning the drained row count so the optimizer cannot elide the work.
+fn spill_and_drain(records: &[Record], compress: bool) -> usize {
+    let schema = records[0].schema().clone();
+    let mut writer: SpillWriter<()> =
+        SpillWriter::new(schema, None, compress).expect("open spill writer");
+    for record in records {
+        writer.write_record(record).expect("spill write");
+    }
+    let file = writer.finish().expect("finish spill");
+    let reader: SpillReader<()> = file.reader().expect("open spill reader");
+    let mut drained = 0usize;
+    for item in reader {
+        item.expect("spill read");
+        drained += 1;
+    }
+    drained
+}
+
+fn bench_spill_compression(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spill_compression");
+
+    for target in TARGET_BATCH_BYTES {
+        let batch = make_batch(target);
+        group.throughput(Throughput::Bytes(target as u64));
+
+        // `auto` resolves once per batch from the schema width and row count,
+        // matching the runtime decision; `on` / `off` force the frame choice.
+        for mode in [CompressMode::On, CompressMode::Off, CompressMode::Auto] {
+            let compress =
+                mode.resolve_for_schema(batch[0].schema().column_count(), batch.len() as u64);
+            let label = format!("{mode:?}");
+            group.bench_with_input(
+                BenchmarkId::new(label, target),
+                &compress,
+                |b, &compress| {
+                    b.iter(|| black_box(spill_and_drain(&batch, compress)));
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_spill_compression);
+criterion_main!(benches);

--- a/crates/clinker-exec/src/aggregation/hash.rs
+++ b/crates/clinker-exec/src/aggregation/hash.rs
@@ -140,6 +140,11 @@ pub struct HashAggregator {
     spill_files: Vec<AggSpillFile>,
     spill_schema: Arc<Schema>,
     spill_dir: Option<PathBuf>,
+    /// Whether spill files are LZ4-compressed. Resolved by the dispatcher
+    /// from the workspace `[storage.spill] compress` knob against this
+    /// aggregate's output-schema width and the run's batch size, so the
+    /// on-disk format matches what `--explain` reports for the operator.
+    spill_compress: bool,
     output_schema: Arc<Schema>,
     transform_name: String,
     evaluator: ProgramEvaluator,
@@ -215,6 +220,13 @@ pub struct AggregatorConfig {
     /// Directory for spill files; `None` keeps the aggregator
     /// in-memory-only.
     pub spill_dir: Option<PathBuf>,
+    /// Whether spill files are LZ4-compressed, resolved from the workspace
+    /// `[storage.spill] compress` knob (see
+    /// [`clinker_plan::config::CompressMode`]) against this aggregate's
+    /// output-schema width and the run's batch size. Recorded in each spill
+    /// file's leading format tag so the on-disk format matches what
+    /// `--explain` reports for the operator.
+    pub spill_compress: bool,
     /// Node name, used for diagnostics and the synthetic
     /// `$ck.aggregate.<name>` lineage column.
     pub transform_name: String,
@@ -237,6 +249,7 @@ impl HashAggregator {
             spill_schema,
             memory_budget,
             spill_dir,
+            spill_compress,
             transform_name,
             consumer_handle,
         } = config;
@@ -284,6 +297,7 @@ impl HashAggregator {
             spill_files: Vec::new(),
             spill_schema,
             spill_dir,
+            spill_compress,
             output_schema,
             transform_name,
             evaluator,
@@ -1013,17 +1027,18 @@ impl HashAggregator {
         Ok(())
     }
 
-    /// Spill the in-memory groups to disk as postcard + LZ4.
+    /// Spill the in-memory groups to disk as postcard, optionally LZ4.
     ///
     /// 1. Drain `self.groups` (fold-mode) or `self.buffered_groups`
     ///    (buffer-mode) into a Vec, wrapping each state in `SpillState`.
     /// 2. Encode sort keys and sort by memcmp bytes so the k-way merge
     ///    can walk entries in group-key order.
     /// 3. Write each `AggSpillEntry` (sort_key + group_key + state) as a
-    ///    length-prefixed postcard record into an LZ4 frame-compressed
-    ///    temp file. Postcard is a compact binary format with no
-    ///    self-describing framing of its own; the explicit length prefix
-    ///    delimits records inside the LZ4 frame.
+    ///    length-prefixed postcard record into a temp file — raw or inside
+    ///    an LZ4 frame per the resolved `[storage.spill] compress` decision.
+    ///    Postcard is a compact binary format with no self-describing
+    ///    framing of its own; the explicit length prefix delimits records
+    ///    inside the (optionally framed) record stream.
     /// 4. Push the resulting `AggSpillFile` onto `self.spill_files`.
     /// 5. Reset `value_heap_bytes = 0`.
     fn spill(&mut self) -> Result<(), HashAggError> {
@@ -1071,8 +1086,9 @@ impl HashAggregator {
         }
         prepared.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 
-        // 3. Write sorted entries as postcard + LZ4.
-        let mut writer = AggSpillWriter::new(self.spill_dir.as_deref())?;
+        // 3. Write sorted entries as postcard, raw or LZ4-framed per the
+        //    resolved `[storage.spill] compress` decision.
+        let mut writer = AggSpillWriter::new(self.spill_dir.as_deref(), self.spill_compress)?;
         for (sort_key, idx) in prepared {
             let (key, state) = &drained[idx];
             let entry = AggSpillEntry {
@@ -1579,6 +1595,7 @@ mod spill_trigger_tests {
             spill_schema,
             memory_budget,
             spill_dir,
+            spill_compress: true,
             transform_name: "test_agg".to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
         })
@@ -2848,6 +2865,7 @@ mod spill_trigger_tests {
             spill_schema,
             memory_budget,
             spill_dir,
+            spill_compress: true,
             transform_name: transform_name.to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
         })

--- a/crates/clinker-exec/src/aggregation/spill.rs
+++ b/crates/clinker-exec/src/aggregation/spill.rs
@@ -1,10 +1,21 @@
-//! Binary aggregation spill infrastructure (postcard + LZ4).
+//! Binary aggregation spill infrastructure (postcard, optionally LZ4).
 //!
 //! External-merge machinery the [`HashAggregator`](super::HashAggregator)
 //! drives when in-memory group state exceeds the configured budget:
 //! per-group payloads ([`SpillState`]) are written as length-prefixed
-//! postcard records into LZ4 frame-compressed temp files and read back
-//! as [`AggMergeEntry`] for the `LoserTree` k-way merge on finalize.
+//! postcard records into temp files — raw or inside an LZ4 frame per the
+//! workspace `[storage.spill] compress` knob — and read back as
+//! [`AggMergeEntry`] for the `LoserTree` k-way merge on finalize.
+//!
+//! Each spill file opens with a 1-byte format tag (`0x00` uncompressed,
+//! `0x01` LZ4 frame) ahead of the record stream, mirroring the inter-stage
+//! [`SpillWriter`](crate::pipeline::spill::SpillWriter): the reader
+//! dispatches on the on-disk format without the writer's compression choice
+//! travelling out of band. `off` skips the LZ4 frame so small aggregate
+//! spills avoid LZ4's per-frame fixed cost (see
+//! [`clinker_plan::config::CompressMode`]).
+
+use std::io::{Read, Write};
 
 use serde::{Deserialize, Serialize};
 
@@ -13,6 +24,74 @@ use clinker_record::GroupByKey;
 
 use super::error::HashAggError;
 use super::{AggregatorGroupState, BufferedGroupState};
+
+/// On-disk format tag for an uncompressed aggregate spill file: the
+/// postcard record stream is written raw, with no LZ4 frame.
+const FORMAT_TAG_UNCOMPRESSED: u8 = 0x00;
+/// On-disk format tag for an LZ4-frame-compressed aggregate spill file.
+const FORMAT_TAG_LZ4: u8 = 0x01;
+
+/// Record-stream sink for an aggregate spill file: either a raw buffered
+/// writer (uncompressed) or an LZ4 frame encoder wrapping one. Mirrors the
+/// inter-stage spill path's sink; the variant is chosen at construction from
+/// the resolved compression decision and recorded in the leading format tag.
+enum AggSpillSink {
+    /// Uncompressed: postcard records written straight to the buffered file.
+    Uncompressed(std::io::BufWriter<tempfile::NamedTempFile>),
+    /// LZ4-frame-compressed: the historical default for large spills.
+    Lz4(lz4_flex::frame::FrameEncoder<std::io::BufWriter<tempfile::NamedTempFile>>),
+}
+
+impl Write for AggSpillSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            AggSpillSink::Uncompressed(w) => w.write(buf),
+            AggSpillSink::Lz4(e) => e.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            AggSpillSink::Uncompressed(w) => w.flush(),
+            AggSpillSink::Lz4(e) => e.flush(),
+        }
+    }
+}
+
+impl AggSpillSink {
+    /// Finalize the stream and recover the temp file. For LZ4 this flushes
+    /// the frame's buffered tail; for the uncompressed sink it flushes the
+    /// `BufWriter`.
+    fn into_temp_file(self) -> Result<tempfile::NamedTempFile, HashAggError> {
+        let buf_writer = match self {
+            AggSpillSink::Uncompressed(w) => w,
+            AggSpillSink::Lz4(e) => e.finish().map_err(|e| HashAggError::Spill(e.to_string()))?,
+        };
+        buf_writer
+            .into_inner()
+            .map_err(|e| HashAggError::Spill(e.into_error().to_string()))
+    }
+}
+
+/// Record-stream source for an aggregate spill file, mirroring
+/// [`AggSpillSink`]: either a raw buffered file (uncompressed) or an LZ4
+/// decoder over one. The variant is selected from the file's leading format
+/// tag at [`AggSpillFile::reader`].
+enum AggSpillSource {
+    /// Uncompressed: postcard records read straight from the buffered file.
+    Uncompressed(std::io::BufReader<std::fs::File>),
+    /// LZ4-frame-compressed.
+    Lz4(std::io::BufReader<lz4_flex::frame::FrameDecoder<std::fs::File>>),
+}
+
+impl Read for AggSpillSource {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            AggSpillSource::Uncompressed(r) => r.read(buf),
+            AggSpillSource::Lz4(r) => r.read(buf),
+        }
+    }
+}
 
 /// Merge entry for the binary aggregation spill path. Ordered by
 /// pre-encoded sort key bytes for the `LoserTree` k-way merge.
@@ -62,17 +141,28 @@ pub(super) struct AggSpillEntry {
 }
 
 /// Binary aggregation spill writer. Writes `AggSpillEntry` records as
-/// length-prefixed postcard payloads into an LZ4 frame-compressed temp
-/// file. Postcard has no record-level framing of its own, so each entry
-/// is preceded by a 4-byte little-endian u32 holding the encoded
-/// payload length. No schema header — the caller knows the group-by
-/// layout at construction time.
+/// length-prefixed postcard payloads into a temp file — raw or inside an
+/// LZ4 frame per the resolved `compress` decision, recorded in the leading
+/// format tag. Postcard has no record-level framing of its own, so each
+/// entry is preceded by a 4-byte little-endian u32 holding the encoded
+/// payload length. No schema header — the caller knows the group-by layout
+/// at construction time.
 pub(super) struct AggSpillWriter {
-    encoder: lz4_flex::frame::FrameEncoder<std::io::BufWriter<tempfile::NamedTempFile>>,
+    sink: AggSpillSink,
 }
 
 impl AggSpillWriter {
-    pub(super) fn new(spill_dir: Option<&std::path::Path>) -> Result<Self, HashAggError> {
+    /// Create a new spill writer in `spill_dir` (or the OS temp dir when
+    /// `None`). `compress` selects the body encoding: `true` wraps the
+    /// postcard record stream in an LZ4 frame, `false` writes it raw. The
+    /// caller resolves it from the workspace `[storage.spill] compress` knob
+    /// (see [`clinker_plan::config::CompressMode`]); the choice is recorded
+    /// in the file's leading format tag so the reader dispatches without
+    /// out-of-band state.
+    pub(super) fn new(
+        spill_dir: Option<&std::path::Path>,
+        compress: bool,
+    ) -> Result<Self, HashAggError> {
         // A create failure in a spill dir the run validated at startup means
         // the directory went bad mid-run (unmounted, removed, remounted
         // read-only). Classify it through the shared `from_spill_dir_io`
@@ -88,33 +178,41 @@ impl AggSpillWriter {
                 tempfile::NamedTempFile::new().map_err(|e| HashAggError::Spill(e.to_string()))?
             }
         };
-        let buf_writer = std::io::BufWriter::new(temp_file);
-        let encoder = lz4_flex::frame::FrameEncoder::new(buf_writer);
-        Ok(Self { encoder })
+        let mut buf_writer = std::io::BufWriter::new(temp_file);
+        // The format tag is the very first on-disk byte and sits ahead of the
+        // (optionally framed) record stream so the reader dispatches before
+        // opening a decoder.
+        let tag = if compress {
+            FORMAT_TAG_LZ4
+        } else {
+            FORMAT_TAG_UNCOMPRESSED
+        };
+        buf_writer
+            .write_all(&[tag])
+            .map_err(|e| HashAggError::Spill(e.to_string()))?;
+        let sink = if compress {
+            AggSpillSink::Lz4(lz4_flex::frame::FrameEncoder::new(buf_writer))
+        } else {
+            AggSpillSink::Uncompressed(buf_writer)
+        };
+        Ok(Self { sink })
     }
 
     pub(super) fn write_entry(&mut self, entry: &AggSpillEntry) -> Result<(), HashAggError> {
-        use std::io::Write;
         let bytes = postcard::to_stdvec(entry).map_err(|e| HashAggError::Spill(e.to_string()))?;
         let len = u32::try_from(bytes.len())
             .map_err(|_| HashAggError::Spill("spill entry exceeds 4 GiB".to_string()))?;
-        self.encoder
+        self.sink
             .write_all(&len.to_le_bytes())
             .map_err(|e| HashAggError::Spill(e.to_string()))?;
-        self.encoder
+        self.sink
             .write_all(&bytes)
             .map_err(|e| HashAggError::Spill(e.to_string()))?;
         Ok(())
     }
 
     pub(super) fn finish(self) -> Result<AggSpillFile, HashAggError> {
-        let buf_writer = self
-            .encoder
-            .finish()
-            .map_err(|e| HashAggError::Spill(e.to_string()))?;
-        let temp_file = buf_writer
-            .into_inner()
-            .map_err(|e| HashAggError::Spill(e.into_error().to_string()))?;
+        let temp_file = self.sink.into_temp_file()?;
         let path = temp_file.into_temp_path();
         Ok(AggSpillFile { path })
     }
@@ -126,13 +224,32 @@ pub struct AggSpillFile {
 }
 
 impl AggSpillFile {
+    /// Open a reader over this spill file.
+    ///
+    /// Reads the leading format tag and selects the matching record-stream
+    /// source: an LZ4 decoder for `0x01`, the raw file for `0x00`. An unknown
+    /// tag is a corrupt-file error.
     pub(super) fn reader(&self) -> Result<AggSpillReader, HashAggError> {
-        let file =
+        let mut file =
             std::fs::File::open(&self.path).map_err(|e| HashAggError::Spill(e.to_string()))?;
-        let decoder = lz4_flex::frame::FrameDecoder::new(file);
-        let buf_reader = std::io::BufReader::new(decoder);
+        // The format tag is a single byte ahead of the (optionally framed)
+        // record stream, written by `AggSpillWriter::new`.
+        let mut tag = [0u8; 1];
+        file.read_exact(&mut tag)
+            .map_err(|e| HashAggError::Spill(e.to_string()))?;
+        let source = match tag[0] {
+            FORMAT_TAG_LZ4 => AggSpillSource::Lz4(std::io::BufReader::new(
+                lz4_flex::frame::FrameDecoder::new(file),
+            )),
+            FORMAT_TAG_UNCOMPRESSED => AggSpillSource::Uncompressed(std::io::BufReader::new(file)),
+            other => {
+                return Err(HashAggError::Spill(format!(
+                    "unknown aggregate spill format tag {other:#04x}; file is corrupt"
+                )));
+            }
+        };
         Ok(AggSpillReader {
-            reader: buf_reader,
+            source,
             len_buf: [0u8; 4],
         })
     }
@@ -140,25 +257,25 @@ impl AggSpillFile {
 
 /// Binary aggregation spill reader. Yields `AggMergeEntry` by reading a
 /// 4-byte little-endian length prefix followed by a postcard-encoded
-/// payload from an LZ4 frame-compressed file. A clean-boundary EOF on
-/// the length prefix terminates the stream cleanly; any other read or
-/// decode failure surfaces as `HashAggError::Spill`.
+/// payload, dispatching on the file's format tag for the compressed or
+/// uncompressed record stream. A clean-boundary EOF on the length prefix
+/// terminates the stream cleanly; any other read or decode failure surfaces
+/// as `HashAggError::Spill`.
 pub(super) struct AggSpillReader {
-    reader: std::io::BufReader<lz4_flex::frame::FrameDecoder<std::fs::File>>,
+    source: AggSpillSource,
     len_buf: [u8; 4],
 }
 
 impl AggSpillReader {
     pub(super) fn next_entry(&mut self) -> Result<Option<AggMergeEntry>, HashAggError> {
-        use std::io::Read;
-        match self.reader.read_exact(&mut self.len_buf) {
+        match self.source.read_exact(&mut self.len_buf) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
             Err(e) => return Err(HashAggError::Spill(e.to_string())),
         }
         let len = u32::from_le_bytes(self.len_buf) as usize;
         let mut buf = vec![0u8; len];
-        self.reader
+        self.source
             .read_exact(&mut buf)
             .map_err(|e| HashAggError::Spill(e.to_string()))?;
         let entry: AggSpillEntry =
@@ -176,6 +293,80 @@ mod tests {
     use super::*;
     use clinker_plan::error::PipelineError;
 
+    /// LZ4 frame magic number, little-endian `0x184D2204` — the four bytes a
+    /// compressed aggregate spill opens with right after the 1-byte tag.
+    const LZ4_FRAME_MAGIC: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
+
+    /// A trivially-constructed spill entry: empty group key, empty
+    /// fold-mode accumulator row. Enough to exercise the framing and the
+    /// read path without standing up an `AccumulatorFactory`.
+    fn sample_entry(sort_key: Vec<u8>) -> AggSpillEntry {
+        AggSpillEntry {
+            sort_key,
+            group_key: Vec::new(),
+            state: SpillState::Folded(AggregatorGroupState::new(Vec::new())),
+        }
+    }
+
+    // The leading format tag must record the writer's compression choice and
+    // the body must honor it: an `off` aggregate spill is byte-raw (no LZ4
+    // frame magic after the tag) and an `on` one is LZ4-framed. Without this
+    // the `--explain` per-operator compress line is a falsehood for the
+    // hash-aggregation operator, which hardcoded LZ4 before the knob reached
+    // this writer.
+    #[test]
+    fn format_tag_and_body_honor_compress_knob() {
+        for (compress, expected_tag) in [(true, FORMAT_TAG_LZ4), (false, FORMAT_TAG_UNCOMPRESSED)] {
+            let mut writer = AggSpillWriter::new(None, compress).unwrap();
+            writer.write_entry(&sample_entry(vec![1, 2, 3])).unwrap();
+            let file = writer.finish().unwrap();
+            let bytes = std::fs::read(&file.path).unwrap();
+            assert_eq!(
+                bytes[0], expected_tag,
+                "compress={compress} must write tag {expected_tag:#04x}"
+            );
+            // The four bytes after the tag are the LZ4 frame magic only when
+            // compressed; an `off` body opens straight into the first
+            // length-prefixed postcard entry, never the frame magic.
+            let body_head = &bytes[1..5];
+            if compress {
+                assert_eq!(
+                    body_head, &LZ4_FRAME_MAGIC,
+                    "on-mode body must be LZ4-framed"
+                );
+            } else {
+                assert_ne!(
+                    body_head, &LZ4_FRAME_MAGIC,
+                    "off-mode body must be byte-raw, with no LZ4 frame magic"
+                );
+            }
+        }
+    }
+
+    // Entries round-trip through both the compressed and the uncompressed
+    // format identically: the knob changes only on-disk bytes, never the
+    // decoded entries, so the k-way merge sees the same group order either way.
+    #[test]
+    fn entries_roundtrip_in_both_modes() {
+        for compress in [true, false] {
+            let mut writer = AggSpillWriter::new(None, compress).unwrap();
+            for i in 0u8..5 {
+                writer.write_entry(&sample_entry(vec![i])).unwrap();
+            }
+            let file = writer.finish().unwrap();
+            let mut reader = file.reader().unwrap();
+            let mut read_keys = Vec::new();
+            while let Some(entry) = reader.next_entry().unwrap() {
+                read_keys.push(entry.sort_key);
+            }
+            assert_eq!(
+                read_keys,
+                (0u8..5).map(|i| vec![i]).collect::<Vec<_>>(),
+                "compress={compress}: entries must round-trip in input order"
+            );
+        }
+    }
+
     #[test]
     fn spill_dir_removed_mid_run_yields_distinct_diagnostic() {
         // Mirror of the node-buffer/sort spill regression: a configured
@@ -190,7 +381,7 @@ mod tests {
         std::fs::create_dir(&spill_dir).unwrap();
         std::fs::remove_dir(&spill_dir).unwrap();
 
-        let err = match AggSpillWriter::new(Some(&spill_dir)) {
+        let err = match AggSpillWriter::new(Some(&spill_dir), true) {
             Ok(_) => panic!("AggSpillWriter::new should fail when the dir is gone"),
             Err(e) => e,
         };

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -140,6 +140,18 @@ pub(crate) fn dispatch_aggregation(
 
     let mem_limit = parse_memory_limit(ctx.config);
 
+    // Resolve the spill compression mode against this aggregate's
+    // output-schema width and the run's batch size, so spilled group state
+    // matches what `--explain` projects for the operator. The explain line
+    // for an Aggregation node resolves the same way against
+    // `stored_output_schema().column_count()`, so resolving here against the
+    // output schema keeps the reported mode and the on-disk format in
+    // lockstep. `auto` skips LZ4 on narrow/short aggregates where the
+    // per-frame fixed cost outweighs the savings.
+    let spill_compress = ctx
+        .spill_compress
+        .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
+
     let agg_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
     let input_count = input.len() as u64;
 
@@ -207,6 +219,7 @@ pub(crate) fn dispatch_aggregation(
                 spill_schema,
                 memory_budget: mem_limit,
                 spill_dir: Some(ctx.spill_root_path.to_path_buf()),
+                spill_compress,
                 transform_name: name.clone(),
                 consumer_handle: agg_consumer_handle,
             },
@@ -612,6 +625,13 @@ impl WindowedAggContext<'_> {
         let agg_consumer_id = ctx.memory_budget.register_consumer(Arc::new(
             crate::aggregation::AggregateConsumer::new(agg_consumer_handle.clone()),
         ));
+        // Resolve the spill compression mode against this aggregate's
+        // output-schema width and the run's batch size, matching the
+        // `--explain` projection for the Aggregation node so each window's
+        // spill file's on-disk format agrees with the reported mode.
+        let spill_compress = ctx
+            .spill_compress
+            .resolve_for_schema(self.output_schema.column_count(), ctx.batch_size as u64);
         let stream = crate::aggregation::AggregateStream::for_node(
             self.strategy,
             crate::aggregation::AggregatorConfig {
@@ -621,6 +641,7 @@ impl WindowedAggContext<'_> {
                 spill_schema: Arc::clone(&self.spill_schema),
                 memory_budget: self.mem_limit,
                 spill_dir: Some(ctx.spill_root_path.to_path_buf()),
+                spill_compress,
                 transform_name: self.name.to_string(),
                 consumer_handle: agg_consumer_handle,
             },

--- a/crates/clinker-exec/src/executor/batch_handoff.rs
+++ b/crates/clinker-exec/src/executor/batch_handoff.rs
@@ -47,7 +47,7 @@ use clinker_plan::error::PipelineError;
 /// streaming channel's in-flight bound) is a negligible fraction of the
 /// default 512 MiB budget for typical record widths, large enough that
 /// the per-flush handoff cost is amortized over thousands of records.
-pub(crate) const DEFAULT_BATCH_SIZE: usize = 2048;
+pub const DEFAULT_BATCH_SIZE: usize = 2048;
 
 /// One bounded slice of a streaming stage's output.
 ///
@@ -258,6 +258,13 @@ pub(crate) struct StreamingChargeHandle {
     spill_root_path: Arc<Path>,
     node_name: String,
     spill_allowed: bool,
+    /// Workspace `[storage.spill] compress` policy, resolved per spilled run
+    /// against the run's schema width and `batch_size` so `auto` skips LZ4 on
+    /// narrow streaming spills where the per-frame fixed cost outweighs the
+    /// savings.
+    spill_compress: clinker_plan::config::CompressMode,
+    /// Run-wide batch size, the `auto` heuristic's rows-per-batch projection.
+    batch_size: usize,
 }
 
 impl StreamingChargeHandle {
@@ -267,13 +274,16 @@ impl StreamingChargeHandle {
     /// the arbitrator as a `NodeBufferConsumer`; the same `Arc` is cloned
     /// into the writer thread so the discharge side subtracts from the
     /// counter this side adds to. `spill_allowed` mirrors
-    /// `dispatch::node_buffer_spill_allowed` for the slot.
+    /// `dispatch::node_buffer_spill_allowed` for the slot. `spill_compress`
+    /// and `batch_size` resolve the spill-file compression mode per run.
     pub(crate) fn new(
         handle: Arc<ConsumerHandle>,
         arbitrator: Arc<MemoryArbitrator>,
         spill_root_path: Arc<Path>,
         node_name: String,
         spill_allowed: bool,
+        spill_compress: clinker_plan::config::CompressMode,
+        batch_size: usize,
     ) -> Self {
         Self {
             handle,
@@ -281,6 +291,8 @@ impl StreamingChargeHandle {
             spill_root_path,
             node_name,
             spill_allowed,
+            spill_compress,
+            batch_size,
         }
     }
 
@@ -353,9 +365,20 @@ impl StreamingChargeHandle {
         run: Vec<(clinker_record::Record, u64)>,
         send: &mut impl FnMut(StreamEvent) -> Result<(), PipelineError>,
     ) -> Result<(), PipelineError> {
+        // Resolve the compression mode against this run's schema width and the
+        // run-wide batch size, so the streaming spill file matches what
+        // `--explain` projects for the slot.
+        let column_count = run
+            .first()
+            .map(|(r, _)| r.schema().column_count())
+            .unwrap_or(0);
+        let compress = self
+            .spill_compress
+            .resolve_for_schema(column_count, self.batch_size as u64);
         let Some((file, _count)) = crate::executor::node_buffer_spill::spill_node_buffer(
             run,
             Some(self.spill_root_path.as_ref()),
+            compress,
         )?
         else {
             return Ok(());
@@ -599,6 +622,8 @@ mod tests {
             spill_root,
             "stream-spill-test".to_string(),
             true,
+            clinker_plan::config::CompressMode::On,
+            2,
         );
 
         // One document: open, three records, close — at this batch size
@@ -700,6 +725,8 @@ mod tests {
             spill_root,
             "stream-spill-two-docs".to_string(),
             true,
+            clinker_plan::config::CompressMode::On,
+            2,
         );
 
         // [Open(A), r0, r1, Close(A), Open(B), r2, Close(B)] — two record

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -627,6 +627,17 @@ pub(crate) fn dispatch_combine(
                 });
             let body_typed = ctx.artifacts.typed.get(name);
             let combine_output_schema_arc = combine_output_schema.clone();
+            // Resolve the spill compression mode against the combine's output
+            // schema width and the run's batch size, so Phase A spill runs
+            // match what `--explain` projects. `auto` skips LZ4 on narrow
+            // combines where the per-frame fixed cost outweighs the savings.
+            let sm_column_count = combine_output_schema_arc
+                .as_ref()
+                .map(|s| s.column_count())
+                .unwrap_or(0);
+            let sm_spill_compress = ctx
+                .spill_compress
+                .resolve_for_schema(sm_column_count, ctx.batch_size as u64);
             let sm_ctx = ctx.merged_eval_ctx();
             // CPU-bound sort-merge join kernel: two-cursor merge
             // over pre-sorted inputs. The kernel owns its inputs
@@ -651,6 +662,7 @@ pub(crate) fn dispatch_combine(
                     ctx: &sm_ctx,
                     budget: &ctx.memory_budget,
                     spill_dir: ctx.spill_root_path.as_ref(),
+                    spill_compress: sm_spill_compress,
                     consumer_handle: sm_consumer_handle,
                     strategy: ctx.strategy,
                 })

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -512,6 +512,18 @@ pub(crate) fn dispatch_combine(
                 });
             let body_typed = ctx.artifacts.typed.get(name);
             let combine_output_schema_arc = combine_output_schema.clone();
+            // Resolve the spill compression mode against the combine's output
+            // schema width and the run's batch size, so the grace-hash
+            // partition spill files match what `--explain` projects. `auto`
+            // skips LZ4 on narrow combines where the per-frame fixed cost
+            // outweighs the savings.
+            let grace_column_count = combine_output_schema_arc
+                .as_ref()
+                .map(|s| s.column_count())
+                .unwrap_or(0);
+            let grace_spill_compress = ctx
+                .spill_compress
+                .resolve_for_schema(grace_column_count, ctx.batch_size as u64);
             let grace_ctx = ctx.merged_eval_ctx();
             // CPU-bound grace-hash join kernel: partition build +
             // probe + spill I/O. The kernel owns its inputs and
@@ -536,6 +548,7 @@ pub(crate) fn dispatch_combine(
                     ctx: &grace_ctx,
                     budget: &ctx.memory_budget,
                     spill_dir: ctx.spill_root_path.as_ref(),
+                    spill_compress: grace_spill_compress,
                     consumer_handle: grace_consumer_handle,
                     strategy: ctx.strategy,
                 })

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -870,6 +870,13 @@ pub(crate) struct ExecutorContext<'a> {
     /// for that one stage via [`Self::batch_size_for`]. Read by the fused
     /// streaming arms to size their [`crate::executor::batch_handoff::EventBatcher`].
     pub(crate) batch_size: usize,
+
+    /// Spill-file compression policy from the workspace `[storage.spill]
+    /// compress` knob. Resolved per blocking operator against the slot's
+    /// schema width and [`Self::batch_size`] at each spill site, so `auto`
+    /// can skip LZ4 on narrow/short batches where the per-frame fixed cost
+    /// outweighs the savings. See [`clinker_plan::config::CompressMode`].
+    pub(crate) spill_compress: clinker_plan::config::CompressMode,
 }
 
 /// Map keying (active composition body, outgoing edge id) to the rows
@@ -1024,6 +1031,8 @@ impl<'a> ExecutorContext<'a> {
             std::sync::Arc::clone(&self.spill_root_path),
             node_name.to_string(),
             spill_allowed,
+            self.spill_compress,
+            self.batch_size,
         ))
     }
 
@@ -1379,9 +1388,21 @@ pub(crate) fn admit_node_buffer(
     if !spill_allowed || !ctx.memory_budget.should_spill() {
         return Ok(NodeBuffer::memory_from_records_and_puncts(rows, puncts));
     }
+    // Resolve the spill compression mode against this slot's schema width and
+    // the run's batch size, so the file's on-disk format matches what
+    // `--explain` projects. `auto` skips LZ4 on narrow/short batches where the
+    // per-frame fixed cost outweighs the savings.
+    let column_count = rows
+        .first()
+        .map(|(r, _)| r.schema().column_count())
+        .unwrap_or(0);
+    let compress = ctx
+        .spill_compress
+        .resolve_for_schema(column_count, ctx.batch_size as u64);
     match crate::executor::node_buffer_spill::spill_node_buffer(
         rows,
         Some(ctx.spill_root_path.as_ref()),
+        compress,
     )? {
         Some((file, count)) => {
             // Rows are now on disk; the in-memory portion of this slot

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -32,6 +32,7 @@ mod util;
 pub(crate) mod watermark;
 pub(crate) mod window_runtime;
 
+pub use batch_handoff::DEFAULT_BATCH_SIZE;
 use context::build_stable_eval_context;
 pub use dlq::DlqEntry;
 use ingest::{IngestTaskOutcome, ingest_source};
@@ -1270,6 +1271,7 @@ impl PipelineExecutor {
                 .pipeline
                 .batch_size
                 .unwrap_or(crate::executor::batch_handoff::DEFAULT_BATCH_SIZE),
+            spill_compress: params.spill_compress,
         };
 
         // Resolve dispatch order through the memory arbitrator rather

--- a/crates/clinker-exec/src/executor/node_buffer.rs
+++ b/crates/clinker-exec/src/executor/node_buffer.rs
@@ -350,7 +350,7 @@ impl Iterator for NodeBufferDrain {
 /// every consumer drain decrements it. `try_spill` flips the handle's
 /// spill-request flag; the dispatcher reads it at the next admission
 /// boundary and routes through the existing `spill_node_buffer`
-/// (postcard + LZ4 via `SpillWriter<u64>`) path.
+/// (postcard, optionally LZ4-framed, via `SpillWriter<u64>`) path.
 ///
 /// `spill_priority = 0`: cheapest victim. Inter-stage buffers are
 /// already row-oriented and write straight through `SpillWriter<u64>`;
@@ -449,7 +449,7 @@ mod tests {
         } else {
             schema()
         };
-        let mut w: SpillWriter<u64> = SpillWriter::new(s, None).unwrap();
+        let mut w: SpillWriter<u64> = SpillWriter::new(s, None, true).unwrap();
         let count = rows.len() as u64;
         for (r, rn) in &rows {
             w.write_pair(r, rn).unwrap();

--- a/crates/clinker-exec/src/executor/node_buffer_spill.rs
+++ b/crates/clinker-exec/src/executor/node_buffer_spill.rs
@@ -8,8 +8,9 @@
 //! per-spill rows via `SpillReader<u64>`), so this module exposes only
 //! the producer-side packaging.
 //!
-//! Goes through the same generic `pipeline/spill.rs` envelope (JSON
-//! schema header + length-prefixed postcard + LZ4 frame) that
+//! Goes through the same generic `pipeline/spill.rs` envelope (format
+//! tag + JSON schema header + length-prefixed postcard, optionally
+//! LZ4-framed per the `[storage.spill] compress` knob) that
 //! `sort_buffer.rs` writes today. `pipeline/grace_spill.rs` is a
 //! distinct, partition-aware format reserved for grace-hash combine
 //! and is intentionally not used here.
@@ -31,19 +32,25 @@ use clinker_plan::error::PipelineError;
 /// `(SpillFile<u64>, row_count)` pair. Schema is read from the first
 /// record; an empty input is a no-op (`Ok(None)`).
 ///
+/// `compress` selects LZ4 framing for the spill file. The caller resolves it
+/// from the workspace `[storage.spill] compress` knob (see
+/// [`clinker_plan::config::CompressMode`]) so the on-disk format matches what
+/// `--explain` reports.
+///
 /// Errors from `SpillWriter::new` (temp-file creation), `write_pair`
-/// (postcard encode + LZ4 write), and `finish` (frame finalize) all
+/// (postcard encode + write), and `finish` (frame finalize) all
 /// surface as `PipelineError::Spill` via the existing
 /// `From<SpillError>` conversion.
 pub(crate) fn spill_node_buffer(
     rows: Vec<(Record, u64)>,
     spill_dir: Option<&Path>,
+    compress: bool,
 ) -> Result<Option<(SpillFile<u64>, u64)>, PipelineError> {
     let Some((first, _)) = rows.first() else {
         return Ok(None);
     };
     let schema = Arc::clone(first.schema());
-    let mut writer: SpillWriter<u64> = SpillWriter::new(schema, spill_dir)?;
+    let mut writer: SpillWriter<u64> = SpillWriter::new(schema, spill_dir, compress)?;
     let count = rows.len() as u64;
     for (record, rn) in &rows {
         writer.write_pair(record, rn)?;
@@ -79,7 +86,7 @@ mod tests {
             (rec(&s, 3, "c"), 102),
         ];
 
-        let (file, count) = spill_node_buffer(rows.clone(), None)
+        let (file, count) = spill_node_buffer(rows.clone(), None, true)
             .expect("spill ok")
             .expect("non-empty input produces a chunk");
         assert_eq!(count, 3);
@@ -102,22 +109,30 @@ mod tests {
 
     #[test]
     fn spill_node_buffer_empty_input_is_none() {
-        let result = spill_node_buffer(Vec::new(), None).expect("spill ok");
+        let result = spill_node_buffer(Vec::new(), None, true).expect("spill ok");
         assert!(result.is_none(), "empty input must not create a spill file");
     }
 
     #[test]
     fn multiple_spill_chunks_drain_in_order() {
         let s = schema();
-        let chunk_a = spill_node_buffer(vec![(rec(&s, 1, "a"), 10), (rec(&s, 2, "b"), 11)], None)
+        let chunk_a = spill_node_buffer(
+            vec![(rec(&s, 1, "a"), 10), (rec(&s, 2, "b"), 11)],
+            None,
+            true,
+        )
+        .unwrap()
+        .unwrap();
+        let chunk_b = spill_node_buffer(vec![(rec(&s, 3, "c"), 12)], None, true)
             .unwrap()
             .unwrap();
-        let chunk_b = spill_node_buffer(vec![(rec(&s, 3, "c"), 12)], None)
-            .unwrap()
-            .unwrap();
-        let chunk_c = spill_node_buffer(vec![(rec(&s, 4, "d"), 13), (rec(&s, 5, "e"), 14)], None)
-            .unwrap()
-            .unwrap();
+        let chunk_c = spill_node_buffer(
+            vec![(rec(&s, 4, "d"), 13), (rec(&s, 5, "e"), 14)],
+            None,
+            true,
+        )
+        .unwrap()
+        .unwrap();
 
         let nb = NodeBuffer::Spilled {
             chunks: vec![chunk_a, chunk_b, chunk_c],
@@ -134,7 +149,7 @@ mod tests {
     fn spilled_variant_len_hint_matches_written_rows() {
         let s = schema();
         let rows = vec![(rec(&s, 1, "a"), 1), (rec(&s, 2, "b"), 2)];
-        let (file, count) = spill_node_buffer(rows, None).unwrap().unwrap();
+        let (file, count) = spill_node_buffer(rows, None, true).unwrap().unwrap();
 
         let nb = NodeBuffer::Spilled {
             chunks: vec![(file, count)],

--- a/crates/clinker-exec/src/executor/params.rs
+++ b/crates/clinker-exec/src/executor/params.rs
@@ -53,6 +53,13 @@ pub struct PipelineRunParams {
     /// `PipelineError::SpillCapExceeded` (E320) — a disk-cap surface kept
     /// distinct from both the RSS budget (E310) and a full volume (E321).
     pub spill_disk_cap_bytes: Option<u64>,
+    /// Spill-file compression policy, resolved from the workspace
+    /// `clinker.toml` `[storage.spill] compress` setting. Defaults to
+    /// [`clinker_plan::config::CompressMode::Auto`] (the `Default`), which
+    /// compresses only when a spilled batch is projected large enough to
+    /// amortize LZ4's per-frame fixed cost. Threaded into the dispatch
+    /// context and resolved per blocking operator at each spill site.
+    pub spill_compress: clinker_plan::config::CompressMode,
 }
 
 /// Summary returned after a pipeline execution completes (success or partial).

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -78,10 +78,16 @@ pub(crate) fn dispatch_sort(
 
     let schema = input_records[0].0.schema().clone();
     let mem_limit = parse_memory_limit(ctx.config);
+    // Resolve the spill compression mode against this sort's schema width and
+    // the run's batch size, so spilled runs match what `--explain` projects.
+    let spill_compress = ctx
+        .spill_compress
+        .resolve_for_schema(schema.column_count(), ctx.batch_size as u64);
     let mut buf: SortBuffer<u64> = SortBuffer::new(
         sort_fields.clone(),
         mem_limit,
         Some(ctx.spill_root_path.to_path_buf()),
+        spill_compress,
         schema,
     );
 

--- a/crates/clinker-exec/src/executor/tests/aggregation.rs
+++ b/crates/clinker-exec/src/executor/tests/aggregation.rs
@@ -95,6 +95,7 @@ mod dispatch {
             spill_schema,
             memory_budget,
             spill_dir,
+            spill_compress: true,
             transform_name: transform_name.to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
         })
@@ -1366,6 +1367,7 @@ mod two_phase_bytes_spill {
             spill_schema,
             memory_budget,
             spill_dir: None,
+            spill_compress: true,
             transform_name: transform_name.to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
         })

--- a/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
@@ -188,6 +188,11 @@ pub(crate) struct GraceHashExec<'a> {
     /// `tempfile::TempPath` Drop; the pipeline-scoped TempDir Drop
     /// closes the panic-leak hole for files committed mid-combine.
     pub spill_dir: &'a Path,
+    /// Whether partition spill files are LZ4-compressed. Resolved by the
+    /// dispatcher from the workspace `[storage.spill] compress` knob against
+    /// this combine's output-schema width and the run's batch size, so the
+    /// build/probe/repartition spill files match what `--explain` reports.
+    pub spill_compress: bool,
     /// Shared with the registered `GraceHashConsumer` wrapper.
     /// Passed through to `GraceHashExecutor::new` so the operator's
     /// partition bytes mirror into the arbitrator's pull-mode
@@ -227,6 +232,11 @@ pub(crate) struct GraceHashExecutor {
     /// `bytes_estimated`. On-disk partitions don't count against
     /// `handle.bytes` — Velox's "reclaimable ≠ held" point.
     consumer_handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
+    /// Whether partition spill files are LZ4-compressed. Resolved by the
+    /// dispatcher from the workspace `[storage.spill] compress` knob against
+    /// this combine's output-schema width and the run's batch size, so the
+    /// on-disk format matches what `--explain` reports for the operator.
+    spill_compress: bool,
 }
 
 impl GraceHashExecutor {
@@ -239,6 +249,7 @@ impl GraceHashExecutor {
         partition_bits: u8,
         spill_dir: &Path,
         consumer_handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
+        spill_compress: bool,
     ) -> std::io::Result<Self> {
         let assigner = PartitionAssigner::new(partition_bits.max(1));
         let n = assigner.num_partitions();
@@ -257,6 +268,7 @@ impl GraceHashExecutor {
             hash_state: RandomState::new(),
             spilled_bytes: 0,
             consumer_handle,
+            spill_compress,
         })
     }
 
@@ -334,7 +346,12 @@ impl GraceHashExecutor {
                 }
             }
             Some(hash_bits) => {
-                let mut w = GraceSpillWriter::new(&self.spill_dir, hash_bits, p as u16)?;
+                let mut w = GraceSpillWriter::new(
+                    &self.spill_dir,
+                    hash_bits,
+                    p as u16,
+                    self.spill_compress,
+                )?;
                 w.write_record(&record)?;
                 let (new_path, written) = w.finish()?;
                 self.spilled_bytes = self.spilled_bytes.saturating_add(written);
@@ -405,7 +422,12 @@ impl GraceHashExecutor {
                 return Ok(());
             }
         };
-        let mut writer = GraceSpillWriter::new(&self.spill_dir, hash_bits, partition_id)?;
+        let mut writer = GraceSpillWriter::new(
+            &self.spill_dir,
+            hash_bits,
+            partition_id,
+            self.spill_compress,
+        )?;
         let count = records.len() as u64;
         for r in records {
             writer.write_record(&r)?;
@@ -514,6 +536,7 @@ impl GraceHashExecutor {
                         // it serves as a probe-vs-build tag at the
                         // file-name level for diagnostic clarity.
                         (p as u16) | 0x8000,
+                        self.spill_compress,
                     )?));
                 }
                 let w = probe_writer.as_mut().unwrap();
@@ -618,6 +641,7 @@ pub(crate) fn execute_combine_grace_hash(
         ctx,
         budget,
         spill_dir,
+        spill_compress,
         consumer_handle,
         strategy,
     } = args;
@@ -686,13 +710,12 @@ pub(crate) fn execute_combine_grace_hash(
         .unwrap_or_else(|| Arc::new(Schema::new(Vec::new())));
 
     let mut executor =
-        GraceHashExecutor::new(partition_bits, spill_dir, consumer_handle).map_err(|e| {
-            PipelineError::Internal {
+        GraceHashExecutor::new(partition_bits, spill_dir, consumer_handle, spill_compress)
+            .map_err(|e| PipelineError::Internal {
                 op: "combine",
                 node: name.to_string(),
                 detail: format!("grace hash spill dir bind failed: {e}"),
-            }
-        })?;
+            })?;
 
     // ── Build phase ────────────────────────────────────────────────────
     //
@@ -843,6 +866,7 @@ pub(crate) fn execute_combine_grace_hash(
         build_schema: Arc::clone(&build_schema),
         driver_schema: Arc::clone(&driver_schema),
         spill_dir: &spill_dir_path,
+        spill_compress,
         hash_state: &hash_state,
     };
     for sp in spilled {

--- a/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
@@ -73,6 +73,11 @@ pub(super) struct ReloadContext<'a> {
     pub(super) build_schema: Arc<Schema>,
     pub(super) driver_schema: Arc<Schema>,
     pub(super) spill_dir: &'a Path,
+    /// Whether repartition spill files written during reload are
+    /// LZ4-compressed. Carried from the dispatcher's resolved
+    /// `[storage.spill] compress` decision so recursively-split partition
+    /// files honor the same knob the build/probe spill files did.
+    pub(super) spill_compress: bool,
     pub(super) hash_state: &'a RandomState,
 }
 
@@ -94,6 +99,7 @@ pub(super) fn process_spilled_partition(
     let build_schema = Arc::clone(&rc.build_schema);
     let driver_schema = Arc::clone(&rc.driver_schema);
     let spill_dir = rc.spill_dir;
+    let spill_compress = rc.spill_compress;
     let hash_state = rc.hash_state;
     // Reload build records (every build_files entry concatenated).
     // The reader's footer is cross-checked against the SpilledPartition
@@ -263,9 +269,13 @@ pub(super) fn process_spilled_partition(
             (parent_id * 2 + 1, child_b, child_b_probe, child_b_sketch),
         ] {
             let bcount = child_build.len() as u64;
-            let mut bw =
-                GraceSpillWriter::new(spill_dir, child_assigner.hash_bits(), child_id as u16)
-                    .map_err(|e| grace_spill_error(e, name, "repartition build writer"))?;
+            let mut bw = GraceSpillWriter::new(
+                spill_dir,
+                child_assigner.hash_bits(),
+                child_id as u16,
+                spill_compress,
+            )
+            .map_err(|e| grace_spill_error(e, name, "repartition build writer"))?;
             for r in &child_build {
                 bw.write_record(r)
                     .map_err(|e| grace_spill_error(e, name, "repartition build write"))?;
@@ -287,6 +297,7 @@ pub(super) fn process_spilled_partition(
                     spill_dir,
                     child_assigner.hash_bits(),
                     (child_id as u16) | 0x8000,
+                    spill_compress,
                 )
                 .map_err(|e| grace_spill_error(e, name, "repartition probe writer"))?;
                 for r in &child_probe {

--- a/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
@@ -118,6 +118,7 @@ fn pipeline_temp_dir_owns_spill_files_on_drop() {
         4,
         pipeline_dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
+        true,
     )
     .unwrap();
     let schema = schema_with(&["k"]);
@@ -156,6 +157,7 @@ fn pipeline_temp_dir_cleans_on_panic_unwind() {
             4,
             pipeline_dir.path(),
             crate::pipeline::memory::ConsumerHandle::new(),
+            true,
         )
         .unwrap();
         let schema = schema_with(&["k"]);
@@ -186,6 +188,7 @@ fn spill_activates_under_tiny_budget() {
         4,
         dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
+        true,
     )
     .unwrap();
     let budget = tiny_budget();
@@ -223,6 +226,7 @@ fn lazy_probe_spill_routes_to_partition_file() {
         4,
         dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
+        true,
     )
     .unwrap();
     let budget = tiny_budget();
@@ -427,6 +431,7 @@ fn execute_grace_hash_partition_pair_correct() {
         ctx: &ctx,
         budget: &budget,
         spill_dir: dir.path(),
+        spill_compress: true,
         consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
         strategy: clinker_plan::config::ErrorStrategy::FailFast,
     })
@@ -617,6 +622,7 @@ fn execute_grace_hash_spill_then_reload_correct() {
         ctx: &ctx,
         budget: &budget,
         spill_dir: dir.path(),
+        spill_compress: true,
         consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
         strategy: clinker_plan::config::ErrorStrategy::FailFast,
     })
@@ -802,6 +808,7 @@ fn execute_grace_hash_aborts_on_disk_quota_overflow() {
         ctx: &ctx,
         budget: &budget,
         spill_dir: dir.path(),
+        spill_compress: true,
         consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
         strategy: clinker_plan::config::ErrorStrategy::FailFast,
     });
@@ -844,6 +851,7 @@ fn build_spill_reload_records_match() {
         2,
         dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
+        true,
     )
     .unwrap();
     let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy)); // never spills via budget
@@ -1085,6 +1093,7 @@ fn with_reload_context<R>(h: &BnlHarness, f: impl FnOnce(&ReloadContext<'_>) -> 
         build_schema: Arc::clone(&h.build_schema),
         driver_schema: Arc::clone(&h.driver_schema),
         spill_dir: h.spill_dir.path(),
+        spill_compress: true,
         hash_state: &h.hash_state,
     };
     f(&rc)
@@ -1100,7 +1109,7 @@ fn spill_for_bnl(
     partition_id: u16,
     hash_bits: u8,
 ) -> SpilledPartition {
-    let mut bw = GraceSpillWriter::new(h.spill_dir.path(), hash_bits, partition_id).unwrap();
+    let mut bw = GraceSpillWriter::new(h.spill_dir.path(), hash_bits, partition_id, true).unwrap();
     let mut sketch = Hll::new();
     for r in build_records {
         bw.write_record(r).unwrap();
@@ -1115,7 +1124,8 @@ fn spill_for_bnl(
     let mut probe_files: Vec<SpillFilePath> = Vec::new();
     if !probe_records.is_empty() {
         let mut pw =
-            GraceSpillWriter::new(h.spill_dir.path(), hash_bits, partition_id | 0x8000).unwrap();
+            GraceSpillWriter::new(h.spill_dir.path(), hash_bits, partition_id | 0x8000, true)
+                .unwrap();
         for r in probe_records {
             pw.write_record(r).unwrap();
         }

--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -3,24 +3,32 @@
 //! Format per file:
 //!
 //! ```text
-//! [body: LZ4 frame containing
-//!        a stream of records, each prefixed by a 4-byte LE length and
-//!        encoded as a postcard-serialized `Record` (RecordPayload shape)]
+//! [tag:  format byte — 0x00 uncompressed, 0x01 LZ4 frame]
+//! [body: a stream of records, each prefixed by a 4-byte LE length and
+//!        encoded as a postcard-serialized `Record` (RecordPayload shape);
+//!        raw when the tag is 0x00, inside an LZ4 frame when 0x01]
 //! [footer: magic u32 LE | version u16 LE | hash_bits u8 |
 //!          partition_id u16 LE | record_count u64 LE]
 //! ```
 //!
+//! The leading format tag records the workspace `[storage.spill] compress`
+//! decision (see [`clinker_plan::config::CompressMode`]) so the reader
+//! dispatches on the on-disk format without the writer's choice having to
+//! travel out of band — the same posture the inter-stage
+//! [`SpillWriter`](crate::pipeline::spill::SpillWriter) uses. `off` skips
+//! the LZ4 frame so small partition spills avoid LZ4's per-frame fixed cost.
+//!
 //! The footer-trailing layout sidesteps the LZ4 frame finalization
 //! problem: an LZ4 frame cannot be reopened to overwrite a prefix
 //! without rewriting it, and seeking inside a partially-flushed frame
-//! corrupts the encoder state. By writing the LZ4 frame first and then
+//! corrupts the encoder state. By writing the body first and then
 //! appending a fixed-size raw footer, we get an exact `record_count`
 //! at finish-time without juggling encoder buffers.
 //!
-//! Reader path validates the footer magic and version, then opens an
-//! LZ4 decode stream over the body and yields records via postcard.
-//! A 64MB per-record byte budget bounds reader allocations against
-//! malformed input.
+//! Reader path validates the footer magic and version, then opens a
+//! decode stream over the body (matching the format tag) and yields
+//! records via postcard. A 64MB per-record byte budget bounds reader
+//! allocations against malformed input.
 
 use std::fs::File;
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
@@ -32,6 +40,77 @@ use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 use clinker_plan::SpillError;
 use clinker_plan::error::PipelineError;
 use clinker_record::{Record, RecordPayload, Schema};
+
+/// On-disk format tag for an uncompressed grace spill body: the postcard
+/// record stream is written raw, with no LZ4 frame.
+const FORMAT_TAG_UNCOMPRESSED: u8 = 0x00;
+/// On-disk format tag for an LZ4-frame-compressed grace spill body.
+const FORMAT_TAG_LZ4: u8 = 0x01;
+/// Byte length of the leading format tag.
+const TAG_SIZE: u64 = 1;
+
+/// Record-stream sink for a grace spill body: either a raw buffered file
+/// writer (uncompressed) or an LZ4 frame encoder wrapping one. Mirrors the
+/// inter-stage spill path's `SpillSink`; the variant is chosen at
+/// construction from the resolved compression decision and recorded in the
+/// file's leading format tag.
+enum GraceSpillSink {
+    /// Uncompressed: postcard records written straight to the buffered file.
+    Uncompressed(BufWriter<File>),
+    /// LZ4-frame-compressed: the historical default for large partition spills.
+    Lz4(FrameEncoder<BufWriter<File>>),
+}
+
+impl Write for GraceSpillSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            GraceSpillSink::Uncompressed(w) => w.write(buf),
+            GraceSpillSink::Lz4(e) => e.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            GraceSpillSink::Uncompressed(w) => w.flush(),
+            GraceSpillSink::Lz4(e) => e.flush(),
+        }
+    }
+}
+
+impl GraceSpillSink {
+    /// Finalize the body stream and recover the underlying file. For LZ4
+    /// this flushes the frame's buffered tail (its `Into<io::Error>`
+    /// conversion preserves the inner `io::Error` and its `StorageFull`
+    /// kind for the classifier); for the uncompressed sink it flushes the
+    /// `BufWriter`.
+    fn into_file(self) -> std::io::Result<File> {
+        let buf_writer = match self {
+            GraceSpillSink::Uncompressed(w) => w,
+            GraceSpillSink::Lz4(e) => e.finish().map_err(std::io::Error::from)?,
+        };
+        buf_writer.into_inner().map_err(|e| e.into_error())
+    }
+}
+
+/// Record-stream source for a grace spill body, mirroring [`GraceSpillSink`]:
+/// either a raw bounded file (uncompressed) or an LZ4 decoder over one. The
+/// variant is selected from the file's leading format tag at
+/// [`GraceSpillReader::open`].
+enum GraceSpillSource {
+    /// Uncompressed: postcard records read straight from the bounded body.
+    Uncompressed(BoundedRead),
+    /// LZ4-frame-compressed.
+    Lz4(FrameDecoder<BoundedRead>),
+}
+
+impl Read for GraceSpillSource {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            GraceSpillSource::Uncompressed(r) => r.read(buf),
+            GraceSpillSource::Lz4(r) => r.read(buf),
+        }
+    }
+}
 
 /// Failure raised while writing a grace-hash partition spill.
 ///
@@ -134,13 +213,14 @@ pub(crate) struct SpillHeader {
 
 /// Streaming writer for one partition's worth of records.
 ///
-/// Owns a temp file handle plus an LZ4 frame encoder over a buffered
-/// writer. `write_record` postcard-encodes the record and emits a
-/// length-prefixed body chunk. `finish` finalizes the LZ4 frame, appends
-/// the raw footer, and returns the file path; the caller takes ownership
-/// of cleanup via the surrounding `tempfile::TempDir`.
+/// Owns a body sink — a raw buffered file writer or an LZ4 frame encoder
+/// over one, chosen from the resolved compression decision and recorded in
+/// the leading format tag. `write_record` postcard-encodes the record and
+/// emits a length-prefixed body chunk. `finish` finalizes the body, appends
+/// the raw footer, and returns the file path; the caller takes ownership of
+/// cleanup via the surrounding `tempfile::TempDir`.
 pub(crate) struct GraceSpillWriter {
-    encoder: FrameEncoder<BufWriter<File>>,
+    sink: GraceSpillSink,
     path: PathBuf,
     hash_bits: u8,
     partition_id: u16,
@@ -152,10 +232,18 @@ impl GraceSpillWriter {
     /// `partition_id` plus a per-process monotonic sequence so a
     /// single partition that fans out across multiple spill flushes
     /// doesn't overwrite earlier files.
+    ///
+    /// `compress` selects the body encoding: `true` wraps the postcard
+    /// record stream in an LZ4 frame, `false` writes it raw. The caller
+    /// resolves it from the workspace `[storage.spill] compress` knob (see
+    /// [`clinker_plan::config::CompressMode`]); the choice is recorded in
+    /// the file's leading format tag so the reader dispatches without
+    /// out-of-band state.
     pub(crate) fn new(
         dir: &Path,
         hash_bits: u8,
         partition_id: u16,
+        compress: bool,
     ) -> Result<Self, GraceSpillError> {
         use std::sync::atomic::{AtomicU64, Ordering};
         static SEQ: AtomicU64 = AtomicU64::new(0);
@@ -171,21 +259,32 @@ impl GraceSpillWriter {
         // paths do, rather than rendering as a generic internal error. A
         // genuine byte fault on create stays `SpillError::Io` and re-narrows
         // to `GraceSpillError::Io`.
-        let file =
-            File::create(&path).map_err(|e| match SpillError::from_spill_dir_io(dir, e) {
-                dir_err @ SpillError::DirUnavailable { .. } => {
-                    GraceSpillError::DirUnavailable(dir_err)
-                }
-                disk_err @ SpillError::DiskFull { .. } => GraceSpillError::DiskFull(disk_err),
-                SpillError::Io(io) => GraceSpillError::Io(io),
-                // `from_spill_dir_io` returns only `DirUnavailable`, `DiskFull`,
-                // or `Io`; any other variant would be a classifier regression.
-                other => GraceSpillError::Io(std::io::Error::other(other.to_string())),
-            })?;
+        let classify_create = |e: std::io::Error| match SpillError::from_spill_dir_io(dir, e) {
+            dir_err @ SpillError::DirUnavailable { .. } => GraceSpillError::DirUnavailable(dir_err),
+            disk_err @ SpillError::DiskFull { .. } => GraceSpillError::DiskFull(disk_err),
+            SpillError::Io(io) => GraceSpillError::Io(io),
+            // `from_spill_dir_io` returns only `DirUnavailable`, `DiskFull`,
+            // or `Io`; any other variant would be a classifier regression.
+            other => GraceSpillError::Io(std::io::Error::other(other.to_string())),
+        };
+        let mut file = File::create(&path).map_err(classify_create)?;
+        // The format tag is the very first on-disk byte and sits ahead of the
+        // (optionally framed) body so the reader can dispatch before opening a
+        // decoder.
+        let tag = if compress {
+            FORMAT_TAG_LZ4
+        } else {
+            FORMAT_TAG_UNCOMPRESSED
+        };
+        file.write_all(&[tag]).map_err(classify_create)?;
         let buf = BufWriter::new(file);
-        let encoder = FrameEncoder::new(buf);
+        let sink = if compress {
+            GraceSpillSink::Lz4(FrameEncoder::new(buf))
+        } else {
+            GraceSpillSink::Uncompressed(buf)
+        };
         Ok(Self {
-            encoder,
+            sink,
             path,
             hash_bits,
             partition_id,
@@ -206,18 +305,19 @@ impl GraceSpillWriter {
             .map_err(|_| std::io::Error::other("grace spill: record exceeds u32 byte length"))?;
         // Classify a write fault against the partition directory so an
         // `ENOSPC` mid-stream surfaces as `DiskFull` (E321), not internal Io.
-        if let Err(e) = self.encoder.write_all(&len.to_le_bytes()) {
+        if let Err(e) = self.sink.write_all(&len.to_le_bytes()) {
             return Err(self.classify_io(e));
         }
-        if let Err(e) = self.encoder.write_all(&bytes) {
+        if let Err(e) = self.sink.write_all(&bytes) {
             return Err(self.classify_io(e));
         }
         self.record_count += 1;
         Ok(())
     }
 
-    /// Finalize the LZ4 frame, append the footer, return the file
-    /// path along with the byte length of the finished file.
+    /// Finalize the body (LZ4 frame when compressed, a flush when raw),
+    /// append the footer, and return the file path along with the byte
+    /// length of the finished file.
     ///
     /// The byte length feeds [`crate::pipeline::memory::MemoryArbitrator::record_spill_bytes`]
     /// so the disk-quota poll can tally cumulative on-disk usage
@@ -241,17 +341,15 @@ impl GraceSpillWriter {
             }
         };
         let Self {
-            encoder,
+            sink,
             path,
             hash_bits,
             partition_id,
             record_count,
         } = self;
-        let buf = encoder
-            .finish()
-            .map_err(|e| classify(std::io::Error::from(e)))?;
-        let mut file = buf.into_inner().map_err(|e| classify(e.into_error()))?;
-        // Seek to current end and append footer; LZ4 frame is closed.
+        let mut file = sink.into_file().map_err(&classify)?;
+        // Seek to current end and append footer; the body (raw or LZ4 frame)
+        // is closed, and the leading format tag is already on disk.
         let body_end = file.seek(SeekFrom::End(0)).map_err(&classify)?;
         let mut footer = [0u8; FOOTER_SIZE];
         footer[0..4].copy_from_slice(&GRACE_SPILL_MAGIC.to_le_bytes());
@@ -268,11 +366,12 @@ impl GraceSpillWriter {
 
 /// Streaming reader for a finalized spill file.
 ///
-/// Validates the footer magic + version on `open`. Yields records via
-/// `Iterator` until either the LZ4 stream returns EOF mid-frame or the
-/// recorded `record_count` is exhausted.
+/// Validates the footer magic + version on `open`, then dispatches the body
+/// source on the leading format tag (raw vs LZ4). Yields records via
+/// `Iterator` until either the body stream returns EOF or the recorded
+/// `record_count` is exhausted.
 pub(crate) struct GraceSpillReader {
-    decoder: FrameDecoder<BoundedRead>,
+    source: GraceSpillSource,
     schema: Arc<Schema>,
     header: SpillHeader,
     records_read: u64,
@@ -280,21 +379,26 @@ pub(crate) struct GraceSpillReader {
 }
 
 impl GraceSpillReader {
-    /// Open a spill file and validate its footer. The schema is supplied
-    /// by the caller and reattached to each record on read; the file does
-    /// not embed schema.
+    /// Open a spill file, validate its footer, and select the body source
+    /// from the leading format tag. The schema is supplied by the caller and
+    /// reattached to each record on read; the file does not embed schema.
     pub(crate) fn open(path: &Path, schema: Arc<Schema>) -> std::io::Result<Self> {
         let mut file = File::open(path)?;
         let total_len = file.metadata()?.len();
-        if total_len < FOOTER_SIZE as u64 {
+        // The on-disk layout is `tag (1) ++ body ++ footer`; a file shorter
+        // than tag + footer cannot hold even an empty body.
+        let min_len = TAG_SIZE + FOOTER_SIZE as u64;
+        if total_len < min_len {
             return Err(std::io::Error::other(format!(
-                "grace spill {} too short ({total_len} bytes < {FOOTER_SIZE} footer bytes)",
+                "grace spill {} too short ({total_len} bytes < {min_len} tag+footer bytes)",
                 path.display()
             )));
         }
-        let body_len = total_len - FOOTER_SIZE as u64;
+        // Footer sits at the file tail; the body spans `[TAG_SIZE, footer)`.
+        let footer_start = total_len - FOOTER_SIZE as u64;
+        let body_len = footer_start - TAG_SIZE;
         // Read footer.
-        file.seek(SeekFrom::Start(body_len))?;
+        file.seek(SeekFrom::Start(footer_start))?;
         let mut footer = [0u8; FOOTER_SIZE];
         file.read_exact(&mut footer)?;
         let header = SpillHeader {
@@ -320,13 +424,26 @@ impl GraceSpillReader {
                 GRACE_SPILL_VERSION
             )));
         }
-        // Rewind for body read; bound the read at body_len so the LZ4
-        // decoder never advances past the body into the footer.
+        // Read the format tag at offset 0, then position the body read at
+        // offset TAG_SIZE bounded by `body_len` so the decoder never advances
+        // past the body into the footer.
         file.seek(SeekFrom::Start(0))?;
+        let mut tag = [0u8; 1];
+        file.read_exact(&mut tag)?;
+        file.seek(SeekFrom::Start(TAG_SIZE))?;
         let bounded = BoundedRead::new(file, body_len);
-        let decoder = FrameDecoder::new(bounded);
+        let source = match tag[0] {
+            FORMAT_TAG_LZ4 => GraceSpillSource::Lz4(FrameDecoder::new(bounded)),
+            FORMAT_TAG_UNCOMPRESSED => GraceSpillSource::Uncompressed(bounded),
+            other => {
+                return Err(std::io::Error::other(format!(
+                    "grace spill {}: unknown format tag {other:#04x}; file is corrupt",
+                    path.display()
+                )));
+            }
+        };
         Ok(Self {
-            decoder,
+            source,
             schema,
             header,
             records_read: 0,
@@ -346,7 +463,7 @@ impl Iterator for GraceSpillReader {
         if self.records_read >= self.header.record_count {
             return None;
         }
-        match self.decoder.read_exact(&mut self.len_buf) {
+        match self.source.read_exact(&mut self.len_buf) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 // Stream ended before the recorded record_count was
@@ -367,7 +484,7 @@ impl Iterator for GraceSpillReader {
             ))));
         }
         let mut buf = vec![0u8; len];
-        if let Err(e) = self.decoder.read_exact(&mut buf) {
+        if let Err(e) = self.source.read_exact(&mut buf) {
             return Some(Err(e));
         }
         let payload: RecordPayload = match postcard::from_bytes(&buf) {
@@ -380,7 +497,8 @@ impl Iterator for GraceSpillReader {
 }
 
 /// `Read` adapter that surfaces EOF after `limit` bytes. Wraps the
-/// spill file so the LZ4 decoder cannot stray into the trailing footer.
+/// spill file's body region so neither the raw record reader nor the LZ4
+/// decoder strays into the trailing footer.
 struct BoundedRead {
     inner: File,
     remaining: u64,
@@ -424,47 +542,99 @@ mod tests {
         )
     }
 
+    /// LZ4 frame magic number, little-endian `0x184D2204` — the four bytes a
+    /// compressed grace body opens with right after the 1-byte format tag.
+    const LZ4_FRAME_MAGIC: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
+
     #[test]
     fn writer_reader_roundtrip() {
+        // Round-trip through both the compressed and the uncompressed body
+        // format; the knob changes only on-disk bytes, never the records.
+        for compress in [true, false] {
+            let dir = TempDir::new().unwrap();
+            let s = schema();
+            let mut w = GraceSpillWriter::new(dir.path(), 4, 7, compress).unwrap();
+            for i in 0..50 {
+                w.write_record(&record(&s, i, &format!("row-{i}"))).unwrap();
+            }
+            let (path, bytes) = w.finish().unwrap();
+            let on_disk = std::fs::metadata(&*path).unwrap().len();
+            assert_eq!(
+                bytes, on_disk,
+                "reported byte count must match file size (compress={compress})"
+            );
+
+            let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
+            assert_eq!(reader.header().record_count, 50);
+            assert_eq!(reader.header().hash_bits, 4);
+            assert_eq!(reader.header().partition_id, 7);
+            let recs: Vec<Record> = reader.map(|r| r.unwrap()).collect();
+            assert_eq!(recs.len(), 50, "compress={compress}");
+            for (i, r) in recs.iter().enumerate() {
+                assert_eq!(r.get("id"), Some(&Value::Integer(i as i64)));
+                assert_eq!(r.get("v"), Some(&Value::String(format!("row-{i}").into())));
+            }
+        }
+    }
+
+    // The leading format tag must record the writer's compression choice and
+    // the body must honor it: an `off` grace spill is byte-raw (no LZ4 frame
+    // magic after the tag) and an `on` one is LZ4-framed. This is the grace
+    // half of the `[storage.spill] compress` knob guarantee — without it the
+    // `--explain` per-operator compress line is a falsehood for grace-hash
+    // Combine and SortMerge Phase B.
+    #[test]
+    fn format_tag_and_body_honor_compress_knob() {
         let dir = TempDir::new().unwrap();
         let s = schema();
-        let mut w = GraceSpillWriter::new(dir.path(), 4, 7).unwrap();
-        for i in 0..50 {
-            w.write_record(&record(&s, i, &format!("row-{i}"))).unwrap();
-        }
-        let (path, bytes) = w.finish().unwrap();
-        let on_disk = std::fs::metadata(&*path).unwrap().len();
-        assert_eq!(bytes, on_disk, "reported byte count must match file size");
-
-        let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
-        assert_eq!(reader.header().record_count, 50);
-        assert_eq!(reader.header().hash_bits, 4);
-        assert_eq!(reader.header().partition_id, 7);
-        let recs: Vec<Record> = reader.map(|r| r.unwrap()).collect();
-        assert_eq!(recs.len(), 50);
-        for (i, r) in recs.iter().enumerate() {
-            assert_eq!(r.get("id"), Some(&Value::Integer(i as i64)));
-            assert_eq!(r.get("v"), Some(&Value::String(format!("row-{i}").into())));
+        for (compress, expected_tag) in [(true, FORMAT_TAG_LZ4), (false, FORMAT_TAG_UNCOMPRESSED)] {
+            let mut w = GraceSpillWriter::new(dir.path(), 4, 3, compress).unwrap();
+            for i in 0..8 {
+                w.write_record(&record(&s, i, "x")).unwrap();
+            }
+            let (path, _bytes) = w.finish().unwrap();
+            let raw = std::fs::read(&*path).unwrap();
+            assert_eq!(
+                raw[0], expected_tag,
+                "compress={compress} must write tag {expected_tag:#04x}"
+            );
+            // The four bytes after the tag are the LZ4 frame magic only when
+            // compressed; an `off` body opens straight into the first
+            // length-prefixed postcard record, never the frame magic.
+            let body_head = &raw[1..5];
+            if compress {
+                assert_eq!(
+                    body_head, &LZ4_FRAME_MAGIC,
+                    "on-mode body must be LZ4-framed"
+                );
+            } else {
+                assert_ne!(
+                    body_head, &LZ4_FRAME_MAGIC,
+                    "off-mode body must be byte-raw, with no LZ4 frame magic"
+                );
+            }
         }
     }
 
     #[test]
     fn empty_partition_iterates_cleanly() {
-        let dir = TempDir::new().unwrap();
-        let s = schema();
-        let w = GraceSpillWriter::new(dir.path(), 4, 0).unwrap();
-        let (path, _bytes) = w.finish().unwrap();
-        let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
-        assert_eq!(reader.header().record_count, 0);
-        let recs: Vec<_> = reader.collect();
-        assert!(recs.is_empty());
+        for compress in [true, false] {
+            let dir = TempDir::new().unwrap();
+            let s = schema();
+            let w = GraceSpillWriter::new(dir.path(), 4, 0, compress).unwrap();
+            let (path, _bytes) = w.finish().unwrap();
+            let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
+            assert_eq!(reader.header().record_count, 0);
+            let recs: Vec<_> = reader.collect();
+            assert!(recs.is_empty(), "compress={compress}");
+        }
     }
 
     #[test]
     fn truncated_body_returns_error() {
         let dir = TempDir::new().unwrap();
         let s = schema();
-        let mut w = GraceSpillWriter::new(dir.path(), 4, 1).unwrap();
+        let mut w = GraceSpillWriter::new(dir.path(), 4, 1, true).unwrap();
         for i in 0..10 {
             w.write_record(&record(&s, i, "x")).unwrap();
         }
@@ -507,7 +677,7 @@ mod tests {
     fn bad_magic_rejected() {
         let dir = TempDir::new().unwrap();
         let s = schema();
-        let mut w = GraceSpillWriter::new(dir.path(), 4, 0).unwrap();
+        let mut w = GraceSpillWriter::new(dir.path(), 4, 0, true).unwrap();
         w.write_record(&record(&s, 1, "a")).unwrap();
         let (path, _bytes) = w.finish().unwrap();
 
@@ -539,7 +709,7 @@ mod tests {
         std::fs::create_dir(&spill_dir).unwrap();
         std::fs::remove_dir(&spill_dir).unwrap();
 
-        let err = match GraceSpillWriter::new(&spill_dir, 4, 0) {
+        let err = match GraceSpillWriter::new(&spill_dir, 4, 0, true) {
             Ok(_) => panic!("GraceSpillWriter::new should fail when the dir is gone"),
             Err(e) => e,
         };

--- a/crates/clinker-exec/src/pipeline/sort_buffer.rs
+++ b/crates/clinker-exec/src/pipeline/sort_buffer.rs
@@ -3,7 +3,8 @@
 //!
 //! Used at source-sort, output-sort, and DAG enforcer-sort intercept points.
 //! The buffer tracks its own memory usage and spills sorted chunks to
-//! NDJSON+LZ4 temp files when the budget is exceeded.
+//! postcard temp files — optionally LZ4-framed per the workspace
+//! `[storage.spill] compress` knob — when the budget is exceeded.
 //!
 //! Generic over per-record payload `P`. Source/output sort uses
 //! `SortBuffer<()>`; the DAG executor's `PlanNode::Sort` dispatch arm uses
@@ -43,6 +44,11 @@ pub struct SortBuffer<P> {
     bytes_used: usize,
     spill_threshold: usize,
     spill_dir: Option<PathBuf>,
+    /// Whether spilled sorted runs are LZ4-compressed. Resolved by the caller
+    /// from the workspace `[storage.spill] compress` knob against the sort
+    /// schema's width and the run's batch size, so the on-disk format matches
+    /// what `--explain` reports.
+    spill_compress: bool,
     spill_files: Vec<SpillFile<P>>,
     schema: Arc<Schema>,
 }
@@ -52,6 +58,7 @@ impl<P: Serialize + DeserializeOwned + Send> SortBuffer<P> {
         sort_by: Vec<SortField>,
         spill_threshold: usize,
         spill_dir: Option<PathBuf>,
+        spill_compress: bool,
         schema: Arc<Schema>,
     ) -> Self {
         Self {
@@ -60,6 +67,7 @@ impl<P: Serialize + DeserializeOwned + Send> SortBuffer<P> {
             bytes_used: 0,
             spill_threshold,
             spill_dir,
+            spill_compress,
             spill_files: Vec::new(),
             schema,
         }
@@ -92,8 +100,11 @@ impl<P: Serialize + DeserializeOwned + Send> SortBuffer<P> {
         self.pairs
             .par_sort_by(|(a, _), (b, _)| compare_records_by_fields(a, b, sort_by));
 
-        let mut writer: SpillWriter<P> =
-            SpillWriter::new(self.schema.clone(), self.spill_dir.as_deref())?;
+        let mut writer: SpillWriter<P> = SpillWriter::new(
+            self.schema.clone(),
+            self.spill_dir.as_deref(),
+            self.spill_compress,
+        )?;
         for (record, payload) in self.pairs.drain(..) {
             writer.write_pair(&record, &payload)?;
         }
@@ -210,7 +221,7 @@ mod tests {
     fn test_sort_buffer_push_tracks_bytes() {
         let schema = test_schema();
         let mut buf: SortBuffer<()> =
-            SortBuffer::new(sort_by_value_asc(), 1_000_000, None, schema.clone());
+            SortBuffer::new(sort_by_value_asc(), 1_000_000, None, true, schema.clone());
         assert_eq!(buf.bytes_used(), 0);
         buf.push(make_record(&schema, "Alice", 1), ());
         assert!(buf.bytes_used() > 0);
@@ -224,7 +235,7 @@ mod tests {
         let schema = test_schema();
         // Very small threshold — should spill after a few records
         let mut buf: SortBuffer<()> =
-            SortBuffer::new(sort_by_value_asc(), 100, None, schema.clone());
+            SortBuffer::new(sort_by_value_asc(), 100, None, true, schema.clone());
         assert!(!buf.should_spill());
         // Push records until we exceed 100 bytes
         for i in 0..10 {
@@ -240,7 +251,7 @@ mod tests {
     fn test_sort_buffer_in_memory_sort() {
         let schema = test_schema();
         let mut buf: SortBuffer<()> =
-            SortBuffer::new(sort_by_value_asc(), 1_000_000, None, schema.clone());
+            SortBuffer::new(sort_by_value_asc(), 1_000_000, None, true, schema.clone());
         buf.push(make_record(&schema, "Charlie", 30), ());
         buf.push(make_record(&schema, "Alice", 10), ());
         buf.push(make_record(&schema, "Bob", 20), ());
@@ -259,7 +270,8 @@ mod tests {
     #[test]
     fn test_sort_buffer_spill_produces_spill_files() {
         let schema = test_schema();
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by_value_asc(), 1, None, schema.clone()); // threshold=1 → spill immediately
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by_value_asc(), 1, None, true, schema.clone()); // threshold=1 → spill immediately
         buf.push(make_record(&schema, "Alice", 10), ());
         assert!(buf.should_spill());
         buf.sort_and_spill().unwrap();
@@ -270,7 +282,8 @@ mod tests {
     #[test]
     fn test_sort_buffer_finish_spilled_returns_files() {
         let schema = test_schema();
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by_value_asc(), 1, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by_value_asc(), 1, None, true, schema.clone());
 
         // Push and spill twice
         buf.push(make_record(&schema, "B", 20), ());
@@ -291,7 +304,8 @@ mod tests {
     #[test]
     fn test_sort_buffer_spill_files_are_sorted() {
         let schema = test_schema();
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by_value_asc(), 1, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by_value_asc(), 1, None, true, schema.clone());
         buf.push(make_record(&schema, "C", 30), ());
         buf.push(make_record(&schema, "A", 10), ());
         buf.push(make_record(&schema, "B", 20), ());
@@ -316,7 +330,7 @@ mod tests {
         // Pattern B gate: payload travels with the record through sort permutation.
         let schema = test_schema();
         let mut buf: SortBuffer<u64> =
-            SortBuffer::new(sort_by_value_asc(), 1_000_000, None, schema.clone());
+            SortBuffer::new(sort_by_value_asc(), 1_000_000, None, true, schema.clone());
         buf.push(make_record(&schema, "Charlie", 30), 100);
         buf.push(make_record(&schema, "Alice", 10), 200);
         buf.push(make_record(&schema, "Bob", 20), 300);
@@ -334,10 +348,10 @@ mod tests {
 
     #[test]
     fn test_sort_buffer_payload_survives_spill() {
-        // Pattern B gate: payload survives the NDJSON+LZ4 spill envelope.
+        // Payload survives the postcard spill envelope through the round-trip.
         let schema = test_schema();
         let mut buf: SortBuffer<u64> =
-            SortBuffer::new(sort_by_value_asc(), 1, None, schema.clone());
+            SortBuffer::new(sort_by_value_asc(), 1, None, true, schema.clone());
         buf.push(make_record(&schema, "C", 30), 100);
         buf.push(make_record(&schema, "A", 10), 200);
         buf.push(make_record(&schema, "B", 20), 300);
@@ -361,7 +375,8 @@ mod tests {
     #[test]
     fn test_sort_buffer_empty_returns_empty() {
         let schema = test_schema();
-        let buf: SortBuffer<()> = SortBuffer::new(sort_by_value_asc(), 1_000_000, None, schema);
+        let buf: SortBuffer<()> =
+            SortBuffer::new(sort_by_value_asc(), 1_000_000, None, true, schema);
         match buf.finish().unwrap() {
             SortedOutput::InMemory(pairs) => assert!(pairs.is_empty()),
             SortedOutput::Spilled(_) => panic!("expected InMemory"),

--- a/crates/clinker-exec/src/pipeline/sort_integration.rs
+++ b/crates/clinker-exec/src/pipeline/sort_integration.rs
@@ -101,7 +101,8 @@ mod tests {
     fn test_sort_single_field_asc() {
         let schema = schema_2();
         let sort_by = vec![sf("value", SortOrder::Asc)];
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 10_000_000, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by, 10_000_000, None, true, schema.clone());
         for i in (0..100).rev() {
             buf.push(rec2(&schema, &format!("r{i}"), i), ());
         }
@@ -120,7 +121,8 @@ mod tests {
     fn test_sort_single_field_desc() {
         let schema = schema_2();
         let sort_by = vec![sf("name", SortOrder::Desc)];
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 10_000_000, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by, 10_000_000, None, true, schema.clone());
         for name in &["alpha", "charlie", "bravo", "delta", "echo"] {
             buf.push(rec2(&schema, name, 0), ());
         }
@@ -143,7 +145,8 @@ mod tests {
     fn test_sort_compound_keys() {
         let schema = schema_3();
         let sort_by = vec![sf("dept", SortOrder::Asc), sf("salary", SortOrder::Desc)];
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 10_000_000, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by, 10_000_000, None, true, schema.clone());
         buf.push(rec3(&schema, "B", 200, 1), ());
         buf.push(rec3(&schema, "A", 100, 2), ());
         buf.push(rec3(&schema, "A", 300, 3), ());
@@ -166,7 +169,8 @@ mod tests {
     fn test_sort_nulls_first() {
         let schema = schema_2();
         let sort_by = vec![sf_nulls("value", SortOrder::Asc, NullOrder::First)];
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 10_000_000, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by, 10_000_000, None, true, schema.clone());
         buf.push(rec2(&schema, "a", 30), ());
         buf.push(
             Record::new(schema.clone(), vec![Value::String("b".into()), Value::Null]),
@@ -187,7 +191,8 @@ mod tests {
     fn test_sort_nulls_last() {
         let schema = schema_2();
         let sort_by = vec![sf_nulls("value", SortOrder::Asc, NullOrder::Last)];
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 10_000_000, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by, 10_000_000, None, true, schema.clone());
         buf.push(rec2(&schema, "a", 30), ());
         buf.push(
             Record::new(schema.clone(), vec![Value::String("b".into()), Value::Null]),
@@ -208,7 +213,8 @@ mod tests {
     fn test_sort_stable_equal_keys() {
         let schema = schema_3();
         let sort_by = vec![sf("dept", SortOrder::Asc)];
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 10_000_000, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by, 10_000_000, None, true, schema.clone());
         // All same dept — seq should preserve original order (stable sort)
         buf.push(rec3(&schema, "A", 100, 1), ());
         buf.push(rec3(&schema, "A", 200, 2), ());
@@ -229,7 +235,7 @@ mod tests {
         let schema = schema_2();
         let sort_by = vec![sf("value", SortOrder::Asc)];
         // 1KB budget — records will exceed this quickly
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 1024, None, schema.clone());
+        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by, 1024, None, true, schema.clone());
         let mut spilled = false;
         for i in 0..100 {
             buf.push(rec2(&schema, &format!("record_{i:04}"), i), ());
@@ -246,7 +252,8 @@ mod tests {
         let schema = schema_2();
         let sort_by = vec![sf("value", SortOrder::Asc)];
         // Create 32 spill files (exceeds k_max=16 → requires cascade)
-        let mut buf: SortBuffer<()> = SortBuffer::new(sort_by.clone(), 1, None, schema.clone());
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by.clone(), 1, None, true, schema.clone());
         for i in 0..32 {
             buf.push(rec2(&schema, &format!("r{i}"), i), ());
             buf.sort_and_spill().unwrap();
@@ -271,8 +278,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let schema = schema_2();
         let sort_by = vec![sf("value", SortOrder::Asc)];
-        let mut buf: SortBuffer<()> =
-            SortBuffer::new(sort_by, 1, Some(dir.path().to_path_buf()), schema.clone());
+        let mut buf: SortBuffer<()> = SortBuffer::new(
+            sort_by,
+            1,
+            Some(dir.path().to_path_buf()),
+            true,
+            schema.clone(),
+        );
         for i in 0..5 {
             buf.push(rec2(&schema, &format!("r{i}"), i), ());
             buf.sort_and_spill().unwrap();
@@ -311,6 +323,7 @@ mod tests {
             sort_by,
             10_000_000,
             Some(dir.path().to_path_buf()),
+            true,
             schema.clone(),
         );
         for i in (0..10).rev() {

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -368,6 +368,11 @@ pub(crate) struct SortMergeExec<'a> {
     /// land inside it; the surrounding `Arc<TempDir>` Drop is the
     /// secondary panic-safe cleanup sweep.
     pub spill_dir: &'a Path,
+    /// Whether Phase A external-sort spill runs are LZ4-compressed. Resolved
+    /// by the dispatcher from the workspace `[storage.spill] compress` knob
+    /// against the combine's schema width and batch size, so the on-disk
+    /// format matches what `--explain` reports.
+    pub spill_compress: bool,
     /// Shared with the registered `SortMergeConsumer` wrapper.
     /// Phase A per-side `SortBuffer.bytes_used` plus Phase B
     /// matching-run accumulator size mirror into `handle.bytes`
@@ -442,6 +447,7 @@ fn execute_combine_sort_merge_with_stats(
         ctx,
         budget,
         spill_dir,
+        spill_compress,
         consumer_handle,
         strategy,
     } = args;
@@ -623,6 +629,7 @@ fn execute_combine_sort_merge_with_stats(
             name,
             &driver_field,
             budget,
+            spill_compress,
             &consumer_handle,
         )?;
         sort_build_pairs_externally(
@@ -630,6 +637,7 @@ fn execute_combine_sort_merge_with_stats(
             name,
             &build_field,
             budget,
+            spill_compress,
             &consumer_handle,
         )?;
         stats.phase_a_sort_invocations = 2;
@@ -817,6 +825,7 @@ fn sort_driver_pairs_externally(
     name: &str,
     range_field: &Option<String>,
     budget: &MemoryArbitrator,
+    spill_compress: bool,
     consumer_handle: &Arc<crate::pipeline::memory::ConsumerHandle>,
 ) -> Result<(), PipelineError> {
     if pairs.is_empty() {
@@ -844,8 +853,13 @@ fn sort_driver_pairs_externally(
         order: clinker_plan::config::SortOrder::Asc,
         null_order: None,
     };
-    let mut buf: SortBuffer<RecordOrder> =
-        SortBuffer::new(vec![sort_field], spill_threshold, None, schema);
+    let mut buf: SortBuffer<RecordOrder> = SortBuffer::new(
+        vec![sort_field],
+        spill_threshold,
+        None,
+        spill_compress,
+        schema,
+    );
 
     // Track this helper's contribution to the consumer handle so the
     // Spilled-finish branch can rewind correctly. Without a local
@@ -945,6 +959,7 @@ fn sort_build_pairs_externally(
     name: &str,
     range_field: &Option<String>,
     budget: &MemoryArbitrator,
+    spill_compress: bool,
     consumer_handle: &Arc<crate::pipeline::memory::ConsumerHandle>,
 ) -> Result<(), PipelineError> {
     if pairs.is_empty() {
@@ -966,7 +981,13 @@ fn sort_build_pairs_externally(
         order: clinker_plan::config::SortOrder::Asc,
         null_order: None,
     };
-    let mut buf: SortBuffer<()> = SortBuffer::new(vec![sort_field], spill_threshold, None, schema);
+    let mut buf: SortBuffer<()> = SortBuffer::new(
+        vec![sort_field],
+        spill_threshold,
+        None,
+        spill_compress,
+        schema,
+    );
 
     let mut local_charged: u64 = 0;
 
@@ -1815,6 +1836,7 @@ mod tests {
             ctx: &ctx,
             budget: &mut budget,
             spill_dir: dir.path(),
+            spill_compress: true,
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
             strategy: clinker_plan::config::ErrorStrategy::FailFast,
         };

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -136,6 +136,7 @@ fn push_to_buffer(
     record: Record,
     byte_limit: usize,
     spill_dir: &std::path::Path,
+    spill_compress: bool,
     spill_seq: &mut u32,
     consumer_handle: &Arc<crate::pipeline::memory::ConsumerHandle>,
 ) -> Result<u64, GraceSpillError> {
@@ -154,7 +155,8 @@ fn push_to_buffer(
                 let mut drained = std::mem::take(records);
                 let schema = Arc::clone(drained[0].schema());
                 drained.push(record);
-                let (segment_path, written) = write_spill_segment(spill_dir, spill_seq, &drained)?;
+                let (segment_path, written) =
+                    write_spill_segment(spill_dir, spill_compress, spill_seq, &drained)?;
                 let count = drained.len() as u64;
                 *buf = MatchingRunBuffer::Spilled {
                     segments: vec![segment_path],
@@ -185,7 +187,8 @@ fn push_to_buffer(
                 let prev_tail = *tail_bytes as u64;
                 let mut drained = std::mem::take(tail);
                 drained.push(record);
-                let (segment_path, written) = write_spill_segment(spill_dir, spill_seq, &drained)?;
+                let (segment_path, written) =
+                    write_spill_segment(spill_dir, spill_compress, spill_seq, &drained)?;
                 *spilled_count = spilled_count.saturating_add(drained.len() as u64);
                 *tail_bytes = 0;
                 segments.push(segment_path);
@@ -208,12 +211,13 @@ fn push_to_buffer(
 /// [`crate::pipeline::memory::MemoryArbitrator::record_spill_bytes`].
 fn write_spill_segment(
     spill_dir: &std::path::Path,
+    spill_compress: bool,
     spill_seq: &mut u32,
     records: &[Record],
 ) -> Result<(SpillFilePath, u64), GraceSpillError> {
     let seq = *spill_seq;
     *spill_seq = spill_seq.wrapping_add(1);
-    let mut writer = GraceSpillWriter::new(spill_dir, 0, (seq & 0xFFFF) as u16)?;
+    let mut writer = GraceSpillWriter::new(spill_dir, 0, (seq & 0xFFFF) as u16, spill_compress)?;
     for r in records {
         writer.write_record(r)?;
     }
@@ -698,6 +702,7 @@ fn execute_combine_sort_merge_with_stats(
         ctx,
         byte_limit,
         spill_dir,
+        spill_compress,
         spill_seq: &mut spill_seq,
         stats: &mut stats,
         output: &mut output_records,
@@ -1087,6 +1092,11 @@ struct WalkArgs<'a, 'b, 'c> {
     ctx: &'a EvalContext<'a>,
     byte_limit: usize,
     spill_dir: &'a std::path::Path,
+    /// Whether Phase B matching-run spill segments are LZ4-compressed.
+    /// Carried from [`SortMergeExec::spill_compress`] so Phase B honors the
+    /// same `[storage.spill] compress` decision Phase A's external sort does
+    /// and `--explain` reports a single truthful mode for the operator.
+    spill_compress: bool,
     spill_seq: &'b mut u32,
     stats: &'b mut SortMergeStats,
     output: &'b mut Vec<(Record, RecordOrder)>,
@@ -1126,6 +1136,7 @@ fn walk_two_cursors(args: WalkArgs<'_, '_, '_>) -> Result<(), PipelineError> {
         ctx,
         byte_limit,
         spill_dir,
+        spill_compress,
         spill_seq,
         stats,
         output,
@@ -1159,6 +1170,7 @@ fn walk_two_cursors(args: WalkArgs<'_, '_, '_>) -> Result<(), PipelineError> {
                     build_record.clone(),
                     byte_limit,
                     spill_dir,
+                    spill_compress,
                     spill_seq,
                     consumer_handle,
                 )

--- a/crates/clinker-exec/src/pipeline/spill.rs
+++ b/crates/clinker-exec/src/pipeline/spill.rs
@@ -1,4 +1,5 @@
-//! Spill-to-disk infrastructure: LZ4-compressed record streams with a JSON schema header.
+//! Spill-to-disk infrastructure: postcard record streams, optionally
+//! LZ4-compressed, with a JSON schema header.
 //!
 //! `SpillWriter<P>` serializes (record, payload) pairs to a temp file;
 //! `SpillReader<P>` reads them back. Parameterized over per-record payload
@@ -13,10 +14,18 @@
 //! RFC and the KAFKA-9408 postmortem.
 //!
 //! File format:
-//!   Line 0: JSON array of column names (schema header)
-//!   Line 1..N: postcard-encoded `(RecordPayload, P)` pairs, length-prefixed
-//!              as a 4-byte little-endian u32 before each record.
-//! Entire stream is LZ4 frame-compressed.
+//!   Byte 0: format tag — `0x00` uncompressed, `0x01` LZ4 frame.
+//!   Then a record stream (raw when uncompressed, inside an LZ4 frame when
+//!   compressed):
+//!     Line 0: JSON array of column names (schema header)
+//!     Line 1..N: postcard-encoded `(RecordPayload, P)` pairs, length-prefixed
+//!                as a 4-byte little-endian u32 before each record.
+//!
+//! The leading tag lets the reader dispatch on the on-disk format without
+//! the writer's compression choice having to travel out-of-band. The choice
+//! is the workspace `[storage.spill] compress` knob: `off` skips the LZ4
+//! frame so small spills avoid LZ4's per-frame fixed cost, `on`/`auto` keep
+//! it. See [`clinker_plan::config::CompressMode`].
 //!
 //! The schema header stays as JSON because it is a tiny human-readable
 //! manifest written once per file. Record bodies use postcard for compact
@@ -35,13 +44,72 @@ use clinker_record::{Record, RecordPayload, Schema};
 
 use clinker_plan::SpillError;
 
-/// Writes (record, payload) pairs to an LZ4-compressed spill file.
+/// On-disk format tag for an uncompressed spill file: the postcard record
+/// stream is written raw, with no LZ4 frame.
+const FORMAT_TAG_UNCOMPRESSED: u8 = 0x00;
+/// On-disk format tag for an LZ4-frame-compressed spill file.
+const FORMAT_TAG_LZ4: u8 = 0x01;
+
+/// Record-stream sink for a spill file: either a raw buffered writer
+/// (uncompressed) or an LZ4 frame encoder wrapping one. Both expose
+/// `io::Write` for the schema header and per-record bodies; the variant is
+/// chosen at construction from the resolved compression decision and recorded
+/// in the file's leading format tag.
+enum SpillSink {
+    /// Uncompressed: postcard records written straight to the buffered file.
+    Uncompressed(BufWriter<NamedTempFile>),
+    /// LZ4-frame-compressed: the historical default for large spills.
+    Lz4(FrameEncoder<BufWriter<NamedTempFile>>),
+}
+
+impl Write for SpillSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            SpillSink::Uncompressed(w) => w.write(buf),
+            SpillSink::Lz4(e) => e.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            SpillSink::Uncompressed(w) => w.flush(),
+            SpillSink::Lz4(e) => e.flush(),
+        }
+    }
+}
+
+impl SpillSink {
+    /// Finalize the stream and recover the underlying temp file. For LZ4 this
+    /// flushes the frame's buffered tail; for the uncompressed sink it flushes
+    /// the `BufWriter`. The spill directory is threaded in so an `ENOSPC` on
+    /// the final flush is classified as `DiskFull` (E321) rather than a
+    /// generic `Io`.
+    fn into_temp_file(self, spill_dir: &Path) -> Result<NamedTempFile, SpillError> {
+        let buf_writer = match self {
+            SpillSink::Uncompressed(w) => w,
+            // The lz4 frame error preserves the underlying `io::Error` (and
+            // its `StorageFull` kind) through its `Into<io::Error>`
+            // conversion, so the classifier still sees the real cause rather
+            // than a flattened "other".
+            SpillSink::Lz4(e) => e
+                .finish()
+                .map_err(|e| SpillError::from_spill_dir_io(spill_dir, std::io::Error::from(e)))?,
+        };
+        buf_writer
+            .into_inner()
+            .map_err(|e| SpillError::from_spill_dir_io(spill_dir, e.into_error()))
+    }
+}
+
+/// Writes (record, payload) pairs to a spill file, optionally LZ4-compressed.
 ///
-/// The schema is written once as a JSON header line. Each subsequent
-/// record is written as a 4-byte little-endian length prefix followed
-/// by a postcard-encoded `(RecordPayload, P)` tuple.
+/// A 1-byte format tag is written first, then the schema as a JSON header
+/// line, then each record as a 4-byte little-endian length prefix followed by
+/// a postcard-encoded `(RecordPayload, P)` tuple. The `compress` flag at
+/// construction selects the LZ4 or raw record stream and is recorded in the
+/// tag so [`SpillReader`] dispatches without out-of-band state.
 pub struct SpillWriter<P> {
-    encoder: FrameEncoder<BufWriter<NamedTempFile>>,
+    sink: SpillSink,
     schema: Arc<Schema>,
     /// Directory the spill file lives in, retained so a mid-stream write or
     /// finalize fault can be classified against it: an `ENOSPC` becomes
@@ -54,9 +122,15 @@ pub struct SpillWriter<P> {
 }
 
 impl<P: Serialize> SpillWriter<P> {
-    /// Create a new SpillWriter. Writes schema header immediately.
-    /// Files are created in `spill_dir` or the system temp directory.
-    pub fn new(schema: Arc<Schema>, spill_dir: Option<&Path>) -> Result<Self, SpillError> {
+    /// Create a new `SpillWriter`. Writes the format tag and schema header
+    /// immediately. Files are created in `spill_dir` or the system temp
+    /// directory. `compress` selects LZ4 framing (`true`) or a raw postcard
+    /// stream (`false`); the choice is recorded in the file's leading tag.
+    pub fn new(
+        schema: Arc<Schema>,
+        spill_dir: Option<&Path>,
+        compress: bool,
+    ) -> Result<Self, SpillError> {
         // A create failure in a spill dir the run validated at startup means
         // the directory went bad mid-run (unmounted, removed, remounted
         // read-only) or the volume is full. `from_spill_dir_io` lifts those
@@ -71,22 +145,36 @@ impl<P: Serialize> SpillWriter<P> {
             NamedTempFile::new().map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?
         };
 
-        let buf_writer = BufWriter::new(temp_file);
-        let mut encoder = FrameEncoder::new(buf_writer);
+        let mut buf_writer = BufWriter::new(temp_file);
+
+        // The format tag is the very first on-disk byte and sits outside the
+        // LZ4 frame so the reader can dispatch before opening a decoder.
+        let tag = if compress {
+            FORMAT_TAG_LZ4
+        } else {
+            FORMAT_TAG_UNCOMPRESSED
+        };
+        buf_writer
+            .write_all(&[tag])
+            .map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?;
+
+        let mut sink = if compress {
+            SpillSink::Lz4(FrameEncoder::new(buf_writer))
+        } else {
+            SpillSink::Uncompressed(buf_writer)
+        };
 
         // Write schema as first line: JSON array of column names.
         // Kept as JSON so the header is human-inspectable without a postcard decoder.
         let columns: Vec<&str> = schema.columns().iter().map(|c| &**c).collect();
         let schema_json = serde_json::to_string(&columns)?;
-        encoder
-            .write_all(schema_json.as_bytes())
+        sink.write_all(schema_json.as_bytes())
             .map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?;
-        encoder
-            .write_all(b"\n")
+        sink.write_all(b"\n")
             .map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?;
 
         Ok(SpillWriter {
-            encoder,
+            sink,
             schema,
             spill_dir: resolved_dir,
             _payload: PhantomData,
@@ -107,10 +195,10 @@ impl<P: Serialize> SpillWriter<P> {
         let len = bytes.len() as u32;
         // Classify a write fault against the spill directory so an `ENOSPC`
         // mid-stream surfaces as `DiskFull` (E321), not a generic `Io`.
-        self.encoder
+        self.sink
             .write_all(&len.to_le_bytes())
             .map_err(|e| SpillError::from_spill_dir_io(&self.spill_dir, e))?;
-        self.encoder
+        self.sink
             .write_all(&bytes)
             .map_err(|e| SpillError::from_spill_dir_io(&self.spill_dir, e))?;
         Ok(())
@@ -124,21 +212,10 @@ impl<P: Serialize> SpillWriter<P> {
         self.write_pair(record, &P::default())
     }
 
-    /// Flush, finalize LZ4 frame, return handle to the completed spill file.
+    /// Flush, finalize the record stream (LZ4 frame if compressed), and return
+    /// a handle to the completed spill file.
     pub fn finish(self) -> Result<SpillFile<P>, SpillError> {
-        let spill_dir = self.spill_dir;
-        // The encoder's buffered tail flushes here; an `ENOSPC` on that final
-        // flush is the disk filling, classified as `DiskFull` (E321). The lz4
-        // frame error preserves the underlying `io::Error` (and its
-        // `StorageFull` kind) through its `Into<io::Error>` conversion, so the
-        // classifier still sees the real cause rather than a flattened "other".
-        let buf_writer = self
-            .encoder
-            .finish()
-            .map_err(|e| SpillError::from_spill_dir_io(&spill_dir, std::io::Error::from(e)))?;
-        let temp_file = buf_writer
-            .into_inner()
-            .map_err(|e| SpillError::from_spill_dir_io(&spill_dir, e.into_error()))?;
+        let temp_file = self.sink.into_temp_file(&self.spill_dir)?;
         let path = temp_file.into_temp_path();
         Ok(SpillFile {
             path,
@@ -157,14 +234,36 @@ pub struct SpillFile<P> {
 
 impl<P: DeserializeOwned> SpillFile<P> {
     /// Open a reader over this spill file.
+    ///
+    /// Reads the leading format tag and selects the matching record-stream
+    /// source: an LZ4 decoder for `0x01`, the raw file for `0x00`. An unknown
+    /// tag is a corrupt-file error.
     pub fn reader(&self) -> Result<SpillReader<P>, SpillError> {
-        let file = std::fs::File::open(&self.path)?;
-        let decoder = FrameDecoder::new(file);
-        let mut buf_reader = BufReader::new(decoder);
+        let mut file = std::fs::File::open(&self.path)?;
+
+        // The format tag is a single byte ahead of the (optionally framed)
+        // record stream, written by `SpillWriter::new`.
+        let mut tag = [0u8; 1];
+        file.read_exact(&mut tag)?;
+        let source = match tag[0] {
+            FORMAT_TAG_LZ4 => SpillSource::Lz4(BufReader::new(FrameDecoder::new(file))),
+            FORMAT_TAG_UNCOMPRESSED => SpillSource::Uncompressed(BufReader::new(file)),
+            other => {
+                return Err(SpillError::InvalidSchema(format!(
+                    "unknown spill format tag {other:#04x}; file is corrupt or not a spill file"
+                )));
+            }
+        };
+        let mut reader = SpillReader {
+            source,
+            schema: Arc::clone(&self.schema),
+            len_buf: [0u8; 4],
+            _payload: PhantomData,
+        };
 
         // Read and verify schema line
         let mut schema_line = String::new();
-        buf_reader.read_line(&mut schema_line)?;
+        reader.source.read_line(&mut schema_line)?;
         let columns: Vec<String> = serde_json::from_str(schema_line.trim())?;
 
         let expected: Vec<&str> = self.schema.columns().iter().map(|c| &**c).collect();
@@ -176,12 +275,7 @@ impl<P: DeserializeOwned> SpillFile<P> {
             )));
         }
 
-        Ok(SpillReader {
-            reader: buf_reader,
-            schema: Arc::clone(&self.schema),
-            len_buf: [0u8; 4],
-            _payload: PhantomData,
-        })
+        Ok(reader)
     }
 }
 
@@ -197,9 +291,45 @@ impl<P> SpillFile<P> {
     }
 }
 
-/// Reads (record, payload) pairs from an LZ4-compressed spill file.
+/// Record-stream source for a spill file, mirroring [`SpillSink`]: either a
+/// raw buffered file (uncompressed) or an LZ4 decoder over one. The variant is
+/// selected from the file's leading format tag at [`SpillFile::reader`].
+enum SpillSource {
+    /// Uncompressed: postcard records read straight from the buffered file.
+    Uncompressed(BufReader<std::fs::File>),
+    /// LZ4-frame-compressed.
+    Lz4(BufReader<FrameDecoder<std::fs::File>>),
+}
+
+impl Read for SpillSource {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            SpillSource::Uncompressed(r) => r.read(buf),
+            SpillSource::Lz4(r) => r.read(buf),
+        }
+    }
+}
+
+impl BufRead for SpillSource {
+    fn fill_buf(&mut self) -> std::io::Result<&[u8]> {
+        match self {
+            SpillSource::Uncompressed(r) => r.fill_buf(),
+            SpillSource::Lz4(r) => r.fill_buf(),
+        }
+    }
+
+    fn consume(&mut self, amt: usize) {
+        match self {
+            SpillSource::Uncompressed(r) => r.consume(amt),
+            SpillSource::Lz4(r) => r.consume(amt),
+        }
+    }
+}
+
+/// Reads (record, payload) pairs from a spill file, dispatching on the file's
+/// format tag for the compressed or uncompressed record stream.
 pub struct SpillReader<P> {
-    reader: BufReader<FrameDecoder<std::fs::File>>,
+    source: SpillSource,
     schema: Arc<Schema>,
     len_buf: [u8; 4],
     _payload: PhantomData<P>,
@@ -210,14 +340,14 @@ impl<P: DeserializeOwned> Iterator for SpillReader<P> {
 
     fn next(&mut self) -> Option<Self::Item> {
         // Read 4-byte length prefix
-        match self.reader.read_exact(&mut self.len_buf) {
+        match self.source.read_exact(&mut self.len_buf) {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return None,
             Err(e) => return Some(Err(SpillError::Io(e))),
         }
         let len = u32::from_le_bytes(self.len_buf) as usize;
         let mut buf = vec![0u8; len];
-        if let Err(e) = self.reader.read_exact(&mut buf) {
+        if let Err(e) = self.source.read_exact(&mut buf) {
             return Some(Err(SpillError::Io(e)));
         }
         Some(self.parse_pair(&buf))
@@ -256,66 +386,72 @@ mod tests {
         )
     }
 
+    // Round-trip every Value variant through both the compressed and the
+    // uncompressed spill format. Both must reconstruct identical records: the
+    // compression knob changes only the on-disk encoding, never the data.
     #[test]
     fn test_spill_roundtrip_all_value_types() {
-        let schema = Arc::new(Schema::new(vec![
-            "null_col".into(),
-            "bool_col".into(),
-            "int_col".into(),
-            "float_col".into(),
-            "str_col".into(),
-            "date_col".into(),
-            "dt_col".into(),
-            "arr_col".into(),
-        ]));
+        for compress in [true, false] {
+            let schema = Arc::new(Schema::new(vec![
+                "null_col".into(),
+                "bool_col".into(),
+                "int_col".into(),
+                "float_col".into(),
+                "str_col".into(),
+                "date_col".into(),
+                "dt_col".into(),
+                "arr_col".into(),
+            ]));
 
-        let mut writer: SpillWriter<()> = SpillWriter::new(Arc::clone(&schema), None).unwrap();
+            let mut writer: SpillWriter<()> =
+                SpillWriter::new(Arc::clone(&schema), None, compress).unwrap();
 
-        for i in 0..100 {
-            let record = Record::new(
-                Arc::clone(&schema),
-                vec![
-                    Value::Null,
-                    Value::Bool(i % 2 == 0),
-                    Value::Integer(i as i64 * 100),
-                    Value::Float(i as f64 * 1.5),
-                    Value::String(format!("row_{i}").into()),
-                    Value::Date(
-                        chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()
-                            + chrono::Duration::days(i as i64),
-                    ),
-                    Value::DateTime(
-                        chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
-                            .unwrap()
-                            .and_hms_opt(12, 0, 0)
-                            .unwrap()
-                            + chrono::Duration::seconds(i as i64),
-                    ),
-                    Value::Array(vec![Value::Integer(i as i64), Value::String("x".into())]),
-                ],
+            for i in 0..100 {
+                let record = Record::new(
+                    Arc::clone(&schema),
+                    vec![
+                        Value::Null,
+                        Value::Bool(i % 2 == 0),
+                        Value::Integer(i as i64 * 100),
+                        Value::Float(i as f64 * 1.5),
+                        Value::String(format!("row_{i}").into()),
+                        Value::Date(
+                            chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()
+                                + chrono::Duration::days(i as i64),
+                        ),
+                        Value::DateTime(
+                            chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+                                .unwrap()
+                                .and_hms_opt(12, 0, 0)
+                                .unwrap()
+                                + chrono::Duration::seconds(i as i64),
+                        ),
+                        Value::Array(vec![Value::Integer(i as i64), Value::String("x".into())]),
+                    ],
+                );
+                writer.write_record(&record).unwrap();
+            }
+
+            let spill_file = writer.finish().unwrap();
+            let reader = spill_file.reader().unwrap();
+            let records: Vec<Record> = reader.map(|r| r.unwrap().0).collect();
+
+            assert_eq!(records.len(), 100, "compress={compress}");
+
+            // Check first record field-by-field
+            assert_eq!(records[0].get("null_col"), Some(&Value::Null));
+            assert_eq!(records[0].get("bool_col"), Some(&Value::Bool(true)));
+            assert_eq!(records[0].get("int_col"), Some(&Value::Integer(0)));
+            assert_eq!(records[0].get("float_col"), Some(&Value::Float(0.0)));
+            assert_eq!(
+                records[0].get("str_col"),
+                Some(&Value::String("row_0".into()))
             );
-            writer.write_record(&record).unwrap();
+
+            // Check last record
+            assert_eq!(records[99].get("int_col"), Some(&Value::Integer(9900)));
+            assert_eq!(records[99].get("bool_col"), Some(&Value::Bool(false)));
         }
-
-        let spill_file = writer.finish().unwrap();
-        let reader = spill_file.reader().unwrap();
-        let records: Vec<Record> = reader.map(|r| r.unwrap().0).collect();
-
-        assert_eq!(records.len(), 100);
-
-        // Check first record field-by-field
-        assert_eq!(records[0].get("null_col"), Some(&Value::Null));
-        assert_eq!(records[0].get("bool_col"), Some(&Value::Bool(true)));
-        assert_eq!(records[0].get("int_col"), Some(&Value::Integer(0)));
-        assert_eq!(records[0].get("float_col"), Some(&Value::Float(0.0)));
-        assert_eq!(
-            records[0].get("str_col"),
-            Some(&Value::String("row_0".into()))
-        );
-
-        // Check last record
-        assert_eq!(records[99].get("int_col"), Some(&Value::Integer(9900)));
-        assert_eq!(records[99].get("bool_col"), Some(&Value::Bool(false)));
     }
 
     #[test]
@@ -327,7 +463,8 @@ mod tests {
             "m_col".into(),
         ]));
 
-        let mut writer: SpillWriter<()> = SpillWriter::new(Arc::clone(&schema), None).unwrap();
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, true).unwrap();
         let record = Record::new(
             Arc::clone(&schema),
             vec![Value::Integer(1), Value::Integer(2), Value::Integer(3)],
@@ -353,7 +490,8 @@ mod tests {
     #[test]
     fn test_spill_lz4_compression_ratio() {
         let schema = test_schema();
-        let mut writer: SpillWriter<()> = SpillWriter::new(Arc::clone(&schema), None).unwrap();
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, true).unwrap();
 
         // Write 1000 records; postcard binary is significantly more compact
         // than NDJSON. Assert the spill file is under 50% of the equivalent
@@ -382,10 +520,82 @@ mod tests {
         );
     }
 
+    // The leading format tag must record the writer's compression choice so
+    // the reader dispatches on it: `0x01` for LZ4, `0x00` for raw.
+    #[test]
+    fn format_tag_records_compression_choice() {
+        let schema = test_schema();
+        for (compress, expected_tag) in [(true, 0x01u8), (false, 0x00u8)] {
+            let mut writer: SpillWriter<()> =
+                SpillWriter::new(Arc::clone(&schema), None, compress).unwrap();
+            writer
+                .write_record(&make_record(&schema, "Alice", 100, true))
+                .unwrap();
+            let spill_file = writer.finish().unwrap();
+            let bytes = std::fs::read(spill_file.path()).unwrap();
+            assert_eq!(
+                bytes[0], expected_tag,
+                "compress={compress} must write tag {expected_tag:#04x}"
+            );
+        }
+    }
+
+    // `compress = off` must produce a spill file with no LZ4 frame: after the
+    // 1-byte tag, the body begins with the plain JSON schema header (`[`),
+    // never the LZ4 frame magic `0x04 0x22 0x4D 0x18`.
+    #[test]
+    fn uncompressed_spill_has_no_lz4_frame_header() {
+        let schema = test_schema();
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, false).unwrap();
+        writer
+            .write_record(&make_record(&schema, "Alice", 100, true))
+            .unwrap();
+        let spill_file = writer.finish().unwrap();
+        let bytes = std::fs::read(spill_file.path()).unwrap();
+
+        assert_eq!(bytes[0], 0x00, "uncompressed tag");
+        // LZ4 frame magic number, little-endian 0x184D2204.
+        const LZ4_FRAME_MAGIC: [u8; 4] = [0x04, 0x22, 0x4D, 0x18];
+        assert_ne!(
+            &bytes[1..5],
+            &LZ4_FRAME_MAGIC,
+            "uncompressed body must not start with an LZ4 frame header"
+        );
+        // The raw body is the JSON schema header, which opens with `[`.
+        assert_eq!(
+            bytes[1], b'[',
+            "uncompressed body must begin with the JSON schema header"
+        );
+    }
+
+    // Payload round-trips through the uncompressed format identically to the
+    // compressed one — the knob changes only on-disk bytes.
+    #[test]
+    fn uncompressed_spill_roundtrips_payload() {
+        let schema = test_schema();
+        let mut writer: SpillWriter<u64> =
+            SpillWriter::new(Arc::clone(&schema), None, false).unwrap();
+        writer
+            .write_pair(&make_record(&schema, "Alice", 100, true), &7)
+            .unwrap();
+        writer
+            .write_pair(&make_record(&schema, "Bob", 200, false), &9)
+            .unwrap();
+        let spill_file = writer.finish().unwrap();
+        let pairs: Vec<(Record, u64)> = spill_file.reader().unwrap().map(|r| r.unwrap()).collect();
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(pairs[0].0.get("name"), Some(&Value::String("Alice".into())));
+        assert_eq!(pairs[0].1, 7);
+        assert_eq!(pairs[1].0.get("name"), Some(&Value::String("Bob".into())));
+        assert_eq!(pairs[1].1, 9);
+    }
+
     #[test]
     fn test_spill_tempfile_cleanup() {
         let schema = test_schema();
-        let mut writer: SpillWriter<()> = SpillWriter::new(Arc::clone(&schema), None).unwrap();
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, true).unwrap();
         writer
             .write_record(&make_record(&schema, "Alice", 100, true))
             .unwrap();
@@ -401,7 +611,7 @@ mod tests {
     #[test]
     fn test_spill_empty_chunk() {
         let schema = test_schema();
-        let writer: SpillWriter<()> = SpillWriter::new(Arc::clone(&schema), None).unwrap();
+        let writer: SpillWriter<()> = SpillWriter::new(Arc::clone(&schema), None, true).unwrap();
         // Finish immediately — no records written
         let spill_file = writer.finish().unwrap();
 
@@ -422,7 +632,8 @@ mod tests {
             "extra_field".into(),
             "score".into(),
         ]));
-        let mut writer: SpillWriter<()> = SpillWriter::new(Arc::clone(&schema), None).unwrap();
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, true).unwrap();
 
         let record = Record::new(
             Arc::clone(&schema),
@@ -454,7 +665,7 @@ mod tests {
         let custom_dir = tempfile::tempdir().unwrap();
         let schema = test_schema();
         let mut writer: SpillWriter<()> =
-            SpillWriter::new(Arc::clone(&schema), Some(custom_dir.path())).unwrap();
+            SpillWriter::new(Arc::clone(&schema), Some(custom_dir.path()), true).unwrap();
         writer
             .write_record(&make_record(&schema, "Alice", 100, true))
             .unwrap();
@@ -481,7 +692,7 @@ mod tests {
         let schema = test_schema();
         std::fs::remove_dir(&spill_dir).unwrap();
 
-        let err = match SpillWriter::<()>::new(Arc::clone(&schema), Some(&spill_dir)) {
+        let err = match SpillWriter::<()>::new(Arc::clone(&schema), Some(&spill_dir), true) {
             Ok(_) => panic!("spill writer creation should fail when the dir is gone"),
             Err(e) => e,
         };

--- a/crates/clinker-exec/tests/auto_widen_integration.rs
+++ b/crates/clinker-exec/tests/auto_widen_integration.rs
@@ -596,7 +596,7 @@ fn h6b_record_round_trips_through_sort_spill() {
     ];
 
     let mut writer: SpillWriter<()> =
-        SpillWriter::new(Arc::clone(&schema), None).expect("open spill writer");
+        SpillWriter::new(Arc::clone(&schema), None, true).expect("open spill writer");
     for rec in &inputs {
         writer.write_record(rec).expect("spill write_record");
     }

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -38,6 +38,8 @@ pub use route::*;
 pub use scoped_var::*;
 pub use sort::*;
 pub use source::*;
-pub use storage::{ClinkerToml, SpillConfig, StagingConfig, StorageConfig, StorageConfigError};
+pub use storage::{
+    ClinkerToml, CompressMode, SpillConfig, StagingConfig, StorageConfig, StorageConfigError,
+};
 pub use transform::*;
 pub use utils::*;

--- a/crates/clinker-plan/src/config/storage.rs
+++ b/crates/clinker-plan/src/config/storage.rs
@@ -82,6 +82,89 @@ pub struct StorageConfig {
     pub staging: StagingConfig,
 }
 
+/// How spill files are compressed: `auto` (the default), `off`, or `on`.
+///
+/// Spill bodies are postcard-encoded record streams. LZ4 frame compression
+/// shrinks large spilled runs, but on small spills the per-frame fixed cost
+/// — clearing the compressor's internal state on every frame reset — can
+/// dominate the byte savings. The LZ4 v1.8.2 release notes call this out
+/// directly, and Pentaho Kettle ships explicit guidance to disable spill
+/// compression for small rows. `Auto` encodes that guidance as a heuristic
+/// so the common case needs no tuning; `Off` / `On` force the choice.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CompressMode {
+    /// Compress only when the projected spill is large enough that LZ4's
+    /// per-frame fixed cost is amortized (see [`CompressMode::resolve`]).
+    #[default]
+    Auto,
+    /// Never compress: postcard records are written straight to disk with no
+    /// LZ4 frame wrapping. Cheapest for small spills; largest on-disk size.
+    Off,
+    /// Always compress with an LZ4 frame, regardless of projected size. The
+    /// pre-knob behavior, kept for spills of large, compressible rows.
+    On,
+}
+
+/// Minimum projected bytes-per-batch at which `auto` enables compression.
+///
+/// Below ~4 KiB a spilled batch fits inside a single LZ4 block, so the frame
+/// reset cost the v1.8.2 release notes flag is paid with little compressible
+/// volume to offset it. 4 KiB matches the small-row threshold Pentaho Kettle
+/// documents.
+const AUTO_COMPRESS_MIN_BYTES_PER_BATCH: u64 = 4 * 1024;
+
+/// Minimum projected rows-per-batch at which `auto` enables compression.
+///
+/// Pairs with [`AUTO_COMPRESS_MIN_BYTES_PER_BATCH`]: a batch must be both
+/// wide (≥ 4 KiB) and tall (≥ 1024 rows) before compression pays for itself.
+/// 1024 is the small-row row-count threshold from the same Pentaho guidance.
+const AUTO_COMPRESS_MIN_ROWS_PER_BATCH: u64 = 1024;
+
+/// Per-column byte estimate used to project a spilled batch's size from a
+/// schema's column count alone.
+///
+/// A `Value` slot is 24 bytes; `32` adds a small heap allowance for the
+/// typical mix of short strings and fixed-width scalars a spilled row holds.
+/// The projection only has to land on the correct side of the 4 KiB
+/// threshold, so a coarse per-column constant is sufficient and keeps the
+/// heuristic a pure function of the schema width and batch size.
+const ESTIMATED_BYTES_PER_COLUMN: u64 = 32;
+
+impl CompressMode {
+    /// Resolve this mode against a projected spill batch's size into a
+    /// concrete "compress this file?" decision.
+    ///
+    /// `On` and `Off` ignore the projection. `Auto` compresses only when the
+    /// batch is projected to be both ≥ 4 KiB and ≥ 1024 rows — the point at
+    /// which LZ4's per-frame fixed cost is amortized by enough compressible
+    /// volume (see [`CompressMode`]).
+    pub fn resolve(self, projected_bytes_per_batch: u64, projected_rows_per_batch: u64) -> bool {
+        match self {
+            CompressMode::On => true,
+            CompressMode::Off => false,
+            CompressMode::Auto => {
+                projected_bytes_per_batch >= AUTO_COMPRESS_MIN_BYTES_PER_BATCH
+                    && projected_rows_per_batch >= AUTO_COMPRESS_MIN_ROWS_PER_BATCH
+            }
+        }
+    }
+
+    /// Project a spilled batch's byte size from its schema width and the
+    /// configured rows-per-batch, then resolve to a compression decision.
+    ///
+    /// Convenience over [`CompressMode::resolve`] for callers that hold a
+    /// column count and batch size rather than a pre-computed byte figure:
+    /// the projection is `column_count × 32 bytes × rows_per_batch`. The
+    /// `--explain` plan and the runtime spill writer call this so the
+    /// reported mode matches the mode the run actually applies.
+    pub fn resolve_for_schema(self, column_count: usize, rows_per_batch: u64) -> bool {
+        let bytes_per_row = column_count as u64 * ESTIMATED_BYTES_PER_COLUMN;
+        let bytes_per_batch = bytes_per_row.saturating_mul(rows_per_batch);
+        self.resolve(bytes_per_batch, rows_per_batch)
+    }
+}
+
 /// `[storage.spill]` — spill-file root directory.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -112,6 +195,12 @@ pub struct SpillConfig {
     /// rendered as "OOM with 187 GiB available").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disk_cap_bytes: Option<ByteSize>,
+    /// Whether spill files are LZ4-compressed. Defaults to [`CompressMode::Auto`],
+    /// which compresses only when a spilled batch is projected large enough
+    /// to amortize LZ4's per-frame fixed cost. `off` and `on` force the
+    /// choice. See [`CompressMode`] for the rationale and threshold.
+    #[serde(default)]
+    pub compress: CompressMode,
 }
 
 impl SpillConfig {
@@ -379,5 +468,64 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(err, StorageConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn compress_defaults_to_auto() {
+        let doc = ClinkerToml::parse("").unwrap();
+        assert_eq!(doc.storage.spill.compress, CompressMode::Auto);
+    }
+
+    #[test]
+    fn compress_parses_each_mode() {
+        for (text, expected) in [
+            ("auto", CompressMode::Auto),
+            ("off", CompressMode::Off),
+            ("on", CompressMode::On),
+        ] {
+            let doc =
+                ClinkerToml::parse(&format!("[storage.spill]\ncompress = \"{text}\"\n")).unwrap();
+            assert_eq!(doc.storage.spill.compress, expected, "mode {text}");
+        }
+    }
+
+    #[test]
+    fn compress_rejects_unknown_mode() {
+        let err = ClinkerToml::parse(
+            r#"
+            [storage.spill]
+            compress = "gzip"
+            "#,
+        )
+        .unwrap_err();
+        assert!(matches!(err, StorageConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn resolve_on_off_ignore_projection() {
+        // `on` / `off` are forced regardless of the projected batch size.
+        assert!(CompressMode::On.resolve(0, 0));
+        assert!(!CompressMode::Off.resolve(u64::MAX, u64::MAX));
+    }
+
+    #[test]
+    fn resolve_auto_needs_both_thresholds() {
+        // Both the byte and the row threshold must be met.
+        assert!(CompressMode::Auto.resolve(4096, 1024));
+        assert!(CompressMode::Auto.resolve(64 * 1024, 4096));
+        // Wide but too few rows → no compression.
+        assert!(!CompressMode::Auto.resolve(64 * 1024, 1023));
+        // Many rows but too few bytes → no compression.
+        assert!(!CompressMode::Auto.resolve(4095, 8192));
+    }
+
+    #[test]
+    fn resolve_for_schema_projects_from_width_and_rows() {
+        // 1 column × 32 B/col × 1024 rows = 32 KiB ≥ 4 KiB and rows ≥ 1024 →
+        // compress.
+        assert!(CompressMode::Auto.resolve_for_schema(1, 1024));
+        // 8 columns × 32 B/col × 16 rows = 4 KiB of bytes but only 16 rows →
+        // below the row threshold, so no compression.
+        assert!(!CompressMode::Auto.resolve_for_schema(8, 16));
     }
 }

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -949,6 +949,50 @@ impl ExecutionPlanDag {
         out
     }
 
+    /// Render the per-blocking-operator spill-compression decision for the
+    /// `--explain` text output.
+    ///
+    /// Each operator that can spill (Aggregate, sort, grace-hash Combine —
+    /// the nodes that register a spillable consumer at runtime) gets one line
+    /// resolving `compress` against that operator's output-schema width and
+    /// the run's `batch_size`. Under [`CompressMode::Auto`] the decision
+    /// varies per operator because a wide operator clears the per-batch byte
+    /// threshold a narrow one does not; `On` / `Off` report the same forced
+    /// choice for every operator. The header line names the configured mode so
+    /// an operator can confirm both the policy and its resolved effect before
+    /// a run. Returns an empty string when the plan has no spill-eligible
+    /// operator.
+    pub fn spill_compression_explain(
+        &self,
+        compress: crate::config::CompressMode,
+        batch_size: usize,
+    ) -> String {
+        let blocking: Vec<NodeIndex> = self
+            .topo_order
+            .iter()
+            .copied()
+            .filter(|&idx| arbitration_class(&self.graph[idx]).spill_priority.is_some())
+            .collect();
+        if blocking.is_empty() {
+            return String::new();
+        }
+        let mut out = format!("Spill compression: {compress:?} [storage.spill.compress]\n");
+        for idx in blocking {
+            let node = &self.graph[idx];
+            let column_count = node
+                .stored_output_schema()
+                .map(|s| s.column_count())
+                .unwrap_or(0);
+            let chosen = if compress.resolve_for_schema(column_count, batch_size as u64) {
+                "lz4"
+            } else {
+                "off"
+            };
+            out.push_str(&format!("  {} → {chosen}\n", node.display_name()));
+        }
+        out
+    }
+
     /// Append the `CXL Expressions`, `Type Annotations`, `Memory Budget`
     /// trailing sections that `explain_full` adds onto a base
     /// `explain()` body. Factored so the artifacts-aware variant can

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -714,6 +714,18 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                     }
                     None => println!("Spill disk cap: unlimited (default)"),
                 }
+                // Resolved spill-compression decision per blocking operator.
+                // Under `auto` the choice varies by operator width, so an
+                // operator can confirm which spills will be LZ4-framed and
+                // which write raw postcard before committing to the run.
+                let batch_size = pipeline_config
+                    .pipeline
+                    .batch_size
+                    .unwrap_or(clinker_exec::executor::DEFAULT_BATCH_SIZE);
+                print!(
+                    "{}",
+                    dag.spill_compression_explain(storage_config.spill.compress, batch_size)
+                );
             }
             ExplainFormat::Json => {
                 let view = clinker_plan::plan::execution::ExplainJson::new(dag, artifacts);
@@ -1030,6 +1042,7 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         shutdown_token: Some(shutdown_token),
         spill_root_dir: spill_root_dir.clone(),
         spill_disk_cap_bytes,
+        spill_compress: storage_config.spill.compress,
     };
     let report = match PipelineExecutor::run_plan_with_readers_writers_in_context(
         &compiled_plan,

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -16,6 +16,7 @@ the per-pipeline YAML:
 [storage.spill]
 dir = "/var/clinker/spill"   # optional; default = OS temp dir
 disk_cap_bytes = "10GB"      # optional; default = unlimited
+compress = "auto"            # optional; auto | off | on   (default = auto)
 
 [storage.staging]
 enabled = false              # parsed but inactive — staging is not yet implemented
@@ -81,6 +82,17 @@ Spill disk cap: 10737418240 bytes [storage.spill.disk_cap_bytes]
 Spill disk cap: unlimited (default)
 ```
 
+Finally, `--explain` reports the resolved compression decision per blocking
+operator, so you can see which spills will be LZ4-framed (`lz4`) and which will
+be written raw (`off`) before the run starts. Under `auto` the choice varies by
+operator width:
+
+```text
+Spill compression: Auto [storage.spill.compress]
+  Aggregate 'totals' → lz4
+  Sort 'by_amount' → off
+```
+
 ## `storage.spill.disk_cap_bytes` — cap cumulative spill
 
 By default a run will spill as much as it needs, limited only by the physical
@@ -106,6 +118,42 @@ budget and the physical volume size. A run can sit well inside its
 spill files; the cap lets an operator bound that on a shared volume. It is the
 guard DataFusion shipped without ([apache/datafusion#15358]) until production
 runs filled volumes.
+
+## `storage.spill.compress` — LZ4 compression policy
+
+Spill files are postcard-encoded record streams. By default each stream is
+wrapped in an LZ4 frame, which shrinks large spilled runs. But LZ4 carries a
+**per-frame fixed cost** — clearing the compressor's internal state on every
+frame reset — and on small spills that cost can outweigh the byte savings. The
+LZ4 v1.8.2 release notes call this out directly, and Pentaho Kettle ships
+explicit guidance to turn spill compression **off** for small rows.
+
+`compress` controls the policy:
+
+```toml
+[storage.spill]
+compress = "auto"   # auto | off | on   (default = auto)
+```
+
+| Mode | Behavior |
+| --- | --- |
+| `auto` (default) | Compress only when a spilled batch is projected large enough to amortize LZ4's per-frame cost — both **≥ 4 KiB** and **≥ 1024 rows**. Below either threshold the batch is written raw. The projection comes from the operator's schema width and the run's `batch_size`, so the decision is made per blocking operator. |
+| `off` | Never compress. Postcard records are written straight to disk with no LZ4 frame. Cheapest for small spills; largest on-disk size. |
+| `on` | Always compress with an LZ4 frame. The pre-knob behavior, best for spills of large, compressible rows. |
+
+Each spill file records its compression choice in a one-byte header tag, so the
+read path always dispatches to the right decoder regardless of the mode the
+file was written with — changing the knob between runs never breaks re-reading
+an earlier run's files.
+
+The 4 KiB / 1024-row thresholds mark the empirical crossover: below them the
+LZ4 frame's fixed cost dominates the small amount of compressible payload, and
+writing raw is faster end-to-end (the `spill_compression` benchmark sweeps
+batch sizes from 256 B to 64 KiB and confirms `auto` tracks the faster of
+`on` / `off` across the range). Most pipelines should leave `compress` at
+`auto`; set `on` when spilling wide, highly compressible rows to a
+space-constrained volume, and `off` when spills are dominated by many small
+batches.
 
 ## Distinguishing the four spill-related failure conditions
 


### PR DESCRIPTION
## Summary

Adds a configurable compression knob for on-disk spill data. When a pipeline's working set exceeds the memory budget, the engine spills intermediate state to disk (hash-aggregate partitions, grace-hash join partitions, external sort runs, and node buffers). Until now that spill data was always written uncompressed. This change lets operators control whether spill payloads are LZ4-compressed, trading a small amount of CPU for substantially less disk I/O and space on large spills.

## What changed

- New `[storage]` setting `spill.compress` with three modes:
  - `auto` (default) — compress per batch only when it is large enough to pay for itself, skipping compression for tiny batches where the framing overhead would dominate.
  - `off` — always write spill payloads uncompressed.
  - `on` — always compress spill payloads.
- The `auto` mode uses a small-row heuristic: batches below a byte/row threshold are written uncompressed because compressing them costs more CPU than it saves in I/O. This mirrors the behavior of established ETL engines that disable compression on small record batches.
- The knob is honored uniformly across every spill writer: hash-aggregate spill, grace-hash join spill, external sort runs/buffers, sort-merge-join, and node buffers — so the configured policy applies to all spill paths, not just one.
- The selected compression mode is surfaced in `--explain` output so a plan inspection shows how spill data will be encoded.
- Documentation added under the operations guide describing the setting and the heuristic.

## Testing

Unit and integration tests cover all three modes, the small-row heuristic boundary, round-trip correctness of compressed and uncompressed spill payloads across each spill writer, and the explain-annotation surface. A benchmark for spill compression is included. CI runs the full fmt/clippy/test/benches/deny gauntlet plus the Windows and macOS cross-compile checks.

Closes #171

Milestone: storage: configurable spill location + opt-in source staging