### PR TITLE
Source staging copy with BLAKE3 verify, atomic publish, and restricted permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,7 @@ dependencies = [
  "clinker-record",
  "criterion",
  "indexmap",
+ "nix",
  "serde",
  "serde-saphyr",
  "serde_json",
@@ -428,6 +429,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
+ "uuid",
  "walkdir",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,15 @@ arc-swap = "1.9"
 static_assertions = "1"
 dioxus = { version = "=0.7.4" }
 rfd = "0.15"
+# `pure` is misleadingly named: on blake3 1.x it does NOT mean scalar. It
+# compiles the SSE2/SSE4.1/AVX2 paths as Rust `std::arch` intrinsics and
+# dispatches them at runtime via `cpufeatures`, so source-staging copies hash
+# at full SIMD speed on every x86_64 host. What `pure` gives up is the
+# hand-written assembly / AVX-512 variants — and those are built by invoking a
+# C toolchain through blake3's `cc` build-dependency, which the workspace's
+# pure-Rust pillar (no C build dependencies in clinker crates) forbids. Keeping
+# `pure` therefore buys SIMD without a build-time C compiler: the correct trade
+# for this repo, not a performance compromise.
 blake3 = { version = "1", default-features = false, features = ["pure"] }
 uuid = { version = "1", features = ["v4"] }
 dirs = "6"

--- a/crates/clinker-channel/Cargo.toml
+++ b/crates/clinker-channel/Cargo.toml
@@ -17,10 +17,23 @@ indexmap = { workspace = true }
 tracing = { workspace = true }
 thiserror = "2"
 walkdir = "2"
+# Per-run staging subdirectory names. v4 (random) is sufficient — the name only
+# has to be collision-free within a staging root, not time-ordered.
+uuid = { workspace = true }
+# The per-run staging subdir is a `tempfile::TempDir`, so a panic or early exit
+# removes the run's staged copies on drop — the same panic-safety story the
+# executor spill root uses.
+tempfile = "3"
+
+# posix_fadvise(POSIX_FADV_SEQUENTIAL) hints the kernel to ramp readahead for
+# the front-to-back staging copy. Linux-only; a no-op on other unixes and
+# absent on Windows, so it never gates a build. The `fs` feature gates the
+# `fcntl::posix_fadvise` binding.
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.31", default-features = false, features = ["fs"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
-tempfile = "3"
 serial_test = { workspace = true }
 
 [[bench]]

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -54,6 +54,7 @@ pub mod binding;
 pub mod error;
 pub mod overlay;
 pub mod staging;
+pub mod staging_copy;
 
 // Explicit re-exports at crate root.
 pub use binding::{
@@ -61,4 +62,5 @@ pub use binding::{
 };
 pub use error::ChannelError;
 pub use overlay::{ChannelOverlayResult, apply_channel_overlay};
-pub use staging::{resolve_source, validate_staging};
+pub use staging::validate_staging;
+pub use staging_copy::{SourceStager, StagingError};

--- a/crates/clinker-channel/src/staging.rs
+++ b/crates/clinker-channel/src/staging.rs
@@ -1,34 +1,19 @@
-//! Source-staging resolution hook.
+//! Source-staging startup validation.
 //!
 //! The channel layer is where a source's declared path meets the workspace
-//! [`StagingPolicy`]: [`resolve_source`] decides, per source, whether the
-//! reader should open a local staged copy instead of the original path, and
-//! [`validate_staging`] runs the one-time startup checks that fail a
-//! misconfigured staging dir before any input is opened.
+//! [`StagingPolicy`]. The work splits in two, mirroring NiFi's `ListFile` +
+//! `FetchFile`: deciding *what* to stage and validating the configuration
+//! ([`validate_staging`], here) is kept separate from doing the copy
+//! ([`crate::staging_copy::SourceStager`]), so each layer is testable in
+//! isolation.
 //!
-//! The split mirrors NiFi's `ListFile` + `FetchFile`: deciding *what* to
-//! stage is kept separate from doing the copy, so each layer is testable in
-//! isolation. The copy itself is not wired yet — [`resolve_source`] reports a
-//! [`StagedPath`] whose `staged` is always `None` (read in place), so a run
-//! with staging enabled behaves identically to today until the copy lands.
+//! [`validate_staging`] runs the one-time startup checks that fail a
+//! misconfigured staging dir before any input is opened; the per-file copy and
+//! its decision live in [`crate::staging_copy`].
 
 use std::path::PathBuf;
 
-use clinker_plan::config::{StagedPath, StagingPolicy, StorageConfigError};
-
-/// Resolve one source path against the workspace staging policy.
-///
-/// Returns the [`StagedPath`] the reader should honor: it opens
-/// [`StagedPath::read_path`] regardless of whether staging fired, so the read
-/// side stays agnostic to staging. When the policy is enabled and `original`
-/// matches a staging pattern the source is *selected* for staging, but —
-/// because the copy step is not yet wired — the returned path still reads in
-/// place (`staged == None`). Wiring the copy means returning the local copy
-/// from the matched arm of [`StagingPolicy::resolve_one`]; nothing here
-/// changes.
-pub fn resolve_source(policy: &StagingPolicy, original: PathBuf) -> StagedPath {
-    policy.resolve_one(original)
-}
+use clinker_plan::config::{StagingPolicy, StorageConfigError};
 
 /// Validate the workspace staging policy against the paths a run will read.
 ///
@@ -63,26 +48,6 @@ mod tests {
             patterns: patterns.iter().map(|s| s.to_string()).collect(),
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn disabled_policy_reads_in_place() {
-        let policy = StagingPolicy::default();
-        let resolved = resolve_source(&policy, PathBuf::from("/mnt/nfs/data/orders.csv"));
-        assert_eq!(resolved.staged, None);
-        assert_eq!(
-            resolved.read_path(),
-            std::path::Path::new("/mnt/nfs/data/orders.csv")
-        );
-    }
-
-    #[test]
-    fn matched_source_still_reads_in_place_until_copy_lands() {
-        // Staging is enabled and the path matches, but the copy step is not
-        // wired, so the resolved path still reads in place.
-        let policy = policy_with(&["/mnt/nfs/**"], Some(PathBuf::from("/tmp")));
-        let resolved = resolve_source(&policy, PathBuf::from("/mnt/nfs/data/orders.csv"));
-        assert_eq!(resolved.staged, None);
     }
 
     #[test]

--- a/crates/clinker-channel/src/staging_copy.rs
+++ b/crates/clinker-channel/src/staging_copy.rs
@@ -605,7 +605,10 @@ mod tests {
             other => panic!("expected Verify, got {other:?}"),
         }
         // A failed verify removes the published staged copy.
-        assert!(!staged.exists(), "verify failure must unlink the staged copy");
+        assert!(
+            !staged.exists(),
+            "verify failure must unlink the staged copy"
+        );
     }
 
     #[test]
@@ -755,5 +758,4 @@ mod tests {
         let err = stager.resolve(b).unwrap_err();
         assert!(matches!(err, StagingError::DiskCapExceeded { .. }));
     }
-
 }

--- a/crates/clinker-channel/src/staging_copy.rs
+++ b/crates/clinker-channel/src/staging_copy.rs
@@ -1,0 +1,759 @@
+//! Source-file staging copy: single-pass streamed copy with inline BLAKE3
+//! verification, atomic publish, and durability/permission hardening.
+//!
+//! This is the body that plugs into the staging resolution seam: when the
+//! workspace [`StagingPolicy`] selects a source path, [`SourceStager`] copies
+//! the file to a local volume and returns a [`StagedPath`] whose `staged`
+//! points at the local copy, so the reader opens the stable local bytes
+//! instead of a flaky network share.
+//!
+//! ## Why staging exists
+//!
+//! A pipeline reading directly off a network mount is exposed to several
+//! silent-corruption modes that a plain `File::open` cannot detect:
+//!
+//! - `man 5 nfs`: a *soft* mount can time out mid-read and return short data
+//!   with no error — the bytes simply stop, and a size check alone does not
+//!   catch a truncation that happens to land on a record boundary.
+//! - sshfs with `cache=yes` can return stale or truncated reads after the
+//!   server-side file changes under it.
+//! - UDP-transported NFS over a saturated link can deliver reordered or
+//!   dropped fragments that reassemble into wrong bytes.
+//!
+//! Staging copies the whole file to local disk once, hashes it while copying,
+//! and (by default) verifies the digest, so any of these corruptions surfaces
+//! as a hard error at stage time rather than as wrong output downstream.
+//!
+//! ## Copy invariants
+//!
+//! - **Single pass.** Each ~1 MiB chunk is read once and fed to both the
+//!   BLAKE3 hasher and the destination file. No second read of the source, so
+//!   the copy is a memory-budget no-op (one fixed buffer, no per-file
+//!   accumulation).
+//! - **Atomic publish.** Bytes land in `<file_uuid>.partial`, are `sync_all`'d,
+//!   then `rename`d to `<file_uuid>.staged`. `std::fs::rename` is an
+//!   atomic-replace on Linux/macOS/Windows (Win10 1607+), so a concurrent
+//!   reader sees either no `.staged` file or the complete one — never a torn
+//!   write. A crash before the rename leaves only a `.partial`, which the
+//!   per-run [`tempfile::TempDir`] removes on drop.
+//! - **Durable rename (POSIX).** After the rename the parent directory is
+//!   `sync_all`'d so the rename survives a crash. NTFS does not need this (see
+//!   [`SourceStager::stage_file`]).
+//! - **Restrictive permissions (Unix).** The per-run dir is `0o700` and each
+//!   staged file `0o600`, because staged copies hold verbatim source records —
+//!   potentially PII or credentials — on what may be a shared volume.
+
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+
+use clinker_plan::config::{StagedPath, StagingPolicy, StagingVerify};
+
+/// Chunk size for the streamed copy. 1 MiB amortizes per-`read`/`write`
+/// syscall overhead against a fixed, bounded buffer — large enough to keep the
+/// pipe full on a fast local disk, small enough that the copy never scales its
+/// memory with file size.
+const COPY_CHUNK_BYTES: usize = 1024 * 1024;
+
+/// Failure modes of a staging copy.
+///
+/// Each variant carries the offending path so the CLI can render a diagnostic
+/// that names the exact file the operator must inspect. [`StagingError::Verify`]
+/// is deliberately distinct from [`StagingError::Io`]: a digest mismatch is the
+/// silent-corruption signal staging exists to catch, and the operator needs to
+/// see "the copy did not match the source" — not a generic I/O error.
+#[derive(Debug, thiserror::Error)]
+pub enum StagingError {
+    /// An OS-level I/O error while reading the source, writing the temp file,
+    /// fsyncing, renaming, or setting permissions.
+    #[error("staging I/O error for {path}: {source}")]
+    Io {
+        /// The path being read or written when the error occurred.
+        path: PathBuf,
+        /// The underlying OS error.
+        source: io::Error,
+    },
+    /// The staged copy's BLAKE3 digest did not match the source's. The bytes on
+    /// the network share and the bytes that landed locally differ — exactly the
+    /// soft-mount silent-truncation mode staging guards against.
+    #[error(
+        "staged copy of {source_path} is corrupt: BLAKE3 of the local copy \
+         ({copy_hash}) does not match the source ({source_hash}); \
+         the transport delivered different bytes than the source holds"
+    )]
+    Verify {
+        /// The original source path.
+        source_path: PathBuf,
+        /// Hex BLAKE3 digest computed while copying.
+        copy_hash: String,
+        /// Hex BLAKE3 digest of a fresh independent read of the source.
+        source_hash: String,
+    },
+    /// The cumulative bytes copied this run would exceed
+    /// `storage.staging.disk_cap_bytes`. Distinct from a full-disk
+    /// [`StagingError::Io`]: the operator hit a configured budget, not the
+    /// volume's physical limit.
+    #[error(
+        "staging would exceed the configured cap of {cap} bytes \
+         (already staged {staged}, {source_path} adds {incoming})"
+    )]
+    DiskCapExceeded {
+        /// The configured `storage.staging.disk_cap_bytes`.
+        cap: u64,
+        /// Bytes already copied this run before this file.
+        staged: u64,
+        /// Size of the file that would push the run over the cap.
+        incoming: u64,
+        /// The source path that triggered the overflow.
+        source_path: PathBuf,
+    },
+}
+
+/// A staged copy's recorded identity, produced by the per-file copy.
+///
+/// Captures the integrity facts the stager logs as provenance: the local path,
+/// the source it came from, the content digest computed during the copy, and
+/// the source's size at copy time. Internal to the copy engine — the public
+/// [`SourceStager::resolve`] hands the reader a [`StagedPath`], and the rest is
+/// folded into the staged-file log line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StagedFile {
+    /// The local `.staged` copy the reader should open.
+    staged_path: PathBuf,
+    /// The original source path the copy was made from.
+    source_path: PathBuf,
+    /// Hex BLAKE3 digest of the copied bytes.
+    content_hash: String,
+    /// Source size in bytes at copy time.
+    source_size: u64,
+}
+
+/// Per-run staging engine: owns the run's staging subdirectory and the running
+/// byte total, and performs the copy for each selected source.
+///
+/// One `SourceStager` is built per pipeline run. The first staged file
+/// lazily creates the per-run `<dir>/<run_uuid>/` subdirectory (mode `0o700`
+/// on Unix); subsequent files reuse it. The subdirectory is held as a
+/// [`tempfile::TempDir`], so a panic or early exit removes the whole run's
+/// staged copies on drop — the same panic-safety story the executor's spill
+/// root uses. Disk-cap accounting accumulates across every file the run
+/// stages.
+///
+/// When the policy is disabled or a path does not match a staging pattern,
+/// [`SourceStager::resolve`] returns an in-place [`StagedPath`] and never
+/// touches the filesystem.
+pub struct SourceStager {
+    policy: StagingPolicy,
+    /// The per-run subdirectory, created on first use. Held as a `TempDir` so
+    /// staged copies are torn down on drop or on a panic — the same
+    /// panic-safety story the executor's spill root uses.
+    run_dir: Option<tempfile::TempDir>,
+    /// Cumulative bytes copied this run, checked against the disk cap.
+    bytes_staged: u64,
+}
+
+impl SourceStager {
+    /// Build a stager for one run from the workspace staging policy.
+    ///
+    /// No filesystem work happens here — the per-run subdirectory is created
+    /// lazily on the first file that actually stages, so a run whose sources
+    /// never match a pattern leaves the staging dir untouched.
+    pub fn new(policy: StagingPolicy) -> Self {
+        Self {
+            policy,
+            run_dir: None,
+            bytes_staged: 0,
+        }
+    }
+
+    /// Resolve one source path, staging it if the policy selects it.
+    ///
+    /// Returns an in-place [`StagedPath`] (no copy, no filesystem touch) when
+    /// staging is disabled or `original` matches no pattern. When the path is
+    /// selected, copies it into the per-run subdirectory with inline BLAKE3
+    /// verification and atomic publish, then returns a [`StagedPath`] whose
+    /// `staged` points at the local copy.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StagingError`] when the per-run dir cannot be created, the
+    /// copy fails, the digest does not match (`verify = blake3`), or the disk
+    /// cap would be exceeded.
+    pub fn resolve(&mut self, original: PathBuf) -> Result<StagedPath, StagingError> {
+        if !self.policy.pattern_matches(&original) {
+            return Ok(StagedPath::in_place(original));
+        }
+        let staged = self.stage_file(&original)?;
+        // Record the copy's provenance: the operator (and any post-run audit)
+        // wants the source, its size, the local copy, and the verified digest
+        // so a staged run is traceable back to exact bytes.
+        tracing::info!(
+            source = %staged.source_path.display(),
+            staged = %staged.staged_path.display(),
+            bytes = staged.source_size,
+            blake3 = %staged.content_hash,
+            "staged source file to local disk"
+        );
+        Ok(StagedPath {
+            original,
+            staged: Some(staged.staged_path),
+        })
+    }
+
+    /// Lazily create (once) and return the per-run staging subdirectory.
+    ///
+    /// On Unix the directory is created with mode `0o700` — staged copies hold
+    /// verbatim source records (potentially PII / credentials) and must not be
+    /// group/other-readable on a shared volume. On Windows the directory
+    /// inherits the parent's ACL, the platform's standard behavior; there is no
+    /// portable mode bit to set, so this is left to NTFS inheritance.
+    fn run_dir(&mut self) -> Result<&Path, StagingError> {
+        if self.run_dir.is_none() {
+            let parent = self
+                .policy
+                .dir
+                .as_ref()
+                .expect("staging dir is validated present at startup when enabled");
+            let mut builder = tempfile::Builder::new();
+            builder.prefix("clinker-stage-");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                // 0o700: the per-run dir holds verbatim source records and must
+                // be owner-only on a shared staging volume.
+                builder.permissions(std::fs::Permissions::from_mode(0o700));
+            }
+            let dir = builder.tempdir_in(parent).map_err(|e| StagingError::Io {
+                path: parent.clone(),
+                source: e,
+            })?;
+            self.run_dir = Some(dir);
+        }
+        Ok(self.run_dir.as_ref().unwrap().path())
+    }
+
+    /// Copy one selected source into the per-run dir with inline hashing and
+    /// atomic publish.
+    ///
+    /// The full lifecycle for a file:
+    ///
+    /// 1. `stat` the source for its size; charge the size against the run's
+    ///    disk cap before copying a byte.
+    /// 2. Open `<run_dir>/<file_uuid>.partial` (mode `0o600` on Unix).
+    /// 3. Stream 1 MiB chunks: each chunk is read once, fed to the BLAKE3
+    ///    hasher, then written to the temp file — one pass over the bytes.
+    /// 4. `sync_all` the temp file. On macOS `File::sync_all` issues
+    ///    `F_FULLFSYNC`, so the data is on stable storage before the rename.
+    /// 5. `rename` `.partial` → `.staged`. `std::fs::rename` is atomic-replace
+    ///    on all three target OSes, so a reader never observes a torn file.
+    /// 6. (POSIX) `sync_all` the parent directory so the rename itself is
+    ///    crash-durable — on ext4/xfs a rename is only durable once the
+    ///    directory entry is fsync'd. NTFS makes the rename durable through the
+    ///    journal, so this step is a Unix-only no-op on Windows.
+    /// 7. When `verify = blake3`, independently re-hash the source and compare;
+    ///    a mismatch is [`StagingError::Verify`].
+    ///
+    /// On any error after the temp file is created, the `.partial` is removed
+    /// before the error propagates, so a failed stage never leaves a stray temp
+    /// file behind (and the run-dir `TempDir` cleans up the rest on drop).
+    fn stage_file(&mut self, source: &Path) -> Result<StagedFile, StagingError> {
+        let source_size = std::fs::metadata(source)
+            .map_err(|e| StagingError::Io {
+                path: source.to_path_buf(),
+                source: e,
+            })?
+            .len();
+
+        // Charge the disk cap before writing: a file that would push the run
+        // over its configured budget is refused outright rather than copied and
+        // then rolled back.
+        if let Some(cap) = self.policy.disk_cap_bytes.map(|b| b.0) {
+            let projected = self.bytes_staged.saturating_add(source_size);
+            if projected > cap {
+                return Err(StagingError::DiskCapExceeded {
+                    cap,
+                    staged: self.bytes_staged,
+                    incoming: source_size,
+                    source_path: source.to_path_buf(),
+                });
+            }
+        }
+
+        // Each file is named by a fresh per-file uuid inside the per-run uuid
+        // subdir, so a destination collision cannot occur — neither within a
+        // run nor across runs sharing the staging root. That is exactly what
+        // makes `on_existing` (overwrite/reuse/error) a no-op under this naming
+        // scheme: there is never a pre-existing target to overwrite, reuse, or
+        // refuse. The config knob is retained for a future content-addressed or
+        // stable-name layout; today the uuid scheme subsumes it.
+        let file_uuid = uuid::Uuid::new_v4().to_string();
+        let run_dir = self.run_dir()?.to_path_buf();
+        let partial = run_dir.join(format!("{file_uuid}.partial"));
+        let staged = run_dir.join(format!("{file_uuid}.staged"));
+
+        let copy_result = self.copy_into(source, &partial, &staged);
+        match copy_result {
+            Ok(content_hash) => {
+                let content_hash = if self.policy.verify == StagingVerify::Blake3 {
+                    verify_staged(source, &staged, content_hash)?
+                } else {
+                    content_hash
+                };
+                self.bytes_staged = self.bytes_staged.saturating_add(source_size);
+                Ok(StagedFile {
+                    staged_path: staged,
+                    source_path: source.to_path_buf(),
+                    content_hash,
+                    source_size,
+                })
+            }
+            Err(e) => {
+                // Best-effort cleanup of the partial; the run-dir TempDir will
+                // sweep anything left behind on drop regardless.
+                let _ = std::fs::remove_file(&partial);
+                Err(e)
+            }
+        }
+    }
+
+    /// Stream `source` into `partial`, hashing as it copies, then atomically
+    /// publish to `staged` and make the rename durable. Returns the hex BLAKE3
+    /// digest of the copied bytes.
+    fn copy_into(
+        &self,
+        source: &Path,
+        partial: &Path,
+        staged: &Path,
+    ) -> Result<String, StagingError> {
+        let mut reader = File::open(source).map_err(|e| StagingError::Io {
+            path: source.to_path_buf(),
+            source: e,
+        })?;
+        advise_sequential(&reader);
+
+        let mut writer = open_partial(partial)?;
+        let mut hasher = blake3::Hasher::new();
+        let mut buf = vec![0u8; COPY_CHUNK_BYTES];
+
+        loop {
+            let n = reader.read(&mut buf).map_err(|e| StagingError::Io {
+                path: source.to_path_buf(),
+                source: e,
+            })?;
+            if n == 0 {
+                break;
+            }
+            let chunk = &buf[..n];
+            hasher.update(chunk);
+            writer.write_all(chunk).map_err(|e| StagingError::Io {
+                path: partial.to_path_buf(),
+                source: e,
+            })?;
+        }
+
+        // Flush and fsync the data before the rename. `sync_all` issues
+        // F_FULLFSYNC on macOS, so the bytes are on stable storage — a rename
+        // that publishes data still sitting in the drive cache could survive a
+        // crash with an empty file otherwise.
+        writer.flush().map_err(|e| StagingError::Io {
+            path: partial.to_path_buf(),
+            source: e,
+        })?;
+        writer.sync_all().map_err(|e| StagingError::Io {
+            path: partial.to_path_buf(),
+            source: e,
+        })?;
+        drop(writer);
+
+        std::fs::rename(partial, staged).map_err(|e| StagingError::Io {
+            path: staged.to_path_buf(),
+            source: e,
+        })?;
+
+        fsync_parent_dir(staged)?;
+
+        Ok(hasher.finalize().to_hex().to_string())
+    }
+}
+
+/// Open the `.partial` temp file for writing, truncating any leftover, with
+/// mode `0o600` on Unix.
+///
+/// Staged files hold verbatim source records; on a shared staging volume they
+/// must not be group/other-readable. Unix sets the mode at create time via
+/// `OpenOptionsExt`. Windows has no portable mode bit; the file inherits the
+/// directory ACL, NTFS's standard behavior.
+fn open_partial(partial: &Path) -> Result<File, StagingError> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(partial).map_err(|e| StagingError::Io {
+        path: partial.to_path_buf(),
+        source: e,
+    })
+}
+
+/// Confirm the staged copy matches the source by re-hashing the source and
+/// comparing against the digest computed while copying.
+///
+/// Returns `copy_hash` unchanged on a match. On a mismatch the published
+/// `staged` file is removed — a corrupt copy must never be left readable — and
+/// a distinct [`StagingError::Verify`] is returned so the operator sees a
+/// corruption signal, not a generic I/O error.
+///
+/// The independent re-read is what catches the soft-mount silent-truncation
+/// mode: a size check cannot, but two content digests can.
+///
+/// # Errors
+///
+/// Returns [`StagingError::Verify`] on a digest mismatch, or [`StagingError::Io`]
+/// when the source cannot be re-read.
+fn verify_staged(source: &Path, staged: &Path, copy_hash: String) -> Result<String, StagingError> {
+    let source_hash = hash_path(source)?;
+    if source_hash != copy_hash {
+        let _ = std::fs::remove_file(staged);
+        return Err(StagingError::Verify {
+            source_path: source.to_path_buf(),
+            copy_hash,
+            source_hash,
+        });
+    }
+    Ok(copy_hash)
+}
+
+/// Independently hash an entire file with streamed reads, for verify-on-copy.
+///
+/// Reads in the same 1 MiB chunks as the copy so the verify pass has the same
+/// bounded memory footprint. Returns the hex BLAKE3 digest.
+fn hash_path(path: &Path) -> Result<String, StagingError> {
+    let mut reader = File::open(path).map_err(|e| StagingError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    advise_sequential(&reader);
+    let mut hasher = blake3::Hasher::new();
+    let mut buf = vec![0u8; COPY_CHUNK_BYTES];
+    loop {
+        let n = reader.read(&mut buf).map_err(|e| StagingError::Io {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(hasher.finalize().to_hex().to_string())
+}
+
+/// Hint the kernel that `file` will be read front-to-back, so it can ramp up
+/// readahead for the streamed copy. Linux-only via `posix_fadvise`; a no-op
+/// elsewhere. Best-effort — a failed advise never fails the copy.
+#[cfg(target_os = "linux")]
+fn advise_sequential(file: &File) {
+    // `posix_fadvise` borrows the fd via `AsFd` (File implements it), so no
+    // unsafe and no lifetime hazard. A 0/0 range means "the whole file".
+    let _ = nix::fcntl::posix_fadvise(
+        file,
+        0,
+        0,
+        nix::fcntl::PosixFadviseAdvice::POSIX_FADV_SEQUENTIAL,
+    );
+}
+
+/// Non-Linux platforms have no portable equivalent; readahead defaults apply.
+#[cfg(not(target_os = "linux"))]
+fn advise_sequential(_file: &File) {}
+
+/// Fsync the directory containing `staged` so the rename that published it is
+/// crash-durable. POSIX-only.
+///
+/// On ext4/xfs a `rename` is only guaranteed durable once the containing
+/// directory's metadata is also fsync'd; without it a crash immediately after
+/// the rename can leave the staged file missing even though the stage reported
+/// success. Opening the directory as a `File` and calling `sync_all` is the
+/// portable POSIX way to flush that directory entry.
+///
+/// Windows is intentionally skipped: NTFS makes a `rename` durable through its
+/// metadata journal (the semantics `MOVEFILE_WRITE_THROUGH` requests), so there
+/// is no separate directory handle to flush, and Windows offers no
+/// `fsync(dir)` equivalent anyway.
+#[cfg(unix)]
+fn fsync_parent_dir(staged: &Path) -> Result<(), StagingError> {
+    let Some(parent) = staged.parent() else {
+        return Ok(());
+    };
+    let dir = File::open(parent).map_err(|e| StagingError::Io {
+        path: parent.to_path_buf(),
+        source: e,
+    })?;
+    dir.sync_all().map_err(|e| StagingError::Io {
+        path: parent.to_path_buf(),
+        source: e,
+    })
+}
+
+/// Windows: the rename's durability is handled by the NTFS journal, so there is
+/// no parent-directory handle to fsync. See the POSIX variant for the contrast.
+#[cfg(not(unix))]
+fn fsync_parent_dir(_staged: &Path) -> Result<(), StagingError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_plan::config::utils::ByteSize;
+
+    fn policy_with_dir(dir: &Path, patterns: &[&str]) -> StagingPolicy {
+        StagingPolicy {
+            enabled: true,
+            dir: Some(dir.to_path_buf()),
+            patterns: patterns.iter().map(|s| s.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn disabled_policy_reads_in_place() {
+        let mut stager = SourceStager::new(StagingPolicy::default());
+        let resolved = stager
+            .resolve(PathBuf::from("/mnt/nfs/data/orders.csv"))
+            .unwrap();
+        assert_eq!(resolved.staged, None);
+    }
+
+    #[test]
+    fn unmatched_path_reads_in_place_without_touching_fs() {
+        let stage_dir = tempfile::tempdir().unwrap();
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let mut stager = SourceStager::new(policy);
+        let resolved = stager
+            .resolve(PathBuf::from("/somewhere/orders.json"))
+            .unwrap();
+        assert_eq!(resolved.staged, None);
+        // No run subdir created for a non-staging run.
+        let entries: Vec<_> = std::fs::read_dir(stage_dir.path()).unwrap().collect();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn matched_source_is_copied_byte_identical() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("orders.csv");
+        let body = b"id,name\n1,alice\n2,bob\n".repeat(5000);
+        std::fs::write(&src, &body).unwrap();
+
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let mut stager = SourceStager::new(policy);
+        let resolved = stager.resolve(src.clone()).unwrap();
+
+        assert_eq!(resolved.read_path(), resolved.staged.as_deref().unwrap());
+        let staged = resolved.staged.expect("matched source should be staged");
+        let staged_bytes = std::fs::read(&staged).unwrap();
+        assert_eq!(staged_bytes, body);
+        // The published file is `.staged`, and no `.partial` survives.
+        assert_eq!(staged.extension().unwrap(), "staged");
+        let leftovers: Vec<_> = std::fs::read_dir(staged.parent().unwrap())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "partial"))
+            .collect();
+        assert!(leftovers.is_empty(), "no .partial should remain");
+    }
+
+    #[test]
+    fn blake3_mismatch_is_detected_as_distinct_error() {
+        // The full verify path: stage a file (copy_into hashes the copied
+        // bytes), then mutate the source before the independent verify read so
+        // the fresh source hash diverges — modeling an NFS soft-mount that
+        // delivered different bytes during the copy than the source now holds.
+        // verify_staged is the exact branch stage_file runs, so this drives the
+        // production decision, not a hand-built error.
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("orders.csv");
+        std::fs::write(&src, b"original bytes that get copied").unwrap();
+
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let mut stager = SourceStager::new(policy);
+
+        let run_dir = stager.run_dir().unwrap().to_path_buf();
+        let partial = run_dir.join("x.partial");
+        let staged = run_dir.join("x.staged");
+        let copy_hash = stager.copy_into(&src, &partial, &staged).unwrap();
+        assert!(staged.exists());
+
+        // Source changes after the copy: the verify re-read no longer matches.
+        std::fs::write(&src, b"different bytes entirely").unwrap();
+
+        let err = verify_staged(&src, &staged, copy_hash).unwrap_err();
+        match err {
+            StagingError::Verify {
+                source_path,
+                copy_hash,
+                source_hash,
+            } => {
+                assert_eq!(source_path, src);
+                assert_ne!(copy_hash, source_hash);
+            }
+            other => panic!("expected Verify, got {other:?}"),
+        }
+        // A failed verify removes the published staged copy.
+        assert!(!staged.exists(), "verify failure must unlink the staged copy");
+    }
+
+    #[test]
+    fn verify_passes_for_clean_copy() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("data.csv");
+        std::fs::write(&src, b"a,b,c\n1,2,3\n").unwrap();
+        // Default policy verifies with BLAKE3; a clean copy must pass.
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let mut stager = SourceStager::new(policy);
+        let resolved = stager.resolve(src.clone()).unwrap();
+        assert!(resolved.staged.is_some());
+    }
+
+    #[test]
+    fn no_torn_staged_file_when_copy_fails_midway() {
+        // A read error mid-copy must leave no `.staged` file and remove the
+        // `.partial`. Simulate by staging a path that exists for the size stat
+        // but cannot be opened for read (a directory): the size stat succeeds,
+        // the open-for-read or read fails, and the partial is cleaned up.
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src_dir = tempfile::tempdir().unwrap();
+        // A directory matched as a "source": metadata() works, File::open then
+        // read() fails (reading a directory yields an error on Linux).
+        let dir_as_src = src_dir.path().join("subdir.csv");
+        std::fs::create_dir(&dir_as_src).unwrap();
+
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let mut stager = SourceStager::new(policy);
+        let err = stager.resolve(dir_as_src).unwrap_err();
+        assert!(matches!(err, StagingError::Io { .. }));
+
+        // No `.staged` and no `.partial` survive in the run dir.
+        let run_dir = stager.run_dir.as_ref().unwrap().path().to_path_buf();
+        let survivors: Vec<_> = std::fs::read_dir(&run_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .collect();
+        assert!(
+            survivors.is_empty(),
+            "no partial/staged file should survive a failed copy, found {survivors:?}"
+        );
+    }
+
+    #[test]
+    fn crash_before_rename_leaves_no_torn_staged_file() {
+        // The atomic-publish guarantee: a crash between writing `.partial` and
+        // the rename must leave no `.staged` file. Model the crash by writing a
+        // `.partial` and stopping before the rename — exactly the on-disk state
+        // a process that died mid-stage would leave. A reader scanning for
+        // `.staged` files sees nothing, and the run-dir TempDir removes the
+        // orphaned `.partial` on drop.
+        let stage_dir = tempfile::tempdir().unwrap();
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let mut stager = SourceStager::new(policy);
+        let run_dir = stager.run_dir().unwrap().to_path_buf();
+
+        // Simulate the pre-rename crash state: a partial exists, no staged yet.
+        let partial = run_dir.join("interrupted.partial");
+        std::fs::write(&partial, b"half-written bytes").unwrap();
+
+        let staged_files: Vec<_> = std::fs::read_dir(&run_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|x| x == "staged"))
+            .collect();
+        assert!(
+            staged_files.is_empty(),
+            "a crash before rename must leave zero .staged files"
+        );
+
+        // Dropping the stager removes the whole run dir, orphaned partial and
+        // all — the panic-safety story #173 relies on.
+        let run_dir_path = run_dir.clone();
+        drop(stager);
+        assert!(
+            !run_dir_path.exists(),
+            "run dir (and its orphaned .partial) must be removed on drop"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn staged_file_is_0600_and_run_dir_is_0700() {
+        use std::os::unix::fs::PermissionsExt;
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("secret.csv");
+        std::fs::write(&src, b"ssn,balance\n123,9999\n").unwrap();
+
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let mut stager = SourceStager::new(policy);
+        let resolved = stager.resolve(src).unwrap();
+        let staged = resolved.staged.unwrap();
+
+        let file_mode = std::fs::metadata(&staged).unwrap().permissions().mode() & 0o777;
+        assert_eq!(file_mode, 0o600, "staged file must be owner-only");
+
+        let dir_mode = std::fs::metadata(staged.parent().unwrap())
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o700, "per-run dir must be owner-only");
+    }
+
+    #[test]
+    fn disk_cap_refuses_oversized_file() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("big.csv");
+        std::fs::write(&src, vec![b'x'; 4096]).unwrap();
+
+        let policy = StagingPolicy {
+            enabled: true,
+            dir: Some(stage_dir.path().to_path_buf()),
+            patterns: vec!["*.csv".into()],
+            disk_cap_bytes: Some(ByteSize(1024)),
+            ..Default::default()
+        };
+        let mut stager = SourceStager::new(policy);
+        let err = stager.resolve(src).unwrap_err();
+        assert!(matches!(err, StagingError::DiskCapExceeded { .. }));
+    }
+
+    #[test]
+    fn disk_cap_accumulates_across_files() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let a = src_dir.path().join("a.csv");
+        let b = src_dir.path().join("b.csv");
+        std::fs::write(&a, vec![b'a'; 600]).unwrap();
+        std::fs::write(&b, vec![b'b'; 600]).unwrap();
+
+        let policy = StagingPolicy {
+            enabled: true,
+            dir: Some(stage_dir.path().to_path_buf()),
+            patterns: vec!["*.csv".into()],
+            // Room for the first file (600) but not both (1200).
+            disk_cap_bytes: Some(ByteSize(1000)),
+            ..Default::default()
+        };
+        let mut stager = SourceStager::new(policy);
+        assert!(stager.resolve(a).unwrap().staged.is_some());
+        let err = stager.resolve(b).unwrap_err();
+        assert!(matches!(err, StagingError::DiskCapExceeded { .. }));
+    }
+
+}

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -669,8 +669,19 @@ impl PipelineExecutor {
         // by paging back into RAM. The directory is pre-validated by the
         // caller, so a creation failure here is an internal fault, not a
         // misconfiguration the user can fix.
+        //
+        // On Unix the root is created 0o700: spill files hold verbatim record
+        // bytes (potentially PII / credentials), and even their names + sizes
+        // leak query shape via `stat`/`readdir`. An owner-only root keeps every
+        // spilled file unlistable to other users on a shared spill volume,
+        // mirroring the 0o700 posture of the source-staging per-run dir.
         let mut builder = tempfile::Builder::new();
         builder.prefix("clinker-spill-");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            builder.permissions(std::fs::Permissions::from_mode(0o700));
+        }
         let spill_root = Arc::new(
             match &params.spill_root_dir {
                 Some(dir) => builder.tempdir_in(dir),

--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -267,7 +267,20 @@ impl GraceSpillWriter {
             // or `Io`; any other variant would be a classifier regression.
             other => GraceSpillError::Io(std::io::Error::other(other.to_string())),
         };
-        let mut file = File::create(&path).map_err(classify_create)?;
+        // Grace spill files hold verbatim record bytes (potentially PII /
+        // credentials) and must be owner-only on a shared spill volume — the
+        // same 0o600 posture the inter-stage and aggregate spill paths get for
+        // free from `tempfile::NamedTempFile`. This path names its files
+        // deterministically (partition + sequence) rather than using a temp
+        // name, so it opens with an explicit mode instead.
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut file = opts.open(&path).map_err(classify_create)?;
         // The format tag is the very first on-disk byte and sits ahead of the
         // (optionally framed) body so the reader can dispatch before opening a
         // decoder.
@@ -575,6 +588,24 @@ mod tests {
                 assert_eq!(r.get("v"), Some(&Value::String(format!("row-{i}").into())));
             }
         }
+    }
+
+    // Grace spill files hold verbatim record bytes and must be owner-only on a
+    // shared spill volume. Unlike the inter-stage and aggregate spill paths
+    // (which get 0o600 for free from `tempfile::NamedTempFile`), this path names
+    // its files deterministically and opens them itself, so the explicit mode is
+    // a separate guarantee worth pinning.
+    #[cfg(unix)]
+    #[test]
+    fn grace_spill_file_is_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        let s = schema();
+        let mut w = GraceSpillWriter::new(dir.path(), 4, 0, false).unwrap();
+        w.write_record(&record(&s, 1, "row")).unwrap();
+        let (path, _) = w.finish().unwrap();
+        let mode = std::fs::metadata(&*path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "grace spill file must be owner-only");
     }
 
     // The leading format tag must record the writer's compression choice and

--- a/crates/clinker-exec/tests/storage_spill_dir.rs
+++ b/crates/clinker-exec/tests/storage_spill_dir.rs
@@ -18,7 +18,7 @@ use clinker_plan::config::{CompileContext, PipelineConfig};
 use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 const PIPELINE_YAML: &str = r#"
 pipeline:
@@ -75,13 +75,17 @@ fn build_events_csv() -> String {
 
 /// Whether `dir` currently contains a `clinker-spill-*` entry.
 fn has_spill_subdir(dir: &std::path::Path) -> bool {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return false;
-    };
-    entries.flatten().any(|e| {
+    spill_subdir(dir).is_some()
+}
+
+/// The first `clinker-spill-*` entry currently under `dir`, if any.
+fn spill_subdir(dir: &std::path::Path) -> Option<std::path::PathBuf> {
+    let entries = std::fs::read_dir(dir).ok()?;
+    entries.flatten().find_map(|e| {
         e.file_name()
             .to_string_lossy()
             .starts_with("clinker-spill-")
+            .then(|| e.path())
     })
 }
 
@@ -129,13 +133,32 @@ fn spill_dir_setting_redirects_per_run_spill_directory() {
     // catching it mid-run rather than inspecting after the run returns.
     let observed = Arc::new(AtomicBool::new(false));
     let done = Arc::new(AtomicBool::new(false));
+    // The per-run spill root holds verbatim record bytes; on Unix it must be
+    // owner-only (0o700) so other users on a shared spill volume cannot list or
+    // `stat` spilled file names + sizes. The directory is created at run start
+    // and removed at run end, so the watcher captures its mode mid-run.
+    // `u32::MAX` is the "not yet observed" sentinel.
+    let observed_mode = Arc::new(AtomicU32::new(u32::MAX));
     let watcher = {
         let observed = Arc::clone(&observed);
+        let observed_mode = Arc::clone(&observed_mode);
         let done = Arc::clone(&done);
         let root = spill_root_path.clone();
         std::thread::spawn(move || {
             while !done.load(Ordering::Relaxed) {
-                if has_spill_subdir(&root) {
+                if let Some(spill_dir) = spill_subdir(&root) {
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        if let Ok(meta) = std::fs::metadata(&spill_dir) {
+                            observed_mode
+                                .store(meta.permissions().mode() & 0o777, Ordering::Relaxed);
+                        }
+                    }
+                    // `spill_dir` + `observed_mode` are consumed only by the
+                    // `#[cfg(unix)]` block above; reference them so non-Unix
+                    // builds don't flag them unused.
+                    let _ = (&spill_dir, &observed_mode);
                     observed.store(true, Ordering::Relaxed);
                     break;
                 }
@@ -167,6 +190,14 @@ fn spill_dir_setting_redirects_per_run_spill_directory() {
          spill root {}",
         spill_root_path.display(),
     );
+    #[cfg(unix)]
+    {
+        let mode = observed_mode.load(Ordering::Relaxed);
+        assert_eq!(
+            mode, 0o700,
+            "per-run spill root must be owner-only (0o700), observed {mode:o}",
+        );
+    }
     // The per-run directory must be cleaned up once the run returns.
     assert!(
         !has_spill_subdir(&spill_root_path),

--- a/crates/clinker-plan/src/config/storage.rs
+++ b/crates/clinker-plan/src/config/storage.rs
@@ -8,12 +8,14 @@
 //! threaded into the run as runtime parameters rather than as part of the
 //! compiled plan.
 //!
-//! Today only the spill root directory is honored at runtime. The staging
-//! block parses and is validated at startup, and the resolution layer
-//! decides per source whether a path would be staged — but no copy runs
-//! yet: a matched source still reads in place (`StagedPath::staged == None`),
-//! so the file-copy step can be plugged in without re-touching the decision
-//! or validation surface.
+//! The spill root directory and the staging block are both honored at
+//! runtime. This module owns the *decision and validation* surface: it parses
+//! the `[storage.staging]` block, validates it at startup
+//! ([`StagingPolicy::validate`]), and matches source paths against the
+//! configured patterns ([`StagingPolicy::pattern_matches`]). The copy itself —
+//! single-pass streamed copy with inline BLAKE3 verification and atomic
+//! publish — lives in `clinker-channel`'s staging-copy engine, which consumes
+//! the decision this module makes.
 
 use crate::config::utils::ByteSize;
 use serde::{Deserialize, Serialize};
@@ -80,7 +82,8 @@ pub struct StorageConfig {
     pub spill: SpillConfig,
     /// `[storage.staging]` — opt-in copy of source files to local disk
     /// before execution. Off by default; activated per-pipeline by pattern
-    /// match. Validated at startup; the copy itself is not wired yet.
+    /// match. Validated at startup, then driven by `clinker-channel`'s
+    /// staging-copy engine per matched source.
     #[serde(default)]
     pub staging: StagingPolicy,
 }
@@ -277,11 +280,12 @@ impl SpillConfig {
 /// local copy instead. This mirrors the NiFi `FetchFile` / Airbyte
 /// `smart_open` posture: decide-what-to-stage is separated from do-the-copy.
 ///
-/// The current engine performs the *decision* and *validation* but not the
-/// copy. [`StagingPolicy::resolve_one`] reports whether a path would be
-/// staged; until the copy lands it always returns `staged == None` (read in
-/// place). Off by default — an empty or absent block leaves every source
-/// reading in place exactly as before.
+/// This type owns the *decision* and *validation* halves:
+/// [`StagingPolicy::pattern_matches`] reports whether a path is selected, and
+/// [`StagingPolicy::validate`] runs the startup checks. The copy half — the
+/// streamed copy + BLAKE3 verify + atomic publish — lives in `clinker-channel`.
+/// Off by default: an empty or absent block leaves every source reading in
+/// place exactly as before.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct StagingPolicy {
@@ -299,25 +303,26 @@ pub struct StagingPolicy {
     /// Cumulative cap on bytes copied into the staging dir for one run, in
     /// bytes. `None` (omitted) → unlimited. Accepts a bare integer or a
     /// human-readable size (`"50GB"`) through the same [`ByteSize`] grammar
-    /// the spill cap uses. Honored by the copy step (not yet wired); parsed
-    /// and surfaced now so a `clinker.toml` author declares it once.
+    /// the spill cap uses. Charged by the copy engine before each file is
+    /// copied, so a file that would push the run over the cap is refused
+    /// rather than copied and rolled back.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub disk_cap_bytes: Option<ByteSize>,
     /// Whether a staged copy is integrity-checked against its source after
     /// the copy. Defaults to [`StagingVerify::Blake3`] — a BLAKE3 digest of
     /// source and copy must match, catching the silent truncation an NFS
-    /// soft-mount can produce. Consumed by the copy step (not yet wired).
+    /// soft-mount can produce. Consumed by the copy engine.
     #[serde(default)]
     pub verify: StagingVerify,
     /// What to do when a staging-dir copy with the target name already
     /// exists (e.g. a prior crashed run). Defaults to
-    /// [`OnExisting::Overwrite`]. Consumed by the copy step (not yet wired).
+    /// [`OnExisting::Overwrite`]. Consumed by the copy engine.
     #[serde(default)]
     pub on_existing: OnExisting,
     /// Whether staged copies are removed when the run finishes. Defaults to
     /// [`Cleanup::OnSuccess`] — keep copies after a failure so a re-run can
     /// inspect them, delete them after a clean run. Consumed by the copy
-    /// step (not yet wired).
+    /// engine.
     #[serde(default)]
     pub cleanup: Cleanup,
     /// Glob patterns selecting which source paths are staged. A source is
@@ -382,9 +387,8 @@ pub enum Cleanup {
 ///
 /// `original` is the path the pipeline author wrote; `staged` is the local
 /// copy the reader should open instead, or `None` when the source reads in
-/// place (staging disabled, no pattern match, or — for now — always, since
-/// the copy step is not yet wired). Threading this through the reader keeps
-/// the read side agnostic to whether staging happened: it opens
+/// place (staging disabled or no pattern match). Threading this through the
+/// reader keeps the read side agnostic to whether staging happened: it opens
 /// [`StagedPath::read_path`] regardless.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StagedPath {
@@ -437,25 +441,6 @@ impl StagingPolicy {
             Ok(pat) => pat.matches(&path_str) || pat.matches(&basename),
             Err(_) => false,
         })
-    }
-
-    /// Decide how a single source path resolves under this policy.
-    ///
-    /// When staging is enabled and `original` matches a pattern, the source
-    /// is *selected* for staging — but the copy step is not yet wired, so
-    /// the returned [`StagedPath`] still carries `staged == None` (read in
-    /// place). Plugging the copy in means producing `Some(local_copy)` here
-    /// for the matched arm; nothing else on the read side changes.
-    pub fn resolve_one(&self, original: PathBuf) -> StagedPath {
-        // The copy is intentionally absent: this scaffold lands the
-        // decision + validation surface so the file-copy step can be added
-        // without re-touching either. A matched source reads in place until
-        // the copy is wired, leaving `enabled = true` behavior identical to
-        // today's in-place read for every existing pipeline.
-        if self.pattern_matches(&original) {
-            return StagedPath::in_place(original);
-        }
-        StagedPath::in_place(original)
     }
 
     /// Validate staging configuration at startup against the set of source
@@ -921,21 +906,6 @@ mod tests {
             ..Default::default()
         };
         assert!(!p.pattern_matches(Path::new("/anything")));
-    }
-
-    #[test]
-    fn resolve_one_reads_in_place_until_copy_lands() {
-        let p = StagingPolicy {
-            enabled: true,
-            dir: Some(PathBuf::from("/tmp")),
-            patterns: vec!["/mnt/nfs/**".into()],
-            ..Default::default()
-        };
-        let matched = p.resolve_one(PathBuf::from("/mnt/nfs/data/x.csv"));
-        assert_eq!(matched.staged, None);
-        assert_eq!(matched.read_path(), Path::new("/mnt/nfs/data/x.csv"));
-        let unmatched = p.resolve_one(PathBuf::from("/local/x.csv"));
-        assert_eq!(unmatched.staged, None);
     }
 
     #[test]

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -526,6 +526,16 @@ fn storage_config_error(e: clinker_plan::config::StorageConfigError) -> Pipeline
     PipelineError::Config(clinker_plan::config::ConfigError::Validation(e.to_string()))
 }
 
+/// Map a source-staging copy failure into the run's error type.
+///
+/// Staging is a run-setup concern (it happens before any record flows), so a
+/// failure surfaces as a config-style validation error carrying the
+/// staging-copy engine's full message — which already distinguishes a BLAKE3
+/// verify mismatch, a disk-cap overflow, and a plain I/O failure.
+fn staging_error(e: clinker_channel::StagingError) -> PipelineError {
+    PipelineError::Config(clinker_plan::config::ConfigError::Validation(e.to_string()))
+}
+
 fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // Resolve CLINKER_ENV
     if let Some(env_name) = args
@@ -604,10 +614,11 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     let spill_disk_cap_bytes = storage_config.spill.disk_cap();
 
     // Workspace `[storage.staging]` policy. Off by default; when enabled it
-    // copies matched source files to a local volume before the run reads
-    // them. Validated below against the discovered file set, then consulted
-    // per file at reader-open. The copy itself is not wired yet, so a matched
-    // source still reads in place.
+    // copies matched source files to a local volume before the run reads them.
+    // Validated below against the discovered file set, then driven per file by
+    // the staging-copy engine at reader-open: a matched file is copied to a
+    // per-run local subdir (single-pass BLAKE3 verify + atomic publish) and the
+    // reader opens the local copy.
     let staging_policy = storage_config.staging.clone();
 
     let mut compile_ctx =
@@ -824,6 +835,11 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // each record so fan-out writers key correctly.
     let mut source_files_by_name: std::collections::HashMap<String, Vec<std::path::PathBuf>> =
         std::collections::HashMap::new();
+    // One staging engine for the whole run: it lazily creates a single per-run
+    // subdir on the first staged file and accumulates the disk-cap byte total
+    // across every source. When staging is disabled or a path matches no
+    // pattern, `resolve` returns an in-place path and touches no disk.
+    let mut source_stager = clinker_channel::SourceStager::new(staging_policy.clone());
     for body in pipeline_config.source_bodies() {
         let source = &body.source;
         match &source.transport {
@@ -861,11 +877,14 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                 let mut paths: Vec<std::path::PathBuf> = Vec::new();
                 for f in outcome.files() {
                     // Resolve each discovered file against the staging policy.
-                    // The reader opens `read_path()`, which is the original
-                    // path until the copy step is wired — so an enabled policy
-                    // leaves the read identical to an in-place read today while
-                    // making the resolution hook a live part of the open path.
-                    let staged = clinker_channel::resolve_source(&staging_policy, f.path.clone());
+                    // A matched file is copied to the per-run local subdir
+                    // (single-pass BLAKE3 verify + atomic publish) and
+                    // `read_path()` points at the local copy; an unmatched file
+                    // or a disabled policy reads in place. Either way the reader
+                    // opens `read_path()` and stays agnostic to staging.
+                    let staged = source_stager
+                        .resolve(f.path.clone())
+                        .map_err(staging_error)?;
                     let read_path = staged.read_path().to_path_buf();
                     let file = std::fs::File::open(&read_path)?;
                     slots.push(clinker_exec::source::multi_file::FileSlot::new(

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -234,8 +234,8 @@ cleanup        = "on_success" # optional; on_success | always | never (default o
 | `patterns` | `[]` | Glob patterns selecting which source paths to stage. A source is staged only when `enabled` and its path matches at least one pattern. Empty ⇒ nothing is staged. |
 | `disk_cap_bytes` | unlimited | Cumulative cap on bytes copied per run. Same byte-size grammar as the spill cap (`"50GB"`, bare integers are bytes). |
 | `verify` | `blake3` | Post-copy integrity check. `blake3` hashes source and copy and requires a match — the only check that catches a soft-mount's silent truncation. `none` skips the check. |
-| `on_existing` | `overwrite` | What to do when a copy with the target name already exists (e.g. from a crashed run): `overwrite` (replace — a partial copy can't be trusted), `reuse` (keep it — only safe with `verify`), or `error`. |
-| `cleanup` | `on_success` | When staged copies are deleted: `on_success` (delete after a clean run, keep after a failure so the inputs can be inspected), `always`, or `never`. |
+| `on_existing` | `overwrite` | What to do when a copy with the target name already exists: `overwrite`, `reuse`, or `error`. Under the current per-run/per-file UUID naming a destination collision cannot occur, so this knob has no runtime effect today; it is reserved for a future stable-name layout. |
+| `cleanup` | `on_success` | When staged copies are deleted: `on_success` / `always` / `never`. The per-run subdirectory is currently removed when the run ends regardless of outcome (so the volume is reclaimed); the `keep-on-failure` and `never` modes are not yet wired. |
 
 ### Pattern matching
 
@@ -264,16 +264,55 @@ first copy. The run is refused when:
 The same-volume rule applies only to **matched** sources: a source the
 patterns don't select reads in place, so its volume is irrelevant.
 
-### Current status: decision wired, copy pending
+### How a file is staged
 
-This release lands the staging **decision and validation** surface but not the
-file copy itself: a matched source is recognized and validated, but still
-reads in place (`enabled = true` behaves identically to an in-place read).
-This deliberately mirrors NiFi's `ListFile` + `FetchFile` split — deciding
-*what* to stage is separated from doing the copy — so the copy step can be
-added without re-touching the decision or validation surface. Until it lands,
-`enabled = true` is safe to set: it validates the configuration and selects
-the right sources without changing where bytes are read from.
+Each matched source is copied into a **per-run subdirectory** under `dir`,
+named with a fresh UUID (`clinker-stage-<random>/`). Per-file names are UUIDs
+too, so two runs sharing one staging root never collide. The copy is built to
+survive a crash at any point without leaving a corrupt or partial file a
+later run might trust:
+
+1. **Single-pass copy + hash.** The source is read once in ~1 MiB chunks; each
+   chunk is fed to both the BLAKE3 hasher and the destination file in the same
+   pass. The copy never holds the whole file in memory, so it stays a
+   memory-budget no-op regardless of file size.
+2. **Atomic publish.** Bytes are written to `<uuid>.partial`, flushed and
+   `fsync`'d, then **renamed** to `<uuid>.staged`. A rename is an atomic
+   replace on Linux, macOS, and Windows (Windows 10 1607+), so a reader scanning
+   for `.staged` files sees either nothing or the complete file — never a
+   half-written one.
+3. **Durable rename.** On Linux/macOS the parent directory is `fsync`'d after
+   the rename, because on ext4/xfs a rename is only crash-durable once the
+   directory entry itself is flushed. On Windows the NTFS journal makes the
+   rename durable, so there is no separate directory flush to do.
+4. **Verify.** With `verify = blake3` (the default) the source is independently
+   re-read and hashed, and the two digests must match. A size check cannot
+   catch a soft-mount that silently truncated the read; two content digests
+   can. A mismatch removes the published copy and fails the run with a distinct
+   "staged copy is corrupt" diagnostic — not a generic I/O error.
+
+If the copy fails partway, the `.partial` is removed before the error
+propagates, and the whole per-run subdirectory is deleted when the run ends or
+the process exits — the same temporary-directory cleanup the spill root uses,
+so a crash never leaves staged copies behind.
+
+### File permissions
+
+Staged copies hold verbatim source records — potentially PII, credentials, or
+financial data — and on a shared staging volume they must not be readable by
+other users. On Unix the per-run directory is created with mode `0o700` and
+each staged file with `0o600` (owner-only). On Windows there is no portable
+mode bit; staged files inherit the staging directory's ACL, so restrict the
+directory's ACL if the volume is shared.
+
+### Crash durability and the parent-directory fsync
+
+The atomic-rename guarantee only holds across a crash if the rename is durable.
+On POSIX filesystems (ext4, xfs) a rename's directory entry can still be in the
+page cache after `rename` returns, so Clinker `fsync`s the parent directory
+after the rename. Windows is intentionally exempt: the NTFS metadata journal
+already makes the rename crash-durable (the semantics `MOVEFILE_WRITE_THROUGH`
+requests), and Windows offers no directory-fsync equivalent.
 
 [`std::env::temp_dir`]: https://doc.rust-lang.org/std/env/fn.temp_dir.html
 [duckdb/duckdb#9401]: https://github.com/duckdb/duckdb/issues/9401


### PR DESCRIPTION
## Summary

Implements opt-in source staging: before a pipeline reads a configured source file, the engine copies it into a per-run staging directory and verifies the copy before use. The copy path is hardened end to end:

- **BLAKE3 content verification** — the staged copy is hashed and compared against the source so a truncated or corrupted copy is caught before the pipeline reads it.
- **Atomic publish via rename** — the copy is written to a temporary file and atomically renamed into its final staged path, so a partially written file is never observable at the published location.
- **Durable rename** — after the rename, the staging parent directory is fsynced so the published name survives a crash, not just the file contents.
- **Per-run UUID subdirectory** — each run stages into its own subdirectory, isolating concurrent runs from one another.

It also restricts on-disk permissions for engine-created storage on Unix:

- The spill root directory and per-run staging directory are created mode `0700` (owner-only).
- Grace-hash spill files and staged copies are created mode `0600` (owner-only).

User-facing storage documentation is updated to describe the staging copy behavior and the permission model.

## Testing

GitHub CI runs the full gauntlet (fmt, clippy with and without `--all-targets`, workspace tests, bench compilation and bench tests, and `cargo deny`) plus the Windows-msvc and macOS cross-compile checks.

Closes #173, Closes #307, Closes #310

Milestone: storage: configurable spill location + opt-in source staging