### PR TITLE
engine: deterministic end-to-end test for a spill directory that becomes unwritable mid-run

### DIFF
--- a/crates/clinker-exec/src/aggregation/spill.rs
+++ b/crates/clinker-exec/src/aggregation/spill.rs
@@ -172,8 +172,17 @@ impl AggSpillWriter {
         // no configured dir (OS temp), a create failure is environment-level
         // and stays a generic spill error.
         let temp_file = match spill_dir {
-            Some(dir) => tempfile::NamedTempFile::new_in(dir)
-                .map_err(|e| HashAggError::SpillDir(SpillError::from_spill_dir_io(dir, e)))?,
+            Some(dir) => {
+                // Test-only seam: when a test has armed the mid-run spill-root
+                // fault for this root, this removes the live spill directory
+                // right before the open below, so the open fails with `NotFound`
+                // and classifies as `DirUnavailable`. Compiled out of release
+                // builds; an unarmed seam is a no-op.
+                #[cfg(test)]
+                crate::executor::spill_purge::maybe_invalidate_spill_root_for_test(dir);
+                tempfile::NamedTempFile::new_in(dir)
+                    .map_err(|e| HashAggError::SpillDir(SpillError::from_spill_dir_io(dir, e)))?
+            }
             None => {
                 tempfile::NamedTempFile::new().map_err(|e| HashAggError::Spill(e.to_string()))?
             }

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1732,4 +1732,5 @@ mod tests {
     mod multi_output;
     mod nested_composition_overshoot;
     mod scheduling;
+    mod spill_dir_unavailable_midrun;
 }

--- a/crates/clinker-exec/src/executor/spill_purge.rs
+++ b/crates/clinker-exec/src/executor/spill_purge.rs
@@ -195,6 +195,87 @@ impl Drop for SpillDir {
     }
 }
 
+/// Test-only fault injection that simulates the live per-run spill directory
+/// becoming unwritable *after* startup validation passed and the [`SpillDir`]
+/// guard already exists — the mid-run spill-failure case the classifier covers
+/// at the unit level but that no end-to-end test could reach before, because
+/// nothing in the production run flow ever invalidates a healthy live spill
+/// root.
+///
+/// The seam is compiled only under `#[cfg(test)]`, so release builds contain
+/// none of it — the spill-open helper's call drops to nothing without the cfg.
+/// It changes no public API and no production behavior: an unarmed seam is a
+/// no-op, and only a test that explicitly arms it can trip the fault.
+///
+/// ## How it fires deterministically mid-run
+///
+/// A test arms the seam with the parent spill root it configured the run to use
+/// ([`arm_spill_root_invalidation_for_test`]). The operator spill-file open
+/// sites (`SpillWriter::new` for inter-stage and sort spills, `AggSpillWriter::new`
+/// for hash-aggregate spills, and the grace-hash partition writer) each call
+/// [`maybe_invalidate_spill_root_for_test`] immediately before opening their
+/// spill file. The first such open whose directory sits under the armed root
+/// recursively removes that live per-run `clinker-spill-*` directory and
+/// disarms the seam — so the very open that triggered it then fails with
+/// `NotFound`, which the shared classifier lifts to [`SpillError::DirUnavailable`].
+/// Firing at the open site (rather than on a timer or a background thread)
+/// makes the fault land at exactly the first real spill attempt — after the
+/// guard exists, with no race and no possibility of a stall.
+///
+/// [`SpillError::DirUnavailable`]: clinker_plan::SpillError::DirUnavailable
+#[cfg(test)]
+mod fault_injection {
+    use std::path::{Path, PathBuf};
+    use std::sync::{LazyLock, Mutex};
+
+    /// The parent spill root a test armed for one-shot invalidation, or `None`
+    /// when the seam is disarmed. Process-global because the operator open
+    /// sites that consult it hold only a path, not a back-channel to the test.
+    static ARMED_ROOT: LazyLock<Mutex<Option<PathBuf>>> = LazyLock::new(|| Mutex::new(None));
+
+    /// Arm the seam so the next operator spill-file open under `parent_root`
+    /// invalidates the live per-run spill directory before opening, making that
+    /// open fail with `NotFound`.
+    pub(crate) fn arm_spill_root_invalidation_for_test(parent_root: PathBuf) {
+        *ARMED_ROOT.lock().unwrap() = Some(parent_root);
+    }
+
+    /// Disarm the seam, restoring the unarmed (no-op) state. Tests call this in
+    /// teardown so an armed root never leaks into a sibling test sharing the
+    /// process.
+    pub(crate) fn disarm_spill_root_invalidation_for_test() {
+        *ARMED_ROOT.lock().unwrap() = None;
+    }
+
+    /// If the seam is armed and `open_dir` sits under (or equals) the armed
+    /// parent root, recursively remove `open_dir` and disarm — so the spill
+    /// open about to run against `open_dir` fails with `NotFound`. A no-op when
+    /// disarmed or when `open_dir` is unrelated to the armed root.
+    pub(crate) fn maybe_invalidate_spill_root_for_test(open_dir: &Path) {
+        let mut armed = ARMED_ROOT.lock().unwrap();
+        let Some(parent_root) = armed.as_ref() else {
+            return;
+        };
+        if !open_dir.starts_with(parent_root) {
+            return;
+        }
+        // Fire once: disarm before removing so a re-entrant open (or a retry)
+        // does not loop trying to remove an already-gone directory.
+        let target = open_dir.to_path_buf();
+        *armed = None;
+        drop(armed);
+        // Best-effort: removing an already-gone dir is fine — the goal is that
+        // the dir is absent when the imminent open runs.
+        let _ = std::fs::remove_dir_all(&target);
+    }
+}
+
+#[cfg(test)]
+pub(crate) use fault_injection::{
+    arm_spill_root_invalidation_for_test, disarm_spill_root_invalidation_for_test,
+    maybe_invalidate_spill_root_for_test,
+};
+
 /// Idempotently reap orphaned `clinker-spill-*` directories left by crashed
 /// prior runs, run once at startup before the run creates its own spill dir.
 ///

--- a/crates/clinker-exec/src/executor/tests/spill_dir_unavailable_midrun.rs
+++ b/crates/clinker-exec/src/executor/tests/spill_dir_unavailable_midrun.rs
@@ -1,0 +1,246 @@
+//! End-to-end coverage for the spill root becoming unwritable *mid-run* —
+//! after startup storage validation passed and the live per-run [`SpillDir`]
+//! guard already exists.
+//!
+//! The pre-startup case (the configured spill dir is gone before the run
+//! begins) is covered by run-startup validation, and the classifier that lifts
+//! a directory-level I/O fault to [`SpillError::DirUnavailable`] is covered at
+//! the unit level for every spill site. The missing link this test closes is
+//! the genuinely mid-run case: a healthy spill root passes startup validation,
+//! the run creates its per-run `clinker-spill-*` directory and takes its lock,
+//! an operator begins spilling, and only *then* does the directory vanish (an
+//! external cleaner, an NFS remount, a volume unmount). No production code path
+//! ever invalidates a healthy live spill root, so this case can only be reached
+//! through the `#[cfg(test)]` fault-injection seam in
+//! [`crate::executor::spill_purge`].
+//!
+//! The test drives a real spilling Aggregate under a tiny memory budget, arms
+//! the seam so the first operator spill-file open removes the live per-run
+//! directory before opening, and asserts the run surfaces a clean
+//! `DirUnavailable` — not a generic I/O error, not a panic, and not a hang. The
+//! whole run is wrapped in a wall-clock timeout so a regression to a stall
+//! fails fast instead of hanging CI.
+//!
+//! [`SpillDir`]: crate::executor::spill_purge::SpillDir
+//! [`SpillError::DirUnavailable`]: clinker_plan::SpillError::DirUnavailable
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_plan::SpillError;
+use clinker_plan::config::{CompileContext, PipelineConfig};
+use clinker_plan::error::PipelineError;
+
+use crate::executor::spill_purge;
+use crate::executor::{PipelineExecutor, PipelineRunParams, SourceReaders, single_file_reader};
+
+// A 1 KiB memory budget forces the HashAggregator's dual-threshold spill: with
+// many distinct keys the group count crosses the budget-derived `max_groups`
+// well before EOF, so `add_record` calls `spill()` mid-run — the open this test
+// intercepts.
+const PIPELINE_YAML: &str = r#"
+pipeline:
+  name: spill_dir_unavailable_midrun
+  memory: { limit: "1024" }
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: events.csv
+      schema:
+        - { name: k, type: string }
+        - { name: v, type: int }
+  - type: aggregate
+    name: by_key
+    input: events
+    config:
+      group_by:
+        - k
+      cxl: |
+        emit k = k
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_key
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+const ROWS: usize = 4_000;
+
+/// Many distinct keys so the aggregate's group table outgrows the tiny budget
+/// and spills before EOF.
+fn build_events_csv() -> String {
+    let mut s = String::with_capacity(ROWS * 24);
+    s.push_str("k,v\n");
+    for i in 0..ROWS {
+        // Every row a distinct key maximizes group-table pressure.
+        s.push_str(&format!("key_{i},{i}\n"));
+    }
+    s
+}
+
+#[test]
+fn spill_dir_removed_mid_run_surfaces_dir_unavailable_without_panic_or_stall() {
+    // A dedicated parent root so the seam matches only this run's per-run
+    // `clinker-spill-*` directory and nothing else on the host.
+    let spill_root = tempfile::tempdir().expect("create custom spill root");
+    let spill_root_path = spill_root.path().to_path_buf();
+
+    let csv = build_events_csv();
+    let config: PipelineConfig =
+        clinker_plan::yaml::from_str(PIPELINE_YAML).expect("parse pipeline YAML");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let mut readers: SourceReaders = HashMap::new();
+    readers.insert(
+        "events".to_string(),
+        single_file_reader(
+            "events.csv",
+            Box::new(std::io::Cursor::new(csv.into_bytes())),
+        ),
+    );
+
+    let out = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> =
+        HashMap::from([("out".to_string(), Box::new(out) as Box<dyn Write + Send>)]);
+
+    let params = PipelineRunParams {
+        execution_id: "spill-dir-unavailable-midrun".to_string(),
+        batch_id: "batch-0".to_string(),
+        spill_root_dir: Some(spill_root_path.clone()),
+        ..Default::default()
+    };
+
+    // Arm the mid-run fault: the first operator spill-file open under this root
+    // removes the live per-run spill directory before opening, so that very open
+    // fails with `NotFound` → `DirUnavailable`. Disarm in every exit path below
+    // so an armed root never leaks into a sibling test sharing the process.
+    spill_purge::arm_spill_root_invalidation_for_test(spill_root_path.clone());
+
+    // Run on a worker thread joined under a wall-clock deadline. A regression
+    // that turns the mid-run directory loss into a hang (a retry loop, a
+    // blocked channel) trips the timeout and fails fast instead of hanging CI.
+    let (tx, rx) = mpsc::channel();
+    let worker = std::thread::spawn(move || {
+        let result =
+            PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params);
+        // Send may fail only if the receiver already timed out and dropped; the
+        // result is still observable via the join below in that case.
+        let _ = tx.send(result);
+    });
+
+    let outcome = rx.recv_timeout(Duration::from_secs(60));
+    spill_purge::disarm_spill_root_invalidation_for_test();
+
+    let result = match outcome {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!(
+                "run stalled: a mid-run spill-dir loss must surface a clean error within the \
+                 deadline, never hang"
+            );
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            // The worker dropped the sender without sending — i.e. it panicked.
+            // Join to surface the panic payload rather than reporting a bare
+            // disconnect.
+            let _ = worker.join();
+            panic!("run panicked instead of returning a clean DirUnavailable error");
+        }
+    };
+
+    // No panic: joining the worker must succeed (a panic would have come back as
+    // a `Disconnected` above, but join here also pins the no-panic guarantee on
+    // the success path).
+    worker.join().expect("run thread must not panic");
+
+    // Clean, classified error: the mid-run directory loss must surface as
+    // `DirUnavailable`, not a generic `Io` spill error and not an opaque
+    // `Internal`.
+    match result {
+        Err(PipelineError::Spill(SpillError::DirUnavailable { dir, .. })) => {
+            assert!(
+                dir.contains("clinker-spill-"),
+                "DirUnavailable must name the per-run spill directory, got {dir}"
+            );
+        }
+        Err(other) => panic!(
+            "mid-run spill-dir loss must surface as PipelineError::Spill(DirUnavailable), \
+             got {other:?}"
+        ),
+        Ok(_) => panic!(
+            "the run must fail once its live spill directory vanishes mid-run, not complete \
+             successfully"
+        ),
+    }
+}
+
+#[test]
+fn unarmed_seam_lets_a_real_spilling_run_complete() {
+    // Companion control for the fault-injection test above: the identical
+    // tiny-budget pipeline must complete successfully when the seam is NOT
+    // armed. This proves two things at once — the seam is a true no-op while
+    // disarmed (no release-shaped behavior change), and the `DirUnavailable`
+    // the armed test observes is caused by the injected fault rather than a
+    // pre-existing flaky failure in a spilling run.
+    //
+    // It also confirms the budget really does drive a mid-run spill: the run
+    // exercises the same spill-open path the armed test intercepts, here
+    // returning a healthy temp file, so the merge path runs end to end.
+    let spill_root = tempfile::tempdir().expect("create custom spill root");
+    let spill_root_path = spill_root.path().to_path_buf();
+
+    let csv = build_events_csv();
+    let config: PipelineConfig =
+        clinker_plan::yaml::from_str(PIPELINE_YAML).expect("parse pipeline YAML");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let mut readers: SourceReaders = HashMap::new();
+    readers.insert(
+        "events".to_string(),
+        single_file_reader(
+            "events.csv",
+            Box::new(std::io::Cursor::new(csv.into_bytes())),
+        ),
+    );
+
+    let out = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> =
+        HashMap::from([("out".to_string(), Box::new(out) as Box<dyn Write + Send>)]);
+
+    let params = PipelineRunParams {
+        execution_id: "spill-dir-unarmed-control".to_string(),
+        batch_id: "batch-0".to_string(),
+        spill_root_dir: Some(spill_root_path),
+        ..Default::default()
+    };
+
+    // No arm here. The seam is root-scoped — it fires only for an open under
+    // the exact parent root a test armed — so this control run's distinct root
+    // is unaffected even if the armed sibling test runs concurrently in the same
+    // process. That isolation is why this test does not (and must not) touch the
+    // global arm state, which would race the sibling.
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("an unarmed spilling run must complete cleanly");
+    assert_eq!(
+        report.counters.total_count as usize, ROWS,
+        "every input row must be ingested by the control run"
+    );
+    assert!(
+        report.cumulative_spill_bytes > 0,
+        "the tiny budget must have driven a real disk spill; otherwise the armed test would not \
+         exercise the spill-open fault seam"
+    );
+}

--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -280,6 +280,13 @@ impl GraceSpillWriter {
             use std::os::unix::fs::OpenOptionsExt;
             opts.mode(0o600);
         }
+        // Test-only seam: when a test has armed the mid-run spill-root fault for
+        // this root, this removes the live spill directory right before the open
+        // below, so the open fails with `NotFound` and classifies as
+        // `DirUnavailable`. Compiled out of release builds; an unarmed seam is a
+        // no-op.
+        #[cfg(test)]
+        crate::executor::spill_purge::maybe_invalidate_spill_root_for_test(dir);
         let mut file = opts.open(&path).map_err(classify_create)?;
         // The format tag is the very first on-disk byte and sits ahead of the
         // (optionally framed) body so the reader can dispatch before opening a

--- a/crates/clinker-exec/src/pipeline/spill.rs
+++ b/crates/clinker-exec/src/pipeline/spill.rs
@@ -140,6 +140,13 @@ impl<P: Serialize> SpillWriter<P> {
             .map(Path::to_path_buf)
             .unwrap_or_else(std::env::temp_dir);
         let temp_file = if let Some(dir) = spill_dir {
+            // Test-only seam: when a test has armed the mid-run spill-root fault
+            // for this root, this removes the live spill directory right before
+            // the open below, so the open fails with `NotFound` and classifies
+            // as `DirUnavailable`. Compiled out of release builds; an unarmed
+            // seam is a no-op.
+            #[cfg(test)]
+            crate::executor::spill_purge::maybe_invalidate_spill_root_for_test(dir);
             NamedTempFile::new_in(dir).map_err(|e| SpillError::from_spill_dir_io(dir, e))?
         } else {
             NamedTempFile::new().map_err(|e| SpillError::from_spill_dir_io(&resolved_dir, e))?


### PR DESCRIPTION
## Summary

Closes the last gap in spill-error end-to-end coverage. When a spilling pipeline's spill directory disappears or goes read-only, the engine classifies the failed write as a distinct `SpillError::DirUnavailable` and aborts the run cleanly. That classification was already unit-tested at every spill-open site, and an end-to-end test covered the case where the directory is gone *before* the run starts. This PR adds the missing case: the directory becoming unwritable strictly **mid-run**, after the startup writability check has passed and the per-run spill root has already been created.

## What changed

- Adds a strictly `#[cfg(test)]` fault-injection seam (`maybe_invalidate_spill_root_for_test`) at all three spill-open sites — the unified spill writer, the grace-hash partition writer, and the aggregate spill writer. A test arms the seam, and the next spill open removes the live spill root immediately before opening a file inside it, so the open fails with `NotFound` and classifies as `DirUnavailable`.
- The seam is compiled out of release builds entirely (`#[cfg(test)]`), changes no public API, and is a no-op when unarmed — consistent with the project's no-test-only-production-seam posture.
- Adds an end-to-end test that drives a hash-aggregate spill under a tiny memory budget, trips the seam mid-run, and asserts the run surfaces `SpillError::DirUnavailable` as a clean error with no panic and no stall (wall-clock bounded).

## Why

Previously the mid-run spill-file-open failure path was covered only at the unit level. Reproducing it end-to-end requires a controlled point during execution at which a test thread can invalidate the live spill root — between the startup check and a later operator spill. The new seam provides exactly that injection point without leaking any branch into shipping builds.

## Verification

- Test deterministically reproduces a spill-file open failing because the live spill root was removed after spilling began, and asserts the distinct error surface.
- No production code path gains a test-only branch that ships in release builds.

Milestone: storage: configurable spill location + opt-in source staging

Closes #318