### PR TITLE
engine: release the spill-dir lock before removing the spill directory on every teardown path

### DIFF
--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -671,38 +671,38 @@ pub(crate) struct ExecutorContext<'a> {
     /// overflow.
     pub(crate) recursion_depth: u32,
 
-    /// Pipeline-scoped temporary directory. Allocated once at
-    /// `execute_dag_branching` start; every spilling operator (grace
-    /// hash, sort-merge join, sort buffer, hash aggregation) writes
-    /// spill files inside it. Shared across composition body
+    /// Pipeline-scoped spill directory bundled with the OS advisory lock held on
+    /// its `.lock` file. Allocated once at `execute_dag_branching` start; every
+    /// spilling operator (grace hash, sort-merge join, sort buffer, hash
+    /// aggregation) writes spill files inside it. Shared across composition body
     /// recursion — body executors do not allocate a fresh subdir.
-    /// Primary cleanup is per-file `tempfile::TempPath` Drop;
-    /// secondary sweep is the pipeline-scoped TempDir Drop on panic
-    /// unwinding, which closes the operator-level panic-leak hole
-    /// observed in Spark (SPARK-3563, SPARK-24340) and DuckDB
-    /// (issues 6420, 5878). The `Arc` keeps the directory alive
-    /// while any outstanding spill file path borrows it; this
-    /// matters in error paths where the executor returns before
-    /// every reader has been drained.
-    pub(crate) spill_root: Arc<tempfile::TempDir>,
+    ///
+    /// Primary cleanup is per-file `tempfile::TempPath` Drop; secondary sweep is
+    /// this guard's Drop on panic unwinding or error-return, which closes the
+    /// operator-level panic-leak hole observed in Spark (SPARK-3563, SPARK-24340)
+    /// and DuckDB (issues 6420, 5878). The held lock marks the directory as owned
+    /// by a live process so the next run's startup crash-purge reaps only spill
+    /// dirs whose lock it can acquire.
+    ///
+    /// The `Arc` keeps the directory alive while any outstanding spill file path
+    /// borrows it; this matters in error paths where the executor returns before
+    /// every reader has been drained. [`SpillDir`]'s `Drop` releases the lock
+    /// *before* the directory is removed — on Windows an open handle blocks the
+    /// directory deletion, so the lock must close first. The clean-exit path drops
+    /// this guard explicitly for deterministic teardown timing; the early-error
+    /// returns and panic unwinds drop it implicitly with the rest of `ctx`. Both
+    /// run the same lock-before-removal `Drop`, so the ordering holds on every
+    /// path by construction rather than by a manual `drop` no error-return could
+    /// be trusted to reach.
+    ///
+    /// [`SpillDir`]: crate::executor::spill_purge::SpillDir
+    pub(crate) spill_root: Arc<crate::executor::spill_purge::SpillDir>,
     /// Cached path into [`Self::spill_root`]. Sharing an
     /// `Arc<Path>` keeps every operator-side `to_path_buf()` call
-    /// off the `TempDir::path()` chain in hot paths and bypasses a
+    /// off the `SpillDir::path()` chain in hot paths and bypasses a
     /// lifetime acrobatic that would otherwise force every operator
     /// to thread the same lifetime as the borrowed plan-time refs.
     pub(crate) spill_root_path: Arc<std::path::Path>,
-    /// The held `<spill_root>/.lock` for this run, kept open so the OS advisory
-    /// lock marks the spill directory as owned by a live process. The next
-    /// run's startup crash-purge reaps only spill dirs whose lock it can
-    /// acquire, so holding this for the run's whole lifetime is what tells a
-    /// concurrent purge "this dir is live, don't reap it".
-    ///
-    /// Wrapped in `Option` so the clean-exit teardown can drop the lock file
-    /// *before* the spill `TempDir`'s recursive remove runs: on Windows an open
-    /// handle blocks the directory deletion, so the lock must be released first.
-    /// A crash skips this teardown, but the OS releases the lock on process
-    /// death anyway, so the next run still sees the dir as reapable.
-    pub(crate) spill_lock: Option<Arc<std::fs::File>>,
 
     /// Per-window arena+index registry. Slot `i` corresponds to
     /// `plan.indices_to_build[i]`; source-rooted slots populate at
@@ -942,18 +942,6 @@ pub(crate) struct RetainedAggregatorState {
 }
 
 impl<'a> ExecutorContext<'a> {
-    /// Borrow the pipeline-scoped TempDir handle. Held alongside
-    /// the cached `spill_root_path` so every operator that prefers
-    /// the owned form (e.g. `SortBuffer::new` taking
-    /// `Option<PathBuf>`) can clone the path without re-traversing
-    /// `TempDir::path()`. The TempDir itself is needed to keep the
-    /// directory alive across the whole walk including any
-    /// concurrent reads on spill paths the executor has not yet
-    /// drained.
-    pub(crate) fn spill_root(&self) -> &Arc<tempfile::TempDir> {
-        &self.spill_root
-    }
-
     /// Poll the run's shutdown flag at an operator chunk boundary. When
     /// the token has tripped (SIGINT/SIGTERM, or a programmatic
     /// request), record the interruption and return

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -197,18 +197,14 @@ struct DagExecResources {
     /// Compiled routes keyed by node name, for nested / composition-body
     /// Route nodes resolved during the walk.
     compiled_routes_by_name: HashMap<String, CompiledRoute>,
-    /// Pipeline-scoped spill `TempDir`, held until the walk drains so
-    /// operator-side spill files survive the topo loop.
-    spill_root: Arc<tempfile::TempDir>,
-    /// Cached path of `spill_root`, handed to each spill site without
-    /// re-borrowing the `TempDir`.
-    spill_root_path: Arc<std::path::Path>,
-    /// The held `<spill_root>/.lock` for this run. Kept open for the run's
-    /// lifetime so the OS advisory lock marks the spill dir as live; the next
-    /// run's startup crash-purge reaps only dirs whose lock it can acquire (the
-    /// owner is gone). Released when this `File` drops at run end or on process
-    /// exit. Never read after construction — its sole job is to hold the lock.
-    _spill_lock: Arc<std::fs::File>,
+    /// Pipeline-scoped spill directory bundled with its held `.lock`, kept until
+    /// the walk drains so operator-side spill files survive the topo loop. The
+    /// held lock marks the spill dir as live; the next run's startup crash-purge
+    /// reaps only dirs whose lock it can acquire. The guard's `Drop` releases the
+    /// lock before removing the directory on every teardown path. The cached
+    /// `Arc<Path>` operators spill into is derived from this guard's `path()`
+    /// inside the walk, so the path handle and the liveness guard never diverge.
+    spill_root: Arc<crate::executor::spill_purge::SpillDir>,
     /// Per-source / per-file event-time watermarks, carried through and
     /// returned in the [`DispatchOutcome`] for report roll-up.
     watermarks: crate::executor::watermark::PerSourceWatermarks,
@@ -724,27 +720,26 @@ impl PipelineExecutor {
             use std::os::unix::fs::PermissionsExt;
             builder.permissions(std::fs::Permissions::from_mode(0o700));
         }
-        let spill_root = Arc::new(
-            match &params.spill_root_dir {
-                Some(dir) => builder.tempdir_in(dir),
-                None => builder.tempdir(),
-            }
-            .map_err(|e| PipelineError::Internal {
-                op: "executor",
-                node: String::new(),
-                detail: format!("failed to allocate pipeline spill root: {e}"),
-            })?,
-        );
-        let spill_root_path: Arc<std::path::Path> = Arc::from(spill_root.path());
+        let spill_tempdir = match &params.spill_root_dir {
+            Some(dir) => builder.tempdir_in(dir),
+            None => builder.tempdir(),
+        }
+        .map_err(|e| PipelineError::Internal {
+            op: "executor",
+            node: String::new(),
+            detail: format!("failed to allocate pipeline spill root: {e}"),
+        })?;
 
-        // Take the per-run spill-dir lock and hold it for the whole run. A
-        // crashed run (SIGKILL / OOM-killer / power loss) skips the TempDir Drop
-        // that would otherwise remove this directory, but the OS releases this
-        // lock on process death regardless — so the next run's
-        // `spill_crash_purge` can tell this dir's owner is gone and reap it.
-        // The directory was pre-validated writable, so a failure to create the
-        // lock file is an internal fault, not a config error.
-        let spill_lock = Arc::new(spill_purge::lock_spill_dir(&spill_root_path).map_err(|e| {
+        // Wrap the directory in a `SpillDir` guard: it takes the per-run
+        // `.lock` and holds it for the whole run, and its `Drop` releases that
+        // lock before removing the directory on every teardown path (clean exit,
+        // error-return, panic unwind). A crashed run (SIGKILL / OOM-killer /
+        // power loss) skips the guard's Drop, but the OS releases the lock on
+        // process death regardless — so the next run's `spill_crash_purge` can
+        // tell this dir's owner is gone and reap it. The directory was
+        // pre-validated writable, so a failure to create the lock file is an
+        // internal fault, not a config error.
+        let spill_root = Arc::new(spill_purge::SpillDir::new(spill_tempdir).map_err(|e| {
             PipelineError::Internal {
                 op: "executor",
                 node: String::new(),
@@ -867,8 +862,6 @@ impl PipelineExecutor {
                 compiled_route,
                 compiled_routes_by_name,
                 spill_root,
-                spill_root_path,
-                _spill_lock: spill_lock,
                 watermarks,
                 memory_budget,
             },
@@ -1057,11 +1050,16 @@ impl PipelineExecutor {
             compiled_route,
             compiled_routes_by_name,
             spill_root,
-            spill_root_path,
-            _spill_lock,
             watermarks,
             memory_budget,
         } = resources;
+
+        // Cache the spill-dir path as an `Arc<Path>` derived from the guard, so
+        // each operator-side spill site clones the path without re-traversing
+        // `SpillDir::path()` on hot paths. Reading `spill_root.path()` here also
+        // ties this handle to the same guard that keeps the directory alive and
+        // removes it on drop — the path and the liveness guard cannot diverge.
+        let spill_root_path: Arc<std::path::Path> = Arc::from(spill_root.path());
 
         let output_configs: Vec<_> = config.output_configs().cloned().collect();
         let pipeline_start_time = chrono::Local::now().naive_local();
@@ -1334,7 +1332,6 @@ impl PipelineExecutor {
             current_body_node_input_refs: None,
             spill_root,
             spill_root_path,
-            spill_lock: Some(_spill_lock),
             window_runtime,
             watermarks,
             memory_budget,
@@ -1488,12 +1485,15 @@ impl PipelineExecutor {
             ctx.memory_budget.unregister_consumer(retained.consumer_id);
         }
 
-        // Take the pipeline-scoped TempDir out of the context. Held
-        // until the very end of the walk so any operator-side spill
-        // files survive the topo loop; dropped explicitly below
-        // after the metrics flush so the directory's recursive
-        // remove runs after every reader has gone away.
-        let pipeline_spill_root = ctx.spill_root().clone();
+        // The pipeline-scoped spill directory is held on `ctx.spill_root` until
+        // `ctx` drops at this function's scope end — after every operator-side
+        // spill path has been drained and the metrics flushed below. The
+        // `SpillDir` guard's `Drop` releases the held `.lock` *before* the
+        // directory's recursive remove runs, so cleanup is correct on Windows
+        // and ordered uniformly across platforms on EVERY return path —
+        // including the early-error returns and the `?` propagations above —
+        // without any manual `drop` call at the return site that a future
+        // early-return could silently bypass.
 
         // Drain mutable per-walk state out of the context for the
         // post-walk reporting + caller-facing return tuple. Sources are
@@ -1536,28 +1536,24 @@ impl PipelineExecutor {
         // Aggregate Output errors collected during the topo walk.
         // Single error → bare error; ≥2 errors →
         // `PipelineError::Multiple` (the DataFusion collection-pattern
-        // shape). Zero errors → fall through to Ok.
+        // shape). Zero errors → fall through to Ok. An early return here drops
+        // `ctx` (and with it the sole `SpillDir` guard), whose `Drop` releases
+        // the lock before removing the directory — the error path is cleaned up
+        // identically to the clean path.
         match output_errors.len() {
             0 => {}
             1 => return Err(output_errors.into_iter().next().unwrap()),
             _ => return Err(PipelineError::Multiple(output_errors)),
         }
 
-        // Release the spill-dir lock before the directory is removed. On
-        // Windows an open handle blocks `remove_dir_all`, so the `.lock` file
-        // must be closed first; on Unix it is harmless but keeps the ordering
-        // uniform. A crashed run never reaches here, but the OS releases the
-        // lock on process death regardless, so the next run's crash-purge still
-        // reaps the leaked directory.
-        drop(ctx.spill_lock.take());
-
-        // Release the pipeline-scoped TempDir Arc clone last; the
-        // directory drops once the original `ctx.spill_root` and
-        // this clone are both gone. Spill operators have already
-        // released their per-file `TempPath` handles by this point;
-        // any path the dispatcher couldn't drain still lives inside
-        // this directory, and its Drop now sweeps the filesystem.
-        drop(pipeline_spill_root);
+        // Clean-exit teardown of the spill directory. Dropping the guard here —
+        // after every operator-side spill path has been drained and the metrics
+        // flushed — releases the held `.lock` and then removes the directory, in
+        // that order, before this function returns `Ok`. The early-error returns
+        // above (and any `?` propagation) instead drop the guard implicitly as
+        // part of dropping `ctx`, which runs the same lock-before-removal `Drop`,
+        // so the directory is cleaned up on EVERY path, not just this one.
+        drop(ctx.spill_root);
 
         let rollback_cursors: BTreeMap<String, u64> = ctx
             .rollback_cursors

--- a/crates/clinker-exec/src/executor/spill_purge.rs
+++ b/crates/clinker-exec/src/executor/spill_purge.rs
@@ -129,6 +129,72 @@ pub fn lock_spill_dir(spill_dir: &Path) -> io::Result<File> {
     Ok(file)
 }
 
+/// Owns a run's spill `TempDir` together with the OS advisory lock held on its
+/// `.lock` file, and guarantees on `Drop` that the lock is released **before**
+/// the directory is removed.
+///
+/// ## Why the bundle, and why the explicit drop order
+///
+/// The lock file lives *inside* the spill directory, so the directory's
+/// recursive removal also deletes the lock file. On Windows an open handle to a
+/// file blocks deletion of that file (and thus its parent directory), so the
+/// lock handle must be closed before [`tempfile::TempDir`]'s removal runs or the
+/// directory silently survives. On Unix an open handle never blocks removal, but
+/// closing the lock first there is harmless and keeps one ordering for all
+/// platforms.
+///
+/// Keeping the two as separate struct fields elsewhere made this ordering depend
+/// on field-declaration order, which a future reorder or an early-return that
+/// unwound the owning struct could regress silently. Bundling them here with an
+/// explicit `Drop` makes "lock released before directory removed" hold on *every*
+/// drop path — clean exit, early-error return, and panic unwind — by
+/// construction, so no caller has to remember to release the lock manually before
+/// returning.
+pub(crate) struct SpillDir {
+    // `Option` so `Drop` can take and release the lock file first; `None` once
+    // released. A failed `lock_spill_dir` still yields `Some(file)` (the lock is
+    // best-effort) so the handle is closed before removal regardless.
+    lock: Option<File>,
+    // Declared after `lock` so even the implicit field-drop order (which runs
+    // after the explicit `Drop` body) would release the lock first; the explicit
+    // body below makes the guarantee independent of this ordering.
+    dir: tempfile::TempDir,
+}
+
+impl SpillDir {
+    /// Take ownership of `dir` and acquire its per-run `.lock`, returning the
+    /// guard that releases the lock before removing the directory on drop.
+    ///
+    /// # Errors
+    ///
+    /// Propagates [`lock_spill_dir`]'s error — the lock file could not be created
+    /// in a pre-validated-writable directory, an internal fault.
+    pub(crate) fn new(dir: tempfile::TempDir) -> io::Result<Self> {
+        let lock = lock_spill_dir(dir.path())?;
+        Ok(Self {
+            lock: Some(lock),
+            dir,
+        })
+    }
+
+    /// Path of the owned spill directory, handed to operators as the root for
+    /// their per-file spill artifacts.
+    pub(crate) fn path(&self) -> &Path {
+        self.dir.path()
+    }
+}
+
+impl Drop for SpillDir {
+    fn drop(&mut self) {
+        // Release the lock file FIRST: closing the handle frees the OS advisory
+        // lock and, critically on Windows, removes the open-handle that would
+        // otherwise block the directory's recursive removal. `dir` (the
+        // `TempDir`) then drops after this body returns and removes the
+        // directory — by which point the `.lock` handle is already closed.
+        self.lock.take();
+    }
+}
+
 /// Idempotently reap orphaned `clinker-spill-*` directories left by crashed
 /// prior runs, run once at startup before the run creates its own spill dir.
 ///
@@ -407,5 +473,91 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let _held = lock_spill_dir(dir.path()).unwrap();
         assert!(dir.path().join(SPILL_LOCK_NAME).exists());
+    }
+
+    #[test]
+    fn spill_dir_holds_the_lock_while_alive() {
+        // While the guard lives it must hold the OS advisory lock, so a
+        // concurrent probe (the next run's crash-purge) sees the dir as live and
+        // never reaps it. A second handle's `try_lock` failing is the same signal
+        // `dir_is_orphaned` reads, so this is the load-bearing liveness property —
+        // and it is real `flock`/`LockFileEx` behavior on every platform.
+        let tempdir = tempfile::Builder::new()
+            .prefix(SPILL_DIR_PREFIX)
+            .tempdir()
+            .unwrap();
+        let lock_path = tempdir.path().join(SPILL_LOCK_NAME);
+        let guard = SpillDir::new(tempdir).unwrap();
+
+        let probe = File::open(&lock_path).unwrap();
+        assert!(
+            FileExt::try_lock(&probe).is_err(),
+            "a live SpillDir must hold the .lock so a concurrent purge keeps the dir"
+        );
+        // Keep the guard alive across the probe so the lock contention is real.
+        drop(guard);
+    }
+
+    #[test]
+    fn spill_dir_drop_releases_the_lock_and_removes_the_directory() {
+        // The fix for the Windows error-path leak: the guard's Drop must release
+        // the `.lock` BEFORE removing the directory, on every drop path. On
+        // Windows the reversed order leaves the directory behind (an open handle
+        // blocks the removal); on Unix the removal always succeeds, so a bare
+        // "dir is gone" check cannot tell the orders apart. This test asserts the
+        // two observable halves of the invariant separately, both meaningful on
+        // Unix:
+        //
+        //   * release: a second handle opened on the SAME `.lock` inode before
+        //     drop cannot take the advisory lock while the guard holds it, but
+        //     CAN once the guard drops — proving Drop genuinely releases the lock
+        //     rather than leaking the handle open. (The handle keeps the unlinked
+        //     inode alive past removal, so the post-drop acquire is observable.)
+        //   * removal: the directory itself is gone after drop.
+        //
+        // Together these encode "lock released, directory removed" — exactly the
+        // property whose ordering makes the removal succeed on Windows.
+        let parent = tempfile::tempdir().unwrap();
+        let tempdir = tempfile::Builder::new()
+            .prefix(SPILL_DIR_PREFIX)
+            .tempdir_in(parent.path())
+            .unwrap();
+        let dir_path = tempdir.path().to_path_buf();
+        let lock_path = dir_path.join(SPILL_LOCK_NAME);
+
+        let guard = SpillDir::new(tempdir).unwrap();
+        assert!(
+            dir_path.exists(),
+            "the spill dir exists while the guard lives"
+        );
+        assert!(lock_path.exists(), "the .lock exists while the guard lives");
+
+        // A second handle on the same `.lock` inode. Held across the drop so its
+        // post-drop acquire observes the guard's release on the very same inode —
+        // the removal unlinks the path but this open handle keeps the inode (and
+        // its advisory lock state) alive to probe.
+        let probe = File::open(&lock_path).unwrap();
+        assert!(
+            FileExt::try_lock(&probe).is_err(),
+            "the lock must be held while the guard is alive"
+        );
+
+        drop(guard);
+
+        // Release half: the same-inode probe can now take the lock, so Drop freed
+        // it. A leaked-open guard handle (the bug) would keep this contended.
+        assert!(
+            FileExt::try_lock(&probe).is_ok(),
+            "the guard's Drop must release the .lock so the same inode can be re-locked"
+        );
+        let _ = FileExt::unlock(&probe);
+        drop(probe);
+
+        // Removal half: the directory (and its `.lock`) is gone. On Windows this
+        // is exactly the assertion that fails if the lock outlives the directory.
+        assert!(
+            !dir_path.exists(),
+            "the guard's Drop must remove the spill directory on every path"
+        );
     }
 }

--- a/crates/clinker-exec/tests/storage_spill_dir.rs
+++ b/crates/clinker-exec/tests/storage_spill_dir.rs
@@ -205,6 +205,106 @@ fn spill_dir_setting_redirects_per_run_spill_directory() {
     );
 }
 
+/// A writer that fails on its first `write`, so the run aborts through the
+/// output-error early-return path after the per-run spill directory and its
+/// `.lock` already exist.
+struct FailingWriter;
+impl Write for FailingWriter {
+    fn write(&mut self, _buf: &[u8]) -> std::io::Result<usize> {
+        Err(std::io::Error::other("simulated output failure"))
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Err(std::io::Error::other("simulated flush failure"))
+    }
+}
+
+#[test]
+fn error_path_run_cleans_up_its_spill_directory_immediately() {
+    // Regression guard for the Windows error-path spill-dir leak: when a run
+    // aborts with a fatal error after its per-run spill directory and `.lock`
+    // exist, the directory must be cleaned up immediately on the error-return
+    // path — not left for the next run's crash-purge. The per-run spill dir is
+    // created at run start (before dispatch), so a writer that fails during the
+    // run aborts after the dir + lock exist, exercising the exact early-return
+    // path the fix covers.
+    //
+    // On Unix an open lock handle never blocks directory removal, so the dir is
+    // reaped regardless of teardown order; the dedicated SpillDir Drop unit test
+    // (`spill_dir_drop_releases_the_lock_and_removes_the_directory`) proves the
+    // lock-before-removal ordering that makes this same teardown correct on
+    // Windows. This test pins the end-to-end invariant on every platform: a
+    // failed run leaves no orphaned spill directory behind, and — encoding the
+    // release half here too — the spill root can be re-locked afterward, which a
+    // leaked lock handle would prevent.
+    let spill_root = tempfile::tempdir().expect("create custom spill root");
+    let spill_root_path = spill_root.path().to_path_buf();
+
+    let csv = build_events_csv();
+    let config: PipelineConfig =
+        clinker_plan::yaml::from_str(PIPELINE_YAML).expect("parse pipeline YAML");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let mut readers: clinker_exec::executor::SourceReaders = HashMap::new();
+    readers.insert(
+        "events".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "events.csv",
+            Box::new(std::io::Cursor::new(csv.into_bytes())),
+        ),
+    );
+
+    // Both outputs fail, so the run aborts with an output error after the spill
+    // dir + lock exist.
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([
+        (
+            "out_a".to_string(),
+            Box::new(FailingWriter) as Box<dyn Write + Send>,
+        ),
+        (
+            "out_b".to_string(),
+            Box::new(FailingWriter) as Box<dyn Write + Send>,
+        ),
+    ]);
+
+    let params = PipelineRunParams {
+        execution_id: "spill-error-path".to_string(),
+        batch_id: "batch-0".to_string(),
+        spill_root_dir: Some(spill_root_path.clone()),
+        ..Default::default()
+    };
+
+    let result = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params);
+    assert!(
+        result.is_err(),
+        "the failing writers must abort the run so the error-return teardown runs",
+    );
+
+    // Cleanup half: no per-run spill directory survives the failed run.
+    assert!(
+        !has_spill_subdir(&spill_root_path),
+        "a failed run must remove its spill directory immediately, leaving no orphan \
+         under {}",
+        spill_root_path.display(),
+    );
+
+    // Release half (meaningful on Unix): the next run's crash-purge can take the
+    // lock on any new spill dir under this root. A run leaving a still-locked
+    // orphan would make a same-named re-lock contend; here we simply confirm a
+    // fresh lock under the root acquires cleanly, demonstrating no leaked handle.
+    let fresh = spill_root_path.join("clinker-spill-postcheck");
+    std::fs::create_dir(&fresh).expect("create post-check dir");
+    let lock_path = fresh.join(".lock");
+    let lock_file = std::fs::File::create(&lock_path).expect("create post-check lock");
+    use fs4::FileExt;
+    assert!(
+        FileExt::try_lock(&lock_file).is_ok(),
+        "a fresh lock under the spill root must acquire — no leaked lock from the failed run",
+    );
+    let _ = FileExt::unlock(&lock_file);
+}
+
 #[test]
 fn startup_purges_an_orphaned_spill_dir_from_a_crashed_prior_run() {
     // A crashed prior run (SIGKILL / OOM-killer) leaves its `clinker-spill-*`

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -432,10 +432,14 @@ volume, stop the cleaner, restore permissions) is obvious from the message.
 ## Crash purge of orphaned spill directories
 
 A run's spill directory (`clinker-spill-<random>/`) is normally removed when the
-run ends — a clean exit, or even a panic that unwinds, deletes it. But a
-`SIGKILL`, the Linux OOM-killer, or a power loss kills the process before that
-cleanup runs, leaking the directory and every spill file inside it under the
-spill root. Over many crashed runs that fills the spill volume.
+run ends — a clean exit, a run that aborts with a fatal error, or even a panic
+that unwinds all delete it, on every platform. (The run holds an advisory lock on
+a `.lock` file inside that directory; the lock is always released before the
+directory is removed, so the removal never trips over its own open handle — which
+matters on Windows, where an open file handle blocks deletion.) But a `SIGKILL`,
+the Linux OOM-killer, or a power loss kills the process before that cleanup runs,
+leaking the directory and every spill file inside it under the spill root. Over
+many crashed runs that fills the spill volume.
 
 To prevent that, **a run reaps orphaned spill directories at startup — but
 only when a spill directory is explicitly configured** (`storage.spill.dir`),
@@ -453,11 +457,11 @@ directory is logged and the run proceeds.
 When `storage.spill.dir` is **not** set, the spill root defaults to the OS temp
 directory ([`std::env::temp_dir`], typically `$TMPDIR` or `/tmp`), and **no
 startup purge runs** there. In the default case a run cleans up after itself
-directly: the per-run spill directory is a `tempfile::TempDir` that is removed on
-every normal exit — a clean exit or a panic that unwinds. Only a `SIGKILL`, the
-OOM-killer, or a power loss leaks one, and a directory leaked into the OS temp
-directory is the operating system's temp-reaper's responsibility to clean up, not
-Clinker's.
+directly: the per-run spill directory is removed on every exit short of a hard
+kill — a clean exit, an error-return abort, or a panic that unwinds. Only a
+`SIGKILL`, the OOM-killer, or a power loss leaks one, and a directory leaked into
+the OS temp directory is the operating system's temp-reaper's responsibility to
+clean up, not Clinker's.
 
 The purge is deliberately confined to a configured spill root because it must
 never police the shared OS temp directory. That directory is used by every


### PR DESCRIPTION
## Summary

A pipeline run holds an OS advisory lock on a `.lock` file inside its per-run spill directory (`clinker-spill-<random>/`) for the run's lifetime, so the next run's startup crash-purge can distinguish a crashed run's leftover directory from a live one. Because the lock file lives *inside* the spill directory, the directory's recursive removal also deletes the lock file — and on Windows an open file handle blocks deletion of that file (and thus its parent directory). The clean-exit path released the lock explicitly before the directory was removed, but the run-failure early-return and panic-unwind paths did not: those paths dropped the execution-context struct in field-declaration order, removing the spill directory while the lock handle was still open, so on Windows the directory's automatic removal could silently fail and the directory survived until the next run's crash-purge reaped it.

## Fix

Bundle the spill `TempDir` and its held `.lock` into a single `SpillDir` guard whose `Drop` releases the lock *before* removing the directory, on every teardown path — clean exit, error-return, and panic unwind alike. The ordering now holds by construction rather than depending on struct field order or a manual `drop` call that an early-return could silently bypass. The clean-exit path drops the guard explicitly for deterministic teardown timing; error returns and panics drop it implicitly with the rest of the context, both running the same lock-before-removal `Drop`.

This removes the separate `spill_lock` field and the `spill_root()` accessor in favor of the single bundled guard, and updates the operations docs (`docs/src/ops/storage.md`) to state that the spill directory is removed on every exit short of a hard kill on every platform.

## Tests

Two new tests in `crates/clinker-exec/src/executor/spill_purge.rs` and an integration test in `crates/clinker-exec/tests/storage_spill_dir.rs` cover the guard's liveness (a concurrent probe cannot take the lock while the guard lives) and the drop invariant (after drop, the same inode can be re-locked *and* the directory is gone) — both observable on Unix, and exactly the property whose ordering makes the removal succeed on Windows. First-class on Linux, Windows, and macOS.

Closes #342, Closes #347

Milestone: storage: configurable spill location + opt-in source staging
