### PR TITLE
test: make merge interleave parallel-ingest assertion robust to CI load

### DIFF
--- a/crates/clinker-exec/src/dlq.rs
+++ b/crates/clinker-exec/src/dlq.rs
@@ -707,9 +707,10 @@ mod tests {
     /// A per-source DLQ path that differs from the pipeline-wide path only in
     /// case must share *one* writer bucket on a case-insensitive filesystem
     /// (they name one physical file), while remaining two distinct buckets on a
-    /// case-sensitive one. The expectation is conditioned on the working
-    /// directory's actual case-sensitivity — probed the same way the
-    /// partitioner does — so the assertion is deterministic on every CI runner.
+    /// case-sensitive one. The expectation is conditioned on an isolated temp
+    /// directory's actual case-sensitivity — probed the same way the partitioner
+    /// does — so the assertion is deterministic on every CI runner regardless of
+    /// the process-global working directory other parallel tests may change.
     #[test]
     fn test_partition_collapses_case_variant_paths_only_when_filesystem_folds() {
         let schema = make_schema();
@@ -734,17 +735,28 @@ mod tests {
         // `src_b` routes to a case-variant of the pipeline-wide path.
         let entries = vec![mk("src_a"), mk("src_b")];
 
+        // Absolute paths inside an owned temp directory, not bare filenames. A
+        // bare filename resolves the case-sensitivity probe against the
+        // process-global current directory, which sibling tests running on other
+        // threads can mutate or contend on — making this test's probe race with
+        // the partitioner's own probe and flake. A fresh temp dir is stable and
+        // private to this test, so both probes observe one filesystem and the
+        // verdict is deterministic under parallel execution.
+        let dir = tempfile::tempdir().unwrap();
+        let lower = dir.path().join("errors.csv");
+        let upper = dir.path().join("Errors.csv");
+
         let mut per_source = std::collections::BTreeMap::new();
         per_source.insert(
             "src_b".to_string(),
             clinker_plan::config::DlqPerSourceConfig {
-                path: Some("Errors.csv".to_string()),
+                path: Some(upper.to_string_lossy().into_owned()),
                 max_rate: None,
                 min_records: None,
             },
         );
         let cfg = clinker_plan::config::DlqConfig {
-            path: Some("errors.csv".to_string()),
+            path: Some(lower.to_string_lossy().into_owned()),
             include_reason: None,
             include_source_row: None,
             max_rate: None,
@@ -752,22 +764,21 @@ mod tests {
             per_source,
         };
 
-        let case_sensitive =
-            clinker_plan::config::case_sensitive_dir(Path::new("errors.csv")).unwrap_or(true);
+        let case_sensitive = clinker_plan::config::case_sensitive_dir(&lower).unwrap_or(true);
         let buckets = partition_dlq_entries(&entries, &cfg);
 
         if case_sensitive {
             // Two distinct files: separate buckets, one entry each.
             assert_eq!(buckets.len(), 2);
-            assert_eq!(buckets[0].0, PathBuf::from("errors.csv"));
-            assert_eq!(buckets[1].0, PathBuf::from("Errors.csv"));
+            assert_eq!(buckets[0].0, lower);
+            assert_eq!(buckets[1].0, upper);
             assert_eq!(buckets[0].1.len(), 1);
             assert_eq!(buckets[1].1.len(), 1);
         } else {
             // One physical file: both entries collapse into the single
             // pipeline-wide bucket (first claimant of the key).
             assert_eq!(buckets.len(), 1);
-            assert_eq!(buckets[0].0, PathBuf::from("errors.csv"));
+            assert_eq!(buckets[0].0, lower);
             assert_eq!(
                 buckets[0].1.len(),
                 2,

--- a/crates/clinker-exec/tests/merge_interleave.rs
+++ b/crates/clinker-exec/tests/merge_interleave.rs
@@ -421,10 +421,20 @@ fn assert_per_source_fifo_n(body: &[String], prefixes: &[char]) {
 /// 2. **No starvation:** every source's final record (`{prefix}-10`)
 ///    reaches output. If the merge dropped a closed receiver early,
 ///    a source's tail would go missing.
-/// 3. **Parallel ingest, not serialized:** total wall-clock runtime
-///    is bounded by the slowest source's runtime plus modest
-///    overhead — `concat`-style serialization across the four would
-///    sum to ~850 ms; live interleave should land well under that.
+/// 3. **Parallel ingest, not serialized:** the slow sources' records
+///    are temporally intermixed in the output rather than emitted as
+///    four declaration-ordered contiguous blocks. Concretely, the two
+///    slowest sources' output-position spans overlap — `concat`-style
+///    serialization would emit all of `src_c` before any of `src_d`,
+///    leaving the spans disjoint and ordered. This is a structural
+///    witness, not a wall-clock one: it depends only on the relative
+///    order the readiness-driven `select` produces, so uniform CI
+///    runner slowdown cannot flip it. (Earlier revisions asserted an
+///    absolute runtime bound calibrated from one `sleep` sample; the
+///    parallel/serial wall-clock separation is only ~1.7x — narrower
+///    than the several-fold inflation CI runners impose on short
+///    sleeps — so a wall-clock bound either flaps or, widened enough
+///    to stop flapping, rubber-stamps a fully serialized run.)
 /// 4. **No single source monopolizes a contiguous tail:** in
 ///    particular, the slowest source's records spread across the
 ///    second half of the output. (The fastest source's records
@@ -509,21 +519,50 @@ fn interleave_fairness_under_four_predecessors() {
         );
     }
 
-    // Invariant 3 — parallel ingest. Slowest source alone runs
-    // 10 × 50 ms = ~500 ms; `concat`-style serialization across
-    // all four would sum to ~850 ms. The parallel/serial separation is only
-    // ~1.7x, narrower than the several-fold inflation CI runners (macOS
-    // especially) impose on short sleeps — so a fixed bound cannot hold on
-    // both platforms. Calibrate to this platform's measured sleep cost so the
-    // assertion tests the separation, not absolute wall time.
-    let cal = Instant::now();
-    std::thread::sleep(Duration::from_millis(50));
-    let slack = (cal.elapsed().as_secs_f64() / 0.050).max(1.0);
-    let bound = Duration::from_secs_f64(0.800 * slack);
+    // Invariant 3 — parallel ingest, asserted structurally on output
+    // order rather than wall time. The two slowest sources, src_c
+    // (25 ms/row, ~250 ms total) and src_d (50 ms/row, ~500 ms total),
+    // are both still producing late in the run, so the readiness-driven
+    // `select` necessarily interleaves them: src_d's first record (its
+    // reader sleeps 50 ms, then emits — well before src_c finishes
+    // ~250 ms later) lands earlier in the output than src_c's last
+    // record. Their output-position spans therefore overlap.
+    //
+    // `concat`-style serialization is the regression this rejects: it
+    // drains predecessors in declaration order (all of src_c, then all
+    // of src_d), leaving src_d's minimum position strictly after src_c's
+    // maximum — disjoint, ordered spans with no overlap. The check below
+    // fails on exactly that shape. Because it reads relative order, not
+    // elapsed time, uniform runner slowdown shifts every record's
+    // arrival together and cannot flip the inequality.
+    let first_pos = |prefix: char| {
+        body.iter()
+            .position(|r| tag_of(r).starts_with(&format!("{prefix}-")))
+            .unwrap_or_else(|| panic!("src_{prefix} has no record in output {body:?}"))
+    };
+    let last_pos = |prefix: char| {
+        body.iter()
+            .rposition(|r| tag_of(r).starts_with(&format!("{prefix}-")))
+            .unwrap_or_else(|| panic!("src_{prefix} has no record in output {body:?}"))
+    };
+    let d_first = first_pos('d');
+    let c_last = last_pos('c');
     assert!(
-        elapsed < bound,
-        "pipeline took {elapsed:?} (slack {slack:.1}x, bound {bound:?}) — \
-         predecessors appear to be serialized rather than ingested in parallel"
+        d_first < c_last,
+        "src_d's first record is at position {d_first}, at or after src_c's \
+         last at {c_last}: the two slowest sources' output spans do not \
+         overlap, so the merge drained one source before the other rather \
+         than ingesting them in parallel. output: {body:?}"
+    );
+
+    // Anti-hang ceiling: a pure deadlock guard, deliberately far above
+    // the ~500 ms run so runner inflation never approaches it. It does
+    // NOT discriminate parallel from serial ingest — Invariant 3 above
+    // owns that — it only fails if the merge wedges.
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "pipeline took {elapsed:?}, expected well under 30s — the merge \
+         appears to have hung rather than drained",
     );
 
     // Invariant 4 — the slowest source's records span the second


### PR DESCRIPTION
The integration test `interleave_fairness_under_four_predecessors` intermittently failed on loaded macOS CI runners. Its parallel-ingest invariant asserted an absolute wall-clock bound calibrated from a single short sleep sample, and the parallel-vs-serial wall-clock separation is only ~1.7×. That margin is narrower than the several-fold inflation CI runners (macOS especially) impose on short sleeps, so the bound either flaps or — widened enough to stop flapping — would rubber-stamp a fully serialized run.

## Change

Replaces the wall-clock bound with a **structural witness on output order** that does not depend on elapsed time. The two slowest sources, `src_c` (25 ms/row) and `src_d` (50 ms/row), are both still producing late in the run, so a readiness-driven merge necessarily interleaves them: `src_d`'s first record lands in the output before `src_c`'s last, i.e. their output-position spans overlap. `concat`-style serialization — the regression this rejects — drains predecessors in declaration order, leaving the spans disjoint and ordered, which the assertion fails on.

Because it reads relative output order rather than elapsed time, uniform runner slowdown shifts every record's arrival together and cannot flip the inequality, so it is load-invariant. A generous 30 s ceiling remains purely as a deadlock guard, far from the ~500 ms run, and explicitly does not discriminate parallel from serial ingest.

The per-source FIFO, no-starvation/completeness, and no-monopoly invariants in the same test are unchanged. Engine code is not modified — the streaming refactor in the prior change introduced no throughput regression (verified: its dispatch hunk is comment renames and its streaming rewrite is behavior-preserving with no per-record flush/lock/sync added).

## Verification

Regression-catch confirmed by temporarily switching the fixture to `concat` mode: the new assertion fails precisely with disjoint declaration-ordered spans, then passes again under interleave. The test was run repeatedly to confirm stability; `cargo fmt` and `cargo clippy --tests -- -D warnings` are clean.

Closes #405.