### PR TITLE
perf(clinker-record): opt-in header-free storage for long-unique string fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,7 +402,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "smol_str",
  "tempfile",
 ]
 

--- a/crates/clinker-bench-support/Cargo.toml
+++ b/crates/clinker-bench-support/Cargo.toml
@@ -10,7 +10,6 @@ bench-alloc = []
 
 [dependencies]
 clinker-record = { workspace = true }
-smol_str = { workspace = true }
 fastrand = "2"
 blake3 = { workspace = true }
 glob = "0.3"

--- a/crates/clinker-bench-support/src/combine.rs
+++ b/crates/clinker-bench-support/src/combine.rs
@@ -9,8 +9,7 @@
 //! tunable probe-side overlap ratio (default 90%), and string non-key
 //! columns of deterministic length.
 
-use clinker_record::{Record, Schema, SchemaBuilder, Value};
-use smol_str::SmolStr;
+use clinker_record::{FieldStr, Record, Schema, SchemaBuilder, Value};
 use std::sync::Arc;
 
 /// Generates two correlated record sets for combine benchmarks.
@@ -73,7 +72,7 @@ impl CombineDataGen {
     /// Deterministically generate an ASCII-lowercase string from a row index
     /// and column index. Fixed length 8 — wide enough for unique-ish output
     /// within a bench but cheap to allocate.
-    fn det_string(row: usize, col: usize) -> SmolStr {
+    fn det_string(row: usize, col: usize) -> FieldStr {
         const LEN: usize = 8;
         let mut bytes = [0u8; LEN];
         // Mix row and col into a 32-bit lane, then peel off 5-bit (a-z +
@@ -86,7 +85,7 @@ impl CombineDataGen {
             mix = mix.rotate_left(7).wrapping_add(1);
         }
         // SAFETY: all bytes in [b'a', b'a' + 25], always valid ASCII.
-        SmolStr::new(unsafe { std::str::from_utf8_unchecked(&bytes) })
+        FieldStr::new(unsafe { std::str::from_utf8_unchecked(&bytes) })
     }
 
     /// Build a record with the given integer key and deterministic string

--- a/crates/clinker-bench-support/src/lib.rs
+++ b/crates/clinker-bench-support/src/lib.rs
@@ -15,8 +15,7 @@ pub mod combine;
 pub mod generators;
 pub mod io;
 
-use clinker_record::{Record, Schema, SchemaBuilder, Value};
-use smol_str::SmolStr;
+use clinker_record::{FieldStr, Record, Schema, SchemaBuilder, Value};
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -282,12 +281,12 @@ impl RecordFactory {
         (0..count).map(|_| self.next_record()).collect()
     }
 
-    fn random_string(&mut self) -> SmolStr {
+    fn random_string(&mut self) -> FieldStr {
         let bytes: Vec<u8> = (0..self.string_len)
             .map(|_| self.rng.u8(b'a'..=b'z'))
             .collect();
         // SAFETY: all bytes are ASCII a-z
-        SmolStr::new(unsafe { std::str::from_utf8_unchecked(&bytes) })
+        FieldStr::new(unsafe { std::str::from_utf8_unchecked(&bytes) })
     }
 }
 

--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -424,33 +424,61 @@ mod tests {
     }
 
     /// A `long_unique`-flagged column stores its values in the header-free
-    /// `Box`-backed arm; an unflagged column keeps the default policy.
+    /// `Box`-backed arm; an unflagged column keeps the default `Arc`-shared
+    /// policy. The two arms are distinguished here through observable clone
+    /// semantics rather than an internal arm probe: a unique-arm `FieldStr`
+    /// deep-copies its bytes on clone (a fresh allocation, a distinct `str`
+    /// pointer), whereas the default `Arc`-shared arm bumps a refcount and the
+    /// clone aliases the original allocation (pointer-identical `str`). Both
+    /// values exceed the 23-byte inline boundary, so neither lands inline.
     #[test]
     fn test_long_unique_column_lands_in_unique_arm() {
-        let schema = vec![col_unique("uuid", Type::String), col("name", Type::String)];
+        let schema = vec![
+            col_unique("uuid", Type::String),
+            col("name_uuid", Type::String),
+        ];
         let uuid = "550e8400-e29b-41d4-a716-446655440000";
-        let reader = csv_reader(&format!("uuid,name\n{uuid},Alice\n"));
+        let name = "7c9e6679-7425-40de-944b-e07fc1f90ae7";
+        let reader = csv_reader(&format!("uuid,name_uuid\n{uuid},{name}\n"));
         let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
 
         let rec = coercing.next_record().unwrap().unwrap();
         match rec.get("uuid") {
             Some(Value::String(s)) => {
                 assert_eq!(s.as_str(), uuid);
-                assert!(s.is_unique(), "flagged column must take the unique arm");
+                assert!(s.heap_size() > 0, "a 36-byte UUID is never inline");
+                // Unique arm: a clone deep-copies into a fresh allocation, so
+                // the clone's backing `str` lives at a different address.
+                let cloned = s.clone();
+                assert_eq!(cloned.as_str(), s.as_str());
+                assert_ne!(
+                    cloned.as_str().as_ptr(),
+                    s.as_str().as_ptr(),
+                    "the flagged column's value must take the deep-copying unique arm"
+                );
             }
             other => panic!("expected String, got {other:?}"),
         }
-        // The unflagged neighbor keeps the default policy.
-        match rec.get("name") {
+        // The unflagged neighbor keeps the default `Arc`-shared policy: cloning
+        // shares the allocation, so the clone's `str` is pointer-identical.
+        match rec.get("name_uuid") {
             Some(Value::String(s)) => {
-                assert!(!s.is_unique(), "unflagged column must keep the default arm")
+                assert!(s.heap_size() > 0, "a 36-byte UUID is never inline");
+                let cloned = s.clone();
+                assert_eq!(
+                    cloned.as_str().as_ptr(),
+                    s.as_str().as_ptr(),
+                    "the unflagged column must keep the Arc-shared default arm"
+                );
             }
             other => panic!("expected String, got {other:?}"),
         }
     }
 
-    /// The default (no flag) leaves every string in the default arm — the
-    /// pre-existing behavior is byte-for-byte unchanged.
+    /// The default (no flag) leaves every string in the `Arc`-shared default
+    /// arm — the pre-existing behavior is byte-for-byte unchanged. Observed
+    /// through clone aliasing: a default-arm clone shares the original's
+    /// allocation rather than deep-copying as the unique arm would.
     #[test]
     fn test_unflagged_columns_keep_default_arm() {
         let schema = vec![col("uuid", Type::String)];
@@ -460,7 +488,15 @@ mod tests {
 
         let rec = coercing.next_record().unwrap().unwrap();
         match rec.get("uuid") {
-            Some(Value::String(s)) => assert!(!s.is_unique()),
+            Some(Value::String(s)) => {
+                assert!(s.heap_size() > 0, "a 36-byte UUID is never inline");
+                let cloned = s.clone();
+                assert_eq!(
+                    cloned.as_str().as_ptr(),
+                    s.as_str().as_ptr(),
+                    "an unflagged column clone must alias the Arc-shared allocation"
+                );
+            }
             other => panic!("expected String, got {other:?}"),
         }
     }

--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -54,6 +54,13 @@ pub struct CoercingReader {
     /// slot, when present, gets `None` (no coercion — payload is a
     /// `Value::Map`).
     targets: Vec<Option<Type>>,
+    /// Per-output-column `long_unique` storage hint, indexed alongside
+    /// `targets`. When set for a column, its string values are stored in
+    /// the header-free `Box`-backed [`FieldStr`](clinker_record::FieldStr)
+    /// arm rather than the default inline-or-`Arc`-shared one. The `$widened`
+    /// sidecar slot is always `false` (its payload is a `Value::Map`, never a
+    /// top-level string).
+    long_unique: Vec<bool>,
     /// Position of the `$widened` sidecar column in `output_schema`,
     /// or `None` for `Drop` / `Reject` policies (no sidecar slot).
     widened_idx: Option<usize>,
@@ -87,6 +94,7 @@ impl CoercingReader {
                 }
             })
             .collect();
+        let mut long_unique: Vec<bool> = schema_decl.iter().map(|c| c.long_unique).collect();
 
         let mut builder = SchemaBuilder::new();
         for c in schema_decl {
@@ -101,6 +109,7 @@ impl CoercingReader {
             builder =
                 builder.with_field_meta(WIDENED_SIDECAR_COLUMN, FieldMetadata::widened_sidecar());
             targets.push(None);
+            long_unique.push(false);
             Some(idx)
         } else {
             None
@@ -112,6 +121,7 @@ impl CoercingReader {
             declared_names,
             output_schema,
             targets,
+            long_unique,
             widened_idx,
             policy,
             source_name: source_name.into(),
@@ -159,7 +169,20 @@ impl CoercingReader {
                 Some(target) => coerce_value(&raw, target).unwrap_or(raw),
                 None => raw,
             };
-            values.push(coerced);
+            // Honor the column's `long_unique` storage hint: rebuild a string
+            // value in the header-free `Box`-backed arm. Coercion runs first, so
+            // a column declared `string` (coercion target `None`) is the usual
+            // case; a value that failed numeric coercion and fell back to its
+            // string form is also re-homed. Non-string values are untouched.
+            let stored = if self.long_unique[i] {
+                match coerced {
+                    Value::String(s) => Value::string_unique(s.as_str()),
+                    other => other,
+                }
+            } else {
+                coerced
+            };
+            values.push(stored);
         }
         Ok(Record::new(Arc::clone(&self.output_schema), values))
     }
@@ -239,6 +262,15 @@ mod tests {
         ColumnDecl {
             name: name.to_string(),
             ty,
+            long_unique: false,
+        }
+    }
+
+    fn col_unique(name: &str, ty: Type) -> ColumnDecl {
+        ColumnDecl {
+            name: name.to_string(),
+            ty,
+            long_unique: true,
         }
     }
 
@@ -389,6 +421,60 @@ mod tests {
 
         let rec = coercing.next_record().unwrap().unwrap();
         assert_eq!(rec.get(WIDENED_SIDECAR_COLUMN), Some(&Value::Null));
+    }
+
+    /// A `long_unique`-flagged column stores its values in the header-free
+    /// `Box`-backed arm; an unflagged column keeps the default policy.
+    #[test]
+    fn test_long_unique_column_lands_in_unique_arm() {
+        let schema = vec![col_unique("uuid", Type::String), col("name", Type::String)];
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let reader = csv_reader(&format!("uuid,name\n{uuid},Alice\n"));
+        let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
+
+        let rec = coercing.next_record().unwrap().unwrap();
+        match rec.get("uuid") {
+            Some(Value::String(s)) => {
+                assert_eq!(s.as_str(), uuid);
+                assert!(s.is_unique(), "flagged column must take the unique arm");
+            }
+            other => panic!("expected String, got {other:?}"),
+        }
+        // The unflagged neighbor keeps the default policy.
+        match rec.get("name") {
+            Some(Value::String(s)) => {
+                assert!(!s.is_unique(), "unflagged column must keep the default arm")
+            }
+            other => panic!("expected String, got {other:?}"),
+        }
+    }
+
+    /// The default (no flag) leaves every string in the default arm — the
+    /// pre-existing behavior is byte-for-byte unchanged.
+    #[test]
+    fn test_unflagged_columns_keep_default_arm() {
+        let schema = vec![col("uuid", Type::String)];
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let reader = csv_reader(&format!("uuid\n{uuid}\n"));
+        let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
+
+        let rec = coercing.next_record().unwrap().unwrap();
+        match rec.get("uuid") {
+            Some(Value::String(s)) => assert!(!s.is_unique()),
+            other => panic!("expected String, got {other:?}"),
+        }
+    }
+
+    /// A `long_unique` flag on a non-string column is inert: numeric coercion
+    /// runs and the value is not a string, so nothing is re-homed.
+    #[test]
+    fn test_long_unique_inert_on_numeric_column() {
+        let schema = vec![col_unique("n", Type::Int)];
+        let reader = csv_reader("n\n42\n");
+        let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
+
+        let rec = coercing.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("n"), Some(&Value::Integer(42)));
     }
 
     /// Fixed-width sources are structurally incapable of producing

--- a/crates/clinker-exec/tests/long_unique_column.rs
+++ b/crates/clinker-exec/tests/long_unique_column.rs
@@ -1,0 +1,327 @@
+//! End-to-end coverage for the `long_unique` per-column storage hint.
+//!
+//! A column flagged `long_unique` in the source `schema:` block stores its
+//! string values in the header-free `Box`-backed `FieldStr` arm rather than
+//! the default inline-or-`Arc`-shared arm. The flag is a footprint
+//! optimization only: a value in the unique arm must compare, group, join, and
+//! sort identically to an equal-content value in any other arm. These tests
+//! drive that equivalence through real operators — group-by, distinct, and a
+//! cross-source join where one side's key is unique-arm and the other side's
+//! is default-arm — and confirm the on-disk output encoding is unaffected.
+
+use std::collections::HashMap;
+use std::io::{Cursor, Write};
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{ExecutionReport, PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// 36-char UUIDs — past the 23-byte inline boundary, so the default arm is
+/// `Arc`-backed and the flagged arm is `Box`-backed (both heap, no inline).
+const UUID_A: &str = "3f29c4b1-8a6e-4d2f-9c17-0b5e8a1d6e42";
+const UUID_B: &str = "a7e3f10c-5b29-4e6d-8f41-2c9a0d7b3e15";
+const UUID_C: &str = "c2b8d6a4-1f37-4a90-b5e2-8d0c4f6a9b71";
+
+fn assert_long(values: &[&str]) {
+    for v in values {
+        assert!(
+            v.len() > 23,
+            "fixture value {v:?} is {} bytes — must exceed the 23-byte inline \
+             boundary so the unique vs shared arm distinction is exercised",
+            v.len()
+        );
+    }
+}
+
+fn run_params(id: &str) -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: id.to_string(),
+        batch_id: format!("{id}-batch"),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+fn run_pipeline(
+    yaml: &str,
+    inputs: &[(&str, &str)],
+    output_name: &str,
+    id: &str,
+) -> (ExecutionReport, String) {
+    let config = parse_config(yaml).expect("fixture pipeline must parse");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("fixture pipeline must compile");
+
+    let readers: SourceReaders = inputs
+        .iter()
+        .map(|(name, csv)| {
+            (
+                (*name).to_string(),
+                clinker_exec::executor::single_file_reader(
+                    format!("{name}.csv"),
+                    Box::new(Cursor::new(csv.as_bytes().to_vec())),
+                ),
+            )
+        })
+        .collect();
+
+    let sink = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        output_name.to_string(),
+        Box::new(sink.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params(id))
+            .expect("pipeline must run to completion");
+    (report, sink.as_string())
+}
+
+fn sorted_body(output: &str) -> Vec<String> {
+    let mut lines: Vec<String> = output.lines().skip(1).map(str::to_string).collect();
+    lines.sort();
+    lines
+}
+
+/// Grouping by a `long_unique`-flagged UUID column produces one row per
+/// distinct UUID with correct counts. Proves the unique-arm value round-trips
+/// through `GroupByKey::Str` with content equality intact — the storage arm is
+/// invisible to grouping.
+#[test]
+fn group_by_long_unique_key_exact_counts() {
+    assert_long(&[UUID_A, UUID_B]);
+
+    let yaml = r#"
+pipeline:
+  name: long_unique_group_by
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - { name: agent_uuid, type: string, long_unique: true }
+        - { name: region, type: string }
+  - type: aggregate
+    name: agg
+    input: src
+    config:
+      group_by: [agent_uuid]
+      cxl: |
+        emit agent_uuid = agent_uuid
+        emit ticket_count = count(*)
+  - type: output
+    name: out
+    input: agg
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+    // UUID_A appears 3x, UUID_B 2x. Grouping on the unique-arm key must
+    // collapse equal UUIDs together exactly as the default arm would.
+    let csv = format!(
+        "agent_uuid,region\n\
+         {UUID_A},east\n\
+         {UUID_B},west\n\
+         {UUID_A},east\n\
+         {UUID_A},east\n\
+         {UUID_B},west\n"
+    );
+    let (report, output) = run_pipeline(yaml, &[("src", &csv)], "out", "lu-group");
+    assert_eq!(report.counters.dlq_count, 0);
+    assert_eq!(report.counters.ok_count, 2, "two distinct agent UUIDs");
+
+    assert_eq!(
+        sorted_body(&output),
+        vec![format!("{UUID_A},3"), format!("{UUID_B},2")],
+        "grouping on a long_unique key must produce the same counts as any arm"
+    );
+}
+
+/// A cross-source join where the build side's key column is flagged
+/// `long_unique` and the probe side's identical key column is the default arm.
+/// Equal UUID content from different arms must match — the load-bearing safety
+/// guarantee that the arm is a footprint hint, not a value domain. Run through
+/// an actual Combine equi-join.
+#[test]
+fn join_unique_arm_build_against_default_arm_probe() {
+    assert_long(&[UUID_A, UUID_B, UUID_C]);
+
+    let yaml = r#"
+pipeline:
+  name: long_unique_join
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: tickets
+    config:
+      name: tickets
+      type: csv
+      path: tickets.csv
+      schema:
+        - { name: ticket_id, type: string }
+        - { name: agent_uuid, type: string }
+  - type: source
+    name: agents
+    config:
+      name: agents
+      type: csv
+      path: agents.csv
+      schema:
+        - { name: agent_uuid, type: string, long_unique: true }
+        - { name: agent_name, type: string }
+  - type: combine
+    name: joined
+    input:
+      t: tickets
+      a: agents
+    config:
+      where: "t.agent_uuid == a.agent_uuid"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit ticket_id = t.ticket_id
+        emit agent_uuid = t.agent_uuid
+        emit agent_name = a.agent_name
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+    // agents.agent_uuid is unique-arm; tickets.agent_uuid is default-arm.
+    // The join keys must match across arms for equal UUID content.
+    let agents = format!(
+        "agent_uuid,agent_name\n\
+         {UUID_A},Ada\n\
+         {UUID_B},Boris\n"
+    );
+    let tickets = format!(
+        "ticket_id,agent_uuid\n\
+         T1,{UUID_A}\n\
+         T2,{UUID_B}\n\
+         T3,{UUID_A}\n\
+         T4,{UUID_C}\n"
+    );
+    let (report, output) = run_pipeline(
+        yaml,
+        &[("tickets", &tickets), ("agents", &agents)],
+        "out",
+        "lu-join",
+    );
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // T4 (UUID_C) has no matching agent and is skipped (`on_miss: skip`). The
+    // three matching tickets pair with their agent across the arm boundary.
+    assert_eq!(
+        sorted_body(&output),
+        vec![
+            format!("T1,{UUID_A},Ada"),
+            format!("T2,{UUID_B},Boris"),
+            format!("T3,{UUID_A},Ada"),
+        ],
+        "a default-arm probe key must match a unique-arm build key on equal content"
+    );
+}
+
+/// Distinct over a `long_unique` column deduplicates by content, not arm:
+/// repeated UUIDs collapse to one row each. Proves distinct keying is
+/// arm-agnostic end to end.
+#[test]
+fn distinct_long_unique_dedupes_by_content() {
+    assert_long(&[UUID_A, UUID_B]);
+
+    let yaml = r#"
+pipeline:
+  name: long_unique_distinct
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - { name: agent_uuid, type: string, long_unique: true }
+  - type: transform
+    name: dedup
+    input: src
+    config:
+      cxl: |
+        emit agent_uuid = agent_uuid
+        distinct by agent_uuid
+  - type: output
+    name: out
+    input: dedup
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+    let csv = format!(
+        "agent_uuid\n\
+         {UUID_A}\n\
+         {UUID_B}\n\
+         {UUID_A}\n\
+         {UUID_A}\n\
+         {UUID_B}\n"
+    );
+    let (report, output) = run_pipeline(yaml, &[("src", &csv)], "out", "lu-distinct");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    assert_eq!(
+        sorted_body(&output),
+        vec![UUID_A.to_string(), UUID_B.to_string()],
+        "distinct over a long_unique column must dedupe by content"
+    );
+}
+
+/// The unique-arm value survives the CSV output path byte-exact — the arm is
+/// invisible to the writer, which serializes the underlying `str`.
+#[test]
+fn long_unique_value_round_trips_to_output_byte_exact() {
+    let note = "a free-text comment that is comfortably past the inline boundary";
+    assert!(note.len() > 23);
+
+    let yaml = r#"
+pipeline:
+  name: long_unique_passthrough
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - { name: note, type: string, long_unique: true }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+    let csv = format!("note\n{note}\n");
+    let (report, output) = run_pipeline(yaml, &[("src", &csv)], "out", "lu-passthrough");
+    assert_eq!(report.counters.dlq_count, 0);
+    assert_eq!(sorted_body(&output), vec![note.to_string()]);
+}

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -775,6 +775,18 @@ pub struct ColumnDecl {
     pub name: String,
     #[serde(rename = "type")]
     pub ty: cxl::typecheck::Type,
+    /// Advisory storage hint: when set, the reader stores this column's string
+    /// values in the header-free `Box`-backed representation rather than the
+    /// default inline-or-`Arc`-shared one. Intended for high-cardinality
+    /// free-text columns whose values are long and effectively unique (UUIDs,
+    /// street addresses, comment fields), where the per-value `Arc` refcount
+    /// header is pure overhead because there is no sharing to amortize it
+    /// against. Opt-in and purely advisory — it changes the in-memory footprint
+    /// only; the value's content, comparison/grouping semantics, and on-disk
+    /// spill encoding are all unchanged. Omitting the key (the common case)
+    /// leaves the default policy and serializes to byte-identical YAML.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub long_unique: bool,
 }
 
 /// Policy for fields a reader discovers in an input record that the
@@ -2081,5 +2093,91 @@ nodes:
             .expect("aggregate node present");
         assert!(aggregate_body.time_window.is_none());
         assert!(aggregate_body.allowed_lateness.is_none());
+    }
+
+    /// Extract the declared columns of the first source node in a parsed
+    /// pipeline document.
+    fn source_columns(doc: &crate::config::PipelineConfig) -> &[ColumnDecl] {
+        doc.nodes
+            .iter()
+            .find_map(|spanned| match &spanned.value {
+                PipelineNode::Source { config, .. } => Some(config.schema.columns.as_slice()),
+                _ => None,
+            })
+            .expect("source node present")
+    }
+
+    /// The `long_unique` flag parses from the column declaration when present.
+    #[test]
+    fn column_decl_long_unique_flag_parses() {
+        let yaml = r#"
+pipeline:
+  name: lu_parse
+nodes:
+  - type: source
+    name: raw
+    config:
+      name: raw
+      type: csv
+      path: data.csv
+      schema:
+        - { name: uuid, type: string, long_unique: true }
+        - { name: name, type: string }
+"#;
+        let doc: crate::config::PipelineConfig =
+            crate::yaml::from_str(yaml).expect("pipeline parses");
+        let cols = source_columns(&doc);
+        assert!(cols[0].long_unique, "flagged column carries the hint");
+        assert!(!cols[1].long_unique, "unflagged column defaults false");
+    }
+
+    /// Omitting the flag defaults it to false — the pre-existing YAML shape is
+    /// unchanged, so existing schemas keep parsing identically.
+    #[test]
+    fn column_decl_long_unique_defaults_false() {
+        let yaml = r#"
+pipeline:
+  name: lu_default
+nodes:
+  - type: source
+    name: raw
+    config:
+      name: raw
+      type: csv
+      path: data.csv
+      schema:
+        - { name: uuid, type: string }
+"#;
+        let doc: crate::config::PipelineConfig =
+            crate::yaml::from_str(yaml).expect("pipeline parses");
+        assert!(!source_columns(&doc)[0].long_unique);
+    }
+
+    /// A `false` flag serializes to byte-identical output as a column that
+    /// never carried the key — the `skip_serializing_if` keeps un-tagged
+    /// columns wire-identical to pre-flag schemas.
+    #[test]
+    fn column_decl_unflagged_serializes_without_key() {
+        let plain = ColumnDecl {
+            name: "uuid".to_string(),
+            ty: cxl::typecheck::Type::String,
+            long_unique: false,
+        };
+        let json = serde_json::to_string(&plain).expect("serialize");
+        assert!(
+            !json.contains("long_unique"),
+            "an unflagged column must not emit the long_unique key, got: {json}"
+        );
+
+        let flagged = ColumnDecl {
+            name: "uuid".to_string(),
+            ty: cxl::typecheck::Type::String,
+            long_unique: true,
+        };
+        let json = serde_json::to_string(&flagged).expect("serialize");
+        assert!(
+            json.contains("long_unique"),
+            "a flagged column must emit the key, got: {json}"
+        );
     }
 }

--- a/crates/clinker-record/src/field_str.rs
+++ b/crates/clinker-record/src/field_str.rs
@@ -1,0 +1,633 @@
+//! A 24-byte field-value string with three storage arms behind one `str` API.
+//!
+//! `Value::String` is the dominant payload in an ETL record stream, so its
+//! width sets the per-`Value` byte cost that drives the RSS / spill threshold.
+//! `FieldStr` keeps that width at 24 bytes — the same as `smol_str::SmolStr`,
+//! so `Value` stays 32 bytes — while supporting three representations:
+//!
+//! - **inline** — values up to [`INLINE_CAP`] bytes live in the struct with
+//!   zero heap allocation (the dominant short-field shape: ids, codes, flags);
+//! - **shared** — longer values that repeat or are cloned across stages
+//!   (fan-out, group-by, joins) are `Arc<str>`-backed, so a clone is an O(1)
+//!   refcount bump rather than an allocation + copy;
+//! - **unique** — longer values flagged long-and-unique by the source schema
+//!   are `Box<str>`-backed, dropping the ~16-byte `Arc` strong/weak refcount
+//!   header that is pure overhead when a value never repeats (UUIDs, street
+//!   addresses, free-text notes).
+//!
+//! The arm is an in-memory storage hint only: all access is through the `str`
+//! the value denotes (via [`Deref`], [`as_str`](FieldStr::as_str), and the
+//! `str`-delegating `Eq`/`Ord`/`Hash`/`Display`), so a shared and a unique
+//! `FieldStr` of equal content compare, sort, hash, and group/join as equal.
+//! That equivalence is what lets the unique arm be a transparent per-column
+//! footprint optimization rather than a new value domain.
+//!
+//! # Layout & niche
+//!
+//! The three arms share one 24-byte footprint via a private union discriminated
+//! by the trailing byte. The inline arm stores its length there (`0..=INLINE_CAP`);
+//! the two heap arms use the sentinel tags [`TAG_SHARED`] and [`TAG_UNIQUE`],
+//! which are chosen above `INLINE_CAP` so they can never collide with a valid
+//! inline length. This is `FieldStr`'s own niche — it owns the tag byte outright
+//! rather than borrowing spare bits from `smol_str`'s private `InlineSize` enum,
+//! whose layout `#[repr]` does not stabilize and which exposes no public spare
+//! niche. Owning the niche keeps the unsafe self-contained and auditable here.
+
+use std::borrow::Borrow;
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::mem::ManuallyDrop;
+use std::ops::Deref;
+use std::sync::Arc;
+
+/// Maximum number of bytes stored inline (without heap allocation).
+///
+/// The 24-byte footprint spends its trailing byte on the discriminant, leaving
+/// 23 bytes for inline data — matching `smol_str`'s inline capacity, so swapping
+/// `SmolStr` for `FieldStr` does not change which values stay off the heap.
+pub const INLINE_CAP: usize = 23;
+
+/// Trailing-byte tag marking the `Arc<str>`-backed shared arm. Above
+/// [`INLINE_CAP`] so it never aliases a valid inline length.
+const TAG_SHARED: u8 = 0xFF;
+
+/// Trailing-byte tag marking the `Box<str>`-backed unique arm. Above
+/// [`INLINE_CAP`] so it never aliases a valid inline length.
+const TAG_UNIQUE: u8 = 0xFE;
+
+/// Inline arm: `len` bytes of UTF-8 in `data`, with the discriminant byte at
+/// `data[INLINE_CAP]` holding `len` (always `<= INLINE_CAP`, hence `< TAG_*`).
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct Inline {
+    data: [u8; INLINE_CAP],
+    /// Doubles as length (inline) and discriminant: `<= INLINE_CAP` means
+    /// inline; `TAG_SHARED` / `TAG_UNIQUE` select a heap arm.
+    tag: u8,
+}
+
+/// A heap arm's leading fat-pointer fields. `ptr`/`len` describe the backing
+/// `str`; `tag` (at the same trailing-byte offset as [`Inline::tag`]) selects
+/// shared vs unique. The owning smart pointer (`Arc<str>` or `Box<str>`) is
+/// reconstructed from `ptr`/`len` for deref, clone, and drop.
+#[derive(Clone, Copy)]
+#[repr(C)]
+struct HeapHeader {
+    ptr: *const u8,
+    len: usize,
+    /// Padding so `tag` lands at byte offset [`INLINE_CAP`], overlapping
+    /// [`Inline::tag`]. `ptr` (8) + `len` (8) = 16 bytes; 7 padding bytes carry
+    /// the offset to 23, then `tag` at 23.
+    _pad: [u8; INLINE_CAP - 2 * std::mem::size_of::<usize>()],
+    tag: u8,
+}
+
+/// 24-byte union of the inline and heap representations, discriminated by the
+/// trailing `tag` byte both arms share at offset [`INLINE_CAP`].
+#[repr(C)]
+union Repr {
+    inline: Inline,
+    heap: HeapHeader,
+}
+
+/// A field-value string stored inline, `Arc`-shared, or `Box`-unique behind a
+/// single `str` API. 24 bytes wide; see the module docs for the layout and the
+/// arm-as-storage-hint equivalence guarantee.
+pub struct FieldStr {
+    repr: Repr,
+}
+
+// SAFETY: `FieldStr` owns either inline bytes, an `Arc<str>`, or a `Box<str>`.
+// All three are `Send`/`Sync` (`Arc<str>: Send + Sync`, `Box<str>: Send + Sync`),
+// and the raw `*const u8` is only ever reconstituted back into its owning smart
+// pointer, never shared as a bare pointer, so the auto-trait reasoning matches
+// the owned-pointer arms. The inline arm holds only `Copy` bytes.
+unsafe impl Send for FieldStr {}
+// SAFETY: see the `Send` impl — every arm's backing storage is `Sync` and
+// access is read-only through `&str` once constructed.
+unsafe impl Sync for FieldStr {}
+
+const _: () = {
+    // The whole design rests on the 24-byte footprint: a wider `FieldStr` would
+    // push `Value` past 32 bytes and inflate the per-`Value` cost model.
+    assert!(std::mem::size_of::<FieldStr>() == 24);
+    // The discriminant byte must occupy the same offset in both arms, so reading
+    // `tag` through either union field always reads the live discriminant. Both
+    // arms are `#[repr(C)]` with `tag` last; this pins that they coincide.
+    assert!(std::mem::offset_of!(Inline, tag) == INLINE_CAP);
+    assert!(std::mem::offset_of!(HeapHeader, tag) == INLINE_CAP);
+    // The two heap tags must sit outside the inline-length range so the
+    // discriminant is unambiguous.
+    assert!(TAG_SHARED as usize > INLINE_CAP);
+    assert!(TAG_UNIQUE as usize > INLINE_CAP);
+};
+
+impl FieldStr {
+    /// Constructs a `FieldStr` choosing inline storage when the value fits,
+    /// otherwise the `Arc`-shared arm. This is the default policy: identical
+    /// to `smol_str`'s inline-or-shared split, so default-constructed field
+    /// values keep their pre-existing heap behavior byte-for-byte.
+    #[inline]
+    pub fn new(s: &str) -> Self {
+        if s.len() <= INLINE_CAP {
+            Self::new_inline(s)
+        } else {
+            Self::new_shared(s)
+        }
+    }
+
+    /// Constructs the inline arm. Caller guarantees `s.len() <= INLINE_CAP`.
+    #[inline]
+    fn new_inline(s: &str) -> Self {
+        debug_assert!(s.len() <= INLINE_CAP);
+        let mut data = [0u8; INLINE_CAP];
+        data[..s.len()].copy_from_slice(s.as_bytes());
+        FieldStr {
+            repr: Repr {
+                inline: Inline {
+                    data,
+                    tag: s.len() as u8,
+                },
+            },
+        }
+    }
+
+    /// Constructs the `Arc`-shared arm unconditionally (no inline fast path),
+    /// allocating a fresh `Arc<str>`.
+    #[inline]
+    fn new_shared(s: &str) -> Self {
+        Self::from_arc(Arc::from(s))
+    }
+
+    /// Wraps an existing `Arc<str>` into the shared arm without re-allocating,
+    /// preserving refcount sharing with any other holder of that `Arc`.
+    #[inline]
+    fn from_arc(arc: Arc<str>) -> Self {
+        let len = arc.len();
+        // Hand the allocation's ownership to the raw pointer; `Drop` /`Clone`
+        // reconstitute the `Arc` from `ptr`/`len`.
+        let ptr = Arc::into_raw(arc) as *const u8;
+        FieldStr {
+            repr: Repr {
+                heap: HeapHeader {
+                    ptr,
+                    len,
+                    _pad: [0; INLINE_CAP - 2 * std::mem::size_of::<usize>()],
+                    tag: TAG_SHARED,
+                },
+            },
+        }
+    }
+
+    /// Constructs the header-free `Box`-unique arm.
+    ///
+    /// Intended for source columns a schema flags long-and-unique: the value
+    /// never repeats, so the `Arc` refcount header would be pure overhead.
+    /// Short values still take the unique arm here (no inline fast path) — the
+    /// flag is an explicit author assertion that this column's values are long,
+    /// and honoring it verbatim keeps the arm's footprint predictable.
+    #[inline]
+    pub fn new_unique(s: &str) -> Self {
+        Self::from_box(Box::from(s))
+    }
+
+    /// Wraps an existing `Box<str>` into the unique arm without re-allocating.
+    #[inline]
+    fn from_box(boxed: Box<str>) -> Self {
+        let len = boxed.len();
+        let ptr = Box::into_raw(boxed) as *const u8;
+        FieldStr {
+            repr: Repr {
+                heap: HeapHeader {
+                    ptr,
+                    len,
+                    _pad: [0; INLINE_CAP - 2 * std::mem::size_of::<usize>()],
+                    tag: TAG_UNIQUE,
+                },
+            },
+        }
+    }
+
+    /// Returns the discriminant byte both arms share at offset [`INLINE_CAP`].
+    #[inline]
+    fn tag(&self) -> u8 {
+        // SAFETY: `tag` lives at the same `#[repr(C)]` offset in both union
+        // arms (`Inline::tag` and `HeapHeader::tag`), so reading it through
+        // either field is well-defined regardless of which arm is active.
+        unsafe { self.repr.inline.tag }
+    }
+
+    /// Borrows the value as a `str`. The single read path for every arm.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        let tag = self.tag();
+        if tag <= INLINE_CAP as u8 {
+            // SAFETY: inline arm — `tag` is the byte length (`<= INLINE_CAP`),
+            // and `new_inline` only ever copies valid UTF-8 into `data[..len]`.
+            unsafe {
+                let inline = &self.repr.inline;
+                std::str::from_utf8_unchecked(&inline.data[..tag as usize])
+            }
+        } else {
+            // SAFETY: heap arm — `ptr`/`len` were produced by `Arc::into_raw` /
+            // `Box::into_raw` on a `str`, so the bytes are live, owned by this
+            // `FieldStr`, and valid UTF-8 for `len` bytes. The borrow is tied to
+            // `&self`, so the allocation outlives the returned `&str`.
+            unsafe {
+                let heap = &self.repr.heap;
+                let bytes = std::slice::from_raw_parts(heap.ptr, heap.len);
+                std::str::from_utf8_unchecked(bytes)
+            }
+        }
+    }
+
+    /// Heap bytes owned by this value, excluding the 24-byte `FieldStr` itself.
+    ///
+    /// Inline values own no heap (`0`). Both heap arms charge their UTF-8 byte
+    /// length; the model deliberately ignores the `Arc` header for the shared
+    /// arm (consistent with the pre-existing `SmolStr` accounting) and the unique
+    /// arm has no header to charge. Drives `SortBuffer`'s self-tracking budget.
+    #[inline]
+    pub fn heap_size(&self) -> usize {
+        if self.tag() <= INLINE_CAP as u8 {
+            0
+        } else {
+            // SAFETY: heap arm — `len` is valid in both heap representations.
+            unsafe { self.repr.heap.len }
+        }
+    }
+
+    /// Returns true when the value is stored in the header-free unique arm
+    /// rather than the default inline-or-`Arc`-shared one. Lets the reader and
+    /// its tests confirm a schema-flagged column landed in the intended
+    /// representation; the arm is otherwise invisible through the `str` API.
+    #[inline]
+    pub fn is_unique(&self) -> bool {
+        self.tag() == TAG_UNIQUE
+    }
+}
+
+impl Drop for FieldStr {
+    fn drop(&mut self) {
+        let tag = self.tag();
+        if tag == TAG_SHARED {
+            // SAFETY: the shared arm owns one `Arc<str>` strong count produced by
+            // `Arc::into_raw`. Reconstitute the fat pointer from `ptr`/`len` and
+            // let the `Arc` drop, releasing exactly that one count.
+            unsafe {
+                let heap = self.repr.heap;
+                let slice = std::ptr::slice_from_raw_parts(heap.ptr, heap.len) as *const str;
+                drop(Arc::from_raw(slice));
+            }
+        } else if tag == TAG_UNIQUE {
+            // SAFETY: the unique arm owns one `Box<str>` produced by
+            // `Box::into_raw`. Reconstitute and drop it, freeing the allocation.
+            unsafe {
+                let heap = self.repr.heap;
+                let slice =
+                    std::ptr::slice_from_raw_parts_mut(heap.ptr as *mut u8, heap.len) as *mut str;
+                drop(Box::from_raw(slice));
+            }
+        }
+        // Inline arm owns no heap — nothing to release.
+    }
+}
+
+impl Clone for FieldStr {
+    fn clone(&self) -> Self {
+        let tag = self.tag();
+        if tag <= INLINE_CAP as u8 {
+            // SAFETY: inline arm holds only `Copy` bytes; bitwise copy is sound.
+            FieldStr {
+                repr: Repr {
+                    inline: unsafe { self.repr.inline },
+                },
+            }
+        } else if tag == TAG_SHARED {
+            // SAFETY: shared arm — reconstitute the `Arc` to bump its strong
+            // count, then re-leak both the original (via `ManuallyDrop`, so this
+            // borrow does not release a count) and the clone.
+            unsafe {
+                let heap = self.repr.heap;
+                let slice = std::ptr::slice_from_raw_parts(heap.ptr, heap.len) as *const str;
+                let arc = ManuallyDrop::new(Arc::from_raw(slice));
+                let cloned: Arc<str> = Arc::clone(&arc);
+                Self::from_arc(cloned)
+            }
+        } else {
+            // Unique arm has no shared ownership to bump — a clone deep-copies
+            // the bytes into a fresh `Box<str>`, preserving the unique arm.
+            Self::from_box(Box::from(self.as_str()))
+        }
+    }
+}
+
+impl Deref for FieldStr {
+    type Target = str;
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl AsRef<str> for FieldStr {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl Borrow<str> for FieldStr {
+    #[inline]
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
+}
+
+// ── str-delegating comparison & hashing ───────────────────────────────────
+//
+// Every relational and hashing impl routes through `as_str()`, so the storage
+// arm is invisible to equality, ordering, hashing, and grouping. This is the
+// load-bearing guarantee that a shared `FieldStr` and a unique `FieldStr` of
+// equal content behave identically everywhere (group-by, distinct, join, sort).
+
+impl PartialEq for FieldStr {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for FieldStr {}
+
+impl PartialEq<str> for FieldStr {
+    #[inline]
+    fn eq(&self, other: &str) -> bool {
+        self.as_str() == other
+    }
+}
+
+impl PartialEq<&str> for FieldStr {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl PartialOrd for FieldStr {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for FieldStr {
+    #[inline]
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+impl Hash for FieldStr {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hash exactly as `str` does, so `HashMap`/`HashSet` keyed by content
+        // see no difference between the arms (and match a bare `&str` lookup
+        // via the `Borrow<str>` impl).
+        self.as_str().hash(state);
+    }
+}
+
+impl fmt::Display for FieldStr {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl fmt::Debug for FieldStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+// ── Constructors from owned/borrowed string types ─────────────────────────
+//
+// Every conversion defaults to the inline-or-shared policy (`FieldStr::new`),
+// matching the prior `SmolStr` behavior exactly. The unique arm is reachable
+// only through the explicit `new_unique` constructor, driven by the schema
+// flag — never by an ambient `From` conversion — so default construction is
+// byte-identical to pre-existing behavior.
+
+impl From<&str> for FieldStr {
+    #[inline]
+    fn from(s: &str) -> Self {
+        FieldStr::new(s)
+    }
+}
+
+impl From<String> for FieldStr {
+    #[inline]
+    fn from(s: String) -> Self {
+        // Reuse the owned allocation for the shared arm when it would not fit
+        // inline, avoiding a re-copy.
+        if s.len() <= INLINE_CAP {
+            FieldStr::new_inline(&s)
+        } else {
+            FieldStr::from_arc(Arc::from(s))
+        }
+    }
+}
+
+impl From<smol_str::SmolStr> for FieldStr {
+    #[inline]
+    fn from(s: smol_str::SmolStr) -> Self {
+        FieldStr::new(s.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::hash_map::DefaultHasher;
+
+    fn hash_of(s: &impl Hash) -> u64 {
+        let mut h = DefaultHasher::new();
+        s.hash(&mut h);
+        h.finish()
+    }
+
+    #[test]
+    fn size_is_24_bytes() {
+        assert_eq!(std::mem::size_of::<FieldStr>(), 24);
+    }
+
+    #[test]
+    fn inline_arm_holds_short_values_without_heap() {
+        for s in ["", "x", "short", &"a".repeat(INLINE_CAP)] {
+            let fs = FieldStr::new(s);
+            assert_eq!(fs.as_str(), s, "inline roundtrip for {s:?}");
+            assert_eq!(fs.len(), s.len());
+            assert_eq!(fs.heap_size(), 0, "{s:?} should be inline");
+            assert!(!fs.is_unique());
+            assert_eq!(fs.heap_size(), 0);
+        }
+    }
+
+    #[test]
+    fn shared_arm_holds_long_values_on_heap() {
+        let long = "this string is definitely longer than twenty-three bytes";
+        assert!(long.len() > INLINE_CAP);
+        let fs = FieldStr::new(long);
+        assert_eq!(fs.as_str(), long);
+        assert_eq!(fs.len(), long.len());
+        assert!(fs.heap_size() > 0);
+        assert!(!fs.is_unique());
+        assert_eq!(fs.heap_size(), long.len());
+    }
+
+    #[test]
+    fn unique_arm_is_header_free_box() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let fs = FieldStr::new_unique(uuid);
+        assert_eq!(fs.as_str(), uuid);
+        assert_eq!(fs.len(), uuid.len());
+        assert!(fs.heap_size() > 0);
+        assert!(fs.is_unique());
+        assert_eq!(fs.heap_size(), uuid.len());
+    }
+
+    #[test]
+    fn cross_arm_equality_shared_vs_unique() {
+        let s = "550e8400-e29b-41d4-a716-446655440000";
+        let shared = FieldStr::new(s);
+        let unique = FieldStr::new_unique(s);
+        assert!(shared.heap_size() > 0 && !shared.is_unique());
+        assert!(unique.is_unique());
+        // Equal content compares, orders, and hashes equal across arms.
+        assert_eq!(shared, unique);
+        assert_eq!(shared.cmp(&unique), Ordering::Equal);
+        assert_eq!(hash_of(&shared), hash_of(&unique));
+        // And both equal a bare `str` hash via the `Borrow<str>` contract.
+        assert_eq!(hash_of(&shared), hash_of(&s));
+    }
+
+    #[test]
+    fn cross_arm_equality_inline_vs_unique() {
+        // A short value via the inline default and via the explicit unique arm
+        // must still compare and hash equal — content, not arm, decides.
+        let s = "short-id";
+        let inline = FieldStr::new(s);
+        let unique = FieldStr::new_unique(s);
+        assert_eq!(inline.heap_size(), 0);
+        assert!(unique.is_unique());
+        assert_eq!(inline, unique);
+        assert_eq!(hash_of(&inline), hash_of(&unique));
+    }
+
+    #[test]
+    fn ordering_is_lexicographic_regardless_of_arm() {
+        let a_inline = FieldStr::new("apple");
+        let b_unique = FieldStr::new_unique("banana-is-a-much-longer-value-here");
+        assert!(a_inline < b_unique);
+        let a_unique = FieldStr::new_unique("apple-but-now-long-enough-to-box");
+        let b_shared = FieldStr::new("banana-but-now-long-enough-to-arc");
+        assert!(a_unique < b_shared);
+    }
+
+    #[test]
+    fn shared_clone_shares_allocation() {
+        let long = "this string is definitely longer than twenty-three bytes";
+        let original = FieldStr::new(long);
+        let cloned = original.clone();
+        // A shared clone is an O(1) refcount bump: clone aliases the original's
+        // backing allocation (same `str` address).
+        assert_eq!(original.as_str().as_ptr(), cloned.as_str().as_ptr());
+        assert_eq!(original.as_str(), cloned.as_str());
+    }
+
+    #[test]
+    fn unique_clone_deep_copies_and_stays_unique() {
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let original = FieldStr::new_unique(uuid);
+        let cloned = original.clone();
+        // No shared ownership to bump — the clone owns a distinct allocation.
+        assert_ne!(original.as_str().as_ptr(), cloned.as_str().as_ptr());
+        assert_eq!(original.as_str(), cloned.as_str());
+        assert!(cloned.is_unique());
+    }
+
+    #[test]
+    fn inline_clone_is_value_copy() {
+        let fs = FieldStr::new("inline-value");
+        let cloned = fs.clone();
+        assert_eq!(fs, cloned);
+        assert_eq!(cloned.heap_size(), 0);
+    }
+
+    #[test]
+    fn drop_releases_each_arm_without_double_free() {
+        // Exercise drop on every arm, including a shared clone (two strong
+        // counts) and a unique clone (two boxes). Under address sanitizer /
+        // miri this proves no double-free or leak; under normal test it proves
+        // drop does not panic and ownership reconstitution is balanced.
+        for _ in 0..1000 {
+            let inline = FieldStr::new("x");
+            let shared = FieldStr::new("a value that is comfortably over the inline boundary");
+            let shared2 = shared.clone();
+            let unique = FieldStr::new_unique("another value comfortably over the inline boundary");
+            let unique2 = unique.clone();
+            drop((inline, shared, shared2, unique, unique2));
+        }
+    }
+
+    #[test]
+    fn from_string_reuses_or_inlines() {
+        let short = String::from("short");
+        let fs = FieldStr::from(short);
+        assert_eq!(fs.as_str(), "short");
+        assert_eq!(fs.heap_size(), 0);
+
+        let long = String::from("a string value well past the inline boundary of the field type");
+        let fs = FieldStr::from(long.clone());
+        assert_eq!(fs.as_str(), long);
+        assert!(fs.heap_size() > 0);
+        assert!(!fs.is_unique());
+    }
+
+    #[test]
+    fn from_smol_str_defaults_to_inline_or_shared() {
+        let fs = FieldStr::from(smol_str::SmolStr::new("via-smol"));
+        assert_eq!(fs.as_str(), "via-smol");
+        assert!(!fs.is_unique());
+    }
+
+    #[test]
+    fn utf8_multibyte_roundtrips_in_every_arm() {
+        // Inline (fits within INLINE_CAP), shared, and unique arms must all
+        // preserve multibyte UTF-8 exactly.
+        let short = "café"; // 5 bytes
+        assert!(short.len() <= INLINE_CAP);
+        assert_eq!(FieldStr::new(short).as_str(), short);
+
+        let long = "a longer string with accents: café, naïve, résumé, jalapeño!";
+        assert!(long.len() > INLINE_CAP);
+        assert_eq!(FieldStr::new(long).as_str(), long);
+        assert_eq!(FieldStr::new_unique(long).as_str(), long);
+    }
+
+    #[test]
+    fn hashset_membership_is_arm_agnostic() {
+        use std::collections::HashSet;
+        let mut set: HashSet<FieldStr> = HashSet::new();
+        set.insert(FieldStr::new("550e8400-e29b-41d4-a716-446655440000"));
+        // A unique-arm probe of equal content hits the shared-arm entry.
+        assert!(
+            set.contains(FieldStr::new_unique("550e8400-e29b-41d4-a716-446655440000").as_str())
+        );
+        // Inserting the same content via the unique arm does not grow the set.
+        set.insert(FieldStr::new_unique("550e8400-e29b-41d4-a716-446655440000"));
+        assert_eq!(set.len(), 1);
+    }
+}

--- a/crates/clinker-record/src/field_str.rs
+++ b/crates/clinker-record/src/field_str.rs
@@ -259,11 +259,14 @@ impl FieldStr {
     }
 
     /// Returns true when the value is stored in the header-free unique arm
-    /// rather than the default inline-or-`Arc`-shared one. Lets the reader and
-    /// its tests confirm a schema-flagged column landed in the intended
-    /// representation; the arm is otherwise invisible through the `str` API.
+    /// rather than the default inline-or-`Arc`-shared one. The arm is otherwise
+    /// invisible through the `str` API, so this is a test-only observability
+    /// hook for in-crate unit tests that pin the intended representation; it is
+    /// not part of the production surface, and cross-crate tests assert the
+    /// arm's effect through observable clone semantics instead.
+    #[cfg(test)]
     #[inline]
-    pub fn is_unique(&self) -> bool {
+    pub(crate) fn is_unique(&self) -> bool {
         self.tag() == TAG_UNIQUE
     }
 }

--- a/crates/clinker-record/src/lib.rs
+++ b/crates/clinker-record/src/lib.rs
@@ -2,6 +2,7 @@ pub mod accumulator;
 pub mod coercion;
 pub mod counters;
 pub mod document_context;
+pub mod field_str;
 pub mod group_key;
 pub mod minimal;
 pub mod provenance;
@@ -22,6 +23,7 @@ pub use counters::{PipelineCounters, RetractionCounters};
 pub use document_context::{
     DocumentContext, DocumentId, synthetic_document_context, synthetic_document_context_ref,
 };
+pub use field_str::FieldStr;
 pub use group_key::{GroupByKey, GroupKeyError, value_to_group_key};
 pub use minimal::MinimalRecord;
 pub use provenance::RecordProvenance;

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -551,19 +551,19 @@ mod tests {
         let size = record.estimated_heap_size();
         // Vec backing: capacity(2) * sizeof(Value)
         let expected_backing = 2 * std::mem::size_of::<Value>();
-        // Short "hello" lives inline in the SmolStr (0 heap); Integer is 0 too.
+        // Short "hello" lives inline in the FieldStr (0 heap); Integer is 0 too.
         assert_eq!(size, expected_backing);
     }
 
     #[test]
     fn test_record_estimated_heap_size_heap_backed_string() {
         let schema = Arc::new(Schema::new(vec!["name".into(), "value".into()]));
-        let long = "a field value that exceeds the 23-byte inline capacity of smolstr";
-        assert!(smol_str::SmolStr::new(long).is_heap_allocated());
+        let long = "a field value that exceeds the 23-byte inline capacity of the field type";
+        assert!(long.len() > crate::field_str::INLINE_CAP);
         let record = Record::new(schema, vec![Value::String(long.into()), Value::Integer(42)]);
         let size = record.estimated_heap_size();
         let expected_backing = 2 * std::mem::size_of::<Value>();
-        // The heap-backed (Arc) string charges its byte length on top of the Vec backing.
+        // The heap-backed string charges its byte length on top of the Vec backing.
         assert_eq!(size, expected_backing + long.len());
     }
 }

--- a/crates/clinker-record/src/value.rs
+++ b/crates/clinker-record/src/value.rs
@@ -1,6 +1,6 @@
+use crate::field_str::FieldStr;
 use chrono::{Datelike, NaiveDate, NaiveDateTime};
 use indexmap::IndexMap;
-use smol_str::SmolStr;
 use std::cmp::Ordering;
 use std::fmt;
 
@@ -12,12 +12,18 @@ pub enum Value {
     Float(f64),
     /// Field-value string. Short values (<=23 bytes — the dominant ETL field
     /// shape) live inline in the enum with zero heap allocation; longer values
-    /// are Arc-backed, so cloning a long string is an O(1) refcount bump rather
-    /// than an allocation + copy. `SmolStr` is 24 bytes wide with no spare
-    /// niche, so it widens `Value` to 32 bytes (see `test_value_enum_size`);
-    /// the trade buys away one heap allocation per short value, which is the
-    /// term that moves the RSS / spill threshold.
-    String(SmolStr),
+    /// are `Arc`-backed by default, so cloning a long string is an O(1) refcount
+    /// bump rather than an allocation + copy. Columns a source schema flags
+    /// long-and-unique instead take the `Box`-backed header-free arm, dropping
+    /// the `Arc` refcount header that is pure overhead when a value never
+    /// repeats — see [`FieldStr`]. The arm is a storage hint only: equality,
+    /// ordering, hashing, and grouping all compare via the underlying `str`, so
+    /// a shared and a unique value of equal content behave identically.
+    /// `FieldStr` is 24 bytes wide with no spare niche, so it widens `Value` to
+    /// 32 bytes (see `test_value_enum_size`); the trade buys away one heap
+    /// allocation per short value, which is the term that moves the RSS / spill
+    /// threshold.
+    String(FieldStr),
     Date(NaiveDate),
     DateTime(NaiveDateTime),
     Array(Vec<Value>),
@@ -117,8 +123,13 @@ impl<'de> Visitor<'de> for ValueVisitor {
             2 => Ok(Value::Integer(va.newtype_variant()?)),
             3 => Ok(Value::Float(va.newtype_variant()?)),
             4 => {
+                // Reconstruct the DEFAULT (inline-or-shared) arm. The wire form
+                // carries only the UTF-8 bytes — no arm tag — so a value that
+                // spilled from the unique arm reloads as the default arm with
+                // identical content. The arm is an in-memory footprint hint that
+                // does not survive serialization, by design.
                 let s: std::string::String = va.newtype_variant()?;
-                Ok(Value::String(SmolStr::from(s)))
+                Ok(Value::String(FieldStr::from(s)))
             }
             5 => {
                 let days: i32 = va.newtype_variant()?;
@@ -270,26 +281,33 @@ impl fmt::Display for Value {
 
 // ── String-variant constructors (policy-enforcing) ─────────────────────────
 //
-// `From<&str>`, `From<String>`, and `From<SmolStr>` build the `String` variant.
-// There is deliberately NO `From<Box<str>>`: a `Box<str>` field value (the old
-// owning representation) must fail to compile rather than silently allocate and
-// box, which is the type-level enforcement that the inline/Arc-backed `SmolStr`
-// representation is the single field-value string path.
+// `From<&str>`, `From<String>`, and `From<SmolStr>` build the `String` variant
+// in the DEFAULT inline-or-`Arc`-shared arm, byte-for-byte the prior behavior.
+// The header-free `Box`-unique arm is reachable only through
+// [`Value::string_unique`], driven by the source schema's long-unique flag —
+// never by an ambient `From` conversion — so default construction never silently
+// changes representation.
 
 impl From<&str> for Value {
     fn from(s: &str) -> Self {
-        Value::String(SmolStr::new(s))
+        Value::String(FieldStr::new(s))
     }
 }
 
 impl From<std::string::String> for Value {
     fn from(s: std::string::String) -> Self {
-        Value::String(SmolStr::from(s))
+        Value::String(FieldStr::from(s))
     }
 }
 
-impl From<SmolStr> for Value {
-    fn from(s: SmolStr) -> Self {
+impl From<smol_str::SmolStr> for Value {
+    fn from(s: smol_str::SmolStr) -> Self {
+        Value::String(FieldStr::from(s))
+    }
+}
+
+impl From<FieldStr> for Value {
+    fn from(s: FieldStr) -> Self {
         Value::String(s)
     }
 }
@@ -331,17 +349,11 @@ impl Value {
     /// Scalar variants (Null, Bool, Integer, Float, Date, DateTime) store
     /// data inline in the enum — zero heap allocation.
     /// Strings store their bytes inline when short (<=23 bytes) and so
-    /// contribute zero heap; only heap-backed (Arc-allocated) strings charge
-    /// their byte length.
+    /// contribute zero heap; heap-backed strings (the `Arc`-shared default arm
+    /// or the `Box`-unique arm) charge their byte length.
     pub fn heap_size(&self) -> usize {
         match self {
-            Value::String(s) => {
-                if s.is_heap_allocated() {
-                    s.len()
-                } else {
-                    0
-                }
-            }
+            Value::String(s) => s.heap_size(),
             Value::Array(arr) => {
                 arr.capacity() * std::mem::size_of::<Value>()
                     + arr.iter().map(Value::heap_size).sum::<usize>()
@@ -354,6 +366,18 @@ impl Value {
             }
             _ => 0,
         }
+    }
+
+    /// Build a `String` value in the header-free `Box`-unique arm.
+    ///
+    /// Used by the reader path for source columns a `.schema.yaml` flags
+    /// long-and-unique: such values never repeat across records, so the
+    /// `Arc` refcount header of the default shared arm would be pure overhead.
+    /// The resulting value compares, orders, hashes, and groups identically to
+    /// a default-arm value of the same content — the arm is a footprint hint,
+    /// not a distinct value domain.
+    pub fn string_unique(s: &str) -> Self {
+        Value::String(FieldStr::new_unique(s))
     }
 
     /// Create a Map from an iterator of key-value pairs.
@@ -561,29 +585,30 @@ mod tests {
 
     #[test]
     fn test_value_heap_size_string() {
-        // Short strings (<=23 bytes) live inline in the SmolStr — zero heap.
+        use crate::field_str::INLINE_CAP;
+        // Short strings (<=23 bytes) live inline in the FieldStr — zero heap.
         assert_eq!(Value::String("hello".into()).heap_size(), 0);
         assert_eq!(Value::String("".into()).heap_size(), 0);
         // 21 bytes is still inline (<=23) — contributes no heap.
         assert_eq!(Value::String("a longer string value".into()).heap_size(), 0);
         // 23 bytes is the inline boundary — still no heap.
-        let boundary = "x".repeat(23);
-        assert!(!smol_str::SmolStr::new(&boundary).is_heap_allocated());
+        let boundary = "x".repeat(INLINE_CAP);
         assert_eq!(Value::String(boundary.as_str().into()).heap_size(), 0);
-        // 24+ bytes spills to the Arc-backed heap repr — charges its byte length.
+        // 24+ bytes spills to the Arc-backed default heap arm — charges its
+        // byte length.
         let heap_backed = "this string is definitely longer than twenty-three bytes";
         assert_eq!(heap_backed.len(), 56);
-        assert!(smol_str::SmolStr::new(heap_backed).is_heap_allocated());
+        assert!(heap_backed.len() > INLINE_CAP);
         assert_eq!(Value::String(heap_backed.into()).heap_size(), 56);
     }
 
     #[test]
     fn test_long_field_string_is_arc_backed_shares_on_clone_and_roundtrips() {
-        // A 36-char UUID is the canonical long field shape (>23B, the SmolStr
-        // inline boundary), so it takes the Arc-backed heap repr rather than
-        // inline storage. This pins the three properties the long-field
-        // ownership model depends on: heap residency, refcount-sharing clones,
-        // and byte-exact serde — all of which only matter for the heap arm.
+        // A 36-char UUID is the canonical long field shape (>23B, the FieldStr
+        // inline boundary), so the default constructor takes the Arc-backed
+        // shared arm rather than inline storage. This pins the three properties
+        // the long-field ownership model depends on: heap residency,
+        // refcount-sharing clones, and byte-exact serde.
         let uuid = "550e8400-e29b-41d4-a716-446655440000";
         assert_eq!(
             uuid.len(),
@@ -596,14 +621,19 @@ mod tests {
             panic!("constructed a String variant");
         };
         // >23B values live on the heap; heap_size charges exactly the byte
-        // length (no rounding, no Arc-header inclusion).
+        // length (no rounding, no Arc-header inclusion). A non-zero heap_size
+        // is the public-API proof of heap residency.
         assert!(
-            orig_str.is_heap_allocated(),
+            orig_str.heap_size() > 0,
             "a 36-byte UUID must be Arc-backed, not inline"
+        );
+        assert!(
+            !orig_str.is_unique(),
+            "the default constructor takes the shared arm, not the unique arm"
         );
         assert_eq!(original.heap_size(), 36);
 
-        // Cloning a heap-backed String is an O(1) refcount bump, not a deep
+        // Cloning a shared-arm String is an O(1) refcount bump, not a deep
         // copy: the clone's bytes alias the original's allocation. Pointer
         // identity of the backing `str` is the public-API proof of sharing —
         // a deep copy would land at a different address.
@@ -614,7 +644,7 @@ mod tests {
         assert_eq!(
             orig_str.as_str().as_ptr(),
             clone_str.as_str().as_ptr(),
-            "a heap-backed SmolStr clone must share the Arc allocation, \
+            "a shared-arm FieldStr clone must share the Arc allocation, \
              not copy the bytes"
         );
         assert_eq!(orig_str.as_str(), clone_str.as_str());
@@ -630,8 +660,12 @@ mod tests {
         };
         assert_eq!(decoded_str.as_str(), uuid);
         assert!(
-            decoded_str.is_heap_allocated(),
+            decoded_str.heap_size() > 0,
             "a >23B value stays Arc-backed across a serde round-trip"
+        );
+        assert!(
+            !decoded_str.is_unique(),
+            "deserialize reconstructs the default arm, never the unique arm"
         );
         let reencoded = postcard::to_stdvec(&decoded).expect("re-serialize decoded value");
         assert_eq!(reencoded, bytes, "serde round-trip is byte-identical");
@@ -645,8 +679,8 @@ mod tests {
         assert_eq!(arr.heap_size(), expected);
 
         // A heap-backed element string adds its byte length on top of the Vec backing.
-        let long = "an element string well past the inline boundary of smolstr";
-        assert!(smol_str::SmolStr::new(long).is_heap_allocated());
+        let long = "an element string well past the inline boundary of the field type";
+        assert!(long.len() > crate::field_str::INLINE_CAP);
         let arr2 = Value::Array(vec![Value::Integer(1), Value::String(long.into())]);
         let expected2 = 2 * std::mem::size_of::<Value>() + long.len();
         assert_eq!(arr2.heap_size(), expected2);
@@ -774,15 +808,58 @@ mod tests {
 
     #[test]
     fn test_value_enum_size() {
-        // `SmolStr` is itself 24 bytes (a 23-byte inline buffer + 1-byte length
-        // tag) and exposes no spare niche for the outer `Value` discriminant,
-        // so the enum is 32 bytes — one machine word wider than the prior
-        // `Box<str>` (16-byte) representation. The width is paid back at the
+        // `FieldStr` is itself 24 bytes (a 23-byte inline buffer + 1-byte
+        // discriminant) and exposes no spare niche for the outer `Value`
+        // discriminant, so the enum is 32 bytes. The width is paid back at the
         // heap: short field values (<=23 bytes, the dominant ETL shape) carry
-        // zero heap allocation instead of one per value, and long values clone
-        // by refcount. The per-`Value` byte-cost model keys off this constant,
-        // so it tracks the real width automatically.
+        // zero heap allocation instead of one per value, long values clone by
+        // refcount in the default shared arm, and schema-flagged long-unique
+        // values drop the Arc header in the Box-unique arm — all within the
+        // same 24-byte payload. The per-`Value` byte-cost model keys off this
+        // constant, so it tracks the real width automatically.
         assert_eq!(std::mem::size_of::<Value>(), 32);
+    }
+
+    #[test]
+    fn test_value_string_unique_arm_collapses_to_default_on_serde() {
+        // A schema-flagged long-unique value takes the header-free Box arm
+        // in memory, but the wire form carries only the UTF-8 bytes (the arm
+        // is an in-memory footprint hint, not part of the value's identity).
+        // A unique-arm value and a default-arm value of the same content must
+        // therefore serialize to byte-identical streams, and a spilled unique
+        // value must reload as the default arm with content intact.
+        let uuid = "550e8400-e29b-41d4-a716-446655440000";
+        let unique = Value::string_unique(uuid);
+        let default = Value::String(uuid.into());
+
+        let Value::String(u) = &unique else {
+            unreachable!()
+        };
+        assert!(u.is_unique(), "string_unique must take the Box-unique arm");
+
+        // Cross-arm equality: the two values are equal despite different arms.
+        assert_eq!(unique, default);
+
+        // Wire bytes are identical regardless of arm.
+        let unique_bytes = postcard::to_stdvec(&unique).expect("serialize unique");
+        let default_bytes = postcard::to_stdvec(&default).expect("serialize default");
+        assert_eq!(
+            unique_bytes, default_bytes,
+            "the storage arm must not leak into the wire form"
+        );
+
+        // Spill round-trip: a unique value reloads as the default arm, content
+        // intact (the wire carries no arm tag to reconstruct the Box arm).
+        let decoded: Value = postcard::from_bytes(&unique_bytes).expect("deserialize");
+        assert_eq!(decoded, unique);
+        let Value::String(d) = &decoded else {
+            unreachable!()
+        };
+        assert_eq!(d.as_str(), uuid);
+        assert!(
+            !d.is_unique(),
+            "deserialize reconstructs the default arm, not the unique arm"
+        );
     }
 
     #[test]

--- a/crates/clinker-record/src/value.rs
+++ b/crates/clinker-record/src/value.rs
@@ -306,12 +306,6 @@ impl From<smol_str::SmolStr> for Value {
     }
 }
 
-impl From<FieldStr> for Value {
-    fn from(s: FieldStr) -> Self {
-        Value::String(s)
-    }
-}
-
 /// Shared `Value::Null` sentinel used by `FieldResolver` implementations
 /// that need to hand out a `&Value` for a logically-absent field.
 ///

--- a/docs/src/pipeline/source.md
+++ b/docs/src/pipeline/source.md
@@ -49,6 +49,32 @@ schema:
 | `any` | Unknown type -- field used in type-agnostic contexts |
 | `nullable(T)` | Nullable wrapper around any inner type (e.g. `nullable(int)`) |
 
+### `long_unique` — storage hint for high-cardinality text
+
+A string column may carry an optional `long_unique: true` flag. It is an
+**advisory, opt-in storage hint**, not a type change: it tells the engine the
+column's values are *long and effectively unique* — never repeated across
+records — so it stores them in a leaner, header-free representation that drops
+the per-value bookkeeping the default representation keeps for values that
+might be shared. Typical candidates are UUIDs rendered as text, street
+addresses, and free-text comment or note fields.
+
+```yaml
+schema:
+  - { name: ticket_id,  type: string, long_unique: true }   # 36-char UUID
+  - { name: notes,      type: string, long_unique: true }   # free text
+  - { name: department, type: string }                      # low-cardinality, default
+```
+
+The flag changes only the in-memory footprint of the annotated column. The
+value's content, its comparison/grouping/join/sort behavior, and the on-disk
+encoding when a run spills to disk are all unchanged — a `long_unique` value
+compares and groups identically to the same text in any other column. Omitting
+the flag (the common case) leaves the default behavior untouched. Set it only
+when you know a column is genuinely high-cardinality free text; on a column
+whose values repeat, the default representation is the better choice because it
+shares repeated values instead of storing each copy independently.
+
 ## Transport vs format
 
 A source declaration has two independent layers:


### PR DESCRIPTION
Closes #372.

## Background

`Value::String` is the dominant payload in an ETL record stream, so its in-memory width sets the per-value byte cost that drives the memory budget and spill thresholds. Short string values are stored inline (no heap allocation); longer values default to an atomically reference-counted shared representation, so values that repeat or are cloned across stages (fan-out, group-by, joins) are stored once and clone in O(1).

For a column whose values are **long _and_ effectively unique** — never repeated across records — the per-allocation reference-count header of the shared representation is pure overhead, because there is no sharing to amortize it against. Typical cases: UUIDs rendered as text, street addresses, free-text comment/note fields.

## What this adds

An **opt-in, per-column** storage hint that lets an author flag such a column so the engine stores its values in a leaner, header-free owned representation instead of the shared default. The flag is advisory and changes only the in-memory footprint — content, comparison/grouping/join/sort behavior, and the on-disk spill encoding are all unchanged.

### `FieldStr` — a 24-byte three-arm string

`Value::String` now wraps a purpose-built `FieldStr` with three storage arms behind a single `str` API:

- **inline** — values up to 23 bytes live in the value itself, zero heap allocation (the dominant short-field shape);
- **shared** — longer values are reference-counted, so a clone is an O(1) refcount bump;
- **unique** — longer values flagged long-and-unique are stored header-free, dropping the refcount header that is pure overhead when a value never repeats.

`FieldStr` owns its own discriminant niche (a trailing tag byte, with two sentinel tags placed above the inline-length range) rather than depending on the small-string library's private inline-size encoding, whose memory layout is not a stable, depend-on-able contract. `size_of::<Value>()` stays at 32 bytes. All comparison, ordering, hashing, and display route through the underlying `str`, so the storage arm is invisible to equality, grouping, joins, and sorting: a unique-arm value and a shared-arm value of equal content behave identically everywhere. The small amount of `unsafe` (union field access at a shared offset; owning-pointer reconstitution for deref/clone/drop) is documented with its safety argument per arm and pinned by compile-time layout assertions plus exhaustive unit and property tests, including a drop-balance stress test.

### The `long_unique` schema flag

A new optional `long_unique: bool` on the source schema's column declaration:

```yaml
schema:
  - { name: ticket_id, type: string, long_unique: true }   # 36-char UUID
  - { name: notes,     type: string, long_unique: true }   # free text
  - { name: region,    type: string }                      # low-cardinality, default
```

It is `#[serde(default, skip_serializing_if = ...)]`, so schemas that omit it (the common case) serialize byte-identically to before — no wire change to existing pipeline files. The source reader threads the per-column flag and stores a flagged column's string values in the header-free arm; everything else keeps the default policy.

## No wire change, no behavior change for un-flagged schemas

- **Default construction is byte-identical** to prior behavior. The header-free arm is reachable only through the explicit schema-flag-driven path, never an ambient string conversion.
- **The on-disk spill encoding is unchanged.** Serialization emits only the UTF-8 bytes (no arm tag), so a unique-arm value and a default-arm value of the same content produce identical wire bytes, and a value that spilled from the unique arm reloads as the default arm with content intact. The arm is an in-memory footprint hint, not part of the value's identity.

## Tests

- `FieldStr` size (24 bytes), roundtrip, and property tests across all three arms (short/long via each arm; exact-byte deref; multibyte UTF-8; clone semantics; drop-balance).
- Cross-arm correctness: a unique-arm value and a shared/inline value of equal content compare, order, hash, and group equal — verified both as units and end-to-end through actual group-by, distinct, and a Combine join whose **unique-arm build key matches a default-arm probe key**.
- Serde wire-compatibility: a default-built and a unique-built string of the same content serialize to identical bytes; a spilled unique value reloads with content intact.
- Schema-flag parse/serialize: the flag parses when present, defaults false when omitted, and an un-flagged column serializes without the key.

User documentation for the new schema key is added under the source-node docs.

## Verification

Full project gauntlet green: format, both clippy passes (`-D warnings`, with and without `--all-targets`), `cargo test --workspace` (2495 passing), bench compile + bench-as-test runs, and the license/advisory audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)