### PR TITLE
perf: store field-value strings as SmolStr for zero-alloc short fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,6 +402,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "smol_str",
  "tempfile",
 ]
 
@@ -563,6 +574,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_json",
+ "smol_str",
 ]
 
 [[package]]
@@ -1848,6 +1860,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "smol_str"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
+dependencies = [
+ "borsh",
+ "serde_core",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,12 @@ clap = { version = "4", features = ["derive"] }
 regex = "1"
 ahash = "0.8"
 indexmap = { version = "2", features = ["serde"] }
+# Field-value string storage for `Value::String`: short strings (<=23 bytes,
+# the dominant ETL field shape) live inline with zero heap allocation; longer
+# strings are Arc-backed for O(1) shared clones. The `serde` feature is left
+# off — the hand-written `Value` (de)serialize impls go through `&str`, so the
+# wire form is unchanged. Maintained in-tree at rust-lang/rust-analyzer/lib/smol_str.
+smol_str = "0.3"
 tracing = "0.1"
 arc-swap = "1.9"
 static_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,14 @@ indexmap = { version = "2", features = ["serde"] }
 # the dominant ETL field shape) live inline with zero heap allocation; longer
 # strings are Arc-backed for O(1) shared clones. The `serde` feature is left
 # off — the hand-written `Value` (de)serialize impls go through `&str`, so the
-# wire form is unchanged. Maintained in-tree at rust-lang/rust-analyzer/lib/smol_str.
-smol_str = "0.3"
+# wire form is unchanged. `default-features = false` with only `std` enabled
+# keeps smol_str's optional `borsh` feature off, so borsh is never compiled
+# into the build graph (we never serialize via borsh); `std` preserves the
+# inline + Arc storage and the AsRef<str>/From impls the code relies on. (Cargo
+# still lists borsh under smol_str in Cargo.lock as a declared-but-unactivated
+# optional dep; it compiles nowhere — confirmed via `cargo tree -i borsh`.)
+# Maintained in-tree at rust-lang/rust-analyzer/lib/smol_str.
+smol_str = { version = "0.3", default-features = false, features = ["std"] }
 tracing = "0.1"
 arc-swap = "1.9"
 static_assertions = "1"

--- a/crates/clinker-bench-support/Cargo.toml
+++ b/crates/clinker-bench-support/Cargo.toml
@@ -10,6 +10,7 @@ bench-alloc = []
 
 [dependencies]
 clinker-record = { workspace = true }
+smol_str = { workspace = true }
 fastrand = "2"
 blake3 = { workspace = true }
 glob = "0.3"

--- a/crates/clinker-bench-support/src/combine.rs
+++ b/crates/clinker-bench-support/src/combine.rs
@@ -10,6 +10,7 @@
 //! columns of deterministic length.
 
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
+use smol_str::SmolStr;
 use std::sync::Arc;
 
 /// Generates two correlated record sets for combine benchmarks.
@@ -72,7 +73,7 @@ impl CombineDataGen {
     /// Deterministically generate an ASCII-lowercase string from a row index
     /// and column index. Fixed length 8 — wide enough for unique-ish output
     /// within a bench but cheap to allocate.
-    fn det_string(row: usize, col: usize) -> Box<str> {
+    fn det_string(row: usize, col: usize) -> SmolStr {
         const LEN: usize = 8;
         let mut bytes = [0u8; LEN];
         // Mix row and col into a 32-bit lane, then peel off 5-bit (a-z +
@@ -85,7 +86,7 @@ impl CombineDataGen {
             mix = mix.rotate_left(7).wrapping_add(1);
         }
         // SAFETY: all bytes in [b'a', b'a' + 25], always valid ASCII.
-        unsafe { String::from_utf8_unchecked(bytes.to_vec()) }.into_boxed_str()
+        SmolStr::new(unsafe { std::str::from_utf8_unchecked(&bytes) })
     }
 
     /// Build a record with the given integer key and deterministic string

--- a/crates/clinker-bench-support/src/lib.rs
+++ b/crates/clinker-bench-support/src/lib.rs
@@ -16,6 +16,7 @@ pub mod generators;
 pub mod io;
 
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
+use smol_str::SmolStr;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -281,12 +282,12 @@ impl RecordFactory {
         (0..count).map(|_| self.next_record()).collect()
     }
 
-    fn random_string(&mut self) -> Box<str> {
+    fn random_string(&mut self) -> SmolStr {
         let bytes: Vec<u8> = (0..self.string_len)
             .map(|_| self.rng.u8(b'a'..=b'z'))
             .collect();
         // SAFETY: all bytes are ASCII a-z
-        unsafe { String::from_utf8_unchecked(bytes) }.into_boxed_str()
+        SmolStr::new(unsafe { std::str::from_utf8_unchecked(&bytes) })
     }
 }
 

--- a/crates/clinker-channel/tests/channel_var_overlay_test.rs
+++ b/crates/clinker-channel/tests/channel_var_overlay_test.rs
@@ -159,7 +159,7 @@ vars:
     );
     assert_eq!(
         result.pipeline_vars.get("cutoff_date"),
-        Some(&Value::String("2026-01-01".to_string().into_boxed_str())),
+        Some(&Value::from("2026-01-01")),
     );
 }
 
@@ -240,10 +240,7 @@ vars:
         .source_vars
         .get("orders")
         .expect("orders source has overrides");
-    assert_eq!(
-        inner.get("ingest_label"),
-        Some(&Value::String("staging".to_string().into_boxed_str())),
-    );
+    assert_eq!(inner.get("ingest_label"), Some(&Value::from("staging")),);
 }
 
 #[test]
@@ -341,7 +338,7 @@ vars:
     );
     assert_eq!(
         result.record_vars.get("tier"),
-        Some(&Value::String("platinum".to_string().into_boxed_str())),
+        Some(&Value::from("platinum")),
     );
 }
 
@@ -367,10 +364,7 @@ vars:
             .iter()
             .all(|d| !matches!(d.severity, Severity::Error))
     );
-    assert_eq!(
-        result.record_vars.get("region"),
-        Some(&Value::String("west".to_string().into_boxed_str())),
-    );
+    assert_eq!(result.record_vars.get("region"), Some(&Value::from("west")),);
 }
 
 // ── Cross-cutting ──────────────────────────────────────────────────────

--- a/crates/clinker-exec/benches/arena.rs
+++ b/crates/clinker-exec/benches/arena.rs
@@ -80,7 +80,7 @@ fn bench_index_build(c: &mut Criterion) {
         let minimals: Vec<MinimalRecord> = (0..record_count)
             .map(|i| {
                 MinimalRecord::new(vec![
-                    Value::String(format!("g{}", i % num_groups).into_boxed_str()),
+                    Value::String(format!("g{}", i % num_groups).into()),
                     Value::Integer(i as i64),
                 ])
             })
@@ -115,7 +115,7 @@ fn bench_index_lookup(c: &mut Criterion) {
     let minimals: Vec<MinimalRecord> = (0..record_count)
         .map(|i| {
             MinimalRecord::new(vec![
-                Value::String(format!("g{}", i % num_groups).into_boxed_str()),
+                Value::String(format!("g{}", i % num_groups).into()),
                 Value::Integer(i as i64),
             ])
         })

--- a/crates/clinker-exec/benches/deferred_buffer_pruning.rs
+++ b/crates/clinker-exec/benches/deferred_buffer_pruning.rs
@@ -40,7 +40,7 @@ fn build_wide_rows() -> Vec<(Record, u64)> {
     (0..ROW_COUNT)
         .map(|i| {
             let values: Vec<Value> = (0..WIDE_COLUMN_COUNT)
-                .map(|c| Value::String(format!("row{i}_col{c}").into_boxed_str()))
+                .map(|c| Value::String(format!("row{i}_col{c}").into()))
                 .collect();
             (Record::new(Arc::clone(&schema), values), i as u64)
         })

--- a/crates/clinker-exec/benches/window.rs
+++ b/crates/clinker-exec/benches/window.rs
@@ -17,7 +17,7 @@ fn build_numeric_arena(partition_size: usize) -> (Arena, Vec<u64>) {
     for i in 0..partition_size {
         minimals.push(MinimalRecord::new(vec![
             Value::Float(rng.f64() * 10_000.0),
-            Value::String(format!("cat_{}", i % 50).into_boxed_str()),
+            Value::String(format!("cat_{}", i % 50).into()),
         ]));
     }
     let positions: Vec<u64> = (0..partition_size as u64).collect();

--- a/crates/clinker-exec/src/aggregation/mod.rs
+++ b/crates/clinker-exec/src/aggregation/mod.rs
@@ -188,7 +188,7 @@ fn literal_to_value(lit: &LiteralValue) -> Value {
     match lit {
         LiteralValue::Int(n) => Value::Integer(*n),
         LiteralValue::Float(f) => Value::Float(*f),
-        LiteralValue::String(s) => Value::String(s.clone()),
+        LiteralValue::String(s) => Value::String(s.as_ref().into()),
         LiteralValue::Bool(b) => Value::Bool(*b),
         LiteralValue::Date(d) => Value::Date(*d),
         LiteralValue::Null => Value::Null,

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -425,12 +425,8 @@ fn drive_record_source(
                     } else {
                         clinker_record::Value::Null
                     };
-                    values.push(clinker_record::Value::String(
-                        file_arc.as_ref().to_string().into_boxed_str(),
-                    ));
-                    values.push(clinker_record::Value::String(
-                        source_name_arc.as_ref().to_string().into_boxed_str(),
-                    ));
+                    values.push(clinker_record::Value::from(file_arc.as_ref()));
+                    values.push(clinker_record::Value::from(source_name_arc.as_ref()));
                     values.push(event_time_value);
                     let mut widened_record =
                         clinker_record::Record::new(Arc::clone(&widened_schema), values);

--- a/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
@@ -609,7 +609,7 @@ o6,ENG,300
         e.original_record
             .values()
             .iter()
-            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "HR"))
+            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "HR"))
     });
     assert!(
         hr_dlq.is_some(),
@@ -850,7 +850,7 @@ o6,ENG,300
         e.original_record
             .values()
             .iter()
-            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "HR"))
+            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "HR"))
     });
     assert!(
         hr_dlq.is_some(),

--- a/crates/clinker-exec/tests/correlated_dlq_retract.rs
+++ b/crates/clinker-exec/tests/correlated_dlq_retract.rs
@@ -901,7 +901,7 @@ O6,ENG,200,6
             .filter(|d| {
                 d.trigger
                     && d.original_record.values().iter().any(
-                        |v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "O3"),
+                        |v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "O3"),
                     )
             })
             .collect();

--- a/crates/clinker-exec/tests/correlated_window_after_aggregate_retract.rs
+++ b/crates/clinker-exec/tests/correlated_window_after_aggregate_retract.rs
@@ -330,7 +330,7 @@ O6,ENG,300
             .original_record
             .values()
             .iter()
-            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "HR")),
+            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "HR")),
         "trigger record must be the HR aggregate output row"
     );
     assert!(

--- a/crates/clinker-exec/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/tests/deferred_dispatch.rs
@@ -852,7 +852,7 @@ o6,ENG,300
         e.original_record
             .values()
             .iter()
-            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "HR"))
+            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "HR"))
     });
     assert!(
         hr_dlq.is_some(),

--- a/crates/clinker-exec/tests/retract_demo_smoke.rs
+++ b/crates/clinker-exec/tests/retract_demo_smoke.rs
@@ -265,7 +265,7 @@ fn demo_dlq_contains_upstream_and_post_aggregate_triggers() {
             && e.original_record
                 .values()
                 .iter()
-                .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "O08"))
+                .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "O08"))
     });
     assert!(
         upstream_trigger.is_some(),
@@ -290,7 +290,7 @@ fn demo_dlq_contains_upstream_and_post_aggregate_triggers() {
             .original_record
             .values()
             .iter()
-            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "HR"));
+            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "HR"));
         assert!(
             department_is_hr,
             "every post-aggregate trigger row belongs to the HR department; got: {entry:?}",

--- a/crates/clinker-exec/tests/route_fanout_soft_spill.rs
+++ b/crates/clinker-exec/tests/route_fanout_soft_spill.rs
@@ -13,7 +13,7 @@
 //! Per-row admission cost is the `estimate_node_buffer_bytes`
 //! formula in `executor/dispatch.rs`: `size_of::<Value>() * cols +
 //! size_of::<(Record, u64)>()`. For the 5-column schema below this
-//! resolves to ~264 B/row, so 2 000 rows charge ~528 KiB — under the
+//! resolves to ~216 B/row, so 2 000 rows charge ~432 KiB — under the
 //! 1 MiB hard limit but well above the 819 KiB soft floor against
 //! which the RSS check is compared.
 //!

--- a/crates/clinker-exec/tests/transform_stream_fusion.rs
+++ b/crates/clinker-exec/tests/transform_stream_fusion.rs
@@ -765,10 +765,16 @@ fn fused_transform_charges_one_batch_not_full_stage() {
     // Generous bytes-per-row upper bound for the in-flight ceiling.
     const PER_ROW_UPPER: usize = 256;
     // Bounded in-flight capacity: the source ingest channel (1024), the
-    // streaming-output channel (256), and one extra batch (64). The peak
-    // charged footprint cannot exceed this many records' worth of bytes
-    // regardless of the total input size.
-    const IN_FLIGHT_RECORDS: usize = 1024 + 256 + 64;
+    // streaming-output channel (256), and one in-transit batch's worth of
+    // headroom (256). The peak charged footprint cannot exceed this many
+    // records' worth of bytes regardless of the total input size — the bound
+    // is the live channel depths, not the full stage. The batch headroom
+    // covers the transient where a fast producer fills the bounded source
+    // channel to capacity before the consumer drains it; with zero-allocation
+    // inline storage for short fields the producer reaches that depth readily,
+    // so the slack reflects a full output-channel-sized batch rather than a
+    // fraction of one.
+    const IN_FLIGHT_RECORDS: usize = 1024 + 256 + 256;
 
     let yaml = r#"
 pipeline:

--- a/crates/clinker-exec/tests/transform_stream_fusion.rs
+++ b/crates/clinker-exec/tests/transform_stream_fusion.rs
@@ -764,17 +764,21 @@ fn fused_transform_charges_one_batch_not_full_stage() {
     const PER_ROW_LOWER: usize = 48;
     // Generous bytes-per-row upper bound for the in-flight ceiling.
     const PER_ROW_UPPER: usize = 256;
-    // Bounded in-flight capacity: the source ingest channel (1024), the
-    // streaming-output channel (256), and one in-transit batch's worth of
-    // headroom (256). The peak charged footprint cannot exceed this many
-    // records' worth of bytes regardless of the total input size — the bound
-    // is the live channel depths, not the full stage. The batch headroom
-    // covers the transient where a fast producer fills the bounded source
-    // channel to capacity before the consumer drains it; with zero-allocation
-    // inline storage for short fields the producer reaches that depth readily,
-    // so the slack reflects a full output-channel-sized batch rather than a
-    // fraction of one.
-    const IN_FLIGHT_RECORDS: usize = 1024 + 256 + 256;
+    // Bounded in-flight capacity, summed across the two registered memory
+    // consumers whose live charge the arbitrator peaks over:
+    //   - the source ingest channel, `crossbeam_channel::bounded(1024)` —
+    //     its `SourceConsumer` charge is `queued * per-record-bytes`, capped at
+    //     the channel's 1024-event depth;
+    //   - the streaming-output slot, `crossbeam_channel::bounded(256)` — the
+    //     fused Transform `add_bytes` a whole batch before sending its events,
+    //     so the slot's charged-but-undischarged footprint is at most the
+    //     channel's 256-event depth plus the one batch (`batch_size = 64`)
+    //     charged ahead of the blocking sends.
+    // Hence the tight ceiling is input_cap + output_cap + one real batch =
+    // 1024 + 256 + 64, independent of total input size. The last term is the
+    // fixture's `batch_size` (64), not the output channel depth — the channel
+    // depth is already the 256 term and must not be double-counted as a batch.
+    const IN_FLIGHT_RECORDS: usize = 1024 + 256 + 64;
 
     let yaml = r#"
 pipeline:

--- a/crates/clinker-exec/tests/window_recompute_correctness.rs
+++ b/crates/clinker-exec/tests/window_recompute_correctness.rs
@@ -250,7 +250,7 @@ fn post_aggregate_window_recompute_corrects_running_total() {
             .original_record
             .values()
             .iter()
-            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "HR")),
+            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "HR")),
         "trigger record must carry department=HR"
     );
     assert!(
@@ -258,7 +258,7 @@ fn post_aggregate_window_recompute_corrects_running_total() {
             .original_record
             .values()
             .iter()
-            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_ref() == "north")),
+            .any(|v| matches!(v, clinker_record::Value::String(s) if s.as_str() == "north")),
         "trigger record must carry region=north"
     );
 

--- a/crates/clinker-plan/src/config/scoped_var.rs
+++ b/crates/clinker-plan/src/config/scoped_var.rs
@@ -275,7 +275,7 @@ pub fn coerce_scoped_var_default(
         (
             ScopedVarType::String | ScopedVarType::Date | ScopedVarType::DateTime,
             serde_json::Value::String(s),
-        ) => Value::String(s.clone().into_boxed_str()),
+        ) => Value::String(s.as_str().into()),
         _ => unreachable!("check_scoped_var_default should reject mismatched defaults"),
     }
 }

--- a/crates/clinker-plan/src/config/storage.rs
+++ b/crates/clinker-plan/src/config/storage.rs
@@ -130,8 +130,9 @@ const AUTO_COMPRESS_MIN_ROWS_PER_BATCH: u64 = 1024;
 /// Per-column byte estimate used to project a spilled batch's size from a
 /// schema's column count alone.
 ///
-/// A `Value` slot is 24 bytes; `32` adds a small heap allowance for the
-/// typical mix of short strings and fixed-width scalars a spilled row holds.
+/// A `Value` slot is 32 bytes (its widest variant is the 24-byte inline
+/// string plus the enum discriminant); short strings and fixed-width scalars
+/// carry no extra heap, so the per-column slot width alone is the estimate.
 /// The projection only has to land on the correct side of the 4 KiB
 /// threshold, so a coarse per-column constant is sufficient and keeps the
 /// heuristic a pure function of the schema width and batch size.

--- a/crates/clinker-record/Cargo.toml
+++ b/crates/clinker-record/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = { workspace = true }
 chrono = { workspace = true }
 ahash = { workspace = true }
 indexmap = { workspace = true }
+smol_str = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/crates/clinker-record/benches/record_ops.rs
+++ b/crates/clinker-record/benches/record_ops.rs
@@ -16,7 +16,7 @@ fn make_values(n: usize) -> Vec<Value> {
             if i % 2 == 0 {
                 Value::Integer(i as i64 * 42)
             } else {
-                Value::String(format!("value_{i}").into_boxed_str())
+                Value::String(format!("value_{i}").into())
             }
         })
         .collect()
@@ -132,7 +132,7 @@ fn bench_value_from_string(c: &mut Criterion) {
     for len in [8, 64, 512] {
         let s: String = "x".repeat(len);
         group.bench_with_input(BenchmarkId::from_parameter(len), &len, |b, _| {
-            b.iter(|| Value::String(black_box(s.clone()).into_boxed_str()));
+            b.iter(|| Value::String(black_box(s.clone()).into()));
         });
     }
     group.finish();

--- a/crates/clinker-record/src/coercion.rs
+++ b/crates/clinker-record/src/coercion.rs
@@ -103,7 +103,7 @@ pub fn coerce_to_float_lenient(value: &Value) -> Option<Value> {
 pub fn coerce_to_string(value: &Value) -> Result<Value, CoercionError> {
     match value {
         Value::Null => Ok(Value::Null),
-        other => Ok(Value::String(other.to_string().into_boxed_str())),
+        other => Ok(Value::String(other.to_string().into())),
     }
 }
 

--- a/crates/clinker-record/src/group_key.rs
+++ b/crates/clinker-record/src/group_key.rs
@@ -40,7 +40,10 @@ impl GroupByKey {
         match self {
             GroupByKey::Null => Value::Null,
             GroupByKey::Int(n) => Value::Integer(*n),
-            GroupByKey::Str(s) => Value::String(s.clone()),
+            // `GroupByKey::Str` keeps its own `Box<str>` (it is an independent
+            // HashMap/HashSet key); convert through `&str` to the inline/Arc-
+            // backed field-value string when materializing the group key.
+            GroupByKey::Str(s) => Value::String(s.as_ref().into()),
             GroupByKey::Bool(b) => Value::Bool(*b),
             GroupByKey::Date(d) => Value::Date(*d),
             GroupByKey::DateTime(dt) => Value::DateTime(*dt),
@@ -146,7 +149,9 @@ pub fn value_to_group_key(
             Ok(Some(GroupByKey::Float((*i as f64).to_bits())))
         }
 
-        Value::String(s) => Ok(Some(GroupByKey::Str(s.clone()))),
+        // Materialize an owned `Box<str>` key from the field-value string;
+        // `GroupByKey` keys must own independently of the source `Value`.
+        Value::String(s) => Ok(Some(GroupByKey::Str(Box::from(s.as_str())))),
         Value::Bool(b) => Ok(Some(GroupByKey::Bool(*b))),
         Value::Date(d) => Ok(Some(GroupByKey::Date(*d))),
         Value::DateTime(dt) => Ok(Some(GroupByKey::DateTime(*dt))),

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -551,8 +551,19 @@ mod tests {
         let size = record.estimated_heap_size();
         // Vec backing: capacity(2) * sizeof(Value)
         let expected_backing = 2 * std::mem::size_of::<Value>();
-        // String "hello" = 5 bytes heap, Integer = 0
-        let expected_heap = 5;
-        assert_eq!(size, expected_backing + expected_heap);
+        // Short "hello" lives inline in the SmolStr (0 heap); Integer is 0 too.
+        assert_eq!(size, expected_backing);
+    }
+
+    #[test]
+    fn test_record_estimated_heap_size_heap_backed_string() {
+        let schema = Arc::new(Schema::new(vec!["name".into(), "value".into()]));
+        let long = "a field value that exceeds the 23-byte inline capacity of smolstr";
+        assert!(smol_str::SmolStr::new(long).is_heap_allocated());
+        let record = Record::new(schema, vec![Value::String(long.into()), Value::Integer(42)]);
+        let size = record.estimated_heap_size();
+        let expected_backing = 2 * std::mem::size_of::<Value>();
+        // The heap-backed (Arc) string charges its byte length on top of the Vec backing.
+        assert_eq!(size, expected_backing + long.len());
     }
 }

--- a/crates/clinker-record/src/value.rs
+++ b/crates/clinker-record/src/value.rs
@@ -1,5 +1,6 @@
 use chrono::{Datelike, NaiveDate, NaiveDateTime};
 use indexmap::IndexMap;
+use smol_str::SmolStr;
 use std::cmp::Ordering;
 use std::fmt;
 
@@ -9,12 +10,20 @@ pub enum Value {
     Bool(bool),
     Integer(i64),
     Float(f64),
-    String(Box<str>),
+    /// Field-value string. Short values (<=23 bytes — the dominant ETL field
+    /// shape) live inline in the enum with zero heap allocation; longer values
+    /// are Arc-backed, so cloning a long string is an O(1) refcount bump rather
+    /// than an allocation + copy. `SmolStr` is 24 bytes wide with no spare
+    /// niche, so it widens `Value` to 32 bytes (see `test_value_enum_size`);
+    /// the trade buys away one heap allocation per short value, which is the
+    /// term that moves the RSS / spill threshold.
+    String(SmolStr),
     Date(NaiveDate),
     DateTime(NaiveDateTime),
     Array(Vec<Value>),
     /// Nested key-value map (ordered, insertion-preserving).
-    /// Box<IndexMap> is 8 bytes — enum stays at 24 bytes (Vec<Value> is already 24).
+    /// `Box<IndexMap>` is 8 bytes; the enum width is set by `String(SmolStr)`
+    /// and `Array(Vec<Value>)`, not by this variant.
     Map(Box<IndexMap<Box<str>, Value>>),
 }
 
@@ -54,7 +63,7 @@ impl Serialize for Value {
             Value::Integer(n) => serializer.serialize_newtype_variant("Value", 2, "Integer", n),
             Value::Float(f) => serializer.serialize_newtype_variant("Value", 3, "Float", f),
             Value::String(s) => {
-                serializer.serialize_newtype_variant("Value", 4, "String", s.as_ref())
+                serializer.serialize_newtype_variant("Value", 4, "String", s.as_str())
             }
             Value::Date(d) => {
                 // days from proleptic Gregorian ordinal (1 = 0001-01-01)
@@ -109,7 +118,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
             3 => Ok(Value::Float(va.newtype_variant()?)),
             4 => {
                 let s: std::string::String = va.newtype_variant()?;
-                Ok(Value::String(s.into_boxed_str()))
+                Ok(Value::String(SmolStr::from(s)))
             }
             5 => {
                 let days: i32 = va.newtype_variant()?;
@@ -256,6 +265,32 @@ impl fmt::Display for Value {
                 write!(f, "}}")
             }
         }
+    }
+}
+
+// ── String-variant constructors (policy-enforcing) ─────────────────────────
+//
+// `From<&str>`, `From<String>`, and `From<SmolStr>` build the `String` variant.
+// There is deliberately NO `From<Box<str>>`: a `Box<str>` field value (the old
+// owning representation) must fail to compile rather than silently allocate and
+// box, which is the type-level enforcement that the inline/Arc-backed `SmolStr`
+// representation is the single field-value string path.
+
+impl From<&str> for Value {
+    fn from(s: &str) -> Self {
+        Value::String(SmolStr::new(s))
+    }
+}
+
+impl From<std::string::String> for Value {
+    fn from(s: std::string::String) -> Self {
+        Value::String(SmolStr::from(s))
+    }
+}
+
+impl From<SmolStr> for Value {
+    fn from(s: SmolStr) -> Self {
+        Value::String(s)
     }
 }
 
@@ -655,7 +690,15 @@ mod tests {
 
     #[test]
     fn test_value_enum_size() {
-        assert_eq!(std::mem::size_of::<Value>(), 24);
+        // `SmolStr` is itself 24 bytes (a 23-byte inline buffer + 1-byte length
+        // tag) and exposes no spare niche for the outer `Value` discriminant,
+        // so the enum is 32 bytes — one machine word wider than the prior
+        // `Box<str>` (16-byte) representation. The width is paid back at the
+        // heap: short field values (<=23 bytes, the dominant ETL shape) carry
+        // zero heap allocation instead of one per value, and long values clone
+        // by refcount. The per-`Value` byte-cost model keys off this constant,
+        // so it tracks the real width automatically.
+        assert_eq!(std::mem::size_of::<Value>(), 32);
     }
 
     #[test]

--- a/crates/clinker-record/src/value.rs
+++ b/crates/clinker-record/src/value.rs
@@ -330,9 +330,18 @@ impl Value {
     /// Used by SortBuffer for self-tracking allocation counting.
     /// Scalar variants (Null, Bool, Integer, Float, Date, DateTime) store
     /// data inline in the enum — zero heap allocation.
+    /// Strings store their bytes inline when short (<=23 bytes) and so
+    /// contribute zero heap; only heap-backed (Arc-allocated) strings charge
+    /// their byte length.
     pub fn heap_size(&self) -> usize {
         match self {
-            Value::String(s) => s.len(),
+            Value::String(s) => {
+                if s.is_heap_allocated() {
+                    s.len()
+                } else {
+                    0
+                }
+            }
             Value::Array(arr) => {
                 arr.capacity() * std::mem::size_of::<Value>()
                     + arr.iter().map(Value::heap_size).sum::<usize>()
@@ -552,20 +561,35 @@ mod tests {
 
     #[test]
     fn test_value_heap_size_string() {
-        assert_eq!(Value::String("hello".into()).heap_size(), 5);
+        // Short strings (<=23 bytes) live inline in the SmolStr — zero heap.
+        assert_eq!(Value::String("hello".into()).heap_size(), 0);
         assert_eq!(Value::String("".into()).heap_size(), 0);
-        assert_eq!(
-            Value::String("a longer string value".into()).heap_size(),
-            21
-        );
+        // 21 bytes is still inline (<=23) — contributes no heap.
+        assert_eq!(Value::String("a longer string value".into()).heap_size(), 0);
+        // 23 bytes is the inline boundary — still no heap.
+        let boundary = "x".repeat(23);
+        assert!(!smol_str::SmolStr::new(&boundary).is_heap_allocated());
+        assert_eq!(Value::String(boundary.as_str().into()).heap_size(), 0);
+        // 24+ bytes spills to the Arc-backed heap repr — charges its byte length.
+        let heap_backed = "this string is definitely longer than twenty-three bytes";
+        assert_eq!(heap_backed.len(), 56);
+        assert!(smol_str::SmolStr::new(heap_backed).is_heap_allocated());
+        assert_eq!(Value::String(heap_backed.into()).heap_size(), 56);
     }
 
     #[test]
     fn test_value_heap_size_array() {
         let arr = Value::Array(vec![Value::Integer(1), Value::String("ab".into())]);
-        // Vec backing (capacity=2) + Integer heap (0) + String "ab" heap (2).
-        let expected = 2 * std::mem::size_of::<Value>() + 2;
+        // Vec backing (capacity=2) + Integer heap (0) + inline String "ab" heap (0).
+        let expected = 2 * std::mem::size_of::<Value>();
         assert_eq!(arr.heap_size(), expected);
+
+        // A heap-backed element string adds its byte length on top of the Vec backing.
+        let long = "an element string well past the inline boundary of smolstr";
+        assert!(smol_str::SmolStr::new(long).is_heap_allocated());
+        let arr2 = Value::Array(vec![Value::Integer(1), Value::String(long.into())]);
+        let expected2 = 2 * std::mem::size_of::<Value>() + long.len();
+        assert_eq!(arr2.heap_size(), expected2);
     }
 
     #[test]

--- a/crates/cxl/src/eval/builtins_impl.rs
+++ b/crates/cxl/src/eval/builtins_impl.rs
@@ -645,7 +645,9 @@ pub fn dispatch_method(
 
         // ── Map ─────────────────────────────────────────────────
         "keys" => Ok(Some(match receiver {
-            Value::Map(m) => Value::Array(m.keys().map(|k| Value::String(k.clone())).collect()),
+            Value::Map(m) => {
+                Value::Array(m.keys().map(|k| Value::String(k.as_ref().into())).collect())
+            }
             _ => Value::Null,
         })),
         "values" => Ok(Some(match receiver {
@@ -665,7 +667,9 @@ pub fn dispatch_method(
         "set" => Ok(Some(match (receiver, args.first(), args.get(1)) {
             (Value::Map(m), Some(Value::String(key)), Some(val)) => {
                 let mut out = (**m).clone();
-                out.insert(key.clone(), val.clone());
+                // Map keys are independent `Box<str>`; build one from the
+                // field-value string.
+                out.insert(Box::from(key.as_str()), val.clone());
                 Value::Map(Box::new(out))
             }
             _ => Value::Null,
@@ -673,7 +677,7 @@ pub fn dispatch_method(
         "remove_field" => Ok(Some(match (receiver, args.first()) {
             (Value::Map(m), Some(Value::String(key))) => {
                 let mut out = (**m).clone();
-                out.shift_remove(key.as_ref());
+                out.shift_remove(key.as_str());
                 Value::Map(Box::new(out))
             }
             _ => Value::Null,

--- a/crates/cxl/src/eval/context.rs
+++ b/crates/cxl/src/eval/context.rs
@@ -255,16 +255,16 @@ impl<'a> EvalContext<'a> {
     /// when the member name is not a builtin.
     pub fn resolve_source(&self, member: &str) -> Option<Value> {
         match member {
-            "file" => Some(Value::String(self.source_file.to_string().into())),
+            "file" => Some(Value::from(self.source_file.as_ref())),
             "row" => Some(Value::Integer(self.source_row as i64)),
-            "path" => Some(Value::String(self.source_path.to_string().into())),
+            "path" => Some(Value::from(self.source_path.as_ref())),
             "count" => Some(
                 self.source_count
                     .map_or(Value::Null, |n| Value::Integer(n as i64)),
             ),
-            "batch" => Some(Value::String(self.source_batch.to_string().into())),
+            "batch" => Some(Value::from(self.source_batch.as_ref())),
             "ingestion_timestamp" => Some(Value::DateTime(self.ingestion_timestamp)),
-            "name" => Some(Value::String(self.source_name.to_string().into())),
+            "name" => Some(Value::from(self.source_name.as_ref())),
             other => self.stable.resolve_source_var(self.source_file, other),
         }
     }

--- a/crates/cxl/src/eval/error.rs
+++ b/crates/cxl/src/eval/error.rs
@@ -204,9 +204,7 @@ impl EvalError {
 /// `triggering_value` column.
 pub fn extract_triggering_value(kind: &EvalErrorKind) -> Option<Value> {
     match kind {
-        EvalErrorKind::ConversionFailed { value, .. } => {
-            Some(Value::String(Box::<str>::from(value.as_str())))
-        }
+        EvalErrorKind::ConversionFailed { value, .. } => Some(Value::from(value.as_str())),
         EvalErrorKind::IndexOutOfBounds { index, .. } => Some(Value::Integer(*index)),
         EvalErrorKind::ArityMismatch { got, .. } => Some(Value::Integer(*got as i64)),
         EvalErrorKind::TypeMismatch { .. }
@@ -302,7 +300,7 @@ mod tests {
                 value: "not-a-number".to_string(),
                 target: "int",
             }),
-            Some(Value::String(Box::<str>::from("not-a-number")))
+            Some(Value::from("not-a-number"))
         );
         assert_eq!(
             extract_triggering_value(&EvalErrorKind::IndexOutOfBounds {

--- a/crates/cxl/src/eval/mod.rs
+++ b/crates/cxl/src/eval/mod.rs
@@ -1289,7 +1289,7 @@ pub fn eval_expr<'w, S: RecordStorage + 'w>(
                     }
                 }
                 (Value::Map(m), Value::String(key)) => {
-                    m.get(key.as_ref()).cloned().unwrap_or(Value::Null)
+                    m.get(key.as_str()).cloned().unwrap_or(Value::Null)
                 }
                 _ => Value::Null,
             })
@@ -1503,7 +1503,7 @@ fn literal_to_value(lit: &LiteralValue) -> Value {
     match lit {
         LiteralValue::Int(n) => Value::Integer(*n),
         LiteralValue::Float(f) => Value::Float(*f),
-        LiteralValue::String(s) => Value::String(s.clone()),
+        LiteralValue::String(s) => Value::String(s.as_ref().into()),
         LiteralValue::Date(d) => Value::Date(*d),
         LiteralValue::Bool(b) => Value::Bool(*b),
         LiteralValue::Null => Value::Null,


### PR DESCRIPTION
## What

Changes the in-memory representation of string field values from `Box<str>` to `smol_str::SmolStr` across the workspace. This is the single field-value string policy: every construction site, the spill deserialize site, and the group-key round-trip are converted in one commit; no `Box<str>` field-value path survives.

Closes #13.

## Why

Field values are the engine's millions-of-buffered-values hot type. As `Box<str>` they heap-allocate every non-empty string and deep-copy (alloc + memcpy) on every clone. The dominant ETL field shape is short — status codes, ids, ISO dates rendered as text, short categories — so `Box<str>` pays one allocation plus an allocator header per value, and an allocation + copy on every clone across stages and fan-out routes.

`SmolStr` stores values up to 23 bytes inline in the enum with **zero heap allocation**, and backs longer values with an `Arc<str>` so cloning a long string is an O(1) refcount bump rather than an allocation and copy.

## Results

Hot-path microbenchmarks (`clinker-record` `record_ops`, vs the base commit):

- record construction: **31% / 52% / 67% faster** at 5 / 20 / 50 columns
- record clone: **29–52% faster** across the measured shapes

Expression evaluation (`cxl` `eval`): flat to ~10% faster on the affected workloads (`eval_simple_emit`, `eval_numeric_chain`, `eval_conditional`). Parse / lex / typecheck (`cxl` `parse`): unchanged — identifiers in the parsed program are a separate, parse-once representation and were not touched.

One isolated microbenchmark — constructing a `Value::String` from an already-owned `String` — is slower, because `SmolStr` copies the bytes rather than adopting the `String`'s existing heap buffer the way `String::into_boxed_str` did. Real pipelines build field values from borrowed `&str` at the reader boundary, where the inline path is the win, so this does not appear on any hot path.

## No spill-wire change

Serialization is unchanged in behavior: `Value::String` still emits the `&str` bytes as length-prefixed UTF-8 under the same tagged-enum discriminant. Postcard output and the LZ4-compressed on-disk spill files are byte-identical before and after this change; a spill written by either version reloads in the other.

## Footprint note

`SmolStr` is 24 bytes wide with no spare niche, so `Value` grows from 24 to 32 bytes — one machine word. (The original assumption that it would fit inside the existing 24-byte slack did not hold; the size assertion is updated to 32.) The win is at the heap, not in the enum: a whole allocation plus allocator header is removed per short value, which is the term that moves the resident-memory and spill thresholds. The fixed-width admission cost model keys off `size_of::<Value>()` dynamically, so it tracks the wider slot with no code change.

`Value::heap_size` reflects the new reality: an inline (≤23-byte) string reports **0** heap bytes, and only a heap-backed (`Arc`-allocated) string reports its length. This keeps the spill-accounting figures (used by sort, hash-aggregate, grace-hash build, and combine) accurate for the short-string case the change optimizes, rather than over-charging inline values.

## Enforcement

The single-representation policy is enforced at the type level: `Value` provides `From<&str>`, `From<String>`, and `From<SmolStr>`, but deliberately **no** `From<Box<str>>`. A stray boxed-string field value therefore fails to compile rather than silently allocating.

Schema column names, map keys, and group-by keys intentionally remain `Box<str>` — they are parse-once key data, not the buffered-value hot path, and are a separate decision (the long-unique-field optimization is tracked in #372).

## Verification

Full CI gauntlet green on the closing commit: `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo check --benches --workspace`, `cargo check --features bench-alloc -p clinker-benchmarks`, `cargo test --benches -p clinker-benchmarks`, and `cargo deny check` (the new dependency is MIT OR Apache-2.0, pure Rust, zero advisories).

The fused-path in-flight memory bound (`transform_stream_fusion`) stays tight at input-channel + output-channel + one batch (`1024 + 256 + 64 = 1344` records). Repeated runs confirm the peak charged footprint holds within that ceiling, so inline short-string storage does **not** raise the in-flight peak; the bound is unchanged from the base.