### PR TITLE
engine: per-document Aggregate flush + Combine document-boundary reconciliation

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -9,10 +9,11 @@
 //! dispatcher's `Aggregation` arm is a single delegating call into
 //! [`dispatch_aggregation`].
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use clinker_record::{GroupByKey, Record, Schema, SchemaBuilder, Value};
-use cxl::eval::ProgramEvaluator;
+use clinker_record::{DocumentId, GroupByKey, Record, Schema, SchemaBuilder, Value};
+use cxl::eval::{EvalContext, ProgramEvaluator};
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
@@ -232,26 +233,22 @@ pub(crate) fn dispatch_aggregation(
                 .expect("guarded by is_time_windowed"),
             config.allowed_lateness,
         )?
-    } else {
-        // Single ConsumerHandle shared between the
-        // AggregateConsumer wrapper that the arbitrator's
-        // policy registry holds and the HashAggregator that
-        // mirrors its value_heap_bytes total into the
-        // handle's counter on every admit / spill / reset.
+    } else if is_relaxed {
+        // Relaxed-CK retraction path: one retained `HashAggregator`
+        // spanning the whole input, parked on
+        // `relaxed_aggregator_states` so the correlation-commit
+        // orchestrator can `retract_row` + `finalize_in_place` against
+        // the same instance that produced these rows. The commit model
+        // requires every group live across the retract iterations, so
+        // per-document flush does not apply here — a document-aware
+        // relaxed-CK aggregate keeps its single cross-document table.
         //
-        // The returned `ConsumerId` is captured so the wrapper is
-        // unregistered the moment its aggregator's state stops
-        // being live. A strict aggregate's `finalize` consumes
-        // the stream and emits every group, so the arm exit
-        // unregisters it directly; without that the finalized
-        // group state keeps contributing to `sum_consumer_usage`
-        // for the rest of the run, inflating the reported peak
-        // even though the bytes are gone. A relaxed aggregate
-        // parks its aggregator on `relaxed_aggregator_states` and
-        // carries this id with it, because the commit phase keeps
-        // retracting and re-finalizing that instance — its bytes
-        // stay live until the aggregator is dropped, at which
-        // point the unregister fires from that state.
+        // The single `ConsumerHandle` is shared with the
+        // `AggregateConsumer` the arbitrator holds; its `ConsumerId` is
+        // captured so the wrapper is unregistered the moment the
+        // aggregator's state stops being live. Parking transfers
+        // ownership of the unregister to `RetainedAggregatorState`,
+        // which fires it when the aggregator drops.
         let agg_consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
         let agg_consumer_id = ctx.memory_budget.register_consumer(Arc::new(
             crate::aggregation::AggregateConsumer::new(agg_consumer_handle.clone()),
@@ -291,229 +288,99 @@ pub(crate) fn dispatch_aggregation(
                     advance_cursor(ctx, &source_name_arc, *row_num);
                 }
                 if let Err(e) = add_result {
-                    match ctx.config.error_handling.strategy {
-                        ErrorStrategy::FailFast => return Err(e.into()),
-                        ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
-                            let stage = Some(clinker_core_types::dlq::stage_aggregate(name));
-                            let routed = record_error_to_buffer_if_grouped(
-                                ctx,
-                                record,
-                                *row_num,
-                                clinker_core_types::dlq::DlqErrorCategory::AggregateFinalize,
-                                format!("aggregate {name}: {e}"),
-                                stage.clone(),
-                                None,
-                            );
-                            if !routed {
-                                let source_name = source_name_arc_of(record);
-                                push_dlq(
-                                    ctx,
-                                    DlqEntry {
-                                        source_row: *row_num,
-                                        category: clinker_core_types::dlq::DlqErrorCategory::AggregateFinalize,
-                                        error_message: format!("aggregate {name}: {e}"),
-                                        original_record: record.clone(),
-                                        stage,
-                                        route: None,
-                                        trigger: true,
-                                        source_name,
-                                        triggering_field: None,
-                                        triggering_value: None,
-                                    },
-                                )?;
-                            }
-                        }
-                    }
+                    handle_aggregate_add_error(ctx, name, record, *row_num, e)?;
                 }
             }
             Ok(())
         })()?;
 
-        // Finalize. Accumulator finalize errors get the
-        // typed `PipelineError::Accumulator` mapping; under
-        // `Continue` we route to the DLQ and emit zero rows
-        // for the failed group. All other engine errors
-        // propagate (Internal/Spill/Residual always abort).
-        //
-        // Relaxed-CK aggregates split the finalize path: instead
-        // of consuming the wrapper, the Hash-arm boxed aggregator
-        // is extracted and kept on `ExecutorContext.relaxed_aggregator_states`
-        // so the correlation-commit orchestrator can call
-        // `retract_row` + `finalize_in_place` against the same
-        // instance that produced these rows. Strict aggregates
-        // continue to consume-and-discard so non-relaxed
-        // pipelines pay zero overhead.
+        // Finalize into the retained boxed aggregator (rather than
+        // consuming it) so the commit phase can drive the same
+        // instance. Accumulator finalize errors route to the DLQ under
+        // `Continue` / `BestEffort`; all other engine errors propagate.
         let finalize_ctx = ctx.merged_eval_ctx();
-        let agg_out = if is_relaxed {
-            let mut hash_box = match stream.into_retained_hash() {
-                Some(b) => b,
-                None => {
-                    // Streaming + retraction-mode is rejected at
-                    // compile time (E15Y); reaching this branch is
-                    // a planner-pass bug.
-                    return Err(PipelineError::Internal {
-                        op: "aggregation",
-                        node: name.clone(),
-                        detail: "retraction-mode aggregate produced a non-Hash \
-                                 stream — E15Y should have rejected this at compile time"
-                            .to_string(),
-                    });
-                }
-            };
-            let emits_synthetic = hash_box.emits_synthetic_ck();
-            let pre_finalize_len = emitted_rows.len();
-            match hash_box.finalize_in_place(&finalize_ctx, &mut emitted_rows) {
-                Ok(()) => {
-                    if emits_synthetic {
-                        ctx.counters.retraction.synthetic_ck_columns_emitted_total +=
-                            (emitted_rows.len() - pre_finalize_len) as u64;
-                    }
-                    ctx.relaxed_aggregator_states.insert(
-                        node_idx,
-                        RetainedAggregatorState {
-                            aggregator: hash_box,
-                            consumer_id: agg_consumer_id,
-                        },
-                    );
-                    emitted_rows
-                }
-                Err(HashAggError::Accumulator {
-                    transform,
-                    binding,
-                    source,
-                }) => match ctx.config.error_handling.strategy {
-                    ErrorStrategy::FailFast => {
-                        return Err(PipelineError::Accumulator {
-                            transform,
-                            binding,
-                            source,
-                        });
-                    }
-                    ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
-                        // Empty-input finalize failures have no real
-                        // record to attribute to a Source, so stamp
-                        // the aggregate node's own name as the
-                        // source label. The DLQ reader sees a
-                        // specific aggregate identifier instead of
-                        // the generic `<merged>` fallthrough
-                        // `source_name_arc_of` would yield for a
-                        // schema-only synthetic record.
-                        let (synthetic, source_name) = if let Some((rec, _)) = input.first() {
-                            let sn = source_name_arc_of(rec);
-                            (rec.clone(), sn)
-                        } else {
-                            (
-                                Record::new(Arc::clone(output_schema), Vec::new()),
-                                Arc::from(name.as_str()),
-                            )
-                        };
-                        push_dlq(
-                            ctx,
-                            DlqEntry {
-                                source_row: 0,
-                                category:
-                                    clinker_core_types::dlq::DlqErrorCategory::AggregateFinalize,
-                                error_message: format!(
-                                    "aggregate {transform}.{binding}: {source:?}"
-                                ),
-                                original_record: synthetic,
-                                stage: Some(clinker_core_types::dlq::stage_aggregate(name)),
-                                route: None,
-                                trigger: true,
-                                source_name,
-                                triggering_field: None,
-                                triggering_value: None,
-                            },
-                        )?;
-                        Vec::new()
-                    }
-                },
-                Err(other) => return Err(other.into()),
-            }
-        } else {
-            match stream.finalize(&finalize_ctx, &mut emitted_rows) {
-                Ok(()) => emitted_rows,
-                Err(HashAggError::Accumulator {
-                    transform,
-                    binding,
-                    source,
-                }) => match ctx.config.error_handling.strategy {
-                    ErrorStrategy::FailFast => {
-                        return Err(PipelineError::Accumulator {
-                            transform,
-                            binding,
-                            source,
-                        });
-                    }
-                    ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
-                        // Empty-input finalize failures have no real
-                        // record to attribute to a Source, so stamp
-                        // the aggregate node's own name as the
-                        // source label. The DLQ reader sees a
-                        // specific aggregate identifier instead of
-                        // the generic `<merged>` fallthrough
-                        // `source_name_arc_of` would yield for a
-                        // schema-only synthetic record.
-                        let (synthetic, source_name) = if let Some((rec, _)) = input.first() {
-                            let sn = source_name_arc_of(rec);
-                            (rec.clone(), sn)
-                        } else {
-                            (
-                                Record::new(Arc::clone(output_schema), Vec::new()),
-                                Arc::from(name.as_str()),
-                            )
-                        };
-                        push_dlq(
-                            ctx,
-                            DlqEntry {
-                                source_row: 0,
-                                category:
-                                    clinker_core_types::dlq::DlqErrorCategory::AggregateFinalize,
-                                error_message: format!(
-                                    "aggregate {transform}.{binding}: {source:?}"
-                                ),
-                                original_record: synthetic,
-                                stage: Some(clinker_core_types::dlq::stage_aggregate(name)),
-                                route: None,
-                                trigger: true,
-                                source_name,
-                                triggering_field: None,
-                                triggering_value: None,
-                            },
-                        )?;
-                        Vec::new()
-                    }
-                },
-                Err(other) => return Err(other.into()),
+        let mut hash_box = match stream.into_retained_hash() {
+            Some(b) => b,
+            None => {
+                // Streaming + retraction-mode is rejected at
+                // compile time (E15Y); reaching this branch is
+                // a planner-pass bug.
+                return Err(PipelineError::Internal {
+                    op: "aggregation",
+                    node: name.clone(),
+                    detail: "retraction-mode aggregate produced a non-Hash \
+                             stream — E15Y should have rejected this at compile time"
+                        .to_string(),
+                });
             }
         };
-        // The aggregate's working set is live exactly as long as
-        // its aggregator is. A strict `finalize` above consumed
-        // the stream and emitted every group, so that state is
-        // now gone; unregister the wrapper here so the finalized
-        // bytes leave `sum_consumer_usage` immediately and the
-        // run peak reflects only concurrently-live state, making
-        // it sensitive to the order aggregates complete in.
-        //
-        // A relaxed aggregate that finalized successfully parked
-        // its boxed aggregator on `relaxed_aggregator_states`
-        // (the key is present): that state stays live across the
-        // commit phase's retract + re-finalize iterations, so its
-        // wrapper must stay registered. Ownership of the
-        // unregister transfers to `RetainedAggregatorState`,
-        // which fires it when the aggregator is dropped — at the
-        // commit-phase degrade `remove`, or at the top-scope
-        // teardown that drains the surviving states once the walk
-        // ends. A relaxed aggregate whose finalize failed and
-        // routed to the DLQ dropped its aggregator without
-        // parking it, so the key is absent and the wrapper is
-        // unregistered here alongside the strict case — the
-        // presence of the retained key, not `is_relaxed`, is the
-        // exact predicate for "the state outlives this arm".
+        let emits_synthetic = hash_box.emits_synthetic_ck();
+        let pre_finalize_len = emitted_rows.len();
+        let agg_out = match hash_box.finalize_in_place(&finalize_ctx, &mut emitted_rows) {
+            Ok(()) => {
+                if emits_synthetic {
+                    ctx.counters.retraction.synthetic_ck_columns_emitted_total +=
+                        (emitted_rows.len() - pre_finalize_len) as u64;
+                }
+                ctx.relaxed_aggregator_states.insert(
+                    node_idx,
+                    RetainedAggregatorState {
+                        aggregator: hash_box,
+                        consumer_id: agg_consumer_id,
+                    },
+                );
+                emitted_rows
+            }
+            Err(HashAggError::Accumulator {
+                transform,
+                binding,
+                source,
+            }) => match ctx.config.error_handling.strategy {
+                ErrorStrategy::FailFast => {
+                    return Err(PipelineError::Accumulator {
+                        transform,
+                        binding,
+                        source,
+                    });
+                }
+                ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
+                    emit_aggregate_finalize_dlq(
+                        ctx,
+                        name,
+                        &input,
+                        output_schema,
+                        &transform,
+                        &binding,
+                        &source,
+                    )?;
+                    Vec::new()
+                }
+            },
+            Err(other) => return Err(other.into()),
+        };
+        // A relaxed aggregate that finalized successfully parked its
+        // boxed aggregator on `relaxed_aggregator_states` (the key is
+        // present): that state stays live across the commit phase's
+        // retract + re-finalize iterations, so its wrapper must stay
+        // registered — `RetainedAggregatorState` owns the unregister and
+        // fires it when the aggregator drops. A finalize that failed and
+        // routed to the DLQ dropped its aggregator without parking it, so
+        // the key is absent and the wrapper is unregistered here.
         if !ctx.relaxed_aggregator_states.contains_key(&node_idx) {
             ctx.memory_budget.unregister_consumer(agg_consumer_id);
         }
         agg_out
+    } else {
+        // Strict path with per-document group flush. The single
+        // `evaluator` built above is unused — each document's table builds
+        // its own behind an `Arc<TypedProgram>`. Drop it (and the
+        // single-stream `spill_schema`, which the factory re-derives) so
+        // any throwaway state releases promptly.
+        drop(evaluator);
+        drop(spill_schema);
+        let factory =
+            DocAggregatorFactory::from_ctx(ctx, name, agg_strategy, compiled, output_schema)?;
+        run_strict_aggregate_per_document(ctx, factory, name, output_schema, &input, &input_puncts)?
     };
 
     finalize_aggregate_emit(
@@ -564,16 +431,11 @@ fn finalize_aggregate_emit(
         // without an extra commit-time materialization for the
         // no-retraction case. Retraction iterations overwrite
         // the slot in `recompute_aggregates::emit_post_recompute`.
-        // Aggregate forwards inbound punctuations to its
-        // output buffer (Preserving). Document-scoped flush
-        // semantics — "flush groups on `DocumentClose` before
-        // forwarding the punctuation" — land as a follow-up
-        // commit within this sprint; today the punctuation
-        // travels at the tail of the aggregated output, which
-        // matches the streaming contract for single-document
-        // pipelines but does not yet split per-document
-        // groups when multiple documents enter the same
-        // aggregate.
+        // `out_rows` already carries each closing document's groups
+        // flushed at its `DocumentClose` boundary (the ingest arm
+        // split them per document); the inbound punctuations forward
+        // unchanged at the output buffer tail (Preserving), trailing
+        // the document's flushed rows.
         let buffer_schema = region.buffer_schema.clone();
         let projected = project_rows_to_buffer_schema(out_rows, &buffer_schema);
         finalize_node_rooted_windows(ctx, current_dag, node_idx, &projected)?;
@@ -645,6 +507,375 @@ fn finalize_aggregate_emit(
     Ok(())
 }
 
+/// `ctx`-free factory for one document's [`crate::aggregation::AggregateStream`].
+///
+/// A document-aware source feeds an Aggregate one document per source
+/// file, each carrying its own [`DocumentId`] and a `DocumentClose`
+/// boundary at its tail. Per-document aggregation builds a fresh group
+/// table for each document and flushes it at the document's close, so a
+/// multi-document run produces one set of grouped rows per document rather
+/// than a single cross-document aggregate.
+///
+/// This factory captures everything [`crate::aggregation::AggregateStream::for_node`]
+/// needs without borrowing the [`ExecutorContext`], so it works on both
+/// the dispatch thread (materialized path) and the streaming-ingest scoped
+/// thread, which holds no `&mut ExecutorContext`. Each built table
+/// registers its own [`crate::aggregation::AggregateConsumer`] with the
+/// shared arbitrator, so the open document's group bytes count toward the
+/// run's RSS accounting and the existing per-aggregator spill triggers
+/// fire normally.
+struct DocAggregatorFactory {
+    strategy: AggregateStrategy,
+    compiled: Arc<cxl::plan::CompiledAggregate>,
+    typed: Arc<cxl::typecheck::TypedProgram>,
+    has_distinct: bool,
+    max_expansion: u64,
+    output_schema: Arc<Schema>,
+    spill_schema: Arc<Schema>,
+    mem_limit: usize,
+    spill_dir: std::path::PathBuf,
+    spill_compress: bool,
+    transform_name: String,
+    arbitrator: Arc<crate::pipeline::memory::MemoryArbitrator>,
+}
+
+impl DocAggregatorFactory {
+    /// Snapshot the build inputs out of `ctx` for an aggregate node.
+    /// Resolves the spill schema, memory limit, and spill-compression mode
+    /// from `ctx` itself — the same derivations the single-stream paths run
+    /// inline — so the caller passes only the node identity.
+    ///
+    /// Returns an error when no compiled transform backs the node — the
+    /// same hard-abort `PipelineError::Internal` the single-stream paths
+    /// raise, surfaced here once at construction so [`Self::make`] only
+    /// fails on the never-taken `for_node` arm.
+    fn from_ctx(
+        ctx: &ExecutorContext<'_>,
+        node_name: &str,
+        strategy: AggregateStrategy,
+        compiled: &Arc<cxl::plan::CompiledAggregate>,
+        output_schema: &Arc<Schema>,
+    ) -> Result<Self, PipelineError> {
+        let transform_idx = ctx
+            .transform_by_name
+            .get(node_name)
+            .copied()
+            .ok_or_else(|| PipelineError::Internal {
+                op: "aggregation",
+                node: node_name.to_string(),
+                detail: "no compiled transform found for aggregate node".to_string(),
+            })?;
+        let compiled_transform = &ctx.compiled_transforms[transform_idx];
+        // Spill schema mirrors `HashAggregator::spill`: group-by columns ++
+        // `__acc_state` ++ `__meta_tracker`. The compression mode resolves
+        // against the output-schema width and batch size so a spilled
+        // table's on-disk format matches what `--explain` reports.
+        let spill_schema = compiled
+            .group_by_fields
+            .iter()
+            .map(|s| Box::<str>::from(s.as_str()))
+            .chain([
+                Box::<str>::from("__acc_state"),
+                Box::<str>::from("__meta_tracker"),
+            ])
+            .collect::<SchemaBuilder>()
+            .build();
+        let spill_compress = ctx
+            .spill_compress
+            .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
+        Ok(Self {
+            strategy,
+            compiled: Arc::clone(compiled),
+            typed: Arc::clone(&compiled_transform.typed),
+            has_distinct: compiled_transform.has_distinct(),
+            max_expansion: compiled_transform.max_expansion,
+            output_schema: Arc::clone(output_schema),
+            spill_schema,
+            mem_limit: parse_memory_limit(ctx.config),
+            spill_dir: ctx.spill_root_path.to_path_buf(),
+            spill_compress,
+            transform_name: node_name.to_string(),
+            arbitrator: Arc::clone(&ctx.memory_budget),
+        })
+    }
+
+    /// Build a fresh stream + register its arbitrator consumer. Building a
+    /// new `ProgramEvaluator` per document is cheap: the heavy CXL
+    /// pipeline lives behind `Arc<TypedProgram>`.
+    fn make(
+        &self,
+    ) -> Result<
+        (
+            crate::aggregation::AggregateStream,
+            crate::pipeline::memory::ConsumerId,
+        ),
+        PipelineError,
+    > {
+        let evaluator = ProgramEvaluator::with_max_expansion(
+            Arc::clone(&self.typed),
+            self.has_distinct,
+            self.max_expansion,
+        );
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let consumer_id = self.arbitrator.register_consumer(Arc::new(
+            crate::aggregation::AggregateConsumer::new(handle.clone()),
+        ));
+        let stream = crate::aggregation::AggregateStream::for_node(
+            self.strategy,
+            crate::aggregation::AggregatorConfig {
+                compiled: Arc::clone(&self.compiled),
+                evaluator,
+                output_schema: Arc::clone(&self.output_schema),
+                spill_schema: Arc::clone(&self.spill_schema),
+                memory_budget: self.mem_limit,
+                spill_dir: Some(self.spill_dir.clone()),
+                spill_compress: self.spill_compress,
+                transform_name: self.transform_name.clone(),
+                consumer_handle: handle,
+            },
+        )?;
+        Ok((stream, consumer_id))
+    }
+}
+
+/// Single live group table that flushes on each document-close boundary,
+/// for the streaming-ingest path where boundaries arrive inline with
+/// records.
+///
+/// Holds at most one [`crate::aggregation::AggregateStream`] at a time —
+/// the open document's groups. On `DocumentClose` the current table
+/// finalizes, emits, and resets, so a fused single-source stream (whose
+/// boundaries arrive in document order) produces one set of grouped rows
+/// per document. A non-fused Merge instead delivers its forwarded
+/// punctuations after every record, so the lone table accumulates the
+/// whole stream and flushes once at the tail — folding unreconciled
+/// documents together exactly as a no-document run would.
+///
+/// Holding one table at a time keeps the peak footprint at a single
+/// document's group state (plus its arbitrator consumer), so per-document
+/// flush lowers peak memory rather than inflating it. The materialized
+/// drain-to-`Vec` path keys tables by document instead (see
+/// [`run_strict_aggregate_per_document`]) because its boundaries are split
+/// out of arrival order.
+struct DocumentFlushAggregator {
+    factory: DocAggregatorFactory,
+    current: Option<(
+        crate::aggregation::AggregateStream,
+        crate::pipeline::memory::ConsumerId,
+    )>,
+}
+
+impl DocumentFlushAggregator {
+    fn new(factory: DocAggregatorFactory) -> Self {
+        Self {
+            factory,
+            current: None,
+        }
+    }
+
+    /// Borrow the open table, building (and registering) a fresh one when
+    /// none is open.
+    fn stream(&mut self) -> Result<&mut crate::aggregation::AggregateStream, PipelineError> {
+        if self.current.is_none() {
+            self.current = Some(self.factory.make()?);
+        }
+        Ok(&mut self.current.as_mut().expect("just populated").0)
+    }
+
+    /// Finalize, emit, and reset the open table (if any). The next
+    /// `stream` call builds a fresh one for the following document. A
+    /// `DocumentClose` for a document that contributed no records finds no
+    /// open table and is a no-op.
+    fn flush_current(
+        &mut self,
+        finalize_ctx: &EvalContext,
+        out: &mut Vec<crate::aggregation::SortRow>,
+    ) -> Result<(), crate::aggregation::HashAggError> {
+        let Some((stream, consumer_id)) = self.current.take() else {
+            return Ok(());
+        };
+        let result = stream.finalize(finalize_ctx, out);
+        // `finalize` consumed the stream — its group bytes are gone, so
+        // unregister regardless of whether finalize succeeded.
+        self.factory.arbitrator.unregister_consumer(consumer_id);
+        result
+    }
+
+    /// Force an empty table into existence so an empty input still runs
+    /// one finalize. A global fold (no group-by) over empty input emits its
+    /// single defaulted row; an empty grouped fold emits nothing —
+    /// reproducing the single-stream finalize this replaced. Idempotent.
+    fn ensure_open(&mut self) -> Result<(), PipelineError> {
+        if self.current.is_none() {
+            self.current = Some(self.factory.make()?);
+        }
+        Ok(())
+    }
+}
+
+/// Drive a strict (non-relaxed, non-time-windowed) Aggregate with
+/// per-document group flush over a fully-drained input batch.
+///
+/// `drain_split` separated the predecessor's records from its boundaries,
+/// so the closing-document set is read once from `input_puncts`, then each
+/// record routes to a live group table keyed by a *flush key*: its own doc
+/// id when that document's close was forwarded, or a shared sentinel
+/// otherwise. On `DocumentClose(D)` the table for D finalizes, emits, and
+/// drops; the sentinel table (every unreconciled / no-document record)
+/// flushes at end-of-input. Keying by flush key — rather than tracking a
+/// running document — is robust to arbitrary record interleaving (an
+/// upstream Merge in `interleave` mode): a closing document's groups stay
+/// isolated even when another document's records arrive between them, and
+/// unreconciled documents fold together exactly as a no-document run would.
+///
+/// A no-document or single-document run keys every record to one table
+/// (the file's single closing document, or the sentinel) flushed once —
+/// byte-identical to a plain finalize.
+///
+/// Punctuations are not consumed here — the caller forwards the full
+/// `input_puncts` at the output tail, preserving the boundary for
+/// downstream operators while this arm flushes the closing document's
+/// groups ahead of it. Peak footprint is the concurrently-open closing
+/// documents plus the sentinel; each closing document drops at its close,
+/// so per-document flush lowers peak rather than inflating it.
+fn run_strict_aggregate_per_document(
+    ctx: &mut ExecutorContext<'_>,
+    factory: DocAggregatorFactory,
+    name: &str,
+    output_schema: &Arc<Schema>,
+    input: &[(Record, u64)],
+    input_puncts: &[crate::executor::stream_event::Punctuation],
+) -> Result<Vec<crate::aggregation::SortRow>, PipelineError> {
+    use crate::executor::stream_event::PunctuationKind;
+
+    // Documents whose close was forwarded to this Aggregate. Only these key
+    // their own table; every other record (unreconciled documents from a
+    // Merge that swallowed their closes, and the synthetic no-document id)
+    // shares the `SYNTHETIC` sentinel table and folds together. A real
+    // closing document never collides with the sentinel — sources allocate
+    // ids from a counter that starts past `DocumentId::SYNTHETIC`.
+    let closing_docs: std::collections::HashSet<DocumentId> = input_puncts
+        .iter()
+        .filter(|p| p.kind() == PunctuationKind::DocumentClose)
+        .map(|p| p.doc_id())
+        .collect();
+    let flush_key = |doc_id: DocumentId| -> DocumentId {
+        if closing_docs.contains(&doc_id) {
+            doc_id
+        } else {
+            DocumentId::SYNTHETIC
+        }
+    };
+
+    let mut tables: HashMap<
+        DocumentId,
+        (
+            crate::aggregation::AggregateStream,
+            crate::pipeline::memory::ConsumerId,
+        ),
+    > = HashMap::new();
+    let mut out_rows: Vec<crate::aggregation::SortRow> = Vec::with_capacity(64);
+
+    for (record, row_num) in input {
+        let key = flush_key(record.doc_ctx().id());
+        let source_file_arc = source_file_arc_of(record);
+        let source_name_arc = source_name_arc_of(record);
+        let eval_ctx = ctx.eval_ctx_for_record(
+            &source_file_arc,
+            &source_name_arc,
+            *row_num,
+            record.doc_ctx(),
+        );
+        let entry = match tables.entry(key) {
+            std::collections::hash_map::Entry::Occupied(o) => o.into_mut(),
+            std::collections::hash_map::Entry::Vacant(v) => v.insert(factory.make()?),
+        };
+        let add_result = entry
+            .0
+            .add_record(record, *row_num, &eval_ctx, &mut out_rows);
+        if add_result.is_ok() {
+            advance_cursor(ctx, &source_name_arc, *row_num);
+        }
+        if let Err(e) = add_result {
+            handle_aggregate_add_error(ctx, name, record, *row_num, e)?;
+        }
+    }
+
+    // Flush each closing document at its boundary (in `input_puncts`
+    // order), dropping its table. The merged-provenance finalize context
+    // borrows only `'a`-lifetime data, so it survives the `&mut ctx` DLQ
+    // routing between flushes.
+    let finalize_ctx = ctx.merged_eval_ctx();
+    for p in input_puncts {
+        if p.kind() == PunctuationKind::DocumentClose
+            && let Some((stream, consumer_id)) = tables.remove(&p.doc_id())
+        {
+            let result = stream.finalize(&finalize_ctx, &mut out_rows);
+            factory.arbitrator.unregister_consumer(consumer_id);
+            route_document_flush_result(ctx, name, input, output_schema, result)?;
+        }
+    }
+
+    // An empty input opened no table; a global fold still owes its single
+    // defaulted row, so force the sentinel table open before the final
+    // flush. Gated on truly-empty input so a run whose only document
+    // already flushed on its close is not given a phantom global-fold row.
+    if input.is_empty() {
+        tables.insert(DocumentId::SYNTHETIC, factory.make()?);
+    }
+    // Flush whatever is left in `DocumentId` order for deterministic emit
+    // ordering: the sentinel (unreconciled / no-document remainder) and any
+    // closing document whose close never arrived.
+    let finalize_ctx = ctx.merged_eval_ctx();
+    let mut remaining: Vec<DocumentId> = tables.keys().copied().collect();
+    remaining.sort_unstable();
+    for key in remaining {
+        let (stream, consumer_id) = tables.remove(&key).expect("key from this map");
+        let result = stream.finalize(&finalize_ctx, &mut out_rows);
+        factory.arbitrator.unregister_consumer(consumer_id);
+        route_document_flush_result(ctx, name, input, output_schema, result)?;
+    }
+
+    Ok(out_rows)
+}
+
+/// Route a document-flush finalize result: an `Accumulator` failure goes
+/// to the DLQ under `Continue` / `BestEffort` (mirroring the single-stream
+/// strict arm), `FailFast` and every other engine error propagate.
+fn route_document_flush_result(
+    ctx: &mut ExecutorContext<'_>,
+    name: &str,
+    input: &[(Record, u64)],
+    output_schema: &Arc<Schema>,
+    result: Result<(), crate::aggregation::HashAggError>,
+) -> Result<(), PipelineError> {
+    use crate::aggregation::HashAggError;
+    match result {
+        Ok(_) => Ok(()),
+        Err(HashAggError::Accumulator {
+            transform,
+            binding,
+            source,
+        }) => match ctx.config.error_handling.strategy {
+            ErrorStrategy::FailFast => Err(PipelineError::Accumulator {
+                transform,
+                binding,
+                source,
+            }),
+            ErrorStrategy::Continue | ErrorStrategy::BestEffort => emit_aggregate_finalize_dlq(
+                ctx,
+                name,
+                input,
+                output_schema,
+                &transform,
+                &binding,
+                &source,
+            ),
+        },
+        Err(other) => Err(other.into()),
+    }
+}
+
 /// Per-record side effects a streaming-ingest scoped thread cannot apply
 /// directly (it holds no `&mut ExecutorContext`), replayed onto the
 /// dispatcher after the scope joins. Ordering within each vector is the
@@ -680,12 +911,15 @@ struct StreamingIngestOutput {
 /// batch into the channel, while a scoped thread drives `add_record` off
 /// the receiver. The bounded `send` is the back-pressure pivot — a slow
 /// `add_record` (e.g. a hash aggregate spilling) stalls the producer and
-/// lets the upstream Source channel fill. The finalize half stays blocking:
-/// the scoped thread runs `finalize` once the channel disconnects (every
-/// sender dropped at the producer arm's clean exit), then returns the
-/// finalized rows. Document-boundary punctuations are collected and
-/// forwarded at the output tail — byte-identical to the materialized hash
-/// path, whose per-document group flush is a separate follow-up.
+/// lets the upstream Source channel fill. Group state is bucketed per
+/// [`DocumentId`]: a `DocumentClose(D)` arriving in stream order flushes
+/// document D's groups before the boundary forwards at the output tail, so
+/// a multi-document run emits one set of grouped rows per document. The
+/// finalize half stays blocking: once the channel disconnects (every
+/// sender dropped at the producer arm's clean exit), any document still
+/// open (the synthetic doc id of a no-envelope pipeline, or a document
+/// never closed) flushes and the finalized rows return. Document-boundary
+/// punctuations are forwarded at the output tail unchanged.
 ///
 /// The scoped thread holds no `&mut ExecutorContext`; it accumulates cursor
 /// advances and `add_record` DLQ errors into [`StreamingIngestEffects`],
@@ -706,68 +940,21 @@ fn run_streaming_aggregate_ingest(
 ) -> Result<StreamingIngestOutput, PipelineError> {
     use crate::aggregation::SortRow as AggSortRow;
     use crate::executor::stream_event::StreamEvent;
-    use cxl::eval::EvalContext;
 
     let expected_input = current_dag.graph[node_idx]
         .expected_input_schema_in(current_dag)
         .cloned();
     let upstream_name = current_dag.graph[producer_idx].name().to_string();
 
-    // Build the per-aggregation runtime artifacts (mirrors the materialized
-    // path): the executor owns the evaluator + spill metadata; the wrapper
-    // enum owns the engine. Register exactly one `AggregateConsumer` so the
-    // growing group state contributes to `sum_consumer_usage` while it is
-    // live, and unregister it after `finalize` consumes the stream.
-    let transform_idx = ctx.transform_by_name.get(name).copied();
-    let evaluator = match transform_idx {
-        Some(idx) => ProgramEvaluator::with_max_expansion(
-            Arc::clone(&ctx.compiled_transforms[idx].typed),
-            ctx.compiled_transforms[idx].has_distinct(),
-            ctx.compiled_transforms[idx].max_expansion,
-        ),
-        None => {
-            return Err(PipelineError::Internal {
-                op: "aggregation",
-                node: name.to_string(),
-                detail: "no compiled transform found for aggregate node".to_string(),
-            });
-        }
-    };
-    let spill_schema = compiled
-        .group_by_fields
-        .iter()
-        .map(|s| Box::<str>::from(s.as_str()))
-        .chain([
-            Box::<str>::from("__acc_state"),
-            Box::<str>::from("__meta_tracker"),
-        ])
-        .collect::<SchemaBuilder>()
-        .build();
-    let mem_limit = parse_memory_limit(ctx.config);
-    let spill_compress = ctx
-        .spill_compress
-        .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
-
-    let agg_consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
-    let agg_consumer_id =
-        ctx.memory_budget
-            .register_consumer(Arc::new(crate::aggregation::AggregateConsumer::new(
-                agg_consumer_handle.clone(),
-            )));
-    let mut stream = crate::aggregation::AggregateStream::for_node(
-        agg_strategy,
-        crate::aggregation::AggregatorConfig {
-            compiled: Arc::clone(compiled),
-            evaluator,
-            output_schema: Arc::clone(output_schema),
-            spill_schema,
-            memory_budget: mem_limit,
-            spill_dir: Some(ctx.spill_root_path.to_path_buf()),
-            spill_compress,
-            transform_name: name.to_string(),
-            consumer_handle: agg_consumer_handle,
-        },
-    )?;
+    // Build the `ctx`-free document-aggregator factory (same one the
+    // materialized path uses). The scoped thread holds no
+    // `&mut ExecutorContext`, so it builds and registers each document's
+    // table through the factory's captured `Arc<MemoryArbitrator>`. Each
+    // table's `AggregateConsumer` contributes its growing group state to
+    // `sum_consumer_usage` while live, and is unregistered when that
+    // document flushes (on its `DocumentClose`, or at disconnect for the
+    // document left open).
+    let factory = DocAggregatorFactory::from_ctx(ctx, name, agg_strategy, compiled, output_schema)?;
 
     // Install the bounded streaming-ingest channel keyed by the producer's
     // index, so its dispatch arm streams into it with no producer-side
@@ -792,11 +979,12 @@ fn run_streaming_aggregate_ingest(
     let mut out_rows: Vec<AggSortRow> = Vec::with_capacity(64);
     let mut puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
     let mut input_count: u64 = 0;
+    let mut agg = DocumentFlushAggregator::new(factory);
 
     // Run the ingest recv loop and the producer concurrently. The scoped
-    // thread owns the `AggregateStream` and drains the channel; the main
-    // thread redispatches the producer (which streams into the channel and
-    // drops its sender at clean exit, disconnecting the channel). The
+    // thread owns the document-flush aggregator and drains the channel; the
+    // main thread redispatches the producer (which streams into the channel
+    // and drops its sender at clean exit, disconnecting the channel). The
     // producer's `?` error and the ingest thread's error both surface; the
     // ingest thread always drains to disconnect first so a producer `send`
     // can never deadlock on a dead consumer.
@@ -807,10 +995,22 @@ fn run_streaming_aggregate_ingest(
                 let (record, rn) = match event {
                     StreamEvent::Record(r, rn) => (r, rn),
                     StreamEvent::Punctuation(p) => {
-                        // Collect for the output tail (byte-identical to the
-                        // materialized hash path; per-document flush is a
-                        // separate follow-up). Punctuations carry zero
+                        // A `DocumentClose` arriving in stream order means the
+                        // open document is fully delivered: flush its groups
+                        // now (its records arrived contiguously before this
+                        // boundary), then forward the boundary at the output
+                        // tail. Opens only forward. Punctuations carry zero
                         // charge, so no discharge here.
+                        if p.kind() == crate::executor::stream_event::PunctuationKind::DocumentClose
+                            && let Err(e) = agg.flush_current(&finalize_ctx, &mut out_rows)
+                        {
+                            // The streaming-ingest arm aborts on a finalize
+                            // failure (no DLQ fallback, matching the prior
+                            // single-stream behavior); drain first so the
+                            // producer's bounded `send` can't deadlock.
+                            while rx.recv().is_ok() {}
+                            return Err(e.into());
+                        }
                         puncts.push(p);
                         continue;
                     }
@@ -841,6 +1041,7 @@ fn run_streaming_aggregate_ingest(
                     source_name: &source_name_arc,
                     doc_ctx: record.doc_ctx(),
                 };
+                let stream = agg.stream()?;
                 match stream.add_record(&record, rn, &eval_ctx, &mut out_rows) {
                     Ok(()) => effects.cursor_advances.push((source_name_arc, rn)),
                     Err(e) => match strategy {
@@ -859,9 +1060,15 @@ fn run_streaming_aggregate_ingest(
                 }
             }
             // Channel disconnected — every sender dropped at the producer
-            // arm's clean exit. Finalize the blocking half and return.
-            stream
-                .finalize(&finalize_ctx, &mut out_rows)
+            // arm's clean exit. An empty stream opened no table; a global
+            // fold still owes one defaulted row, so force one open before the
+            // final flush. Then flush whatever is still open (the trailing
+            // document, the synthetic doc id of a no-envelope run, or the
+            // unreconciled-Merge remainder) and return.
+            if input_count == 0 {
+                agg.ensure_open()?;
+            }
+            agg.flush_current(&finalize_ctx, &mut out_rows)
                 .map_err(PipelineError::from)
         });
 
@@ -890,13 +1097,13 @@ fn run_streaming_aggregate_ingest(
     // Charge bookkeeping is complete: the producer charged each batch and
     // the ingest thread discharged each record. Pin to zero defensively (a
     // heuristic mismatch between batch charge and per-record discharge must
-    // not leave a stale positive for the arbitrator), then unregister both
-    // the per-edge charge consumer and the aggregate consumer — `finalize`
-    // consumed the group state, so its bytes leave `sum_consumer_usage`.
+    // not leave a stale positive for the arbitrator), then unregister the
+    // per-edge charge consumer. Each per-document bucket's aggregate
+    // consumer already unregistered itself as that document flushed, so no
+    // aggregate consumer survives this arm.
     charge_handle.set_bytes(0);
     ctx.streaming_charge_consumers.remove(&producer_idx);
     ctx.memory_budget.unregister_consumer(charge_consumer_id);
-    ctx.memory_budget.unregister_consumer(agg_consumer_id);
 
     ingest_result?;
 
@@ -1061,7 +1268,6 @@ fn run_time_windowed_aggregate(
     };
     use clinker_plan::config::pipeline_node::TimeWindowSpec;
     use clinker_record::group_key::value_to_group_key;
-    use std::collections::HashMap;
 
     let upstream_sources = upstream_source_names(current_dag, node_idx);
     let allowed_lateness_nanos = allowed_lateness.map(duration_to_nanos).unwrap_or(0);
@@ -1471,9 +1677,10 @@ fn add_to_window(
     handle_aggregate_add_error(ctx, win_ctx.name, record, row_num, e)
 }
 
-/// Shared per-record `add_record` error handler for both
-/// tumbling/hopping and session arms. Mirrors the positional
-/// aggregate arm's error-strategy switch.
+/// Shared per-record `add_record` error handler for every materialized
+/// ingest arm — the strict per-document path, the relaxed-CK path, and
+/// the tumbling/hopping/session windowed arms. `FailFast` surfaces the
+/// error; `Continue` / `BestEffort` routes the failing record to the DLQ.
 fn handle_aggregate_add_error(
     ctx: &mut ExecutorContext<'_>,
     name: &str,
@@ -1618,9 +1825,10 @@ fn push_late_record(
 }
 
 /// Emit an `AggregateFinalize` DLQ entry for an accumulator failure at
-/// finalize-time. Shared by tumbling/hopping `finalize_windows` and
-/// the session arm; mirrors the positional aggregate arm's
-/// synthetic-record fallback when input is empty.
+/// finalize-time. Shared by the strict per-document flush, the relaxed-CK
+/// arm, and the tumbling/hopping/session windowed finalizers. Falls back
+/// to a synthetic record stamped with the node name when the input was
+/// empty (the failure has no real record to attribute to a Source).
 fn emit_aggregate_finalize_dlq(
     ctx: &mut ExecutorContext<'_>,
     name: &str,

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -239,13 +239,12 @@ pub(crate) fn dispatch_combine(
         None
     };
 
-    // Combine collects puncts from both inputs and forwards
-    // them to the output buffer. Per-document dedup
-    // (Merge-style barrier counter) for two-input Combine is
-    // out of scope for #91 (deferred to follow-up); the
-    // simple union here may emit `DocumentClose` twice
-    // downstream for documents that span both inputs, which
-    // any downstream Aggregate would handle idempotently.
+    // Combine collects puncts from both inputs and forwards a
+    // reconciled set downstream. Like Merge, it folds the two
+    // inputs' boundary signals so a document spanning both sides
+    // emits one `DocumentOpen` and one `DocumentClose` — withholding
+    // the close until both inputs have closed the document prevents a
+    // downstream per-document Aggregate flush from double-firing.
     //
     // Under streaming-probe the driver slot is empty (the driver has not
     // dispatched yet — it streams into the probe channel during the redispatch
@@ -269,8 +268,13 @@ pub(crate) fn dispatch_combine(
         Some(nb) => nb.drain_split()?,
         None => (Vec::new(), Vec::new()),
     };
-    let combined_puncts: Vec<crate::executor::stream_event::Punctuation> =
-        driver_puncts.into_iter().chain(build_puncts).collect();
+    // Binary Combine: fan-in degree is 2 (driver + build). The empty-
+    // punctuation common case folds to an empty vector, leaving the
+    // no-document path byte-identical to a bare union.
+    let combined_puncts = crate::executor::stream_event::reconcile_document_boundaries(
+        driver_puncts.into_iter().chain(build_puncts),
+        2,
+    );
 
     // Operator-entry schema check per D4: every record
     // arriving on the probe and build channels is

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -280,37 +280,11 @@ pub(crate) fn dispatch_merge(
         merged
     };
 
-    // Merge is rejected as a window root at compile time
-    // (E150d) because the multi-producer concatenation has no
-    // single producer identity for record_pos to anchor
-    // against. The call below is a defense-in-depth no-op:
-    // the helper iterates plan.indices_to_build and matches
-    // nothing because no spec roots at a Merge NodeIndex.
-    // Punctuation dedup pass: emit `DocumentOpen` once per
-    // document (first sighting wins) and `DocumentClose` only
+    // Reconcile boundaries across every Merge input: one `DocumentOpen`
+    // per document (first sighting wins) and one `DocumentClose` only
     // after every input branch has closed the same document.
-    let mut deduped_puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
-    let mut open_seen: std::collections::HashSet<clinker_record::DocumentId> =
-        std::collections::HashSet::new();
-    let mut close_counts: std::collections::HashMap<clinker_record::DocumentId, usize> =
-        std::collections::HashMap::new();
-    for p in all_puncts {
-        let id = p.doc_id();
-        match p.kind() {
-            crate::executor::stream_event::PunctuationKind::DocumentOpen => {
-                if open_seen.insert(id) {
-                    deduped_puncts.push(p);
-                }
-            }
-            crate::executor::stream_event::PunctuationKind::DocumentClose => {
-                let count = close_counts.entry(id).or_insert(0);
-                *count += 1;
-                if *count == fan_in_degree {
-                    deduped_puncts.push(p);
-                }
-            }
-        }
-    }
+    let deduped_puncts =
+        crate::executor::stream_event::reconcile_document_boundaries(all_puncts, fan_in_degree);
 
     // Non-fused streaming path: the predecessors' slots are
     // already drained into the full `merged` Vec, so this does not
@@ -342,6 +316,12 @@ pub(crate) fn dispatch_merge(
         return Ok(());
     }
 
+    // Merge is rejected as a window root at compile time
+    // (E150d) because the multi-producer concatenation has no
+    // single producer identity for record_pos to anchor
+    // against. The call below is a defense-in-depth no-op:
+    // the helper iterates plan.indices_to_build and matches
+    // nothing because no spec roots at a Merge NodeIndex.
     finalize_node_rooted_windows(ctx, current_dag, node_idx, &merged)?;
     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &merged)?;
     let nb = admit_node_buffer(

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -22,6 +22,7 @@
 //! `SignalTo`, Logstash atomic boolean) are the FLINK-4329 failure
 //! mode and explicitly rejected.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use clinker_record::{DocumentContext, DocumentId, Record};
@@ -125,10 +126,66 @@ impl StreamEvent {
     }
 }
 
+/// Fold a fan-in's document-boundary punctuations down to one downstream
+/// signal per document, the way a multi-input operator must.
+///
+/// A document whose records arrive across several inputs (a forked
+/// document stream rejoining at a Merge, or a document spanning both
+/// sides of a binary Combine) contributes its `DocumentOpen` /
+/// `DocumentClose` boundary once per input. Forwarding that union
+/// unchanged would open the document several times and — worse — close
+/// it several times, double-firing any downstream consumer that flushes
+/// on close (per-document Aggregate finalize, Output finalize).
+///
+/// The reconciliation emits `DocumentOpen` on first sighting (later
+/// duplicates are dropped) and `DocumentClose` only once the close count
+/// for a document reaches `fan_in_degree` — i.e. every input has closed
+/// it. A document that traverses fewer than `fan_in_degree` inputs (e.g.
+/// distinct source files with distinct [`DocumentId`]s, each appearing on
+/// one input only) never reaches the threshold, so its close is withheld;
+/// this is the intended fan-in semantics, identical across every
+/// multi-input operator that calls this function. Input order is
+/// preserved for the events that survive.
+pub(crate) fn reconcile_document_boundaries(
+    puncts: impl IntoIterator<Item = Punctuation>,
+    fan_in_degree: usize,
+) -> Vec<Punctuation> {
+    let mut deduped: Vec<Punctuation> = Vec::new();
+    let mut open_seen: HashSet<DocumentId> = HashSet::new();
+    let mut close_counts: HashMap<DocumentId, usize> = HashMap::new();
+    for p in puncts {
+        let id = p.doc_id();
+        match p.kind() {
+            PunctuationKind::DocumentOpen => {
+                if open_seen.insert(id) {
+                    deduped.push(p);
+                }
+            }
+            PunctuationKind::DocumentClose => {
+                let count = close_counts.entry(id).or_insert(0);
+                *count += 1;
+                if *count == fan_in_degree {
+                    deduped.push(p);
+                }
+            }
+        }
+    }
+    deduped
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clinker_record::{Schema, Value, synthetic_document_context};
+    use clinker_record::{DocumentContext, Schema, Value, synthetic_document_context};
+    use indexmap::IndexMap;
+
+    fn doc_ctx() -> Arc<DocumentContext> {
+        Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("doc.x12"),
+            IndexMap::new(),
+        ))
+    }
 
     fn rec(id: i64) -> Record {
         Record::new(
@@ -171,5 +228,87 @@ mod tests {
         let r_event = StreamEvent::record(rec(5), 7);
         let (_, rn) = r_event.into_record().unwrap();
         assert_eq!(rn, 7);
+    }
+
+    fn kinds_for(puncts: &[Punctuation], id: DocumentId) -> Vec<PunctuationKind> {
+        puncts
+            .iter()
+            .filter(|p| p.doc_id() == id)
+            .map(|p| p.kind())
+            .collect()
+    }
+
+    #[test]
+    fn reconcile_collapses_duplicate_boundaries_for_spanning_document() {
+        // One document whose open+close arrives on each of two inputs
+        // collapses to a single open and a single close downstream — no
+        // double-close to double-fire a downstream per-document flush.
+        let ctx = doc_ctx();
+        let id = ctx.id();
+        let union = vec![
+            Punctuation::document_open(Arc::clone(&ctx)),
+            Punctuation::document_open(Arc::clone(&ctx)),
+            Punctuation::document_close(Arc::clone(&ctx)),
+            Punctuation::document_close(Arc::clone(&ctx)),
+        ];
+        let out = reconcile_document_boundaries(union, 2);
+        assert_eq!(
+            kinds_for(&out, id),
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ]
+        );
+    }
+
+    #[test]
+    fn reconcile_withholds_close_for_partial_coverage_document() {
+        // A document that opens+closes on only ONE input never reaches the
+        // fan-in degree, so its open is forwarded but its close is withheld
+        // — the shared fan-in semantics across every multi-input operator.
+        let ctx = doc_ctx();
+        let id = ctx.id();
+        let union = vec![
+            Punctuation::document_open(Arc::clone(&ctx)),
+            Punctuation::document_close(Arc::clone(&ctx)),
+        ];
+        let out = reconcile_document_boundaries(union, 2);
+        assert_eq!(kinds_for(&out, id), vec![PunctuationKind::DocumentOpen]);
+    }
+
+    #[test]
+    fn reconcile_is_per_document_independent() {
+        // Two distinct documents reconcile independently: a fully-covered
+        // one emits open+close, a partially-covered one emits open only.
+        let spanning = doc_ctx();
+        let partial = doc_ctx();
+        let union = vec![
+            Punctuation::document_open(Arc::clone(&spanning)),
+            Punctuation::document_open(Arc::clone(&partial)),
+            Punctuation::document_open(Arc::clone(&spanning)),
+            Punctuation::document_close(Arc::clone(&spanning)),
+            Punctuation::document_close(Arc::clone(&partial)),
+            Punctuation::document_close(Arc::clone(&spanning)),
+        ];
+        let out = reconcile_document_boundaries(union, 2);
+        assert_eq!(
+            kinds_for(&out, spanning.id()),
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ]
+        );
+        assert_eq!(
+            kinds_for(&out, partial.id()),
+            vec![PunctuationKind::DocumentOpen]
+        );
+    }
+
+    #[test]
+    fn reconcile_empty_input_yields_empty_output() {
+        // The common case — no punctuations on either input — passes
+        // through byte-identically to an empty vector.
+        let out = reconcile_document_boundaries(Vec::new(), 2);
+        assert!(out.is_empty());
     }
 }

--- a/crates/clinker-exec/tests/aggregate_per_document_flush.rs
+++ b/crates/clinker-exec/tests/aggregate_per_document_flush.rs
@@ -1,0 +1,550 @@
+//! Per-document Aggregate flush on the document-close boundary.
+//!
+//! A document-aware source feeds each source file to an Aggregate as its
+//! own document, carrying a `DocumentClose` boundary at its tail. Correct
+//! per-document aggregation flushes the groups belonging to a closing
+//! document at that boundary, so a multi-document run produces one set of
+//! grouped rows per document rather than a single cross-document
+//! aggregate. These tests drive that end to end through a multi-file CSV
+//! glob source (each file is a document) into a group-by `count(*)`
+//! aggregate, and assert per-group counts match each document's body. A
+//! no-document / single-document control proves the dominant path is
+//! unchanged, a tiny memory budget exercises the spilling strategy across
+//! a document boundary, the streaming-ingest path is covered via a fused
+//! producer, and `concat` / `interleave` Merges of two single-document
+//! sources prove documents whose close never reaches the aggregate fold
+//! together into one cross-document result rather than splitting — even
+//! when an interleave Merge delivers their records non-contiguously.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// Slice the indented `--explain` property block for the node whose
+/// stanza starts with `slug:`, up to the next blank line. The physical
+/// properties stanzas are two-space-indented and blank-line separated.
+fn properties_block(explain: &str, slug: &str) -> String {
+    let marker = format!("{slug}:");
+    explain
+        .lines()
+        .skip_while(|l| l.trim_start() != marker)
+        .skip(1)
+        .take_while(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Group-by `count(*)` over a CSV glob source, output to CSV. The
+/// `memory.limit` is templated so the same pipeline drives both the
+/// in-memory and the spilling strategy.
+fn count_by_category_yaml(memory_limit: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: per_doc_agg
+  memory: {{ limit: "{memory_limit}", backpressure: spill }}
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - {{ name: category, type: string }}
+  - type: aggregate
+    name: by_category
+    input: events
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#
+    )
+}
+
+/// Run the count-by-category pipeline over a set of in-memory CSV files,
+/// each fed as a distinct `FileSlot` (hence a distinct document). Returns
+/// the sorted body lines (`category,n`) and the run's ok/dlq counts.
+fn run_multi_file(memory_limit: &str, files: &[(&str, &str)]) -> (Vec<String>, u64, u64) {
+    let yaml = count_by_category_yaml(memory_limit);
+    let config = parse_config(&yaml).expect("parse per-document aggregate pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile per-document aggregate pipeline");
+
+    let slots: Vec<FileSlot> = files
+        .iter()
+        .map(|(name, body)| {
+            FileSlot::new(
+                PathBuf::from(*name),
+                Box::new(Cursor::new(body.as_bytes().to_vec())),
+            )
+        })
+        .collect();
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run per-document aggregate pipeline");
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    (body, report.counters.ok_count, report.counters.dlq_count)
+}
+
+#[test]
+fn multi_document_emits_one_group_set_per_document() {
+    // File A is one document: category x appears twice, y once. File B is
+    // a separate document: category x appears three times. Per-document
+    // aggregation must emit x=2 and y=1 for document A and a SEPARATE x=3
+    // for document B — a single cross-document aggregate would instead
+    // collapse to x=5, y=1.
+    let (body, ok, dlq) = run_multi_file(
+        "512M",
+        &[
+            ("a.csv", "category\nx\nx\ny\n"),
+            ("b.csv", "category\nx\nx\nx\n"),
+        ],
+    );
+    assert_eq!(dlq, 0, "no DLQ entries expected");
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "expected per-document groups (x=2,y=1 for doc A; x=3 for doc B), \
+         not a single cross-document x=5",
+    );
+    assert_eq!(ok, 3, "three grouped rows across the two documents");
+}
+
+#[test]
+fn three_documents_each_flush_independently() {
+    // Three documents, each contributing its own group set; the same
+    // category key recurs in every document with a different count, so a
+    // correct run yields three distinct rows for it rather than one
+    // summed row.
+    let (body, ok, dlq) = run_multi_file(
+        "512M",
+        &[
+            ("d1.csv", "category\na\na\n"),
+            ("d2.csv", "category\na\nb\n"),
+            ("d3.csv", "category\na\na\na\nb\nb\n"),
+        ],
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec![
+            "a,1".to_string(), // d2
+            "a,2".to_string(), // d1
+            "a,3".to_string(), // d3
+            "b,1".to_string(), // d2
+            "b,2".to_string(), // d3
+        ],
+    );
+    assert_eq!(ok, 5);
+}
+
+#[test]
+fn single_document_emits_one_aggregate_unchanged() {
+    // One file = one document: the dominant path must accumulate every row
+    // and emit a single aggregate per group, byte-identical to the
+    // pre-per-document behavior. x=2, y=1 — never split.
+    let (body, ok, dlq) = run_multi_file("512M", &[("only.csv", "category\nx\nx\ny\n")]);
+    assert_eq!(dlq, 0);
+    assert_eq!(body, vec!["x,2".to_string(), "y,1".to_string()]);
+    assert_eq!(ok, 2, "single document emits one aggregate per group");
+}
+
+#[test]
+fn spilling_strategy_flushes_per_document_across_boundary() {
+    // A 1 KB budget clamps the in-memory group cap so the aggregator
+    // spills to disk; the per-document flush must still split groups by
+    // document across the spill round-trip. Many distinct keys per
+    // document force spill within each document's bucket.
+    let mut doc_a = String::from("category\n");
+    for i in 0..200 {
+        doc_a.push_str(&format!("a{}\n", i % 50));
+    }
+    let mut doc_b = String::from("category\n");
+    for i in 0..200 {
+        doc_b.push_str(&format!("b{}\n", i % 50));
+    }
+    let (body, ok, dlq) = run_multi_file(
+        "1K",
+        &[("a.csv", doc_a.as_str()), ("b.csv", doc_b.as_str())],
+    );
+    assert_eq!(dlq, 0, "spilling run produces no DLQ entries");
+    // 50 distinct `a*` keys (each count 4) from document A, 50 distinct
+    // `b*` keys (each count 4) from document B — 100 groups total, every
+    // key namespaced to its own document.
+    assert_eq!(ok, 100, "50 groups per document, kept per-document");
+    assert_eq!(body.len(), 100);
+    let a_groups = body.iter().filter(|r| r.starts_with("a")).count();
+    let b_groups = body.iter().filter(|r| r.starts_with("b")).count();
+    assert_eq!(a_groups, 50, "document A contributes 50 groups");
+    assert_eq!(b_groups, 50, "document B contributes 50 groups");
+    for row in &body {
+        assert!(
+            row.ends_with(",4"),
+            "every key appears 4 times within its document: {row}"
+        );
+    }
+}
+
+/// A fused `Source → Transform` feeding a strict hash Aggregate is
+/// certified for the streaming-ingest substrate: the aggregate drives
+/// `add_record` off a bounded channel rather than draining a charged
+/// inter-stage slot. This exercises the per-document flush on THAT path —
+/// the `DocumentClose` arriving in stream order flushes its document's
+/// groups inside the scoped ingest thread.
+const STREAMING_INGEST_YAML: &str = r#"
+pipeline:
+  name: per_doc_agg_streaming
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+  - type: transform
+    name: passthrough
+    input: events
+    config:
+      cxl: |
+        emit category = category
+  - type: aggregate
+    name: by_category
+    input: passthrough
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn streaming_ingest_path_flushes_per_document() {
+    let config = parse_config(STREAMING_INGEST_YAML).expect("parse streaming-ingest pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile streaming-ingest pipeline");
+
+    // Confirm the planner certified the fused Transform → Aggregate edge
+    // for streaming ingest, so this run actually drives the scoped-thread
+    // ingest path (not the materialized drain). The transform classifies
+    // `buffer: streaming` and emits no charged node_buffer edge to the
+    // aggregate.
+    let (dag, _) =
+        clinker_exec::executor::PipelineExecutor::explain_plan_dag(&plan).expect("explain dag");
+    let explain = dag.explain_text(&config);
+    let block = properties_block(&explain, "transform.passthrough");
+    assert!(
+        block.contains("buffer: streaming") && !block.contains("buffer: materialized"),
+        "expected the fused transform feeding the aggregate to classify \
+         streaming (so the streaming-ingest aggregate path runs), got:\n{block}"
+    );
+    assert!(
+        !explain.contains("edge transform.passthrough -> aggregation.by_category"),
+        "a streaming-ingest aggregate must consume no charged inter-stage \
+         slot from its producer, got:\n{explain}"
+    );
+
+    // Same multi-document data as the materialized test: per-document
+    // flush must hold on the streaming-ingest path too.
+    let slots = vec![
+        FileSlot::new(
+            PathBuf::from("a.csv"),
+            Box::new(Cursor::new(b"category\nx\nx\ny\n".to_vec())),
+        ),
+        FileSlot::new(
+            PathBuf::from("b.csv"),
+            Box::new(Cursor::new(b"category\nx\nx\nx\n".to_vec())),
+        ),
+    ];
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run streaming-ingest pipeline");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "streaming-ingest path must also split groups per document",
+    );
+}
+
+/// A `concat` Merge of two distinct single-document sources feeds the
+/// Aggregate records carrying two different document ids — but the Merge
+/// reconciles boundaries and forwards a `DocumentClose` only when every
+/// branch closed the same document, which never happens for distinct
+/// per-source documents. With no close reaching the Aggregate, the two
+/// documents must fold together into ONE cross-document aggregate, exactly
+/// as a no-envelope stream would: per-document flush must NOT split an
+/// unreconciled merge into one aggregate per source file.
+const UNRECONCILED_MERGE_YAML: &str = r#"
+pipeline:
+  name: unreconciled_merge_agg
+nodes:
+  - type: source
+    name: sa
+    config:
+      name: sa
+      type: csv
+      path: ./sa.csv
+      schema:
+        - { name: category, type: string }
+  - type: source
+    name: sb
+    config:
+      name: sb
+      type: csv
+      path: ./sb.csv
+      schema:
+        - { name: category, type: string }
+  - type: merge
+    name: m
+    inputs: [sa, sb]
+    config:
+      mode: concat
+  - type: aggregate
+    name: by_category
+    input: m
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn unreconciled_merge_folds_documents_together() {
+    let config = parse_config(UNRECONCILED_MERGE_YAML).expect("parse unreconciled-merge pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile unreconciled-merge pipeline");
+
+    // sa contributes x×2, y×1; sb contributes x×1. With the two documents
+    // unreconciled (no forwarded close), the aggregate folds them together:
+    // x=3 (2 from sa + 1 from sb), y=1 — a single cross-document result,
+    // NOT a per-document split (which would yield x=2, y=1, x=1).
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([
+        (
+            "sa".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sa.csv",
+                Box::new(Cursor::new(b"category\nx\nx\ny\n".to_vec())),
+            ),
+        ),
+        (
+            "sb".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sb.csv",
+                Box::new(Cursor::new(b"category\nx\n".to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run unreconciled-merge pipeline");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    assert_eq!(
+        body,
+        vec!["x,3".to_string(), "y,1".to_string()],
+        "an unreconciled merge must fold its source documents into one \
+         aggregate (x=3, y=1), not split per source file",
+    );
+}
+
+/// An `interleave` Merge round-robins records from two distinct-document
+/// sources, so the aggregate's input carries the two documents' records
+/// non-contiguously. Their closes are unreconciled (never forwarded), so
+/// the records must still fold into one aggregate regardless of arrival
+/// order — proving the per-document flush keys group state by document
+/// rather than by a running "current document" that interleaving would
+/// corrupt.
+#[test]
+fn interleaved_unreconciled_documents_fold_together() {
+    let yaml = r#"
+pipeline:
+  name: interleave_merge_agg
+nodes:
+  - type: source
+    name: sa
+    config:
+      name: sa
+      type: csv
+      path: ./sa.csv
+      schema:
+        - { name: category, type: string }
+  - type: source
+    name: sb
+    config:
+      name: sb
+      type: csv
+      path: ./sb.csv
+      schema:
+        - { name: category, type: string }
+  - type: merge
+    name: m
+    inputs: [sa, sb]
+    config:
+      mode: interleave
+      interleave_seed: 7
+  - type: aggregate
+    name: by_category
+    input: m
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+    let config = parse_config(yaml).expect("parse interleave-merge pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile interleave-merge pipeline");
+
+    // sa: x×3; sb: x×2, y×1. Interleaved and unreconciled → one aggregate:
+    // x=5, y=1.
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([
+        (
+            "sa".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sa.csv",
+                Box::new(Cursor::new(b"category\nx\nx\nx\n".to_vec())),
+            ),
+        ),
+        (
+            "sb".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sb.csv",
+                Box::new(Cursor::new(b"category\nx\nx\ny\n".to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run interleave-merge pipeline");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    assert_eq!(
+        body,
+        vec!["x,5".to_string(), "y,1".to_string()],
+        "interleaved unreconciled documents must fold into one aggregate \
+         (x=5, y=1) regardless of round-robin arrival order",
+    );
+}

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -22,8 +22,10 @@ use std::sync::{Arc, OnceLock};
 /// Monotonic per-process. Sources allocate via [`DocumentId::next`] when
 /// constructing a new context per file. Used by `Merge` punctuation dedup
 /// (keys a per-document `HashMap` / `HashSet`) to fold a document's
-/// boundary down to one downstream emission.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// boundary down to one downstream emission, and by the Aggregate's
+/// per-document group flush to walk its open documents in a stable order.
+/// `Ord` follows allocation order: a document opened earlier sorts first.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DocumentId(u64);
 
 impl DocumentId {

--- a/docs/src/cookbook/aggregation.md
+++ b/docs/src/cookbook/aggregation.md
@@ -108,6 +108,20 @@ Available aggregate functions in CXL:
 | `first(expr)` | First value encountered |
 | `last(expr)` | Last value encountered |
 
+### Per-document aggregation
+
+When the source is document-aware — a `glob:` / `paths:` source that
+treats each file as its own document, or an enveloped format like XML or
+EDI — the Aggregate produces **one set of grouped rows per document**
+rather than a single aggregate spanning every file. Each document's
+groups finalize and emit at that document's close boundary, so a glob
+over twelve monthly files yields twelve independent monthly roll-ups, and
+only one document's groups are live in memory at a time. A plain
+single-file source is one document and still emits a single aggregate.
+See [Envelopes & Document Context](../pipeline/envelope-and-doc-context.md#per-document-aggregation)
+for the boundary rules (including how a `Merge` of distinct sources folds
+them back into one aggregate).
+
 ### Strategy selection
 
 Clinker offers two aggregation strategies:

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -174,11 +174,31 @@ reflects the file that record came from.
 
 Document boundaries flow through the pipeline as inline punctuation
 signals (one when a document opens, one when it closes). These signals
-let document-scoped operators — for example a future per-document
-aggregate flush or trailer-count validation — fire at exactly the right
-point. Today the signals propagate through Source, Transform, Route,
-Sort, and Combine, and are reconciled at Merge (a document that fans in
-through several branches closes downstream exactly once).
+let document-scoped operators fire at exactly the right point. They
+propagate through Source, Transform, Route, Sort, and Combine, and are
+reconciled at Merge (a document that fans in through several branches
+closes downstream exactly once).
+
+### Per-document aggregation
+
+A grouped or global `Aggregate` reading a multi-document source produces
+**one set of grouped rows per document**, not a single aggregate spanning
+every document. When a document closes, the Aggregate finalizes and emits
+the groups belonging to that document, then drops their state before the
+next document accumulates — so a `glob:` source over twelve monthly files
+through a `group_by` Aggregate yields twelve independent monthly
+roll-ups, and only one document's groups are ever live at once (the
+others have already been emitted and freed, or have not yet started).
+
+This applies only when a document boundary actually reaches the
+Aggregate. A plain single-file source is one document, so it still emits
+one aggregate. A `Merge` that combines several distinct single-document
+sources does **not** forward a per-source close (it reconciles boundaries
+and emits a close only when *every* branch closed the same document), so
+those sources fold together into one cross-source aggregate — the same
+result you would get with no envelopes at all. To keep per-document
+roll-ups across files, feed the multi-file source straight into the
+Aggregate rather than merging distinct sources first.
 
 ## Nested (multi-level) envelopes
 

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -174,10 +174,13 @@ reflects the file that record came from.
 
 Document boundaries flow through the pipeline as inline punctuation
 signals (one when a document opens, one when it closes). These signals
-let document-scoped operators fire at exactly the right point. They
-propagate through Source, Transform, Route, Sort, and Combine, and are
-reconciled at Merge (a document that fans in through several branches
-closes downstream exactly once).
+let document-scoped operators fire at exactly the right point. Today the
+signals propagate through Source, Transform, Route, and Sort, and are
+reconciled at the multi-input operators — Merge and Combine. A document
+that fans in through several branches opens downstream once (on first
+sighting) and closes downstream once (only after every input has closed
+it), so a downstream document-scoped operator fires exactly once
+regardless of how many inputs the document spanned.
 
 ### Per-document aggregation
 
@@ -240,7 +243,8 @@ keeps every level independently visible.
 Boundaries nest correctly through the pipeline: each level opens before
 the records inside it and closes after them, in strict innermost-first
 order. A level that fans in through several branches is still reconciled
-once at Merge, exactly like a single-level document.
+once at a multi-input operator (Merge or Combine), exactly like a
+single-level document.
 
 ## Header-only interchanges
 


### PR DESCRIPTION
Two document-shape engine changes that make document-boundary signals drive cross-record operators correctly.

## Closes #192 — per-document Aggregate flush

A document-aware source (a `glob:`/`paths:` source treating each file as a document, or an enveloped format like XML or EDI) emits an inline document-close boundary at each document's tail. The `Aggregate` previously forwarded those boundaries but accumulated all groups across every document, emitting a single cross-document aggregate at end of input.

Now a multi-document source through a `group_by` (or global) `Aggregate` produces **one set of grouped rows per document**: a document's groups finalize and emit at its close boundary, then drop before the next document accumulates.

- The materialized drain path keys live group tables by a flush key (a record's own document id when its close reached the aggregate, else a shared sentinel), so it is robust to records interleaved by an upstream `Merge`.
- The streaming-ingest path holds one live table and flushes it inline on each close, keeping peak footprint at a single document's group state.
- A `Merge` of distinct single-document sources forwards no per-source close, so those sources fold together into one aggregate — exactly as a no-envelope run would. To keep per-document rollups across files, feed the multi-file source straight into the `Aggregate`.
- The relaxed-correlation-key retraction path keeps its single cross-document table (the commit phase retracts and re-finalizes the same instance); time-windowed aggregates are unchanged. No-document and single-document pipelines are byte-identical to before.

## Closes #193 — Combine document-boundary reconciliation

A `Combine` joins two inputs; a document spanning both contributes its boundary signal from each side. The previous code unioned both inputs' boundaries, so such a document emitted its close twice downstream, double-firing any consumer that flushes on a close (notably the per-document `Aggregate` finalize above).

`Combine` now reconciles the two inputs' boundaries the way `Merge` does: one open on first sighting, one close only once both inputs have closed the document. The reconciliation is extracted into a single shared helper that `Merge` and `Combine` both call, so the two multi-input operators fold boundaries identically rather than through two copies of the logic.

## Tests & verification

- New `crates/clinker-exec/tests/aggregate_per_document_flush.rs` (7 tests): multi-document and three-document per-document rollups, single-document control, spilling strategy across a document boundary, the streaming-ingest path (asserted via `--explain`), and concat/interleave `Merge` fold-together cases.
- New unit tests for the shared `reconcile_document_boundaries` helper (collapse, partial-coverage withhold, per-document independence, empty input).
- Full local gauntlet green: `fmt`, `clippy --workspace`, `clippy --workspace --all-targets`, `test --workspace`, `check --benches --workspace`, `bench-alloc`, `test --benches -p clinker-benchmarks`, `cargo deny check`.

## User docs

`docs/src/pipeline/envelope-and-doc-context.md` (per-document aggregation + Combine as a reconciling multi-input operator) and `docs/src/cookbook/aggregation.md`.

## Follow-ups filed

Gaps surfaced while implementing, out of scope here: #416 (inline/streaming-probe `Combine` paths drop boundaries), #417 (streaming-ingest `Aggregate` + multi-document `Merge` edge case), #418 (per-document spill-trigger budget), #419 (`too_many_arguments` cleanup). Fused-`Merge` boundary-forwarding intel added to #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)