### PR TITLE
storage: dedicated diagnostic codes (E335/E336/E337) for staging-copy failures

### DIFF
--- a/crates/clinker-channel/src/overlay.rs
+++ b/crates/clinker-channel/src/overlay.rs
@@ -2,7 +2,8 @@
 //!
 //! Applies a [`ChannelBinding`] to a [`CompiledPlan`], overlaying config
 //! values as `ChannelDefault` or `ChannelFixed` provenance layers on the
-//! plan's [`ProvenanceDb`], and resolving channel-supplied var
+//! plan's [`ProvenanceDb`](clinker_plan::config::composition::ProvenanceDb),
+//! and resolving channel-supplied var
 //! overrides/adds for the four scoped registries (`$vars.*`,
 //! `$pipeline.*`, `$source.*`, `$record.*`) against the pipeline's
 //! declarations. Stamps a [`ChannelIdentity`] for cache-keying.
@@ -44,7 +45,8 @@ pub struct ChannelOverlayResult {
 /// Performs three things:
 ///
 /// 1. Overlays `config.default` / `config.fixed` onto the plan's
-///    [`ProvenanceDb`] as `ChannelDefault` / `ChannelFixed` layers
+///    [`ProvenanceDb`](clinker_plan::config::composition::ProvenanceDb) as
+///    `ChannelDefault` / `ChannelFixed` layers
 ///    (W103 for keys not matched in the plan).
 /// 2. Resolves the channel's `vars:` block against the pipeline's
 ///    declared registries — typecheck on override (E107), reserved

--- a/crates/clinker-channel/src/staging_copy.rs
+++ b/crates/clinker-channel/src/staging_copy.rs
@@ -151,6 +151,14 @@ const REAP_GRACE: Duration = Duration::from_secs(5);
 /// is deliberately distinct from [`StagingError::Io`]: a digest mismatch is the
 /// silent-corruption signal staging exists to catch, and the operator needs to
 /// see "the copy did not match the source" — not a generic I/O error.
+///
+/// The three policy/budget failures carry stable diagnostic codes the operator
+/// can look up with `clinker explain --code <CODE>`, mirroring the spill
+/// subsystem's E320/E321: [`StagingError::Verify`] is **E335**,
+/// [`StagingError::DiskCapExceeded`] is **E336**, and
+/// [`StagingError::AlreadyExists`] is **E337**. [`StagingError::Io`] is a
+/// generic OS fault with no stable code — its remediation depends on the
+/// underlying `errno`, not a clinker policy.
 #[derive(Debug, thiserror::Error)]
 pub enum StagingError {
     /// An OS-level I/O error while reading the source, writing the temp file,
@@ -162,13 +170,14 @@ pub enum StagingError {
         /// The underlying OS error.
         source: io::Error,
     },
-    /// The staged copy's BLAKE3 digest did not match the source's. The bytes on
-    /// the network share and the bytes that landed locally differ — exactly the
-    /// soft-mount silent-truncation mode staging guards against.
+    /// E335 — the staged copy's BLAKE3 digest did not match the source's. The
+    /// bytes on the network share and the bytes that landed locally differ —
+    /// exactly the soft-mount silent-truncation mode staging guards against.
     #[error(
-        "staged copy of {source_path} is corrupt: BLAKE3 of the local copy \
+        "E335 staged copy of {source_path} is corrupt: BLAKE3 of the local copy \
          ({copy_hash}) does not match the source ({source_hash}); \
-         the transport delivered different bytes than the source holds"
+         the transport delivered different bytes than the source holds. \
+         See: clinker explain --code E335"
     )]
     Verify {
         /// The original source path.
@@ -178,13 +187,14 @@ pub enum StagingError {
         /// Hex BLAKE3 digest of a fresh independent read of the source.
         source_hash: String,
     },
-    /// The cumulative bytes copied this run would exceed
+    /// E336 — the cumulative bytes copied this run would exceed
     /// `storage.staging.disk_cap_bytes`. Distinct from a full-disk
     /// [`StagingError::Io`]: the operator hit a configured budget, not the
     /// volume's physical limit.
     #[error(
-        "staging would exceed the configured cap of {cap} bytes \
-         (already staged {staged}, {source_path} adds {incoming})"
+        "E336 staging would exceed the configured cap of {cap} bytes \
+         (already staged {staged}, {source_path} adds {incoming}). \
+         See: clinker explain --code E336"
     )]
     DiskCapExceeded {
         /// The configured `storage.staging.disk_cap_bytes`.
@@ -196,12 +206,13 @@ pub enum StagingError {
         /// The source path that triggered the overflow.
         source_path: PathBuf,
     },
-    /// `on_existing = error` and a staged copy of this source already exists.
-    /// The operator asked to be told rather than silently reuse or overwrite a
-    /// prior artifact, so the run fails fast naming the existing copy.
+    /// E337 — `on_existing = error` and a staged copy of this source already
+    /// exists. The operator asked to be told rather than silently reuse or
+    /// overwrite a prior artifact, so the run fails fast naming the existing copy.
     #[error(
-        "staging on_existing = error: a staged copy of {source_path} already \
-         exists at {staged_path}; remove it or set on_existing to overwrite or reuse"
+        "E337 staging on_existing = error: a staged copy of {source_path} already \
+         exists at {staged_path}; remove it or set on_existing to overwrite or reuse. \
+         See: clinker explain --code E337"
     )]
     AlreadyExists {
         /// The original source path.
@@ -277,7 +288,7 @@ struct StagedFile {
 /// `--explain` does no copy, but it can `stat` the source and read a committed
 /// manifest read-only to predict whether the real run would reuse a fresh prior
 /// copy (a cache *hit*) or re-stage (a *miss*). The decision is exactly the one
-/// [`SourceStager::stage_locked`] makes at run time, computed without touching
+/// `SourceStager::stage_locked` makes at run time, computed without touching
 /// the copy path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReuseDecision {
@@ -406,7 +417,7 @@ impl SourceStager {
     /// staging pattern, the stable content-addressed staged path it would land
     /// at, and — under `on_existing = reuse` — whether a fresh prior copy would
     /// be reused. The reuse check `stat`s the source and reads the committed
-    /// manifest exactly as the real run's [`Self::stage_locked`] does, so the
+    /// manifest exactly as the real run's `Self::stage_locked` does, so the
     /// `--explain` prediction matches the run's decision without doing I/O on the
     /// copy path. An in-place source (staging disabled or no pattern match)
     /// returns `staged = false` and a [`ReuseDecision::NotApplicable`].
@@ -735,7 +746,7 @@ impl SourceStager {
     ///
     /// - `<source_id>.<run_uuid>.partial` — an interrupted copy. Reaped **only
     ///   when its owning run is dead**: liveness-aware, so a concurrent sibling's
-    ///   in-flight partial is never reaped. See [`partial_is_orphaned`].
+    ///   in-flight partial is never reaped. See `partial_is_orphaned`.
     /// - `*.staged` with no matching `*.manifest.json` — a copy that crashed
     ///   after the rename but before the manifest was published. The manifest is
     ///   the committed-copy marker, so a manifestless `.staged` is always an
@@ -1858,5 +1869,77 @@ mod tests {
         let entry = stager.plan_entry(&src);
         assert!(entry.staged);
         assert_eq!(entry.reuse, ReuseDecision::NotApplicable);
+    }
+
+    #[test]
+    fn verify_mismatch_renders_stable_code_e335() {
+        // A content-hash mismatch must carry E335 and the explain pointer so the
+        // operator can look the failure up — the staging counterpart to the
+        // spill subsystem's E320/E321.
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("orders.csv");
+        std::fs::write(&src, b"original bytes that get copied").unwrap();
+
+        let policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        let stager = SourceStager::new(policy);
+        let partial = stage_dir.path().join("x.partial");
+        let staged = stage_dir.path().join("x.staged");
+        let copy_hash = stager.copy_into(&src, &partial, &staged).unwrap();
+
+        std::fs::write(&src, b"different bytes entirely").unwrap();
+        let err = verify_staged(&src, &staged, copy_hash).unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.contains("E335"), "{rendered}");
+        assert!(
+            rendered.contains("clinker explain --code E335"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn disk_cap_overflow_renders_stable_code_e336() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("big.csv");
+        std::fs::write(&src, vec![b'x'; 4096]).unwrap();
+
+        let policy = StagingPolicy {
+            enabled: true,
+            dir: Some(stage_dir.path().to_path_buf()),
+            patterns: vec!["*.csv".into()],
+            disk_cap_bytes: Some(ByteSize(1024)),
+            ..Default::default()
+        };
+        let mut stager = SourceStager::new(policy);
+        let err = stager.resolve(src).unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.contains("E336"), "{rendered}");
+        assert!(
+            rendered.contains("clinker explain --code E336"),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn already_exists_renders_stable_code_e337() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let stage_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("orders.csv");
+        std::fs::write(&src, b"data").unwrap();
+
+        let mut seed = SourceStager::new(policy_with_dir(stage_dir.path(), &["*.csv"]));
+        seed.resolve(src.clone()).unwrap();
+
+        let mut policy = policy_with_dir(stage_dir.path(), &["*.csv"]);
+        policy.on_existing = OnExisting::Error;
+        let mut stager = SourceStager::new(policy);
+        let err = stager.resolve(src).unwrap_err();
+        let rendered = err.to_string();
+        assert!(rendered.contains("E337"), "{rendered}");
+        assert!(
+            rendered.contains("clinker explain --code E337"),
+            "{rendered}"
+        );
     }
 }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -226,6 +226,9 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E332" => Some(include_str!("../../../../docs/explain/E332.md")),
         "E333" => Some(include_str!("../../../../docs/explain/E333.md")),
         "E334" => Some(include_str!("../../../../docs/explain/E334.md")),
+        "E335" => Some(include_str!("../../../../docs/explain/E335.md")),
+        "E336" => Some(include_str!("../../../../docs/explain/E336.md")),
+        "E337" => Some(include_str!("../../../../docs/explain/E337.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
         "E150d" => Some(include_str!("../../../../docs/explain/E150d.md")),
@@ -383,6 +386,31 @@ mod tests {
     }
 
     #[test]
+    fn test_explain_code_e335_staging_verify_mismatch() {
+        let doc = explain_code("E335").unwrap();
+        assert!(doc.contains("E335"));
+        assert!(doc.contains("BLAKE3"));
+        // Must keep the content-hash mismatch distinct from a plain I/O fault.
+        assert!(doc.contains("corrupt"));
+    }
+
+    #[test]
+    fn test_explain_code_e336_staging_disk_cap() {
+        let doc = explain_code("E336").unwrap();
+        assert!(doc.contains("E336"));
+        assert!(doc.contains("storage.staging.disk_cap_bytes"));
+        // The configured cap is distinct from a physically full volume.
+        assert!(doc.contains("cap"));
+    }
+
+    #[test]
+    fn test_explain_code_e337_staging_already_exists() {
+        let doc = explain_code("E337").unwrap();
+        assert!(doc.contains("E337"));
+        assert!(doc.contains("on_existing"));
+    }
+
+    #[test]
     fn test_explain_code_unknown() {
         assert!(explain_code("E999").is_none());
     }
@@ -393,7 +421,7 @@ mod tests {
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E330", "E331", "E332",
-            "E333", "E334", "E15Y", "W101", "W302", "W305", "W306",
+            "E333", "E334", "E335", "E336", "E337", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -91,7 +91,9 @@ Inspect field-level provenance chains or look up error/warning code documentatio
 Use --field to trace where a composition config value comes from across all \
 configuration layers (composition defaults, channel defaults, channel fixed). \
 Use --code to look up the documentation for a diagnostic code (composition codes \
-E101–E108, combine codes E300-E319 and W302/W305/W306, and W101).",
+E101–E108, combine codes E300-E319 and W302/W305/W306, memory codes E310-E312, \
+spill codes E320/E321, storage-validation codes E330-E334, staging-copy codes \
+E335-E337, and W101).",
         after_long_help = "\
 EXAMPLES:
   # Show provenance for a composition config field
@@ -1982,7 +1984,8 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E311/E313/E319, W101/W302/W305/W306"
+                     E15Y, E300/E301/E303-E313/E319, E320/E321, E330-E337, \
+                     W101/W302/W305/W306"
                 )
                 .into());
             }

--- a/crates/clinker/tests/explain_provenance_test.rs
+++ b/crates/clinker/tests/explain_provenance_test.rs
@@ -203,3 +203,42 @@ fn test_explain_error_code_e15y_streaming_help() {
         "E15Y doc must mention the streaming strategy interaction.\nstdout: {stdout}"
     );
 }
+
+#[test]
+fn test_explain_staging_codes_are_lookup_able() {
+    // Each staging-copy failure carries a stable code the operator can look up,
+    // mirroring the spill subsystem's E320/E321.
+    for code in ["E335", "E336", "E337"] {
+        let output = Command::new(clinker_bin())
+            .arg("explain")
+            .arg("--code")
+            .arg(code)
+            .output()
+            .expect("spawn clinker");
+        assert!(
+            output.status.success(),
+            "clinker explain --code {code} must succeed.\nstderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains(code),
+            "{code} doc must reference its own code.\nstdout: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn test_explain_help_lists_staging_codes() {
+    let output = Command::new(clinker_bin())
+        .arg("explain")
+        .arg("--help")
+        .output()
+        .expect("spawn clinker");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("E335-E337"),
+        "help output must advertise the staging-copy code range.\nstdout: {stdout}"
+    );
+}

--- a/docs/explain/E335.md
+++ b/docs/explain/E335.md
@@ -1,0 +1,93 @@
+# Error E335: Staged copy failed content verification
+
+## What it means
+
+Clinker staged a source file to local disk and then re-read the source to
+confirm the copy is byte-identical, but the two **BLAKE3 digests did not
+match**. The bytes that landed in the staging directory differ from the bytes
+the source holds, so the copy is corrupt and the run is refused rather than
+fed wrong data downstream.
+
+This is the exact silent-corruption mode staging exists to catch. A network
+share can deliver short or wrong bytes without raising an I/O error: an NFS
+soft-mount can time out mid-read and return truncated data, sshfs with a stale
+cache can hand back the wrong contents, and UDP-transported NFS over a
+saturated link can reassemble reordered fragments into bytes the source never
+held. A size check alone misses a truncation that lands on a record boundary;
+a content digest is the only check that catches it.
+
+E335 is deliberately distinct from a generic staging I/O error: an I/O error
+means the OS reported a fault, whereas E335 means the copy completed with no
+OS-level error yet still does not match the source.
+
+The runtime diagnostic names the source and both digests:
+
+```
+E335 staged copy of /mnt/nfs/orders.csv is corrupt: BLAKE3 of the local copy
+(9f86d081...) does not match the source (2c26b46b...); the transport
+delivered different bytes than the source holds. See: clinker explain --code
+E335
+```
+
+## Example
+
+```toml
+# clinker.toml — staging on, content verification on (the default).
+[storage.staging]
+enabled  = true
+dir      = "/var/clinker/staging"
+patterns = ["*.csv"]
+verify   = "blake3"
+```
+
+A run over a flaky NFS soft-mount stages `/mnt/nfs/orders.csv`, the mount
+truncates the read mid-copy, and the post-copy verify fails with E335 rather
+than letting the truncated copy flow into the pipeline.
+
+```toml
+# A retry over a healthy transport stages the complete file and the digests
+# match, so the run proceeds. The fix is the transport, not the config.
+[storage.staging]
+enabled  = true
+dir      = "/var/clinker/staging"
+patterns = ["*.csv"]
+verify   = "blake3"
+```
+
+## How to fix
+
+1. **Re-run once the transport is healthy.** E335 means the network share
+   delivered bad bytes during the copy. A retry over a stable connection
+   usually stages the complete file and passes verification.
+
+2. **Harden the mount.** A soft-mount that times out mid-read is the common
+   cause; a `hard` NFS mount blocks instead of returning short data, and
+   tuning `timeo`/`retrans` (see `man 5 nfs`) reduces truncated reads.
+
+3. **Inspect the source.** If the digests keep diverging, the source itself
+   may be changing under the run, or the share may be genuinely corrupting
+   data — stage from a stable snapshot instead.
+
+4. **Do not disable verification to make the error go away.** Setting
+   `verify = "none"` suppresses the check, not the corruption; the truncated
+   bytes would then flow silently into your output. Only set `verify = "none"`
+   on a transport already trusted to deliver complete bytes.
+
+## Technical context
+
+E335 is raised by the staging-copy engine in `clinker-channel`. The copy is a
+single streamed pass that feeds each chunk to a BLAKE3 hasher and the
+destination file at once, so the copy hash costs no second read. After the
+atomic publish, when `verify = "blake3"` (the default), the engine performs a
+fresh independent read of the source, hashes it, and compares it to the copy
+hash. A mismatch returns `StagingError::Verify`, which the CLI surfaces as a
+startup-style validation failure (staging happens before any record flows) and
+exits with the configuration status code. On a verify failure the staged copy
+is unlinked so a later run does not reuse the corrupt bytes.
+
+## See also
+
+- E336 (staging cumulative byte cap exceeded — a configured budget, not corruption)
+- E337 (a staged copy already exists under `on_existing = error`)
+- E321 (spill volume out of space — a full disk on the spill side)
+- "Storage & Spill Location" in the operations guide

--- a/docs/explain/E336.md
+++ b/docs/explain/E336.md
@@ -1,0 +1,87 @@
+# Error E336: Staging disk cap exceeded
+
+## What it means
+
+Source-file staging copies matched inputs to local disk before the pipeline
+reads them, and the cumulative size of the files staged this run would cross
+the configured `storage.staging.disk_cap_bytes` quota. Clinker refuses the
+copy that would push the run over the cap rather than continuing to fill the
+staging volume.
+
+This is deliberately **not** a disk-full error. The staging volume may still
+have free space — the run simply reached the staging byte budget you told it to
+stop at. The cap is charged **before** each file is copied, so a file that
+would overflow the budget is refused up front rather than copied and then
+rolled back.
+
+The runtime diagnostic names the configured cap, the bytes already staged this
+run, and the size of the file that would cross it:
+
+```
+E336 staging would exceed the configured cap of 1048576 bytes (already staged
+600, /mnt/nfs/big.csv adds 4096). See: clinker explain --code E336
+```
+
+## Example
+
+```toml
+# clinker.toml — a 1 MiB staging budget on a job whose matched sources
+# total well over 1 MiB.
+[storage.staging]
+enabled        = true
+dir            = "/var/clinker/staging"
+patterns       = ["*.csv"]
+disk_cap_bytes = "1MB"
+```
+
+```toml
+# Corrected: raise the cap to fit the staged footprint, or remove it
+# entirely to let staging copy until the volume itself fills.
+[storage.staging]
+enabled        = true
+dir            = "/var/clinker/staging"
+patterns       = ["*.csv"]
+disk_cap_bytes = "50GB"
+```
+
+## How to fix
+
+Pick the remediation that matches your intent:
+
+1. **Raise the cap.** If the job legitimately needs to stage more bytes and the
+   volume has the space, increase `storage.staging.disk_cap_bytes`. It accepts
+   a bare integer or a human-readable size (`"50GB"`).
+
+2. **Give staging a larger volume.** Point `storage.staging.dir` at a mount
+   with more headroom; the cap is a policy ceiling independent of the physical
+   volume.
+
+3. **Stage fewer sources.** Narrow `storage.staging.patterns` so only the
+   inputs that actually benefit from a local copy are staged, leaving the rest
+   to read in place.
+
+4. **Remove the cap** by omitting `disk_cap_bytes`. Staging then copies until
+   the volume physically fills, which surfaces as a staging I/O error instead.
+
+## Technical context
+
+E336 is raised by the staging-copy engine in `clinker-channel`. The engine
+keeps a running total of bytes copied this run; before staging each matched
+source it adds the source's size to that total and, when the sum would cross
+`storage.staging.disk_cap_bytes`, returns `StagingError::DiskCapExceeded`
+without copying. A reused (skipped) copy under `on_existing = reuse` charges
+nothing — only bytes actually written count toward the cap. The CLI surfaces
+the failure as a startup-style validation error (staging happens before any
+record flows) and exits with the configuration status code.
+
+Keeping E336 distinct from a physically full staging volume mirrors the spill
+subsystem's split between E320 (configured cap) and E321 (full disk): a cap hit
+must not render as an out-of-space message, so the operator does not inspect
+`df`, find free space, and chase the wrong cause.
+
+## See also
+
+- E335 (staged copy failed content verification — corruption, not a budget)
+- E337 (a staged copy already exists under `on_existing = error`)
+- E320 (spill disk cap exceeded — the same cap-vs-full-disk split on the spill side)
+- "Storage & Spill Location" in the operations guide

--- a/docs/explain/E337.md
+++ b/docs/explain/E337.md
@@ -1,0 +1,91 @@
+# Error E337: A staged copy already exists under on_existing = error
+
+## What it means
+
+Source-file staging is configured with `on_existing = error`, and a staged
+copy of this source already exists in the staging directory. You asked to be
+told rather than silently reuse or overwrite a prior artifact, so the run fails
+fast and names the existing copy instead of touching it.
+
+A staged copy left in place is usually the residue of an earlier run — a clean
+prior run that did not clean up, or a crashed run whose copy was preserved for
+inspection. Under `on_existing = error` clinker treats any pre-existing copy as
+a signal that needs a human decision: it neither trusts it (as `reuse` would)
+nor replaces it (as `overwrite` would).
+
+The diagnostic names both the source and the blocking copy:
+
+```
+E337 staging on_existing = error: a staged copy of /mnt/nfs/orders.csv already
+exists at /var/clinker/staging/3f5a....staged; remove it or set on_existing to
+overwrite or reuse. See: clinker explain --code E337
+```
+
+## Example
+
+```toml
+# clinker.toml — fail rather than touch an existing staged copy.
+[storage.staging]
+enabled     = true
+dir         = "/var/clinker/staging"
+patterns    = ["*.csv"]
+on_existing = "error"
+```
+
+A prior run left `3f5a....staged` in the staging directory; the next run with
+`on_existing = "error"` refuses to start until that copy is dealt with.
+
+```toml
+# Corrected (option A): overwrite stale copies on every run.
+[storage.staging]
+enabled     = true
+dir         = "/var/clinker/staging"
+patterns    = ["*.csv"]
+on_existing = "overwrite"
+```
+
+```toml
+# Corrected (option B): reuse a fresh prior copy, re-staging only when the
+# source changed. Pair with verify to guard against a partial prior copy.
+[storage.staging]
+enabled     = true
+dir         = "/var/clinker/staging"
+patterns    = ["*.csv"]
+on_existing = "reuse"
+verify      = "blake3"
+```
+
+## How to fix
+
+1. **Remove the existing copy** the diagnostic names, then re-run. This is the
+   right move when the prior copy is stale or you simply want a clean stage.
+
+2. **Switch to `on_existing = "overwrite"`** if every run should re-stage from
+   scratch, discarding any prior copy. This is the default policy.
+
+3. **Switch to `on_existing = "reuse"`** if a fresh prior copy should be reused
+   without re-copying. Reuse re-stages only when the source's mtime or size
+   changed since it was staged; pair it with `verify = "blake3"` so a partial
+   prior copy is caught rather than trusted.
+
+## Technical context
+
+E337 is raised by the staging-copy engine in `clinker-channel`. Each source
+maps to a stable, content-addressed staged path derived from the canonical
+source path, so the same source always resolves to the same `.staged` file
+across runs. Under `on_existing = error`, the engine checks for that committed
+path under a per-source lock and, when it exists, returns
+`StagingError::AlreadyExists` without copying. The CLI surfaces the failure as
+a startup-style validation error (staging happens before any record flows) and
+exits with the configuration status code.
+
+The three `on_existing` policies are mutually exclusive choices about a
+pre-existing artifact: `overwrite` re-copies every run, `reuse` reuses a fresh
+copy and re-stages a stale one, and `error` refuses to proceed so the operator
+decides — which is what E337 reports.
+
+## See also
+
+- E335 (staged copy failed content verification — corruption)
+- E336 (staging cumulative byte cap exceeded — a configured budget)
+- "Storage & Spill Location" in the operations guide

--- a/docs/src/ops/storage.md
+++ b/docs/src/ops/storage.md
@@ -364,14 +364,18 @@ spill amplification, where an optimizer interaction turned 30 GB of input into
 > dispatches on each spill file's own one-byte header tag, so re-reading is
 > robust regardless.
 
-## Distinguishing the four spill-related failure conditions
+## Distinguishing the runtime storage-abort conditions
 
-Spill-related aborts are split into four distinct diagnostics so a single
-glance at the error tells you exactly what to fix — instead of every disk and
-memory problem rendering as one ambiguous "out of memory" message (the trap
-DuckDB hit in [duckdb/duckdb#14142], where a temp-dir cap was reported as
-"Out of Memory Error … 187.3 GiB/187.3 GiB used" and users inspected `df`
-only to find free space).
+A run that fails while spilling or staging emits one of several distinct
+diagnostics so a single glance at the error tells you exactly what to fix —
+instead of every disk and memory problem rendering as one ambiguous "out of
+memory" message (the trap DuckDB hit in [duckdb/duckdb#14142], where a temp-dir
+cap was reported as "Out of Memory Error … 187.3 GiB/187.3 GiB used" and users
+inspected `df` only to find free space). The aborts split along two axes: the
+**spill** side (in-memory operator state landing on disk) and the **staging**
+side (matched source files copied to local disk before they are read).
+
+### Spill aborts
 
 | Condition | Code | What happened | What to do |
 | --- | --- | --- | --- |
@@ -391,6 +395,27 @@ The key separations:
 
 (A future per-operator memory-reservation surface will add a fifth,
 reservation-exhausted condition; it is not part of the engine yet.)
+
+### Staging-copy aborts
+
+When `storage.staging` is enabled, copying a matched source to local disk can
+fail in three distinct ways. Like the spill split, each has its own code so a
+content-corruption problem never renders as a budget problem and vice versa.
+Staging runs before any record flows, so these surface as startup-style
+validation failures.
+
+| Condition | Code | What happened | What to do |
+| --- | --- | --- | --- |
+| **Staged copy corrupt** | E335 | The local copy's BLAKE3 digest did not match the source — the transport (e.g. a soft-mount NFS share) delivered different bytes than the source holds. | Re-run over a healthy transport, harden the mount, or stage from a stable snapshot. Do not set `verify = "none"` to silence it — that hides corruption, not fixes it. |
+| **Staging cap exceeded** | E336 | The cumulative bytes staged this run would cross `storage.staging.disk_cap_bytes`. The volume may still have free space — you hit the configured budget, **not** a full disk. | Raise `disk_cap_bytes`, point `storage.staging.dir` at a larger volume, narrow `storage.staging.patterns`, or remove the cap. |
+| **Staged copy already exists** | E337 | A staged copy of this source already exists and `on_existing = error` refuses to touch it. | Remove the existing copy, or switch `on_existing` to `overwrite` (re-stage) or `reuse` (reuse a fresh copy). |
+
+The same cap-vs-full-disk separation applies here as on the spill side: **E336**
+is the budget you set (mirroring E320), so it must not render as an
+out-of-space message — a physically full staging volume instead surfaces as a
+staging I/O error (mirroring E321). **E335** is distinct from a generic staging
+I/O error: an I/O error means the OS reported a fault, whereas E335 means the
+copy completed cleanly yet still does not match the source.
 
 ## Startup storage validation
 
@@ -643,7 +668,8 @@ partial file a later run might trust:
    re-read and hashed, and the two digests must match. A size check cannot
    catch a soft-mount that silently truncated the read; two content digests
    can. A mismatch removes the published copy and fails the run with a distinct
-   "staged copy is corrupt" diagnostic — not a generic I/O error.
+   "staged copy is corrupt" diagnostic ([E335](#staging-copy-aborts)) — not a
+   generic I/O error.
 5. **Commit the manifest.** The identity manifest is written with the same
    atomic temp-file + rename discipline. **The manifest is the commit marker:**
    a `.staged` file is only trustworthy once its manifest exists. A crash


### PR DESCRIPTION
## Summary

Source-staging copy failures now surface as stable, numbered diagnostics, matching the precedent the spill subsystem already set (E310/E320/E321). Previously every staging-copy failure was rendered as a generic config-validation message carrying the staging engine's raw text, so the distinct cases — a BLAKE3 verify mismatch, a staging disk-cap overflow, or a plain I/O error — had no stable codes an operator or a monitoring script could match on.

### New diagnostic codes

- **E335 — staged copy corrupt (verify mismatch).** A BLAKE3 hash mismatch between the source bytes and the staged copy. This is the soft-mount silent-truncation signal: real data corruption caught in flight, now distinct from a generic I/O error so operators can grep and alert on it specifically.
- **E336 — staging disk cap exceeded.** The configured `storage.staging.disk_cap_bytes` limit was exceeded, distinct from the spill cap (E320) and from a full volume.
- **E337 — staging I/O error.** A plain I/O failure during the staging copy.

Each code ships an `explain` entry (`docs/explain/E335.md`, `E336.md`, `E337.md`) so `clinker explain --code E33x` resolves, and the runtime failure-conditions table in `docs/src/ops/storage.md` now lists the staging codes alongside the spill codes.

### Documentation fix

Resolves two unresolved intra-doc links to `ProvenanceDb` in `crates/clinker-channel/src/overlay.rs` that caused `cargo doc -p clinker-channel --no-deps` to fail under `RUSTDOCFLAGS="-D warnings"`. The links now resolve cleanly so strict-warnings doc builds pass.

## Testing

Covered by `crates/clinker/tests/explain_provenance_test.rs`, which exercises the new code lookups end to end. The full CI gauntlet (fmt, clippy, workspace tests, benches, deny, plus the Windows-msvc and macOS cross-compile checks) runs on this PR.

Closes #339, Closes #345

Milestone: storage: configurable spill location + opt-in source staging
