### PR TITLE
engine: --explain spill volume reports the real bytes and column count a run produces

### DIFF
--- a/crates/clinker-exec/src/source/mod.rs
+++ b/crates/clinker-exec/src/source/mod.rs
@@ -1,15 +1,13 @@
-//! Source-side discovery and multi-file ingestion.
+//! Source-side multi-file ingestion.
 //!
-//! [`discovery`] resolves a [`clinker_plan::config::SourceConfig`] matcher
-//! (`path` / `glob` / `regex` / `paths`) into a concrete file set,
-//! applying the post-discovery filters (`exclude`, `modified_after/before`,
-//! `min_size`/`max_size`, `files.sort_by`/`take_first|last`,
-//! `files.recursive`, `files.on_no_match`).
-//!
-//! Multi-file format streaming (header skipping across files, per-file
-//! `RecordProvenance` Arc swaps) lives alongside in §3.
+//! File-set discovery — resolving a [`clinker_plan::config::SourceConfig`]
+//! matcher (`path` / `glob` / `regex` / `paths`) and applying the
+//! post-discovery filters — lives in [`clinker_plan::config::discovery`], so
+//! the planner's `--explain` spill-volume estimate and the runtime ingest
+//! path resolve the same file set. This module owns the multi-file format
+//! streaming that consumes that resolved set (header skipping across files,
+//! per-file `RecordProvenance` Arc swaps).
 
-pub mod discovery;
 pub mod multi_file;
 
 use std::sync::Arc;

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
@@ -54,7 +54,7 @@ edge aggregation.dept_totals -> output.out:
 
 Estimated spill volume (per blocking stage):
   [aggregation:hash] dept_totals → unknown
-  Total (known stages): 0B (excludes stages whose volume is unknown at plan time — a glob/regex multi-file source, a network source, or a missing input)
+  Total (known stages): 0B (excludes stages whose volume is unknown at plan time — a network source, a missing or unreadable input, or a glob/regex matcher whose discovery fails)
 
 === CXL Expressions ===
 

--- a/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
+++ b/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
@@ -96,7 +96,7 @@ edge aggregation.dept_totals -> output.out:
 Estimated spill volume (per blocking stage):
   [sort] __correlation_sort_orders → unknown
   [aggregation:hash] dept_totals → unknown
-  Total (known stages): 0B (excludes stages whose volume is unknown at plan time — a glob/regex multi-file source, a network source, or a missing input)
+  Total (known stages): 0B (excludes stages whose volume is unknown at plan time — a network source, a missing or unreadable input, or a glob/regex matcher whose discovery fails)
 
 === Retraction ===
 

--- a/crates/clinker-exec/tests/volume_estimates.rs
+++ b/crates/clinker-exec/tests/volume_estimates.rs
@@ -1,9 +1,12 @@
 //! Gate tests for per-node input-volume byte estimates.
 //!
 //! `derive_volume_estimates` seeds `predicted_peak_bytes` at file-backed
-//! Sources from the on-disk `path:` file size (resolved against the pipeline
-//! file's directory, never the process CWD) and propagates it forward in
-//! topological order. A blocking node (hash Aggregate) carries a non-zero
+//! Sources from the matched files' on-disk sizes (resolved against the
+//! pipeline file's directory, never the process CWD): a `path:` single file,
+//! the sum of a `paths:` list, or the sum of every file a `glob:`/`regex:`
+//! matcher expands to through the shared discovery resolver. It propagates
+//! that seed forward in topological order. A blocking node (hash Aggregate)
+//! carries a non-zero
 //! `predicted_freed_bytes_on_complete` equal to the volume it accumulates;
 //! streaming/fused nodes free nothing. A second, reverse-topological pass
 //! then propagates `predicted_subtree_reclaim_bytes` UP each chain — the
@@ -255,13 +258,15 @@ fn missing_file_source_seeds_zero() {
 }
 
 #[test]
-fn glob_multi_file_source_seeds_zero() {
-    // A glob matcher fans out to multiple files at discovery time and has no
-    // single literal size to seed, so it stays at the `0` unknown sentinel
-    // even when matching files exist on disk.
+fn glob_multi_file_source_seeds_sum_of_matched_files() {
+    // A glob matcher fans out to multiple files at discovery time. The seed
+    // expands the glob through the same discovery resolver the run uses and
+    // sums the matched files' sizes, so the estimate names exactly the bytes
+    // the run reads — no longer the `0` unknown sentinel.
     let tmp = tempfile::tempdir().unwrap();
-    write_file(tmp.path(), "a.csv", "department,amount\nsales,100\n");
-    write_file(tmp.path(), "b.csv", "department,amount\nops,250\n");
+    let a = write_file(tmp.path(), "a.csv", "department,amount\nsales,100\n");
+    let b = write_file(tmp.path(), "b.csv", "department,amount\nops,250\n");
+    assert!(a > 0 && b > 0);
 
     let yaml = r#"
 pipeline:
@@ -289,8 +294,48 @@ nodes:
 
     let src = props_for_node(dag, "orders");
     assert_eq!(
+        src.predicted_peak_bytes,
+        a + b,
+        "a glob Source must seed the summed size of every matched file"
+    );
+}
+
+#[test]
+fn glob_no_match_source_seeds_zero() {
+    // A glob that matches nothing has zero matched bytes. With the default
+    // `on_no_match: error` policy the discovery resolver reports an error, so
+    // the seed is the `0` unknown sentinel rather than a misleading concrete
+    // size — the run's own discovery surfaces the same error at startup.
+    let tmp = tempfile::tempdir().unwrap();
+
+    let yaml = r#"
+pipeline:
+  name: vol
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      glob: "nonexistent_*.csv"
+      schema:
+        - { name: department, type: string }
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let plan = compile_anchored(yaml, tmp.path());
+    let dag = plan.dag();
+
+    let src = props_for_node(dag, "orders");
+    assert_eq!(
         src.predicted_peak_bytes, 0,
-        "a multi-file (glob) Source must seed 0 (unknown)"
+        "a glob that matches no files must seed 0 (unknown)"
     );
 }
 

--- a/crates/clinker-plan/src/config/discovery.rs
+++ b/crates/clinker-plan/src/config/discovery.rs
@@ -1,4 +1,4 @@
-//! File discovery for [`clinker_plan::config::SourceConfig`].
+//! File discovery for [`crate::config::SourceConfig`].
 //!
 //! Resolves the matcher (`path` / `glob` / `regex` / `paths`) and applies
 //! the post-discovery filters (`exclude`, `modified_after`/`modified_before`,
@@ -21,7 +21,7 @@
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-use clinker_plan::config::{FileSortKey, NoMatchPolicy, SortDir, SourceConfig, TimeBound};
+use crate::config::{FileSortKey, NoMatchPolicy, SortDir, SourceConfig, TimeBound};
 
 /// One discovered file with its metadata stamps. Returned in the order
 /// the discovery pipeline produced (post-sort, post-take).
@@ -426,7 +426,7 @@ fn sort_files(files: &mut [DiscoveredFile], key: FileSortKey, dir: SortDir) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clinker_plan::config::{
+    use crate::config::{
         ByteSize, FileListingControls, FileSortKey, InputFormat, NoMatchPolicy, SortDir,
         SourceConfig, TimeBound,
     };
@@ -455,7 +455,7 @@ mod tests {
             schema_overrides: None,
             array_paths: None,
             sort_order: None,
-            transport: clinker_plan::config::SourceTransport::File,
+            transport: crate::config::SourceTransport::File,
             format: InputFormat::Csv(None),
             notes: None,
         }

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -1,6 +1,7 @@
 pub mod aggregate;
 pub mod compile_context;
 pub mod composition;
+pub mod discovery;
 pub mod error;
 pub mod format;
 pub mod fs_type;
@@ -26,6 +27,7 @@ pub use composition::{
     ResolvedValue, Resource, ResourceDecl, ResourceKind, ResourceName, ScopedVarsSchema, SourceMap,
     SpannedNodeRef, WORKSPACE_COMPOSITION_BUDGET, scan_workspace_signatures, validate_signatures,
 };
+pub use discovery::{DiscoveredFile, DiscoveryError, DiscoveryOutcome, discover};
 pub use error::*;
 pub use format::*;
 pub use fs_type::{FsKind, classify, same_device};

--- a/crates/clinker-plan/src/plan/execution/composition.rs
+++ b/crates/clinker-plan/src/plan/execution/composition.rs
@@ -331,25 +331,31 @@ pub(crate) fn resolve_composition_body_windows(
 
 /// On-disk byte seed for a file-backed Source's `predicted_peak_bytes`.
 ///
-/// Resolves each literal path against `anchor` (the pipeline file's directory)
-/// so the size is independent of the process CWD, and absolute paths resolve
+/// Resolves each matcher against `anchor` (the pipeline file's directory) so
+/// the size is independent of the process CWD, and absolute paths resolve
 /// as-is — matching the source-discovery resolver.
 ///
 /// Coverage:
 /// - **`path:`** (single file) — `Some(len)`.
 /// - **`paths:`** (explicit list) — `Some(sum)` of every readable listed file.
 ///   The explicit list carries no glob/exclude/min-size discovery filters, so
-///   summing the listed sizes is exact and reuses no discovery logic. An
-///   unreadable entry contributes nothing; the sum still seeds the others.
+///   summing the listed sizes is exact. An unreadable entry contributes
+///   nothing; the sum still seeds the others.
+/// - **`glob:` / `regex:`** (multi-file matchers) — `Some(sum)` of the matched
+///   files' sizes, computed by running the same [`discover`] resolver the
+///   staging and ingest paths use. Reusing that one resolver (its `exclude`
+///   list, `min_size`/`max_size`, `modified_after`/`before`, `take`, and sort
+///   filters) means the seed names exactly the bytes the run will read, with
+///   no second implementation to drift. An empty match seeds `Some(0)`, which
+///   the caller renders as `unknown` like any other zero seed.
 ///
-/// Returns `None` — the "unknown" seed the caller writes as `0` — for:
-/// - **`glob:` / `regex:`** matchers, which fan out through the full
-///   source-discovery resolver (exclude lists, `min_size`/`max_size`,
-///   `modified_after`/`before`, `take`, sort). Summing matched sizes here
-///   would mean re-implementing that resolver and risk diverging from the
-///   bytes the run actually reads, so these stay unknown by design — the
-///   `--explain` output and `docs/src/ops/storage.md` flag the limitation.
-/// - an absent matcher, or a `path:` whose `std::fs::metadata` fails.
+/// Returns `None` — the "unknown" seed the caller writes as `0` — for an
+/// absent matcher, a `path:` whose `std::fs::metadata` fails, an empty
+/// `paths:` list, or a discovery failure on a `glob:`/`regex:` matcher
+/// (invalid pattern, a no-match under `on_no_match: error`, or a walk I/O
+/// error). A discovery failure is reported as unknown rather than `0` so a
+/// broken matcher does not masquerade as a zero-byte input; the run's own
+/// discovery surfaces the same error at startup.
 pub(crate) fn source_seed_bytes(source: &SourceConfig, anchor: &std::path::Path) -> Option<u64> {
     let resolve = |p: &str| -> std::path::PathBuf {
         let p = std::path::Path::new(p);
@@ -374,10 +380,21 @@ pub(crate) fn source_seed_bytes(source: &SourceConfig, anchor: &std::path::Path)
         return Some(total);
     }
 
-    // `glob` / `regex` route through the discovery resolver and its filters;
-    // estimating them here would duplicate that resolver, so leave unknown.
+    // `glob` / `regex` fan out through the discovery resolver and its filters.
+    // Run that one resolver and sum the matched files' already-stat'd sizes so
+    // the estimate equals the bytes the run reads — never a second, divergent
+    // re-implementation of the filter pipeline. A discovery error is unknown
+    // (`None`), not a misleading `0`.
     if source.glob.is_some() || source.regex.is_some() {
-        return None;
+        return match crate::config::discovery::discover(source, anchor) {
+            Ok(outcome) => Some(
+                outcome
+                    .files()
+                    .iter()
+                    .fold(0u64, |acc, f| acc.saturating_add(f.size)),
+            ),
+            Err(_) => None,
+        };
     }
 
     let path = source.path.as_deref()?;

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -998,7 +998,8 @@ impl ExecutionPlanDag {
         if any_unknown {
             out.push_str(&format!(
                 "  Total (known stages): {} (excludes stages whose volume is unknown at plan time — \
-                 a glob/regex multi-file source, a network source, or a missing input)\n",
+                 a network source, a missing or unreadable input, or a glob/regex matcher whose \
+                 discovery fails)\n",
                 format_bytes(total),
             ));
         } else {
@@ -1007,13 +1008,33 @@ impl ExecutionPlanDag {
         out
     }
 
+    /// Column count the spill-compression decision resolves against for the
+    /// node at `idx` — the same width the runtime spill writer sees.
+    ///
+    /// Returns the node's *effective* output-schema column count via
+    /// [`PlanNode::output_schema_in`], which for a row-preserving operator
+    /// (an enforcer [`PlanNode::Sort`], whose own `stored_output_schema` is
+    /// `None`) walks to its sole upstream and reports that schema's width.
+    /// This is exactly the width the runtime sort buffer reads off its first
+    /// input record (`sort_dispatch`), so the `--explain` projection and the
+    /// on-disk spill file agree on the column count the `auto` heuristic
+    /// weighs. Hash Aggregate and grace-hash / sort-merge Combine carry a
+    /// stored output schema, so `output_schema_in` returns it directly — the
+    /// same `Arc<Schema>` their runtime dispatch arms resolve compression
+    /// against.
+    fn spill_decision_column_count(&self, idx: NodeIndex) -> usize {
+        self.graph[idx].output_schema_in(self).column_count()
+    }
+
     /// Render the per-blocking-operator spill-compression decision for the
     /// `--explain` text output.
     ///
     /// Each operator that actually writes spill files (hash Aggregate,
     /// external sort, grace-hash / sort-merge Combine — see
-    /// [`writes_spill_files`]) gets one line resolving `compress` against that
-    /// operator's output-schema width and the run's `batch_size`. In-memory
+    /// [`writes_spill_files`]) gets one line resolving `compress` against the
+    /// column count its runtime spill writer sees
+    /// ([`Self::spill_decision_column_count`]) and the run's `batch_size`, so
+    /// the projected mode equals the on-disk format the run produces. In-memory
     /// join strategies (inline hash build/probe, IEJoin) carry a
     /// `spill_priority` for memory arbitration but never open a spill writer,
     /// so they are excluded — spill compression has no meaning for state that
@@ -1041,10 +1062,7 @@ impl ExecutionPlanDag {
         let mut out = format!("Spill compression: {compress:?} [storage.spill.compress]\n");
         for idx in blocking {
             let node = &self.graph[idx];
-            let column_count = node
-                .stored_output_schema()
-                .map(|s| s.column_count())
-                .unwrap_or(0);
+            let column_count = self.spill_decision_column_count(idx);
             let chosen = if compress.resolve_for_schema(column_count, batch_size as u64) {
                 "lz4"
             } else {
@@ -1091,8 +1109,9 @@ impl ExecutionPlanDag {
     ///
     /// Mirrors [`Self::spill_compression_explain`]: the same spill-writing
     /// operators (in-memory joins excluded), the same per-operator `lz4` /
-    /// `off` resolution against output-schema width and `batch_size`, under
-    /// the same configured mode.
+    /// `off` resolution against the runtime spill writer's column count
+    /// ([`Self::spill_decision_column_count`]) and `batch_size`, under the
+    /// same configured mode.
     pub fn spill_compression_json(
         &self,
         compress: crate::config::CompressMode,
@@ -1105,10 +1124,7 @@ impl ExecutionPlanDag {
             .filter(|&idx| writes_spill_files(&self.graph[idx]))
             .map(|idx| {
                 let node = &self.graph[idx];
-                let column_count = node
-                    .stored_output_schema()
-                    .map(|s| s.column_count())
-                    .unwrap_or(0);
+                let column_count = self.spill_decision_column_count(idx);
                 let compression = if compress.resolve_for_schema(column_count, batch_size as u64) {
                     "lz4"
                 } else {
@@ -2002,6 +2018,21 @@ mod spill_projection_tests {
         }
     }
 
+    /// A Source carrying an explicit output schema of `column_names`. The
+    /// schema is the exact `Arc` every record this Source emits carries, so a
+    /// downstream node's runtime input-record width equals this column count.
+    fn source_node(name: &str, column_names: &[&str]) -> PlanNode {
+        let schema = clinker_record::Schema::new(
+            column_names.iter().map(|c| Box::<str>::from(*c)).collect(),
+        );
+        PlanNode::Source {
+            name: name.to_string(),
+            span: Span::SYNTHETIC,
+            resolved: None,
+            output_schema: Arc::new(schema),
+        }
+    }
+
     /// Push a node onto the DAG, register it in `topo_order`, and seed a
     /// `predicted_peak_bytes` so the per-stage estimate has a non-zero
     /// figure to report for the spill-writing variants.
@@ -2115,5 +2146,58 @@ mod spill_projection_tests {
         );
         // The disk-volume total counts the real spiller only.
         assert_eq!(dag.estimated_spill_bytes(), 7_000);
+    }
+
+    /// The spill-compression projection resolves an enforcer `Sort`'s column
+    /// count against the records that actually flow into it — its upstream's
+    /// output-schema width — not the Sort's own `stored_output_schema`, which
+    /// is `None` for a row-preserving operator.
+    ///
+    /// At runtime `sort_dispatch` reads the column count off its first input
+    /// record's schema (the upstream's emitted schema), so the basis the
+    /// `--explain` projection prints must equal that width or the reported
+    /// compression mode can disagree with the on-disk spill file. A Source
+    /// emits records widened with engine-stamped tail columns, so a five-wide
+    /// upstream makes the Sort's runtime spilled-batch five columns wide —
+    /// `spill_decision_column_count` must report exactly that, never `0`.
+    #[test]
+    fn sort_spill_column_count_matches_runtime_input_width() {
+        let mut dag = empty_dag();
+        // Five-wide upstream: three declared columns plus two engine-stamped
+        // tail columns, the shape ingest hands every record at runtime.
+        let upstream_columns = ["sku", "price", "qty", "$source.file", "$source.name"];
+        let src_idx = dag.graph.add_node(source_node("orders", &upstream_columns));
+        let sort_idx = dag.graph.add_node(sort_node("__sort__orders"));
+        dag.graph.add_edge(
+            src_idx,
+            sort_idx,
+            PlanEdge {
+                dependency_type: DependencyType::Data,
+                port: None,
+            },
+        );
+        dag.topo_order = vec![src_idx, sort_idx];
+        dag.node_properties
+            .insert(src_idx, NodeProperties::unordered_single());
+        dag.node_properties
+            .insert(sort_idx, NodeProperties::unordered_single());
+
+        // The width the runtime sort buffer reads off its first input record
+        // is exactly the upstream Source's emitted-schema width.
+        let runtime_input_width = dag.graph[src_idx]
+            .stored_output_schema()
+            .expect("a Source carries an output schema")
+            .column_count();
+        assert_eq!(runtime_input_width, upstream_columns.len());
+
+        // `--explain` must resolve the Sort's compression decision against the
+        // same width — not the Sort's own `stored_output_schema` (which is
+        // `None`, and would otherwise collapse the projected width to `0`).
+        assert!(dag.graph[sort_idx].stored_output_schema().is_none());
+        assert_eq!(
+            dag.spill_decision_column_count(sort_idx),
+            runtime_input_width,
+            "the --explain Sort column count must equal the runtime spilled-batch width"
+        );
     }
 }

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -931,9 +931,9 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         let source = &body.source;
         match &source.transport {
             clinker_plan::config::SourceTransport::File => {
-                let outcome = clinker_exec::source::discovery::discover(source, &workspace_root)
+                let outcome = clinker_plan::config::discovery::discover(source, &workspace_root)
                     .map_err(|e| {
-                        use clinker_exec::source::discovery::DiscoveryError;
+                        use clinker_plan::config::discovery::DiscoveryError;
                         let code = match &e {
                             DiscoveryError::MultipleMatchers { .. } => "E210",
                             DiscoveryError::NoMatcher => "E211",
@@ -1768,7 +1768,7 @@ fn staging_plan_explain(
         // uses. A discovery failure (no match, bad glob) is reported inline
         // rather than aborting the explain; the run's own discovery will
         // surface the coded diagnostic.
-        match clinker_exec::source::discovery::discover(source, discovery_anchor) {
+        match clinker_plan::config::discovery::discover(source, discovery_anchor) {
             Ok(outcome) => {
                 let files = outcome.files();
                 if files.is_empty() {
@@ -1903,7 +1903,7 @@ fn build_storage_summary_json(
                 });
                 continue;
             }
-            match clinker_exec::source::discovery::discover(source, discovery_anchor) {
+            match clinker_plan::config::discovery::discover(source, discovery_anchor) {
                 Ok(outcome) => {
                     let files = outcome
                         .files()

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -225,19 +225,22 @@ are excluded:
 ```text
   [aggregation:hash] dept_totals → unknown
   Total (known stages): 0B (excludes stages whose volume is unknown at plan time
-  — a glob/regex multi-file source, a network source, or a missing input)
+  — a network source, a missing or unreadable input, or a glob/regex matcher
+  whose discovery fails)
 ```
 
-The seed is known for a single-file `path:` source and for an explicit `paths:`
-list (the listed files' sizes sum exactly, since the list carries no discovery
-filters). It is **unknown** for a `glob:` or `regex:` matcher — those fan out
-through the full discovery resolver (with `exclude`, `min_size`/`max_size`,
-`modified_after`/`before`, `take`, and sort filters), and estimating them at
-plan time would mean re-implementing that resolver and risk naming different
-bytes than the run actually reads. It is also unknown for a network source and
-for a missing or unreadable file. To get a concrete estimate for a glob/regex
-source, list the files explicitly with `paths:`, or check the post-run actuals
-below.
+The seed is known for every file-backed matcher whose files can be sized at
+plan time: a single-file `path:` source, an explicit `paths:` list, and a
+`glob:` or `regex:` matcher. A glob/regex seed runs the same discovery resolver
+the run uses — applying its `exclude`, `min_size`/`max_size`,
+`modified_after`/`before`, `take`, and sort filters — and sums the matched
+files' sizes, so the estimate names exactly the bytes the run will read with no
+second implementation to drift. A glob/regex that matches nothing seeds zero
+(rendered as `unknown`, since there is no spill volume to preview). The seed is
+genuinely **unknown** for a network source, for a missing or unreadable input
+file, and for a glob/regex matcher whose discovery itself fails (an invalid
+pattern, or no match under `on_no_match: error`) — the run surfaces the same
+error at startup. Check the post-run actuals below to calibrate any estimate.
 
 ### Staging plan per source
 
@@ -351,12 +354,15 @@ spill amplification, where an optimizer interaction turned 30 GB of input into
 
 > **Note on the `--explain` compression projection.** The per-operator
 > spill-compression decision shown under `Spill compression:` is projected from
-> each operator's *stored output schema* width at plan time. At runtime the
-> actual spilled batch may carry a different column count (engine-stamped
-> identity columns, intermediate-stage shapes), so a stage's projected `auto`
-> verdict can differ from the file it actually writes. The read path always
-> dispatches on the spill file's own one-byte header tag, so this never breaks
-> re-reading; the projection is a best-effort preview, not a guarantee.
+> the same column count the operator's runtime spill writer sees, so the
+> projected `auto` verdict matches the file the run actually writes. A hash
+> Aggregate and a grace-hash / sort-merge Combine project against their output
+> schema (engine-stamped identity columns included), exactly the width their
+> dispatch arms resolve compression against; an enforcer sort projects against
+> the width of the records flowing into it — its upstream's emitted schema —
+> which is the width its sort buffer reads at runtime. The read path also
+> dispatches on each spill file's own one-byte header tag, so re-reading is
+> robust regardless.
 
 ## Distinguishing the four spill-related failure conditions
 


### PR DESCRIPTION
## Summary

Two accuracy fixes to the `clinker run --explain` spill-volume preview so the plan-time report names exactly what a run does to disk.

### Spill-compression column count (Closes #346)

The per-operator spill-compression projection resolved each operator's `auto` verdict against its stored output schema width. A row-preserving enforcer sort has no stored output schema, so its projected width collapsed to zero and the reported compression mode could disagree with the file the run actually writes.

The projection now resolves every spill-writing operator against the same column count its runtime spill writer sees:

- A hash Aggregate and a grace-hash / sort-merge Combine resolve against their output schema (the width their dispatch arms already use).
- An enforcer sort resolves against the width of the records flowing into it — its upstream's emitted schema, which is what the sort buffer reads at runtime.

The on-disk one-byte format tag still makes re-reading robust regardless of which decision was made; this removes the projection's residual divergence rather than documenting it.

### Glob/regex spill estimate (Closes #351)

The per-stage spill estimate reported `unknown` for a `glob:` or `regex:` multi-file source, because the seed could not size a fanned-out matcher without re-implementing the discovery filter pipeline.

The discovery resolver now lives in the planning crate, so both the run's source path and the explain seed call the one resolver — no second, divergent matcher. A glob/regex source now seeds the summed size of every matched file, applying the same `exclude`, `min_size`/`max_size`, `modified_after`/`modified_before`, `take`, and sort filters the run applies, so the per-stage estimate and total are concrete instead of `unknown`. An empty match seeds zero (rendered as `unknown`, since there is no spill volume to preview); a discovery failure (invalid pattern, a no-match under `on_no_match: error`, or a walk I/O error) stays `unknown` rather than masquerading as a zero-byte input.

## Tests

- A unit test pins the enforcer sort's explain column count to its runtime input width.
- The glob estimate test asserts the summed matched-file size; a new no-match test pins the `unknown` seed.

## Docs

The storage operations guide (`docs/src/ops/storage.md`) now describes the reconciled column-count basis and the glob/regex spill estimate.

Closes #346, Closes #351

Milestone: storage: configurable spill location + opt-in source staging