### PR TITLE
Streaming consumer-kind handoff + EDIFACT format support

### DIFF
--- a/crates/clinker-benchmarks/src/format_mapping.rs
+++ b/crates/clinker-benchmarks/src/format_mapping.rs
@@ -7,6 +7,7 @@ use clinker_plan::config::{InputFormat, JsonFormat};
 #[derive(Debug)]
 pub enum FormatMappingError {
     UnsupportedJsonObject,
+    UnsupportedEdifact,
 }
 
 impl std::fmt::Display for FormatMappingError {
@@ -14,6 +15,9 @@ impl std::fmt::Display for FormatMappingError {
         match self {
             Self::UnsupportedJsonObject => {
                 f.write_str("JSON object format has no benchmark DataFormat equivalent")
+            }
+            Self::UnsupportedEdifact => {
+                f.write_str("EDIFACT format has no benchmark DataFormat equivalent")
             }
         }
     }
@@ -29,6 +33,7 @@ pub fn input_format_to_data_format(input: &InputFormat) -> Result<DataFormat, Fo
         InputFormat::Csv(_) => Ok(DataFormat::Csv),
         InputFormat::Xml(_) => Ok(DataFormat::Xml),
         InputFormat::FixedWidth(_) => Ok(DataFormat::FixedWidth),
+        InputFormat::Edifact(_) => Err(FormatMappingError::UnsupportedEdifact),
         InputFormat::Json(opts) => {
             let json_fmt = opts.as_ref().and_then(|o| o.format.as_ref());
             match json_fmt {

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -78,6 +78,7 @@
 //! | `E317`      | error    | `error_handling.dlq.per_source` key does not name a declared Source |
 //! | `E318`      | error    | `error_handling.dlq.*.max_rate` out of `[0.0, 1.0]` or DLQ path collides |
 //! | `E322`      | error    | Two output destinations (Output nodes, or an Output node and a DLQ path) resolve to the same file |
+//! | `E323`      | error    | `edifact` output combined with byte-limit `split` (an interchange is one indivisible UNB..UNZ envelope) |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1464,7 +1464,7 @@ pub(crate) fn admit_node_buffer(
 /// punctuations, so their relative position past the records is immaterial
 /// to the sink, and the within-records order — the FIFO the writer
 /// observes — is preserved by the batcher's append-only cut). Callers
-/// reach this only when [`super::streaming_output_producer`] certified the
+/// reach this only when [`super::certify_streaming_edge`] certified the
 /// producer roots no window and tees to no deferred region, so no
 /// materialized-tail bookkeeping is skipped that a downstream stage
 /// depends on.
@@ -2218,7 +2218,7 @@ pub(crate) fn transform_fused_consume(
     // non-fused Transform arm). In streaming mode both stay empty: the
     // batcher sink sends every event to the Output thread instead, and a
     // streaming-eligible Transform roots no window and tees to no region
-    // (enforced by `streaming_output_producer`), so the helper calls see
+    // (enforced by `certify_streaming_edge`), so the helper calls see
     // an empty slice and the slot is never admitted.
     //
     // The fused loop pushes each emitted record AND each document-boundary
@@ -2426,7 +2426,7 @@ pub(crate) fn transform_fused_consume(
     // inter-stage memory for this stage is one batch rather than the whole
     // output. The window-root / region-tee helpers are skipped because a
     // streaming-eligible Transform roots no node-anchored window and tees
-    // to no deferred region (enforced by `streaming_output_producer`), and
+    // to no deferred region (enforced by `certify_streaming_edge`), and
     // `output_records` is empty in this mode anyway.
     if streaming {
         return Ok(());

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -6,6 +6,7 @@ use std::io::Read;
 use std::sync::Arc;
 
 use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
+use clinker_format::edifact::reader::{EdifactReader, EdifactReaderConfig};
 use clinker_format::fixed_width::reader::{FixedWidthReader, FixedWidthReaderConfig};
 use clinker_format::json::reader::{
     ArrayPathMode, ArrayPathSpec, JsonMode, JsonReader, JsonReaderConfig,
@@ -43,6 +44,10 @@ fn build_format_reader(
             let fields = extract_field_defs(input)?;
             let config = build_fw_reader_config(opts.as_ref());
             Ok(Box::new(FixedWidthReader::new(reader, fields, config)?))
+        }
+        clinker_plan::config::InputFormat::Edifact(opts) => {
+            let config = build_edifact_reader_config(opts.as_ref());
+            Ok(Box::new(EdifactReader::new(reader, config)))
         }
     }
 }
@@ -589,6 +594,18 @@ fn build_fw_reader_config(
         && let Some(ref sep) = opts.line_separator
     {
         config.line_separator = sep.clone();
+    }
+    config
+}
+
+fn build_edifact_reader_config(
+    opts: Option<&clinker_plan::config::EdifactInputOptions>,
+) -> EdifactReaderConfig {
+    let mut config = EdifactReaderConfig::default();
+    if let Some(opts) = opts
+        && let Some(max) = opts.max_elements
+    {
+        config.max_elements = max;
     }
     config
 }

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -9,6 +9,7 @@ use clinker_record::Schema;
 
 use clinker_format::counting::{CountedFormatWriter, CountingWriter, SharedByteCounter};
 use clinker_format::csv::writer::{CsvWriter, CsvWriterConfig, HeaderCapturingCsvWriter};
+use clinker_format::edifact::writer::{EdifactWriter, EdifactWriterConfig};
 use clinker_format::fixed_width::writer::{FixedWidthWriter, FixedWidthWriterConfig};
 use clinker_format::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
 use clinker_format::splitting::{OversizeGroupPolicy, SplitPolicy, SplittingWriter, WriterFactory};
@@ -107,6 +108,21 @@ fn build_fw_writer_config(
         config.line_separator = sep.clone();
     }
     config
+}
+
+fn build_edifact_writer_config(
+    opts: Option<&clinker_plan::config::EdifactOutputOptions>,
+) -> EdifactWriterConfig {
+    // `segment_newline` defaults to `true` (readable per-segment lines);
+    // `write_una` to `false`. The struct literal expresses both up front
+    // so an unset option falls through to the documented default.
+    EdifactWriterConfig {
+        interchange: opts.and_then(|o| o.interchange.clone()),
+        interchange_from_doc: opts.and_then(|o| o.interchange_from_doc.clone()),
+        message_type: opts.and_then(|o| o.message_type.clone()),
+        write_una: opts.and_then(|o| o.write_una).unwrap_or(false),
+        segment_newline: opts.and_then(|o| o.segment_newline).unwrap_or(true),
+    }
 }
 
 /// Extract `Vec<FieldDef>` from an output config's schema for fixed-width format.
@@ -222,6 +238,16 @@ fn build_writer_factory(
                     fields.clone(),
                     fw_config.clone(),
                 )?))
+            })
+        }
+        OutputFormat::Edifact(opts) => {
+            let edi_config = build_edifact_writer_config(opts.as_ref());
+            Box::new(move |counting_writer, schema| {
+                Ok(Box::new(EdifactWriter::new(
+                    counting_writer,
+                    schema,
+                    edi_config.clone(),
+                )))
             })
         }
     }

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -1,23 +1,28 @@
-//! The streaming-output writer thread and its per-Output spec.
+//! The streaming-consumer substrate and its sole `Output` instantiation.
 //!
-//! Installs the fused producer → single-`Output` chains that the plan's
-//! streaming-fusion analysis flagged as bypassing a `node_buffers` slot,
-//! moving each such Output's writer onto its own thread fed by a bounded
-//! channel. The eligibility verdict comes from the plan layer's
-//! `streaming_output_producer`, so this runtime install can never disagree
-//! with the `--explain` buffer-class annotation.
+//! Installs the fused producer → single streaming-consumer chains that the
+//! plan's streaming-fusion analysis flagged as bypassing a `node_buffers`
+//! slot, moving each such consumer onto its own thread fed by a bounded
+//! channel. The channel-drain + per-record-discharge skeleton
+//! ([`drain_streaming_channel`]) is parameterized over a
+//! [`StreamingConsumer`], with [`OutputStreamConsumer`] (a file-writer)
+//! as the sole instantiation today. The eligibility verdict comes from the
+//! plan layer's `certify_streaming_edge`, so this runtime install can never
+//! disagree with the `--explain` buffer-class annotation.
 
 use std::collections::HashSet;
 use std::io::Write;
+use std::ops::ControlFlow;
 use std::sync::Arc;
 
-use clinker_record::Schema;
+use clinker_record::{Record, Schema};
 
 use clinker_format::traits::FormatWriter;
 use clinker_plan::config::{OutputConfig, PipelineConfig};
 use clinker_plan::error::PipelineError;
-use clinker_plan::plan::execution::streaming_output_producer;
+use clinker_plan::plan::execution::certify_streaming_edge;
 
+use super::stream_event::{Punctuation, StreamEvent};
 use super::{WriterRegistry, build_format_writer, dispatch, stage_metrics};
 
 /// Identify fused producer → single `Output` chains eligible for
@@ -35,10 +40,12 @@ use super::{WriterRegistry, build_format_writer, dispatch, stage_metrics};
 /// `node_buffers` slot, so peak inter-stage memory for that stage is one
 /// bounded batch rather than its whole output.
 ///
-/// Eligibility is decided by [`streaming_output_producer`] (the shared
+/// Eligibility is decided by [`certify_streaming_edge`] (the shared
 /// plan-derived predicate); this function adds the runtime writer-
 /// registry checks (the writer must be a registered single writer, not a
-/// fan-out) and packages the owned per-task metadata.
+/// fan-out) and packages the owned per-task metadata. It is the `Output`
+/// instantiation of the generalized substrate: the writer-registry guard,
+/// `out_cfg`, and projection metadata are all Output-specific.
 ///
 /// Returns the list of streaming specs (one per qualifying Output). Empty
 /// for pipelines that don't match the topology, leaving every Output on
@@ -69,16 +76,16 @@ pub(super) fn compute_streaming_output_specs(
             continue;
         };
         let Some(producer_idx) =
-            streaming_output_producer(plan, output_idx, fused_transforms, init_phase_set)
+            certify_streaming_edge(plan, output_idx, fused_transforms, init_phase_set)
         else {
             continue;
         };
 
         // Runtime writer-registry checks: the writer must be registered
         // as a single writer, never a fan-out. (The plan-derived
-        // fan-out / split exclusions live in `streaming_output_producer`
-        // so the explain surface agrees; this is the runtime-only
-        // registry confirmation.)
+        // fan-out / split exclusions live in `certify_streaming_edge`'s
+        // Output arm so the explain surface agrees; this is the
+        // runtime-only registry confirmation.)
         if !writers.single.contains_key(output_name) || writers.fan_out.contains_key(output_name) {
             continue;
         }
@@ -184,52 +191,70 @@ impl StreamingOutputTaskOutput {
     }
 }
 
-/// Streaming-output writer thread body. Drains the crossbeam `Receiver`
-/// populated by the fused `Merge.interleave` arm, projects each record
-/// through `project_output_from_record`, lazily constructs the writer on
-/// the first record, calls `Writer::write_record` per record, and
-/// flushes at channel close. Errors are accumulated rather than aborting
-/// the loop so the dispatcher can surface them alongside any sibling
-/// `output_errors`. See [`StreamingOutputSpec`] for the eligibility
-/// predicate and https://github.com/rustpunk/clinker/issues/72 for the
-/// rationale.
-pub(super) fn streaming_output(
-    rx: crossbeam_channel::Receiver<crate::executor::stream_event::StreamEvent>,
-    raw_writer: Box<dyn Write + Send>,
-    spec: StreamingOutputSpec,
-    charge_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
-) -> StreamingOutputTaskOutput {
-    use crate::projection::project_output_from_record;
+/// A streaming consumer plugged into [`drain_streaming_channel`].
+///
+/// The skeleton owns the channel recv loop, the per-record memory
+/// discharge, the back-pressure semantics, and the deadlock-safe
+/// drain-on-fatal; the consumer owns only what to do with each event.
+/// Consumers are single-threaded — the skeleton drives one consumer per
+/// streaming thread, so `&mut self` is the only mutation path and the
+/// peak inter-stage footprint is one bounded batch.
+///
+/// `Output` (file writer) is the sole implementation today; future
+/// streaming consumers (an `Aggregate` ingest, a `Combine` probe) plug in
+/// as additional implementations without re-deriving the recv loop.
+pub(super) trait StreamingConsumer {
+    /// Handle one body record (already discharged from the shared charge
+    /// handle by the skeleton). Return [`ControlFlow::Continue`] to keep
+    /// draining or [`ControlFlow::Break`] on a fatal consumer error; on
+    /// `Break` the skeleton drains the rest of the channel (so the bounded
+    /// producer `send` never deadlocks), zeroes the charge, and returns
+    /// without calling [`StreamingConsumer::on_close`].
+    fn on_record(&mut self, record: Record, row_num: u64) -> ControlFlow<()>;
 
-    let mut out = StreamingOutputTaskOutput {
-        records_written: 0,
-        records_emitted: 0,
-        seen_row_nums: HashSet::new(),
-        write_timer: stage_metrics::CumulativeTimer::new(),
-        projection_timer: stage_metrics::CumulativeTimer::new(),
-        errors: Vec::new(),
-        stage_metrics: Vec::new(),
-    };
-    let cxl_emit_names_opt: Option<&[String]> = if spec.cxl_emit_names.is_empty() {
-        None
-    } else {
-        Some(&spec.cxl_emit_names)
-    };
+    /// Handle one document-boundary punctuation. Carries no memory
+    /// discharge — punctuations contribute zero to
+    /// `EventBatch::estimated_bytes`, so the record-only discharge stays
+    /// symmetric.
+    fn on_punctuation(&mut self, punct: Punctuation);
 
-    let mut scan_timer_slot: Option<stage_metrics::StageTimer> = Some(
-        stage_metrics::StageTimer::new(stage_metrics::StageName::SchemaScan),
-    );
-    let mut writer: Option<Box<dyn FormatWriter>> = None;
-    let mut raw_writer_slot: Option<Box<dyn Write + Send>> = Some(raw_writer);
+    /// Finalize at channel disconnect (every sender dropped). Called
+    /// exactly once on the clean-drain path, never after an `on_record`
+    /// `Break`.
+    fn on_close(&mut self);
+}
 
+/// Drain a streaming consumer's bounded channel to disconnect, applying
+/// the per-record memory discharge and deadlock-safe fatal handling that
+/// every streaming consumer shares.
+///
+/// Streaming, not blocking: back-pressure flows consumer → producer →
+/// Source through the bounded channel, and the per-batch admit/discharge
+/// model keeps the slot's live byte count tracking only the batches in
+/// flight, never the whole stage. For each body record the skeleton
+/// discharges the record's `record_byte_cost` from `charge_handle` *before*
+/// handing it to [`StreamingConsumer::on_record`] — the consume half of the
+/// producer's per-batch `EventBatch::estimated_bytes` charge, so a fully
+/// drained stream nets the counter back to zero. On an `on_record`
+/// `Break`, the skeleton drains the rest of the channel (so the producer's
+/// bounded `send` never blocks forever on a dead consumer) and pins the
+/// charge to zero without finalizing the consumer. On clean disconnect it
+/// finalizes the consumer, then pins the charge to zero defensively so a
+/// heuristic mismatch between the batch charge and the per-record discharge
+/// can never leave a stale positive charge for the post-join arbitrator
+/// read.
+pub(super) fn drain_streaming_channel<C: StreamingConsumer>(
+    rx: &crossbeam_channel::Receiver<StreamEvent>,
+    charge_handle: &Arc<crate::pipeline::memory::ConsumerHandle>,
+    consumer: &mut C,
+) {
     while let Ok(event) = rx.recv() {
-        // Streaming output is terminal — it writes records straight to
-        // disk. Punctuations are consumed here; per-document writer
-        // finalization (envelope header/footer streaming reconstruction
-        // on `DocumentClose`) is a follow-up filed under #91 backlog.
         let (record, rn) = match event {
-            crate::executor::stream_event::StreamEvent::Record(r, rn) => (r, rn),
-            crate::executor::stream_event::StreamEvent::Punctuation(_) => continue,
+            StreamEvent::Record(r, rn) => (r, rn),
+            StreamEvent::Punctuation(p) => {
+                consumer.on_punctuation(p);
+                continue;
+            }
         };
         // Discharge this record's per-row cost from the shared charge
         // handle — the consume half of the per-batch admit/discharge
@@ -237,111 +262,362 @@ pub(super) fn streaming_output(
         // `EventBatch::estimated_bytes` on flush; subtracting each
         // record's `record_byte_cost` as it drains keeps the slot's live
         // count tracking exactly what is still buffered between producer
-        // and writer. The formula matches the producer's charge, so a
-        // fully-drained stream nets the counter back to zero.
+        // and consumer. The formula matches the producer's charge, so a
+        // fully-drained stream nets the counter back to zero. It runs
+        // before `on_record` so a consumer that drops the record still
+        // accounts for it.
         charge_handle.sub_bytes(crate::executor::node_buffer::record_byte_cost(
             record.schema().column_count(),
         ));
-        if let Some(expected) = spec.expected_input_schema.as_ref()
+        if consumer.on_record(record, rn).is_break() {
+            // Drain the rest of the channel so the producer's bounded
+            // `send` doesn't deadlock — the skeleton must keep consuming
+            // until every sender drops even when the consumer is dead,
+            // otherwise the producer blocks forever on a full bounded
+            // channel. The consumer is not finalized: a fatal `on_record`
+            // already abandoned its work.
+            while rx.recv().is_ok() {}
+            // Nothing is buffered downstream once the channel drains, so
+            // zero the slot's charge unconditionally — the fatal path never
+            // discharged the records it dropped on the floor above.
+            charge_handle.set_bytes(0);
+            return;
+        }
+    }
+
+    // Channel closed — every sender dropped (`recv` returned `Err`), so no
+    // more records will arrive. Let the consumer finalize (flush a writer,
+    // emit a final group), then pin the charge to zero.
+    consumer.on_close();
+    charge_handle.set_bytes(0);
+}
+
+/// The `Output` instantiation of [`StreamingConsumer`]: projects each
+/// record through `project_output_from_record`, lazily constructs the
+/// format writer on the first record, calls `Writer::write_record` per
+/// record, and flushes at channel close. Errors are accumulated into
+/// `out` rather than aborting so the dispatcher can surface them alongside
+/// any sibling `output_errors`.
+struct OutputStreamConsumer {
+    spec: StreamingOutputSpec,
+    out: StreamingOutputTaskOutput,
+    /// Pending `SchemaScan` timer, finished on the first writer build (or
+    /// on close for the empty-stream case).
+    scan_timer_slot: Option<stage_metrics::StageTimer>,
+    /// Lazily built on the first record's projected schema.
+    writer: Option<Box<dyn FormatWriter>>,
+    /// Holds the raw sink until the first record triggers the lazy build.
+    raw_writer_slot: Option<Box<dyn Write + Send>>,
+}
+
+impl OutputStreamConsumer {
+    fn new(raw_writer: Box<dyn Write + Send>, spec: StreamingOutputSpec) -> Self {
+        Self {
+            spec,
+            out: StreamingOutputTaskOutput {
+                records_written: 0,
+                records_emitted: 0,
+                seen_row_nums: HashSet::new(),
+                write_timer: stage_metrics::CumulativeTimer::new(),
+                projection_timer: stage_metrics::CumulativeTimer::new(),
+                errors: Vec::new(),
+                stage_metrics: Vec::new(),
+            },
+            scan_timer_slot: Some(stage_metrics::StageTimer::new(
+                stage_metrics::StageName::SchemaScan,
+            )),
+            writer: None,
+            raw_writer_slot: Some(raw_writer),
+        }
+    }
+}
+
+impl StreamingConsumer for OutputStreamConsumer {
+    fn on_record(&mut self, record: Record, row_num: u64) -> ControlFlow<()> {
+        use crate::projection::project_output_from_record;
+
+        let cxl_emit_names_opt: Option<&[String]> = if self.spec.cxl_emit_names.is_empty() {
+            None
+        } else {
+            Some(&self.spec.cxl_emit_names)
+        };
+
+        if let Some(expected) = self.spec.expected_input_schema.as_ref()
             && let Err(err) = crate::executor::schema_check::check_input_schema(
                 expected,
                 record.schema(),
-                &spec.output_name,
+                &self.spec.output_name,
                 "output",
-                &spec.producer_name,
+                &self.spec.producer_name,
             )
         {
-            out.errors.push(err);
-            continue;
+            self.out.errors.push(err);
+            return ControlFlow::Continue(());
         }
 
         let projected = {
-            let _guard = out.projection_timer.guard();
-            project_output_from_record(&record, &spec.out_cfg, cxl_emit_names_opt)
+            let _guard = self.out.projection_timer.guard();
+            project_output_from_record(&record, &self.spec.out_cfg, cxl_emit_names_opt)
         };
 
-        // Lazy writer construction: defer until we have the first
-        // record's projected schema so the writer's column list matches
-        // what `project_output_from_record` actually emits (same source
-        // of truth as the buffered Output arm at dispatch.rs's
-        // `output_schema = Arc::clone(projected.schema())`).
-        if writer.is_none() {
-            let raw = raw_writer_slot
+        // Lazy writer construction: defer until we have the first record's
+        // projected schema so the writer's column list matches what
+        // `project_output_from_record` actually emits (same source of truth
+        // as the buffered Output arm at dispatch.rs's `output_schema =
+        // Arc::clone(projected.schema())`).
+        if self.writer.is_none() {
+            let raw = self
+                .raw_writer_slot
                 .take()
                 .expect("raw_writer_slot is Some until first record arrives");
             let schema = Arc::clone(projected.schema());
-            match build_format_writer(&spec.out_cfg, raw, schema) {
+            match build_format_writer(&self.spec.out_cfg, raw, schema) {
                 Ok(w) => {
-                    writer = Some(w);
-                    if let Some(timer) = scan_timer_slot.take() {
-                        out.stage_metrics.push(timer.finish(1, 1));
+                    self.writer = Some(w);
+                    if let Some(timer) = self.scan_timer_slot.take() {
+                        self.out.stage_metrics.push(timer.finish(1, 1));
                     }
                 }
                 Err(e) => {
-                    out.errors.push(e);
-                    if let Some(timer) = scan_timer_slot.take() {
-                        out.stage_metrics.push(timer.finish(0, 0));
+                    self.out.errors.push(e);
+                    if let Some(timer) = self.scan_timer_slot.take() {
+                        self.out.stage_metrics.push(timer.finish(0, 0));
                     }
-                    // Drain the rest of the channel so the Merge arm's
-                    // bounded `send` doesn't deadlock — the streaming
-                    // thread must keep consuming until every sender drops
-                    // even when the writer is dead, otherwise the Merge
-                    // producer blocks forever on a full bounded channel.
-                    while rx.recv().is_ok() {}
-                    // Nothing is buffered downstream once the channel
-                    // drains, so zero the slot's charge unconditionally —
-                    // the error path never discharged the records it
-                    // dropped on the floor above.
-                    charge_handle.set_bytes(0);
-                    return out;
+                    return ControlFlow::Break(());
                 }
             }
         }
 
         let write_result = {
-            let _guard = out.write_timer.guard();
-            writer
+            let _guard = self.out.write_timer.guard();
+            self.writer
                 .as_mut()
                 .expect("writer is Some after lazy construction")
                 .write_record(&projected)
         };
         match write_result {
             Ok(()) => {
-                out.records_written += 1;
-                out.records_emitted += 1;
-                out.seen_row_nums.insert(rn);
+                self.out.records_written += 1;
+                self.out.records_emitted += 1;
+                self.out.seen_row_nums.insert(row_num);
+                ControlFlow::Continue(())
             }
             Err(e) => {
-                out.errors.push(PipelineError::from(e));
-                while rx.recv().is_ok() {}
-                charge_handle.set_bytes(0);
-                return out;
+                self.out.errors.push(PipelineError::from(e));
+                ControlFlow::Break(())
             }
         }
     }
 
-    // Channel closed — every sender dropped (`recv` returned `Err`),
-    // so no more records will arrive. Flush whatever the writer has
-    // buffered. `writer.is_none()` is the empty-stream case (zero
-    // records arrived); matches the buffered path's
-    // `if unbuffered.is_empty() { return Ok(()); }` short-circuit.
-    if let Some(timer) = scan_timer_slot.take() {
-        out.stage_metrics.push(timer.finish(0, 0));
+    fn on_punctuation(&mut self, _punct: Punctuation) {
+        // Streaming output is terminal — it writes records straight to
+        // disk, so a document boundary needs no writer action here.
+        // Per-document writer finalization (envelope header/footer
+        // streaming reconstruction on `DocumentClose`) is a separate piece
+        // of work; until then punctuations are discarded, byte-for-byte
+        // matching the buffered Output path.
     }
-    if let Some(mut w) = writer {
-        let flush_result = {
-            let _guard = out.write_timer.guard();
-            w.flush()
-        };
-        if let Err(e) = flush_result {
-            out.errors.push(PipelineError::from(e));
+
+    fn on_close(&mut self) {
+        // Flush whatever the writer has buffered. `writer.is_none()` is the
+        // empty-stream case (zero records arrived); matches the buffered
+        // path's `if unbuffered.is_empty() { return Ok(()); }` short-circuit
+        // — the pending scan timer is still finished so the stage metric is
+        // emitted with zero rows.
+        if let Some(timer) = self.scan_timer_slot.take() {
+            self.out.stage_metrics.push(timer.finish(0, 0));
+        }
+        if let Some(w) = self.writer.as_mut() {
+            let flush_result = {
+                let _guard = self.out.write_timer.guard();
+                w.flush()
+            };
+            if let Err(e) = flush_result {
+                self.out.errors.push(PipelineError::from(e));
+            }
         }
     }
-    // The channel is fully drained, so nothing is in flight; the
-    // per-record discharge above should have zeroed the counter already.
-    // Pin it to zero defensively so a heuristic mismatch between the
-    // batch charge and the per-record discharge can never leave a stale
-    // positive charge for the post-join arbitrator read.
-    charge_handle.set_bytes(0);
-    out
+}
+
+/// Streaming-output writer thread body — the `Output` instantiation of the
+/// generalized streaming-consumer substrate. Builds an
+/// [`OutputStreamConsumer`] over the writer lifecycle and drives it with
+/// [`drain_streaming_channel`], returning the folded-back per-task
+/// counters. See [`StreamingOutputSpec`] for the eligibility predicate and
+/// https://github.com/rustpunk/clinker/issues/72 for the rationale.
+pub(super) fn streaming_output(
+    rx: crossbeam_channel::Receiver<StreamEvent>,
+    raw_writer: Box<dyn Write + Send>,
+    spec: StreamingOutputSpec,
+    charge_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
+) -> StreamingOutputTaskOutput {
+    let mut consumer = OutputStreamConsumer::new(raw_writer, spec);
+    drain_streaming_channel(&rx, &charge_handle, &mut consumer);
+    consumer.out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::executor::node_buffer::record_byte_cost;
+    use crate::executor::stream_event::PunctuationKind;
+    use crate::pipeline::memory::ConsumerHandle;
+    use clinker_record::{Schema, Value, synthetic_document_context};
+    use std::sync::Arc;
+
+    /// One-column record used to size the per-record discharge against
+    /// `record_byte_cost(1)`.
+    fn rec(id: i64) -> Record {
+        Record::new(
+            Arc::new(Schema::new(vec!["id".into()])),
+            vec![Value::Integer(id)],
+        )
+    }
+
+    /// Records every event the skeleton routes, so a test can assert
+    /// arrival order, `on_close` invocation count, and the `Break` cutoff.
+    /// `break_at_row` makes `on_record` return `Break` on the matching row
+    /// number, exercising the deadlock-safe drain-on-fatal path.
+    struct Recorder {
+        records: Vec<u64>,
+        puncts: Vec<PunctuationKind>,
+        closes: usize,
+        break_at_row: Option<u64>,
+    }
+
+    impl Recorder {
+        fn new(break_at_row: Option<u64>) -> Self {
+            Self {
+                records: Vec::new(),
+                puncts: Vec::new(),
+                closes: 0,
+                break_at_row,
+            }
+        }
+    }
+
+    impl StreamingConsumer for Recorder {
+        fn on_record(&mut self, _record: Record, row_num: u64) -> ControlFlow<()> {
+            self.records.push(row_num);
+            if self.break_at_row == Some(row_num) {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        }
+
+        fn on_punctuation(&mut self, punct: Punctuation) {
+            self.puncts.push(punct.kind());
+        }
+
+        fn on_close(&mut self) {
+            self.closes += 1;
+        }
+    }
+
+    #[test]
+    fn full_drain_nets_charge_to_zero_and_preserves_order() {
+        let (tx, rx) = crossbeam_channel::unbounded::<StreamEvent>();
+        let charge = ConsumerHandle::new();
+        let n = 4u64;
+        // Mirror the producer's per-batch admit: charge the whole stream
+        // up front, then let the skeleton discharge each record as it
+        // drains.
+        charge.add_bytes(record_byte_cost(1) * n);
+        for rn in 0..n {
+            tx.send(StreamEvent::record(rec(rn as i64), rn)).unwrap();
+        }
+        drop(tx);
+
+        let mut consumer = Recorder::new(None);
+        drain_streaming_channel(&rx, &charge, &mut consumer);
+
+        assert_eq!(consumer.records, vec![0, 1, 2, 3], "records seen in order");
+        assert_eq!(consumer.closes, 1, "on_close fires once on clean drain");
+        assert_eq!(charge.bytes(), 0, "full drain nets the charge to zero");
+    }
+
+    #[test]
+    fn break_drains_channel_zeroes_charge_and_skips_close() {
+        let (tx, rx) = crossbeam_channel::unbounded::<StreamEvent>();
+        let charge = ConsumerHandle::new();
+        let n = 5u64;
+        charge.add_bytes(record_byte_cost(1) * n);
+        for rn in 0..n {
+            tx.send(StreamEvent::record(rec(rn as i64), rn)).unwrap();
+        }
+        drop(tx);
+
+        // Break on row 1: rows 2..5 remain in the channel and must be
+        // drained so a bounded producer `send` could not deadlock.
+        let mut consumer = Recorder::new(Some(1));
+        drain_streaming_channel(&rx, &charge, &mut consumer);
+
+        assert_eq!(
+            consumer.records,
+            vec![0, 1],
+            "stops handing records at Break"
+        );
+        assert_eq!(
+            consumer.closes, 0,
+            "on_close is skipped after a fatal Break"
+        );
+        assert_eq!(charge.bytes(), 0, "charge is zeroed even on the fatal path");
+        assert!(rx.try_recv().is_err(), "remaining events are drained");
+    }
+
+    #[test]
+    fn punctuations_route_without_discharge_in_arrival_order() {
+        let (tx, rx) = crossbeam_channel::unbounded::<StreamEvent>();
+        let charge = ConsumerHandle::new();
+        // Charge only the single record; punctuations contribute nothing.
+        charge.add_bytes(record_byte_cost(1));
+        let doc = synthetic_document_context();
+        tx.send(StreamEvent::punctuation(Punctuation::document_open(
+            Arc::clone(&doc),
+        )))
+        .unwrap();
+        tx.send(StreamEvent::record(rec(0), 0)).unwrap();
+        tx.send(StreamEvent::punctuation(Punctuation::document_close(
+            Arc::clone(&doc),
+        )))
+        .unwrap();
+        drop(tx);
+
+        let mut consumer = Recorder::new(None);
+        drain_streaming_channel(&rx, &charge, &mut consumer);
+
+        assert_eq!(
+            consumer.puncts,
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ],
+            "punctuations routed in arrival order"
+        );
+        assert_eq!(consumer.records, vec![0]);
+        assert_eq!(
+            charge.bytes(),
+            0,
+            "only the record discharged — punctuations carry no cost"
+        );
+    }
+
+    #[test]
+    fn disconnect_fires_close_once_then_zeroes_charge() {
+        let (tx, rx) = crossbeam_channel::unbounded::<StreamEvent>();
+        let charge = ConsumerHandle::new();
+        // Empty stream: no records charged, immediate disconnect.
+        drop(tx);
+
+        let mut consumer = Recorder::new(None);
+        drain_streaming_channel(&rx, &charge, &mut consumer);
+
+        assert!(consumer.records.is_empty(), "no records on an empty stream");
+        assert_eq!(
+            consumer.closes, 1,
+            "on_close fires exactly once on disconnect"
+        );
+        assert_eq!(charge.bytes(), 0);
+    }
 }

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use clinker_record::{Record, SchemaBuilder, Value};
 use indexmap::IndexMap;
@@ -109,7 +110,14 @@ pub fn project_output_from_record(
                 values.push(value.clone());
             }
         }
-        return Record::new(schema_builder.build(), values);
+        let mut out = Record::new(schema_builder.build(), values);
+        // The projected row is the same document's row — carry its
+        // envelope context forward so a writer that reconstructs the
+        // document envelope on output (e.g. EDIFACT `interchange_from_doc`
+        // echoing the source `UNB` header) can still resolve
+        // `$doc.<section>.<field>` after projection drops engine columns.
+        out.set_doc_ctx(Arc::clone(input_record.doc_ctx()));
+        return out;
     }
 
     // Slow path: config requires rewriting field names / dropping
@@ -180,14 +188,18 @@ pub fn project_output_from_record(
         .collect::<SchemaBuilder>()
         .build();
     let values: Vec<Value> = fields.into_values().collect();
-    Record::new(schema, values)
+    let mut out = Record::new(schema, values);
+    // Same document's row after the rename/exclude rewrite — carry the
+    // envelope context forward so document-reconstructing writers still
+    // resolve `$doc.<section>.<field>` on the projected record.
+    out.set_doc_ctx(Arc::clone(input_record.doc_ctx()));
+    out
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use clinker_record::Schema;
-    use std::sync::Arc;
 
     fn make_input() -> Record {
         // Schema is pre-widened to include every field the post-transform
@@ -533,6 +545,63 @@ mod tests {
         assert!(
             result.get("$widened").is_none(),
             "$widened slot must be stripped after expansion"
+        );
+    }
+
+    #[test]
+    fn fast_path_carries_doc_context_forward() {
+        use clinker_record::{DocumentContext, DocumentId};
+        use indexmap::IndexMap as RecIndexMap;
+
+        // The default Output config (no mapping/exclude, include_unmapped
+        // false, cxl_emit_names None) takes the fast path. A document-
+        // reconstructing writer downstream — e.g. EDIFACT
+        // `interchange_from_doc` echoing the source `UNB` — must still
+        // resolve `$doc.<section>.<field>` on the projected record, so the
+        // fast path has to carry the envelope context forward.
+        let schema = Arc::new(Schema::new(vec!["seg_id".into(), "e01".into()]));
+        let mut input = Record::new(
+            schema,
+            vec![Value::String("BGM".into()), Value::String("220".into())],
+        );
+        let mut unb: RecIndexMap<Box<str>, Value> = RecIndexMap::new();
+        unb.insert("e01".into(), Value::String("UNOA:1".into()));
+        let mut sections: RecIndexMap<Box<str>, Value> = RecIndexMap::new();
+        sections.insert("unb".into(), Value::Map(Box::new(unb)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        input.set_doc_ctx(Arc::clone(&ctx));
+
+        let config = OutputConfig {
+            name: "out".into(),
+            format: clinker_plan::config::OutputFormat::Csv(None),
+            path: "/tmp/out.csv".into(),
+            include_unmapped: false,
+            include_header: None,
+            mapping: None,
+            exclude: None,
+            sort_order: None,
+            preserve_nulls: None,
+            include_correlation_keys: false,
+            correlation_fanout_policy: None,
+            if_exists: Default::default(),
+            unique_suffix_width: 0,
+            write_meta: false,
+            schema: None,
+            split: None,
+            notes: None,
+        };
+
+        // cxl_emit_names None keeps drop_unmapped false, so needs_rewrite
+        // is false and the fast path runs.
+        let result = project_output_from_record(&input, &config, None);
+        assert_eq!(
+            result.doc_ctx().get_section_field("unb", "e01"),
+            Some(Value::String("UNOA:1".into())),
+            "fast path must carry the source document context forward"
         );
     }
 }

--- a/crates/clinker-exec/tests/edifact_pipeline.rs
+++ b/crates/clinker-exec/tests/edifact_pipeline.rs
@@ -1,0 +1,481 @@
+//! End-to-end EDIFACT ingestion and round-trip.
+//!
+//! Covers: (1) an EDIFACT source declaring a `UNB` envelope section feeds
+//! `$doc.<section>.<field>` into a Transform and writes CSV; (2) an
+//! EDIFACT→EDIFACT pipeline reconstructs the interchange envelope on
+//! output and re-parses identically (single-message ORDERS and a
+//! representative multi-message INVOIC with composite elements and line
+//! groups); (3) the `edifact`+`split` combination is rejected at config
+//! time; (4) a UNT count mismatch surfaces as a run failure.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// A single-message ORDERS interchange (no UNA; Level-A defaults). UNB
+/// control reference `REF1`; one UNH..UNT message of 4 segments.
+const ORDERS: &str = "UNB+UNOA:1+SENDER+RECEIVER+240101:1200+REF1'\
+    UNH+M1+ORDERS:D:96A:UN'\
+    BGM+220+12345'\
+    NAD+BY+ACME'\
+    UNT+4+M1'\
+    UNZ+1+REF1'";
+
+/// A representative INVOIC interchange: a `UNA` service-string advice
+/// header (explicit Level-A delimiters), two messages, composite elements
+/// (`DTM`/`MOA` data-element groups split on `:`), repeated `LIN`/`PIA`/`QTY`
+/// line-item groups, and recomputed `UNT`/`UNZ` control counts. Exercises a
+/// multi-segment-group message shape — not just a 3-segment synthetic one.
+const INVOIC: &str = "UNA:+.? '\
+    UNB+UNOC:3+SUPPLIER:14+BUYER:14+240310:0900+IC0007'\
+    UNH+INV1+INVOIC:D:96A:UN'\
+    BGM+380+INV-9001+9'\
+    DTM+137:20240310:102'\
+    NAD+SU+SUPPLIER::92'\
+    NAD+BY+BUYER::92'\
+    LIN+1++0764569910:EN'\
+    PIA+1+ABC123:SA'\
+    QTY+47:10'\
+    MOA+203:150.00'\
+    LIN+2++0764569927:EN'\
+    PIA+1+ABC124:SA'\
+    QTY+47:5'\
+    MOA+203:75.00'\
+    MOA+86:225.00'\
+    UNT+15+INV1'\
+    UNH+INV2+INVOIC:D:96A:UN'\
+    BGM+380+INV-9002+9'\
+    DTM+137:20240311:102'\
+    NAD+SU+SUPPLIER::92'\
+    NAD+BY+BUYER::92'\
+    LIN+1++0764569934:EN'\
+    QTY+47:3'\
+    MOA+203:30.00'\
+    MOA+86:30.00'\
+    UNT+10+INV2'\
+    UNZ+2+IC0007'";
+
+fn run(
+    yaml: &str,
+    source_name: &str,
+    fixture: &str,
+    file_name: &str,
+    out_name: &str,
+) -> Result<(clinker_exec::executor::ExecutionReport, String), String> {
+    let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
+    let plan = config
+        .compile(&CompileContext::default())
+        .map_err(|e| format!("compile: {e:?}"))?;
+
+    let file = FileSlot::new(
+        PathBuf::from(file_name),
+        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        source_name.to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        out_name.to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .map_err(|e| format!("run: {e:?}"))?;
+    Ok((report, buf.as_string()))
+}
+
+#[test]
+fn edifact_source_exposes_unb_envelope_to_transform() {
+    let yaml = r#"
+pipeline:
+  name: edifact_envelope
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      envelope:
+        sections:
+          unb:
+            extract: { segment: "UNB" }
+            fields:
+              e05: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: msg_ref, type: string }
+        - { name: e01, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit ref = msg_ref
+        emit control = $doc.unb.e05
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let (report, output) =
+        run(yaml, "interchange", ORDERS, "orders.edi", "out").expect("run edifact pipeline");
+    // Three body segments: UNH, BGM, NAD. Service segments not emitted.
+    assert_eq!(report.counters.total_count, 3, "output was: {output}");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 4, "header + 3 rows; got: {output}");
+    // The UNB control reference (element 5) resolves on every body row.
+    for row in &lines[1..] {
+        assert!(
+            row.contains("REF1"),
+            "row missing $doc.unb.e05 control ref: {row}"
+        );
+    }
+    // First body record is the UNH segment.
+    assert!(lines[1].starts_with("UNH,"), "first row: {}", lines[1]);
+}
+
+#[test]
+fn edifact_round_trip_reparses_identically() {
+    // Source parses EDIFACT and writes EDIFACT, reconstructing the
+    // interchange envelope from literal header elements. Re-parsing the
+    // output must yield the same body segments as the input.
+    let yaml = r#"
+pipeline:
+  name: edifact_round_trip
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      schema:
+        - { name: seg_id, type: string }
+        - { name: msg_ref, type: string }
+        - { name: msg_type, type: string }
+        - { name: e01, type: string }
+        - { name: e02, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: edifact
+      path: out.edi
+      include_unmapped: true
+      options:
+        interchange: ["UNOA:1", "SENDER", "RECEIVER", "240101:1200", "REF1"]
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "interchange", ORDERS, "orders.edi", "out").expect("run round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // The reconstructed envelope echoes the original control reference
+    // and recomputes the message count.
+    assert!(
+        output.contains("UNZ+1+REF1'"),
+        "round-trip UNZ control ref echo; output was: {output}"
+    );
+
+    // Feed the EDIFACT output back through a second pipeline (EDIFACT →
+    // CSV) to prove it re-parses identically: the body segment tags must
+    // round-trip in order.
+    let reparse_yaml = r#"
+pipeline:
+  name: edifact_reparse
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+      include_header: false
+"#;
+    let (reparse_report, reparse_csv) =
+        run(reparse_yaml, "interchange", &output, "echo.edi", "out").expect("re-parse round-trip");
+    assert_eq!(reparse_report.counters.dlq_count, 0);
+    let tags: Vec<&str> = reparse_csv.lines().map(str::trim).collect();
+    assert_eq!(
+        tags,
+        vec!["UNH", "BGM", "NAD"],
+        "round-trip body tags; edifact output was: {output}"
+    );
+}
+
+#[test]
+fn edifact_round_trip_echoes_unb_from_doc_context() {
+    // The output reconstructs the UNB header from the source's `$doc`
+    // envelope section (`interchange_from_doc`) rather than literal
+    // config — the full reader → document-context → writer path. The UNB
+    // here carries an empty middle element (an empty prep date/time, which
+    // keeps the control reference at the standard 5th-element position) and
+    // a release-escaped apostrophe in a body value; both must survive.
+    let input = "UNB+UNOA:1+SENDER+RECEIVER++REF9'\
+        UNH+M1+ORDERS:D:96A:UN'\
+        BGM+220+12345'\
+        NAD+BY+O?'BRIEN'\
+        UNT+4+M1'\
+        UNZ+1+REF9'";
+    let yaml = r#"
+pipeline:
+  name: edifact_from_doc
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      envelope:
+        sections:
+          unb:
+            extract: { segment: "UNB" }
+            fields:
+              e05: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: msg_ref, type: string }
+        - { name: msg_type, type: string }
+        - { name: e01, type: string }
+        - { name: e02, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: edifact
+      path: out.edi
+      include_unmapped: true
+      options:
+        interchange_from_doc: unb
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "interchange", input, "orders.edi", "out").expect("run from-doc round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+    // Empty middle element preserved; control reference echoed by UNZ.
+    assert!(
+        output.starts_with("UNB+UNOA:1+SENDER+RECEIVER++REF9'"),
+        "UNB reconstruction truncated the empty element: {output}"
+    );
+    assert!(output.contains("UNZ+1+REF9'"), "output was: {output}");
+    // The apostrophe is re-escaped on output, not emitted raw.
+    assert!(
+        output.contains("NAD+BY+O?'BRIEN'"),
+        "apostrophe not release-escaped on output: {output}"
+    );
+}
+
+#[test]
+fn edifact_invoic_multi_message_round_trips() {
+    // A representative two-message INVOIC interchange with a UNA header,
+    // composite elements, and repeated line-item groups must re-parse to
+    // the same body segment tags in order, and the writer must recompute
+    // both UNT message counts and the UNZ message count.
+    let yaml = r#"
+pipeline:
+  name: edifact_invoic
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      envelope:
+        sections:
+          unb:
+            extract: { segment: "UNB" }
+            fields:
+              e05: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: msg_ref, type: string }
+        - { name: msg_type, type: string }
+        - { name: e01, type: string }
+        - { name: e02, type: string }
+        - { name: e03, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: edifact
+      path: out.edi
+      include_unmapped: true
+      options:
+        interchange_from_doc: unb
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "interchange", INVOIC, "invoice.edi", "out").expect("run INVOIC round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+    // Two messages; UNZ echoes the original interchange control reference.
+    assert!(
+        output.contains("UNZ+2+IC0007'"),
+        "INVOIC UNZ control echo wrong: {output}"
+    );
+    // Recomputed per-message UNT counts (UNH + body + UNT). The first
+    // message has 13 body segments, the second 8.
+    assert!(
+        output.contains("UNT+15+INV1'"),
+        "first UNT recompute wrong: {output}"
+    );
+    assert!(
+        output.contains("UNT+10+INV2'"),
+        "second UNT recompute wrong: {output}"
+    );
+
+    // Re-parse the written interchange and confirm the body segment tags
+    // round-trip in order across both messages.
+    let reparse_yaml = r#"
+pipeline:
+  name: edifact_invoic_reparse
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+      include_header: false
+"#;
+    let (reparse_report, reparse_csv) =
+        run(reparse_yaml, "interchange", &output, "echo.edi", "out")
+            .expect("re-parse INVOIC round-trip");
+    assert_eq!(reparse_report.counters.dlq_count, 0);
+    let tags: Vec<&str> = reparse_csv.lines().map(str::trim).collect();
+    assert_eq!(
+        tags,
+        vec![
+            "UNH", "BGM", "DTM", "NAD", "NAD", "LIN", "PIA", "QTY", "MOA", "LIN", "PIA", "QTY",
+            "MOA", "MOA", "UNH", "BGM", "DTM", "NAD", "NAD", "LIN", "QTY", "MOA", "MOA",
+        ],
+        "INVOIC body tags did not round-trip; edifact output was: {output}"
+    );
+}
+
+#[test]
+fn edifact_output_with_split_is_rejected_at_config_time() {
+    // An interchange is one envelope; byte-limit splitting would finalize
+    // it mid-stream. The combination must fail config validation, not run
+    // and emit a corrupt interchange.
+    let yaml = r#"
+pipeline:
+  name: edifact_split
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: edifact
+      path: out.edi
+      options:
+        interchange: ["UNOA:1", "S", "R", "240101:1200", "REF1"]
+      split:
+        max_bytes: 1024
+"#;
+    let err = parse_config(yaml).expect_err("edifact + split must fail config validation");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("E323"), "expected E323 diagnostic, got: {msg}");
+}
+
+#[test]
+fn edifact_unt_count_mismatch_fails_the_run() {
+    // The UNT trailer claims 9 segments where the message has 4 — a
+    // truncation/corruption signal the reader surfaces as a run failure.
+    let bad = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+        UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+9+M1'UNZ+1+REF1'";
+    let yaml = r#"
+pipeline:
+  name: edifact_bad_count
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: edifact
+      glob: ./*.edi
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let result = run(yaml, "interchange", bad, "bad.edi", "out");
+    let err = result.expect_err("count mismatch must fail the run");
+    assert!(
+        err.contains("UNT segment count mismatch") || err.contains("EDIFACT"),
+        "error should name the EDIFACT count failure: {err}"
+    );
+}

--- a/crates/clinker-exec/tests/streaming_arms.rs
+++ b/crates/clinker-exec/tests/streaming_arms.rs
@@ -17,7 +17,7 @@
 //! 1. **Memory model.** The producer reports `buffer: streaming` in
 //!    `--explain` and emits NO `node_buffer` edge to its Output. Because
 //!    the explain classifier is derived from the exact
-//!    `streaming_output_producer` predicate the runtime sender-install
+//!    `certify_streaming_edge` predicate the runtime sender-install
 //!    consults, the annotation reflects what the dispatcher does: the
 //!    producer's output is not admitted to a charged, spill-eligible slot
 //!    that the Output would re-drain.

--- a/crates/clinker-exec/tests/transform_stream_fusion.rs
+++ b/crates/clinker-exec/tests/transform_stream_fusion.rs
@@ -542,7 +542,7 @@ nodes:
 /// no `node_buffer` edge is emitted out of it — a materialized Transform
 /// would report `buffer: materialized` and a `node_buffer (slot=N)` edge
 /// to the Output. Because the explain classification is derived from the
-/// exact `streaming_output_producer` predicate the runtime sender-install
+/// exact `certify_streaming_edge` predicate the runtime sender-install
 /// consults, this annotation reflects the dispatcher's runtime behavior.
 #[test]
 fn fused_transform_streams_to_output_without_charging_full_stage() {

--- a/crates/clinker-format/src/edifact/mod.rs
+++ b/crates/clinker-format/src/edifact/mod.rs
@@ -1,0 +1,36 @@
+//! UN/EDIFACT reader/writer pair.
+//!
+//! EDIFACT is a flat, delimiter-structured interchange format. An
+//! interchange opens with an optional `UNA` service-string advice and a
+//! mandatory `UNB` header, wraps one or more `UNH..UNT` messages, and
+//! closes with a `UNZ` trailer. Within a segment, data elements split on
+//! the element separator (default `+`), components on the component
+//! separator (default `:`); a release char (default `?`) escapes a
+//! delimiter that occurs as literal data.
+//!
+//! This module maps one body segment to one [`crate::traits::FormatReader`]
+//! record under a static positional schema (`seg_id`, `msg_ref`,
+//! `msg_type`, `e01..`). Service segments are consumed by the reader to
+//! validate `UNT`/`UNZ` control counts and control-reference echoes
+//! inline; they are never emitted as body records. The writer mirrors
+//! this, reconstructing the envelope around emitted records and
+//! recomputing every control count.
+//!
+//! Memory model: only the interchange header is pre-scanned and retained
+//! (so `$doc` envelope sections over `UNB` cost O(UNB)); the body streams
+//! one segment at a time. The whole interchange is never buffered.
+
+pub mod reader;
+mod tokenizer;
+pub mod writer;
+
+pub use reader::{EdifactReader, EdifactReaderConfig};
+pub use writer::{EdifactWriter, EdifactWriterConfig};
+
+/// Engine-internal key under which the reader stashes the complete,
+/// ordered `UNB` data-element list (empty middle elements included) in a
+/// `$doc` envelope section, for lossless writer reconstruction via
+/// `interchange_from_doc`. The `$` prefix marks it as engine-namespaced
+/// so it is not a user-declarable envelope field and never surfaces in
+/// CXL `$doc.<section>.<field>` typechecking.
+pub(crate) const RAW_ELEMENTS_KEY: &str = "$raw";

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -1,0 +1,829 @@
+//! UN/EDIFACT interchange reader.
+//!
+//! Streaming, row-at-a-time: each non-service segment of an interchange
+//! becomes one [`Record`] with a static positional schema
+//! `[seg_id, msg_ref, msg_type, e01..e<max>]`. Service segments
+//! (`UNB`/`UNZ`/`UNH`/`UNT`) are consumed by the reader to drive
+//! envelope state and inline structural validation; they are never
+//! emitted as body records.
+//!
+//! Memory model: only the interchange header (`UNA` + `UNB`) is
+//! pre-scanned and retained, so `prepare_document` exposes the `UNB`
+//! control fields as a `$doc` section with O(UNB) held memory. The body
+//! streams one segment at a time — the whole interchange is never
+//! buffered. Trailer control counts (`UNT`/`UNZ`) are validated as they
+//! arrive, not surfaced as envelope sections, because they follow the
+//! body and the document context is sealed before body streaming.
+
+use std::io::{BufReader, Read};
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+use indexmap::IndexMap;
+
+use crate::edifact::RAW_ELEMENTS_KEY;
+use crate::edifact::tokenizer::{ParsedSegment, SegmentTokenizer, split_segment};
+use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
+use crate::error::FormatError;
+use crate::traits::FormatReader;
+
+/// Default ceiling on the number of positional element columns the
+/// record schema exposes. A segment carrying more data elements than
+/// this errors with guidance rather than silently truncating.
+const DEFAULT_MAX_ELEMENTS: usize = 32;
+
+/// Configuration for the EDIFACT reader.
+pub struct EdifactReaderConfig {
+    /// Number of positional `eNN` element columns on the record schema.
+    /// A body segment with more data elements than this is rejected.
+    pub max_elements: usize,
+}
+
+impl Default for EdifactReaderConfig {
+    fn default() -> Self {
+        Self {
+            max_elements: DEFAULT_MAX_ELEMENTS,
+        }
+    }
+}
+
+/// Streaming EDIFACT interchange reader.
+///
+/// Holds the tokenizer, the static positional schema, and the inline
+/// envelope-validation state (open-message segment count, control-ref
+/// echoes, interchange message count). The `UNB` elements are stashed
+/// at initialization so [`FormatReader::prepare_document`] can serve a
+/// `UNB` envelope section without re-reading the source.
+pub struct EdifactReader<R: Read> {
+    tokenizer: SegmentTokenizer<BufReader<R>>,
+    schema: Arc<Schema>,
+    max_elements: usize,
+    initialized: bool,
+    /// Raw `UNB` data elements, stashed at init for envelope serving.
+    unb_elements: Vec<String>,
+    /// `UNB` interchange control reference (UNB element 5), echoed by
+    /// `UNZ` for round-trip integrity validation.
+    unb_control_ref: Option<String>,
+    /// State of the message currently being streamed, if any.
+    open_message: Option<OpenMessage>,
+    /// Count of `UNH` messages seen, checked against `UNZ`.
+    message_count: u64,
+    /// `true` once `UNZ` has been consumed; any further segment is an
+    /// after-trailer-content error.
+    interchange_closed: bool,
+    done: bool,
+}
+
+/// Per-message validation state for the message currently streaming.
+struct OpenMessage {
+    /// `UNH` message reference (UNH element 1), echoed by `UNT`.
+    reference: String,
+    /// Count of segments in this message including `UNH` (and, at close,
+    /// `UNT`), checked against the `UNT` segment count.
+    segment_count: u64,
+}
+
+impl<R: Read> EdifactReader<R> {
+    /// Build a reader over any `Read` source with the given element-width
+    /// configuration. Delimiter discovery and `UNB` consumption are
+    /// deferred to the first read.
+    pub fn new(reader: R, config: EdifactReaderConfig) -> Self {
+        let schema = build_schema(config.max_elements);
+        Self {
+            tokenizer: SegmentTokenizer::new(BufReader::new(reader)),
+            schema,
+            max_elements: config.max_elements,
+            initialized: false,
+            unb_elements: Vec::new(),
+            unb_control_ref: None,
+            open_message: None,
+            message_count: 0,
+            interchange_closed: false,
+            done: false,
+        }
+    }
+
+    /// Consume the optional `UNA` and the mandatory `UNB`, stashing the
+    /// interchange control reference and the `UNB` data elements for
+    /// envelope serving. Idempotent.
+    fn ensure_initialized(&mut self) -> Result<(), FormatError> {
+        if self.initialized {
+            return Ok(());
+        }
+        self.initialized = true;
+
+        let first = self.tokenizer.next_segment()?.ok_or_else(|| {
+            FormatError::Edifact("empty interchange: no UNB segment found".into())
+        })?;
+        let delims = self.tokenizer.delimiters();
+        let parsed = split_segment(&first, &delims);
+        if parsed.tag != "UNB" {
+            return Err(FormatError::Edifact(format!(
+                "interchange must begin with a UNB segment, found {:?}",
+                parsed.tag
+            )));
+        }
+        // UNB control reference is data element 5 (index 4). It may be
+        // absent in degenerate fixtures; absence disables the UNZ-echo
+        // check rather than failing the parse.
+        self.unb_control_ref = parsed.elements.get(4).cloned();
+        self.unb_elements = parsed.elements;
+        Ok(())
+    }
+
+    /// Pull the next service-or-body segment and advance envelope state.
+    /// Returns the body record to emit, or `None` at clean interchange
+    /// end. Service segments are consumed transparently (the loop
+    /// continues) so the caller only ever sees body records.
+    fn pull_next(&mut self) -> Result<Option<Record>, FormatError> {
+        loop {
+            let raw = match self.tokenizer.next_segment()? {
+                Some(s) => s,
+                None => {
+                    if !self.interchange_closed {
+                        return Err(FormatError::Edifact(
+                            "interchange truncated: reached end of input with no UNZ trailer"
+                                .into(),
+                        ));
+                    }
+                    self.done = true;
+                    return Ok(None);
+                }
+            };
+            let delims = self.tokenizer.delimiters();
+            let segment = split_segment(&raw, &delims);
+
+            if self.interchange_closed {
+                return Err(FormatError::Edifact(format!(
+                    "segment {:?} found after the UNZ interchange trailer; \
+                     content past UNZ is not permitted",
+                    segment.tag
+                )));
+            }
+
+            match segment.tag.as_str() {
+                "UNB" => {
+                    return Err(FormatError::Edifact(
+                        "a second UNB segment appeared; nested or repeated interchanges \
+                         in one stream are not supported"
+                            .into(),
+                    ));
+                }
+                "UNG" | "UNE" => {
+                    return Err(FormatError::Edifact(format!(
+                        "functional group segment {:?} is not supported; this reader \
+                         handles a single UNB..UNZ interchange without UNG/UNE groups",
+                        segment.tag
+                    )));
+                }
+                "UNH" => {
+                    if self.open_message.is_some() {
+                        return Err(FormatError::Edifact(
+                            "UNH opened a new message before the previous message's UNT \
+                             trailer; messages must be UNH..UNT balanced"
+                                .into(),
+                        ));
+                    }
+                    let reference = segment.elements.first().cloned().unwrap_or_default();
+                    self.open_message = Some(OpenMessage {
+                        reference: reference.clone(),
+                        segment_count: 1,
+                    });
+                    self.message_count += 1;
+                    let record = self.body_record(&segment)?;
+                    return Ok(Some(record));
+                }
+                "UNT" => {
+                    self.close_message(&segment)?;
+                    // UNT is a service segment — consume and continue.
+                }
+                "UNZ" => {
+                    self.close_interchange(&segment)?;
+                    // UNZ is a service segment — consume and continue to
+                    // the EOF check on the next loop turn.
+                }
+                _ => {
+                    let msg = self.open_message.as_mut().ok_or_else(|| {
+                        FormatError::Edifact(format!(
+                            "body segment {:?} appeared outside any UNH..UNT message",
+                            segment.tag
+                        ))
+                    })?;
+                    msg.segment_count += 1;
+                    let record = self.body_record(&segment)?;
+                    return Ok(Some(record));
+                }
+            }
+        }
+    }
+
+    /// Validate and close the open message against its `UNT` trailer.
+    /// `UNT` carries the message segment count (element 1, including
+    /// `UNH` and `UNT`) and the message reference echo (element 2).
+    fn close_message(&mut self, unt: &ParsedSegment) -> Result<(), FormatError> {
+        let msg = self
+            .open_message
+            .take()
+            .ok_or_else(|| FormatError::Edifact("UNT trailer with no open UNH message".into()))?;
+        let claimed: u64 = unt
+            .elements
+            .first()
+            .ok_or_else(|| FormatError::Edifact("UNT missing its segment-count element".into()))?
+            .trim()
+            .parse()
+            .map_err(|_| {
+                FormatError::Edifact(format!(
+                    "UNT segment count {:?} is not a number",
+                    unt.elements.first()
+                ))
+            })?;
+        // The open message's running count tallied UNH + body segments;
+        // the UNT segment itself completes the count.
+        let actual = msg.segment_count + 1;
+        if claimed != actual {
+            return Err(FormatError::Edifact(format!(
+                "UNT segment count mismatch for message {:?}: trailer claims {claimed}, \
+                 interchange contains {actual} (UNH..UNT inclusive)",
+                msg.reference
+            )));
+        }
+        let echoed_ref = unt.elements.get(1).map(|s| s.as_str()).unwrap_or("");
+        if echoed_ref != msg.reference {
+            return Err(FormatError::Edifact(format!(
+                "UNT message reference {echoed_ref:?} does not echo the UNH reference \
+                 {:?}",
+                msg.reference
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validate and close the interchange against its `UNZ` trailer.
+    /// `UNZ` carries the interchange message count (element 1) and the
+    /// interchange control-reference echo (element 2).
+    fn close_interchange(&mut self, unz: &ParsedSegment) -> Result<(), FormatError> {
+        if self.open_message.is_some() {
+            return Err(FormatError::Edifact(
+                "UNZ interchange trailer arrived before the last message's UNT".into(),
+            ));
+        }
+        let claimed: u64 = unz
+            .elements
+            .first()
+            .ok_or_else(|| FormatError::Edifact("UNZ missing its message-count element".into()))?
+            .trim()
+            .parse()
+            .map_err(|_| {
+                FormatError::Edifact(format!(
+                    "UNZ message count {:?} is not a number",
+                    unz.elements.first()
+                ))
+            })?;
+        if claimed != self.message_count {
+            return Err(FormatError::Edifact(format!(
+                "UNZ message count mismatch: trailer claims {claimed}, interchange \
+                 contains {} messages",
+                self.message_count
+            )));
+        }
+        if let Some(expected) = &self.unb_control_ref {
+            let echoed = unz.elements.get(1).map(|s| s.as_str()).unwrap_or("");
+            if echoed != expected {
+                return Err(FormatError::Edifact(format!(
+                    "UNZ control reference {echoed:?} does not echo the UNB reference \
+                     {expected:?}"
+                )));
+            }
+        }
+        self.interchange_closed = true;
+        Ok(())
+    }
+
+    /// Map a parsed segment to a positional [`Record`] under the static
+    /// schema. `seg_id`, `msg_ref`, and `msg_type` are stamped from the
+    /// open message; the data elements fill `e01..`. Absent trailing
+    /// elements stay `Value::Null`; an element count past `max_elements`
+    /// errors with guidance.
+    fn body_record(&self, segment: &ParsedSegment) -> Result<Record, FormatError> {
+        if segment.elements.len() > self.max_elements {
+            return Err(FormatError::Edifact(format!(
+                "segment {:?} carries {} data elements, exceeding the configured \
+                 max_elements of {}; raise the source's `max_elements` option",
+                segment.tag,
+                segment.elements.len(),
+                self.max_elements
+            )));
+        }
+        let (msg_ref, msg_type) = match (segment.tag.as_str(), &self.open_message) {
+            // The UNH record's own elements carry the ref and type; the
+            // open message was just created from them.
+            ("UNH", _) => (
+                segment.elements.first().cloned().unwrap_or_default(),
+                segment.elements.get(1).cloned().unwrap_or_default(),
+            ),
+            (_, Some(msg)) => (msg.reference.clone(), String::new()),
+            (_, None) => (String::new(), String::new()),
+        };
+
+        let mut values: Vec<Value> = Vec::with_capacity(3 + self.max_elements);
+        values.push(Value::String(segment.tag.as_str().into()));
+        values.push(string_or_null(&msg_ref));
+        values.push(string_or_null(&msg_type));
+        for i in 0..self.max_elements {
+            match segment.elements.get(i) {
+                Some(e) => values.push(string_or_null(e)),
+                None => values.push(Value::Null),
+            }
+        }
+        Ok(Record::new(Arc::clone(&self.schema), values))
+    }
+}
+
+impl<R: Read + Send> FormatReader for EdifactReader<R> {
+    fn schema(&mut self) -> Result<Arc<Schema>, FormatError> {
+        Ok(Arc::clone(&self.schema))
+    }
+
+    fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
+        if self.done {
+            return Ok(None);
+        }
+        self.ensure_initialized()?;
+        self.pull_next()
+    }
+
+    fn prepare_document(
+        &mut self,
+        config: &EnvelopeConfig,
+    ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
+        if config.is_empty() {
+            return Ok(IndexMap::new());
+        }
+        self.ensure_initialized()?;
+
+        let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(config.sections.len());
+        for (name, section) in &config.sections {
+            let segment_tag = match &section.extract {
+                EnvelopeExtract::Segment(tag) => tag.as_str(),
+                EnvelopeExtract::XmlPath(_) | EnvelopeExtract::JsonPointer(_) => {
+                    return Err(FormatError::Edifact(format!(
+                        "envelope section {name:?}: declared a non-`segment` extract \
+                         against an EDIFACT source. Use `segment` (e.g. \
+                         `extract: {{ segment: \"UNB\" }}`) for EDIFACT envelope sections."
+                    )));
+                }
+            };
+            if segment_tag != "UNB" {
+                return Err(FormatError::Edifact(format!(
+                    "envelope section {name:?}: segment {segment_tag:?} is not \
+                     extractable. Only the interchange header `UNB` is available as \
+                     an envelope section; trailer segments (UNT/UNZ) arrive after the \
+                     body and are validated by the reader, not exposed as $doc fields."
+                )));
+            }
+            let raw: Vec<(String, String)> = self
+                .unb_elements
+                .iter()
+                .enumerate()
+                .map(|(i, e)| (positional_key(i), e.clone()))
+                .collect();
+            let mut typed =
+                coerce_section_fields(raw, &section.fields).map_err(FormatError::Edifact)?;
+            // Stash the complete, ordered UNB element list (empty middle
+            // elements included) under an engine-internal key so a writer
+            // can reconstruct the header losslessly via
+            // `interchange_from_doc`. The declared `fields` drive typed
+            // CXL `$doc.<section>.<field>` access and intentionally drop
+            // empty/undeclared elements; that filtered view cannot
+            // round-trip a UNB whose middle elements are empty, so the
+            // raw list is carried alongside it for the writer's use.
+            let raw_elements: Vec<Value> = self
+                .unb_elements
+                .iter()
+                .map(|e| Value::String(e.as_str().into()))
+                .collect();
+            typed.insert(Box::from(RAW_ELEMENTS_KEY), Value::Array(raw_elements));
+            out.insert(Box::from(name.as_str()), Value::Map(Box::new(typed)));
+        }
+        Ok(out)
+    }
+}
+
+/// Build the static positional schema `[seg_id, msg_ref, msg_type,
+/// e01..e<max>]`. All columns are string-typed; element text is stored
+/// verbatim so the round-trip is lossless.
+fn build_schema(max_elements: usize) -> Arc<Schema> {
+    let mut columns: Vec<Box<str>> = Vec::with_capacity(3 + max_elements);
+    columns.push(Box::from("seg_id"));
+    columns.push(Box::from("msg_ref"));
+    columns.push(Box::from("msg_type"));
+    for i in 0..max_elements {
+        columns.push(positional_key(i).into_boxed_str());
+    }
+    Arc::new(Schema::new(columns))
+}
+
+/// Positional element column name for element index `i`: `e01`, `e02`, …
+fn positional_key(i: usize) -> String {
+    format!("e{:02}", i + 1)
+}
+
+/// Map an element string to a `Value`: empty text becomes `Null` so an
+/// absent or blank element is uniformly null at the schema slot.
+fn string_or_null(s: &str) -> Value {
+    if s.is_empty() {
+        Value::Null
+    } else {
+        Value::String(s.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{EnvelopeFieldType, EnvelopeSection};
+    use std::io::Cursor;
+
+    fn reader(data: &str) -> EdifactReader<Cursor<Vec<u8>>> {
+        EdifactReader::new(
+            Cursor::new(data.as_bytes().to_vec()),
+            EdifactReaderConfig::default(),
+        )
+    }
+
+    /// A minimal valid single-message ORDERS interchange (no UNA;
+    /// Level-A defaults). UNH..UNT covers 4 segments (UNH, BGM, NAD,
+    /// UNT); UNZ claims 1 message and echoes the UNB ref `REF1`.
+    const ORDERS: &str = "UNB+UNOA:1+SENDER+RECEIVER+240101:1200+REF1'\
+        UNH+M1+ORDERS:D:96A:UN'\
+        BGM+220+12345'\
+        NAD+BY+ACME'\
+        UNT+4+M1'\
+        UNZ+1+REF1'";
+
+    fn collect(data: &str) -> Vec<Record> {
+        let mut r = reader(data);
+        let mut out = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            out.push(rec);
+        }
+        out
+    }
+
+    #[test]
+    fn one_record_per_body_segment_with_positional_columns() {
+        let recs = collect(ORDERS);
+        // UNH, BGM, NAD are body records; UNB/UNZ/UNT are not emitted.
+        assert_eq!(recs.len(), 3);
+        assert_eq!(recs[0].get("seg_id"), Some(&Value::String("UNH".into())));
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("BGM".into())));
+        assert_eq!(recs[1].get("e01"), Some(&Value::String("220".into())));
+        assert_eq!(recs[1].get("e02"), Some(&Value::String("12345".into())));
+        assert_eq!(recs[2].get("seg_id"), Some(&Value::String("NAD".into())));
+    }
+
+    #[test]
+    fn unh_ref_and_type_stamped_on_every_message_record() {
+        let recs = collect(ORDERS);
+        for rec in &recs {
+            assert_eq!(rec.get("msg_ref"), Some(&Value::String("M1".into())));
+        }
+        // The UNH record carries the composite message type verbatim.
+        assert_eq!(
+            recs[0].get("msg_type"),
+            Some(&Value::String("ORDERS:D:96A:UN".into()))
+        );
+    }
+
+    #[test]
+    fn service_segments_never_emitted_as_body() {
+        let recs = collect(ORDERS);
+        for rec in &recs {
+            let seg = rec.get("seg_id").unwrap();
+            assert!(!matches!(seg, Value::String(s) if matches!(&**s, "UNB" | "UNZ" | "UNT")));
+        }
+    }
+
+    #[test]
+    fn absent_trailing_elements_are_null() {
+        let recs = collect(ORDERS);
+        // BGM has 2 elements; e03.. are null.
+        assert_eq!(recs[1].get("e03"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn release_sequences_decode_into_clean_values() {
+        // The NAD element carries a release-escaped apostrophe on the
+        // wire (O?'BRIEN). The reader must decode it so downstream sees
+        // the clean data "O'BRIEN", not the wire escape.
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'NAD+O?'BRIEN'UNT+3+M1'UNZ+1+REF1'";
+        let recs = collect(data);
+        let nad = &recs[1];
+        assert_eq!(
+            nad.get("e01"),
+            Some(&Value::String("O'BRIEN".into())),
+            "release sequence leaked into the parsed value"
+        );
+    }
+
+    #[test]
+    fn escaped_element_separator_decodes_and_does_not_split() {
+        // BGM+A?+B' — the ?+ is one element "A+B", not two elements.
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+A?+B'UNT+3+M1'UNZ+1+REF1'";
+        let recs = collect(data);
+        let bgm = &recs[1];
+        assert_eq!(bgm.get("e01"), Some(&Value::String("A+B".into())));
+        assert_eq!(bgm.get("e02"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn unt_segment_count_mismatch_errors() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+9+M1'UNZ+1+REF1'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected count mismatch error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("UNT segment count mismatch")));
+    }
+
+    #[test]
+    fn unt_ref_unh_ref_mismatch_errors() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+WRONG'UNZ+1+REF1'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected ref mismatch error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("does not echo the UNH")));
+    }
+
+    #[test]
+    fn unz_message_count_mismatch_errors() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+5+REF1'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected message count mismatch"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("UNZ message count mismatch")));
+    }
+
+    #[test]
+    fn unz_ref_unb_ref_mismatch_errors() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+WRONGREF'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected control ref mismatch"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("does not echo the UNB")));
+    }
+
+    #[test]
+    fn missing_unz_at_eof_errors() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected truncation error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("no UNZ")));
+    }
+
+    #[test]
+    fn content_after_unz_errors() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF1'BGM+999'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected after-trailer error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("after the UNZ")));
+    }
+
+    #[test]
+    fn ung_une_unsupported_error() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'UNG+ORDERS+S+R'UNZ+0+REF1'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected UNG unsupported error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("functional group")));
+    }
+
+    #[test]
+    fn max_elements_overflow_errors_with_guidance() {
+        let mut r = EdifactReader::new(
+            Cursor::new(
+                "UNB+UNOA:1+S+R+240101:1200+REF1'\
+                 UNH+M1+ORDERS:D:96A:UN'BGM+a+b+c+d'UNT+3+M1'UNZ+1+REF1'"
+                    .as_bytes()
+                    .to_vec(),
+            ),
+            EdifactReaderConfig { max_elements: 2 },
+        );
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected element overflow"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("max_elements")));
+    }
+
+    fn unb_section(fields: &[(&str, EnvelopeFieldType)]) -> EnvelopeConfig {
+        let mut cfg = EnvelopeConfig::default();
+        let mut field_map = IndexMap::new();
+        for (k, ty) in fields {
+            field_map.insert((*k).to_string(), *ty);
+        }
+        cfg.sections.insert(
+            "interchange".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("UNB".to_string()),
+                fields: field_map,
+            },
+        );
+        cfg
+    }
+
+    #[test]
+    fn prepare_document_extracts_unb_positional_fields_typed() {
+        let cfg = unb_section(&[
+            ("e01", EnvelopeFieldType::String),
+            ("e05", EnvelopeFieldType::String),
+        ]);
+        let mut r = reader(ORDERS);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let interchange = match sections.get("interchange").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // UNB element 1 is the syntax identifier composite "UNOA:1".
+        assert_eq!(
+            interchange.get("e01"),
+            Some(&Value::String("UNOA:1".into()))
+        );
+        // UNB element 5 is the interchange control reference.
+        assert_eq!(interchange.get("e05"), Some(&Value::String("REF1".into())));
+        // Body still streams after the header pre-scan.
+        let recs: Vec<_> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(recs.len(), 3);
+    }
+
+    #[test]
+    fn prepare_document_rejects_non_unb_segment() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "trailer".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("UNZ".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(ORDERS);
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("not extractable")));
+    }
+
+    #[test]
+    fn prepare_document_rejects_xml_path_and_json_pointer_extracts() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "bad".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::XmlPath("/doc".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(ORDERS);
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("non-`segment`")));
+    }
+
+    #[test]
+    fn multi_message_interchange_streams_all_bodies() {
+        let data = "UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220+A'UNT+3+M1'\
+            UNH+M2+ORDERS:D:96A:UN'BGM+220+B'UNT+3+M2'\
+            UNZ+2+REF1'";
+        let recs = collect(data);
+        // Two messages, each UNH + BGM = 2 body records.
+        assert_eq!(recs.len(), 4);
+        assert_eq!(recs[0].get("msg_ref"), Some(&Value::String("M1".into())));
+        assert_eq!(recs[2].get("msg_ref"), Some(&Value::String("M2".into())));
+    }
+
+    #[test]
+    fn una_present_interchange_parses() {
+        let data = "UNA:+.? 'UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF1'";
+        let recs = collect(data);
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[0].get("seg_id"), Some(&Value::String("UNH".into())));
+    }
+
+    /// Full reader → `$doc` → writer → reader round-trip exercising a UNB
+    /// header with an empty middle element and a release-escaped data
+    /// byte — the path that the writer's `interchange_from_doc`
+    /// reconstruction and release-escaping must keep faithful end to end.
+    #[test]
+    fn reader_doc_writer_round_trip_preserves_unb_and_escapes() {
+        use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
+        use crate::envelope::EnvelopeFieldType;
+        use crate::traits::FormatWriter;
+        use clinker_record::{DocumentContext, DocumentId};
+
+        // UNB element 4 (index 3, the prep date/time) is empty, so the
+        // control reference "REF9" stays at the standard 5th-element
+        // position (index 4); the NAD body element carries a literal
+        // apostrophe that arrives release-escaped on the wire.
+        let input = "UNB+UNOA:1+SENDER+RECEIVER++REF9'\
+            UNH+M1+ORDERS:D:96A:UN'NAD+O?'BRIEN'UNT+3+M1'UNZ+1+REF9'";
+
+        // 1. Read the envelope section and body records.
+        let cfg = unb_section(&[("e05", EnvelopeFieldType::String)]);
+        let mut r = reader(input);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 2); // UNH, NAD
+
+        // The decoded NAD value is clean (no wire escape).
+        assert_eq!(
+            body_recs[1].get("e01"),
+            Some(&Value::String("O'BRIEN".into()))
+        );
+
+        // 2. Attach the document context and re-emit through the writer.
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        let schema = r.schema().unwrap();
+        let out = {
+            let mut buf = Vec::new();
+            let mut w = EdifactWriter::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                EdifactWriterConfig {
+                    interchange_from_doc: Some("interchange".into()),
+                    segment_newline: false,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+
+        // The empty middle element and the release-escaped apostrophe both
+        // survive the reconstruction.
+        assert!(
+            out.starts_with("UNB+UNOA:1+SENDER+RECEIVER++REF9'"),
+            "{out}"
+        );
+        assert!(out.contains("NAD+O?'BRIEN'"), "{out}");
+        assert!(out.contains("UNZ+1+REF9'"), "{out}");
+
+        // 3. Re-read the emitted interchange: the decoded value matches.
+        let recs2 = collect(&out);
+        assert_eq!(recs2[1].get("e01"), Some(&Value::String("O'BRIEN".into())));
+    }
+}

--- a/crates/clinker-format/src/edifact/tokenizer.rs
+++ b/crates/clinker-format/src/edifact/tokenizer.rs
@@ -1,0 +1,454 @@
+//! UN/EDIFACT segment tokenizer: delimiter discovery and
+//! release-char-aware splitting.
+//!
+//! An EDIFACT interchange is a flat byte stream of segments terminated
+//! by the segment terminator (default `'`). Each segment splits into a
+//! tag and data elements on the element separator (default `+`); each
+//! element splits into components on the component separator (default
+//! `:`). A leading 9-byte `UNA` service-string-advice overrides those
+//! delimiters; when `UNA` is absent the syntax Level-A defaults apply.
+//!
+//! Memory model: the tokenizer reads one segment at a time from a
+//! buffered source into a bounded scratch buffer. A hard per-segment
+//! byte cap turns a missing terminator (truncated / corrupt input)
+//! into an error rather than letting the buffer grow without limit.
+
+use std::io::{BufRead, Read};
+
+use crate::error::FormatError;
+
+/// Hard ceiling on a single segment's raw byte length. A real EDIFACT
+/// segment is well under a kilobyte; this cap exists only so a stream
+/// with no terminator byte fails fast instead of buffering the whole
+/// file into one "segment".
+pub(crate) const MAX_SEGMENT_BYTES: usize = 64 * 1024;
+
+/// The six EDIFACT service characters discovered from `UNA` (or the
+/// Level-A defaults when `UNA` is absent).
+///
+/// The `repetition` separator is stored but never split on: element
+/// text is kept verbatim, so a repeating element rides inside one
+/// element string intact (no first-only data loss). The Level-A default
+/// is space, which syntax version 3 reserves as unused — splitting on it
+/// would corrupt ordinary text data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Delimiters {
+    pub component: u8,
+    pub element: u8,
+    pub decimal: u8,
+    pub release: u8,
+    pub repetition: u8,
+    pub terminator: u8,
+}
+
+impl Delimiters {
+    /// Syntax Level-A defaults, used when no `UNA` prefix is present.
+    pub(crate) fn level_a() -> Self {
+        Self {
+            component: b':',
+            element: b'+',
+            decimal: b'.',
+            release: b'?',
+            repetition: b' ',
+            terminator: b'\'',
+        }
+    }
+}
+
+/// Streaming EDIFACT segment reader.
+///
+/// Wraps a buffered source and yields one raw segment string at a time
+/// (terminator stripped, inter-segment CR/LF whitespace stripped). The
+/// delimiters are discovered once from the optional `UNA` prefix on the
+/// first read.
+pub(crate) struct SegmentTokenizer<R: Read> {
+    reader: R,
+    delimiters: Delimiters,
+    initialized: bool,
+}
+
+impl<R: BufRead> SegmentTokenizer<R> {
+    /// Build a tokenizer over a buffered source. Delimiter discovery is
+    /// deferred to the first [`Self::next_segment`] call so the `UNA`
+    /// scan and the first segment read share one pass.
+    pub(crate) fn new(reader: R) -> Self {
+        Self {
+            reader,
+            delimiters: Delimiters::level_a(),
+            initialized: false,
+        }
+    }
+
+    /// The active delimiter set (Level-A until the first read resolves
+    /// any `UNA` prefix).
+    pub(crate) fn delimiters(&self) -> Delimiters {
+        self.delimiters
+    }
+
+    /// Resolve the optional `UNA` prefix. Peeks the first bytes of the
+    /// stream: a `UNA` tag consumes the 9-byte service string and the
+    /// (optional) single separator byte that follows it; otherwise the
+    /// Level-A defaults stand and no bytes are consumed.
+    fn initialize(&mut self) -> Result<(), FormatError> {
+        if self.initialized {
+            return Ok(());
+        }
+        self.initialized = true;
+
+        let head = self.reader.fill_buf()?;
+        if head.starts_with(b"UNA") {
+            if head.len() < 9 {
+                // A truncated UNA is unrecoverable — the delimiter set is
+                // undefined, so nothing downstream can be tokenized.
+                return Err(FormatError::Edifact(
+                    "truncated UNA service string: need 9 bytes after the stream start, \
+                     the interchange is corrupt or truncated"
+                        .into(),
+                ));
+            }
+            // UNA layout: bytes 3..9 are component, element, decimal,
+            // release, repetition, terminator in that fixed order.
+            let una = &head[3..9];
+            let delimiters = Delimiters {
+                component: una[0],
+                element: una[1],
+                decimal: una[2],
+                release: una[3],
+                repetition: una[4],
+                terminator: una[5],
+            };
+            self.delimiters = delimiters;
+            self.reader.consume(9);
+            self.skip_inter_segment_whitespace()?;
+        }
+        Ok(())
+    }
+
+    /// Consume CR/LF (and surrounding spaces/tabs) that some producers
+    /// insert between segments for readability. Stops at the first byte
+    /// that could begin a segment tag.
+    fn skip_inter_segment_whitespace(&mut self) -> Result<(), FormatError> {
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                return Ok(());
+            }
+            let mut consumed = 0;
+            for &b in buf {
+                if b == b'\r' || b == b'\n' {
+                    consumed += 1;
+                } else {
+                    break;
+                }
+            }
+            if consumed == 0 {
+                return Ok(());
+            }
+            self.reader.consume(consumed);
+        }
+    }
+
+    /// Read the next raw segment (terminator-delimited), or `None` at
+    /// clean end of stream.
+    ///
+    /// The terminator byte is consumed but not returned. A release char
+    /// immediately before a terminator escapes it (the terminator is
+    /// then literal data, not a boundary). CR/LF between segments is
+    /// dropped; CR/LF inside an element is preserved.
+    pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
+        self.initialize()?;
+        self.skip_inter_segment_whitespace()?;
+
+        let terminator = self.delimiters.terminator;
+        let release = self.delimiters.release;
+
+        let mut raw: Vec<u8> = Vec::new();
+        let mut pending_release = false;
+
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                // EOF. A non-empty pending buffer means a final segment
+                // with no terminator — truncation, not a clean end.
+                if raw.is_empty() {
+                    return Ok(None);
+                }
+                return Err(FormatError::Edifact(format!(
+                    "unterminated final segment ({} bytes read with no segment terminator); \
+                     the interchange is truncated",
+                    raw.len()
+                )));
+            }
+
+            let mut consumed = 0;
+            let mut finished = false;
+            for &b in buf {
+                consumed += 1;
+                if pending_release {
+                    // The previous byte was an unescaped release char;
+                    // this byte is literal regardless of its role.
+                    raw.push(release);
+                    raw.push(b);
+                    pending_release = false;
+                    continue;
+                }
+                if b == release {
+                    pending_release = true;
+                    continue;
+                }
+                if b == terminator {
+                    finished = true;
+                    break;
+                }
+                raw.push(b);
+            }
+            self.reader.consume(consumed);
+
+            if raw.len() > MAX_SEGMENT_BYTES {
+                return Err(FormatError::Edifact(format!(
+                    "segment exceeded the {MAX_SEGMENT_BYTES}-byte cap without a terminator; \
+                     the interchange is malformed or the segment terminator is misconfigured"
+                )));
+            }
+
+            if finished {
+                if pending_release {
+                    // Dangling release char with nothing to escape.
+                    raw.push(release);
+                }
+                let segment = strip_edge_whitespace(&raw);
+                let text = String::from_utf8(segment).map_err(|e| {
+                    FormatError::Edifact(format!(
+                        "segment is not valid UTF-8: {e}. Non-UTF-8 charsets \
+                         (UNOA/UNOB/Latin-1 high bytes) are not supported"
+                    ))
+                })?;
+                return Ok(Some(text));
+            }
+        }
+    }
+}
+
+/// Drop CR/LF that bracket a raw segment body. Interior CR/LF is left
+/// intact — only the readability newlines a producer wraps around the
+/// terminator are insignificant.
+fn strip_edge_whitespace(raw: &[u8]) -> Vec<u8> {
+    let start = raw
+        .iter()
+        .position(|&b| b != b'\r' && b != b'\n')
+        .unwrap_or(raw.len());
+    let end = raw
+        .iter()
+        .rposition(|&b| b != b'\r' && b != b'\n')
+        .map(|p| p + 1)
+        .unwrap_or(start);
+    raw[start..end].to_vec()
+}
+
+/// A parsed segment: its tag plus its decoded data elements.
+///
+/// Release-escape sequences are decoded into their literal data byte
+/// here, so an element value carries clean data (a `?'` on the wire
+/// becomes a literal `'` in the value, a `?+` becomes a literal `+`).
+/// Downstream consumers — CSV/JSON output, CXL string predicates,
+/// `$doc` fields — therefore see the data the EDIFACT producer meant,
+/// never the wire escapes. The writer re-escapes on output, so the
+/// reader → writer → reader round-trip is byte-faithful.
+///
+/// Component and repetition separators are *not* decoded or split:
+/// element text keeps them verbatim, so a composite element `A:B:C`
+/// stays one element string `"A:B:C"` and a repeating element rides
+/// inside one string intact (no first-only data loss). The positional
+/// element model deliberately works above the component/repetition
+/// resolution — only the release mechanism is interpreted, because that
+/// is what distinguishes a delimiter byte from literal data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedSegment {
+    pub tag: String,
+    pub elements: Vec<String>,
+}
+
+/// Split a raw segment string into its tag and decoded element values on
+/// the element separator, honoring the release char.
+///
+/// The tag is the first element; the remainder are data elements. A
+/// release char escapes the following byte, which is emitted as literal
+/// data with the release char dropped (so `?+` decodes to `+`, `?'` to
+/// `'`, `??` to `?`). An unescaped element separator splits; an
+/// unescaped component separator is kept verbatim (it is part of the
+/// element's internal composite structure, not a data byte to decode).
+/// Repetition splitting is not performed — repetitions ride inside the
+/// element text verbatim.
+pub(crate) fn split_segment(raw: &str, delims: &Delimiters) -> ParsedSegment {
+    let element = delims.element;
+    let release = delims.release;
+
+    let bytes = raw.as_bytes();
+    let mut parts: Vec<String> = Vec::new();
+    let mut current: Vec<u8> = Vec::new();
+    let mut pending_release = false;
+
+    for &b in bytes {
+        if pending_release {
+            // The previous byte was a release char: this byte is literal
+            // data regardless of its delimiter role. Emit it decoded —
+            // the release char is consumed, not retained.
+            current.push(b);
+            pending_release = false;
+            continue;
+        }
+        if b == release {
+            pending_release = true;
+            continue;
+        }
+        if b == element {
+            parts.push(bytes_to_string(&current));
+            current.clear();
+            continue;
+        }
+        current.push(b);
+    }
+    if pending_release {
+        // A dangling release char at end of segment has nothing to
+        // escape; keep it as literal data rather than dropping it.
+        current.push(release);
+    }
+    parts.push(bytes_to_string(&current));
+
+    let mut iter = parts.into_iter();
+    let tag = iter.next().unwrap_or_default();
+    let elements = iter.collect();
+    ParsedSegment { tag, elements }
+}
+
+/// Reassemble interior `current` bytes into a `String`. The input is a
+/// UTF-8-validated segment slice, so this never fails.
+fn bytes_to_string(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn tok(data: &[u8]) -> SegmentTokenizer<Cursor<Vec<u8>>> {
+        SegmentTokenizer::new(Cursor::new(data.to_vec()))
+    }
+
+    #[test]
+    fn level_a_defaults_when_una_absent() {
+        let mut t = tok(b"UNB+UNOA:1'");
+        let first = t.next_segment().unwrap().unwrap();
+        assert_eq!(first, "UNB+UNOA:1");
+        assert_eq!(t.delimiters(), Delimiters::level_a());
+    }
+
+    #[test]
+    fn una_overrides_delimiters() {
+        // UNA declares component '|', element '*', decimal ',',
+        // release '#', repetition ' ', terminator '~'.
+        let mut t = tok(b"UNA|*,# ~UNB*UNOA|1~");
+        let first = t.next_segment().unwrap().unwrap();
+        let d = t.delimiters();
+        assert_ne!(d, Delimiters::level_a());
+        assert_eq!(d.component, b'|');
+        assert_eq!(d.element, b'*');
+        assert_eq!(d.terminator, b'~');
+        assert_eq!(first, "UNB*UNOA|1");
+        let parsed = split_segment(&first, &d);
+        assert_eq!(parsed.tag, "UNB");
+        assert_eq!(parsed.elements, vec!["UNOA|1".to_string()]);
+    }
+
+    #[test]
+    fn release_char_decodes_escaped_element_separator() {
+        // BGM+1?+2+done' — the ?+ is an escaped (literal) '+' inside the
+        // first data element; it decodes to a clean '+' in the value. The
+        // unescaped '+' before "done" is the real element boundary, so
+        // the segment has two elements: "1+2" and "done".
+        let mut t = tok(b"BGM+1?+2+done'");
+        let raw = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&raw, &t.delimiters());
+        assert_eq!(parsed.tag, "BGM");
+        assert_eq!(parsed.elements, vec!["1+2".to_string(), "done".to_string()]);
+    }
+
+    #[test]
+    fn release_char_decodes_escaped_terminator() {
+        // FTX+a?'b' — the ?' is a literal apostrophe inside the element
+        // (not a terminator); the unescaped ' terminates the segment. The
+        // element decodes to clean "a'b".
+        let mut t = tok(b"FTX+a?'b'");
+        let raw = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&raw, &t.delimiters());
+        assert_eq!(parsed.tag, "FTX");
+        assert_eq!(parsed.elements, vec!["a'b".to_string()]);
+    }
+
+    #[test]
+    fn double_release_decodes_to_literal_release_char() {
+        // FTX+a??b' — ?? is an escaped (literal) '?'; it decodes to a
+        // single clean '?' in the element value.
+        let mut t = tok(b"FTX+a??b'");
+        let raw = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&raw, &t.delimiters());
+        assert_eq!(parsed.elements, vec!["a?b".to_string()]);
+    }
+
+    #[test]
+    fn unescaped_component_separator_kept_verbatim() {
+        // NAD+UNOA:1 — the ':' is a real component separator, part of the
+        // element's composite structure. It is kept verbatim in the
+        // element value, not decoded, so a composite element round-trips.
+        let d = Delimiters::level_a();
+        let parsed = split_segment("UNB+UNOA:1", &d);
+        assert_eq!(parsed.elements, vec!["UNOA:1".to_string()]);
+    }
+
+    #[test]
+    fn repetition_separator_space_does_not_split_element_text() {
+        // Element text is kept verbatim and never split on the
+        // repetition separator, so a space inside an element is ordinary
+        // text — `"ACME WIDGETS"` is one element, not two.
+        let d = Delimiters::level_a();
+        let parsed = split_segment("NAD+BY+ACME WIDGETS", &d);
+        assert_eq!(
+            parsed.elements,
+            vec!["BY".to_string(), "ACME WIDGETS".to_string()]
+        );
+    }
+
+    #[test]
+    fn crlf_between_segments_stripped_not_inside_elements() {
+        let mut t = tok(b"UNH+1+ORDERS'\r\nBGM+220'\r\n");
+        let s1 = t.next_segment().unwrap().unwrap();
+        assert_eq!(s1, "UNH+1+ORDERS");
+        let s2 = t.next_segment().unwrap().unwrap();
+        assert_eq!(s2, "BGM+220");
+        assert!(t.next_segment().unwrap().is_none());
+    }
+
+    #[test]
+    fn unterminated_segment_hits_byte_cap_error() {
+        let data = vec![b'A'; MAX_SEGMENT_BYTES + 10];
+        let mut t = tok(&data);
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(msg) if msg.contains("cap")));
+    }
+
+    #[test]
+    fn unterminated_final_segment_errors() {
+        let mut t = tok(b"UNH+1+ORDERS'BGM+220");
+        let _ = t.next_segment().unwrap().unwrap();
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(msg) if msg.contains("truncated")));
+    }
+
+    #[test]
+    fn truncated_una_errors() {
+        let mut t = tok(b"UNA:+");
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(msg) if msg.contains("UNA")));
+    }
+}

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -1,0 +1,938 @@
+//! UN/EDIFACT interchange writer.
+//!
+//! Reconstructs the interchange envelope around emitted body records:
+//! an optional `UNA`, a `UNB` header (literal config elements or echoed
+//! from a `$doc` section), `UNH..UNT` messages grouped on the `msg_ref`
+//! column, and a closing `UNZ`. Record columns map positionally —
+//! `seg_id` is the segment tag, `e01..` are the data elements. Element
+//! data is release-escaped on output and decoded by the reader, so a
+//! reader→writer→reader round-trip is byte-faithful even for values
+//! that carry service characters as literal data.
+//!
+//! Memory model: streaming and O(1) in held state — only the
+//! currently-open message's running segment count and the interchange
+//! message count are retained. `flush` is the single end-of-stream
+//! finalizer: it closes the open message and writes the `UNZ` trailer
+//! with recomputed counts, exactly once. An interchange is one envelope,
+//! so byte-limit file splitting (which would flush — and thus finalize —
+//! mid-stream) is rejected for EDIFACT outputs at config-validation
+//! time; this writer is therefore only ever flushed at true end of
+//! stream.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+
+use crate::edifact::RAW_ELEMENTS_KEY;
+use crate::edifact::tokenizer::Delimiters;
+use crate::error::FormatError;
+use crate::traits::FormatWriter;
+
+/// Configuration for the EDIFACT writer.
+#[derive(Clone, Default)]
+pub struct EdifactWriterConfig {
+    /// Literal `UNB` data elements. When set, the writer emits exactly
+    /// these as the interchange header. Takes precedence over
+    /// `interchange_from_doc`.
+    pub interchange: Option<Vec<String>>,
+    /// Name of a `$doc` section to echo the `UNB` elements from (the
+    /// reader's `UNB` positional section), enabling round-trip
+    /// reconstruction. Used only when `interchange` is unset.
+    pub interchange_from_doc: Option<String>,
+    /// Fallback message type when a record carries no `msg_type` column
+    /// value (e.g. body records whose UNH was synthesized upstream).
+    pub message_type: Option<String>,
+    /// Emit a leading `UNA` service-string-advice segment. The YAML
+    /// option default is `false` (Level-A delimiters are implicit).
+    pub write_una: bool,
+    /// Write a newline after each segment terminator for readability.
+    /// The YAML option default is `true`, applied by the config builder;
+    /// the plain `Default` for this struct leaves it `false`, so a
+    /// caller constructing the config directly sets it explicitly.
+    pub segment_newline: bool,
+}
+
+/// Streaming EDIFACT interchange writer.
+pub struct EdifactWriter<W: Write> {
+    writer: W,
+    config: EdifactWriterConfig,
+    delims: Delimiters,
+    /// Wire element columns keyed by the 1-based position parsed from the
+    /// column name (`e01` → 1), each paired with its schema index. The
+    /// numeric suffix — not schema-declaration order — determines the wire
+    /// slot, so a gapped (`e01, e03`) or reordered (`e02, e01`) schema maps
+    /// values to the positions the names declare, with gaps emitted as
+    /// empty elements rather than silently shifting later values left.
+    element_columns: Vec<ElementColumn>,
+    seg_id_idx: Option<usize>,
+    msg_ref_idx: Option<usize>,
+    msg_type_idx: Option<usize>,
+    header_written: bool,
+    finalized: bool,
+    unb_control_ref: String,
+    message_count: u64,
+    open_message: Option<OpenMessage>,
+}
+
+/// A schema `eNN` element column resolved to its wire position and the
+/// schema index its value is read from.
+struct ElementColumn {
+    /// 1-based wire element position parsed from the `eNN` suffix.
+    position: usize,
+    /// The column name (`e01`) — used verbatim in error messages so a
+    /// misrouted value names the exact field the user must fix.
+    name: String,
+    /// Index into the record's value list.
+    schema_index: usize,
+}
+
+/// State for the message currently being written.
+struct OpenMessage {
+    reference: String,
+    /// Segments written so far including `UNH` (the closing `UNT` adds
+    /// one more when the message closes).
+    segment_count: u64,
+}
+
+impl<W: Write> EdifactWriter<W> {
+    /// Build a writer over a sink with the given schema and config. The
+    /// schema's `seg_id` / `msg_ref` / `msg_type` / `eNN` columns are
+    /// resolved to positional indices once.
+    pub fn new(writer: W, schema: Arc<Schema>, config: EdifactWriterConfig) -> Self {
+        let mut element_columns = Vec::new();
+        let mut seg_id_idx = None;
+        let mut msg_ref_idx = None;
+        let mut msg_type_idx = None;
+        for (i, col) in schema.columns().iter().enumerate() {
+            match &**col {
+                "seg_id" => seg_id_idx = Some(i),
+                "msg_ref" => msg_ref_idx = Some(i),
+                "msg_type" => msg_type_idx = Some(i),
+                name => {
+                    if let Some(position) = element_position(name) {
+                        element_columns.push(ElementColumn {
+                            position,
+                            name: name.to_string(),
+                            schema_index: i,
+                        });
+                    }
+                }
+            }
+        }
+        // Order by the declared wire position so a reordered schema
+        // (`e02` before `e01`) still emits elements in ascending position.
+        element_columns.sort_by_key(|c| c.position);
+        Self {
+            writer,
+            config,
+            delims: Delimiters::level_a(),
+            element_columns,
+            seg_id_idx,
+            msg_ref_idx,
+            msg_type_idx,
+            header_written: false,
+            finalized: false,
+            unb_control_ref: String::new(),
+            message_count: 0,
+            open_message: None,
+        }
+    }
+
+    /// Emit the optional `UNA` and the `UNB` header on the first record.
+    fn write_header(&mut self, record: &Record) -> Result<(), FormatError> {
+        if self.header_written {
+            return Ok(());
+        }
+        self.header_written = true;
+
+        if self.config.write_una {
+            // UNA carries the six service chars in fixed order; the
+            // segment is exactly 9 bytes and is not terminator-delimited.
+            let una = [
+                b'U',
+                b'N',
+                b'A',
+                self.delims.component,
+                self.delims.element,
+                self.delims.decimal,
+                self.delims.release,
+                self.delims.repetition,
+                self.delims.terminator,
+            ];
+            self.writer.write_all(&una).map_err(FormatError::Io)?;
+            if self.config.segment_newline {
+                self.writer.write_all(b"\n").map_err(FormatError::Io)?;
+            }
+        }
+
+        let unb_elements = self.resolve_unb_elements(record)?;
+        // The UNB control reference (element 5, index 4) is echoed in
+        // the UNZ trailer; default to empty when the header is short.
+        self.unb_control_ref = unb_elements.get(4).cloned().unwrap_or_default();
+        self.write_segment("UNB", &unb_elements)?;
+        Ok(())
+    }
+
+    /// Resolve the `UNB` data elements: the literal config list wins;
+    /// otherwise echo from the named `$doc` section on the record;
+    /// otherwise a precise configuration error.
+    fn resolve_unb_elements(&self, record: &Record) -> Result<Vec<String>, FormatError> {
+        if let Some(literal) = &self.config.interchange {
+            return Ok(literal.clone());
+        }
+        if let Some(section) = &self.config.interchange_from_doc {
+            let ctx = record.doc_ctx();
+            // Preferred path: the EDIFACT reader stashes the complete,
+            // ordered UNB element list (empty middle elements included)
+            // under an engine-internal key. Reconstructing from it
+            // round-trips a UNB header faithfully without the user having
+            // to declare every contiguous `eNN` field — and without
+            // truncating at an empty element the way a declared-field
+            // walk would.
+            if let Some(Value::Array(raw)) = ctx.get_section_field(section, RAW_ELEMENTS_KEY) {
+                // Each raw item is a stashed UNB element string; name the
+                // positional slot so a non-scalar item names its field.
+                return raw
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| value_to_element(v, &format!("{section}.e{:02}", i + 1)))
+                    .collect();
+            }
+            // Fallback for a section not produced by the EDIFACT reader
+            // (e.g. literal author-supplied `$doc` fields): walk the
+            // declared positional `e01, e02, …` keys until one is absent.
+            // This cannot represent an empty middle element, so it is the
+            // best-effort path, not the round-trip path.
+            let mut elements: Vec<String> = Vec::new();
+            for i in 0.. {
+                let key = format!("e{:02}", i + 1);
+                match ctx.get_section_field(section, &key) {
+                    Some(v) => elements.push(value_to_element(&v, &format!("{section}.{key}"))?),
+                    None => break,
+                }
+            }
+            if elements.is_empty() {
+                return Err(FormatError::Edifact(format!(
+                    "interchange_from_doc names section {section:?}, but the record's \
+                     document context carries no UNB elements for it. Ensure the source \
+                     declares a `segment: \"UNB\"` envelope section of the same name."
+                )));
+            }
+            return Ok(elements);
+        }
+        Err(FormatError::Edifact(
+            "no interchange header configured: set the writer's `interchange` literal \
+             elements or `interchange_from_doc` section name so a UNB header can be \
+             written"
+                .into(),
+        ))
+    }
+
+    /// Map a body record to its segment tag and trimmed element list,
+    /// then write it, opening or closing `UNH..UNT` messages on
+    /// `msg_ref` transitions.
+    fn write_body_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        self.reject_unknown_columns(record)?;
+        let values = record.values();
+        let seg_id = match self.seg_id_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_element(v, "seg_id")?,
+            None => String::new(),
+        };
+
+        // Service segments embedded in the record stream are skipped —
+        // the writer reconstructs envelopes itself, so a UNH/UNT/UNB/UNZ
+        // body record (e.g. from an EDIFACT→EDIFACT pipeline that emits
+        // them verbatim) must not be double-written.
+        let msg_ref = match self.msg_ref_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_element(v, "msg_ref")?,
+            None => String::new(),
+        };
+        let msg_type = match self.msg_type_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_element(v, "msg_type")?,
+            None => String::new(),
+        };
+
+        if matches!(seg_id.as_str(), "UNB" | "UNZ" | "UNH" | "UNT") {
+            // Drive message grouping from the UNH record's identity but
+            // never echo the service segment verbatim.
+            self.transition_message(&msg_ref, &msg_type)?;
+            return Ok(());
+        }
+
+        self.transition_message(&msg_ref, &msg_type)?;
+
+        let elements = self.record_elements(record)?;
+        self.write_segment(&seg_id, &elements)?;
+        if let Some(msg) = self.open_message.as_mut() {
+            msg.segment_count += 1;
+        }
+        Ok(())
+    }
+
+    /// Open a new `UNH` message (closing any previous one) when the
+    /// `msg_ref` changes, or open the first message. A record with an
+    /// empty `msg_ref` joins the current message; if none is open, it
+    /// opens an anonymous single message.
+    fn transition_message(&mut self, msg_ref: &str, msg_type: &str) -> Result<(), FormatError> {
+        let need_new = match &self.open_message {
+            None => true,
+            Some(open) => !msg_ref.is_empty() && open.reference != *msg_ref,
+        };
+        if !need_new {
+            return Ok(());
+        }
+        self.close_open_message()?;
+
+        let resolved_type = if !msg_type.is_empty() {
+            msg_type.to_string()
+        } else if let Some(t) = &self.config.message_type {
+            t.clone()
+        } else {
+            return Err(FormatError::Edifact(
+                "cannot open a UNH message: the record carries no `msg_type` and the \
+                 writer has no `message_type` fallback configured"
+                    .into(),
+            ));
+        };
+        let reference = if msg_ref.is_empty() {
+            (self.message_count + 1).to_string()
+        } else {
+            msg_ref.to_string()
+        };
+        self.write_segment("UNH", &[reference.clone(), resolved_type])?;
+        self.message_count += 1;
+        self.open_message = Some(OpenMessage {
+            reference,
+            segment_count: 1,
+        });
+        Ok(())
+    }
+
+    /// Close the open message with its recomputed `UNT` trailer (segment
+    /// count including `UNH`+`UNT`, message reference echo).
+    fn close_open_message(&mut self) -> Result<(), FormatError> {
+        if let Some(msg) = self.open_message.take() {
+            let count = msg.segment_count + 1;
+            self.write_segment("UNT", &[count.to_string(), msg.reference])?;
+        }
+        Ok(())
+    }
+
+    /// Collect a record's `eNN` columns into wire-position order, filling
+    /// any gap left by a missing position with an empty element, then
+    /// trimming trailing empties so no fabricated delimiters appear.
+    ///
+    /// A column's wire slot is its parsed `eNN` position (1-based), not its
+    /// schema-declaration order: a `seg_id, e01, e03` record writes `e03`'s
+    /// value as wire element 3 with element 2 empty, never as element 2.
+    fn record_elements(&self, record: &Record) -> Result<Vec<String>, FormatError> {
+        let values = record.values();
+        let max_position = self
+            .element_columns
+            .iter()
+            .map(|c| c.position)
+            .max()
+            .unwrap_or(0);
+        let mut elements: Vec<String> = vec![String::new(); max_position];
+        for col in &self.element_columns {
+            let text = match values.get(col.schema_index) {
+                Some(v) => value_to_element(v, &col.name)?,
+                None => String::new(),
+            };
+            // position is 1-based; slot is position-1.
+            elements[col.position - 1] = text;
+        }
+        while matches!(elements.last(), Some(s) if s.is_empty()) {
+            elements.pop();
+        }
+        Ok(elements)
+    }
+
+    /// Reject a record carrying a user column the writer does not map.
+    /// Engine-namespaced columns (`$`-prefixed: `$source.*`, `$ck.*`,
+    /// `$widened`) are excluded from the check and never appear in
+    /// EDIFACT output by design.
+    fn reject_unknown_columns(&self, record: &Record) -> Result<(), FormatError> {
+        for (name, _) in record.iter_user_fields() {
+            if name.starts_with('$') {
+                continue;
+            }
+            let known =
+                matches!(name, "seg_id" | "msg_ref" | "msg_type") || is_element_column(name);
+            if !known {
+                return Err(FormatError::Edifact(format!(
+                    "record column {name:?} has no EDIFACT mapping. The writer maps only \
+                     `seg_id`, `msg_ref`, `msg_type`, and positional `eNN` element \
+                     columns; project the record to those before output"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Write one segment: tag, element separator, release-escaped
+    /// elements joined by the element separator, terminator, optional
+    /// newline.
+    ///
+    /// Element data is release-escaped so a data byte that collides with
+    /// a service character does not corrupt the interchange: an
+    /// apostrophe in `O'BRIEN` is emitted as `O?'BRIEN` (not a premature
+    /// terminator) and a literal `+` in `A+B` as `A?+B` (not a second
+    /// element). The reader decodes these on the next read, so the
+    /// round-trip is byte-faithful for any value the writer is handed —
+    /// including values computed by a Transform or sourced from CSV/JSON,
+    /// which were never EDIFACT-escaped to begin with.
+    fn write_segment(&mut self, tag: &str, elements: &[String]) -> Result<(), FormatError> {
+        self.writer
+            .write_all(tag.as_bytes())
+            .map_err(FormatError::Io)?;
+        for element in elements {
+            self.writer
+                .write_all(&[self.delims.element])
+                .map_err(FormatError::Io)?;
+            self.write_escaped_element(element)?;
+        }
+        self.writer
+            .write_all(&[self.delims.terminator])
+            .map_err(FormatError::Io)?;
+        if self.config.segment_newline {
+            self.writer.write_all(b"\n").map_err(FormatError::Io)?;
+        }
+        Ok(())
+    }
+
+    /// Write one element, prefixing each service character that would
+    /// otherwise be read as a delimiter with the release character.
+    ///
+    /// Escaped: the segment terminator, the element separator, and the
+    /// release character itself. The component separator is *not* escaped
+    /// — a `:` in the stored value is treated as the element's own
+    /// composite structure (mirroring the reader, which keeps unescaped
+    /// component separators verbatim), so composite elements like
+    /// `UNOA:1` re-emit unchanged.
+    fn write_escaped_element(&mut self, element: &str) -> Result<(), FormatError> {
+        let release = self.delims.release;
+        let terminator = self.delims.terminator;
+        let separator = self.delims.element;
+        for &b in element.as_bytes() {
+            if b == release || b == terminator || b == separator {
+                self.writer.write_all(&[release]).map_err(FormatError::Io)?;
+            }
+            self.writer.write_all(&[b]).map_err(FormatError::Io)?;
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write + Send> FormatWriter for EdifactWriter<W> {
+    fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        self.write_header(record)?;
+        self.write_body_record(record)
+    }
+
+    fn flush(&mut self) -> Result<(), FormatError> {
+        if self.finalized {
+            return Ok(());
+        }
+        self.finalized = true;
+        self.close_open_message()?;
+        // Only write UNZ if a header was actually emitted; a writer that
+        // saw zero records produces nothing rather than a bare trailer.
+        if self.header_written {
+            let control_ref = self.unb_control_ref.clone();
+            self.write_segment("UNZ", &[self.message_count.to_string(), control_ref])?;
+        }
+        self.writer.flush().map_err(FormatError::Io)?;
+        Ok(())
+    }
+}
+
+/// Whether a schema column name is a positional EDIFACT element column
+/// (`e01`, `e02`, …): an `e` followed by one or more ASCII digits.
+fn is_element_column(name: &str) -> bool {
+    element_position(name).is_some()
+}
+
+/// Parse the 1-based wire element position from a column name. `e01` → 1,
+/// `e12` → 12. Returns `None` when the name is not an `e`-prefixed digit
+/// run or names position 0 (`e00`, which has no wire slot).
+fn element_position(name: &str) -> Option<usize> {
+    let rest = name.strip_prefix('e')?;
+    if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let position: usize = rest.parse().ok()?;
+    (position >= 1).then_some(position)
+}
+
+/// Render a `Value` to EDIFACT element text (pre-escaping). `Null` renders
+/// as the empty string (an absent element); scalars render via their
+/// natural string form. A `Value::Map` or `Value::Array` has no scalar
+/// EDIFACT element representation, so it raises rather than silently
+/// emitting an empty cell or a fabricated comma-join — mirroring the
+/// CSV/XML/fixed-width writers' explicit-error posture for non-scalar
+/// payloads. `column` names the offending field for the error.
+///
+/// Release-escaping of any service character in the result happens at
+/// write time in [`EdifactWriter::write_escaped_element`].
+fn value_to_element(value: &Value, column: &str) -> Result<String, FormatError> {
+    let text = match value {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Integer(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.to_string(),
+        Value::Date(d) => d.to_string(),
+        Value::DateTime(dt) => dt.to_string(),
+        Value::Map(_) | Value::Array(_) => {
+            return Err(FormatError::UnserializableMapValue {
+                format: "edifact",
+                column: column.to_string(),
+            });
+        }
+    };
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn schema() -> Arc<Schema> {
+        let mut cols: Vec<Box<str>> = vec!["seg_id".into(), "msg_ref".into(), "msg_type".into()];
+        for i in 1..=4 {
+            cols.push(format!("e{i:02}").into_boxed_str());
+        }
+        Arc::new(Schema::new(cols))
+    }
+
+    fn body(
+        schema: &Arc<Schema>,
+        seg: &str,
+        msg_ref: &str,
+        msg_type: &str,
+        els: &[&str],
+    ) -> Record {
+        let mut values = vec![
+            Value::String(seg.into()),
+            if msg_ref.is_empty() {
+                Value::Null
+            } else {
+                Value::String(msg_ref.into())
+            },
+            if msg_type.is_empty() {
+                Value::Null
+            } else {
+                Value::String(msg_type.into())
+            },
+        ];
+        for i in 0..4 {
+            match els.get(i) {
+                Some(e) => values.push(Value::String((*e).into())),
+                None => values.push(Value::Null),
+            }
+        }
+        Record::new(Arc::clone(schema), values)
+    }
+
+    fn write_all(config: EdifactWriterConfig, records: &[Record], schema: &Arc<Schema>) -> String {
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(schema), config);
+        for r in records {
+            w.write_record(r).unwrap();
+        }
+        w.flush().unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn literal_config() -> EdifactWriterConfig {
+        EdifactWriterConfig {
+            interchange: Some(vec![
+                "UNOA:1".into(),
+                "S".into(),
+                "R".into(),
+                "240101:1200".into(),
+                "REF1".into(),
+            ]),
+            segment_newline: false,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn unb_from_literal_options() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "BGM", "M1", "ORDERS", &["220"])],
+            &s,
+        );
+        assert!(out.starts_with("UNB+UNOA:1+S+R+240101:1200+REF1'"));
+    }
+
+    #[test]
+    fn unb_echoed_from_doc_section() {
+        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use indexmap::IndexMap;
+
+        // Build a record carrying a `$doc.unb` section with positional
+        // e01..e05 UNB elements, as the EDIFACT reader's prepare_document
+        // would attach.
+        let s = schema();
+        let mut unb: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        unb.insert("e01".into(), RecVal::String("UNOA:1".into()));
+        unb.insert("e02".into(), RecVal::String("S".into()));
+        unb.insert("e03".into(), RecVal::String("R".into()));
+        unb.insert("e04".into(), RecVal::String("240101:1200".into()));
+        unb.insert("e05".into(), RecVal::String("REF1".into()));
+        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        sections.insert("unb".into(), RecVal::Map(Box::new(unb)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+
+        let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
+        record.set_doc_ctx(ctx);
+
+        let cfg = EdifactWriterConfig {
+            interchange_from_doc: Some("unb".into()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[record], &s);
+        // The UNB header is reconstructed verbatim from the $doc section,
+        // and the UNZ trailer echoes its control reference.
+        assert!(out.starts_with("UNB+UNOA:1+S+R+240101:1200+REF1'"), "{out}");
+        assert!(out.contains("UNZ+1+REF1'"), "{out}");
+    }
+
+    #[test]
+    fn unb_from_doc_raw_preserves_empty_middle_element() {
+        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use indexmap::IndexMap;
+
+        // A real UNB whose element 4 (index 3) is empty. The reader
+        // stashes the complete element list under the engine-internal raw
+        // key; the writer must reconstruct it without truncating at the
+        // empty element, so the control reference "REF9" (element 6)
+        // survives.
+        let s = schema();
+        let raw = RecVal::Array(vec![
+            RecVal::String("UNOA:1".into()),
+            RecVal::String("S".into()),
+            RecVal::String("R".into()),
+            RecVal::String("".into()),
+            RecVal::String("240101:1200".into()),
+            RecVal::String("REF9".into()),
+        ]);
+        let mut unb: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        unb.insert(super::RAW_ELEMENTS_KEY.into(), raw);
+        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        sections.insert("unb".into(), RecVal::Map(Box::new(unb)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
+        record.set_doc_ctx(ctx);
+
+        let cfg = EdifactWriterConfig {
+            interchange_from_doc: Some("unb".into()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[record], &s);
+        // The full UNB is reconstructed — the empty middle element is not
+        // dropped, so nothing after it is lost.
+        assert!(
+            out.starts_with("UNB+UNOA:1+S+R++240101:1200+REF9'"),
+            "UNB was truncated at the empty element: {out}"
+        );
+        // The UNZ control-reference echo is taken from the UNB control
+        // reference (the 5th data element, index 4) and is self-consistent
+        // with the reconstructed UNB, so a re-read validates.
+        assert!(out.contains("UNZ+1+240101:1200'"), "{out}");
+    }
+
+    #[test]
+    fn una_emitted_when_enabled() {
+        let s = schema();
+        let mut cfg = literal_config();
+        cfg.write_una = true;
+        let out = write_all(cfg, &[body(&s, "BGM", "M1", "ORDERS", &["220"])], &s);
+        assert!(out.starts_with("UNA:+.? '"));
+    }
+
+    #[test]
+    fn missing_interchange_config_errors() {
+        let s = schema();
+        let cfg = EdifactWriterConfig {
+            segment_newline: false,
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&s), cfg);
+        let err = w
+            .write_record(&body(&s, "BGM", "M1", "ORDERS", &["220"]))
+            .unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("no interchange header")));
+    }
+
+    #[test]
+    fn unt_counts_include_unh_and_unt_and_echo_msg_ref() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(&s, "BGM", "M1", "ORDERS", &["220"]),
+                body(&s, "NAD", "M1", "ORDERS", &["BY"]),
+            ],
+            &s,
+        );
+        // UNH + BGM + NAD + UNT = 4 segments; UNT echoes M1.
+        assert!(out.contains("UNT+4+M1'"), "output was: {out}");
+    }
+
+    #[test]
+    fn unz_count_and_unb_ref_echo() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(&s, "BGM", "M1", "ORDERS", &["220"]),
+                body(&s, "BGM", "M2", "ORDERS", &["220"]),
+            ],
+            &s,
+        );
+        assert!(out.contains("UNZ+2+REF1'"), "output was: {out}");
+    }
+
+    #[test]
+    fn message_grouping_on_msg_ref_transition() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(&s, "BGM", "M1", "ORDERS", &["a"]),
+                body(&s, "BGM", "M2", "ORDERS", &["b"]),
+            ],
+            &s,
+        );
+        assert_eq!(out.matches("UNH+").count(), 2);
+        assert!(out.contains("UNH+M1+ORDERS'"));
+        assert!(out.contains("UNH+M2+ORDERS'"));
+    }
+
+    #[test]
+    fn trailing_nulls_not_padded() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "BGM", "M1", "ORDERS", &["220"])],
+            &s,
+        );
+        // BGM has one element; no trailing '+' delimiters for the null
+        // e02..e04 columns.
+        assert!(out.contains("BGM+220'"), "output was: {out}");
+        assert!(!out.contains("BGM+220+'"));
+    }
+
+    #[test]
+    fn element_separator_in_data_is_release_escaped() {
+        // A literal '+' in element data must be emitted as ?+ so the
+        // reader does not split it into a second element.
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "BGM", "M1", "ORDERS", &["A+B"])],
+            &s,
+        );
+        assert!(out.contains("BGM+A?+B'"), "output was: {out}");
+    }
+
+    #[test]
+    fn terminator_in_data_is_release_escaped() {
+        // A literal apostrophe in element data must be emitted as ?' so
+        // it does not terminate the segment early.
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "FTX", "M1", "ORDERS", &["O'BRIEN"])],
+            &s,
+        );
+        assert!(out.contains("FTX+O?'BRIEN'"), "output was: {out}");
+    }
+
+    #[test]
+    fn release_char_in_data_is_doubled() {
+        // A literal '?' in element data must be emitted as ?? so the
+        // reader decodes it back to a single '?'.
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "FTX", "M1", "ORDERS", &["why?"])],
+            &s,
+        );
+        assert!(out.contains("FTX+why??'"), "output was: {out}");
+    }
+
+    #[test]
+    fn component_separator_in_data_is_not_escaped() {
+        // The composite element "UNOA:1" must re-emit unchanged — the ':'
+        // is structural, not a data byte to escape.
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "UNH", "M1", "ORDERS:D:96A:UN", &["UNOA:1"])],
+            &s,
+        );
+        assert!(out.contains("UNOA:1"), "output was: {out}");
+        assert!(
+            !out.contains("UNOA?:1"),
+            "component sep was wrongly escaped: {out}"
+        );
+    }
+
+    #[test]
+    fn engine_stamped_columns_excluded() {
+        // A `$`-prefixed engine column on the schema must not trip the
+        // unknown-column rejection, and must not be emitted.
+        let cols: Vec<Box<str>> = vec![
+            "seg_id".into(),
+            "msg_ref".into(),
+            "msg_type".into(),
+            "e01".into(),
+            "$source.file".into(),
+        ];
+        let schema = Arc::new(Schema::new(cols));
+        let values = vec![
+            Value::String("BGM".into()),
+            Value::String("M1".into()),
+            Value::String("ORDERS".into()),
+            Value::String("220".into()),
+            Value::String("/tmp/x.edi".into()),
+        ];
+        let record = Record::new(Arc::clone(&schema), values);
+        let out = write_all(literal_config(), &[record], &schema);
+        assert!(out.contains("BGM+220'"));
+        assert!(!out.contains("/tmp/x.edi"));
+    }
+
+    #[test]
+    fn unrecognized_column_errors_by_name() {
+        let cols: Vec<Box<str>> = vec![
+            "seg_id".into(),
+            "msg_ref".into(),
+            "msg_type".into(),
+            "amount".into(),
+        ];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("BGM".into()),
+                Value::String("M1".into()),
+                Value::String("ORDERS".into()),
+                Value::String("99".into()),
+            ],
+        );
+        let mut buf = Vec::new();
+        let mut w =
+            EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&schema), literal_config());
+        let err = w.write_record(&record).unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("amount")));
+    }
+
+    #[test]
+    fn flush_finalize_idempotent() {
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&s), literal_config());
+        w.write_record(&body(&s, "BGM", "M1", "ORDERS", &["220"]))
+            .unwrap();
+        w.flush().unwrap();
+        w.flush().unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out.matches("UNZ+").count(), 1, "output was: {out}");
+    }
+
+    #[test]
+    fn zero_records_writes_nothing() {
+        let s = schema();
+        let out = write_all(literal_config(), &[], &s);
+        assert!(out.is_empty(), "output was: {out}");
+    }
+
+    #[test]
+    fn gapped_element_columns_map_by_position_not_schema_order() {
+        // A schema declaring only `seg_id, e01, e03` must place e03's value
+        // at wire element 3 with element 2 empty — never collapse it left
+        // into element 2.
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "e01".into(), "e03".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("BGM".into()),
+                Value::String("a".into()),
+                Value::String("c".into()),
+            ],
+        );
+        let mut cfg = literal_config();
+        cfg.message_type = Some("ORDERS".into());
+        let out = write_all(cfg, &[record], &schema);
+        assert!(out.contains("BGM+a++c'"), "gapped mapping wrong: {out}");
+    }
+
+    #[test]
+    fn reordered_element_columns_emit_in_position_order() {
+        // A schema declaring `e02` before `e01` must still emit e01 first.
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "e02".into(), "e01".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("BGM".into()),
+                Value::String("second".into()),
+                Value::String("first".into()),
+            ],
+        );
+        let mut cfg = literal_config();
+        cfg.message_type = Some("ORDERS".into());
+        let out = write_all(cfg, &[record], &schema);
+        assert!(
+            out.contains("BGM+first+second'"),
+            "reordered mapping wrong: {out}"
+        );
+    }
+
+    #[test]
+    fn map_value_in_element_column_errors_by_name() {
+        use indexmap::IndexMap;
+        // A nested object in an `eNN` column has no scalar EDIFACT element
+        // form; the writer must reject it explicitly rather than emit an
+        // empty element.
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "e01".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let mut nested: IndexMap<Box<str>, Value> = IndexMap::new();
+        nested.insert("k".into(), Value::String("v".into()));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::String("BGM".into()), Value::Map(Box::new(nested))],
+        );
+        let mut cfg = literal_config();
+        cfg.message_type = Some("ORDERS".into());
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&schema), cfg);
+        let err = w.write_record(&record).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::UnserializableMapValue { format: "edifact", column } if column == "e01"),
+            "expected UnserializableMapValue for e01, got: {err:?}"
+        );
+    }
+}

--- a/crates/clinker-format/src/envelope.rs
+++ b/crates/clinker-format/src/envelope.rs
@@ -12,6 +12,10 @@
 //! variants surface as a format error so a config-wrong-for-format
 //! mistake fails fast.
 
+use clinker_record::{
+    DEFAULT_DATE_FORMATS, DEFAULT_DATETIME_FORMATS, Value, coerce_to_bool, coerce_to_date,
+    coerce_to_datetime, coerce_to_float, coerce_to_int, coerce_to_string,
+};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
@@ -65,6 +69,13 @@ pub enum EnvelopeExtract {
     /// must be a JSON object; its top-level keys become the section's
     /// `fields` map.
     JsonPointer(String),
+    /// Flat-file service segment tag (e.g. `UNB` for an EDIFACT
+    /// interchange header). The named segment's positional data elements
+    /// become the section's `fields` map keyed `e01`, `e02`, … . Only
+    /// segments the reader can resolve from its bounded header pre-scan
+    /// are extractable; trailer segments that arrive after body streaming
+    /// are validated by the reader, not exposed as envelope sections.
+    Segment(String),
 }
 
 /// Field type vocabulary mirrored from CXL's typechecker — small
@@ -78,4 +89,54 @@ pub enum EnvelopeFieldType {
     Bool,
     Date,
     DateTime,
+}
+
+/// Coerce raw `(name, string)` pairs extracted from a source's envelope
+/// into the section's declared field schema.
+///
+/// Shared by every reader that extracts envelope sections (XML element
+/// payloads, EDIFACT positional service-segment elements). Unknown raw
+/// fields are dropped silently — the section schema is the contract.
+/// Missing declared fields are not reported here; they evaluate to
+/// [`Value::Null`] via the `DocumentContext::get_section_field`
+/// `Option`-to-`Null` mapping at CXL eval time. The first non-empty
+/// observation wins when a raw name repeats.
+///
+/// # Errors
+///
+/// Returns the coercion-failure message (section, field, declared type,
+/// observed value) as a `String` so each caller can wrap it in its own
+/// format-specific [`FormatError`] variant.
+pub(crate) fn coerce_section_fields(
+    raw: Vec<(String, String)>,
+    schema: &IndexMap<String, EnvelopeFieldType>,
+) -> Result<IndexMap<Box<str>, Value>, String> {
+    let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(schema.len());
+    let mut by_name: IndexMap<&str, &str> = IndexMap::with_capacity(raw.len());
+    for (k, v) in &raw {
+        by_name.entry(k.as_str()).or_insert(v.as_str());
+    }
+    for (field, ty) in schema {
+        let raw_str = match by_name.get(field.as_str()) {
+            Some(s) if !s.is_empty() => *s,
+            _ => continue,
+        };
+        let value = Value::String(raw_str.into());
+        let coerced = match ty {
+            EnvelopeFieldType::String => coerce_to_string(&value),
+            EnvelopeFieldType::Int => coerce_to_int(&value),
+            EnvelopeFieldType::Float => coerce_to_float(&value),
+            EnvelopeFieldType::Bool => coerce_to_bool(&value),
+            EnvelopeFieldType::Date => coerce_to_date(&value, DEFAULT_DATE_FORMATS),
+            EnvelopeFieldType::DateTime => coerce_to_datetime(&value, DEFAULT_DATETIME_FORMATS),
+        }
+        .map_err(|e| {
+            format!(
+                "envelope section field {field:?} (declared type {ty:?}): \
+                 cannot coerce value {raw_str:?}: {e}"
+            )
+        })?;
+        out.insert(Box::from(field.as_str()), coerced);
+    }
+    Ok(out)
 }

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -12,6 +12,11 @@ pub enum FormatError {
     Json(String),
     Xml(String),
     FixedWidth(String),
+    /// An EDIFACT parse, envelope-count, or malformed-segment failure.
+    /// Carries a precise message naming the offending control segment or
+    /// constraint (bad UNA, UNT/UNZ count mismatch, control-ref echo
+    /// mismatch, truncation, unsupported UNG/UNE grouping).
+    Edifact(String),
     InvalidRecord {
         row: u64,
         message: String,
@@ -55,6 +60,7 @@ impl fmt::Display for FormatError {
             Self::Json(msg) => write!(f, "JSON error: {msg}"),
             Self::Xml(msg) => write!(f, "XML error: {msg}"),
             Self::FixedWidth(msg) => write!(f, "fixed-width error: {msg}"),
+            Self::Edifact(msg) => write!(f, "EDIFACT error: {msg}"),
             Self::InvalidRecord { row, message } => {
                 write!(f, "invalid record at row {row}: {message}")
             }

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -335,6 +335,13 @@ impl FormatReader for JsonReader {
                          against a JSON source. Use `json_pointer` for JSON envelope sections."
                     )));
                 }
+                EnvelopeExtract::Segment(_) => {
+                    return Err(FormatError::Json(format!(
+                        "envelope section {name:?}: declared `segment` extract \
+                         against a JSON source. The `segment` extract is for \
+                         flat-file formats (EDIFACT); use `json_pointer` for JSON."
+                    )));
+                }
             };
             let node = match root.pointer(pointer) {
                 Some(n) => n,
@@ -761,6 +768,22 @@ mod tests {
         let mut reader = reader_from_str(r#"{"records":[]}"#, default_config());
         let err = reader.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::Json(msg) if msg.contains("xml_path")));
+    }
+
+    #[test]
+    fn prepare_document_rejects_segment_extract() {
+        use crate::envelope::EnvelopeSection;
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "Bad".into(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("UNB".into()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut reader = reader_from_str(r#"{"records":[]}"#, default_config());
+        let err = reader.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Json(msg) if msg.contains("segment")));
     }
 
     #[test]

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bom;
 pub mod counting;
 pub mod csv;
+pub mod edifact;
 pub mod envelope;
 pub mod error;
 pub mod fixed_width;

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -18,13 +18,9 @@ use indexmap::IndexMap;
 use quick_xml::Reader as XmlParser;
 use quick_xml::events::Event;
 
-use clinker_record::{
-    DEFAULT_DATE_FORMATS, DEFAULT_DATETIME_FORMATS, Record, Schema, SchemaBuilder, Value,
-    coerce_to_bool, coerce_to_date, coerce_to_datetime, coerce_to_float, coerce_to_int,
-    coerce_to_string,
-};
+use clinker_record::{Record, Schema, SchemaBuilder, Value};
 
-use crate::envelope::{EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType};
+use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::traits::FormatReader;
 
@@ -423,6 +419,13 @@ impl FormatReader for XmlReader {
                          against an XML source. Use `xml_path` for XML envelope sections."
                     )));
                 }
+                EnvelopeExtract::Segment(_) => {
+                    return Err(FormatError::Xml(format!(
+                        "envelope section {name:?}: declared `segment` extract \
+                         against an XML source. The `segment` extract is for \
+                         flat-file formats (EDIFACT); use `xml_path` for XML."
+                    )));
+                }
             }
         }
 
@@ -455,7 +458,8 @@ impl FormatReader for XmlReader {
                             &self.config.attribute_prefix,
                             path_stack.len(),
                         )?;
-                        let typed = coerce_section_fields(payload, &section.fields)?;
+                        let typed = coerce_section_fields(payload, &section.fields)
+                            .map_err(FormatError::Xml)?;
                         captured.insert(Box::from(&**sec_name), typed);
                         // `read_section_payload` consumed the matched
                         // subtree up to its closing `End`. Pop the
@@ -475,7 +479,8 @@ impl FormatReader for XmlReader {
                         let mut payload: Vec<(String, String)> = Vec::new();
                         let attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
                         payload.extend(attrs);
-                        let typed = coerce_section_fields(payload, &section.fields)?;
+                        let typed = coerce_section_fields(payload, &section.fields)
+                            .map_err(FormatError::Xml)?;
                         captured.insert(Box::from(&**sec_name), typed);
                     }
                     path_stack.pop();
@@ -614,50 +619,6 @@ fn read_section_payload(
     }
 }
 
-/// Coerce raw `(name, string)` pairs from envelope extraction into
-/// the section's declared field schema. Unknown fields are dropped
-/// silently (the section schema is the contract). Missing fields are
-/// not reported here — they evaluate to `Value::Null` via the
-/// `DocumentContext::get_section_field` `Option`-to-`Null` mapping at
-/// CXL eval time. Type-mismatch coercions surface as a format error
-/// citing the section, field, and observed value.
-fn coerce_section_fields(
-    raw: Vec<(String, String)>,
-    schema: &IndexMap<String, EnvelopeFieldType>,
-) -> Result<IndexMap<Box<str>, Value>, FormatError> {
-    let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(schema.len());
-    // Build a lookup so we coerce each raw value through the declared
-    // type. Multiple raw values for the same field name (rare, e.g.
-    // repeated elements) keep the first non-empty observation.
-    let mut by_name: IndexMap<&str, &str> = IndexMap::with_capacity(raw.len());
-    for (k, v) in &raw {
-        by_name.entry(k.as_str()).or_insert(v.as_str());
-    }
-    for (field, ty) in schema {
-        let raw_str = match by_name.get(field.as_str()) {
-            Some(s) if !s.is_empty() => *s,
-            _ => continue,
-        };
-        let value = Value::String(raw_str.into());
-        let coerced = match ty {
-            EnvelopeFieldType::String => coerce_to_string(&value),
-            EnvelopeFieldType::Int => coerce_to_int(&value),
-            EnvelopeFieldType::Float => coerce_to_float(&value),
-            EnvelopeFieldType::Bool => coerce_to_bool(&value),
-            EnvelopeFieldType::Date => coerce_to_date(&value, DEFAULT_DATE_FORMATS),
-            EnvelopeFieldType::DateTime => coerce_to_datetime(&value, DEFAULT_DATETIME_FORMATS),
-        }
-        .map_err(|e| {
-            FormatError::Xml(format!(
-                "envelope section field {field:?} (declared type {ty:?}): \
-                 cannot coerce value {raw_str:?}: {e}"
-            ))
-        })?;
-        out.insert(Box::from(field.as_str()), coerced);
-    }
-    Ok(out)
-}
-
 /// Simple type inference from string values (same rules as JSON).
 fn infer_value(s: &str) -> Value {
     if s.is_empty() {
@@ -681,6 +642,7 @@ fn infer_value(s: &str) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::envelope::EnvelopeFieldType;
     use std::io::Cursor;
 
     fn reader_from_str(xml: &str, config: XmlReaderConfig) -> XmlReader {
@@ -801,6 +763,23 @@ mod tests {
         let mut reader = reader_from_str(xml, default_config_with_path("doc/a"));
         let err = reader.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::Xml(msg) if msg.contains("json_pointer")));
+    }
+
+    #[test]
+    fn prepare_document_rejects_segment_extract() {
+        use crate::envelope::EnvelopeSection;
+        let xml = r#"<doc><a><x>1</x></a></doc>"#;
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "Bad".into(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("UNB".into()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut reader = reader_from_str(xml, default_config_with_path("doc/a"));
+        let err = reader.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Xml(msg) if msg.contains("segment")));
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/format.rs
+++ b/crates/clinker-plan/src/config/format.rs
@@ -15,6 +15,7 @@ pub enum InputFormat {
     Json(Option<JsonInputOptions>),
     Xml(Option<XmlInputOptions>),
     FixedWidth(Option<FixedWidthInputOptions>),
+    Edifact(Option<EdifactInputOptions>),
 }
 
 impl InputFormat {
@@ -25,6 +26,7 @@ impl InputFormat {
             InputFormat::Json(_) => "json",
             InputFormat::Xml(_) => "xml",
             InputFormat::FixedWidth(_) => "fixed_width",
+            InputFormat::Edifact(_) => "edifact",
         }
     }
 
@@ -45,6 +47,7 @@ impl OutputFormat {
             OutputFormat::Json(_) => "json",
             OutputFormat::Xml(_) => "xml",
             OutputFormat::FixedWidth(_) => "fixed_width",
+            OutputFormat::Edifact(_) => "edifact",
         }
     }
 }
@@ -57,6 +60,7 @@ pub enum OutputFormat {
     Json(Option<JsonOutputOptions>),
     Xml(Option<XmlOutputOptions>),
     FixedWidth(Option<FixedWidthOutputOptions>),
+    Edifact(Option<EdifactOutputOptions>),
 }
 
 /// Supported format types.

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -180,3 +180,34 @@ pub struct FixedWidthOutputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_separator: Option<LineSeparator>,
 }
+
+/// EDIFACT output options.
+///
+/// The writer reconstructs the interchange envelope around emitted
+/// records. The `UNB` header comes from `interchange` (literal elements)
+/// or, when that is unset, is echoed from the `$doc` section named by
+/// `interchange_from_doc` for round-trip reconstruction.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct EdifactOutputOptions {
+    /// Literal `UNB` data elements written verbatim. Takes precedence
+    /// over `interchange_from_doc` when both are set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interchange: Option<Vec<String>>,
+    /// Name of a `$doc` section to echo the `UNB` elements from (the
+    /// reader's positional `UNB` envelope section), enabling EDIFACT
+    /// round-trip reconstruction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interchange_from_doc: Option<String>,
+    /// Fallback message type when a record carries no `msg_type` column.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_type: Option<String>,
+    /// Emit a leading `UNA` service-string-advice segment. Defaults to
+    /// `false`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub write_una: Option<bool>,
+    /// Write a newline after each segment terminator for readability.
+    /// Defaults to `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment_newline: Option<bool>,
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2499,6 +2499,27 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         }
     }
 
+    // An EDIFACT interchange is a single envelope: every record sits
+    // inside one UNB..UNZ frame whose trailer counts are recomputed and
+    // written only at end of stream. Byte-limit file splitting flushes
+    // (and therefore finalizes) the writer mid-stream, which would seal
+    // the interchange after the first record and emit later records — and
+    // their fresh UNH headers — after the UNZ trailer. There is no
+    // meaningful way to split one interchange across files, so reject the
+    // combination up front rather than emit a structurally corrupt
+    // interchange that still reports run success.
+    for output in config.output_configs() {
+        if matches!(output.format, OutputFormat::Edifact(_)) && output.split.is_some() {
+            return Err(ConfigError::Validation(format!(
+                "[E323] output '{}': `edifact` output cannot be combined with `split` — \
+                 an EDIFACT interchange is a single UNB..UNZ envelope and cannot be \
+                 divided across files; remove the `split` block or choose a splittable \
+                 format",
+                output.name
+            )));
+        }
+    }
+
     // Validate the flat `vars:` block (`$vars.<key>` static config)
     if let Some(ref vars) = config.pipeline.vars {
         for (name, decl) in vars {

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -537,3 +537,14 @@ pub struct FixedWidthInputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_separator: Option<LineSeparator>,
 }
+
+/// EDIFACT input options.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct EdifactInputOptions {
+    /// Number of positional `eNN` element columns on the record schema.
+    /// A body segment carrying more data elements than this is rejected
+    /// with guidance rather than silently truncated. Defaults to 32.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_elements: Option<usize>,
+}

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -233,7 +233,7 @@ impl BufferClass {
 impl ExecutionPlanDag {
     fn classify_node_buffers(&self, config: &PipelineConfig) -> HashMap<NodeIndex, BufferClass> {
         // Delegate to the fusion classifier whose streaming verdict is
-        // decided by the same `streaming_output_producer` predicate the
+        // decided by the same `certify_streaming_edge` predicate the
         // runtime sender install consults, so the `--explain` annotation
         // can never drift from what the dispatcher actually streams.
         // `StreamClass` is the verdict; `BufferClass` is this surface's

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -21,8 +21,8 @@ pub use enforcer::*;
 pub use explain::*;
 pub use graph_util::{compute_init_phase_node_set, single_predecessor};
 pub use streaming_class::{
-    StreamClass, classify_stream_nodes, compute_merge_interleave_fused_sources,
-    compute_transform_fused_sources, streaming_output_producer,
+    StreamClass, certify_streaming_edge, classify_stream_nodes,
+    compute_merge_interleave_fused_sources, compute_transform_fused_sources,
 };
 
 use std::collections::{BTreeSet, HashMap};

--- a/crates/clinker-plan/src/plan/execution/streaming_class.rs
+++ b/crates/clinker-plan/src/plan/execution/streaming_class.rs
@@ -1,10 +1,12 @@
 //! Streaming fused-path analysis over a compiled plan.
 //!
-//! These predicates decide which producer → single-`Output` chains bypass a
-//! `node_buffers` slot and stream record-by-record to a writer thread. Both
-//! `--explain` (plan-only) and the runtime dispatcher consult the same
-//! predicates so the buffer-class annotation can never drift from what the
-//! dispatcher actually does.
+//! These predicates decide which `producer → streaming-consumer` edges
+//! bypass a `node_buffers` slot and stream record-by-record over a bounded
+//! channel. The consumer side is parameterized over consumer kind, with
+//! `Output` (a file-writer thread) as the sole certified consumer kind
+//! today. Both `--explain` (plan-only) and the runtime dispatcher consult
+//! the same predicates so the buffer-class annotation can never drift from
+//! what the dispatcher actually does.
 
 use std::collections::{HashMap, HashSet};
 
@@ -180,7 +182,7 @@ pub fn compute_transform_fused_sources(
 /// registers a `NodeBufferConsumer` and is spill-eligible.
 ///
 /// The non-trivial verdict — whether a fused Transform streams — is
-/// decided by [`streaming_output_producer`], the one predicate both
+/// decided by [`certify_streaming_edge`], the one predicate both
 /// [`classify_stream_nodes`] (the `--explain` annotation) and the runtime
 /// sender install consult. A Transform is `Streaming` here iff a streaming
 /// sender is installed for it at runtime, so the explain annotation can
@@ -206,7 +208,7 @@ pub enum StreamClass {
 ///   dispatch arm returns without admitting a buffer; the downstream
 ///   fused consumer takes the receiver directly.
 /// - A fused **Transform** whose single downstream is a streaming-
-///   eligible Output, as decided by [`streaming_output_producer`]. Such a
+///   eligible Output, as decided by [`certify_streaming_edge`]. Such a
 ///   Transform hands each bounded batch straight to the streaming Output
 ///   thread over a back-pressured channel and never admits a
 ///   `node_buffers` slot, so its peak inter-stage footprint is one batch
@@ -247,7 +249,7 @@ pub fn classify_stream_nodes(
         plan.graph
             .node_indices()
             .filter_map(|output_idx| {
-                streaming_output_producer(plan, output_idx, &fused_transforms, &init_phase)
+                certify_streaming_edge(plan, output_idx, &fused_transforms, &init_phase)
             })
             .collect()
     };
@@ -285,26 +287,38 @@ pub fn classify_stream_nodes(
         .collect()
 }
 
-/// Resolve the streaming producer for an `Output` node, or `None` when
-/// the Output is not streaming-eligible.
+/// Certify a `producer → consumer` edge for the streaming substrate,
+/// returning the producer's `NodeIndex` when the edge streams, or `None`
+/// when it stays materialized.
 ///
-/// A streaming Output's writer moves into a `std::thread` that consumes a
-/// bounded crossbeam channel; the producer arm sends records into that
-/// channel as it produces them, so back-pressure flows writer → producer
-/// → Source and no inter-stage `node_buffers` slot is charged. Two
-/// producer topologies qualify, and this function is the single
-/// plan-derived eligibility predicate both the runtime spawn path and the
-/// `--explain` buffer-class annotation ([`classify_stream_nodes`])
+/// `consumer_idx` names the downstream streaming consumer; today the only
+/// certified consumer kind is `PlanNode::Output`, but the eligibility
+/// shell is consumer-generic so future streaming consumers (a streaming
+/// `Aggregate` ingest, a `Combine` probe) plug in as additional certifying
+/// arms without re-deriving the producer analysis. A streaming consumer's
+/// work moves into a `std::thread` that consumes a bounded crossbeam
+/// channel; the producer arm sends records into that channel as it
+/// produces them, so back-pressure flows consumer → producer → Source and
+/// no inter-stage `node_buffers` slot is charged. This function is the
+/// single plan-derived eligibility predicate both the runtime spawn path
+/// and the `--explain` buffer-class annotation ([`classify_stream_nodes`])
 /// consult, so the explain annotation can never disagree with what the
 /// dispatcher does.
 ///
 /// Common eligibility (independent of producer kind):
 ///
-/// - The Output has exactly one incoming edge.
-/// - The Output is not in the init-phase ancestor closure.
+/// - The consumer is not in the init-phase ancestor closure.
+/// - The consumer has exactly one incoming edge.
+///
+/// Consumer = `Output` (the sole certified consumer kind today):
+///
 /// - The Output is not a per-source-file fan-out writer and its config
 ///   declares no `split:` block — both own their own writer lifecycle
 ///   and are incompatible with the single streaming writer task.
+///
+/// Every other consumer node kind returns `None`: the consumer-specific
+/// guards above are conjunctive, so no producer edge into a non-`Output`
+/// consumer is certified until that consumer kind grows its own arm.
 ///
 /// Producer = fused `Merge.interleave` (issue #72):
 ///
@@ -369,34 +383,47 @@ pub fn classify_stream_nodes(
 /// Correlation buffering disables streaming pipeline-wide — the
 /// `CorrelationCommit` terminal owns the writes — so the caller short-
 /// circuits before calling this.
-pub fn streaming_output_producer(
+pub fn certify_streaming_edge(
     plan: &ExecutionPlanDag,
-    output_idx: petgraph::graph::NodeIndex,
+    consumer_idx: petgraph::graph::NodeIndex,
     fused_transforms: &HashSet<petgraph::graph::NodeIndex>,
     init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
 ) -> Option<petgraph::graph::NodeIndex> {
     use crate::plan::combine::CombineStrategy;
     use crate::plan::types::AggregateStrategy;
 
-    let PlanNode::Output { resolved, .. } = &plan.graph[output_idx] else {
-        return None;
-    };
-    let payload = resolved.as_deref()?;
-    if init_phase_set.contains(&output_idx) {
+    // Consumer-generic eligibility, hoisted ahead of the consumer-kind
+    // dispatch because every certifying arm shares it: an init-phase
+    // consumer drives the bootstrap DAG (no streaming writer task), and a
+    // consumer with fan-in cannot move a single upstream producer's live
+    // channel into itself.
+    if init_phase_set.contains(&consumer_idx) {
         return None;
     }
-    // Per-source-file fan-out and split writers own their own file
-    // rotation lifecycle and cannot share the single streaming writer
-    // task. Both are plan-derived so the explain and runtime surfaces
-    // agree without consulting the runtime writer registry.
-    if payload.fan_out_per_source_file || payload.output.split.is_some() {
-        return None;
+
+    // Consumer-kind dispatch. `Output` is the sole certified consumer kind
+    // today; every other kind falls through to `None`. The guards here are
+    // the consumer-specific half of the predicate (the producer-kind half
+    // is the `match` on `producer_idx` below).
+    match &plan.graph[consumer_idx] {
+        PlanNode::Output { resolved, .. } => {
+            let payload = resolved.as_deref()?;
+            // Per-source-file fan-out and split writers own their own file
+            // rotation lifecycle and cannot share the single streaming
+            // writer task. Both are plan-derived so the explain and
+            // runtime surfaces agree without consulting the runtime writer
+            // registry.
+            if payload.fan_out_per_source_file || payload.output.split.is_some() {
+                return None;
+            }
+        }
+        _ => return None,
     }
 
     // Exactly one incoming edge.
     let mut incoming = plan
         .graph
-        .neighbors_directed(output_idx, petgraph::Direction::Incoming);
+        .neighbors_directed(consumer_idx, petgraph::Direction::Incoming);
     let producer_idx = incoming.next()?;
     if incoming.next().is_some() {
         return None;

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -229,6 +229,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E335" => Some(include_str!("../../../../docs/explain/E335.md")),
         "E336" => Some(include_str!("../../../../docs/explain/E336.md")),
         "E337" => Some(include_str!("../../../../docs/explain/E337.md")),
+        "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
         "E150d" => Some(include_str!("../../../../docs/explain/E150d.md")),
@@ -420,8 +421,8 @@ mod tests {
         let codes = [
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
-            "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E330", "E331", "E332",
-            "E333", "E334", "E335", "E336", "E337", "E15Y", "W101", "W302", "W305", "W306",
+            "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
+            "E332", "E333", "E334", "E335", "E336", "E337", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-schema/src/model.rs
+++ b/crates/clinker-schema/src/model.rs
@@ -59,6 +59,7 @@ pub enum SourceFormat {
     Jsonl,
     Xml,
     Parquet,
+    Edifact,
 }
 
 impl SourceFormat {
@@ -71,6 +72,7 @@ impl SourceFormat {
             Self::Jsonl => "jsonl",
             Self::Xml => "xml",
             Self::Parquet => "parquet",
+            Self::Edifact => "edifact",
         }
     }
 
@@ -81,6 +83,7 @@ impl SourceFormat {
             Self::Json | Self::Jsonl => FormatCategory::Json,
             Self::Xml => FormatCategory::Xml,
             Self::Parquet => FormatCategory::Parquet,
+            Self::Edifact => FormatCategory::Edifact,
         }
     }
 }
@@ -92,6 +95,7 @@ pub enum FormatCategory {
     Json,
     Xml,
     Parquet,
+    Edifact,
 }
 
 /// A single field in a schema.

--- a/crates/clinker-schema/src/validate.rs
+++ b/crates/clinker-schema/src/validate.rs
@@ -130,6 +130,7 @@ fn validate_input(
         ),
         InputFormat::Xml(_) => schema.metadata.format == crate::model::SourceFormat::Xml,
         InputFormat::FixedWidth(_) => false, // No schema format match for fixed-width yet
+        InputFormat::Edifact(_) => schema.metadata.format == crate::model::SourceFormat::Edifact,
     };
 
     if !format_matches {

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -1991,7 +1991,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321, E330-E337, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E337, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/docs/explain/E323.md
+++ b/docs/explain/E323.md
@@ -1,0 +1,78 @@
+# Error E323: edifact output cannot be combined with split
+
+## What it means
+
+An `Output` node declares the `edifact` format and also carries a byte-limit
+`split:` block. The two are mutually exclusive: an EDIFACT interchange is a
+single `UNB..UNZ` envelope whose trailer counts (`UNZ` message count) and
+control references are recomputed and written only at end of stream. Byte-limit
+file splitting finalizes the writer mid-stream, which would seal the
+interchange after the first file's records and then emit later records — and
+their fresh `UNH` headers — after the `UNZ` trailer, producing a structurally
+corrupt interchange that still reports run success.
+
+Rather than emit corruption, clinker rejects the combination at
+config-validation time.
+
+```
+E323 output 'edi_out': `edifact` output cannot be combined with `split` — an
+EDIFACT interchange is a single UNB..UNZ envelope and cannot be divided across
+files; remove the `split` block or choose a splittable format
+```
+
+## Example
+
+```yaml
+# Rejected: an interchange cannot be split across files.
+nodes:
+  - output: edi_out
+    input: orders
+    format: edifact
+    path: out/orders.edi
+    split:
+      max_bytes: 1048576
+```
+
+```yaml
+# Corrected (option A): drop the split block; write one interchange file.
+nodes:
+  - output: edi_out
+    input: orders
+    format: edifact
+    path: out/orders.edi
+```
+
+```yaml
+# Corrected (option B): partition upstream and run one invocation per
+# partition, so each run produces its own complete interchange.
+#   for f in inputs/*.csv; do clinker run pipeline.yaml --var input="$f"; done
+```
+
+## How to fix
+
+1. **Remove the `split:` block** from the `edifact` output. A single run then
+   writes one complete interchange file.
+
+2. **Choose a splittable format** (`csv`, `json`, `xml`, `fixed_width`) if the
+   byte-limit splitting is the requirement and the EDIFACT envelope is not.
+
+3. **Partition the input and invoke per partition** if you need multiple
+   output files: split the source by file or key upstream and run clinker once
+   per partition, so each invocation emits its own self-contained interchange.
+
+## Technical context
+
+The EDIFACT writer reconstructs the envelope around emitted records: it writes
+`UNB` from the configured interchange header, opens a `UNH..UNT` message per
+`msg_ref` transition, and on `flush()` closes the open message and writes the
+`UNZ` trailer with the recomputed message count and the echoed `UNB` control
+reference. That finalization is the only point at which the interchange is
+well-formed. A byte-limit `split` flushes (and therefore finalizes) the writer
+whenever the per-file cap is reached, so any records after the first split
+boundary would be written outside the sealed envelope. Because no valid
+interchange can span files, the validator rejects the pairing up front.
+
+## See also
+
+- E322 (two output destinations resolve to the same file)
+- "EDIFACT Format" in the pipeline reference

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -13,6 +13,7 @@
 
 - [Pipeline YAML Structure](pipeline/structure.md)
 - [Source Nodes](pipeline/source.md)
+- [EDIFACT Format](pipeline/edifact.md)
 - [Network Sources (REST)](pipeline/source-network.md)
 - [Auto-Widen & Schema Drift](pipeline/auto-widen.md)
 - [Transform Nodes](pipeline/transform.md)

--- a/docs/src/pipeline/edifact.md
+++ b/docs/src/pipeline/edifact.md
@@ -1,0 +1,212 @@
+# EDIFACT Format
+
+Clinker reads and writes UN/EDIFACT interchanges alongside CSV, JSON,
+XML, and fixed-width. An interchange is a finite file: it opens with an
+optional `UNA` service-string advice and a mandatory `UNB` header, wraps
+one or more `UNH..UNT` messages, and closes with a `UNZ` trailer. The
+reader streams one segment at a time and the writer reconstructs the
+envelope around emitted records. The reader decodes release-escape
+sequences into clean data values and the writer re-escapes them on
+output, so a reader → writer → reader round-trip preserves the data
+values and the envelope control references.
+
+## Delimiters and the UNA service string
+
+Each segment is terminated by the segment terminator; within a segment,
+data elements split on the element separator and components on the
+component separator. A release character escapes a delimiter that occurs
+as literal data.
+
+When the file begins with a 9-byte `UNA` prefix, its six service
+characters override the defaults in this fixed order: component,
+element, decimal, release, repetition, terminator. When `UNA` is absent,
+the syntax Level-A defaults apply:
+
+| Role               | Level-A default |
+| ------------------ | --------------- |
+| Component separator | `:`            |
+| Element separator   | `+`            |
+| Decimal notation    | `.`            |
+| Release / escape    | `?`            |
+| Repetition          | space (inactive)|
+| Segment terminator  | `'`            |
+
+`UNA` is optional — a parser that requires it would fail on the common
+no-`UNA` interchange, so Clinker assumes Level-A when it is absent.
+
+### Release character
+
+The release character (default `?`) marks the following byte as literal
+data rather than a delimiter: `?+` is a literal `+` inside an element,
+`?'` is a literal apostrophe (not a terminator), and `??` is a literal
+`?`. The reader **decodes** these sequences into clean data values, so a
+downstream CSV/JSON sink, a CXL string comparison, or a `$doc` field sees
+`O'BRIEN`, never the wire form `O?'BRIEN`. The writer **re-escapes** on
+output: any element value that carries the element separator, the segment
+terminator, or the release character is release-escaped automatically, so
+a value computed by a Transform or sourced from CSV — never
+EDIFACT-escaped to begin with — does not corrupt the interchange. A
+reader → writer → reader round-trip therefore preserves the data values
+exactly.
+
+The component separator inside an element (e.g. the `:` in the composite
+`UNOA:1`) is kept as part of the element's text and is not escaped — the
+positional element model works above component resolution, so a composite
+element round-trips unchanged. A literal colon in free-text data is the
+one ambiguity this introduces: because components are not split into
+separate fields, a `:` in a value re-reads as a component boundary.
+Repeating elements ride inside one element string intact and are likewise
+never truncated to their first repetition.
+
+### Newlines between segments
+
+Some producers insert CR/LF after each segment terminator for
+readability. Those bytes are insignificant and are stripped between
+segments; CR/LF that appears inside an element is preserved.
+
+## Record shape
+
+Each non-service segment becomes one record under a fixed positional
+schema:
+
+| Column     | Meaning                                              |
+| ---------- | ---------------------------------------------------- |
+| `seg_id`   | The segment tag (`BGM`, `NAD`, …)                    |
+| `msg_ref`  | The enclosing message reference (the `UNH` element 1)|
+| `msg_type` | The message type (the `UNH` element 2, full composite)|
+| `e01`, `e02`, … | The segment's positional data elements (release sequences decoded) |
+
+Service segments (`UNB`, `UNZ`, `UNH`, `UNT`) are consumed by the reader
+to drive envelope state and validation — they are never emitted as body
+records. The `UNH` segment that opens a message **is** emitted as a body
+record (its `seg_id` is `UNH`), carrying the message reference and type.
+
+The number of `eNN` columns is controlled by the source `max_elements`
+option (default 32). A segment carrying more data elements than that is
+rejected with guidance rather than silently truncated. Absent trailing
+elements read as `null`.
+
+```yaml
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: edifact
+      glob: ./inbox/*.edi
+      options:
+        max_elements: 48      # widen the positional schema for exotic segments
+      schema:
+        - { name: seg_id, type: string }
+        - { name: msg_ref, type: string }
+        - { name: e01, type: string }
+```
+
+## Envelope sections over UNB
+
+The interchange header `UNB` is extractable as a document envelope
+section, exposing its positional elements to CXL as
+`$doc.<section>.<field>`. Use the `segment` extract rule with the section
+field names matching the positional keys `e01`, `e02`, …:
+
+```yaml
+envelope:
+  sections:
+    interchange:
+      extract: { segment: "UNB" }
+      fields:
+        e05: string          # interchange control reference (UNB element 5)
+```
+
+A Transform can then read `$doc.interchange.e05` on every body record.
+
+Only the `UNB` header is extractable as an envelope section. Trailer
+segments (`UNT`, `UNZ`) arrive after the body and cannot become `$doc`
+fields without buffering the whole interchange — their control counts
+are instead validated inline by the reader (see below). A `segment`
+extract naming any tag other than `UNB`, or an `xml_path` / `json_pointer`
+extract against an EDIFACT source, is rejected at startup.
+
+## Control-count validation
+
+The reader validates the structural integrity claims carried in the
+trailers as they arrive, failing the run on a mismatch (a truncation or
+corruption signal):
+
+- **`UNT` segment count** — must equal the actual number of segments in
+  the message, counting the `UNH` and `UNT` themselves.
+- **`UNT` message reference** — must echo the opening `UNH` reference.
+- **`UNZ` message count** — must equal the actual number of `UNH`
+  messages in the interchange.
+- **`UNZ` control reference** — must echo the `UNB` control reference.
+
+A missing `UNZ` at end of input is a truncation error; content after the
+`UNZ` trailer is rejected.
+
+## Writing EDIFACT
+
+An EDIFACT Output node reconstructs the envelope around emitted records.
+Records map by the same positional columns (`seg_id`, `msg_ref`,
+`msg_type`, `eNN`); trailing `null`/empty elements are trimmed so no
+fabricated delimiters appear, and a column the writer does not recognize
+is an error (project the record to the EDIFACT columns first).
+Engine-internal `$`-namespaced columns are excluded automatically.
+
+```yaml
+nodes:
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: edifact
+      path: ./out/result.edi
+      options:
+        interchange: ["UNOA:1", "SENDER", "RECEIVER", "240101:1200", "REF1"]
+        message_type: "ORDERS:D:96A:UN"
+        write_una: false
+        segment_newline: true
+```
+
+Output options:
+
+| Option                  | Meaning                                                                 |
+| ----------------------- | ----------------------------------------------------------------------- |
+| `interchange`           | Literal `UNB` data elements (release-escaped as needed on write).        |
+| `interchange_from_doc`  | Name of a `$doc` section to echo the `UNB` elements from (round-trip).   |
+| `message_type`          | Fallback `UNH` message type when a record carries no `msg_type` value.   |
+| `write_una`             | Emit a leading `UNA` segment (default `false`).                          |
+| `segment_newline`       | Write a newline after each segment terminator (default `true`).         |
+
+Consecutive records are grouped into `UNH..UNT` messages on `msg_ref`
+transitions. The writer recomputes the `UNT` segment count and `UNZ`
+message count, and echoes the message and interchange control references,
+so the output passes its own count validation on re-read.
+
+`interchange_from_doc` echoes the header from a record's document
+context. That context is populated by a source's `UNB` envelope section
+(declare a `segment: "UNB"` envelope section on the source) and travels
+with every body record through the pipeline — including to a sink that
+sits directly downstream of the source with no intervening Transform. The
+reader stashes the complete, ordered `UNB` element list (empty middle
+elements included), so the reconstructed header is faithful even when a
+middle element is empty and the user declares only the fields they care
+about. Supply `interchange` literal elements instead when the records
+have no source `UNB` section to echo.
+
+## Limitations
+
+- **Charset.** Element text is decoded as UTF-8. Non-UTF-8 interchanges
+  (UNOA/UNOB/Latin-1 high bytes) are rejected explicitly rather than
+  silently corrupted.
+- **Functional groups.** A single `UNB..UNZ` interchange is supported;
+  `UNG`/`UNE` functional-group segments are rejected with a precise
+  error.
+- **UNH composite fidelity.** The reader stamps the `UNH` reference
+  (element 1) and the full message-type composite (element 2). A `UNH`
+  carrying additional elements (e.g. a common access reference) is
+  reconstructed as a two-element `UNH` on round-trip.
+- **Output splitting.** An interchange is a single `UNB..UNZ` envelope and
+  cannot be divided across files. An `edifact` output combined with a
+  `split:` block is rejected at config-validation time (diagnostic
+  `E323`) rather than emitting a structurally corrupt interchange.

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -83,16 +83,40 @@ budget.
 
 Each section declares how the reader locates its payload:
 
-| Format | `extract:` key   | Value                                            |
-| ------ | ---------------- | ------------------------------------------------ |
-| XML    | `xml_path`       | Slash-path to the section element, e.g. `/doc/Head` |
-| JSON   | `json_pointer`   | RFC 6901 pointer, e.g. `/Head`                   |
+| Format  | `extract:` key   | Value                                            |
+| ------- | ---------------- | ------------------------------------------------ |
+| XML     | `xml_path`       | Slash-path to the section element, e.g. `/doc/Head` |
+| JSON    | `json_pointer`   | RFC 6901 pointer, e.g. `/Head`                   |
+| EDIFACT | `segment`        | A service-segment tag — only `UNB`               |
 
-Declaring an `xml_path` section against a JSON source (or vice versa)
-is a configuration error and fails fast when the source opens, rather
-than silently producing empty sections. CSV and fixed-width sources do
-not yet support envelope extraction; declaring envelope sections on
-those formats is a no-op today.
+Declaring an `xml_path` section against a JSON source (or vice versa),
+or a `segment` extract against XML/JSON, is a configuration error and
+fails fast when the source opens, rather than silently producing empty
+sections. CSV and fixed-width sources do not yet support envelope
+extraction; declaring envelope sections on those formats is a no-op
+today.
+
+### EDIFACT `segment` extract
+
+An EDIFACT source exposes its interchange header `UNB` as an envelope
+section. The section's field names are the positional element keys
+`e01`, `e02`, … :
+
+```yaml
+envelope:
+  sections:
+    interchange:
+      extract: { segment: "UNB" }
+      fields:
+        e05: string          # interchange control reference
+```
+
+Only the `UNB` header is extractable. EDIFACT is scanned as a flat byte
+stream with only the header pre-read, so trailer segments (`UNT`, `UNZ`)
+that arrive after the body are **not** envelope sections — their control
+counts are validated inline by the reader instead. A `segment` extract
+naming any tag other than `UNB` is rejected at startup. See
+[EDIFACT Format](edifact.md) for the full reference.
 
 A JSON example:
 

--- a/docs/src/pipeline/output.md
+++ b/docs/src/pipeline/output.md
@@ -14,7 +14,7 @@ Output nodes write processed records to files. They are the terminal nodes of a 
     path: "./output/result.csv"
 ```
 
-The `type:` field selects the output format: `csv`, `json`, `xml`, or `fixed_width`.
+The `type:` field selects the output format: `csv`, `json`, `xml`, `fixed_width`, or `edifact`.
 
 ## Field control
 
@@ -190,6 +190,33 @@ Metadata fields are prefixed with `meta.` in the output.
 ```
 
 Fixed-width output requires a format schema defining field positions and widths.
+
+### EDIFACT
+
+```yaml
+- type: output
+  name: edi_out
+  input: messages
+  config:
+    name: edi_out
+    type: edifact
+    path: "./out/result.edi"
+    options:
+      interchange: ["UNOA:1", "SENDER", "RECEIVER", "240101:1200", "REF1"]
+      message_type: "ORDERS:D:96A:UN"
+      write_una: false
+      segment_newline: true
+```
+
+The EDIFACT writer reconstructs the interchange envelope around emitted
+records, recomputing the `UNT`/`UNZ` control counts and echoing the
+control references, and release-escapes any element data that carries a
+service character. The `UNB` header comes from `interchange` (literal
+elements) or `interchange_from_doc` (echoed from a `$doc` section). An
+interchange is a single envelope, so an `edifact` output cannot be
+combined with a `split:` block — the combination is rejected at
+config-validation time (`E323`). See [EDIFACT Format](edifact.md) for the
+full option reference, the record schema, and the round-trip semantics.
 
 ## Sort order
 

--- a/docs/src/pipeline/source.md
+++ b/docs/src/pipeline/source.md
@@ -80,7 +80,7 @@ shares repeated values instead of storing each copy independently.
 A source declaration has two independent layers:
 
 - **Transport** (`transport:`) selects *where* the records come from. The only transport today is `file` — read bytes from the filesystem, resolved through one of the file matchers (`path` / `glob` / `regex` / `paths`). `transport:` is optional and defaults to `file`, so a source that omits it reads from disk exactly as before.
-- **Format** (`type:`) selects *how* the bytes decode into records: `csv`, `json`, `xml`, `fixed_width`.
+- **Format** (`type:`) selects *how* the bytes decode into records: `csv`, `json`, `xml`, `fixed_width`, `edifact`.
 
 ```yaml
 - type: source
@@ -98,7 +98,15 @@ A `file` transport requires **exactly one** file matcher (`path`, `glob`, `regex
 
 ## Format types
 
-The `type:` field inside `config:` selects the on-disk format. Supported values: `csv`, `json`, `xml`, `fixed_width`.
+The `type:` field inside `config:` selects the on-disk format. Supported values: `csv`, `json`, `xml`, `fixed_width`, `edifact`.
+
+The `edifact` format reads UN/EDIFACT interchanges; it has its own
+reference page covering the segment-record schema, delimiter discovery,
+envelope sections, and control-count validation. See
+[EDIFACT Format](edifact.md). Its one input option is `max_elements`
+(default 32) — the number of positional `eNN` element columns on the
+record schema; a segment with more data elements than that is rejected
+rather than truncated.
 
 ### CSV
 


### PR DESCRIPTION
Adds the first slice of document-shape ETL support: a generalized streaming handoff and a complete EDIFACT reader/writer.

## Changes

**Parameterize the streaming handoff over consumer kind (closes #298).** The push-based streaming substrate was hard-wired to the Output sink. This refactor introduces a consumer-kind abstraction (`StreamingConsumer`, `certify_streaming_edge`, `drain_streaming_channel`) so any eligible consumer can be streamed into; Output remains the sole instantiation today. Behavior-preserving — the `--explain` buffer-class annotation is unchanged. This unblocks streaming Aggregate-ingest and Combine-probe consumers.

**EDIFACT reader/writer with UNB/UNH envelope mapping (closes #379).** Reads and writes UN/EDIFACT interchanges: UNB/UNH header parsing into `$doc` envelope sections, UNT/UNZ/UNE control-count validation (segment counts and control-reference echoes are enforced; mismatches fail the document with a precise diagnostic), and writer round-tripping that recomputes the trailer counts. Adds diagnostic code `E323` for the EDIFACT-plus-split-output rejection.

**Preserve document context through output projection (closes #399).** A Transform-less source → output path rebuilt the projected record with a synthetic document context, dropping the source's `$doc` envelope. Both projection paths now carry the context forward.

## Verification

Full workspace gauntlet green: `cargo fmt`, `clippy --workspace` (with and without `--all-targets`), `cargo test --workspace`, bench checks, and `cargo deny check` all pass. New integration tests cover EDIFACT round-tripping, control-count validation failures, and the streaming consumer-kind certification.

## Known follow-ups (filed)

- #401 — EDIFACT UNB control-reference location is positional; an internally consistent interchange can be spuriously rejected. Tracked for a follow-up.
- #403 — EDIFACT element text is currently assumed UTF-8 rather than decoded per the UNB syntax identifier.