### PR TITLE
Cross-platform: first-class Windows/macOS/Linux support (milestone 12)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,7 @@
-# Snapshot fixtures are parsed with line-ending-sensitive `---` separators.
-# Pin them to LF so a Windows checkout (git autocrlf) does not rewrite them
-# to CRLF and break the parsers that read them back.
-*.snap text eol=lf
+# This repository is authored with LF line endings, and the engine emits LF
+# in its output. Force LF on checkout on every platform — without this, a
+# Windows checkout (core.autocrlf) rewrites committed text fixtures to CRLF,
+# breaking byte-comparison baseline tests (engine LF output vs CRLF fixture)
+# and line-ending-sensitive snapshot parsers. `text=auto` still lets git
+# detect and leave binary files untouched.
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Snapshot fixtures are parsed with line-ending-sensitive `---` separators.
+# Pin them to LF so a Windows checkout (git autocrlf) does not rewrite them
+# to CRLF and break the parsers that read them back.
+*.snap text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,39 @@ jobs:
       - run: cargo check --features bench-alloc -p clinker-benchmarks
       - run: cargo test --benches -p clinker-benchmarks
 
+  # Execute the full suite on the other two first-class targets. These
+  # runners have a native C toolchain, so the `ring` (TLS) build script in
+  # clinker-net/clinker links cleanly here — which the ubuntu cross-check
+  # job below cannot do without an MSVC/Apple cross-linker. This is where
+  # the platform `#[cfg(windows)]` / `#[cfg(target_os = "macos")]` test
+  # modules — including the de-gated RSS-validity assertions — actually run.
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: "1.91"
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  # Type-check the non-Linux targets from the ubuntu host. `--all-targets`
+  # so test and bench targets compile too — a #[cfg(windows)] /
+  # #[cfg(target_os = "macos")] branch that fails to build now fails CI
+  # here, not only when a native runner reaches it. Scoped to the crates
+  # that cross-compile without a C toolchain; clinker-net and clinker pull
+  # in `ring`, whose build script needs a cross-linker the ubuntu host
+  # lacks, so their non-Linux coverage comes from the native runners above.
   cross-platform:
     runs-on: ubuntu-latest
     steps:
@@ -52,8 +85,14 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - run: cargo check --target x86_64-pc-windows-msvc -p clinker-exec -p clinker-plan
-      - run: cargo check --target aarch64-apple-darwin -p clinker-exec -p clinker-plan
+      - run: >-
+          cargo check --all-targets --target x86_64-pc-windows-msvc
+          -p clinker-exec -p clinker-plan -p clinker-schema
+          -p clinker-channel -p cxl-cli
+      - run: >-
+          cargo check --all-targets --target aarch64-apple-darwin
+          -p clinker-exec -p clinker-plan -p clinker-schema
+          -p clinker-channel -p cxl-cli
 
   deny:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,7 +471,6 @@ dependencies = [
  "insta",
  "libc",
  "lz4_flex",
- "mach2",
  "miette",
  "num_cpus",
  "petgraph",
@@ -1163,12 +1162,6 @@ checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
  "twox-hash",
 ]
-
-[[package]]
-name = "mach2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
 
 [[package]]
 name = "matchers"

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -77,6 +77,7 @@
 //! | `E316`      | error    | Per-source DLQ rate exceeded `error_handling.dlq.per_source.<name>.max_rate` |
 //! | `E317`      | error    | `error_handling.dlq.per_source` key does not name a declared Source |
 //! | `E318`      | error    | `error_handling.dlq.*.max_rate` out of `[0.0, 1.0]` or DLQ path collides |
+//! | `E322`      | error    | Two output destinations (Output nodes, or an Output node and a DLQ path) resolve to the same file |
 
 use crate::span::{FileId, Span};
 
@@ -316,7 +317,7 @@ mod diagnostic_tests {
         // explicit entry both here and in the registry table above.
         for code in [
             "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308", "E309", "E310", "E311",
-            "E313", "E314", "E315", "E316", "E317", "E318", "E319",
+            "E313", "E314", "E315", "E316", "E317", "E318", "E319", "E322",
         ] {
             let pattern = format!("`{code}`");
             assert!(

--- a/crates/clinker-exec/Cargo.toml
+++ b/crates/clinker-exec/Cargo.toml
@@ -46,9 +46,6 @@ clinker-bench-support = { workspace = true, optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ctrlc = { version = "3", features = ["termination"] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-mach2 = "0.6"
-
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_System_ProcessStatus",

--- a/crates/clinker-exec/src/dlq.rs
+++ b/crates/clinker-exec/src/dlq.rs
@@ -6,7 +6,7 @@
 //! pipeline's config and executor types.
 
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use clinker_record::{FieldMetadata, Schema, Value};
@@ -129,20 +129,28 @@ pub fn partition_dlq_entries<'a>(
         }
     }
 
-    // Deterministic output order: pipeline-wide path first (if set),
-    // then per-source paths in BTreeMap order.
+    // Bucket identity is the path's *collision key*, not its raw bytes. On a
+    // case-insensitive output filesystem (macOS APFS / Windows NTFS default)
+    // `errors.csv` and `Errors.csv` name one physical file; keying buckets on
+    // the raw `PathBuf` would open two writers onto it and let the per-source
+    // and pipeline-wide records overwrite each other. Folding is conditional on
+    // the actual target filesystem (the same `collision_key` the config-time
+    // check uses), so case-sensitive Linux still keeps distinct files distinct.
+    // The bucket's display `PathBuf` is the first path that claimed the key —
+    // pipeline-wide wins, matching the static check's first-insertion-wins.
     let mut buckets: Vec<(PathBuf, Vec<&'a DlqEntry>)> = Vec::new();
-    let mut index_of: std::collections::HashMap<PathBuf, usize> = std::collections::HashMap::new();
+    let mut index_of: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let key_of = |p: &Path| clinker_plan::config::collision_key(&p.to_string_lossy());
     if let Some(p) = dlq_config.path.as_deref() {
         let pb = PathBuf::from(p);
-        index_of.insert(pb.clone(), 0);
+        index_of.insert(key_of(&pb), 0);
         buckets.push((pb, Vec::new()));
     }
     for path in per_source_paths.values() {
-        if !index_of.contains_key(path) {
-            index_of.insert(path.clone(), buckets.len());
+        index_of.entry(key_of(path)).or_insert_with(|| {
             buckets.push((path.clone(), Vec::new()));
-        }
+            buckets.len() - 1
+        });
     }
 
     for entry in entries {
@@ -151,7 +159,7 @@ pub fn partition_dlq_entries<'a>(
             .cloned()
             .or_else(|| dlq_config.path.as_deref().map(PathBuf::from));
         if let Some(target) = target
-            && let Some(&i) = index_of.get(&target)
+            && let Some(&i) = index_of.get(&key_of(&target))
         {
             buckets[i].1.push(entry);
         }
@@ -694,5 +702,77 @@ mod tests {
         assert_eq!(buckets[1].0, PathBuf::from("dlq_b.csv"));
         assert_eq!(buckets[1].1.len(), 1);
         assert_eq!(buckets[1].1[0].source_name.as_ref(), "src_b");
+    }
+
+    /// A per-source DLQ path that differs from the pipeline-wide path only in
+    /// case must share *one* writer bucket on a case-insensitive filesystem
+    /// (they name one physical file), while remaining two distinct buckets on a
+    /// case-sensitive one. The expectation is conditioned on the working
+    /// directory's actual case-sensitivity — probed the same way the
+    /// partitioner does — so the assertion is deterministic on every CI runner.
+    #[test]
+    fn test_partition_collapses_case_variant_paths_only_when_filesystem_folds() {
+        let schema = make_schema();
+        let mk = |src: &str| {
+            let rec = Record::new(
+                Arc::clone(&schema),
+                vec![Value::String("n".into()), Value::String("v".into())],
+            );
+            DlqEntry {
+                source_row: 0,
+                category: DlqErrorCategory::TypeCoercionFailure,
+                error_message: String::new(),
+                original_record: rec,
+                stage: None,
+                route: None,
+                trigger: true,
+                source_name: Arc::from(src),
+                triggering_field: None,
+                triggering_value: None,
+            }
+        };
+        // `src_b` routes to a case-variant of the pipeline-wide path.
+        let entries = vec![mk("src_a"), mk("src_b")];
+
+        let mut per_source = std::collections::BTreeMap::new();
+        per_source.insert(
+            "src_b".to_string(),
+            clinker_plan::config::DlqPerSourceConfig {
+                path: Some("Errors.csv".to_string()),
+                max_rate: None,
+                min_records: None,
+            },
+        );
+        let cfg = clinker_plan::config::DlqConfig {
+            path: Some("errors.csv".to_string()),
+            include_reason: None,
+            include_source_row: None,
+            max_rate: None,
+            min_records: None,
+            per_source,
+        };
+
+        let case_sensitive =
+            clinker_plan::config::case_sensitive_dir(Path::new("errors.csv")).unwrap_or(true);
+        let buckets = partition_dlq_entries(&entries, &cfg);
+
+        if case_sensitive {
+            // Two distinct files: separate buckets, one entry each.
+            assert_eq!(buckets.len(), 2);
+            assert_eq!(buckets[0].0, PathBuf::from("errors.csv"));
+            assert_eq!(buckets[1].0, PathBuf::from("Errors.csv"));
+            assert_eq!(buckets[0].1.len(), 1);
+            assert_eq!(buckets[1].1.len(), 1);
+        } else {
+            // One physical file: both entries collapse into the single
+            // pipeline-wide bucket (first claimant of the key).
+            assert_eq!(buckets.len(), 1);
+            assert_eq!(buckets[0].0, PathBuf::from("errors.csv"));
+            assert_eq!(
+                buckets[0].1.len(),
+                2,
+                "case-variant per-source path must reuse the pipeline-wide writer"
+            );
+        }
     }
 }

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -334,5 +334,11 @@ fn apply_split_naming(base_path: &str, naming: &str, seq: u32) -> String {
         .replace("{ext}", ext)
         .replace("{seq:04}", &format!("{seq:04}"));
 
-    parent.join(filename).to_string_lossy().into_owned()
+    // Join with a forward slash, not the OS separator: split output paths
+    // must be byte-identical across platforms — Windows `Path::join` would
+    // emit `\`, diverging from the forward-slash paths authored in config.
+    match parent.to_str() {
+        Some(p) if !p.is_empty() => format!("{p}/{filename}"),
+        _ => filename,
+    }
 }

--- a/crates/clinker-exec/src/executor/stage_metrics.rs
+++ b/crates/clinker-exec/src/executor/stage_metrics.rs
@@ -454,14 +454,25 @@ mod tests {
     #[test]
     fn test_cumulative_timer_stop_then_drop_no_double_count() {
         let mut timer = CumulativeTimer::new();
+        let wall = std::time::Instant::now();
         {
             let mut guard = timer.guard();
             std::thread::sleep(std::time::Duration::from_millis(5));
             guard.stop(); // explicit stop
         } // drop after stop — should not double-count
+        let single_span = wall.elapsed();
         let metrics = timer.finish(StageName::Write, 1, 1);
-        // Should be ~5ms, not ~10ms
-        assert!(metrics.elapsed < Duration::from_millis(20));
+        // The guarded span ran exactly once; a double-count (recording it on
+        // both stop() and drop) would report ~2x. Compare against the span's
+        // real wall time rather than an absolute millisecond ceiling — under
+        // CI scheduler load a 5ms sleep can stretch well past any fixed bound,
+        // which would false-fail an absolute assertion without any regression.
+        assert!(
+            metrics.elapsed <= single_span + single_span / 2,
+            "timer double-counted: recorded {:?} vs single wall span {:?}",
+            metrics.elapsed,
+            single_span
+        );
     }
 
     #[test]

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -389,7 +389,7 @@ nodes:
         };
         use crate::pipeline::shutdown::ShutdownToken;
         use clinker_bench_support::io::{SharedBuffer, slow_reader};
-        use std::time::{Duration, Instant};
+        use std::time::Duration;
 
         let yaml = r#"
 pipeline:
@@ -462,34 +462,31 @@ nodes:
 
         // Let the run page a few hundred rows, then signal shutdown.
         std::thread::sleep(Duration::from_millis(300));
-        let signaled_at = Instant::now();
         token.request();
 
-        // The actual regression gate is `total_count < 6000` below: a run
-        // that honors the token stops early, one that ignores it ingests all
-        // 6000 rows. This recv_timeout is only an anti-hang guard, set well
-        // above one chunk's drain time. The bound is generous (per-row sleeps
-        // stretch under CI scheduler load, especially on macOS) yet still
-        // bounded, so a token-ignoring regression surfaces either as the
-        // count assertion or, if it hangs, as a timeout.
+        // The recv_timeout is only an anti-hang guard, generous because one
+        // batch's drain is gated by per-row `thread::sleep` granularity and so
+        // runs several-fold slower on macOS than Linux.
         let report = done_rx
             .recv_timeout(Duration::from_secs(20))
             .expect("interrupted run must terminate within the shutdown bound");
-        let shutdown_latency = signaled_at.elapsed();
         worker.join().expect("executor thread did not panic");
 
         assert!(
             report.interrupted,
             "report must flag the run interrupted so the CLI maps it to exit 130"
         );
+        // Promptness and early-stop are asserted by row count, which is
+        // identical across platforms — unlike wall-clock, where the per-row
+        // sleep is several-fold slower on macOS. A run that honors the token
+        // stops at the next batch boundary, draining at most a couple of
+        // in-flight batches past the few hundred rows it had paged, well short
+        // of the full 6000-row input; one that ignores it ingests all 6000.
         assert!(
-            report.counters.total_count < 6000,
-            "interrupted run stopped early; ingested {} of 6000 rows",
+            report.counters.total_count < 5000,
+            "interrupted run ingested {} of 6000 rows; expected to stop within \
+             a couple of batches of the shutdown signal",
             report.counters.total_count
-        );
-        assert!(
-            shutdown_latency < Duration::from_secs(3),
-            "shutdown took {shutdown_latency:?}, expected prompt unwind"
         );
     }
 

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -465,11 +465,15 @@ nodes:
         let signaled_at = Instant::now();
         token.request();
 
-        // 3 s is generous headroom over one chunk's worth of processing
-        // yet well under the ~6 s clean-run wall time, so a regression
-        // that ignores the token surfaces as a timeout, not a hang.
+        // The actual regression gate is `total_count < 6000` below: a run
+        // that honors the token stops early, one that ignores it ingests all
+        // 6000 rows. This recv_timeout is only an anti-hang guard, set well
+        // above one chunk's drain time. The bound is generous (per-row sleeps
+        // stretch under CI scheduler load, especially on macOS) yet still
+        // bounded, so a token-ignoring regression surfaces either as the
+        // count assertion or, if it hangs, as a timeout.
         let report = done_rx
-            .recv_timeout(Duration::from_secs(3))
+            .recv_timeout(Duration::from_secs(20))
             .expect("interrupted run must terminate within the shutdown bound");
         let shutdown_latency = signaled_at.elapsed();
         worker.join().expect("executor thread did not panic");

--- a/crates/clinker-exec/src/pipeline/combine.rs
+++ b/crates/clinker-exec/src/pipeline/combine.rs
@@ -847,6 +847,21 @@ fn partial_memory_bytes(
             .sum::<usize>()
 }
 
+/// Estimated owned-memory footprint of an accumulated combine output buffer
+/// (`(Record, RecordOrder)` pairs). The IEJoin and sort-merge probe kernels
+/// gate this buffer's growth on its own byte count via `should_abort_local`,
+/// so the memory budget still fires on a platform where process RSS is
+/// unavailable — without it those two kernels would grow unbounded toward an
+/// OOM on the wasm build, unsupported targets, or a transient platform-API
+/// failure. Mirrors the equi-join build-side `partial_memory_bytes` gate.
+pub(crate) fn combine_output_buffer_bytes(records: &[(Record, u64)]) -> usize {
+    std::mem::size_of_val(records)
+        + records
+            .iter()
+            .map(|(r, _)| r.estimated_heap_size())
+            .sum::<usize>()
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // MemoryConsumer wrapper for the inline-combine `CombineHashTable`
 // ──────────────────────────────────────────────────────────────────────────
@@ -1386,6 +1401,34 @@ mod tests {
 
     fn mk_record(schema: &Arc<Schema>, values: Vec<Value>) -> Record {
         Record::new(Arc::clone(schema), values)
+    }
+
+    #[test]
+    fn combine_output_buffer_bytes_is_nonzero_and_grows() {
+        // The IEJoin and sort-merge probe kernels gate their output buffer's
+        // growth on this figure when process RSS is unavailable, so it must be
+        // non-zero for a populated buffer and increase as records accrue.
+        let schema = test_schema(&["id", "name"]);
+        let rec = |id: i64, name: &str| {
+            (
+                mk_record(
+                    &schema,
+                    vec![Value::Integer(id), Value::String(name.into())],
+                ),
+                0u64,
+            )
+        };
+        let empty: Vec<(Record, u64)> = Vec::new();
+        assert_eq!(combine_output_buffer_bytes(&empty), 0);
+
+        let one = vec![rec(1, "alice")];
+        let three = vec![rec(1, "alice"), rec(2, "bob"), rec(3, "carol")];
+        let one_bytes = combine_output_buffer_bytes(&one);
+        assert!(one_bytes > 0, "populated buffer must report non-zero bytes");
+        assert!(
+            combine_output_buffer_bytes(&three) > one_bytes,
+            "byte estimate must grow with the buffer"
+        );
     }
 
     fn test_budget(limit_bytes: u64) -> MemoryArbitrator {

--- a/crates/clinker-exec/src/pipeline/combine.rs
+++ b/crates/clinker-exec/src/pipeline/combine.rs
@@ -666,18 +666,27 @@ impl CombineHashTable {
             keys_cache.push(keys);
             arena.push(rec);
 
-            // Periodic budget poll. `should_abort` observes RSS and returns
-            // true when the process has crossed the hard limit.
-            if (i + 1).is_multiple_of(MEMORY_CHECK_INTERVAL) && budget.should_abort() {
-                // Partial memory footprint (arena + chain + keys_cache +
-                // index-so-far). Finalized memory might be slightly higher
-                // once the HashTable rehashes; we report what we've
-                // allocated up to this point so the diagnostic is honest.
+            // Periodic budget poll. The build-side table's bytes are not
+            // yet mirrored into the registered consumer handle (the
+            // executor seeds it only after build completes), so RSS is the
+            // only whole-process signal — and RSS is unavailable on
+            // unsupported targets and the wasm build, where an RSS-only
+            // gate never fires and the build grows until the OS OOMs.
+            // `should_abort_local` adds the partial table footprint as an
+            // RSS-independent gate: the build aborts when the in-memory
+            // table alone exceeds the budget regardless of RSS
+            // availability. Partial footprint (arena + chain + keys_cache +
+            // index-so-far) under-reports the finalized table slightly once
+            // the HashTable rehashes, which is the honest figure to gate
+            // and report mid-build.
+            if (i + 1).is_multiple_of(MEMORY_CHECK_INTERVAL) {
                 let used = partial_memory_bytes(&index, &chain, &arena, &keys_cache);
-                return Err(CombineError::MemoryLimitExceeded {
-                    used: used as u64,
-                    limit: budget.limit(),
-                });
+                if budget.should_abort_local(used as u64) {
+                    return Err(CombineError::MemoryLimitExceeded {
+                        used: used as u64,
+                        limit: budget.limit(),
+                    });
+                }
             }
         }
 
@@ -690,8 +699,10 @@ impl CombineHashTable {
         };
 
         // Safety-net final check — catches builds shorter than
-        // MEMORY_CHECK_INTERVAL that slipped past the periodic poll.
-        if budget.should_abort() {
+        // MEMORY_CHECK_INTERVAL that slipped past the periodic poll. Gates
+        // on the finalized table's own bytes too, so a sub-interval build
+        // over a tiny budget aborts even when RSS cannot be measured.
+        if budget.should_abort_local(table.memory_bytes() as u64) {
             return Err(CombineError::MemoryLimitExceeded {
                 used: table.memory_bytes() as u64,
                 limit: budget.limit(),
@@ -1821,10 +1832,11 @@ mod tests {
 
     #[test]
     fn test_combine_hash_table_oom_aborts_during_build() {
-        // With a 1-byte budget, the process RSS trivially exceeds the
-        // hard limit — `should_abort()` returns true on the first poll.
-        // The final-check safety net fires even though we have fewer
-        // than MEMORY_CHECK_INTERVAL records.
+        // With a 1-byte budget the 10-record table's own footprint trivially
+        // exceeds the hard limit, so the final-check safety net's
+        // `should_abort_local(table.memory_bytes())` fires regardless of
+        // whether RSS is measurable — the build-side cap is no longer an
+        // RSS-only gate that goes silent when `rss_bytes()` returns `None`.
         let schema = test_schema(&["k"]);
         let records: Vec<Record> = (0..10)
             .map(|i| mk_record(&schema, vec![Value::Integer(i)]))
@@ -1838,24 +1850,48 @@ mod tests {
         match CombineHashTable::build(records, &extractor, &ctx, &budget, None) {
             Err(CombineError::MemoryLimitExceeded { used, limit }) => {
                 assert_eq!(limit, 1);
-                // `used` is either non-zero if the final check fires and
-                // reports table.memory_bytes(), or zero if the periodic
-                // poll fired mid-build — the variant is the gate.
-                let _ = used;
-            }
-            Err(other) => panic!("expected MemoryLimitExceeded, got {other}"),
-            Ok(_) => {
-                // RSS measurement unavailable on this platform
-                // (`rss_bytes()` returns None) — `should_abort()` can't
-                // fire. Accepting Ok here would hide a real abort-path
-                // regression on Linux CI; fail explicitly so the
-                // maintainer has to decide to wire a platform gate.
-                panic!(
-                    "build() succeeded under 1-byte budget — either RSS polling \
-                     returned None on this platform (add a cfg gate), or the \
-                     should_abort wiring regressed"
+                // The 10-record table holds far more than 1 byte, so the
+                // local-bytes gate reports a non-zero footprint.
+                assert!(
+                    used > 1,
+                    "expected a non-trivial table footprint, got {used}"
                 );
             }
+            Err(other) => panic!("expected MemoryLimitExceeded, got {other}"),
+            Ok(_) => panic!(
+                "build() succeeded under a 1-byte budget — the byte-counted \
+                 build-side cap regressed; it must abort even when RSS is \
+                 unavailable"
+            ),
+        }
+    }
+
+    #[test]
+    fn test_combine_build_aborts_under_tiny_budget_without_seeding_rss() {
+        // RSS-independent backstop: a build over input larger than the
+        // budget must abort even with NO seeded peak_rss. `test_budget`
+        // never seeds `peak_rss`, so on a target where `rss_bytes()`
+        // returns `None` the only signal is the byte-counted local-bytes
+        // gate. A 64-byte budget cannot hold a 5000-record integer-key
+        // table, so the build must fail with MemoryLimitExceeded rather
+        // than succeed and risk an OOM.
+        let schema = test_schema(&["k"]);
+        let records: Vec<Record> = (0..5000)
+            .map(|i| mk_record(&schema, vec![Value::Integer(i)]))
+            .collect();
+        let extractor = single_int_key("k");
+        let stable = test_ctx();
+        let ctx = cxl::eval::EvalContext::test_default_borrowed(&stable);
+        let budget = test_budget(64);
+
+        match CombineHashTable::build(records, &extractor, &ctx, &budget, Some(5000)) {
+            Err(CombineError::MemoryLimitExceeded { limit, .. }) => assert_eq!(limit, 64),
+            Err(other) => panic!("expected MemoryLimitExceeded, got {other}"),
+            Ok(_) => panic!(
+                "build() succeeded under a 64-byte budget without a seeded RSS — \
+                 the byte-counted backstop did not fire, so the budget is a no-op \
+                 that would OOM on a platform with no RSS reading"
+            ),
         }
     }
 

--- a/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
@@ -212,6 +212,61 @@ fn spill_activates_under_tiny_budget() {
     );
 }
 
+/// RSS-independent backstop: grace-hash spills on the pull-mode
+/// charged-byte sum even when the RSS arm of `should_spill` is inert.
+/// The executor's `consumer_handle` is registered with the arbitrator
+/// (mirroring production), then pre-charged above the soft limit while a
+/// 1 GiB hard limit keeps the soft threshold (800 MiB) above any real
+/// test-process RSS — the faithful Linux proxy for a platform where
+/// `rss_bytes()` returns `None`. Adding a single build record drives
+/// `add_build_record`'s `should_spill` poll, which must trip on the
+/// charged bytes alone and evict a partition to disk. Without the
+/// charged-byte arm the build would grow unbounded under no RSS reading.
+#[test]
+fn spill_activates_on_charged_bytes_without_rss() {
+    let schema = schema_with(&["k", "v"]);
+    let dir = tempfile::Builder::new()
+        .prefix("gh-test-")
+        .tempdir()
+        .unwrap();
+    let consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
+    let mut exec = GraceHashExecutor::new(4, dir.path(), consumer_handle.clone(), true).unwrap();
+
+    // 1 GiB hard limit → 800 MiB soft limit, above any host's test RSS,
+    // so the RSS arm of `should_spill` cannot trip. Register the handle so
+    // its charged bytes flow into `sum_consumer_usage`.
+    let budget = MemoryArbitrator::with_policy(1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+    budget.register_consumer(Arc::new(GraceHashConsumer::new(consumer_handle.clone())));
+    let soft = budget.soft_limit();
+    assert!(
+        budget.peak_rss().is_none_or(|rss| rss < soft),
+        "test invariant: real RSS must stay under the 800 MiB soft limit so only \
+         the charged-byte arm can trip the spill"
+    );
+
+    // Pre-charge the handle above the soft limit but below the 1 GiB hard
+    // limit (so `should_spill` trips while `should_abort` does not). One
+    // real build record then carries enough Building bytes for
+    // `spill_largest_building` to have a victim.
+    consumer_handle.set_bytes(soft + 1);
+    let rec = record_for(
+        &schema,
+        vec![Value::Integer(0), Value::String("row-0".into())],
+    );
+    exec.add_build_record(rec, 0, &budget).unwrap();
+
+    let on_disk = exec
+        .partitions
+        .iter()
+        .filter(|p| matches!(p, PartitionState::OnDisk { .. }))
+        .count();
+    assert!(
+        on_disk >= 1,
+        "charged bytes over the soft limit must spill a partition with the RSS arm inert; \
+         got {on_disk} on-disk partitions"
+    );
+}
+
 /// Lazy probe spill: a partition pre-spilled during build receives a
 /// probe record and writes it to its probe-side spill file rather
 /// than dropping it.

--- a/crates/clinker-exec/src/pipeline/iejoin.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin.rs
@@ -856,14 +856,19 @@ pub(crate) fn execute_combine_iejoin(
                                     matched_driver[driver_idx] = true;
                                     emitted_since_check += 1;
                                     if emitted_since_check >= MEMORY_CHECK_INTERVAL {
-                                        if budget.should_abort() {
+                                        let used =
+                                            crate::pipeline::combine::combine_output_buffer_bytes(
+                                                &output_records,
+                                            ) as u64;
+                                        if budget.should_abort_local(used) {
                                             return Err(PipelineError::MemoryBudgetExceeded {
                                                 node: name.to_string(),
-                                                used: budget.peak_rss().unwrap_or(0),
+                                                used,
                                                 limit: budget.hard_limit(),
                                                 source: BudgetCategory::Arena,
                                                 detail: Some(
-                                                    "iejoin combine probe RSS abort".to_string(),
+                                                    "iejoin output buffer exceeded budget"
+                                                        .to_string(),
                                                 ),
                                             });
                                         }
@@ -932,13 +937,18 @@ pub(crate) fn execute_combine_iejoin(
                             matched_driver[driver_idx] = true;
                             emitted_since_check += 1;
                             if emitted_since_check >= MEMORY_CHECK_INTERVAL {
-                                if budget.should_abort() {
+                                let used = crate::pipeline::combine::combine_output_buffer_bytes(
+                                    &output_records,
+                                ) as u64;
+                                if budget.should_abort_local(used) {
                                     return Err(PipelineError::MemoryBudgetExceeded {
                                         node: name.to_string(),
-                                        used: budget.peak_rss().unwrap_or(0),
+                                        used,
                                         limit: budget.hard_limit(),
                                         source: BudgetCategory::Arena,
-                                        detail: Some("iejoin combine probe RSS abort".to_string()),
+                                        detail: Some(
+                                            "iejoin output buffer exceeded budget".to_string(),
+                                        ),
                                     });
                                 }
                                 emitted_since_check = 0;
@@ -1029,13 +1039,18 @@ pub(crate) fn execute_combine_iejoin(
                         output_records.push((rec, driver_order));
                         emitted_since_check += 1;
                         if emitted_since_check >= MEMORY_CHECK_INTERVAL {
-                            if budget.should_abort() {
+                            let used = crate::pipeline::combine::combine_output_buffer_bytes(
+                                &output_records,
+                            ) as u64;
+                            if budget.should_abort_local(used) {
                                 return Err(PipelineError::MemoryBudgetExceeded {
                                     node: name.to_string(),
-                                    used: budget.peak_rss().unwrap_or(0),
+                                    used,
                                     limit: budget.hard_limit(),
                                     source: BudgetCategory::Arena,
-                                    detail: Some("iejoin combine probe RSS abort".to_string()),
+                                    detail: Some(
+                                        "iejoin output buffer exceeded budget".to_string(),
+                                    ),
                                 });
                             }
                             emitted_since_check = 0;

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1,9 +1,17 @@
 //! Cross-platform RSS tracking and the central memory arbitrator.
 //!
-//! `rss_bytes()` returns the current process RSS via platform-native APIs:
-//! - Linux: `/proc/self/statm` (resident pages × page size)
-//! - macOS: `mach_task_basic_info` via `mach2` (pure Rust FFI)
-//! - Windows: `K32GetProcessMemoryInfo` via `windows-sys` (pure Rust FFI)
+//! `rss_bytes()` returns the memory the current process is accountable
+//! for via platform-native APIs. The per-platform quantity is chosen to
+//! match "memory this process is responsible for", not whatever each OS
+//! labels "resident":
+//! - Linux: `/proc/self/statm` (resident pages × page size) — a true RSS.
+//! - macOS: `phys_footprint` via `proc_pid_rusage` (pure Rust FFI) — the
+//!   figure Apple's tooling reports, correct under memory compression
+//!   where Mach `resident_size` both under- and over-counts.
+//! - Windows: `PrivateUsage` (commit charge) from
+//!   `PROCESS_MEMORY_COUNTERS_EX` via `windows-sys` (pure Rust FFI), not
+//!   `WorkingSetSize`, which the memory manager trims under pressure and
+//!   so reads low exactly when committed memory is highest.
 //! - Unsupported: returns `None`
 //!
 //! `MemoryArbitrator` is the single seat that governs every spill / abort
@@ -43,58 +51,55 @@ fn rss_bytes_impl() -> Option<u64> {
 
 #[cfg(target_os = "macos")]
 fn rss_bytes_impl() -> Option<u64> {
-    use mach2::kern_return::KERN_SUCCESS;
-    use mach2::message::mach_msg_type_number_t;
-    use mach2::task::task_info;
-    use mach2::task_info::{
-        MACH_TASK_BASIC_INFO, MACH_TASK_BASIC_INFO_COUNT, mach_task_basic_info,
-    };
-    use mach2::traps::mach_task_self;
-
-    // SAFETY: FFI call to mach kernel. `mach_task_self()` returns the current
-    // task port (always valid). `task_info` reads process memory stats into
-    // the zeroed struct. No aliasing or lifetime concerns — all data is copied.
-    unsafe {
-        let mut info = mach_task_basic_info::default();
-        let mut count: mach_msg_type_number_t = MACH_TASK_BASIC_INFO_COUNT;
-        let ret = task_info(
-            mach_task_self(),
-            MACH_TASK_BASIC_INFO,
-            &mut info as *mut mach_task_basic_info as *mut _,
-            &mut count,
-        );
-        if ret == KERN_SUCCESS {
-            Some(info.resident_size)
-        } else {
-            None
-        }
-    }
+    // `phys_footprint` (via `proc_pid_rusage`) is the figure Apple's own
+    // tooling treats as the memory a process is accountable for. Mach
+    // `resident_size` from `MACH_TASK_BASIC_INFO` is wrong for a memory
+    // budget under macOS memory compression: it excludes
+    // compressed-but-still-owned anonymous pages (under-counting toward an
+    // OOM the budget should have prevented) and includes shared framework
+    // pages (over-counting toward spurious spills).
+    super::sysstats::phys_footprint_bytes()
 }
 
 #[cfg(target_os = "windows")]
 fn rss_bytes_impl() -> Option<u64> {
     use std::mem;
     use windows_sys::Win32::System::ProcessStatus::{
-        K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS,
+        K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS, PROCESS_MEMORY_COUNTERS_EX,
     };
     use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
+    // `PrivateUsage` (commit charge) from `PROCESS_MEMORY_COUNTERS_EX` is
+    // the right gate for a memory budget: it is the private, committed
+    // memory the process is accountable for. `WorkingSetSize` (physical
+    // resident pages) is aggressively trimmed by the Windows memory manager
+    // under system pressure, so it reads low — e.g. 300 MB while the
+    // process holds gigabytes of committed private memory — and fails to
+    // spill exactly when memory is exhausted.
+    //
+    // `K32GetProcessMemoryInfo` writes as many bytes as `cb` permits. The
+    // extended struct begins with the same fields as the base
+    // `PROCESS_MEMORY_COUNTERS` and appends the pagefile / `PrivateUsage`
+    // fields; passing the EX struct cast to the base pointer with `cb` set
+    // to the EX size is the documented idiom for reading `PrivateUsage`.
+    //
     // SAFETY: FFI call to Win32 API. `GetCurrentProcess()` returns a
     // pseudo-handle constant (-1) that is always valid and requires no
-    // `CloseHandle`. `K32GetProcessMemoryInfo` reads process memory stats
-    // into the zeroed struct. `cb` must be set to the struct size before the
-    // call for version compatibility.
+    // `CloseHandle`. The pointer cast is sound: `PROCESS_MEMORY_COUNTERS_EX`
+    // is `#[repr(C)]` and layout-compatible with `PROCESS_MEMORY_COUNTERS`
+    // for the leading fields, and `cb` is the EX size so the kernel writes
+    // the full EX struct.
     unsafe {
         let handle = GetCurrentProcess();
-        let mut pmc: PROCESS_MEMORY_COUNTERS = mem::zeroed();
-        pmc.cb = mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32;
+        let mut pmc: PROCESS_MEMORY_COUNTERS_EX = mem::zeroed();
+        pmc.cb = mem::size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32;
         let ok = K32GetProcessMemoryInfo(
             handle,
-            &mut pmc,
-            mem::size_of::<PROCESS_MEMORY_COUNTERS>() as u32,
+            &mut pmc as *mut PROCESS_MEMORY_COUNTERS_EX as *mut PROCESS_MEMORY_COUNTERS,
+            mem::size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32,
         );
         if ok != 0 {
-            Some(pmc.WorkingSetSize as u64)
+            Some(pmc.PrivateUsage as u64)
         } else {
             None
         }
@@ -1232,6 +1237,78 @@ mod tests {
         assert!(
             after >= before,
             "a 64 MiB touched allocation must not lower process RSS, got before={before} after={after}"
+        );
+    }
+
+    /// Touch every page of a heap buffer so the pages are committed and
+    /// resident, then keep the buffer alive across the read. Returns the
+    /// buffer so the caller controls its drop point.
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    fn touch_pages(bytes: usize) -> Vec<u8> {
+        let mut v: Vec<u8> = vec![0u8; bytes];
+        let page = 4096;
+        let mut i = 0;
+        while i < v.len() {
+            v[i] = 1;
+            i += page;
+        }
+        std::hint::black_box(&v);
+        v
+    }
+
+    /// On macOS, `rss_bytes()` reports `phys_footprint`, which rises when a
+    /// large allocation is touched. A delta-threshold assertion would flake
+    /// under harness churn (a sibling test thread can free more than this
+    /// probe commits between samples), so the direction-of-change check is
+    /// `after_alloc >= before` — a touched 64 MiB allocation never lowers
+    /// the footprint. Runs on the macOS CI runner.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_phys_footprint_rises_after_touched_alloc() {
+        let before = rss_bytes().expect("phys_footprint must be readable on macOS");
+        assert!(
+            before > 0,
+            "phys_footprint must be positive for a live process"
+        );
+        let buf = touch_pages(64 * 1024 * 1024);
+        let after_alloc = rss_bytes().expect("phys_footprint must be readable on macOS");
+        assert!(
+            after_alloc >= before,
+            "a touched 64 MiB allocation must not lower phys_footprint, \
+             before={before} after_alloc={after_alloc}"
+        );
+        drop(buf);
+    }
+
+    /// On Windows, `rss_bytes()` reports `PrivateUsage` (commit charge).
+    /// Committing and touching a large private allocation raises commit
+    /// charge; freeing it lowers commit charge — unlike `WorkingSetSize`,
+    /// which the memory manager can trim independently of the allocation's
+    /// lifetime. The assertion checks `after_alloc >= before` (commit
+    /// charge never drops on a fresh touched allocation) and
+    /// `after_free <= after_alloc` (releasing committed pages cannot raise
+    /// commit charge). Runs on the Windows CI runner.
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_private_usage_tracks_commit_charge() {
+        let before = rss_bytes().expect("PrivateUsage must be readable on Windows");
+        assert!(
+            before > 0,
+            "PrivateUsage must be positive for a live process"
+        );
+        let buf = touch_pages(64 * 1024 * 1024);
+        let after_alloc = rss_bytes().expect("PrivateUsage must be readable on Windows");
+        assert!(
+            after_alloc >= before,
+            "a touched 64 MiB private allocation must raise commit charge, \
+             before={before} after_alloc={after_alloc}"
+        );
+        drop(buf);
+        let after_free = rss_bytes().expect("PrivateUsage must be readable on Windows");
+        assert!(
+            after_free <= after_alloc,
+            "freeing committed pages must not raise commit charge, \
+             after_alloc={after_alloc} after_free={after_free}"
         );
     }
 

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1244,23 +1244,32 @@ mod tests {
         assert!(!handle.is_paused());
     }
 
+    /// RSS measurement must return a real positive figure on every
+    /// first-class target — Linux, macOS, and Windows — all of which CI now
+    /// executes. A regression to `None` or `0` in any platform FFI path
+    /// fails this test on that platform's runner rather than passing
+    /// vacuously. The whole `fn` is gated to the supported targets so an
+    /// unsupported-target build (where `rss_bytes()` is `None` by design)
+    /// excludes the test at compile time instead of early-returning out of
+    /// the body — a `cfg` gate, never a mid-body skip.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn test_rss_bytes_returns_some() {
         let rss = rss_bytes();
-        // On Linux (our CI), this should return Some.
-        // On unsupported platforms, this test is a no-op.
-        if cfg!(target_os = "linux") {
-            assert!(rss.is_some(), "rss_bytes() should return Some on Linux");
-            assert!(rss.unwrap() > 0, "RSS should be positive");
-        }
+        assert!(
+            rss.is_some(),
+            "rss_bytes() must return Some on a first-class target"
+        );
+        assert!(rss.unwrap() > 0, "RSS must be positive for a live process");
     }
 
+    /// A 64 MiB touched allocation must never lower this process's reported
+    /// memory on any first-class target. Gated to the supported targets for
+    /// the same reason as [`test_rss_bytes_returns_some`].
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn test_rss_bytes_increases_after_alloc() {
-        if rss_bytes().is_none() {
-            return; // Skip on unsupported platforms
-        }
-        let before = rss_bytes().unwrap();
+        let before = rss_bytes().expect("rss_bytes() must be readable on a first-class target");
         // Allocate 64 MiB and touch every page so the pages are resident.
         // A delta-threshold assertion (`after >= before + N`) flakes under a
         // loaded harness: a concurrent test thread can free more than the
@@ -1278,7 +1287,7 @@ mod tests {
             i += page;
         }
         std::hint::black_box(&big_vec);
-        let after = rss_bytes().unwrap();
+        let after = rss_bytes().expect("rss_bytes() must be readable on a first-class target");
         assert!(
             after >= before,
             "a 64 MiB touched allocation must not lower process RSS, got before={before} after={after}"
@@ -1492,36 +1501,43 @@ mod tests {
         assert!(arbitrator.should_spill_self());
     }
 
+    /// Below-threshold behavior: a 512 MiB budget (410 MiB soft) is far
+    /// above the test harness's own footprint on every first-class target,
+    /// so `should_spill` must stay false with no consumers registered.
+    /// Gated to the supported targets so the assertion runs unconditionally
+    /// on each runner.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn test_memory_arbitrator_below_threshold() {
         let arbitrator =
             MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
-        // Test process RSS should be well under 410MB (80% of 512MB)
-        if rss_bytes().is_some() {
-            assert!(!arbitrator.should_spill());
-        }
+        assert!(!arbitrator.should_spill());
     }
 
+    /// Above-threshold behavior: a 1 MiB budget is below any live process's
+    /// reported memory on every first-class target, so the RSS arm of
+    /// `should_spill` must trip. Gated to the supported targets so the
+    /// assertion runs unconditionally on each runner.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn test_memory_arbitrator_above_threshold() {
-        // Limit of 1MB — any running process exceeds this
         let arbitrator = MemoryArbitrator::with_policy(1024 * 1024, 0.80, Box::new(NoOpPolicy));
-        if rss_bytes().is_some() {
-            assert!(arbitrator.should_spill());
-        }
+        assert!(arbitrator.should_spill());
     }
 
+    /// `observe()` must seed and non-decreasingly raise `peak_rss` on
+    /// every first-class target. Gated to the supported targets so the
+    /// assertions run unconditionally on each runner instead of
+    /// early-returning when RSS is unavailable.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn test_memory_arbitrator_peak_rss_tracked() {
         let arbitrator =
             MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
-        if rss_bytes().is_none() {
-            return; // Skip on unsupported platforms
-        }
         arbitrator.observe();
         assert!(
             arbitrator.peak_rss().is_some(),
-            "peak_rss should be set after observe()"
+            "peak_rss must be set after observe() on a first-class target"
         );
         let first_peak = arbitrator.peak_rss().unwrap();
         arbitrator.observe();

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -757,13 +757,26 @@ impl MemoryArbitrator {
         }
     }
 
-    /// True when current RSS exceeds the soft spill threshold. Also
-    /// updates `peak_rss` as a side-effect and runs one arbitration
-    /// round; the round is a no-op when no consumers are registered.
-    /// False when RSS cannot be measured (sentinel `0`).
+    /// True when EITHER current RSS or the pull-mode charged-byte sum
+    /// exceeds the soft spill threshold. Also updates `peak_rss` as a
+    /// side-effect and runs one arbitration round; the round is a no-op
+    /// when no consumers are registered.
+    ///
+    /// The charged-byte arm is the RSS-independent backstop: when
+    /// `rss_bytes()` returns `None` (unsupported target, the wasm build,
+    /// or a transient platform-API failure) `peak_rss` stays at the
+    /// sentinel `0`, so an RSS-only gate would be permanently false and
+    /// the budget would silently become a no-op that OOMs instead of
+    /// spilling. Summing the registered consumers' live bytes keeps the
+    /// budget degrading to a heuristic ceiling rather than to nothing —
+    /// grace-hash partitions and inter-stage `node_buffers` slots mirror
+    /// their footprint into a registered handle, so their growth trips
+    /// this arm even with no RSS reading.
     pub fn should_spill(&self) -> bool {
         self.observe();
-        let tripped = self.peak_rss.load(Ordering::Relaxed) > self.soft_limit();
+        let soft = self.soft_limit();
+        let tripped =
+            self.peak_rss.load(Ordering::Relaxed) > soft || self.sum_consumer_usage() > soft;
         if tripped {
             // Drive the round-trip: the elected victim is paused
             // (back-pressureable) or asked to spill (everything else).
@@ -790,9 +803,15 @@ impl MemoryArbitrator {
     /// refilling, the dispatch loop blocks on `recv`, and the pipeline
     /// deadlocks. The streaming path's back-pressure is the bounded
     /// inter-stage channel, not a pause signal.
+    ///
+    /// Trips on EITHER RSS or the pull-mode charged-byte sum crossing the
+    /// soft limit, so a streaming stage still spills its in-flight batch
+    /// when `rss_bytes()` is unavailable (see [`Self::should_spill`] for
+    /// why the charged-byte arm is the RSS-independent backstop).
     pub fn should_spill_self(&self) -> bool {
         self.observe();
-        self.peak_rss.load(Ordering::Relaxed) > self.soft_limit()
+        let soft = self.soft_limit();
+        self.peak_rss.load(Ordering::Relaxed) > soft || self.sum_consumer_usage() > soft
     }
 
     /// Soft spill threshold in absolute bytes.
@@ -834,12 +853,38 @@ impl MemoryArbitrator {
         self.hard_limit() - self.soft_limit()
     }
 
-    /// True when RSS exceeds the hard limit. Check periodically in
-    /// probe loops (every 10K output records) to prevent unbounded
-    /// fan-out from blowing the ceiling between spill polls.
+    /// True when EITHER RSS or the pull-mode charged-byte sum exceeds the
+    /// hard limit. Check periodically in probe loops (every 10K output
+    /// records) to prevent unbounded fan-out from blowing the ceiling
+    /// between spill polls.
+    ///
+    /// The charged-byte arm is the RSS-independent backstop: see
+    /// [`Self::should_spill`]. Without it the hard-abort gate is
+    /// permanently false whenever `rss_bytes()` returns `None`, so a join
+    /// or aggregate grows unbounded until the OS kills the process instead
+    /// of aborting cleanly under the configured budget.
     pub fn should_abort(&self) -> bool {
         self.observe();
-        self.peak_rss.load(Ordering::Relaxed) > self.limit.load(Ordering::Relaxed)
+        let hard = self.limit.load(Ordering::Relaxed);
+        self.peak_rss.load(Ordering::Relaxed) > hard || self.sum_consumer_usage() > hard
+    }
+
+    /// True when the hard limit is breached by RSS, by the pull-mode
+    /// charged-byte sum, or by an operator-supplied `local_bytes`
+    /// estimate of in-progress state that is not yet reflected in a
+    /// registered consumer handle.
+    ///
+    /// The combine equi-join build loop registers its `MemoryConsumer`
+    /// wrapper with a zero-seeded handle and only mirrors the table's
+    /// footprint into it *after* the build completes, so the build loop's
+    /// growing bytes are invisible to [`Self::sum_consumer_usage`] while
+    /// the build runs. Passing the running `partial_memory_bytes` here is
+    /// the RSS-independent gate for that window — it aborts the build when
+    /// the in-memory table alone exceeds the budget, even on a target
+    /// where `rss_bytes()` returns `None`. Mirrors the arena's own
+    /// `local_bytes_used > hard_limit` self-trigger.
+    pub fn should_abort_local(&self, local_bytes: u64) -> bool {
+        local_bytes > self.limit.load(Ordering::Relaxed) || self.should_abort()
     }
 
     /// Peak RSS observed so far, or `None` on platforms where
@@ -1358,6 +1403,93 @@ mod tests {
                 "a budget above baseline must be satisfiable under {knob:?}"
             );
         }
+    }
+
+    #[test]
+    fn should_spill_trips_on_charged_bytes_without_rss() {
+        // RSS-independent backstop. A 100 GiB hard limit puts the soft
+        // threshold (80 GiB) far above any real test-process RSS, so the
+        // RSS arm of `should_spill` can never trip — whatever `observe()`
+        // samples stays below the soft limit. That isolates the
+        // charged-byte arm: it is the faithful Linux proxy for a platform
+        // where `rss_bytes()` returns `None` (there the RSS arm is also
+        // permanently below-threshold, just for a different reason). A
+        // registered consumer holding more than the soft limit must trip
+        // the gate through that arm alone.
+        let arbitrator =
+            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let soft = arbitrator.soft_limit();
+        assert!(!arbitrator.should_spill(), "empty registry must not trip");
+        // Whatever RSS `observe()` just sampled is below the soft limit, so
+        // only the charged-byte arm can be responsible for any trip below.
+        assert!(
+            arbitrator.peak_rss().is_none_or(|rss| rss < soft),
+            "test invariant: real RSS must stay under the soft limit so the RSS arm is inert"
+        );
+        arbitrator.register_consumer(Arc::new(MockConsumer::new(soft + 1, 0, 0)));
+        assert!(
+            arbitrator.should_spill(),
+            "charged bytes over the soft limit must trip should_spill via the RSS-independent arm"
+        );
+    }
+
+    #[test]
+    fn should_abort_trips_on_charged_bytes_without_rss() {
+        // Same RSS-independent backstop for the hard-abort gate; the 100
+        // GiB hard limit keeps the RSS arm inert (see the sibling
+        // should_spill test for why this isolates the charged-byte arm).
+        let arbitrator =
+            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let hard = arbitrator.hard_limit();
+        assert!(!arbitrator.should_abort(), "empty registry must not abort");
+        assert!(
+            arbitrator.peak_rss().is_none_or(|rss| rss < hard),
+            "test invariant: real RSS must stay under the hard limit so the RSS arm is inert"
+        );
+        arbitrator.register_consumer(Arc::new(MockConsumer::new(hard + 1, 0, 0)));
+        assert!(
+            arbitrator.should_abort(),
+            "charged bytes over the hard limit must trip should_abort via the RSS-independent arm"
+        );
+    }
+
+    #[test]
+    fn should_abort_local_trips_on_operator_bytes_without_rss() {
+        // The combine build loop's gate: in-progress bytes that are not yet
+        // in any registered consumer handle must still abort the build when
+        // they exceed the hard limit, independent of RSS. The registry is
+        // empty here (the build's handle is zero-seeded until build
+        // completes) and the 100 GiB limit keeps the RSS arm inert, so only
+        // the `local_bytes` arm can fire.
+        let arbitrator =
+            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let hard = arbitrator.hard_limit();
+        assert_eq!(arbitrator.sum_consumer_usage(), 0);
+        assert!(
+            !arbitrator.should_abort_local(hard),
+            "local bytes at exactly the limit must not abort"
+        );
+        assert!(
+            arbitrator.should_abort_local(hard + 1),
+            "local bytes over the hard limit must abort with the RSS arm inert and no registered consumer"
+        );
+    }
+
+    #[test]
+    fn should_spill_self_trips_on_charged_bytes_without_rss() {
+        // The streaming-stage variant carries the same backstop so a
+        // streaming batch still spills itself when RSS is unavailable. The
+        // 100 GiB limit keeps the RSS arm inert.
+        let arbitrator =
+            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let soft = arbitrator.soft_limit();
+        assert!(!arbitrator.should_spill_self());
+        assert!(
+            arbitrator.peak_rss().is_none_or(|rss| rss < soft),
+            "test invariant: real RSS must stay under the soft limit so the RSS arm is inert"
+        );
+        arbitrator.register_consumer(Arc::new(MockConsumer::new(soft + 1, 0, 0)));
+        assert!(arbitrator.should_spill_self());
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -1436,14 +1436,17 @@ fn emit_for_run(args: &mut EmitForRunArgs<'_, '_>) -> Result<(), PipelineError> 
                             args.matched_driver_orders.insert(driver_order);
                             *args.emitted_since_check = args.emitted_since_check.saturating_add(1);
                             if *args.emitted_since_check >= MEMORY_CHECK_INTERVAL {
-                                if args.budget.should_abort() {
+                                let used = crate::pipeline::combine::combine_output_buffer_bytes(
+                                    args.output,
+                                ) as u64;
+                                if args.budget.should_abort_local(used) {
                                     return Err(PipelineError::MemoryBudgetExceeded {
                                         node: name.to_string(),
-                                        used: args.budget.peak_rss().unwrap_or(0),
+                                        used,
                                         limit: args.budget.hard_limit(),
                                         source: BudgetCategory::Arena,
                                         detail: Some(
-                                            "sort-merge combine probe RSS abort".to_string(),
+                                            "sort-merge output buffer exceeded budget".to_string(),
                                         ),
                                     });
                                 }
@@ -1508,13 +1511,18 @@ fn emit_for_run(args: &mut EmitForRunArgs<'_, '_>) -> Result<(), PipelineError> 
                     args.matched_driver_orders.insert(driver_order);
                     *args.emitted_since_check = args.emitted_since_check.saturating_add(1);
                     if *args.emitted_since_check >= MEMORY_CHECK_INTERVAL {
-                        if args.budget.should_abort() {
+                        let used =
+                            crate::pipeline::combine::combine_output_buffer_bytes(args.output)
+                                as u64;
+                        if args.budget.should_abort_local(used) {
                             return Err(PipelineError::MemoryBudgetExceeded {
                                 node: name.to_string(),
-                                used: args.budget.peak_rss().unwrap_or(0),
+                                used,
                                 limit: args.budget.hard_limit(),
                                 source: BudgetCategory::Arena,
-                                detail: Some("sort-merge combine probe RSS abort".to_string()),
+                                detail: Some(
+                                    "sort-merge output buffer exceeded budget".to_string(),
+                                ),
                             });
                         }
                         *args.emitted_since_check = 0;

--- a/crates/clinker-exec/src/pipeline/sysstats.rs
+++ b/crates/clinker-exec/src/pipeline/sysstats.rs
@@ -172,12 +172,15 @@ struct RusageInfoV4 {
 }
 
 #[cfg(target_os = "macos")]
-fn io_counters_impl() -> Option<IoCounters> {
-    const RUSAGE_INFO_V4: i32 = 4;
-    unsafe extern "C" {
-        fn proc_pid_rusage(pid: i32, flavor: i32, buffer: *mut RusageInfoV4) -> i32;
-    }
+const RUSAGE_INFO_V4: i32 = 4;
 
+#[cfg(target_os = "macos")]
+unsafe extern "C" {
+    fn proc_pid_rusage(pid: i32, flavor: i32, buffer: *mut RusageInfoV4) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn rusage_info_v4() -> Option<RusageInfoV4> {
     // SAFETY: FFI to libproc. We pass our own pid and a properly-sized,
     // zeroed `rusage_info_v4` buffer. `proc_pid_rusage` writes the struct
     // on success (return 0). We only read fields on success.
@@ -187,11 +190,27 @@ fn io_counters_impl() -> Option<IoCounters> {
         if proc_pid_rusage(pid, RUSAGE_INFO_V4, &mut info) != 0 {
             return None;
         }
-        Some(IoCounters {
-            read_bytes: info.ri_diskio_bytesread,
-            write_bytes: info.ri_diskio_byteswritten,
-        })
+        Some(info)
     }
+}
+
+/// Returns the current process's physical memory footprint in bytes
+/// (`ri_phys_footprint`), the figure Apple's own tooling reports as the
+/// memory a process is accountable for, or `None` when `proc_pid_rusage`
+/// fails. macOS-only; the memory budget reads this instead of Mach
+/// `resident_size`, which excludes compressed-but-owned anonymous pages
+/// and includes shared framework pages.
+#[cfg(target_os = "macos")]
+pub(crate) fn phys_footprint_bytes() -> Option<u64> {
+    rusage_info_v4().map(|info| info.ri_phys_footprint)
+}
+
+#[cfg(target_os = "macos")]
+fn io_counters_impl() -> Option<IoCounters> {
+    rusage_info_v4().map(|info| IoCounters {
+        read_bytes: info.ri_diskio_bytesread,
+        write_bytes: info.ri_diskio_byteswritten,
+    })
 }
 
 #[cfg(target_os = "windows")]

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -2332,8 +2332,12 @@ nodes:
         let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("tests/snapshots")
             .join(format!("combine_test__tests__{name}.snap"));
+        // Normalize line endings: a Windows checkout (git autocrlf) rewrites
+        // these committed fixtures to CRLF, and the `---\n` separator scan
+        // below is line-ending sensitive.
         let content = std::fs::read_to_string(&path)
-            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+            .replace("\r\n", "\n");
         // An insta snapshot file is:
         //   ---
         //   <yaml metadata>
@@ -2933,8 +2937,11 @@ nodes:
                 "missing baseline snapshot: {}",
                 path.display()
             );
+            // Normalize line endings (Windows autocrlf checkout) before the
+            // line-ending-sensitive `---\n` separator scan.
             let content = std::fs::read_to_string(&path)
-                .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()));
+                .unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+                .replace("\r\n", "\n");
             // An insta snapshot body starts after the second `---`.
             let body_start = content.find("---\n").and_then(|i| {
                 let after = &content[i + 4..];

--- a/crates/clinker-exec/tests/dlq_rate_threshold.rs
+++ b/crates/clinker-exec/tests/dlq_rate_threshold.rs
@@ -537,3 +537,84 @@ nodes:
         "expected E318 path collision, got:\n{combined}"
     );
 }
+
+/// E318: two DLQ paths differing only in case (`errors.csv` vs `Errors.csv`)
+/// resolve to one physical file on a case-insensitive filesystem and must
+/// collide there — while remaining two distinct files (no collision) on a
+/// case-sensitive one. The expectation is therefore conditioned on the *actual*
+/// case-sensitivity of the test's working directory, probed the same way the
+/// validator does, so the assertion is deterministic on every CI runner: it
+/// requires the collision on case-insensitive macOS/Windows runners and forbids
+/// the false positive on case-sensitive Linux runners.
+#[test]
+fn case_variant_dlq_paths_emit_e318_only_when_filesystem_folds_case() {
+    let yaml = r#"
+pipeline:
+  name: e318_case_collision
+error_handling:
+  strategy: continue
+  dlq:
+    path: errors.csv
+    per_source:
+      src_a:
+        path: Errors.csv
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src_a
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    // Probe the working directory the validator will probe (paths resolve
+    // against cwd). `false` ⇒ case-insensitive ⇒ the two paths name one file.
+    let case_sensitive =
+        clinker_plan::config::case_sensitive_dir(std::path::Path::new("errors.csv"))
+            .unwrap_or(true);
+
+    let config = parse_config(yaml).expect("parse");
+    let result = config.compile(&CompileContext::default());
+
+    if case_sensitive {
+        // Case-sensitive filesystem: `errors.csv` and `Errors.csv` are two
+        // distinct files, so no path collision is raised. (The pipeline still
+        // compiles; absence of an E318 *collision* diagnostic is the point.)
+        if let Err(diags) = result {
+            let collision = diags
+                .iter()
+                .any(|d| d.code == "E318" && d.message.contains("collides"));
+            assert!(
+                !collision,
+                "case-sensitive filesystem must not flag a case-only DLQ collision, got: {:?}",
+                diags
+                    .iter()
+                    .map(|d| (&d.code, &d.message))
+                    .collect::<Vec<_>>()
+            );
+        }
+    } else {
+        // Case-insensitive filesystem: the two paths name one file, so the
+        // per-source writer would silently overwrite the pipeline-wide one —
+        // E318 must fire.
+        let diags =
+            result.expect_err("case-insensitive filesystem must flag the case-only DLQ collision");
+        let combined = diags
+            .iter()
+            .map(|d| format!("{}: {}", d.code, d.message))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            combined.contains("E318") && combined.contains("collides"),
+            "expected E318 case-variant collision, got:\n{combined}"
+        );
+    }
+}

--- a/crates/clinker-exec/tests/dlq_rate_threshold.rs
+++ b/crates/clinker-exec/tests/dlq_rate_threshold.rs
@@ -538,6 +538,53 @@ nodes:
     );
 }
 
+/// E322: two Output nodes writing the same path resolve to one physical file
+/// and would silently overwrite each other. The exact-path case collides on
+/// every platform (no case-folding needed), so this is deterministic.
+#[test]
+fn two_outputs_same_path_emit_e322() {
+    let yaml = r#"
+pipeline:
+  name: e322_output_collision
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out1
+    input: src_a
+    config:
+      name: out1
+      type: csv
+      path: shared.csv
+  - type: output
+    name: out2
+    input: src_a
+    config:
+      name: out2
+      type: csv
+      path: shared.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("two outputs writing one path must produce E322");
+    let combined = diags
+        .iter()
+        .map(|d| format!("{}: {}", d.code, d.message))
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        combined.contains("E322") && combined.contains("collides"),
+        "expected E322 output-path collision, got:\n{combined}"
+    );
+}
+
 /// E318: two DLQ paths differing only in case (`errors.csv` vs `Errors.csv`)
 /// resolve to one physical file on a case-insensitive filesystem and must
 /// collide there — while remaining two distinct files (no collision) on a

--- a/crates/clinker-exec/tests/merge_interleave.rs
+++ b/crates/clinker-exec/tests/merge_interleave.rs
@@ -511,11 +511,18 @@ fn interleave_fairness_under_four_predecessors() {
 
     // Invariant 3 — parallel ingest. Slowest source alone runs
     // 10 × 50 ms = ~500 ms; `concat`-style serialization across
-    // all four would sum to ~850 ms. Allow generous headroom for
-    // CI jitter while still proving the inputs run in parallel.
+    // all four would sum to ~850 ms. The parallel/serial separation is only
+    // ~1.7x, narrower than the several-fold inflation CI runners (macOS
+    // especially) impose on short sleeps — so a fixed bound cannot hold on
+    // both platforms. Calibrate to this platform's measured sleep cost so the
+    // assertion tests the separation, not absolute wall time.
+    let cal = Instant::now();
+    std::thread::sleep(Duration::from_millis(50));
+    let slack = (cal.elapsed().as_secs_f64() / 0.050).max(1.0);
+    let bound = Duration::from_secs_f64(0.800 * slack);
     assert!(
-        elapsed < Duration::from_millis(800),
-        "pipeline took {elapsed:?}, expected < 800 ms — \
+        elapsed < bound,
+        "pipeline took {elapsed:?} (slack {slack:.1}x, bound {bound:?}) — \
          predecessors appear to be serialized rather than ingested in parallel"
     );
 
@@ -645,29 +652,28 @@ fn interleave_shutdown_unwinds_mid_stream() {
 
     // Let the merge interleave a few hundred rows, then signal shutdown.
     std::thread::sleep(Duration::from_millis(300));
-    let signaled_at = Instant::now();
     token.request();
 
-    // 3 s is generous over one select iteration yet well under the ~6 s
-    // clean-run wall time, so a regression that ignores the token in the
-    // fused merge loop surfaces as a timeout, not a silent full drain.
+    // The recv_timeout is only an anti-hang guard, generous because draining
+    // the in-flight batch is gated by per-row sleep granularity and so runs
+    // several-fold slower on macOS than Linux.
     let report = done_rx
-        .recv_timeout(Duration::from_secs(3))
+        .recv_timeout(Duration::from_secs(20))
         .expect("interrupted fused-merge run must terminate within the shutdown bound");
-    let shutdown_latency = signaled_at.elapsed();
     worker.join().expect("executor thread did not panic");
 
     assert!(
         report.interrupted,
         "report must flag the fused-merge run interrupted"
     );
+    // Promptness is asserted by row count, which is identical across platforms
+    // — a run honoring the token stops within a couple of batches of the
+    // signal, far short of the full 12000-row input; one that ignores it
+    // ingests all 12000. Wall-clock here is unreliable (per-row sleep is
+    // several-fold slower on macOS).
     assert!(
         report.counters.total_count < 12000,
-        "interrupted run stopped early; ingested {} of 12000 rows",
+        "interrupted run did not stop early; ingested {} of 12000 rows",
         report.counters.total_count
-    );
-    assert!(
-        shutdown_latency < Duration::from_secs(3),
-        "shutdown took {shutdown_latency:?}, expected prompt unwind"
     );
 }

--- a/crates/clinker-exec/tests/merge_interleave.rs
+++ b/crates/clinker-exec/tests/merge_interleave.rs
@@ -602,7 +602,6 @@ fn distinct_seeds_diverge() {
 #[test]
 fn interleave_shutdown_unwinds_mid_stream() {
     use clinker_exec::pipeline::shutdown::ShutdownToken;
-    use std::time::Instant;
 
     let yaml = pipeline_yaml("mode: interleave");
     let config = parse_config(&yaml).unwrap();

--- a/crates/clinker-exec/tests/transform_stream_fusion.rs
+++ b/crates/clinker-exec/tests/transform_stream_fusion.rs
@@ -511,13 +511,20 @@ nodes:
     assert_eq!(a_lines, expected_a);
     assert_eq!(b_lines, expected_b);
 
-    // Slow branch's drain is ~250 ms. Total pipeline runtime must
-    // stay well under the worst-case serialization of two slow drains
-    // (~500 ms) — 700 ms gives generous CI jitter headroom while still
-    // bounding the regression.
+    // Slow branch's drain is ~250 ms. Total pipeline runtime must stay well
+    // under the worst-case serialization of two slow drains (~500 ms). The
+    // fused/serial separation is only ~1.4x, narrower than the several-fold
+    // inflation CI runners (macOS especially) impose on short sleeps, so a
+    // fixed bound cannot hold on both platforms. Calibrate to this platform's
+    // measured sleep cost so the assertion tests the separation, not absolute
+    // wall time.
+    let cal = Instant::now();
+    std::thread::sleep(Duration::from_millis(50));
+    let slack = (cal.elapsed().as_secs_f64() / 0.050).max(1.0);
+    let bound = Duration::from_secs_f64(0.700 * slack);
     assert!(
-        elapsed < Duration::from_millis(700),
-        "pipeline took {elapsed:?}, expected < 700 ms — \
+        elapsed < bound,
+        "pipeline took {elapsed:?} (slack {slack:.1}x, bound {bound:?}) — \
          two-branch fused transforms appear to be serializing on the slow \
          Source's drain. With fusion the slow branch's transform_a arm \
          consumes src_a's live channel without blocking src_b's parallel ingest."

--- a/crates/clinker-format/src/bom.rs
+++ b/crates/clinker-format/src/bom.rs
@@ -1,0 +1,143 @@
+//! Leading UTF-8 byte-order-mark (BOM) handling for format readers.
+//!
+//! Excel's "CSV UTF-8" export and PowerShell `Out-File -Encoding utf8`
+//! prepend a UTF-8 BOM (`U+FEFF`, bytes `EF BB BF`) to text files. Left
+//! in place the BOM corrupts the first parsed token on every OS: a CSV
+//! header cell becomes `\u{feff}id`, JSON auto-detect sees `0xEF` instead
+//! of `[`/`{`, and `str::trim` leaves the BOM on the first NDJSON line
+//! (`U+FEFF` does not carry the Unicode `White_Space` property). The
+//! helpers here strip a single leading BOM once at the start of input.
+
+use std::io::Read;
+
+/// The UTF-8 encoding of `U+FEFF`, the byte-order mark.
+pub const UTF8_BOM: [u8; 3] = [0xEF, 0xBB, 0xBF];
+
+/// A `Read` adapter that transparently drops a single leading UTF-8 BOM
+/// from the wrapped stream, then yields the remaining bytes verbatim.
+///
+/// Streaming readers (e.g. CSV) wrap their source in this so the BOM is
+/// gone before any parsing begins, regardless of whether the first
+/// downstream token is a header cell or a data field. The BOM may arrive
+/// split across `read` calls, so the first read buffers up to three
+/// prefix bytes to decide reliably before emitting anything.
+pub struct SkipBom<R: Read> {
+    inner: R,
+    /// Prefix bytes already pulled from `inner` but not yet handed to the
+    /// caller. After the one-time BOM check this holds any non-BOM prefix
+    /// bytes that must be replayed; `head..` is the unconsumed slice.
+    carry: Vec<u8>,
+    head: usize,
+    /// Whether the one-time leading-BOM check has run.
+    checked: bool,
+}
+
+impl<R: Read> SkipBom<R> {
+    /// Wraps `inner`, stripping a leading UTF-8 BOM on first read.
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            carry: Vec::new(),
+            head: 0,
+            checked: false,
+        }
+    }
+
+    /// Reads up to three prefix bytes from `inner` and, if they are the
+    /// UTF-8 BOM, discards them; otherwise retains them for replay.
+    fn check_bom(&mut self) -> std::io::Result<()> {
+        let mut prefix = [0u8; 3];
+        let mut filled = 0;
+        while filled < prefix.len() {
+            let n = self.inner.read(&mut prefix[filled..])?;
+            if n == 0 {
+                break;
+            }
+            filled += n;
+        }
+        let prefix = &prefix[..filled];
+        if prefix != UTF8_BOM {
+            self.carry.extend_from_slice(prefix);
+        }
+        self.checked = true;
+        Ok(())
+    }
+}
+
+impl<R: Read> Read for SkipBom<R> {
+    fn read(&mut self, out: &mut [u8]) -> std::io::Result<usize> {
+        if !self.checked {
+            self.check_bom()?;
+        }
+        if self.head < self.carry.len() {
+            let n = (self.carry.len() - self.head).min(out.len());
+            out[..n].copy_from_slice(&self.carry[self.head..self.head + n]);
+            self.head += n;
+            return Ok(n);
+        }
+        self.inner.read(out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Read;
+
+    fn read_all<R: Read>(mut r: R) -> Vec<u8> {
+        let mut v = Vec::new();
+        r.read_to_end(&mut v).unwrap();
+        v
+    }
+
+    #[test]
+    fn skip_bom_drops_leading_marker() {
+        let mut input = UTF8_BOM.to_vec();
+        input.extend_from_slice(b"hello world");
+        assert_eq!(read_all(SkipBom::new(&input[..])), b"hello world");
+    }
+
+    #[test]
+    fn skip_bom_passes_non_bom_input_through() {
+        assert_eq!(read_all(SkipBom::new(&b"hello world"[..])), b"hello world");
+    }
+
+    #[test]
+    fn skip_bom_handles_bom_split_across_reads() {
+        // A reader that yields one byte per `read` call must still have
+        // its BOM detected and stripped — the adapter buffers the full
+        // three-byte prefix before deciding.
+        struct OneByteAtATime(std::io::Cursor<Vec<u8>>);
+        impl Read for OneByteAtATime {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                if buf.is_empty() {
+                    return Ok(0);
+                }
+                self.0.read(&mut buf[..1])
+            }
+        }
+        let mut input = UTF8_BOM.to_vec();
+        input.extend_from_slice(b"payload");
+        let src = OneByteAtATime(std::io::Cursor::new(input));
+        assert_eq!(read_all(SkipBom::new(src)), b"payload");
+    }
+
+    #[test]
+    fn skip_bom_preserves_partial_prefix_that_is_not_a_bom() {
+        // First two bytes match the BOM but the third differs — none of
+        // the three prefix bytes may be lost.
+        let input = [0xEF, 0xBB, 0x21, b'a'];
+        assert_eq!(read_all(SkipBom::new(&input[..])), input);
+    }
+
+    #[test]
+    fn skip_bom_on_short_input_shorter_than_bom() {
+        let input = [0xEFu8, 0xBB];
+        assert_eq!(read_all(SkipBom::new(&input[..])), input);
+    }
+
+    #[test]
+    fn skip_bom_on_empty_input() {
+        assert_eq!(read_all(SkipBom::new(&b""[..])), b"");
+    }
+}

--- a/crates/clinker-format/src/csv/reader.rs
+++ b/crates/clinker-format/src/csv/reader.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
 
+use crate::bom::SkipBom;
 use crate::error::FormatError;
 use crate::traits::FormatReader;
 
@@ -28,8 +29,13 @@ impl Default for CsvReaderConfig {
 /// All fields are read as `Value::String` — type coercion is CXL's
 /// responsibility. Schema is inferred from the header row (or generated
 /// synthetically as `col_0`, `col_1`, ...).
+///
+/// A leading UTF-8 BOM (prepended by Excel "CSV UTF-8" and PowerShell
+/// `Out-File -Encoding utf8`) is stripped before parsing via [`SkipBom`],
+/// so the first header cell — or first data field under
+/// `has_header: false` — never carries the `U+FEFF` marker.
 pub struct CsvReader<R: Read> {
-    inner: csv::Reader<R>,
+    inner: csv::Reader<SkipBom<R>>,
     schema: Option<Arc<Schema>>,
     config: CsvReaderConfig,
     row_count: u64,
@@ -42,7 +48,7 @@ impl<R: Read> CsvReader<R> {
             .delimiter(config.delimiter)
             .quote(config.quote_char)
             .has_headers(config.has_header)
-            .from_reader(reader);
+            .from_reader(SkipBom::new(reader));
         Self {
             inner,
             schema: None,
@@ -211,6 +217,90 @@ mod tests {
     fn test_format_reader_is_send() {
         fn assert_send<T: Send>() {}
         assert_send::<CsvReader<std::io::Cursor<Vec<u8>>>>();
+    }
+
+    /// Prefixes `body` with a UTF-8 BOM, mimicking an Excel "CSV UTF-8"
+    /// or PowerShell `Out-File -Encoding utf8` export.
+    fn with_bom(body: &str) -> Vec<u8> {
+        let mut bytes = crate::bom::UTF8_BOM.to_vec();
+        bytes.extend_from_slice(body.as_bytes());
+        bytes
+    }
+
+    #[test]
+    fn test_csv_reader_strips_leading_bom_header() {
+        // The first header cell must resolve as `id`, not `\u{feff}id`,
+        // so downstream field references parse identically to BOM-less
+        // input.
+        let body = "id,name\n1,Alice\n2,Bob";
+        let bytes = with_bom(body);
+        let mut bom = CsvReader::from_reader(&bytes[..], CsvReaderConfig::default());
+        let schema = bom.schema().unwrap();
+        assert_eq!(
+            schema.columns().iter().map(|c| &**c).collect::<Vec<_>>(),
+            vec!["id", "name"]
+        );
+        let r1 = bom.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("id"), Some(&Value::String("1".into())));
+        assert_eq!(r1.get("name"), Some(&Value::String("Alice".into())));
+    }
+
+    #[test]
+    fn test_csv_reader_bom_matches_bomless() {
+        // Full parse equivalence: a BOM-prefixed file and its BOM-less
+        // twin yield identical schema and records.
+        let body = "id,name\n1,Alice\n2,Bob\n3,Carol";
+
+        let mut plain = CsvReader::from_reader(body.as_bytes(), CsvReaderConfig::default());
+        let plain_schema: Vec<String> = plain
+            .schema()
+            .unwrap()
+            .columns()
+            .iter()
+            .map(|c| c.to_string())
+            .collect();
+        let mut plain_rows = Vec::new();
+        while let Some(r) = plain.next_record().unwrap() {
+            plain_rows.push((r.get("id").cloned(), r.get("name").cloned()));
+        }
+
+        let bytes = with_bom(body);
+        let mut bom = CsvReader::from_reader(&bytes[..], CsvReaderConfig::default());
+        let bom_schema: Vec<String> = bom
+            .schema()
+            .unwrap()
+            .columns()
+            .iter()
+            .map(|c| c.to_string())
+            .collect();
+        let mut bom_rows = Vec::new();
+        while let Some(r) = bom.next_record().unwrap() {
+            bom_rows.push((r.get("id").cloned(), r.get("name").cloned()));
+        }
+
+        assert_eq!(plain_schema, bom_schema);
+        assert_eq!(plain_rows, bom_rows);
+        assert_eq!(plain_rows.len(), 3);
+    }
+
+    #[test]
+    fn test_csv_reader_strips_leading_bom_no_header() {
+        // Under `has_header: false` the BOM would otherwise corrupt the
+        // first data field of the first record, not a header cell.
+        let body = "Alice,30\nBob,25";
+        let config = CsvReaderConfig {
+            has_header: false,
+            ..Default::default()
+        };
+        let bytes = with_bom(body);
+        let mut bom = CsvReader::from_reader(&bytes[..], config);
+        let _schema = bom.schema().unwrap();
+        let r1 = bom.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("col_0"), Some(&Value::String("Alice".into())));
+        assert_eq!(r1.get("col_1"), Some(&Value::String("30".into())));
+        let r2 = bom.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("col_0"), Some(&Value::String("Bob".into())));
+        assert!(bom.next_record().unwrap().is_none());
     }
 
     // FieldResolver integration — verify Record from CSV implements it

--- a/crates/clinker-format/src/fixed_width/reader.rs
+++ b/crates/clinker-format/src/fixed_width/reader.rs
@@ -21,6 +21,8 @@ use std::io::{BufRead, BufReader, Read};
 use std::sync::Arc;
 
 use chrono::NaiveDate;
+
+use crate::bom::SkipBom;
 use clinker_record::schema_def::{FieldDef, FieldType, Justify, LineSeparator};
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
 
@@ -44,7 +46,10 @@ impl Default for FixedWidthReaderConfig {
 /// Byte-offset extraction with per-field UTF-8 validation and type coercion.
 /// Schema injected at construction (constructor injection pattern).
 pub struct FixedWidthReader<R: Read> {
-    reader: BufReader<R>,
+    // Source wrapped in `SkipBom` so a leading UTF-8 BOM (Windows utf8
+    // export) is dropped before byte-offset extraction, which would
+    // otherwise shift every field of the first record.
+    reader: BufReader<SkipBom<R>>,
     fields: Vec<ResolvedField>,
     schema: Arc<Schema>,
     config: FixedWidthReaderConfig,
@@ -138,7 +143,7 @@ impl<R: Read> FixedWidthReader<R> {
             .unwrap_or(0);
 
         Ok(Self {
-            reader: BufReader::new(reader),
+            reader: BufReader::new(SkipBom::new(reader)),
             fields: resolved,
             schema,
             config,
@@ -417,6 +422,48 @@ mod tests {
         assert_eq!(rec.get("name"), Some(&Value::String("Alice".into())));
         assert_eq!(rec.get("date"), Some(&Value::String("20240115".into())));
 
+        assert!(reader.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_fixedwidth_strips_leading_bom() {
+        // A leading UTF-8 BOM (Windows utf8 export) must be dropped before
+        // byte-offset extraction, or it shifts every field of the first row.
+        let mut data = crate::bom::UTF8_BOM.to_vec();
+        data.extend_from_slice(b"00042Alice               20240115\n");
+
+        let fields = vec![
+            {
+                let mut f = field("id");
+                f.field_type = Some(FieldType::Integer);
+                f.start = Some(0);
+                f.width = Some(5);
+                f.justify = Some(Justify::Right);
+                f.pad = Some("0".into());
+                f
+            },
+            {
+                let mut f = field("name");
+                f.field_type = Some(FieldType::String);
+                f.start = Some(5);
+                f.width = Some(20);
+                f
+            },
+            {
+                let mut f = field("date");
+                f.field_type = Some(FieldType::String);
+                f.start = Some(25);
+                f.width = Some(8);
+                f
+            },
+        ];
+
+        let mut reader =
+            FixedWidthReader::new(&data[..], fields, FixedWidthReaderConfig::default()).unwrap();
+        let rec = reader.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("id"), Some(&Value::Integer(42)));
+        assert_eq!(rec.get("name"), Some(&Value::String("Alice".into())));
+        assert_eq!(rec.get("date"), Some(&Value::String("20240115".into())));
         assert!(reader.next_record().unwrap().is_none());
     }
 

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -25,6 +25,7 @@ use clinker_record::{
 };
 use indexmap::IndexMap;
 
+use crate::bom::UTF8_BOM;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType};
 use crate::error::FormatError;
 use crate::traits::FormatReader;
@@ -96,6 +97,13 @@ impl JsonReader {
     ) -> Result<Self, FormatError> {
         let mut bytes_vec = Vec::new();
         reader.read_to_end(&mut bytes_vec)?;
+        // Strip a single leading UTF-8 BOM once at the source. `raw_bytes`
+        // feeds every JSON path — array/object auto-detect, the NDJSON
+        // line scan, and the envelope pre-scan's `serde_json::from_slice`
+        // — so one strip here clears the marker from all of them.
+        if bytes_vec.starts_with(&UTF8_BOM) {
+            bytes_vec.drain(..UTF8_BOM.len());
+        }
         let raw_bytes: Arc<[u8]> = Arc::from(bytes_vec);
         let body_cursor: Box<dyn Read + Send> = Box::new(Cursor::new(Arc::clone(&raw_bytes)));
         let mut buf = BufReader::new(body_cursor);
@@ -639,6 +647,14 @@ mod tests {
         JsonReader::from_reader(std::io::Cursor::new(input.as_bytes().to_vec()), config).unwrap()
     }
 
+    /// Builds a reader over `input` prefixed with a UTF-8 BOM, mimicking
+    /// a Windows-authored JSON file (Excel / PowerShell utf8 export).
+    fn reader_from_str_with_bom(input: &str, config: JsonReaderConfig) -> JsonReader {
+        let mut bytes = UTF8_BOM.to_vec();
+        bytes.extend_from_slice(input.as_bytes());
+        JsonReader::from_reader(std::io::Cursor::new(bytes), config).unwrap()
+    }
+
     fn default_config() -> JsonReaderConfig {
         JsonReaderConfig::default()
     }
@@ -840,6 +856,99 @@ mod tests {
             Some(&Value::Integer(2))
         );
         assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_json_array_strips_leading_bom() {
+        // Auto-detect must see `[`, not the leading `0xEF` of the BOM,
+        // and the parse must be identical to BOM-less input.
+        let mut r = reader_from_str_with_bom(r#"[{"a":1},{"a":2}]"#, default_config());
+        let s = r.schema().unwrap();
+        assert_eq!(s.columns().len(), 1);
+        assert_eq!(&*s.columns()[0], "a");
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("a"),
+            Some(&Value::Integer(1))
+        );
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("a"),
+            Some(&Value::Integer(2))
+        );
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_json_ndjson_strips_leading_bom() {
+        // `str::trim` does not remove `U+FEFF`, so without the source
+        // strip the first NDJSON line would fail `serde_json::from_str`.
+        let mut r = reader_from_str_with_bom("{\"a\":1}\n{\"a\":2}\n", default_config());
+        let s = r.schema().unwrap();
+        assert_eq!(s.columns().len(), 1);
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("a"),
+            Some(&Value::Integer(1))
+        );
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("a"),
+            Some(&Value::Integer(2))
+        );
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_json_bom_matches_bomless() {
+        // Full parse equivalence across a multi-field array: a
+        // BOM-prefixed document and its BOM-less twin emit identical
+        // records.
+        let input = r#"[{"id":1,"name":"Alice"},{"id":2,"name":"Bob"}]"#;
+        let collect = |mut r: JsonReader| {
+            let _ = r.schema().unwrap();
+            let mut rows = Vec::new();
+            while let Some(rec) = r.next_record().unwrap() {
+                rows.push((rec.get("id").cloned(), rec.get("name").cloned()));
+            }
+            rows
+        };
+        let plain = collect(reader_from_str(input, default_config()));
+        let bom = collect(reader_from_str_with_bom(input, default_config()));
+        assert_eq!(plain, bom);
+        assert_eq!(plain.len(), 2);
+    }
+
+    #[test]
+    fn test_json_envelope_prescan_strips_leading_bom() {
+        // The envelope pre-scan re-parses `raw_bytes` via
+        // `serde_json::from_slice`; the source-level strip must clear
+        // the BOM for that path too, not just body iteration.
+        let json = r#"{
+            "BatchInfo": {"batch_id": "RUN-001", "count": 42},
+            "records": [{"x": 1}, {"x": 2}]
+        }"#;
+        let cfg = envelope_config(&[(
+            "BatchInfo",
+            "/BatchInfo",
+            &[
+                ("batch_id", EnvelopeFieldType::String),
+                ("count", EnvelopeFieldType::Int),
+            ],
+        )]);
+        let mut reader = reader_from_str_with_bom(
+            json,
+            JsonReaderConfig {
+                record_path: Some("records".into()),
+                ..Default::default()
+            },
+        );
+        let sections = reader.prepare_document(&cfg).expect("envelope pre-scan");
+        let head = unwrap_section_map(sections.get("BatchInfo").unwrap());
+        assert_eq!(head.get("batch_id"), Some(&Value::String("RUN-001".into())));
+        assert_eq!(head.get("count"), Some(&Value::Integer(42)));
+
+        let r1 = reader.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("x"), Some(&Value::Integer(1)));
+        let r2 = reader.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("x"), Some(&Value::Integer(2)));
+        assert!(reader.next_record().unwrap().is_none());
     }
 
     #[test]

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod bom;
 pub mod counting;
 pub mod csv;
 pub mod envelope;

--- a/crates/clinker-format/src/splitting/tests.rs
+++ b/crates/clinker-format/src/splitting/tests.rs
@@ -888,5 +888,10 @@ pub(crate) fn apply_split_naming_wrapper(base_path: &str, naming: &str, seq: u32
         .replace("{ext}", ext)
         .replace("{seq:04}", &format!("{seq:04}"));
 
-    parent.join(filename).to_string_lossy().into_owned()
+    // Mirror the executor: forward-slash join so the result is identical
+    // across platforms (Windows `Path::join` would emit `\`).
+    match parent.to_str() {
+        Some(p) if !p.is_empty() => format!("{p}/{filename}"),
+        _ => filename,
+    }
 }

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -102,6 +102,11 @@ impl XmlReader {
     pub fn new<R: Read>(mut reader: R, config: XmlReaderConfig) -> io::Result<Self> {
         let mut bytes_vec = Vec::new();
         reader.read_to_end(&mut bytes_vec)?;
+        // Strip a leading UTF-8 BOM (Windows utf8 export) before the bytes
+        // reach the parser, so it does not precede the prolog/root element.
+        if bytes_vec.starts_with(&crate::bom::UTF8_BOM) {
+            bytes_vec.drain(..crate::bom::UTF8_BOM.len());
+        }
         let bytes: Arc<[u8]> = Arc::from(bytes_vec);
         Ok(Self::from_bytes(bytes, config))
     }
@@ -879,6 +884,25 @@ mod tests {
         let r2 = r.next_record().unwrap().unwrap();
         assert_eq!(r2.get("id"), Some(&Value::Integer(2)));
 
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_xml_strips_leading_bom() {
+        // A leading UTF-8 BOM (Windows utf8 export) must be stripped, or it
+        // precedes the root element and breaks element-path matching.
+        let xml = r#"<Root><Orders><Order><id>1</id><name>Alice</name></Order></Orders></Root>"#;
+        let mut bytes = crate::bom::UTF8_BOM.to_vec();
+        bytes.extend_from_slice(xml.as_bytes());
+        let mut r = XmlReader::new(
+            Cursor::new(bytes),
+            default_config_with_path("Root/Orders/Order"),
+        )
+        .expect("XML buffer read");
+
+        let rec = r.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("id"), Some(&Value::Integer(1)));
+        assert_eq!(rec.get("name"), Some(&Value::String("Alice".into())));
         assert!(r.next_record().unwrap().is_none());
     }
 

--- a/crates/clinker-plan/src/config/discovery.rs
+++ b/crates/clinker-plan/src/config/discovery.rs
@@ -376,8 +376,13 @@ fn compile_globs(patterns: &[String]) -> Result<Vec<glob::Pattern>, DiscoveryErr
 /// Match a path against any of the compiled exclude patterns. Tested
 /// against both the basename (gitignore-style) and the full path string
 /// — Logstash's `exclude` works similarly.
+///
+/// The full path is normalized to forward slashes before matching, mirroring
+/// the regex matcher: the `glob` crate treats only `/` as a path separator on
+/// every platform, so a separator-bearing exclude (e.g. `**/old/*`) would never
+/// match the backslash-separated path string Windows yields without this.
 fn matches_any(path: &Path, patterns: &[glob::Pattern]) -> bool {
-    let path_str = path.to_string_lossy();
+    let path_str = path.to_string_lossy().replace('\\', "/");
     let basename = path
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
@@ -761,5 +766,50 @@ mod tests {
         s.glob = Some("**/*.csv".into());
         let out = discover(&s, tmp.path()).unwrap();
         assert_eq!(out.files().len(), 2);
+    }
+
+    /// A separator-bearing exclude pattern matches a backslash-separated path
+    /// string. The `glob` crate only treats `/` as a separator, so without the
+    /// normalization in `matches_any` this pattern would never match the path
+    /// shape Windows yields. The backslash path is built directly so the
+    /// assertion runs and verifies the normalization on any host.
+    #[test]
+    fn exclude_matches_windows_backslash_path() {
+        let compiled = compile_globs(&["**/old/*".into()]).unwrap();
+        // A path string with backslash separators, as Windows produces. On
+        // Linux the bytes are identical; backslashes are ordinary characters
+        // there, so this exercises the same normalization path.
+        let windows_path = Path::new(r"C:\data\old\x.csv");
+        assert!(
+            matches_any(windows_path, &compiled),
+            "separator-bearing exclude must match a backslash path after normalization"
+        );
+        // A file outside the excluded directory must survive.
+        let kept = Path::new(r"C:\data\fresh\y.csv");
+        assert!(!matches_any(kept, &compiled));
+    }
+
+    /// `exclude: ["**/old/*"]` drops nested files under `old/` during real
+    /// discovery, the cross-OS behavioral guarantee. The host separator is
+    /// native, so this pins the Linux/macOS side; the unit test above pins the
+    /// Windows backslash shape.
+    #[test]
+    fn exclude_drops_nested_subdir_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("old")).unwrap();
+        std::fs::create_dir(tmp.path().join("fresh")).unwrap();
+        write(&tmp.path().join("old"), "stale.csv", "");
+        write(&tmp.path().join("fresh"), "current.csv", "");
+        let mut s = cfg();
+        s.glob = Some("**/*.csv".into());
+        s.exclude = Some(vec!["**/old/*".into()]);
+        let out = discover(&s, tmp.path()).unwrap();
+        let names: Vec<_> = out
+            .files()
+            .iter()
+            .map(|f| f.path.file_name().unwrap().to_string_lossy().into_owned())
+            .collect();
+        assert!(names.contains(&"current.csv".to_string()));
+        assert!(!names.contains(&"stale.csv".to_string()));
     }
 }

--- a/crates/clinker-plan/src/config/fs_type.rs
+++ b/crates/clinker-plan/src/config/fs_type.rs
@@ -81,6 +81,132 @@ pub fn same_device(a: &Path, b: &Path) -> io::Result<bool> {
     same_device_impl(a, b)
 }
 
+/// Whether the filesystem that *would back a file at `path`* preserves case in
+/// filenames (`true`) or folds it (`false`).
+///
+/// This drives output-path collision detection: two paths differing only in
+/// case (`errors.csv` vs `Errors.csv`) are two distinct files on a
+/// case-sensitive filesystem but **one** physical file on a case-insensitive
+/// one (the common macOS APFS and Windows NTFS default). Case must therefore
+/// be folded *conditionally* — only when the target filesystem actually folds
+/// it — otherwise a correct case-sensitive Linux pipeline would be wrongly
+/// flagged for a collision that does not exist on its disk.
+///
+/// The answer is obtained by **active probe**, not by mapping a filesystem-type
+/// table to a case-sensitivity guess: a real file is created and the same path
+/// re-cased is re-statted. This is the mechanism Git uses to auto-detect
+/// `core.ignorecase`, and it is correct regardless of OS, mount options, or
+/// per-directory case-sensitivity attributes (Windows per-directory case
+/// sensitivity, APFS case-sensitive volumes) that a static table cannot see.
+///
+/// `path` itself need not exist. The probe runs in the **nearest existing
+/// ancestor directory** of `path`, because that is the filesystem the file will
+/// be created on once its parent directories are materialized (the writer
+/// `create_dir_all`s the missing parents onto that same filesystem). The
+/// probe file is created and removed inside that directory; it never collides
+/// with the real output path.
+///
+/// # Errors
+///
+/// Returns the underlying [`io::Error`] when no existing ancestor directory can
+/// be found or the probe file cannot be created in it. Callers treat a probe
+/// failure as "assume case-sensitive" (do not flag a collision) so a transient
+/// or permission failure never converts a correct pipeline into a hard
+/// validation error; the silent-data-loss risk a probe failure leaves unguarded
+/// is confined to filesystems that are simultaneously case-insensitive *and*
+/// unprobeable, which a writable output directory never is in practice.
+pub fn case_sensitive_dir(path: &Path) -> io::Result<bool> {
+    let dir = nearest_existing_dir(path).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::NotFound,
+            "no existing ancestor directory to probe for case-sensitivity",
+        )
+    })?;
+    probe_case_sensitive(&dir)
+}
+
+/// Walk up from `path`'s parent to the first directory that exists. Returns
+/// `None` only when neither the parent chain nor the current directory exists,
+/// which cannot happen for a relative path (`.` always exists) but can for an
+/// absolute path whose entire prefix is absent.
+fn nearest_existing_dir(path: &Path) -> Option<std::path::PathBuf> {
+    let mut candidate = match path.parent() {
+        Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+        // A bare filename (`errors.csv`) or empty parent resolves against the
+        // current working directory.
+        _ => std::path::PathBuf::from("."),
+    };
+    loop {
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+        match candidate.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => candidate = parent.to_path_buf(),
+            _ => return None,
+        }
+    }
+}
+
+/// Create a uniquely-named lowercase probe file in `dir` and report whether its
+/// uppercased name resolves to the same file. OS-agnostic: it measures the
+/// filesystem's actual behavior rather than inferring it from a type table, so
+/// no `#[cfg]` arm is needed.
+fn probe_case_sensitive(dir: &Path) -> io::Result<bool> {
+    // A lowercase, process+time-unique stem so two concurrent probes in one
+    // directory never clash. The extension stays lowercase; only the stem case
+    // is toggled for the re-stat.
+    let stem = format!(
+        "clinker-case-probe-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    );
+    let lower = dir.join(format!("{stem}.tmp"));
+    // Create exclusively so a stale same-named file can never make the probe
+    // read a foreign filesystem state as our own.
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&lower)?;
+    drop(file);
+
+    let upper = dir.join(format!("{}.TMP", stem.to_ascii_uppercase()));
+    // If the uppercased name resolves to a file, the filesystem folded the case
+    // back onto the lowercase probe we just created — it is case-insensitive.
+    let insensitive = upper.exists();
+
+    // Best-effort cleanup; a leaked probe file is harmless and the temp dir is
+    // the writer's own output directory, but removal failure must not mask the
+    // probe result.
+    let _ = std::fs::remove_file(&lower);
+
+    Ok(!insensitive)
+}
+
+/// Canonical collision key for an output path: the key under which two paths
+/// are considered to name the *same physical file*.
+///
+/// On a case-insensitive output filesystem (macOS APFS / Windows NTFS default)
+/// paths differing only in case resolve to one file, so their keys must
+/// coincide; on a case-sensitive one they are distinct files and must not. Case
+/// is folded *conditionally* — only when [`case_sensitive_dir`] reports the
+/// target filesystem folds it — so two legitimately-distinct files on
+/// case-sensitive Linux are never falsely merged. A probe failure falls back to
+/// the raw (case-sensitive) key, the safe default that never merges two paths
+/// the filesystem might keep distinct.
+///
+/// Both the config-time DLQ-collision check and the runtime DLQ partitioner key
+/// on this single function so their notions of "same file" cannot drift.
+pub fn collision_key(path: &str) -> String {
+    if case_sensitive_dir(Path::new(path)).unwrap_or(true) {
+        path.to_string()
+    } else {
+        path.to_ascii_lowercase()
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Linux
 // ---------------------------------------------------------------------------
@@ -355,5 +481,63 @@ mod tests {
         std::fs::write(&real, b"x").unwrap();
         let missing = dir.path().join("nope.txt");
         assert!(same_device(&real, &missing).is_err());
+    }
+
+    #[test]
+    fn case_sensitive_dir_probes_an_existing_dir_without_error() {
+        // The host tempdir is whatever the OS provides; the contract here is
+        // only that the active probe runs to completion and returns a verdict
+        // (whichever the host filesystem actually is) rather than erroring.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("errors.csv");
+        let verdict = case_sensitive_dir(&target).unwrap();
+        // The probe leaves no file behind: it cleans up its temp probe and the
+        // real output path was never created.
+        assert!(!target.exists());
+        // `verdict` is a real measurement of this filesystem; both values are
+        // legitimate depending on the host (case-sensitive ext4/tmpfs vs a
+        // case-insensitive mount), so we only assert it is one of the two.
+        let _ = verdict;
+    }
+
+    #[test]
+    fn case_sensitive_dir_walks_up_to_an_existing_ancestor() {
+        // A path whose parent directories do not exist yet still probes: the
+        // walk-up lands on the nearest existing ancestor (the filesystem the
+        // writer will `create_dir_all` the missing parents onto).
+        let dir = tempfile::tempdir().unwrap();
+        let deep = dir.path().join("a/b/c/errors.csv");
+        assert!(!deep.parent().unwrap().exists());
+        // Should not error — it probes `dir` (the nearest existing ancestor).
+        let _ = case_sensitive_dir(&deep).unwrap();
+    }
+
+    #[test]
+    fn case_sensitive_dir_handles_bare_filename_against_cwd() {
+        // A bare filename has an empty parent and must resolve against the
+        // current working directory, which always exists, so the probe never
+        // fails for lack of an ancestor.
+        let verdict = case_sensitive_dir(Path::new("errors.csv"));
+        assert!(verdict.is_ok());
+    }
+
+    #[test]
+    fn case_sensitive_dir_agrees_with_a_direct_re_case_stat() {
+        // Cross-check the probe against the ground truth on whatever filesystem
+        // the host provides: create a lowercase file, ask whether its uppercase
+        // twin resolves to it, and assert `case_sensitive_dir` returns the
+        // opposite of that fold. Deterministic on every host (it measures the
+        // real filesystem) and never a silent no-op.
+        let dir = tempfile::tempdir().unwrap();
+        let lower = dir.path().join("errors.csv");
+        std::fs::write(&lower, b"x").unwrap();
+        let upper_twin = dir.path().join("ERRORS.CSV");
+        let folded = upper_twin.exists();
+
+        let target = dir.path().join("out.csv");
+        let sensitive = case_sensitive_dir(&target).unwrap();
+        // Case-insensitive filesystem ⇔ the uppercase twin folded onto the
+        // lowercase file.
+        assert_eq!(sensitive, !folded);
     }
 }

--- a/crates/clinker-plan/src/config/fs_type.rs
+++ b/crates/clinker-plan/src/config/fs_type.rs
@@ -66,6 +66,19 @@ pub enum FsKind {
 /// path does not exist, cannot be stat'd / queried, or the OS call returns an
 /// error.
 pub fn classify(path: &Path) -> io::Result<FsKind> {
+    // Enforce the documented "path must exist" contract uniformly. Unix
+    // statfs(2) already errors on a missing path, but the Windows volume query
+    // resolves the path's drive root and would succeed for a non-existent
+    // file — so check existence here rather than leave the behavior per-OS.
+    if !path.exists() {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!(
+                "cannot classify filesystem: path does not exist: {}",
+                path.display()
+            ),
+        ));
+    }
     classify_impl(path)
 }
 

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -30,7 +30,7 @@ pub use composition::{
 pub use discovery::{DiscoveredFile, DiscoveryError, DiscoveryOutcome, discover};
 pub use error::*;
 pub use format::*;
-pub use fs_type::{FsKind, classify, same_device};
+pub use fs_type::{FsKind, case_sensitive_dir, classify, collision_key, same_device};
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use output::*;
 pub use pipeline::*;

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -666,6 +666,11 @@ impl PipelineConfig {
             &self.nodes,
             &mut diags,
         );
+        crate::plan::bind_schema::validate_output_path_collisions(
+            &self.nodes,
+            self.error_handling.dlq.as_ref(),
+            &mut diags,
+        );
 
         // Only abort on non-composition CXL errors (E200/E201) and
         // source-CK validation errors (E153). Composition binding

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1040,6 +1040,82 @@ pub(crate) fn validate_dlq_per_source(
     }
 }
 
+/// Flags E322 when two output destinations resolve to the same physical
+/// file: two `Output` nodes' paths, or an `Output` node's path and a
+/// configured DLQ path. The engine otherwise only checks whether a single
+/// output path already exists on disk (`validate_path`), so two writers onto
+/// one file are silent — and on a case-insensitive output filesystem (macOS
+/// APFS / Windows NTFS) paths differing only in case (`out.csv` / `Out.csv`)
+/// name one file.
+///
+/// Case is folded conditionally via [`crate::config::collision_key`] — the
+/// same primitive the DLQ collision check uses — so two legitimately-distinct
+/// files on case-sensitive Linux are not flagged. Paths are compared
+/// as-authored; collisions that only emerge after path-template token
+/// resolution are left to runtime. DLQ-vs-DLQ collisions stay owned by
+/// [`validate_dlq_per_source`] (E318): this pass seeds the map with DLQ paths
+/// only to catch Output-vs-DLQ overlap, and never re-reports a DLQ-only
+/// collision.
+pub(crate) fn validate_output_path_collisions(
+    nodes: &[Spanned<PipelineNode>],
+    dlq: Option<&crate::config::DlqConfig>,
+    diags: &mut Vec<Diagnostic>,
+) {
+    // (raw path, config label) keyed by the case-folded collision key.
+    let mut paths: HashMap<String, (String, String)> = HashMap::new();
+
+    // Seed DLQ paths silently so an Output colliding with one surfaces, while
+    // DLQ-vs-DLQ collisions remain E318's responsibility.
+    if let Some(dlq) = dlq {
+        if let Some(p) = dlq.path.as_deref() {
+            paths.insert(
+                crate::config::collision_key(p),
+                (p.to_string(), "error_handling.dlq.path".to_string()),
+            );
+        }
+        for (src_name, per) in &dlq.per_source {
+            if let Some(p) = per.path.as_deref() {
+                paths.insert(
+                    crate::config::collision_key(p),
+                    (
+                        p.to_string(),
+                        format!("error_handling.dlq.per_source.{src_name}.path"),
+                    ),
+                );
+            }
+        }
+    }
+
+    for n in nodes {
+        let PipelineNode::Output { config, .. } = &n.value else {
+            continue;
+        };
+        let p = config.output.path.as_str();
+        if p.is_empty() {
+            continue;
+        }
+        let name = config.output.name.as_str();
+        if let Some((prev_path, prev_label)) = paths.insert(
+            crate::config::collision_key(p),
+            (p.to_string(), format!("output {name:?}")),
+        ) {
+            let collide_note = if prev_path == p {
+                format!("collides with {prev_label}")
+            } else {
+                format!(
+                    "collides with {prev_label} ({prev_path:?}) — these paths name the \
+                     same file on a case-insensitive output filesystem"
+                )
+            };
+            diags.push(Diagnostic::error(
+                "E322",
+                format!("output {name:?} path {p:?} {collide_note}"),
+                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+        }
+    }
+}
+
 fn synthetic_typed_program(output_row: Row) -> TypedProgram {
     TypedProgram {
         program: cxl::ast::Program {

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -970,10 +970,23 @@ pub(crate) fn validate_dlq_per_source(
         .collect();
 
     // Track path collisions across the pipeline-wide + every per-source
-    // entry. First insertion wins; subsequent insertions emit E318.
-    let mut paths: HashMap<&str, String> = HashMap::new();
+    // entry. Two paths collide when they name the *same physical file*, which
+    // on a case-insensitive output filesystem (macOS APFS / Windows NTFS
+    // default) includes paths differing only in case — `errors.csv` and
+    // `Errors.csv` resolve to one file there, so the per-source and
+    // pipeline-wide writers would silently overwrite each other. The
+    // collision key is therefore folded *conditionally*: only when the actual
+    // target filesystem folds case (probed via `case_sensitive_dir`), never
+    // unconditionally, so two legitimately-distinct files on case-sensitive
+    // Linux are not falsely flagged. First insertion wins; subsequent
+    // insertions onto the same key emit E318. The stored value keeps the raw
+    // path for the diagnostic message; the value's `.1` is the config label.
+    let mut paths: HashMap<String, (String, String)> = HashMap::new();
     if let Some(p) = dlq.path.as_deref() {
-        paths.insert(p, "error_handling.dlq.path".to_string());
+        paths.insert(
+            crate::config::collision_key(p),
+            (p.to_string(), "error_handling.dlq.path".to_string()),
+        );
     }
 
     for (src_name, per) in &dlq.per_source {
@@ -1000,15 +1013,27 @@ pub(crate) fn validate_dlq_per_source(
             ));
         }
         if let Some(p) = per.path.as_deref()
-            && let Some(prev) =
-                paths.insert(p, format!("error_handling.dlq.per_source.{src_name}.path"))
+            && let Some((prev_path, prev_label)) = paths.insert(
+                crate::config::collision_key(p),
+                (
+                    p.to_string(),
+                    format!("error_handling.dlq.per_source.{src_name}.path"),
+                ),
+            )
         {
+            // Surface the prior path explicitly so a case-only collision reads
+            // clearly (`Errors.csv` collides with `errors.csv` …).
+            let collide_note = if prev_path == p {
+                format!("collides with {prev_label}")
+            } else {
+                format!(
+                    "collides with {prev_label} ({prev_path:?}) — these paths name \
+                     the same file on a case-insensitive output filesystem"
+                )
+            };
             diags.push(Diagnostic::error(
                 "E318",
-                format!(
-                    "error_handling.dlq.per_source.{src_name}.path {p:?} collides \
-                     with {prev}"
-                ),
+                format!("error_handling.dlq.per_source.{src_name}.path {p:?} {collide_note}"),
                 LabeledSpan::primary(Span::SYNTHETIC, String::new()),
             ));
         }

--- a/crates/clinker-plan/src/security.rs
+++ b/crates/clinker-plan/src/security.rs
@@ -258,6 +258,11 @@ mod tests {
         assert!(err.message.contains("directory traversal"));
     }
 
+    // POSIX symlinks need no special privilege to create, so this test is
+    // Unix-only. The Windows junction equivalent lives in the `#[cfg(windows)]`
+    // tests below; gating the whole fn (rather than early-returning mid-body)
+    // keeps non-Unix builds free of unreachable-tail warnings.
+    #[cfg(unix)]
     #[test]
     fn test_validate_path_rejects_symlink_escape() {
         let outside = tempfile::tempdir().unwrap();
@@ -265,13 +270,7 @@ mod tests {
 
         let base = tempfile::tempdir().unwrap();
         let link = base.path().join("leak");
-        #[cfg(unix)]
         std::os::unix::fs::symlink(outside.path().join("secret.txt"), &link).unwrap();
-        #[cfg(not(unix))]
-        {
-            // On non-unix targets we can't create a symlink without admin rights.
-            return;
-        }
 
         let err = validate_path(Path::new("leak"), base.path(), false).unwrap_err();
         assert!(

--- a/crates/clinker-plan/src/security.rs
+++ b/crates/clinker-plan/src/security.rs
@@ -105,16 +105,26 @@ pub fn validate_path(
         }
     }
 
-    if raw.is_absolute() && !allow_absolute {
+    // A leading drive prefix or root means the path is not provably relative to
+    // `base_dir`. `Path::is_absolute()` is insufficient here: on Windows it
+    // returns `false` for drive-relative paths like `C:evil.csv` (a prefix with
+    // no root) and root-relative paths like `\x` (a root with no prefix), yet
+    // both discard `base_dir` when joined and resolve against a current
+    // directory the validator never sanctioned. Inspecting the leading
+    // component directly rejects every drive- or root-anchored form on every
+    // platform, closing the Windows escape that `is_absolute()` lets through.
+    if is_drive_or_root_anchored(raw) && !allow_absolute {
         return Err(sec_diag(format!(
             "absolute path not allowed: {raw:?} — use --allow-absolute-paths to override"
         )));
     }
 
-    let resolved = if raw.is_relative() {
-        base_dir.join(raw)
-    } else {
+    let resolved = if is_drive_or_root_anchored(raw) {
+        // Reached only when `allow_absolute` is set; honor the anchored path
+        // verbatim rather than joining it onto `base_dir`.
         raw.to_path_buf()
+    } else {
+        base_dir.join(raw)
     };
 
     // Symlink-escape check: if both the candidate and the base exist, compare
@@ -133,6 +143,21 @@ pub fn validate_path(
     }
 
     Ok(ValidatedPath(resolved))
+}
+
+/// Report whether `path` begins with a drive prefix or a root component.
+///
+/// Returns `true` for Unix absolute paths (`/x`), Windows drive-rooted paths
+/// (`C:\x`), Windows drive-relative paths (`C:x`), Windows root-relative paths
+/// (`\x`), and UNC/verbatim prefixes. These are exactly the forms that ignore a
+/// `base_dir` when joined, so the validator treats them all as non-relative.
+/// Strictly broader than [`Path::is_absolute`], which misses the drive-relative
+/// and root-relative Windows cases.
+fn is_drive_or_root_anchored(path: &Path) -> bool {
+    matches!(
+        path.components().next(),
+        Some(std::path::Component::Prefix(_) | std::path::Component::RootDir)
+    )
 }
 
 fn sec_diag(message: String) -> Diagnostic {
@@ -283,6 +308,44 @@ mod tests {
     #[test]
     fn test_path_reject_absolute() {
         let err = validate_path(Path::new("/tmp/out.csv"), &base(), false).unwrap_err();
+        assert!(err.message.contains("absolute path not allowed"));
+    }
+
+    // Windows drive-relative (`C:x`) and drive-rooted (`C:\x`) paths must be
+    // rejected when absolutes are disallowed. The former is the dangerous case:
+    // `Path::is_absolute()` reports `false` for it, so before the explicit
+    // prefix inspection it slipped the gate and discarded `base_dir` on join.
+    #[cfg(windows)]
+    #[test]
+    fn test_path_reject_windows_drive_relative() {
+        let err = validate_path(Path::new("C:evil.csv"), &base(), false).unwrap_err();
+        assert_eq!(err.code, "E-SEC-001");
+        assert!(
+            err.message.contains("absolute path not allowed"),
+            "expected absolute-path rejection, got: {}",
+            err.message
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn test_path_reject_windows_drive_rooted() {
+        let err = validate_path(Path::new("C:\\x"), &base(), false).unwrap_err();
+        assert_eq!(err.code, "E-SEC-001");
+        assert!(
+            err.message.contains("absolute path not allowed"),
+            "expected absolute-path rejection, got: {}",
+            err.message
+        );
+    }
+
+    // `\x` (root-relative to the current drive) is likewise non-relative and
+    // must not be joined onto `base_dir`.
+    #[cfg(windows)]
+    #[test]
+    fn test_path_reject_windows_root_relative() {
+        let err = validate_path(Path::new("\\x"), &base(), false).unwrap_err();
+        assert_eq!(err.code, "E-SEC-001");
         assert!(err.message.contains("absolute path not allowed"));
     }
 

--- a/crates/clinker-plan/src/security.rs
+++ b/crates/clinker-plan/src/security.rs
@@ -131,11 +131,17 @@ pub fn validate_path(
     // their canonicalized forms. Non-existent paths (not-yet-created outputs,
     // for example) skip the check — there is no filesystem state to trust or
     // distrust yet.
+    //
+    // On Windows, `canonicalize` returns extended-length `\\?\` verbatim paths.
+    // A directory junction's target can canonicalize to a different prefix form
+    // than the base, so both sides are passed through `strip_verbatim_prefix`
+    // before the `starts_with` comparison to ensure the prefix never skews the
+    // containment test. On Unix the strip is a no-op.
     if let (Ok(resolved_canon), Ok(base_canon)) = (
         std::fs::canonicalize(&resolved),
         std::fs::canonicalize(base_dir),
     ) && !allow_absolute
-        && !resolved_canon.starts_with(&base_canon)
+        && !strip_verbatim_prefix(&resolved_canon).starts_with(strip_verbatim_prefix(&base_canon))
     {
         return Err(sec_diag(format!(
             "path escapes base directory via symlink: {raw:?} -> {resolved_canon:?}"
@@ -143,6 +149,58 @@ pub fn validate_path(
     }
 
     Ok(ValidatedPath(resolved))
+}
+
+/// Strip a Windows `\\?\` extended-length (verbatim) prefix from a canonical
+/// path so two canonicalized paths can be compared on equal footing.
+///
+/// `std::fs::canonicalize` returns verbatim paths on Windows (`\\?\C:\dir`,
+/// `\\?\UNC\server\share`). A directory junction's resolved target may carry a
+/// different prefix form than the base directory's, which would make a plain
+/// `Path::starts_with` containment test spuriously fail (false-reject) or, in
+/// principle, pass (false-accept). Normalizing both operands through this
+/// function removes the prefix as a confounder before the comparison.
+///
+/// On non-Windows targets this is the identity function: POSIX canonical paths
+/// carry no verbatim prefix.
+#[cfg(not(windows))]
+fn strip_verbatim_prefix(path: &Path) -> &Path {
+    path
+}
+
+#[cfg(windows)]
+fn strip_verbatim_prefix(path: &Path) -> &Path {
+    use std::path::Prefix;
+
+    let Some(std::path::Component::Prefix(prefix)) = path.components().next() else {
+        return path;
+    };
+    let stripped = match prefix.kind() {
+        // `\\?\C:\rest` -> `C:\rest`: drop the leading `\\?\`.
+        Prefix::VerbatimDisk(_) => path
+            .as_os_str()
+            .to_str()
+            .and_then(|s| s.strip_prefix(r"\\?\"))
+            .map(Path::new),
+        // `\\?\UNC\server\share\rest` -> `\server\share\rest`: drop only the
+        // `\\?\UNC` portion, leaving a borrowed sub-slice. The base and target
+        // share this rewriting, so the comparison stays sound even though the
+        // result is not a fully-formed UNC path on its own.
+        Prefix::VerbatimUNC(_, _) => path
+            .as_os_str()
+            .to_str()
+            .and_then(|s| s.strip_prefix(r"\\?\UNC"))
+            .map(Path::new),
+        // `\\?\rest` (bare verbatim): drop the `\\?\`.
+        Prefix::Verbatim(_) => path
+            .as_os_str()
+            .to_str()
+            .and_then(|s| s.strip_prefix(r"\\?\"))
+            .map(Path::new),
+        // Non-verbatim prefixes (plain `C:\`, `\\server\share`) need no change.
+        _ => None,
+    };
+    stripped.unwrap_or(path)
 }
 
 /// Report whether `path` begins with a drive prefix or a root component.
@@ -303,6 +361,54 @@ mod tests {
             "expected symlink-escape diagnostic, got: {}",
             err.message
         );
+    }
+
+    // A directory junction inside `base` that points outside it must be caught
+    // by the canonicalization escape check. Junctions need no admin privilege
+    // to create (unlike symlinks), so this is the Windows analogue of the
+    // Unix-only symlink-escape test. Exercised by CI on the Windows runner.
+    #[cfg(windows)]
+    #[test]
+    fn test_validate_path_rejects_junction_escape() {
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("secret.txt"), "shh").unwrap();
+
+        let base = tempfile::tempdir().unwrap();
+        let link = base.path().join("leak");
+
+        // `mklink /J` creates a directory junction without elevation.
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(&link)
+            .arg(outside.path())
+            .status()
+            .expect("failed to spawn mklink");
+        assert!(status.success(), "mklink /J did not succeed");
+
+        let err = validate_path(Path::new("leak\\secret.txt"), base.path(), false).unwrap_err();
+        assert_eq!(err.code, "E-SEC-001");
+        assert!(
+            err.message.contains("escapes base directory"),
+            "expected junction-escape diagnostic, got: {}",
+            err.message
+        );
+    }
+
+    // A legitimate path inside `base` must be accepted even though Windows
+    // `canonicalize` decorates both operands with a `\\?\` verbatim prefix. The
+    // `starts_with` containment test must see through the prefix; this guards
+    // against the false-reject failure mode the prefix could otherwise cause.
+    #[cfg(windows)]
+    #[test]
+    fn test_validate_path_accepts_intra_base_despite_verbatim_prefix() {
+        let base = tempfile::tempdir().unwrap();
+        let sub = base.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        fs::write(sub.join("ok.txt"), "fine").unwrap();
+
+        let vp = validate_path(Path::new("sub\\ok.txt"), base.path(), false)
+            .expect("intra-base path must be accepted despite the \\\\?\\ prefix");
+        assert!(vp.as_path().ends_with("ok.txt"));
     }
 
     #[test]

--- a/crates/clinker-schema/src/discovery.rs
+++ b/crates/clinker-schema/src/discovery.rs
@@ -162,10 +162,13 @@ fn glob_paths(pattern: &str) -> Result<Vec<PathBuf>, ()> {
         return Ok(entries
             .filter_map(|e| e.ok())
             .filter(|e| {
+                // Case-insensitive: a case-preserving filesystem (macOS APFS,
+                // Windows NTFS) returns the on-disk casing, so `*.yaml` must
+                // still match a file stored as `flow.YAML`.
                 e.path()
                     .extension()
                     .and_then(|ext| ext.to_str())
-                    .is_some_and(|ext| ext == ext_match)
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case(ext_match))
             })
             .map(|e| e.path())
             .collect());
@@ -563,6 +566,28 @@ fields:
             !names
                 .iter()
                 .any(|n| n.to_ascii_lowercase().contains(".schema."))
+        );
+    }
+
+    #[test]
+    fn test_glob_discovery_mixed_case_extension() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join("schemas")).unwrap();
+
+        // The glob-driven path (manifest `include` globs) must match a
+        // case-preserving filesystem's on-disk casing: `*.yaml` finds
+        // `flow.YAML`.
+        write_file(root, "flow.YAML", "pipeline: {name: test}");
+
+        let pipelines = discover_pipelines(root, "schemas", &["*.yaml".to_string()], &[]);
+        let names: Vec<_> = pipelines
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert!(
+            names.contains(&"flow.YAML"),
+            "glob discovery missed mixed-case extension: {names:?}"
         );
     }
 

--- a/crates/clinker-schema/src/discovery.rs
+++ b/crates/clinker-schema/src/discovery.rs
@@ -14,11 +14,37 @@ use crate::parse::{SchemaParseError, parse_schema};
 /// Default schema directory name relative to workspace root.
 pub const DEFAULT_SCHEMA_DIR: &str = "schemas";
 
+/// Returns whether the path's extension is a YAML extension, ignoring case.
+///
+/// Case-folds the extension so that case-preserving filesystems (macOS APFS,
+/// Windows NTFS) surface files stored as `*.YAML`/`*.YML` identically to the
+/// lowercase forms a case-sensitive Linux filesystem would carry.
+fn has_yaml_extension(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("yaml") || ext.eq_ignore_ascii_case("yml"))
+}
+
+/// Returns whether the path's file stem ends in the `.schema` marker, ignoring case.
+///
+/// The stem of `customers.schema.YAML` is `customers.schema`; case-folding the
+/// `.schema` suffix lets a schema authored as `customers.SCHEMA.yaml` on a
+/// case-preserving filesystem still be recognized as a schema file.
+fn has_schema_stem(path: &Path) -> bool {
+    path.file_stem()
+        .and_then(|s| s.to_str())
+        .is_some_and(|stem| {
+            stem.len() >= ".schema".len()
+                && stem[stem.len() - ".schema".len()..].eq_ignore_ascii_case(".schema")
+        })
+}
+
 /// Discover all `.schema.yaml` files in the given directory (non-recursive).
 ///
-/// Returns parsed schemas with their `path` fields set. The caller is
-/// responsible for populating `referencing_pipelines` via
-/// [`resolve_schema_references`].
+/// Extension and `.schema` stem matching is case-insensitive, so a schema
+/// stored as `customers.schema.YAML` on a case-preserving filesystem is found
+/// alongside the lowercase form. Returns parsed schemas with their `path`
+/// fields set. The caller is responsible for populating
+/// `referencing_pipelines` via [`resolve_schema_references`].
 pub fn discover_schemas(
     schema_dir: &Path,
 ) -> Vec<Result<SourceSchema, (PathBuf, SchemaParseError)>> {
@@ -29,15 +55,8 @@ pub fn discover_schemas(
     entries
         .filter_map(|entry| entry.ok())
         .filter(|entry| {
-            entry
-                .path()
-                .extension()
-                .is_some_and(|ext| ext == "yaml" || ext == "yml")
-                && entry
-                    .path()
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .is_some_and(|name| name.ends_with(".schema"))
+            let path = entry.path();
+            has_yaml_extension(&path) && has_schema_stem(&path)
         })
         .map(|entry| {
             let path = entry.path();
@@ -52,7 +71,10 @@ pub fn discover_schemas(
 ///
 /// Scans the workspace root for `.yaml`/`.yml` files (non-recursive by default),
 /// and optionally uses include/exclude glob patterns from the manifest.
-/// Excludes the schema directory and common non-pipeline directories.
+/// Extension matching and the `.schema` exclusion are case-insensitive, so a
+/// pipeline saved as `flow.YAML` is discovered and a `*.schema.YAML` file is
+/// still excluded on case-preserving filesystems. Excludes the schema directory
+/// and common non-pipeline directories.
 pub fn discover_pipelines(
     workspace_root: &Path,
     schema_dir: &str,
@@ -81,18 +103,11 @@ pub fn discover_pipelines(
                 return false;
             }
             // Must be YAML
-            let is_yaml = path
-                .extension()
-                .is_some_and(|ext| ext == "yaml" || ext == "yml");
-            if !is_yaml {
+            if !has_yaml_extension(&path) {
                 return false;
             }
             // Exclude schema files
-            let is_schema = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .is_some_and(|name| name.ends_with(".schema"));
-            if is_schema {
+            if has_schema_stem(&path) {
                 return false;
             }
             // Exclude kiln.toml companion files
@@ -455,5 +470,162 @@ outputs:
         assert!(names.contains(&"pipeline.yaml"));
         assert!(names.contains(&"another.yml"));
         assert!(!names.iter().any(|n| n.contains("schema")));
+    }
+
+    #[test]
+    fn test_discover_schemas_mixed_case_extension_and_stem() {
+        let tmp = TempDir::new().unwrap();
+        let schemas_dir = tmp.path().join("schemas");
+        fs::create_dir(&schemas_dir).unwrap();
+
+        // Uppercase extension — the case a macOS APFS / Windows NTFS file
+        // preserves verbatim and a case-sensitive Linux scan would miss.
+        write_file(
+            &schemas_dir,
+            "customers.schema.YAML",
+            r#"
+_schema:
+  name: customers
+  format: csv
+fields:
+  - name: id
+    type: int
+    nullable: false
+"#,
+        );
+
+        // Uppercase short extension.
+        write_file(
+            &schemas_dir,
+            "orders.schema.YML",
+            r#"
+_schema:
+  name: orders
+  format: csv
+fields:
+  - name: order_id
+    type: string
+    nullable: false
+"#,
+        );
+
+        // Uppercase `.SCHEMA` stem marker.
+        write_file(
+            &schemas_dir,
+            "events.SCHEMA.yaml",
+            r#"
+_schema:
+  name: events
+  format: jsonl
+fields:
+  - name: event_id
+    type: string
+    nullable: false
+"#,
+        );
+
+        let results = discover_schemas(&schemas_dir);
+        let schemas: Vec<_> = results.into_iter().filter_map(|r| r.ok()).collect();
+
+        assert_eq!(schemas.len(), 3);
+        let names: Vec<_> = schemas.iter().map(|s| s.metadata.name.as_str()).collect();
+        assert!(names.contains(&"customers"));
+        assert!(names.contains(&"orders"));
+        assert!(names.contains(&"events"));
+    }
+
+    #[test]
+    fn test_discover_pipelines_mixed_case_extension() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        fs::create_dir(root.join("schemas")).unwrap();
+
+        // Mixed-case pipeline extensions must be discovered.
+        write_file(root, "flow.YAML", "pipeline: {name: test}");
+        write_file(root, "other.YML", "pipeline: {name: test2}");
+        // A mixed-case schema file at the root must still be excluded.
+        write_file(
+            root,
+            "inline.schema.YAML",
+            "_schema: {name: x, format: csv}",
+        );
+
+        let pipelines = discover_pipelines(root, "schemas", &[], &[]);
+
+        let names: Vec<_> = pipelines
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+        assert!(names.contains(&"flow.YAML"));
+        assert!(names.contains(&"other.YML"));
+        assert!(
+            !names
+                .iter()
+                .any(|n| n.to_ascii_lowercase().contains(".schema."))
+        );
+    }
+
+    #[test]
+    fn test_full_workspace_discovery_mixed_case_extension() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+
+        let schemas_dir = root.join("schemas");
+        fs::create_dir(&schemas_dir).unwrap();
+
+        // Schema stored with an uppercase extension, as a case-preserving
+        // filesystem would surface it.
+        write_file(
+            &schemas_dir,
+            "customers.schema.YAML",
+            r#"
+_schema:
+  name: customers
+  format: csv
+fields:
+  - name: id
+    type: int
+    nullable: false
+  - name: email
+    type: string
+"#,
+        );
+
+        write_file(
+            root,
+            "pipeline.yaml",
+            r#"
+pipeline:
+  name: test
+
+inputs:
+  - name: source
+    type: csv
+    path: ./data/customers.csv
+    schema: schemas/customers.schema.YAML
+
+transformations:
+  - name: t1
+    cxl: "emit x = id"
+
+outputs:
+  - name: dest
+    type: csv
+    path: ./output.csv
+"#,
+        );
+
+        let (index, errors) = build_workspace_schema_index(root, "schemas", &[], &[]);
+
+        assert!(errors.is_empty());
+        assert_eq!(index.len(), 1);
+
+        // The mixed-case schema file is discovered, parsed, and bound to its
+        // referencing pipeline.
+        let schema_path = schemas_dir.join("customers.schema.YAML");
+        let schema = index.get(&schema_path).unwrap();
+        assert_eq!(schema.metadata.name, "customers");
+        assert_eq!(schema.referencing_pipelines.len(), 1);
     }
 }

--- a/crates/clinker/tests/miette_rendering.rs
+++ b/crates/clinker/tests/miette_rendering.rs
@@ -140,14 +140,21 @@ nodes:
 /// Create an ephemeral per-test temp directory under the system
 /// temp root. Avoids adding a `tempfile` dev-dep.
 fn tempdir_path() -> std::path::PathBuf {
+    // A per-process atomic counter guarantees a distinct directory per call.
+    // pid + timestamp alone can collide on a platform whose clock resolution
+    // is coarser than the nanosecond unit (macOS), letting two concurrent
+    // tests share one directory and clobber each other's fixtures.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
     let mut base = std::env::temp_dir();
     let name = format!(
-        "clinker-miette-test-{}-{}",
+        "clinker-miette-test-{}-{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
-            .unwrap_or(0)
+            .unwrap_or(0),
+        SEQ.fetch_add(1, Ordering::Relaxed)
     );
     base.push(name);
     std::fs::create_dir_all(&base).expect("create tempdir");

--- a/crates/clinker/tests/storage_config_cli.rs
+++ b/crates/clinker/tests/storage_config_cli.rs
@@ -529,14 +529,22 @@ fn real_run_logs_per_stage_actual_spill() {
 }
 
 fn tempdir_path() -> std::path::PathBuf {
+    // A per-process atomic counter guarantees a distinct directory per call.
+    // pid + timestamp alone can collide: on a platform whose clock resolution
+    // is coarser than the nanosecond unit (macOS), two concurrent tests can
+    // read the same value, land in one shared directory, and leak one test's
+    // clinker.toml into the other's config discovery.
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(0);
     let mut base = std::env::temp_dir();
     let name = format!(
-        "clinker-storage-cli-{}-{}",
+        "clinker-storage-cli-{}-{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .map(|d| d.as_nanos())
-            .unwrap_or(0)
+            .unwrap_or(0),
+        SEQ.fetch_add(1, Ordering::Relaxed)
     );
     base.push(name);
     std::fs::create_dir_all(&base).expect("create tempdir");


### PR DESCRIPTION
## Summary

Makes Windows and macOS first-class alongside Linux. The bounded-memory guarantee — spill before OOM, within the configured RSS budget — now holds, and is verified in CI, on all three platforms, and the path/format bugs that diverged per-OS are fixed. This PR delivers the full milestone, including the follow-on gaps surfaced during integration.

Until now the engine compiled for three OSes but the memory budget was calibrated for Linux only: it silently became a no-op when the platform memory API returned `None`, read the wrong metric on Windows/macOS, and was never *executed* off-Linux in CI.

## Memory budget

- **#237** — CI now runs `cargo test --workspace` on `windows-latest` and `macos-latest`; the RSS-validity tests are de-gated; the ubuntu cross-check gains `--all-targets` (scoped to the crates that cross-compile without a C toolchain — `ring`-dependent crates are covered by the native runners).
- **#235** — RSS-independent, byte-counted spill/abort backstop so the budget degrades to a heuristic ceiling, not to nothing, when `rss_bytes()` is unavailable (equi-join, grace-hash, node_buffers).
- **#236** — per-platform metric: `PrivateUsage` on Windows, `phys_footprint` on macOS (drops the now-unused `mach2`).
- **#366** — extend the #235 backstop to the IEJoin and sort-merge join probe kernels, which still gated their growing output buffer on RSS only and could OOM on a None-RSS platform.

## Path & format portability

- **#238 / #367** — strip a leading UTF-8 BOM in the CSV, JSON/NDJSON, XML, and fixed-width readers.
- **#239** — reject Windows drive-relative output paths (`C:evil.csv`) in `validate_path`.
- **#240** — cover the symlink/junction escape check on Windows.
- **#241** — normalize path separators in glob `exclude` matching.
- **#242 / #368** — case-insensitive extension/stem matching in both the default and glob-driven discovery paths.
- **#243 / #369** — case-insensitive collision detection for DLQ paths (E318) and cross-Output-node paths (E322), conditioned on the target filesystem's actual case-sensitivity.
- **#335** — gate the symlink-escape test on Unix to clear Windows `--all-targets` clippy.

## Cross-platform test hardening (completing #237's "passes on all three OSes")

Turning on the native runners surfaced pre-existing latent failures that had never executed off-Linux. Fixed as part of #237: committed text fixtures pinned to LF (`.gitattributes`) so Windows `autocrlf` no longer breaks byte-comparison and snapshot tests; split output paths joined with a portable `/`; wall-clock timing assertions whose good/serial separation is narrower than CI sleep inflation calibrated to the platform's measured sleep cost (or replaced with deterministic row-count gates); and `fs_type::classify` made to honor its documented "missing path errors" contract on Windows.

## Verification

- Full local gauntlet green on Linux (fmt, both clippy passes, `cargo test --workspace`, bench checks, `cargo deny`) plus cross-target `cargo clippy --all-targets` for both `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`.
- The runtime cross-platform assertions execute on the new native CI runners this PR adds — the real behavioral gate.

Closes #235, #236, #237, #238, #239, #240, #241, #242, #243, #335, #366, #367, #368, #369, #244.

Remaining standalone follow-up (not part of this milestone): #370 (remove the dead `dioxus` workspace dependency and the unused GTK/webkit CI step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
