### PR TITLE
Document-shape ETL: multi-level envelopes, X12, streaming Aggregate/Combine ingest, nested CXL fan-out

### DIFF
--- a/crates/clinker-benchmarks/src/format_mapping.rs
+++ b/crates/clinker-benchmarks/src/format_mapping.rs
@@ -8,6 +8,7 @@ use clinker_plan::config::{InputFormat, JsonFormat};
 pub enum FormatMappingError {
     UnsupportedJsonObject,
     UnsupportedEdifact,
+    UnsupportedX12,
 }
 
 impl std::fmt::Display for FormatMappingError {
@@ -18,6 +19,9 @@ impl std::fmt::Display for FormatMappingError {
             }
             Self::UnsupportedEdifact => {
                 f.write_str("EDIFACT format has no benchmark DataFormat equivalent")
+            }
+            Self::UnsupportedX12 => {
+                f.write_str("X12 format has no benchmark DataFormat equivalent")
             }
         }
     }
@@ -34,6 +38,7 @@ pub fn input_format_to_data_format(input: &InputFormat) -> Result<DataFormat, Fo
         InputFormat::Xml(_) => Ok(DataFormat::Xml),
         InputFormat::FixedWidth(_) => Ok(DataFormat::FixedWidth),
         InputFormat::Edifact(_) => Err(FormatMappingError::UnsupportedEdifact),
+        InputFormat::X12(_) => Err(FormatMappingError::UnsupportedX12),
         InputFormat::Json(opts) => {
             let json_fmt = opts.as_ref().and_then(|o| o.format.as_ref());
             match json_fmt {

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -79,6 +79,7 @@
 //! | `E318`      | error    | `error_handling.dlq.*.max_rate` out of `[0.0, 1.0]` or DLQ path collides |
 //! | `E322`      | error    | Two output destinations (Output nodes, or an Output node and a DLQ path) resolve to the same file |
 //! | `E323`      | error    | `edifact` output combined with byte-limit `split` (an interchange is one indivisible UNB..UNZ envelope) |
+//! | `E338`      | error    | `x12` output combined with byte-limit `split` (an interchange is one indivisible ISA..IEA envelope) |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -81,6 +81,53 @@ pub(crate) fn dispatch_aggregation(
         "aggregation",
         name,
     )?;
+
+    // Streaming-ingest fast path (issue #299): when `pred` is the certified
+    // streaming producer for this Aggregate (top-level plan only — a
+    // composition body shares the `NodeIndex` space but installs no ingest
+    // edges), drive `add_record` off a bounded channel the producer fills
+    // rather than pre-draining its whole output from a charged
+    // `node_buffers` slot. Strict aggregates only: relaxed-CK and
+    // time-windowed shapes were excluded by `certify_streaming_edge`, so
+    // this never collides with the retain / multi-window branches below.
+    let streaming_ingest_producer: Option<NodeIndex> = if ctx.current_body_node_input_refs.is_none()
+        && !is_relaxed
+        && !is_time_windowed
+        && ctx
+            .streaming_aggregate_ingest_edges
+            .get(&pred)
+            .is_some_and(|&agg| agg == node_idx)
+    {
+        Some(pred)
+    } else {
+        None
+    };
+
+    let agg_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
+
+    if let Some(producer_idx) = streaming_ingest_producer {
+        let ingest = run_streaming_aggregate_ingest(
+            ctx,
+            current_dag,
+            node_idx,
+            producer_idx,
+            name,
+            agg_strategy,
+            compiled,
+            output_schema,
+        )?;
+        return finalize_aggregate_emit(
+            ctx,
+            current_dag,
+            node_idx,
+            name,
+            agg_timer,
+            ingest.input_count,
+            ingest.out_rows,
+            ingest.puncts,
+        );
+    }
+
     let (input, input_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
@@ -152,7 +199,6 @@ pub(crate) fn dispatch_aggregation(
         .spill_compress
         .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
 
-    let agg_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
     let input_count = input.len() as u64;
 
     let out_rows: Vec<AggSortRow> = if is_time_windowed {
@@ -470,6 +516,35 @@ pub(crate) fn dispatch_aggregation(
         agg_out
     };
 
+    finalize_aggregate_emit(
+        ctx,
+        current_dag,
+        node_idx,
+        name,
+        agg_timer,
+        input_count,
+        out_rows,
+        input_puncts,
+    )
+}
+
+/// Emit a strict aggregate's finalized rows: record the stage timer, then
+/// route `out_rows` to the deferred-region slot, the streaming-Output
+/// handoff, or a charged `node_buffers` slot, forwarding `input_puncts` at
+/// the output tail. Shared by the materialized ingest path and the
+/// streaming-ingest path ([`run_streaming_aggregate_ingest`]) — both
+/// produce the same finalized `out_rows`, so the emit half is identical.
+#[allow(clippy::too_many_arguments)]
+fn finalize_aggregate_emit(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    name: &str,
+    agg_timer: stage_metrics::StageTimer,
+    input_count: u64,
+    out_rows: Vec<crate::aggregation::SortRow>,
+    input_puncts: Vec<crate::executor::stream_event::Punctuation>,
+) -> Result<(), PipelineError> {
     ctx.collector
         .record(agg_timer.finish(input_count, out_rows.len() as u64));
     if let Some(region) = current_dag.deferred_region_at_producer(node_idx) {
@@ -568,6 +643,315 @@ pub(crate) fn dispatch_aggregation(
     }
 
     Ok(())
+}
+
+/// Per-record side effects a streaming-ingest scoped thread cannot apply
+/// directly (it holds no `&mut ExecutorContext`), replayed onto the
+/// dispatcher after the scope joins. Ordering within each vector is the
+/// channel arrival order, so the replay reproduces the materialized
+/// path's cursor / DLQ sequencing exactly.
+struct StreamingIngestEffects {
+    /// `(source_name, row_num)` for each successfully ingested record —
+    /// replayed via [`advance_cursor`] so rollback cursors and watermark
+    /// liveness match the drain-to-`Vec` path.
+    cursor_advances: Vec<(Arc<str>, u64)>,
+    /// `(record, row_num, error_message)` for each `add_record` failure
+    /// under `Continue` / `BestEffort`, replayed via the dispatcher's DLQ
+    /// routing after join. `FailFast` surfaces the error eagerly instead.
+    add_errors: Vec<(Record, u64, String)>,
+}
+
+/// Streaming-ingest result handed back to [`dispatch_aggregation`]: the
+/// finalized group rows, the document-boundary punctuations forwarded at
+/// the output tail, and the count of records the producer fed in.
+struct StreamingIngestOutput {
+    out_rows: Vec<crate::aggregation::SortRow>,
+    puncts: Vec<crate::executor::stream_event::Punctuation>,
+    input_count: u64,
+}
+
+/// Drive a strict (non-relaxed, non-time-windowed) Aggregate's ingest off
+/// a bounded channel the producer fills, instead of pre-draining the
+/// producer's whole output from a charged `node_buffers` slot.
+///
+/// Streaming, not blocking on its ingest half: the producer runs inside
+/// this call on the dispatch thread (its own topo turn was short-circuited
+/// by [`crate::executor::dispatch::dispatch_plan_node`]), streaming each
+/// batch into the channel, while a scoped thread drives `add_record` off
+/// the receiver. The bounded `send` is the back-pressure pivot — a slow
+/// `add_record` (e.g. a hash aggregate spilling) stalls the producer and
+/// lets the upstream Source channel fill. The finalize half stays blocking:
+/// the scoped thread runs `finalize` once the channel disconnects (every
+/// sender dropped at the producer arm's clean exit), then returns the
+/// finalized rows. Document-boundary punctuations are collected and
+/// forwarded at the output tail — byte-identical to the materialized hash
+/// path, whose per-document group flush is a separate follow-up.
+///
+/// The scoped thread holds no `&mut ExecutorContext`; it accumulates cursor
+/// advances and `add_record` DLQ errors into [`StreamingIngestEffects`],
+/// replayed on the dispatch thread after the scope joins so rollback
+/// cursors, watermark liveness, and DLQ sequencing match the drain-to-`Vec`
+/// path exactly. Spill stays RSS-triggered inside `add_record` /
+/// `finalize`, never channel-depth-triggered.
+#[allow(clippy::too_many_arguments)]
+fn run_streaming_aggregate_ingest(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    producer_idx: NodeIndex,
+    name: &str,
+    agg_strategy: AggregateStrategy,
+    compiled: &Arc<cxl::plan::CompiledAggregate>,
+    output_schema: &Arc<Schema>,
+) -> Result<StreamingIngestOutput, PipelineError> {
+    use crate::aggregation::SortRow as AggSortRow;
+    use crate::executor::stream_event::StreamEvent;
+    use cxl::eval::EvalContext;
+
+    let expected_input = current_dag.graph[node_idx]
+        .expected_input_schema_in(current_dag)
+        .cloned();
+    let upstream_name = current_dag.graph[producer_idx].name().to_string();
+
+    // Build the per-aggregation runtime artifacts (mirrors the materialized
+    // path): the executor owns the evaluator + spill metadata; the wrapper
+    // enum owns the engine. Register exactly one `AggregateConsumer` so the
+    // growing group state contributes to `sum_consumer_usage` while it is
+    // live, and unregister it after `finalize` consumes the stream.
+    let transform_idx = ctx.transform_by_name.get(name).copied();
+    let evaluator = match transform_idx {
+        Some(idx) => ProgramEvaluator::with_max_expansion(
+            Arc::clone(&ctx.compiled_transforms[idx].typed),
+            ctx.compiled_transforms[idx].has_distinct(),
+            ctx.compiled_transforms[idx].max_expansion,
+        ),
+        None => {
+            return Err(PipelineError::Internal {
+                op: "aggregation",
+                node: name.to_string(),
+                detail: "no compiled transform found for aggregate node".to_string(),
+            });
+        }
+    };
+    let spill_schema = compiled
+        .group_by_fields
+        .iter()
+        .map(|s| Box::<str>::from(s.as_str()))
+        .chain([
+            Box::<str>::from("__acc_state"),
+            Box::<str>::from("__meta_tracker"),
+        ])
+        .collect::<SchemaBuilder>()
+        .build();
+    let mem_limit = parse_memory_limit(ctx.config);
+    let spill_compress = ctx
+        .spill_compress
+        .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
+
+    let agg_consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
+    let agg_consumer_id =
+        ctx.memory_budget
+            .register_consumer(Arc::new(crate::aggregation::AggregateConsumer::new(
+                agg_consumer_handle.clone(),
+            )));
+    let mut stream = crate::aggregation::AggregateStream::for_node(
+        agg_strategy,
+        crate::aggregation::AggregatorConfig {
+            compiled: Arc::clone(compiled),
+            evaluator,
+            output_schema: Arc::clone(output_schema),
+            spill_schema,
+            memory_budget: mem_limit,
+            spill_dir: Some(ctx.spill_root_path.to_path_buf()),
+            spill_compress,
+            transform_name: name.to_string(),
+            consumer_handle: agg_consumer_handle,
+        },
+    )?;
+
+    // Install the producer's streaming sender + per-batch charge consumer
+    // keyed by the producer's index, so its dispatch arm streams into our
+    // channel with no producer-side change (the same `take_streaming_sender`
+    // path the streaming-Output producers use). The charge handle's
+    // per-batch `add_bytes` on flush is netted to zero by the scoped
+    // thread's per-record `sub_bytes` discharge below; a 256-event bound
+    // mirrors the Source ingest channel so back-pressure paces both ends.
+    let (tx, rx) = crossbeam_channel::bounded::<StreamEvent>(256);
+    let charge_handle = crate::pipeline::memory::ConsumerHandle::new();
+    let charge_consumer_id = ctx.memory_budget.register_consumer(Arc::new(
+        crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone(), false),
+    ));
+    ctx.streaming_output_senders.insert(producer_idx, tx);
+    ctx.streaming_charge_consumers
+        .insert(producer_idx, (charge_consumer_id, charge_handle.clone()));
+
+    // Copy the stable-context reference out of `ctx` *before* the scope so
+    // the scoped thread borrows `&'a StableEvalContext` directly (shared,
+    // `Sync`) rather than through the `&mut ctx` the main thread holds for
+    // the producer redispatch — the two borrows are disjoint.
+    let stable = ctx.stable;
+    let source_batch_arc = ctx.source_batch_arc;
+    let ingestion_timestamp = ctx.source_ingestion_timestamp;
+    let strategy = ctx.config.error_handling.strategy;
+
+    let mut effects = StreamingIngestEffects {
+        cursor_advances: Vec::new(),
+        add_errors: Vec::new(),
+    };
+    let mut out_rows: Vec<AggSortRow> = Vec::with_capacity(64);
+    let mut puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
+    let mut input_count: u64 = 0;
+
+    // Run the ingest recv loop and the producer concurrently. The scoped
+    // thread owns the `AggregateStream` and drains the channel; the main
+    // thread redispatches the producer (which streams into the channel and
+    // drops its sender at clean exit, disconnecting the channel). The
+    // producer's `?` error and the ingest thread's error both surface; the
+    // ingest thread always drains to disconnect first so a producer `send`
+    // can never deadlock on a dead consumer.
+    let finalize_ctx = ctx.merged_eval_ctx();
+    let ingest_result: Result<(), PipelineError> = std::thread::scope(|scope| {
+        let handle = scope.spawn(|| -> Result<(), PipelineError> {
+            while let Ok(event) = rx.recv() {
+                let (record, rn) = match event {
+                    StreamEvent::Record(r, rn) => (r, rn),
+                    StreamEvent::Punctuation(p) => {
+                        // Collect for the output tail (byte-identical to the
+                        // materialized hash path; per-document flush is a
+                        // separate follow-up). Punctuations carry zero
+                        // charge, so no discharge here.
+                        puncts.push(p);
+                        continue;
+                    }
+                };
+                // Discharge this record's per-row cost — the consume half of
+                // the producer's per-batch admit. The formula matches the
+                // producer's charge so a fully-drained stream nets to zero.
+                charge_handle.sub_bytes(crate::executor::node_buffer::record_byte_cost(
+                    record.schema().column_count(),
+                ));
+                input_count += 1;
+                if let Some(exp) = expected_input.as_ref() {
+                    check_input_schema(exp, record.schema(), name, "aggregation", &upstream_name)?;
+                }
+                let source_file_arc = source_file_arc_of(&record);
+                let source_name_arc = source_name_arc_of(&record);
+                // Mid-stream `$source.count` is `None` (defer-emit) — the
+                // total is unknown until the source disconnects, exactly as
+                // the per-record eval sites resolve it.
+                let eval_ctx = EvalContext {
+                    stable,
+                    source_file: &source_file_arc,
+                    source_row: rn,
+                    source_path: &source_file_arc,
+                    source_count: None,
+                    source_batch: source_batch_arc,
+                    ingestion_timestamp,
+                    source_name: &source_name_arc,
+                    doc_ctx: record.doc_ctx(),
+                };
+                match stream.add_record(&record, rn, &eval_ctx, &mut out_rows) {
+                    Ok(()) => effects.cursor_advances.push((source_name_arc, rn)),
+                    Err(e) => match strategy {
+                        ErrorStrategy::FailFast => {
+                            // Drain the rest so the producer's bounded `send`
+                            // can't deadlock, then surface the error.
+                            while rx.recv().is_ok() {}
+                            return Err(e.into());
+                        }
+                        ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
+                            effects
+                                .add_errors
+                                .push((record, rn, format!("aggregate {name}: {e}")));
+                        }
+                    },
+                }
+            }
+            // Channel disconnected — every sender dropped at the producer
+            // arm's clean exit. Finalize the blocking half and return.
+            stream
+                .finalize(&finalize_ctx, &mut out_rows)
+                .map_err(PipelineError::from)
+        });
+
+        // Redispatch the producer on the main thread. Clear its ingest-edge
+        // entry first so the dispatcher's streaming-ingest short-circuit
+        // (which made the producer's own topo turn a no-op) does not fire
+        // again here — this is the one turn the producer must actually run.
+        // It takes the sender we installed and streams into the channel,
+        // dropping it at clean exit.
+        ctx.streaming_aggregate_ingest_edges.remove(&producer_idx);
+        let producer_result =
+            crate::executor::dispatch::dispatch_plan_node(ctx, current_dag, producer_idx);
+        // Belt-and-suspenders: ensure the channel disconnects even if a
+        // producer error left a sender lingering on `ctx`, so the ingest
+        // thread's `recv` returns `Err` and the join below cannot hang.
+        ctx.streaming_output_senders.remove(&producer_idx);
+
+        let ingest = handle.join().map_err(|_| PipelineError::Internal {
+            op: "aggregation",
+            node: name.to_string(),
+            detail: "streaming aggregate ingest thread panicked".to_string(),
+        })?;
+        producer_result.and(ingest)
+    });
+
+    // Charge bookkeeping is complete: the producer charged each batch and
+    // the ingest thread discharged each record. Pin to zero defensively (a
+    // heuristic mismatch between batch charge and per-record discharge must
+    // not leave a stale positive for the arbitrator), then unregister both
+    // the per-edge charge consumer and the aggregate consumer — `finalize`
+    // consumed the group state, so its bytes leave `sum_consumer_usage`.
+    charge_handle.set_bytes(0);
+    ctx.streaming_charge_consumers.remove(&producer_idx);
+    ctx.memory_budget.unregister_consumer(charge_consumer_id);
+    ctx.memory_budget.unregister_consumer(agg_consumer_id);
+
+    ingest_result?;
+
+    // Replay the per-record side effects the scoped thread accumulated. The
+    // cursor advances keep rollback / watermark state consistent; the DLQ
+    // errors route through the same `Continue` / `BestEffort` path the
+    // materialized ingest loop uses.
+    for (source_name_arc, rn) in std::mem::take(&mut effects.cursor_advances) {
+        advance_cursor(ctx, &source_name_arc, rn);
+    }
+    for (record, rn, message) in std::mem::take(&mut effects.add_errors) {
+        let stage = Some(clinker_core_types::dlq::stage_aggregate(name));
+        let routed = record_error_to_buffer_if_grouped(
+            ctx,
+            &record,
+            rn,
+            clinker_core_types::dlq::DlqErrorCategory::AggregateFinalize,
+            message.clone(),
+            stage.clone(),
+            None,
+        );
+        if !routed {
+            let source_name = source_name_arc_of(&record);
+            push_dlq(
+                ctx,
+                DlqEntry {
+                    source_row: rn,
+                    category: clinker_core_types::dlq::DlqErrorCategory::AggregateFinalize,
+                    error_message: message,
+                    original_record: record,
+                    stage,
+                    route: None,
+                    trigger: true,
+                    source_name,
+                    triggering_field: None,
+                    triggering_value: None,
+                },
+            )?;
+        }
+    }
+
+    Ok(StreamingIngestOutput {
+        out_rows,
+        puncts,
+        input_count,
+    })
 }
 
 /// Immutable build configuration for a time-windowed aggregate, shared

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -769,21 +769,12 @@ fn run_streaming_aggregate_ingest(
         },
     )?;
 
-    // Install the producer's streaming sender + per-batch charge consumer
-    // keyed by the producer's index, so its dispatch arm streams into our
-    // channel with no producer-side change (the same `take_streaming_sender`
-    // path the streaming-Output producers use). The charge handle's
-    // per-batch `add_bytes` on flush is netted to zero by the scoped
-    // thread's per-record `sub_bytes` discharge below; a 256-event bound
-    // mirrors the Source ingest channel so back-pressure paces both ends.
-    let (tx, rx) = crossbeam_channel::bounded::<StreamEvent>(256);
-    let charge_handle = crate::pipeline::memory::ConsumerHandle::new();
-    let charge_consumer_id = ctx.memory_budget.register_consumer(Arc::new(
-        crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone(), false),
-    ));
-    ctx.streaming_output_senders.insert(producer_idx, tx);
-    ctx.streaming_charge_consumers
-        .insert(producer_idx, (charge_consumer_id, charge_handle.clone()));
+    // Install the bounded streaming-ingest channel keyed by the producer's
+    // index, so its dispatch arm streams into it with no producer-side
+    // change. The scoped thread's per-record `sub_bytes` discharge below
+    // nets the producer's per-batch charge to zero.
+    let (rx, charge_handle, charge_consumer_id) =
+        ctx.install_streaming_ingest_channel(producer_idx);
 
     // Copy the stable-context reference out of `ctx` *before* the scope so
     // the scoped thread borrows `&'a StableEvalContext` directly (shared,

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -30,6 +30,11 @@ use clinker_plan::config::ErrorStrategy;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 
+/// Cap on matches collected per driver row under `match: collect` before
+/// truncation. 10K mirrors the module constants in `pipeline/combine.rs`
+/// and aligns with DataFusion's collect-list bound.
+const COLLECT_PER_GROUP_CAP: usize = 10_000;
+
 /// Execute the `Combine` arm for `node_idx`: dispatch on the planner-
 /// selected [`clinker_plan::plan::combine::CombineStrategy`], drive the build and
 /// probe sides, emit combined rows onto the node's widened output schema,
@@ -55,12 +60,11 @@ pub(crate) fn dispatch_combine(
     else {
         unreachable!("dispatch_combine called with non-Combine node");
     };
-    use crate::executor::combine::{CombineResolver, CombineResolverMapping};
+    use crate::executor::combine::CombineResolverMapping;
     use crate::pipeline::combine::{CombineHashTable, KeyExtractor};
     use crate::pipeline::grace_hash::{GraceHashExec, execute_combine_grace_hash};
     use crate::pipeline::iejoin::{IEJoinExec, execute_combine_iejoin};
     use crate::pipeline::sort_merge_join::{SortMergeExec, execute_combine_sort_merge};
-    use clinker_plan::config::pipeline_node::{MatchMode, OnMiss};
     use clinker_plan::plan::combine::CombineStrategy;
 
     // Strategy dispatch up front. HashBuildProbe stays
@@ -95,12 +99,6 @@ pub(crate) fn dispatch_combine(
             });
         }
     };
-
-    // Cap on matches collected per driver under
-    // `match: collect` before truncation. 10K mirrors
-    // the module constants in pipeline/combine.rs and
-    // aligns with DataFusion's collect-list bound.
-    const COLLECT_PER_GROUP_CAP: usize = 10_000;
 
     // Combine's widened output schema — every emitted
     // record lands on this `Arc<Schema>` so downstream
@@ -221,6 +219,26 @@ pub(crate) fn dispatch_combine(
             ),
         })?;
 
+    // Streaming-probe detection (issue #300). When the driver predecessor
+    // is the certified probe-side streaming producer for this Combine
+    // (`HashBuildProbe` only, top-level plan only — composition bodies
+    // share the `NodeIndex` space but install no probe edges), the driver's
+    // records are NOT pre-drained from a `node_buffers` slot. Instead the
+    // build side is materialized first, then the driver producer streams
+    // record-at-a-time into a bounded channel a probe thread drains. The
+    // detection mirrors the Aggregate-ingest gate.
+    let streaming_probe_driver: Option<NodeIndex> = if matches!(dispatch, Dispatch::Inline)
+        && ctx.current_body_node_input_refs.is_none()
+        && ctx
+            .streaming_combine_probe_edges
+            .get(&driver_pred)
+            .is_some_and(|&combine| combine == node_idx)
+    {
+        Some(driver_pred)
+    } else {
+        None
+    };
+
     // Combine collects puncts from both inputs and forwards
     // them to the output buffer. Per-document dedup
     // (Merge-style barrier counter) for two-input Combine is
@@ -228,12 +246,21 @@ pub(crate) fn dispatch_combine(
     // simple union here may emit `DocumentClose` twice
     // downstream for documents that span both inputs, which
     // any downstream Aggregate would handle idempotently.
+    //
+    // Under streaming-probe the driver slot is empty (the driver has not
+    // dispatched yet — it streams into the probe channel during the redispatch
+    // below), so this drains nothing and the driver records arrive on the
+    // channel instead.
     let (driver_buf, driver_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match drain_node_buffer_slot(ctx, driver_pred) {
-        Some(nb) => nb.drain_split()?,
-        None => (Vec::new(), Vec::new()),
+    ) = if streaming_probe_driver.is_some() {
+        (Vec::new(), Vec::new())
+    } else {
+        match drain_node_buffer_slot(ctx, driver_pred) {
+            Some(nb) => nb.drain_split()?,
+            None => (Vec::new(), Vec::new()),
+        }
     };
     let (build_buf, build_puncts): (
         Vec<(Record, u64)>,
@@ -788,464 +815,129 @@ pub(crate) fn dispatch_combine(
     ctx.collector
         .record(build_timer.finish(build_records_in, build_records_out));
 
-    // Body evaluator (only used when the body is not
-    // empty — `match: collect` leaves it empty).
-    let body_typed = ctx.artifacts.typed.get(name).cloned();
-    let mut body_evaluator = body_typed
-        .as_ref()
-        .map(|bt| ProgramEvaluator::new(Arc::clone(bt), false));
+    // Body typed program (only used when the body is not empty —
+    // `match: collect` and body-less synthetic N-ary steps leave it
+    // `None`). Shared with the streaming-probe thread via the kernel.
+    let body_program = ctx.artifacts.typed.get(name).cloned();
 
-    // Per-driver probe loop. Stage timer covers the
-    // full per-driver iteration; on early-return via the
-    // 10K-cadence E310 abort or a residual/body eval
-    // error, the timer is dropped without recording.
-    let probe_records_in = driver_buf.len() as u64;
+    // The probe matching kernel — owns the materialized hash table and
+    // every per-combine artifact the probe reads, and holds no
+    // `&mut ExecutorContext`. The materialized loop below and the
+    // streaming-probe thread both drive it, so the two paths return a
+    // byte-identical result set.
+    let kernel = CombineProbeKernel {
+        name,
+        hash_table: &hash_table,
+        resolver_mapping: &resolver_mapping,
+        probe_extractor: &probe_extractor,
+        decomposed,
+        body_program,
+        combine_output_schema: combine_output_schema.clone(),
+        build_qualifier: &build_qualifier,
+        match_mode: *match_mode,
+        on_miss: *on_miss,
+        propagate_ck,
+        fail_fast: ctx.strategy == ErrorStrategy::FailFast,
+    };
+
+    // Per-driver probe loop. Stage timer covers the full per-driver
+    // iteration; on early-return via the 10K-cadence E310 abort or a
+    // residual/body eval error, the timer is dropped without recording.
+    let mut probe_records_in = driver_buf.len() as u64;
     let probe_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::CombineProbe {
         name: name.clone(),
     });
-    let mut output_records = Vec::with_capacity(driver_buf.len());
-    let mut emitted_since_check: usize = 0;
-    // Reused across every probe iteration to avoid an
-    // allocation per driver row. `KeyExtractor::extract`
-    // pushes into the end; we clear before each call.
-    let mut probe_keys_buf: Vec<Value> = Vec::with_capacity(probe_extractor.len());
+    let output_records: Vec<(Record, u64)> = if let Some(driver_producer) = streaming_probe_driver {
+        // Streaming-probe path: the build side is materialized into the
+        // hash table above; now spawn the probe consumer on its own thread,
+        // redispatch the driver producer to stream into the bounded channel,
+        // and collect the probe output. The kernel + `&budget` move into the
+        // thread; counter/cursor/DLQ effects replay onto `ctx` after the
+        // join inside the helper.
+        let streamed = run_streaming_combine_probe(
+            ctx,
+            current_dag,
+            node_idx,
+            driver_producer,
+            name,
+            &kernel,
+            &budget,
+        )?;
+        // The driver streamed its records over the channel, so the input
+        // count comes from the probe thread rather than a pre-drained Vec.
+        probe_records_in = streamed.input_count;
+        streamed.output_records
+    } else {
+        let mut output_records = Vec::with_capacity(driver_buf.len());
+        let mut emitted_since_check: usize = 0;
+        let mut probe_counters = ProbeCounters::default();
+        // Reused across every probe iteration to avoid an allocation per
+        // driver row. `KeyExtractor::extract_into` pushes onto the end; the
+        // kernel clears it before each call.
+        let mut probe_keys_buf: Vec<Value> = Vec::with_capacity(probe_extractor.len());
 
-    'driver: for (probe_record, rn) in driver_buf {
-        let source_file_arc = source_file_arc_of(&probe_record);
-        let source_name_arc = source_name_arc_of(&probe_record);
-        let eval_ctx = ctx.eval_ctx_for_record(
-            &source_file_arc,
-            &source_name_arc,
-            rn,
-            probe_record.doc_ctx(),
-        );
+        for (probe_record, rn) in driver_buf {
+            let source_file_arc = source_file_arc_of(&probe_record);
+            let source_name_arc = source_name_arc_of(&probe_record);
+            let before = output_records.len();
+            let eval_ctx = ctx.eval_ctx_for_record(
+                &source_file_arc,
+                &source_name_arc,
+                rn,
+                probe_record.doc_ctx(),
+            );
+            let step = kernel.probe_row(
+                &eval_ctx,
+                &probe_record,
+                rn,
+                &mut probe_keys_buf,
+                &mut probe_counters,
+                &mut output_records,
+            )?;
+            if let ProbeRowStep::Deferred(f) = step {
+                let f = *f;
+                dispatch_combine_output_error(
+                    ctx,
+                    node_idx,
+                    &f.probe_record,
+                    f.rn,
+                    f.matched_build.as_ref(),
+                    name,
+                    f.error,
+                )?;
+                // A deferred failure routes the whole driver row to the DLQ;
+                // no output rows survive for it.
+                output_records.truncate(before);
+                continue;
+            }
+            emitted_since_check += output_records.len() - before;
 
-        // Probe-side key extraction routes through the
-        // shared `CombineResolver` so chain-buried
-        // qualifiers (e.g. `b.id` against an N-ary
-        // decomposition step's encoded intermediate
-        // record) resolve via the resolved column map
-        // rather than `Record::resolve_qualified`'s
-        // bare-name fallback. For non-chain combines
-        // the lookup goes through the same path with
-        // the same answer (probe-side qualifier maps
-        // to its native source-row position).
-        let probe_key_resolver = CombineResolver::new(&resolver_mapping, &probe_record, None);
-        probe_keys_buf.clear();
-        if let Err(e) =
-            probe_extractor.extract_into(&eval_ctx, &probe_key_resolver, &mut probe_keys_buf)
-        {
-            if ctx.strategy == ErrorStrategy::FailFast {
-                return Err(PipelineError::Compilation {
-                    transform_name: name.clone(),
-                    messages: vec![format!("combine probe key eval error: {e}")],
+            // Budget check every 10K emitted records to bound memory under
+            // fan-out. The build phase polls `should_abort` every 10K
+            // inserts inside `CombineHashTable::build`; this covers the
+            // symmetric probe-side risk where a small build × large driver
+            // fan-out can blow RSS even though the table itself is bounded.
+            if emitted_since_check >= 10_000 && budget.should_abort() {
+                return Err(PipelineError::MemoryBudgetExceeded {
+                    node: name.clone(),
+                    used: budget.peak_rss().unwrap_or(0),
+                    limit: budget.hard_limit(),
+                    source: BudgetCategory::Arena,
+                    detail: Some("combine probe RSS abort".to_string()),
                 });
             }
-            // No build candidate has matched yet — the failure is
-            // on the probe key itself, so only the driver source
-            // rewinds.
-            dispatch_combine_output_error(ctx, node_idx, &probe_record, rn, None, name, e)?;
-            continue 'driver;
-        }
-
-        match match_mode {
-            MatchMode::Collect => {
-                // Synthesize the output directly. No
-                // body evaluator runs. On miss, emit
-                // an empty array (E311-guarded: the
-                // body is enforced empty at compile
-                // time, so on_miss policy does not
-                // bypass emission under Collect).
-                let mut arr: Vec<Value> = Vec::new();
-                let mut first_collected_build: Option<Record> = None;
-                let mut truncated = false;
-                let probe_iter = hash_table.probe(&probe_keys_buf);
-                for candidate in probe_iter {
-                    // Residual filter, if any.
-                    if let Some(residual) = decomposed.residual.as_ref() {
-                        let resolver = CombineResolver::new(
-                            &resolver_mapping,
-                            &probe_record,
-                            Some(candidate.record),
-                        );
-                        let mut residual_eval = ProgramEvaluator::new(Arc::clone(residual), false);
-                        match residual_eval.eval_record::<NullStorage>(&eval_ctx, &resolver, None) {
-                            Ok(EvalResult::Skip(SkipReason::Filtered)) => {
-                                continue;
-                            }
-                            Ok(EvalResult::Emit { .. }) => {}
-                            Ok(EvalResult::EmitMany { .. }) => {
-                                return Err(PipelineError::Internal {
-                                            op: "combine residual",
-                                            node: name.clone(),
-                                            detail: "emit_each fan-out is not supported in a combine residual filter".into(),
-                                        });
-                            }
-                            Ok(EvalResult::Skip(SkipReason::Duplicate)) => {
-                                continue;
-                            }
-                            Err(e) => {
-                                if ctx.strategy == ErrorStrategy::FailFast {
-                                    return Err(PipelineError::from(e));
-                                }
-                                dispatch_combine_output_error(
-                                    ctx,
-                                    node_idx,
-                                    &probe_record,
-                                    rn,
-                                    Some(candidate.record),
-                                    name,
-                                    e,
-                                )?;
-                                continue 'driver;
-                            }
-                        }
-                    }
-                    if arr.len() >= COLLECT_PER_GROUP_CAP {
-                        truncated = true;
-                        break;
-                    }
-                    if first_collected_build.is_none() {
-                        first_collected_build = Some(candidate.record.clone());
-                    }
-                    // Build a Value::Map for every matched
-                    // build record, preserving its own
-                    // schema order. `iter_user_fields`
-                    // filters every engine-stamped column
-                    // — both `$ck.*` (correlation lineage;
-                    // not meaningful nested inside a
-                    // collect-array entry) and `$widened`
-                    // (auto_widen sidecar; build-side
-                    // sidecars drop at the join boundary
-                    // by design, mirroring
-                    // `propagate_ck: Driver`). Without
-                    // this filter, a build record's
-                    // `$widened` `Value::Map` payload
-                    // nests inside the collect-mode
-                    // `Value::Map` and reaches the writer
-                    // as a nested Map, triggering
-                    // `FormatError::UnserializableMapValue`.
-                    let mut m: IndexMap<Box<str>, Value> = IndexMap::new();
-                    for (fname, val) in candidate.record.iter_user_fields() {
-                        m.insert(fname.into(), val.clone());
-                    }
-                    arr.push(Value::Map(Box::new(m)));
-                }
-                if truncated {
-                    eprintln!(
-                        "W: combine {:?} match: collect truncated at \
-                                 {COLLECT_PER_GROUP_CAP} matches for driver row {}",
-                        name, rn
-                    );
-                }
-
-                // Output record inherits the probe's
-                // data re-projected onto the combine's
-                // widened output_schema; the
-                // `<build_qualifier>` column is
-                // guaranteed to exist on it.
-                let mut rec = match combine_output_schema.as_ref() {
-                    Some(s) => widen_record_to_schema(&probe_record, s),
-                    None => probe_record.clone(),
-                };
-                // Build-side `$ck.<field>` propagation under
-                // collect mode is single-valued: the first
-                // matched build's CK fills the slot. Every
-                // matched build's full payload is still
-                // preserved inside the array via the
-                // per-row `Value::Map` encoding above, so
-                // nothing is lost — the slot simply mirrors
-                // the first match's identity. Skipped under
-                // `propagate_ck: driver`.
-                if let Some(first_build) = first_collected_build.as_ref() {
-                    crate::executor::copy_build_ck_columns(&mut rec, first_build, propagate_ck);
-                }
-                rec.set(&build_qualifier, Value::Array(arr));
-                output_records.push((rec, rn));
-                emitted_since_check += 1;
-            }
-
-            MatchMode::First | MatchMode::All => {
-                // Residual-filter + emit pass. We
-                // clone each surviving build record
-                // before dropping the iterator so the
-                // evaluator borrow doesn't alias the
-                // hash-table borrow.
-                let matched_records: Vec<Record> = {
-                    let probe_iter = hash_table.probe(&probe_keys_buf);
-                    let mut matched: Vec<Record> = Vec::new();
-                    for candidate in probe_iter {
-                        if let Some(residual) = decomposed.residual.as_ref() {
-                            let resolver = CombineResolver::new(
-                                &resolver_mapping,
-                                &probe_record,
-                                Some(candidate.record),
-                            );
-                            let mut residual_eval =
-                                ProgramEvaluator::new(Arc::clone(residual), false);
-                            match residual_eval
-                                .eval_record::<NullStorage>(&eval_ctx, &resolver, None)
-                            {
-                                Ok(EvalResult::Skip(_)) => continue,
-                                Ok(EvalResult::Emit { .. }) => {}
-                                Ok(EvalResult::EmitMany { .. }) => {
-                                    return Err(PipelineError::Internal {
-                                                op: "combine residual",
-                                                node: name.clone(),
-                                                detail: "emit_each fan-out is not supported in a combine residual filter".into(),
-                                            });
-                                }
-                                Err(e) => {
-                                    if ctx.strategy == ErrorStrategy::FailFast {
-                                        return Err(PipelineError::from(e));
-                                    }
-                                    dispatch_combine_output_error(
-                                        ctx,
-                                        node_idx,
-                                        &probe_record,
-                                        rn,
-                                        Some(candidate.record),
-                                        name,
-                                        e,
-                                    )?;
-                                    continue 'driver;
-                                }
-                            }
-                        }
-                        matched.push(candidate.record.clone());
-                        if matches!(match_mode, MatchMode::First) {
-                            break;
-                        }
-                    }
-                    matched
-                };
-
-                if matched_records.is_empty() {
-                    // On-miss dispatch.
-                    match on_miss {
-                        OnMiss::Skip => {
-                            continue;
-                        }
-                        OnMiss::Error => {
-                            return Err(PipelineError::CombineMissingMatch {
-                                combine: name.clone(),
-                                driver_row: rn,
-                            });
-                        }
-                        OnMiss::NullFields => {
-                            // Evaluate body against a
-                            // resolver whose build
-                            // slot is None — build-
-                            // qualified fields return
-                            // Value::Null.
-                            let resolver =
-                                CombineResolver::new(&resolver_mapping, &probe_record, None);
-                            let evaluator =
-                                body_evaluator
-                                    .as_mut()
-                                    .ok_or_else(|| PipelineError::Internal {
-                                        op: "combine",
-                                        node: name.clone(),
-                                        detail: "combine body typed program \
-                                                         missing for on_miss: null_fields"
-                                            .to_string(),
-                                    })?;
-                            match evaluator.eval_record::<NullStorage>(&eval_ctx, &resolver, None) {
-                                Ok(EvalResult::Emit {
-                                    fields: emitted,
-                                    record_vars,
-                                    ..
-                                }) => {
-                                    let mut rec = match combine_output_schema.as_ref() {
-                                        Some(s) => widen_record_to_schema(&probe_record, s),
-                                        None => probe_record.clone(),
-                                    };
-                                    for (n, v) in emitted {
-                                        rec.set(&n, v);
-                                    }
-                                    for (k, v) in *record_vars {
-                                        let _ = rec.set_record_var(&k, v);
-                                    }
-                                    output_records.push((rec, rn));
-                                    emitted_since_check += 1;
-                                }
-                                Ok(EvalResult::Skip(SkipReason::Filtered)) => {
-                                    ctx.counters.filtered_count += 1;
-                                }
-                                Ok(EvalResult::Skip(SkipReason::Duplicate)) => {
-                                    ctx.counters.distinct_count += 1;
-                                }
-                                Ok(EvalResult::EmitMany { .. }) => {
-                                    return Err(PipelineError::Internal {
-                                        op: "combine on_miss body",
-                                        node: name.clone(),
-                                        detail:
-                                            "emit_each fan-out is not supported in a combine body"
-                                                .into(),
-                                    });
-                                }
-                                Err(e) => {
-                                    if ctx.strategy == ErrorStrategy::FailFast {
-                                        return Err(PipelineError::from(e));
-                                    }
-                                    // on_miss path: no build row
-                                    // matched, so only the driver
-                                    // source rewinds.
-                                    dispatch_combine_output_error(
-                                        ctx,
-                                        node_idx,
-                                        &probe_record,
-                                        rn,
-                                        None,
-                                        name,
-                                        e,
-                                    )?;
-                                    continue 'driver;
-                                }
-                            }
-                        }
-                    }
-                } else if let Some(evaluator) = body_evaluator.as_mut() {
-                    for matched in &matched_records {
-                        let resolver =
-                            CombineResolver::new(&resolver_mapping, &probe_record, Some(matched));
-                        match evaluator.eval_record::<NullStorage>(&eval_ctx, &resolver, None) {
-                            Ok(EvalResult::Emit {
-                                fields: emitted,
-                                record_vars,
-                                ..
-                            }) => {
-                                let mut rec = match combine_output_schema.as_ref() {
-                                    Some(s) => widen_record_to_schema(&probe_record, s),
-                                    None => probe_record.clone(),
-                                };
-                                for (n, v) in emitted {
-                                    rec.set(&n, v);
-                                }
-                                for (k, v) in *record_vars {
-                                    let _ = rec.set_record_var(&k, v);
-                                }
-                                // Build-side `$ck.<field>` propagation
-                                // for this matched row. Driver-only
-                                // pipelines short-circuit inside the
-                                // helper; the call is uniform across
-                                // every emit site so the policy is one
-                                // code path for the whole engine.
-                                crate::executor::copy_build_ck_columns(
-                                    &mut rec,
-                                    matched,
-                                    propagate_ck,
-                                );
-                                output_records.push((rec, rn));
-                                emitted_since_check += 1;
-                            }
-                            Ok(EvalResult::Skip(SkipReason::Filtered)) => {
-                                ctx.counters.filtered_count += 1;
-                            }
-                            Ok(EvalResult::Skip(SkipReason::Duplicate)) => {
-                                ctx.counters.distinct_count += 1;
-                            }
-                            Ok(EvalResult::EmitMany { .. }) => {
-                                return Err(PipelineError::Internal {
-                                    op: "combine matched body",
-                                    node: name.clone(),
-                                    detail: "emit_each fan-out is not supported in a combine body"
-                                        .into(),
-                                });
-                            }
-                            Err(e) => {
-                                if ctx.strategy == ErrorStrategy::FailFast {
-                                    return Err(PipelineError::from(e));
-                                }
-                                dispatch_combine_output_error(
-                                    ctx,
-                                    node_idx,
-                                    &probe_record,
-                                    rn,
-                                    Some(matched),
-                                    name,
-                                    e,
-                                )?;
-                                continue 'driver;
-                            }
-                        }
-                    }
-                } else {
-                    // Body-less synthetic step from
-                    // N-ary combine decomposition: the
-                    // step's encoded output schema
-                    // concatenates driver columns then
-                    // build columns, both in the order
-                    // their `intermediate_row.fields()`
-                    // walk produces. Emit one record
-                    // per match by concatenating value
-                    // slices and constructing on the
-                    // encoded `Arc<Schema>`.
-                    //
-                    // No `copy_build_ck_columns` call here:
-                    // build-side `$ck.<field>` values are
-                    // already in the concatenated tail under
-                    // their encoded names (`__<qualifier>__$ck.<field>`).
-                    // The chain's final step then resolves
-                    // them via `widen_record_to_schema`'s
-                    // engine-stamped fallback when projecting
-                    // onto the original output schema.
-                    let target_schema =
-                        combine_output_schema
-                            .as_ref()
-                            .ok_or_else(|| PipelineError::Internal {
-                                op: "combine",
-                                node: name.clone(),
-                                detail: "synthetic combine step has no output \
-                                             schema; decomposition pass did not run"
-                                    .to_string(),
-                            })?;
-                    for matched in &matched_records {
-                        let mut values: Vec<Value> =
-                            Vec::with_capacity(target_schema.column_count());
-                        values.extend(probe_record.values().iter().cloned());
-                        values.extend(matched.values().iter().cloned());
-                        if values.len() != target_schema.column_count() {
-                            return Err(PipelineError::Internal {
-                                op: "combine",
-                                node: name.clone(),
-                                detail: format!(
-                                    "synthetic combine step produced {} \
-                                             concatenated values; encoded schema \
-                                             has {} columns",
-                                    values.len(),
-                                    target_schema.column_count()
-                                ),
-                            });
-                        }
-                        let rec = Record::new(Arc::clone(target_schema), values);
-                        output_records.push((rec, rn));
-                        emitted_since_check += 1;
-                    }
-                }
+            if emitted_since_check >= 10_000 {
+                emitted_since_check = 0;
             }
         }
 
-        // Budget check every 10K emitted records to
-        // bound memory under fan-out. The build phase
-        // polls `should_abort` every 10K inserts inside
-        // `CombineHashTable::build`; this loop covers
-        // the symmetric probe-side risk where a small
-        // build × large driver fan-out can blow RSS
-        // even though the table itself is bounded.
-        if emitted_since_check >= 10_000 && budget.should_abort() {
-            return Err(PipelineError::MemoryBudgetExceeded {
-                node: name.clone(),
-                used: budget.peak_rss().unwrap_or(0),
-                limit: budget.hard_limit(),
-                source: BudgetCategory::Arena,
-                detail: Some("combine probe RSS abort".to_string()),
-            });
-        }
-        if emitted_since_check >= 10_000 {
-            emitted_since_check = 0;
-        }
-    }
+        // Fold the probe kernel's `distinct` / `filtered` skip counts into
+        // the run counters — applied after the loop, the same place the
+        // per-row `ctx.counters.*` increments used to live.
+        ctx.counters.filtered_count += probe_counters.filtered;
+        ctx.counters.distinct_count += probe_counters.distinct;
+        output_records
+    };
 
     let probe_records_out = output_records.len() as u64;
     ctx.collector
@@ -1310,6 +1002,717 @@ pub(crate) fn dispatch_combine(
     ctx.memory_budget.unregister_consumer(inline_consumer_id);
 
     Ok(())
+}
+
+/// Result of a streaming-probe run handed back to [`dispatch_combine`]:
+/// the probe output rows and the count of driver records the producer fed
+/// over the channel (the streaming analogue of the materialized
+/// `driver_buf.len()` probe input).
+struct StreamingProbeOutput {
+    output_records: Vec<(Record, u64)>,
+    input_count: u64,
+}
+
+/// Per-record side effects the streaming-probe thread cannot apply directly
+/// (it holds no `&mut ExecutorContext`), replayed onto the dispatcher after
+/// the probe scope joins. Ordering within each vector is channel-arrival
+/// order, so the replay reproduces the materialized path's cursor / DLQ
+/// sequencing exactly.
+struct StreamingProbeEffects {
+    /// `(source_name, row_num)` for each driver record the probe consumed —
+    /// replayed via [`advance_cursor`], the streaming analogue of the
+    /// materialized arm's operator-entry driver cursor advance.
+    cursor_advances: Vec<(Arc<str>, u64)>,
+    /// Distinct driver source names the probe consumed, in first-seen
+    /// order. After the join — once the producer has fully advanced its
+    /// sources but before the deferred combine advances replay — the
+    /// dispatch thread reads each source's live cursor as its pre-fold
+    /// floor, matching the materialized path's fold-start snapshot timing.
+    driver_sources: Vec<Arc<str>>,
+    /// Recoverable per-row failures, replayed via [`dispatch_combine_output_error`]
+    /// after join (cursor rewind + DLQ) — matching the inline arm's per-row
+    /// routing in arrival order. `FailFast` surfaces eagerly instead.
+    failures: Vec<ProbeFailure>,
+}
+
+/// Drive an inline hash build-probe Combine's probe (driver) side off a
+/// bounded channel the driver producer fills, instead of pre-draining the
+/// driver's whole output from a charged `node_buffers` slot. The build-side
+/// hash table is already materialized inside `kernel` before this runs.
+///
+/// Build-before-probe is the deadlock-free invariant this enforces: the
+/// hash table is complete (it lives in `kernel`) before the driver producer
+/// is redispatched, so the probe never reads an incomplete table. The probe
+/// consumer runs on its OWN scoped thread and is live before the driver's
+/// first `send`, so the bounded channel can never deadlock — a slow driver
+/// stalls on a full channel and the probe paces it; a slow probe (large
+/// fan-out) back-pressures the driver → Source. The finalize is trivial
+/// (the hash table is read-only), so there is no blocking finalize half.
+///
+/// The probe thread holds no `&mut ExecutorContext`; it accumulates cursor
+/// advances, driver-snapshot floors, and DLQ failures into
+/// [`StreamingProbeEffects`], replayed on the dispatch thread after the
+/// scope joins so rollback cursors, the per-fold rewind snapshot, and DLQ
+/// sequencing match the drain-to-`Vec` path exactly. Mid-stream
+/// `$source.count` is `None` (the driver total is unknown until disconnect),
+/// the same defer-emit semantic the streaming Aggregate ingest uses.
+#[allow(clippy::too_many_arguments)]
+fn run_streaming_combine_probe(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    producer_idx: NodeIndex,
+    name: &str,
+    kernel: &CombineProbeKernel<'_>,
+    budget: &crate::pipeline::memory::MemoryArbitrator,
+) -> Result<StreamingProbeOutput, PipelineError> {
+    use crate::executor::stream_event::StreamEvent;
+    use cxl::eval::EvalContext;
+
+    let expected_input = current_dag.graph[producer_idx]
+        .output_schema_in(current_dag)
+        .clone();
+    let upstream_name = current_dag.graph[producer_idx].name().to_string();
+
+    // Install the bounded streaming-ingest channel keyed by the driver
+    // producer's index, so its dispatch arm streams into it with no
+    // producer-side change. The probe thread's per-record `sub_bytes`
+    // discharge nets the producer's per-batch charge to zero.
+    let (rx, charge_handle, charge_consumer_id) =
+        ctx.install_streaming_ingest_channel(producer_idx);
+
+    // Copy the stable-context references out of `ctx` before the scope so
+    // the probe thread borrows `&'a StableEvalContext` directly (shared,
+    // `Sync`) rather than through the `&mut ctx` the main thread holds for
+    // the driver redispatch — the two borrows are disjoint.
+    let stable = ctx.stable;
+    let source_batch_arc = ctx.source_batch_arc;
+    let ingestion_timestamp = ctx.source_ingestion_timestamp;
+
+    let mut effects = StreamingProbeEffects {
+        cursor_advances: Vec::new(),
+        driver_sources: Vec::new(),
+        failures: Vec::new(),
+    };
+    let mut output_records: Vec<(Record, u64)> = Vec::new();
+    let mut counters = ProbeCounters::default();
+    let mut input_count: u64 = 0;
+
+    // Run the probe recv loop and the driver producer concurrently. The
+    // scoped thread owns the channel drain + probe; the main thread
+    // redispatches the driver (which streams into the channel and drops its
+    // sender at clean exit, disconnecting the channel). Both the driver's
+    // `?` error and the probe thread's error surface; the probe thread
+    // always drains to disconnect first so a driver `send` can never
+    // deadlock on a dead consumer.
+    let probe_result: Result<(), PipelineError> = std::thread::scope(|scope| {
+        let handle = scope.spawn(|| -> Result<(), PipelineError> {
+            let mut probe_keys_buf: Vec<Value> = Vec::with_capacity(kernel.probe_extractor.len());
+            let mut budget_cadence: usize = 0;
+            while let Ok(event) = rx.recv() {
+                let (record, rn) = match event {
+                    StreamEvent::Record(r, rn) => (r, rn),
+                    // Punctuations carry zero charge and the inline path
+                    // forwards no puncts on the streaming-Output handoff, so
+                    // the probe drops them — byte-identical to the
+                    // materialized inline admit. Per-document combine flush
+                    // is a separate follow-up.
+                    StreamEvent::Punctuation(_) => continue,
+                };
+                // Discharge this record's per-row cost — the consume half of
+                // the driver's per-batch admit. The formula matches the
+                // charge so a fully-drained stream nets to zero.
+                charge_handle.sub_bytes(crate::executor::node_buffer::record_byte_cost(
+                    record.schema().column_count(),
+                ));
+                input_count += 1;
+
+                let source_file_arc = source_file_arc_of(&record);
+                let source_name_arc = source_name_arc_of(&record);
+
+                // Operator-entry schema check, mirroring the materialized
+                // driver-side `check_input_schema` loop.
+                if let Err(err) = check_input_schema(
+                    &expected_input,
+                    record.schema(),
+                    name,
+                    "combine",
+                    &upstream_name,
+                ) {
+                    // A schema mismatch is a fatal E314 in both paths; drain
+                    // to disconnect first so the driver `send` cannot
+                    // deadlock, then surface.
+                    while rx.recv().is_ok() {}
+                    return Err(err);
+                }
+
+                // Track the driver source on first sight (for the post-join
+                // pre-fold floor capture) and record the cursor advance for
+                // replay.
+                if !effects
+                    .driver_sources
+                    .iter()
+                    .any(|s| Arc::ptr_eq(s, &source_name_arc))
+                {
+                    effects.driver_sources.push(Arc::clone(&source_name_arc));
+                }
+                effects
+                    .cursor_advances
+                    .push((Arc::clone(&source_name_arc), rn));
+
+                // Mid-stream `$source.count` is `None` (the driver total is
+                // unknown until disconnect) — the same defer-emit semantic
+                // the streaming Aggregate ingest uses.
+                let eval_ctx = EvalContext {
+                    stable,
+                    source_file: &source_file_arc,
+                    source_row: rn,
+                    source_path: &source_file_arc,
+                    source_count: None,
+                    source_batch: source_batch_arc,
+                    ingestion_timestamp,
+                    source_name: &source_name_arc,
+                    doc_ctx: record.doc_ctx(),
+                };
+
+                let before = output_records.len();
+                let step = match kernel.probe_row(
+                    &eval_ctx,
+                    &record,
+                    rn,
+                    &mut probe_keys_buf,
+                    &mut counters,
+                    &mut output_records,
+                ) {
+                    Ok(step) => step,
+                    Err(e) => {
+                        // Fatal (FailFast surfacing, on_miss::error,
+                        // planner-invariant) — drain to disconnect, then
+                        // surface.
+                        while rx.recv().is_ok() {}
+                        return Err(e);
+                    }
+                };
+                if let ProbeRowStep::Deferred(f) = step {
+                    // The whole driver row routes to the DLQ; no output rows
+                    // survive for it.
+                    output_records.truncate(before);
+                    effects.failures.push(*f);
+                    continue;
+                }
+
+                // Budget check every 10K emitted records, the same cadence
+                // and abort the materialized loop uses.
+                budget_cadence += output_records.len() - before;
+                if budget_cadence >= 10_000 && budget.should_abort() {
+                    while rx.recv().is_ok() {}
+                    return Err(PipelineError::MemoryBudgetExceeded {
+                        node: name.to_string(),
+                        used: budget.peak_rss().unwrap_or(0),
+                        limit: budget.hard_limit(),
+                        source: BudgetCategory::Arena,
+                        detail: Some("combine probe RSS abort".to_string()),
+                    });
+                }
+                if budget_cadence >= 10_000 {
+                    budget_cadence = 0;
+                }
+            }
+            Ok(())
+        });
+
+        // Redispatch the driver producer on the main thread. Clear its
+        // probe-edge entry first so the dispatcher's streaming-probe
+        // short-circuit (which made the producer's own topo turn a no-op)
+        // does not fire again here — this is the one turn the producer must
+        // actually run. It takes the sender we installed and streams into
+        // the channel, dropping it at clean exit.
+        ctx.streaming_combine_probe_edges.remove(&producer_idx);
+        let producer_result =
+            crate::executor::dispatch::dispatch_plan_node(ctx, current_dag, producer_idx);
+        // Belt-and-suspenders: ensure the channel disconnects even if a
+        // producer error left a sender lingering on `ctx`, so the probe
+        // thread's `recv` returns `Err` and the join below cannot hang.
+        ctx.streaming_output_senders.remove(&producer_idx);
+
+        let probe = handle.join().map_err(|_| PipelineError::Internal {
+            op: "combine",
+            node: name.to_string(),
+            detail: "streaming combine probe thread panicked".to_string(),
+        })?;
+        producer_result.and(probe)
+    });
+
+    // Charge bookkeeping is complete: the driver charged each batch and the
+    // probe thread discharged each record. Pin to zero defensively (a
+    // heuristic mismatch between batch charge and per-record discharge must
+    // not leave a stale positive), then unregister the per-edge charge
+    // consumer.
+    charge_handle.set_bytes(0);
+    ctx.streaming_charge_consumers.remove(&producer_idx);
+    ctx.memory_budget.unregister_consumer(charge_consumer_id);
+
+    probe_result?;
+
+    // Capture each driver source's pre-fold floor from its LIVE cursor and
+    // merge it into the installed combine snapshot, BEFORE the deferred
+    // combine advances replay below. At this point the producer has fully
+    // advanced its sources (it ran to completion on the main thread inside
+    // the scope) but the combine's own operator-entry advance has not — so
+    // the live cursor is exactly the floor the materialized path captures at
+    // fold start. `or_insert` leaves any existing build-side entry (a source
+    // that also drives) untouched.
+    let driver_floors: Vec<(Arc<str>, u64)> = effects
+        .driver_sources
+        .iter()
+        .map(|src| {
+            let floor = ctx.rollback_cursors.get(src).copied().unwrap_or(0);
+            (Arc::clone(src), floor)
+        })
+        .collect();
+    if let Some(snapshot) = ctx.combine_input_snapshots.get_mut(&node_idx) {
+        for (src, floor) in driver_floors {
+            snapshot.entry(src).or_insert(floor);
+        }
+    }
+
+    // Replay the per-record side effects the probe thread accumulated. The
+    // cursor advances keep rollback / watermark state consistent; the DLQ
+    // failures route through the same recoverable path the inline loop uses.
+    for (source_name_arc, rn) in std::mem::take(&mut effects.cursor_advances) {
+        advance_cursor(ctx, &source_name_arc, rn);
+    }
+    for f in std::mem::take(&mut effects.failures) {
+        dispatch_combine_output_error(
+            ctx,
+            node_idx,
+            &f.probe_record,
+            f.rn,
+            f.matched_build.as_ref(),
+            name,
+            f.error,
+        )?;
+    }
+
+    ctx.counters.filtered_count += counters.filtered;
+    ctx.counters.distinct_count += counters.distinct;
+
+    Ok(StreamingProbeOutput {
+        output_records,
+        input_count,
+    })
+}
+
+/// Per-driver-row outcome the probe kernel returns to its caller. The
+/// materialized inline loop and the streaming-probe thread both drive
+/// [`CombineProbeKernel::probe_row`], which emits output rows directly into
+/// the caller's buffer and signals row-level disposition here. Fatal errors
+/// (FailFast surfacing, `on_miss: error`, planner-invariant violations,
+/// `EmitMany` fan-out) short-circuit as `Err` instead.
+enum ProbeRowStep {
+    /// The row produced zero or more output records (already pushed) and
+    /// the driver loop continues.
+    Continue,
+    /// A recoverable per-row eval failure under `Continue` / `BestEffort`.
+    /// The caller routes it through `dispatch_combine_output_error` (cursor
+    /// rewind + DLQ) — inline immediately, or after the streaming join.
+    Deferred(Box<ProbeFailure>),
+}
+
+/// A recoverable combine output-row failure deferred for DLQ routing. The
+/// streaming-probe thread cannot touch `&mut ExecutorContext`, so it
+/// accumulates these and the dispatch thread replays each via
+/// [`dispatch_combine_output_error`] after the probe scope joins — matching
+/// the inline path's per-row routing in channel-arrival order.
+struct ProbeFailure {
+    probe_record: Record,
+    rn: u64,
+    matched_build: Option<Record>,
+    error: cxl::eval::EvalError,
+}
+
+/// `distinct` / `filtered` skip counts the probe kernel accumulates so the
+/// streaming thread (which holds no `&mut ExecutorContext`) can fold them
+/// into `ctx.counters` after the join, exactly as the inline loop folds
+/// them inline.
+#[derive(Default)]
+struct ProbeCounters {
+    filtered: u64,
+    distinct: u64,
+}
+
+/// The inline hash build-probe matching kernel for a single driver
+/// (probe-side) record. Owns the fully-materialized build-side hash table
+/// and every per-combine artifact the probe reads; holds no
+/// `&mut ExecutorContext`, so it runs identically on the dispatch thread
+/// (materialized path) and on a scoped probe thread (streaming path),
+/// guaranteeing a byte-identical result set across the two paths.
+///
+/// The kernel borrows the hash table and the per-combine metadata for its
+/// lifetime; the build side is complete before the first `probe_row` call,
+/// so the table is read-only throughout.
+struct CombineProbeKernel<'k> {
+    name: &'k str,
+    hash_table: &'k crate::pipeline::combine::CombineHashTable,
+    resolver_mapping: &'k crate::executor::combine::CombineResolverMapping,
+    probe_extractor: &'k crate::pipeline::combine::KeyExtractor,
+    decomposed: &'k clinker_plan::plan::combine::DecomposedPredicate,
+    /// Body typed program, `None` for `match: collect` (empty body) and
+    /// body-less synthetic N-ary steps.
+    body_program: Option<Arc<TypedProgram>>,
+    combine_output_schema: Option<Arc<clinker_record::Schema>>,
+    build_qualifier: &'k str,
+    match_mode: clinker_plan::config::pipeline_node::MatchMode,
+    on_miss: clinker_plan::config::pipeline_node::OnMiss,
+    propagate_ck: &'k clinker_plan::config::pipeline_node::PropagateCkSpec,
+    /// Whether `ErrorStrategy::FailFast` is active: surface a recoverable
+    /// per-row eval failure as `Err` rather than deferring it to the DLQ.
+    /// Constant for the whole probe, so it lives on the kernel rather than
+    /// a per-call argument.
+    fail_fast: bool,
+}
+
+impl CombineProbeKernel<'_> {
+    /// Probe one driver record against the materialized hash table, pushing
+    /// every emitted `(Record, row_num)` into `out` and accumulating
+    /// `distinct` / `filtered` skips into `counters`. Returns
+    /// [`ProbeRowStep::Continue`] on success (zero or more rows emitted) or
+    /// [`ProbeRowStep::Deferred`] for a recoverable per-row failure the
+    /// caller routes through the DLQ (or as `Err` when `self.fail_fast` is
+    /// set). The signature is `&mut ExecutorContext`-free so the streaming
+    /// probe thread can call it.
+    fn probe_row(
+        &self,
+        eval_ctx: &cxl::eval::EvalContext<'_>,
+        probe_record: &Record,
+        rn: u64,
+        probe_keys_buf: &mut Vec<Value>,
+        counters: &mut ProbeCounters,
+        out: &mut Vec<(Record, u64)>,
+    ) -> Result<ProbeRowStep, PipelineError> {
+        use crate::executor::combine::CombineResolver;
+        use clinker_plan::config::pipeline_node::{MatchMode, OnMiss};
+
+        let name = self.name;
+
+        let probe_key_resolver = CombineResolver::new(self.resolver_mapping, probe_record, None);
+        probe_keys_buf.clear();
+        if let Err(e) =
+            self.probe_extractor
+                .extract_into(eval_ctx, &probe_key_resolver, probe_keys_buf)
+        {
+            if self.fail_fast {
+                return Err(PipelineError::Compilation {
+                    transform_name: name.to_string(),
+                    messages: vec![format!("combine probe key eval error: {e}")],
+                });
+            }
+            // No build candidate matched yet — the failure is on the probe
+            // key itself, so only the driver source rewinds.
+            return Ok(ProbeRowStep::Deferred(Box::new(ProbeFailure {
+                probe_record: probe_record.clone(),
+                rn,
+                matched_build: None,
+                error: e,
+            })));
+        }
+
+        match self.match_mode {
+            MatchMode::Collect => {
+                let mut arr: Vec<Value> = Vec::new();
+                let mut first_collected_build: Option<Record> = None;
+                let mut truncated = false;
+                let probe_iter = self.hash_table.probe(probe_keys_buf);
+                for candidate in probe_iter {
+                    if let Some(residual) = self.decomposed.residual.as_ref() {
+                        let resolver = CombineResolver::new(
+                            self.resolver_mapping,
+                            probe_record,
+                            Some(candidate.record),
+                        );
+                        let mut residual_eval = ProgramEvaluator::new(Arc::clone(residual), false);
+                        match residual_eval.eval_record::<NullStorage>(eval_ctx, &resolver, None) {
+                            Ok(EvalResult::Skip(SkipReason::Filtered)) => continue,
+                            Ok(EvalResult::Emit { .. }) => {}
+                            Ok(EvalResult::EmitMany { .. }) => {
+                                return Err(PipelineError::Internal {
+                                    op: "combine residual",
+                                    node: name.to_string(),
+                                    detail:
+                                        "emit_each fan-out is not supported in a combine residual filter"
+                                            .into(),
+                                });
+                            }
+                            Ok(EvalResult::Skip(SkipReason::Duplicate)) => continue,
+                            Err(e) => {
+                                if self.fail_fast {
+                                    return Err(PipelineError::from(e));
+                                }
+                                return Ok(ProbeRowStep::Deferred(Box::new(ProbeFailure {
+                                    probe_record: probe_record.clone(),
+                                    rn,
+                                    matched_build: Some(candidate.record.clone()),
+                                    error: e,
+                                })));
+                            }
+                        }
+                    }
+                    if arr.len() >= COLLECT_PER_GROUP_CAP {
+                        truncated = true;
+                        break;
+                    }
+                    if first_collected_build.is_none() {
+                        first_collected_build = Some(candidate.record.clone());
+                    }
+                    // Build a `Value::Map` for every matched build record,
+                    // preserving its own schema order. `iter_user_fields`
+                    // filters engine-stamped columns (`$ck.*`, `$widened`)
+                    // so a build record's sidecar Map payload never nests
+                    // and reaches the writer as a nested Map.
+                    let mut m: IndexMap<Box<str>, Value> = IndexMap::new();
+                    for (fname, val) in candidate.record.iter_user_fields() {
+                        m.insert(fname.into(), val.clone());
+                    }
+                    arr.push(Value::Map(Box::new(m)));
+                }
+                if truncated {
+                    eprintln!(
+                        "W: combine {:?} match: collect truncated at \
+                         {COLLECT_PER_GROUP_CAP} matches for driver row {}",
+                        name, rn
+                    );
+                }
+                let mut rec = match self.combine_output_schema.as_ref() {
+                    Some(s) => widen_record_to_schema(probe_record, s),
+                    None => probe_record.clone(),
+                };
+                if let Some(first_build) = first_collected_build.as_ref() {
+                    crate::executor::copy_build_ck_columns(
+                        &mut rec,
+                        first_build,
+                        self.propagate_ck,
+                    );
+                }
+                rec.set(self.build_qualifier, Value::Array(arr));
+                out.push((rec, rn));
+                Ok(ProbeRowStep::Continue)
+            }
+
+            MatchMode::First | MatchMode::All => {
+                // Residual-filter + emit pass. Clone each surviving build
+                // record before dropping the iterator so the evaluator
+                // borrow doesn't alias the hash-table borrow.
+                let matched_records: Vec<Record> = {
+                    let probe_iter = self.hash_table.probe(probe_keys_buf);
+                    let mut matched: Vec<Record> = Vec::new();
+                    for candidate in probe_iter {
+                        if let Some(residual) = self.decomposed.residual.as_ref() {
+                            let resolver = CombineResolver::new(
+                                self.resolver_mapping,
+                                probe_record,
+                                Some(candidate.record),
+                            );
+                            let mut residual_eval =
+                                ProgramEvaluator::new(Arc::clone(residual), false);
+                            match residual_eval
+                                .eval_record::<NullStorage>(eval_ctx, &resolver, None)
+                            {
+                                Ok(EvalResult::Skip(_)) => continue,
+                                Ok(EvalResult::Emit { .. }) => {}
+                                Ok(EvalResult::EmitMany { .. }) => {
+                                    return Err(PipelineError::Internal {
+                                        op: "combine residual",
+                                        node: name.to_string(),
+                                        detail:
+                                            "emit_each fan-out is not supported in a combine residual filter"
+                                                .into(),
+                                    });
+                                }
+                                Err(e) => {
+                                    if self.fail_fast {
+                                        return Err(PipelineError::from(e));
+                                    }
+                                    return Ok(ProbeRowStep::Deferred(Box::new(ProbeFailure {
+                                        probe_record: probe_record.clone(),
+                                        rn,
+                                        matched_build: Some(candidate.record.clone()),
+                                        error: e,
+                                    })));
+                                }
+                            }
+                        }
+                        matched.push(candidate.record.clone());
+                        if matches!(self.match_mode, MatchMode::First) {
+                            break;
+                        }
+                    }
+                    matched
+                };
+
+                if matched_records.is_empty() {
+                    match self.on_miss {
+                        OnMiss::Skip => Ok(ProbeRowStep::Continue),
+                        OnMiss::Error => Err(PipelineError::CombineMissingMatch {
+                            combine: name.to_string(),
+                            driver_row: rn,
+                        }),
+                        OnMiss::NullFields => {
+                            let resolver =
+                                CombineResolver::new(self.resolver_mapping, probe_record, None);
+                            let body = self.body_program.as_ref().ok_or_else(|| {
+                                PipelineError::Internal {
+                                    op: "combine",
+                                    node: name.to_string(),
+                                    detail: "combine body typed program missing for on_miss: null_fields"
+                                        .to_string(),
+                                }
+                            })?;
+                            let mut evaluator = ProgramEvaluator::new(Arc::clone(body), false);
+                            match evaluator.eval_record::<NullStorage>(eval_ctx, &resolver, None) {
+                                Ok(EvalResult::Emit {
+                                    fields: emitted,
+                                    record_vars,
+                                    ..
+                                }) => {
+                                    let mut rec = match self.combine_output_schema.as_ref() {
+                                        Some(s) => widen_record_to_schema(probe_record, s),
+                                        None => probe_record.clone(),
+                                    };
+                                    for (n, v) in emitted {
+                                        rec.set(&n, v);
+                                    }
+                                    for (k, v) in *record_vars {
+                                        let _ = rec.set_record_var(&k, v);
+                                    }
+                                    out.push((rec, rn));
+                                    Ok(ProbeRowStep::Continue)
+                                }
+                                Ok(EvalResult::Skip(SkipReason::Filtered)) => {
+                                    counters.filtered += 1;
+                                    Ok(ProbeRowStep::Continue)
+                                }
+                                Ok(EvalResult::Skip(SkipReason::Duplicate)) => {
+                                    counters.distinct += 1;
+                                    Ok(ProbeRowStep::Continue)
+                                }
+                                Ok(EvalResult::EmitMany { .. }) => Err(PipelineError::Internal {
+                                    op: "combine on_miss body",
+                                    node: name.to_string(),
+                                    detail: "emit_each fan-out is not supported in a combine body"
+                                        .into(),
+                                }),
+                                Err(e) => {
+                                    if self.fail_fast {
+                                        return Err(PipelineError::from(e));
+                                    }
+                                    // on_miss path: no build row matched, so
+                                    // only the driver source rewinds.
+                                    Ok(ProbeRowStep::Deferred(Box::new(ProbeFailure {
+                                        probe_record: probe_record.clone(),
+                                        rn,
+                                        matched_build: None,
+                                        error: e,
+                                    })))
+                                }
+                            }
+                        }
+                    }
+                } else if let Some(body) = self.body_program.as_ref() {
+                    let mut evaluator = ProgramEvaluator::new(Arc::clone(body), false);
+                    for matched in &matched_records {
+                        let resolver = CombineResolver::new(
+                            self.resolver_mapping,
+                            probe_record,
+                            Some(matched),
+                        );
+                        match evaluator.eval_record::<NullStorage>(eval_ctx, &resolver, None) {
+                            Ok(EvalResult::Emit {
+                                fields: emitted,
+                                record_vars,
+                                ..
+                            }) => {
+                                let mut rec = match self.combine_output_schema.as_ref() {
+                                    Some(s) => widen_record_to_schema(probe_record, s),
+                                    None => probe_record.clone(),
+                                };
+                                for (n, v) in emitted {
+                                    rec.set(&n, v);
+                                }
+                                for (k, v) in *record_vars {
+                                    let _ = rec.set_record_var(&k, v);
+                                }
+                                crate::executor::copy_build_ck_columns(
+                                    &mut rec,
+                                    matched,
+                                    self.propagate_ck,
+                                );
+                                out.push((rec, rn));
+                            }
+                            Ok(EvalResult::Skip(SkipReason::Filtered)) => counters.filtered += 1,
+                            Ok(EvalResult::Skip(SkipReason::Duplicate)) => counters.distinct += 1,
+                            Ok(EvalResult::EmitMany { .. }) => {
+                                return Err(PipelineError::Internal {
+                                    op: "combine matched body",
+                                    node: name.to_string(),
+                                    detail: "emit_each fan-out is not supported in a combine body"
+                                        .into(),
+                                });
+                            }
+                            Err(e) => {
+                                if self.fail_fast {
+                                    return Err(PipelineError::from(e));
+                                }
+                                return Ok(ProbeRowStep::Deferred(Box::new(ProbeFailure {
+                                    probe_record: probe_record.clone(),
+                                    rn,
+                                    matched_build: Some(matched.clone()),
+                                    error: e,
+                                })));
+                            }
+                        }
+                    }
+                    Ok(ProbeRowStep::Continue)
+                } else {
+                    // Body-less synthetic step from N-ary combine
+                    // decomposition: the encoded output schema concatenates
+                    // driver columns then build columns. Emit one record per
+                    // match by concatenating value slices onto the encoded
+                    // `Arc<Schema>`. Build-side `$ck.<field>` values are
+                    // already in the concatenated tail under their encoded
+                    // names, recovered later by `widen_record_to_schema`.
+                    let target_schema =
+                        self.combine_output_schema
+                            .as_ref()
+                            .ok_or_else(|| PipelineError::Internal {
+                                op: "combine",
+                                node: name.to_string(),
+                                detail: "synthetic combine step has no output schema; decomposition pass did not run"
+                                    .to_string(),
+                            })?;
+                    for matched in &matched_records {
+                        let mut values: Vec<Value> =
+                            Vec::with_capacity(target_schema.column_count());
+                        values.extend(probe_record.values().iter().cloned());
+                        values.extend(matched.values().iter().cloned());
+                        if values.len() != target_schema.column_count() {
+                            return Err(PipelineError::Internal {
+                                op: "combine",
+                                node: name.to_string(),
+                                detail: format!(
+                                    "synthetic combine step produced {} concatenated values; encoded schema has {} columns",
+                                    values.len(),
+                                    target_schema.column_count()
+                                ),
+                            });
+                        }
+                        let rec = Record::new(Arc::clone(target_schema), values);
+                        out.push((rec, rn));
+                    }
+                    Ok(ProbeRowStep::Continue)
+                }
+            }
+        }
+    }
 }
 
 fn dispatch_combine_output_error(

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -846,6 +846,23 @@ pub(crate) struct ExecutorContext<'a> {
     /// buffered batch to drain. Empty when no streaming chain
     /// qualified.
     pub(crate) streaming_output_nodes: HashSet<NodeIndex>,
+
+    /// `producer → Aggregate` edges whose ingest streams. Keyed by the
+    /// producer's `NodeIndex`, valued by the consuming `Aggregate`'s
+    /// `NodeIndex`. Computed once at executor entry from the plan's fusion
+    /// analysis ([`certify_streaming_edge`] with an `Aggregation`
+    /// consumer).
+    ///
+    /// The producer's own topo turn is short-circuited (the dispatcher
+    /// skips a node whose index is a key here): the producer instead runs
+    /// inside the consuming Aggregate's dispatch turn, on the main thread,
+    /// streaming each batch into a bounded channel while a scoped thread
+    /// drives `add_record` off the receiver. Running the producer inside
+    /// the consumer's turn is what keeps the bounded `send` from
+    /// dead-locking — the drain side is live before the producer's first
+    /// flush, and back-pressure flows Aggregate-ingest → producer →
+    /// Source. Empty for pipelines with no streaming-ingest Aggregate.
+    pub(crate) streaming_aggregate_ingest_edges: HashMap<NodeIndex, NodeIndex>,
     /// `JoinHandle`s for spawned streaming-output writer threads. Owned
     /// by the dispatcher so the end-of-DAG join surface (in
     /// `execute_dag_branching`) folds per-thread counter / timer /
@@ -2469,6 +2486,19 @@ pub(crate) fn dispatch_plan_node(
     // One guard, two pass modes — the architectural payoff of routing
     // both passes through the same operator arms.
     if !ctx.in_deferred_dispatch && current_dag.is_deferred_consumer(node_idx) {
+        return Ok(());
+    }
+    // Streaming-ingest producer short-circuit. A producer feeding a
+    // streaming-ingest Aggregate runs inside that Aggregate's dispatch turn
+    // (on the main thread, streaming into the bounded channel a scoped
+    // ingest thread drains), so its own topo turn is a no-op — mirroring the
+    // streaming-Output producer-stays / consumer-no-ops split, inverted. The
+    // composition-body guard matches `take_streaming_sender`: a body
+    // operator's index can collide with a top-level producer's, and only the
+    // top-level plan installs ingest edges.
+    if ctx.current_body_node_input_refs.is_none()
+        && ctx.streaming_aggregate_ingest_edges.contains_key(&node_idx)
+    {
         return Ok(());
     }
     let node = current_dag.graph[node_idx].clone();

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -863,6 +863,26 @@ pub(crate) struct ExecutorContext<'a> {
     /// flush, and back-pressure flows Aggregate-ingest → producer →
     /// Source. Empty for pipelines with no streaming-ingest Aggregate.
     pub(crate) streaming_aggregate_ingest_edges: HashMap<NodeIndex, NodeIndex>,
+
+    /// `driver-producer → Combine` edges whose probe-side ingest streams.
+    /// Keyed by the driver (probe-side) producer's `NodeIndex`, valued by
+    /// the consuming `Combine`'s `NodeIndex`. Computed once at executor
+    /// entry from the plan's fusion analysis
+    /// ([`certify_streaming_edge`] with a `Combine` consumer, resolving
+    /// the driver via the plan-stamped `driving_upstream` index).
+    ///
+    /// The driver producer's own topo turn is short-circuited (the
+    /// dispatcher skips a node whose index is a key here): it instead runs
+    /// inside the consuming Combine's dispatch turn, on the main thread,
+    /// streaming each batch into a bounded channel while the probe consumer
+    /// drains it on its own thread. The build side is fully materialized
+    /// into the hash table on the main thread *before* the driver producer
+    /// is redispatched, so the probe never reads an incomplete table and
+    /// the bounded `send` cannot deadlock — the probe consumer is live
+    /// before the driver's first flush, and back-pressure flows probe →
+    /// driver → Source. Empty for pipelines with no streaming-probe
+    /// Combine.
+    pub(crate) streaming_combine_probe_edges: HashMap<NodeIndex, NodeIndex>,
     /// `JoinHandle`s for spawned streaming-output writer threads. Owned
     /// by the dispatcher so the end-of-DAG join surface (in
     /// `execute_dag_branching`) folds per-thread counter / timer /
@@ -1022,6 +1042,39 @@ impl<'a> ExecutorContext<'a> {
             return None;
         }
         self.streaming_output_senders.remove(&node_idx)
+    }
+
+    /// Install a bounded streaming-ingest channel for the producer at
+    /// `producer_idx`: register a per-edge `NodeBufferConsumer` charge
+    /// consumer, key the sender by the producer index so its dispatch arm
+    /// streams into the channel via the shared `take_streaming_sender`
+    /// path, and return the receiver, the charge handle, and the charge
+    /// consumer's id for later unregistration.
+    ///
+    /// Shared by the streaming-ingest consumers (Aggregate ingest, Combine
+    /// probe): both move a producer's emit onto a back-pressured channel a
+    /// consumer thread drains. The 256-event bound mirrors the Source
+    /// ingest channel so back-pressure paces both ends, and the per-batch
+    /// `add_bytes` the producer charges on flush is netted to zero by the
+    /// consumer's per-record `sub_bytes` discharge.
+    pub(crate) fn install_streaming_ingest_channel(
+        &mut self,
+        producer_idx: NodeIndex,
+    ) -> (
+        crossbeam_channel::Receiver<crate::executor::stream_event::StreamEvent>,
+        Arc<crate::pipeline::memory::ConsumerHandle>,
+        crate::pipeline::memory::ConsumerId,
+    ) {
+        let (tx, rx) =
+            crossbeam_channel::bounded::<crate::executor::stream_event::StreamEvent>(256);
+        let charge_handle = crate::pipeline::memory::ConsumerHandle::new();
+        let charge_consumer_id = self.memory_budget.register_consumer(Arc::new(
+            crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone(), false),
+        ));
+        self.streaming_output_senders.insert(producer_idx, tx);
+        self.streaming_charge_consumers
+            .insert(producer_idx, (charge_consumer_id, charge_handle.clone()));
+        (rx, charge_handle, charge_consumer_id)
     }
 
     /// Build the [`crate::executor::batch_handoff::StreamingChargeHandle`]
@@ -2498,6 +2551,19 @@ pub(crate) fn dispatch_plan_node(
     // top-level plan installs ingest edges.
     if ctx.current_body_node_input_refs.is_none()
         && ctx.streaming_aggregate_ingest_edges.contains_key(&node_idx)
+    {
+        return Ok(());
+    }
+    // Streaming-probe producer short-circuit. A driver (probe-side)
+    // producer feeding a streaming-probe Combine runs inside that Combine's
+    // dispatch turn — the Combine materializes its build-side hash table on
+    // the main thread, spawns the probe consumer on its own thread, then
+    // redispatches this driver producer to stream into the bounded channel.
+    // So the driver's own topo turn is a no-op here. Same composition-body
+    // guard as the Aggregate-ingest short-circuit: only the top-level plan
+    // installs probe edges.
+    if ctx.current_body_node_input_refs.is_none()
+        && ctx.streaming_combine_probe_edges.contains_key(&node_idx)
     {
         return Ok(());
     }

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -12,6 +12,7 @@ use clinker_format::json::reader::{
     ArrayPathMode, ArrayPathSpec, JsonMode, JsonReader, JsonReaderConfig,
 };
 use clinker_format::traits::FormatReader;
+use clinker_format::x12::reader::{X12Reader, X12ReaderConfig};
 use clinker_format::xml::reader::{
     NamespaceMode, XmlArrayMode, XmlArrayPath, XmlReader, XmlReaderConfig,
 };
@@ -48,6 +49,10 @@ fn build_format_reader(
         clinker_plan::config::InputFormat::Edifact(opts) => {
             let config = build_edifact_reader_config(opts.as_ref());
             Ok(Box::new(EdifactReader::new(reader, config)))
+        }
+        clinker_plan::config::InputFormat::X12(opts) => {
+            let config = build_x12_reader_config(opts.as_ref());
+            Ok(Box::new(X12Reader::new(reader, config)))
         }
     }
 }
@@ -789,6 +794,18 @@ fn build_edifact_reader_config(
     opts: Option<&clinker_plan::config::EdifactInputOptions>,
 ) -> EdifactReaderConfig {
     let mut config = EdifactReaderConfig::default();
+    if let Some(opts) = opts
+        && let Some(max) = opts.max_elements
+    {
+        config.max_elements = max;
+    }
+    config
+}
+
+fn build_x12_reader_config(
+    opts: Option<&clinker_plan::config::X12InputOptions>,
+) -> X12ReaderConfig {
+    let mut config = X12ReaderConfig::default();
     if let Some(opts) = opts
         && let Some(max) = opts.max_elements
     {

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -344,26 +344,25 @@ fn drive_record_source(
         let mut rn: u64 = 0;
         let mut total_count: u64 = 0;
         let mut watermark_observations: Vec<(Arc<str>, i64)> = Vec::new();
-        // Per-file envelope context. Tracks the document currently
-        // being streamed; transitions to a new file emit `DocumentClose`
-        // for the previous context and `DocumentOpen` for the new one.
-        // Envelope sections are empty until reader-side pre-scan lands
-        // — CXL `$doc.<section>.<field>` against this context resolves
-        // to `Value::Null`, which is the streaming-resolver convention
-        // for an absent section.
-        let mut current_doc: Option<Arc<clinker_record::DocumentContext>> = None;
-        // A closed channel during punctuation delivery carries the same
-        // meaning as during record delivery — the consumer stopped pulling
-        // (shutdown unwind or early downstream completion). No further
-        // punctuation matters once the receiver is gone, so treat it as a
-        // benign no-op; the loop's record push breaks on the same signal.
-        let push_punct = |stream: &mut crate::executor::source_stream::SourceIngestChannel,
-                          punct: crate::executor::stream_event::Punctuation|
-         -> Result<(), PipelineError> {
-            match stream.push_punctuation(punct) {
-                Ok(()) | Err(crate::executor::source_stream::SourceStreamError::Closed) => Ok(()),
-            }
-        };
+        // Per-file envelope-level stack, outermost (file-level) first.
+        //
+        // A single-level source (XML, JSON, EDIFACT, plain CSV) holds at
+        // most one entry: the file-level document opened from the reader's
+        // pre-scan. A multi-level source (EDI X12 ISA → GS → ST) pushes a
+        // child context per nested `OpenLevel` event and pops it on the
+        // matching `CloseLevel`, so the stack depth tracks the live
+        // envelope nesting. The INNERMOST entry (`last()`) is the context
+        // every body record carries — its flattened sections expose every
+        // enclosing level's `$doc.<section>.<field>` through the unchanged
+        // two-level lookup. Envelope sections are empty until reader-side
+        // pre-scan lands; absent sections resolve to `Value::Null` per the
+        // streaming-resolver convention.
+        // The file currently being streamed is the `source_file` of the
+        // file-level document at the base of the stack (`doc_stack[0]`), so
+        // no separate file-tracking variable is needed — the stack is the
+        // single source of truth for both the live nesting and the open
+        // file's identity.
+        let mut doc_stack: Vec<Arc<clinker_record::DocumentContext>> = Vec::new();
         loop {
             match src_reader.next_record() {
                 Ok(Some(record)) => {
@@ -373,51 +372,35 @@ fn drive_record_source(
                         .current_source_file()
                         .cloned()
                         .unwrap_or_else(|| Arc::clone(&static_source_file));
-                    // Document boundary detection: on the first record,
-                    // or when the reader transitions to a new file, close
-                    // the previous document (if any) and open a fresh one
-                    // whose Arc is shared across all records of this file.
-                    let need_new_doc = match current_doc.as_ref() {
-                        None => true,
-                        Some(ctx) => !Arc::ptr_eq(ctx.source_file(), &file_arc),
-                    };
-                    if need_new_doc {
-                        if let Some(prev) = current_doc.take() {
-                            push_punct(
-                                &mut stream,
-                                crate::executor::stream_event::Punctuation::document_close(prev),
-                            )?;
-                        }
-                        // Pre-scan declared envelope sections for the new
-                        // file. Sources without `envelope:` config pass
-                        // an empty section map; the default trait impl
-                        // also returns an empty section map. Sections
-                        // populate before the first body record's
-                        // punctuation emits so every record carries the
-                        // same fully-populated context.
-                        let envelope_sections = match src_cfg.envelope.as_ref() {
-                            Some(cfg) => src_reader.prepare_document(cfg).map_err(|e| {
-                                PipelineError::Internal {
-                                    op: "envelope-pre-scan",
-                                    node: src_cfg.name.clone(),
-                                    detail: e.to_string(),
-                                }
-                            })?,
-                            None => indexmap::IndexMap::new(),
-                        };
-                        let new_ctx = Arc::new(clinker_record::DocumentContext::new(
-                            clinker_record::DocumentId::next(),
-                            Arc::clone(&file_arc),
-                            envelope_sections,
-                        ));
-                        push_punct(
+                    // Document boundary detection: on the first record, or
+                    // when the reader transitions to a new file, close the
+                    // prior file's whole level stack and open a fresh
+                    // file-level document whose Arc is shared across all
+                    // records of this file.
+                    if stack_belongs_to_other_file(&doc_stack, &file_arc) {
+                        open_file_level_doc(
+                            &src_cfg,
                             &mut stream,
-                            crate::executor::stream_event::Punctuation::document_open(Arc::clone(
-                                &new_ctx,
-                            )),
+                            &mut doc_stack,
+                            &mut src_reader,
+                            &file_arc,
                         )?;
-                        current_doc = Some(new_ctx);
                     }
+                    // Apply the envelope boundaries the reader crossed to
+                    // reach this record BEFORE stamping it, so the record
+                    // carries the innermost level it actually sits inside.
+                    // A reader queues `OpenLevel`/`CloseLevel` as it crosses
+                    // each envelope segment during `next_record`; draining
+                    // here puts every level opened ahead of this record on
+                    // the stack first, and pops every level that closed
+                    // before it.
+                    apply_envelope_events(
+                        &src_cfg,
+                        &mut stream,
+                        &mut doc_stack,
+                        &mut src_reader,
+                        &file_arc,
+                    )?;
                     let mut values: Vec<clinker_record::Value> = record.values().to_vec();
                     let event_time_value: clinker_record::Value = if let Some(idx) =
                         watermark_column_idx
@@ -435,7 +418,9 @@ fn drive_record_source(
                     values.push(event_time_value);
                     let mut widened_record =
                         clinker_record::Record::new(Arc::clone(&widened_schema), values);
-                    if let Some(ctx) = current_doc.as_ref() {
+                    // The record carries the INNERMOST open level, so its
+                    // `$doc.*` sees every enclosing envelope's sections.
+                    if let Some(ctx) = doc_stack.last() {
                         widened_record.set_doc_ctx(Arc::clone(ctx));
                     }
                     // A closed channel means the consumer stopped pulling —
@@ -448,17 +433,48 @@ fn drive_record_source(
                         break;
                     }
                 }
-                Ok(None) => break,
+                Ok(None) => {
+                    // End of input. The reader may still hold trailing
+                    // envelope events — a header-only interchange (envelope
+                    // structure, zero body records), or an inner envelope
+                    // that closed, or even one that opened, after the last
+                    // body record. Applying them here, NOT skipping them, is
+                    // load-bearing: a trailing `OpenLevel` left unapplied
+                    // would leave the level stack unbalanced and every
+                    // downstream `DocumentClose` count would be off,
+                    // aborting the run. This is the symmetric end of the
+                    // before-record drain above — every event a reader
+                    // queues is applied, whether a record follows it or not.
+                    //
+                    // The reader's own `current_source_file()` names the
+                    // file these trailing events belong to: a header-only
+                    // interchange for a NEW file (one whose body produced no
+                    // record) points here at that new file, and
+                    // `apply_envelope_events` then transitions to it,
+                    // closing the prior file's stack first. The static
+                    // fallback covers a single-file reader with no
+                    // per-record file identity.
+                    let file_arc = src_reader
+                        .current_source_file()
+                        .cloned()
+                        .unwrap_or_else(|| Arc::clone(&static_source_file));
+                    apply_envelope_events(
+                        &src_cfg,
+                        &mut stream,
+                        &mut doc_stack,
+                        &mut src_reader,
+                        &file_arc,
+                    )?;
+                    break;
+                }
                 Err(other) => return Err(other.into()),
             }
         }
-        // Close the last document (if any records were emitted).
-        if let Some(last) = current_doc.take() {
-            push_punct(
-                &mut stream,
-                crate::executor::stream_event::Punctuation::document_close(last),
-            )?;
-        }
+        // Close every level still open at end-of-input, innermost first.
+        // This balances both the file-level document and any nested level
+        // a reader left open (a truncated `--dry-run -n` read, or a reader
+        // that opens a level it never explicitly closes).
+        close_open_levels(&mut stream, &mut doc_stack)?;
         // Drop the sender so the dispatch-side `recv` returns `Err`
         // (channel disconnected) once the channel drains.
         drop(stream);
@@ -468,6 +484,177 @@ fn drive_record_source(
             watermark_observations,
         })
     }
+}
+
+/// `true` when no file-level document is open yet, or the open stack
+/// belongs to a different file than `file_arc` — i.e. the driver must open
+/// a fresh file-level document (closing the prior file's stack first)
+/// before streaming `file_arc`'s records or applying its envelope events.
+///
+/// The file-level document sits at the base of the stack (`doc_stack[0]`)
+/// and carries the file's `source_file` identity, so this is a pointer
+/// comparison against that base — the same `Arc::ptr_eq` discriminator the
+/// reader uses to mark file transitions.
+fn stack_belongs_to_other_file(
+    doc_stack: &[Arc<clinker_record::DocumentContext>],
+    file_arc: &Arc<str>,
+) -> bool {
+    match doc_stack.first() {
+        None => true,
+        Some(file_doc) => !Arc::ptr_eq(file_doc.source_file(), file_arc),
+    }
+}
+
+/// Push a document-boundary punctuation, treating a closed channel as a
+/// benign stop.
+///
+/// A closed channel during punctuation delivery carries the same meaning
+/// as during record delivery — the consumer dropped the receiver (a
+/// shutdown unwind or an early-completing downstream). No further
+/// punctuation matters once the receiver is gone, so the close is a no-op;
+/// the driver's record push breaks on the same signal.
+fn push_doc_punctuation(
+    stream: &mut crate::executor::source_stream::SourceIngestChannel,
+    punct: crate::executor::stream_event::Punctuation,
+) -> Result<(), PipelineError> {
+    match stream.push_punctuation(punct) {
+        Ok(()) | Err(crate::executor::source_stream::SourceStreamError::Closed) => Ok(()),
+    }
+}
+
+/// Close every open level on `doc_stack`, innermost first, draining it to
+/// empty.
+///
+/// Each `DocumentOpen` is balanced by exactly one `DocumentClose` in
+/// strict LIFO order. Used at a file transition (the prior file's stack
+/// closes before the next file opens) and at end-of-input.
+fn close_open_levels(
+    stream: &mut crate::executor::source_stream::SourceIngestChannel,
+    doc_stack: &mut Vec<Arc<clinker_record::DocumentContext>>,
+) -> Result<(), PipelineError> {
+    while let Some(level) = doc_stack.pop() {
+        push_doc_punctuation(
+            stream,
+            crate::executor::stream_event::Punctuation::document_close(level),
+        )?;
+    }
+    Ok(())
+}
+
+/// Open the file-level document for `file_arc`, closing the prior file's
+/// entire level stack first.
+///
+/// Runs the envelope pre-scan that populates the file-level sections (the
+/// head/tail metadata a single-level reader extracts), emits the
+/// file-level `DocumentOpen`, and seeds `doc_stack` with the new
+/// file-level context. The file-level document opens on whichever comes
+/// first for a file — its first body record or its first envelope event;
+/// a header-only interchange with no body still surfaces its envelope and
+/// boundaries (issue #395).
+///
+/// # Errors
+///
+/// Returns [`PipelineError::Internal`] if the reader's envelope pre-scan
+/// fails for a source that declares an `envelope:` config.
+fn open_file_level_doc(
+    src_cfg: &clinker_plan::config::SourceConfig,
+    stream: &mut crate::executor::source_stream::SourceIngestChannel,
+    doc_stack: &mut Vec<Arc<clinker_record::DocumentContext>>,
+    src_reader: &mut Box<dyn crate::source::RecordSource>,
+    file_arc: &Arc<str>,
+) -> Result<(), PipelineError> {
+    close_open_levels(stream, doc_stack)?;
+    // Pre-scan declared envelope sections for the new file. Sources
+    // without `envelope:` config — and the default trait impl — return an
+    // empty section map. Sections populate before the `DocumentOpen`
+    // emits, so every record of this file carries the same fully-populated
+    // context.
+    let envelope_sections = match src_cfg.envelope.as_ref() {
+        Some(cfg) => src_reader
+            .prepare_document(cfg)
+            .map_err(|e| PipelineError::Internal {
+                op: "envelope-pre-scan",
+                node: src_cfg.name.clone(),
+                detail: e.to_string(),
+            })?,
+        None => indexmap::IndexMap::new(),
+    };
+    let new_ctx = Arc::new(clinker_record::DocumentContext::new(
+        clinker_record::DocumentId::next(),
+        Arc::clone(file_arc),
+        envelope_sections,
+    ));
+    push_doc_punctuation(
+        stream,
+        crate::executor::stream_event::Punctuation::document_open(Arc::clone(&new_ctx)),
+    )?;
+    doc_stack.push(new_ctx);
+    Ok(())
+}
+
+/// Apply the reader's pending nested-envelope events to the level stack.
+///
+/// `OpenLevel` mints a child of the current innermost level (flattening
+/// the enclosing sections in) and emits its `DocumentOpen`; `CloseLevel`
+/// pops the innermost nested level and emits its `DocumentClose`. A file
+/// that has not yet opened its file-level document opens it here before
+/// applying any nested event, so an envelope boundary with no preceding
+/// body record still frames the document (issue #395).
+///
+/// A stray `CloseLevel` that would pop the file-level document or
+/// underflow an empty stack is ignored: the file-transition / end-of-input
+/// sweep owns the file-level close, and a balanced reader never emits one.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::Internal`] if opening the file-level document
+/// (when a nested event arrives before any record) triggers an envelope
+/// pre-scan failure.
+fn apply_envelope_events(
+    src_cfg: &clinker_plan::config::SourceConfig,
+    stream: &mut crate::executor::source_stream::SourceIngestChannel,
+    doc_stack: &mut Vec<Arc<clinker_record::DocumentContext>>,
+    src_reader: &mut Box<dyn crate::source::RecordSource>,
+    file_arc: &Arc<str>,
+) -> Result<(), PipelineError> {
+    for event in src_reader.take_envelope_events() {
+        match event {
+            clinker_format::EnvelopeEvent::OpenLevel { sections } => {
+                // Open a fresh file-level document when none is open yet,
+                // or when the open stack belongs to a different file than
+                // this event — a trailing header-only interchange for a new
+                // file (one whose body produced no record) reaches the
+                // driver only through this path, so the file transition
+                // (closing the prior file's stack) must happen here too,
+                // not just on a record boundary. `open_file_level_doc`
+                // closes the stale stack before opening the new one.
+                if stack_belongs_to_other_file(doc_stack, file_arc) {
+                    open_file_level_doc(src_cfg, stream, doc_stack, src_reader, file_arc)?;
+                }
+                let parent = doc_stack.last().expect("file-level document opened above");
+                let child = Arc::new(parent.child(clinker_record::DocumentId::next(), sections));
+                push_doc_punctuation(
+                    stream,
+                    crate::executor::stream_event::Punctuation::document_open(Arc::clone(&child)),
+                )?;
+                doc_stack.push(child);
+            }
+            clinker_format::EnvelopeEvent::CloseLevel => {
+                // Keep the file-level document (index 0) — its close is the
+                // file-transition / EOF sweep's job — so only pop a
+                // genuinely nested level.
+                if doc_stack.len() > 1
+                    && let Some(level) = doc_stack.pop()
+                {
+                    push_doc_punctuation(
+                        stream,
+                        crate::executor::stream_event::Punctuation::document_close(level),
+                    )?;
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Extract `Vec<FieldDef>` from `SourceConfig.schema` for fixed-width format.
@@ -608,4 +795,263 @@ fn build_edifact_reader_config(
         config.max_elements = max;
     }
     config
+}
+
+#[cfg(test)]
+mod tests {
+    //! These tests observe the exact `StreamEvent` punctuation stream the
+    //! driver emits — the only place the document open/close boundaries
+    //! are visible before downstream operators consume them. End-to-end
+    //! pipeline tests assert on record counts and `$doc` resolution; they
+    //! cannot see whether a *record-less* boundary (a header-only
+    //! interchange, or a trailing empty inner envelope) was emitted at
+    //! all, because such a boundary contributes no record and no `$doc`
+    //! read. Draining the source channel here pins exactly that: that the
+    //! end-of-input drain emits the trailing/header-only document
+    //! boundaries instead of dropping them.
+
+    use super::*;
+    use crate::executor::stream_event::{PunctuationKind, StreamEvent};
+    use clinker_format::EnvelopeEvent;
+    use clinker_record::{Schema, SchemaBuilder, Value};
+    use indexmap::IndexMap;
+
+    /// A scripted step: emit a record, or queue an envelope boundary the
+    /// driver drains around the surrounding `next_record` call.
+    enum Step {
+        Open(&'static str),
+        Close,
+        Record(i64),
+    }
+
+    /// Replays a fixed [`Step`] script as a `RecordSource`, modeling a
+    /// multi-level envelope reader. Single pathless file (no per-record
+    /// file identity), so the driver uses one stable synthetic id.
+    struct ScriptedReader {
+        schema: Arc<Schema>,
+        steps: std::collections::VecDeque<Step>,
+        pending: Vec<EnvelopeEvent>,
+    }
+
+    impl ScriptedReader {
+        fn new(steps: Vec<Step>) -> Self {
+            Self {
+                schema: SchemaBuilder::with_capacity(1).with_field("id").build(),
+                steps: steps.into_iter().collect(),
+                pending: Vec::new(),
+            }
+        }
+    }
+
+    impl crate::source::RecordSource for ScriptedReader {
+        fn schema(&mut self) -> Result<Arc<Schema>, clinker_format::FormatError> {
+            Ok(Arc::clone(&self.schema))
+        }
+
+        fn next_record(
+            &mut self,
+        ) -> Result<Option<clinker_record::Record>, clinker_format::FormatError> {
+            while let Some(step) = self.steps.pop_front() {
+                match step {
+                    Step::Open(name) => {
+                        let mut field = IndexMap::new();
+                        field.insert(Box::from("tag"), Value::String(name.into()));
+                        let mut sections = IndexMap::new();
+                        sections.insert(Box::from(name), Value::Map(Box::new(field)));
+                        self.pending.push(EnvelopeEvent::OpenLevel { sections });
+                    }
+                    Step::Close => self.pending.push(EnvelopeEvent::CloseLevel),
+                    Step::Record(id) => {
+                        return Ok(Some(clinker_record::Record::new(
+                            Arc::clone(&self.schema),
+                            vec![Value::Integer(id)],
+                        )));
+                    }
+                }
+            }
+            Ok(None)
+        }
+
+        fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+            std::mem::take(&mut self.pending)
+        }
+    }
+
+    /// One observed event from the driver's output channel, projected to
+    /// just what the boundary assertions need.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Observed {
+        Open,
+        Close,
+        Record(i64),
+    }
+
+    /// Minimal pathless CSV `SourceConfig` — the transport the driver
+    /// drives is supplied directly, so only the name/format matter.
+    fn pathless_source_config() -> clinker_plan::config::SourceConfig {
+        let yaml = r#"
+pipeline:
+  name: drive_test
+nodes:
+  - type: source
+    name: edi
+    config:
+      name: edi
+      type: csv
+      path: placeholder.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: edi
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+        let mut config = clinker_plan::config::parse_config(yaml).expect("parse");
+        for spanned in &mut config.nodes {
+            if let clinker_plan::config::PipelineNode::Source { config: body, .. } =
+                &mut spanned.value
+            {
+                body.source.path = None;
+                return body.source.clone();
+            }
+        }
+        unreachable!("source node present")
+    }
+
+    /// Drive `drive_record_source` over the script and return the ordered
+    /// stream of records and document boundaries the driver emitted.
+    fn drive(steps: Vec<Step>) -> Vec<Observed> {
+        let src_cfg = pathless_source_config();
+        let reader: Box<dyn crate::source::RecordSource> = Box::new(ScriptedReader::new(steps));
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let (stream, rx) = crate::executor::source_stream::SourceIngestChannel::new(
+            crate::executor::source_stream::SourceIngestChannel::DEFAULT_CAPACITY,
+            handle,
+        );
+
+        // The script is far smaller than the channel capacity, so the
+        // driver never blocks on a full channel; it runs to completion on
+        // this thread and drops the sender, after which the receiver
+        // drains cleanly.
+        drive_record_source(src_cfg, reader, stream, None).expect("drive");
+
+        rx.iter()
+            .map(|ev| match ev {
+                StreamEvent::Record(rec, _) => match rec.values()[0] {
+                    Value::Integer(id) => Observed::Record(id),
+                    ref other => panic!("unexpected record value {other:?}"),
+                },
+                StreamEvent::Punctuation(p) => match p.kind() {
+                    PunctuationKind::DocumentOpen => Observed::Open,
+                    PunctuationKind::DocumentClose => Observed::Close,
+                },
+            })
+            .collect()
+    }
+
+    #[test]
+    fn nested_levels_emit_balanced_open_close_around_records() {
+        // ISA → GS → ST → record → close ST → close GS → close ISA.
+        let observed = drive(vec![
+            Step::Open("interchange"),
+            Step::Open("group"),
+            Step::Open("transaction"),
+            Step::Record(1),
+            Step::Close, // ST
+            Step::Close, // GS
+            Step::Close, // ISA
+        ]);
+        // File-level Open, then the three nested Opens, the record, the
+        // three nested Closes, and the file-level Close — every Open
+        // balanced by a Close, innermost first.
+        assert_eq!(
+            observed,
+            vec![
+                Observed::Open, // file-level document
+                Observed::Open, // interchange
+                Observed::Open, // group
+                Observed::Open, // transaction
+                Observed::Record(1),
+                Observed::Close, // transaction
+                Observed::Close, // group
+                Observed::Close, // interchange
+                Observed::Close, // file-level document
+            ]
+        );
+    }
+
+    #[test]
+    fn trailing_inner_envelope_after_last_record_emits_its_boundaries() {
+        // The desync regression, observed at the boundary stream: an inner
+        // envelope that OPENS and closes after the last body record. The
+        // end-of-input drain must emit that trailing open AND its close —
+        // reverting the drain to a bare `break` drops both, which this
+        // assertion catches.
+        let observed = drive(vec![
+            Step::Open("interchange"),
+            Step::Open("transaction"),
+            Step::Record(10),
+            Step::Close, // ST closes after its record
+            // Trailing inner envelope: opens and closes with no record
+            // between, after the file's final record.
+            Step::Open("transaction"),
+            Step::Close,
+            Step::Close, // ISA
+        ]);
+        assert_eq!(
+            observed,
+            vec![
+                Observed::Open, // file-level document
+                Observed::Open, // interchange
+                Observed::Open, // transaction
+                Observed::Record(10),
+                Observed::Close, // transaction
+                Observed::Open,  // trailing transaction — emitted by the EOF drain
+                Observed::Close, // trailing transaction close
+                Observed::Close, // interchange
+                Observed::Close, // file-level document
+            ]
+        );
+        // Three of the boundaries (the trailing inner open+close and the
+        // interchange close) are produced entirely by the end-of-input
+        // drain — there is no body record after the final close to carry
+        // them. A bare `break` at end-of-input would emit only the
+        // file-level close (the sweep), losing the trailing pair.
+        let opens = observed.iter().filter(|o| **o == Observed::Open).count();
+        let closes = observed.iter().filter(|o| **o == Observed::Close).count();
+        assert_eq!(opens, 4, "file + interchange + 2 transaction opens");
+        assert_eq!(closes, 4, "every open balanced by a close");
+    }
+
+    #[test]
+    fn header_only_interchange_emits_open_and_close_with_no_records() {
+        // Issue #395: a file carrying envelope structure but zero body
+        // records still opens a document and emits its open/close
+        // boundaries. The entire script is an interchange that opens and
+        // closes with nothing inside — every boundary here is produced by
+        // the end-of-input drain, since no record ever triggers the
+        // record-arm open.
+        let observed = drive(vec![Step::Open("interchange"), Step::Close]);
+        assert_eq!(
+            observed,
+            vec![
+                Observed::Open,  // file-level document, opened by the first envelope event
+                Observed::Open,  // interchange
+                Observed::Close, // interchange
+                Observed::Close, // file-level document
+            ],
+            "header-only interchange must surface its document boundaries"
+        );
+        // No records, but four boundary punctuations — the #395 fix. With
+        // the end-of-input drain reverted, zero punctuations are emitted
+        // and this vector would be empty.
+        assert!(
+            observed.iter().all(|o| *o != Observed::Record(0)),
+            "header-only interchange has no body records"
+        );
+        assert_eq!(observed.len(), 4);
+    }
 }

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1228,6 +1228,28 @@ impl PipelineExecutor {
             )
         };
 
+        // Streaming Combine probe-side ingest edges (issue #300). Each
+        // entry is a `driver-producer → Combine` edge whose probe ingest
+        // streams: the driver producer runs inside the Combine's dispatch
+        // turn, streaming each batch into a bounded channel the probe
+        // consumer drains on its own thread — after the build side is
+        // materialized into the hash table. Correlation buffering disables
+        // streaming pipeline-wide, mirroring the Aggregate-ingest and
+        // streaming-Output short-circuits so the explain annotation and the
+        // runtime probe path agree.
+        let streaming_combine_probe_edges: HashMap<
+            petgraph::graph::NodeIndex,
+            petgraph::graph::NodeIndex,
+        > = if config.any_source_has_correlation_key() {
+            HashMap::new()
+        } else {
+            clinker_plan::plan::execution::compute_streaming_combine_probe_edges(
+                plan,
+                &fused_transforms,
+                &init_phase_set,
+            )
+        };
+
         // Shared Rayon pool for the CPU-bound owned-input kernels (sort,
         // grace-hash partition build, IEJoin, sort-merge). Sized off the
         // pipeline's `concurrency.threads` knob; `0`/absent defers to
@@ -1383,6 +1405,7 @@ impl PipelineExecutor {
             streaming_output_senders,
             streaming_output_nodes,
             streaming_aggregate_ingest_edges,
+            streaming_combine_probe_edges,
             streaming_output_tasks,
             streaming_charge_consumers,
             kernel_pool,
@@ -1442,13 +1465,28 @@ impl PipelineExecutor {
                 .copied()
                 .filter(|idx| !init_phase_set.contains(idx))
                 .collect();
-            let mut seq = scheduled_pass_order(plan, &ctx.memory_budget, &init_phase_set);
-            seq.extend(scheduled_pass_order(plan, &ctx.memory_budget, &runtime_set));
+            let mut seq = scheduled_pass_order(
+                plan,
+                &ctx.memory_budget,
+                &init_phase_set,
+                &ctx.streaming_combine_probe_edges,
+            );
+            seq.extend(scheduled_pass_order(
+                plan,
+                &ctx.memory_budget,
+                &runtime_set,
+                &ctx.streaming_combine_probe_edges,
+            ));
             seq
         } else {
             let all: HashSet<petgraph::graph::NodeIndex> =
                 plan.topo_order.iter().copied().collect();
-            scheduled_pass_order(plan, &ctx.memory_budget, &all)
+            scheduled_pass_order(
+                plan,
+                &ctx.memory_budget,
+                &all,
+                &ctx.streaming_combine_probe_edges,
+            )
         };
 
         let walk_result: Result<(), PipelineError> = (|| {

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1206,6 +1206,28 @@ impl PipelineExecutor {
             );
         fused_sources.extend(extra_fused_sources);
 
+        // Streaming Aggregate-ingest edges (issue #299). Each entry is a
+        // `producer → Aggregate` edge whose ingest streams: the producer
+        // runs inside the Aggregate's dispatch turn, streaming each batch
+        // into a bounded channel a scoped thread drains via `add_record`.
+        // Correlation buffering routes every record through the
+        // `CorrelationCommit` terminal, so it disables streaming
+        // pipeline-wide — mirror the same short-circuit the streaming-Output
+        // spec computation uses so the explain annotation and the runtime
+        // ingest path agree.
+        let streaming_aggregate_ingest_edges: HashMap<
+            petgraph::graph::NodeIndex,
+            petgraph::graph::NodeIndex,
+        > = if config.any_source_has_correlation_key() {
+            HashMap::new()
+        } else {
+            clinker_plan::plan::execution::compute_streaming_aggregate_ingest_edges(
+                plan,
+                &fused_transforms,
+                &init_phase_set,
+            )
+        };
+
         // Shared Rayon pool for the CPU-bound owned-input kernels (sort,
         // grace-hash partition build, IEJoin, sort-merge). Sized off the
         // pipeline's `concurrency.threads` knob; `0`/absent defers to
@@ -1360,6 +1382,7 @@ impl PipelineExecutor {
             in_deferred_dispatch: false,
             streaming_output_senders,
             streaming_output_nodes,
+            streaming_aggregate_ingest_edges,
             streaming_output_tasks,
             streaming_charge_consumers,
             kernel_pool,

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -14,6 +14,7 @@ use clinker_format::fixed_width::writer::{FixedWidthWriter, FixedWidthWriterConf
 use clinker_format::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
 use clinker_format::splitting::{OversizeGroupPolicy, SplitPolicy, SplittingWriter, WriterFactory};
 use clinker_format::traits::FormatWriter;
+use clinker_format::x12::writer::{X12Writer, X12WriterConfig};
 use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
 use clinker_plan::config::{OutputConfig, OutputFormat};
 use clinker_plan::error::PipelineError;
@@ -121,6 +122,21 @@ fn build_edifact_writer_config(
         interchange_from_doc: opts.and_then(|o| o.interchange_from_doc.clone()),
         message_type: opts.and_then(|o| o.message_type.clone()),
         write_una: opts.and_then(|o| o.write_una).unwrap_or(false),
+        segment_newline: opts.and_then(|o| o.segment_newline).unwrap_or(true),
+    }
+}
+
+fn build_x12_writer_config(
+    opts: Option<&clinker_plan::config::X12OutputOptions>,
+) -> X12WriterConfig {
+    // `segment_newline` defaults to `true` (readable per-segment lines).
+    // The struct literal expresses it up front so an unset option falls
+    // through to the documented default.
+    X12WriterConfig {
+        interchange: opts.and_then(|o| o.interchange.clone()),
+        interchange_from_doc: opts.and_then(|o| o.interchange_from_doc.clone()),
+        group_header: opts.and_then(|o| o.group_header.clone()),
+        set_type: opts.and_then(|o| o.set_type.clone()),
         segment_newline: opts.and_then(|o| o.segment_newline).unwrap_or(true),
     }
 }
@@ -247,6 +263,16 @@ fn build_writer_factory(
                     counting_writer,
                     schema,
                     edi_config.clone(),
+                )))
+            })
+        }
+        OutputFormat::X12(opts) => {
+            let x12_config = build_x12_writer_config(opts.as_ref());
+            Box::new(move |counting_writer, schema| {
+                Ok(Box::new(X12Writer::new(
+                    counting_writer,
+                    schema,
+                    x12_config.clone(),
                 )))
             })
         }

--- a/crates/clinker-exec/src/executor/tests/scheduling.rs
+++ b/crates/clinker-exec/src/executor/tests/scheduling.rs
@@ -138,7 +138,7 @@ fn no_estimates_reproduces_topo_order_exactly() {
         MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, MemoryArbitrator::default_policy());
     let all: HashSet<NodeIndex> = dag.topo_order.iter().copied().collect();
 
-    let order = scheduled_pass_order(dag, &arbitrator, &all);
+    let order = scheduled_pass_order(dag, &arbitrator, &all, &std::collections::HashMap::new());
     assert_eq!(
         order, dag.topo_order,
         "with no estimates the scheduler must reproduce topo order exactly"
@@ -345,7 +345,7 @@ fn scheduler_elects_heavy_chain_source_before_lower_index_light_source() {
     // task specifies (no spill, no back-pressure, fully decoupled from RSS).
     let arbitrator = huge_budget_arbitrator();
     let all: HashSet<NodeIndex> = dag.topo_order.iter().copied().collect();
-    let order = scheduled_pass_order(dag, &arbitrator, &all);
+    let order = scheduled_pass_order(dag, &arbitrator, &all, &std::collections::HashMap::new());
     let pos = |idx: NodeIndex| order.iter().position(|&n| n == idx).unwrap();
 
     assert!(

--- a/crates/clinker-exec/src/executor/util.rs
+++ b/crates/clinker-exec/src/executor/util.rs
@@ -46,12 +46,39 @@ pub(super) fn scheduled_pass_order(
     plan: &clinker_plan::plan::execution::ExecutionPlanDag,
     arbitrator: &crate::pipeline::memory::MemoryArbitrator,
     candidates: &HashSet<petgraph::graph::NodeIndex>,
+    combine_probe_edges: &std::collections::HashMap<
+        petgraph::graph::NodeIndex,
+        petgraph::graph::NodeIndex,
+    >,
 ) -> Vec<petgraph::graph::NodeIndex> {
     use clinker_plan::plan::scheduling_hint::SchedulingHint;
 
     let mut emitted: HashSet<petgraph::graph::NodeIndex> = HashSet::with_capacity(candidates.len());
     let mut order: Vec<petgraph::graph::NodeIndex> = Vec::with_capacity(candidates.len());
     let hint: &dyn SchedulingHint = plan;
+
+    // Build-before-probe ordering (issue #300). A streaming-probe driver
+    // producer must not be selected until the consuming Combine's build-side
+    // predecessor cone has materialized — the Combine arm builds the hash
+    // table on the main thread before redispatching the driver, and pinning
+    // that order here keeps `--explain`'s dispatch sequence and the runtime
+    // coherent. The build side is every incoming neighbor of the Combine
+    // except the driver itself; a driver is gated until all such build
+    // predecessors that are in this pass's candidate set are emitted. This
+    // is acyclic because a certified driver is single-outgoing into the
+    // Combine and never feeds the build cone, so the build predecessors
+    // become runnable independently and eventually unblock the driver.
+    let build_ready = |driver: petgraph::graph::NodeIndex,
+                       emitted: &HashSet<petgraph::graph::NodeIndex>|
+     -> bool {
+        let Some(&combine_idx) = combine_probe_edges.get(&driver) else {
+            return true;
+        };
+        plan.graph
+            .neighbors_directed(combine_idx, petgraph::Direction::Incoming)
+            .filter(|&pred| pred != driver)
+            .all(|build_pred| !candidates.contains(&build_pred) || emitted.contains(&build_pred))
+    };
 
     // A node is runnable once every in-`candidates` predecessor is
     // already emitted. Recomputed each step from `emitted` so that
@@ -66,6 +93,7 @@ pub(super) fn scheduled_pass_order(
                     .neighbors_directed(idx, petgraph::Direction::Incoming)
                     .all(|pred| !candidates.contains(&pred) || emitted.contains(&pred))
             })
+            .filter(|&idx| build_ready(idx, &emitted))
             .collect();
 
         // The candidate set is the node set of an acyclic graph, so as

--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -214,6 +214,14 @@ impl FormatReader for CoercingReader {
         // records only, so forward the pre-scan straight through.
         self.inner.prepare_document(config)
     }
+
+    fn take_envelope_events(&mut self) -> Vec<clinker_format::EnvelopeEvent> {
+        // Nested-envelope boundaries are a property of the raw source's
+        // structure, untouched by per-record type coercion — forward them
+        // verbatim so a multi-level source streamed through coercion keeps
+        // its envelope nesting.
+        self.inner.take_envelope_events()
+    }
 }
 
 /// Unwrap Nullable to get the inner type for coercion.

--- a/crates/clinker-exec/src/pipeline/take.rs
+++ b/crates/clinker-exec/src/pipeline/take.rs
@@ -42,6 +42,17 @@ impl<R: FormatReader> FormatReader for TakeReader<R> {
         }
         Ok(record)
     }
+
+    fn take_envelope_events(&mut self) -> Vec<clinker_format::EnvelopeEvent> {
+        // Forward the inner reader's nested-envelope boundaries so a
+        // `--dry-run -n N` over a multi-level source still frames the
+        // records it does emit. Once the record limit truncates the read
+        // the inner reader stops producing events; any envelope level left
+        // open at that point is closed by the ingest driver's
+        // end-of-input sweep, so a truncated dry-run never desyncs the
+        // downstream document stack.
+        self.inner.take_envelope_events()
+    }
 }
 
 #[cfg(test)]

--- a/crates/clinker-exec/src/source/mod.rs
+++ b/crates/clinker-exec/src/source/mod.rs
@@ -13,7 +13,7 @@ pub mod multi_file;
 use std::sync::Arc;
 
 use clinker_format::traits::FormatReader;
-use clinker_format::{EnvelopeConfig, FormatError};
+use clinker_format::{EnvelopeConfig, EnvelopeEvent, FormatError};
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
@@ -62,6 +62,17 @@ pub trait RecordSource: Send {
         Ok(IndexMap::new())
     }
 
+    /// Drain the envelope-nesting events the source queued while serving
+    /// the most recent `next_record` (or its end-of-input transition).
+    /// Mirrors [`FormatReader::take_envelope_events`]: the ingest driver
+    /// polls this after every `next_record` and once at end-of-input,
+    /// opening/closing nested document contexts per event. The default
+    /// returns an empty `Vec` for transports without multi-level envelope
+    /// semantics (every transport shipping today).
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        Vec::new()
+    }
+
     /// Hand the source its run shutdown handle so it can poll for
     /// cancellation at page/row-batch boundaries and stop cleanly
     /// (returning `Ok(None)` like a normal EOF). The ingest driver
@@ -95,6 +106,10 @@ impl RecordSource for Box<dyn FormatReader> {
         config: &EnvelopeConfig,
     ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
         (**self).prepare_document(config)
+    }
+
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        (**self).take_envelope_events()
     }
 }
 

--- a/crates/clinker-exec/src/source/multi_file.rs
+++ b/crates/clinker-exec/src/source/multi_file.rs
@@ -207,6 +207,18 @@ impl FormatReader for MultiFileFormatReader {
             .prepare_document(config)
     }
 
+    fn take_envelope_events(&mut self) -> Vec<clinker_format::EnvelopeEvent> {
+        // Forward the active per-file reader's nested-envelope boundaries.
+        // Each file is a self-contained document, so its inner levels open
+        // and close entirely within that file's stream; the wrapper never
+        // bridges a level across a file boundary. Before any file is
+        // materialized there are no events to drain.
+        match self.active.as_mut() {
+            Some(active) => active.take_envelope_events(),
+            None => Vec::new(),
+        }
+    }
+
     fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
         // Materialize file 0 if we haven't yet.
         if self.active.is_none() {

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -4491,6 +4491,7 @@ nodes:
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
             build_inputs: Vec::new(),
+            driving_upstream: None,
             predicate_summary: CombinePredicateSummary::default(),
             match_mode: clinker_plan::config::pipeline_node::MatchMode::First,
             on_miss: clinker_plan::config::pipeline_node::OnMiss::NullFields,

--- a/crates/clinker-exec/tests/intra_record_closures.rs
+++ b/crates/clinker-exec/tests/intra_record_closures.rs
@@ -192,6 +192,128 @@ nodes:
     assert_eq!(prices, vec![10, 20, 5]);
 }
 
+/// Nested `emit each` fans out within fan-out for one trigger row: the
+/// outer iterates `groups`, the inner iterates each group's elements,
+/// producing one output record per (group, item) through the full
+/// executor path. Exercises the document-shape "article → section → tag"
+/// fan-out end to end.
+#[test]
+fn ndjson_nested_emit_each_fans_out_within_fan_out() {
+    let yaml = r#"
+pipeline:
+  name: nested_fanout
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: json
+      options:
+        format: ndjson
+      path: rows.ndjson
+      schema:
+        - { name: groups, type: any }
+  - type: transform
+    name: explode
+    input: rows
+    config:
+      cxl: |
+        emit each g in groups {
+          emit each it in g {
+            emit val = it
+          }
+        }
+  - type: output
+    name: out
+    input: explode
+    config:
+      name: out
+      type: json
+      options:
+        format: ndjson
+      path: out.json
+      include_unmapped: false
+      exclude: [groups]
+"#;
+    let payload = br#"{"groups":[[1,2],[3],[4,5,6]]}
+"#;
+    let (_report, output) = run_with_payload(yaml, "rows.ndjson", payload);
+    let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        6,
+        "one record per (group, item): 2 + 1 + 3 = 6: {output:?}"
+    );
+    let vals: Vec<i64> = lines
+        .iter()
+        .map(|l| {
+            let r: serde_json::Value = serde_json::from_str(l).expect("ndjson line parses");
+            r.get("val").and_then(|v| v.as_i64()).expect("val")
+        })
+        .collect();
+    assert_eq!(vals, vec![1, 2, 3, 4, 5, 6]);
+}
+
+/// The `max_expansion` cap is cumulative across nesting levels: nested
+/// `emit each` charges every leaf record against one budget, so a deep
+/// fan-out that overflows in aggregate routes the originating record to
+/// the DLQ even when no single level exceeds the cap.
+#[test]
+fn nested_emit_each_cumulative_overflow_routes_to_expansion_dlq() {
+    let yaml = r#"
+pipeline:
+  name: nested_overflow
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: json
+      options:
+        format: ndjson
+      path: rows.ndjson
+      schema:
+        - { name: groups, type: any }
+  - type: transform
+    name: explode
+    input: rows
+    config:
+      max_expansion: 5
+      cxl: |
+        emit each g in groups {
+          emit each it in g {
+            emit val = it
+          }
+        }
+  - type: output
+    name: out
+    input: explode
+    config:
+      name: out
+      type: json
+      options:
+        format: ndjson
+      path: out.json
+"#;
+    // Three groups of two = six leaves; a cap of 5 trips on the sixth.
+    let payload = br#"{"groups":[[1,2],[3,4],[5,6]]}
+"#;
+    let (report, _output) = run_with_payload(yaml, "rows.ndjson", payload);
+    let saw_expansion = report
+        .dlq_entries
+        .iter()
+        .any(|e| e.category.as_str() == "expansion_limit_exceeded");
+    assert!(
+        saw_expansion,
+        "cumulative nesting overflow must route to expansion_limit_exceeded: {:#?}",
+        report.dlq_entries
+    );
+}
+
 /// `max_expansion` (set on `TransformBody`) caps the cumulative number
 /// of records `emit each` can produce from a single original input. On
 /// exceed, the originating record routes to the DLQ with category

--- a/crates/clinker-exec/tests/nested_envelope_test.rs
+++ b/crates/clinker-exec/tests/nested_envelope_test.rs
@@ -1,0 +1,465 @@
+//! Multi-level (nested) envelope ingestion driven through the full
+//! source-ingest driver stack.
+//!
+//! A reader signals nested envelope boundaries via
+//! [`clinker_format::EnvelopeEvent`] as it crosses them; the ingest
+//! driver maps each `OpenLevel` to a child `DocumentContext` (its sections
+//! layered as siblings over the enclosing levels) and a `DocumentOpen`
+//! punctuation, and each `CloseLevel` to the matching `DocumentClose`. A
+//! record streamed inside the innermost level resolves every enclosing
+//! level's `$doc.<section>.<field>` through the unchanged two-level CXL
+//! lookup — distinct per-level section names keep the levels apart.
+//!
+//! These tests drive the real `drive_record_source` loop (not an isolated
+//! half) through `PipelineExecutor::run_plan_with_readers_writers`, and
+//! cover the cases that previously desynced the level stack:
+//!
+//! - a trailing envelope level that opens AND closes after the last body
+//!   record (header-only inner envelope in trailing position);
+//! - a header-only interchange — envelope structure with zero body records
+//!   — which must still open a file-level document and emit boundaries
+//!   (issue #395);
+//! - multiple files, each carrying its own nested envelopes, so a file
+//!   transition closes the prior file's whole level stack before the next
+//!   file opens.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::sync::Arc;
+
+use clinker_format::{EnvelopeEvent, FormatError};
+use clinker_record::{Record, Schema, SchemaBuilder, Value};
+use indexmap::IndexMap;
+
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, SourceInput};
+use clinker_exec::source::RecordSource;
+
+/// One scripted step a [`ScriptedReader`] performs on a `next_record`
+/// call: emit a body record, or queue an envelope boundary the driver
+/// drains around that call. A step also pins the file the reader is
+/// "currently" inside, so the multi-file driver path (file-transition
+/// stack close) is exercised.
+enum Step {
+    /// Queue an `OpenLevel` carrying one section named `name` with a
+    /// single string field `tag` = `tag_val`. The driver opens a child
+    /// document context layering this section over the enclosing levels.
+    Open {
+        file: &'static str,
+        name: &'static str,
+        tag_val: &'static str,
+    },
+    /// Queue a `CloseLevel`. The driver pops the innermost nested level.
+    Close { file: &'static str },
+    /// Emit a body record with `id` = the given integer. The record
+    /// carries the innermost open level's flattened `$doc.*` sections.
+    Record { file: &'static str, id: i64 },
+}
+
+/// A `RecordSource` that replays a fixed [`Step`] script, modeling a
+/// multi-level envelope reader. Envelope events queued by the steps
+/// processed during one `next_record` call are drained by the driver
+/// after that call (and at end-of-input) — exactly the contract a real
+/// X12 reader meets.
+struct ScriptedReader {
+    schema: Arc<Schema>,
+    steps: std::collections::VecDeque<Step>,
+    pending_events: Vec<EnvelopeEvent>,
+    current_file: Option<Arc<str>>,
+    file_arcs: HashMap<&'static str, Arc<str>>,
+}
+
+impl ScriptedReader {
+    fn new(steps: Vec<Step>) -> Self {
+        let schema = SchemaBuilder::with_capacity(1).with_field("id").build();
+        Self {
+            schema,
+            steps: steps.into_iter().collect(),
+            pending_events: Vec::new(),
+            current_file: None,
+            file_arcs: HashMap::new(),
+        }
+    }
+
+    /// Resolve (and cache) the stable `Arc<str>` identity for a file name
+    /// so the driver's `Arc::ptr_eq` file-transition check sees one
+    /// pointer per file, the same way a real multi-file reader does.
+    fn file_arc(&mut self, file: &'static str) -> Arc<str> {
+        Arc::clone(
+            self.file_arcs
+                .entry(file)
+                .or_insert_with(|| Arc::from(file)),
+        )
+    }
+
+    fn section(name: &str, tag_val: &str) -> IndexMap<Box<str>, Value> {
+        let mut field = IndexMap::new();
+        field.insert(Box::from("tag"), Value::String(tag_val.into()));
+        let mut sections = IndexMap::new();
+        sections.insert(Box::from(name), Value::Map(Box::new(field)));
+        sections
+    }
+}
+
+impl RecordSource for ScriptedReader {
+    fn schema(&mut self) -> Result<Arc<Schema>, FormatError> {
+        Ok(Arc::clone(&self.schema))
+    }
+
+    fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
+        // Process steps until one yields a record (or the script drains).
+        // Envelope-event steps queue into `pending_events`, which the
+        // driver pulls via `take_envelope_events` after this call returns.
+        while let Some(step) = self.steps.pop_front() {
+            match step {
+                Step::Open {
+                    file,
+                    name,
+                    tag_val,
+                } => {
+                    self.current_file = Some(self.file_arc(file));
+                    self.pending_events.push(EnvelopeEvent::OpenLevel {
+                        sections: Self::section(name, tag_val),
+                    });
+                }
+                Step::Close { file } => {
+                    self.current_file = Some(self.file_arc(file));
+                    self.pending_events.push(EnvelopeEvent::CloseLevel);
+                }
+                Step::Record { file, id } => {
+                    self.current_file = Some(self.file_arc(file));
+                    return Ok(Some(Record::new(
+                        Arc::clone(&self.schema),
+                        vec![Value::Integer(id)],
+                    )));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn current_source_file(&self) -> Option<&Arc<str>> {
+        self.current_file.as_ref()
+    }
+
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+}
+
+/// A pipeline whose transform projects the three nested levels' tags onto
+/// every body record. `$doc.interchange.tag`, `$doc.group.tag`, and
+/// `$doc.transaction.tag` are read through the ordinary two-level `$doc`
+/// surface — proving the flattened-sibling representation exposes all
+/// three nesting levels without any CXL syntax change.
+const PIPELINE: &str = r#"
+pipeline:
+  name: nested_envelope
+nodes:
+  - type: source
+    name: edi
+    config:
+      name: edi
+      type: csv
+      path: placeholder.csv
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: tag
+    input: edi
+    config:
+      cxl: |
+        emit id = id
+        emit isa = $doc.interchange.tag
+        emit gs = $doc.group.tag
+        emit st = $doc.transaction.tag
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+fn run(steps: Vec<Step>) -> (clinker_exec::executor::ExecutionReport, String) {
+    let mut config = clinker_plan::config::parse_config(PIPELINE).unwrap();
+    // Pathless source: the executor drives the registered `Records`
+    // transport, never fs discovery. The reader supplies its own per-file
+    // identity through `current_source_file`.
+    for spanned in &mut config.nodes {
+        if let clinker_plan::config::PipelineNode::Source { config: body, .. } = &mut spanned.value
+        {
+            body.source.path = None;
+        }
+    }
+    let plan = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("compile nested-envelope pipeline");
+
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "edi".to_string(),
+        SourceInput::Records(Box::new(ScriptedReader::new(steps))),
+    )]);
+
+    let output_buf = clinker_bench_support::io::SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(output_buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams {
+            execution_id: "nested-exec".to_string(),
+            batch_id: "nested-batch".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("drive nested-envelope source to completion");
+
+    let output = output_buf.as_string();
+    (report, output)
+}
+
+#[test]
+fn nested_levels_resolve_all_ancestor_sections_on_body_records() {
+    // ISA → GS → ST → two records → close ST → close GS → close ISA.
+    let steps = vec![
+        Step::Open {
+            file: "claim.x12",
+            name: "interchange",
+            tag_val: "ISA-1",
+        },
+        Step::Open {
+            file: "claim.x12",
+            name: "group",
+            tag_val: "GS-HC",
+        },
+        Step::Open {
+            file: "claim.x12",
+            name: "transaction",
+            tag_val: "ST-837",
+        },
+        Step::Record {
+            file: "claim.x12",
+            id: 1,
+        },
+        Step::Record {
+            file: "claim.x12",
+            id: 2,
+        },
+        Step::Close { file: "claim.x12" }, // ST
+        Step::Close { file: "claim.x12" }, // GS
+        Step::Close { file: "claim.x12" }, // ISA
+    ];
+
+    let (report, output) = run(steps);
+    assert_eq!(report.counters.total_count, 2, "two body records");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 3, "header + 2 rows; got:\n{output}");
+    // Every body record resolves all THREE nesting levels through the
+    // two-level $doc surface — the flattened-sibling representation.
+    for row in &lines[1..] {
+        assert!(
+            row.contains("ISA-1"),
+            "row missing $doc.interchange.tag: {row}"
+        );
+        assert!(row.contains("GS-HC"), "row missing $doc.group.tag: {row}");
+        assert!(
+            row.contains("ST-837"),
+            "row missing $doc.transaction.tag: {row}"
+        );
+    }
+}
+
+#[test]
+fn trailing_inner_envelope_after_last_record_does_not_desync() {
+    // The desync regression: an inner envelope that OPENS and closes after
+    // the last body record. A driver that skips trailing `OpenLevel`
+    // events at end-of-input would leave the level stack unbalanced and
+    // abort; the run must instead complete cleanly with the records it
+    // produced.
+    let steps = vec![
+        Step::Open {
+            file: "trail.x12",
+            name: "interchange",
+            tag_val: "ISA-9",
+        },
+        Step::Open {
+            file: "trail.x12",
+            name: "transaction",
+            tag_val: "ST-A",
+        },
+        Step::Record {
+            file: "trail.x12",
+            id: 10,
+        },
+        Step::Close { file: "trail.x12" }, // ST closes after its record
+        // A trailing inner envelope: opens AND closes with no body record
+        // between, after the final record of the file. This is the
+        // sequence that previously desynced the stack at EOF.
+        Step::Open {
+            file: "trail.x12",
+            name: "transaction",
+            tag_val: "ST-EMPTY",
+        },
+        Step::Close { file: "trail.x12" },
+        Step::Close { file: "trail.x12" }, // ISA
+    ];
+
+    let (report, output) = run(steps);
+    // The run completed (no abort) and emitted exactly the one real body
+    // record; the trailing empty envelope contributed none.
+    assert_eq!(report.counters.total_count, 1);
+    assert_eq!(report.counters.dlq_count, 0);
+    let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 2, "header + 1 row; got:\n{output}");
+    assert!(lines[1].contains("ISA-9"));
+    assert!(lines[1].contains("ST-A"));
+}
+
+#[test]
+fn header_only_interchange_opens_a_document_with_no_body_records() {
+    // Issue #395: a file carrying envelope structure but zero body records
+    // must still open a file-level document and emit open/close
+    // boundaries. Here the entire script is an interchange that opens and
+    // closes with nothing inside.
+    let steps = vec![
+        Step::Open {
+            file: "empty.x12",
+            name: "interchange",
+            tag_val: "ISA-EMPTY",
+        },
+        Step::Close { file: "empty.x12" },
+    ];
+
+    let (report, _output) = run(steps);
+    // Zero body records, and the run completed without aborting — the
+    // header-only interchange opened and closed its document cleanly
+    // instead of leaving the stack unbalanced.
+    assert_eq!(report.counters.total_count, 0);
+    assert_eq!(report.counters.dlq_count, 0);
+    assert_eq!(report.counters.ok_count, 0);
+}
+
+#[test]
+fn multi_file_each_with_nested_envelopes_and_a_header_only_file() {
+    // Multi-file × nested-envelope through the full driver stack: the
+    // first file carries a normal nested interchange with body records,
+    // the second is a header-only interchange (zero body). The file
+    // transition must close the first file's whole level stack before the
+    // second file opens, and the header-only second file must still frame
+    // a document.
+    let steps = vec![
+        // File a: ISA → GS → ST → 1 record → close all.
+        Step::Open {
+            file: "a.x12",
+            name: "interchange",
+            tag_val: "A-ISA",
+        },
+        Step::Open {
+            file: "a.x12",
+            name: "group",
+            tag_val: "A-GS",
+        },
+        Step::Open {
+            file: "a.x12",
+            name: "transaction",
+            tag_val: "A-ST",
+        },
+        Step::Record {
+            file: "a.x12",
+            id: 100,
+        },
+        Step::Close { file: "a.x12" }, // ST
+        Step::Close { file: "a.x12" }, // GS
+        Step::Close { file: "a.x12" }, // ISA
+        // File b: header-only interchange, no body records.
+        Step::Open {
+            file: "b.x12",
+            name: "interchange",
+            tag_val: "B-ISA",
+        },
+        Step::Close { file: "b.x12" },
+    ];
+
+    let (report, output) = run(steps);
+    assert_eq!(
+        report.counters.total_count, 1,
+        "one body record, from file a"
+    );
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 2, "header + 1 row; got:\n{output}");
+    // The single body record sees file a's three nesting levels and never
+    // file b's interchange — cross-file context never leaks.
+    assert!(lines[1].contains("A-ISA"));
+    assert!(lines[1].contains("A-GS"));
+    assert!(lines[1].contains("A-ST"));
+    assert!(
+        !lines[1].contains("B-ISA"),
+        "file b context leaked: {}",
+        lines[1]
+    );
+}
+
+#[test]
+fn second_file_record_carries_its_own_context_not_the_first_files() {
+    // Two files, each with body records inside their own interchange. The
+    // file transition must rebind every per-file document context: the
+    // second file's record must resolve its OWN interchange tag, never the
+    // first file's. This is the observable counterpart to the header-only
+    // multi-file case — a record makes the cross-file attribution visible.
+    let steps = vec![
+        Step::Open {
+            file: "a.x12",
+            name: "interchange",
+            tag_val: "A-ISA",
+        },
+        Step::Record {
+            file: "a.x12",
+            id: 1,
+        },
+        Step::Close { file: "a.x12" },
+        Step::Open {
+            file: "b.x12",
+            name: "interchange",
+            tag_val: "B-ISA",
+        },
+        Step::Record {
+            file: "b.x12",
+            id: 2,
+        },
+        Step::Close { file: "b.x12" },
+    ];
+
+    let (report, output) = run(steps);
+    assert_eq!(report.counters.total_count, 2);
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let lines: Vec<&str> = output.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 3, "header + 2 rows; got:\n{output}");
+    // CSV order follows input order: row for id=1 (file a), then id=2
+    // (file b). Each carries only its own file's interchange tag.
+    let row_a = lines[1..]
+        .iter()
+        .find(|l| l.starts_with("1,"))
+        .expect("file a row");
+    let row_b = lines[1..]
+        .iter()
+        .find(|l| l.starts_with("2,"))
+        .expect("file b row");
+    assert!(
+        row_a.contains("A-ISA") && !row_a.contains("B-ISA"),
+        "{row_a}"
+    );
+    assert!(
+        row_b.contains("B-ISA") && !row_b.contains("A-ISA"),
+        "{row_b}"
+    );
+}

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_aggregate_windowed.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_aggregate_windowed.snap
@@ -34,7 +34,7 @@ transform.active_only:
   ordering_provenance: DestroyedByDistinct { at_node: "active_only", confidence: Proven }
   partitioning: Single
   partitioning_provenance: SingleStream
-  buffer: materialized
+  buffer: streaming
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
 aggregation.by_dept:
@@ -52,12 +52,6 @@ output.dept_totals:
   partitioning_provenance: SingleStream
   buffer: streaming
   arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
-
-=== Buffer Edges ===
-
-edge transform.active_only -> aggregation.by_dept:
-  buffer: node_buffer (slot=1)
-  arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: transform)
 
 === CXL Expressions ===
 

--- a/crates/clinker-exec/tests/streaming_arms.rs
+++ b/crates/clinker-exec/tests/streaming_arms.rs
@@ -31,6 +31,20 @@
 //! streaming handoff preserves per-document ordering end-to-end. (The
 //! substrate's trailing-`DocumentClose`-across-batch-splits invariant is
 //! pinned in isolation by `executor::batch_handoff`'s unit tests.)
+//!
+//! A second family covers the streaming-ingest *consumer*: an eligible
+//! producer streams record-at-a-time into an `Aggregate`'s `add_record`
+//! over the bounded channel rather than the Aggregate pre-draining the
+//! producer's whole output from a charged `node_buffers` slot. The
+//! producer runs inside the Aggregate's dispatch turn (its own topo turn a
+//! no-op), streaming each batch while a scoped thread drives ingest; the
+//! Aggregate finalizes on channel disconnect. These tests pin the same two
+//! properties — the producer reports `buffer: streaming` and emits no
+//! `node_buffer` edge to the Aggregate, and the aggregated value matches
+//! the materialized path — across `Source → Transform → Aggregate` and
+//! `Merge → Aggregate` shapes, plus a back-pressure regression that drives
+//! far more records than the bounded channel holds (a deadlock would hang
+//! the run rather than complete).
 
 use std::collections::HashMap;
 use std::io::{Cursor, Write};
@@ -79,10 +93,11 @@ fn properties_block(explain: &str, slug: &str) -> String {
 }
 
 /// Assert the producer named `producer_slug` is classified `streaming`
-/// and emits no charged `node_buffer` edge to `output_slug` — the
+/// and emits no charged `node_buffer` edge to `consumer_slug` — the
 /// user-observable proof that its output never crosses a spill-eligible
-/// inter-stage buffer.
-fn assert_streaming_to_output(explain: &str, producer_slug: &str, output_slug: &str) {
+/// inter-stage buffer. `consumer_slug` is any downstream sink: an
+/// `output.*` writer or an `aggregation.*` streaming-ingest consumer.
+fn assert_streaming_to_output(explain: &str, producer_slug: &str, consumer_slug: &str) {
     let block = properties_block(explain, producer_slug);
     assert!(
         block.contains("buffer: streaming"),
@@ -92,11 +107,11 @@ fn assert_streaming_to_output(explain: &str, producer_slug: &str, output_slug: &
         !block.contains("buffer: materialized"),
         "{producer_slug} must not be materialized:\n{block}"
     );
-    let edge = format!("edge {producer_slug} -> {output_slug}");
+    let edge = format!("edge {producer_slug} -> {consumer_slug}");
     assert!(
         !explain.contains(&edge),
         "a streaming {producer_slug} must emit no node_buffer edge to its \
-         Output (the whole point: no charged inter-stage slot), got:\n{explain}"
+         consumer (the whole point: no charged inter-stage slot), got:\n{explain}"
     );
 }
 
@@ -725,4 +740,295 @@ nodes:
              bled across documents through the streaming Merge handoff)"
         );
     }
+}
+
+/// A fused `Source → Transform` whose sole downstream is a (strict, hash)
+/// `Aggregate` streams record-at-a-time into the Aggregate's ingest rather
+/// than pre-draining its whole output from a charged `node_buffers` slot.
+/// The Transform reports `buffer: streaming` and emits no `node_buffer`
+/// edge to the Aggregate, and the grouped totals match the materialized
+/// path exactly. The `group_by: [dept]` keeps the aggregate on the hash
+/// strategy (no pre-sorted ordering), so this exercises the hash ingest.
+#[test]
+fn fused_transform_streams_ingest_into_aggregate() {
+    let yaml = r#"
+pipeline:
+  name: streaming_agg_ingest
+nodes:
+  - type: source
+    name: sales
+    config:
+      name: sales
+      type: csv
+      path: ./sales.csv
+      options: { has_header: true }
+      schema:
+        - { name: dept, type: string }
+        - { name: amount, type: string }
+        - { name: status, type: string }
+  - type: transform
+    name: active_only
+    input: sales
+    config:
+      cxl: |
+        filter status == "active"
+        emit dept = dept
+        emit amount = amount
+  - type: aggregate
+    name: totals
+    input: active_only
+    config:
+      group_by: [dept]
+      cxl: |
+        emit dept = dept
+        emit total = sum(amount.to_int())
+        emit n = count(*)
+  - type: output
+    name: out
+    input: totals
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let explain = explain_of(&config, &plan);
+    // The aggregate stays on the hash strategy (grouped, unsorted input).
+    assert!(
+        explain.contains("[aggregation:hash] totals"),
+        "expected a grouped aggregate over unsorted input to resolve hash, \
+         got:\n{explain}"
+    );
+    // The fused Transform streams its ingest into the Aggregate: no charged
+    // node_buffer edge crosses transform.active_only -> aggregation.totals.
+    assert_streaming_to_output(&explain, "transform.active_only", "aggregation.totals");
+
+    // a:10+30=40 (n=2), b:20+40=60 (n=2); one inactive row filtered out.
+    let csv = "dept,amount,status\n\
+        a,10,active\n\
+        b,20,active\n\
+        a,30,active\n\
+        b,40,active\n\
+        a,99,inactive\n";
+    let readers: SourceReaders = HashMap::from([(
+        "sales".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![fast_slot("sales", csv)]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("fused transform streams ingest into aggregate");
+    let mut lines = body_lines(&buf);
+    lines.sort();
+    assert_eq!(lines.len(), 2, "two groups expected: {lines:?}");
+    assert!(
+        lines.iter().any(|l| l.starts_with("a,40,2")),
+        "dept a total diverged from the materialized path: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l.starts_with("b,60,2")),
+        "dept b total diverged from the materialized path: {lines:?}"
+    );
+    assert_eq!(report.counters.dlq_count, 0);
+}
+
+/// A non-fused `Merge` (`concat` of two Transform outputs) whose sole
+/// downstream is a strict `Aggregate` streams the merged stream into the
+/// Aggregate's ingest. The Merge reports `buffer: streaming` and emits no
+/// `node_buffer` edge to the Aggregate, and the global total over both
+/// branches matches the materialized path.
+#[test]
+fn nonfused_merge_streams_ingest_into_aggregate() {
+    let yaml = r#"
+pipeline:
+  name: streaming_merge_agg_ingest
+nodes:
+  - type: source
+    name: sa
+    config:
+      name: sa
+      type: csv
+      path: ./sa.csv
+      schema:
+        - { name: amount, type: string }
+  - type: source
+    name: sb
+    config:
+      name: sb
+      type: csv
+      path: ./sb.csv
+      schema:
+        - { name: amount, type: string }
+  - type: transform
+    name: ta
+    input: sa
+    config:
+      cxl: |
+        emit amount = amount
+  - type: transform
+    name: tb
+    input: sb
+    config:
+      cxl: |
+        emit amount = amount
+  - type: merge
+    name: m
+    inputs: [ta, tb]
+    config:
+      mode: concat
+  - type: aggregate
+    name: totals
+    input: m
+    config:
+      group_by: []
+      cxl: |
+        emit total = sum(amount.to_int())
+        emit n = count(*)
+  - type: output
+    name: out
+    input: totals
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    assert_streaming_to_output(&explain_of(&config, &plan), "merge.m", "aggregation.totals");
+
+    let sa = "amount\n10\n20\n30\n";
+    let sb = "amount\n40\n50\n";
+    let readers: SourceReaders = HashMap::from([
+        (
+            "sa".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sa.csv",
+                Box::new(Cursor::new(sa.as_bytes().to_vec())),
+            ),
+        ),
+        (
+            "sb".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sb.csv",
+                Box::new(Cursor::new(sb.as_bytes().to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("non-fused merge streams ingest into aggregate");
+    let lines = body_lines(&buf);
+    assert_eq!(lines.len(), 1, "global aggregate emits one row: {lines:?}");
+    // 10+20+30+40+50 = 150 over 5 records.
+    assert!(
+        lines[0].starts_with("150,5"),
+        "merged global aggregate diverged: {}",
+        lines[0]
+    );
+    assert_eq!(report.counters.dlq_count, 0);
+}
+
+/// Streaming ingest must not deadlock under back-pressure: the producer's
+/// bounded `send` blocks when the channel fills, and the Aggregate's scoped
+/// ingest thread drains it concurrently. Drive far more records than the
+/// 256-event channel bound through a fused `Source → Transform → Aggregate`
+/// chain — a deadlock would hang the run rather than complete. The global
+/// `count` must equal every input row, and the run must finish.
+#[test]
+fn aggregate_ingest_no_deadlock_under_backpressure() {
+    const ROWS: usize = 5_000;
+    let yaml = r#"
+pipeline:
+  name: streaming_agg_ingest_backpressure
+  batch_size: 64
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: ./events.csv
+      options: { has_header: true }
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: string }
+  - type: transform
+    name: pass
+    input: events
+    config:
+      cxl: |
+        emit amount = amount
+  - type: aggregate
+    name: totals
+    input: pass
+    config:
+      group_by: []
+      cxl: |
+        emit total = sum(amount.to_int())
+        emit n = count(*)
+  - type: output
+    name: out
+    input: totals
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    assert_streaming_to_output(
+        &explain_of(&config, &plan),
+        "transform.pass",
+        "aggregation.totals",
+    );
+
+    let mut csv = String::from("id,amount\n");
+    let mut expected_total: i64 = 0;
+    for i in 1..=ROWS {
+        csv.push_str(&format!("e-{i},{i}\n"));
+        expected_total += i as i64;
+    }
+    let readers: SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![fast_slot("events", &csv)]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("streaming aggregate ingest must not deadlock under back-pressure");
+    let lines = body_lines(&buf);
+    assert_eq!(lines.len(), 1, "global aggregate emits one row: {lines:?}");
+    assert!(
+        lines[0].starts_with(&format!("{expected_total},{ROWS}")),
+        "back-pressured aggregate ingest dropped/duplicated records: {}",
+        lines[0]
+    );
+    assert_eq!(report.counters.total_count as usize, ROWS);
+    assert_eq!(report.counters.dlq_count, 0);
 }

--- a/crates/clinker-exec/tests/streaming_arms.rs
+++ b/crates/clinker-exec/tests/streaming_arms.rs
@@ -1032,3 +1032,470 @@ nodes:
     assert_eq!(report.counters.total_count as usize, ROWS);
     assert_eq!(report.counters.dlq_count, 0);
 }
+
+/// A fused `Source → Transform` whose sole downstream is the driver
+/// (probe) side of a hash build-probe `Combine` streams its records
+/// record-at-a-time into the probe rather than the Combine pre-draining
+/// the driver's whole output. The build side (`products`) stays
+/// materialized in the hash table; the driver Transform reports
+/// `buffer: streaming` and emits no `node_buffer` edge to the Combine, and
+/// the joined result matches the materialized path.
+#[test]
+fn fused_transform_streams_probe_into_combine() {
+    let yaml = r#"
+pipeline:
+  name: streaming_combine_probe
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+  - type: source
+    name: products
+    config:
+      name: products
+      type: csv
+      path: ./products.csv
+      schema:
+        - { name: product_id, type: string }
+        - { name: name, type: string }
+  - type: transform
+    name: norm
+    input: orders
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit product_id = product_id
+  - type: combine
+    name: c
+    input:
+      norm: norm
+      products: products
+    config:
+      where: "norm.product_id == products.product_id"
+      match: first
+      on_miss: skip
+      drive: norm
+      cxl: |
+        emit order_id = norm.order_id
+        emit product_name = products.name
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: c
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    // The fused Transform streams its probe into the Combine: no charged
+    // node_buffer edge from the driver Transform to the Combine.
+    assert_streaming_to_output(&explain_of(&config, &plan), "transform.norm", "combine.c");
+
+    let orders = "order_id,product_id\no1,p1\no2,p2\no3,p1\no4,p3\n";
+    let products = "product_id,name\np1,Prod1\np2,Prod2\n";
+    let readers: SourceReaders = HashMap::from([
+        (
+            "orders".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "orders.csv",
+                Box::new(Cursor::new(orders.as_bytes().to_vec())),
+            ),
+        ),
+        (
+            "products".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "products.csv",
+                Box::new(Cursor::new(products.as_bytes().to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("fused transform streams probe into combine");
+    let mut lines = body_lines(&buf);
+    lines.sort();
+    // o1->Prod1, o2->Prod2, o3->Prod1 match; o4 (p3) misses and is skipped.
+    assert_eq!(
+        lines,
+        vec!["o1,Prod1", "o2,Prod2", "o3,Prod1"],
+        "streaming combine probe diverged from the materialized join"
+    );
+    assert_eq!(report.counters.dlq_count, 0);
+}
+
+/// A non-fused `Merge` whose sole downstream is the driver (probe) side of
+/// a hash build-probe `Combine` streams the merged stream into the probe.
+/// The Merge reports `buffer: streaming` and emits no `node_buffer` edge to
+/// the Combine, and the joined result over both merged driver inputs
+/// matches the materialized path.
+#[test]
+fn nonfused_merge_streams_probe_into_combine() {
+    let yaml = r#"
+pipeline:
+  name: streaming_merge_combine_probe
+nodes:
+  - type: source
+    name: oa
+    config:
+      name: oa
+      type: csv
+      path: ./oa.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+  - type: source
+    name: ob
+    config:
+      name: ob
+      type: csv
+      path: ./ob.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+  - type: source
+    name: products
+    config:
+      name: products
+      type: csv
+      path: ./products.csv
+      schema:
+        - { name: product_id, type: string }
+        - { name: name, type: string }
+  - type: transform
+    name: ta
+    input: oa
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit product_id = product_id
+  - type: transform
+    name: tb
+    input: ob
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit product_id = product_id
+  - type: merge
+    name: m
+    inputs: [ta, tb]
+    config:
+      mode: concat
+  - type: combine
+    name: c
+    input:
+      m: m
+      products: products
+    config:
+      where: "m.product_id == products.product_id"
+      match: first
+      on_miss: skip
+      drive: m
+      cxl: |
+        emit order_id = m.order_id
+        emit product_name = products.name
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: c
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    assert_streaming_to_output(&explain_of(&config, &plan), "merge.m", "combine.c");
+
+    let oa = "order_id,product_id\no1,p1\no2,p2\n";
+    let ob = "order_id,product_id\no3,p1\no4,p3\n";
+    let products = "product_id,name\np1,Prod1\np2,Prod2\n";
+    let readers: SourceReaders = HashMap::from([
+        (
+            "oa".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "oa.csv",
+                Box::new(Cursor::new(oa.as_bytes().to_vec())),
+            ),
+        ),
+        (
+            "ob".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "ob.csv",
+                Box::new(Cursor::new(ob.as_bytes().to_vec())),
+            ),
+        ),
+        (
+            "products".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "products.csv",
+                Box::new(Cursor::new(products.as_bytes().to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("non-fused merge streams probe into combine");
+    let mut lines = body_lines(&buf);
+    lines.sort();
+    // o1->Prod1, o2->Prod2, o3->Prod1 match; o4 (p3) misses and is skipped.
+    assert_eq!(
+        lines,
+        vec!["o1,Prod1", "o2,Prod2", "o3,Prod1"],
+        "streaming merged combine probe diverged from the materialized join"
+    );
+    assert_eq!(report.counters.dlq_count, 0);
+}
+
+/// Streaming combine probe must not deadlock under back-pressure: the
+/// driver producer's bounded `send` blocks when the channel fills, and the
+/// probe consumer thread drains it concurrently — after the build side is
+/// materialized into the hash table. Drive far more driver rows than the
+/// 256-event channel bound through a fused `Source → Transform → Combine`
+/// chain; a deadlock would hang the run rather than complete. Every driver
+/// row matches the single build row, so the output row count equals the
+/// driver row count and the run must finish.
+#[test]
+fn combine_probe_no_deadlock_under_backpressure() {
+    const ROWS: usize = 5_000;
+    let yaml = r#"
+pipeline:
+  name: streaming_combine_probe_backpressure
+  batch_size: 64
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      options: { has_header: true }
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+  - type: source
+    name: products
+    config:
+      name: products
+      type: csv
+      path: ./products.csv
+      options: { has_header: true }
+      schema:
+        - { name: product_id, type: string }
+        - { name: name, type: string }
+  - type: transform
+    name: norm
+    input: orders
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit product_id = product_id
+  - type: combine
+    name: c
+    input:
+      norm: norm
+      products: products
+    config:
+      where: "norm.product_id == products.product_id"
+      match: first
+      on_miss: skip
+      drive: norm
+      cxl: |
+        emit order_id = norm.order_id
+        emit product_name = products.name
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: c
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    assert_streaming_to_output(&explain_of(&config, &plan), "transform.norm", "combine.c");
+
+    // One build row (all driver rows share product_id `p1`) so every driver
+    // row matches exactly once — the output row count equals the driver row
+    // count.
+    let products = "product_id,name\np1,Prod1\n";
+    let mut orders = String::from("order_id,product_id\n");
+    for i in 1..=ROWS {
+        orders.push_str(&format!("o-{i},p1\n"));
+    }
+    let readers: SourceReaders = HashMap::from([
+        (
+            "orders".to_string(),
+            clinker_exec::executor::SourceInput::Files(vec![fast_slot("orders", &orders)]),
+        ),
+        (
+            "products".to_string(),
+            clinker_exec::executor::SourceInput::Files(vec![fast_slot("products", products)]),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("streaming combine probe must not deadlock under back-pressure");
+    let lines = body_lines(&buf);
+    assert_eq!(
+        lines.len(),
+        ROWS,
+        "back-pressured combine probe dropped/duplicated rows"
+    );
+    assert_eq!(report.counters.dlq_count, 0);
+}
+
+/// Per-source dead-letter rewind must survive a streaming driver. A
+/// streaming-probe `Combine` whose matched body divides by zero on one
+/// driver row routes only that row to the DLQ under
+/// `error_handling: continue`, while the surviving driver rows reach the
+/// writer and the run completes. This exercises the streaming path's
+/// deferred-failure replay: the probe thread cannot touch the DLQ, so it
+/// accumulates the failure and the dispatch thread replays it through the
+/// same `dispatch_combine_output_error` rewind the materialized path uses,
+/// after merging the driver-side pre-fold snapshot floor.
+#[test]
+fn streaming_combine_probe_preserves_dlq_rewind() {
+    let yaml = r#"
+pipeline:
+  name: streaming_combine_probe_dlq
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+        - { name: qty, type: int }
+  - type: source
+    name: products
+    config:
+      name: products
+      type: csv
+      path: ./products.csv
+      schema:
+        - { name: product_id, type: string }
+        - { name: divisor, type: int }
+  - type: transform
+    name: norm
+    input: orders
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit product_id = product_id
+        emit qty = qty
+  - type: combine
+    name: c
+    input:
+      norm: norm
+      products: products
+    config:
+      where: "norm.product_id == products.product_id"
+      match: first
+      on_miss: skip
+      drive: norm
+      cxl: |
+        emit order_id = norm.order_id
+        emit ratio = norm.qty / products.divisor
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: c
+    config:
+      name: out
+      type: csv
+      path: ./out.csv
+"#;
+    let config = parse_config(yaml).expect("parse_config");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    assert_streaming_to_output(&explain_of(&config, &plan), "transform.norm", "combine.c");
+
+    // Driver `o2` matches build `p2` whose divisor is 0 → the matched body
+    // `qty / divisor` divides by zero, routing o2 to the DLQ. o1 and o3
+    // (divisor 2) survive.
+    let orders = "order_id,product_id,qty\no1,p1,10\no2,p2,20\no3,p1,30\n";
+    let products = "product_id,divisor\np1,2\np2,0\n";
+    let readers: SourceReaders = HashMap::from([
+        (
+            "orders".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "orders.csv",
+                Box::new(Cursor::new(orders.as_bytes().to_vec())),
+            ),
+        ),
+        (
+            "products".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "products.csv",
+                Box::new(Cursor::new(products.as_bytes().to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("streaming combine probe completes under continue strategy");
+    let mut lines = body_lines(&buf);
+    lines.sort();
+    // o1 -> 10/2 = 5, o3 -> 30/2 = 15 survive; o2 div-by-zero is DLQ'd.
+    assert_eq!(
+        lines,
+        vec!["o1,5", "o3,15"],
+        "surviving streaming-probe rows diverged"
+    );
+    // The matched-body failure routes two DLQ entries — the driver row
+    // (trigger) and its contributing build row (attribution) — exactly as
+    // the materialized path does via `dispatch_combine_output_error`.
+    assert_eq!(
+        report.counters.dlq_count, 2,
+        "the failing driver row and its matched build row both route to the DLQ"
+    );
+}

--- a/crates/clinker-exec/tests/x12_pipeline.rs
+++ b/crates/clinker-exec/tests/x12_pipeline.rs
@@ -1,0 +1,388 @@
+//! End-to-end X12 ingestion and round-trip.
+//!
+//! Covers: (1) an X12 source surfaces all three envelope tiers
+//! (`ISA` interchange, `GS` functional group, `ST` transaction set) as
+//! distinct `$doc` sections on every body record, proving the multi-level
+//! envelope nesting (`OpenLevel`/`CloseLevel`) flows through the executor;
+//! (2) an X12→X12 pipeline reconstructs the three-tier envelope on output
+//! and re-parses identically; (3) the `x12`+`split` combination is rejected
+//! at config time (diagnostic `E338`); (4) an `SE` count mismatch surfaces
+//! as a run failure.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// The canonical 106-byte ISA header (`*` element, `:` sub-element, `~`
+/// terminator), interchange control number `000000001`.
+const ISA: &str = "ISA*00*          *00*          *ZZ*SENDER         \
+    *ZZ*RECEIVER       *240101*1200*U*00401*000000001*0*P*:~";
+
+/// A single-group, single-set 850 purchase-order interchange. The set
+/// holds two body segments (BEG, PO1); SE claims 4 segments (ST..SE), GE
+/// claims 1 set echoing group control `1`, IEA claims 1 group echoing the
+/// ISA13 control number.
+fn purchase_order() -> String {
+    format!(
+        "{ISA}\
+        GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+        ST*850*0001~\
+        BEG*00*NE*PO12345**20240101~\
+        PO1*1*10*EA*9.99~\
+        SE*4*0001~\
+        GE*1*1~\
+        IEA*1*000000001~"
+    )
+}
+
+fn run(
+    yaml: &str,
+    source_name: &str,
+    fixture: &str,
+    file_name: &str,
+    out_name: &str,
+) -> Result<(clinker_exec::executor::ExecutionReport, String), String> {
+    let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
+    let plan = config
+        .compile(&CompileContext::default())
+        .map_err(|e| format!("compile: {e:?}"))?;
+
+    let file = FileSlot::new(
+        PathBuf::from(file_name),
+        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        source_name.to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        out_name.to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .map_err(|e| format!("run: {e:?}"))?;
+    Ok((report, buf.as_string()))
+}
+
+#[test]
+fn x12_source_surfaces_all_three_envelope_tiers() {
+    // Every body record carries the innermost (ST) document level, whose
+    // flattened sections expose all three enclosing tiers. The Transform
+    // reads one field from each tier:
+    //   ISA13 (interchange control number) via the declared `interchange`
+    //     section,
+    //   GS06 (group control number) via the reader-supplied
+    //     `functional_group` section,
+    //   ST02 (set control number) via the reader-supplied `transaction_set`
+    //     section.
+    let yaml = r#"
+pipeline:
+  name: x12_envelope
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields:
+              e13: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: e01, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit set_ref = set_ref
+        emit isa13 = $doc.interchange.e13
+        emit gs06 = $doc.functional_group.e06
+        emit st02 = $doc.transaction_set.e02
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let (report, output) =
+        run(yaml, "interchange", &purchase_order(), "po.x12", "out").expect("run x12 pipeline");
+    // Three body segments: ST, BEG, PO1. Service segments not emitted.
+    assert_eq!(report.counters.total_count, 3, "output was: {output}");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 4, "header + 3 rows; got: {output}");
+    // All three tiers resolve on every body row.
+    for row in &lines[1..] {
+        assert!(
+            row.contains("000000001"),
+            "row missing $doc.interchange.e13 (ISA13): {row}"
+        );
+        // GS06 is the group control number "1"; ST02 is the set control
+        // number "0001". Both must be present in each row.
+        assert!(
+            row.contains("0001"),
+            "row missing $doc.transaction_set.e02: {row}"
+        );
+    }
+    // First body record is the ST segment.
+    assert!(lines[1].starts_with("ST,"), "first row: {}", lines[1]);
+}
+
+#[test]
+fn x12_round_trip_reparses_identically() {
+    // Source parses X12 and writes X12, reconstructing the three-tier
+    // envelope from the echoed ISA `$doc` section plus a literal GS header.
+    // Re-parsing the output must yield the same body segments in order.
+    let yaml = r#"
+pipeline:
+  name: x12_round_trip
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields:
+              e13: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: set_type, type: string }
+        - { name: e01, type: string }
+        - { name: e02, type: string }
+        - { name: e03, type: string }
+        - { name: e04, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: x12
+      path: out.x12
+      include_unmapped: true
+      options:
+        interchange_from_doc: interchange
+        group_header: ["PO", "SENDER", "RECEIVER", "20240101", "1200", "1", "X", "004010"]
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "interchange", &purchase_order(), "po.x12", "out").expect("run round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // The reconstructed envelope echoes the original ISA control number and
+    // recomputes the SE/GE/IEA counts.
+    assert!(
+        output.starts_with(ISA),
+        "ISA echo wrong; output was: {output}"
+    );
+    assert!(
+        output.contains("SE*4*0001~"),
+        "SE recompute wrong: {output}"
+    );
+    assert!(output.contains("GE*1*1~"), "GE recompute wrong: {output}");
+    assert!(
+        output.contains("IEA*1*000000001~"),
+        "IEA control echo wrong: {output}"
+    );
+
+    // Feed the X12 output back through a second pipeline (X12 → CSV) to
+    // prove it re-parses identically: the body segment tags must round-trip
+    // in order.
+    let reparse_yaml = r#"
+pipeline:
+  name: x12_reparse
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+      include_header: false
+"#;
+    let (reparse_report, reparse_csv) =
+        run(reparse_yaml, "interchange", &output, "echo.x12", "out").expect("re-parse round-trip");
+    assert_eq!(reparse_report.counters.dlq_count, 0);
+    let tags: Vec<&str> = reparse_csv.lines().map(str::trim).collect();
+    assert_eq!(
+        tags,
+        vec!["ST", "BEG", "PO1"],
+        "round-trip body tags; x12 output was: {output}"
+    );
+}
+
+#[test]
+fn x12_multi_set_multi_group_round_trips() {
+    // A two-group interchange: the first group holds two transaction sets,
+    // the second holds one. The reader surfaces each GS/ST as a nested
+    // level; re-parsing the body tags after a round-trip through CSV
+    // confirms every body segment streams in order across all groups/sets.
+    let multi = format!(
+        "{ISA}\
+        GS*PO*S*R*20240101*1200*1*X*004010~\
+        ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~\
+        ST*850*0002~BEG*00*NE*B**20240101~SE*3*0002~\
+        GE*2*1~\
+        GS*PO*S*R*20240101*1300*2*X*004010~\
+        ST*850*0003~BEG*00*NE*C**20240101~SE*3*0003~\
+        GE*1*2~\
+        IEA*2*000000001~"
+    );
+    let yaml = r#"
+pipeline:
+  name: x12_multi
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit ref = set_ref
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+"#;
+    let (report, output) =
+        run(yaml, "interchange", &multi, "multi.x12", "out").expect("run multi-group");
+    assert_eq!(report.counters.dlq_count, 0);
+    // 3 sets × (ST + BEG) = 6 body records.
+    assert_eq!(report.counters.total_count, 6, "output was: {output}");
+    let rows: Vec<&str> = output.lines().collect();
+    // Each set's records carry that set's control number.
+    assert!(rows[0].starts_with("ST,0001"), "row 0: {}", rows[0]);
+    assert!(rows[2].starts_with("ST,0002"), "row 2: {}", rows[2]);
+    assert!(rows[4].starts_with("ST,0003"), "row 4: {}", rows[4]);
+}
+
+#[test]
+fn x12_output_with_split_is_rejected_at_config_time() {
+    // An interchange is one three-tier envelope; byte-limit splitting would
+    // finalize it mid-stream. The combination must fail config validation,
+    // not run and emit a corrupt interchange.
+    let yaml = r#"
+pipeline:
+  name: x12_split
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: x12
+      path: out.x12
+      options:
+        interchange: ["00", "          ", "00", "          ", "ZZ", "SENDER", "ZZ", "RECEIVER", "240101", "1200", "U", "00401", "000000001", "0", "P", ":"]
+        group_header: ["PO", "S", "R", "20240101", "1200", "1", "X", "004010"]
+      split:
+        max_bytes: 1024
+"#;
+    let err = parse_config(yaml).expect_err("x12 + split must fail config validation");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("E338"), "expected E338 diagnostic, got: {msg}");
+}
+
+#[test]
+fn x12_se_count_mismatch_fails_the_run() {
+    // The SE trailer claims 9 segments where the set has 3 — a
+    // truncation/corruption signal the reader surfaces as a run failure.
+    let bad = format!(
+        "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+        ST*850*0001~BEG*00*NE*A**20240101~SE*9*0001~GE*1*1~IEA*1*000000001~"
+    );
+    let yaml = r#"
+pipeline:
+  name: x12_bad_count
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let result = run(yaml, "interchange", &bad, "bad.x12", "out");
+    let err = result.expect_err("count mismatch must fail the run");
+    assert!(
+        err.contains("SE segment count mismatch") || err.contains("X12"),
+        "error should name the X12 count failure: {err}"
+    );
+}

--- a/crates/clinker-format/src/edifact/mod.rs
+++ b/crates/clinker-format/src/edifact/mod.rs
@@ -34,3 +34,42 @@ pub use writer::{EdifactWriter, EdifactWriterConfig};
 /// so it is not a user-declarable envelope field and never surfaces in
 /// CXL `$doc.<section>.<field>` typechecking.
 pub(crate) const RAW_ELEMENTS_KEY: &str = "$raw";
+
+/// Count of mandatory composite data elements that precede the
+/// interchange control reference in a `UNB` segment, per ISO 9735:
+/// S001 (syntax identifier), S002 (interchange sender), S003
+/// (interchange recipient), and S004 (date/time of preparation). The
+/// control reference (data element 0020) is the first *simple* element
+/// after this leading composite group, so its canonical wire index is
+/// this count.
+const UNB_LEADING_COMPOSITES: usize = 4;
+
+/// Locate the interchange control reference (UNB data element 0020) by
+/// its defined position in the segment structure rather than a fixed
+/// absolute index.
+///
+/// The control reference follows the four mandatory leading composite
+/// elements S001–S004 (syntax identifier, sender, recipient,
+/// date/time). In a conformant `UNB` those occupy wire indices 0–3 and
+/// the control reference sits at index 4. Real interchanges, however,
+/// carry an empty optional or placeholder element ahead of the control
+/// reference — e.g. an empty recipient-reference slot — which shifts it
+/// to a later index. Locating it at a fixed index 4 then extracts the
+/// empty padding instead, so the reader spuriously rejects an
+/// internally consistent interchange and the writer echoes the wrong
+/// element into `UNZ`.
+///
+/// Both the reader and the writer call this so the located reference is
+/// identical on read and on re-emit, keeping a round-tripped header and
+/// trailer self-consistent. The control reference 0020 is a mandatory,
+/// non-empty element, so the rule is: the first non-empty element at or
+/// after the canonical position (the count of leading composites).
+/// Returns `None` only for a degenerate header with no such element,
+/// which disables the `UNZ`-echo check rather than failing the parse.
+pub(crate) fn unb_control_reference(elements: &[String]) -> Option<&str> {
+    elements
+        .iter()
+        .skip(UNB_LEADING_COMPOSITES)
+        .map(String::as_str)
+        .find(|e| !e.is_empty())
+}

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -21,8 +21,8 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
-use crate::edifact::RAW_ELEMENTS_KEY;
 use crate::edifact::tokenizer::{ParsedSegment, SegmentTokenizer, split_segment};
+use crate::edifact::{RAW_ELEMENTS_KEY, unb_control_reference};
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::traits::FormatReader;
@@ -61,7 +61,8 @@ pub struct EdifactReader<R: Read> {
     initialized: bool,
     /// Raw `UNB` data elements, stashed at init for envelope serving.
     unb_elements: Vec<String>,
-    /// `UNB` interchange control reference (UNB element 5), echoed by
+    /// `UNB` interchange control reference (data element 0020), located
+    /// structurally after the mandatory leading composites and echoed by
     /// `UNZ` for round-trip integrity validation.
     unb_control_ref: Option<String>,
     /// State of the message currently being streamed, if any.
@@ -123,10 +124,12 @@ impl<R: Read> EdifactReader<R> {
                 parsed.tag
             )));
         }
-        // UNB control reference is data element 5 (index 4). It may be
-        // absent in degenerate fixtures; absence disables the UNZ-echo
-        // check rather than failing the parse.
-        self.unb_control_ref = parsed.elements.get(4).cloned();
+        // Locate the interchange control reference structurally — after
+        // the four mandatory leading composites — rather than at a fixed
+        // index, so an empty optional element ahead of it does not cause
+        // the wrong element to be read. Absence in a degenerate header
+        // disables the UNZ-echo check rather than failing the parse.
+        self.unb_control_ref = unb_control_reference(&parsed.elements).map(str::to_owned);
         self.unb_elements = parsed.elements;
         Ok(())
     }
@@ -592,6 +595,39 @@ mod tests {
             match r.next_record() {
                 Ok(Some(_)) => continue,
                 Ok(None) => panic!("expected control ref mismatch"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("does not echo the UNB")));
+    }
+
+    #[test]
+    fn unb_control_ref_located_past_empty_padding_element_validates() {
+        // The UNB carries an empty optional element (index 4) ahead of
+        // the control reference, shifting "REF1" to index 5. A fixed
+        // index-4 lookup reads the empty padding and spuriously rejects
+        // this internally consistent interchange (UNZ correctly echoes
+        // "REF1"); the structural locator finds the real reference.
+        let data = "UNB+UNOA:1+S+R+240101:1200++REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF1'";
+        let recs = collect(data);
+        // One body BGM record streams; no spurious control-ref rejection.
+        assert_eq!(recs.len(), 2); // UNH, BGM
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("BGM".into())));
+    }
+
+    #[test]
+    fn shifted_control_ref_still_rejects_genuine_unz_mismatch() {
+        // With the control reference shifted to index 5 by empty padding,
+        // a UNZ that does *not* echo it must still be rejected — the
+        // structural locator must not weaken the echo check.
+        let data = "UNB+UNOA:1+S+R+240101:1200++REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+WRONGREF'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected control ref mismatch for shifted reference"),
                 Err(e) => break e,
             }
         };

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -24,8 +24,8 @@ use std::sync::Arc;
 
 use clinker_record::{Record, Schema, Value};
 
-use crate::edifact::RAW_ELEMENTS_KEY;
 use crate::edifact::tokenizer::Delimiters;
+use crate::edifact::{RAW_ELEMENTS_KEY, unb_control_reference};
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
 
@@ -167,9 +167,14 @@ impl<W: Write> EdifactWriter<W> {
         }
 
         let unb_elements = self.resolve_unb_elements(record)?;
-        // The UNB control reference (element 5, index 4) is echoed in
-        // the UNZ trailer; default to empty when the header is short.
-        self.unb_control_ref = unb_elements.get(4).cloned().unwrap_or_default();
+        // Echo the same control reference into the UNZ trailer that the
+        // reader validates against, located structurally (after the
+        // mandatory leading composites) so an empty optional element in
+        // the header does not push the trailer out of sync with it.
+        // Default to empty when the header carries no control reference.
+        self.unb_control_ref = unb_control_reference(&unb_elements)
+            .unwrap_or_default()
+            .to_owned();
         self.write_segment("UNB", &unb_elements)?;
         Ok(())
     }
@@ -657,6 +662,53 @@ mod tests {
         // reference (the 5th data element, index 4) and is self-consistent
         // with the reconstructed UNB, so a re-read validates.
         assert!(out.contains("UNZ+1+240101:1200'"), "{out}");
+    }
+
+    #[test]
+    fn unz_echoes_control_ref_shifted_past_empty_padding() {
+        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use indexmap::IndexMap;
+
+        // A UNB with all four mandatory leading composites populated plus
+        // an empty optional element (index 4) ahead of the control
+        // reference, which shifts "REF1" to index 5. A fixed index-4
+        // echo would emit the empty padding into UNZ, producing a trailer
+        // that contradicts its own header; the structural locator echoes
+        // the real reference so the output validates on re-read.
+        let s = schema();
+        let raw = RecVal::Array(vec![
+            RecVal::String("UNOA:1".into()),
+            RecVal::String("S".into()),
+            RecVal::String("R".into()),
+            RecVal::String("240101:1200".into()),
+            RecVal::String("".into()),
+            RecVal::String("REF1".into()),
+        ]);
+        let mut unb: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        unb.insert(super::RAW_ELEMENTS_KEY.into(), raw);
+        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        sections.insert("unb".into(), RecVal::Map(Box::new(unb)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
+        record.set_doc_ctx(ctx);
+
+        let cfg = EdifactWriterConfig {
+            interchange_from_doc: Some("unb".into()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[record], &s);
+        assert!(
+            out.starts_with("UNB+UNOA:1+S+R+240101:1200++REF1'"),
+            "UNB header not reconstructed verbatim: {out}"
+        );
+        // UNZ echoes the structurally-located control reference, not the
+        // empty padding at index 4, so the trailer matches its header.
+        assert!(out.contains("UNZ+1+REF1'"), "{out}");
     }
 
     #[test]

--- a/crates/clinker-format/src/envelope.rs
+++ b/crates/clinker-format/src/envelope.rs
@@ -19,6 +19,40 @@ use clinker_record::{
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
+/// A reader-driven envelope-nesting signal, queued by a multi-level
+/// format reader and drained by the source ingest driver after each
+/// `next_record`.
+///
+/// Single-level envelope formats (XML, JSON, EDIFACT) never produce
+/// these — their whole document is one `prepare_document` pre-scan, so
+/// the driver opens exactly one document per file. Multi-level formats
+/// (EDI X12 ISA → GS → ST) cross envelope boundaries *mid-file*: the
+/// reader emits `OpenLevel` when it enters a nested envelope and
+/// `CloseLevel` when it leaves one. The driver maps each `OpenLevel` to a
+/// child [`clinker_record::DocumentContext`] (carrying the level's
+/// extracted sections, layered as siblings over the enclosing levels) and
+/// a `DocumentOpen` punctuation, and each `CloseLevel` to the matching
+/// `DocumentClose`.
+///
+/// Events are inline with the record stream, not an out-of-band channel:
+/// the driver drains them in arrival order relative to records, so a
+/// level opens before the records inside it and closes after them. A
+/// trailing `OpenLevel`/`CloseLevel` pair with no records between (a
+/// header-only inner envelope, or a header-only interchange) is a
+/// legitimate, balanced shape the driver applies in full — it must not be
+/// skipped at end-of-input.
+#[derive(Debug, Clone)]
+pub enum EnvelopeEvent {
+    /// Enter a nested envelope level, carrying the sections the reader
+    /// extracted for it (already coerced to their declared field types,
+    /// keyed by user-declared section name). The driver opens a child
+    /// document context whose sections layer over the enclosing levels.
+    OpenLevel { sections: IndexMap<Box<str>, Value> },
+    /// Leave the innermost open nested envelope level. The driver closes
+    /// the matching document context.
+    CloseLevel,
+}
+
 /// Configuration for one source's envelope sections.
 ///
 /// Section keys are user-chosen identifiers — the engine reserves

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -17,6 +17,12 @@ pub enum FormatError {
     /// constraint (bad UNA, UNT/UNZ count mismatch, control-ref echo
     /// mismatch, truncation, unsupported UNG/UNE grouping).
     Edifact(String),
+    /// An X12 parse, envelope-count, or malformed-segment failure. Carries
+    /// a precise message naming the offending control segment or
+    /// constraint (truncated ISA header, SE/GE/IEA count mismatch,
+    /// control-number echo mismatch, truncation, a delimiter byte in data
+    /// that X12 cannot escape).
+    X12(String),
     InvalidRecord {
         row: u64,
         message: String,
@@ -61,6 +67,7 @@ impl fmt::Display for FormatError {
             Self::Xml(msg) => write!(f, "XML error: {msg}"),
             Self::FixedWidth(msg) => write!(f, "fixed-width error: {msg}"),
             Self::Edifact(msg) => write!(f, "EDIFACT error: {msg}"),
+            Self::X12(msg) => write!(f, "X12 error: {msg}"),
             Self::InvalidRecord { row, message } => {
                 write!(f, "invalid record at row {row}: {message}")
             }

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -11,6 +11,8 @@ pub mod traits;
 pub mod xml;
 
 pub use counting::{CountedFormatWriter, CountingWriter, SharedByteCounter};
-pub use envelope::{EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection};
+pub use envelope::{
+    EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection,
+};
 pub use error::FormatError;
 pub use traits::{FormatReader, FormatWriter};

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -8,6 +8,7 @@ pub mod fixed_width;
 pub mod json;
 pub mod splitting;
 pub mod traits;
+pub mod x12;
 pub mod xml;
 
 pub use counting::{CountedFormatWriter, CountingWriter, SharedByteCounter};

--- a/crates/clinker-format/src/traits.rs
+++ b/crates/clinker-format/src/traits.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
-use crate::envelope::EnvelopeConfig;
+use crate::envelope::{EnvelopeConfig, EnvelopeEvent};
 use crate::error::FormatError;
 
 /// Streaming record reader. Yields records one at a time.
@@ -46,6 +46,25 @@ pub trait FormatReader: Send {
         _config: &EnvelopeConfig,
     ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
         Ok(IndexMap::new())
+    }
+
+    /// Drain the envelope-nesting events the reader queued while serving
+    /// the most recent `next_record` (or its end-of-input transition).
+    /// The source ingest driver polls this after every `next_record` and
+    /// once more at end-of-input, applying each [`EnvelopeEvent`] to its
+    /// document-level stack — `OpenLevel` opens a nested document context,
+    /// `CloseLevel` closes the innermost.
+    ///
+    /// Default impl returns an empty `Vec` — single-level envelope formats
+    /// (CSV, fixed-width, XML, JSON, EDIFACT) never nest mid-file, so they
+    /// open exactly one document per file via `prepare_document` and never
+    /// queue an event. Multi-level formats (EDI X12 ISA/GS/ST) override
+    /// this to surface their envelope boundaries. Wrappers holding an
+    /// inner reader (`CoercingReader`, `MultiFileFormatReader`,
+    /// `TakeReader`) must delegate so a nested-envelope source streamed
+    /// through them keeps emitting boundaries.
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        Vec::new()
     }
 }
 

--- a/crates/clinker-format/src/x12/mod.rs
+++ b/crates/clinker-format/src/x12/mod.rs
@@ -1,0 +1,44 @@
+//! ANSI ASC X12 reader/writer pair.
+//!
+//! X12 is a flat, delimiter-structured interchange format with a
+//! three-tier envelope: an `ISA..IEA` interchange wraps one or more
+//! `GS..GE` functional groups, each of which wraps one or more `ST..SE`
+//! transaction sets. Unlike EDIFACT's optional `UNA`, X12 declares its
+//! delimiters in a fixed-length 106-byte `ISA` header — the element
+//! separator is the byte after the `ISA` tag, the sub-element separator is
+//! `ISA16`, and the segment terminator is the byte after `ISA16`. X12 has
+//! no release/escape character.
+//!
+//! This module maps one body segment to one [`crate::traits::FormatReader`]
+//! record under a static positional schema (`seg_id`, `set_ref`,
+//! `set_type`, `e01..`). Service segments (`ISA`/`IEA`/`GS`/`GE`/`ST`/`SE`)
+//! are consumed by the reader to validate control counts inline and drive
+//! the three-level envelope; they are never emitted as body records. The
+//! writer mirrors this, reconstructing the three envelope tiers around
+//! emitted records and recomputing every control count.
+//!
+//! The three envelope tiers surface as nested document-context levels via
+//! the multi-level envelope events introduced in the engine's document
+//! context: the `ISA` interchange is the file-level document (extracted in
+//! the one-time pre-scan), and each `GS` group and `ST` set opens a nested
+//! level whose `$doc` sections layer over the enclosing tiers. The X12
+//! reader is the first producer of these nested-envelope events.
+//!
+//! Memory model: only the interchange header is pre-scanned and retained
+//! (so `$doc` envelope sections over `ISA` cost O(ISA)); the body streams
+//! one segment at a time. The whole interchange is never buffered.
+
+pub mod reader;
+mod tokenizer;
+pub mod writer;
+
+pub use reader::{X12Reader, X12ReaderConfig};
+pub use writer::{X12Writer, X12WriterConfig};
+
+/// Engine-internal key under which the reader stashes the complete,
+/// ordered `ISA` data-element list in a `$doc` envelope section, for
+/// lossless writer reconstruction via `interchange_from_doc`. The `$`
+/// prefix marks it as engine-namespaced so it is not a user-declarable
+/// envelope field and never surfaces in CXL `$doc.<section>.<field>`
+/// typechecking.
+pub(crate) const RAW_ELEMENTS_KEY: &str = "$raw";

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -1,0 +1,1001 @@
+//! ANSI ASC X12 interchange reader.
+//!
+//! Streaming, row-at-a-time: each non-service segment of an interchange
+//! becomes one [`Record`] with a static positional schema
+//! `[seg_id, set_ref, set_type, e01..e<max>]`. Service segments
+//! (`ISA`/`IEA`/`GS`/`GE`/`SE`) are consumed by the reader to drive the
+//! three-tier envelope and inline structural validation; the `ST` segment
+//! that opens a transaction set **is** emitted as a body record. Service
+//! segments are never emitted.
+//!
+//! The three envelope tiers map onto nested document-context levels: the
+//! `ISA` interchange is the file-level document served by
+//! [`FormatReader::prepare_document`], and each `GS` functional group and
+//! `ST` transaction set opens a nested level via [`EnvelopeEvent`] the
+//! source ingest driver drains after each `next_record`. A `GS` queues an
+//! `OpenLevel` carrying the group's `$doc` sections; an `ST` queues a
+//! nested `OpenLevel`; an `SE` queues `CloseLevel` (transaction set) and a
+//! `GE` queues `CloseLevel` (functional group). The `ISA`-level close is
+//! the driver's end-of-input / file-transition sweep.
+//!
+//! Memory model: only the interchange header (`ISA`) is pre-scanned and
+//! retained, so `prepare_document` exposes the `ISA` control fields as a
+//! `$doc` section with O(ISA) held memory. The body streams one segment at
+//! a time — the whole interchange is never buffered. Trailer control
+//! counts (`SE`/`GE`/`IEA`) are validated as they arrive, not surfaced as
+//! envelope sections, because they follow the body they close.
+
+use std::io::{BufReader, Read};
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+use indexmap::IndexMap;
+
+use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, coerce_section_fields};
+use crate::error::FormatError;
+use crate::traits::FormatReader;
+use crate::x12::RAW_ELEMENTS_KEY;
+use crate::x12::tokenizer::{ParsedSegment, SegmentTokenizer, split_isa, split_segment};
+
+/// Default ceiling on the number of positional element columns the record
+/// schema exposes. A segment carrying more data elements than this errors
+/// with guidance rather than silently truncating.
+const DEFAULT_MAX_ELEMENTS: usize = 32;
+
+/// The envelope segment tags `prepare_document` can extract as `$doc`
+/// sections. Only the interchange header `ISA` is resolvable from the
+/// bounded header pre-scan; `GS` and `ST` headers arrive mid-body and
+/// surface as nested document levels instead.
+const ISA_TAG: &str = "ISA";
+
+/// Configuration for the X12 reader.
+pub struct X12ReaderConfig {
+    /// Number of positional `eNN` element columns on the record schema. A
+    /// body segment with more data elements than this is rejected.
+    pub max_elements: usize,
+}
+
+impl Default for X12ReaderConfig {
+    fn default() -> Self {
+        Self {
+            max_elements: DEFAULT_MAX_ELEMENTS,
+        }
+    }
+}
+
+/// Streaming X12 interchange reader.
+///
+/// Holds the tokenizer, the static positional schema, the inline
+/// envelope-validation state for all three tiers, and the queue of
+/// nested-envelope events the source ingest driver drains after each
+/// `next_record`. The `ISA` elements are stashed at initialization so
+/// [`FormatReader::prepare_document`] can serve an `ISA` envelope section
+/// without re-reading the source.
+pub struct X12Reader<R: Read> {
+    tokenizer: SegmentTokenizer<BufReader<R>>,
+    schema: Arc<Schema>,
+    max_elements: usize,
+    initialized: bool,
+    /// Raw `ISA` data elements, stashed at init for envelope serving.
+    isa_elements: Vec<String>,
+    /// `ISA13` interchange control number, echoed by `IEA02`.
+    isa_control_number: Option<String>,
+    /// State of the functional group currently open, if any.
+    open_group: Option<OpenGroup>,
+    /// State of the transaction set currently streaming, if any.
+    open_set: Option<OpenSet>,
+    /// Count of `GS` groups seen, checked against `IEA01`.
+    group_count: u64,
+    /// `true` once `IEA` has been consumed; any further segment is an
+    /// after-trailer-content error.
+    interchange_closed: bool,
+    /// Nested-envelope events queued during the most recent `next_record`,
+    /// drained by the driver via [`FormatReader::take_envelope_events`].
+    pending_events: Vec<EnvelopeEvent>,
+    done: bool,
+}
+
+/// Per-group validation state for the functional group currently open.
+struct OpenGroup {
+    /// `GS06` group control number, echoed by `GE02`.
+    control_number: String,
+    /// Count of transaction sets (`ST`) seen in this group, checked
+    /// against the `GE01` transaction-set count.
+    set_count: u64,
+}
+
+/// Per-set validation state for the transaction set currently streaming.
+struct OpenSet {
+    /// `ST02` transaction set control number, echoed by `SE02`.
+    control_number: String,
+    /// `ST01` transaction set identifier code (e.g. `850`), stamped on
+    /// every record of the set as `set_type`.
+    set_type: String,
+    /// Count of segments in this set including `ST` (and, at close, `SE`),
+    /// checked against the `SE01` segment count.
+    segment_count: u64,
+}
+
+impl<R: Read> X12Reader<R> {
+    /// Build a reader over any `Read` source with the given element-width
+    /// configuration. Delimiter discovery and `ISA` consumption are
+    /// deferred to the first read.
+    pub fn new(reader: R, config: X12ReaderConfig) -> Self {
+        let schema = build_schema(config.max_elements);
+        Self {
+            tokenizer: SegmentTokenizer::new(BufReader::new(reader)),
+            schema,
+            max_elements: config.max_elements,
+            initialized: false,
+            isa_elements: Vec::new(),
+            isa_control_number: None,
+            open_group: None,
+            open_set: None,
+            group_count: 0,
+            interchange_closed: false,
+            pending_events: Vec::new(),
+            done: false,
+        }
+    }
+
+    /// Consume the fixed 106-byte `ISA` header, stashing the interchange
+    /// control number (`ISA13`) and the `ISA` data elements for envelope
+    /// serving. Idempotent.
+    fn ensure_initialized(&mut self) -> Result<(), FormatError> {
+        if self.initialized {
+            return Ok(());
+        }
+        self.initialized = true;
+
+        let header = self.tokenizer.read_isa_header()?;
+        let delims = self.tokenizer.delimiters();
+        let parsed = split_isa(&header, &delims);
+        // ISA13 (the interchange control number) is element index 12. It
+        // is located structurally — the 13th element of the split header —
+        // not by absolute byte offset, so producer padding quirks do not
+        // misalign it.
+        self.isa_control_number = parsed.elements.get(12).cloned();
+        self.isa_elements = parsed.elements;
+        Ok(())
+    }
+
+    /// Pull the next service-or-body segment and advance the three-tier
+    /// envelope state. Returns the body record to emit, or `None` at clean
+    /// interchange end. Service segments are consumed transparently (the
+    /// loop continues) so the caller only ever sees body records; envelope
+    /// boundaries crossed on the way are queued for the driver.
+    fn pull_next(&mut self) -> Result<Option<Record>, FormatError> {
+        loop {
+            let raw = match self.tokenizer.next_segment()? {
+                Some(s) => s,
+                None => {
+                    if !self.interchange_closed {
+                        return Err(FormatError::X12(
+                            "interchange truncated: reached end of input with no IEA trailer"
+                                .into(),
+                        ));
+                    }
+                    self.done = true;
+                    return Ok(None);
+                }
+            };
+            let delims = self.tokenizer.delimiters();
+            let segment = split_segment(&raw, &delims);
+
+            if self.interchange_closed {
+                return Err(FormatError::X12(format!(
+                    "segment {:?} found after the IEA interchange trailer; \
+                     content past IEA is not permitted",
+                    segment.tag
+                )));
+            }
+
+            match segment.tag.as_str() {
+                "ISA" => {
+                    return Err(FormatError::X12(
+                        "a second ISA segment appeared; nested or repeated interchanges \
+                         in one stream are not supported"
+                            .into(),
+                    ));
+                }
+                "GS" => {
+                    self.open_functional_group(&segment)?;
+                    // GS opens a nested level — queue the OpenLevel and
+                    // continue to the first body segment (the ST).
+                }
+                "GE" => {
+                    self.close_functional_group(&segment)?;
+                    // GE is a service segment — consume and continue.
+                }
+                "ST" => {
+                    self.open_transaction_set(&segment)?;
+                    let record = self.body_record(&segment)?;
+                    return Ok(Some(record));
+                }
+                "SE" => {
+                    self.close_transaction_set(&segment)?;
+                    // SE is a service segment — consume and continue.
+                }
+                "IEA" => {
+                    self.close_interchange(&segment)?;
+                    // IEA is a service segment — consume and continue to
+                    // the EOF check on the next loop turn.
+                }
+                _ => {
+                    let set = self.open_set.as_mut().ok_or_else(|| {
+                        FormatError::X12(format!(
+                            "body segment {:?} appeared outside any ST..SE transaction set",
+                            segment.tag
+                        ))
+                    })?;
+                    set.segment_count += 1;
+                    let record = self.body_record(&segment)?;
+                    return Ok(Some(record));
+                }
+            }
+        }
+    }
+
+    /// Open a functional group on a `GS` segment, queuing the group's
+    /// `OpenLevel` so the driver opens a nested document context. `GS06`
+    /// (element index 5) is the group control number echoed by `GE02`.
+    fn open_functional_group(&mut self, gs: &ParsedSegment) -> Result<(), FormatError> {
+        if self.open_group.is_some() {
+            return Err(FormatError::X12(
+                "GS opened a new functional group before the previous group's GE trailer; \
+                 groups must be GS..GE balanced"
+                    .into(),
+            ));
+        }
+        let control_number = gs.elements.get(5).cloned().unwrap_or_default();
+        self.open_group = Some(OpenGroup {
+            control_number,
+            set_count: 0,
+        });
+        self.group_count += 1;
+        self.pending_events.push(EnvelopeEvent::OpenLevel {
+            sections: group_sections(gs),
+        });
+        Ok(())
+    }
+
+    /// Validate and close the open functional group against its `GE`
+    /// trailer, queuing a `CloseLevel`. `GE01` (element index 0) is the
+    /// transaction-set count; `GE02` (element index 1) echoes the `GS06`
+    /// group control number.
+    fn close_functional_group(&mut self, ge: &ParsedSegment) -> Result<(), FormatError> {
+        if self.open_set.is_some() {
+            return Err(FormatError::X12(
+                "GE functional-group trailer arrived before the last transaction set's SE".into(),
+            ));
+        }
+        let group = self.open_group.take().ok_or_else(|| {
+            FormatError::X12("GE trailer with no open GS functional group".into())
+        })?;
+        let claimed = parse_count(ge.elements.first(), "GE", "transaction-set count")?;
+        if claimed != group.set_count {
+            return Err(FormatError::X12(format!(
+                "GE transaction-set count mismatch for group {:?}: trailer claims {claimed}, \
+                 group contains {} transaction sets",
+                group.control_number, group.set_count
+            )));
+        }
+        let echoed = ge.elements.get(1).map(|s| s.as_str()).unwrap_or("");
+        if echoed != group.control_number {
+            return Err(FormatError::X12(format!(
+                "GE group control number {echoed:?} does not echo the GS06 control number {:?}",
+                group.control_number
+            )));
+        }
+        self.pending_events.push(EnvelopeEvent::CloseLevel);
+        Ok(())
+    }
+
+    /// Open a transaction set on an `ST` segment, queuing a nested
+    /// `OpenLevel`. `ST01` (element index 0) is the set identifier code
+    /// (`set_type`); `ST02` (element index 1) is the set control number
+    /// echoed by `SE02`.
+    fn open_transaction_set(&mut self, st: &ParsedSegment) -> Result<(), FormatError> {
+        if self.open_group.is_none() {
+            return Err(FormatError::X12(
+                "ST transaction set appeared outside any GS..GE functional group".into(),
+            ));
+        }
+        if self.open_set.is_some() {
+            return Err(FormatError::X12(
+                "ST opened a new transaction set before the previous set's SE trailer; \
+                 sets must be ST..SE balanced"
+                    .into(),
+            ));
+        }
+        let set_type = st.elements.first().cloned().unwrap_or_default();
+        let control_number = st.elements.get(1).cloned().unwrap_or_default();
+        self.open_set = Some(OpenSet {
+            control_number,
+            set_type,
+            // ST counts as the first segment of the set.
+            segment_count: 1,
+        });
+        if let Some(group) = self.open_group.as_mut() {
+            group.set_count += 1;
+        }
+        self.pending_events.push(EnvelopeEvent::OpenLevel {
+            sections: set_sections(st),
+        });
+        Ok(())
+    }
+
+    /// Validate and close the open transaction set against its `SE`
+    /// trailer, queuing a `CloseLevel`. `SE01` (element index 0) is the
+    /// segment count (`ST`..`SE` inclusive); `SE02` (element index 1)
+    /// echoes the `ST02` set control number.
+    fn close_transaction_set(&mut self, se: &ParsedSegment) -> Result<(), FormatError> {
+        let set = self
+            .open_set
+            .take()
+            .ok_or_else(|| FormatError::X12("SE trailer with no open ST transaction set".into()))?;
+        let claimed = parse_count(se.elements.first(), "SE", "segment count")?;
+        // The running count tallied ST + body segments; the SE segment
+        // itself completes the count.
+        let actual = set.segment_count + 1;
+        if claimed != actual {
+            return Err(FormatError::X12(format!(
+                "SE segment count mismatch for transaction set {:?}: trailer claims {claimed}, \
+                 set contains {actual} (ST..SE inclusive)",
+                set.control_number
+            )));
+        }
+        let echoed = se.elements.get(1).map(|s| s.as_str()).unwrap_or("");
+        if echoed != set.control_number {
+            return Err(FormatError::X12(format!(
+                "SE set control number {echoed:?} does not echo the ST02 control number {:?}",
+                set.control_number
+            )));
+        }
+        self.pending_events.push(EnvelopeEvent::CloseLevel);
+        Ok(())
+    }
+
+    /// Validate and close the interchange against its `IEA` trailer.
+    /// `IEA01` (element index 0) is the functional-group count; `IEA02`
+    /// (element index 1) echoes the `ISA13` interchange control number.
+    fn close_interchange(&mut self, iea: &ParsedSegment) -> Result<(), FormatError> {
+        if self.open_group.is_some() {
+            return Err(FormatError::X12(
+                "IEA interchange trailer arrived before the last group's GE".into(),
+            ));
+        }
+        let claimed = parse_count(iea.elements.first(), "IEA", "functional-group count")?;
+        if claimed != self.group_count {
+            return Err(FormatError::X12(format!(
+                "IEA functional-group count mismatch: trailer claims {claimed}, interchange \
+                 contains {} groups",
+                self.group_count
+            )));
+        }
+        if let Some(expected) = &self.isa_control_number {
+            let echoed = iea.elements.get(1).map(|s| s.as_str()).unwrap_or("");
+            if echoed != expected {
+                return Err(FormatError::X12(format!(
+                    "IEA interchange control number {echoed:?} does not echo the ISA13 \
+                     control number {expected:?}"
+                )));
+            }
+        }
+        self.interchange_closed = true;
+        Ok(())
+    }
+
+    /// Map a parsed segment to a positional [`Record`] under the static
+    /// schema. `seg_id`, `set_ref`, and `set_type` are stamped from the
+    /// open transaction set; the data elements fill `e01..`. Absent
+    /// trailing elements stay `Value::Null`; an element count past
+    /// `max_elements` errors with guidance.
+    fn body_record(&self, segment: &ParsedSegment) -> Result<Record, FormatError> {
+        if segment.elements.len() > self.max_elements {
+            return Err(FormatError::X12(format!(
+                "segment {:?} carries {} data elements, exceeding the configured \
+                 max_elements of {}; raise the source's `max_elements` option",
+                segment.tag,
+                segment.elements.len(),
+                self.max_elements
+            )));
+        }
+        let (set_ref, set_type) = match self.open_set.as_ref() {
+            Some(set) => (set.control_number.clone(), set.set_type.clone()),
+            None => (String::new(), String::new()),
+        };
+
+        let mut values: Vec<Value> = Vec::with_capacity(3 + self.max_elements);
+        values.push(Value::String(segment.tag.as_str().into()));
+        values.push(string_or_null(&set_ref));
+        values.push(string_or_null(&set_type));
+        for i in 0..self.max_elements {
+            match segment.elements.get(i) {
+                Some(e) => values.push(string_or_null(e)),
+                None => values.push(Value::Null),
+            }
+        }
+        Ok(Record::new(Arc::clone(&self.schema), values))
+    }
+}
+
+impl<R: Read + Send> FormatReader for X12Reader<R> {
+    fn schema(&mut self) -> Result<Arc<Schema>, FormatError> {
+        Ok(Arc::clone(&self.schema))
+    }
+
+    fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
+        if self.done {
+            return Ok(None);
+        }
+        self.ensure_initialized()?;
+        self.pull_next()
+    }
+
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+
+    fn prepare_document(
+        &mut self,
+        config: &EnvelopeConfig,
+    ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
+        if config.is_empty() {
+            return Ok(IndexMap::new());
+        }
+        self.ensure_initialized()?;
+
+        let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(config.sections.len());
+        for (name, section) in &config.sections {
+            let segment_tag = match &section.extract {
+                EnvelopeExtract::Segment(tag) => tag.as_str(),
+                EnvelopeExtract::XmlPath(_) | EnvelopeExtract::JsonPointer(_) => {
+                    return Err(FormatError::X12(format!(
+                        "envelope section {name:?}: declared a non-`segment` extract \
+                         against an X12 source. Use `segment` (e.g. \
+                         `extract: {{ segment: \"ISA\" }}`) for X12 envelope sections."
+                    )));
+                }
+            };
+            if segment_tag != ISA_TAG {
+                return Err(FormatError::X12(format!(
+                    "envelope section {name:?}: segment {segment_tag:?} is not extractable \
+                     as a file-level $doc section. Only the interchange header `ISA` is \
+                     available from the header pre-scan; `GS` and `ST` headers surface as \
+                     nested document levels, and trailer segments (`SE`/`GE`/`IEA`) are \
+                     validated by the reader, not exposed as $doc fields."
+                )));
+            }
+            let raw: Vec<(String, String)> = self
+                .isa_elements
+                .iter()
+                .enumerate()
+                .map(|(i, e)| (positional_key(i), e.clone()))
+                .collect();
+            let mut typed =
+                coerce_section_fields(raw, &section.fields).map_err(FormatError::X12)?;
+            // Stash the complete, ordered ISA element list under an
+            // engine-internal key so a writer can reconstruct the header
+            // losslessly via `interchange_from_doc`. The declared `fields`
+            // drive typed CXL `$doc.<section>.<field>` access and
+            // intentionally drop empty/undeclared elements; that filtered
+            // view cannot round-trip an ISA whose elements include
+            // fixed-width blanks, so the raw list is carried alongside it.
+            let raw_elements: Vec<Value> = self
+                .isa_elements
+                .iter()
+                .map(|e| Value::String(e.as_str().into()))
+                .collect();
+            typed.insert(Box::from(RAW_ELEMENTS_KEY), Value::Array(raw_elements));
+            out.insert(Box::from(name.as_str()), Value::Map(Box::new(typed)));
+        }
+        Ok(out)
+    }
+}
+
+/// Build the `GS` functional-group `$doc` sections under a fixed
+/// `functional_group` name keyed by positional `eNN` elements.
+///
+/// A nested level surfaces its header through the document context exactly
+/// as the file-level `ISA` does, so a `$doc.functional_group.e06`
+/// reference resolves to the group control number on every record inside
+/// the group.
+fn group_sections(gs: &ParsedSegment) -> IndexMap<Box<str>, Value> {
+    positional_section("functional_group", &gs.elements)
+}
+
+/// Build the `ST` transaction-set `$doc` sections under a fixed
+/// `transaction_set` name keyed by positional `eNN` elements.
+fn set_sections(st: &ParsedSegment) -> IndexMap<Box<str>, Value> {
+    positional_section("transaction_set", &st.elements)
+}
+
+/// Build a single-named `$doc` section whose fields are the segment's
+/// positional elements (`e01`, `e02`, …). Used for the nested `GS`/`ST`
+/// levels, which carry their whole header verbatim rather than a
+/// user-declared field schema.
+fn positional_section(name: &str, elements: &[String]) -> IndexMap<Box<str>, Value> {
+    let mut fields: IndexMap<Box<str>, Value> = IndexMap::with_capacity(elements.len());
+    for (i, e) in elements.iter().enumerate() {
+        fields.insert(positional_key(i).into_boxed_str(), string_or_null(e));
+    }
+    let mut sections: IndexMap<Box<str>, Value> = IndexMap::with_capacity(1);
+    sections.insert(Box::from(name), Value::Map(Box::new(fields)));
+    sections
+}
+
+/// Parse a trailer control count, naming the segment and field on failure.
+fn parse_count(raw: Option<&String>, segment: &str, field: &str) -> Result<u64, FormatError> {
+    let text =
+        raw.ok_or_else(|| FormatError::X12(format!("{segment} missing its {field} element")))?;
+    text.trim()
+        .parse()
+        .map_err(|_| FormatError::X12(format!("{segment} {field} {text:?} is not a number")))
+}
+
+/// Build the static positional schema `[seg_id, set_ref, set_type,
+/// e01..e<max>]`. All columns are string-typed; element text is stored
+/// verbatim so the round-trip is lossless.
+fn build_schema(max_elements: usize) -> Arc<Schema> {
+    let mut columns: Vec<Box<str>> = Vec::with_capacity(3 + max_elements);
+    columns.push(Box::from("seg_id"));
+    columns.push(Box::from("set_ref"));
+    columns.push(Box::from("set_type"));
+    for i in 0..max_elements {
+        columns.push(positional_key(i).into_boxed_str());
+    }
+    Arc::new(Schema::new(columns))
+}
+
+/// Positional element column name for element index `i`: `e01`, `e02`, …
+fn positional_key(i: usize) -> String {
+    format!("e{:02}", i + 1)
+}
+
+/// Map an element string to a `Value`: empty text becomes `Null` so an
+/// absent or blank element is uniformly null at the schema slot.
+fn string_or_null(s: &str) -> Value {
+    if s.is_empty() {
+        Value::Null
+    } else {
+        Value::String(s.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{EnvelopeFieldType, EnvelopeSection};
+    use std::io::Cursor;
+
+    /// The canonical 106-byte ISA header (`*` element, `:` sub-element,
+    /// `~` terminator) with interchange control number `000000001`.
+    const ISA: &str = "ISA*00*          *00*          *ZZ*SENDER         \
+        *ZZ*RECEIVER       *240101*1200*U*00401*000000001*0*P*:~";
+
+    /// A minimal valid single-set 850 interchange: ISA, one GS..GE group
+    /// containing one ST..SE set with two body segments (BEG, PO1). SE
+    /// claims 4 segments (ST, BEG, PO1, SE); GE claims 1 set echoing
+    /// group control `1`; IEA claims 1 group echoing `000000001`.
+    fn interchange() -> String {
+        format!(
+            "{ISA}\
+            GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+            ST*850*0001~\
+            BEG*00*NE*PO12345**20240101~\
+            PO1*1*10*EA*9.99~\
+            SE*4*0001~\
+            GE*1*1~\
+            IEA*1*000000001~"
+        )
+    }
+
+    fn reader(data: &str) -> X12Reader<Cursor<Vec<u8>>> {
+        X12Reader::new(
+            Cursor::new(data.as_bytes().to_vec()),
+            X12ReaderConfig::default(),
+        )
+    }
+
+    fn collect(data: &str) -> Vec<Record> {
+        let mut r = reader(data);
+        let mut out = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            out.push(rec);
+        }
+        out
+    }
+
+    #[test]
+    fn one_record_per_body_segment_with_positional_columns() {
+        let recs = collect(&interchange());
+        // ST, BEG, PO1 are body records; ISA/GS/GE/SE/IEA are not.
+        assert_eq!(recs.len(), 3);
+        assert_eq!(recs[0].get("seg_id"), Some(&Value::String("ST".into())));
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("BEG".into())));
+        assert_eq!(recs[1].get("e01"), Some(&Value::String("00".into())));
+        assert_eq!(recs[1].get("e02"), Some(&Value::String("NE".into())));
+        assert_eq!(recs[2].get("seg_id"), Some(&Value::String("PO1".into())));
+    }
+
+    #[test]
+    fn set_ref_and_type_stamped_on_every_record() {
+        let recs = collect(&interchange());
+        for rec in &recs {
+            assert_eq!(rec.get("set_ref"), Some(&Value::String("0001".into())));
+            assert_eq!(rec.get("set_type"), Some(&Value::String("850".into())));
+        }
+    }
+
+    #[test]
+    fn service_segments_never_emitted_as_body() {
+        let recs = collect(&interchange());
+        for rec in &recs {
+            let seg = rec.get("seg_id").unwrap();
+            assert!(
+                !matches!(seg, Value::String(s) if matches!(&**s, "ISA" | "IEA" | "GS" | "GE" | "SE"))
+            );
+        }
+    }
+
+    #[test]
+    fn absent_trailing_elements_are_null() {
+        let recs = collect(&interchange());
+        // BEG has 5 elements (one empty in the middle); e06.. are null.
+        assert_eq!(recs[1].get("e06"), Some(&Value::Null));
+        // BEG element 4 is empty on the wire (PO12345**20240101), null.
+        assert_eq!(recs[1].get("e04"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn nested_envelope_events_open_group_then_set() {
+        // The driver drains events after each next_record. The first body
+        // record (ST) must be preceded by OpenLevel(group), OpenLevel(set).
+        let data = interchange();
+        let mut r = reader(&data);
+        let _first = r.next_record().unwrap().unwrap(); // ST
+        let events = r.take_envelope_events();
+        assert_eq!(events.len(), 2, "GS and ST each open one level");
+        assert!(matches!(events[0], EnvelopeEvent::OpenLevel { .. }));
+        assert!(matches!(events[1], EnvelopeEvent::OpenLevel { .. }));
+    }
+
+    #[test]
+    fn nested_envelope_events_close_set_then_group_at_end() {
+        let data = interchange();
+        let mut r = reader(&data);
+        // Drain all body records, taking events after each.
+        while r.next_record().unwrap().is_some() {
+            let _ = r.take_envelope_events();
+        }
+        // The terminal next_record crosses SE, GE, IEA — SE and GE each
+        // queue a CloseLevel (IEA's close is the driver's sweep).
+        let trailing = r.take_envelope_events();
+        assert_eq!(trailing.len(), 2, "SE and GE each close one level");
+        assert!(matches!(trailing[0], EnvelopeEvent::CloseLevel));
+        assert!(matches!(trailing[1], EnvelopeEvent::CloseLevel));
+    }
+
+    #[test]
+    fn group_section_exposes_gs_control_number() {
+        // Inspect the OpenLevel sections directly.
+        let data = interchange();
+        let mut r = reader(&data);
+        let _ = r.next_record().unwrap().unwrap();
+        let events = r.take_envelope_events();
+        let EnvelopeEvent::OpenLevel { sections } = &events[0] else {
+            panic!("expected group OpenLevel");
+        };
+        let group = match sections.get("functional_group").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // GS06 (group control number) is positional e06.
+        assert_eq!(group.get("e06"), Some(&Value::String("1".into())));
+    }
+
+    #[test]
+    fn set_section_exposes_st_fields() {
+        let data = interchange();
+        let mut r = reader(&data);
+        let _ = r.next_record().unwrap().unwrap();
+        let events = r.take_envelope_events();
+        let EnvelopeEvent::OpenLevel { sections } = &events[1] else {
+            panic!("expected set OpenLevel");
+        };
+        let set = match sections.get("transaction_set").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        assert_eq!(set.get("e01"), Some(&Value::String("850".into())));
+        assert_eq!(set.get("e02"), Some(&Value::String("0001".into())));
+    }
+
+    #[test]
+    fn multi_set_multi_group_interchange_streams_all_bodies() {
+        let data = format!(
+            "{ISA}\
+            GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~\
+            ST*850*0002~BEG*00*NE*B**20240101~SE*3*0002~\
+            GE*2*1~\
+            GS*PO*S*R*20240101*1300*2*X*004010~\
+            ST*850*0003~BEG*00*NE*C**20240101~SE*3*0003~\
+            GE*1*2~\
+            IEA*2*000000001~"
+        );
+        let recs = collect(&data);
+        // 3 sets × (ST + BEG) = 6 body records.
+        assert_eq!(recs.len(), 6);
+        assert_eq!(recs[0].get("set_ref"), Some(&Value::String("0001".into())));
+        assert_eq!(recs[2].get("set_ref"), Some(&Value::String("0002".into())));
+        assert_eq!(recs[4].get("set_ref"), Some(&Value::String("0003".into())));
+    }
+
+    #[test]
+    fn se_segment_count_mismatch_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*9*0001~GE*1*1~IEA*1*000000001~"
+        );
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("SE segment count mismatch")));
+    }
+
+    #[test]
+    fn se_ref_st_ref_mismatch_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*WRONG~GE*1*1~IEA*1*000000001~"
+        );
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("does not echo the ST02")));
+    }
+
+    #[test]
+    fn ge_set_count_mismatch_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~GE*9*1~IEA*1*000000001~"
+        );
+        let err = error_from(&data);
+        assert!(
+            matches!(err, FormatError::X12(m) if m.contains("GE transaction-set count mismatch"))
+        );
+    }
+
+    #[test]
+    fn ge_ref_gs_ref_mismatch_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~GE*1*WRONG~IEA*1*000000001~"
+        );
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("does not echo the GS06")));
+    }
+
+    #[test]
+    fn iea_group_count_mismatch_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~GE*1*1~IEA*9*000000001~"
+        );
+        let err = error_from(&data);
+        assert!(
+            matches!(err, FormatError::X12(m) if m.contains("IEA functional-group count mismatch"))
+        );
+    }
+
+    #[test]
+    fn iea_control_number_mismatch_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~GE*1*1~IEA*1*999999999~"
+        );
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("does not echo the ISA13")));
+    }
+
+    #[test]
+    fn missing_iea_at_eof_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~GE*1*1~"
+        );
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("no IEA")));
+    }
+
+    #[test]
+    fn content_after_iea_errors() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~GE*1*1~IEA*1*000000001~BEG*99~"
+        );
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("after the IEA")));
+    }
+
+    #[test]
+    fn body_segment_outside_set_errors() {
+        let data =
+            format!("{ISA}GS*PO*S*R*20240101*1200*1*X*004010~BEG*00~GE*0*1~IEA*1*000000001~");
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("outside any ST..SE")));
+    }
+
+    #[test]
+    fn st_outside_group_errors() {
+        // An ST with no enclosing GS is rejected. (GS is consumed before
+        // ST in a valid stream; here we omit it.)
+        let data = format!("{ISA}ST*850*0001~SE*2*0001~IEA*0*000000001~");
+        let err = error_from(&data);
+        assert!(matches!(err, FormatError::X12(m) if m.contains("outside any GS..GE")));
+    }
+
+    #[test]
+    fn max_elements_overflow_errors_with_guidance() {
+        let data = format!(
+            "{ISA}GS*PO*S*R*20240101*1200*1*X*004010~\
+            ST*850*0001~BEG*a*b*c*d*e~SE*3*0001~GE*1*1~IEA*1*000000001~"
+        );
+        let mut r = X12Reader::new(
+            Cursor::new(data.into_bytes()),
+            X12ReaderConfig { max_elements: 2 },
+        );
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected element overflow"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::X12(m) if m.contains("max_elements")));
+    }
+
+    fn error_from(data: &str) -> FormatError {
+        let mut r = reader(data);
+        loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected an error, got clean end"),
+                Err(e) => break e,
+            }
+        }
+    }
+
+    fn isa_section(fields: &[(&str, EnvelopeFieldType)]) -> EnvelopeConfig {
+        let mut cfg = EnvelopeConfig::default();
+        let mut field_map = IndexMap::new();
+        for (k, ty) in fields {
+            field_map.insert((*k).to_string(), *ty);
+        }
+        cfg.sections.insert(
+            "interchange".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("ISA".to_string()),
+                fields: field_map,
+            },
+        );
+        cfg
+    }
+
+    #[test]
+    fn prepare_document_extracts_isa_positional_fields_typed() {
+        let cfg = isa_section(&[("e13", EnvelopeFieldType::String)]);
+        let mut r = reader(&interchange());
+        let sections = r.prepare_document(&cfg).unwrap();
+        let interchange = match sections.get("interchange").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // ISA13 (element 13) is the interchange control number.
+        assert_eq!(
+            interchange.get("e13"),
+            Some(&Value::String("000000001".into()))
+        );
+        // Body still streams after the header pre-scan.
+        let recs: Vec<_> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(recs.len(), 3);
+    }
+
+    #[test]
+    fn prepare_document_rejects_non_isa_segment() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "group".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("GS".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(&interchange());
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("not extractable")));
+    }
+
+    #[test]
+    fn prepare_document_rejects_xml_path_extract() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "bad".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::XmlPath("/doc".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(&interchange());
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("non-`segment`")));
+    }
+
+    /// Full reader → `$doc` → writer → reader round-trip exercising the
+    /// ISA header reconstruction and the three-tier envelope rebuild.
+    #[test]
+    fn reader_doc_writer_round_trip_preserves_isa_and_structure() {
+        use crate::traits::FormatWriter;
+        use crate::x12::writer::{X12Writer, X12WriterConfig};
+        use clinker_record::{DocumentContext, DocumentId};
+
+        let input = interchange();
+
+        // 1. Read the ISA envelope section and body records.
+        let cfg = isa_section(&[("e13", EnvelopeFieldType::String)]);
+        let mut r = reader(&input);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 3); // ST, BEG, PO1
+
+        // 2. Attach the document context and re-emit through the writer.
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.x12"),
+            sections,
+        ));
+        let schema = r.schema().unwrap();
+        let out = {
+            let mut buf = Vec::new();
+            let mut w = X12Writer::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                X12WriterConfig {
+                    interchange_from_doc: Some("interchange".into()),
+                    group_header: Some(vec![
+                        "PO".into(),
+                        "SENDER".into(),
+                        "RECEIVER".into(),
+                        "20240101".into(),
+                        "1200".into(),
+                        "1".into(),
+                        "X".into(),
+                        "004010".into(),
+                    ]),
+                    segment_newline: false,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+
+        // The reconstructed interchange opens with the echoed ISA and
+        // closes with an IEA echoing its control number.
+        assert!(out.starts_with(ISA), "{out}");
+        assert!(out.contains("IEA*1*000000001~"), "{out}");
+        assert!(out.contains("ST*850*0001~"), "{out}");
+        assert!(out.contains("SE*4*0001~"), "{out}");
+        assert!(out.contains("GE*1*1~"), "{out}");
+
+        // 3. Re-read the emitted interchange: it validates and yields the
+        // same body records.
+        let recs2 = collect(&out);
+        assert_eq!(recs2.len(), 3);
+        assert_eq!(recs2[2].get("seg_id"), Some(&Value::String("PO1".into())));
+    }
+}

--- a/crates/clinker-format/src/x12/tokenizer.rs
+++ b/crates/clinker-format/src/x12/tokenizer.rs
@@ -1,0 +1,475 @@
+//! ANSI ASC X12 segment tokenizer: ISA-driven delimiter discovery and
+//! delimiter-aware splitting.
+//!
+//! An X12 interchange is a flat byte stream of segments terminated by the
+//! segment terminator. Each segment splits into a tag and data elements on
+//! the element (data) separator; an element splits into components on the
+//! sub-element (component) separator. Unlike EDIFACT, X12 declares its
+//! delimiters in a fixed-length 106-byte `ISA` header rather than an
+//! optional service-string advice, and X12 has **no** release/escape
+//! character — a data value that contains a delimiter byte is
+//! unrepresentable, so the writer rejects it rather than corrupt the
+//! interchange.
+//!
+//! Delimiter discovery reads three bytes at fixed structural positions of
+//! the ISA: the element separator is the byte immediately after the `ISA`
+//! tag (index 3), the sub-element separator is the `ISA16` byte (index
+//! 104), and the segment terminator is the byte immediately after `ISA16`
+//! (index 105). Splitting the 106-byte ISA on the discovered element
+//! separator yields the 16 ISA elements, so downstream code locates
+//! `ISA13` (the interchange control number) as the 13th element rather
+//! than by an absolute byte offset.
+//!
+//! Memory model: the tokenizer reads one segment at a time from a buffered
+//! source into a bounded scratch buffer. A hard per-segment byte cap turns
+//! a missing terminator (truncated / corrupt input) into an error rather
+//! than letting the buffer grow without limit.
+
+use std::io::{BufRead, Read};
+
+use crate::error::FormatError;
+
+/// Hard ceiling on a single segment's raw byte length. A real X12 segment
+/// is well under a kilobyte; this cap exists only so a stream with no
+/// terminator byte fails fast instead of buffering the whole file into one
+/// "segment".
+pub(crate) const MAX_SEGMENT_BYTES: usize = 64 * 1024;
+
+/// The fixed byte length of an `ISA` interchange header, terminator
+/// included. The header is read as one 106-byte slice; the three
+/// delimiters live at structural positions within it.
+pub(crate) const ISA_LEN: usize = 106;
+
+/// 0-based index of the element (data) separator within the ISA — the
+/// byte immediately following the three-character `ISA` tag.
+const ISA_ELEMENT_SEP_IDX: usize = 3;
+
+/// 0-based index of the `ISA16` sub-element (component) separator within
+/// the ISA — the last single-byte element of the header.
+const ISA_SUBELEMENT_SEP_IDX: usize = 104;
+
+/// 0-based index of the segment terminator within the ISA — the byte
+/// immediately following `ISA16`.
+const ISA_TERMINATOR_IDX: usize = 105;
+
+/// The three X12 service delimiters discovered from the fixed `ISA`
+/// header.
+///
+/// X12 has no release/escape character, so a delimiter byte appearing in
+/// data is unrepresentable; the writer rejects such a value rather than
+/// emit a structurally corrupt interchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Delimiters {
+    /// Data-element separator (between elements of a segment).
+    pub element: u8,
+    /// Sub-element / component separator (within a composite element).
+    /// Stored but never split on: element text is kept verbatim, so a
+    /// composite element rides inside one element string intact.
+    pub subelement: u8,
+    /// Segment terminator.
+    pub terminator: u8,
+}
+
+/// Streaming X12 segment reader.
+///
+/// Wraps a buffered source and yields one raw segment string at a time
+/// (terminator stripped, inter-segment CR/LF whitespace stripped). The
+/// delimiters are discovered once from the fixed 106-byte `ISA` header on
+/// the first read.
+pub(crate) struct SegmentTokenizer<R: Read> {
+    reader: R,
+    delimiters: Delimiters,
+    initialized: bool,
+}
+
+impl<R: BufRead> SegmentTokenizer<R> {
+    /// Build a tokenizer over a buffered source. Delimiter discovery is
+    /// deferred to the first [`Self::next_segment`] call so the `ISA`
+    /// header scan and the first segment read share one pass.
+    pub(crate) fn new(reader: R) -> Self {
+        Self {
+            reader,
+            // A placeholder until the ISA is read; never used because the
+            // first read initializes from the header before splitting.
+            delimiters: Delimiters {
+                element: b'*',
+                subelement: b':',
+                terminator: b'~',
+            },
+            initialized: false,
+        }
+    }
+
+    /// The active delimiter set, valid only after the first read has
+    /// resolved the `ISA` header.
+    pub(crate) fn delimiters(&self) -> Delimiters {
+        self.delimiters
+    }
+
+    /// Consume CR/LF (and surrounding spaces/tabs producers sometimes add)
+    /// between segments for readability. Stops at the first byte that
+    /// could begin a segment tag.
+    fn skip_inter_segment_whitespace(&mut self) -> Result<(), FormatError> {
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                return Ok(());
+            }
+            let mut consumed = 0;
+            for &b in buf {
+                if b == b'\r' || b == b'\n' {
+                    consumed += 1;
+                } else {
+                    break;
+                }
+            }
+            if consumed == 0 {
+                return Ok(());
+            }
+            self.reader.consume(consumed);
+        }
+    }
+
+    /// Read and consume the fixed 106-byte `ISA` header, returning its raw
+    /// bytes and resolving the delimiter set from it.
+    ///
+    /// A 106-byte `ISA` segment declares the element separator (index 3),
+    /// the sub-element separator (`ISA16`, index 104), and the segment
+    /// terminator (index 105). The header bytes are consumed, and any CR/LF
+    /// the producer wrote after the terminator is skipped so the next read
+    /// starts cleanly at the `GS`. The reader's `ensure_initialized` guards
+    /// against a second call, so this runs exactly once before any
+    /// [`Self::next_segment`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::X12`] when the stream does not begin with a
+    /// full 106-byte `ISA` header (a truncated or non-X12 stream leaves the
+    /// delimiter set undefined, so nothing downstream can be tokenized).
+    pub(crate) fn read_isa_header(&mut self) -> Result<Vec<u8>, FormatError> {
+        // Read exactly ISA_LEN bytes. `fill_buf` may return a short slice
+        // when the source delivers the header across multiple reads, so
+        // accumulate until the header is whole or the stream ends.
+        let mut header: Vec<u8> = Vec::with_capacity(ISA_LEN);
+        while header.len() < ISA_LEN {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                return Err(FormatError::X12(format!(
+                    "truncated ISA header: need {ISA_LEN} bytes at the stream start, \
+                     read {}; the interchange is empty, corrupt, or not X12",
+                    header.len()
+                )));
+            }
+            let want = ISA_LEN - header.len();
+            let take = want.min(buf.len());
+            header.extend_from_slice(&buf[..take]);
+            self.reader.consume(take);
+        }
+
+        if !header.starts_with(b"ISA") {
+            return Err(FormatError::X12(format!(
+                "interchange must begin with an ISA header, found {:?}",
+                String::from_utf8_lossy(&header[..3.min(header.len())])
+            )));
+        }
+
+        self.delimiters = Delimiters {
+            element: header[ISA_ELEMENT_SEP_IDX],
+            subelement: header[ISA_SUBELEMENT_SEP_IDX],
+            terminator: header[ISA_TERMINATOR_IDX],
+        };
+        self.initialized = true;
+        // Drop the trailing terminator (and any CR/LF a producer wrote
+        // after it) so the next read starts cleanly at GS.
+        self.skip_inter_segment_whitespace()?;
+        Ok(header)
+    }
+
+    /// Read the next raw segment (terminator-delimited), or `None` at
+    /// clean end of stream.
+    ///
+    /// The terminator byte is consumed but not returned. X12 has no
+    /// release/escape mechanism, so every terminator byte is a segment
+    /// boundary. CR/LF between segments is dropped; CR/LF inside an
+    /// element is preserved.
+    pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
+        debug_assert!(
+            self.initialized,
+            "read_isa_header must run before next_segment"
+        );
+        self.skip_inter_segment_whitespace()?;
+
+        let terminator = self.delimiters.terminator;
+        let mut raw: Vec<u8> = Vec::new();
+
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                // EOF. A non-empty pending buffer means a final segment
+                // with no terminator — truncation, not a clean end.
+                if raw.is_empty() {
+                    return Ok(None);
+                }
+                return Err(FormatError::X12(format!(
+                    "unterminated final segment ({} bytes read with no segment terminator); \
+                     the interchange is truncated",
+                    raw.len()
+                )));
+            }
+
+            let mut consumed = 0;
+            let mut finished = false;
+            for &b in buf {
+                consumed += 1;
+                if b == terminator {
+                    finished = true;
+                    break;
+                }
+                raw.push(b);
+            }
+            self.reader.consume(consumed);
+
+            if raw.len() > MAX_SEGMENT_BYTES {
+                return Err(FormatError::X12(format!(
+                    "segment exceeded the {MAX_SEGMENT_BYTES}-byte cap without a terminator; \
+                     the interchange is malformed or the segment terminator is misconfigured"
+                )));
+            }
+
+            if finished {
+                let segment = strip_edge_whitespace(&raw);
+                let text = String::from_utf8(segment).map_err(|e| {
+                    FormatError::X12(format!(
+                        "segment is not valid UTF-8: {e}. Non-UTF-8 charsets are not supported"
+                    ))
+                })?;
+                return Ok(Some(text));
+            }
+        }
+    }
+}
+
+/// Drop CR/LF that bracket a raw segment body. Interior CR/LF is left
+/// intact — only the readability newlines a producer wraps around the
+/// terminator are insignificant.
+fn strip_edge_whitespace(raw: &[u8]) -> Vec<u8> {
+    let start = raw
+        .iter()
+        .position(|&b| b != b'\r' && b != b'\n')
+        .unwrap_or(raw.len());
+    let end = raw
+        .iter()
+        .rposition(|&b| b != b'\r' && b != b'\n')
+        .map(|p| p + 1)
+        .unwrap_or(start);
+    raw[start..end].to_vec()
+}
+
+/// A parsed segment: its tag plus its data elements.
+///
+/// The sub-element (component) separator is *not* split or decoded:
+/// element text keeps it verbatim, so a composite element `A:B:C` stays
+/// one element string `"A:B:C"`. The positional element model
+/// deliberately works above component resolution. X12 has no release
+/// mechanism, so no escape decoding occurs — element text is the raw bytes
+/// between element separators.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedSegment {
+    pub tag: String,
+    pub elements: Vec<String>,
+}
+
+/// Split a raw segment string into its tag and element values on the
+/// element separator.
+///
+/// The tag is the first part; the remainder are data elements. An
+/// unescaped sub-element separator is kept verbatim (it is part of the
+/// element's internal composite structure). X12 has no release character,
+/// so every element-separator byte splits.
+pub(crate) fn split_segment(raw: &str, delims: &Delimiters) -> ParsedSegment {
+    let element = delims.element;
+    let bytes = raw.as_bytes();
+    let mut parts: Vec<String> = Vec::new();
+    let mut current: Vec<u8> = Vec::new();
+
+    for &b in bytes {
+        if b == element {
+            parts.push(bytes_to_string(&current));
+            current.clear();
+        } else {
+            current.push(b);
+        }
+    }
+    parts.push(bytes_to_string(&current));
+
+    let mut iter = parts.into_iter();
+    let tag = iter.next().unwrap_or_default();
+    let elements = iter.collect();
+    ParsedSegment { tag, elements }
+}
+
+/// Split the fixed `ISA` header bytes into the `ISA` tag plus its 16 data
+/// elements on the discovered element separator.
+///
+/// The header is split structurally (on the element separator), not by
+/// absolute byte offset, so a consumer reads `ISA13` (the interchange
+/// control number) as element index 12 regardless of any producer
+/// padding quirk — mirroring the rest of the parser's
+/// locate-by-structure discipline.
+pub(crate) fn split_isa(header: &[u8], delims: &Delimiters) -> ParsedSegment {
+    // The header's final byte is the segment terminator; trim it so the
+    // last element (ISA16) is not contaminated by it.
+    let body = if header.last() == Some(&delims.terminator) {
+        &header[..header.len() - 1]
+    } else {
+        header
+    };
+    let text = String::from_utf8_lossy(body).into_owned();
+    split_segment(&text, delims)
+}
+
+/// Reassemble interior `current` bytes into a `String`. The input is a
+/// UTF-8-validated segment slice, so this is lossless.
+fn bytes_to_string(bytes: &[u8]) -> String {
+    String::from_utf8_lossy(bytes).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// A minimal valid ISA header (default `*` element, `:` sub-element,
+    /// `~` terminator), 106 bytes, followed by a GS segment.
+    fn isa_header() -> String {
+        // Build the canonical 106-byte ISA with `*` separators and `~`
+        // terminator; the control number is "000000001".
+        let isa = "ISA*00*          *00*          *ZZ*SENDER         \
+                   *ZZ*RECEIVER       *240101*1200*U*00401*000000001*0*P*:~";
+        assert_eq!(isa.len(), ISA_LEN, "ISA fixture must be 106 bytes");
+        isa.to_string()
+    }
+
+    fn tok(data: &[u8]) -> SegmentTokenizer<Cursor<Vec<u8>>> {
+        SegmentTokenizer::new(Cursor::new(data.to_vec()))
+    }
+
+    #[test]
+    fn isa_header_declares_delimiters() {
+        let data = format!("{}GS*PO*S*R*20240101*1200*1*X*004010~", isa_header());
+        let mut t = tok(data.as_bytes());
+        let header = t.read_isa_header().unwrap();
+        let d = t.delimiters();
+        assert_eq!(d.element, b'*');
+        assert_eq!(d.subelement, b':');
+        assert_eq!(d.terminator, b'~');
+        let parsed = split_isa(&header, &d);
+        assert_eq!(parsed.tag, "ISA");
+        assert_eq!(parsed.elements.len(), 16, "ISA carries 16 elements");
+        // ISA13 (interchange control number) is element index 12.
+        assert_eq!(parsed.elements[12], "000000001");
+        // ISA16 (the sub-element separator) is the last element.
+        assert_eq!(parsed.elements[15], ":");
+    }
+
+    #[test]
+    fn custom_delimiters_discovered_from_isa() {
+        // Element separator '|', sub-element '^', terminator '\n'. Build a
+        // 106-byte ISA using those bytes.
+        let isa = "ISA|00|          |00|          |ZZ|SENDER         \
+                   |ZZ|RECEIVER       |240101|1200|U|00401|000000001|0|P|^\n";
+        assert_eq!(isa.len(), ISA_LEN);
+        let mut t = tok(isa.as_bytes());
+        let _ = t.read_isa_header().unwrap();
+        let d = t.delimiters();
+        assert_eq!(d.element, b'|');
+        assert_eq!(d.subelement, b'^');
+        assert_eq!(d.terminator, b'\n');
+    }
+
+    #[test]
+    fn next_segment_after_isa_reads_gs() {
+        let data = format!("{}GS*PO*S*R*20240101*1200*1*X*004010~", isa_header());
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_isa_header().unwrap();
+        let gs = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&gs, &t.delimiters());
+        assert_eq!(parsed.tag, "GS");
+        assert_eq!(parsed.elements[0], "PO");
+    }
+
+    #[test]
+    fn composite_subelement_kept_verbatim() {
+        let data = format!("{}REF*ZZ*A:B:C~", isa_header());
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_isa_header().unwrap();
+        let seg = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&seg, &t.delimiters());
+        assert_eq!(parsed.tag, "REF");
+        assert_eq!(parsed.elements, vec!["ZZ".to_string(), "A:B:C".to_string()]);
+    }
+
+    #[test]
+    fn crlf_between_segments_stripped() {
+        let data = format!(
+            "{}GS*PO*S*R*20240101*1200*1*X*004010~\r\nST*850*0001~\r\n",
+            isa_header()
+        );
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_isa_header().unwrap();
+        let gs = t.next_segment().unwrap().unwrap();
+        assert!(gs.starts_with("GS*"));
+        let st = t.next_segment().unwrap().unwrap();
+        assert_eq!(st, "ST*850*0001");
+        assert!(t.next_segment().unwrap().is_none());
+    }
+
+    #[test]
+    fn truncated_isa_errors() {
+        let mut t = tok(b"ISA*00*  ");
+        let err = t.read_isa_header().unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("truncated ISA")));
+    }
+
+    #[test]
+    fn non_isa_start_errors() {
+        // 106 bytes that do not begin with ISA.
+        let data = "X".repeat(ISA_LEN);
+        let mut t = tok(data.as_bytes());
+        let err = t.read_isa_header().unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("must begin with an ISA")));
+    }
+
+    #[test]
+    fn unterminated_final_segment_errors() {
+        let data = format!("{}GS*PO*S*R*20240101*1200*1*X*004010", isa_header());
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_isa_header().unwrap();
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("truncated")));
+    }
+
+    #[test]
+    fn unterminated_segment_hits_byte_cap() {
+        let data = format!("{}{}", isa_header(), "A".repeat(MAX_SEGMENT_BYTES + 10));
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_isa_header().unwrap();
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("cap")));
+    }
+
+    #[test]
+    fn isa_split_across_buffer_boundaries() {
+        // A BufReader with a tiny capacity forces fill_buf to deliver the
+        // 106-byte header in fragments; initialization must still
+        // assemble the whole header.
+        use std::io::BufReader;
+        let data = format!("{}GS*PO*S*R*20240101*1200*1*X*004010~", isa_header());
+        let inner = Cursor::new(data.into_bytes());
+        let buffered = BufReader::with_capacity(16, inner);
+        let mut t = SegmentTokenizer::new(buffered);
+        let header = t.read_isa_header().unwrap();
+        assert_eq!(header.len(), ISA_LEN);
+        assert_eq!(t.delimiters().element, b'*');
+    }
+}

--- a/crates/clinker-format/src/x12/writer.rs
+++ b/crates/clinker-format/src/x12/writer.rs
@@ -1,0 +1,947 @@
+//! ANSI ASC X12 interchange writer.
+//!
+//! Reconstructs the three-tier interchange envelope around emitted body
+//! records: an `ISA` header (literal config elements or echoed from a
+//! `$doc` section), one `GS..GE` functional group, `ST..SE` transaction
+//! sets grouped on the `set_ref` column, and a closing `IEA`. Record
+//! columns map positionally — `seg_id` is the segment tag, `e01..` are the
+//! data elements.
+//!
+//! X12 has **no** release/escape character: a data value carrying a
+//! delimiter byte (the element separator, the sub-element separator, or
+//! the segment terminator) is unrepresentable. Rather than emit a
+//! structurally corrupt interchange, the writer rejects such a value with
+//! a precise error naming the offending column.
+//!
+//! Memory model: streaming and O(1) in held state — only the currently
+//! open transaction set's segment count, the functional group's set count,
+//! and the interchange group count are retained. `flush` is the single
+//! end-of-stream finalizer: it closes the open set, the group, and writes
+//! the `IEA` trailer with recomputed counts, exactly once. An interchange
+//! is one envelope, so byte-limit file splitting (which would flush — and
+//! thus finalize — mid-stream) is rejected for X12 outputs at
+//! config-validation time; this writer is therefore only ever flushed at
+//! true end of stream.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+
+use crate::error::FormatError;
+use crate::traits::FormatWriter;
+use crate::x12::RAW_ELEMENTS_KEY;
+use crate::x12::tokenizer::Delimiters;
+
+/// Default X12 service delimiters used when no `ISA` header dictates
+/// otherwise: `*` element, `:` sub-element, `~` terminator. When the
+/// header is echoed from a `$doc` section, its `ISA16` sub-element byte
+/// overrides the default; the literal-`interchange` path keeps these
+/// defaults.
+fn default_delimiters() -> Delimiters {
+    Delimiters {
+        element: b'*',
+        subelement: b':',
+        terminator: b'~',
+    }
+}
+
+/// Configuration for the X12 writer.
+#[derive(Clone, Default)]
+pub struct X12WriterConfig {
+    /// Literal `ISA` data elements (the 16 fixed-width ISA fields). When
+    /// set, the writer emits exactly these as the interchange header.
+    /// Takes precedence over `interchange_from_doc`.
+    pub interchange: Option<Vec<String>>,
+    /// Name of a `$doc` section to echo the `ISA` elements from (the
+    /// reader's `ISA` positional section), enabling round-trip
+    /// reconstruction. Used only when `interchange` is unset.
+    pub interchange_from_doc: Option<String>,
+    /// Literal `GS` functional-group header elements (`GS01..GS08`). The
+    /// `GS06` group control number is recomputed by the writer, so the
+    /// configured value at that position is overwritten. Required to open
+    /// a functional group.
+    pub group_header: Option<Vec<String>>,
+    /// Fallback transaction set type (`ST01`) when a record carries no
+    /// `set_type` column value.
+    pub set_type: Option<String>,
+    /// Write a newline after each segment terminator for readability. The
+    /// YAML option default is `true`, applied by the config builder; the
+    /// plain `Default` for this struct leaves it `false`, so a caller
+    /// constructing the config directly sets it explicitly.
+    pub segment_newline: bool,
+}
+
+/// Streaming X12 interchange writer.
+pub struct X12Writer<W: Write> {
+    writer: W,
+    config: X12WriterConfig,
+    delims: Delimiters,
+    /// Wire element columns keyed by the 1-based position parsed from the
+    /// column name (`e01` → 1), each paired with its schema index. The
+    /// numeric suffix — not schema-declaration order — determines the wire
+    /// slot, so a gapped (`e01, e03`) or reordered (`e02, e01`) schema maps
+    /// values to the positions the names declare, with gaps emitted as
+    /// empty elements rather than silently shifting later values left.
+    element_columns: Vec<ElementColumn>,
+    seg_id_idx: Option<usize>,
+    set_ref_idx: Option<usize>,
+    set_type_idx: Option<usize>,
+    header_written: bool,
+    finalized: bool,
+    /// `ISA13` interchange control number, echoed in the `IEA02` trailer.
+    isa_control_number: String,
+    /// `GS06` group control number for the single open functional group.
+    group_control_number: String,
+    /// Count of `ST` transaction sets written, for the `GE01` count.
+    set_count: u64,
+    /// Count of `GS` functional groups written, for the `IEA01` count.
+    group_count: u64,
+    open_set: Option<OpenSet>,
+    group_open: bool,
+}
+
+/// A schema `eNN` element column resolved to its wire position and the
+/// schema index its value is read from.
+struct ElementColumn {
+    /// 1-based wire element position parsed from the `eNN` suffix.
+    position: usize,
+    /// The column name (`e01`) — used verbatim in error messages so a
+    /// misrouted value names the exact field the user must fix.
+    name: String,
+    /// Index into the record's value list.
+    schema_index: usize,
+}
+
+/// State for the transaction set currently being written.
+struct OpenSet {
+    /// `ST02` control number echoed by `SE02`.
+    control_number: String,
+    /// Segments written so far including `ST` (the closing `SE` adds one
+    /// more when the set closes).
+    segment_count: u64,
+}
+
+impl<W: Write> X12Writer<W> {
+    /// Build a writer over a sink with the given schema and config. The
+    /// schema's `seg_id` / `set_ref` / `set_type` / `eNN` columns are
+    /// resolved to positional indices once.
+    pub fn new(writer: W, schema: Arc<Schema>, config: X12WriterConfig) -> Self {
+        let mut element_columns = Vec::new();
+        let mut seg_id_idx = None;
+        let mut set_ref_idx = None;
+        let mut set_type_idx = None;
+        for (i, col) in schema.columns().iter().enumerate() {
+            match &**col {
+                "seg_id" => seg_id_idx = Some(i),
+                "set_ref" => set_ref_idx = Some(i),
+                "set_type" => set_type_idx = Some(i),
+                name => {
+                    if let Some(position) = element_position(name) {
+                        element_columns.push(ElementColumn {
+                            position,
+                            name: name.to_string(),
+                            schema_index: i,
+                        });
+                    }
+                }
+            }
+        }
+        element_columns.sort_by_key(|c| c.position);
+        Self {
+            writer,
+            config,
+            delims: default_delimiters(),
+            element_columns,
+            seg_id_idx,
+            set_ref_idx,
+            set_type_idx,
+            header_written: false,
+            finalized: false,
+            isa_control_number: String::new(),
+            group_control_number: String::new(),
+            set_count: 0,
+            group_count: 0,
+            open_set: None,
+            group_open: false,
+        }
+    }
+
+    /// Emit the `ISA` interchange header and the `GS` functional-group
+    /// header on the first record.
+    fn write_header(&mut self, record: &Record) -> Result<(), FormatError> {
+        if self.header_written {
+            return Ok(());
+        }
+        self.header_written = true;
+
+        let isa_elements = self.resolve_isa_elements(record)?;
+        // The ISA control number (ISA13, element index 12) is echoed in
+        // the IEA trailer; default to empty when the header is short.
+        self.isa_control_number = isa_elements.get(12).cloned().unwrap_or_default();
+        // The ISA is written verbatim with the writer's element separator
+        // and terminator; its fields are fixed-width control values, never
+        // trailing-empty. ISA16 declares the sub-element separator, but the
+        // writer keeps the element separator and terminator at their
+        // defaults so the header is self-consistent on re-read.
+        self.write_segment("ISA", &isa_elements)?;
+        self.open_functional_group()?;
+        Ok(())
+    }
+
+    /// Resolve the `ISA` data elements: the literal config list wins;
+    /// otherwise echo from the named `$doc` section on the record;
+    /// otherwise a precise configuration error.
+    fn resolve_isa_elements(&self, record: &Record) -> Result<Vec<String>, FormatError> {
+        if let Some(literal) = &self.config.interchange {
+            return Ok(literal.clone());
+        }
+        if let Some(section) = &self.config.interchange_from_doc {
+            let ctx = record.doc_ctx();
+            // Preferred path: the X12 reader stashes the complete, ordered
+            // ISA element list under an engine-internal key. Reconstructing
+            // from it round-trips an ISA header faithfully without the user
+            // declaring every `eNN` field.
+            if let Some(Value::Array(raw)) = ctx.get_section_field(section, RAW_ELEMENTS_KEY) {
+                return raw
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| value_to_element(v, &format!("{section}.e{:02}", i + 1)))
+                    .collect();
+            }
+            // Fallback for a section not produced by the X12 reader (e.g.
+            // literal author-supplied `$doc` fields): walk the declared
+            // positional `e01, e02, …` keys until one is absent.
+            let mut elements: Vec<String> = Vec::new();
+            for i in 0.. {
+                let key = format!("e{:02}", i + 1);
+                match ctx.get_section_field(section, &key) {
+                    Some(v) => elements.push(value_to_element(&v, &format!("{section}.{key}"))?),
+                    None => break,
+                }
+            }
+            if elements.is_empty() {
+                return Err(FormatError::X12(format!(
+                    "interchange_from_doc names section {section:?}, but the record's \
+                     document context carries no ISA elements for it. Ensure the source \
+                     declares a `segment: \"ISA\"` envelope section of the same name."
+                )));
+            }
+            return Ok(elements);
+        }
+        Err(FormatError::X12(
+            "no interchange header configured: set the writer's `interchange` literal \
+             elements or `interchange_from_doc` section name so an ISA header can be written"
+                .into(),
+        ))
+    }
+
+    /// Open the single functional group from the configured `group_header`,
+    /// recomputing its `GS06` control number.
+    fn open_functional_group(&mut self) -> Result<(), FormatError> {
+        let header = self.config.group_header.clone().ok_or_else(|| {
+            FormatError::X12(
+                "no functional-group header configured: set the writer's `group_header` \
+                 (GS01..GS08 elements) so a GS..GE group can wrap the transaction sets"
+                    .into(),
+            )
+        })?;
+        self.group_count += 1;
+        // GS06 (element index 5) is the group control number; recompute it
+        // so it is unique per group and echoed correctly by GE.
+        self.group_control_number = self.group_count.to_string();
+        let mut gs = header;
+        set_or_push(&mut gs, 5, self.group_control_number.clone());
+        self.write_segment("GS", &gs)?;
+        self.group_open = true;
+        Ok(())
+    }
+
+    /// Map a body record to its segment tag and element list, then write
+    /// it, opening or closing `ST..SE` transaction sets on `set_ref`
+    /// transitions.
+    fn write_body_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        self.reject_unknown_columns(record)?;
+        let values = record.values();
+        let seg_id = match self.seg_id_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_element(v, "seg_id")?,
+            None => String::new(),
+        };
+        let set_ref = match self.set_ref_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_element(v, "set_ref")?,
+            None => String::new(),
+        };
+        let set_type = match self.set_type_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_element(v, "set_type")?,
+            None => String::new(),
+        };
+
+        // Service segments embedded in the record stream are skipped — the
+        // writer reconstructs envelopes itself, so an ISA/GS/ST/SE/GE/IEA
+        // body record (e.g. from an X12→X12 pipeline that emits them
+        // verbatim) must not be double-written, but still drives set
+        // grouping when it is an ST.
+        if matches!(seg_id.as_str(), "ISA" | "IEA" | "GS" | "GE" | "ST" | "SE") {
+            self.transition_set(&set_ref, &set_type)?;
+            return Ok(());
+        }
+
+        self.transition_set(&set_ref, &set_type)?;
+
+        let elements = self.record_elements(record)?;
+        self.write_segment(&seg_id, &elements)?;
+        if let Some(set) = self.open_set.as_mut() {
+            set.segment_count += 1;
+        }
+        Ok(())
+    }
+
+    /// Open a new `ST` transaction set (closing any previous one) when the
+    /// `set_ref` changes, or open the first set. A record with an empty
+    /// `set_ref` joins the current set; if none is open, it opens an
+    /// anonymous single set.
+    fn transition_set(&mut self, set_ref: &str, set_type: &str) -> Result<(), FormatError> {
+        let need_new = match &self.open_set {
+            None => true,
+            Some(open) => !set_ref.is_empty() && open.control_number != *set_ref,
+        };
+        if !need_new {
+            return Ok(());
+        }
+        self.close_open_set()?;
+
+        let resolved_type = if !set_type.is_empty() {
+            set_type.to_string()
+        } else if let Some(t) = &self.config.set_type {
+            t.clone()
+        } else {
+            return Err(FormatError::X12(
+                "cannot open an ST transaction set: the record carries no `set_type` and \
+                 the writer has no `set_type` fallback configured"
+                    .into(),
+            ));
+        };
+        let control_number = if set_ref.is_empty() {
+            format!("{:04}", self.set_count + 1)
+        } else {
+            set_ref.to_string()
+        };
+        self.write_segment("ST", &[resolved_type, control_number.clone()])?;
+        self.set_count += 1;
+        self.open_set = Some(OpenSet {
+            control_number,
+            segment_count: 1,
+        });
+        Ok(())
+    }
+
+    /// Close the open transaction set with its recomputed `SE` trailer
+    /// (segment count including `ST`+`SE`, set control-number echo).
+    fn close_open_set(&mut self) -> Result<(), FormatError> {
+        if let Some(set) = self.open_set.take() {
+            let count = set.segment_count + 1;
+            self.write_segment("SE", &[count.to_string(), set.control_number])?;
+        }
+        Ok(())
+    }
+
+    /// Close the open functional group with its recomputed `GE` trailer
+    /// (transaction-set count, group control-number echo).
+    fn close_functional_group(&mut self) -> Result<(), FormatError> {
+        if self.group_open {
+            self.group_open = false;
+            self.write_segment(
+                "GE",
+                &[
+                    self.set_count.to_string(),
+                    self.group_control_number.clone(),
+                ],
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Collect a record's `eNN` columns into wire-position order, filling
+    /// any gap left by a missing position with an empty element, then
+    /// trimming trailing empties so no fabricated delimiters appear.
+    fn record_elements(&self, record: &Record) -> Result<Vec<String>, FormatError> {
+        let values = record.values();
+        let max_position = self
+            .element_columns
+            .iter()
+            .map(|c| c.position)
+            .max()
+            .unwrap_or(0);
+        let mut elements: Vec<String> = vec![String::new(); max_position];
+        for col in &self.element_columns {
+            let text = match values.get(col.schema_index) {
+                Some(v) => value_to_element(v, &col.name)?,
+                None => String::new(),
+            };
+            // position is 1-based; slot is position-1.
+            elements[col.position - 1] = text;
+        }
+        // Trim trailing empties so no fabricated delimiters appear after the
+        // last populated element.
+        while matches!(elements.last(), Some(s) if s.is_empty()) {
+            elements.pop();
+        }
+        Ok(elements)
+    }
+
+    /// Reject a record carrying a user column the writer does not map.
+    /// Engine-namespaced columns (`$`-prefixed) are excluded from the
+    /// check and never appear in X12 output by design.
+    fn reject_unknown_columns(&self, record: &Record) -> Result<(), FormatError> {
+        for (name, _) in record.iter_user_fields() {
+            if name.starts_with('$') {
+                continue;
+            }
+            let known =
+                matches!(name, "seg_id" | "set_ref" | "set_type") || is_element_column(name);
+            if !known {
+                return Err(FormatError::X12(format!(
+                    "record column {name:?} has no X12 mapping. The writer maps only \
+                     `seg_id`, `set_ref`, `set_type`, and positional `eNN` element \
+                     columns; project the record to those before output"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Write one segment verbatim: tag, element separator, elements joined
+    /// by the element separator, terminator, optional newline.
+    ///
+    /// The caller is responsible for the element list's shape — body
+    /// records trim their trailing empties in [`Self::record_elements`]
+    /// before reaching here, while the fixed-shape `ISA` header and the
+    /// count-bearing trailers (`SE`/`GE`/`IEA`) carry no trailing empties to
+    /// trim. X12 has no escape mechanism, so an element value carrying a
+    /// delimiter byte is rejected rather than corrupting the interchange.
+    fn write_segment(&mut self, tag: &str, elements: &[String]) -> Result<(), FormatError> {
+        self.writer
+            .write_all(tag.as_bytes())
+            .map_err(FormatError::Io)?;
+        for element in elements {
+            self.reject_delimiter_in_data(element, tag)?;
+            self.writer
+                .write_all(&[self.delims.element])
+                .map_err(FormatError::Io)?;
+            self.writer
+                .write_all(element.as_bytes())
+                .map_err(FormatError::Io)?;
+        }
+        self.writer
+            .write_all(&[self.delims.terminator])
+            .map_err(FormatError::Io)?;
+        if self.config.segment_newline {
+            self.writer.write_all(b"\n").map_err(FormatError::Io)?;
+        }
+        Ok(())
+    }
+
+    /// Reject an element value that carries a structural delimiter byte. X12
+    /// cannot escape a delimiter inside data, so a value containing the
+    /// element separator or the segment terminator would silently corrupt
+    /// the interchange. The sub-element (component) separator is deliberately
+    /// *not* rejected — a composite element value legitimately carries it as
+    /// internal structure, mirroring the reader, which keeps it verbatim. The
+    /// error names the offending segment so the user can re-route or
+    /// re-encode the value.
+    fn reject_delimiter_in_data(&self, element: &str, tag: &str) -> Result<(), FormatError> {
+        for &b in element.as_bytes() {
+            if b == self.delims.element || b == self.delims.terminator {
+                return Err(FormatError::X12(format!(
+                    "segment {tag:?} element value {element:?} contains the X12 \
+                     {} delimiter byte {:?}. X12 has no escape character, so a delimiter \
+                     cannot appear inside data; re-encode the value or choose delimiters \
+                     the data does not contain.",
+                    if b == self.delims.element {
+                        "element"
+                    } else {
+                        "segment-terminator"
+                    },
+                    b as char
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write + Send> FormatWriter for X12Writer<W> {
+    fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        self.write_header(record)?;
+        self.write_body_record(record)
+    }
+
+    fn flush(&mut self) -> Result<(), FormatError> {
+        if self.finalized {
+            return Ok(());
+        }
+        self.finalized = true;
+        self.close_open_set()?;
+        self.close_functional_group()?;
+        // Only write IEA if a header was actually emitted; a writer that
+        // saw zero records produces nothing rather than a bare trailer.
+        if self.header_written {
+            let control_number = self.isa_control_number.clone();
+            self.write_segment("IEA", &[self.group_count.to_string(), control_number])?;
+        }
+        self.writer.flush().map_err(FormatError::Io)?;
+        Ok(())
+    }
+}
+
+/// Set element at index `i` (0-based) to `value`, growing the vector with
+/// empty elements if it is shorter than `i`. Used to overwrite the `GS06`
+/// control number at its fixed position regardless of the configured
+/// header's length.
+fn set_or_push(elements: &mut Vec<String>, i: usize, value: String) {
+    while elements.len() <= i {
+        elements.push(String::new());
+    }
+    elements[i] = value;
+}
+
+/// Whether a schema column name is a positional X12 element column
+/// (`e01`, `e02`, …): an `e` followed by one or more ASCII digits.
+fn is_element_column(name: &str) -> bool {
+    element_position(name).is_some()
+}
+
+/// Parse the 1-based wire element position from a column name. `e01` → 1,
+/// `e12` → 12. Returns `None` when the name is not an `e`-prefixed digit
+/// run or names position 0 (`e00`, which has no wire slot).
+fn element_position(name: &str) -> Option<usize> {
+    let rest = name.strip_prefix('e')?;
+    if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let position: usize = rest.parse().ok()?;
+    (position >= 1).then_some(position)
+}
+
+/// Render a `Value` to X12 element text. `Null` renders as the empty
+/// string (an absent element); scalars render via their natural string
+/// form. A `Value::Map` or `Value::Array` has no scalar X12 element
+/// representation, so it raises rather than silently emitting an empty
+/// cell — mirroring the CSV/XML/fixed-width/EDIFACT writers'
+/// explicit-error posture for non-scalar payloads. `column` names the
+/// offending field for the error.
+fn value_to_element(value: &Value, column: &str) -> Result<String, FormatError> {
+    let text = match value {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Integer(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.to_string(),
+        Value::Date(d) => d.to_string(),
+        Value::DateTime(dt) => dt.to_string(),
+        Value::Map(_) | Value::Array(_) => {
+            return Err(FormatError::UnserializableMapValue {
+                format: "x12",
+                column: column.to_string(),
+            });
+        }
+    };
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    const ISA_ELEMENTS: &[&str] = &[
+        "00",
+        "          ",
+        "00",
+        "          ",
+        "ZZ",
+        "SENDER         ",
+        "ZZ",
+        "RECEIVER       ",
+        "240101",
+        "1200",
+        "U",
+        "00401",
+        "000000001",
+        "0",
+        "P",
+        ":",
+    ];
+
+    const GS_HEADER: &[&str] = &[
+        "PO", "SENDER", "RECEIVER", "20240101", "1200", "1", "X", "004010",
+    ];
+
+    fn schema() -> Arc<Schema> {
+        let mut cols: Vec<Box<str>> = vec!["seg_id".into(), "set_ref".into(), "set_type".into()];
+        for i in 1..=4 {
+            cols.push(format!("e{i:02}").into_boxed_str());
+        }
+        Arc::new(Schema::new(cols))
+    }
+
+    fn body(
+        schema: &Arc<Schema>,
+        seg: &str,
+        set_ref: &str,
+        set_type: &str,
+        els: &[&str],
+    ) -> Record {
+        let mut values = vec![
+            Value::String(seg.into()),
+            if set_ref.is_empty() {
+                Value::Null
+            } else {
+                Value::String(set_ref.into())
+            },
+            if set_type.is_empty() {
+                Value::Null
+            } else {
+                Value::String(set_type.into())
+            },
+        ];
+        for i in 0..4 {
+            match els.get(i) {
+                Some(e) => values.push(Value::String((*e).into())),
+                None => values.push(Value::Null),
+            }
+        }
+        Record::new(Arc::clone(schema), values)
+    }
+
+    fn literal_config() -> X12WriterConfig {
+        X12WriterConfig {
+            interchange: Some(ISA_ELEMENTS.iter().map(|s| s.to_string()).collect()),
+            group_header: Some(GS_HEADER.iter().map(|s| s.to_string()).collect()),
+            segment_newline: false,
+            ..Default::default()
+        }
+    }
+
+    fn write_all(config: X12WriterConfig, records: &[Record], schema: &Arc<Schema>) -> String {
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(schema), config);
+        for r in records {
+            w.write_record(r).unwrap();
+        }
+        w.flush().unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn isa_from_literal_options() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "BEG", "0001", "850", &["00"])],
+            &s,
+        );
+        assert!(
+            out.starts_with(
+                "ISA*00*          *00*          *ZZ*SENDER         \
+                 *ZZ*RECEIVER       *240101*1200*U*00401*000000001*0*P*:~"
+            ),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn three_tier_envelope_reconstructed() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(&s, "BEG", "0001", "850", &["00"]),
+                body(&s, "PO1", "0001", "850", &["1"]),
+            ],
+            &s,
+        );
+        // GS opens, ST opens, body, SE closes (ST+BEG+PO1+SE = 4), GE
+        // closes (1 set), IEA closes (1 group, echoing ISA13).
+        assert!(
+            out.contains("GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~"),
+            "{out}"
+        );
+        assert!(out.contains("ST*850*0001~"), "{out}");
+        assert!(out.contains("SE*4*0001~"), "{out}");
+        assert!(out.contains("GE*1*1~"), "{out}");
+        assert!(out.contains("IEA*1*000000001~"), "{out}");
+    }
+
+    #[test]
+    fn isa_echoed_from_doc_section() {
+        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use indexmap::IndexMap;
+
+        let s = schema();
+        let raw = RecVal::Array(
+            ISA_ELEMENTS
+                .iter()
+                .map(|e| RecVal::String((*e).into()))
+                .collect(),
+        );
+        let mut isa: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        isa.insert(super::RAW_ELEMENTS_KEY.into(), raw);
+        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        sections.insert("interchange".into(), RecVal::Map(Box::new(isa)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.x12"),
+            sections,
+        ));
+
+        let mut record = body(&s, "BEG", "0001", "850", &["00"]);
+        record.set_doc_ctx(ctx);
+
+        let cfg = X12WriterConfig {
+            interchange_from_doc: Some("interchange".into()),
+            group_header: Some(GS_HEADER.iter().map(|s| s.to_string()).collect()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[record], &s);
+        assert!(out.contains("000000001"), "{out}");
+        assert!(out.contains("IEA*1*000000001~"), "{out}");
+    }
+
+    #[test]
+    fn se_counts_include_st_and_se_and_echo_set_ref() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(&s, "BEG", "0001", "850", &["00"]),
+                body(&s, "PO1", "0001", "850", &["1"]),
+            ],
+            &s,
+        );
+        // ST + BEG + PO1 + SE = 4 segments; SE echoes 0001.
+        assert!(out.contains("SE*4*0001~"), "{out}");
+    }
+
+    #[test]
+    fn set_grouping_on_set_ref_transition() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(&s, "BEG", "0001", "850", &["a"]),
+                body(&s, "BEG", "0002", "850", &["b"]),
+            ],
+            &s,
+        );
+        assert_eq!(out.matches("ST*").count(), 2);
+        assert!(out.contains("ST*850*0001~"));
+        assert!(out.contains("ST*850*0002~"));
+        // Two sets in one group; GE echoes the set count.
+        assert!(out.contains("GE*2*1~"), "{out}");
+    }
+
+    #[test]
+    fn trailing_nulls_not_padded() {
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[body(&s, "BEG", "0001", "850", &["00"])],
+            &s,
+        );
+        // BEG has one element; no trailing '*' delimiters for null e02..e04.
+        assert!(out.contains("BEG*00~"), "{out}");
+        assert!(!out.contains("BEG*00*~"));
+    }
+
+    #[test]
+    fn gapped_element_columns_map_by_position() {
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "e01".into(), "e03".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("PO1".into()),
+                Value::String("a".into()),
+                Value::String("c".into()),
+            ],
+        );
+        let mut cfg = literal_config();
+        cfg.set_type = Some("850".into());
+        let out = write_all(cfg, &[record], &schema);
+        assert!(out.contains("PO1*a**c~"), "gapped mapping wrong: {out}");
+    }
+
+    #[test]
+    fn reordered_element_columns_emit_in_position_order() {
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "e02".into(), "e01".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("PO1".into()),
+                Value::String("second".into()),
+                Value::String("first".into()),
+            ],
+        );
+        let mut cfg = literal_config();
+        cfg.set_type = Some("850".into());
+        let out = write_all(cfg, &[record], &schema);
+        assert!(
+            out.contains("PO1*first*second~"),
+            "reordered mapping wrong: {out}"
+        );
+    }
+
+    #[test]
+    fn delimiter_byte_in_data_is_rejected() {
+        // X12 has no escape: an element value carrying the element
+        // separator must be rejected, not silently corrupt the segment.
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&s), literal_config());
+        let err = w
+            .write_record(&body(&s, "BEG", "0001", "850", &["A*B"]))
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("element") && m.contains("no escape")),
+            "expected delimiter rejection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn terminator_byte_in_data_is_rejected() {
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&s), literal_config());
+        let err = w
+            .write_record(&body(&s, "BEG", "0001", "850", &["A~B"]))
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("segment-terminator")),
+            "expected terminator rejection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn missing_interchange_config_errors() {
+        let s = schema();
+        let cfg = X12WriterConfig {
+            group_header: Some(GS_HEADER.iter().map(|s| s.to_string()).collect()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&s), cfg);
+        let err = w
+            .write_record(&body(&s, "BEG", "0001", "850", &["00"]))
+            .unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("no interchange header")));
+    }
+
+    #[test]
+    fn missing_group_header_config_errors() {
+        let s = schema();
+        let cfg = X12WriterConfig {
+            interchange: Some(ISA_ELEMENTS.iter().map(|s| s.to_string()).collect()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&s), cfg);
+        let err = w
+            .write_record(&body(&s, "BEG", "0001", "850", &["00"]))
+            .unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("no functional-group header")));
+    }
+
+    #[test]
+    fn engine_stamped_columns_excluded() {
+        let cols: Vec<Box<str>> = vec![
+            "seg_id".into(),
+            "set_ref".into(),
+            "set_type".into(),
+            "e01".into(),
+            "$source.file".into(),
+        ];
+        let schema = Arc::new(Schema::new(cols));
+        let values = vec![
+            Value::String("BEG".into()),
+            Value::String("0001".into()),
+            Value::String("850".into()),
+            Value::String("00".into()),
+            Value::String("/tmp/x.x12".into()),
+        ];
+        let record = Record::new(Arc::clone(&schema), values);
+        let out = write_all(literal_config(), &[record], &schema);
+        assert!(out.contains("BEG*00~"));
+        assert!(!out.contains("/tmp/x.x12"));
+    }
+
+    #[test]
+    fn unrecognized_column_errors_by_name() {
+        let cols: Vec<Box<str>> = vec![
+            "seg_id".into(),
+            "set_ref".into(),
+            "set_type".into(),
+            "amount".into(),
+        ];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("BEG".into()),
+                Value::String("0001".into()),
+                Value::String("850".into()),
+                Value::String("99".into()),
+            ],
+        );
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&schema), literal_config());
+        let err = w.write_record(&record).unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("amount")));
+    }
+
+    #[test]
+    fn flush_finalize_idempotent() {
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&s), literal_config());
+        w.write_record(&body(&s, "BEG", "0001", "850", &["00"]))
+            .unwrap();
+        w.flush().unwrap();
+        w.flush().unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out.matches("IEA*").count(), 1, "{out}");
+    }
+
+    #[test]
+    fn zero_records_writes_nothing() {
+        let s = schema();
+        let out = write_all(literal_config(), &[], &s);
+        assert!(out.is_empty(), "{out}");
+    }
+
+    #[test]
+    fn map_value_in_element_column_errors_by_name() {
+        use indexmap::IndexMap;
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "e01".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let mut nested: IndexMap<Box<str>, Value> = IndexMap::new();
+        nested.insert("k".into(), Value::String("v".into()));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::String("PO1".into()), Value::Map(Box::new(nested))],
+        );
+        let mut cfg = literal_config();
+        cfg.set_type = Some("850".into());
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&schema), cfg);
+        let err = w.write_record(&record).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::UnserializableMapValue { format: "x12", column } if column == "e01"),
+            "expected UnserializableMapValue for e01, got: {err:?}"
+        );
+    }
+}

--- a/crates/clinker-plan/src/config/format.rs
+++ b/crates/clinker-plan/src/config/format.rs
@@ -16,6 +16,7 @@ pub enum InputFormat {
     Xml(Option<XmlInputOptions>),
     FixedWidth(Option<FixedWidthInputOptions>),
     Edifact(Option<EdifactInputOptions>),
+    X12(Option<X12InputOptions>),
 }
 
 impl InputFormat {
@@ -27,6 +28,7 @@ impl InputFormat {
             InputFormat::Xml(_) => "xml",
             InputFormat::FixedWidth(_) => "fixed_width",
             InputFormat::Edifact(_) => "edifact",
+            InputFormat::X12(_) => "x12",
         }
     }
 
@@ -48,6 +50,7 @@ impl OutputFormat {
             OutputFormat::Xml(_) => "xml",
             OutputFormat::FixedWidth(_) => "fixed_width",
             OutputFormat::Edifact(_) => "edifact",
+            OutputFormat::X12(_) => "x12",
         }
     }
 }
@@ -61,6 +64,7 @@ pub enum OutputFormat {
     Xml(Option<XmlOutputOptions>),
     FixedWidth(Option<FixedWidthOutputOptions>),
     Edifact(Option<EdifactOutputOptions>),
+    X12(Option<X12OutputOptions>),
 }
 
 /// Supported format types.

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -211,3 +211,40 @@ pub struct EdifactOutputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_newline: Option<bool>,
 }
+
+/// X12 output options.
+///
+/// The writer reconstructs the three-tier interchange envelope
+/// (`ISA..IEA` → `GS..GE` → `ST..SE`) around emitted records. The `ISA`
+/// header comes from `interchange` (literal elements) or, when that is
+/// unset, is echoed from the `$doc` section named by `interchange_from_doc`
+/// for round-trip reconstruction. The `GS` functional-group header comes
+/// from `group_header`; transaction sets are grouped on the `set_ref`
+/// column, and the `SE`/`GE`/`IEA` control counts are recomputed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct X12OutputOptions {
+    /// Literal `ISA` data elements (the 16 fixed-width ISA fields) written
+    /// verbatim. Takes precedence over `interchange_from_doc` when both
+    /// are set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interchange: Option<Vec<String>>,
+    /// Name of a `$doc` section to echo the `ISA` elements from (the
+    /// reader's positional `ISA` envelope section), enabling X12
+    /// round-trip reconstruction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interchange_from_doc: Option<String>,
+    /// Literal `GS` functional-group header elements (`GS01..GS08`). The
+    /// `GS06` group control number is recomputed by the writer. Required
+    /// to wrap transaction sets in a functional group.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_header: Option<Vec<String>>,
+    /// Fallback transaction set type (`ST01`) when a record carries no
+    /// `set_type` column value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub set_type: Option<String>,
+    /// Write a newline after each segment terminator for readability.
+    /// Defaults to `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment_newline: Option<bool>,
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2242,6 +2242,7 @@ pub(crate) fn lower_node_to_plan_node(
                 strategy: CombineStrategy::HashBuildProbe,
                 driving_input: String::new(),
                 build_inputs: Vec::new(),
+                driving_upstream: None,
                 predicate_summary,
                 match_mode: config.match_mode,
                 on_miss: config.on_miss,
@@ -2513,6 +2514,27 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
             return Err(ConfigError::Validation(format!(
                 "[E323] output '{}': `edifact` output cannot be combined with `split` — \
                  an EDIFACT interchange is a single UNB..UNZ envelope and cannot be \
+                 divided across files; remove the `split` block or choose a splittable \
+                 format",
+                output.name
+            )));
+        }
+    }
+
+    // An X12 interchange is likewise a single three-tier envelope:
+    // ISA..IEA wraps GS..GE groups wrapping ST..SE sets, and every trailer
+    // count (SE/GE/IEA) is recomputed and written only at end of stream.
+    // Byte-limit file splitting flushes (and therefore finalizes) the
+    // writer mid-stream, sealing the interchange after the first file and
+    // emitting later records — and their fresh ST/GS headers — after the
+    // IEA trailer. There is no meaningful way to split one interchange
+    // across files, so reject the combination up front rather than emit a
+    // structurally corrupt interchange that still reports run success.
+    for output in config.output_configs() {
+        if matches!(output.format, OutputFormat::X12(_)) && output.split.is_some() {
+            return Err(ConfigError::Validation(format!(
+                "[E338] output '{}': `x12` output cannot be combined with `split` — \
+                 an X12 interchange is a single ISA..IEA envelope and cannot be \
                  divided across files; remove the `split` block or choose a splittable \
                  format",
                 output.name

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -548,3 +548,14 @@ pub struct EdifactInputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_elements: Option<usize>,
 }
+
+/// X12 input options.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct X12InputOptions {
+    /// Number of positional `eNN` element columns on the record schema.
+    /// A body segment carrying more data elements than this is rejected
+    /// with guidance rather than silently truncated. Defaults to 32.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_elements: Option<usize>,
+}

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -760,7 +760,7 @@ fn collect_scope_reads_in_statement(
             collect_scope_reads_in_expr(message, out);
         }
         Statement::UseStmt { .. } | Statement::Distinct { .. } => {}
-        Statement::EmitEach { source, body, .. } => {
+        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
             collect_scope_reads_in_expr(source, out);
             for inner in body {
                 collect_scope_reads_in_statement(inner, out);
@@ -3375,7 +3375,7 @@ fn statement_exprs(stmt: &Statement) -> Vec<&Expr> {
             v
         }
         Statement::Distinct { .. } | Statement::UseStmt { .. } => Vec::new(),
-        Statement::EmitEach { source, body, .. } => {
+        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
             // Surface the source expression plus the expressions from
             // each body statement so qualified-ref walking covers the
             // entire fan-out block, not just the outer driver.
@@ -3723,7 +3723,7 @@ fn walk_statement_exprs(stmt: &Statement, cx: CombineWalkContext<'_>, diags: &mu
             walk_for_unknown_refs(message, cx, diags);
         }
         Statement::UseStmt { .. } | Statement::Distinct { .. } => {}
-        Statement::EmitEach { source, body, .. } => {
+        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
             walk_for_unknown_refs(source, cx, diags);
             for inner in body {
                 walk_statement_exprs(inner, cx, diags);

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -903,16 +903,44 @@ pub(crate) fn select_combine_strategies_in_graph(
             CombineStrategy::HashBuildProbe
         };
 
+        // Resolve the driver predecessor's `NodeIndex` from the driving
+        // qualifier's `upstream_name`, matching it against the combine's
+        // incoming neighbors. The probe-side streaming-ingest predicate
+        // reads this index to identify the driver predecessor without
+        // `CompileArtifacts` access (combine edges carry `port: None`, so
+        // a qualifier cannot otherwise be mapped back to a node). Mirrors
+        // the executor's `predecessor_matches` resolution, including the
+        // `__correlation_sort_<source>` splice alias so the index resolves
+        // through an injected correlation Sort. Stays `None` when no
+        // incoming neighbor matches — e.g. an N-ary decomposition step
+        // whose driver is a synthetic intermediate not present as a direct
+        // predecessor; the streaming-ingest path declines those.
+        let driver_upstream = inputs.get(&driving).map(|ci| Arc::clone(&ci.upstream_name));
+        let resolved_driving_upstream: Option<NodeIndex> =
+            driver_upstream.and_then(|driver_name| {
+                graph
+                    .neighbors_directed(idx, petgraph::Direction::Incoming)
+                    .find(|&p| {
+                        let pname = graph[p].name();
+                        pname == driver_name.as_ref()
+                            || pname
+                                .strip_prefix(crate::plan::execution::CORRELATION_SORT_PREFIX)
+                                .is_some_and(|stripped| stripped == driver_name.as_ref())
+                    })
+            });
+
         if let PlanNode::Combine {
             strategy,
             driving_input,
             build_inputs,
+            driving_upstream,
             ..
         } = &mut graph[idx]
         {
             *strategy = chosen_strategy;
             *driving_input = driving;
             *build_inputs = build;
+            *driving_upstream = resolved_driving_upstream;
         }
     }
 }
@@ -1918,6 +1946,7 @@ pub(crate) fn decompose_nary_combines(
                         strategy: CombineStrategy::HashBuildProbe,
                         driving_input: String::new(),
                         build_inputs: Vec::new(),
+                        driving_upstream: None,
                         predicate_summary,
                         match_mode: MatchMode::All,
                         on_miss: OnMiss::Skip,
@@ -1938,6 +1967,7 @@ pub(crate) fn decompose_nary_combines(
                     strategy,
                     driving_input,
                     build_inputs,
+                    driving_upstream,
                     predicate_summary: ps,
                     match_mode: mm,
                     on_miss: om,
@@ -1951,6 +1981,11 @@ pub(crate) fn decompose_nary_combines(
                     *strategy = CombineStrategy::HashBuildProbe;
                     *driving_input = String::new();
                     *build_inputs = Vec::new();
+                    // The strategy post-pass re-resolves the driver
+                    // predecessor; clear the stale index so the invariant
+                    // "non-empty driving_input ⇒ driving_upstream resolved"
+                    // is not transiently violated between the two passes.
+                    *driving_upstream = None;
                     *ps = predicate_summary;
                     *mm = match_mode;
                     *om = on_miss;
@@ -2342,6 +2377,7 @@ mod tests {
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
             build_inputs: Vec::new(),
+            driving_upstream: None,
             predicate_summary,
             match_mode: MatchMode::First,
             on_miss: OnMiss::NullFields,
@@ -2522,6 +2558,7 @@ mod tests {
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
             build_inputs: Vec::new(),
+            driving_upstream: None,
             predicate_summary: CombinePredicateSummary::default(),
             match_mode: MatchMode::First,
             on_miss: OnMiss::NullFields,
@@ -2655,6 +2692,7 @@ mod tests {
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
             build_inputs: Vec::new(),
+            driving_upstream: None,
             predicate_summary: CombinePredicateSummary::from_decomposed(
                 artifacts.combine_predicates.get(combine_name).unwrap(),
             ),

--- a/crates/clinker-plan/src/plan/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/deferred_region.rs
@@ -1061,7 +1061,8 @@ fn accumulate_program_support(program: &cxl::ast::Program, set: &mut HashSet<Str
             }
             Statement::ExprStmt { expr, .. } => expr.support_into(set),
             Statement::Distinct { .. } | Statement::UseStmt { .. } => {}
-            Statement::EmitEach { source, body, .. } => {
+            Statement::EmitEach { source, body, .. }
+            | Statement::ExplodeOuter { source, body, .. } => {
                 source.support_into(set);
                 // Recurse via a fresh Program-shaped wrapper so the
                 // same statement walker covers body statements

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -2000,6 +2000,7 @@ mod spill_projection_tests {
             strategy,
             driving_input: "a".to_string(),
             build_inputs: vec!["b".to_string()],
+            driving_upstream: None,
             predicate_summary: CombinePredicateSummary::default(),
             match_mode: crate::config::pipeline_node::MatchMode::First,
             on_miss: crate::config::pipeline_node::OnMiss::NullFields,

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -23,7 +23,7 @@ pub use graph_util::{compute_init_phase_node_set, single_predecessor};
 pub use streaming_class::{
     StreamClass, certify_streaming_edge, classify_stream_nodes,
     compute_merge_interleave_fused_sources, compute_streaming_aggregate_ingest_edges,
-    compute_transform_fused_sources,
+    compute_streaming_combine_probe_edges, compute_transform_fused_sources,
 };
 
 use std::collections::{BTreeSet, HashMap};
@@ -293,6 +293,19 @@ pub enum PlanNode {
         /// the driver, in declaration order. Empty when the driver has
         /// not yet been selected.
         build_inputs: Vec<String>,
+        /// `NodeIndex` of the driving (probe-side) predecessor in the DAG,
+        /// resolved from `driving_input` against the combine's incoming
+        /// neighbors during the `select_combine_strategies` post-pass.
+        /// `None` until that pass runs (or when the driver predecessor
+        /// could not be resolved — e.g. an N-ary decomposition step whose
+        /// driver is a synthetic intermediate not present as a direct
+        /// neighbor). The probe-side streaming-ingest predicate
+        /// ([`certify_streaming_edge`]) reads this to identify the driver
+        /// predecessor without `CompileArtifacts` access, because combine
+        /// edges carry `port: None` and the predicate cannot map an input
+        /// qualifier back to a node any other way.
+        #[serde(skip)]
+        driving_upstream: Option<petgraph::graph::NodeIndex>,
         /// Shape-only projection of the decomposed `where:` predicate
         /// (equalities count, ranges count, residual presence). Populated
         /// at lowering time from `CompileArtifacts.combine_predicates[name]`;

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -22,7 +22,8 @@ pub use explain::*;
 pub use graph_util::{compute_init_phase_node_set, single_predecessor};
 pub use streaming_class::{
     StreamClass, certify_streaming_edge, classify_stream_nodes,
-    compute_merge_interleave_fused_sources, compute_transform_fused_sources,
+    compute_merge_interleave_fused_sources, compute_streaming_aggregate_ingest_edges,
+    compute_transform_fused_sources,
 };
 
 use std::collections::{BTreeSet, HashMap};

--- a/crates/clinker-plan/src/plan/execution/streaming_class.rs
+++ b/crates/clinker-plan/src/plan/execution/streaming_class.rs
@@ -287,6 +287,45 @@ pub fn classify_stream_nodes(
         .collect()
 }
 
+/// Identify every `producer → Aggregate` edge whose ingest streams:
+/// the producer feeds `add_record` per record over a bounded channel
+/// rather than the Aggregate pre-draining the producer's whole output
+/// from a charged `node_buffers` slot. Returns a map from the producer's
+/// `NodeIndex` to the consuming Aggregate's `NodeIndex`.
+///
+/// This is the [`certify_streaming_edge`] predicate applied with each
+/// `Aggregation` node as the consumer; the producer-kind half of the
+/// predicate (fused `Source → Transform`, non-fused `Merge`, single-branch
+/// `Route`, streaming-strategy `Aggregate`) is shared with the `Output`
+/// consumer, so the same fusion analysis decides both. The runtime
+/// installs one bounded channel per returned edge: the producer arm
+/// streams into it during its own dispatch turn, and the Aggregate arm
+/// drains it via a back-pressured recv loop — so a slow producer paces
+/// the Aggregate's ingest and no inter-stage slot is charged for the edge.
+///
+/// Correlation buffering disables streaming pipeline-wide (the
+/// `CorrelationCommit` terminal owns the writes), so the caller passes a
+/// fused-transform set computed only when correlation is inactive; an
+/// empty fused set leaves the map empty for those topologies.
+pub fn compute_streaming_aggregate_ingest_edges(
+    plan: &ExecutionPlanDag,
+    fused_transforms: &HashSet<petgraph::graph::NodeIndex>,
+    init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
+) -> HashMap<petgraph::graph::NodeIndex, petgraph::graph::NodeIndex> {
+    let mut edges = HashMap::new();
+    for agg_idx in plan.graph.node_indices() {
+        if !matches!(&plan.graph[agg_idx], PlanNode::Aggregation { .. }) {
+            continue;
+        }
+        if let Some(producer_idx) =
+            certify_streaming_edge(plan, agg_idx, fused_transforms, init_phase_set)
+        {
+            edges.insert(producer_idx, agg_idx);
+        }
+    }
+    edges
+}
+
 /// Certify a `producer → consumer` edge for the streaming substrate,
 /// returning the producer's `NodeIndex` when the edge streams, or `None`
 /// when it stays materialized.
@@ -401,10 +440,11 @@ pub fn certify_streaming_edge(
         return None;
     }
 
-    // Consumer-kind dispatch. `Output` is the sole certified consumer kind
-    // today; every other kind falls through to `None`. The guards here are
-    // the consumer-specific half of the predicate (the producer-kind half
-    // is the `match` on `producer_idx` below).
+    // Consumer-kind dispatch. `Output` (the file-writer sink) and
+    // `Aggregation` (the per-record ingest half of a GROUP BY) are the
+    // certified consumer kinds; every other kind falls through to `None`.
+    // The guards here are the consumer-specific half of the predicate (the
+    // producer-kind half is the `match` on `producer_idx` below).
     match &plan.graph[consumer_idx] {
         PlanNode::Output { resolved, .. } => {
             let payload = resolved.as_deref()?;
@@ -414,6 +454,37 @@ pub fn certify_streaming_edge(
             // runtime surfaces agree without consulting the runtime writer
             // registry.
             if payload.fan_out_per_source_file || payload.output.split.is_some() {
+                return None;
+            }
+        }
+        PlanNode::Aggregation {
+            config, compiled, ..
+        } => {
+            // The ingest half streams: an eligible producer feeds
+            // `add_record` per record over the bounded channel rather than
+            // pre-draining the producer's whole output from a charged
+            // `node_buffers` slot. The finalize half stays blocking (it
+            // accumulates every group before emitting) — that is the
+            // operator's nature, not a buffer this lifts.
+            //
+            // Two aggregate shapes keep the materialized ingest:
+            //
+            // - Relaxed-CK aggregates (`requires_lineage` /
+            //   `requires_buffer_mode`) retain their hash state for the
+            //   correlation-commit phase, which re-`retract` + re-finalize
+            //   the same instance; streaming ingest would have to hand that
+            //   live state across a thread boundary and back, so the commit
+            //   path keeps draining a materialized slot.
+            // - Time-windowed aggregates run a multi-pass per-window (and,
+            //   for sessions, global-sort) algorithm over the whole input
+            //   batch, which is incompatible with a single forward
+            //   record-at-a-time pass.
+            //
+            // Both are plan-derived flags, so the explain buffer-class
+            // annotation and the runtime ingest path agree without
+            // inspecting runtime state.
+            let is_relaxed = compiled.requires_lineage || compiled.requires_buffer_mode;
+            if is_relaxed || config.time_window.is_some() {
                 return None;
             }
         }

--- a/crates/clinker-plan/src/plan/execution/streaming_class.rs
+++ b/crates/clinker-plan/src/plan/execution/streaming_class.rs
@@ -241,8 +241,11 @@ pub fn classify_stream_nodes(
     // annotation matches.
     let correlation_active = config.any_source_has_correlation_key();
 
-    // A fused Transform streams iff some streaming-eligible Output names
-    // it as its producer. Collect those producer indices once.
+    // A producer streams iff some streaming-eligible consumer (Output,
+    // Aggregate ingest, or Combine probe) certifies it as its producer.
+    // `certify_streaming_edge` returns the producer index for every
+    // certified consumer kind, so collecting it across all node indices
+    // yields every streaming producer in one pass.
     let streaming_producers: HashSet<petgraph::graph::NodeIndex> = if correlation_active {
         HashSet::new()
     } else {
@@ -263,10 +266,11 @@ pub fn classify_stream_nodes(
                     StreamClass::Streaming
                 }
                 // Any producer the eligibility predicate accepts as
-                // feeding a streaming Output — fused Transform, non-fused
+                // feeding a streaming consumer (Output writer, Aggregate
+                // ingest, or Combine probe) — fused Transform, non-fused
                 // Merge, single-branch Route, streaming Aggregate, inline
-                // Combine probe — streams its output to the writer thread
-                // and admits no `node_buffers` slot, so it renders
+                // Combine probe — streams its output over the bounded
+                // channel and admits no `node_buffers` slot, so it renders
                 // `streaming`. The predicate already excluded blocking
                 // strategies (hash Aggregate, range/sort-merge/grace
                 // Combine) and window roots, so this branch only fires for
@@ -326,98 +330,112 @@ pub fn compute_streaming_aggregate_ingest_edges(
     edges
 }
 
+/// Identify every `producer → Combine(driver)` edge whose probe-side
+/// ingest streams: the driver (probe-side) producer feeds the hash-probe
+/// kernel per record over a bounded channel rather than the Combine arm
+/// pre-draining the driver's whole output from a charged `node_buffers`
+/// slot. Returns a map from the driver producer's `NodeIndex` to the
+/// consuming `Combine`'s `NodeIndex`.
+///
+/// This is the [`certify_streaming_edge`] predicate applied with each
+/// `Combine` node as the consumer. The build side stays fully
+/// materialized inside the arm — it is the hash table the probe reads —
+/// so only the probe (driver) ingest lifts, and only for the
+/// `HashBuildProbe` strategy (range / sort-merge / grace-hash re-sort or
+/// re-scan the driver and stay blocking). The predicate resolves the
+/// driver predecessor from the plan-stamped `driving_upstream` index, so a
+/// Combine's build edge is never mistaken for the streaming edge.
+///
+/// The runtime installs one bounded channel per returned edge: the Combine
+/// arm materializes the build-side hash table on the main thread, spawns
+/// the probe consumer on its own thread, then redispatches the driver
+/// producer (which streams into the channel during the Combine's dispatch
+/// turn). Build-before-probe holds because the hash table is complete
+/// before the driver producer's first send; a slow driver paces the probe
+/// over the bounded channel and no inter-stage slot is charged for the
+/// edge.
+///
+/// Correlation buffering disables streaming pipeline-wide (the
+/// `CorrelationCommit` terminal owns the writes), so the caller passes a
+/// fused-transform set computed only when correlation is inactive.
+pub fn compute_streaming_combine_probe_edges(
+    plan: &ExecutionPlanDag,
+    fused_transforms: &HashSet<petgraph::graph::NodeIndex>,
+    init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
+) -> HashMap<petgraph::graph::NodeIndex, petgraph::graph::NodeIndex> {
+    let mut edges = HashMap::new();
+    for combine_idx in plan.graph.node_indices() {
+        if !matches!(&plan.graph[combine_idx], PlanNode::Combine { .. }) {
+            continue;
+        }
+        if let Some(producer_idx) =
+            certify_streaming_edge(plan, combine_idx, fused_transforms, init_phase_set)
+        {
+            edges.insert(producer_idx, combine_idx);
+        }
+    }
+    edges
+}
+
 /// Certify a `producer → consumer` edge for the streaming substrate,
 /// returning the producer's `NodeIndex` when the edge streams, or `None`
 /// when it stays materialized.
 ///
-/// `consumer_idx` names the downstream streaming consumer; today the only
-/// certified consumer kind is `PlanNode::Output`, but the eligibility
-/// shell is consumer-generic so future streaming consumers (a streaming
-/// `Aggregate` ingest, a `Combine` probe) plug in as additional certifying
-/// arms without re-deriving the producer analysis. A streaming consumer's
-/// work moves into a `std::thread` that consumes a bounded crossbeam
-/// channel; the producer arm sends records into that channel as it
-/// produces them, so back-pressure flows consumer → producer → Source and
-/// no inter-stage `node_buffers` slot is charged. This function is the
+/// `consumer_idx` names the downstream streaming consumer. Three consumer
+/// kinds are certified: `Output` (the file-writer sink), `Aggregation`
+/// (the per-record ingest half of a strict GROUP BY), and `Combine` (the
+/// probe-side ingest half of a hash build-probe join). A streaming
+/// consumer's work moves into a `std::thread` that consumes a bounded
+/// crossbeam channel; the producer arm sends records into that channel as
+/// it produces them, so back-pressure flows consumer → producer → Source
+/// and no inter-stage `node_buffers` slot is charged. This function is the
 /// single plan-derived eligibility predicate both the runtime spawn path
 /// and the `--explain` buffer-class annotation ([`classify_stream_nodes`])
 /// consult, so the explain annotation can never disagree with what the
 /// dispatcher does.
 ///
-/// Common eligibility (independent of producer kind):
+/// Common eligibility (independent of consumer or producer kind):
 ///
 /// - The consumer is not in the init-phase ancestor closure.
-/// - The consumer has exactly one incoming edge.
 ///
-/// Consumer = `Output` (the sole certified consumer kind today):
+/// Consumer-specific eligibility, and how each resolves its producer:
 ///
-/// - The Output is not a per-source-file fan-out writer and its config
-///   declares no `split:` block — both own their own writer lifecycle
-///   and are incompatible with the single streaming writer task.
+/// - `Output`: not a per-source-file fan-out writer and no `split:` block
+///   (both own their own writer lifecycle, incompatible with the single
+///   streaming writer task). Producer = its sole incoming edge.
+/// - `Aggregation`: strict only — not relaxed-CK (`requires_lineage` /
+///   `requires_buffer_mode`, which retains state for the correlation
+///   commit) and not time-windowed (multi-pass over the whole batch).
+///   Producer = its sole incoming edge.
+/// - `Combine`: strategy `HashBuildProbe` only (range / sort-merge /
+///   grace-hash re-sort or re-scan the driver and stay blocking). A
+///   Combine is fan-in (build edge + driver edge), so its producer is the
+///   plan-stamped `driving_upstream` (probe-side) predecessor, not a sole
+///   incoming edge; `None` when the driver could not be resolved to a
+///   direct predecessor.
 ///
-/// Every other consumer node kind returns `None`: the consumer-specific
-/// guards above are conjunctive, so no producer edge into a non-`Output`
-/// consumer is certified until that consumer kind grows its own arm.
+/// Every other consumer node kind returns `None`.
 ///
-/// Producer = fused `Merge.interleave` (issue #72):
+/// The resolved producer is then certified by [`certify_linear_producer`],
+/// which admits these producer kinds (each must have exactly one outgoing
+/// edge — into this consumer — and root no node-anchored window arena,
+/// because a window rooted at the producer needs the producer's full
+/// output materialized and streaming would starve it):
 ///
-/// - The predecessor is a `PlanNode::Merge` in `interleave` mode whose
-///   every direct predecessor is a fused Source, with exactly one
-///   outgoing edge (this Output).
-///
-/// Producer = fused `Source → Transform` (the bounded per-batch
-/// inter-stage handoff):
-///
-/// - The predecessor is a `PlanNode::Transform` that
-///   `compute_transform_fused_sources` classified as fused (its sole
-///   upstream is a single-outgoing Source it streams off directly), with
-///   exactly one outgoing edge (this Output).
-/// - The Transform roots no node-anchored window arena. A window rooted
-///   at this Transform needs the Transform's full output materialized to
-///   build the arena, so streaming would starve it; such a Transform
-///   stays on the buffered path.
-///
-/// Producer = non-fused `Merge` (concat, or interleave with non-Source
-/// inputs):
-///
-/// - The Merge feeds only this Output and roots no window arena. The
-///   arm drains its predecessors' `node_buffers` slots in declaration
-///   order (concat) or round-robin (interleave) into the merged result,
-///   then streams that result to the writer thread rather than admitting
-///   it to its own charged `node_buffers` slot. (The fused
-///   Merge.interleave path streams record-by-record off the live Source
-///   channels instead and is the only Merge whose footprint is one
-///   batch.)
-///
-/// Producer = single-branch `Route`:
-///
-/// - The Route has exactly one outgoing edge (its sole branch) and that
-///   edge feeds this Output, and the Route roots no window arena. A
-///   multi-branch Route forks records across several successor slots and
-///   stays on the materialized fan-out path so each branch keeps its own
-///   slot — only a Route with a single downstream consumer is a linear
-///   producer the streaming writer can drain.
-///
-/// Producer = streaming-strategy `Aggregate`:
-///
-/// - The aggregate resolved to [`crate::plan::types::AggregateStrategy::Streaming`] (the
-///   planner certified pre-sorted input), feeds only this Output, and
-///   roots no window arena. Hash aggregation stays blocking: it must
-///   accumulate every group before emitting, so it cannot stream.
-///
-/// Producer = `Combine` probe-side (`HashBuildProbe`):
-///
-/// - The combine resolved to [`CombineStrategy::HashBuildProbe`], feeds
-///   only this Output, and roots no window arena. The build side stays
-///   fully materialized inside the arm; only the probe-side emit streams.
-///   Range / sort-merge / grace-hash strategies are blocking and stay
-///   materialized.
-///
-/// Common to every non-`Output` producer kind below: the producer must
-/// have exactly one outgoing edge (this Output) and root no node-anchored
-/// window arena, because a window rooted at the producer needs the
-/// producer's full output materialized to build the arena and streaming
-/// would starve it.
+/// - fused `Merge.interleave` (issue #72): a `PlanNode::Merge` in
+///   `interleave` mode whose every direct predecessor is a fused Source.
+/// - non-fused `Merge` (concat, or interleave with non-Source inputs):
+///   the arm drains its predecessors' `node_buffers` slots and forwards
+///   each record to the consumer rather than admitting its own slot.
+/// - fused `Source → Transform`: a `PlanNode::Transform` that
+///   `compute_transform_fused_sources` classified as fused.
+/// - single-branch `Route`: exactly one outgoing edge into this consumer.
+/// - streaming-strategy `Aggregate`
+///   ([`crate::plan::types::AggregateStrategy::Streaming`]): emits one
+///   group per sort-key boundary; hash aggregation stays blocking.
+/// - hash build-probe `Combine`
+///   ([`CombineStrategy::HashBuildProbe`]): only the probe-side emit
+///   streams; the build side stays materialized inside the arm.
 ///
 /// Correlation buffering disables streaming pipeline-wide — the
 /// `CorrelationCommit` terminal owns the writes — so the caller short-
@@ -429,7 +447,6 @@ pub fn certify_streaming_edge(
     init_phase_set: &HashSet<petgraph::graph::NodeIndex>,
 ) -> Option<petgraph::graph::NodeIndex> {
     use crate::plan::combine::CombineStrategy;
-    use crate::plan::types::AggregateStrategy;
 
     // Consumer-generic eligibility, hoisted ahead of the consumer-kind
     // dispatch because every certifying arm shares it: an init-phase
@@ -440,12 +457,20 @@ pub fn certify_streaming_edge(
         return None;
     }
 
-    // Consumer-kind dispatch. `Output` (the file-writer sink) and
-    // `Aggregation` (the per-record ingest half of a GROUP BY) are the
-    // certified consumer kinds; every other kind falls through to `None`.
-    // The guards here are the consumer-specific half of the predicate (the
-    // producer-kind half is the `match` on `producer_idx` below).
-    match &plan.graph[consumer_idx] {
+    // Consumer-kind dispatch resolves the producer (probe-side) index per
+    // consumer kind, then defers to `certify_linear_producer` for the
+    // shared producer-kind half. `Output` (file-writer sink), `Aggregation`
+    // (the per-record ingest half of a GROUP BY), and `Combine` (the
+    // probe-side ingest half of a hash build-probe join) are the certified
+    // consumer kinds; every other kind falls through to `None`.
+    //
+    // `Output` and `Aggregation` are linear consumers with exactly one
+    // incoming edge, so they share the generic single-incoming guard.
+    // `Combine` is fan-in by construction (build edge + driver edge), so it
+    // resolves its driver predecessor directly from the plan-stamped
+    // `driving_upstream` index instead — the single-incoming guard would
+    // reject it.
+    let producer_idx: petgraph::graph::NodeIndex = match &plan.graph[consumer_idx] {
         PlanNode::Output { resolved, .. } => {
             let payload = resolved.as_deref()?;
             // Per-source-file fan-out and split writers own their own file
@@ -456,6 +481,7 @@ pub fn certify_streaming_edge(
             if payload.fan_out_per_source_file || payload.output.split.is_some() {
                 return None;
             }
+            single_incoming_producer(plan, consumer_idx)?
         }
         PlanNode::Aggregation {
             config, compiled, ..
@@ -487,11 +513,48 @@ pub fn certify_streaming_edge(
             if is_relaxed || config.time_window.is_some() {
                 return None;
             }
+            single_incoming_producer(plan, consumer_idx)?
+        }
+        PlanNode::Combine {
+            strategy,
+            driving_upstream,
+            ..
+        } => {
+            // The probe (driver) ingest half streams: the driver producer
+            // feeds the probe kernel per record over the bounded channel
+            // rather than the arm pre-draining the driver's whole output
+            // from a charged `node_buffers` slot. The build side stays
+            // fully materialized inside the arm — it is the hash table the
+            // probe reads, complete before the first probe — so only the
+            // probe-side ingest lifts. Range / sort-merge / grace-hash
+            // joins re-sort or re-scan the driver and stay blocking.
+            if !matches!(strategy, CombineStrategy::HashBuildProbe) {
+                return None;
+            }
+            // Resolve the driver predecessor from the plan-stamped index
+            // rather than the incoming edges: a Combine has both a build
+            // edge and a driver edge, so it never has exactly one incoming
+            // neighbor. `driving_upstream` is `None` when the strategy
+            // post-pass could not resolve the driver to a direct
+            // predecessor (e.g. an N-ary decomposition step whose driver is
+            // a synthetic intermediate) — decline streaming for those.
+            (*driving_upstream)?
         }
         _ => return None,
-    }
+    };
 
-    // Exactly one incoming edge.
+    certify_linear_producer(plan, producer_idx, fused_transforms)
+}
+
+/// Resolve the sole incoming producer of a linear (single-fan-in)
+/// streaming consumer, or `None` when the consumer has zero or more than
+/// one incoming edge. Used by the `Output` / `Aggregation` consumer arms,
+/// whose streaming model moves a single upstream producer's live channel
+/// into the consumer; a consumer with fan-in cannot do that.
+fn single_incoming_producer(
+    plan: &ExecutionPlanDag,
+    consumer_idx: petgraph::graph::NodeIndex,
+) -> Option<petgraph::graph::NodeIndex> {
     let mut incoming = plan
         .graph
         .neighbors_directed(consumer_idx, petgraph::Direction::Incoming);
@@ -499,6 +562,28 @@ pub fn certify_streaming_edge(
     if incoming.next().is_some() {
         return None;
     }
+    Some(producer_idx)
+}
+
+/// Certify the producer-kind half of a streaming edge: given the resolved
+/// producer index, return `Some(producer_idx)` when the producer is a
+/// linear streaming source (fused `Merge.interleave`, non-fused `Merge`,
+/// fused `Source → Transform`, single-branch `Route`, streaming-strategy
+/// `Aggregate`, or hash build-probe `Combine`) feeding only the consumer
+/// and rooting no node-anchored window arena, or `None` otherwise.
+///
+/// Shared by every consumer arm of [`certify_streaming_edge`] so the
+/// producer eligibility rules are derived once. A window rooted at the
+/// producer needs the producer's full output materialized to build the
+/// arena, so a streaming producer must root no node-anchored window —
+/// enforced uniformly here.
+fn certify_linear_producer(
+    plan: &ExecutionPlanDag,
+    producer_idx: petgraph::graph::NodeIndex,
+    fused_transforms: &HashSet<petgraph::graph::NodeIndex>,
+) -> Option<petgraph::graph::NodeIndex> {
+    use crate::plan::combine::CombineStrategy;
+    use crate::plan::types::AggregateStrategy;
 
     // A window rooted at the producer needs the producer's full output
     // materialized to build the arena, so a streaming producer must root
@@ -521,7 +606,7 @@ pub fn certify_streaming_edge(
             // its predecessors' `node_buffers` slots and forwards each
             // record to the writer thread. Both route their emit through
             // the streaming sender — the runtime arm picks the path — so
-            // every Merge with a single downstream Output and no window
+            // every Merge with a single downstream consumer and no window
             // root is eligible regardless of fusion.
             let has_predecessor = plan
                 .graph
@@ -538,7 +623,7 @@ pub fn certify_streaming_edge(
         }
         PlanNode::Transform { .. } => {
             // The Transform must be a fused Source→Transform that feeds
-            // only this Output and roots no node-anchored window arena.
+            // only this consumer and roots no node-anchored window arena.
             if !fused_transforms.contains(&producer_idx)
                 || !has_single_outgoing(plan, producer_idx)
                 || roots_window(producer_idx)
@@ -549,7 +634,7 @@ pub fn certify_streaming_edge(
         }
         PlanNode::Route { .. } => {
             // Single-branch Route: exactly one outgoing edge (this
-            // Output). A multi-branch Route forks across successor slots
+            // consumer). A multi-branch Route forks across successor slots
             // and stays materialized.
             if !has_single_outgoing(plan, producer_idx) || roots_window(producer_idx) {
                 return None;
@@ -558,7 +643,7 @@ pub fn certify_streaming_edge(
         }
         PlanNode::Aggregation { strategy, .. } => {
             // Streaming aggregation emits one group per sort-key
-            // boundary, so it can stream to the writer; hash aggregation
+            // boundary, so it can stream to the consumer; hash aggregation
             // must accumulate every group before emitting and stays
             // blocking.
             if !matches!(strategy, AggregateStrategy::Streaming) {

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -229,6 +229,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E335" => Some(include_str!("../../../../docs/explain/E335.md")),
         "E336" => Some(include_str!("../../../../docs/explain/E336.md")),
         "E337" => Some(include_str!("../../../../docs/explain/E337.md")),
+        "E338" => Some(include_str!("../../../../docs/explain/E338.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -412,6 +413,16 @@ mod tests {
     }
 
     #[test]
+    fn test_explain_code_e338_x12_split_rejected() {
+        let doc = explain_code("E338").unwrap();
+        assert!(doc.contains("E338"));
+        // The doc must name the three-tier envelope so the user sees why a
+        // single interchange cannot span split files.
+        assert!(doc.contains("ISA..IEA"));
+        assert!(doc.contains("split"));
+    }
+
+    #[test]
     fn test_explain_code_unknown() {
         assert!(explain_code("E999").is_none());
     }
@@ -422,7 +433,8 @@ mod tests {
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
-            "E332", "E333", "E334", "E335", "E336", "E337", "E15Y", "W101", "W302", "W305", "W306",
+            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E15Y", "W101", "W302", "W305",
+            "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -81,6 +81,38 @@ impl DocumentContext {
         &self.source_file
     }
 
+    /// Open a nested envelope level beneath this one, flattening the
+    /// ancestry into a single sibling sections map.
+    ///
+    /// Multi-level envelope formats (EDI X12 ISA → GS → ST) nest
+    /// envelopes inside a file. Rather than chain `DocumentContext`s,
+    /// each inner level mints a fresh context that carries every section
+    /// the enclosing levels declared *plus* its own — all siblings in one
+    /// map. A record streamed inside the ST level therefore resolves the
+    /// ISA's `$doc.interchange.*`, the GS's `$doc.group.*`, and its own
+    /// `$doc.transaction.*` through the same two-level lookup, with no CXL
+    /// syntax change. Per-level section *names* keep the levels distinct;
+    /// a child section name that collides with an ancestor's shadows the
+    /// ancestor (innermost wins), matching the lexical-scope intuition.
+    ///
+    /// The new level gets a distinct [`DocumentId`] (so Merge dedup and
+    /// any per-document operator treat each level as its own document
+    /// frame) and inherits the parent's `source_file` (every level of one
+    /// file shares the file identity). Sections are cloned by `Arc`/`Value`
+    /// — envelope payloads are small (a few fields per level), so the copy
+    /// is O(declared sections), not O(body).
+    pub fn child(&self, id: DocumentId, sections: IndexMap<Box<str>, Value>) -> Self {
+        let mut merged = self.sections.clone();
+        for (name, payload) in sections {
+            merged.insert(name, payload);
+        }
+        Self {
+            id,
+            source_file: Arc::clone(&self.source_file),
+            sections: merged,
+        }
+    }
+
     /// Resolve `$doc.<section>.<field>` by chained lookup. Returns
     /// `None` if either the section is undeclared on this document or
     /// the field is missing from the section's payload. CXL eval maps
@@ -192,6 +224,68 @@ mod tests {
         assert!(ctx.get_section_field("Middle", "x").is_none());
         // Known section, unknown field.
         assert!(ctx.get_section_field("Head", "missing").is_none());
+    }
+
+    #[test]
+    fn child_layers_sibling_sections_and_inherits_file() {
+        let mut isa = IndexMap::new();
+        isa.insert(
+            Box::from("interchange"),
+            make_section(&[("control_ref", Value::String("000000001".into()))]),
+        );
+        let file: Arc<str> = Arc::from("claim.x12");
+        let parent = DocumentContext::new(DocumentId::next(), Arc::clone(&file), isa);
+
+        let mut gs = IndexMap::new();
+        gs.insert(
+            Box::from("group"),
+            make_section(&[("functional_id", Value::String("HC".into()))]),
+        );
+        let group_id = DocumentId::next();
+        let child = parent.child(group_id, gs);
+
+        // Distinct identity per level, shared file.
+        assert_ne!(child.id(), parent.id());
+        assert_eq!(child.id(), group_id);
+        assert!(Arc::ptr_eq(child.source_file(), &file));
+
+        // The child resolves BOTH its own section and the inherited
+        // ancestor section through the same two-level lookup — the
+        // flattened-sibling representation that lets nested levels read
+        // via distinct names with no $doc syntax change.
+        assert_eq!(
+            child.get_section_field("interchange", "control_ref"),
+            Some(Value::String("000000001".into()))
+        );
+        assert_eq!(
+            child.get_section_field("group", "functional_id"),
+            Some(Value::String("HC".into()))
+        );
+        // The parent never gained the child's section.
+        assert!(parent.get_section_field("group", "functional_id").is_none());
+    }
+
+    #[test]
+    fn child_section_name_collision_shadows_ancestor() {
+        let mut outer = IndexMap::new();
+        outer.insert(
+            Box::from("meta"),
+            make_section(&[("level", Value::String("interchange".into()))]),
+        );
+        let parent = DocumentContext::new(DocumentId::next(), Arc::from("f.x12"), outer);
+
+        let mut inner = IndexMap::new();
+        inner.insert(
+            Box::from("meta"),
+            make_section(&[("level", Value::String("transaction".into()))]),
+        );
+        let child = parent.child(DocumentId::next(), inner);
+
+        // Innermost wins on a name collision — lexical-scope intuition.
+        assert_eq!(
+            child.get_section_field("meta", "level"),
+            Some(Value::String("transaction".into()))
+        );
     }
 
     #[test]

--- a/crates/clinker-schema/src/model.rs
+++ b/crates/clinker-schema/src/model.rs
@@ -60,6 +60,7 @@ pub enum SourceFormat {
     Xml,
     Parquet,
     Edifact,
+    X12,
 }
 
 impl SourceFormat {
@@ -73,6 +74,7 @@ impl SourceFormat {
             Self::Xml => "xml",
             Self::Parquet => "parquet",
             Self::Edifact => "edifact",
+            Self::X12 => "x12",
         }
     }
 
@@ -84,6 +86,7 @@ impl SourceFormat {
             Self::Xml => FormatCategory::Xml,
             Self::Parquet => FormatCategory::Parquet,
             Self::Edifact => FormatCategory::Edifact,
+            Self::X12 => FormatCategory::X12,
         }
     }
 }
@@ -96,6 +99,7 @@ pub enum FormatCategory {
     Xml,
     Parquet,
     Edifact,
+    X12,
 }
 
 /// A single field in a schema.

--- a/crates/clinker-schema/src/validate.rs
+++ b/crates/clinker-schema/src/validate.rs
@@ -131,6 +131,7 @@ fn validate_input(
         InputFormat::Xml(_) => schema.metadata.format == crate::model::SourceFormat::Xml,
         InputFormat::FixedWidth(_) => false, // No schema format match for fixed-width yet
         InputFormat::Edifact(_) => schema.metadata.format == crate::model::SourceFormat::Edifact,
+        InputFormat::X12(_) => schema.metadata.format == crate::model::SourceFormat::X12,
     };
 
     if !format_matches {

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -92,8 +92,8 @@ Use --field to trace where a composition config value comes from across all \
 configuration layers (composition defaults, channel defaults, channel fixed). \
 Use --code to look up the documentation for a diagnostic code (composition codes \
 E101–E108, combine codes E300-E319 and W302/W305/W306, memory codes E310-E312, \
-spill codes E320/E321, storage-validation codes E330-E334, staging-copy codes \
-E335-E337, and W101).",
+spill codes E320/E321, EDI output-split codes E323/E338, storage-validation \
+codes E330-E334, staging-copy codes E335-E337, and W101).",
         after_long_help = "\
 EXAMPLES:
   # Show provenance for a composition config field
@@ -1991,7 +1991,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E337, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E338, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -441,7 +441,8 @@ fn collect_field_refs_stmt(stmt: &cxl::ast::Statement, names: &mut Vec<String>) 
             }
             collect_field_refs_expr(message, names);
         }
-        cxl::ast::Statement::EmitEach { source, body, .. } => {
+        cxl::ast::Statement::EmitEach { source, body, .. }
+        | cxl::ast::Statement::ExplodeOuter { source, body, .. } => {
             collect_field_refs_expr(source, names);
             for inner in body {
                 collect_field_refs_stmt(inner, names);
@@ -598,6 +599,26 @@ fn format_statement(stmt: &cxl::ast::Statement) -> String {
                 .join("\n  ");
             format!(
                 "emit each {} in {} {{\n  {}\n}}",
+                binding,
+                format_expr(source),
+                body_str,
+            )
+        }
+        cxl::ast::Statement::ExplodeOuter {
+            binding,
+            source,
+            body,
+            ..
+        } => {
+            let body_str = body
+                .iter()
+                .map(format_statement)
+                .collect::<Vec<_>>()
+                .join("\n  ");
+            // The trailing `outer` modifier distinguishes the variant that
+            // preserves the trigger row when the source is null/empty.
+            format!(
+                "emit each {} in {} outer {{\n  {}\n}}",
                 binding,
                 format_expr(source),
                 body_str,

--- a/crates/cxl/src/analyzer/mod.rs
+++ b/crates/cxl/src/analyzer/mod.rs
@@ -144,7 +144,7 @@ fn walk_statement(stmt: &Statement, calls: &mut Vec<WindowCallInfo>, fields: &mu
         Statement::UseStmt { .. } => {}
         Statement::Filter { predicate, .. } => walk_expr(predicate, calls, fields, None),
         Statement::Distinct { .. } => {}
-        Statement::EmitEach { source, body, .. } => {
+        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
             walk_expr(source, calls, fields, None);
             for inner in body {
                 walk_statement(inner, calls, fields);

--- a/crates/cxl/src/ast.rs
+++ b/crates/cxl/src/ast.rs
@@ -99,7 +99,10 @@ pub enum Statement {
     /// Evaluates `source` to a `Value::Array`, then for each element runs
     /// `body` with `binding` bound to the element value. Body emit
     /// statements produce one output record per iteration. Null source
-    /// emits zero records. Nesting is rejected at parse time.
+    /// emits zero records. The body may contain further `emit each` /
+    /// `emit each ... outer` blocks — fan-out within fan-out for one
+    /// trigger row — governed by one cumulative `max_expansion` budget
+    /// across all nesting levels.
     EmitEach {
         node_id: NodeId,
         binding: Box<str>,
@@ -112,8 +115,8 @@ pub enum Statement {
     /// but a null or empty-array source still emits the trigger row once
     /// with `binding` bound to null rather than emitting zero records —
     /// the outer-join (`LATERAL VIEW OUTER EXPLODE`) shape that preserves
-    /// a trigger row carrying no array elements. Nesting is rejected at
-    /// parse time, the same as `emit each`.
+    /// a trigger row carrying no array elements. The body may nest
+    /// further fan-out blocks, the same as `emit each`.
     ExplodeOuter {
         node_id: NodeId,
         binding: Box<str>,
@@ -133,8 +136,8 @@ pub enum Statement {
 /// silently wrong for programs whose only output emits live inside
 /// `emit each` — bind-schema, executor route resolution, and the
 /// transform write-set all diverge from runtime behavior, surfacing as
-/// schema mismatches at the first downstream operator. The parser
-/// rejects nesting, so a single level of recursion suffices.
+/// schema mismatches at the first downstream operator. Fan-out may
+/// nest, so the descent recurses to arbitrary depth.
 pub fn for_each_field_emit<'a>(stmts: &'a [Statement], visit: &mut dyn FnMut(&'a str, &'a Expr)) {
     for stmt in stmts {
         match stmt {

--- a/crates/cxl/src/ast.rs
+++ b/crates/cxl/src/ast.rs
@@ -107,11 +107,26 @@ pub enum Statement {
         body: Vec<Statement>,
         span: Span,
     },
+    /// Outer fan-out statement: `emit each <binding> in <source> outer { <body> }`.
+    /// Identical to [`Statement::EmitEach`] for a non-empty array source,
+    /// but a null or empty-array source still emits the trigger row once
+    /// with `binding` bound to null rather than emitting zero records —
+    /// the outer-join (`LATERAL VIEW OUTER EXPLODE`) shape that preserves
+    /// a trigger row carrying no array elements. Nesting is rejected at
+    /// parse time, the same as `emit each`.
+    ExplodeOuter {
+        node_id: NodeId,
+        binding: Box<str>,
+        source: Expr,
+        body: Vec<Statement>,
+        span: Span,
+    },
 }
 
 /// Visit every `Statement::Emit { target: Field, .. }` reachable from
-/// `stmts`, descending through `Statement::EmitEach.body`. The visitor
-/// receives `(name, expr)` for each field-targeted emit.
+/// `stmts`, descending through `Statement::EmitEach.body` and
+/// `Statement::ExplodeOuter.body`. The visitor receives `(name, expr)`
+/// for each field-targeted emit.
 ///
 /// Use anywhere downstream code collects the bare field names a CXL
 /// program writes to the record stream. A non-recursive walker is
@@ -129,20 +144,24 @@ pub fn for_each_field_emit<'a>(stmts: &'a [Statement], visit: &mut dyn FnMut(&'a
                 target: EmitTarget::Field,
                 ..
             } => visit(name.as_ref(), expr),
-            Statement::EmitEach { body, .. } => for_each_field_emit(body, visit),
+            Statement::EmitEach { body, .. } | Statement::ExplodeOuter { body, .. } => {
+                for_each_field_emit(body, visit)
+            }
             _ => {}
         }
     }
 }
 
 /// True when `stmts` contains at least one `Statement::Emit` (any
-/// target), recursing through `Statement::EmitEach.body`. Mirrors the
-/// "does this program emit anything" check while staying coherent in
-/// the presence of fan-out.
+/// target), recursing through `Statement::EmitEach.body` and
+/// `Statement::ExplodeOuter.body`. Mirrors the "does this program emit
+/// anything" check while staying coherent in the presence of fan-out.
 pub fn contains_emit(stmts: &[Statement]) -> bool {
     stmts.iter().any(|stmt| match stmt {
         Statement::Emit { .. } => true,
-        Statement::EmitEach { body, .. } => contains_emit(body),
+        Statement::EmitEach { body, .. } | Statement::ExplodeOuter { body, .. } => {
+            contains_emit(body)
+        }
         _ => false,
     })
 }

--- a/crates/cxl/src/eval/builtins_impl.rs
+++ b/crates/cxl/src/eval/builtins_impl.rs
@@ -666,11 +666,10 @@ pub fn dispatch_method(
         })),
         "set" => Ok(Some(match (receiver, args.first(), args.get(1)) {
             (Value::Map(m), Some(Value::String(key)), Some(val)) => {
-                let mut out = (**m).clone();
-                // Map keys are independent `Box<str>`; build one from the
-                // field-value string.
-                out.insert(Box::from(key.as_str()), val.clone());
-                Value::Map(Box::new(out))
+                // A bare key (no `.` / `[n]`) inserts at the top level. A
+                // dotted/indexed path descends, auto-creating missing
+                // intermediate Maps; see `map_set_path` for the conflict rules.
+                map_set_path(m, key.as_str(), val)
             }
             _ => Value::Null,
         })),
@@ -684,6 +683,135 @@ pub fn dispatch_method(
         })),
 
         _ => Ok(None), // Unknown method
+    }
+}
+
+// ── `.set` path navigation ──────────────────────────────────
+//
+// `.set` accepts a dotted/indexed path as its key so a single call can write
+// into a nested document: `m.set("address.city", "NYC")`, `m.set("items[0].sku",
+// "x")`. The receiver is copy-on-write — every level on the write path is cloned,
+// the upstream binding is never mutated.
+
+/// One step along a `.set` path: a map key or an array position.
+enum PathSeg<'a> {
+    /// Field lookup into a `Value::Map` by string key.
+    Field(&'a str),
+    /// Positional access into a `Value::Array` by zero-based index.
+    Index(usize),
+}
+
+/// Splits a `.set` key into navigation segments.
+///
+/// `.`-separated names become [`PathSeg::Field`]; a `[n]` suffix on a name or
+/// on a prior index becomes [`PathSeg::Index`], so `a.b[0].c` parses as
+/// `[Field("a"), Field("b"), Index(0), Field("c")]`. Returns `None` for a
+/// malformed bracket group (empty, non-numeric, or unterminated) so the whole
+/// `.set` resolves to `Null` rather than guessing intent. An empty field name
+/// (a leading/trailing/doubled `.`) is a real key — a map can hold `""` — so it
+/// is preserved rather than rejected.
+fn parse_set_path(key: &str) -> Option<Vec<PathSeg<'_>>> {
+    let bytes = key.as_bytes();
+    let mut segs = Vec::new();
+    let mut i = 0;
+    // A path opens with a field name; thereafter each step is either `.field`
+    // or `[index]`, both of which this loop consumes from the current cursor.
+    let mut field_start = 0;
+    let mut in_field = true;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'.' if in_field => {
+                segs.push(PathSeg::Field(&key[field_start..i]));
+                i += 1;
+                field_start = i;
+            }
+            b'[' => {
+                if in_field {
+                    segs.push(PathSeg::Field(&key[field_start..i]));
+                }
+                let close = key[i + 1..].find(']')? + i + 1;
+                let idx: usize = key[i + 1..close].parse().ok()?;
+                segs.push(PathSeg::Index(idx));
+                i = close + 1;
+                // A `]` is followed by either `.field`, another `[index]`, or
+                // end-of-path — never a bare field name glued onto the bracket.
+                if i < bytes.len() {
+                    match bytes[i] {
+                        b'.' => {
+                            i += 1;
+                            field_start = i;
+                            in_field = true;
+                        }
+                        b'[' => in_field = false,
+                        _ => return None,
+                    }
+                } else {
+                    in_field = false;
+                }
+            }
+            _ => {
+                in_field = true;
+                i += 1;
+            }
+        }
+    }
+    if in_field {
+        segs.push(PathSeg::Field(&key[field_start..]));
+    }
+    Some(segs)
+}
+
+/// Sets `val` at `key` within map `m`, returning a fresh `Value::Map`.
+///
+/// Missing intermediate map segments are auto-created as empty maps, so a path
+/// can build structure that does not yet exist (jq `setpath` / Bloblang
+/// convention). Returns `Value::Null` for the whole operation on a hard
+/// conflict — an existing intermediate is present but the wrong kind for the
+/// next segment (e.g. indexing a map, or fielding an array) — and on an array
+/// index past the end (no silent auto-grow). A malformed path string is also
+/// `Null`.
+fn map_set_path(m: &indexmap::IndexMap<Box<str>, Value>, key: &str, val: &Value) -> Value {
+    let Some(segs) = parse_set_path(key) else {
+        return Value::Null;
+    };
+    let mut root = Value::Map(Box::new(m.clone()));
+    if set_in(&mut root, &segs, val) {
+        root
+    } else {
+        Value::Null
+    }
+}
+
+/// Writes `val` at the path `segs` inside `target`, descending in place into
+/// the caller's already-cloned copy. Returns `false` on any conflict so the
+/// caller can discard the partial copy and yield `Null` for the whole `.set`.
+fn set_in(target: &mut Value, segs: &[PathSeg<'_>], val: &Value) -> bool {
+    let Some((head, rest)) = segs.split_first() else {
+        *target = val.clone();
+        return true;
+    };
+    match (head, target) {
+        (PathSeg::Field(name), Value::Map(map)) => {
+            if rest.is_empty() {
+                map.insert(Box::from(*name), val.clone());
+                true
+            } else {
+                // Auto-create a missing intermediate as an empty map so the
+                // path can build structure; an existing wrong-kind child trips
+                // the conflict check one level down.
+                let child = map
+                    .entry(Box::from(*name))
+                    .or_insert_with(|| Value::Map(Box::new(indexmap::IndexMap::new())));
+                set_in(child, rest, val)
+            }
+        }
+        (PathSeg::Index(idx), Value::Array(items)) => match items.get_mut(*idx) {
+            Some(child) => set_in(child, rest, val),
+            None => false, // index past the end → Null, no auto-grow
+        },
+        // Field-into-array, index-into-map, or any scalar where a container is
+        // required: a hard type conflict.
+        _ => false,
     }
 }
 

--- a/crates/cxl/src/eval/compiled.rs
+++ b/crates/cxl/src/eval/compiled.rs
@@ -104,6 +104,13 @@ pub(crate) struct EvalState {
     /// running emit count reaches this, the originating record errors
     /// with `ExpansionLimitExceeded` rather than expanding unboundedly.
     max_expansion: u64,
+    /// Records this input has fanned out so far, summed across every
+    /// nesting level of `emit each` / `emit each ... outer`. The ceiling
+    /// is cumulative, not per-level: an article → section → tag fan-out
+    /// charges every emitted leaf against one budget so nesting cannot
+    /// multiply past `max_expansion` undetected. Reset to zero at the
+    /// start of each [`CompiledProgram::eval_record`].
+    expansion_count: u64,
 }
 
 impl EvalState {
@@ -115,6 +122,7 @@ impl EvalState {
             distinct_seen: has_distinct.then(HashSet::new),
             current_partition_key: None,
             max_expansion,
+            expansion_count: 0,
         }
     }
 
@@ -271,11 +279,15 @@ struct StmtOut<'s> {
     record_vars: indexmap::IndexMap<String, Value>,
     /// Records produced by `emit each` blocks this record. Non-empty at
     /// end-of-program promotes the result to [`EvalResult::EmitMany`].
+    /// A nested `emit each` body runs against a child `StmtOut` whose
+    /// `fan_out` collects that level's records; the parent lifts them
+    /// into its own `fan_out` so every leaf record reaches the top.
     fan_out: Vec<super::EmitOne>,
-    /// Running fan-out cardinality across all `emit each` blocks for this
-    /// record, checked against [`EvalState::max_expansion`].
-    expansion_count: u64,
-    /// Cross-record dedup state, borrowed for the duration of the record.
+    /// Cross-record dedup state plus the cumulative fan-out counter,
+    /// borrowed for the duration of the record. The expansion count lives
+    /// on [`EvalState`] (not here) so it accumulates across nesting levels:
+    /// each nested `emit each` body shares the same `state`, charging every
+    /// leaf record against one cumulative `max_expansion` budget.
     state: &'s mut EvalState,
 }
 
@@ -333,11 +345,14 @@ impl<S: RecordStorage + 'static> CompiledProgram<S> {
             window,
             env: HashMap::new(),
         };
+        // The cumulative fan-out budget is per input record; reset it
+        // before any `emit each` block runs so one record's expansion
+        // never charges against the next.
+        state.expansion_count = 0;
         let mut out = StmtOut {
             fields: indexmap::IndexMap::new(),
             record_vars: indexmap::IndexMap::new(),
             fan_out: Vec::new(),
-            expansion_count: 0,
             state,
         };
         for stmt in &self.statements {
@@ -537,9 +552,15 @@ fn compile_stmt<S: RecordStorage + 'static>(
             let binding = binding.to_string();
             let source = compile_expr::<S>(typed, source);
             let span = *span;
-            // The body is a restricted sub-program: only let / emit /
-            // trace / use / expression statements. `filter` / `distinct` /
-            // nested `emit each` are rejected at compile time with a
+            // Whether the body itself fans out (a nested `emit each` /
+            // `emit each ... outer` statement). Decides how a leaf record
+            // is collected — see `run_fan_out`. A property of the body
+            // shape, so it is computed once here, not re-derived per record.
+            let body_fans_out = body_has_fan_out(body);
+            // The body is a restricted sub-program: let / emit / trace /
+            // use / expression statements plus nested `emit each` /
+            // `emit each ... outer` (fan-out within fan-out). `filter` /
+            // `distinct` are still rejected at compile time with a
             // span-anchored type error — a fan-out block applies once per
             // outer record, so a body filter/distinct has no representable
             // meaning.
@@ -564,43 +585,7 @@ fn compile_stmt<S: RecordStorage + 'static>(
                         ));
                     }
                 };
-                for element in elements {
-                    // Ceiling check before binding/evaluating the element:
-                    // an oversized fan-out errors before unbounded work.
-                    if out.expansion_count >= out.state.max_expansion {
-                        return Err(EvalError::new(
-                            EvalErrorKind::ExpansionLimitExceeded {
-                                limit: out.state.max_expansion,
-                            },
-                            span,
-                        ));
-                    }
-                    frame.env.insert(binding.clone(), element);
-                    // Seed each emitted record with the field / record-var
-                    // writes already produced before this block — a
-                    // top-level `emit name = ...` preceding the fan-out
-                    // applies to every record it produces.
-                    let mut iter = StmtOut {
-                        fields: out.fields.clone(),
-                        record_vars: out.record_vars.clone(),
-                        fan_out: Vec::new(),
-                        expansion_count: 0,
-                        state: &mut *out.state,
-                    };
-                    for stmt in &body {
-                        // A restricted body never skips or fans out, so the
-                        // flow result is always `Continue`; an error
-                        // propagates with the per-element binding still in
-                        // env (per-record scratch, discarded on error).
-                        stmt(frame, &mut iter)?;
-                    }
-                    frame.env.remove(binding.as_str());
-                    out.fan_out.push(super::EmitOne {
-                        fields: iter.fields,
-                        record_vars: Box::new(iter.record_vars),
-                    });
-                    out.expansion_count += 1;
-                }
+                run_fan_out(frame, out, &binding, &body, body_fans_out, elements, span)?;
                 Ok(StmtFlow::Continue)
             })
         }
@@ -614,9 +599,10 @@ fn compile_stmt<S: RecordStorage + 'static>(
             let binding = binding.to_string();
             let source = compile_expr::<S>(typed, source);
             let span = *span;
-            // Same restricted body surface as `emit each`: only let / emit
-            // / trace / use / expression statements; filter / distinct /
-            // nested fan-out are rejected at compile time.
+            let body_fans_out = body_has_fan_out(body);
+            // Same restricted body surface as `emit each`: let / emit /
+            // trace / use / expression statements plus nested fan-out;
+            // filter / distinct are rejected at compile time.
             let body: Vec<CompiledStmt<S>> = body
                 .iter()
                 .map(|s| compile_emit_each_body_stmt(typed, s))
@@ -650,47 +636,152 @@ fn compile_stmt<S: RecordStorage + 'static>(
                     elements
                 };
 
-                for element in elements {
-                    // Ceiling check before binding/evaluating the element:
-                    // an oversized fan-out errors before unbounded work.
-                    if out.expansion_count >= out.state.max_expansion {
-                        return Err(EvalError::new(
-                            EvalErrorKind::ExpansionLimitExceeded {
-                                limit: out.state.max_expansion,
-                            },
-                            span,
-                        ));
-                    }
-                    frame.env.insert(binding.clone(), element);
-                    let mut iter = StmtOut {
-                        fields: out.fields.clone(),
-                        record_vars: out.record_vars.clone(),
-                        fan_out: Vec::new(),
-                        expansion_count: 0,
-                        state: &mut *out.state,
-                    };
-                    for stmt in &body {
-                        stmt(frame, &mut iter)?;
-                    }
-                    frame.env.remove(binding.as_str());
-                    out.fan_out.push(super::EmitOne {
-                        fields: iter.fields,
-                        record_vars: Box::new(iter.record_vars),
-                    });
-                    out.expansion_count += 1;
-                }
+                run_fan_out(frame, out, &binding, &body, body_fans_out, elements, span)?;
                 Ok(StmtFlow::Continue)
             })
         }
     }
 }
 
+/// Drive one `emit each` / `emit each ... outer` block: bind each element,
+/// run the (already-compiled) body, and lift the produced records into
+/// `out.fan_out`. Shared by both fan-out statements — they differ only in
+/// how their caller derives `elements` (a null source is zero records for
+/// `emit each`, one null-bound trigger row for the `outer` variant), so
+/// every behavior past element derivation is identical.
+///
+/// Nested fan-out: each element runs against a child [`StmtOut`] seeded
+/// with the records emitted before this block. `body_fans_out` (computed
+/// once at compile time by [`body_has_fan_out`]) selects how a leaf is
+/// collected:
+///
+/// - **Body fans out** (it contains a nested `emit each` / `... outer`):
+///   the child's `fan_out` *is* this element's output — zero or more leaf
+///   records. They are moved up into the parent's `fan_out`, so a deeply
+///   nested article → section → tag expansion surfaces every leaf at the
+///   top, and a nested block that produces nothing (a plain inner
+///   `emit each` over a null/empty group) correctly contributes no leaf.
+/// - **Body does not fan out**: the body produced exactly one leaf record
+///   (its field / record-var channels), which is pushed directly.
+///
+/// This distinction must be a compile-time property of the body, not a
+/// runtime `iter.fan_out.is_empty()` test: a nested fan-out that emits
+/// zero records leaves `fan_out` empty yet must still contribute nothing,
+/// not a spurious single record.
+///
+/// The `max_expansion` ceiling is **cumulative** across nesting levels:
+/// every leaf record (whether produced here or by a nested block) charges
+/// against `state.expansion_count`, and the leaf-level check fires before
+/// the element's work, so an oversized fan-out errors before unbounded
+/// allocation and nesting cannot multiply the budget. The binding is
+/// save/restored around the loop so a same-named outer binding survives a
+/// nested block that rebinds it (`emit each it in a { emit each it in b }`).
+fn run_fan_out<'a, 'w, S: RecordStorage + 'static>(
+    frame: &mut Frame<'a, 'w, S>,
+    out: &mut StmtOut<'_>,
+    binding: &str,
+    body: &[CompiledStmt<S>],
+    body_fans_out: bool,
+    elements: Vec<Value>,
+    span: Span,
+) -> Result<(), EvalError> {
+    // Save any same-named binding shadowed by this block (a nested
+    // fan-out reusing the binding name, or a record field). The loop's
+    // result is computed first, then the binding is restored on every
+    // exit path below — so the restore is written once, not duplicated at
+    // each early return.
+    let shadowed = frame.env.remove(binding);
+    let mut result = Ok(());
+    for element in elements {
+        // For a leaf body (no nested fan-out) each element yields exactly
+        // one record; charge the cumulative budget before doing the work
+        // so an oversized fan-out errors before unbounded allocation. A
+        // nesting body defers the check to its inner leaves.
+        if !body_fans_out && out.state.expansion_count >= out.state.max_expansion {
+            result = Err(EvalError::new(
+                EvalErrorKind::ExpansionLimitExceeded {
+                    limit: out.state.max_expansion,
+                },
+                span,
+            ));
+            break;
+        }
+        frame.env.insert(binding.to_string(), element);
+        // Seed each emitted record with the field / record-var writes
+        // already produced before this block — a top-level
+        // `emit name = ...` preceding the fan-out applies to every record
+        // it produces. The child shares `out.state`, so its cumulative
+        // expansion count and dedup set are the parent's.
+        let mut iter = StmtOut {
+            fields: out.fields.clone(),
+            record_vars: out.record_vars.clone(),
+            fan_out: Vec::new(),
+            state: &mut *out.state,
+        };
+        let mut body_err = None;
+        for stmt in body {
+            // A restricted body never skips, and a nested fan-out reports
+            // `Continue` after collecting into `iter.fan_out`, so the flow
+            // result is always `Continue` on success.
+            if let Err(e) = stmt(frame, &mut iter) {
+                body_err = Some(e);
+                break;
+            }
+        }
+        // Move the child's owned channels out so its `&mut out.state`
+        // borrow ends here, freeing `out.state` for the append below.
+        let StmtOut {
+            fields: iter_fields,
+            record_vars: iter_record_vars,
+            fan_out: mut iter_fan_out,
+            state: _,
+        } = iter;
+        if let Some(e) = body_err {
+            result = Err(e);
+            break;
+        }
+        if body_fans_out {
+            // The nested fan-out already charged each inner leaf against
+            // the cumulative budget; lift its records (zero or more) up.
+            out.fan_out.append(&mut iter_fan_out);
+        } else {
+            out.fan_out.push(super::EmitOne {
+                fields: iter_fields,
+                record_vars: Box::new(iter_record_vars),
+            });
+            out.state.expansion_count += 1;
+        }
+    }
+    frame.env.remove(binding);
+    if let Some(prev) = shadowed {
+        frame.env.insert(binding.to_string(), prev);
+    }
+    result
+}
+
+/// Whether a fan-out body contains a top-level `emit each` /
+/// `emit each ... outer` statement — i.e. whether running the body
+/// produces its output records via the child's `fan_out` channel rather
+/// than a single field map. Computed once at compile time so
+/// [`run_fan_out`] never re-derives it per record. Only the immediate
+/// level matters; a fan-out nested two levels down is reached transitively
+/// through this same body's nested block.
+fn body_has_fan_out(body: &[Statement]) -> bool {
+    body.iter().any(|s| {
+        matches!(
+            s,
+            Statement::EmitEach { .. } | Statement::ExplodeOuter { .. }
+        )
+    })
+}
+
 /// Compile one statement of an `emit each` body. The body surface is
-/// restricted to let / emit / trace / use / expression statements;
-/// `filter` / `distinct` / nested `emit each` are rejected here at
-/// compile time with a span-anchored type error. The returned closure
-/// shares the same `StmtOut` shape as a top-level statement but only ever
-/// reports `Continue`.
+/// let / emit / trace / use / expression statements plus nested fan-out
+/// (`emit each` / `emit each ... outer`); `filter` / `distinct` are
+/// rejected here at compile time with a span-anchored type error. The
+/// returned closure shares the same `StmtOut` shape as a top-level
+/// statement; a nested fan-out reports `Continue` after collecting its
+/// records into the child `StmtOut.fan_out`.
 ///
 /// `trace` and `use` are compiled to bare `Continue` no-ops here, *not*
 /// routed through `compile_stmt`: inside a fan-out body a `trace`'s guard
@@ -705,19 +796,21 @@ fn compile_emit_each_body_stmt<S: RecordStorage + 'static>(
         Statement::Trace { .. } | Statement::UseStmt { .. } => {
             Box::new(|_frame, _out| Ok(StmtFlow::Continue))
         }
-        Statement::Let { .. } | Statement::Emit { .. } | Statement::ExprStmt { .. } => {
-            compile_stmt(typed, stmt)
-        }
-        Statement::Filter { span, .. }
-        | Statement::Distinct { span, .. }
-        | Statement::EmitEach { span, .. }
-        | Statement::ExplodeOuter { span, .. } => {
+        // Nested fan-out is a first-class body statement: its compiled
+        // closure collects into the child `StmtOut.fan_out`, which the
+        // surrounding `run_fan_out` lifts up a level.
+        Statement::Let { .. }
+        | Statement::Emit { .. }
+        | Statement::ExprStmt { .. }
+        | Statement::EmitEach { .. }
+        | Statement::ExplodeOuter { .. } => compile_stmt(typed, stmt),
+        Statement::Filter { span, .. } | Statement::Distinct { span, .. } => {
             let span = *span;
             Box::new(move |_frame, _out| {
                 Err(EvalError::new(
                     EvalErrorKind::TypeMismatch {
-                        expected: "let / emit / trace inside emit each body",
-                        got: "filter / distinct / nested emit_each",
+                        expected: "let / emit / trace / nested emit each inside emit each body",
+                        got: "filter / distinct",
                     },
                     span,
                 ))

--- a/crates/cxl/src/eval/compiled.rs
+++ b/crates/cxl/src/eval/compiled.rs
@@ -604,6 +604,84 @@ fn compile_stmt<S: RecordStorage + 'static>(
                 Ok(StmtFlow::Continue)
             })
         }
+        Statement::ExplodeOuter {
+            binding,
+            source,
+            body,
+            span,
+            ..
+        } => {
+            let binding = binding.to_string();
+            let source = compile_expr::<S>(typed, source);
+            let span = *span;
+            // Same restricted body surface as `emit each`: only let / emit
+            // / trace / use / expression statements; filter / distinct /
+            // nested fan-out are rejected at compile time.
+            let body: Vec<CompiledStmt<S>> = body
+                .iter()
+                .map(|s| compile_emit_each_body_stmt(typed, s))
+                .collect();
+            Box::new(move |frame, out| {
+                let source_val = source(frame)?;
+                let elements = match source_val {
+                    Value::Array(arr) => arr,
+                    // A null source is treated as an empty array — the
+                    // outer variant's defining difference from `emit each`.
+                    Value::Null => Vec::new(),
+                    other => {
+                        return Err(EvalError::new(
+                            EvalErrorKind::TypeMismatch {
+                                expected: "Array",
+                                got: other.type_name(),
+                            },
+                            span,
+                        ));
+                    }
+                };
+
+                // The outer-join (`LATERAL VIEW OUTER EXPLODE`) shape:
+                // an empty/null source still emits the trigger row once
+                // with the binding bound to null, rather than emitting
+                // zero records. Driving the same per-element loop over a
+                // synthetic `[null]` keeps the two cases on one code path.
+                let elements = if elements.is_empty() {
+                    vec![Value::Null]
+                } else {
+                    elements
+                };
+
+                for element in elements {
+                    // Ceiling check before binding/evaluating the element:
+                    // an oversized fan-out errors before unbounded work.
+                    if out.expansion_count >= out.state.max_expansion {
+                        return Err(EvalError::new(
+                            EvalErrorKind::ExpansionLimitExceeded {
+                                limit: out.state.max_expansion,
+                            },
+                            span,
+                        ));
+                    }
+                    frame.env.insert(binding.clone(), element);
+                    let mut iter = StmtOut {
+                        fields: out.fields.clone(),
+                        record_vars: out.record_vars.clone(),
+                        fan_out: Vec::new(),
+                        expansion_count: 0,
+                        state: &mut *out.state,
+                    };
+                    for stmt in &body {
+                        stmt(frame, &mut iter)?;
+                    }
+                    frame.env.remove(binding.as_str());
+                    out.fan_out.push(super::EmitOne {
+                        fields: iter.fields,
+                        record_vars: Box::new(iter.record_vars),
+                    });
+                    out.expansion_count += 1;
+                }
+                Ok(StmtFlow::Continue)
+            })
+        }
     }
 }
 
@@ -632,7 +710,8 @@ fn compile_emit_each_body_stmt<S: RecordStorage + 'static>(
         }
         Statement::Filter { span, .. }
         | Statement::Distinct { span, .. }
-        | Statement::EmitEach { span, .. } => {
+        | Statement::EmitEach { span, .. }
+        | Statement::ExplodeOuter { span, .. } => {
             let span = *span;
             Box::new(move |_frame, _out| {
                 Err(EvalError::new(

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -1976,4 +1976,127 @@ mod intra_record {
             parsed.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
         );
     }
+
+    // ── explode_outer (`emit each ... outer`) ──────────────────────
+    // The outer variant matches `emit each` on a non-empty array but
+    // preserves the trigger row (binding bound to null) when the source
+    // is null or empty.
+
+    #[test]
+    fn explode_outer_fans_out_one_per_element_when_non_empty() {
+        let out = run(
+            "emit each it in nums outer {\n  emit val = it\n}",
+            &["nums"],
+            HashMap::from([(
+                "nums".into(),
+                arr(vec![
+                    Value::Integer(1),
+                    Value::Integer(2),
+                    Value::Integer(3),
+                ]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 3);
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Integer(1)));
+                assert_eq!(records[1].fields.get("val"), Some(&Value::Integer(2)));
+                assert_eq!(records[2].fields.get("val"), Some(&Value::Integer(3)));
+            }
+            other => panic!("expected EmitMany, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explode_outer_null_source_preserves_trigger_row_with_null_binding() {
+        let out = run(
+            "emit each it in nums outer {\n  emit val = it\n}",
+            &["nums"],
+            HashMap::from([("nums".into(), Value::Null)]),
+        )
+        .unwrap();
+        // Unlike `emit each` (which emits nothing on a null source), the
+        // outer variant emits exactly one record with the binding bound
+        // to null — the LATERAL VIEW OUTER EXPLODE shape.
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 1);
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Null));
+            }
+            other => panic!("expected single EmitMany record on null source, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explode_outer_empty_array_preserves_trigger_row_with_null_binding() {
+        let out = run(
+            "emit each it in nums outer {\n  emit val = it\n}",
+            &["nums"],
+            HashMap::from([("nums".into(), arr(vec![]))]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 1);
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Null));
+            }
+            other => panic!("expected single EmitMany record on empty array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explode_outer_trigger_row_carries_pre_block_emits() {
+        // A top-level emit preceding the fan-out applies to the preserved
+        // trigger row too, so the outer-join row is never bare.
+        let out = run(
+            "emit kept = 7\nemit each it in nums outer {\n  emit val = it\n}",
+            &["nums"],
+            HashMap::from([("nums".into(), Value::Null)]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 1);
+                assert_eq!(records[0].fields.get("kept"), Some(&Value::Integer(7)));
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Null));
+            }
+            other => {
+                panic!("expected single EmitMany record carrying pre-block emit, got {other:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn explode_outer_max_expansion_governs_non_empty_fan_out() {
+        let big: Vec<Value> = (0..20).map(Value::Integer).collect();
+        let err = run_with_max_expansion(
+            "emit each it in nums outer {\n  emit val = it\n}",
+            &["nums"],
+            HashMap::from([("nums".into(), arr(big))]),
+            5,
+        )
+        .expect_err("expected ExpansionLimitExceeded");
+        match err.kind {
+            crate::eval::EvalErrorKind::ExpansionLimitExceeded { limit } => {
+                assert_eq!(limit, 5);
+            }
+            other => panic!("expected ExpansionLimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_explode_outer_rejected_by_parser() {
+        let result = Parser::parse(
+            "emit each it in nums outer {\n  emit each x in others outer { emit val = x }\n}",
+        );
+        assert!(
+            result
+                .errors
+                .iter()
+                .any(|e| e.message.contains("emit_each cannot be nested")),
+            "expected nested fan-out parse error, got: {:?}",
+            result.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
+        );
+    }
 }

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -1942,17 +1942,160 @@ mod intra_record {
     }
 
     #[test]
-    fn nested_emit_each_rejected_by_parser() {
-        let result =
-            Parser::parse("emit each it in nums {\n  emit each x in others { emit val = x }\n}");
-        assert!(
-            result
-                .errors
-                .iter()
-                .any(|e| e.message.contains("emit_each cannot be nested")),
-            "expected nested emit_each parse error, got: {:?}",
-            result.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
-        );
+    fn nested_emit_each_fans_out_within_fan_out() {
+        // Two-level fan-out for one trigger row: the outer iterates
+        // `groups`, the inner iterates each group's `items`, producing one
+        // leaf record per (group, item). The inner binding reads the
+        // current element while the outer binding stays visible.
+        let out = run(
+            "emit each g in groups {\n  emit each it in g {\n    emit val = it\n  }\n}",
+            &["groups"],
+            HashMap::from([(
+                "groups".into(),
+                arr(vec![
+                    arr(vec![Value::Integer(1), Value::Integer(2)]),
+                    arr(vec![Value::Integer(3)]),
+                ]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 3, "2 + 1 leaf records");
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Integer(1)));
+                assert_eq!(records[1].fields.get("val"), Some(&Value::Integer(2)));
+                assert_eq!(records[2].fields.get("val"), Some(&Value::Integer(3)));
+            }
+            other => panic!("expected EmitMany, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_emit_each_outer_binding_visible_in_inner_body() {
+        // The outer binding (`g`) must remain readable inside the inner
+        // fan-out body alongside the inner binding (`it`).
+        let out = run(
+            "emit each g in groups {\n  emit each it in g {\n    emit pair = it\n  }\n}",
+            &["groups"],
+            HashMap::from([(
+                "groups".into(),
+                arr(vec![arr(vec![Value::Integer(10), Value::Integer(20)])]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 2);
+                assert_eq!(records[0].fields.get("pair"), Some(&Value::Integer(10)));
+                assert_eq!(records[1].fields.get("pair"), Some(&Value::Integer(20)));
+            }
+            other => panic!("expected EmitMany, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_emit_each_pre_block_emits_apply_to_every_leaf() {
+        // A top-level emit before the outer block, and an emit inside the
+        // outer body before the inner block, both apply to every leaf
+        // record the nested fan-out produces.
+        let out = run(
+            "emit kept = 9\nemit each g in groups {\n  emit gid = 7\n  emit each it in g {\n    emit val = it\n  }\n}",
+            &["groups"],
+            HashMap::from([(
+                "groups".into(),
+                arr(vec![arr(vec![Value::Integer(1), Value::Integer(2)])]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 2);
+                for r in &records {
+                    assert_eq!(r.fields.get("kept"), Some(&Value::Integer(9)));
+                    assert_eq!(r.fields.get("gid"), Some(&Value::Integer(7)));
+                }
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Integer(1)));
+                assert_eq!(records[1].fields.get("val"), Some(&Value::Integer(2)));
+            }
+            other => panic!("expected EmitMany, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_emit_each_max_expansion_is_cumulative() {
+        // The cap counts leaf records across both nesting levels, not
+        // per-level. Three groups of two items = six leaves; a cap of 5
+        // trips on the sixth.
+        let groups = arr(vec![
+            arr(vec![Value::Integer(1), Value::Integer(2)]),
+            arr(vec![Value::Integer(3), Value::Integer(4)]),
+            arr(vec![Value::Integer(5), Value::Integer(6)]),
+        ]);
+        let err = run_with_max_expansion(
+            "emit each g in groups {\n  emit each it in g {\n    emit val = it\n  }\n}",
+            &["groups"],
+            HashMap::from([("groups".into(), groups)]),
+            5,
+        )
+        .expect_err("expected cumulative ExpansionLimitExceeded across nesting");
+        match err.kind {
+            crate::eval::EvalErrorKind::ExpansionLimitExceeded { limit } => {
+                assert_eq!(limit, 5);
+            }
+            other => panic!("expected ExpansionLimitExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_emit_each_inner_null_source_emits_no_leaf_for_that_group() {
+        // A plain inner `emit each` over a null/empty group fans out zero
+        // leaves for that group while sibling groups still expand.
+        let out = run(
+            "emit each g in groups {\n  emit each it in g {\n    emit val = it\n  }\n}",
+            &["groups"],
+            HashMap::from([(
+                "groups".into(),
+                arr(vec![
+                    arr(vec![Value::Integer(1)]),
+                    Value::Null,
+                    arr(vec![Value::Integer(2)]),
+                ]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 2, "null group contributes no leaf");
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Integer(1)));
+                assert_eq!(records[1].fields.get("val"), Some(&Value::Integer(2)));
+            }
+            other => panic!("expected EmitMany, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_emit_each_same_binding_name_restores_outer_after_inner() {
+        // The inner block reuses the outer binding name (`it`). After the
+        // inner loop the outer `it` must be restored so a trailing
+        // outer-body emit still reads the outer element, not a leftover
+        // inner value.
+        let out = run(
+            "emit each it in groups {\n  emit each it in it {\n    emit leaf = it\n  }\n}",
+            &["groups"],
+            HashMap::from([(
+                "groups".into(),
+                arr(vec![arr(vec![Value::Integer(1), Value::Integer(2)])]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 2);
+                assert_eq!(records[0].fields.get("leaf"), Some(&Value::Integer(1)));
+                assert_eq!(records[1].fields.get("leaf"), Some(&Value::Integer(2)));
+            }
+            other => panic!("expected EmitMany, got {other:?}"),
+        }
     }
 
     #[test]
@@ -2086,16 +2229,70 @@ mod intra_record {
     }
 
     #[test]
-    fn nested_explode_outer_rejected_by_parser() {
-        let result = Parser::parse(
-            "emit each it in nums outer {\n  emit each x in others outer { emit val = x }\n}",
-        );
+    fn nested_explode_outer_preserves_trigger_row_for_empty_inner_group() {
+        // Inner `outer` over an empty group preserves one trigger row with
+        // the inner binding bound to null, instead of dropping the group.
+        let out = run(
+            "emit each g in groups {\n  emit each it in g outer {\n    emit val = it\n  }\n}",
+            &["groups"],
+            HashMap::from([(
+                "groups".into(),
+                arr(vec![arr(vec![Value::Integer(1)]), arr(vec![])]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                // First group: one leaf (val=1). Second group is empty, but
+                // the inner `outer` still emits one null-bound trigger row.
+                assert_eq!(records.len(), 2);
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Integer(1)));
+                assert_eq!(records[1].fields.get("val"), Some(&Value::Null));
+            }
+            other => panic!("expected EmitMany, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_outer_outer_null_top_source_preserves_single_trigger_row() {
+        // A null top-level source under `outer` synthesizes one null
+        // element; the nested inner `outer` over that null binding then
+        // preserves a single trigger row with both bindings null.
+        let out = run(
+            "emit each g in groups outer {\n  emit each it in g outer {\n    emit val = it\n  }\n}",
+            &["groups"],
+            HashMap::from([("groups".into(), Value::Null)]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::EmitMany { records } => {
+                assert_eq!(records.len(), 1);
+                assert_eq!(records[0].fields.get("val"), Some(&Value::Null));
+            }
+            other => panic!("expected single preserved trigger row, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_emit_each_too_deep_rejected_by_parser() {
+        // Fan-out nesting is bounded (32 levels) so adversarial input
+        // cannot overflow the parser's statement recursion. Build 40
+        // nested `emit each` blocks and confirm the depth guard fires.
+        let mut src = String::new();
+        for i in 0..40 {
+            src.push_str(&format!("emit each b{i} in arr{i} {{\n"));
+        }
+        src.push_str("emit val = 1\n");
+        for _ in 0..40 {
+            src.push_str("}\n");
+        }
+        let result = Parser::parse(&src);
         assert!(
             result
                 .errors
                 .iter()
-                .any(|e| e.message.contains("emit_each cannot be nested")),
-            "expected nested fan-out parse error, got: {:?}",
+                .any(|e| e.message.contains("nesting too deep")),
+            "expected emit-each depth-limit parse error, got: {:?}",
             result.errors.iter().map(|e| &e.message).collect::<Vec<_>>()
         );
     }

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -1650,6 +1650,209 @@ mod intra_record {
     }
 
     #[test]
+    fn nested_set_replaces_existing_leaf() {
+        let out = run(
+            "emit updated = doc.set(\"address.city\", \"NYC\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "address",
+                    map(vec![
+                        ("city", Value::String("LA".into())),
+                        ("zip", Value::String("90001".into())),
+                    ]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("updated"),
+                    Some(&map(vec![(
+                        "address",
+                        map(vec![
+                            ("city", Value::String("NYC".into())),
+                            ("zip", Value::String("90001".into())),
+                        ]),
+                    )]))
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_set_auto_creates_missing_intermediates() {
+        let out = run(
+            "emit built = doc.set(\"a.b.c\", 7)",
+            &["doc"],
+            HashMap::from([("doc".into(), map(vec![]))]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("built"),
+                    Some(&map(vec![(
+                        "a",
+                        map(vec![("b", map(vec![("c", Value::Integer(7))]))]),
+                    )]))
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_set_type_conflict_returns_null() {
+        // `a` exists but is a scalar, so descending into `a.b` is a hard
+        // conflict: the whole op returns Null.
+        let out = run(
+            "emit r = doc.set(\"a.b\", 1)",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![("a", Value::String("scalar".into()))]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(fields.get("r"), Some(&Value::Null));
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_set_into_existing_array_element() {
+        let out = run(
+            "emit r = doc.set(\"items[1].name\", \"X\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "items",
+                    arr(vec![
+                        map(vec![("name", Value::String("a".into()))]),
+                        map(vec![("name", Value::String("b".into()))]),
+                    ]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![(
+                        "items",
+                        arr(vec![
+                            map(vec![("name", Value::String("a".into()))]),
+                            map(vec![("name", Value::String("X".into()))]),
+                        ]),
+                    )]))
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_set_array_index_past_end_returns_null() {
+        // Index 5 is past the 2-element array → Null for the whole op, with no
+        // silent auto-grow.
+        let out = run(
+            "emit r = doc.set(\"items[5].name\", \"X\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "items",
+                    arr(vec![
+                        map(vec![("name", Value::String("a".into()))]),
+                        map(vec![("name", Value::String("b".into()))]),
+                    ]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(fields.get("r"), Some(&Value::Null));
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_set_field_into_array_returns_null() {
+        // `items` is an array; a field segment against it is a type conflict.
+        let out = run(
+            "emit r = doc.set(\"items.name\", \"X\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![("items", arr(vec![Value::Integer(1)]))]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(fields.get("r"), Some(&Value::Null));
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_set_does_not_mutate_receiver() {
+        // `.set` is copy-on-write: emitting both the original and the mutated
+        // path must show the original untouched.
+        let out = run(
+            "emit before = doc\nemit after = doc.set(\"a.b\", 9)",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![("a", map(vec![("b", Value::Integer(1))]))]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("before"),
+                    Some(&map(vec![("a", map(vec![("b", Value::Integer(1))]))]))
+                );
+                assert_eq!(
+                    fields.get("after"),
+                    Some(&map(vec![("a", map(vec![("b", Value::Integer(9))]))]))
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_key_set_still_inserts_at_top_level() {
+        // The bare-key fast path must be unchanged by the nested-path work.
+        let out = run(
+            "emit r = doc.set(\"k\", 1)",
+            &["doc"],
+            HashMap::from([("doc".into(), map(vec![]))]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(fields.get("r"), Some(&map(vec![("k", Value::Integer(1))])));
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn array_remove_returns_new_array_without_index() {
         let out = run(
             "emit val = nums.remove(1)",

--- a/crates/cxl/src/parser.rs
+++ b/crates/cxl/src/parser.rs
@@ -425,11 +425,14 @@ impl Parser {
         })
     }
 
-    /// Parse `emit each <binding> in <source> { <body> }`. Called from
-    /// [`Self::parse_emit`] after the `each` keyword has been peeked
-    /// (but not consumed). `nid` and `start` are taken from the parent's
-    /// allocator so the resulting `Statement::EmitEach` carries the
-    /// same NodeId/Span origin as a plain `emit`.
+    /// Parse `emit each <binding> in <source> { <body> }`, or its
+    /// outer-join variant `emit each <binding> in <source> outer
+    /// { <body> }`. Called from [`Self::parse_emit`] after the `each`
+    /// keyword has been peeked (but not consumed). `nid` and `start` are
+    /// taken from the parent's allocator so the resulting statement
+    /// carries the same NodeId/Span origin as a plain `emit`. A trailing
+    /// `outer` modifier yields [`Statement::ExplodeOuter`]; its absence
+    /// yields [`Statement::EmitEach`].
     fn parse_emit_each(&mut self, nid: NodeId, start: Span) -> Result<Statement, ParseError> {
         if self.in_emit_each {
             return Err(self.error(
@@ -480,6 +483,18 @@ impl Parser {
             }
         }
         let source = self.parse_expr(0)?;
+
+        // Detect the trailing `outer` modifier — the outer-join variant
+        // that preserves the trigger row when the source is null/empty.
+        // `outer` is a bare identifier (not a reserved keyword), so it is
+        // only meaningful in this position; `parse_expr` above stops at it
+        // because an identifier carries no infix binding power, leaving it
+        // as the current token between the source and the `{`.
+        let is_outer = matches!(self.peek(), Token::Ident(name) if name.as_ref() == "outer");
+        if is_outer {
+            self.advance(); // consume 'outer' ident
+        }
+
         self.expect_token(&Token::LBrace, "'{'")?;
 
         self.in_emit_each = true;
@@ -499,13 +514,24 @@ impl Parser {
         let end_span = self.current_span();
         self.expect_token(&Token::RBrace, "'}'")?;
 
-        Ok(Statement::EmitEach {
-            node_id: nid,
-            binding: binding.into(),
-            source,
-            body,
-            span: Span::new(start.start as usize, end_span.end as usize),
-        })
+        let span = Span::new(start.start as usize, end_span.end as usize);
+        if is_outer {
+            Ok(Statement::ExplodeOuter {
+                node_id: nid,
+                binding: binding.into(),
+                source,
+                body,
+                span,
+            })
+        } else {
+            Ok(Statement::EmitEach {
+                node_id: nid,
+                binding: binding.into(),
+                source,
+                body,
+                span,
+            })
+        }
     }
 
     fn parse_filter(&mut self) -> Result<Statement, ParseError> {
@@ -2603,6 +2629,80 @@ mod tests {
                 assert!(matches!(&**lhs, Expr::FieldRef { name, .. } if &**name == "sum"));
             }
             _ => panic!("expected Binary"),
+        }
+    }
+
+    #[test]
+    fn test_parse_emit_each_without_outer_is_emit_each() {
+        let r = parse_ok("emit each it in items {\n  emit val = it\n}");
+        match first_stmt(&r) {
+            Statement::EmitEach { binding, .. } => assert_eq!(&**binding, "it"),
+            other => panic!("expected EmitEach, got {:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    #[test]
+    fn test_parse_emit_each_outer_modifier_is_explode_outer() {
+        // The trailing non-reserved `outer` identifier selects the
+        // outer-join variant. The source expression parses greedily and
+        // stops at `outer` because a bare identifier carries no infix
+        // binding power.
+        let r = parse_ok("emit each it in items outer {\n  emit val = it\n}");
+        match first_stmt(&r) {
+            Statement::ExplodeOuter {
+                binding, source, ..
+            } => {
+                assert_eq!(&**binding, "it");
+                // `outer` must not have been absorbed into the source.
+                assert!(
+                    matches!(source, Expr::FieldRef { name, .. } if &**name == "items"),
+                    "source should be the `items` FieldRef, got {:?}",
+                    std::mem::discriminant(source)
+                );
+            }
+            other => panic!(
+                "expected ExplodeOuter, got {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    #[test]
+    fn test_parse_emit_each_outer_with_named_binding() {
+        let r = parse_ok("emit each tag in tags outer {\n  emit t = tag\n}");
+        match first_stmt(&r) {
+            Statement::ExplodeOuter { binding, .. } => assert_eq!(&**binding, "tag"),
+            other => panic!(
+                "expected ExplodeOuter, got {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    #[test]
+    fn test_parse_emit_each_source_named_outer_is_not_explode_outer() {
+        // A source field literally named `outer` is consumed by the
+        // source `parse_expr`; the modifier check then sees `{`, not a
+        // trailing `outer`, so this is a plain EmitEach over
+        // `FieldRef("outer")`, never ExplodeOuter. The modifier only
+        // fires when an `outer` identifier sits *between* the source
+        // expression and the `{`.
+        let r = parse_ok("emit each it in outer {\n  emit val = it\n}");
+        match first_stmt(&r) {
+            Statement::EmitEach {
+                binding, source, ..
+            } => {
+                assert_eq!(&**binding, "it");
+                assert!(
+                    matches!(source, Expr::FieldRef { name, .. } if &**name == "outer"),
+                    "source should be the `outer` FieldRef, got {:?}",
+                    std::mem::discriminant(source)
+                );
+            }
+            other => panic!(
+                "expected EmitEach over FieldRef(\"outer\"), got {:?}",
+                std::mem::discriminant(other)
+            ),
         }
     }
 }

--- a/crates/cxl/src/parser.rs
+++ b/crates/cxl/src/parser.rs
@@ -50,12 +50,23 @@ pub struct Parser {
     errors: Vec<ParseError>,
     depth: u32,
     next_id: u32,
-    /// Tracks whether parser is currently inside the body of an
-    /// `emit each` block. Nested `emit each` is forbidden so the
-    /// per-record fan-out remains a single flat expansion; the
-    /// `max_expansion` ceiling is the only gate on output cardinality.
-    in_emit_each: bool,
+    /// Current `emit each` block nesting depth. Fan-out may nest (an
+    /// `emit each` inside another `emit each` body, fanning out within
+    /// fan-out for one trigger row); the cumulative `max_expansion`
+    /// ceiling — not a parser-level ban — gates total output cardinality.
+    /// The depth is still capped at [`MAX_EMIT_EACH_DEPTH`] so adversarial
+    /// input cannot drive `parse_emit_each`'s statement recursion into a
+    /// stack overflow, the same stack-safety guarantee `depth` gives the
+    /// expression parser.
+    emit_each_depth: u32,
 }
+
+/// Maximum `emit each` block nesting depth. Bounds `parse_emit_each`'s
+/// statement-level recursion so deeply nested fan-out in malicious input
+/// cannot overflow the parser stack. Real document fan-out (article →
+/// section → tag) is a handful of levels; 32 is far beyond any legitimate
+/// pipeline yet small enough to keep recursion shallow.
+const MAX_EMIT_EACH_DEPTH: u32 = 32;
 
 // Binding power pairs (left_bp, right_bp).
 // Lower number = looser binding. Right-associative: right_bp < left_bp.
@@ -123,7 +134,7 @@ impl Parser {
             errors: Vec::new(),
             depth: 0,
             next_id: 0,
-            in_emit_each: false,
+            emit_each_depth: 0,
         };
         let start_span = parser.current_span();
         let mut statements = Vec::new();
@@ -180,7 +191,7 @@ impl Parser {
             errors: Vec::new(),
             depth: 0,
             next_id: 0,
-            in_emit_each: false,
+            emit_each_depth: 0,
         };
         let start_span = parser.current_span();
         let mut functions = Vec::new();
@@ -432,13 +443,16 @@ impl Parser {
     /// taken from the parent's allocator so the resulting statement
     /// carries the same NodeId/Span origin as a plain `emit`. A trailing
     /// `outer` modifier yields [`Statement::ExplodeOuter`]; its absence
-    /// yields [`Statement::EmitEach`].
+    /// yields [`Statement::EmitEach`]. Fan-out may nest — an `emit each`
+    /// body may itself contain `emit each` blocks — bounded by
+    /// [`MAX_EMIT_EACH_DEPTH`] so adversarial input cannot overflow the
+    /// statement-recursion stack.
     fn parse_emit_each(&mut self, nid: NodeId, start: Span) -> Result<Statement, ParseError> {
-        if self.in_emit_each {
+        if self.emit_each_depth >= MAX_EMIT_EACH_DEPTH {
             return Err(self.error(
-                "emit_each cannot be nested inside another emit_each",
-                "Nested fan-out would compound expansion ratios without a clear cardinality bound — the per-record max_expansion limit governs flat fan-out only",
-                "Flatten the producer (e.g. precompute the cross product into a single array) and emit once",
+                "emit each nesting too deep (max 32 levels)",
+                "Deeply nested fan-out is bounded to keep parser recursion stack-safe; legitimate document fan-out is only a few levels deep",
+                "Flatten part of the nesting (e.g. precompute a flattened array with .flat_map) and fan out over fewer levels",
             ));
         }
 
@@ -497,20 +511,24 @@ impl Parser {
 
         self.expect_token(&Token::LBrace, "'{'")?;
 
-        self.in_emit_each = true;
+        // Enter one nesting level. A nested `emit each` inside the body
+        // re-enters here and increments again; on the error path the
+        // depth is restored so a recoverable parse does not leak a
+        // permanently-elevated depth into sibling statements.
+        self.emit_each_depth += 1;
         let mut body = Vec::new();
         self.skip_newlines();
         while *self.peek() != Token::RBrace && !self.at_eof() {
             match self.parse_statement() {
                 Ok(stmt) => body.push(stmt),
                 Err(e) => {
-                    self.in_emit_each = false;
+                    self.emit_each_depth -= 1;
                     return Err(e);
                 }
             }
             self.skip_newlines();
         }
-        self.in_emit_each = false;
+        self.emit_each_depth -= 1;
         let end_span = self.current_span();
         self.expect_token(&Token::RBrace, "'}'")?;
 
@@ -2674,6 +2692,27 @@ mod tests {
             Statement::ExplodeOuter { binding, .. } => assert_eq!(&**binding, "tag"),
             other => panic!(
                 "expected ExplodeOuter, got {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
+    }
+
+    #[test]
+    fn test_parse_nested_emit_each_is_accepted() {
+        // Nesting is no longer a parse error: an `emit each` body may
+        // contain another `emit each`, parsed as a body statement.
+        let r =
+            parse_ok("emit each g in groups {\n  emit each it in g {\n    emit val = it\n  }\n}");
+        match first_stmt(&r) {
+            Statement::EmitEach { body, .. } => {
+                assert!(
+                    matches!(body.first(), Some(Statement::EmitEach { .. })),
+                    "expected a nested EmitEach in the body, got {:?}",
+                    body.first().map(std::mem::discriminant)
+                );
+            }
+            other => panic!(
+                "expected outer EmitEach, got {:?}",
                 std::mem::discriminant(other)
             ),
         }

--- a/crates/cxl/src/plan/extract_aggregates.rs
+++ b/crates/cxl/src/plan/extract_aggregates.rs
@@ -104,12 +104,12 @@ pub fn extract_aggregates(
                 // ExprStmt in aggregate mode is meaningless and
                 // already rejected upstream.
             }
-            Statement::EmitEach { span, .. } => {
-                // emit_each fan-out has no defined meaning at an aggregate
-                // boundary — finalize() emits one record per group, so a
-                // body Emit's fan-out shape cannot collapse onto a single
-                // group key. Reject at extraction time with the same
-                // shape `Distinct` uses.
+            Statement::EmitEach { span, .. } | Statement::ExplodeOuter { span, .. } => {
+                // Fan-out (plain or outer) has no defined meaning at an
+                // aggregate boundary — finalize() emits one record per
+                // group, so a body Emit's fan-out shape cannot collapse
+                // onto a single group key. Reject at extraction time with
+                // the same shape `Distinct` uses.
                 diagnostics.push(diag_distinct_in_aggregate(*span));
             }
         }

--- a/crates/cxl/src/resolve/pass.rs
+++ b/crates/cxl/src/resolve/pass.rs
@@ -207,13 +207,21 @@ impl<'a> Resolver<'a> {
                 source,
                 body,
                 ..
+            }
+            | Statement::ExplodeOuter {
+                binding,
+                source,
+                body,
+                ..
             } => {
                 // Resolve the source expression in the outer scope; the
                 // binding only becomes visible inside the body. The
                 // binding is registered as a let-var so FieldRef
                 // resolution will find it before falling back to the
                 // input schema; pop it on exit to keep let_vars accurate
-                // for subsequent statements outside the EmitEach block.
+                // for subsequent statements outside the fan-out block.
+                // The outer variant resolves identically — only its
+                // empty/null-source runtime behavior differs.
                 self.resolve_expr(source);
                 let saved_len = self.let_vars.len();
                 self.let_vars.push(binding.to_string());

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -361,6 +361,26 @@ impl<'a> TypeChecker<'a> {
                     self.check_statement(stmt);
                 }
             }
+            Statement::ExplodeOuter { source, body, .. } => {
+                let source_ty = self.check_expr(source, false);
+                let inner = source_ty.unwrap_nullable();
+                // The outer variant additionally accepts a statically-null
+                // source: a null/empty array is the case it exists to
+                // handle — it preserves the trigger row with the binding
+                // bound to null rather than emitting nothing.
+                if !matches!(inner, Type::Array | Type::Any | Type::Null) {
+                    self.error(
+                        source.span(),
+                        format!(
+                            "emit_each ... outer requires an Array, Null, or Any source, got {source_ty}"
+                        ),
+                        Some("Use an Array-valued (or nullable Array) expression; the outer variant preserves the trigger row when that array is null or empty".into()),
+                    );
+                }
+                for stmt in body {
+                    self.check_statement(stmt);
+                }
+            }
         }
     }
 
@@ -994,10 +1014,12 @@ impl<'a> TypeChecker<'a> {
                     self.agg_function_depth = 0;
                     self.walk_agg_ctx_row_only(predicate);
                 }
-                Statement::EmitEach { source, body, .. } => {
-                    // emit_each is a row-level fan-out: the source must
-                    // not contain aggregates, and body statements obey
-                    // the same context rules as the surrounding block.
+                Statement::EmitEach { source, body, .. }
+                | Statement::ExplodeOuter { source, body, .. } => {
+                    // Fan-out (plain or outer) is a row-level operation:
+                    // the source must not contain aggregates, and body
+                    // statements obey the same context rules as the
+                    // surrounding block.
                     self.agg_function_depth = 0;
                     self.walk_agg_ctx_row_only(source);
                     // Recurse the body via the existing dispatch by
@@ -1392,8 +1414,9 @@ impl<'a> TypeChecker<'a> {
     }
 
     /// Check that the program has at least one emit statement. Recurses
-    /// through `Statement::EmitEach.body` so a program whose only emits
-    /// live inside a fan-out block still counts as having emits.
+    /// through `Statement::EmitEach.body` and `Statement::ExplodeOuter.body`
+    /// so a program whose only emits live inside a fan-out block still
+    /// counts as having emits.
     fn check_emit_count(&mut self, program: &Program) {
         let has_emit = crate::ast::contains_emit(&program.statements);
         if !has_emit {

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -996,51 +996,48 @@ impl<'a> TypeChecker<'a> {
             .collect();
 
         for stmt in &program.statements {
-            match stmt {
-                Statement::Emit { expr, .. } => {
-                    self.agg_function_depth = 0;
-                    self.walk_agg_ctx(expr, &let_exprs);
-                }
-                // Let bindings are checked through their usage sites
-                // (PostgreSQL-style alias expansion): a bare non-grouped
-                // field in a let body is only an error if the let var is
-                // referenced outside an aggregate function.
-                Statement::Let { .. } => {}
-                Statement::Filter { predicate, .. } => {
-                    // Filter in an aggregate transform acts as a row-level
-                    // gate (WHERE semantics). AggCalls here are rejected in
-                    // both modes — GroupBy also rejects because aggregates
-                    // belong in HAVING (not supported), matching PostgreSQL.
-                    self.agg_function_depth = 0;
-                    self.walk_agg_ctx_row_only(predicate);
-                }
-                Statement::EmitEach { source, body, .. }
-                | Statement::ExplodeOuter { source, body, .. } => {
-                    // Fan-out (plain or outer) is a row-level operation:
-                    // the source must not contain aggregates, and body
-                    // statements obey the same context rules as the
-                    // surrounding block.
-                    self.agg_function_depth = 0;
-                    self.walk_agg_ctx_row_only(source);
-                    // Recurse the body via the existing dispatch by
-                    // wrapping each body statement through the same
-                    // pattern.
-                    for stmt in body {
-                        match stmt {
-                            Statement::Emit { expr, .. } => {
-                                self.agg_function_depth = 0;
-                                self.walk_agg_ctx(expr, &let_exprs);
-                            }
-                            Statement::Filter { predicate, .. } => {
-                                self.agg_function_depth = 0;
-                                self.walk_agg_ctx_row_only(predicate);
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-                _ => {}
+            self.check_aggregate_context_stmt(stmt, &let_exprs);
+        }
+    }
+
+    /// Enforce aggregate-context rules on one statement, recursing through
+    /// `emit each` / `emit each ... outer` bodies — including a fan-out
+    /// nested inside another fan-out, so a nested block's emits and the
+    /// aggregate calls inside them are never invisible to this check. A
+    /// non-recursive walker that handled only the immediate body silently
+    /// admitted aggregates buried one fan-out level deeper.
+    fn check_aggregate_context_stmt(&mut self, stmt: &Statement, let_exprs: &[Expr]) {
+        match stmt {
+            Statement::Emit { expr, .. } => {
+                self.agg_function_depth = 0;
+                self.walk_agg_ctx(expr, let_exprs);
             }
+            // Let bindings are checked through their usage sites
+            // (PostgreSQL-style alias expansion): a bare non-grouped
+            // field in a let body is only an error if the let var is
+            // referenced outside an aggregate function.
+            Statement::Let { .. } => {}
+            Statement::Filter { predicate, .. } => {
+                // Filter in an aggregate transform acts as a row-level
+                // gate (WHERE semantics). AggCalls here are rejected in
+                // both modes — GroupBy also rejects because aggregates
+                // belong in HAVING (not supported), matching PostgreSQL.
+                self.agg_function_depth = 0;
+                self.walk_agg_ctx_row_only(predicate);
+            }
+            Statement::EmitEach { source, body, .. }
+            | Statement::ExplodeOuter { source, body, .. } => {
+                // Fan-out (plain or outer) is a row-level operation: the
+                // source must not contain aggregates, and body statements
+                // — at every nesting level — obey the same context rules
+                // as the surrounding block.
+                self.agg_function_depth = 0;
+                self.walk_agg_ctx_row_only(source);
+                for inner in body {
+                    self.check_aggregate_context_stmt(inner, let_exprs);
+                }
+            }
+            _ => {}
         }
     }
 
@@ -1840,6 +1837,23 @@ mod tests {
     fn test_agg_in_row_context_rejected() {
         let errs = row_err("emit total = sum(amount)", &["amount"]);
         assert!(errs.iter().any(|d| d.message.contains("sum")));
+    }
+
+    #[test]
+    fn test_agg_inside_nested_emit_each_body_row_context_rejected() {
+        // The aggregate-context walker must descend through both fan-out
+        // levels: an aggregate call buried in a body nested two `emit each`
+        // blocks deep is still forbidden in a row-level transform. A
+        // walker that handled only the immediate body would let this slip.
+        let errs = row_err(
+            "emit each g in groups {\n  emit each it in g {\n    emit bad = sum(it)\n  }\n}",
+            &["groups"],
+        );
+        assert!(
+            errs.iter().any(|d| d.message.contains("sum")),
+            "expected the buried aggregate to be rejected, got: {:?}",
+            errs.iter().map(|d| &d.message).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/docs/explain/E338.md
+++ b/docs/explain/E338.md
@@ -1,0 +1,84 @@
+# Error E338: x12 output cannot be combined with split
+
+## What it means
+
+An `Output` node declares the `x12` format and also carries a byte-limit
+`split:` block. The two are mutually exclusive: an X12 interchange is a single
+three-tier envelope — `ISA..IEA` wraps `GS..GE` functional groups, each
+wrapping `ST..SE` transaction sets — whose trailer counts (`SE` segment count,
+`GE` transaction-set count, `IEA` functional-group count) and control numbers
+are recomputed and written only at end of stream. Byte-limit file splitting
+finalizes the writer mid-stream, which would seal the interchange after the
+first file's records and then emit later records — and their fresh `ST`/`GS`
+headers — after the `IEA` trailer, producing a structurally corrupt
+interchange that still reports run success.
+
+Rather than emit corruption, clinker rejects the combination at
+config-validation time.
+
+```
+E338 output 'x12_out': `x12` output cannot be combined with `split` — an X12
+interchange is a single ISA..IEA envelope and cannot be divided across files;
+remove the `split` block or choose a splittable format
+```
+
+## Example
+
+```yaml
+# Rejected: an interchange cannot be split across files.
+nodes:
+  - output: x12_out
+    input: orders
+    format: x12
+    path: out/orders.x12
+    split:
+      max_bytes: 1048576
+```
+
+```yaml
+# Corrected (option A): drop the split block; write one interchange file.
+nodes:
+  - output: x12_out
+    input: orders
+    format: x12
+    path: out/orders.x12
+```
+
+```yaml
+# Corrected (option B): partition upstream and run one invocation per
+# partition, so each run produces its own complete interchange.
+#   for f in inputs/*.csv; do clinker run pipeline.yaml --var input="$f"; done
+```
+
+## How to fix
+
+1. **Remove the `split:` block** from the `x12` output. A single run then
+   writes one complete interchange file.
+
+2. **Choose a splittable format** (`csv`, `json`, `xml`, `fixed_width`) if the
+   byte-limit splitting is the requirement and the X12 envelope is not.
+
+3. **Partition the input and invoke per partition** if you need multiple
+   output files: split the source by file or key upstream and run clinker once
+   per partition, so each invocation emits its own self-contained interchange.
+
+## Technical context
+
+The X12 writer reconstructs the three envelope tiers around emitted records: it
+writes `ISA` from the configured interchange header, opens one `GS..GE`
+functional group, opens an `ST..SE` transaction set per `set_ref` transition,
+and on `flush()` closes the open set (writing `SE` with the recomputed segment
+count and the echoed `ST02` control number), closes the group (writing `GE`
+with the recomputed transaction-set count and the echoed `GS06` control
+number), and writes the `IEA` trailer with the recomputed functional-group
+count and the echoed `ISA13` control number. That finalization is the only
+point at which the interchange is well-formed. A byte-limit `split` flushes
+(and therefore finalizes) the writer whenever the per-file cap is reached, so
+any records after the first split boundary would be written outside the sealed
+envelope. Because no valid interchange can span files, the validator rejects
+the pairing up front.
+
+## See also
+
+- E323 (`edifact` output combined with byte-limit `split`)
+- "X12 Format" in the pipeline reference

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Pipeline YAML Structure](pipeline/structure.md)
 - [Source Nodes](pipeline/source.md)
 - [EDIFACT Format](pipeline/edifact.md)
+- [X12 Format](pipeline/x12.md)
 - [Network Sources (REST)](pipeline/source-network.md)
 - [Auto-Widen & Schema Drift](pipeline/auto-widen.md)
 - [Transform Nodes](pipeline/transform.md)

--- a/docs/src/cookbook/intra-record-closures.md
+++ b/docs/src/cookbook/intra-record-closures.md
@@ -142,6 +142,17 @@ Drop the `explode` transform and route `filter_lines` directly to the Output. Ea
 
 When the per-element transformation is simple enough to fit in a single closure body, [`flat_map`](../cxl/builtins-array.md#flat_mapit--array---array) collapses the filter + project + explode pattern into one expression. It produces a flat array, which downstream nodes still see as a single field on the input record; the explicit `emit each` is what produces multiple output records.
 
+### Rewrite a nested field in place with `.set`
+
+When you want to keep the record at order grain but mutate a value buried inside it, the [`set`](../cxl/builtins-map.md#nested-paths) map method takes a dotted/indexed path and rewrites a single leaf, leaving every sibling untouched:
+
+```yaml
+    cxl: |
+      emit order = order.set("items[0].sku", "A-100").set("ship.region", "us-east")
+```
+
+The first `set` overwrites the SKU of the first item; the second writes `ship.region`, auto-creating the `ship` map if the order had no `ship` field yet. Because `set` is copy-on-write, this builds a fresh order document without disturbing the upstream binding. A path that conflicts with the existing shape (descending into a scalar, or an array index past the end) yields `null` for that `set` rather than partially writing -- guard with [`catch`](../cxl/builtins-introspection.md) if a path may not match every record.
+
 ## See also
 
 - [Closures](../cxl/closures.md) -- the `it => body` form.

--- a/docs/src/cxl/builtins-map.md
+++ b/docs/src/cxl/builtins-map.md
@@ -58,6 +58,25 @@ Returns a new map with `key` set to `value`. If the key was already present, its
 
 `stamped` is `{"name":"Alice","tier":"gold","since":"2021-04","region":"us-east"}`.
 
+#### Nested paths
+
+`key` may be a dotted/indexed path that descends into nested maps and arrays, so a single `set` writes into a deep document. Dots separate map keys; a `[n]` suffix indexes an array.
+
+```yaml
+    cxl: |
+      emit moved = profile.set("address.city", "NYC")
+      emit relabel = order.set("items[0].sku", "A-100")
+```
+
+- **Auto-create.** Missing intermediate map segments are created as empty maps, so a path can build structure that does not yet exist. `{}.set("a.b.c", 7)` returns `{"a":{"b":{"c":7}}}`. This is what lets `set` assemble a nested document from scratch (matching jq `setpath` and Bloblang assignment).
+- **Type conflict -> null.** If an intermediate segment already exists but is the wrong kind for the next step -- descending into a key whose value is a scalar, indexing a map with `[n]`, or naming a field on an array -- the whole operation returns `null`. Nothing is partially written.
+- **Array index past the end -> null.** Indexing past the last element returns `null` for the whole operation; arrays are never silently grown. The path can only overwrite an array slot that already exists.
+- **A bare key is a single key, not a path.** `"region"` writes the top-level `region`. Only `.` and `[n]` introduce nesting; a key with neither behaves exactly as before.
+
+For `profile = {"name":"Alice","address":{"city":"LA"}}`, `profile.set("address.city", "NYC")` is `{"name":"Alice","address":{"city":"NYC"}}` -- the sibling `name` and any other `address` keys are preserved.
+
+> **Known limitation.** Because `.` and `[` are path syntax, `set` cannot target a key whose name *literally* contains a `.` or `[` (for example a JSON field literally named `"a.b"`). To write such a key, build it with [`merge`](#mergeother-map---map) and a map literal; to remove it, use [`remove_field`](#remove_fieldkey-string---map), which matches the exact key string.
+
 ### remove_field(key: String) -> Map
 
 Returns a new map without `key`. If the key was absent, the receiver is returned unchanged.

--- a/docs/src/cxl/builtins.md
+++ b/docs/src/cxl/builtins.md
@@ -103,5 +103,5 @@ Builders and accessors for `Value::Map` payloads. All map methods return new map
 |--------|-------------|
 | `keys`, `values` | List map keys / values as arrays |
 | `merge` | Union of two maps (right wins on conflict) |
-| `set` | Insert / replace a single entry |
+| `set` | Insert / replace an entry, by single key or by a nested `a.b[0].c` path |
 | `remove_field` | Drop a single entry by key |

--- a/docs/src/cxl/emit-each.md
+++ b/docs/src/cxl/emit-each.md
@@ -1,6 +1,6 @@
 # Emit Each
 
-The `emit each` statement fans one input record into multiple output records -- one per element of an array on the input. The body emits the fields each output record carries.
+The `emit each` statement fans one input record into multiple output records -- one per element of an array on the input. The body emits the fields each output record carries. A trailing [`outer`](#preserving-the-trigger-row-outer) modifier preserves the trigger row when the array is empty or null.
 
 ## Syntax
 
@@ -52,6 +52,55 @@ The body reads both `it` (the current element) and `order_id` (an outer record f
 If the source array has N elements, `emit each` produces exactly N output records. Empty array sources produce zero records. A `null` source also produces zero records -- no DLQ entry, no error -- mirroring the explode-on-null convention used elsewhere in CXL.
 
 A non-array, non-null source raises a runtime type-mismatch error and routes the originating record to the DLQ.
+
+## Preserving the trigger row: `outer`
+
+A trailing `outer` modifier switches `emit each` to its outer-join variant. The grammar is identical except for the keyword after the source:
+
+```
+emit each <binding> in <source> outer {
+  <statements>
+}
+```
+
+The only behavioral difference is what happens when the source is `null` or an empty array. Plain `emit each` drops the trigger row entirely (zero output records). The `outer` variant instead emits the trigger row **once**, with `<binding>` bound to `null`:
+
+| Source       | `emit each ...`         | `emit each ... outer`                       |
+| ------------ | ----------------------- | ------------------------------------------- |
+| 3-element    | 3 records               | 3 records (identical)                       |
+| empty array  | 0 records               | 1 record, binding = `null`                  |
+| `null`       | 0 records               | 1 record, binding = `null`                  |
+
+This is the shape SQL engines spell `LATERAL VIEW OUTER EXPLODE` (Spark, Hive) or an outer `UNNEST` (DuckDB): "for each tag on this article emit a tagged row, **but keep articles that have no tags**."
+
+Using the worked example above with an order that carries no items:
+
+```ndjson
+{"order_id":"O-2","items":[]}
+```
+
+```yaml
+- type: transform
+  name: explode_outer
+  input: orders
+  config:
+    cxl: |
+      emit each it in items outer {
+        emit order_id = order_id
+        emit sku = it["sku"]
+        emit price = it["price"]
+      }
+```
+
+produces a single record that keeps `order_id` while the per-item fields read through the null binding:
+
+```ndjson
+{"order_id":"O-2","sku":null,"price":null}
+```
+
+Outer-record fields (like `order_id`) and any `emit` statements preceding the block still apply to the preserved trigger row, so an `outer` row is never bare.
+
+The source type rule is slightly wider than plain `emit each`: a statically-`null` source is accepted (it is the case the variant exists to handle), alongside arrays and `Any`. Everything else in this page — the `max_expansion` cap, the no-nesting rule, the body-statement restrictions — applies unchanged to the `outer` variant.
 
 ## Output schema
 

--- a/docs/src/cxl/emit-each.md
+++ b/docs/src/cxl/emit-each.md
@@ -51,6 +51,8 @@ The body reads both `it` (the current element) and `order_id` (an outer record f
 
 If the source array has N elements, `emit each` produces exactly N output records. Empty array sources produce zero records. A `null` source also produces zero records -- no DLQ entry, no error -- mirroring the explode-on-null convention used elsewhere in CXL.
 
+When fan-out [nests](#nested-fan-out-fan-out-within-fan-out), the cardinalities multiply: an outer array of M elements whose inner arrays have N elements each produces up to M×N records. The cumulative [`max_expansion`](#safety-cap-max_expansion) cap bounds that product.
+
 A non-array, non-null source raises a runtime type-mismatch error and routes the originating record to the DLQ.
 
 ## Preserving the trigger row: `outer`
@@ -100,7 +102,7 @@ produces a single record that keeps `order_id` while the per-item fields read th
 
 Outer-record fields (like `order_id`) and any `emit` statements preceding the block still apply to the preserved trigger row, so an `outer` row is never bare.
 
-The source type rule is slightly wider than plain `emit each`: a statically-`null` source is accepted (it is the case the variant exists to handle), alongside arrays and `Any`. Everything else in this page — the `max_expansion` cap, the no-nesting rule, the body-statement restrictions — applies unchanged to the `outer` variant.
+The source type rule is slightly wider than plain `emit each`: a statically-`null` source is accepted (it is the case the variant exists to handle), alongside arrays and `Any`. Everything else in this page — the cumulative `max_expansion` cap, the [nesting](#nested-fan-out-fan-out-within-fan-out) rules, the body-statement restrictions — applies unchanged to the `outer` variant. The two variants compose freely: an `outer` block may nest inside a plain `emit each` block and vice versa.
 
 ## Output schema
 
@@ -108,25 +110,37 @@ The body's `emit` statements define the output record's field set, the same way 
 
 Fields written by the body shadow same-named fields on the originating input record.
 
-## Nested emit_each is rejected
+## Nested fan-out: fan-out within fan-out
 
-Each transform body may contain at most one level of `emit each`. The parser rejects an `emit each` inside another `emit each` body:
+An `emit each` body may itself contain `emit each` blocks — fan-out within fan-out for one trigger row. This is the canonical "for each article, for each section, for each tag, emit a row" shape:
 
 ```
-emit each it in items {
-  emit each sub in it["children"] { ... }   -- parse error
+emit each section in article["sections"] {
+  emit each tag in section["tags"] {
+    emit article_id = article_id
+    emit section = section["name"]
+    emit tag = tag
+  }
 }
 ```
 
-If you need a cartesian product, precompute the flattened array (for example with [`.flat_map`](builtins-array.md#flat_mapit--array---array)) and use a single `emit each` over the result.
+For one input article, this produces one output record per (section, tag) pair. The inner binding (`tag`) reads the current inner element; the outer binding (`section`) and any outer-record field (`article_id`) stay visible inside the inner body. A field name reused as both an outer and inner binding shadows lexically — the inner binding wins inside the inner body, and the outer value is restored when the inner block finishes.
+
+Emits are positional: an `emit` placed in the outer body *before* a nested block applies to every leaf record that block produces, but an `emit` placed *after* a nested block does not retroactively reach the records that block already emitted. Put the fields shared across leaves above the nested block.
+
+Plain and `outer` blocks compose in any order. An inner plain `emit each` over an empty or null array contributes no records for that branch, while an inner `emit each ... outer` preserves one trigger row (inner binding bound to `null`) — exactly the per-level semantics from the [single-level table](#preserving-the-trigger-row-outer), applied at each level.
+
+Nesting is bounded to 32 levels so that adversarially deep input cannot exhaust the parser stack; legitimate document fan-out is only a few levels deep. Beyond that bound, parsing fails with a "nesting too deep" diagnostic.
+
+The flat-array workaround (precompute a flattened array with [`.flat_map`](builtins-array.md#flat_mapit--array---array) and use a single `emit each`) is still available and may be clearer for a simple two-level cartesian product, but is no longer required.
 
 ## Body-statement restrictions
 
-Within the body, only `let`, `emit`, and `trace` are accepted. `filter`, `distinct`, and nested `emit each` are rejected at evaluation time -- a body filter would split work between branches the engine can't represent. Move filter/distinct logic into a downstream transform, or pre-filter the source array with `.filter` before the `emit each` block.
+Within the body, `let`, `emit`, `trace`, and nested `emit each` / `emit each ... outer` are accepted. `filter` and `distinct` are rejected at evaluation time -- a body filter would split work between branches the engine can't represent. Move filter/distinct logic into a downstream transform, or pre-filter the source array with `.filter` before the `emit each` block.
 
 ## Safety cap: `max_expansion`
 
-To bound fan-out, every transform body carries a `max_expansion` cap on the cumulative records `emit each` may produce from a single original input record. If the cap is exceeded, the originating record routes to the DLQ with category `expansion_limit_exceeded` instead of producing a truncated or unbounded result. The default cap is 10000.
+To bound fan-out, every transform body carries a `max_expansion` cap on the cumulative records `emit each` may produce from a single original input record. The cap is **cumulative across all nesting levels**: every leaf record a nested fan-out produces charges against one shared budget, so nesting cannot multiply past the cap undetected. If the cap is exceeded, the originating record routes to the DLQ with category `expansion_limit_exceeded` instead of producing a truncated or unbounded result. The default cap is 10000.
 
 See [Transform Nodes -> Expansion Cap](../pipeline/transform.md#expansion-cap-max_expansion) for the YAML field and tuning guidance.
 

--- a/docs/src/ops/streaming-vs-blocking.md
+++ b/docs/src/ops/streaming-vs-blocking.md
@@ -9,7 +9,7 @@ This distinction is what makes Clinker a bounded-memory executor: a pipeline's p
 
 ## Which stages stream
 
-A stage streams when its output is handed straight to a single downstream consumer instead of crossing a charged inter-stage buffer. The downstream consumer is either a sink `Output` writer or an `Aggregate`'s ingest — see [Streaming into an Aggregate](#streaming-into-an-aggregate) below.
+A stage streams when its output is handed straight to a single downstream consumer instead of crossing a charged inter-stage buffer. The downstream consumer is a sink `Output` writer, an `Aggregate`'s ingest, or a hash build-probe `Combine`'s probe (driver) side — see [Streaming into an Aggregate](#streaming-into-an-aggregate) and [Streaming into a Combine probe](#streaming-into-a-combine-probe) below.
 
 Two stages stream *and* bound their own footprint to one batch, because they pull records off a live upstream channel and forward each batch without ever building a full result:
 
@@ -36,6 +36,12 @@ The streaming consumer above is usually a sink `Output`. It can also be an `Aggr
 This streams the aggregate's *ingest* half only — the producer no longer needs a charged inter-stage slot, and a slow aggregate (one that is spilling, say) paces the producer through the bounded channel. The aggregate's *finalize* half stays blocking by nature: a `group_by` value depends on every member, so the group table accumulates the whole input and emits only after the channel closes (end of input). Spill stays driven by RSS pressure, never by channel depth, exactly as on the materialized path.
 
 Two aggregate shapes keep the materialized ingest, because their finalize is not a single forward pass: a **time-windowed** aggregate runs a multi-pass per-window algorithm over the whole input, and a **relaxed correlation-key** aggregate retains its group state for the correlation-commit phase. Both show `buffer: materialized` on the edge into them.
+
+### Streaming into a Combine probe
+
+A producer can also stream into a hash build-probe `Combine`'s *probe* (driver) side. When an eligible producer (a fused `Source → Transform`, a single-branch `Route`, a non-fused `Merge`, a `streaming`-strategy `Aggregate`, or another hash build-probe `Combine`) is the Combine's driver input, the producer streams record-at-a-time into the probe kernel over a back-pressured channel rather than the Combine pre-draining the driver's whole output from a charged buffer. The driver producer reports `buffer: streaming` and `--explain` shows no `node_buffer` edge between it and the Combine. Only the `HashBuildProbe` strategy qualifies — the range, sort-merge, and grace-hash kernels re-sort or re-scan the driver and stay materialized.
+
+This streams the Combine's *probe* half only. The build side stays fully materialized: the engine builds the complete hash table on the main thread *before* the driver producer streams its first record, so the probe never matches against an incomplete index. The probe consumer runs on its own thread, so a slow driver paces the probe through the bounded channel and a slow probe (a large fan-out) back-pressures the driver. The build relation's footprint is the hash table, exactly as on the materialized path; the streaming handoff spares only the driver's inter-stage slot. Per-source dead-letter rewind, memory accounting, and output are byte-identical to the materialized path.
 
 ## Which stages block
 

--- a/docs/src/ops/streaming-vs-blocking.md
+++ b/docs/src/ops/streaming-vs-blocking.md
@@ -9,25 +9,33 @@ This distinction is what makes Clinker a bounded-memory executor: a pipeline's p
 
 ## Which stages stream
 
-A stage streams when its output is handed straight to a single downstream consumer instead of crossing a charged inter-stage buffer.
+A stage streams when its output is handed straight to a single downstream consumer instead of crossing a charged inter-stage buffer. The downstream consumer is either a sink `Output` writer or an `Aggregate`'s ingest — see [Streaming into an Aggregate](#streaming-into-an-aggregate) below.
 
 Two stages stream *and* bound their own footprint to one batch, because they pull records off a live upstream channel and forward each batch without ever building a full result:
 
 - **Source → Transform → Output** fused chains. A non-windowed Transform whose only upstream is a single Source and whose only downstream is a single sink Output consumes that Source's records directly and hands each batch to the Output's writer thread over a back-pressured channel; neither the Transform nor the Output materializes the whole record set. A Transform that fans out to multiple consumers, feeds another operator, or roots a window keeps the buffered (materialized) path.
 - **`Merge` in `interleave` mode** fed entirely by Sources. The merge reads each Source's live stream and forwards records as they arrive.
 
-These stages stream their output to a single downstream Output too — sparing the second copy and overlapping the writer — but each still builds its full result first, so its own working set is not bounded to one batch:
+These stages stream their output to a single downstream consumer too — sparing the second copy and overlapping the consumer — but each still builds its full result first, so its own working set is not bounded to one batch:
 
 - **Single-branch `Route`**. A Route with exactly one branch feeding one sink Output streams that branch's records to the writer thread. A multi-branch Route forks records across several successor buffers and stays materialized.
 - **`Merge` in `concat` mode, or `interleave` fed by non-Source inputs**, feeding one sink Output. The merge drains its predecessors' buffers in order (concat) or round-robin (interleave) into the merged result, then streams it.
 - **`streaming`-strategy `Aggregate`** feeding one sink Output. When the planner certifies the aggregate's input is pre-sorted on the group key, it finalizes the group rows and streams them rather than buffering them for a downstream arm.
 - **`Combine` probe side** (hash build-probe strategy) feeding one sink Output. The build relation stays fully materialized in the hash table; the matched probe output streams to the writer.
 
-Each of these requires the producer to feed exactly one downstream Output and to root no window; a producer that roots a window keeps the materialized path because the window arena needs the producer's full output to build.
+Each of these requires the producer to feed exactly one downstream consumer and to root no window; a producer that roots a window keeps the materialized path because the window arena needs the producer's full output to build.
 
 - **Every `Output`**. A sink writes records to its configured writer and never buffers a whole stage.
 
 Document-boundary punctuations (`DocumentOpen` / `DocumentClose`, the signals behind [`$doc.*`](../pipeline/envelope-and-doc-context.md)) flow inline with records through streaming stages, preserving their order: a document's close always trails the document's last record, even when the document's records span several batches.
+
+### Streaming into an Aggregate
+
+The streaming consumer above is usually a sink `Output`. It can also be an `Aggregate`'s *ingest*: when an eligible producer (a fused `Source → Transform`, a single-branch `Route`, a non-fused `Merge`, or a `streaming`-strategy `Aggregate`) feeds exactly one downstream `Aggregate`, the producer streams record-at-a-time into the aggregate's `add_record` over a back-pressured channel rather than the aggregate pre-draining the producer's whole output from a charged buffer. The producer reports `buffer: streaming` and `--explain` shows no `node_buffer` edge between it and the aggregate.
+
+This streams the aggregate's *ingest* half only — the producer no longer needs a charged inter-stage slot, and a slow aggregate (one that is spilling, say) paces the producer through the bounded channel. The aggregate's *finalize* half stays blocking by nature: a `group_by` value depends on every member, so the group table accumulates the whole input and emits only after the channel closes (end of input). Spill stays driven by RSS pressure, never by channel depth, exactly as on the materialized path.
+
+Two aggregate shapes keep the materialized ingest, because their finalize is not a single forward pass: a **time-windowed** aggregate runs a multi-pass per-window algorithm over the whole input, and a **relaxed correlation-key** aggregate retains its group state for the correlation-commit phase. Both show `buffer: materialized` on the edge into them.
 
 ## Which stages block
 

--- a/docs/src/pipeline/edifact.md
+++ b/docs/src/pipeline/edifact.md
@@ -140,6 +140,15 @@ corruption signal):
   messages in the interchange.
 - **`UNZ` control reference** — must echo the `UNB` control reference.
 
+The `UNB` control reference (data element 0020) is located by its
+structural position — the first data element after the four mandatory
+leading composites (syntax identifier, sender, recipient, date/time) —
+rather than at a fixed element index. An interchange that carries an
+empty optional element ahead of the control reference (shifting it past
+the fifth position) therefore validates and round-trips correctly: the
+reader reads the real reference and the writer echoes the same one into
+`UNZ`, so the trailer never contradicts its own header.
+
 A missing `UNZ` at end of input is a truncation error; content after the
 `UNZ` trailer is rejected.
 

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -88,6 +88,7 @@ Each section declares how the reader locates its payload:
 | XML     | `xml_path`       | Slash-path to the section element, e.g. `/doc/Head` |
 | JSON    | `json_pointer`   | RFC 6901 pointer, e.g. `/Head`                   |
 | EDIFACT | `segment`        | A service-segment tag — only `UNB`               |
+| X12     | `segment`        | A service-segment tag — only `ISA` (GS/ST surface as nested levels) |
 
 Declaring an `xml_path` section against a JSON source (or vice versa),
 or a `segment` extract against XML/JSON, is a configuration error and
@@ -182,25 +183,30 @@ through several branches closes downstream exactly once).
 ## Nested (multi-level) envelopes
 
 Some formats wrap their records in *several* envelope levels, one inside
-another. EDI X12 is the canonical example: an **interchange** (ISA/IEA)
-contains one or more **functional groups** (GS/GE), each containing one
-or more **transaction sets** (ST/SE), each containing the records. A
-single file can carry multiple interchanges back to back.
+another. EDI X12 is the canonical example and the first format that
+implements this: an **interchange** (ISA/IEA) contains one or more
+**functional groups** (GS/GE), each containing one or more **transaction
+sets** (ST/SE), each containing the records. A single file can carry
+multiple interchanges back to back. See [X12 Format](x12.md) for the full
+reference.
 
 A reader for such a format opens and closes each nested level as it
 crosses the corresponding envelope boundary mid-file. Each level
-contributes its own sections to `$doc`, under names *you* choose for that
-level. There is no new `$doc` syntax for nesting — every level's sections
-are read through the same two-level `$doc.<section>.<field>` lookup. Give
-each level a distinct section name and a record inside the innermost
-level sees them all:
+contributes its own sections to `$doc`. There is no new `$doc` syntax for
+nesting — every level's sections are read through the same two-level
+`$doc.<section>.<field>` lookup. A record inside the innermost level sees
+every enclosing level's sections at once. For X12 the interchange header is
+a *declared* `segment: "ISA"` envelope section (you choose its name), while
+the `GS` group and `ST` set surface automatically as the reader-supplied
+sections `functional_group` and `transaction_set`, each keyed by positional
+`eNN` elements:
 
 ```yaml
 project:
-  - interchange_control: $doc.interchange.control_ref   # ISA level
-  - functional_id:       $doc.group.functional_id       # GS level
-  - transaction_type:    $doc.transaction.set_id         # ST level
-  - claim_amount:        amount                          # body field
+  - interchange_control: $doc.interchange.e13        # ISA13, declared section
+  - functional_id:       $doc.functional_group.e01   # GS01 (reader-supplied)
+  - transaction_type:    $doc.transaction_set.e01     # ST01 (reader-supplied)
+  - claim_amount:        amount                       # body field
 ```
 
 A record streamed inside the ST level resolves the ST section, the

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -178,3 +178,56 @@ aggregate flush or trailer-count validation — fire at exactly the right
 point. Today the signals propagate through Source, Transform, Route,
 Sort, and Combine, and are reconciled at Merge (a document that fans in
 through several branches closes downstream exactly once).
+
+## Nested (multi-level) envelopes
+
+Some formats wrap their records in *several* envelope levels, one inside
+another. EDI X12 is the canonical example: an **interchange** (ISA/IEA)
+contains one or more **functional groups** (GS/GE), each containing one
+or more **transaction sets** (ST/SE), each containing the records. A
+single file can carry multiple interchanges back to back.
+
+A reader for such a format opens and closes each nested level as it
+crosses the corresponding envelope boundary mid-file. Each level
+contributes its own sections to `$doc`, under names *you* choose for that
+level. There is no new `$doc` syntax for nesting — every level's sections
+are read through the same two-level `$doc.<section>.<field>` lookup. Give
+each level a distinct section name and a record inside the innermost
+level sees them all:
+
+```yaml
+project:
+  - interchange_control: $doc.interchange.control_ref   # ISA level
+  - functional_id:       $doc.group.functional_id       # GS level
+  - transaction_type:    $doc.transaction.set_id         # ST level
+  - claim_amount:        amount                          # body field
+```
+
+A record streamed inside the ST level resolves the ST section, the
+enclosing GS section, and the outermost ISA section, all at once: each
+inner level inherits every enclosing level's sections as siblings in one
+flat namespace. If two levels declare a section with the *same* name, the
+innermost wins for records inside it — the same shadowing rule a nested
+scope follows in any language. Picking distinct per-level names (as above)
+keeps every level independently visible.
+
+Boundaries nest correctly through the pipeline: each level opens before
+the records inside it and closes after them, in strict innermost-first
+order. A level that fans in through several branches is still reconciled
+once at Merge, exactly like a single-level document.
+
+## Header-only interchanges
+
+A multi-level envelope file can legitimately carry an interchange whose
+body is empty — envelope structure (an interchange header, and possibly
+inner group headers) with zero records inside. Such an interchange still
+opens a document and emits its open/close boundaries, so downstream
+operators and trailer-count validation observe it just like any other
+document. The interchange's `$doc.*` sections are extracted and the
+boundaries flow even though no body record ever streams from it.
+
+The same holds for an empty *inner* envelope — an open/close pair with no
+records between — and for an inner envelope that opens or closes after the
+file's last body record. Every envelope boundary a reader signals is
+applied, whether or not a record follows it, so the document frame stays
+balanced end to end.

--- a/docs/src/pipeline/output.md
+++ b/docs/src/pipeline/output.md
@@ -14,7 +14,7 @@ Output nodes write processed records to files. They are the terminal nodes of a 
     path: "./output/result.csv"
 ```
 
-The `type:` field selects the output format: `csv`, `json`, `xml`, `fixed_width`, or `edifact`.
+The `type:` field selects the output format: `csv`, `json`, `xml`, `fixed_width`, `edifact`, or `x12`. The `edifact` and `x12` writers reconstruct their EDI interchange envelopes around emitted records; see [EDIFACT Format](edifact.md) and [X12 Format](x12.md).
 
 ## Field control
 
@@ -65,7 +65,7 @@ Set `include_correlation_keys: true` to surface the shadow columns in the writer
 
 ### Writer rejection of `Value::Map` payloads
 
-CSV, XML, and fixed-width writers refuse records carrying a `Value::Map` payload at any column slot, raising `FormatError::UnserializableMapValue { format, column }`. JSON serializes `Value::Map` natively as a nested object.
+CSV, XML, fixed-width, EDIFACT, and X12 writers refuse records carrying a `Value::Map` payload at any column slot, raising `FormatError::UnserializableMapValue { format, column }`. JSON serializes `Value::Map` natively as a nested object.
 
 The typical cause is a `$widened` sidecar reaching a non-JSON writer because the Output node set `include_unmapped: false`. See [Auto-Widen & Schema Drift -> Writer rejection](auto-widen.md#writer-rejection-of-valuemap-payloads) for the rejection contract and remediation routes.
 

--- a/docs/src/pipeline/source.md
+++ b/docs/src/pipeline/source.md
@@ -80,7 +80,7 @@ shares repeated values instead of storing each copy independently.
 A source declaration has two independent layers:
 
 - **Transport** (`transport:`) selects *where* the records come from. The only transport today is `file` — read bytes from the filesystem, resolved through one of the file matchers (`path` / `glob` / `regex` / `paths`). `transport:` is optional and defaults to `file`, so a source that omits it reads from disk exactly as before.
-- **Format** (`type:`) selects *how* the bytes decode into records: `csv`, `json`, `xml`, `fixed_width`, `edifact`.
+- **Format** (`type:`) selects *how* the bytes decode into records: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`.
 
 ```yaml
 - type: source
@@ -98,7 +98,7 @@ A `file` transport requires **exactly one** file matcher (`path`, `glob`, `regex
 
 ## Format types
 
-The `type:` field inside `config:` selects the on-disk format. Supported values: `csv`, `json`, `xml`, `fixed_width`, `edifact`.
+The `type:` field inside `config:` selects the on-disk format. Supported values: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`.
 
 The `edifact` format reads UN/EDIFACT interchanges; it has its own
 reference page covering the segment-record schema, delimiter discovery,
@@ -107,6 +107,11 @@ envelope sections, and control-count validation. See
 (default 32) — the number of positional `eNN` element columns on the
 record schema; a segment with more data elements than that is rejected
 rather than truncated.
+
+The `x12` format reads ANSI ASC X12 interchanges with their three-tier
+`ISA..IEA` → `GS..GE` → `ST..SE` envelope, surfacing all three tiers as
+nested `$doc` sections. It shares the same `max_elements` input option and
+has its own reference page. See [X12 Format](x12.md).
 
 ### CSV
 

--- a/docs/src/pipeline/x12.md
+++ b/docs/src/pipeline/x12.md
@@ -1,0 +1,215 @@
+# X12 Format
+
+Clinker reads and writes ANSI ASC X12 interchanges alongside CSV, JSON,
+XML, fixed-width, and EDIFACT. An X12 interchange is a finite file with a
+three-tier envelope: an `ISA..IEA` interchange wraps one or more `GS..GE`
+functional groups, and each functional group wraps one or more `ST..SE`
+transaction sets. The reader streams one segment at a time and the writer
+reconstructs the three envelope tiers around emitted records.
+
+The three tiers surface as nested document-context levels: the `ISA`
+interchange becomes the file-level `$doc` document, and each `GS` group and
+`ST` set opens a nested level whose `$doc` sections layer over the
+enclosing tiers. A body record therefore sees every enclosing tier's
+fields through one `$doc.<section>.<field>` lookup.
+
+## Delimiters and the ISA header
+
+Unlike EDIFACT's optional `UNA` service-string advice, X12 declares its
+delimiters in a fixed-length 106-byte `ISA` header. Three delimiter bytes
+live at structural positions within it:
+
+| Role                          | Source in the ISA                          |
+| ----------------------------- | ------------------------------------------ |
+| Element (data) separator      | The byte immediately after the `ISA` tag   |
+| Sub-element (component) sep.  | `ISA16`, the last single-byte ISA element  |
+| Segment terminator            | The byte immediately after `ISA16`         |
+
+The reader reads these three bytes from the header rather than assuming a
+fixed delimiter set, so an interchange that uses `*`/`:`/`~`,
+`|`/`^`/newline, or any other producer-chosen delimiters parses correctly.
+The `ISA13` interchange control number is located as the 13th element of
+the header split on the discovered element separator — structurally, not by
+an absolute byte offset — so producer padding quirks do not misalign it.
+
+### No escape character
+
+X12 has **no** release/escape character (EDIFACT's `?` has no X12
+equivalent). A data value that contains a delimiter byte is therefore
+unrepresentable. On output the writer rejects any element value carrying
+the element separator or the segment terminator with a precise error rather
+than silently corrupting the interchange; re-encode the value or choose
+delimiters the data does not contain.
+
+The sub-element (component) separator inside an element (e.g. the `:` in a
+composite `A:B:C`) is kept as part of the element's text and is not split —
+the positional element model works above component resolution, so a
+composite element round-trips unchanged.
+
+### Newlines between segments
+
+Some producers insert CR/LF after each segment terminator for readability.
+Those bytes are insignificant and are stripped between segments; CR/LF that
+appears inside an element is preserved.
+
+## Record shape
+
+Each non-service segment becomes one record under a fixed positional
+schema:
+
+| Column     | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| `seg_id`   | The segment tag (`BEG`, `PO1`, …)                             |
+| `set_ref`  | The enclosing transaction set control number (`ST02`)        |
+| `set_type` | The transaction set identifier code (`ST01`, e.g. `850`)     |
+| `e01`, `e02`, … | The segment's positional data elements                  |
+
+Service segments (`ISA`, `IEA`, `GS`, `GE`, `SE`) are consumed by the
+reader to drive the envelope and validation — they are never emitted as
+body records. The `ST` segment that opens a transaction set **is** emitted
+as a body record (its `seg_id` is `ST`), carrying the set reference and
+type.
+
+The number of `eNN` columns is controlled by the source `max_elements`
+option (default 32). A segment carrying more data elements than that is
+rejected with guidance rather than silently truncated. Absent trailing
+elements read as `null`.
+
+```yaml
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: x12
+      glob: ./inbox/*.x12
+      options:
+        max_elements: 48      # widen the positional schema for exotic segments
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: e01, type: string }
+```
+
+## Envelope sections over the three tiers
+
+The interchange header `ISA` is extractable as a file-level document
+envelope section, exposing its positional elements to CXL as
+`$doc.<section>.<field>`. Use the `segment` extract rule with the section
+field names matching the positional keys `e01`, `e02`, …:
+
+```yaml
+envelope:
+  sections:
+    interchange:
+      extract: { segment: "ISA" }
+      fields:
+        e13: string          # interchange control number (ISA13)
+```
+
+The `GS` functional group and the `ST` transaction set surface
+automatically as the nested `$doc` sections `functional_group` and
+`transaction_set`, each keyed by positional `eNN` elements — no envelope
+declaration is needed for them. A Transform on any body record can read
+all three tiers at once:
+
+```cxl
+emit isa13 = $doc.interchange.e13       # interchange control number
+emit gs06  = $doc.functional_group.e06  # group control number (GS06)
+emit st02  = $doc.transaction_set.e02   # set control number (ST02)
+```
+
+Only the `ISA` header is extractable as a *declared* envelope section.
+Trailer segments (`SE`, `GE`, `IEA`) arrive after the body they close and
+cannot become `$doc` fields without buffering the whole interchange — their
+control counts are instead validated inline by the reader (see below). A
+`segment` extract naming any tag other than `ISA`, or an `xml_path` /
+`json_pointer` extract against an X12 source, is rejected at startup.
+
+## Control-count validation
+
+The reader validates the structural integrity claims carried in the
+trailers as they arrive, failing the run on a mismatch (a truncation or
+corruption signal):
+
+- **`SE` segment count (`SE01`)** — must equal the number of segments in
+  the transaction set, counting the `ST` and `SE` themselves.
+- **`SE` set control number (`SE02`)** — must echo the opening `ST02`.
+- **`GE` transaction-set count (`GE01`)** — must equal the number of `ST`
+  sets in the functional group.
+- **`GE` group control number (`GE02`)** — must echo the `GS06`.
+- **`IEA` functional-group count (`IEA01`)** — must equal the number of
+  `GS` groups in the interchange.
+- **`IEA` control number (`IEA02`)** — must echo the `ISA13`.
+
+A missing `IEA` at end of input is a truncation error; content after the
+`IEA` trailer is rejected.
+
+## Writing X12
+
+An X12 Output node reconstructs the three-tier envelope around emitted
+records. Records map by the same positional columns (`seg_id`, `set_ref`,
+`set_type`, `eNN`); trailing `null`/empty elements are trimmed so no
+fabricated delimiters appear, and a column the writer does not recognize is
+an error (project the record to the X12 columns first). Engine-internal
+`$`-namespaced columns are excluded automatically.
+
+```yaml
+nodes:
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: x12
+      path: ./out/result.x12
+      options:
+        interchange:
+          ["00", "          ", "00", "          ", "ZZ", "SENDER         ",
+           "ZZ", "RECEIVER       ", "240101", "1200", "U", "00401",
+           "000000001", "0", "P", ":"]
+        group_header: ["PO", "SENDER", "RECEIVER", "20240101", "1200", "1", "X", "004010"]
+        set_type: "850"
+        segment_newline: true
+```
+
+Output options:
+
+| Option                  | Meaning                                                                |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `interchange`           | Literal `ISA` data elements (the 16 fixed-width ISA fields).           |
+| `interchange_from_doc`  | Name of a `$doc` section to echo the `ISA` elements from (round-trip). |
+| `group_header`          | Literal `GS01..GS08` elements (`GS06` control number recomputed).      |
+| `set_type`              | Fallback `ST01` set type when a record carries no `set_type` value.    |
+| `segment_newline`       | Write a newline after each segment terminator (default `true`).        |
+
+Consecutive records are grouped into `ST..SE` transaction sets on `set_ref`
+transitions, and all sets are wrapped in a single `GS..GE` functional
+group. The writer recomputes the `SE` segment count, the `GE`
+transaction-set count, and the `IEA` functional-group count, and echoes the
+set, group, and interchange control numbers, so the output passes its own
+count validation on re-read.
+
+`interchange_from_doc` echoes the header from a record's document context.
+That context is populated by a source's `ISA` envelope section (declare a
+`segment: "ISA"` envelope section on the source) and travels with every
+body record through the pipeline — including to a sink that sits directly
+downstream of the source with no intervening Transform. The reader stashes
+the complete, ordered `ISA` element list, so the reconstructed header is
+faithful. Supply `interchange` literal elements instead when the records
+have no source `ISA` section to echo.
+
+## Limitations
+
+- **Charset.** Element text is decoded as UTF-8. Non-UTF-8 interchanges are
+  rejected explicitly rather than silently corrupted.
+- **No escape character.** X12 has no release mechanism, so a data value
+  that contains a delimiter byte is rejected on output rather than
+  corrupting the interchange.
+- **One functional group on output.** The writer wraps all transaction sets
+  in a single `GS..GE` functional group; the reader handles any number of
+  groups on input. A multi-group output shape requires multiple runs.
+- **Output splitting.** An interchange is a single `ISA..IEA` envelope and
+  cannot be divided across files. An `x12` output combined with a `split:`
+  block is rejected at config-validation time (diagnostic `E338`) rather
+  than emitting a structurally corrupt interchange.


### PR DESCRIPTION
Eight related changes advancing document-shape ETL support.

## Formats & envelopes
- **Multi-level envelope nesting + header-only documents (closes #99, #395).** A reader can emit nested envelope open/close events that the ingest driver tracks as a level stack, flattening each level into one document context read through the existing `$doc.<section>.<field>` (no new CXL syntax). Trailing empty inner envelopes and header-only interchanges no longer desync the stack.
- **X12 EDI reader/writer (closes #378).** Reads/writes ANSI ASC X12 with ISA/GS/ST tiers surfaced as nested `$doc` sections; ISA-declared delimiters drive tokenizing; SE/GE/IEA counts and control-number echoes are validated inline and recomputed on write. New diagnostic E338 for the unsupported x12-plus-split-output case.
- **EDIFACT control-reference fix (closes #401).** The UNB interchange control reference is now located structurally instead of by a fixed element index, so an interchange carrying an empty leading element is no longer spuriously rejected and the writer echoes the correct reference into UNZ.

## Streaming consumers
- **Aggregate-ingest streaming (closes #299)** and **Combine probe-side streaming (closes #300).** A strict Aggregate, and the probe side of a hash Combine, can now ingest record-at-a-time over a bounded channel instead of pre-draining a buffer. The build side materializes first; a dedicated thread drains the ingest while the producer streams; output, DLQ, and cursor-rewind semantics stay byte-identical to the buffered path; `--explain` and the runtime derive eligibility from one predicate.

## CXL
- **`set()` with a dotted/indexed path (closes #94)** builds nested map structure, auto-creating intermediates and returning null only on a type conflict or out-of-range index.
- **`emit each … outer` (closes #95)** preserves the trigger row once (binding null) when the source is empty/null.
- **Nested `emit each` (closes #96)** fans out within a fan-out for one trigger row, with a cumulative expansion cap across nesting levels.

## Verification
Full workspace gauntlet green — `fmt`, `clippy` (with and without `--all-targets`), `cargo test --workspace`, bench checks, and `cargo deny`. New unit + integration tests accompany each change, including document-boundary punctuation assertions, back-pressure no-deadlock regressions for both streaming consumers, and end-to-end X12 round-trips.