### PR TITLE
engine: --explain spill surfaces describe only what hits disk; JSON storage summary at text parity

### DIFF
--- a/crates/clinker-plan/src/config/storage.rs
+++ b/crates/clinker-plan/src/config/storage.rs
@@ -169,6 +169,19 @@ impl CompressMode {
         let bytes_per_batch = bytes_per_row.saturating_mul(rows_per_batch);
         self.resolve(bytes_per_batch, rows_per_batch)
     }
+
+    /// Lowercase mode label for JSON output, matching the YAML surface
+    /// grammar (`auto` / `off` / `on`). The text `--explain` path renders
+    /// the `Debug` form (`Auto` / `Off` / `On`); JSON consumers expect the
+    /// wire grammar they would write back, so the two surfaces differ in
+    /// case by design.
+    pub fn json_label(self) -> &'static str {
+        match self {
+            CompressMode::Auto => "auto",
+            CompressMode::Off => "off",
+            CompressMode::On => "on",
+        }
+    }
 }
 
 /// `[storage.spill]` — spill-file root directory.

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -149,36 +149,40 @@ impl ExecutionPlanDag {
     }
 
     /// Coarse plan-time estimate, in bytes, of the disk volume the run could
-    /// spill — the sum of every spilling operator's predicted peak live state.
+    /// spill — the sum of every spill-writing operator's predicted peak live
+    /// state.
     ///
-    /// A spilling operator (hash Aggregate, sort, grace-hash / sort-merge /
-    /// IEJoin / hash Combine) holds its whole accumulated input before it can
-    /// emit, and spills that state when the memory budget trips; a streaming
-    /// or sink stage spills nothing. Summing rather than taking the max is the
-    /// conservative choice for a free-space preflight: two blocking operators
-    /// can be live and spilled simultaneously, so their footprints add. The
-    /// figure derives from the same `predicted_peak_bytes` estimates
-    /// `--explain` surfaces, so a preflight warning lines up with the numbers
-    /// a pipeline author already sees. Returns `0` when no node spills or when
-    /// volume estimates are unknown (no on-disk file seed reached the plan).
+    /// A spill-writing operator (external sort, hash Aggregate, grace-hash /
+    /// sort-merge Combine — see [`super::writes_spill_files`]) holds its whole
+    /// accumulated input before it can emit, and writes that state to a spill
+    /// file when the memory budget trips. In-memory join strategies (inline
+    /// hash build/probe, IEJoin) carry an arbitration `spill_priority` but run
+    /// their kernel entirely in RAM, so they contribute nothing to disk
+    /// volume and are excluded — counting them would over-state the free-space
+    /// a run needs. Summing rather than taking the max is the conservative
+    /// choice for a free-space preflight: two blocking operators can be live
+    /// and spilled simultaneously, so their footprints add. The figure derives
+    /// from the same `predicted_peak_bytes` estimates `--explain` surfaces, so
+    /// a preflight warning lines up with the numbers a pipeline author already
+    /// sees. Returns `0` when no node spills or when volume estimates are
+    /// unknown (no on-disk file seed reached the plan).
     pub fn estimated_spill_bytes(&self) -> u64 {
         self.topo_order
             .iter()
-            .filter(|&&idx| {
-                super::arbitration_class(&self.graph[idx])
-                    .spill_priority
-                    .is_some()
-            })
+            .filter(|&&idx| super::writes_spill_files(&self.graph[idx]))
             .filter_map(|idx| self.node_properties.get(idx))
             .fold(0u64, |acc, props| {
                 acc.saturating_add(props.predicted_peak_bytes)
             })
     }
 
-    /// Per-blocking-stage spill-volume estimate, one entry per spilling
-    /// operator (hash Aggregate, external sort, grace-hash / sort-merge /
-    /// IEJoin / hash Combine) in topological order.
+    /// Per-blocking-stage spill-volume estimate, one entry per spill-writing
+    /// operator (external sort, hash Aggregate, grace-hash / sort-merge
+    /// Combine — see [`super::writes_spill_files`]) in topological order.
     ///
+    /// In-memory join strategies (inline hash build/probe, IEJoin) carry an
+    /// arbitration `spill_priority` but never write a spill file, so they do
+    /// not appear here — the per-stage estimate describes what reaches disk.
     /// Each [`StageSpillEstimate`] carries the operator's node name, its
     /// `--explain` display name, and its `predicted_peak_bytes` — the coarse
     /// plan-time estimate of the live state it could spill. `estimate_bytes`
@@ -192,11 +196,7 @@ impl ExecutionPlanDag {
     pub fn per_stage_spill_estimates(&self) -> Vec<StageSpillEstimate> {
         self.topo_order
             .iter()
-            .filter(|&&idx| {
-                super::arbitration_class(&self.graph[idx])
-                    .spill_priority
-                    .is_some()
-            })
+            .filter(|&&idx| super::writes_spill_files(&self.graph[idx]))
             .map(|&idx| {
                 let node = &self.graph[idx];
                 StageSpillEstimate {

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -1522,8 +1522,9 @@ impl<'a> ExplainJson<'a> {
 /// Every field is structured rather than a stringified blob so downstream
 /// tooling (Kiln canvas, third-party consumers) can read per-stage spill
 /// estimates and the cap / staging summary without re-parsing prose. The
-/// CLI builds it via [`ExecutionPlanDag::spill_summary_json`] (the
-/// plan-derivable parts) plus the CLI-resolved spill root / cap / staging
+/// CLI assembles it from [`ExecutionPlanDag::estimated_spill_json`] and
+/// [`ExecutionPlanDag::spill_compression_json`] (the plan-derivable parts)
+/// plus the CLI-resolved spill root / cap / staging
 /// fields.
 #[derive(Debug, Clone, Serialize)]
 pub struct StorageSummaryJson {

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -962,8 +962,8 @@ impl ExecutionPlanDag {
 
     /// Render the per-blocking-stage estimated spill volume for `--explain`.
     ///
-    /// One line per spilling operator (hash Aggregate, external sort,
-    /// grace-hash / sort-merge / IEJoin / hash Combine) giving its plan-time
+    /// One line per spill-writing operator (external sort, hash Aggregate,
+    /// grace-hash / sort-merge Combine) giving its plan-time
     /// `predicted_peak_bytes` estimate, followed by a total. A stage whose
     /// volume is unknown at plan time (no on-disk file-size seed reached it —
     /// a `glob`/`regex` multi-file source, a network source, or a
@@ -1010,15 +1010,19 @@ impl ExecutionPlanDag {
     /// Render the per-blocking-operator spill-compression decision for the
     /// `--explain` text output.
     ///
-    /// Each operator that can spill (Aggregate, sort, grace-hash Combine —
-    /// the nodes that register a spillable consumer at runtime) gets one line
-    /// resolving `compress` against that operator's output-schema width and
-    /// the run's `batch_size`. Under [`CompressMode::Auto`] the decision
-    /// varies per operator because a wide operator clears the per-batch byte
+    /// Each operator that actually writes spill files (hash Aggregate,
+    /// external sort, grace-hash / sort-merge Combine — see
+    /// [`writes_spill_files`]) gets one line resolving `compress` against that
+    /// operator's output-schema width and the run's `batch_size`. In-memory
+    /// join strategies (inline hash build/probe, IEJoin) carry a
+    /// `spill_priority` for memory arbitration but never open a spill writer,
+    /// so they are excluded — spill compression has no meaning for state that
+    /// never reaches disk. Under [`CompressMode::Auto`] the decision varies
+    /// per operator because a wide operator clears the per-batch byte
     /// threshold a narrow one does not; `On` / `Off` report the same forced
     /// choice for every operator. The header line names the configured mode so
     /// an operator can confirm both the policy and its resolved effect before
-    /// a run. Returns an empty string when the plan has no spill-eligible
+    /// a run. Returns an empty string when the plan has no spill-writing
     /// operator.
     pub fn spill_compression_explain(
         &self,
@@ -1029,7 +1033,7 @@ impl ExecutionPlanDag {
             .topo_order
             .iter()
             .copied()
-            .filter(|&idx| arbitration_class(&self.graph[idx]).spill_priority.is_some())
+            .filter(|&idx| writes_spill_files(&self.graph[idx]))
             .collect();
         if blocking.is_empty() {
             return String::new();
@@ -1049,6 +1053,78 @@ impl ExecutionPlanDag {
             out.push_str(&format!("  {} → {chosen}\n", node.display_name()));
         }
         out
+    }
+
+    /// Structured per-stage spill estimate for the JSON `--explain` output.
+    ///
+    /// Mirrors [`Self::spill_estimate_explain`] field-for-field — the same
+    /// spill-writing operators, the same `unknown`-vs-bytes distinction
+    /// (rendered here as `None` vs `Some`), the same known-stage total — so
+    /// the JSON and text storage summaries cannot drift.
+    pub fn estimated_spill_json(&self) -> EstimatedSpillJson {
+        let mut per_stage = Vec::new();
+        let mut total_known_bytes: u64 = 0;
+        let mut any_unknown = false;
+        for est in self.per_stage_spill_estimates() {
+            let estimate_bytes = if est.estimate_bytes == 0 {
+                any_unknown = true;
+                None
+            } else {
+                total_known_bytes = total_known_bytes.saturating_add(est.estimate_bytes);
+                Some(est.estimate_bytes)
+            };
+            per_stage.push(StageSpillEstimateJson {
+                node_name: est.node_name,
+                display_name: est.display_name,
+                estimate_bytes,
+            });
+        }
+        EstimatedSpillJson {
+            per_stage,
+            total_known_bytes,
+            any_unknown,
+        }
+    }
+
+    /// Structured per-operator spill-compression decision for the JSON
+    /// `--explain` output.
+    ///
+    /// Mirrors [`Self::spill_compression_explain`]: the same spill-writing
+    /// operators (in-memory joins excluded), the same per-operator `lz4` /
+    /// `off` resolution against output-schema width and `batch_size`, under
+    /// the same configured mode.
+    pub fn spill_compression_json(
+        &self,
+        compress: crate::config::CompressMode,
+        batch_size: usize,
+    ) -> SpillCompressionJson {
+        let per_operator = self
+            .topo_order
+            .iter()
+            .copied()
+            .filter(|&idx| writes_spill_files(&self.graph[idx]))
+            .map(|idx| {
+                let node = &self.graph[idx];
+                let column_count = node
+                    .stored_output_schema()
+                    .map(|s| s.column_count())
+                    .unwrap_or(0);
+                let compression = if compress.resolve_for_schema(column_count, batch_size as u64) {
+                    "lz4"
+                } else {
+                    "off"
+                };
+                OperatorCompressionJson {
+                    node_name: node.name().to_string(),
+                    display_name: node.display_name(),
+                    compression: compression.to_string(),
+                }
+            })
+            .collect();
+        SpillCompressionJson {
+            mode: compress.json_label().to_string(),
+            per_operator,
+        }
     }
 
     /// Append the `CXL Expressions`, `Type Annotations`, `Memory Budget`
@@ -1404,6 +1480,14 @@ struct NodeEntry<'a> {
 pub struct ExplainJson<'a> {
     dag: &'a ExecutionPlanDag,
     artifacts: &'a crate::plan::bind_schema::CompileArtifacts,
+    /// Storage observability at parity with the text `--explain` output:
+    /// per-stage spill estimates, the resolved spill root / disk cap, the
+    /// per-operator compression decision, cap headroom, and the staging
+    /// plan. `None` when the JSON view is built without storage context
+    /// (e.g. the field-provenance path), in which case the
+    /// `storage_summary` key is omitted entirely rather than emitted as
+    /// `null`.
+    storage_summary: Option<StorageSummaryJson>,
 }
 
 impl<'a> ExplainJson<'a> {
@@ -1412,13 +1496,171 @@ impl<'a> ExplainJson<'a> {
         dag: &'a ExecutionPlanDag,
         artifacts: &'a crate::plan::bind_schema::CompileArtifacts,
     ) -> Self {
-        Self { dag, artifacts }
+        Self {
+            dag,
+            artifacts,
+            storage_summary: None,
+        }
     }
+
+    /// Attach the storage observability summary so the JSON `--explain`
+    /// output carries the same per-stage spill estimates, spill root /
+    /// disk cap, compression decision, cap headroom, and staging plan the
+    /// text output renders. The CLI assembles the summary because it holds
+    /// the resolved storage config, spill root, batch size, and staging
+    /// policy the plan layer does not.
+    pub fn with_storage_summary(mut self, summary: StorageSummaryJson) -> Self {
+        self.storage_summary = Some(summary);
+        self
+    }
+}
+
+/// Structured storage observability for the JSON `--explain` output, at
+/// parity with the text path's per-stage spill estimate, spill root,
+/// spill disk cap, spill compression, cap headroom, and staging plan.
+///
+/// Every field is structured rather than a stringified blob so downstream
+/// tooling (Kiln canvas, third-party consumers) can read per-stage spill
+/// estimates and the cap / staging summary without re-parsing prose. The
+/// CLI builds it via [`ExecutionPlanDag::spill_summary_json`] (the
+/// plan-derivable parts) plus the CLI-resolved spill root / cap / staging
+/// fields.
+#[derive(Debug, Clone, Serialize)]
+pub struct StorageSummaryJson {
+    /// Resolved spill root: where the per-run spill directory is created.
+    pub spill_root: SpillRootJson,
+    /// Resolved cumulative on-disk spill cap in bytes; `None` is unlimited
+    /// (`storage.spill.disk_cap_bytes` unset).
+    pub spill_disk_cap_bytes: Option<u64>,
+    /// Per-blocking-stage estimated spill volume, plus a total over the
+    /// stages whose volume is known at plan time.
+    pub estimated_spill: EstimatedSpillJson,
+    /// Per-spill-writing-operator compression decision under the resolved
+    /// `storage.spill.compress` mode.
+    pub spill_compression: SpillCompressionJson,
+    /// Cap headroom: cap minus estimated spill volume. `None` when no cap
+    /// is configured or the estimate is unknown (`0`) — mirrors the text
+    /// path, which omits the line in those cases.
+    pub cap_headroom: Option<CapHeadroomJson>,
+    /// Per-source staging plan: whether each source (or each discovered
+    /// file) would be staged, the resolved staged path, and the
+    /// reuse-if-fresh decision.
+    pub staging: StagingPlanJson,
+}
+
+/// Resolved spill root for the JSON storage summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpillRootJson {
+    /// The directory under which the per-run spill directory is created.
+    pub path: String,
+    /// Where the value came from: `storage.spill.dir` or the OS temp-dir
+    /// default.
+    pub source: String,
+}
+
+/// Per-stage estimated spill volume for the JSON storage summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct EstimatedSpillJson {
+    /// One entry per spill-writing blocking stage, in topological order.
+    pub per_stage: Vec<StageSpillEstimateJson>,
+    /// Sum over stages whose estimate is known; excludes `unknown` stages.
+    pub total_known_bytes: u64,
+    /// `true` when at least one stage's volume is unknown at plan time, so
+    /// the total understates the real footprint.
+    pub any_unknown: bool,
+}
+
+/// One blocking stage's spill estimate for the JSON storage summary.
+/// `estimate_bytes` is `None` when the stage's volume is unknown at plan
+/// time (no on-disk file-size seed reached it), matching the text path's
+/// `unknown` rendering rather than a misleading `0`.
+#[derive(Debug, Clone, Serialize)]
+pub struct StageSpillEstimateJson {
+    pub node_name: String,
+    pub display_name: String,
+    pub estimate_bytes: Option<u64>,
+}
+
+/// Per-operator spill-compression decision for the JSON storage summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpillCompressionJson {
+    /// The configured `storage.spill.compress` mode (`auto` / `on` / `off`).
+    pub mode: String,
+    /// One entry per spill-writing operator, in topological order.
+    pub per_operator: Vec<OperatorCompressionJson>,
+}
+
+/// One operator's resolved spill-compression choice (`lz4` / `off`).
+#[derive(Debug, Clone, Serialize)]
+pub struct OperatorCompressionJson {
+    pub node_name: String,
+    pub display_name: String,
+    pub compression: String,
+}
+
+/// Cap-headroom figures for the JSON storage summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct CapHeadroomJson {
+    /// Cap minus estimated spill volume, in bytes.
+    pub headroom_bytes: u64,
+    /// The run's estimated spill volume, in bytes.
+    pub estimated_bytes: u64,
+    /// The configured disk cap, in bytes.
+    pub cap_bytes: u64,
+    /// Estimated volume as a percentage of the cap.
+    pub pct_of_cap: f64,
+    /// `true` when the estimate is at or above 80% of the cap, so a real
+    /// run may abort with a spill-cap error (E320).
+    pub over_threshold: bool,
+}
+
+/// Per-source staging plan for the JSON storage summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct StagingPlanJson {
+    /// Whether source staging is enabled. When `false`, `sources` is empty
+    /// and every source reads in place.
+    pub enabled: bool,
+    /// One entry per source, in declaration order.
+    pub sources: Vec<StagingSourceJson>,
+}
+
+/// One source's staging plan for the JSON storage summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct StagingSourceJson {
+    pub name: String,
+    /// `false` for network sources (not stagable; they read in place).
+    pub stagable: bool,
+    /// Per-file staging decision; empty for an unstagable source or one
+    /// whose matcher resolved to no files.
+    pub files: Vec<StagingFileJson>,
+    /// Present when matcher resolution failed during the explain; mirrors
+    /// the text path's inline `(discovery failed: …)` note.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discovery_error: Option<String>,
+}
+
+/// One staged file's decision for the JSON storage summary.
+#[derive(Debug, Clone, Serialize)]
+pub struct StagingFileJson {
+    /// The matched source file path.
+    pub source_path: String,
+    /// `true` when the file matches a staging pattern and would be copied.
+    pub staged: bool,
+    /// The resolved staged path; `None` when the file reads in place.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub staged_path: Option<String>,
+    /// The reuse-if-fresh decision label (`hit` / `miss`); `None` when the
+    /// file is not staged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reuse: Option<String>,
 }
 
 impl<'a> Serialize for ExplainJson<'a> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(Some(3))?;
+        // schema_version + nodes + node_properties, plus storage_summary
+        // when the CLI threaded the storage context through.
+        let entry_count = 3 + usize::from(self.storage_summary.is_some());
+        let mut map = serializer.serialize_map(Some(entry_count))?;
         map.serialize_entry("schema_version", "1")?;
 
         // Combine-aware node list. Walks `topo_order` and emits a
@@ -1504,6 +1746,13 @@ impl<'a> Serialize for ExplainJson<'a> {
             }
         }
         map.serialize_entry("node_properties", &PropsMap(self.dag))?;
+
+        // Storage observability at parity with the text `--explain`
+        // output. Omitted (not `null`) when the JSON view was built
+        // without storage context.
+        if let Some(summary) = &self.storage_summary {
+            map.serialize_entry("storage_summary", summary)?;
+        }
         map.end()
     }
 }
@@ -1702,5 +1951,168 @@ fn combine_operand_qualified(expr: &cxl::ast::Expr, input: &std::sync::Arc<str>)
             .collect::<Vec<_>>()
             .join("."),
         _ => format!("{}.<expr>", input),
+    }
+}
+
+#[cfg(test)]
+mod spill_projection_tests {
+    use super::*;
+    use crate::plan::combine::{CombinePredicateSummary, CombineStrategy};
+    use crate::plan::properties::NodeProperties;
+    use petgraph::graph::DiGraph;
+    use std::sync::Arc;
+
+    fn empty_dag() -> ExecutionPlanDag {
+        ExecutionPlanDag::from_parts(
+            DiGraph::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+            ParallelismProfile {
+                per_transform: Vec::new(),
+                worker_threads: 1,
+            },
+        )
+    }
+
+    fn combine_node(name: &str, strategy: CombineStrategy) -> PlanNode {
+        PlanNode::Combine {
+            name: name.to_string(),
+            span: Span::SYNTHETIC,
+            strategy,
+            driving_input: "a".to_string(),
+            build_inputs: vec!["b".to_string()],
+            predicate_summary: CombinePredicateSummary::default(),
+            match_mode: crate::config::pipeline_node::MatchMode::First,
+            on_miss: crate::config::pipeline_node::OnMiss::NullFields,
+            propagate_ck: crate::config::pipeline_node::PropagateCkSpec::Driver,
+            decomposed_from: None,
+            output_schema: Arc::new(clinker_record::Schema::new(Vec::new())),
+            resolved_column_map: Arc::new(std::collections::HashMap::new()),
+        }
+    }
+
+    fn sort_node(name: &str) -> PlanNode {
+        PlanNode::Sort {
+            name: name.to_string(),
+            span: Span::SYNTHETIC,
+            sort_fields: Vec::new(),
+        }
+    }
+
+    /// Push a node onto the DAG, register it in `topo_order`, and seed a
+    /// `predicted_peak_bytes` so the per-stage estimate has a non-zero
+    /// figure to report for the spill-writing variants.
+    fn add_node(dag: &mut ExecutionPlanDag, node: PlanNode, peak_bytes: u64) {
+        let idx = dag.graph.add_node(node);
+        dag.topo_order.push(idx);
+        let mut props = NodeProperties::unordered_single();
+        props.predicted_peak_bytes = peak_bytes;
+        dag.node_properties.insert(idx, props);
+    }
+
+    /// The `--explain` spill-compression projection lists only operators
+    /// backed by a real spill writer. In-memory join strategies
+    /// (`HashBuildProbe`, `IEJoin`, `HashPartitionIEJoin`) carry a
+    /// `spill_priority` for memory arbitration but never open a spill file,
+    /// so they must not appear; the genuinely-spilling external sort and
+    /// grace-hash / sort-merge Combine must.
+    #[test]
+    fn spill_compression_lists_only_real_spill_writers() {
+        let mut dag = empty_dag();
+        add_node(
+            &mut dag,
+            combine_node("inline_join", CombineStrategy::HashBuildProbe),
+            1_000,
+        );
+        add_node(
+            &mut dag,
+            combine_node("range_join", CombineStrategy::IEJoin),
+            1_000,
+        );
+        add_node(
+            &mut dag,
+            combine_node(
+                "hashpart_join",
+                CombineStrategy::HashPartitionIEJoin { partition_bits: 4 },
+            ),
+            1_000,
+        );
+        add_node(
+            &mut dag,
+            combine_node(
+                "grace_join",
+                CombineStrategy::GraceHash { partition_bits: 4 },
+            ),
+            1_000,
+        );
+        add_node(
+            &mut dag,
+            combine_node("merge_join", CombineStrategy::SortMerge),
+            1_000,
+        );
+        add_node(&mut dag, sort_node("external_sort"), 1_000);
+
+        let out = dag.spill_compression_explain(crate::config::CompressMode::Auto, 1_024);
+
+        // In-memory joins are excluded: their state never reaches disk.
+        assert!(
+            !out.contains("inline_join"),
+            "HashBuildProbe must not appear in the spill-compression projection:\n{out}"
+        );
+        assert!(
+            !out.contains("range_join"),
+            "IEJoin must not appear in the spill-compression projection:\n{out}"
+        );
+        assert!(
+            !out.contains("hashpart_join"),
+            "HashPartitionIEJoin must not appear in the spill-compression projection:\n{out}"
+        );
+
+        // Genuine spill writers are included.
+        assert!(
+            out.contains("grace_join"),
+            "grace-hash Combine must appear in the spill-compression projection:\n{out}"
+        );
+        assert!(
+            out.contains("merge_join"),
+            "sort-merge Combine must appear in the spill-compression projection:\n{out}"
+        );
+        assert!(
+            out.contains("external_sort"),
+            "external sort must appear in the spill-compression projection:\n{out}"
+        );
+    }
+
+    /// The per-stage estimated-spill-volume projection applies the same
+    /// spill-writer predicate, so an in-memory join contributes nothing to
+    /// the disk estimate while a real spiller does.
+    #[test]
+    fn per_stage_estimate_excludes_in_memory_joins() {
+        let mut dag = empty_dag();
+        add_node(
+            &mut dag,
+            combine_node("inline_join", CombineStrategy::HashBuildProbe),
+            5_000,
+        );
+        add_node(
+            &mut dag,
+            combine_node(
+                "grace_join",
+                CombineStrategy::GraceHash { partition_bits: 4 },
+            ),
+            7_000,
+        );
+
+        let estimates = dag.per_stage_spill_estimates();
+        let names: Vec<&str> = estimates.iter().map(|e| e.node_name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["grace_join"],
+            "only the grace-hash Combine writes spill files"
+        );
+        // The disk-volume total counts the real spiller only.
+        assert_eq!(dag.estimated_spill_bytes(), 7_000);
     }
 }

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -812,6 +812,62 @@ pub(super) fn arbitration_class(node: &PlanNode) -> ArbitrationClass {
     }
 }
 
+/// `true` iff this operator backs its state with a real on-disk spill
+/// writer — i.e. it actually writes spill files when the memory budget
+/// trips, rather than merely carrying a `spill_priority` for memory
+/// arbitration.
+///
+/// This is a strict subset of "has a non-`None` [`arbitration_class`]
+/// spill priority". Some operators register a spillable `MemoryConsumer`
+/// so the arbitrator can rank them, yet run their kernel entirely
+/// in-memory and never open a spill file:
+///
+/// - inline hash Combine (`HashBuildProbe`) builds its hash table in RAM;
+///   its consumer's `try_spill` requests a rebuild, it does not write a
+///   spill file.
+/// - `IEJoin` / `HashPartitionIEJoin` register under the sort-buffer
+///   consumer for arbitration accounting but their range-join kernel
+///   partitions and walks in memory — no spill writer is wired.
+///
+/// The operators that DO write spill files (`SpillWriter` /
+/// `AggSpillWriter` / `GraceSpillWriter`):
+///
+/// - external sort (`PlanNode::Sort`),
+/// - hash Aggregate (`PlanNode::Aggregation` with the hash strategy;
+///   streaming aggregate holds one group and never spills),
+/// - grace-hash and sort-merge Combine.
+///
+/// Surfaces that describe what hits disk — the `--explain`
+/// spill-compression projection, the per-stage estimated spill volume,
+/// and the run-startup free-space / cap-headroom preflight — must filter
+/// on this predicate, not on `spill_priority.is_some()`, so an in-memory
+/// join never appears as a disk-spilling stage.
+pub(super) fn writes_spill_files(node: &PlanNode) -> bool {
+    use crate::plan::combine::CombineStrategy;
+    match node {
+        PlanNode::Sort { .. } => true,
+        PlanNode::Aggregation {
+            strategy: AggregateStrategy::Hash,
+            ..
+        } => true,
+        PlanNode::Aggregation {
+            strategy: AggregateStrategy::Streaming,
+            ..
+        } => false,
+        PlanNode::Combine { strategy, .. } => matches!(
+            strategy,
+            CombineStrategy::GraceHash { .. } | CombineStrategy::SortMerge
+        ),
+        PlanNode::Source { .. }
+        | PlanNode::Transform { .. }
+        | PlanNode::Route { .. }
+        | PlanNode::Merge { .. }
+        | PlanNode::Output { .. }
+        | PlanNode::Composition { .. }
+        | PlanNode::CorrelationCommit { .. } => false,
+    }
+}
+
 /// DAG-based execution plan — replaces ExecutionPlan.
 ///
 /// The single source of truth for pipeline topology and execution strategy.

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -698,7 +698,18 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     )
     .map_err(PipelineError::Config)?;
 
-    if args.explain.is_some() || (args.dry_run && args.dry_run_n.is_none()) {
+    // The resolved-outputs preamble is human-readable text decoration. The
+    // text explain and the config-validation dry run want it; the JSON and
+    // DOT explain formats are machine-consumed, so emitting a non-JSON / non-
+    // DOT preamble to stdout would make their output unparseable (the JSON
+    // form exists precisely so downstream tooling can read the plan and the
+    // storage summary without parsing prose).
+    let preamble_wanted = match args.explain {
+        Some(ExplainFormat::Text) => true,
+        Some(ExplainFormat::Json) | Some(ExplainFormat::Dot) => false,
+        None => args.dry_run && args.dry_run_n.is_none(),
+    };
+    if preamble_wanted {
         print_resolved_outputs(&pipeline_config);
     }
 
@@ -790,7 +801,20 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                 );
             }
             ExplainFormat::Json => {
-                let view = clinker_plan::plan::execution::ExplainJson::new(dag, artifacts);
+                // Storage observability at parity with the text path: the
+                // same per-stage spill estimate, spill root / disk cap,
+                // compression decision, cap headroom, and staging plan,
+                // structured so downstream tooling reads it without
+                // re-parsing prose.
+                let storage_summary = build_storage_summary_json(
+                    dag,
+                    &pipeline_config,
+                    &storage_config,
+                    spill_root_dir.as_deref(),
+                    &args.config,
+                );
+                let view = clinker_plan::plan::execution::ExplainJson::new(dag, artifacts)
+                    .with_storage_summary(storage_summary);
                 let json = serde_json::to_string_pretty(&view).map_err(|e| {
                     PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
                         "JSON serialization failed: {e}"
@@ -1779,6 +1803,162 @@ fn staging_plan_explain(
     }
     out.push('\n');
     out
+}
+
+/// Assemble the structured storage observability summary for
+/// `clinker run --explain --format json`.
+///
+/// Carries the same information the text path renders — per-stage spill
+/// estimate, resolved spill root, spill disk cap, per-operator spill
+/// compression, cap headroom, and the per-source staging plan — but
+/// structured so downstream tooling reads per-stage figures and the cap /
+/// staging summary without re-parsing prose. The plan-derivable parts come
+/// from the DAG ([`estimated_spill_json`](clinker_plan::plan::execution::ExecutionPlanDag::estimated_spill_json)
+/// / [`spill_compression_json`](clinker_plan::plan::execution::ExecutionPlanDag::spill_compression_json)),
+/// so they cannot drift from the text rendering; the resolved storage
+/// config the CLI loaded supplies the spill root / cap / compression /
+/// staging. `config_path` is the pipeline file's path: its parent is the
+/// discovery anchor the run uses, so the staged paths shown match the
+/// paths the real run would write.
+fn build_storage_summary_json(
+    dag: &clinker_plan::plan::execution::ExecutionPlanDag,
+    config: &clinker_plan::config::PipelineConfig,
+    storage: &clinker_plan::config::StorageConfig,
+    spill_root_dir: Option<&std::path::Path>,
+    config_path: &std::path::Path,
+) -> clinker_plan::plan::execution::StorageSummaryJson {
+    use clinker_plan::plan::execution::{
+        CapHeadroomJson, SpillRootJson, StagingFileJson, StagingPlanJson, StagingSourceJson,
+        StorageSummaryJson,
+    };
+
+    let spill_disk_cap_bytes = storage.spill.disk_cap();
+    let compress = storage.spill.compress;
+    let staging_policy = &storage.staging;
+    let batch_size = config
+        .pipeline
+        .batch_size
+        .unwrap_or(clinker_exec::executor::DEFAULT_BATCH_SIZE);
+    let discovery_anchor = config_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let discovery_anchor = discovery_anchor.as_path();
+
+    // Spill root: configured dir, else the OS temp dir — the same
+    // resolution the text path's "Spill root" line reports.
+    let spill_root = match spill_root_dir {
+        Some(dir) => SpillRootJson {
+            path: dir.display().to_string(),
+            source: "storage.spill.dir".to_string(),
+        },
+        None => SpillRootJson {
+            path: std::env::temp_dir().display().to_string(),
+            source: "OS temp dir (default)".to_string(),
+        },
+    };
+
+    // Cap headroom: cap minus the run's estimated spill volume. Omitted
+    // when no cap is configured or the estimate is unknown (`0`), matching
+    // the text path's `cap_headroom_explain` suppression.
+    let estimated_spill_bytes = dag.estimated_spill_bytes();
+    let cap_headroom = match spill_disk_cap_bytes {
+        Some(cap) if estimated_spill_bytes > 0 => {
+            let headroom_bytes = cap.saturating_sub(estimated_spill_bytes);
+            let pct_of_cap = if cap == 0 {
+                0.0
+            } else {
+                (estimated_spill_bytes as f64 / cap as f64) * 100.0
+            };
+            let over_threshold = estimated_spill_bytes as f64 >= cap as f64 * 0.80;
+            Some(CapHeadroomJson {
+                headroom_bytes,
+                estimated_bytes: estimated_spill_bytes,
+                cap_bytes: cap,
+                pct_of_cap,
+                over_threshold,
+            })
+        }
+        _ => None,
+    };
+
+    // Staging plan: resolve each source's matcher through the same
+    // `SourceStager::plan_entry` the text path consults, copying nothing.
+    let staging = if !staging_policy.enabled {
+        StagingPlanJson {
+            enabled: false,
+            sources: Vec::new(),
+        }
+    } else {
+        let stager = clinker_channel::SourceStager::new(staging_policy.clone());
+        let mut sources = Vec::new();
+        for body in config.source_bodies() {
+            let source = &body.source;
+            if !source.transport.is_file() {
+                sources.push(StagingSourceJson {
+                    name: source.name.clone(),
+                    stagable: false,
+                    files: Vec::new(),
+                    discovery_error: None,
+                });
+                continue;
+            }
+            match clinker_exec::source::discovery::discover(source, discovery_anchor) {
+                Ok(outcome) => {
+                    let files = outcome
+                        .files()
+                        .iter()
+                        .map(|f| {
+                            let entry = stager.plan_entry(&f.path);
+                            if entry.staged {
+                                StagingFileJson {
+                                    source_path: f.path.display().to_string(),
+                                    staged: true,
+                                    staged_path: entry
+                                        .staged_path
+                                        .as_ref()
+                                        .map(|p| p.display().to_string()),
+                                    reuse: Some(entry.reuse.label().to_string()),
+                                }
+                            } else {
+                                StagingFileJson {
+                                    source_path: f.path.display().to_string(),
+                                    staged: false,
+                                    staged_path: None,
+                                    reuse: None,
+                                }
+                            }
+                        })
+                        .collect();
+                    sources.push(StagingSourceJson {
+                        name: source.name.clone(),
+                        stagable: true,
+                        files,
+                        discovery_error: None,
+                    });
+                }
+                Err(e) => sources.push(StagingSourceJson {
+                    name: source.name.clone(),
+                    stagable: true,
+                    files: Vec::new(),
+                    discovery_error: Some(e.to_string()),
+                }),
+            }
+        }
+        StagingPlanJson {
+            enabled: true,
+            sources,
+        }
+    };
+
+    StorageSummaryJson {
+        spill_root,
+        spill_disk_cap_bytes,
+        estimated_spill: dag.estimated_spill_json(),
+        spill_compression: dag.spill_compression_json(compress, batch_size),
+        cap_headroom,
+        staging,
+    }
 }
 
 /// Best-effort hostname for the metrics payload.

--- a/crates/clinker/tests/storage_config_cli.rs
+++ b/crates/clinker/tests/storage_config_cli.rs
@@ -283,6 +283,105 @@ fn explain_surfaces_per_stage_spill_estimate() {
 }
 
 #[test]
+fn explain_json_carries_storage_summary_at_text_parity() {
+    let tmp = tempdir_path();
+    let pipeline = tmp.join("pipeline.yaml");
+    std::fs::write(&pipeline, AGG_PIPELINE_YAML).expect("write pipeline yaml");
+    write_orders_csv(&tmp);
+
+    // Configure a spill dir and a generous disk cap so the storage summary
+    // populates the spill-root, disk-cap, and cap-headroom fields rather than
+    // their default-omitted forms.
+    let spill = tmp.join("spill");
+    std::fs::create_dir(&spill).expect("create spill dir");
+    std::fs::write(
+        tmp.join("clinker.toml"),
+        format!(
+            "[storage.spill]\ndir = \"{}\"\ndisk_cap_bytes = 1000000000\n",
+            spill.display().to_string().replace('\\', "\\\\")
+        ),
+    )
+    .expect("write clinker.toml");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        .arg("--explain")
+        .arg("json")
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        output.status.success(),
+        "json explain must succeed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout)
+        .unwrap_or_else(|e| panic!("explain json must parse: {e}\n{stdout}"));
+
+    let summary = json
+        .get("storage_summary")
+        .unwrap_or_else(|| panic!("json explain must carry storage_summary; got:\n{stdout}"));
+
+    // Spill root reflects the configured dir.
+    assert_eq!(
+        summary["spill_root"]["source"], "storage.spill.dir",
+        "spill_root source must name the configured dir; got:\n{summary:#}"
+    );
+
+    // Disk cap is the configured value, structured (not stringified).
+    assert_eq!(
+        summary["spill_disk_cap_bytes"], 1_000_000_000_u64,
+        "spill_disk_cap_bytes must carry the configured cap; got:\n{summary:#}"
+    );
+
+    // Per-stage estimate lists the blocking hash Aggregate as a structured
+    // entry — the same stage the text path reports.
+    let per_stage = summary["estimated_spill"]["per_stage"]
+        .as_array()
+        .expect("estimated_spill.per_stage must be an array");
+    assert!(
+        per_stage.iter().any(|s| s["node_name"] == "dept_totals"),
+        "the blocking Aggregate must appear in estimated_spill.per_stage; got:\n{summary:#}"
+    );
+
+    // Compression decision is structured, with the mode and a per-operator
+    // breakdown that includes the same Aggregate stage.
+    assert_eq!(
+        summary["spill_compression"]["mode"], "auto",
+        "spill_compression.mode must reflect the default auto mode; got:\n{summary:#}"
+    );
+    assert!(
+        summary["spill_compression"]["per_operator"]
+            .as_array()
+            .expect("spill_compression.per_operator must be an array")
+            .iter()
+            .any(|o| o["node_name"] == "dept_totals"),
+        "the Aggregate stage must appear in spill_compression.per_operator; got:\n{summary:#}"
+    );
+
+    // Cap headroom is present and structured (cap configured + non-zero
+    // estimate), carrying the cap and the over-threshold flag.
+    assert_eq!(
+        summary["cap_headroom"]["cap_bytes"], 1_000_000_000_u64,
+        "cap_headroom must carry the configured cap; got:\n{summary:#}"
+    );
+    assert!(
+        summary["cap_headroom"]["over_threshold"].is_boolean(),
+        "cap_headroom.over_threshold must be a boolean; got:\n{summary:#}"
+    );
+
+    // Staging defaults to disabled and is reported structurally.
+    assert_eq!(
+        summary["staging"]["enabled"], false,
+        "staging must report disabled by default; got:\n{summary:#}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp);
+}
+
+#[test]
 fn explain_surfaces_staging_plan_per_source() {
     let tmp = tempdir_path();
     let pipeline = tmp.join("pipeline.yaml");

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -84,16 +84,23 @@ Spill disk cap: 10737418240 bytes [storage.spill.disk_cap_bytes]
 Spill disk cap: unlimited (default)
 ```
 
-Finally, `--explain` reports the resolved compression decision per blocking
-operator, so you can see which spills will be LZ4-framed (`lz4`) and which will
-be written raw (`off`) before the run starts. Under `auto` the choice varies by
-operator width:
+Finally, `--explain` reports the resolved compression decision per
+spill-writing operator, so you can see which spills will be LZ4-framed (`lz4`)
+and which will be written raw (`off`) before the run starts. Under `auto` the
+choice varies by operator width:
 
 ```text
 Spill compression: Auto [storage.spill.compress]
   Aggregate 'totals' → lz4
   Sort 'by_amount' → off
 ```
+
+Only operators that actually write spill files appear here: the external sort,
+the hash Aggregate, and the grace-hash / sort-merge Combine. In-memory join
+strategies (the inline hash build/probe and the IEJoin range join) run their
+kernel entirely in RAM and never open a spill file, so spill compression does
+not apply to them and they are omitted from this list — even though they carry
+a spill priority for memory arbitration.
 
 ## `storage.spill.disk_cap_bytes` — cap cumulative spill
 
@@ -186,9 +193,11 @@ are comparing the same unit the actuals report.
 
 ### Estimated spill volume per stage
 
-The `=== Estimated Spill Volume ===` section lists one line per blocking stage
-(hash Aggregate, external sort, grace-hash / sort-merge / IEJoin / hash Combine)
-with its plan-time spill-volume estimate, followed by a total:
+The `=== Estimated Spill Volume ===` section lists one line per spill-writing
+stage (hash Aggregate, external sort, grace-hash / sort-merge Combine) with its
+plan-time spill-volume estimate, followed by a total. In-memory join strategies
+(inline hash build/probe, IEJoin) never write spill files, so they do not
+appear here and do not inflate the total:
 
 ```text
 === Estimated Spill Volume ===
@@ -265,6 +274,59 @@ Cap headroom: 5000000000 bytes free (5000000000 estimated of 10000000000 cap, 50
   [per invocation — does NOT account for sibling invocations sharing the spill
   volume under partition-and-run]
 ```
+
+### Machine-readable form — `--explain json`
+
+`clinker run --explain json` emits the whole plan as JSON for tooling (the Kiln
+canvas, dashboards, CI gates). The same storage observability the text form
+prints lives under a structured `storage_summary` object, so a consumer reads
+per-stage spill estimates and the cap / staging summary without re-parsing
+prose:
+
+```json
+{
+  "schema_version": "1",
+  "nodes": [ ... ],
+  "node_properties": { ... },
+  "storage_summary": {
+    "spill_root": { "path": "/mnt/fast-ssd/clinker-spill", "source": "storage.spill.dir" },
+    "spill_disk_cap_bytes": 1000000000,
+    "estimated_spill": {
+      "per_stage": [
+        { "node_name": "dept_totals", "display_name": "[aggregation:hash] dept_totals", "estimate_bytes": 1024 },
+        { "node_name": "by_amount", "display_name": "[sort] by_amount", "estimate_bytes": 4096 }
+      ],
+      "total_known_bytes": 5120,
+      "any_unknown": false
+    },
+    "spill_compression": {
+      "mode": "auto",
+      "per_operator": [
+        { "node_name": "dept_totals", "display_name": "[aggregation:hash] dept_totals", "compression": "lz4" },
+        { "node_name": "by_amount", "display_name": "[sort] by_amount", "compression": "off" }
+      ]
+    },
+    "cap_headroom": {
+      "headroom_bytes": 999994880,
+      "estimated_bytes": 5120,
+      "cap_bytes": 1000000000,
+      "pct_of_cap": 0.000512,
+      "over_threshold": false
+    },
+    "staging": { "enabled": false, "sources": [] }
+  }
+}
+```
+
+The fields mirror the text sections one-for-one: `estimated_spill` is the
+`=== Estimated Spill Volume ===` section (a stage whose volume is unknown at
+plan time carries `estimate_bytes: null` and sets `any_unknown: true`),
+`spill_compression` is the `Spill compression:` projection, `cap_headroom` is
+the cap-headroom line (omitted when no cap is configured or the estimate is
+zero), and `staging` is the `=== Staging Plan ===` section. The JSON and DOT
+formats emit only their machine payload — the human-readable
+`=== Resolved Outputs ===` preamble the text form prints is suppressed so the
+output parses cleanly.
 
 ### Post-run actuals — calibrating the estimate
 


### PR DESCRIPTION
## What this changes

This makes `clinker run --explain` describe storage behavior truthfully and at parity across its text and JSON output paths.

### Truthful per-operator spill surfaces (Closes #329)

Previously, `--explain` printed a spill-compression line for every plan node that registers a spillable consumer for memory-arbitration ranking. That predicate incorrectly swept in two Combine strategies that join entirely in memory and never write a spill file — the in-memory hash-build-probe path and the IEJoin / hash-partition-IEJoin path. For a Combine node planned as one of these strategies, `--explain` would report a compression mode (e.g. `-> lz4`) for an operator that produces zero spill bytes, implying an on-disk format decision for work that never touches disk.

The fix decouples on-disk-format reporting from the arbitration-ranking flag: the explain spill surfaces now describe only the operators that actually write spill files (Aggregate, sort, grace-hash Combine, sort-merge Combine matching-run spill, and inter-stage node-buffer overflow). The same scope holds for any future in-memory operator that registers for arbitration ranking.

### JSON storage summary at text parity (Closes #331)

The text `--explain` output carries a `=== Storage ===` section summarizing pre-run storage signal: the resolved spill root and its source, the resolved disk cap (or unlimited), the resolved spill-compression mode, per-operator estimated spill volume paired with its compression decision, the total estimated spill volume, and the per-invocation cap headroom. The JSON view (`--explain --format json`) did not carry this pipeline-level summary.

This adds a top-level `storage` object to the JSON `--explain` payload, adjacent to `nodes` and `node_properties`, carrying the same resolved pipeline-level fields the text section shows. The per-operator estimates and the headroom match the text-path values for the same plan, so a JSON consumer (the visual canvas or third-party tooling) reads the same pre-run storage signal an operator sees in the text output.

## Milestone

storage: configurable spill location + opt-in source staging

Closes #329, Closes #331
