### PR TITLE
engine: per-document aggregation works behind any join — coverage-based boundary reconciliation + unified streaming flush

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -634,108 +634,6 @@ impl DocAggregatorFactory {
     }
 }
 
-/// Single live group table that flushes on each document-close boundary,
-/// for the streaming-ingest path where boundaries arrive inline with
-/// records.
-///
-/// Holds at most one [`crate::aggregation::AggregateStream`] at a time —
-/// the open document's groups. On `DocumentClose` the current table
-/// finalizes, emits, and resets, so a fused single-source stream (whose
-/// boundaries arrive in document order) produces one set of grouped rows
-/// per document. A non-fused Merge instead delivers its forwarded
-/// punctuations after every record, so the lone table accumulates the
-/// whole stream and flushes once at the tail — folding unreconciled
-/// documents together exactly as a no-document run would.
-///
-/// Holding one table at a time keeps the peak footprint at a single
-/// document's group state (plus its arbitrator consumer), so per-document
-/// flush lowers peak memory rather than inflating it. The materialized
-/// drain-to-`Vec` path keys tables by document instead (see
-/// [`run_strict_aggregate_per_document`]) because its boundaries are split
-/// out of arrival order.
-struct DocumentFlushAggregator {
-    factory: DocAggregatorFactory,
-    current: Option<(
-        crate::aggregation::AggregateStream,
-        crate::pipeline::memory::ConsumerId,
-    )>,
-}
-
-impl DocumentFlushAggregator {
-    fn new(factory: DocAggregatorFactory) -> Self {
-        Self {
-            factory,
-            current: None,
-        }
-    }
-
-    /// Borrow the open table, building (and registering) a fresh one when
-    /// none is open.
-    fn stream(&mut self) -> Result<&mut crate::aggregation::AggregateStream, PipelineError> {
-        if self.current.is_none() {
-            self.current = Some(self.factory.make()?);
-        }
-        Ok(&mut self.current.as_mut().expect("just populated").0)
-    }
-
-    /// Finalize, emit, and reset the open table (if any). The next
-    /// `stream` call builds a fresh one for the following document. A
-    /// `DocumentClose` for a document that contributed no records finds no
-    /// open table and is a no-op.
-    fn flush_current(
-        &mut self,
-        finalize_ctx: &EvalContext,
-        out: &mut Vec<crate::aggregation::SortRow>,
-    ) -> Result<(), crate::aggregation::HashAggError> {
-        let Some((stream, consumer_id)) = self.current.take() else {
-            return Ok(());
-        };
-        let result = stream.finalize(finalize_ctx, out);
-        // `finalize` consumed the stream — its group bytes are gone, so
-        // unregister regardless of whether finalize succeeded.
-        self.factory.arbitrator.unregister_consumer(consumer_id);
-        result
-    }
-
-    /// Force an empty table into existence so an empty input still runs
-    /// one finalize. A global fold (no group-by) over empty input emits its
-    /// single defaulted row; an empty grouped fold emits nothing —
-    /// reproducing the single-stream finalize this replaced. Idempotent.
-    fn ensure_open(&mut self) -> Result<(), PipelineError> {
-        if self.current.is_none() {
-            self.current = Some(self.factory.make()?);
-        }
-        Ok(())
-    }
-
-    /// `true` when this aggregate is a global fold (no group-by columns).
-    /// A global fold owes one defaulted row per closing document even when
-    /// that document contributed zero records; a grouped fold owes nothing
-    /// for an empty document.
-    fn is_global_fold(&self) -> bool {
-        self.factory.compiled.group_by_fields.is_empty()
-    }
-}
-
-impl Drop for DocumentFlushAggregator {
-    /// Release the open table's arbitrator consumer on every exit path.
-    ///
-    /// `flush_current` takes `current` and unregisters the consumer on the
-    /// normal flush, so a cleanly-drained aggregator drops with
-    /// `current == None` and this is a no-op. An error return from the
-    /// ingest loop, by contrast, drops the aggregator with a table still
-    /// open; without this the open table's `AggregateConsumer` would linger
-    /// in the arbitrator's registry — the registry holds an independent
-    /// `Arc` keyed by `ConsumerId`, so dropping the `AggregateStream` alone
-    /// does not unregister it. `unregister_consumer` is idempotent, so even
-    /// a redundant call is harmless.
-    fn drop(&mut self) {
-        if let Some((_, consumer_id)) = self.current.take() {
-            self.factory.arbitrator.unregister_consumer(consumer_id);
-        }
-    }
-}
-
 /// Per-document group tables keyed by flush key, with a teardown that
 /// unregisters any table still present from the shared arbitrator.
 ///
@@ -1026,17 +924,40 @@ struct DocumentFlushCtx<'f> {
     output_schema: &'f Arc<Schema>,
 }
 
-/// Finalize one already-removed group table, release its arbitrator
-/// consumer, and route the finalize result through
-/// [`route_document_flush_result`]. Shared by the punct-loop (each closing
-/// document) and the leftover-loop (the sentinel + any never-closed
-/// document) in [`run_strict_aggregate_per_document`].
+/// Finalize one already-removed bucket: finalize its group state into `out`,
+/// then release its arbitrator consumer. `ctx`-free, so the streaming-ingest
+/// scoped thread (which holds no `&mut ExecutorContext`) can call it directly;
+/// the materialized path wraps it with DLQ routing in
+/// [`finalize_and_route_table`].
 ///
 /// The caller `remove`s the `(stream, consumer_id)` entry from
 /// [`RegisteredTables`] *before* calling this, so the guard no longer tracks
-/// it: unregistering here cannot double-unregister, and a `?` return from
-/// the routing cannot strand a consumer the guard already forgot. This keeps
-/// the guard's remove-before-unregister discipline intact across both loops.
+/// it: unregistering here cannot double-unregister, and an error return cannot
+/// strand a consumer the guard already forgot. `finalize` consumes the stream
+/// — its group bytes are gone — so the consumer is unregistered whether
+/// finalize succeeds or fails, and the finalize result is returned for the
+/// caller to route (materialized) or propagate as a hard error (streaming).
+fn finalize_bucket(
+    table: (
+        crate::aggregation::AggregateStream,
+        crate::pipeline::memory::ConsumerId,
+    ),
+    finalize_ctx: &EvalContext,
+    arbitrator: &crate::pipeline::memory::MemoryArbitrator,
+    out: &mut Vec<crate::aggregation::SortRow>,
+) -> Result<(), crate::aggregation::HashAggError> {
+    let (stream, consumer_id) = table;
+    let result = stream.finalize(finalize_ctx, out);
+    arbitrator.unregister_consumer(consumer_id);
+    result
+}
+
+/// Finalize one already-removed group table, then route the finalize result
+/// through [`route_document_flush_result`]. Thin wrapper over
+/// [`finalize_bucket`] that adds the materialized path's DLQ routing. Shared
+/// by the punct-loop (each closing document) and the leftover-loop (the
+/// sentinel + any never-closed document) in
+/// [`run_strict_aggregate_per_document`].
 fn finalize_and_route_table(
     ctx: &mut ExecutorContext<'_>,
     flush: &DocumentFlushCtx<'_>,
@@ -1047,9 +968,7 @@ fn finalize_and_route_table(
     ),
     out_rows: &mut Vec<crate::aggregation::SortRow>,
 ) -> Result<(), PipelineError> {
-    let (stream, consumer_id) = table;
-    let result = stream.finalize(flush.finalize_ctx, out_rows);
-    flush.arbitrator.unregister_consumer(consumer_id);
+    let result = finalize_bucket(table, flush.finalize_ctx, flush.arbitrator, out_rows);
     route_document_flush_result(ctx, flush.name, attribution, flush.output_schema, result)
 }
 
@@ -1130,22 +1049,43 @@ struct StreamingIngestOutput {
 /// batch into the channel, while a scoped thread drives `add_record` off
 /// the receiver. The bounded `send` is the back-pressure pivot — a slow
 /// `add_record` (e.g. a hash aggregate spilling) stalls the producer and
-/// lets the upstream Source channel fill. Group state is bucketed per
-/// [`DocumentId`]: a `DocumentClose(D)` arriving in stream order flushes
-/// document D's groups before the boundary forwards at the output tail, so
-/// a multi-document run emits one set of grouped rows per document. The
-/// finalize half stays blocking: once the channel disconnects (every
-/// sender dropped at the producer arm's clean exit), any document still
-/// open (the synthetic doc id of a no-envelope pipeline, or a document
-/// never closed) flushes and the finalized rows return. Document-boundary
-/// punctuations are forwarded at the output tail unchanged.
+/// lets the upstream Source channel fill.
+///
+/// Group state is bucketed per [`DocumentId`] through the same
+/// [`RegisteredTables`] engine the materialized path uses: each record adds
+/// to the bucket for its raw document id, and a `DocumentClose(D)` flushes
+/// only document D's bucket. This is correct for both producer emit orders.
+/// A *fused* producer emits each close right after its document's records,
+/// so only one bucket is ever live — identical row output and peak footprint
+/// to a single-table flush. A *non-fused* producer
+/// ([`crate::executor::dispatch::stream_linear_producer_emit`]) tail-batches
+/// every close after all records, so several buckets populate during the
+/// record run and each close flushes its own — splitting the documents
+/// rather than folding them. The finalize half stays blocking: once the
+/// channel disconnects (every sender dropped at the producer arm's clean
+/// exit), every surviving bucket (the synthetic-doc-id sentinel of a
+/// no-envelope pipeline, plus any document whose close never arrived) flushes
+/// in ascending `DocumentId` order and the finalized rows return.
+/// Document-boundary punctuations are forwarded at the output tail unchanged.
+///
+/// Memory: this holds one open table per open-but-not-yet-closed document —
+/// the same envelope as the materialized path, which already buckets. For a
+/// fused producer that is one table at a time; for a non-fused producer it is
+/// bounded by the number of documents whose records have streamed but whose
+/// closes have not. Each table registers its own `AggregateConsumer` and
+/// spills independently under RSS pressure; flushing a table unregisters its
+/// consumer, so the arbitrator's live-usage reflects exactly the open
+/// documents. This is a deliberate, bounded change from the prior
+/// single-table model — the correct per-document memory shape.
 ///
 /// The scoped thread holds no `&mut ExecutorContext`; it accumulates cursor
 /// advances and `add_record` DLQ errors into [`StreamingIngestEffects`],
 /// replayed on the dispatch thread after the scope joins so rollback
 /// cursors, watermark liveness, and DLQ sequencing match the drain-to-`Vec`
-/// path exactly. Spill stays RSS-triggered inside `add_record` /
-/// `finalize`, never channel-depth-triggered.
+/// path exactly. A finalize error surfaces as a hard error (no DLQ on the
+/// streaming finalize path, matching the prior behavior). Spill stays
+/// RSS-triggered inside `add_record` / `finalize`, never
+/// channel-depth-triggered.
 #[allow(clippy::too_many_arguments)]
 fn run_streaming_aggregate_ingest(
     ctx: &mut ExecutorContext<'_>,
@@ -1198,13 +1138,21 @@ fn run_streaming_aggregate_ingest(
     let mut out_rows: Vec<AggSortRow> = Vec::with_capacity(64);
     let mut puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
     let mut input_count: u64 = 0;
-    // Set once any `DocumentClose` flushes a table. The disconnect-time
+    // Set once any `DocumentClose` flushes a bucket. The disconnect-time
     // empty-input flush owes a global fold its single defaulted row only
     // when no close already paid that debt — an all-empty-documents run
     // flushes one defaulted row per close and must not gain an extra
     // phantom row at the tail.
     let mut flushed_close = false;
-    let mut agg = DocumentFlushAggregator::new(factory);
+    let is_global_fold = factory.compiled.group_by_fields.is_empty();
+    // Bucket group state per `DocumentId`, the same engine the materialized
+    // path uses. `tables` and `flushed` live in the OUTER (non-`move`) frame
+    // so the `RegisteredTables` RAII `Drop` runs when this function returns —
+    // including the `ingest_result?` early-return — releasing any bucket still
+    // open on an error exit. `flushed` makes a duplicate `DocumentClose` for
+    // an already-flushed document a no-op.
+    let mut tables = RegisteredTables::new(Arc::clone(&factory.arbitrator));
+    let mut flushed: std::collections::HashSet<DocumentId> = std::collections::HashSet::new();
 
     // Run the ingest recv loop and the producer concurrently. The scoped
     // thread owns the document-flush aggregator and drains the channel; the
@@ -1229,29 +1177,45 @@ fn run_streaming_aggregate_ingest(
                     let (record, rn) = match event {
                         StreamEvent::Record(r, rn) => (r, rn),
                         StreamEvent::Punctuation(p) => {
-                            // A `DocumentClose` arriving in stream order means
-                            // the open document is fully delivered: flush its
-                            // groups now (its records arrived contiguously
-                            // before this boundary), then forward the boundary
-                            // at the output tail. A global fold owes one
-                            // defaulted row per closing document even when that
-                            // document contributed zero records, so force a
-                            // table open before flushing an empty global-fold
-                            // document — matching what a standalone empty run
-                            // emits. A grouped fold owes nothing for an empty
-                            // document, and a closing document that DID see
-                            // records already holds an open table, so neither
-                            // path gains a phantom row. Opens only forward.
-                            // Punctuations carry zero charge, so no discharge
-                            // here.
+                            // On `DocumentClose(D)`, flush ONLY document D's
+                            // bucket — correct whether closes arrive in stream
+                            // order (fused producer: D's bucket is the only one
+                            // live) or tail-batched after every record
+                            // (non-fused producer: each close flushes its own
+                            // bucket, splitting the documents). A duplicate
+                            // close for an already-flushed document is a no-op.
+                            // A global fold owes one defaulted row per closing
+                            // document even when that document contributed zero
+                            // records, so build a fresh bucket for D before
+                            // finalizing the empty global-fold document; a
+                            // grouped fold owes nothing for an empty document.
+                            // Opens only forward. Punctuations carry zero
+                            // charge, so no discharge here. The finalize `?`
+                            // stays inside `drive`, so a finalize error funnels
+                            // through the single drain-then-return site below —
+                            // a finalize failure surfaces as a hard error,
+                            // matching the streaming arm's no-DLQ-on-finalize
+                            // behavior.
                             if p.kind()
                                 == crate::executor::stream_event::PunctuationKind::DocumentClose
                             {
-                                if agg.is_global_fold() {
-                                    agg.ensure_open()?;
+                                let doc_id = p.doc_id();
+                                if flushed.insert(doc_id) {
+                                    let bucket = match tables.remove(doc_id) {
+                                        Some(bucket) => Some(bucket),
+                                        None if is_global_fold => Some(factory.make()?),
+                                        None => None,
+                                    };
+                                    if let Some(bucket) = bucket {
+                                        finalize_bucket(
+                                            bucket,
+                                            &finalize_ctx,
+                                            &factory.arbitrator,
+                                            &mut out_rows,
+                                        )?;
+                                        flushed_close = true;
+                                    }
                                 }
-                                agg.flush_current(&finalize_ctx, &mut out_rows)?;
-                                flushed_close = true;
                             }
                             puncts.push(p);
                             continue;
@@ -1290,7 +1254,14 @@ fn run_streaming_aggregate_ingest(
                         source_name: &source_name_arc,
                         doc_ctx: record.doc_ctx(),
                     };
-                    let stream = agg.stream()?;
+                    // Bucket by the record's raw document id. The streaming
+                    // path cannot know which documents will close upfront
+                    // (closes arrive at the tail for a non-fused producer), so
+                    // unlike the materialized `flush_key` it keys on the raw id:
+                    // a no-envelope record carries `DocumentId::SYNTHETIC` and
+                    // buckets to the sentinel; a real document buckets to its
+                    // own id and flushes when its close arrives.
+                    let stream = tables.entry_or_make(record.doc_ctx().id(), &factory)?;
                     match stream.add_record(&record, rn, &eval_ctx, &mut out_rows) {
                         Ok(()) => effects.cursor_advances.push((source_name_arc, rn)),
                         Err(e) => match strategy {
@@ -1307,19 +1278,24 @@ fn run_streaming_aggregate_ingest(
                 }
                 // Channel disconnected — every sender dropped at the producer
                 // arm's clean exit. A completely empty stream (no records, no
-                // forwarded close) opened no table; a global fold still owes
-                // one defaulted row, so force one open before the final flush.
-                // Gated on `!flushed_close` so an all-empty-documents run —
-                // whose per-document closes already each flushed a defaulted
-                // row — is not given an extra phantom row here. Then flush
-                // whatever is still open (the trailing document, the synthetic
-                // doc id of a no-envelope run, or the unreconciled-Merge
-                // remainder) and return.
-                if input_count == 0 && !flushed_close {
-                    agg.ensure_open()?;
+                // forwarded close) opened no bucket; a global fold still owes
+                // one defaulted row, so force the sentinel bucket open before
+                // the final flush. Gated on `!flushed_close` so an
+                // all-empty-documents run — whose per-document closes already
+                // each flushed a defaulted row — is not given an extra phantom
+                // row here. Then flush every surviving bucket in ascending
+                // `DocumentId` order (SYNTHETIC id 0 sorts first): the sentinel
+                // for no-document / unreconciled records, plus any document
+                // whose close never arrived. A finalize error propagates as a
+                // hard error through the drain-then-return site below.
+                if input_count == 0 && !flushed_close && is_global_fold {
+                    tables.entry_or_make(DocumentId::SYNTHETIC, &factory)?;
                 }
-                agg.flush_current(&finalize_ctx, &mut out_rows)
-                    .map_err(PipelineError::from)
+                for key in tables.sorted_keys() {
+                    let bucket = tables.remove(key).expect("key from this map");
+                    finalize_bucket(bucket, &finalize_ctx, &factory.arbitrator, &mut out_rows)?;
+                }
+                Ok(())
             };
             let result = drive();
             if result.is_err() {
@@ -1360,9 +1336,9 @@ fn run_streaming_aggregate_ingest(
     // heuristic mismatch between batch charge and per-record discharge must
     // not leave a stale positive for the arbitrator), then unregister the
     // per-edge charge consumer. The per-document aggregate consumers are
-    // released separately: a flushed document unregisters its own as it
-    // finalizes, and `DocumentFlushAggregator`'s `Drop` releases any table
-    // still open when `agg` falls out of scope below — including on the
+    // released separately: a flushed bucket unregisters its own via
+    // `finalize_bucket`, and `RegisteredTables`' `Drop` releases any bucket
+    // still open when `tables` falls out of scope below — including on the
     // error path, where `ingest_result?` returns before the success-path
     // replay. So no aggregate consumer survives this arm on any exit.
     charge_handle.set_bytes(0);

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -242,14 +242,17 @@ pub(crate) fn dispatch_combine(
     // Combine collects puncts from both inputs and forwards a
     // reconciled set downstream. Like Merge, it folds the two
     // inputs' boundary signals so a document spanning both sides
-    // emits one `DocumentOpen` and one `DocumentClose` — withholding
-    // the close until both inputs have closed the document prevents a
-    // downstream per-document Aggregate flush from double-firing.
+    // emits one `DocumentOpen` and one `DocumentClose`; a document
+    // carried by only one side forwards its single close. Reconciling
+    // before forwarding keeps a downstream per-document Aggregate flush
+    // from double-firing on a spanning document while still flushing
+    // per side-local document.
     //
     // Under streaming-probe the driver slot is empty (the driver has not
     // dispatched yet — it streams into the probe channel during the redispatch
-    // below), so this drains nothing and the driver records arrive on the
-    // channel instead.
+    // below), so this drains nothing and the driver records (and their
+    // punctuations) arrive on the channel instead, to be reconciled with the
+    // retained `build_puncts` after the probe joins.
     let (driver_buf, driver_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
@@ -268,13 +271,22 @@ pub(crate) fn dispatch_combine(
         Some(nb) => nb.drain_split()?,
         None => (Vec::new(), Vec::new()),
     };
-    // Binary Combine: fan-in degree is 2 (driver + build). The empty-
-    // punctuation common case folds to an empty vector, leaving the
-    // no-document path byte-identical to a bare union.
-    let combined_puncts = crate::executor::stream_event::reconcile_document_boundaries(
-        driver_puncts.into_iter().chain(build_puncts),
-        2,
-    );
+    // The empty-punctuation common case folds to an empty vector,
+    // leaving the no-document path byte-identical to a bare union. For
+    // the streaming-probe path the driver's punctuations have not arrived
+    // yet (they stream over the channel below), so defer the reconcile:
+    // retain `build_puncts` and rebuild `combined_puncts` once the probe
+    // returns its `driver_puncts`. For every other path both sides are
+    // already drained, so reconcile now.
+    let mut combined_puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
+    let mut build_puncts_retained: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
+    if streaming_probe_driver.is_some() {
+        build_puncts_retained = build_puncts;
+    } else {
+        combined_puncts = crate::executor::stream_event::reconcile_document_boundaries(
+            driver_puncts.into_iter().chain(build_puncts),
+        );
+    }
 
     // Operator-entry schema check per D4: every record
     // arriving on the probe and build channels is
@@ -870,6 +882,18 @@ pub(crate) fn dispatch_combine(
         // The driver streamed its records over the channel, so the input
         // count comes from the probe thread rather than a pre-drained Vec.
         probe_records_in = streamed.input_count;
+        // The driver's punctuations arrived over the channel during the
+        // probe and were collected by the probe thread. Reconcile them now
+        // with the retained build-side punctuations — same fold as the
+        // materialized path, so a document spanning both inputs collapses
+        // to one open + one close and a side-local document forwards its
+        // close.
+        combined_puncts = crate::executor::stream_event::reconcile_document_boundaries(
+            streamed
+                .driver_puncts
+                .into_iter()
+                .chain(std::mem::take(&mut build_puncts_retained)),
+        );
         streamed.output_records
     } else {
         let mut output_records = Vec::with_capacity(driver_buf.len());
@@ -959,11 +983,12 @@ pub(crate) fn dispatch_combine(
     // re-drain, and overlap the writer with the next topo node.
     // The eligibility predicate certified this combine roots no
     // window and tees to no deferred region, so the helper calls
-    // below are correctly skipped. Punctuations are dropped on the
-    // inline path (matching the materialized inline admit, which
-    // forwards no puncts), and the terminal writer drops them
-    // regardless. The per-fold snapshot and hash-table consumer
-    // are still released before the streaming return.
+    // below are correctly skipped. The reconciled document boundaries
+    // are forwarded on the inline path just like the materialized arms,
+    // so a per-document Aggregate reached through this streamed handoff
+    // flushes per document; a terminal writer downstream consumes them
+    // harmlessly. The per-fold snapshot and hash-table consumer are
+    // still released before the streaming return.
     if let Some(sender) = ctx.take_streaming_sender(node_idx) {
         let batch_size = ctx.batch_size;
         let spill_allowed = node_buffer_spill_allowed(current_dag, node_idx);
@@ -975,7 +1000,7 @@ pub(crate) fn dispatch_combine(
             batch_size,
             name,
             output_records,
-            Vec::new(),
+            combined_puncts,
             &charge,
         )?;
         ctx.combine_input_snapshots.remove(&node_idx);
@@ -990,7 +1015,7 @@ pub(crate) fn dispatch_combine(
         name,
         node_idx,
         output_records,
-        Vec::new(),
+        combined_puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
     ctx.node_buffers.insert(node_idx, nb);
@@ -1009,12 +1034,15 @@ pub(crate) fn dispatch_combine(
 }
 
 /// Result of a streaming-probe run handed back to [`dispatch_combine`]:
-/// the probe output rows and the count of driver records the producer fed
+/// the probe output rows, the count of driver records the producer fed
 /// over the channel (the streaming analogue of the materialized
-/// `driver_buf.len()` probe input).
+/// `driver_buf.len()` probe input), and the driver's document-boundary
+/// punctuations collected off the channel for post-join reconciliation
+/// with the build side.
 struct StreamingProbeOutput {
     output_records: Vec<(Record, u64)>,
     input_count: u64,
+    driver_puncts: Vec<crate::executor::stream_event::Punctuation>,
 }
 
 /// Per-record side effects the streaming-probe thread cannot apply directly
@@ -1099,6 +1127,7 @@ fn run_streaming_combine_probe(
         failures: Vec::new(),
     };
     let mut output_records: Vec<(Record, u64)> = Vec::new();
+    let mut driver_puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
     let mut counters = ProbeCounters::default();
     let mut input_count: u64 = 0;
 
@@ -1116,12 +1145,15 @@ fn run_streaming_combine_probe(
             while let Ok(event) = rx.recv() {
                 let (record, rn) = match event {
                     StreamEvent::Record(r, rn) => (r, rn),
-                    // Punctuations carry zero charge and the inline path
-                    // forwards no puncts on the streaming-Output handoff, so
-                    // the probe drops them — byte-identical to the
-                    // materialized inline admit. Per-document combine flush
-                    // is a separate follow-up.
-                    StreamEvent::Punctuation(_) => continue,
+                    // Punctuations carry zero record charge (no `sub_bytes`
+                    // discharge, no `input_count` increment), so collect them
+                    // for post-join reconciliation with the build side rather
+                    // than dropping them. The driver's document boundaries
+                    // must reach a downstream per-document consumer.
+                    StreamEvent::Punctuation(p) => {
+                        driver_puncts.push(p);
+                        continue;
+                    }
                 };
                 // Discharge this record's per-row cost — the consume half of
                 // the driver's per-batch admit. The formula matches the
@@ -1304,6 +1336,7 @@ fn run_streaming_combine_probe(
     Ok(StreamingProbeOutput {
         output_records,
         input_count,
+        driver_puncts,
     })
 }
 

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -123,7 +123,6 @@ pub(crate) fn dispatch_merge(
     // through merge_fused_interleave's recv loop); the else
     // branch's drain logic fills `all_puncts` from each input
     // NodeBuffer.
-    let fan_in_degree = sorted_preds.len();
     let mut all_puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
 
     // Streaming-Output handoff: if a single Output downstream of
@@ -281,10 +280,12 @@ pub(crate) fn dispatch_merge(
     };
 
     // Reconcile boundaries across every Merge input: one `DocumentOpen`
-    // per document (first sighting wins) and one `DocumentClose` only
-    // after every input branch has closed the same document.
-    let deduped_puncts =
-        crate::executor::stream_event::reconcile_document_boundaries(all_puncts, fan_in_degree);
+    // per document (first sighting wins) and one `DocumentClose` once
+    // every input that opened a document has closed it. A document
+    // carried by a single input branch forwards its close after that
+    // branch's close, so a Merge of distinct single-document sources
+    // lets each document flush independently downstream.
+    let deduped_puncts = crate::executor::stream_event::reconcile_document_boundaries(all_puncts);
 
     // Non-fused streaming path: the predecessors' slots are
     // already drained into the full `merged` Vec, so this does not

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -12,10 +12,10 @@
 //! body record of each source file and one `DocumentClose` after the
 //! last. Operators preserve, transform, or consume punctuations
 //! according to their punctuation discipline (Transform / Route =
-//! Preserving; Merge = Reconciling — emits one downstream `Close` only
-//! when every input has closed the same document; Aggregate /
-//! Output = WindowBound — flush document-scoped state on `Close` then
-//! forward).
+//! Preserving; Merge / Combine = Reconciling — emits one downstream
+//! `Close` per document once every input that opened that document has
+//! also closed it; Aggregate / Output = WindowBound — flush
+//! document-scoped state on `Close` then forward).
 //!
 //! Tucker 2003-style semantics: punctuations flow inline with records,
 //! preserving strict ordering. Out-of-band side-channels (Vector
@@ -132,28 +132,54 @@ impl StreamEvent {
 /// A document whose records arrive across several inputs (a forked
 /// document stream rejoining at a Merge, or a document spanning both
 /// sides of a binary Combine) contributes its `DocumentOpen` /
-/// `DocumentClose` boundary once per input. Forwarding that union
-/// unchanged would open the document several times and — worse — close
-/// it several times, double-firing any downstream consumer that flushes
-/// on close (per-document Aggregate finalize, Output finalize).
+/// `DocumentClose` boundary once per input that carries it. Forwarding
+/// that union unchanged would open the document several times and —
+/// worse — close it several times, double-firing any downstream
+/// consumer that flushes on close (per-document Aggregate finalize,
+/// Output finalize).
 ///
-/// The reconciliation emits `DocumentOpen` on first sighting (later
-/// duplicates are dropped) and `DocumentClose` only once the close count
-/// for a document reaches `fan_in_degree` — i.e. every input has closed
-/// it. A document that traverses fewer than `fan_in_degree` inputs (e.g.
-/// distinct source files with distinct [`DocumentId`]s, each appearing on
-/// one input only) never reaches the threshold, so its close is withheld;
-/// this is the intended fan-in semantics, identical across every
-/// multi-input operator that calls this function. Input order is
-/// preserved for the events that survive.
+/// The reconciliation forwards each document's `DocumentOpen` on first
+/// sighting (later duplicates are dropped) and its `DocumentClose`
+/// exactly once — when every input that opened the document has also
+/// closed it, i.e. when the per-document close count reaches the
+/// per-document open count. A document carried by a single input
+/// (distinct source files with distinct [`DocumentId`]s, a join whose
+/// two sides carry different documents) has open count 1, so its close
+/// forwards after that one input's close; a document genuinely spanning
+/// N inputs forwards its close only after all N closes. Either way
+/// exactly one downstream open and one downstream close survive per
+/// document. Input order is preserved for the events that survive.
+///
+/// Malformed input is tolerated without breaking the single-close
+/// guarantee: a document opened but never closed forwards its open and
+/// no close (the downstream document stays open, and a per-document
+/// consumer's end-of-stream tail flush handles it); a duplicate close
+/// beyond the open count is dropped (the `==` test holds for exactly
+/// one close); a close with no matching open is dropped.
 pub(crate) fn reconcile_document_boundaries(
     puncts: impl IntoIterator<Item = Punctuation>,
-    fan_in_degree: usize,
 ) -> Vec<Punctuation> {
+    let events: Vec<Punctuation> = puncts.into_iter().collect();
+
+    // Pass 1 tallies how many inputs opened each document; that total is
+    // the coverage target the document's close count must reach. The
+    // pre-tally is load-bearing: a document spanning two inputs yields
+    // the union `[open, close, open, close]`, so the first close arrives
+    // with only one open seen so far. A single-pass "close == opens seen
+    // so far" test would fire that close early, before the second input
+    // closes. Counting all opens up front makes the close fire only on
+    // the last input's close.
+    let mut open_counts: HashMap<DocumentId, usize> = HashMap::new();
+    for p in &events {
+        if p.kind() == PunctuationKind::DocumentOpen {
+            *open_counts.entry(p.doc_id()).or_insert(0) += 1;
+        }
+    }
+
     let mut deduped: Vec<Punctuation> = Vec::new();
     let mut open_seen: HashSet<DocumentId> = HashSet::new();
     let mut close_counts: HashMap<DocumentId, usize> = HashMap::new();
-    for p in puncts {
+    for p in events {
         let id = p.doc_id();
         match p.kind() {
             PunctuationKind::DocumentOpen => {
@@ -164,7 +190,7 @@ pub(crate) fn reconcile_document_boundaries(
             PunctuationKind::DocumentClose => {
                 let count = close_counts.entry(id).or_insert(0);
                 *count += 1;
-                if *count == fan_in_degree {
+                if *count == open_counts.get(&id).copied().unwrap_or(0) {
                     deduped.push(p);
                 }
             }
@@ -251,7 +277,7 @@ mod tests {
             Punctuation::document_close(Arc::clone(&ctx)),
             Punctuation::document_close(Arc::clone(&ctx)),
         ];
-        let out = reconcile_document_boundaries(union, 2);
+        let out = reconcile_document_boundaries(union);
         assert_eq!(
             kinds_for(&out, id),
             vec![
@@ -262,35 +288,126 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_withholds_close_for_partial_coverage_document() {
-        // A document that opens+closes on only ONE input never reaches the
-        // fan-in degree, so its open is forwarded but its close is withheld
-        // — the shared fan-in semantics across every multi-input operator.
+    fn reconcile_holds_close_under_interleaved_spanning_order() {
+        // The two-pass tally is load-bearing for the INTERLEAVED union order
+        // `[open, close, open, close]` — the real ordering when each input's
+        // `drain_split` yields its own document's `[open, close]` pair and the
+        // two pairs chain together for a same-id document spanning both inputs.
+        // Here the FIRST close arrives with only one open seen so far; a naive
+        // single-pass "close == opens-seen-so-far" test would fire it early and
+        // emit two downstream closes. Pre-tallying the total open count (2) in
+        // pass 1 forces the close to fire only on the LAST close, so exactly
+        // one open and one close survive.
+        let ctx = doc_ctx();
+        let id = ctx.id();
+        let union = vec![
+            Punctuation::document_open(Arc::clone(&ctx)),
+            Punctuation::document_close(Arc::clone(&ctx)),
+            Punctuation::document_open(Arc::clone(&ctx)),
+            Punctuation::document_close(Arc::clone(&ctx)),
+        ];
+        let out = reconcile_document_boundaries(union);
+        assert_eq!(
+            kinds_for(&out, id),
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ],
+            "interleaved spanning order must still yield exactly one open + one \
+             close (a single-pass regression would fire the first close early)"
+        );
+    }
+
+    #[test]
+    fn reconcile_forwards_close_for_one_sided_document() {
+        // A document that opens+closes on only ONE input (open count == 1)
+        // forwards BOTH its open and its close — the common join case where
+        // each side carries its own document, so each document's close must
+        // reach a downstream per-document flush.
         let ctx = doc_ctx();
         let id = ctx.id();
         let union = vec![
             Punctuation::document_open(Arc::clone(&ctx)),
             Punctuation::document_close(Arc::clone(&ctx)),
         ];
-        let out = reconcile_document_boundaries(union, 2);
-        assert_eq!(kinds_for(&out, id), vec![PunctuationKind::DocumentOpen]);
+        let out = reconcile_document_boundaries(union);
+        assert_eq!(
+            kinds_for(&out, id),
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ]
+        );
+    }
+
+    #[test]
+    fn reconcile_forwards_both_one_sided_documents() {
+        // The join case: a driver document D and a build document B, each
+        // carried by one input only. Both forward open+close independently.
+        let driver = doc_ctx();
+        let build = doc_ctx();
+        let union = vec![
+            Punctuation::document_open(Arc::clone(&driver)),
+            Punctuation::document_close(Arc::clone(&driver)),
+            Punctuation::document_open(Arc::clone(&build)),
+            Punctuation::document_close(Arc::clone(&build)),
+        ];
+        let out = reconcile_document_boundaries(union);
+        assert_eq!(
+            kinds_for(&out, driver.id()),
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ]
+        );
+        assert_eq!(
+            kinds_for(&out, build.id()),
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ]
+        );
+    }
+
+    #[test]
+    fn reconcile_emits_single_close_on_duplicate_close() {
+        // A malformed input that double-closes a one-sided document
+        // (open count 1, close count 2) still forwards exactly one close:
+        // the close at which close-count == open-count forwards, every
+        // later close is dropped. The single-close guarantee survives.
+        let ctx = doc_ctx();
+        let id = ctx.id();
+        let union = vec![
+            Punctuation::document_open(Arc::clone(&ctx)),
+            Punctuation::document_close(Arc::clone(&ctx)),
+            Punctuation::document_close(Arc::clone(&ctx)),
+        ];
+        let out = reconcile_document_boundaries(union);
+        assert_eq!(
+            kinds_for(&out, id),
+            vec![
+                PunctuationKind::DocumentOpen,
+                PunctuationKind::DocumentClose
+            ]
+        );
     }
 
     #[test]
     fn reconcile_is_per_document_independent() {
         // Two distinct documents reconcile independently: a fully-covered
-        // one emits open+close, a partially-covered one emits open only.
+        // spanning one (open count 2) emits open+close, a genuinely
+        // never-closed one (open with no close) emits open only — covering
+        // the unterminated-document branch.
         let spanning = doc_ctx();
-        let partial = doc_ctx();
+        let unterminated = doc_ctx();
         let union = vec![
             Punctuation::document_open(Arc::clone(&spanning)),
-            Punctuation::document_open(Arc::clone(&partial)),
+            Punctuation::document_open(Arc::clone(&unterminated)),
             Punctuation::document_open(Arc::clone(&spanning)),
             Punctuation::document_close(Arc::clone(&spanning)),
-            Punctuation::document_close(Arc::clone(&partial)),
             Punctuation::document_close(Arc::clone(&spanning)),
         ];
-        let out = reconcile_document_boundaries(union, 2);
+        let out = reconcile_document_boundaries(union);
         assert_eq!(
             kinds_for(&out, spanning.id()),
             vec![
@@ -299,7 +416,7 @@ mod tests {
             ]
         );
         assert_eq!(
-            kinds_for(&out, partial.id()),
+            kinds_for(&out, unterminated.id()),
             vec![PunctuationKind::DocumentOpen]
         );
     }
@@ -308,7 +425,7 @@ mod tests {
     fn reconcile_empty_input_yields_empty_output() {
         // The common case — no punctuations on either input — passes
         // through byte-identically to an empty vector.
-        let out = reconcile_document_boundaries(Vec::new(), 2);
+        let out = reconcile_document_boundaries(Vec::new());
         assert!(out.is_empty());
     }
 }

--- a/crates/clinker-exec/tests/aggregate_per_document_flush.rs
+++ b/crates/clinker-exec/tests/aggregate_per_document_flush.rs
@@ -11,10 +11,11 @@
 //! no-document / single-document control proves the dominant path is
 //! unchanged, a tiny memory budget exercises the spilling strategy across
 //! a document boundary, the streaming-ingest path is covered via a fused
-//! producer, and `concat` / `interleave` Merges of two single-document
-//! sources prove documents whose close never reaches the aggregate fold
-//! together into one cross-document result rather than splitting — even
-//! when an interleave Merge delivers their records non-contiguously.
+//! producer, and `concat` / seeded-`interleave` Merges of two
+//! single-document sources prove a non-fused Merge forwards each source's
+//! per-document close, so each source document flushes independently
+//! downstream — even when a seeded interleave delivers their records
+//! non-contiguously.
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -341,14 +342,16 @@ fn streaming_ingest_path_flushes_per_document() {
 }
 
 /// A `concat` Merge of two distinct single-document sources feeds the
-/// Aggregate records carrying two different document ids — but the Merge
-/// reconciles boundaries and forwards a `DocumentClose` only when every
-/// branch closed the same document, which never happens for distinct
-/// per-source documents. With no close reaching the Aggregate, the two
-/// documents must fold together into ONE cross-document aggregate, exactly
-/// as a no-envelope stream would: per-document flush must NOT split an
-/// unreconciled merge into one aggregate per source file.
-const UNRECONCILED_MERGE_YAML: &str = r#"
+/// Aggregate records carrying two different document ids. The non-fused
+/// Merge reconciles boundaries by open-coverage: each source document has
+/// open count == close count == 1 on its single branch, so the Merge
+/// forwards each document's `DocumentClose`. A non-fused Merge is a
+/// certified streaming producer, so the downstream Aggregate runs the
+/// streaming ingest path and buckets group state per document — flushing
+/// each source document's bucket on its close even though the closes arrive
+/// tail-batched after every record. The per-document flush therefore splits
+/// into one group set per source file.
+const PER_SOURCE_MERGE_YAML: &str = r#"
 pipeline:
   name: unreconciled_merge_agg
 nodes:
@@ -393,16 +396,16 @@ nodes:
 "#;
 
 #[test]
-fn unreconciled_merge_folds_documents_together() {
-    let config = parse_config(UNRECONCILED_MERGE_YAML).expect("parse unreconciled-merge pipeline");
+fn concat_merge_forwards_per_source_document_close() {
+    let config = parse_config(PER_SOURCE_MERGE_YAML).expect("parse per-source-merge pipeline");
     let plan = config
         .compile(&CompileContext::default())
-        .expect("compile unreconciled-merge pipeline");
+        .expect("compile per-source-merge pipeline");
 
-    // sa contributes x×2, y×1; sb contributes x×1. With the two documents
-    // unreconciled (no forwarded close), the aggregate folds them together:
-    // x=3 (2 from sa + 1 from sb), y=1 — a single cross-document result,
-    // NOT a per-document split (which would yield x=2, y=1, x=1).
+    // sa contributes x×2, y×1; sb contributes x×1. The non-fused Merge
+    // forwards each source document's close (open == close == 1 per
+    // document), so the aggregate flushes per document: x=2, y=1 from sa's
+    // document and a SEPARATE x=1 from sb's document — not a folded x=3.
     let readers: clinker_exec::executor::SourceReaders = HashMap::from([
         (
             "sa".to_string(),
@@ -432,7 +435,7 @@ fn unreconciled_merge_folds_documents_together() {
         ..Default::default()
     };
     let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
-        .expect("run unreconciled-merge pipeline");
+        .expect("run per-source-merge pipeline");
     assert_eq!(report.counters.dlq_count, 0);
 
     let output = buf.as_string();
@@ -440,21 +443,27 @@ fn unreconciled_merge_folds_documents_together() {
     body.sort();
     assert_eq!(
         body,
-        vec!["x,3".to_string(), "y,1".to_string()],
-        "an unreconciled merge must fold its source documents into one \
-         aggregate (x=3, y=1), not split per source file",
+        vec!["x,1".to_string(), "x,2".to_string(), "y,1".to_string()],
+        "a non-fused concat merge forwards each source document's close, so \
+         the aggregate flushes per document (x=2,y=1 from sa; x=1 from sb), \
+         not a folded x=3",
     );
 }
 
-/// An `interleave` Merge round-robins records from two distinct-document
-/// sources, so the aggregate's input carries the two documents' records
-/// non-contiguously. Their closes are unreconciled (never forwarded), so
-/// the records must still fold into one aggregate regardless of arrival
-/// order — proving the per-document flush keys group state by document
-/// rather than by a running "current document" that interleaving would
-/// corrupt.
+/// A SEEDED `interleave` Merge round-robins records from two
+/// distinct-document sources, so the aggregate's input carries the two
+/// documents' records non-contiguously. A seeded interleave is non-fused
+/// (the seed excludes it from the all-Source fusion fast path so its
+/// schedule stays deterministic over a pre-buffered Vec), so it reconciles
+/// boundaries and forwards each source's per-document close, and — being a
+/// certified streaming producer — feeds the streaming Aggregate ingest path,
+/// which buckets group state per document even though the closes arrive
+/// tail-batched after all records. The aggregate therefore flushes per
+/// document regardless of round-robin arrival order — proving the
+/// per-document bucketing keys group state by document rather than by a
+/// running "current document" that interleaving would corrupt.
 #[test]
-fn interleaved_unreconciled_documents_fold_together() {
+fn seeded_interleave_merge_forwards_per_source_document_close() {
     let yaml = r#"
 pipeline:
   name: interleave_merge_agg
@@ -504,8 +513,10 @@ nodes:
         .compile(&CompileContext::default())
         .expect("compile interleave-merge pipeline");
 
-    // sa: x×3; sb: x×2, y×1. Interleaved and unreconciled → one aggregate:
-    // x=5, y=1.
+    // sa: x×3 (one document); sb: x×2, y×1 (another document). The seeded
+    // interleave is non-fused, so it reconciles boundaries and forwards
+    // each source's per-document close → per-document flush: x=3 from sa's
+    // document, and x=2, y=1 from sb's document.
     let readers: clinker_exec::executor::SourceReaders = HashMap::from([
         (
             "sa".to_string(),
@@ -543,8 +554,9 @@ nodes:
     body.sort();
     assert_eq!(
         body,
-        vec!["x,5".to_string(), "y,1".to_string()],
-        "interleaved unreconciled documents must fold into one aggregate \
-         (x=5, y=1) regardless of round-robin arrival order",
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "a seeded interleave is non-fused, so it forwards each source's \
+         per-document close → per-document flush (x=3 from sa; x=2,y=1 from \
+         sb), regardless of round-robin arrival order",
     );
 }

--- a/crates/clinker-exec/tests/combine_per_document_flush.rs
+++ b/crates/clinker-exec/tests/combine_per_document_flush.rs
@@ -1,0 +1,833 @@
+//! Per-document Aggregate flush downstream of a Combine (join), across every
+//! Combine strategy.
+//!
+//! A document-aware driver source (a multi-file CSV glob, each file its own
+//! document) joins against a small build/lookup source, then a group-by
+//! Aggregate rolls the joined records up. Correct document-boundary handling
+//! forwards each driver document's `DocumentClose` through the Combine to the
+//! Aggregate, which flushes that document's groups at its boundary — so a
+//! multi-document run emits one group set per driver document rather than one
+//! cross-document fold.
+//!
+//! The Combine forwards reconciled boundaries on EVERY strategy: the inline
+//! hash build-probe arm and the streaming-probe arm (both certified streaming
+//! producers, so the downstream Aggregate runs the streaming-ingest bucket
+//! path), and the materialized IEJoin / grace-hash / sort-merge arms (blocking
+//! producers → the materialized Aggregate bucket path). The inline and
+//! streaming-probe tests are the load-bearing ones — they exercise the
+//! forwarded-boundary path that previously dropped punctuations; the
+//! materialized-strategy tests are regression guards proving no break.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// Build a driver `SourceInput::Files` from in-memory bodies (each file a
+/// distinct document) plus a single-file build/lookup reader, run the plan,
+/// and return the sorted output body lines and the dlq count.
+fn run_combine(
+    yaml: &str,
+    driver_name: &str,
+    driver_files: &[(&str, &str)],
+    build_name: &str,
+    build_file: (&str, &str),
+) -> (Vec<String>, u64) {
+    let config = parse_config(yaml).expect("parse combine per-document pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile combine per-document pipeline");
+
+    let slots: Vec<FileSlot> = driver_files
+        .iter()
+        .map(|(name, body)| {
+            FileSlot::new(
+                PathBuf::from(*name),
+                Box::new(Cursor::new(body.as_bytes().to_vec())),
+            )
+        })
+        .collect();
+    let mut readers: clinker_exec::executor::SourceReaders = HashMap::new();
+    readers.insert(
+        driver_name.to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    );
+    readers.insert(
+        build_name.to_string(),
+        clinker_exec::executor::single_file_reader(
+            build_file.0,
+            Box::new(Cursor::new(build_file.1.as_bytes().to_vec())),
+        ),
+    );
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("run combine per-document pipeline");
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    (body, report.counters.dlq_count)
+}
+
+/// Assert the Combine selected `expected_tag` — the `[combine:<tag>]` glyph
+/// in the `--explain` DAG topology (`hash_build_probe`, `iejoin`,
+/// `sort_merge`, `grace_hash`) — so each test forces the arm it claims to
+/// exercise.
+fn assert_combine_strategy(yaml: &str, expected_tag: &str) {
+    let config = parse_config(yaml).expect("parse pipeline for explain");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline for explain");
+    let (dag, _) = PipelineExecutor::explain_plan_dag(&plan).expect("explain dag");
+    let explain = dag.explain_text(&config);
+    assert!(
+        explain.contains(&format!("[combine:{expected_tag}]")),
+        "expected Combine strategy [combine:{expected_tag}], got explain:\n{explain}"
+    );
+}
+
+/// Slice the indented `--explain` property block for the node whose stanza
+/// starts with `slug:`, up to the next blank line.
+fn properties_block(explain: &str, slug: &str) -> String {
+    let marker = format!("{slug}:");
+    explain
+        .lines()
+        .skip_while(|l| l.trim_start() != marker)
+        .skip(1)
+        .take_while(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Assert the driver `producer_slug` classifies `streaming` and emits no
+/// charged `node_buffer` edge to `consumer_slug` — the positive proof that
+/// the producer's output streams into the consumer (the streaming-probe
+/// runtime arm) rather than crossing a materialized inter-stage buffer.
+fn assert_streaming_into(yaml: &str, producer_slug: &str, consumer_slug: &str) {
+    let config = parse_config(yaml).expect("parse pipeline for explain");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile pipeline for explain");
+    let (dag, _) = PipelineExecutor::explain_plan_dag(&plan).expect("explain dag");
+    let explain = dag.explain_text(&config);
+    let block = properties_block(&explain, producer_slug);
+    assert!(
+        block.contains("buffer: streaming") && !block.contains("buffer: materialized"),
+        "{producer_slug} should classify streaming, got:\n{block}"
+    );
+    assert!(
+        !explain.contains(&format!("edge {producer_slug} -> {consumer_slug}")),
+        "a streaming {producer_slug} must emit no charged node_buffer edge to \
+         {consumer_slug}, got:\n{explain}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Inline hash build-probe Combine (pure-equi) → per-document Aggregate.
+// ---------------------------------------------------------------------------
+
+/// Pure-equi join (default `HashBuildProbe`) of a document-aware driver glob
+/// against a single-row lookup, then a group-by Aggregate. The build is a
+/// single-row lookup that is NOT a fused `Source→Transform`, so the
+/// streaming-probe edge does not certify and the Combine runs the
+/// materialized inline hash build-probe arm.
+const INLINE_EQUI_YAML: &str = r#"
+pipeline:
+  name: inline_combine_per_doc
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+        - { name: k, type: string }
+  - type: source
+    name: lookup
+    config:
+      name: lookup
+      type: csv
+      path: ./lookup.csv
+      schema:
+        - { name: k, type: string }
+        - { name: label, type: string }
+  - type: combine
+    name: j
+    input:
+      driver: driver
+      lookup: lookup
+    config:
+      where: "driver.k == lookup.k"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit category = driver.category
+        emit k = driver.k
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn inline_combine_then_per_document_aggregate_flushes_per_document() {
+    assert_combine_strategy(INLINE_EQUI_YAML, "hash_build_probe");
+
+    // doc A: x×2, y×1. doc B: x×3. Every record's `k=1` matches the single
+    // lookup row, so the join is a passthrough that preserves each driver
+    // document. The Combine forwards each document's close to the Aggregate,
+    // which buckets per document → x=2,y=1 from doc A and a SEPARATE x=3 from
+    // doc B, not a folded x=5.
+    let (body, dlq) = run_combine(
+        INLINE_EQUI_YAML,
+        "driver",
+        &[
+            ("a.csv", "category,k\nx,1\nx,1\ny,1\n"),
+            ("b.csv", "category,k\nx,1\nx,1\nx,1\n"),
+        ],
+        "lookup",
+        ("lookup.csv", "k,label\n1,one\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "an inline Combine must forward each driver document's close so the \
+         downstream Aggregate flushes per document (x=2,y=1; x=3), not x=5"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Streaming-probe Combine (fused Source→Transform driver) → per-document Agg.
+// ---------------------------------------------------------------------------
+
+/// Pure-equi join whose driver is a fused `Source→Transform` — the only
+/// producer kind that certifies the streaming-probe edge (a bare Source never
+/// certifies). The driver streams its records (and its document-boundary
+/// punctuations) over the bounded probe channel; the probe collects the
+/// punctuations and reconciles them with the build side after the join.
+const STREAMING_PROBE_EQUI_YAML: &str = r#"
+pipeline:
+  name: streaming_probe_combine_per_doc
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+        - { name: k, type: string }
+  - type: transform
+    name: drive_t
+    input: driver
+    config:
+      cxl: |
+        emit category = category
+        emit k = k
+  - type: source
+    name: lookup
+    config:
+      name: lookup
+      type: csv
+      path: ./lookup.csv
+      schema:
+        - { name: k, type: string }
+        - { name: label, type: string }
+  - type: combine
+    name: j
+    input:
+      drive_t: drive_t
+      lookup: lookup
+    config:
+      where: "drive_t.k == lookup.k"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit category = drive_t.category
+        emit k = drive_t.k
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn streaming_probe_combine_then_per_document_aggregate_flushes_per_document() {
+    assert_combine_strategy(STREAMING_PROBE_EQUI_YAML, "hash_build_probe");
+    // Positively prove the streaming-probe arm runs: the fused
+    // `Source→Transform` driver classifies `buffer: streaming` and emits no
+    // charged node_buffer edge into the Combine, so its records (and document
+    // punctuations) reach the probe over the channel rather than a
+    // materialized drain. Without this the correct per-document output would
+    // be reachable via the materialized arm too, leaving the streaming-probe
+    // punctuation-collection path unexercised.
+    assert_streaming_into(STREAMING_PROBE_EQUI_YAML, "transform.drive_t", "combine.j");
+
+    // Same per-document split as the inline test, but the driver streams over
+    // the probe channel, so this exercises the channel-collected driver
+    // punctuations reconciled with the build side after the join.
+    let (body, dlq) = run_combine(
+        STREAMING_PROBE_EQUI_YAML,
+        "driver",
+        &[
+            ("a.csv", "category,k\nx,1\nx,1\ny,1\n"),
+            ("b.csv", "category,k\nx,1\nx,1\nx,1\n"),
+        ],
+        "lookup",
+        ("lookup.csv", "k,label\n1,one\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "a streaming-probe Combine must collect the driver's punctuations off \
+         the channel and forward them so the Aggregate flushes per document"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Materialized strategy regression guards: IEJoin / GraceHash / SortMerge.
+// ---------------------------------------------------------------------------
+
+/// Pure-range join (`driver.v < lookup.cap`) with no `sort_order`, forcing
+/// IEJoin. A single high-cap lookup row matches every driver record.
+const IEJOIN_RANGE_YAML: &str = r#"
+pipeline:
+  name: iejoin_combine_per_doc
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+        - { name: v, type: int }
+  - type: source
+    name: lookup
+    config:
+      name: lookup
+      type: csv
+      path: ./lookup.csv
+      schema:
+        - { name: cap, type: int }
+        - { name: label, type: string }
+  - type: combine
+    name: j
+    input:
+      driver: driver
+      lookup: lookup
+    config:
+      where: "driver.v < lookup.cap"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit category = driver.category
+        emit v = driver.v
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn iejoin_combine_preserves_document_boundaries() {
+    assert_combine_strategy(IEJOIN_RANGE_YAML, "iejoin");
+
+    // doc A: x×2, y×1 (v small). doc B: x×3. Every v < 100, so the single
+    // lookup row matches all. The materialized IEJoin arm forwards reconciled
+    // boundaries → per-document flush.
+    let (body, dlq) = run_combine(
+        IEJOIN_RANGE_YAML,
+        "driver",
+        &[
+            ("a.csv", "category,v\nx,1\nx,2\ny,3\n"),
+            ("b.csv", "category,v\nx,4\nx,5\nx,6\n"),
+        ],
+        "lookup",
+        ("lookup.csv", "cap,label\n100,hi\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "a materialized IEJoin Combine must preserve document boundaries → \
+         per-document flush (x=2,y=1; x=3)"
+    );
+}
+
+/// Pure-equi join with a `strategy: grace_hash` hint on the Combine node,
+/// forcing the disk-spilling grace-hash arm.
+const GRACE_HASH_EQUI_YAML: &str = r#"
+pipeline:
+  name: grace_hash_combine_per_doc
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+        - { name: k, type: string }
+  - type: source
+    name: lookup
+    config:
+      name: lookup
+      type: csv
+      path: ./lookup.csv
+      schema:
+        - { name: k, type: string }
+        - { name: label, type: string }
+  - type: combine
+    name: j
+    input:
+      driver: driver
+      lookup: lookup
+    config:
+      where: "driver.k == lookup.k"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      strategy: grace_hash
+      cxl: |
+        emit category = driver.category
+        emit k = driver.k
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn grace_hash_combine_preserves_document_boundaries() {
+    assert_combine_strategy(GRACE_HASH_EQUI_YAML, "grace_hash");
+
+    let (body, dlq) = run_combine(
+        GRACE_HASH_EQUI_YAML,
+        "driver",
+        &[
+            ("a.csv", "category,k\nx,1\nx,1\ny,1\n"),
+            ("b.csv", "category,k\nx,1\nx,1\nx,1\n"),
+        ],
+        "lookup",
+        ("lookup.csv", "k,label\n1,one\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "a grace-hash Combine must preserve document boundaries → per-document \
+         flush (x=2,y=1; x=3)"
+    );
+}
+
+/// Single-range join with `sort_order` on both inputs' range key, forcing
+/// SortMerge over IEJoin.
+const SORT_MERGE_RANGE_YAML: &str = r#"
+pipeline:
+  name: sort_merge_combine_per_doc
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      sort_order:
+        - field: v
+      schema:
+        - { name: category, type: string }
+        - { name: v, type: int }
+  - type: source
+    name: lookup
+    config:
+      name: lookup
+      type: csv
+      path: ./lookup.csv
+      sort_order:
+        - field: cap
+      schema:
+        - { name: cap, type: int }
+        - { name: label, type: string }
+  - type: combine
+    name: j
+    input:
+      driver: driver
+      lookup: lookup
+    config:
+      where: "driver.v < lookup.cap"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit category = driver.category
+        emit v = driver.v
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn sort_merge_combine_preserves_document_boundaries() {
+    assert_combine_strategy(SORT_MERGE_RANGE_YAML, "sort_merge");
+
+    // Each file is pre-sorted on v (ascending). The lookup cap=100 matches
+    // every driver record. The materialized SortMerge arm forwards reconciled
+    // boundaries → per-document flush.
+    let (body, dlq) = run_combine(
+        SORT_MERGE_RANGE_YAML,
+        "driver",
+        &[
+            ("a.csv", "category,v\nx,1\nx,2\ny,3\n"),
+            ("b.csv", "category,v\nx,4\nx,5\nx,6\n"),
+        ],
+        "lookup",
+        ("lookup.csv", "cap,label\n100,hi\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "a SortMerge Combine must preserve document boundaries → per-document \
+         flush (x=2,y=1; x=3)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Boundary-exactness: spanning doc, driver-only doc, no-document byte-identity.
+// ---------------------------------------------------------------------------
+
+/// Both the driver and the build input of an inline Combine carry one
+/// single-file document each (the same bytes). These are NOT the same
+/// document id — each source allocates its own `DocumentId` from the global
+/// counter — but the join's output rows carry only the DRIVER's document id,
+/// and only the driver's records populate a per-document bucket downstream.
+/// The reconciliation forwards each input's one open + one close (open ==
+/// close == 1 per input), so the driver's close flushes its bucket exactly
+/// once and the build's separate close lands on an empty bucket (grouped
+/// fold → no-op). The result is one group set, never a doubled one. (The
+/// genuine same-id spanning case — one document id whose boundary arrives on
+/// both join inputs — is covered by the `reconcile_*` unit tests in
+/// `stream_event.rs`, which a fork-rejoin topology is not needed to exercise.)
+const SPANNING_DOC_YAML: &str = r#"
+pipeline:
+  name: spanning_doc_combine
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: ./shared.csv
+      schema:
+        - { name: category, type: string }
+        - { name: k, type: string }
+  - type: source
+    name: build
+    config:
+      name: build
+      type: csv
+      path: ./shared.csv
+      schema:
+        - { name: category, type: string }
+        - { name: k, type: string }
+  - type: combine
+    name: j
+    input:
+      driver: driver
+      build: build
+    config:
+      where: "driver.k == build.k"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit category = driver.category
+        emit k = driver.k
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn spanning_document_emits_exactly_one_open_and_one_close() {
+    // Each join input carries one single-file document. The output rows carry
+    // the driver's document id, so the driver's close flushes its bucket once;
+    // the build input's separate close lands on an empty grouped bucket and is
+    // a no-op. The per-document flush therefore fires exactly once, producing
+    // one group set — a regression that double-fired a close would duplicate
+    // it.
+    let config = parse_config(SPANNING_DOC_YAML).expect("parse spanning-doc pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile spanning-doc pipeline");
+    let mut readers: clinker_exec::executor::SourceReaders = HashMap::new();
+    readers.insert(
+        "driver".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "shared.csv",
+            Box::new(Cursor::new(b"category,k\nx,1\nx,1\ny,1\n".to_vec())),
+        ),
+    );
+    readers.insert(
+        "build".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "shared.csv",
+            Box::new(Cursor::new(b"category,k\nx,1\nx,1\ny,1\n".to_vec())),
+        ),
+    );
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("run spanning-doc pipeline");
+    assert_eq!(report.counters.dlq_count, 0);
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    // One flush over the driver's document: x=2, y=1 emitted exactly once (a
+    // double-fired close would duplicate the group set).
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "y,1".to_string()],
+        "the driver document must flush exactly once (x=2, y=1); the build's \
+         separate close must not double-fire the per-document group set"
+    );
+}
+
+/// A driver-only document (the build side is a disjoint lookup document) now
+/// forwards its close, so its per-document Aggregate flushes — the core Fix-1
+/// win. Uses the inline arm; the driver glob carries two documents, the build
+/// is a separate single-row lookup document.
+#[test]
+fn driver_only_document_now_forwards_its_close() {
+    assert_combine_strategy(INLINE_EQUI_YAML, "hash_build_probe");
+
+    // Two driver documents, each carried only on the driver input; the build
+    // lookup is its own disjoint document. Each driver document's open ==
+    // close == 1, so the reconciliation forwards each close → per-document
+    // flush. Before Fix 1, a one-sided document's close was withheld (it never
+    // reached the old degree-2 threshold) and the documents folded.
+    let (body, dlq) = run_combine(
+        INLINE_EQUI_YAML,
+        "driver",
+        &[
+            ("a.csv", "category,k\nx,1\nx,1\ny,1\n"),
+            ("b.csv", "category,k\nx,1\nx,1\nx,1\n"),
+        ],
+        "lookup",
+        ("lookup.csv", "k,label\n1,one\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "a driver-only document must forward its close so its per-document \
+         Aggregate flushes (x=2,y=1; x=3), not fold to x=5"
+    );
+}
+
+/// A Combine of two no-envelope single-file sources: the punctuation union is
+/// empty (no document boundaries), so the reconciliation folds to empty and
+/// the dominant no-document path is byte-identical to a single cross-document
+/// aggregate.
+const NO_DOCUMENT_YAML: &str = r#"
+pipeline:
+  name: no_document_combine
+nodes:
+  - type: source
+    name: driver
+    config:
+      name: driver
+      type: csv
+      path: ./driver.csv
+      schema:
+        - { name: category, type: string }
+        - { name: k, type: string }
+  - type: source
+    name: lookup
+    config:
+      name: lookup
+      type: csv
+      path: ./lookup.csv
+      schema:
+        - { name: k, type: string }
+        - { name: label, type: string }
+  - type: combine
+    name: j
+    input:
+      driver: driver
+      lookup: lookup
+    config:
+      where: "driver.k == lookup.k"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit category = driver.category
+        emit k = driver.k
+  - type: aggregate
+    name: by_category
+    input: j
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn no_document_combine_path_byte_identical() {
+    // Two single-file no-envelope sources: each carries one file-level
+    // document, but those documents are disjoint and each closes once, so the
+    // join's records fold into a single per-driver-document aggregate. The
+    // driver's lone document closes once → one flush over all its records:
+    // x=3 (2 from the joined x rows + 1 more), y=1. This is the dominant
+    // single-document shape; the punctuation handling adds no extra rows.
+    let (body, dlq) = run_combine(
+        NO_DOCUMENT_YAML,
+        "driver",
+        &[("driver.csv", "category,k\nx,1\nx,1\nx,1\ny,1\n")],
+        "lookup",
+        ("lookup.csv", "k,label\n1,one\n"),
+    );
+    assert_eq!(dlq, 0);
+    assert_eq!(
+        body,
+        vec!["x,3".to_string(), "y,1".to_string()],
+        "a single-document Combine folds its one driver document into one \
+         aggregate (x=3, y=1), unchanged by the boundary handling"
+    );
+}

--- a/crates/clinker-exec/tests/streaming_arms.rs
+++ b/crates/clinker-exec/tests/streaming_arms.rs
@@ -844,8 +844,11 @@ nodes:
 /// A non-fused `Merge` (`concat` of two Transform outputs) whose sole
 /// downstream is a strict `Aggregate` streams the merged stream into the
 /// Aggregate's ingest. The Merge reports `buffer: streaming` and emits no
-/// `node_buffer` edge to the Aggregate, and the global total over both
-/// branches matches the materialized path.
+/// `node_buffer` edge to the Aggregate. Each branch carries its own
+/// single-file document, and the non-fused Merge forwards each document's
+/// close, so the streaming Aggregate buckets per document: a GLOBAL fold
+/// emits one row per source document, matching what feeding each branch to
+/// its own Aggregate would produce.
 #[test]
 fn nonfused_merge_streams_ingest_into_aggregate() {
     let yaml = r#"
@@ -935,13 +938,24 @@ nodes:
     let report =
         PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
             .expect("non-fused merge streams ingest into aggregate");
-    let lines = body_lines(&buf);
-    assert_eq!(lines.len(), 1, "global aggregate emits one row: {lines:?}");
-    // 10+20+30+40+50 = 150 over 5 records.
+    let mut lines = body_lines(&buf);
+    lines.sort();
+    // sa.csv (10+20+30) and sb.csv (40+50) are two distinct documents. The
+    // non-fused Merge forwards each branch's document close, so the streaming
+    // Aggregate buckets per document and the global fold emits one row per
+    // document: 60 over 3 records, 90 over 2.
+    assert_eq!(
+        lines.len(),
+        2,
+        "global fold emits one row per source document: {lines:?}"
+    );
     assert!(
-        lines[0].starts_with("150,5"),
-        "merged global aggregate diverged: {}",
-        lines[0]
+        lines.iter().any(|l| l.starts_with("60,3")),
+        "sa document's global fold diverged: {lines:?}"
+    );
+    assert!(
+        lines.iter().any(|l| l.starts_with("90,2")),
+        "sb document's global fold diverged: {lines:?}"
     );
     assert_eq!(report.counters.dlq_count, 0);
 }

--- a/crates/clinker-exec/tests/streaming_ingest_fixes.rs
+++ b/crates/clinker-exec/tests/streaming_ingest_fixes.rs
@@ -1,8 +1,8 @@
 //! Regression coverage for the streaming-ingest aggregate arm.
 //!
-//! These tests pin three behaviors of the bounded-channel ingest path a
-//! strict Aggregate takes when its producer is a fused, streaming-certified
-//! `Source → Transform`:
+//! These tests pin behaviors of the bounded-channel ingest path a strict
+//! Aggregate takes when its producer streams (a fused, streaming-certified
+//! `Source → Transform`, or a non-fused Merge):
 //!
 //! 1. An ingest error must not deadlock. The producer streams into a bounded
 //!    channel on the dispatch thread while a scoped thread drives
@@ -27,9 +27,17 @@
 //!    — and the force-open ensures such a close still emits its global-fold
 //!    defaulted row.)
 //!
-//! All tests assert (via the `--explain` `buffer: streaming` classification)
-//! that the fused producer actually drives the streaming-ingest path rather
-//! than the materialized drain.
+//! 3. Per-document bucketing under tail-batched closes. The streaming ingest
+//!    aggregate keys group state per `DocumentId`. When the producer is
+//!    non-fused (a concat Merge of distinct single-document sources), it
+//!    emits every record first and every `DocumentClose` afterward, so the
+//!    closes arrive tail-batched rather than in stream order. The bucket
+//!    model still flushes each document's groups on its own close, splitting
+//!    the documents rather than folding them into one cross-document result.
+//!
+//! The fused tests assert (via the `--explain` `buffer: streaming`
+//! classification) that the fused producer actually drives the
+//! streaming-ingest path rather than the materialized drain.
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -480,4 +488,194 @@ fn empty_input_grouped_aggregate_emits_nothing() {
         "an empty grouped aggregate emits no rows, got: {body:?}"
     );
     assert_eq!(ok, 0, "no rows for an empty grouped aggregate");
+}
+
+/// A `concat` Merge of two distinct single-document sources feeds a grouped
+/// Aggregate. A non-fused Merge is a certified streaming producer, so the
+/// Aggregate runs the streaming-ingest path — but the Merge tail-batches its
+/// forwarded `DocumentClose` punctuations after every record (records first,
+/// then both closes), so the closes do NOT arrive in stream order. The
+/// per-document bucket model must still flush each document's groups on its
+/// own close, splitting the two documents instead of folding them into one
+/// cross-document result.
+const NON_FUSED_MERGE_GROUPED_YAML: &str = r#"
+pipeline:
+  name: non_fused_streaming_buckets
+nodes:
+  - type: source
+    name: sa
+    config:
+      name: sa
+      type: csv
+      path: ./sa.csv
+      schema:
+        - { name: category, type: string }
+  - type: source
+    name: sb
+    config:
+      name: sb
+      type: csv
+      path: ./sb.csv
+      schema:
+        - { name: category, type: string }
+  - type: merge
+    name: m
+    inputs: [sa, sb]
+    config:
+      mode: concat
+  - type: aggregate
+    name: by_category
+    input: m
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn non_fused_streaming_multi_document_buckets_per_document() {
+    let config =
+        parse_config(NON_FUSED_MERGE_GROUPED_YAML).expect("parse non-fused-merge pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile non-fused-merge pipeline");
+
+    // doc A (sa): x×2, y×1. doc B (sb): x×3. The Merge forwards both
+    // documents' closes (open == close == 1 per document) but tail-batches
+    // them after every record. The streaming Aggregate buckets per document,
+    // so each close flushes only its own bucket: x=2,y=1 from doc A and a
+    // SEPARATE x=3 from doc B — NOT a folded x=5.
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([
+        (
+            "sa".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sa.csv",
+                Box::new(Cursor::new(b"category\nx\nx\ny\n".to_vec())),
+            ),
+        ),
+        (
+            "sb".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sb.csv",
+                Box::new(Cursor::new(b"category\nx\nx\nx\n".to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("run non-fused-merge pipeline");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "the streaming Aggregate must bucket per document under tail-batched \
+         closes (x=2,y=1 from doc A; x=3 from doc B), not fold to x=5"
+    );
+}
+
+/// A fused single no-envelope source into a global fold: every record
+/// carries the synthetic document id, so the bucket model keeps exactly one
+/// table (the sentinel) and finalizes it once at disconnect — byte-identical
+/// to the prior single-table flush for the dominant no-document case.
+const NO_DOCUMENT_GLOBAL_FOLD_YAML: &str = r#"
+pipeline:
+  name: streaming_no_document_global_fold
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: ./events.csv
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: passthrough
+    input: events
+    config:
+      cxl: |
+        emit amount = amount
+  - type: aggregate
+    name: total
+    input: passthrough
+    config:
+      group_by: []
+      cxl: |
+        emit total = sum(amount)
+        emit n = count(*)
+  - type: output
+    name: out
+    input: total
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn streaming_no_document_single_table_byte_identical() {
+    assert_streaming_ingest(
+        NO_DOCUMENT_GLOBAL_FOLD_YAML,
+        "transform.passthrough",
+        "aggregation.total",
+    );
+
+    // A single populated no-envelope source: every record buckets to the
+    // synthetic sentinel, so exactly one table is built and finalized once at
+    // disconnect — one global-fold row (total=12, n=3), byte-identical to the
+    // old single-table flush.
+    let config = parse_config(NO_DOCUMENT_GLOBAL_FOLD_YAML).expect("parse no-document pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile no-document pipeline");
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "events.csv",
+            Box::new(Cursor::new(b"amount\n3\n4\n5\n".to_vec())),
+        ),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .expect("run no-document global-fold pipeline");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    assert_eq!(
+        body,
+        vec!["12,3".to_string()],
+        "a no-document global fold buckets every record to the sentinel and \
+         emits exactly one row (total=12, n=3)"
+    );
+    assert_eq!(
+        report.counters.ok_count, 1,
+        "exactly one global-fold row for the single sentinel bucket"
+    );
 }

--- a/docs/src/cookbook/aggregation.md
+++ b/docs/src/cookbook/aggregation.md
@@ -110,17 +110,45 @@ Available aggregate functions in CXL:
 
 ### Per-document aggregation
 
-When the source is document-aware — a `glob:` / `paths:` source that
-treats each file as its own document, or an enveloped format like XML or
-EDI — the Aggregate produces **one set of grouped rows per document**
-rather than a single aggregate spanning every file. Each document's
-groups finalize and emit at that document's close boundary, so a glob
-over twelve monthly files yields twelve independent monthly roll-ups, and
-only one document's groups are live in memory at a time. A plain
-single-file source is one document and still emits a single aggregate.
+Per-document aggregation works after **any upstream that forwards
+document boundaries** — a document-aware source (a `glob:` / `paths:`
+source that treats each file as its own document, or an enveloped format
+like XML or EDI), a `Merge`, or a `Combine`. The Aggregate produces **one
+set of grouped rows per document** rather than a single aggregate
+spanning every file. Each document's groups finalize and emit at that
+document's close boundary, so a glob over twelve monthly files yields
+twelve independent monthly roll-ups. A plain single-file source is one
+document and still emits a single aggregate. This holds **whether the
+Aggregate's upstream streams or materializes** its output — both flush
+per document.
+
+A `Merge` of distinct single-document sources now forwards each source's
+per-document close, so each source flushes its own roll-up. And
+per-document aggregation also works **after a `Combine`** on any join
+strategy — for example a driver `glob:` source joined to a lookup table,
+then a group-by Aggregate, yields one roll-up per driver document:
+
+```yaml
+nodes:
+  - type: source            # driver: each monthly file is a document
+    name: orders
+    config: { name: orders, type: csv, glob: "./orders/*.csv", schema: [ ... ] }
+  - type: source            # small lookup table
+    name: products
+    config: { name: products, type: csv, path: "./products.csv", schema: [ ... ] }
+  - type: combine
+    name: enrich
+    input: { orders: orders, products: products }
+    config: { where: "orders.product_id == products.product_id", match: first, on_miss: skip, propagate_ck: driver, cxl: "..." }
+  - type: aggregate
+    name: monthly_totals    # one roll-up per driver document (per month)
+    input: enrich
+    config: { group_by: [category], cxl: "..." }
+```
+
 See [Envelopes & Document Context](../pipeline/envelope-and-doc-context.md#per-document-aggregation)
-for the boundary rules (including how a `Merge` of distinct sources folds
-them back into one aggregate).
+for the boundary rules (including the one fused-interleave Merge exception
+that still folds distinct sources together).
 
 ### Strategy selection
 

--- a/docs/src/cookbook/combine.md
+++ b/docs/src/cookbook/combine.md
@@ -305,3 +305,7 @@ With `drive: products`, the pipeline emits one row per product enriched with a m
 ## Memory considerations
 
 Build-side inputs are materialized in memory as hash tables keyed by the equi columns. For each non-driving input, plan for roughly 1.5-2x the raw CSV size in heap. A 50 MB product catalog typically uses 75-100 MB of hash-table memory. Tune with `--memory-limit`; see [Memory Tuning](../ops/memory.md) for spill thresholds and strategy overrides.
+
+## Document boundaries
+
+When the driver carries document boundaries -- a `glob:` source where each file is its own document -- the Combine forwards those boundaries to its output, so a per-document `Aggregate` after the join rolls up per driver document. See [Combine -- Document boundaries](../pipeline/combine.md#document-boundaries).

--- a/docs/src/pipeline/combine.md
+++ b/docs/src/pipeline/combine.md
@@ -253,6 +253,10 @@ Driver wins on a name collision: if both the driver and a build input declare `$
 
 Build-side inputs are materialized in memory as hash tables keyed by the equi columns. For each non-driving input, plan for roughly 1.5-2x the raw CSV size in heap. A 50 MB product catalog typically uses 75-100 MB of hash-table memory. Tune with `pipeline.memory.limit` at the pipeline level; see [Memory Tuning](../ops/memory.md) for spill thresholds, the backpressure knob, and strategy overrides.
 
+## Document boundaries
+
+A Combine forwards reconciled document boundaries to its output on **every** strategy -- the inline hash build-probe, IEJoin, grace-hash, sort-merge, and the streaming-probe path. So a per-document `Aggregate` downstream of a join flushes per document: a driver source that carries several documents (a `glob:` over monthly files, say) produces one roll-up per driver document after the join, not one fold spanning all of them. A document that spans both join inputs (the same document carried on the driver and the build side) opens and closes exactly once downstream -- the boundary is reconciled, never double-fired. See [Document Context & Envelopes](envelope-and-doc-context.md) for the per-document aggregation model.
+
 ## Complete example
 
 ```yaml

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -177,10 +177,14 @@ signals (one when a document opens, one when it closes). These signals
 let document-scoped operators fire at exactly the right point. Today the
 signals propagate through Source, Transform, Route, and Sort, and are
 reconciled at the multi-input operators — Merge and Combine. A document
-that fans in through several branches opens downstream once (on first
-sighting) and closes downstream once (only after every input has closed
-it), so a downstream document-scoped operator fires exactly once
-regardless of how many inputs the document spanned.
+opens downstream once (on first sighting) and closes downstream once —
+after **every input that opened the document has closed it** (its
+per-document close-count reaches its open-count). A document carried by
+one input closes after that input's single close; a document that
+genuinely spans several inputs closes only after the last of them, and
+emits one downstream close either way. So a downstream document-scoped
+operator fires exactly once regardless of how many inputs the document
+spanned.
 
 ### Per-document aggregation
 
@@ -196,12 +200,24 @@ others have already been emitted and freed, or have not yet started).
 This applies only when a document boundary actually reaches the
 Aggregate. A plain single-file source is one document, so it still emits
 one aggregate. A `Merge` that combines several distinct single-document
-sources does **not** forward a per-source close (it reconciles boundaries
-and emits a close only when *every* branch closed the same document), so
-those sources fold together into one cross-source aggregate — the same
-result you would get with no envelopes at all. To keep per-document
-roll-ups across files, feed the multi-file source straight into the
-Aggregate rather than merging distinct sources first.
+sources now forwards **each** source document's close (each document has
+open-count == close-count == 1 on its single branch), so those sources
+flush **independently** downstream — one roll-up per source document,
+exactly as feeding each source to its own Aggregate would. This holds for
+`mode: concat`, `mode: interleave` over non-Source inputs, and `mode:
+interleave` with an explicit `interleave_seed`. The roll-up split holds
+**regardless of whether the Aggregate's upstream streams or materializes**
+its output — both paths flush per document.
+
+The **one** exception is the fused all-Source `mode: interleave` fast
+path **without** a seed: it consumes punctuations inline and forwards no
+per-source close, so distinct single-document sources merged that way
+fold into one cross-source aggregate (the same result you would get with
+no envelopes at all). This is a known limitation; add an
+`interleave_seed` (or use `mode: concat`) to get per-document roll-ups. A
+`Combine` (join) carries reconciled boundaries on every strategy, so a
+per-document Aggregate downstream of a join also rolls up per driver
+document.
 
 ## Nested (multi-level) envelopes
 
@@ -243,8 +259,9 @@ keeps every level independently visible.
 Boundaries nest correctly through the pipeline: each level opens before
 the records inside it and closes after them, in strict innermost-first
 order. A level that fans in through several branches is still reconciled
-once at a multi-input operator (Merge or Combine), exactly like a
-single-level document.
+once at a multi-input operator (Merge or Combine) — it opens downstream on
+first sighting and closes downstream once every input that opened it has
+closed it — exactly like a single-level document.
 
 ## Header-only interchanges
 


### PR DESCRIPTION
A per-document `Aggregate` placed after a `Combine` (join) previously produced a single cross-document result with no error. This change makes per-document aggregation work behind any join, on any strategy, fixing three linked causes.

## 1. Boundary reconciliation closes a document on input coverage

A multi-input operator (`Merge`, `Combine`) forwarded a document's close only once *every* input had closed it. But a join's two sides usually carry *different* documents (the driver carries the main stream; the build side is a lookup), so a document present on one side never reached the threshold and its close was silently withheld — and a downstream per-document `Aggregate` never flushed per document.

The shared reconciler now forwards a document's close once every input that **opened** that document has closed it (per-document close-count reaches open-count): a document on one input closes after its single close; a document genuinely spanning both inputs closes exactly once (no double-fire). This also corrects a `Merge` of distinct document sources, which previously swallowed their per-source closes.

## 2. Combine forwards boundaries on every strategy

The inline hash-build-probe arm and the streaming-probe arm dropped *all* document boundaries (they admitted an empty set). They now forward the reconciled boundaries like the sort-merge / range / grace-hash arms, collecting the streamed driver's boundaries off the channel.

## 3. The streaming and materialized per-document aggregates are unified

The streaming aggregate ingested with a single running table that flushed on the first boundary it saw — but streaming producers deliver all records, then all boundaries at the tail, so multiple documents folded together. The streaming path now drives the **same per-document bucket engine the materialized path uses** (bucket each record by its document, flush a bucket at its close), which is correct whether boundaries arrive interleaved (one table live at a time, preserving the streaming memory profile) or batched at the tail. The separate single-table aggregator type is deleted — the two per-document code paths are now one.

## Tests

New per-strategy coverage in `combine_per_document_flush.rs` (per-document split after inline / IEJoin / sort-merge / grace-hash / streaming-probe Combine; spanning-document one-open-one-close; driver-only forwards its close; no-document byte-identical), a non-fused streaming multi-document gate, an interleaved-ordering unit test that pins the reconciler's two-pass tally, and inverted assertions on the three tests that previously baked in the fold. Existing per-document and streaming-ingest suites stay green. Full local gauntlet green (fmt, clippy `--workspace` and `--all-targets`, `test --workspace`, bench checks, `test --benches`, `cargo deny`).

## Docs

`docs/src/pipeline/envelope-and-doc-context.md` (coverage-based reconciliation + streaming/materialized guarantee), `docs/src/pipeline/combine.md` and `docs/src/cookbook/{combine,aggregation}.md`.

## Follow-up

#424 (a pre-existing arbitrator-consumer leak if aggregate-stream construction fails — out of scope here, filed for tracking).

Closes #416. Closes #417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)