### PR TITLE
fix(clinker-exec): per-document aggregate correctness — deadlock, leak, DLQ attribution, empty global-fold

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -713,6 +713,99 @@ impl DocumentFlushAggregator {
     }
 }
 
+/// Per-document group tables keyed by flush key, with a teardown that
+/// unregisters any table still present from the shared arbitrator.
+///
+/// Each built [`crate::aggregation::AggregateStream`] registers an
+/// [`crate::aggregation::AggregateConsumer`] keyed by a [`ConsumerId`]; the
+/// arbitrator's registry holds an independent `Arc`, so dropping the stream
+/// alone leaves its consumer charged against `sum_consumer_usage`. The
+/// per-document flush loop `remove`s and finalizes each table, then
+/// unregisters it explicitly — but an `add_record` `FailFast` error, a
+/// non-`Accumulator` finalize error, or a `factory.make()` failure can exit
+/// the routine with tables still live. This guard's `Drop` unregisters
+/// every still-present consumer on *every* exit, so an early `?` cannot
+/// strand a consumer in the registry. A normal completion `remove`s every
+/// key as it flushes, so the guard drops an empty map and is a no-op; a
+/// `remove`d-and-flushed table is gone from the map before drop, so no
+/// consumer is unregistered twice.
+struct RegisteredTables {
+    tables: HashMap<
+        DocumentId,
+        (
+            crate::aggregation::AggregateStream,
+            crate::pipeline::memory::ConsumerId,
+        ),
+    >,
+    arbitrator: Arc<crate::pipeline::memory::MemoryArbitrator>,
+}
+
+impl RegisteredTables {
+    fn new(arbitrator: Arc<crate::pipeline::memory::MemoryArbitrator>) -> Self {
+        Self {
+            tables: HashMap::new(),
+            arbitrator,
+        }
+    }
+
+    /// Borrow the table for `key`, building (and registering) a fresh one
+    /// via `factory` when none exists yet. The freshly built consumer is
+    /// tracked by the guard the moment it lands in the map, so a later early
+    /// return unregisters it.
+    fn entry_or_make(
+        &mut self,
+        key: DocumentId,
+        factory: &DocAggregatorFactory,
+    ) -> Result<&mut crate::aggregation::AggregateStream, PipelineError> {
+        let entry = match self.tables.entry(key) {
+            std::collections::hash_map::Entry::Occupied(o) => o.into_mut(),
+            std::collections::hash_map::Entry::Vacant(v) => v.insert(factory.make()?),
+        };
+        Ok(&mut entry.0)
+    }
+
+    /// Build (and register) a fresh table for `key` unconditionally. Used to
+    /// force a global fold's defaulted row for an empty document.
+    fn insert_fresh(
+        &mut self,
+        key: DocumentId,
+        factory: &DocAggregatorFactory,
+    ) -> Result<(), PipelineError> {
+        self.tables.insert(key, factory.make()?);
+        Ok(())
+    }
+
+    /// Take the table for `key` out of the guard, transferring its consumer
+    /// to the caller, which must unregister it after finalizing. Removing it
+    /// here is what keeps the guard's `Drop` from double-unregistering a
+    /// flushed table.
+    fn remove(
+        &mut self,
+        key: DocumentId,
+    ) -> Option<(
+        crate::aggregation::AggregateStream,
+        crate::pipeline::memory::ConsumerId,
+    )> {
+        self.tables.remove(&key)
+    }
+
+    /// Flush keys in ascending [`DocumentId`] order for deterministic emit
+    /// ordering across the leftover fold.
+    fn sorted_keys(&self) -> Vec<DocumentId> {
+        let mut keys: Vec<DocumentId> = self.tables.keys().copied().collect();
+        keys.sort_unstable();
+        keys
+    }
+}
+
+impl Drop for RegisteredTables {
+    fn drop(&mut self) {
+        for (_, (_, consumer_id)) in self.tables.drain() {
+            self.arbitrator.unregister_consumer(consumer_id);
+        }
+    }
+}
+
 /// Drive a strict (non-relaxed, non-time-windowed) Aggregate with
 /// per-document group flush over a fully-drained input batch.
 ///
@@ -767,14 +860,20 @@ fn run_strict_aggregate_per_document(
         }
     };
 
-    let mut tables: HashMap<
-        DocumentId,
-        (
-            crate::aggregation::AggregateStream,
-            crate::pipeline::memory::ConsumerId,
-        ),
-    > = HashMap::new();
+    // Hold the per-document tables behind a guard that unregisters any
+    // still-present consumer on drop. A `FailFast` add error, a non-
+    // `Accumulator` finalize error, or a `factory.make()` failure exits via
+    // `?` with tables still live; without the guard each would strand its
+    // arbitrator consumer in `sum_consumer_usage`. Normal completion removes
+    // every key as it flushes, so the guard drops empty.
+    let mut tables = RegisteredTables::new(Arc::clone(&factory.arbitrator));
     let mut out_rows: Vec<crate::aggregation::SortRow> = Vec::with_capacity(64);
+
+    // A global fold (no group-by) owes one defaulted row per closing
+    // document even when that document contributed zero records, matching a
+    // standalone empty single-file run; a grouped fold owes nothing for an
+    // empty document.
+    let is_global_fold = factory.compiled.group_by_fields.is_empty();
 
     for (record, row_num) in input {
         let key = flush_key(record.doc_ctx().id());
@@ -786,13 +885,8 @@ fn run_strict_aggregate_per_document(
             *row_num,
             record.doc_ctx(),
         );
-        let entry = match tables.entry(key) {
-            std::collections::hash_map::Entry::Occupied(o) => o.into_mut(),
-            std::collections::hash_map::Entry::Vacant(v) => v.insert(factory.make()?),
-        };
-        let add_result = entry
-            .0
-            .add_record(record, *row_num, &eval_ctx, &mut out_rows);
+        let stream = tables.entry_or_make(key, &factory)?;
+        let add_result = stream.add_record(record, *row_num, &eval_ctx, &mut out_rows);
         if add_result.is_ok() {
             advance_cursor(ctx, &source_name_arc, *row_num);
         }
@@ -806,31 +900,56 @@ fn run_strict_aggregate_per_document(
     // borrows only `'a`-lifetime data, so it survives the `&mut ctx` DLQ
     // routing between flushes.
     let finalize_ctx = ctx.merged_eval_ctx();
+    // Documents already flushed in this loop, so a duplicate `DocumentClose`
+    // for the same id does not synthesize a second global-fold row for a
+    // document that already emitted.
+    let mut flushed: std::collections::HashSet<DocumentId> = std::collections::HashSet::new();
     for p in input_puncts {
-        if p.kind() == PunctuationKind::DocumentClose
-            && let Some((stream, consumer_id)) = tables.remove(&p.doc_id())
-        {
+        if p.kind() != PunctuationKind::DocumentClose {
+            continue;
+        }
+        let doc_id = p.doc_id();
+        if !flushed.insert(doc_id) {
+            continue;
+        }
+        // A closing document that contributed records owns a table built
+        // lazily on its first record. One that contributed none has no table
+        // — for a global fold, build a fresh table so its defaulted row
+        // still emits; for a grouped fold, emit nothing.
+        let entry = match tables.remove(doc_id) {
+            Some(entry) => Some(entry),
+            None if is_global_fold => Some(factory.make()?),
+            None => None,
+        };
+        if let Some((stream, consumer_id)) = entry {
             let result = stream.finalize(&finalize_ctx, &mut out_rows);
             factory.arbitrator.unregister_consumer(consumer_id);
-            route_document_flush_result(ctx, name, input, output_schema, result)?;
+            // Attribute a finalize failure to a record from THIS document so
+            // the DLQ entry points at the document's own source file, not the
+            // batch's first document.
+            let attribution = document_attribution_record(input, doc_id);
+            route_document_flush_result(ctx, name, attribution, output_schema, result)?;
         }
     }
 
-    // An empty input opened no table; a global fold still owes its single
-    // defaulted row, so force the sentinel table open before the final
-    // flush. Gated on truly-empty input so a run whose only document
-    // already flushed on its close is not given a phantom global-fold row.
-    if input.is_empty() {
-        tables.insert(DocumentId::SYNTHETIC, factory.make()?);
+    // A wholly-empty input that flushed no closing document (the synthetic
+    // no-document case — a fused single-source run whose only document never
+    // forwarded a close) still owes its single defaulted row under a global
+    // fold, so force the sentinel table open before the final flush. The
+    // `flushed.is_empty()` guard keeps this from double-emitting when a
+    // closing document already produced the global-fold row in the punct-loop
+    // above (e.g. a global fold whose lone closing document flushed empty).
+    if input.is_empty() && flushed.is_empty() {
+        tables.insert_fresh(DocumentId::SYNTHETIC, &factory)?;
     }
     // Flush whatever is left in `DocumentId` order for deterministic emit
     // ordering: the sentinel (unreconciled / no-document remainder) and any
-    // closing document whose close never arrived.
+    // closing document whose close never arrived. This leftover fold spans
+    // no single document, so its DLQ attribution keeps the batch-first-record
+    // behavior.
     let finalize_ctx = ctx.merged_eval_ctx();
-    let mut remaining: Vec<DocumentId> = tables.keys().copied().collect();
-    remaining.sort_unstable();
-    for key in remaining {
-        let (stream, consumer_id) = tables.remove(&key).expect("key from this map");
+    for key in tables.sorted_keys() {
+        let (stream, consumer_id) = tables.remove(key).expect("key from this map");
         let result = stream.finalize(&finalize_ctx, &mut out_rows);
         factory.arbitrator.unregister_consumer(consumer_id);
         route_document_flush_result(ctx, name, input, output_schema, result)?;
@@ -839,13 +958,32 @@ fn run_strict_aggregate_per_document(
     Ok(out_rows)
 }
 
+/// Pick a representative record for a flushing document so a finalize-time
+/// DLQ entry is attributed to that document's source file, not the batch's
+/// first document. Returns the input slice narrowed to the first record
+/// whose `doc_ctx().id()` matches `doc_id`; when no record carries that id
+/// (an empty closing document), returns the whole slice so
+/// [`emit_aggregate_finalize_dlq`] keeps its existing first-record / node-
+/// name fallback.
+fn document_attribution_record(input: &[(Record, u64)], doc_id: DocumentId) -> &[(Record, u64)] {
+    match input.iter().position(|(r, _)| r.doc_ctx().id() == doc_id) {
+        Some(pos) => &input[pos..=pos],
+        None => input,
+    }
+}
+
 /// Route a document-flush finalize result: an `Accumulator` failure goes
 /// to the DLQ under `Continue` / `BestEffort` (mirroring the single-stream
 /// strict arm), `FailFast` and every other engine error propagate.
+///
+/// `attribution` is the input slice narrowed to the flushing document — a
+/// single record from that document, or the whole batch for the cross-
+/// document leftover fold — so a DLQ entry points at the document that
+/// actually failed rather than the batch's first document.
 fn route_document_flush_result(
     ctx: &mut ExecutorContext<'_>,
     name: &str,
-    input: &[(Record, u64)],
+    attribution: &[(Record, u64)],
     output_schema: &Arc<Schema>,
     result: Result<(), crate::aggregation::HashAggError>,
 ) -> Result<(), PipelineError> {
@@ -865,7 +1003,7 @@ fn route_document_flush_result(
             ErrorStrategy::Continue | ErrorStrategy::BestEffort => emit_aggregate_finalize_dlq(
                 ctx,
                 name,
-                input,
+                attribution,
                 output_schema,
                 &transform,
                 &binding,
@@ -1826,19 +1964,26 @@ fn push_late_record(
 
 /// Emit an `AggregateFinalize` DLQ entry for an accumulator failure at
 /// finalize-time. Shared by the strict per-document flush, the relaxed-CK
-/// arm, and the tumbling/hopping/session windowed finalizers. Falls back
-/// to a synthetic record stamped with the node name when the input was
-/// empty (the failure has no real record to attribute to a Source).
+/// arm, and the tumbling/hopping/session windowed finalizers.
+///
+/// `records` carries the failure's source attribution: its first element
+/// stamps the DLQ entry's `original_record` and `source_name`. The
+/// per-document flush narrows it to a single record from the failing
+/// document so the entry points at that document's file; the windowed and
+/// relaxed-CK callers pass the whole batch (their failures span no single
+/// document). Falls back to a synthetic record stamped with the node name
+/// when `records` is empty (the failure has no real record to attribute to
+/// a Source).
 fn emit_aggregate_finalize_dlq(
     ctx: &mut ExecutorContext<'_>,
     name: &str,
-    input: &[(Record, u64)],
+    records: &[(Record, u64)],
     output_schema: &Arc<Schema>,
     transform: &str,
     binding: &str,
     source: &clinker_record::accumulator::AccumulatorError,
 ) -> Result<(), PipelineError> {
-    let (synthetic, source_name) = if let Some((rec, _)) = input.first() {
+    let (synthetic, source_name) = if let Some((rec, _)) = records.first() {
         let sn = source_name_arc_of(rec);
         (rec.clone(), sn)
     } else {
@@ -1862,4 +2007,82 @@ fn emit_aggregate_finalize_dlq(
             triggering_value: None,
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::{DocumentContext, Value};
+    use indexmap::IndexMap;
+
+    fn record_in_document(doc_id: DocumentId, tag: &str) -> Record {
+        let schema = Arc::new(Schema::new(vec!["tag".into()]));
+        let mut record = Record::new(schema, vec![Value::from(tag)]);
+        record.set_doc_ctx(Arc::new(DocumentContext::new(
+            doc_id,
+            Arc::from("file.csv"),
+            IndexMap::new(),
+        )));
+        record
+    }
+
+    /// `document_attribution_record` narrows the batch to the first record of
+    /// the named document so a finalize-time DLQ entry is stamped with that
+    /// document's record, not the batch's first.
+    #[test]
+    fn attribution_narrows_to_the_named_document() {
+        let doc_a = DocumentId::next();
+        let doc_b = DocumentId::next();
+        let input = vec![
+            (record_in_document(doc_a, "a0"), 0),
+            (record_in_document(doc_a, "a1"), 1),
+            (record_in_document(doc_b, "b0"), 2),
+            (record_in_document(doc_b, "b1"), 3),
+        ];
+
+        // Document B narrows to B's first record, never A's.
+        let attr_b = document_attribution_record(&input, doc_b);
+        assert_eq!(
+            attr_b.len(),
+            1,
+            "narrowed to a single representative record"
+        );
+        assert_eq!(
+            attr_b[0].0.get("tag"),
+            Some(&Value::from("b0")),
+            "attribution points at document B's first record",
+        );
+
+        // Document A narrows to A's first record.
+        let attr_a = document_attribution_record(&input, doc_a);
+        assert_eq!(
+            attr_a[0].0.get("tag"),
+            Some(&Value::from("a0")),
+            "attribution points at document A's first record",
+        );
+    }
+
+    /// A document id absent from the batch (an empty closing document, or the
+    /// cross-document leftover fold) falls back to the whole slice so the DLQ
+    /// emitter keeps its first-record / node-name fallback.
+    #[test]
+    fn attribution_falls_back_to_whole_slice_when_document_absent() {
+        let doc_a = DocumentId::next();
+        let absent = DocumentId::next();
+        let input = vec![
+            (record_in_document(doc_a, "a0"), 0),
+            (record_in_document(doc_a, "a1"), 1),
+        ];
+
+        let attr = document_attribution_record(&input, absent);
+        assert_eq!(
+            attr.len(),
+            input.len(),
+            "an absent document keeps the whole slice for the existing fallback",
+        );
+
+        // The empty-input case yields an empty slice (no record to attribute).
+        let empty: Vec<(Record, u64)> = Vec::new();
+        assert!(document_attribution_record(&empty, absent).is_empty());
+    }
 }

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -711,6 +711,33 @@ impl DocumentFlushAggregator {
         }
         Ok(())
     }
+
+    /// `true` when this aggregate is a global fold (no group-by columns).
+    /// A global fold owes one defaulted row per closing document even when
+    /// that document contributed zero records; a grouped fold owes nothing
+    /// for an empty document.
+    fn is_global_fold(&self) -> bool {
+        self.factory.compiled.group_by_fields.is_empty()
+    }
+}
+
+impl Drop for DocumentFlushAggregator {
+    /// Release the open table's arbitrator consumer on every exit path.
+    ///
+    /// `flush_current` takes `current` and unregisters the consumer on the
+    /// normal flush, so a cleanly-drained aggregator drops with
+    /// `current == None` and this is a no-op. An error return from the
+    /// ingest loop, by contrast, drops the aggregator with a table still
+    /// open; without this the open table's `AggregateConsumer` would linger
+    /// in the arbitrator's registry — the registry holds an independent
+    /// `Arc` keyed by `ConsumerId`, so dropping the `AggregateStream` alone
+    /// does not unregister it. `unregister_consumer` is idempotent, so even
+    /// a redundant call is harmless.
+    fn drop(&mut self) {
+        if let Some((_, consumer_id)) = self.current.take() {
+            self.factory.arbitrator.unregister_consumer(consumer_id);
+        }
+    }
 }
 
 /// Per-document group tables keyed by flush key, with a teardown that
@@ -1117,6 +1144,12 @@ fn run_streaming_aggregate_ingest(
     let mut out_rows: Vec<AggSortRow> = Vec::with_capacity(64);
     let mut puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
     let mut input_count: u64 = 0;
+    // Set once any `DocumentClose` flushes a table. The disconnect-time
+    // empty-input flush owes a global fold its single defaulted row only
+    // when no close already paid that debt — an all-empty-documents run
+    // flushes one defaulted row per close and must not gain an extra
+    // phantom row at the tail.
+    let mut flushed_close = false;
     let mut agg = DocumentFlushAggregator::new(factory);
 
     // Run the ingest recv loop and the producer concurrently. The scoped
@@ -1129,85 +1162,121 @@ fn run_streaming_aggregate_ingest(
     let finalize_ctx = ctx.merged_eval_ctx();
     let ingest_result: Result<(), PipelineError> = std::thread::scope(|scope| {
         let handle = scope.spawn(|| -> Result<(), PipelineError> {
-            while let Ok(event) = rx.recv() {
-                let (record, rn) = match event {
-                    StreamEvent::Record(r, rn) => (r, rn),
-                    StreamEvent::Punctuation(p) => {
-                        // A `DocumentClose` arriving in stream order means the
-                        // open document is fully delivered: flush its groups
-                        // now (its records arrived contiguously before this
-                        // boundary), then forward the boundary at the output
-                        // tail. Opens only forward. Punctuations carry zero
-                        // charge, so no discharge here.
-                        if p.kind() == crate::executor::stream_event::PunctuationKind::DocumentClose
-                            && let Err(e) = agg.flush_current(&finalize_ctx, &mut out_rows)
-                        {
-                            // The streaming-ingest arm aborts on a finalize
-                            // failure (no DLQ fallback, matching the prior
-                            // single-stream behavior); drain first so the
-                            // producer's bounded `send` can't deadlock.
-                            while rx.recv().is_ok() {}
-                            return Err(e.into());
+            // The recv body is a single fallible closure so EVERY error exit
+            // funnels through the one drain-then-return site below. `rx` lives
+            // in the outer function frame, not in this closure, so an early
+            // `?` return would NOT disconnect the channel — a producer blocked
+            // on the bounded `send` would then deadlock and the join would
+            // hang forever. Draining `rx` to disconnect before propagating any
+            // error closes that gap structurally: no `?` site inside the
+            // closure can reintroduce the non-draining asymmetry.
+            let mut drive = || -> Result<(), PipelineError> {
+                while let Ok(event) = rx.recv() {
+                    let (record, rn) = match event {
+                        StreamEvent::Record(r, rn) => (r, rn),
+                        StreamEvent::Punctuation(p) => {
+                            // A `DocumentClose` arriving in stream order means
+                            // the open document is fully delivered: flush its
+                            // groups now (its records arrived contiguously
+                            // before this boundary), then forward the boundary
+                            // at the output tail. A global fold owes one
+                            // defaulted row per closing document even when that
+                            // document contributed zero records, so force a
+                            // table open before flushing an empty global-fold
+                            // document — matching what a standalone empty run
+                            // emits. A grouped fold owes nothing for an empty
+                            // document, and a closing document that DID see
+                            // records already holds an open table, so neither
+                            // path gains a phantom row. Opens only forward.
+                            // Punctuations carry zero charge, so no discharge
+                            // here.
+                            if p.kind()
+                                == crate::executor::stream_event::PunctuationKind::DocumentClose
+                            {
+                                if agg.is_global_fold() {
+                                    agg.ensure_open()?;
+                                }
+                                agg.flush_current(&finalize_ctx, &mut out_rows)?;
+                                flushed_close = true;
+                            }
+                            puncts.push(p);
+                            continue;
                         }
-                        puncts.push(p);
-                        continue;
+                    };
+                    // Discharge this record's per-row cost — the consume half
+                    // of the producer's per-batch admit. The formula matches
+                    // the producer's charge so a fully-drained stream nets to
+                    // zero.
+                    charge_handle.sub_bytes(crate::executor::node_buffer::record_byte_cost(
+                        record.schema().column_count(),
+                    ));
+                    input_count += 1;
+                    if let Some(exp) = expected_input.as_ref() {
+                        check_input_schema(
+                            exp,
+                            record.schema(),
+                            name,
+                            "aggregation",
+                            &upstream_name,
+                        )?;
                     }
-                };
-                // Discharge this record's per-row cost — the consume half of
-                // the producer's per-batch admit. The formula matches the
-                // producer's charge so a fully-drained stream nets to zero.
-                charge_handle.sub_bytes(crate::executor::node_buffer::record_byte_cost(
-                    record.schema().column_count(),
-                ));
-                input_count += 1;
-                if let Some(exp) = expected_input.as_ref() {
-                    check_input_schema(exp, record.schema(), name, "aggregation", &upstream_name)?;
+                    let source_file_arc = source_file_arc_of(&record);
+                    let source_name_arc = source_name_arc_of(&record);
+                    // Mid-stream `$source.count` is `None` (defer-emit) — the
+                    // total is unknown until the source disconnects, exactly as
+                    // the per-record eval sites resolve it.
+                    let eval_ctx = EvalContext {
+                        stable,
+                        source_file: &source_file_arc,
+                        source_row: rn,
+                        source_path: &source_file_arc,
+                        source_count: None,
+                        source_batch: source_batch_arc,
+                        ingestion_timestamp,
+                        source_name: &source_name_arc,
+                        doc_ctx: record.doc_ctx(),
+                    };
+                    let stream = agg.stream()?;
+                    match stream.add_record(&record, rn, &eval_ctx, &mut out_rows) {
+                        Ok(()) => effects.cursor_advances.push((source_name_arc, rn)),
+                        Err(e) => match strategy {
+                            ErrorStrategy::FailFast => return Err(e.into()),
+                            ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
+                                effects.add_errors.push((
+                                    record,
+                                    rn,
+                                    format!("aggregate {name}: {e}"),
+                                ));
+                            }
+                        },
+                    }
                 }
-                let source_file_arc = source_file_arc_of(&record);
-                let source_name_arc = source_name_arc_of(&record);
-                // Mid-stream `$source.count` is `None` (defer-emit) — the
-                // total is unknown until the source disconnects, exactly as
-                // the per-record eval sites resolve it.
-                let eval_ctx = EvalContext {
-                    stable,
-                    source_file: &source_file_arc,
-                    source_row: rn,
-                    source_path: &source_file_arc,
-                    source_count: None,
-                    source_batch: source_batch_arc,
-                    ingestion_timestamp,
-                    source_name: &source_name_arc,
-                    doc_ctx: record.doc_ctx(),
-                };
-                let stream = agg.stream()?;
-                match stream.add_record(&record, rn, &eval_ctx, &mut out_rows) {
-                    Ok(()) => effects.cursor_advances.push((source_name_arc, rn)),
-                    Err(e) => match strategy {
-                        ErrorStrategy::FailFast => {
-                            // Drain the rest so the producer's bounded `send`
-                            // can't deadlock, then surface the error.
-                            while rx.recv().is_ok() {}
-                            return Err(e.into());
-                        }
-                        ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
-                            effects
-                                .add_errors
-                                .push((record, rn, format!("aggregate {name}: {e}")));
-                        }
-                    },
+                // Channel disconnected — every sender dropped at the producer
+                // arm's clean exit. A completely empty stream (no records, no
+                // forwarded close) opened no table; a global fold still owes
+                // one defaulted row, so force one open before the final flush.
+                // Gated on `!flushed_close` so an all-empty-documents run —
+                // whose per-document closes already each flushed a defaulted
+                // row — is not given an extra phantom row here. Then flush
+                // whatever is still open (the trailing document, the synthetic
+                // doc id of a no-envelope run, or the unreconciled-Merge
+                // remainder) and return.
+                if input_count == 0 && !flushed_close {
+                    agg.ensure_open()?;
                 }
+                agg.flush_current(&finalize_ctx, &mut out_rows)
+                    .map_err(PipelineError::from)
+            };
+            let result = drive();
+            if result.is_err() {
+                // Drain to disconnect before surfacing the error so a producer
+                // blocked on the bounded `send` cannot deadlock the join. The
+                // streaming-ingest arm aborts on any ingest error (schema
+                // mismatch, FailFast `add_record`, finalize failure) with no
+                // DLQ fallback, matching the prior single-stream behavior.
+                while rx.recv().is_ok() {}
             }
-            // Channel disconnected — every sender dropped at the producer
-            // arm's clean exit. An empty stream opened no table; a global
-            // fold still owes one defaulted row, so force one open before the
-            // final flush. Then flush whatever is still open (the trailing
-            // document, the synthetic doc id of a no-envelope run, or the
-            // unreconciled-Merge remainder) and return.
-            if input_count == 0 {
-                agg.ensure_open()?;
-            }
-            agg.flush_current(&finalize_ctx, &mut out_rows)
-                .map_err(PipelineError::from)
+            result
         });
 
         // Redispatch the producer on the main thread. Clear its ingest-edge
@@ -1236,9 +1305,12 @@ fn run_streaming_aggregate_ingest(
     // the ingest thread discharged each record. Pin to zero defensively (a
     // heuristic mismatch between batch charge and per-record discharge must
     // not leave a stale positive for the arbitrator), then unregister the
-    // per-edge charge consumer. Each per-document bucket's aggregate
-    // consumer already unregistered itself as that document flushed, so no
-    // aggregate consumer survives this arm.
+    // per-edge charge consumer. The per-document aggregate consumers are
+    // released separately: a flushed document unregisters its own as it
+    // finalizes, and `DocumentFlushAggregator`'s `Drop` releases any table
+    // still open when `agg` falls out of scope below — including on the
+    // error path, where `ingest_result?` returns before the success-path
+    // replay. So no aggregate consumer survives this arm on any exit.
     charge_handle.set_bytes(0);
     ctx.streaming_charge_consumers.remove(&producer_idx);
     ctx.memory_budget.unregister_consumer(charge_consumer_id);

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -29,6 +29,25 @@ use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 use clinker_plan::plan::types::AggregateStrategy;
 
+/// Build the on-disk spill schema for an aggregate's group state: the
+/// group-by columns ++ `__acc_state` ++ `__meta_tracker`. Mirrors the
+/// column layout `HashAggregator::spill` writes, so a spilled table round-
+/// trips through the same schema it was serialized against. Shared by every
+/// arm that builds an `AggregateStream` (the relaxed-CK and windowed
+/// preludes, and the per-document factory).
+fn aggregate_spill_schema(compiled: &cxl::plan::CompiledAggregate) -> Arc<Schema> {
+    compiled
+        .group_by_fields
+        .iter()
+        .map(|s| Box::<str>::from(s.as_str()))
+        .chain([
+            Box::<str>::from("__acc_state"),
+            Box::<str>::from("__meta_tracker"),
+        ])
+        .collect::<SchemaBuilder>()
+        .build()
+}
+
 /// Execute the `Aggregation` arm for `node_idx`: select hash or streaming
 /// strategy, ingest the predecessor's records (per-record for hash, sorted
 /// for streaming), trip soft/hard spill thresholds inside the RSS budget,
@@ -153,65 +172,18 @@ pub(crate) fn dispatch_aggregation(
         }
     }
 
-    // Build the per-aggregation runtime artifacts. The
-    // executor owns the evaluator + spill metadata; the
-    // wrapper enum owns the engine.
-    let transform_idx = ctx.transform_by_name.get(name.as_str()).copied();
-    let evaluator = match transform_idx {
-        Some(idx) => ProgramEvaluator::with_max_expansion(
-            Arc::clone(&ctx.compiled_transforms[idx].typed),
-            ctx.compiled_transforms[idx].has_distinct(),
-            ctx.compiled_transforms[idx].max_expansion,
-        ),
-        None => {
-            return Err(PipelineError::Internal {
-                op: "aggregation",
-                node: name.clone(),
-                detail: "no compiled transform found for aggregate node".to_string(),
-            });
-        }
-    };
-
-    // Spill schema follows the format used by
-    // `HashAggregator::spill`: group-by columns ++
-    // `__acc_state` ++ `__meta_tracker`.
-    let spill_schema = compiled
-        .group_by_fields
-        .iter()
-        .map(|s| Box::<str>::from(s.as_str()))
-        .chain([
-            Box::<str>::from("__acc_state"),
-            Box::<str>::from("__meta_tracker"),
-        ])
-        .collect::<SchemaBuilder>()
-        .build();
-
-    let mem_limit = parse_memory_limit(ctx.config);
-
-    // Resolve the spill compression mode against this aggregate's
-    // output-schema width and the run's batch size, so spilled group state
-    // matches what `--explain` projects for the operator. The explain line
-    // for an Aggregation node resolves the same way against
-    // `stored_output_schema().column_count()`, so resolving here against the
-    // output schema keeps the reported mode and the on-disk format in
-    // lockstep. `auto` skips LZ4 on narrow/short aggregates where the
-    // per-frame fixed cost outweighs the savings.
-    let spill_compress = ctx
-        .spill_compress
-        .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
-
     let input_count = input.len() as u64;
 
     let out_rows: Vec<AggSortRow> = if is_time_windowed {
-        // Time-windowed path: per-(window) AggregateStream
-        // instances dispatched in `run_time_windowed_aggregate`.
-        // The single positional `stream` built above is unused
-        // here — drop it so its spill files (if any) are cleaned
-        // up promptly. Building a fresh evaluator + spill setup
-        // per window keeps the time-windowed code self-
-        // contained at the cost of one extra evaluator clone per
-        // window (the heavy `TypedProgram` lives behind an Arc).
-        drop(evaluator);
+        // Time-windowed path: per-(window) AggregateStream instances
+        // dispatched in `run_time_windowed_aggregate`, each building its own
+        // evaluator from `transform_idx` (the heavy `TypedProgram` lives
+        // behind an Arc, so a per-window evaluator clone is cheap). The
+        // strict path below never reaches here, so the spill schema is built
+        // only on this windowed branch — never built-then-dropped.
+        let transform_idx = ctx.transform_by_name.get(name.as_str()).copied();
+        let spill_schema = aggregate_spill_schema(compiled);
+        let mem_limit = parse_memory_limit(ctx.config);
         let win_ctx = WindowedAggContext {
             name,
             compiled,
@@ -249,6 +221,38 @@ pub(crate) fn dispatch_aggregation(
         // aggregator's state stops being live. Parking transfers
         // ownership of the unregister to `RetainedAggregatorState`,
         // which fires it when the aggregator drops.
+        //
+        // Build the single retained-stream artifacts here, on the branch
+        // that consumes them — the strict path below re-derives its own per
+        // document, so nothing is built-then-dropped on the dominant arm.
+        let transform_idx = ctx.transform_by_name.get(name.as_str()).copied();
+        let evaluator = match transform_idx {
+            Some(idx) => ProgramEvaluator::with_max_expansion(
+                Arc::clone(&ctx.compiled_transforms[idx].typed),
+                ctx.compiled_transforms[idx].has_distinct(),
+                ctx.compiled_transforms[idx].max_expansion,
+            ),
+            None => {
+                return Err(PipelineError::Internal {
+                    op: "aggregation",
+                    node: name.clone(),
+                    detail: "no compiled transform found for aggregate node".to_string(),
+                });
+            }
+        };
+        let spill_schema = aggregate_spill_schema(compiled);
+        let mem_limit = parse_memory_limit(ctx.config);
+        // Resolve the spill compression mode against this aggregate's
+        // output-schema width and the run's batch size, so spilled group
+        // state matches what `--explain` projects for the operator: the
+        // explain line resolves the same way against
+        // `stored_output_schema().column_count()`, keeping the reported mode
+        // and the on-disk format in lockstep. `auto` skips LZ4 on
+        // narrow/short aggregates where the per-frame fixed cost outweighs
+        // the savings.
+        let spill_compress = ctx
+            .spill_compress
+            .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
         let agg_consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
         let agg_consumer_id = ctx.memory_budget.register_consumer(Arc::new(
             crate::aggregation::AggregateConsumer::new(agg_consumer_handle.clone()),
@@ -371,13 +375,10 @@ pub(crate) fn dispatch_aggregation(
         }
         agg_out
     } else {
-        // Strict path with per-document group flush. The single
-        // `evaluator` built above is unused — each document's table builds
-        // its own behind an `Arc<TypedProgram>`. Drop it (and the
-        // single-stream `spill_schema`, which the factory re-derives) so
-        // any throwaway state releases promptly.
-        drop(evaluator);
-        drop(spill_schema);
+        // Strict path with per-document group flush — the dominant arm.
+        // Builds nothing in the prelude: each document's table derives its
+        // own evaluator + spill schema through the `ctx`-free factory, so a
+        // strict run allocates no throwaway evaluator or spill schema here.
         let factory =
             DocAggregatorFactory::from_ctx(ctx, name, agg_strategy, compiled, output_schema)?;
         run_strict_aggregate_per_document(ctx, factory, name, output_schema, &input, &input_puncts)?
@@ -566,20 +567,10 @@ impl DocAggregatorFactory {
                 detail: "no compiled transform found for aggregate node".to_string(),
             })?;
         let compiled_transform = &ctx.compiled_transforms[transform_idx];
-        // Spill schema mirrors `HashAggregator::spill`: group-by columns ++
-        // `__acc_state` ++ `__meta_tracker`. The compression mode resolves
-        // against the output-schema width and batch size so a spilled
-        // table's on-disk format matches what `--explain` reports.
-        let spill_schema = compiled
-            .group_by_fields
-            .iter()
-            .map(|s| Box::<str>::from(s.as_str()))
-            .chain([
-                Box::<str>::from("__acc_state"),
-                Box::<str>::from("__meta_tracker"),
-            ])
-            .collect::<SchemaBuilder>()
-            .build();
+        // The compression mode resolves against the output-schema width and
+        // batch size so a spilled table's on-disk format matches what
+        // `--explain` reports.
+        let spill_schema = aggregate_spill_schema(compiled);
         let spill_compress = ctx
             .spill_compress
             .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
@@ -628,6 +619,11 @@ impl DocAggregatorFactory {
                 output_schema: Arc::clone(&self.output_schema),
                 spill_schema: Arc::clone(&self.spill_schema),
                 memory_budget: self.mem_limit,
+                // `AggregatorConfig` owns its `spill_dir: Option<PathBuf>`
+                // and `transform_name: String`, so each table takes an owned
+                // copy — an `Arc<Path>` / `Arc<str>` here would still have to
+                // materialize an owned value at this boundary, not bump a
+                // refcount.
                 spill_dir: Some(self.spill_dir.clone()),
                 spill_compress: self.spill_compress,
                 transform_name: self.transform_name.clone(),
@@ -817,10 +813,14 @@ impl RegisteredTables {
     }
 
     /// Flush keys in ascending [`DocumentId`] order for deterministic emit
-    /// ordering across the leftover fold.
+    /// ordering across the leftover fold. The dominant no-/single-document
+    /// run leaves at most the one sentinel table here, where ordering is
+    /// already trivial — skip the sort in that case.
     fn sorted_keys(&self) -> Vec<DocumentId> {
         let mut keys: Vec<DocumentId> = self.tables.keys().copied().collect();
-        keys.sort_unstable();
+        if keys.len() > 1 {
+            keys.sort_unstable();
+        }
         keys
     }
 }
@@ -922,20 +922,39 @@ fn run_strict_aggregate_per_document(
         }
     }
 
-    // Flush each closing document at its boundary (in `input_puncts`
-    // order), dropping its table. The merged-provenance finalize context
-    // borrows only `'a`-lifetime data, so it survives the `&mut ctx` DLQ
-    // routing between flushes.
+    // The merged-provenance finalize context borrows only `'a`/`'static`
+    // data (the stable context and shared statics), not `ctx` itself, so one
+    // binding stays valid across the `&mut ctx` DLQ routing of both flush
+    // loops below — the merged `$source.count` is fixed by ingestion and does
+    // not move between the two loops.
     let finalize_ctx = ctx.merged_eval_ctx();
-    // Documents already flushed in this loop, so a duplicate `DocumentClose`
-    // for the same id does not synthesize a second global-fold row for a
-    // document that already emitted.
+    let flush = DocumentFlushCtx {
+        finalize_ctx: &finalize_ctx,
+        arbitrator: &factory.arbitrator,
+        name,
+        output_schema,
+    };
+
+    // Flush each closing document at its boundary (in `input_puncts` order),
+    // dropping its table. `flushed` records documents already flushed here so
+    // a duplicate `DocumentClose` for the same id does not synthesize a
+    // second global-fold row for a document that already emitted.
     let mut flushed: std::collections::HashSet<DocumentId> = std::collections::HashSet::new();
     for p in input_puncts {
         if p.kind() != PunctuationKind::DocumentClose {
             continue;
         }
         let doc_id = p.doc_id();
+        // A real closing document keys its own table; the flush-key model
+        // depends on its id never colliding with the sentinel. Sources
+        // allocate ids from a counter that starts past `DocumentId::SYNTHETIC`,
+        // so this holds by construction — assert it in debug builds.
+        debug_assert_ne!(
+            doc_id,
+            DocumentId::SYNTHETIC,
+            "a real closing document's id must never equal the sentinel id, \
+             or its groups would fold into the unreconciled-remainder table"
+        );
         if !flushed.insert(doc_id) {
             continue;
         }
@@ -948,14 +967,12 @@ fn run_strict_aggregate_per_document(
             None if is_global_fold => Some(factory.make()?),
             None => None,
         };
-        if let Some((stream, consumer_id)) = entry {
-            let result = stream.finalize(&finalize_ctx, &mut out_rows);
-            factory.arbitrator.unregister_consumer(consumer_id);
+        if let Some(table) = entry {
             // Attribute a finalize failure to a record from THIS document so
             // the DLQ entry points at the document's own source file, not the
             // batch's first document.
             let attribution = document_attribution_record(input, doc_id);
-            route_document_flush_result(ctx, name, attribution, output_schema, result)?;
+            finalize_and_route_table(ctx, &flush, attribution, table, &mut out_rows)?;
         }
     }
 
@@ -973,13 +990,11 @@ fn run_strict_aggregate_per_document(
     // ordering: the sentinel (unreconciled / no-document remainder) and any
     // closing document whose close never arrived. This leftover fold spans
     // no single document, so its DLQ attribution keeps the batch-first-record
-    // behavior.
-    let finalize_ctx = ctx.merged_eval_ctx();
+    // behavior. The dominant no-/single-document run leaves exactly one
+    // table here, so `sorted_keys` skips the Vec-collect + sort in that case.
     for key in tables.sorted_keys() {
-        let (stream, consumer_id) = tables.remove(key).expect("key from this map");
-        let result = stream.finalize(&finalize_ctx, &mut out_rows);
-        factory.arbitrator.unregister_consumer(consumer_id);
-        route_document_flush_result(ctx, name, input, output_schema, result)?;
+        let table = tables.remove(key).expect("key from this map");
+        finalize_and_route_table(ctx, &flush, input, table, &mut out_rows)?;
     }
 
     Ok(out_rows)
@@ -997,6 +1012,45 @@ fn document_attribution_record(input: &[(Record, u64)], doc_id: DocumentId) -> &
         Some(pos) => &input[pos..=pos],
         None => input,
     }
+}
+
+/// The invariant routing context shared by both per-document flush loops in
+/// [`run_strict_aggregate_per_document`]: the merged-provenance finalize
+/// context, the node name, the output schema, and the arbitrator. Built once
+/// and borrowed across both loops so the per-table flush step takes only its
+/// loop-varying inputs.
+struct DocumentFlushCtx<'f> {
+    finalize_ctx: &'f EvalContext<'f>,
+    arbitrator: &'f crate::pipeline::memory::MemoryArbitrator,
+    name: &'f str,
+    output_schema: &'f Arc<Schema>,
+}
+
+/// Finalize one already-removed group table, release its arbitrator
+/// consumer, and route the finalize result through
+/// [`route_document_flush_result`]. Shared by the punct-loop (each closing
+/// document) and the leftover-loop (the sentinel + any never-closed
+/// document) in [`run_strict_aggregate_per_document`].
+///
+/// The caller `remove`s the `(stream, consumer_id)` entry from
+/// [`RegisteredTables`] *before* calling this, so the guard no longer tracks
+/// it: unregistering here cannot double-unregister, and a `?` return from
+/// the routing cannot strand a consumer the guard already forgot. This keeps
+/// the guard's remove-before-unregister discipline intact across both loops.
+fn finalize_and_route_table(
+    ctx: &mut ExecutorContext<'_>,
+    flush: &DocumentFlushCtx<'_>,
+    attribution: &[(Record, u64)],
+    table: (
+        crate::aggregation::AggregateStream,
+        crate::pipeline::memory::ConsumerId,
+    ),
+    out_rows: &mut Vec<crate::aggregation::SortRow>,
+) -> Result<(), PipelineError> {
+    let (stream, consumer_id) = table;
+    let result = stream.finalize(flush.finalize_ctx, out_rows);
+    flush.arbitrator.unregister_consumer(consumer_id);
+    route_document_flush_result(ctx, flush.name, attribution, flush.output_schema, result)
 }
 
 /// Route a document-flush finalize result: an `Accumulator` failure goes

--- a/crates/clinker-exec/tests/aggregate_materialized_fixes.rs
+++ b/crates/clinker-exec/tests/aggregate_materialized_fixes.rs
@@ -1,0 +1,279 @@
+//! Per-document Aggregate flush over a fully-materialized input: DLQ
+//! attribution and global-fold row semantics.
+//!
+//! The materialized strict-aggregate path drains its predecessor to a
+//! `Vec`, buckets records into per-document group tables, and flushes each
+//! closing document at its boundary. These tests cover, end to end through a
+//! multi-file CSV glob (each file is a document):
+//!
+//! - A finalize failure (integer `sum` overflow) in a *later* document must
+//!   stamp the resulting DLQ entry with a record from THAT document, not the
+//!   batch's first document. Before the fix every finalize DLQ entry was
+//!   attributed to the first record of the whole batch.
+//! - A global fold (no `group_by`) owes exactly one row per closing document
+//!   and one row for a whole-empty input — never a phantom extra row; a
+//!   grouped fold owes nothing for an empty input. These guard the
+//!   `flushed` de-duplication and the whole-empty synthetic-sentinel gate.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{ExecutionReport, PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// Run `yaml` over a set of in-memory CSV files, each fed as a distinct
+/// `FileSlot` (hence a distinct document) through the `events` source.
+/// Returns the sorted output body lines (header stripped) and the run's
+/// full [`ExecutionReport`] so a caller can inspect DLQ entries.
+fn run_multi_file(yaml: &str, files: &[(&str, &str)]) -> (Vec<String>, ExecutionReport) {
+    let config = parse_config(yaml).expect("parse pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline");
+
+    let slots: Vec<FileSlot> = files
+        .iter()
+        .map(|(name, body)| {
+            FileSlot::new(
+                PathBuf::from(*name),
+                Box::new(Cursor::new(body.as_bytes().to_vec())),
+            )
+        })
+        .collect();
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run pipeline");
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    (body, report)
+}
+
+/// Group-by `sum(amount)` over a multi-file glob, with `continue` error
+/// handling so a finalize-time integer overflow routes to the DLQ rather
+/// than aborting the run.
+const SUM_BY_CATEGORY_YAML: &str = r#"
+pipeline:
+  name: sum_by_category
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+        - { name: amount, type: int }
+  - type: aggregate
+    name: by_category
+    input: events
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit total = sum(amount)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn finalize_failure_attributes_dlq_to_the_failing_document() {
+    // Two documents. Document A (a.csv) sums cleanly; document B (b.csv)
+    // sums two `i64::MAX` values whose i128 accumulator overflows `i64` at
+    // finalize, so group "b" finalize fails. Under `continue` that failure
+    // routes to the DLQ. The entry must be attributed to a record from
+    // document B (the document that actually failed) — before the fix it was
+    // stamped with document A's first record, since the whole batch's first
+    // record was used regardless of which document failed.
+    let i64_max = i64::MAX.to_string();
+    let doc_a = "category,amount\na,1\na,2\n".to_string();
+    let doc_b = format!("category,amount\nb,{i64_max}\nb,{i64_max}\n");
+
+    let (body, report) = run_multi_file(
+        SUM_BY_CATEGORY_YAML,
+        &[("a.csv", doc_a.as_str()), ("b.csv", doc_b.as_str())],
+    );
+
+    // Document A still emits its clean group row; document B's overflow
+    // landed in the DLQ instead of an output row.
+    assert_eq!(body, vec!["a,3".to_string()], "document A sums cleanly");
+    assert_eq!(report.dlq_entries.len(), 1, "one finalize DLQ entry");
+
+    let entry = &report.dlq_entries[0];
+    assert_eq!(
+        entry.category,
+        clinker_core_types::dlq::DlqErrorCategory::AggregateFinalize,
+        "finalize-time overflow is an aggregate-finalize DLQ entry",
+    );
+    assert!(
+        entry.error_message.contains("SumOverflow"),
+        "the failure is an integer sum overflow, got: {}",
+        entry.error_message,
+    );
+    // The decisive attribution check: the entry's original record belongs to
+    // the FAILING document (B, category "b"), not the batch's first document
+    // (A, category "a"). Before the fix this was always "a".
+    assert_eq!(
+        entry.original_record.get("category"),
+        Some(&clinker_record::Value::from("b")),
+        "DLQ entry must be attributed to the failing document's record, \
+         not the batch's first document",
+    );
+}
+
+/// Global fold (no `group_by`) directly over a multi-file glob: `count(*)`.
+/// A direct Source → Aggregate edge keeps the materialized per-document flush
+/// path (a bare Source is not a certified streaming producer).
+const COUNT_GLOBAL_YAML: &str = r#"
+pipeline:
+  name: count_global
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+  - type: aggregate
+    name: total
+    input: events
+    config:
+      group_by: []
+      cxl: |
+        emit n = count(*)
+  - type: output
+    name: out
+    input: total
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+/// Grouped fold directly over the same multi-file glob: `count(*)` per
+/// category.
+const COUNT_GROUPED_YAML: &str = r#"
+pipeline:
+  name: count_grouped
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+  - type: aggregate
+    name: by_category
+    input: events
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn whole_empty_input_emits_global_fold_default_row() {
+    // A single header-only file produces zero records and no closing
+    // document, so the materialized aggregate drains an empty input. A global
+    // fold still owes its single defaulted row, which the synthetic-sentinel
+    // fallback emits — `count(*) == 0`. This guards the `flushed.is_empty()`
+    // gate added alongside the per-document empty-document fix: the whole-empty
+    // path must still produce exactly one global-fold row.
+    let (body, report) = run_multi_file(COUNT_GLOBAL_YAML, &[("empty.csv", "category\n")]);
+    assert_eq!(report.dlq_entries.len(), 0, "no DLQ entries expected");
+    assert_eq!(
+        body,
+        vec!["0".to_string()],
+        "a whole-empty global fold emits its single defaulted row",
+    );
+}
+
+#[test]
+fn whole_empty_input_emits_nothing_for_grouped_fold() {
+    // The control for the global-fold case: a whole-empty grouped fold owns
+    // no group, so it emits nothing — the synthetic sentinel must not
+    // synthesize a phantom grouped row.
+    let (body, report) = run_multi_file(COUNT_GROUPED_YAML, &[("empty.csv", "category\n")]);
+    assert_eq!(report.dlq_entries.len(), 0, "no DLQ entries expected");
+    assert!(
+        body.is_empty(),
+        "a whole-empty grouped fold emits nothing, got: {body:?}",
+    );
+}
+
+#[test]
+fn multi_document_global_fold_emits_one_row_per_document() {
+    // Each file is a closing document; a global fold flushes each document at
+    // its boundary in the punct-loop and owes exactly one row per document.
+    // This guards the `flushed` de-duplication and the punct-loop global-fold
+    // flush against emitting a phantom extra row for a document that
+    // contributed records.
+    let (body, report) = run_multi_file(
+        COUNT_GLOBAL_YAML,
+        &[
+            ("a.csv", "category\nx\ny\n"),
+            ("b.csv", "category\nz\n"),
+            ("c.csv", "category\np\nq\nr\n"),
+        ],
+    );
+    assert_eq!(report.dlq_entries.len(), 0, "no DLQ entries expected");
+    assert_eq!(
+        body,
+        vec!["1".to_string(), "2".to_string(), "3".to_string()],
+        "three documents each flush exactly one global-fold row (counts \
+         2, 1, 3), with no phantom extra row",
+    );
+}

--- a/crates/clinker-exec/tests/streaming_ingest_fixes.rs
+++ b/crates/clinker-exec/tests/streaming_ingest_fixes.rs
@@ -20,9 +20,12 @@
 //!    disconnect-time empty-input flush is gated so a run whose closes
 //!    already paid that debt gains no phantom duplicate. (A plain multi-file
 //!    CSV glob delivers an empty trailing file as no document at all, so the
-//!    reachable empty case here is the empty stream; the per-document
-//!    force-open is the symmetric guard for envelope formats that do deliver
-//!    a zero-record close.)
+//!    empty case the tests here exercise is the empty stream. The per-document
+//!    zero-record close IS reachable, though: an envelope source emits a
+//!    balanced `DocumentOpen`/`DocumentClose` pair with no records between for
+//!    a header-only / body-less document — e.g. a header-only EDI interchange
+//!    — and the force-open ensures such a close still emits its global-fold
+//!    defaulted row.)
 //!
 //! All tests assert (via the `--explain` `buffer: streaming` classification)
 //! that the fused producer actually drives the streaming-ingest path rather

--- a/crates/clinker-exec/tests/streaming_ingest_fixes.rs
+++ b/crates/clinker-exec/tests/streaming_ingest_fixes.rs
@@ -1,0 +1,480 @@
+//! Regression coverage for the streaming-ingest aggregate arm.
+//!
+//! These tests pin three behaviors of the bounded-channel ingest path a
+//! strict Aggregate takes when its producer is a fused, streaming-certified
+//! `Source → Transform`:
+//!
+//! 1. An ingest error must not deadlock. The producer streams into a bounded
+//!    channel on the dispatch thread while a scoped thread drives
+//!    `add_record`; if that thread returned on an error without first
+//!    draining the channel, a producer blocked on a full bounded `send`
+//!    would hang forever and the join would never complete. A `fail_fast`
+//!    run whose aggregate errors early — with far more than the channel's
+//!    depth still queued behind it — must surface the error and terminate.
+//!
+//! 2. A global fold (no group-by) over an empty stream still owes its single
+//!    defaulted row, matching what a standalone empty run emits via
+//!    `HashAggregator::finalize`. A grouped fold owes nothing. The fix also
+//!    forces a table open on a global fold's zero-record `DocumentClose` so
+//!    an empty closing document emits its defaulted row, while the
+//!    disconnect-time empty-input flush is gated so a run whose closes
+//!    already paid that debt gains no phantom duplicate. (A plain multi-file
+//!    CSV glob delivers an empty trailing file as no document at all, so the
+//!    reachable empty case here is the empty stream; the per-document
+//!    force-open is the symmetric guard for envelope formats that do deliver
+//!    a zero-record close.)
+//!
+//! All tests assert (via the `--explain` `buffer: streaming` classification)
+//! that the fused producer actually drives the streaming-ingest path rather
+//! than the materialized drain.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+use std::sync::mpsc;
+use std::time::Duration;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// Slice the indented `--explain` property block for the node whose stanza
+/// starts with `slug:`, up to the next blank line. The physical-properties
+/// stanzas are two-space-indented and blank-line separated.
+fn properties_block(explain: &str, slug: &str) -> String {
+    let marker = format!("{slug}:");
+    explain
+        .lines()
+        .skip_while(|l| l.trim_start() != marker)
+        .skip(1)
+        .take_while(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Assert the fused transform feeding the aggregate classifies `streaming`
+/// (so the run drives the scoped-thread ingest path, not the materialized
+/// drain) and routes no charged inter-stage slot into the aggregate.
+fn assert_streaming_ingest(config_yaml: &str, transform_slug: &str, aggregate_slug: &str) {
+    let config = parse_config(config_yaml).expect("parse streaming-ingest pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile streaming-ingest pipeline");
+    let (dag, _) = PipelineExecutor::explain_plan_dag(&plan).expect("explain dag");
+    let explain = dag.explain_text(&config);
+    let block = properties_block(&explain, transform_slug);
+    assert!(
+        block.contains("buffer: streaming") && !block.contains("buffer: materialized"),
+        "expected {transform_slug} feeding {aggregate_slug} to classify \
+         streaming (so the streaming-ingest aggregate path runs), got:\n{block}"
+    );
+    assert!(
+        !explain.contains(&format!("edge {transform_slug} -> {aggregate_slug}")),
+        "a streaming-ingest aggregate must consume no charged inter-stage \
+         slot from its producer, got:\n{explain}"
+    );
+}
+
+/// Build the readers map for a CSV glob `events` source from in-memory file
+/// bodies, each fed as its own `FileSlot` (hence its own document).
+fn file_readers(files: &[(&str, String)]) -> clinker_exec::executor::SourceReaders {
+    let slots: Vec<FileSlot> = files
+        .iter()
+        .map(|(name, body)| {
+            FileSlot::new(
+                PathBuf::from(*name),
+                Box::new(Cursor::new(body.as_bytes().to_vec())),
+            )
+        })
+        .collect();
+    HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )])
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// A fused `Source → Transform` feeding a strict hash Aggregate over a CSV
+/// glob, with `fail_fast` error handling and a per-record division whose
+/// divisor is read straight from the input. A `divisor` of `0` divides by
+/// zero inside the aggregate's `add_record`, the deterministic mid-stream
+/// ingest error the deadlock test relies on.
+const FAIL_FAST_DIVIDE_YAML: &str = r#"
+pipeline:
+  name: streaming_ingest_fail_fast
+error_handling:
+  strategy: fail_fast
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+        - { name: divisor, type: int }
+  - type: transform
+    name: passthrough
+    input: events
+    config:
+      cxl: |
+        emit category = category
+        emit divisor = divisor
+  - type: aggregate
+    name: by_category
+    input: passthrough
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit ratio = sum(100 / divisor)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn streaming_ingest_fail_fast_error_terminates_without_hanging() {
+    // Confirm the run actually drives the streaming-ingest path.
+    assert_streaming_ingest(
+        FAIL_FAST_DIVIDE_YAML,
+        "transform.passthrough",
+        "aggregation.by_category",
+    );
+
+    // One record with `divisor = 0` near the front poisons the aggregate's
+    // `add_record` on the second row, while several thousand records queue
+    // behind it. The bounded ingest channel holds 256 events, so the
+    // producer's `send` blocks long before the consumer reaches end-of-input
+    // — the exact condition under which a non-draining error return would
+    // deadlock the join. The fix drains the channel before surfacing the
+    // error, so the producer's blocked `send` makes progress, the producer
+    // finishes and drops its sender, and the run terminates with an error.
+    let mut body = String::from("category,divisor\n");
+    body.push_str("a,2\n");
+    body.push_str("a,0\n"); // poison: 100 / 0 → division by zero
+    for _ in 0..4000 {
+        body.push_str("a,2\n");
+    }
+    let config = parse_config(FAIL_FAST_DIVIDE_YAML).expect("parse");
+    let plan = config.compile(&CompileContext::default()).expect("compile");
+
+    // Run on a worker thread and join with a timeout: a regression that
+    // reintroduces the non-draining return would hang here rather than
+    // returning an error, and the timeout converts that hang into a test
+    // failure instead of a stuck suite.
+    let (done_tx, done_rx) = mpsc::channel::<bool>();
+    let worker = std::thread::spawn(move || {
+        let readers = file_readers(&[("events.csv", body)]);
+        let buf = SharedBuffer::new();
+        let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+            "out".to_string(),
+            Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+        )]);
+        let result =
+            PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params());
+        // Signal completion with whether the run errored, then let the thread
+        // finish so its resources release.
+        let _ = done_tx.send(result.is_err());
+    });
+
+    match done_rx.recv_timeout(Duration::from_secs(30)) {
+        Ok(errored) => {
+            worker.join().expect("ingest worker thread panicked");
+            assert!(
+                errored,
+                "a fail_fast division-by-zero in the aggregate must surface as \
+                 a run error, not a silent success"
+            );
+        }
+        Err(mpsc::RecvTimeoutError::Timeout) => {
+            panic!(
+                "streaming-ingest run did not complete within 30s — the ingest \
+                 thread likely returned on the aggregate error without draining \
+                 the bounded channel, deadlocking the producer's send"
+            );
+        }
+        Err(mpsc::RecvTimeoutError::Disconnected) => {
+            panic!("ingest worker thread dropped its completion channel");
+        }
+    }
+}
+
+/// A fused `Source → Transform` feeding a GLOBAL-fold Aggregate (no
+/// group-by) over a CSV glob. The fold sums `amount` across the document.
+const GLOBAL_FOLD_YAML: &str = r#"
+pipeline:
+  name: streaming_ingest_global_fold
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: passthrough
+    input: events
+    config:
+      cxl: |
+        emit amount = amount
+  - type: aggregate
+    name: total
+    input: passthrough
+    config:
+      group_by: []
+      cxl: |
+        emit total = sum(amount)
+        emit n = count(*)
+  - type: output
+    name: out
+    input: total
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+/// The same data into a GROUPED Aggregate (group-by `amount`). An empty
+/// document owes no group row, so the empty document emits nothing.
+const GROUPED_FOLD_YAML: &str = r#"
+pipeline:
+  name: streaming_ingest_grouped_fold
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: passthrough
+    input: events
+    config:
+      cxl: |
+        emit amount = amount
+  - type: aggregate
+    name: total
+    input: passthrough
+    config:
+      group_by:
+        - amount
+      cxl: |
+        emit amount = amount
+        emit n = count(*)
+  - type: output
+    name: out
+    input: total
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+/// Run a streaming-ingest pipeline over the given CSV files; return the
+/// sorted output body lines and the ok / dlq counts.
+fn run_streaming(yaml: &str, files: &[(&str, String)]) -> (Vec<String>, u64, u64) {
+    let config = parse_config(yaml).expect("parse streaming-ingest pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile streaming-ingest pipeline");
+    let readers = file_readers(files);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("run streaming-ingest pipeline");
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    (body, report.counters.ok_count, report.counters.dlq_count)
+}
+
+#[test]
+fn empty_input_global_fold_emits_one_defaulted_row() {
+    assert_streaming_ingest(
+        GLOBAL_FOLD_YAML,
+        "transform.passthrough",
+        "aggregation.total",
+    );
+
+    // A lone header-only file delivers no records and no document close to
+    // the aggregate, so the stream is empty. A global fold still owes its
+    // single defaulted row (`total` empty, `n=0`) — exactly what a standalone
+    // empty run emits via `HashAggregator::finalize`'s zero-rows-seen,
+    // no-group-by branch. The disconnect-time `ensure_open` forces a table
+    // into existence so that finalize runs and the defaulted row is not
+    // silently dropped. Exactly one row — never doubled.
+    let (body, ok, dlq) = run_streaming(GLOBAL_FOLD_YAML, &[("only.csv", "amount\n".to_string())]);
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec![",0".to_string()],
+        "an empty global fold emits exactly one defaulted row (empty total, n=0)"
+    );
+    assert_eq!(ok, 1, "exactly one defaulted row, not a doubled phantom");
+}
+
+#[test]
+fn multiple_empty_files_global_fold_emit_one_defaulted_row() {
+    assert_streaming_ingest(
+        GLOBAL_FOLD_YAML,
+        "transform.passthrough",
+        "aggregation.total",
+    );
+
+    // Several header-only files still deliver no records and no closes, so
+    // the aggregate sees one empty stream and owes exactly one defaulted
+    // row at disconnect — the `!flushed_close` gate ensures the single
+    // disconnect-time finalize is not multiplied into a phantom row per
+    // file.
+    let (body, ok, dlq) = run_streaming(
+        GLOBAL_FOLD_YAML,
+        &[
+            ("a.csv", "amount\n".to_string()),
+            ("b.csv", "amount\n".to_string()),
+            ("c.csv", "amount\n".to_string()),
+        ],
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec![",0".to_string()],
+        "empty files collapse to exactly one defaulted global-fold row"
+    );
+    assert_eq!(ok, 1, "one defaulted row total, never one per empty file");
+}
+
+#[test]
+fn populated_global_fold_emits_no_phantom_row() {
+    assert_streaming_ingest(
+        GLOBAL_FOLD_YAML,
+        "transform.passthrough",
+        "aggregation.total",
+    );
+
+    // A single populated document closes and flushes its real fold row
+    // (`total=7`, `n=2`). The disconnect-time flush must add no extra
+    // defaulted row — a closing document that DID see records already paid
+    // its debt, so the global-fold force-open never fabricates a phantom.
+    let (body, ok, dlq) =
+        run_streaming(GLOBAL_FOLD_YAML, &[("a.csv", "amount\n3\n4\n".to_string())]);
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["7,2".to_string()],
+        "a populated global fold emits its single real row and no phantom"
+    );
+    assert_eq!(ok, 1, "one fold row, no extra defaulted row at disconnect");
+}
+
+#[test]
+fn multi_document_populated_global_fold_emits_one_row_per_document() {
+    assert_streaming_ingest(
+        GLOBAL_FOLD_YAML,
+        "transform.passthrough",
+        "aggregation.total",
+    );
+
+    // Two populated documents, each closing at its own file boundary. The
+    // global fold force-opens on each `DocumentClose`, but the table is
+    // already open (records arrived), so the force-open is a no-op and each
+    // document emits exactly its own real fold row — no phantom defaulted
+    // row, and no cross-document collapse.
+    let (body, ok, dlq) = run_streaming(
+        GLOBAL_FOLD_YAML,
+        &[
+            ("a.csv", "amount\n3\n4\n".to_string()),
+            ("b.csv", "amount\n10\n".to_string()),
+        ],
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["10,1".to_string(), "7,2".to_string()],
+        "each populated document emits its own global-fold row (7,2 and 10,1)"
+    );
+    assert_eq!(ok, 2, "one fold row per document, no phantom");
+}
+
+#[test]
+fn empty_files_grouped_aggregate_emit_nothing() {
+    assert_streaming_ingest(
+        GROUPED_FOLD_YAML,
+        "transform.passthrough",
+        "aggregation.total",
+    );
+
+    // Same multi-file shape, but grouped by `amount`. File A yields one
+    // group per distinct amount; the empty file B owes nothing — a grouped
+    // aggregate has no defaulted row for an empty document or an empty
+    // stream, so the global-fold force-open path is correctly NOT taken.
+    let (body, ok, dlq) = run_streaming(
+        GROUPED_FOLD_YAML,
+        &[
+            ("a.csv", "amount\n3\n4\n3\n".to_string()),
+            ("b.csv", "amount\n".to_string()),
+        ],
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["3,2".to_string(), "4,1".to_string()],
+        "the grouped aggregate emits only document A's groups; the empty \
+         file contributes no row"
+    );
+    assert_eq!(ok, 2, "two groups from document A, none for the empty file");
+}
+
+#[test]
+fn empty_input_grouped_aggregate_emits_nothing() {
+    assert_streaming_ingest(
+        GROUPED_FOLD_YAML,
+        "transform.passthrough",
+        "aggregation.total",
+    );
+
+    // A lone header-only file is an empty stream into a grouped aggregate:
+    // no groups, no defaulted row. The disconnect-time `ensure_open` fires
+    // (input was empty) but the grouped finalize emits nothing, exactly as a
+    // standalone empty grouped run does.
+    let (body, ok, dlq) = run_streaming(GROUPED_FOLD_YAML, &[("only.csv", "amount\n".to_string())]);
+    assert_eq!(dlq, 0);
+    assert!(
+        body.is_empty(),
+        "an empty grouped aggregate emits no rows, got: {body:?}"
+    );
+    assert_eq!(ok, 0, "no rows for an empty grouped aggregate");
+}


### PR DESCRIPTION
Post-merge code-review of the per-document Aggregate flush + Combine boundary reconciliation work surfaced several defects in the aggregate dispatch paths. This PR fixes them. (One review finding — Combine's degree-based boundary reconciliation swallowing a document carried by only one join input — is a design question tracked separately, not addressed here.)

## Fixes

**Streaming-ingest path** (`run_streaming_aggregate_ingest`):
- **Latent deadlock.** Several error returns from the scoped ingest thread (operator-entry schema check, per-document table build, the disconnect-time force-open) left the bounded record channel undrained, so a producer blocked on a full send could hang the run with no error and no exit. The receive body is now a single fallible step with one drain-then-return site, so every error exit drains the channel first and no future early-return can reintroduce the asymmetry.
- **Consumer-accounting leak.** An error return dropped the open group table without releasing its memory-arbitrator consumer; the flush aggregator now releases it on drop, covering every error path with no double-release.

**Materialized path** (`run_strict_aggregate_per_document`):
- **Consumer-accounting leak.** Early error returns dropped the live per-document tables without unregistering their consumers; an RAII guard now releases every still-open consumer on any exit, with remove-before-unregister so a clean run releases nothing twice.
- **Dead-letter misattribution.** A per-document finalize failure stamped the DLQ entry with the first record of the whole input batch, pointing operators at the wrong source file; the entry is now attributed to a record from the document whose flush actually failed.

**Both paths:**
- **Empty global-fold document.** A document that closes having contributed no records emitted nothing, where a global (no-group-by) fold owes its single defaulted row per document. A global fold now finalizes that row; a grouped fold still emits nothing; a record-bearing document gains no phantom row. (Reachable via a header-only / body-less envelope document.)

**Refactor / cleanup (behavior-preserving):**
- The strict path no longer builds a throwaway evaluator and spill schema only to drop them; the spill-schema layout is one shared helper instead of three copies; the two per-document flush loops collapse into one helper over a single merged evaluation context; the leftover-table sort is skipped for the single-table case; a debug assertion machine-checks the synthetic-sentinel invariant; and a comment that wrongly called the empty-document branch unreachable is corrected.

## Verification
- Each fix was independently adversarially reviewed (correctness + leak-freedom + behavior-preservation).
- Full local gauntlet green: fmt, clippy (`--workspace` and `--all-targets`), `test --workspace`, `check --benches --workspace`, bench-alloc, `test --benches`, `cargo deny`.

## Follow-ups filed
#421 (end-to-end coverage for an empty envelope document into a global fold; arbitrator-accounting assertion after a forced error exit), #422 (share the per-document spill-dir/node-name via reference-counted handles to drop per-document clones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)