### PR TITLE
engine: fail fast on an unsatisfiable memory budget; unify the limit parser

### DIFF
--- a/crates/clinker-benchmarks/src/runner.rs
+++ b/crates/clinker-benchmarks/src/runner.rs
@@ -39,6 +39,18 @@ impl BenchPipelineRunner {
     pub fn run(&self, config_path: &Path, scale: Scale) -> Result<ExecutionReport, PipelineError> {
         let mut config = load_config(config_path).expect("bench config must parse");
 
+        // Bench configs carry no `memory:` block, so they run at the 512 MiB
+        // default. The benchmark harness process (criterion + the data cache
+        // + every linked crate) carries a far larger baseline RSS than a real
+        // `clinker run`, and that baseline can exceed the 512 MiB default —
+        // which the executor's unsatisfiable-budget guard rejects at startup
+        // under the default `pause` policy. Selecting `spill` keeps the same
+        // 512 MiB spill threshold (so any spill behavior these throughput
+        // benchmarks exercise is unchanged) while opting out of the
+        // producer-pausing policy the guard targets, so the inflated bench
+        // baseline never trips a false-positive rejection.
+        config.pipeline.memory.backpressure = clinker_plan::config::BackpressureKnob::Spill;
+
         // Split outputs create files on disk via a file factory, so we need a
         // real temp directory for them instead of the placeholder `bench://` path.
         let _split_dir = rewrite_split_output_paths(&mut config);

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -384,6 +384,22 @@ impl PipelineExecutor {
         params: &PipelineRunParams,
         compile_ctx: clinker_plan::config::CompileContext,
     ) -> Result<ExecutionReport, PipelineError> {
+        // Reject an unsatisfiable memory budget before building the run.
+        // A `memory.limit` below the process's live baseline RSS can never
+        // be met (the empty pipeline already exceeds it), and under the
+        // default producer-pausing policy it deadlocks rather than failing
+        // fast — so surface a clear E312 startup error here, alongside the
+        // storage-config validation the CLI run path performs, instead of
+        // letting the run park. Scoped to the pausing policies; `spill`
+        // makes forward progress under a tiny budget and is left alone.
+        let configured_limit = clinker_plan::config::utils::parse_memory_limit_bytes(
+            config.pipeline.memory.limit.as_deref(),
+        );
+        crate::pipeline::memory::reject_unsatisfiable_budget(
+            configured_limit,
+            config.pipeline.memory.backpressure,
+        )?;
+
         let arbitrator = build_arbitrator_from_config(config);
         // Fold the workspace `storage.spill.disk_cap_bytes` quota into the
         // arbitrator's disk-spill ceiling. Absent config leaves the cap at

--- a/crates/clinker-exec/src/executor/tests/spill_dir_unavailable_midrun.rs
+++ b/crates/clinker-exec/src/executor/tests/spill_dir_unavailable_midrun.rs
@@ -40,11 +40,14 @@ use crate::executor::{PipelineExecutor, PipelineRunParams, SourceReaders, single
 // A 1 KiB memory budget forces the HashAggregator's dual-threshold spill: with
 // many distinct keys the group count crosses the budget-derived `max_groups`
 // well before EOF, so `add_record` calls `spill()` mid-run — the open this test
-// intercepts.
+// intercepts. `backpressure: spill` is required: the budget is below the
+// process baseline RSS, which the default `pause` policy rejects at startup
+// (E312); the spill policy never pauses a producer and so spills mid-run as
+// this test intends rather than being rejected.
 const PIPELINE_YAML: &str = r#"
 pipeline:
   name: spill_dir_unavailable_midrun
-  memory: { limit: "1024" }
+  memory: { limit: "1024", backpressure: spill }
 nodes:
   - type: source
     name: events

--- a/crates/clinker-exec/src/executor/util.rs
+++ b/crates/clinker-exec/src/executor/util.rs
@@ -260,24 +260,23 @@ pub(crate) fn record_with_emitted_fields(
     widen_record_to_schema(input, &widened)
 }
 
-/// Parse memory limit from config (default 512MB).
+/// Resolve the pipeline `memory.limit` into a byte count for the
+/// spill-threshold sizing the aggregate and sort arms perform.
+///
+/// Delegates to the authoritative [`clinker_plan::config::utils::parse_memory_limit_bytes`]
+/// so the spill-threshold budget honors the same `K`/`M`/`G` binary
+/// suffixes as the arbitrator ceiling. A second local parser previously
+/// lived here and silently dropped the `K` suffix, so a `limit: "256K"`
+/// sized a 256 KiB arbitrator but a 512 MiB aggregate spill budget; that
+/// divergence is gone — there is exactly one limit parser. Narrowed from
+/// the parser's `u64` to `usize` for the operator-facing budget fields;
+/// on a 32-bit host a limit above `usize::MAX` saturates rather than
+/// wrapping.
 pub(crate) fn parse_memory_limit(config: &PipelineConfig) -> usize {
-    config
-        .pipeline
-        .memory
-        .limit
-        .as_ref()
-        .and_then(|s| {
-            let s = s.trim();
-            if let Some(num) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
-                num.parse::<usize>().ok().map(|n| n * 1024 * 1024 * 1024)
-            } else if let Some(num) = s.strip_suffix('M').or_else(|| s.strip_suffix('m')) {
-                num.parse::<usize>().ok().map(|n| n * 1024 * 1024)
-            } else {
-                s.parse::<usize>().ok()
-            }
-        })
-        .unwrap_or(512 * 1024 * 1024) // 512MB default
+    usize::try_from(clinker_plan::config::utils::parse_memory_limit_bytes(
+        config.pipeline.memory.limit.as_deref(),
+    ))
+    .unwrap_or(usize::MAX)
 }
 
 /// Build a `MemoryArbitrator` from the pipeline-level `memory:` block.
@@ -296,4 +295,70 @@ pub(crate) fn build_arbitrator_from_config(
         0.80,
         crate::pipeline::memory::build_policy(mem.backpressure),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_memory_limit;
+
+    const MINIMAL_PIPELINE: &str = r#"
+pipeline:
+  name: budget_parse
+  memory: { limit: "__LIMIT__" }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: a, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+    fn budget_for(limit: &str) -> usize {
+        let yaml = MINIMAL_PIPELINE.replace("__LIMIT__", limit);
+        let config = clinker_plan::config::parse_config(&yaml).expect("minimal pipeline parses");
+        parse_memory_limit(&config)
+    }
+
+    #[test]
+    fn aggregate_spill_budget_honors_binary_suffixes() {
+        // The aggregate / sort spill budget must resolve the same binary
+        // suffixes as the arbitrator ceiling. A `K` suffix that the budget
+        // parser silently dropped used to size a 256 KiB arbitrator but a
+        // 512 MiB spill budget; this pins the single-parser equivalence.
+        assert_eq!(budget_for("256K"), 256 * 1024);
+        assert_eq!(budget_for("256k"), 256 * 1024);
+        assert_eq!(budget_for("4M"), 4 * 1024 * 1024);
+        assert_eq!(budget_for("2G"), 2 * 1024 * 1024 * 1024);
+        assert_eq!(budget_for("1024"), 1024);
+    }
+
+    #[test]
+    fn aggregate_spill_budget_matches_arbitrator_parser() {
+        // The budget the aggregate arm sizes from and the arbitrator
+        // ceiling come from one parser, so a suffixed limit yields the same
+        // byte count on both paths — no divergence between the arbitrator
+        // limit and the aggregate spill budget.
+        for limit in ["256K", "4M", "2G", "1024"] {
+            let yaml = MINIMAL_PIPELINE.replace("__LIMIT__", limit);
+            let config = clinker_plan::config::parse_config(&yaml).expect("parses");
+            let arbitrator_ceiling = clinker_plan::config::utils::parse_memory_limit_bytes(
+                config.pipeline.memory.limit.as_deref(),
+            );
+            assert_eq!(
+                parse_memory_limit(&config) as u64,
+                arbitrator_ceiling,
+                "aggregate spill budget for {limit:?} must equal the arbitrator ceiling"
+            );
+        }
+    }
 }

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -70,6 +70,7 @@ mod tests {
                 | PipelineError::CompositionUnknownPort { .. }
                 | PipelineError::CompositionBodyError { .. }
                 | PipelineError::MemoryBudgetExceeded { .. }
+                | PipelineError::UnsatisfiableMemoryBudget { .. }
                 | PipelineError::CombineMissingMatch { .. },
             ) => 1,
             Err(

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -106,6 +106,54 @@ fn rss_bytes_impl() -> Option<u64> {
     None
 }
 
+/// Reject an unsatisfiable memory budget at startup, before any
+/// source-ingest thread spawns.
+///
+/// A `memory.limit` below the process's live baseline RSS is
+/// unsatisfiable: the process already exceeds the ceiling with an empty
+/// pipeline, so no amount of spilling operator state or pausing producers
+/// can ever bring RSS under it. Under a producer-pausing policy (`pause`,
+/// the default, and `both`) this otherwise deadlocks — the arbitration
+/// round parks the Source on a pause that only `resume()` releases, but
+/// `resume()` fires only when RSS drops back under the threshold, which
+/// can never happen — while a blocking consumer waits forever for input.
+/// Converting that hang into an immediate [`PipelineError::UnsatisfiableMemoryBudget`]
+/// (E312) lets the operator fix the config rather than watch the run park.
+///
+/// Scoped to producer-pausing policies on purpose: under `spill` (bare
+/// `Priority`) a sub-baseline budget never pauses, so it spills or aborts
+/// fast and makes forward progress — that path is a legitimate way to
+/// force aggressive spilling and is left alone.
+///
+/// Skipped when `rss_bytes()` is unavailable: with no baseline to compare
+/// against, the budget cannot be judged unsatisfiable, and the run
+/// proceeds to surface any overflow through the normal runtime path.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::UnsatisfiableMemoryBudget`] when the policy
+/// pauses producers and `limit` is below the measured baseline RSS.
+pub fn reject_unsatisfiable_budget(
+    limit: u64,
+    knob: clinker_plan::config::BackpressureKnob,
+) -> Result<(), clinker_plan::error::PipelineError> {
+    if !knob.pauses_producers() {
+        return Ok(());
+    }
+    let Some(baseline_rss) = rss_bytes() else {
+        return Ok(());
+    };
+    if limit < baseline_rss {
+        return Err(
+            clinker_plan::error::PipelineError::UnsatisfiableMemoryBudget {
+                limit,
+                baseline_rss,
+            },
+        );
+    }
+    Ok(())
+}
+
 /// Stable identifier for a memory consumer registered with the
 /// arbitrator. Assigned by `MemoryArbitrator` at registration time and
 /// referenced by every subsequent arbitration decision.
@@ -1163,15 +1211,76 @@ mod tests {
             return; // Skip on unsupported platforms
         }
         let before = rss_bytes().unwrap();
-        // Allocate 10MB and touch it to ensure pages are resident
-        let big_vec: Vec<u8> = vec![1u8; 10 * 1024 * 1024];
+        // Allocate 64 MiB and touch every page so the pages are resident.
+        // A delta-threshold assertion (`after >= before + N`) flakes under a
+        // loaded harness: a concurrent test thread can free more than the
+        // probe allocates between the two samples, so the resident set can
+        // momentarily dip. Asserting `after >= before` keeps the real
+        // coverage (a large touched allocation never lowers this process's
+        // RSS) without depending on a fixed delta surviving harness churn;
+        // the absolute-value coverage that `rss_bytes` reads a positive
+        // figure lives in `test_rss_bytes_returns_some`.
+        let mut big_vec: Vec<u8> = vec![0u8; 64 * 1024 * 1024];
+        let page = 4096;
+        let mut i = 0;
+        while i < big_vec.len() {
+            big_vec[i] = 1;
+            i += page;
+        }
         std::hint::black_box(&big_vec);
         let after = rss_bytes().unwrap();
-        // RSS should increase by at least 5MB (accounting for page granularity)
         assert!(
-            after >= before + 5 * 1024 * 1024,
-            "RSS should increase by at least 5MB after 10MB alloc, got before={before} after={after}"
+            after >= before,
+            "a 64 MiB touched allocation must not lower process RSS, got before={before} after={after}"
         );
+    }
+
+    #[test]
+    fn reject_unsatisfiable_budget_pins_both_policies() {
+        use clinker_plan::config::BackpressureKnob;
+        use clinker_plan::error::PipelineError;
+
+        // No baseline to compare against → cannot judge; never rejects.
+        let Some(baseline) = rss_bytes() else {
+            assert!(reject_unsatisfiable_budget(1, BackpressureKnob::Pause).is_ok());
+            return;
+        };
+
+        // A 1-byte budget is below baseline RSS. Under the producer-pausing
+        // policies (pause/both) it would deadlock, so it is rejected at
+        // startup with the configured limit and the measured baseline.
+        for knob in [BackpressureKnob::Pause, BackpressureKnob::Both] {
+            match reject_unsatisfiable_budget(1, knob) {
+                Err(PipelineError::UnsatisfiableMemoryBudget {
+                    limit,
+                    baseline_rss,
+                }) => {
+                    assert_eq!(limit, 1);
+                    assert!(baseline_rss >= baseline, "baseline must be the live RSS");
+                }
+                other => panic!("pausing policy must reject a sub-baseline budget; got {other:?}"),
+            }
+        }
+
+        // Under spill the same sub-baseline budget never pauses, so it is
+        // NOT rejected — it spills/aborts via the runtime admission path.
+        assert!(
+            reject_unsatisfiable_budget(1, BackpressureKnob::Spill).is_ok(),
+            "spill policy must not reject a sub-baseline budget at startup"
+        );
+
+        // A budget well above baseline is satisfiable under every policy.
+        let generous = baseline.saturating_mul(4).max(512 * 1024 * 1024);
+        for knob in [
+            BackpressureKnob::Pause,
+            BackpressureKnob::Both,
+            BackpressureKnob::Spill,
+        ] {
+            assert!(
+                reject_unsatisfiable_budget(generous, knob).is_ok(),
+                "a budget above baseline must be satisfiable under {knob:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -3556,41 +3556,131 @@ nodes:
         }
     }
 
-    /// MemoryArbitrator abort — a 1-byte hard limit forces
-    /// `MemoryArbitrator::should_abort` to return true on the first poll
-    /// inside `CombineHashTable::build` (process RSS trivially exceeds
-    /// 1 byte). The build's safety-net final check fires for the small
-    /// build set, the executor wraps `CombineError::MemoryLimitExceeded`
-    /// as a typed `MemoryBudgetExceeded` carrying the combine node's
-    /// name and the budget source, and that surfaces in the run error.
+    /// Unsatisfiable memory budget — a 1-byte hard limit is below the test
+    /// process's baseline RSS, so under the default `pause` backpressure
+    /// policy the run is rejected at startup with E312
+    /// (`UnsatisfiableMemoryBudget`) before any source-ingest thread spawns
+    /// or any combine build begins.
     ///
-    /// Mirrors the build-side regression test in
-    /// `pipeline/combine.rs::test_combine_hash_table_oom_aborts_during_build`,
-    /// but exercised end-to-end through the combine executor arm so a
-    /// regression in the arm's error mapping is caught here.
+    /// This pins the fail-fast path for the deadlock a sub-baseline budget
+    /// would otherwise cause: under `pause`, the arbitration round parks
+    /// the Source on a pause that never resumes (nothing frees memory below
+    /// 1 byte) while the combine build waits for input that never arrives.
+    /// Detecting the unsatisfiable budget at startup converts that hang
+    /// into an immediate, clear configuration error.
     ///
-    /// Determinism: `backpressure: spill` installs the bare `Priority`
-    /// policy so no producer is ever elected as a pause victim. Under the
-    /// default `pause` policy a 1-byte budget can pause the Source ingest
-    /// thread on a `Condvar` that never resumes (nothing ever frees memory
-    /// below 1 byte) while the consumer blocks on `recv`, deadlocking the
-    /// run; choosing `spill` removes that path so the synchronous arena /
-    /// NodeBuffer admission charge surfaces the abort on the first record.
     /// The run is wrapped in `run_combine_fixture_bounded` so even a future
-    /// regression that reintroduces the deadlock fails fast instead of
-    /// hanging `cargo test`.
+    /// regression that reintroduces the deadlock — rather than rejecting at
+    /// startup — fails fast on the wall-clock bound instead of hanging
+    /// `cargo test`. The companion `test_combine_exec_spill_budget_aborts_fast`
+    /// pins the `spill`-policy half: a sub-baseline budget there is NOT
+    /// rejected at startup but instead aborts fast via the per-record
+    /// admission charge.
     ///
     /// Skipped silently when `rss_bytes()` is unavailable on the host
-    /// platform — the same gate the unit test uses, applied via
-    /// `clinker_exec::pipeline::memory::rss_bytes()`.
+    /// platform — the unsatisfiable check needs a baseline to compare
+    /// against, applied via `clinker_exec::pipeline::memory::rss_bytes()`.
     #[test]
-    fn test_combine_exec_e310_memory_abort() {
+    fn test_combine_exec_e312_unsatisfiable_budget_rejected_at_startup() {
         if clinker_exec::pipeline::memory::rss_bytes().is_none() {
             return;
         }
         let yaml = r#"
 pipeline:
-  name: combine_exec_e310
+  name: combine_exec_e312
+  memory: { limit: "1" }
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+        - { name: amount, type: int }
+  - type: source
+    name: products
+    config:
+      name: products
+      type: csv
+      path: products.csv
+      schema:
+        - { name: product_id, type: string }
+        - { name: name, type: string }
+        - { name: category, type: string }
+  - type: combine
+    name: enriched
+    input:
+      orders: orders
+      products: products
+    config:
+      where: "orders.product_id == products.product_id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit order_id = orders.order_id
+        emit product_name = products.name
+      propagate_ck: driver
+  - type: output
+    name: enriched_out
+    input: enriched
+    config:
+      name: enriched_out
+      type: csv
+      path: enriched.csv
+"#;
+        let err = run_combine_fixture_bounded(
+            yaml,
+            &[("orders", EXEC_ORDERS), ("products", EXEC_PRODUCTS)],
+            Some("orders"),
+            std::time::Duration::from_secs(30),
+        )
+        .expect_err("1-byte mem_limit must be rejected at startup under the default pause policy");
+        match &err {
+            CombineFixtureError::Run(
+                clinker_plan::error::PipelineError::UnsatisfiableMemoryBudget {
+                    limit,
+                    baseline_rss,
+                },
+            ) => {
+                assert_eq!(*limit, 1, "the rejection must carry the configured limit");
+                assert!(
+                    *baseline_rss > *limit,
+                    "the rejection must report a baseline RSS above the unsatisfiable limit; \
+                     got baseline_rss={baseline_rss} limit={limit}"
+                );
+            }
+            other => {
+                panic!(
+                    "unsatisfiable budget must surface UnsatisfiableMemoryBudget; got: {other:?}"
+                )
+            }
+        }
+    }
+
+    /// The `spill`-policy half of the unsatisfiable-budget contract: a
+    /// sub-baseline 1-byte budget under `backpressure: spill` is NOT
+    /// rejected at startup (the bare `Priority` policy never pauses a
+    /// producer, so it cannot deadlock), and instead aborts fast via the
+    /// synchronous per-record arena / NodeBuffer admission charge — the
+    /// run surfaces a typed `MemoryBudgetExceeded` rather than hanging.
+    ///
+    /// Pins both backpressure policies the way #352 requires: `pause`
+    /// rejects at startup (see
+    /// `test_combine_exec_e312_unsatisfiable_budget_rejected_at_startup`),
+    /// `spill` runs and aborts on the first admission. Wrapped in
+    /// `run_combine_fixture_bounded` so a regression that hangs fails fast
+    /// on the wall-clock bound.
+    #[test]
+    fn test_combine_exec_spill_budget_aborts_fast() {
+        if clinker_exec::pipeline::memory::rss_bytes().is_none() {
+            return;
+        }
+        let yaml = r#"
+pipeline:
+  name: combine_exec_spill_abort
   memory: { limit: "1", backpressure: spill }
 nodes:
   - type: source
@@ -3640,7 +3730,7 @@ nodes:
             Some("orders"),
             std::time::Duration::from_secs(30),
         )
-        .expect_err("1-byte mem_limit must abort combine");
+        .expect_err("1-byte mem_limit under spill must abort fast on the first admission");
         match &err {
             CombineFixtureError::Run(
                 clinker_plan::error::PipelineError::MemoryBudgetExceeded { node, source, .. },
@@ -3650,8 +3740,7 @@ nodes:
                 // build/probe path or the per-Vec NodeBuffer admission
                 // charge at any upstream insert can be the first surface
                 // to trip the 1-byte ceiling. Both report the producing
-                // operator's name and the BudgetCategory tag — the
-                // architectural guarantee this regression test pins.
+                // operator's name and the BudgetCategory tag.
                 assert!(
                     matches!(*source, BudgetCategory::Arena | BudgetCategory::NodeBuffer),
                     "memory abort must carry a BudgetCategory; got {source:?}"
@@ -3661,7 +3750,7 @@ nodes:
                     "memory abort must name the producing operator; got empty string"
                 );
             }
-            other => panic!("memory abort must surface MemoryBudgetExceeded; got: {other:?}"),
+            other => panic!("spill-policy abort must surface MemoryBudgetExceeded; got: {other:?}"),
         }
     }
 

--- a/crates/clinker-exec/tests/correlated_dlq_retract.rs
+++ b/crates/clinker-exec/tests/correlated_dlq_retract.rs
@@ -1210,10 +1210,15 @@ O5,ENG,200
 /// finding so the bug can be addressed in a dedicated commit.
 #[test]
 fn degrade_fallback_runtime_protection_or_documented_panic() {
+    // `backpressure: spill` keeps the bare `Priority` policy: the 1-byte
+    // budget is below the process baseline RSS, which the default `pause`
+    // policy rejects at startup (E312), but this test needs the run to
+    // reach the per-row admission guard, which only the non-pausing spill
+    // policy does under a sub-baseline budget.
     let yaml = r#"
 pipeline:
   name: degrade_fallback
-  memory: { limit: "1" }
+  memory: { limit: "1", backpressure: spill }
 error_handling:
   strategy: continue
 nodes:

--- a/crates/clinker-exec/tests/correlated_post_aggregate_retract.rs
+++ b/crates/clinker-exec/tests/correlated_post_aggregate_retract.rs
@@ -320,10 +320,15 @@ o9,ENG,300
 /// or the failure is surfaced through DLQ accounting.
 #[test]
 fn aggregator_state_degraded_falls_back_without_panic() {
+    // `backpressure: spill` keeps the bare `Priority` policy: the 1-byte
+    // budget is below the process baseline RSS, which the default `pause`
+    // policy rejects at startup (E312), but this test needs the run to
+    // reach the aggregator degrade path, which only the non-pausing spill
+    // policy does under a sub-baseline budget.
     let yaml = r#"
 pipeline:
   name: degraded_post_aggregate
-  memory: { limit: "1" }
+  memory: { limit: "1", backpressure: spill }
 error_handling:
   strategy: continue
 nodes:

--- a/crates/clinker-exec/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/tests/deferred_dispatch.rs
@@ -172,11 +172,15 @@ o3,ENG,100
 fn memory_budget_overflow_on_deferred_buffer_raises_e310() {
     // Force the per-arena budget to a very small value so the deferred
     // region producer's narrow projection trips memory accounting on
-    // the first record.
+    // the first record. `backpressure: spill` keeps the bare `Priority`
+    // policy: the 500-byte budget is below the process baseline RSS, which
+    // the default `pause` policy would reject at startup (E312), but the
+    // spill policy never pauses a producer and so reaches the per-record
+    // admission charge that this test asserts trips on the first record.
     let yaml = r#"
 pipeline:
   name: deferred_budget_overflow
-  memory: { limit: "500" }
+  memory: { limit: "500", backpressure: spill }
 error_handling:
   strategy: continue
 nodes:

--- a/crates/clinker-exec/tests/route_fanout_soft_spill.rs
+++ b/crates/clinker-exec/tests/route_fanout_soft_spill.rs
@@ -35,7 +35,7 @@ use std::io::Write;
 const PIPELINE_YAML: &str = r#"
 pipeline:
   name: route_fanout_soft_spill
-  memory: { limit: "1M" }
+  memory: { limit: "1M", backpressure: spill }
 nodes:
   - type: source
     name: events

--- a/crates/clinker-exec/tests/storage_spill_dir.rs
+++ b/crates/clinker-exec/tests/storage_spill_dir.rs
@@ -23,7 +23,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 const PIPELINE_YAML: &str = r#"
 pipeline:
   name: storage_spill_dir
-  memory: { limit: "1M" }
+  memory: { limit: "1M", backpressure: spill }
 nodes:
   - type: source
     name: events

--- a/crates/clinker-exec/tests/streaming_arms.rs
+++ b/crates/clinker-exec/tests/streaming_arms.rs
@@ -189,6 +189,13 @@ nodes:
 /// `should_abort`, so a tiny test budget spills rather than aborts, the
 /// same posture the materialized `route_fanout_soft_spill` test relies on.
 ///
+/// `backpressure: spill` is required because the budget is below the
+/// process's baseline RSS: under the default `pause` policy such a budget
+/// is rejected at startup (E312, the unsatisfiable-budget guard), so a
+/// sub-baseline budget that intends to *spill* rather than *pause* must
+/// select the spill policy, which never pauses a producer and so is not
+/// rejected.
+///
 /// Asserts every record is delivered in order and
 /// `cumulative_spill_bytes > 0`. The companion `route_fanout_soft_spill`
 /// pins the blocking full-stage spill path; the unit test
@@ -208,7 +215,7 @@ fn streaming_arm_soft_spills_under_one_megabyte_budget() {
 pipeline:
   name: streaming_route_soft_spill
   batch_size: 128
-  memory: { limit: "1M" }
+  memory: { limit: "1M", backpressure: spill }
 nodes:
   - type: source
     name: orders

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -151,6 +151,24 @@ impl BackpressureKnob {
         matches!(self, Self::Pause)
     }
 
+    /// Whether this policy can park a producer on a pause that only a
+    /// later `resume()` releases.
+    ///
+    /// `Pause` and `Both` both install a `BackPressurePreferred` front
+    /// that prefers pausing a back-pressureable producer over forcing a
+    /// spill; `Spill` (bare `Priority`) never pauses. The distinction is
+    /// load-bearing for the unsatisfiable-budget startup check: a budget
+    /// below the process baseline RSS deadlocks only under a pausing
+    /// policy (the paused Source never resumes because RSS can never drop
+    /// under the ceiling), whereas under `Spill` the same budget spills
+    /// or aborts immediately and makes forward progress.
+    pub fn pauses_producers(&self) -> bool {
+        match self {
+            Self::Spill => false,
+            Self::Pause | Self::Both => true,
+        }
+    }
+
     /// Display name of the arbitration policy this knob selects.
     ///
     /// Matches the `policy_name()` the corresponding boxed policy reports

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -169,6 +169,23 @@ pub enum PipelineError {
         source: crate::runtime_error::BudgetCategory,
         detail: Option<String>,
     },
+    /// E312 — the configured `memory.limit` is below the process's
+    /// baseline resident memory (RSS), measured at startup before any
+    /// pipeline data loads. Such a budget is unsatisfiable: no amount of
+    /// spilling or back-pressure can bring RSS under a ceiling that the
+    /// process already exceeds with an empty pipeline. Under the default
+    /// `memory.backpressure: pause` policy this would otherwise park the
+    /// Source ingest thread on a pause that never resumes (resume fires
+    /// only when RSS drops back under the threshold, which can never
+    /// happen) while a blocking consumer waits forever for input —
+    /// a deadlock. Rejecting at startup converts that hang into an
+    /// immediate, clear configuration error. `limit` is the configured
+    /// ceiling in bytes; `baseline_rss` is the measured startup RSS.
+    /// Always aborts the run before any source-ingest thread spawns.
+    UnsatisfiableMemoryBudget {
+        limit: u64,
+        baseline_rss: u64,
+    },
     /// E319 — a combine with `on_miss: error` saw a driver row that
     /// matched no build row. Semantically distinct from E310 (which
     /// is a memory-budget overflow). Always aborts the run.
@@ -336,6 +353,18 @@ impl fmt::Display for PipelineError {
                 ),
                 None => write!(f, "E310 {node}: {source} exceeded budget ({used}/{limit})"),
             },
+            Self::UnsatisfiableMemoryBudget {
+                limit,
+                baseline_rss,
+            } => write!(
+                f,
+                "E312 memory.limit of {limit} bytes is below the process's baseline \
+                 resident memory ({baseline_rss} bytes) measured before any data \
+                 loads, so no amount of spilling or back-pressure can bring the run \
+                 under it — raise memory.limit above the baseline (realistic budgets \
+                 are hundreds of MiB) or partition the input across smaller \
+                 invocations. See: clinker explain --code E312"
+            ),
             Self::CombineMissingMatch {
                 combine,
                 driver_row,

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -216,6 +216,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E309" => Some(include_str!("../../../../docs/explain/E309.md")),
         "E310" => Some(include_str!("../../../../docs/explain/E310.md")),
         "E311" => Some(include_str!("../../../../docs/explain/E311.md")),
+        "E312" => Some(include_str!("../../../../docs/explain/E312.md")),
         "E313" => Some(include_str!("../../../../docs/explain/E313.md")),
         "E319" => Some(include_str!("../../../../docs/explain/E319.md")),
         "E320" => Some(include_str!("../../../../docs/explain/E320.md")),
@@ -391,8 +392,8 @@ mod tests {
         let codes = [
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
-            "E309", "E310", "E311", "E313", "E319", "E320", "E321", "E330", "E331", "E332", "E333",
-            "E334", "E15Y", "W101", "W302", "W305", "W306",
+            "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E330", "E331", "E332",
+            "E333", "E334", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -317,6 +317,7 @@ fn main() -> ExitCode {
                         | PipelineError::CompositionUnknownPort { .. }
                         | PipelineError::CompositionBodyError { .. }
                         | PipelineError::MemoryBudgetExceeded { .. }
+                        | PipelineError::UnsatisfiableMemoryBudget { .. }
                         | PipelineError::CombineMissingMatch { .. } => ExitCode::from(1),
                         // Disk-cap exceedance (E320) is a resource-exhaustion
                         // halt — the run filled its configured spill budget.

--- a/crates/clinker/tests/storage_config_cli.rs
+++ b/crates/clinker/tests/storage_config_cli.rs
@@ -385,9 +385,13 @@ fn real_run_logs_per_stage_actual_spill() {
     let tmp = tempdir_path();
     let pipeline = tmp.join("pipeline.yaml");
     // Inline a 1 MiB memory budget so the node-buffer admission spills.
+    // `backpressure: spill` is required: 1 MiB is below the binary's
+    // baseline RSS, which the default `pause` policy rejects at startup
+    // (E312); the spill policy never pauses a producer and so spills as
+    // this test intends rather than being rejected.
     let yaml = AGG_PIPELINE_YAML.replace(
         "pipeline:\n  name: storage_obs\n",
-        "pipeline:\n  name: storage_obs\n  memory: { limit: \"1M\" }\n",
+        "pipeline:\n  name: storage_obs\n  memory: { limit: \"1M\", backpressure: spill }\n",
     );
     std::fs::write(&pipeline, &yaml).expect("write pipeline yaml");
     // A larger input raises the chance the 1 MiB budget trips a spill.

--- a/docs/explain/E312.md
+++ b/docs/explain/E312.md
@@ -1,0 +1,86 @@
+# Error E312: memory.limit is below the process baseline RSS
+
+## What it means
+
+The `memory.limit` you configured is **smaller than the process's own
+resident memory (RSS) before any pipeline data is loaded**. Clinker measures
+the baseline RSS at startup and refuses the run when the configured ceiling
+is already below it: such a budget is unsatisfiable. The process needs that
+baseline just to hold its own code, stack, and allocator state, so no amount
+of spilling operator state to disk or pausing producers can ever bring RSS
+under a ceiling the empty pipeline already exceeds.
+
+Under the default `memory.backpressure: pause` policy this is worse than a
+slow run — it is a deadlock. The arbitration round keeps electing the Source
+ingest thread as the pause victim (preferring back-pressure over forcing a
+spill), and the Source parks on a condition variable that only `resume()`
+releases. But `resume()` fires only once RSS drops back under the threshold,
+which never happens because the limit is below baseline. Meanwhile a blocking
+consumer (hash Aggregate, external sort, grace-hash / sort-merge / IEJoin /
+hash Combine) waits forever for input that the paused Source will never
+deliver. Both threads are parked permanently. Rejecting at startup converts
+that hang into an immediate, clear error.
+
+The startup diagnostic reports both figures:
+
+```
+E312 memory.limit of 1024 bytes is below the process's baseline resident
+memory (37748736 bytes) measured before any data loads, so no amount of
+spilling or back-pressure can bring the run under it — raise memory.limit
+above the baseline (realistic budgets are hundreds of MiB) or partition the
+input across smaller invocations. See: clinker explain --code E312
+```
+
+## Example
+
+```yaml
+# pipeline.yaml — a 1 MiB ceiling is below the process's own baseline RSS.
+pipeline:
+  name: too_tight
+  memory: { limit: "1M" }
+```
+
+```yaml
+# Corrected: a realistic budget comfortably above baseline RSS.
+pipeline:
+  name: too_tight
+  memory: { limit: "512M" }
+```
+
+## How to fix
+
+1. **Raise `memory.limit` above the baseline RSS** the diagnostic reports.
+   Realistic budgets are hundreds of MiB to several GiB; the default when the
+   knob is omitted is 512 MiB.
+
+2. **Partition the input** and run several `clinker` invocations over smaller
+   slices if a single host genuinely cannot fit the work under a satisfiable
+   budget — the architectural escape hatch for a workload too large for one
+   process.
+
+3. **If you were deliberately forcing spill with a tiny budget** (a test
+   idiom), set `memory.backpressure: spill` instead. The bare spill policy
+   never pauses a producer, so a sub-baseline budget spills immediately
+   rather than deadlocking — and the startup rejection only fires for the
+   producer-pausing policies (`pause`, the default, and `both`).
+
+## Technical context
+
+E312 is a startup-validation diagnostic raised after the plan compiles and
+the arbitrator is built, before any source-ingest thread spawns. The check
+compares the configured ceiling against the live `rss_bytes()` reading and
+only fires when the active backpressure policy can pause a producer
+indefinitely — the `pause` and `both` policies. The `spill` policy reacts by
+spilling rather than pausing, so a sub-baseline budget under `spill` makes
+forward progress (or aborts fast via the per-record admission charge) without
+deadlocking, and is not rejected.
+
+On a platform where `rss_bytes()` is unavailable, the baseline cannot be
+measured and the check is skipped — the run proceeds and surfaces a
+budget overflow through the normal runtime path instead.
+
+## See also
+
+- E310 (memory-budget surface exceeded the hard limit at runtime)
+- E320 (cumulative spill bytes crossed the configured disk cap)
+- "Memory & Backpressure" in the operations guide

--- a/docs/src/ops/cli-reference.md
+++ b/docs/src/ops/cli-reference.md
@@ -20,7 +20,7 @@ clinker run [OPTIONS] <CONFIG>
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--memory-limit <SIZE>` | `256M` | Memory budget for the execution. Accepts `K`, `M`, `G` suffixes. When the limit is approached, aggregation operators spill to disk rather than crashing. CLI value overrides any `memory.limit` set in the YAML. |
+| `--memory-limit <SIZE>` | `256M` | Memory budget for the execution. Accepts binary (1024-based) `K`/`M`/`G` suffixes (`K` = 1024 bytes, `M` = 1024², `G` = 1024³); a bare integer is bytes. When the limit is approached, aggregation operators spill to disk rather than crashing. CLI value overrides any `memory.limit` set in the YAML. |
 | `--threads <N>` | number of CPUs | Size of the thread pool used for parallel node execution. |
 | `--error-threshold <N>` | `0` (unlimited) | Maximum number of records routed to the dead-letter queue before the pipeline aborts. `0` means no limit -- the pipeline will run to completion regardless of DLQ volume. |
 | `--batch-id <ID>` | UUID v7 | Custom execution identifier. Appears in metrics output and log lines. Use a meaningful value (e.g. `daily-2026-04-11`) for correlation across retries. |

--- a/docs/src/ops/memory.md
+++ b/docs/src/ops/memory.md
@@ -48,7 +48,7 @@ pipeline:
     limit: "512M"
 ```
 
-The CLI flag overrides the YAML value. Accepted suffixes: `K` (kilobytes), `M` (megabytes), `G` (gigabytes).
+The CLI flag overrides the YAML value. Suffixes are **binary (1024-based)**: `K` = 1024 bytes, `M` = 1024², `G` = 1024³; a bare integer is bytes. (This differs from the **decimal** `KB`/`MB`/`GB` used by `min_size`/`max_size`, which are 1000-based.)
 
 **Default:** 512 MB.
 


### PR DESCRIPTION
## Summary

Three related memory-backpressure fixes in the bounded-memory executor, plus the docs that go with them.

### 1. Fail fast on an unsatisfiable memory budget (#352)

Under the default `memory.backpressure: pause` policy, a pipeline whose `memory.limit` is below the process's baseline resident memory (RSS) — i.e. the empty process already exceeds the ceiling before any data loads — could **deadlock** instead of erroring. The arbitration round parks the Source on a pause that only `resume()` releases, but `resume()` fires only when RSS drops back under the threshold, which can never happen; meanwhile a blocking consumer (hash aggregate, external sort, grace-hash/IEJoin combine) waits forever for input.

This converts that hang into an immediate, clear startup error. Before any source-ingest thread spawns, the executor measures baseline RSS and, under a producer-pausing policy (`pause`, `both`), rejects a sub-baseline budget with a new `E312 UnsatisfiableMemoryBudget` diagnostic. The `spill` policy is deliberately left alone: a tiny budget under `spill` never pauses, so it spills or aborts immediately and makes forward progress — a legitimate way to force aggressive spilling. The check is also skipped when RSS is unavailable on a platform, since there is no baseline to judge against.

`E312` is a full diagnostic: registered in `explain_code`, documented in `docs/explain/E312.md`, mapped to exit code 1 in the CLI, and discoverable via `clinker explain --code E312`.

### 2. Unify the two divergent memory-limit parsers (#356)

`memory.limit` was parsed by two functions that disagreed on suffixes. The planning-layer parser accepted `K`/`M`/`G`; the executor's local aggregate/sort spill-budget parser accepted only `M`/`G`, so a `K` suffix silently fell through to the 512 MiB default. A config of `limit: "256K"` therefore sized a 256 KiB arbitrator ceiling but a 512 MiB aggregate spill budget — one config value interpreted two ways, with no warning.

The executor's local parser is deleted; the spill-budget sizing now delegates to the single authoritative planning-layer parser. There is exactly one limit parser, so every consumer of `memory.limit` resolves the same byte count.

While unifying, the suffix convention is now documented: `memory.limit` suffixes are **binary** (1024-based) — `K` = 1024 bytes, `M` = 1024², `G` = 1024³, bare integer = bytes — which is distinct from the **decimal** (1000-based) `KB`/`MB`/`GB` used by `min_size`/`max_size`. `docs/src/ops/memory.md` and the CLI reference now spell this out.

### 3. De-flake the RSS allocation test (#344)

`test_rss_bytes_increases_after_alloc` asserted that process RSS rose by at least 5 MiB after a 10 MiB allocation. Process RSS is a whole-process, OS-scheduled quantity; under a loaded multi-threaded harness a concurrent thread can free more than the probe allocates between the two samples, so the fixed-delta lower bound flaked (~1 in 6 full-suite runs). The test now allocates 64 MiB, touches every page, and asserts the directional invariant `after >= before` — preserving the real coverage (a large touched allocation never lowers this process's RSS) without depending on a fixed delta surviving harness churn. The positive-reading coverage continues to live in `test_rss_bytes_returns_some`.

## Tests

- New unit tests pin the single-parser equivalence (`256K`/`256k`/`4M`/`2G`/`1024` all resolve identically for the aggregate spill budget and the arbitrator ceiling).
- A new test pins the startup-rejection behavior across all three backpressure policies: `pause`/`both` reject a sub-baseline budget; `spill` does not; an above-baseline budget is satisfiable under every policy.
- The de-flaked RSS test now asserts the directional invariant.

Closes #352, Closes #344, Closes #356

Milestone: storage: configurable spill location + opt-in source staging
