### PR TITLE
engine: --explain storage observability (spill estimates, staging plan, headroom) + CI memory-abort test fix

### DIFF
--- a/crates/clinker-benchmarks/src/report.rs
+++ b/crates/clinker-benchmarks/src/report.rs
@@ -423,6 +423,7 @@ mod tests {
                     io_write_delta: None,
                     heap_delta_bytes: None,
                     heap_alloc_count: None,
+                    spill_bytes: 0,
                 },
                 StageMetrics {
                     name: StageName::TransformEval,
@@ -437,6 +438,7 @@ mod tests {
                     io_write_delta: Some(300_000),
                     heap_delta_bytes: None,
                     heap_alloc_count: None,
+                    spill_bytes: 0,
                 },
                 StageMetrics {
                     name: StageName::Write,
@@ -451,6 +453,7 @@ mod tests {
                     io_write_delta: Some(50_000),
                     heap_delta_bytes: None,
                     heap_alloc_count: None,
+                    spill_bytes: 0,
                 },
             ],
             per_source_file_watermarks: Default::default(),
@@ -460,6 +463,7 @@ mod tests {
             per_source_record_counts: Default::default(),
             per_source_dlq_counts: Default::default(),
             cumulative_spill_bytes: 0,
+            per_stage_spill_bytes: Default::default(),
             peak_consumer_usage_bytes: 0,
             interrupted: false,
         };
@@ -518,6 +522,7 @@ mod tests {
                     io_write_delta: None,
                     heap_delta_bytes: None,
                     heap_alloc_count: None,
+                    spill_bytes: 0,
                 },
                 StageMetrics {
                     name: StageName::Write,
@@ -532,6 +537,7 @@ mod tests {
                     io_write_delta: None,
                     heap_delta_bytes: None,
                     heap_alloc_count: None,
+                    spill_bytes: 0,
                 },
             ],
             per_source_file_watermarks: Default::default(),
@@ -541,6 +547,7 @@ mod tests {
             per_source_record_counts: Default::default(),
             per_source_dlq_counts: Default::default(),
             cumulative_spill_bytes: 0,
+            per_stage_spill_bytes: Default::default(),
             peak_consumer_usage_bytes: 0,
             interrupted: false,
         };

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -61,4 +61,4 @@ pub use binding::{
 };
 pub use error::ChannelError;
 pub use overlay::{ChannelOverlayResult, apply_channel_overlay};
-pub use staging_copy::{SourceStager, StagingError};
+pub use staging_copy::{ReuseDecision, SourceStager, StagingError, StagingPlanEntry};

--- a/crates/clinker-channel/src/staging_copy.rs
+++ b/crates/clinker-channel/src/staging_copy.rs
@@ -271,6 +271,61 @@ struct StagedFile {
     manifest: StagedManifest,
 }
 
+/// The reuse decision `clinker run --explain` reports for a staged source under
+/// `on_existing = reuse`.
+///
+/// `--explain` does no copy, but it can `stat` the source and read a committed
+/// manifest read-only to predict whether the real run would reuse a fresh prior
+/// copy (a cache *hit*) or re-stage (a *miss*). The decision is exactly the one
+/// [`SourceStager::stage_locked`] makes at run time, computed without touching
+/// the copy path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReuseDecision {
+    /// `on_existing = reuse` and a committed staged copy matches the live source
+    /// (mtime + size) — the real run would reuse it and copy no bytes.
+    Hit,
+    /// `on_existing = reuse` but no fresh committed copy exists (absent, stale,
+    /// or orphaned) — the real run would re-stage.
+    Miss,
+    /// `on_existing` is not `reuse` (`overwrite` re-copies every run; `error`
+    /// fails on an existing copy), so the reuse-if-fresh cache does not apply.
+    NotApplicable,
+}
+
+impl ReuseDecision {
+    /// Lowercase label for the `--explain` staging-plan line.
+    pub fn label(self) -> &'static str {
+        match self {
+            ReuseDecision::Hit => "hit",
+            ReuseDecision::Miss => "miss",
+            ReuseDecision::NotApplicable => "n/a",
+        }
+    }
+}
+
+/// A read-only prediction of what staging would do to one source, for
+/// `clinker run --explain`.
+///
+/// Computed by [`SourceStager::plan_entry`] without copying a byte: it reports
+/// whether the source matches a staging pattern (`staged`), the stable
+/// content-addressed path the copy would land at (`staged_path`, present only
+/// when staged), and — under `on_existing = reuse` — whether a fresh prior copy
+/// would be reused (`reuse`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagingPlanEntry {
+    /// The source path the pipeline author declared.
+    pub source: PathBuf,
+    /// Whether staging is enabled and this source matches a staging pattern.
+    /// `false` means the run reads the source in place.
+    pub staged: bool,
+    /// The stable `<staging_root>/<source_id>.staged` path the copy would land
+    /// at. `Some` only when `staged`; `None` for an in-place source.
+    pub staged_path: Option<PathBuf>,
+    /// The reuse-if-fresh cache decision the real run would make. Always
+    /// [`ReuseDecision::NotApplicable`] for an in-place source.
+    pub reuse: ReuseDecision,
+}
+
 /// Per-run staging engine: owns the staging-policy decision, the running byte
 /// total, and the set of staged files this run produced for cleanup.
 ///
@@ -342,6 +397,58 @@ impl SourceStager {
             original,
             staged: Some(staged.staged_path),
         })
+    }
+
+    /// Predict, read-only, what staging would do to `source` — for
+    /// `clinker run --explain`.
+    ///
+    /// Copies nothing and acquires no lock. Reports whether the source matches a
+    /// staging pattern, the stable content-addressed staged path it would land
+    /// at, and — under `on_existing = reuse` — whether a fresh prior copy would
+    /// be reused. The reuse check `stat`s the source and reads the committed
+    /// manifest exactly as the real run's [`Self::stage_locked`] does, so the
+    /// `--explain` prediction matches the run's decision without doing I/O on the
+    /// copy path. An in-place source (staging disabled or no pattern match)
+    /// returns `staged = false` and a [`ReuseDecision::NotApplicable`].
+    pub fn plan_entry(&self, source: &Path) -> StagingPlanEntry {
+        if !self.policy.pattern_matches(source) {
+            return StagingPlanEntry {
+                source: source.to_path_buf(),
+                staged: false,
+                staged_path: None,
+                reuse: ReuseDecision::NotApplicable,
+            };
+        }
+        let root = self.staging_root();
+        let source_id = source_id(source);
+        let staged_path = root.join(format!("{source_id}.{STAGED_EXT}"));
+        let manifest_path = root.join(format!("{source_id}{MANIFEST_SUFFIX}"));
+
+        let reuse = match self.policy.on_existing {
+            OnExisting::Reuse => {
+                // Mirror the run-time freshness check: a committed copy whose
+                // recorded mtime + size still match the live source is a hit.
+                match (
+                    load_clean_manifest(&staged_path, &manifest_path),
+                    std::fs::metadata(source),
+                ) {
+                    (Some(manifest), Ok(meta)) if manifest.matches_source(&meta) => {
+                        ReuseDecision::Hit
+                    }
+                    _ => ReuseDecision::Miss,
+                }
+            }
+            // `overwrite` re-copies every run; `error` aborts on an existing
+            // copy. Neither consults the reuse-if-fresh cache.
+            OnExisting::Overwrite | OnExisting::Error => ReuseDecision::NotApplicable,
+        };
+
+        StagingPlanEntry {
+            source: source.to_path_buf(),
+            staged: true,
+            staged_path: Some(staged_path),
+            reuse,
+        }
     }
 
     /// The staging root the policy targets. Present and validated whenever
@@ -1665,5 +1772,91 @@ mod tests {
         std::fs::write(&src, b"abcd").unwrap();
         let meta2 = std::fs::metadata(&src).unwrap();
         assert!(!back.matches_source(&meta2), "a size change is stale");
+    }
+
+    #[test]
+    fn plan_entry_in_place_when_disabled_or_unmatched() {
+        // Staging disabled → in place.
+        let stager = SourceStager::new(StagingPolicy::default());
+        let entry = stager.plan_entry(Path::new("/data/orders.csv"));
+        assert!(!entry.staged);
+        assert_eq!(entry.staged_path, None);
+        assert_eq!(entry.reuse, ReuseDecision::NotApplicable);
+
+        // Enabled but the pattern does not match → in place.
+        let stage_dir = tempfile::tempdir().unwrap();
+        let stager = SourceStager::new(policy_with_dir(stage_dir.path(), &["*.csv"]));
+        let entry = stager.plan_entry(Path::new("/data/orders.json"));
+        assert!(!entry.staged);
+        assert_eq!(entry.staged_path, None);
+    }
+
+    #[test]
+    fn plan_entry_reports_staged_path_and_reuse_miss_when_absent() {
+        // A matched source under reuse with no prior copy → staged, reuse miss,
+        // and the staged path is the stable content-addressed path under root.
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("orders.csv");
+        std::fs::write(&src, b"a,b\n1,2\n").unwrap();
+        let policy = StagingPolicy {
+            on_existing: OnExisting::Reuse,
+            ..policy_with_dir(stage_dir.path(), &["*.csv"])
+        };
+        let stager = SourceStager::new(policy);
+        let entry = stager.plan_entry(&src);
+        assert!(entry.staged);
+        let expected = stage_dir
+            .path()
+            .join(format!("{}.{STAGED_EXT}", source_id(&src)));
+        assert_eq!(entry.staged_path.as_deref(), Some(expected.as_path()));
+        assert_eq!(
+            entry.reuse,
+            ReuseDecision::Miss,
+            "no prior copy exists, so the real run would re-stage"
+        );
+    }
+
+    #[test]
+    fn plan_entry_reports_reuse_hit_after_a_fresh_copy() {
+        // Stage once, then a read-only plan_entry under reuse predicts a hit —
+        // matching the run-time freshness check without copying again.
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("orders.csv");
+        std::fs::write(&src, b"a,b\n1,2\n").unwrap();
+        let policy = StagingPolicy {
+            on_existing: OnExisting::Reuse,
+            ..policy_with_dir(stage_dir.path(), &["*.csv"])
+        };
+        let mut stager = SourceStager::new(policy.clone());
+        stager.resolve(src.clone()).expect("first stage copies");
+
+        let planner = SourceStager::new(policy);
+        let entry = planner.plan_entry(&src);
+        assert!(entry.staged);
+        assert_eq!(
+            entry.reuse,
+            ReuseDecision::Hit,
+            "a committed fresh copy must predict a reuse hit"
+        );
+
+        // Rewriting the source makes the copy stale → the prediction flips to miss.
+        std::fs::write(&src, b"a,b\n1,2\n3,4\n").unwrap();
+        assert_eq!(planner.plan_entry(&src).reuse, ReuseDecision::Miss);
+    }
+
+    #[test]
+    fn plan_entry_reuse_not_applicable_under_overwrite() {
+        // Under the default overwrite policy the reuse cache does not apply even
+        // when a matching copy exists.
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("orders.csv");
+        std::fs::write(&src, b"a,b\n1,2\n").unwrap();
+        let stager = SourceStager::new(policy_with_dir(stage_dir.path(), &["*.csv"]));
+        let entry = stager.plan_entry(&src);
+        assert!(entry.staged);
+        assert_eq!(entry.reuse, ReuseDecision::NotApplicable);
     }
 }

--- a/crates/clinker-exec/src/executor/batch_handoff.rs
+++ b/crates/clinker-exec/src/executor/batch_handoff.rs
@@ -384,7 +384,10 @@ impl StreamingChargeHandle {
             return Ok(());
         };
         let file_bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
-        if self.arbitrator.record_spill_bytes(file_bytes) {
+        if self
+            .arbitrator
+            .record_spill_bytes(&self.node_name, file_bytes)
+        {
             return Err(PipelineError::spill_cap_exceeded(
                 self.node_name.clone(),
                 self.arbitrator.max_spill_bytes(),

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1423,7 +1423,7 @@ pub(crate) fn admit_node_buffer(
             // Velox's "reclaimable ≠ held" point.
             handle.set_bytes(0);
             let file_bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
-            if ctx.memory_budget.record_spill_bytes(file_bytes) {
+            if ctx.memory_budget.record_spill_bytes(node_name, file_bytes) {
                 return Err(PipelineError::spill_cap_exceeded(
                     node_name,
                     ctx.memory_budget.max_spill_bytes(),

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -44,7 +44,8 @@ pub use registry::WriterRegistry;
 pub(crate) use registry::build_format_writer;
 pub(crate) use route::{CompiledRoute, CompiledRouteBranch};
 pub use storage_validate::{
-    FreeSpaceWarning, ResolvedStorage, StorageValidationError, validate_storage_config,
+    CapHeadroomWarning, FreeSpaceWarning, ResolvedStorage, StorageValidationError,
+    validate_storage_config,
 };
 pub(crate) use streaming::StreamingOutputTaskOutput;
 use streaming::{compute_streaming_output_specs, streaming_output};
@@ -136,6 +137,11 @@ pub(crate) struct DispatchOutcome {
     /// running total at dispatch close so an aborted run still
     /// reports the last committed value.
     pub(crate) cumulative_spill_bytes: u64,
+    /// Per-stage on-disk spill totals, keyed by the spilling node's name.
+    /// The sum equals `cumulative_spill_bytes`; this breakdown is what an
+    /// operator compares against the per-stage pre-run `--explain`
+    /// estimate to calibrate. Empty when no stage spilled.
+    pub(crate) per_stage_spill_bytes: BTreeMap<String, u64>,
     /// High-water mark of `MemoryArbitrator::sum_consumer_usage()` sampled
     /// at every streaming per-batch charge. A streaming stage's peak stays
     /// bounded to one in-flight batch (plus the channel's bound), proving
@@ -843,6 +849,7 @@ impl PipelineExecutor {
             per_source_record_counts,
             per_source_dlq_counts,
             cumulative_spill_bytes,
+            per_stage_spill_bytes,
             peak_consumer_usage_bytes,
             interrupted,
         } = Self::execute_dag(
@@ -897,7 +904,19 @@ impl PipelineExecutor {
         }
         collector.record(reader_timer.finish(total_ingested, total_ingested));
 
-        let stages = collector.into_stages();
+        let mut stages = collector.into_stages();
+        // Attribute the arbitrator's per-stage spill breakdown (keyed by node
+        // name) onto each node-scoped StageMetrics entry, so a combine's
+        // build/probe stage carries the bytes that combine actually spilled.
+        // The full map still rides on the report unchanged — this only mirrors
+        // the per-node share onto the timed stages an operator reads inline.
+        for stage in &mut stages {
+            if let Some(name) = stage.name.node_name()
+                && let Some(&bytes) = per_stage_spill_bytes.get(name)
+            {
+                stage.spill_bytes = bytes;
+            }
+        }
         let (total_cpu_user_ns, total_cpu_sys_ns, total_io_read_bytes, total_io_write_bytes) =
             sum_cpu_io_totals(&stages);
 
@@ -942,6 +961,7 @@ impl PipelineExecutor {
             per_source_record_counts,
             per_source_dlq_counts,
             cumulative_spill_bytes,
+            per_stage_spill_bytes,
             peak_consumer_usage_bytes,
             interrupted,
         })
@@ -1559,6 +1579,7 @@ impl PipelineExecutor {
             .collect();
 
         let cumulative_spill_bytes = ctx.memory_budget.cumulative_spill_bytes();
+        let per_stage_spill_bytes = ctx.memory_budget.per_stage_spill_bytes();
         let peak_consumer_usage_bytes = ctx.memory_budget.peak_consumer_usage();
         let interrupted = ctx.interrupted;
         Ok(DispatchOutcome {
@@ -1570,6 +1591,7 @@ impl PipelineExecutor {
             per_source_record_counts,
             per_source_dlq_counts,
             cumulative_spill_bytes,
+            per_stage_spill_bytes,
             peak_consumer_usage_bytes,
             interrupted,
         })

--- a/crates/clinker-exec/src/executor/params.rs
+++ b/crates/clinker-exec/src/executor/params.rs
@@ -149,6 +149,13 @@ pub struct ExecutionReport {
     /// `MemoryArbitrator`'s running total at dispatch close; an aborted
     /// run still surfaces the last committed value.
     pub cumulative_spill_bytes: u64,
+    /// Per-stage on-disk spill totals, keyed by the spilling node's name.
+    /// The sum of the values equals [`Self::cumulative_spill_bytes`]; this
+    /// breakdown is the per-stage actual an operator compares against the
+    /// pre-run `--explain` per-stage estimate (the calibration loop #176
+    /// exists for). Empty when no stage spilled. Distinct from
+    /// `cumulative_spill_bytes`, which is the single pipeline-wide total.
+    pub per_stage_spill_bytes: BTreeMap<String, u64>,
     /// High-water mark of the arbitrator's summed pull-mode charged bytes
     /// observed across streaming per-batch charges. For a streaming stage
     /// this stays bounded to one in-flight batch (plus the bounded

--- a/crates/clinker-exec/src/executor/stage_metrics.rs
+++ b/crates/clinker-exec/src/executor/stage_metrics.rs
@@ -36,6 +36,14 @@ pub struct StageMetrics {
     pub heap_delta_bytes: Option<i64>,
     /// Number of heap allocations during the stage. `bench-alloc` feature-gated.
     pub heap_alloc_count: Option<u64>,
+    /// On-disk bytes this stage spilled, attributed from the arbitrator's
+    /// per-stage spill breakdown after the run completes. `0` for a stage
+    /// that never spilled (and for streaming/non-blocking stages, which
+    /// hold no spillable state). This is the *actual* spilled volume an
+    /// operator compares against the pre-run `--explain` per-stage estimate
+    /// to calibrate (#176): a large estimate-vs-actual delta is the
+    /// highest-leverage debugging input when a pipeline spills unexpectedly.
+    pub spill_bytes: u64,
 }
 
 /// Named pipeline stages (not stringly-typed).
@@ -68,6 +76,25 @@ pub enum StageName {
     CombineProbe {
         name: String,
     },
+}
+
+impl StageName {
+    /// The pipeline node name this stage runs for, when the variant is
+    /// scoped to a single named node (combine build/probe, named index
+    /// builds). Returns `None` for the run-wide phases (Compile, Sort,
+    /// GroupFlush, …) that are not tied to one node by name.
+    ///
+    /// Used at run completion to attribute the arbitrator's per-stage spill
+    /// breakdown (keyed by node name) onto the matching `StageMetrics`
+    /// entry, so a combine's spilled volume lands on its build/probe stage.
+    pub fn node_name(&self) -> Option<&str> {
+        match self {
+            StageName::CombineBuild { name }
+            | StageName::CombineProbe { name }
+            | StageName::IndexBuild { name } => Some(name),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for StageName {
@@ -164,6 +191,7 @@ impl StageTimer {
             io_write_delta,
             heap_delta_bytes: heap_delta,
             heap_alloc_count: heap_count,
+            spill_bytes: 0,
         }
     }
 }
@@ -221,6 +249,7 @@ impl CumulativeTimer {
             io_write_delta: None,
             heap_delta_bytes: None,
             heap_alloc_count: None,
+            spill_bytes: 0,
         }
     }
 }
@@ -383,6 +412,7 @@ mod tests {
             io_write_delta: None,
             heap_delta_bytes: None,
             heap_alloc_count: None,
+            spill_bytes: 0,
         };
         assert!(m.cpu_user_delta_ns.is_none());
         assert!(m.cpu_sys_delta_ns.is_none());
@@ -505,6 +535,47 @@ mod tests {
         };
         let merged = a.clone().merge(ChunkTimers::default());
         assert_eq!(merged.transform_eval, Duration::from_millis(10));
+    }
+
+    #[test]
+    fn stage_metrics_default_spill_bytes_zero() {
+        let timer = StageTimer::new(StageName::Sort);
+        let metrics = timer.finish(0, 0);
+        assert_eq!(
+            metrics.spill_bytes, 0,
+            "a freshly-timed stage spills nothing until the per-stage breakdown is folded in"
+        );
+        let cumulative = CumulativeTimer::new().finish(StageName::Projection, 0, 0);
+        assert_eq!(cumulative.spill_bytes, 0);
+    }
+
+    #[test]
+    fn stage_name_node_name_only_for_node_scoped_variants() {
+        assert_eq!(
+            StageName::CombineBuild {
+                name: "enriched".into()
+            }
+            .node_name(),
+            Some("enriched")
+        );
+        assert_eq!(
+            StageName::CombineProbe {
+                name: "enriched".into()
+            }
+            .node_name(),
+            Some("enriched")
+        );
+        assert_eq!(
+            StageName::IndexBuild {
+                name: "employees:dept".into()
+            }
+            .node_name(),
+            Some("employees:dept")
+        );
+        // Run-wide phases are not tied to one named node.
+        assert_eq!(StageName::Sort.node_name(), None);
+        assert_eq!(StageName::Compile.node_name(), None);
+        assert_eq!(StageName::GroupFlush.node_name(), None);
     }
 
     #[test]

--- a/crates/clinker-exec/src/executor/storage_validate.rs
+++ b/crates/clinker-exec/src/executor/storage_validate.rs
@@ -48,6 +48,14 @@ pub struct ResolvedStorage {
     /// and the runtime disk cap (E320) / full-volume (E321) surfaces remain the
     /// hard backstops.
     pub free_space_warning: Option<FreeSpaceWarning>,
+    /// A cap-headroom advisory, present only when a `storage.spill.disk_cap_bytes`
+    /// is configured AND the run's estimated spill volume exceeds 80% of it. The
+    /// run is likely to abort mid-stream with the spill-cap diagnostic (E320), so
+    /// surfacing the signal at startup lets the operator raise the cap or reduce
+    /// the footprint before committing. Advisory, not fatal — the estimate is a
+    /// coarse upper bound, and a run that compresses well or never trips its
+    /// memory budget may finish comfortably under the cap.
+    pub cap_headroom_warning: Option<CapHeadroomWarning>,
 }
 
 /// A startup free-space preflight finding: the spill volume looks too small
@@ -77,6 +85,53 @@ impl std::fmt::Display for FreeSpaceWarning {
             self.spill_dir.display(),
             self.available_bytes,
             self.estimated_spill_bytes,
+        )
+    }
+}
+
+/// The fraction of `storage.spill.disk_cap_bytes` above which a run's estimated
+/// spill volume trips the [`CapHeadroomWarning`]. 80% is the headroom-warning
+/// threshold #176 specifies — enough margin that the estimate's coarseness does
+/// not constantly false-alarm, while still firing before a run that would
+/// realistically blow the cap.
+pub const CAP_HEADROOM_WARN_FRACTION: f64 = 0.80;
+
+/// A startup cap-headroom finding: the run's estimated spill volume is within
+/// 80% of (or above) the configured `storage.spill.disk_cap_bytes`, so it is
+/// likely to abort with the spill-cap diagnostic (E320) mid-stream.
+///
+/// Advisory by design — see [`ResolvedStorage::cap_headroom_warning`]. The
+/// figure is **per invocation**: under the partition-and-run model several
+/// sibling `clinker` invocations can share one spill volume and one cap, so the
+/// real headroom is smaller than any single invocation sees. The rendered
+/// message states this so an operator running siblings does not read the
+/// per-invocation headroom as the whole-volume headroom.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapHeadroomWarning {
+    /// The configured cumulative spill cap, in bytes
+    /// (`storage.spill.disk_cap_bytes`).
+    pub disk_cap_bytes: u64,
+    /// The run's coarse plan-time estimate of the bytes it could spill.
+    pub estimated_spill_bytes: u64,
+}
+
+impl std::fmt::Display for CapHeadroomWarning {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let pct = if self.disk_cap_bytes == 0 {
+            0.0
+        } else {
+            (self.estimated_spill_bytes as f64 / self.disk_cap_bytes as f64) * 100.0
+        };
+        write!(
+            f,
+            "W331: this run is estimated to spill up to {} bytes, which is {:.0}% of the \
+             configured spill cap storage.spill.disk_cap_bytes ({} bytes); the run may abort \
+             with a spill-cap error (E320) before it finishes — raise disk_cap_bytes or reduce \
+             the spill footprint (raise memory.limit, partition the input). This headroom is \
+             per invocation: if you partition the input and run several clinker invocations \
+             against the same spill volume and cap, they share the cap, so the real headroom \
+             is smaller than this figure",
+            self.estimated_spill_bytes, pct, self.disk_cap_bytes,
         )
     }
 }
@@ -269,10 +324,44 @@ pub fn validate_storage_config(
         None
     };
 
+    // Cap-headroom preflight (advisory). When a cumulative spill cap is
+    // configured and the run's estimate is within 80% of it, warn at startup so
+    // the operator sees the signal before the run aborts with E320 mid-stream.
+    // Skipped when the estimate is unknown (`0`) or no cap is set (unlimited
+    // spill has no headroom to overrun).
+    let cap_headroom_warning =
+        cap_headroom_preflight(storage.spill.disk_cap(), estimated_spill_bytes);
+
     Ok(ResolvedStorage {
         spill_root_dir,
         free_space_warning,
+        cap_headroom_warning,
     })
+}
+
+/// Produce a [`CapHeadroomWarning`] when a cumulative spill cap is configured
+/// and the run's estimated spill volume reaches 80% of it.
+///
+/// Pure over its two inputs (no filesystem probe), so the warn/no-warn boundary
+/// is testable without a real volume. Returns `None` when no cap is set, the
+/// estimate is unknown (`0`), or the estimate sits below the threshold.
+fn cap_headroom_preflight(
+    disk_cap_bytes: Option<u64>,
+    estimated_spill_bytes: u64,
+) -> Option<CapHeadroomWarning> {
+    let cap = disk_cap_bytes?;
+    if cap == 0 || estimated_spill_bytes == 0 {
+        return None;
+    }
+    let threshold = (cap as f64 * CAP_HEADROOM_WARN_FRACTION) as u64;
+    if estimated_spill_bytes >= threshold {
+        Some(CapHeadroomWarning {
+            disk_cap_bytes: cap,
+            estimated_spill_bytes,
+        })
+    } else {
+        None
+    }
 }
 
 /// The configured staging directory, if `enabled` set one. The `enabled`
@@ -532,6 +621,63 @@ mod tests {
             "expected E334 spill-equals-staging, got {err}"
         );
         assert!(err.to_string().contains("E334"));
+    }
+
+    #[test]
+    fn cap_headroom_warns_at_or_above_80_percent() {
+        // 8 GB estimate against a 10 GB cap is exactly 80% → warn.
+        let w = cap_headroom_preflight(Some(10_000_000_000), 8_000_000_000)
+            .expect("80% of the cap must trip the headroom warning");
+        assert_eq!(w.disk_cap_bytes, 10_000_000_000);
+        assert_eq!(w.estimated_spill_bytes, 8_000_000_000);
+        let msg = w.to_string();
+        assert!(
+            msg.contains("W331"),
+            "message must carry the W331 code: {msg}"
+        );
+        // enh-6 #311: the per-invocation disclaimer must be present so an
+        // operator running siblings does not misread the headroom.
+        assert!(
+            msg.contains("per invocation"),
+            "the headroom must state it is per-invocation: {msg}"
+        );
+
+        // An estimate above the cap warns just as well.
+        assert!(cap_headroom_preflight(Some(10_000_000_000), 11_000_000_000).is_some());
+    }
+
+    #[test]
+    fn cap_headroom_silent_below_threshold_or_when_no_cap() {
+        // 7 GB against a 10 GB cap is 70% → below the 80% threshold, no warn.
+        assert!(cap_headroom_preflight(Some(10_000_000_000), 7_000_000_000).is_none());
+        // No cap configured → unlimited spill has no headroom to overrun.
+        assert!(cap_headroom_preflight(None, 8_000_000_000).is_none());
+        // Unknown estimate (0) → nothing to compare.
+        assert!(cap_headroom_preflight(Some(10_000_000_000), 0).is_none());
+    }
+
+    #[test]
+    fn validate_surfaces_cap_headroom_warning() {
+        // Drive the full validator: a tiny cap with a large estimate trips the
+        // headroom advisory without aborting the run.
+        let dir = tempfile::tempdir().unwrap();
+        let storage = storage_with(
+            SpillConfig {
+                dir: Some(dir.path().to_path_buf()),
+                disk_cap_bytes: Some(clinker_plan::config::ByteSize(1_000)),
+                ..Default::default()
+            },
+            StagingPolicy::default(),
+        );
+        // 2000-byte estimate vs a 1000-byte cap = 200% → warn. Use a small
+        // estimate so the free-space preflight on the real tempdir does not
+        // also fire and obscure the cap-headroom assertion.
+        let resolved = validate_storage_config(&storage, &[], 2_000).unwrap();
+        let warning = resolved
+            .cap_headroom_warning
+            .expect("an estimate above the cap must trip the cap-headroom warning");
+        assert_eq!(warning.disk_cap_bytes, 1_000);
+        assert_eq!(warning.estimated_spill_bytes, 2_000);
     }
 
     #[test]

--- a/crates/clinker-exec/src/executor/storage_validate.rs
+++ b/crates/clinker-exec/src/executor/storage_validate.rs
@@ -635,7 +635,7 @@ mod tests {
             msg.contains("W331"),
             "message must carry the W331 code: {msg}"
         );
-        // enh-6 #311: the per-invocation disclaimer must be present so an
+        // #311: the per-invocation disclaimer must be present so an
         // operator running siblings does not misread the headroom.
         assert!(
             msg.contains("per invocation"),

--- a/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
@@ -751,7 +751,7 @@ pub(crate) fn execute_combine_grace_hash(
     }
     executor.finish_build(&build_extractor, ctx, budget, name)?;
     let build_spilled = executor.take_spilled_bytes();
-    if budget.record_spill_bytes(build_spilled) {
+    if budget.record_spill_bytes(name, build_spilled) {
         return Err(PipelineError::spill_cap_exceeded(
             name,
             budget.disk_quota(),
@@ -841,7 +841,7 @@ pub(crate) fn execute_combine_grace_hash(
         .finalize_probe_spills()
         .map_err(|e| grace_spill_error(e, name, "probe finalize failed"))?;
     let probe_spilled = executor.take_spilled_bytes();
-    if budget.record_spill_bytes(probe_spilled) {
+    if budget.record_spill_bytes(name, probe_spilled) {
         return Err(PipelineError::spill_cap_exceeded(
             name,
             budget.disk_quota(),

--- a/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
@@ -283,7 +283,7 @@ pub(super) fn process_spilled_partition(
             let (bpath, b_written) = bw
                 .finish()
                 .map_err(|e| grace_spill_error(e, name, "repartition build finalize"))?;
-            if budget.record_spill_bytes(b_written) {
+            if budget.record_spill_bytes(name, b_written) {
                 return Err(PipelineError::spill_cap_exceeded(
                     name,
                     budget.disk_quota(),
@@ -307,7 +307,7 @@ pub(super) fn process_spilled_partition(
                 let (p, p_written) = pw
                     .finish()
                     .map_err(|e| grace_spill_error(e, name, "repartition probe finalize"))?;
-                if budget.record_spill_bytes(p_written) {
+                if budget.record_spill_bytes(name, p_written) {
                     return Err(PipelineError::spill_cap_exceeded(
                         name,
                         budget.disk_quota(),

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -615,6 +615,15 @@ pub struct MemoryArbitrator {
     /// E310 with a partition + spill-bytes diagnostic.
     max_spill_bytes: AtomicU64,
     cumulative_spill_bytes: AtomicU64,
+    /// Per-stage on-disk spill totals, keyed by the spilling node's name.
+    /// The pipeline-wide `cumulative_spill_bytes` is the sum of these, but
+    /// the calibration loop #176 exists for needs the per-stage breakdown:
+    /// an operator compares each stage's *actual* spilled volume against the
+    /// pre-run `--explain` *estimate* for that same stage. Spill is off the
+    /// per-record hot path (it fires only when a blocking operator's state
+    /// trips the memory budget), so a `Mutex<BTreeMap>` here costs nothing
+    /// observable while keeping the breakdown allocation-stable and ordered.
+    per_stage_spill_bytes: Mutex<std::collections::BTreeMap<String, u64>>,
     /// High-water mark of `sum_consumer_usage()` sampled whenever a
     /// streaming charge handle admits a batch. Lets a test prove the
     /// charged-bytes peak of a streaming stage stays bounded to one
@@ -662,6 +671,7 @@ impl MemoryArbitrator {
             peak_rss: AtomicU64::new(0),
             max_spill_bytes: AtomicU64::new(u64::MAX),
             cumulative_spill_bytes: AtomicU64::new(0),
+            per_stage_spill_bytes: Mutex::new(std::collections::BTreeMap::new()),
             peak_consumer_usage: AtomicU64::new(0),
             consumers: ArcSwap::from_pointee(Vec::new()),
             next_consumer_id: AtomicU32::new(0),
@@ -814,22 +824,49 @@ impl MemoryArbitrator {
     }
 
     /// Cumulative spill bytes recorded so far across every spill
-    /// operator polling this arbitrator.
+    /// operator polling this arbitrator. Equals the sum of every entry
+    /// in [`Self::per_stage_spill_bytes`].
     pub fn cumulative_spill_bytes(&self) -> u64 {
         self.cumulative_spill_bytes.load(Ordering::Relaxed)
     }
 
-    /// Add `n` bytes to the cumulative spill counter. Returns `true`
-    /// when the running total has exceeded `max_spill_bytes` — the
-    /// operator's signal to surface E310 instead of continuing to
-    /// write. Saturating-add via `fetch_update` keeps an overflowing
-    /// pipeline from wrapping back below the quota silently.
-    pub fn record_spill_bytes(&self, n: u64) -> bool {
+    /// Snapshot of the per-stage on-disk spill totals, keyed by the
+    /// spilling node's name. The sum of the values equals
+    /// [`Self::cumulative_spill_bytes`]. Read once at run completion to
+    /// populate [`crate::executor::ExecutionReport::per_stage_spill_bytes`]
+    /// so an operator can compare each stage's actual spilled volume
+    /// against its pre-run `--explain` estimate.
+    pub fn per_stage_spill_bytes(&self) -> std::collections::BTreeMap<String, u64> {
+        self.per_stage_spill_bytes
+            .lock()
+            .expect("per_stage_spill_bytes mutex poisoned")
+            .clone()
+    }
+
+    /// Charge `n` spilled bytes against the named stage and the
+    /// pipeline-wide cumulative total. Returns `true` when the running
+    /// cumulative total has exceeded `max_spill_bytes` — the operator's
+    /// signal to surface the spill-cap diagnostic (E320) instead of
+    /// continuing to write.
+    ///
+    /// `node` is the spilling operator's node name, so the per-stage
+    /// breakdown attributes the bytes to the exact stage that wrote them.
+    /// Saturating-add via `fetch_update` keeps an overflowing pipeline
+    /// from wrapping back below the quota silently.
+    pub fn record_spill_bytes(&self, node: &str, n: u64) -> bool {
         let _ =
             self.cumulative_spill_bytes
                 .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
                     Some(cur.saturating_add(n))
                 });
+        {
+            let mut per_stage = self
+                .per_stage_spill_bytes
+                .lock()
+                .expect("per_stage_spill_bytes mutex poisoned");
+            let entry = per_stage.entry(node.to_string()).or_insert(0);
+            *entry = entry.saturating_add(n);
+        }
         self.cumulative_spill_bytes.load(Ordering::Relaxed)
             > self.max_spill_bytes.load(Ordering::Relaxed)
     }
@@ -1195,9 +1232,9 @@ mod tests {
         let arbitrator =
             MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
         arbitrator.set_max_spill_bytes(1024);
-        assert!(!arbitrator.record_spill_bytes(256));
+        assert!(!arbitrator.record_spill_bytes("sort", 256));
         assert_eq!(arbitrator.cumulative_spill_bytes(), 256);
-        assert!(!arbitrator.record_spill_bytes(512));
+        assert!(!arbitrator.record_spill_bytes("sort", 512));
         assert_eq!(arbitrator.cumulative_spill_bytes(), 768);
     }
 
@@ -1206,8 +1243,8 @@ mod tests {
         let arbitrator =
             MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
         arbitrator.set_max_spill_bytes(1024);
-        assert!(!arbitrator.record_spill_bytes(1024));
-        assert!(arbitrator.record_spill_bytes(1));
+        assert!(!arbitrator.record_spill_bytes("sort", 1024));
+        assert!(arbitrator.record_spill_bytes("sort", 1));
         assert_eq!(arbitrator.cumulative_spill_bytes(), 1025);
     }
 
@@ -1222,8 +1259,27 @@ mod tests {
         arbitrator
             .cumulative_spill_bytes
             .store(u64::MAX - 10, Ordering::Relaxed);
-        assert!(arbitrator.record_spill_bytes(100));
+        assert!(arbitrator.record_spill_bytes("sort", 100));
         assert_eq!(arbitrator.cumulative_spill_bytes(), u64::MAX);
+    }
+
+    #[test]
+    fn test_record_spill_bytes_attributes_per_stage() {
+        // Two stages spill; the per-stage breakdown keeps their totals
+        // distinct and the cumulative total equals their sum.
+        let arbitrator =
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        arbitrator.record_spill_bytes("sort_by_amount", 256);
+        arbitrator.record_spill_bytes("dept_totals", 512);
+        arbitrator.record_spill_bytes("sort_by_amount", 128);
+        let per_stage = arbitrator.per_stage_spill_bytes();
+        assert_eq!(per_stage.get("sort_by_amount"), Some(&384));
+        assert_eq!(per_stage.get("dept_totals"), Some(&512));
+        assert_eq!(
+            per_stage.values().sum::<u64>(),
+            arbitrator.cumulative_spill_bytes(),
+            "the per-stage totals must sum to the pipeline-wide cumulative total"
+        );
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -1175,7 +1175,7 @@ fn walk_two_cursors(args: WalkArgs<'_, '_, '_>) -> Result<(), PipelineError> {
                     consumer_handle,
                 )
                 .map_err(|e| grace_spill_error(e, name, "sort-merge matching-run spill failed"))?;
-                if written > 0 && budget.record_spill_bytes(written) {
+                if written > 0 && budget.record_spill_bytes(name, written) {
                     return Err(PipelineError::spill_cap_exceeded(
                         name,
                         budget.disk_quota(),

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -3498,6 +3498,64 @@ nodes:
         }
     }
 
+    /// Run `run_combine_fixture` under a hard wall-clock bound, failing
+    /// fast instead of letting `cargo test` (which has no per-test
+    /// timeout) block the whole suite forever.
+    ///
+    /// The fixture runs on a worker thread; the caller waits for its
+    /// result over an `mpsc` channel with `recv_timeout`. A memory-abort
+    /// fixture that deadlocks (e.g. a future regression that reintroduces
+    /// a never-resumed producer pause under a permanently over-budget RSS)
+    /// trips the timeout and panics with a clear message rather than
+    /// hanging. The bound is generous relative to the few-millisecond
+    /// happy path, so it never flakes on a slow CI host.
+    ///
+    /// `yaml` and the input CSVs are copied into owned `String`s so the
+    /// worker closure is `'static` and the borrowed fixture constants
+    /// stay usable at the call site.
+    fn run_combine_fixture_bounded(
+        yaml: &str,
+        inputs: &[(&str, &str)],
+        primary_override: Option<&str>,
+        bound: std::time::Duration,
+    ) -> Result<CombineFixtureResult, CombineFixtureError> {
+        let yaml = yaml.to_string();
+        let inputs: Vec<(String, String)> = inputs
+            .iter()
+            .map(|(name, data)| ((*name).to_string(), (*data).to_string()))
+            .collect();
+        let primary_override = primary_override.map(str::to_string);
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let input_refs: Vec<(&str, &str)> = inputs
+                .iter()
+                .map(|(name, data)| (name.as_str(), data.as_str()))
+                .collect();
+            let result = run_combine_fixture(&yaml, &input_refs, primary_override.as_deref());
+            // A send error means the receiver already gave up (timed out);
+            // drop the result silently in that case.
+            let _ = tx.send(result);
+        });
+
+        match rx.recv_timeout(bound) {
+            Ok(result) => {
+                handle
+                    .join()
+                    .expect("combine fixture worker thread panicked");
+                result
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => panic!(
+                "combine fixture did not complete within {bound:?}; a memory-abort \
+                 pipeline that hangs instead of surfacing a typed error indicates a \
+                 producer-pause deadlock under a permanently over-budget RSS"
+            ),
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("combine fixture worker thread dropped its result sender without sending")
+            }
+        }
+    }
+
     /// MemoryArbitrator abort — a 1-byte hard limit forces
     /// `MemoryArbitrator::should_abort` to return true on the first poll
     /// inside `CombineHashTable::build` (process RSS trivially exceeds
@@ -3511,6 +3569,17 @@ nodes:
     /// but exercised end-to-end through the combine executor arm so a
     /// regression in the arm's error mapping is caught here.
     ///
+    /// Determinism: `backpressure: spill` installs the bare `Priority`
+    /// policy so no producer is ever elected as a pause victim. Under the
+    /// default `pause` policy a 1-byte budget can pause the Source ingest
+    /// thread on a `Condvar` that never resumes (nothing ever frees memory
+    /// below 1 byte) while the consumer blocks on `recv`, deadlocking the
+    /// run; choosing `spill` removes that path so the synchronous arena /
+    /// NodeBuffer admission charge surfaces the abort on the first record.
+    /// The run is wrapped in `run_combine_fixture_bounded` so even a future
+    /// regression that reintroduces the deadlock fails fast instead of
+    /// hanging `cargo test`.
+    ///
     /// Skipped silently when `rss_bytes()` is unavailable on the host
     /// platform — the same gate the unit test uses, applied via
     /// `clinker_exec::pipeline::memory::rss_bytes()`.
@@ -3522,7 +3591,7 @@ nodes:
         let yaml = r#"
 pipeline:
   name: combine_exec_e310
-  memory: { limit: "1" }
+  memory: { limit: "1", backpressure: spill }
 nodes:
   - type: source
     name: orders
@@ -3565,10 +3634,11 @@ nodes:
       type: csv
       path: enriched.csv
 "#;
-        let err = run_combine_fixture(
+        let err = run_combine_fixture_bounded(
             yaml,
             &[("orders", EXEC_ORDERS), ("products", EXEC_PRODUCTS)],
             Some("orders"),
+            std::time::Duration::from_secs(30),
         )
         .expect_err("1-byte mem_limit must abort combine");
         match &err {

--- a/crates/clinker-exec/tests/explain_arbitration.rs
+++ b/crates/clinker-exec/tests/explain_arbitration.rs
@@ -225,3 +225,74 @@ fn explain_nonzero_predictions_are_surfaced() {
         "the Source→Aggregate node_buffer edge must carry the producer's non-zero volume, got:\n{text}"
     );
 }
+
+/// The `=== Estimated Spill Volume ===` section lists one estimate per
+/// blocking stage and a total. With a sized 1 KiB input feeding a hash
+/// Aggregate, the section names the Aggregate at its `1K` predicted peak and
+/// reports a `1K` total — the per-stage estimate AC#1 surfaces.
+#[test]
+fn explain_renders_per_stage_spill_estimate() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_sized(tmp.path(), "orders.csv", &orders_csv_1kib(), 1024);
+
+    let text = render_explain_anchored(source_aggregate_output_yaml(), tmp.path());
+
+    assert!(
+        text.contains("=== Estimated Spill Volume ==="),
+        "explain text must carry the per-stage spill-estimate section, got:\n{text}"
+    );
+    let section_start = text
+        .find("=== Estimated Spill Volume ===")
+        .expect("estimate section present");
+    let section = &text[section_start..];
+    assert!(
+        section.contains("dept_totals") && section.contains("→ 1K"),
+        "the hash Aggregate stage must show its 1K estimate, got:\n{section}"
+    );
+    assert!(
+        section.contains("Total: 1K"),
+        "the section must report a 1K total for the single spilling stage, got:\n{section}"
+    );
+}
+
+/// A streaming-only pipeline (Source → Transform → Output, no blocking
+/// operator) has nothing that spills, so the estimate section is omitted
+/// entirely rather than rendering an empty or zero block.
+#[test]
+fn explain_omits_spill_estimate_for_streaming_only() {
+    let yaml = r#"
+pipeline:
+  name: streaming_only
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: department, type: string }
+        - { name: amount, type: int }
+  - type: transform
+    name: tag
+    input: orders
+    config:
+      cxl: |
+        emit department = department
+        emit amount = amount
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+    let text = render_explain(yaml);
+    assert!(
+        !text.contains("=== Estimated Spill Volume ==="),
+        "a streaming-only pipeline has no spilling stage, so the estimate section must be omitted, \
+         got:\n{text}"
+    );
+}

--- a/crates/clinker-exec/tests/route_fanout_soft_spill.rs
+++ b/crates/clinker-exec/tests/route_fanout_soft_spill.rs
@@ -170,6 +170,22 @@ fn route_fanout_emits_spill_under_one_megabyte_budget() {
         report.cumulative_spill_bytes,
     );
 
+    // The per-stage spill breakdown (#176, AC#3) must be populated on a real
+    // run that spilled, attribute the bytes to a named node, and sum exactly to
+    // the pipeline-wide cumulative total — the per-stage actual an operator
+    // compares against the pre-run `--explain` per-stage estimate.
+    assert!(
+        !report.per_stage_spill_bytes.is_empty(),
+        "a run that spilled must populate the per-stage breakdown, got an empty map",
+    );
+    let per_stage_sum: u64 = report.per_stage_spill_bytes.values().sum();
+    assert_eq!(
+        per_stage_sum, report.cumulative_spill_bytes,
+        "the per-stage spill totals must sum to the pipeline-wide cumulative total \
+         (per_stage_sum={per_stage_sum}, cumulative={})",
+        report.cumulative_spill_bytes,
+    );
+
     assert_eq!(
         count_data_rows(&out_a.as_string()),
         ROWS_A,

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
@@ -50,6 +50,12 @@ edge aggregation.dept_totals -> output.out:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: aggregation)
 
+=== Estimated Spill Volume ===
+
+Estimated spill volume (per blocking stage):
+  [aggregation:hash] dept_totals → unknown
+  Total (known stages): 0B (excludes stages whose volume is unknown at plan time — a glob/regex multi-file source, a network source, or a missing input)
+
 === CXL Expressions ===
 
 Transform 'dept_totals':

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output_sized.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output_sized.snap
@@ -50,6 +50,12 @@ edge aggregation.dept_totals -> output.out:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=1K, predicted_freed=1K (producer: aggregation)
 
+=== Estimated Spill Volume ===
+
+Estimated spill volume (per blocking stage):
+  [aggregation:hash] dept_totals → 1K
+  Total: 1K
+
 === CXL Expressions ===
 
 Transform 'dept_totals':

--- a/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
+++ b/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
@@ -91,6 +91,13 @@ edge aggregation.dept_totals -> output.out:
   buffer: node_buffer (slot=2)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: aggregation)
 
+=== Estimated Spill Volume ===
+
+Estimated spill volume (per blocking stage):
+  [sort] __correlation_sort_orders → unknown
+  [aggregation:hash] dept_totals → unknown
+  Total (known stages): 0B (excludes stages whose volume is unknown at plan time — a glob/regex multi-file source, a network source, or a missing input)
+
 === Retraction ===
 
 retraction enabled — 1 relaxed aggregates, 1 buffer-mode windows, fanout policy: any.

--- a/crates/clinker-exec/tests/storage_validate.rs
+++ b/crates/clinker-exec/tests/storage_validate.rs
@@ -159,7 +159,7 @@ fn free_space_preflight_warns_on_low_space() {
 
 /// The cap-headroom preflight (W331, #176 AC#4) warns — without erroring —
 /// when the estimated spill volume reaches 80% of the configured spill cap. The
-/// message disclaims that the headroom is per-invocation (enh-6 #311).
+/// message disclaims that the headroom is per-invocation (#311).
 #[test]
 fn cap_headroom_preflight_warns_above_eighty_percent() {
     let dir = tempfile::tempdir().expect("spill dir");

--- a/crates/clinker-exec/tests/storage_validate.rs
+++ b/crates/clinker-exec/tests/storage_validate.rs
@@ -157,6 +157,55 @@ fn free_space_preflight_warns_on_low_space() {
     assert!(warning.to_string().contains("W330"));
 }
 
+/// The cap-headroom preflight (W331, #176 AC#4) warns — without erroring —
+/// when the estimated spill volume reaches 80% of the configured spill cap. The
+/// message disclaims that the headroom is per-invocation (enh-6 #311).
+#[test]
+fn cap_headroom_preflight_warns_above_eighty_percent() {
+    let dir = tempfile::tempdir().expect("spill dir");
+    let cfg = storage(
+        SpillConfig {
+            dir: Some(dir.path().to_path_buf()),
+            disk_cap_bytes: Some(clinker_plan::config::ByteSize(1_000)),
+            ..Default::default()
+        },
+        StagingPolicy::default(),
+    );
+    // 900-byte estimate against a 1000-byte cap = 90%, over the 80% threshold.
+    // Small enough that the real tempdir's free space does not also trip W330.
+    let resolved =
+        validate_storage_config(&cfg, &[], 900).expect("cap-headroom warns, does not error");
+    let warning = resolved
+        .cap_headroom_warning
+        .expect("cap-headroom advisory must fire above 80% of the cap");
+    assert_eq!(warning.disk_cap_bytes, 1_000);
+    assert_eq!(warning.estimated_spill_bytes, 900);
+    let msg = warning.to_string();
+    assert!(msg.contains("W331"), "message must carry W331: {msg}");
+    assert!(
+        msg.contains("per invocation"),
+        "the headroom must disclaim sibling invocations: {msg}"
+    );
+}
+
+/// No cap-headroom warning when the estimate sits comfortably below 80% of the
+/// cap, or when no cap is configured.
+#[test]
+fn cap_headroom_silent_below_threshold() {
+    let dir = tempfile::tempdir().expect("spill dir");
+    let cfg = storage(
+        SpillConfig {
+            dir: Some(dir.path().to_path_buf()),
+            disk_cap_bytes: Some(clinker_plan::config::ByteSize(1_000_000_000)),
+            ..Default::default()
+        },
+        StagingPolicy::default(),
+    );
+    // 1 KB estimate against a 1 GB cap is far under the threshold.
+    let resolved = validate_storage_config(&cfg, &[], 1_000).expect("clean validate");
+    assert!(resolved.cap_headroom_warning.is_none());
+}
+
 /// A directory-validity failure from the reused spill-dir check carries through
 /// as the same message, on every platform.
 #[test]

--- a/crates/clinker-exec/tests/volume_estimates.rs
+++ b/crates/clinker-exec/tests/volume_estimates.rs
@@ -295,6 +295,48 @@ nodes:
 }
 
 #[test]
+fn explicit_paths_source_seeds_sum_of_listed_files() {
+    // An explicit `paths:` list carries no glob/exclude/size discovery filters,
+    // so the seed is the exact sum of the listed files' sizes — the multi-file
+    // case the estimate now covers (a glob/regex matcher still seeds 0).
+    let tmp = tempfile::tempdir().unwrap();
+    let a = write_file(tmp.path(), "a.csv", "department,amount\nsales,100\n");
+    let b = write_file(tmp.path(), "b.csv", "department,amount\nops,250\nops,40\n");
+    assert!(a > 0 && b > 0);
+
+    let yaml = r#"
+pipeline:
+  name: vol
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      paths: [a.csv, b.csv]
+      schema:
+        - { name: department, type: string }
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let plan = compile_anchored(yaml, tmp.path());
+    let dag = plan.dag();
+
+    let src = props_for_node(dag, "orders");
+    assert_eq!(
+        src.predicted_peak_bytes,
+        a + b,
+        "an explicit paths: list must seed the sum of the listed files' sizes"
+    );
+}
+
+#[test]
 fn propagation_source_transform_aggregate() {
     // Source -> Transform -> Aggregate: the Transform inherits the Source's
     // seeded volume (pass-through), the hash Aggregate's peak equals the

--- a/crates/clinker-plan/src/plan/execution/composition.rs
+++ b/crates/clinker-plan/src/plan/execution/composition.rs
@@ -331,27 +331,57 @@ pub(crate) fn resolve_composition_body_windows(
 
 /// On-disk byte seed for a file-backed Source's `predicted_peak_bytes`.
 ///
-/// Returns `Some(len)` only for the single-file `path:` matcher, resolving
-/// the path against `anchor` (the pipeline file's directory) so the size is
-/// independent of the process CWD. Returns `None` — the universal "unknown"
-/// seed, written as `0` by the caller — for every case this issue does not
-/// cover: multi-file matchers (`glob`/`regex`/`paths`), an absent `path:`,
-/// or an unreadable/missing file (`std::fs::metadata` error). Absolute paths
-/// resolve as-is, matching the source-discovery resolver.
+/// Resolves each literal path against `anchor` (the pipeline file's directory)
+/// so the size is independent of the process CWD, and absolute paths resolve
+/// as-is — matching the source-discovery resolver.
+///
+/// Coverage:
+/// - **`path:`** (single file) — `Some(len)`.
+/// - **`paths:`** (explicit list) — `Some(sum)` of every readable listed file.
+///   The explicit list carries no glob/exclude/min-size discovery filters, so
+///   summing the listed sizes is exact and reuses no discovery logic. An
+///   unreadable entry contributes nothing; the sum still seeds the others.
+///
+/// Returns `None` — the "unknown" seed the caller writes as `0` — for:
+/// - **`glob:` / `regex:`** matchers, which fan out through the full
+///   source-discovery resolver (exclude lists, `min_size`/`max_size`,
+///   `modified_after`/`before`, `take`, sort). Summing matched sizes here
+///   would mean re-implementing that resolver and risk diverging from the
+///   bytes the run actually reads, so these stay unknown by design — the
+///   `--explain` output and `docs/src/ops/storage.md` flag the limitation.
+/// - an absent matcher, or a `path:` whose `std::fs::metadata` fails.
 pub(crate) fn source_seed_bytes(source: &SourceConfig, anchor: &std::path::Path) -> Option<u64> {
-    // Multi-file matchers fan out to a `Vec<PathBuf>` at discovery time with
-    // no single literal size to seed; leave them unknown.
-    if source.glob.is_some() || source.regex.is_some() || source.paths.is_some() {
+    let resolve = |p: &str| -> std::path::PathBuf {
+        let p = std::path::Path::new(p);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            anchor.join(p)
+        }
+    };
+
+    // An explicit `paths:` list has no discovery filters, so the sum of the
+    // listed files' sizes is an exact seed. Sum the readable ones; an
+    // unreadable entry contributes 0 rather than poisoning the whole estimate.
+    if let Some(paths) = source.paths.as_ref() {
+        if paths.is_empty() {
+            return None;
+        }
+        let total = paths.iter().fold(0u64, |acc, p| {
+            let len = std::fs::metadata(resolve(p)).map(|m| m.len()).unwrap_or(0);
+            acc.saturating_add(len)
+        });
+        return Some(total);
+    }
+
+    // `glob` / `regex` route through the discovery resolver and its filters;
+    // estimating them here would duplicate that resolver, so leave unknown.
+    if source.glob.is_some() || source.regex.is_some() {
         return None;
     }
+
     let path = source.path.as_deref()?;
-    let p = std::path::Path::new(path);
-    let resolved = if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        anchor.join(p)
-    };
-    std::fs::metadata(resolved).ok().map(|m| m.len())
+    std::fs::metadata(resolve(path)).ok().map(|m| m.len())
 }
 
 /// Idempotency predicate for enforcer-sort insertion.

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -15,6 +15,26 @@ use crate::plan::index::{AnalyticWindowSpec, IndexSpec};
 
 use cxl::analyzer::ParallelismHint;
 
+/// One blocking operator's plan-time spill-volume estimate, surfaced in
+/// `clinker run --explain` so an operator sees the per-stage footprint
+/// before a run fills the spill volume.
+///
+/// Produced by [`ExecutionPlanDag::per_stage_spill_estimates`]. `estimate_bytes`
+/// is `0` when the stage's volume is unknown at plan time (no on-disk file-size
+/// seed reached it) — the renderer shows "unknown" rather than a misleading `0`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StageSpillEstimate {
+    /// The spilling operator's pipeline node name (the key the runtime
+    /// per-stage actual-spill breakdown also uses, so estimate and actual
+    /// line up by name).
+    pub node_name: String,
+    /// The operator's `--explain` display name (strategy/role suffix and all).
+    pub display_name: String,
+    /// Coarse plan-time estimate, in bytes, of the live state this stage
+    /// could spill. `0` means unknown — see the type-level note.
+    pub estimate_bytes: u64,
+}
+
 impl ExecutionPlanDag {
     /// Construct from already-computed parts. The compile path supplies
     /// the populated graph + topology + per-transform plan metadata;
@@ -153,6 +173,42 @@ impl ExecutionPlanDag {
             .fold(0u64, |acc, props| {
                 acc.saturating_add(props.predicted_peak_bytes)
             })
+    }
+
+    /// Per-blocking-stage spill-volume estimate, one entry per spilling
+    /// operator (hash Aggregate, external sort, grace-hash / sort-merge /
+    /// IEJoin / hash Combine) in topological order.
+    ///
+    /// Each [`StageSpillEstimate`] carries the operator's node name, its
+    /// `--explain` display name, and its `predicted_peak_bytes` — the coarse
+    /// plan-time estimate of the live state it could spill. `estimate_bytes`
+    /// is `0` (rendered "unknown") when no on-disk file-size seed reached the
+    /// node: a multi-file source matcher (glob/regex/paths) whose discovered
+    /// sizes were not summed at plan time, a missing/unreadable input, or a
+    /// network source. Summing the entries equals [`Self::estimated_spill_bytes`].
+    /// The figures are the same `predicted_peak_bytes` the Physical Properties
+    /// arbitration line surfaces, so the per-stage estimate and the cap-headroom
+    /// preflight line up with what an operator already reads.
+    pub fn per_stage_spill_estimates(&self) -> Vec<StageSpillEstimate> {
+        self.topo_order
+            .iter()
+            .filter(|&&idx| {
+                super::arbitration_class(&self.graph[idx])
+                    .spill_priority
+                    .is_some()
+            })
+            .map(|&idx| {
+                let node = &self.graph[idx];
+                StageSpillEstimate {
+                    node_name: node.name().to_string(),
+                    display_name: node.display_name(),
+                    estimate_bytes: self
+                        .node_properties
+                        .get(&idx)
+                        .map_or(0, |p| p.predicted_peak_bytes),
+                }
+            })
+            .collect()
     }
 
     /// Get transform nodes in topological order.

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -465,6 +465,17 @@ impl ExecutionPlanDag {
             }
         }
 
+        // Estimated spill volume per blocking stage. Plan-only (reads
+        // `predicted_peak_bytes` already computed by the volume-estimate pass),
+        // so it renders on every `--explain` path. A streaming-only pipeline
+        // has no spilling operator and adds nothing here.
+        let spill_estimate = self.spill_estimate_explain();
+        if !spill_estimate.is_empty() {
+            out.push_str("=== Estimated Spill Volume ===\n\n");
+            out.push_str(&spill_estimate);
+            out.push('\n');
+        }
+
         // Show route info from graph nodes
         for node in self.graph.node_weights() {
             if let PlanNode::Route {
@@ -946,6 +957,53 @@ impl ExecutionPlanDag {
     ) -> String {
         let mut out = self.explain_full_with_artifacts(config, artifacts);
         self.append_topology_section(&mut out);
+        out
+    }
+
+    /// Render the per-blocking-stage estimated spill volume for `--explain`.
+    ///
+    /// One line per spilling operator (hash Aggregate, external sort,
+    /// grace-hash / sort-merge / IEJoin / hash Combine) giving its plan-time
+    /// `predicted_peak_bytes` estimate, followed by a total. A stage whose
+    /// volume is unknown at plan time (no on-disk file-size seed reached it —
+    /// a `glob`/`regex` multi-file source, a network source, or a
+    /// missing/unreadable input) renders `unknown` instead of a misleading
+    /// `0B`, and the total notes that unknown stages are excluded. Returns an
+    /// empty string when the plan has no spill-eligible operator, so a
+    /// streaming-only pipeline adds no section.
+    ///
+    /// Bytes render in binary units (`G`/`M`/`K` = GiB/MiB/KiB), matching the
+    /// Physical Properties `predicted_peak` line these figures derive from.
+    pub fn spill_estimate_explain(&self) -> String {
+        let estimates = self.per_stage_spill_estimates();
+        if estimates.is_empty() {
+            return String::new();
+        }
+        let mut out = String::from("Estimated spill volume (per blocking stage):\n");
+        let mut total: u64 = 0;
+        let mut any_unknown = false;
+        for est in &estimates {
+            if est.estimate_bytes == 0 {
+                any_unknown = true;
+                out.push_str(&format!("  {} → unknown\n", est.display_name));
+            } else {
+                total = total.saturating_add(est.estimate_bytes);
+                out.push_str(&format!(
+                    "  {} → {}\n",
+                    est.display_name,
+                    format_bytes(est.estimate_bytes)
+                ));
+            }
+        }
+        if any_unknown {
+            out.push_str(&format!(
+                "  Total (known stages): {} (excludes stages whose volume is unknown at plan time — \
+                 a glob/regex multi-file source, a network source, or a missing input)\n",
+                format_bytes(total),
+            ));
+        } else {
+            out.push_str(&format!("  Total: {}\n", format_bytes(total)));
+        }
         out
     }
 

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2178,7 +2178,7 @@ mod tests {
     #[test]
     fn cap_headroom_explain_states_per_invocation_and_warns_over_threshold() {
         // 9 GB estimate vs a 10 GB cap is 90%, over the 80% threshold → warning
-        // line, plus the per-invocation disclaimer (enh-6 #311).
+        // line, plus the per-invocation disclaimer (#311).
         let out = cap_headroom_explain(Some(10_000_000_000), 9_000_000_000);
         assert!(
             out.contains("Cap headroom:"),

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -764,6 +764,29 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                     "{}",
                     dag.spill_compression_explain(storage_config.spill.compress, batch_size)
                 );
+                // Cap-headroom: the spill cap minus the run's estimated spill
+                // volume. Surfaced only when a cap is configured; the figure is
+                // per invocation and explicitly disclaims sibling invocations
+                // sharing the volume under the partition-and-run model.
+                print!(
+                    "{}",
+                    cap_headroom_explain(spill_disk_cap_bytes, dag.estimated_spill_bytes())
+                );
+                // Staging plan per source: whether each source (or each
+                // discovered file under a multi-file matcher) would be staged,
+                // the resolved staged path, and the reuse-if-fresh decision.
+                // The discovery anchor matches the run path's
+                // (`args.config.parent()`), so the staged paths shown are the
+                // exact paths the real run would write.
+                let discovery_anchor = args
+                    .config
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| std::path::PathBuf::from("."));
+                print!(
+                    "{}",
+                    staging_plan_explain(&pipeline_config, &staging_policy, &discovery_anchor)
+                );
             }
             ExplainFormat::Json => {
                 let view = clinker_plan::plan::execution::ExplainJson::new(dag, artifacts);
@@ -947,6 +970,14 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     .map_err(storage_validation_error)?;
     let spill_root_dir = resolved_storage.spill_root_dir;
     if let Some(warning) = &resolved_storage.free_space_warning {
+        tracing::warn!("{warning}");
+        eprintln!("{warning}");
+    }
+    // Cap-headroom warning: the run's estimated spill volume is within 80% of
+    // the configured `storage.spill.disk_cap_bytes`, so it is likely to abort
+    // with E320 mid-stream. Fired here on the REAL run path — before any source
+    // ingest — so the operator sees the signal at startup; advisory, not fatal.
+    if let Some(warning) = &resolved_storage.cap_headroom_warning {
         tracing::warn!("{warning}");
         eprintln!("{warning}");
     }
@@ -1353,6 +1384,21 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         counters.dlq_count
     );
 
+    // Per-stage actual spill volume at end-of-run, so an operator can compare
+    // each stage's real spilled bytes against the pre-run `--explain` per-stage
+    // estimate (the calibration loop #176 exists for). Printed only when a stage
+    // actually spilled; a run that stayed in memory adds no noise.
+    if !report.per_stage_spill_bytes.is_empty() {
+        println!("=== Spill Volume (actual, per stage) ===");
+        for (stage, bytes) in &report.per_stage_spill_bytes {
+            println!("  {stage} → {bytes} bytes");
+        }
+        println!(
+            "  Total: {} bytes (compare against the --explain estimate)",
+            report.cumulative_spill_bytes
+        );
+    }
+
     // Exit codes per spec §10.2. An interrupted run takes precedence:
     // the pipeline drained what it could before unwinding on the
     // shutdown signal, so report the conventional SIGINT status (130)
@@ -1621,6 +1667,117 @@ fn print_resolved_outputs(config: &clinker_plan::config::PipelineConfig) {
         );
     }
     println!();
+}
+
+/// Render the cap-headroom line for `clinker run --explain`.
+///
+/// Reports the spill cap minus the run's estimated spill volume, plus a
+/// per-invocation disclaimer. Returns an empty string when no
+/// `storage.spill.disk_cap_bytes` is configured (unlimited spill has no
+/// headroom to report) or the estimate is unknown (`0`). The figure is **per
+/// invocation**: under the partition-and-run model several `clinker`
+/// invocations can share one spill volume and one cap, so the disclaimer states
+/// the headroom does not account for sibling invocations sharing the volume.
+/// Rendered in raw bytes, matching the "Spill disk cap" line above it.
+fn cap_headroom_explain(disk_cap_bytes: Option<u64>, estimated_spill_bytes: u64) -> String {
+    let Some(cap) = disk_cap_bytes else {
+        return String::new();
+    };
+    if estimated_spill_bytes == 0 {
+        return String::new();
+    }
+    let headroom = cap.saturating_sub(estimated_spill_bytes);
+    let pct = if cap == 0 {
+        0.0
+    } else {
+        (estimated_spill_bytes as f64 / cap as f64) * 100.0
+    };
+    let over_threshold = estimated_spill_bytes as f64 >= cap as f64 * 0.80;
+    let mut out = format!(
+        "Cap headroom: {headroom} bytes free ({estimated_spill_bytes} estimated of {cap} cap, \
+         {pct:.0}%) [per invocation — does NOT account for sibling invocations sharing the \
+         spill volume under partition-and-run]\n",
+    );
+    if over_threshold {
+        out.push_str(
+            "  WARNING: the estimate exceeds 80% of the cap; a real run may abort with a \
+             spill-cap error (E320). Raise storage.spill.disk_cap_bytes or reduce the spill \
+             footprint.\n",
+        );
+    }
+    out
+}
+
+/// Render the `=== Staging Plan ===` block for `clinker run --explain`.
+///
+/// For each file-backed source, resolves its matcher to the file set the run
+/// would read and emits one line per file: whether it would be staged, the
+/// resolved `<staging_root>/<source_id>.staged` path, and (under
+/// `on_existing = reuse`) the reuse-if-fresh cache decision (hit/miss). Network
+/// sources are not stagable and render an explicit in-place note. When staging
+/// is disabled the block states that every source reads in place. Read-only:
+/// resolves through the same [`clinker_channel::SourceStager::plan_entry`] the
+/// run would consult, copying nothing.
+fn staging_plan_explain(
+    config: &clinker_plan::config::PipelineConfig,
+    staging_policy: &clinker_plan::config::StagingPolicy,
+    discovery_anchor: &std::path::Path,
+) -> String {
+    let mut out = String::from("=== Staging Plan ===\n\n");
+    if !staging_policy.enabled {
+        out.push_str("Source staging is disabled — every source reads in place.\n\n");
+        return out;
+    }
+    let stager = clinker_channel::SourceStager::new(staging_policy.clone());
+    for body in config.source_bodies() {
+        let source = &body.source;
+        if !source.transport.is_file() {
+            out.push_str(&format!(
+                "Source '{}': not stagable (network source reads in place)\n",
+                source.name
+            ));
+            continue;
+        }
+        out.push_str(&format!("Source '{}':\n", source.name));
+        // Resolve the matcher to its file set with the same anchor the run
+        // uses. A discovery failure (no match, bad glob) is reported inline
+        // rather than aborting the explain; the run's own discovery will
+        // surface the coded diagnostic.
+        match clinker_exec::source::discovery::discover(source, discovery_anchor) {
+            Ok(outcome) => {
+                let files = outcome.files();
+                if files.is_empty() {
+                    out.push_str("  (no files matched)\n");
+                }
+                for f in files {
+                    let entry = stager.plan_entry(&f.path);
+                    if entry.staged {
+                        let path = entry
+                            .staged_path
+                            .as_ref()
+                            .map(|p| p.display().to_string())
+                            .unwrap_or_default();
+                        out.push_str(&format!(
+                            "  {} → staged: yes, path: {}, reuse: {}\n",
+                            f.path.display(),
+                            path,
+                            entry.reuse.label(),
+                        ));
+                    } else {
+                        out.push_str(&format!(
+                            "  {} → staged: no (no pattern match, reads in place)\n",
+                            f.path.display(),
+                        ));
+                    }
+                }
+            }
+            Err(e) => {
+                out.push_str(&format!("  (discovery failed: {e})\n"));
+            }
+        }
+    }
+    out.push('\n');
+    out
 }
 
 /// Best-effort hostname for the metrics payload.
@@ -2016,5 +2173,112 @@ mod tests {
             }
             _ => panic!("expected Run command"),
         }
+    }
+
+    #[test]
+    fn cap_headroom_explain_states_per_invocation_and_warns_over_threshold() {
+        // 9 GB estimate vs a 10 GB cap is 90%, over the 80% threshold → warning
+        // line, plus the per-invocation disclaimer (enh-6 #311).
+        let out = cap_headroom_explain(Some(10_000_000_000), 9_000_000_000);
+        assert!(
+            out.contains("Cap headroom:"),
+            "must render headroom line: {out}"
+        );
+        assert!(
+            out.contains("per invocation") && out.contains("sibling invocations"),
+            "must disclaim sibling invocations sharing the volume: {out}"
+        );
+        assert!(
+            out.contains("WARNING"),
+            "90% of cap must emit a warning: {out}"
+        );
+
+        // 50% of the cap is under threshold → headroom line, no WARNING.
+        let ok = cap_headroom_explain(Some(10_000_000_000), 5_000_000_000);
+        assert!(ok.contains("Cap headroom:"));
+        assert!(!ok.contains("WARNING"), "50% of cap must not warn: {ok}");
+
+        // No cap configured → nothing rendered (unlimited spill has no headroom).
+        assert!(cap_headroom_explain(None, 5_000_000_000).is_empty());
+    }
+
+    #[test]
+    fn staging_plan_explain_reports_disabled_in_place() {
+        let config: clinker_plan::config::PipelineConfig = clinker_plan::config::parse_config(
+            r#"
+pipeline:
+  name: x
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: a, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+        )
+        .expect("parse");
+        let policy = clinker_plan::config::StagingPolicy::default();
+        let out = staging_plan_explain(&config, &policy, std::path::Path::new("."));
+        assert!(out.contains("=== Staging Plan ==="));
+        assert!(
+            out.contains("Source staging is disabled"),
+            "disabled policy must say every source reads in place: {out}"
+        );
+    }
+
+    #[test]
+    fn staging_plan_explain_reports_staged_path_for_matched_source() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(tmp.path().join("orders.csv"), b"a\n1\n").expect("write source");
+        let stage_dir = tempfile::tempdir().expect("stage dir");
+        let config: clinker_plan::config::PipelineConfig = clinker_plan::config::parse_config(
+            r#"
+pipeline:
+  name: x
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: a, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+        )
+        .expect("parse");
+        let policy = clinker_plan::config::StagingPolicy {
+            enabled: true,
+            dir: Some(stage_dir.path().to_path_buf()),
+            patterns: vec!["*.csv".into()],
+            ..Default::default()
+        };
+        let out = staging_plan_explain(&config, &policy, tmp.path());
+        assert!(out.contains("=== Staging Plan ==="));
+        assert!(
+            out.contains("Source 'orders':") && out.contains("staged: yes"),
+            "a matched source must report staged: yes with its path: {out}"
+        );
+        assert!(
+            out.contains(".staged"),
+            "the resolved staged path must appear: {out}"
+        );
     }
 }

--- a/crates/clinker/tests/storage_config_cli.rs
+++ b/crates/clinker/tests/storage_config_cli.rs
@@ -209,6 +209,222 @@ fn explain_without_storage_block_shows_default_spill_root() {
     let _ = std::fs::remove_dir_all(&tmp);
 }
 
+/// A pipeline with a real CSV source and a blocking hash Aggregate, so the
+/// per-stage spill estimate and the staging plan have a sized input + a
+/// spilling stage to report.
+const AGG_PIPELINE_YAML: &str = r#"pipeline:
+  name: storage_obs
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: department, type: string }
+        - { name: amount, type: int }
+  - type: aggregate
+    name: dept_totals
+    input: orders
+    config:
+      group_by: [department]
+      cxl: |
+        emit department = department
+        emit total = sum(amount)
+  - type: output
+    name: out
+    input: dept_totals
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+fn write_orders_csv(dir: &std::path::Path) {
+    let mut body = String::from("department,amount\n");
+    for i in 0..200 {
+        body.push_str(&format!("dept{},{}\n", i % 7, i * 3));
+    }
+    std::fs::write(dir.join("orders.csv"), body).expect("write orders.csv");
+}
+
+#[test]
+fn explain_surfaces_per_stage_spill_estimate() {
+    let tmp = tempdir_path();
+    let pipeline = tmp.join("pipeline.yaml");
+    std::fs::write(&pipeline, AGG_PIPELINE_YAML).expect("write pipeline yaml");
+    write_orders_csv(&tmp);
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        .arg("--explain")
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "explain must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== Estimated Spill Volume ==="),
+        "explain must carry the per-stage spill-estimate section; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("dept_totals"),
+        "the blocking Aggregate stage must appear in the estimate; got:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn explain_surfaces_staging_plan_per_source() {
+    let tmp = tempdir_path();
+    let pipeline = tmp.join("pipeline.yaml");
+    std::fs::write(&pipeline, AGG_PIPELINE_YAML).expect("write pipeline yaml");
+    write_orders_csv(&tmp);
+
+    // Enable staging onto a sibling directory so the *.csv source matches a
+    // pattern and the plan reports a staged path + reuse decision.
+    let staging = tmp.join("staging");
+    std::fs::create_dir(&staging).expect("create staging dir");
+    std::fs::write(
+        tmp.join("clinker.toml"),
+        format!(
+            "[storage.staging]\nenabled = true\ndir = \"{}\"\npatterns = [\"*.csv\"]\non_existing = \"reuse\"\n",
+            staging.display().to_string().replace('\\', "\\\\")
+        ),
+    )
+    .expect("write clinker.toml");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        .arg("--explain")
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "explain with staging configured must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("=== Staging Plan ==="),
+        "explain must carry the staging-plan section; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Source 'orders':") && stdout.contains("staged: yes"),
+        "the matched source must report staged: yes; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("reuse: miss"),
+        "with no prior copy the reuse decision must be a miss; got:\n{stdout}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn real_run_warns_when_estimate_exceeds_eighty_percent_of_cap() {
+    let tmp = tempdir_path();
+    let pipeline = tmp.join("pipeline.yaml");
+    std::fs::write(&pipeline, AGG_PIPELINE_YAML).expect("write pipeline yaml");
+    write_orders_csv(&tmp);
+
+    // A spill dir plus a tiny 100-byte cap. The sized input's estimate (the CSV
+    // is well over 100 bytes) dwarfs the cap, so the startup cap-headroom
+    // warning fires on the REAL run (not gated behind --explain). The run still
+    // completes — the warning is advisory, and the small input does not actually
+    // trip the memory budget to spill.
+    let spill = tmp.join("spill");
+    std::fs::create_dir(&spill).expect("create spill dir");
+    std::fs::write(
+        tmp.join("clinker.toml"),
+        format!(
+            "[storage.spill]\ndir = \"{}\"\ndisk_cap_bytes = 100\n",
+            spill.display().to_string().replace('\\', "\\\\")
+        ),
+    )
+    .expect("write clinker.toml");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        // Run from the tempdir so the pipeline's relative output `out.csv`
+        // lands here, not in the crate working tree.
+        .current_dir(&tmp)
+        .output()
+        .expect("spawn clinker");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("W331"),
+        "a real run whose estimate exceeds 80% of the cap must warn at startup (W331), \
+         NOT only under --explain; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("per invocation"),
+        "the startup warning must disclaim sibling invocations sharing the volume; stderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
+fn real_run_logs_per_stage_actual_spill() {
+    // A real run that spills (1 MiB memory budget over a sized input) prints the
+    // per-stage actual-spill section at end-of-run so an operator can compare it
+    // against the --explain estimate (#176 AC#3).
+    let tmp = tempdir_path();
+    let pipeline = tmp.join("pipeline.yaml");
+    // Inline a 1 MiB memory budget so the node-buffer admission spills.
+    let yaml = AGG_PIPELINE_YAML.replace(
+        "pipeline:\n  name: storage_obs\n",
+        "pipeline:\n  name: storage_obs\n  memory: { limit: \"1M\" }\n",
+    );
+    std::fs::write(&pipeline, &yaml).expect("write pipeline yaml");
+    // A larger input raises the chance the 1 MiB budget trips a spill.
+    let mut body = String::from("department,amount\n");
+    for i in 0..50_000 {
+        body.push_str(&format!("dept{},{}\n", i % 50, i * 3));
+    }
+    std::fs::write(tmp.join("orders.csv"), body).expect("write orders.csv");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        // Run from the tempdir so the pipeline's relative output `out.csv`
+        // lands here, not in the crate working tree.
+        .current_dir(&tmp)
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "run must complete; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // RSS-based spill is platform/host dependent; only assert the per-stage
+    // actuals section when a spill actually happened (the section is omitted on
+    // a fully in-memory run by design).
+    if stdout.contains("=== Spill Volume (actual, per stage) ===") {
+        assert!(
+            stdout.contains("Total:") && stdout.contains("bytes"),
+            "the actual-spill section must report a per-stage total; got:\n{stdout}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
 fn tempdir_path() -> std::path::PathBuf {
     let mut base = std::env::temp_dir();
     let name = format!(

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -157,6 +157,126 @@ batch sizes from 256 B to 64 KiB and confirms `auto` tracks the faster of
 space-constrained volume, and `off` when spills are dominated by many small
 batches.
 
+## Observability — what the planner will do before you run
+
+`clinker run --explain` is plan-only (it reads no input and spills nothing), so
+it is the safe place to see what a run *would* do to the spill volume and to the
+staging dir before committing to it. On top of the resolved spill root, disk
+cap, and compression decision documented above, `--explain` surfaces three
+storage-observability sections, and a real `clinker run` reports the matching
+*actuals* at end-of-run so you can calibrate the estimate.
+
+### Estimated spill volume per stage
+
+The `=== Estimated Spill Volume ===` section lists one line per blocking stage
+(hash Aggregate, external sort, grace-hash / sort-merge / IEJoin / hash Combine)
+with its plan-time spill-volume estimate, followed by a total:
+
+```text
+=== Estimated Spill Volume ===
+
+Estimated spill volume (per blocking stage):
+  [aggregation:hash] dept_totals → 1K
+  [sort] by_amount → 4K
+  Total: 5K
+```
+
+Each figure is the operator's coarse predicted peak live state — the same
+`predicted_peak` the Physical Properties arbitration line shows — and bytes
+render in binary units (`K`/`M`/`G` = KiB/MiB/GiB). Summing rather than maxing is
+the conservative choice for a preflight: two blocking operators can be live and
+spilled at the same time, so their footprints add.
+
+A streaming-only pipeline (no blocking operator) has nothing that spills, so the
+section is omitted entirely.
+
+**Unknown stages.** The estimate is seeded from input file sizes resolved at
+plan time. A stage whose volume cannot be known before the run renders
+`unknown` instead of a misleading `0B`, and the total notes that unknown stages
+are excluded:
+
+```text
+  [aggregation:hash] dept_totals → unknown
+  Total (known stages): 0B (excludes stages whose volume is unknown at plan time
+  — a glob/regex multi-file source, a network source, or a missing input)
+```
+
+The seed is known for a single-file `path:` source and for an explicit `paths:`
+list (the listed files' sizes sum exactly, since the list carries no discovery
+filters). It is **unknown** for a `glob:` or `regex:` matcher — those fan out
+through the full discovery resolver (with `exclude`, `min_size`/`max_size`,
+`modified_after`/`before`, `take`, and sort filters), and estimating them at
+plan time would mean re-implementing that resolver and risk naming different
+bytes than the run actually reads. It is also unknown for a network source and
+for a missing or unreadable file. To get a concrete estimate for a glob/regex
+source, list the files explicitly with `paths:`, or check the post-run actuals
+below.
+
+### Staging plan per source
+
+When `storage.staging` is enabled, the `=== Staging Plan ===` section reports,
+for each source (and each discovered file under a multi-file matcher): whether
+it would be staged, the resolved content-addressed staged path, and — under
+`on_existing = reuse` — the reuse-if-fresh cache decision (`hit` if a committed
+prior copy still matches the live source, `miss` if it would be re-staged):
+
+```text
+=== Staging Plan ===
+
+Source 'orders':
+  /data/in/orders-2024.csv → staged: yes, path: /mnt/local/staging/3f2a…b1.staged, reuse: hit
+  /data/in/orders-2025.csv → staged: yes, path: /mnt/local/staging/9c4e…07.staged, reuse: miss
+```
+
+The reuse prediction runs the exact freshness check (mtime + size against the
+committed manifest) the real run makes, read-only — `--explain` copies nothing.
+A source that matches no staging pattern reports `staged: no (reads in place)`;
+a network source reports `not stagable`. When staging is disabled the section
+states that every source reads in place.
+
+### Cap headroom
+
+When a spill cap is configured, `--explain` reports the headroom (cap minus
+estimate) with the same per-invocation disclaimer the startup
+[cap-headroom preflight](#cap-headroom-preflight) carries, and the same 80%
+warning:
+
+```text
+Cap headroom: 5000000000 bytes free (5000000000 estimated of 10000000000 cap, 50%)
+  [per invocation — does NOT account for sibling invocations sharing the spill
+  volume under partition-and-run]
+```
+
+### Post-run actuals — calibrating the estimate
+
+A real `clinker run` that spills prints a per-stage **actual** spill-volume
+section at end-of-run, so you can compare it against the `--explain` estimate
+for the same stage — the calibration loop that turns a coarse pre-run estimate
+into a trustworthy one over repeated runs:
+
+```text
+=== Spill Volume (actual, per stage) ===
+  dept_totals → 1048576 bytes
+  by_amount → 4194304 bytes
+  Total: 5242880 bytes (compare against the --explain estimate)
+```
+
+The per-stage breakdown sums to the pipeline-wide cumulative spill total. A run
+that stayed within memory spilled nothing and prints no section. A large
+estimate-vs-actual delta is the single highest-leverage signal when a pipeline
+starts spilling unexpectedly (the failure mode behind Polars' documented 13.5×
+spill amplification, where an optimizer interaction turned 30 GB of input into
+400 GB of spill with no per-stage visibility).
+
+> **Note on the `--explain` compression projection.** The per-operator
+> spill-compression decision shown under `Spill compression:` is projected from
+> each operator's *stored output schema* width at plan time. At runtime the
+> actual spilled batch may carry a different column count (engine-stamped
+> identity columns, intermediate-stage shapes), so a stage's projected `auto`
+> verdict can differ from the file it actually writes. The read path always
+> dispatches on the spill file's own one-byte header tag, so this never breaks
+> re-reading; the projection is a best-effort preview, not a guarantee.
+
 ## Distinguishing the four spill-related failure conditions
 
 Spill-related aborts are split into four distinct diagnostics so a single
@@ -236,6 +356,41 @@ die at its final spill surfaces that risk before it runs for an hour, rather
 than after. The free-space query uses a cross-platform probe (statvfs on
 Unix, `GetDiskFreeSpaceExW` on Windows) that returns a 64-bit byte count, so
 the historical 32-bit `f_bavail` truncation never affects the comparison.
+
+### Cap-headroom preflight
+
+When `storage.spill.disk_cap_bytes` is configured, the same startup pass also
+runs a **cap-headroom preflight**: it compares the run's estimated spill volume
+to the configured cap and warns when the estimate reaches **80% of the cap**.
+Unlike the free-space preflight (which probes the physical volume), this checks
+the run against the *policy* ceiling you set, so it fires even on a volume with
+plenty of free space:
+
+```
+W331: this run is estimated to spill up to 9000000000 bytes, which is 90% of the
+configured spill cap storage.spill.disk_cap_bytes (10000000000 bytes); the run
+may abort with a spill-cap error (E320) before it finishes — raise disk_cap_bytes
+or reduce the spill footprint (raise memory.limit, partition the input). This
+headroom is per invocation: if you partition the input and run several clinker
+invocations against the same spill volume and cap, they share the cap, so the
+real headroom is smaller than this figure
+```
+
+Like W330, this is **advisory, not fatal** — the estimate is a coarse upper
+bound, so a run that compresses well or never trips its memory budget may finish
+comfortably under the cap. It fires on a normal `clinker run` (before ingestion,
+at startup), not only under `--explain`, so an operator sees the signal on the
+real run even when they did not explicitly inspect the plan first.
+
+**Per-invocation accounting.** The cap and the headroom figure are scoped to a
+single `clinker` invocation. Under the [partition-and-run](#) model — where you
+split a large input by file or key and launch several `clinker` processes that
+share one spill volume and one `disk_cap_bytes` — the physical spill volume is
+shared by every sibling, so the real headroom is smaller than any one
+invocation's figure. The warning text states this explicitly rather than
+silently presenting a per-invocation number as a whole-volume guarantee. Clinker
+is single-process by design (one invocation = one OS process), so the engine
+cannot see its siblings; the disclaimer is the honest stance.
 
 ## Mid-run spill failures
 

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -166,6 +166,24 @@ cap, and compression decision documented above, `--explain` surfaces three
 storage-observability sections, and a real `clinker run` reports the matching
 *actuals* at end-of-run so you can calibrate the estimate.
 
+**A note on byte units.** Three different unit conventions appear across the
+storage surface, and it helps to know which is which before comparing figures:
+
+- **Config values you write** (`disk_cap_bytes = "10GB"`) use **decimal** units
+  — `1GB` = 1,000,000,000 bytes — matching `du`, `df`, and the AWS CLI (see
+  [the disk-cap grammar](#storagespilldisk_cap_bytes--cap-cumulative-spill)).
+- **The `=== Estimated Spill Volume ===` section** humanizes with **binary**
+  suffixes — `K`/`M`/`G` = KiB/MiB/GiB — so it lines up with the
+  `predicted_peak` figure on each stage's Physical Properties line, which uses
+  the same humanizer.
+- **The cap-headroom line and the post-run actuals** print **raw bytes** with no
+  suffix, so the cap-minus-estimate subtraction and the estimate-vs-actual
+  comparison are exact rather than rounded.
+
+When you calibrate the estimate against the post-run actual, convert the binary
+estimate suffix to bytes first (`1K` = 1024 bytes, `1M` = 1,048,576 bytes) so you
+are comparing the same unit the actuals report.
+
 ### Estimated spill volume per stage
 
 The `=== Estimated Spill Volume ===` section lists one line per blocking stage
@@ -230,9 +248,10 @@ Source 'orders':
 
 The reuse prediction runs the exact freshness check (mtime + size against the
 committed manifest) the real run makes, read-only — `--explain` copies nothing.
-A source that matches no staging pattern reports `staged: no (reads in place)`;
-a network source reports `not stagable`. When staging is disabled the section
-states that every source reads in place.
+A source that matches no staging pattern reports
+`staged: no (no pattern match, reads in place)`; a network source reports
+`not stagable (network source reads in place)`. When staging is disabled the
+section states that every source reads in place.
 
 ### Cap headroom
 


### PR DESCRIPTION
## Summary

Adds storage observability to `clinker run --explain` / `clinker explain` so operators can see what the planner will do to disk before a pipeline fills the spill volume, plus end-of-run actuals to calibrate the estimates. Also lands a CI-stability fix for an RSS-dependent memory-abort test that could hang indefinitely.

This is the closing sprint of the storage milestone. It builds on the configurable spill directory, disk cap, compression knob, and source-staging work already on this branch.

## What changed

**Per-stage spill estimates and actuals (#176)**
- Each blocking operator (sort, hash aggregate, grace-hash combine) now reports an estimated spill volume in `--explain`, derived from the existing cardinality/schema plumbing. A stage whose cardinality is unknown is marked `unknown` rather than guessed.
- The explain payload carries chosen compression mode and, for grace-hash, the partition count with the cardinality estimate that drove it.
- At end of run, actual per-stage spill volume is logged alongside the estimate so operators can compare prediction against reality.

**Pipeline-level storage plan (#176)**
- `--explain` surfaces the resolved spill/staging directories and disk caps, the staging plan per source (staged yes/no, resolved staging path, reuse cache hit/miss), and a cap-headroom estimate.
- A pipeline whose estimated spill exceeds 80% of the configured cap emits a startup warning (not a failure — the estimate can be wrong, but the operator should see the signal).

**Concurrent-invocation headroom disclaimer (#311)**
- The cap-headroom figure is per-invocation. Under the partition-and-run model, sibling invocations share one physical spill volume, so the real headroom is smaller. The `--explain` output now explicitly states that headroom does not account for concurrent siblings, rather than silently over-reporting.

**Deterministic memory-abort test (#337)**
- The combine memory-abort test previously relied on real process RSS crossing the abort threshold; on runners with a different memory profile it could loop until GitHub's job ceiling. It is now bounded and deterministic — the feed loop is capped and the test asserts the abort fired within that bound (failing fast rather than hanging).

## Docs

- `docs/src/ops/storage.md` gains an observability section with annotated example `--explain` output.
- New diagnostic explainers for the storage error/warning codes (E320-E334).

## Acceptance

- `clinker run --explain` on a sort pipeline shows the estimated spill volume for the sort stage.
- `clinker run --explain` on a staging-configured pipeline shows the staging plan per source.
- `clinker run` on a spilling pipeline logs actual per-stage spill volume at end of run.
- A pipeline whose estimate exceeds 80% of the cap warns at startup.
- The memory-abort test is bounded and cannot hang CI.

Closes #176, Closes #311, Closes #337

Part of the milestone: storage: configurable spill location + opt-in source staging
