### PR TITLE
engine: forward document boundaries through the fused interleave Merge (#191)

### DIFF
--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -2204,12 +2204,23 @@ pub(crate) fn merge_fused_interleave(
     let deduped_puncts =
         crate::executor::stream_event::reconcile_document_boundaries(collected_puncts);
     if streaming.is_some() {
-        if !deduped_puncts.is_empty() {
-            let mut batch =
-                crate::executor::batch_handoff::EventBatch::with_capacity(deduped_puncts.len());
-            for p in deduped_puncts {
-                batch.push_punctuation(p);
+        // Emit the reconciled boundaries through the same bounded channel,
+        // chunked at `batch_size` exactly like the record stream above and
+        // the non-fused arm's `stream_linear_producer_emit`, so a run
+        // spanning very many documents never builds one unbounded tail
+        // batch. The sender then drops with this frame, disconnecting the
+        // writer thread's `recv` loop and triggering its flush.
+        let mut batch = crate::executor::batch_handoff::EventBatch::with_capacity(batch_size);
+        for p in deduped_puncts {
+            batch.push_punctuation(p);
+            if batch.len() >= batch_size {
+                flush_stream_batch(std::mem::replace(
+                    &mut batch,
+                    crate::executor::batch_handoff::EventBatch::with_capacity(batch_size),
+                ))?;
             }
+        }
+        if !batch.is_empty() {
             flush_stream_batch(batch)?;
         }
         return Ok(FusedMergeOutput {

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1861,6 +1861,30 @@ pub(crate) fn finalize_node_rooted_windows(
     Ok(())
 }
 
+/// Streaming handoff bundle for the fused `Merge.interleave` arm: the
+/// bounded-channel sender to the writer thread, the slot's per-batch
+/// charge handle, and the flush batch size. Present only when a single
+/// streaming-eligible Output downstream of the Merge installed its sender;
+/// absent on the materialized path (the arm accumulates a full `merged`
+/// Vec instead). Bundled into one struct so the arm's signature stays
+/// under the argument-count lint.
+pub(crate) struct MergeStreamHandoff<'a> {
+    pub(crate) sender: crossbeam_channel::Sender<crate::executor::stream_event::StreamEvent>,
+    pub(crate) charge: &'a crate::executor::batch_handoff::StreamingChargeHandle,
+    pub(crate) batch_size: usize,
+}
+
+/// Materialized result of the fused `Merge.interleave` arm: the merged
+/// records on the Merge's output schema and the document boundaries the
+/// arm reconciled across its Source inputs. Both empty on the streaming
+/// path (records and boundaries went out the bounded channel instead);
+/// on the materialized path the caller admits both into the node buffer,
+/// boundaries trailing the records.
+pub(crate) struct FusedMergeOutput {
+    pub(crate) records: Vec<(Record, u64)>,
+    pub(crate) puncts: Vec<crate::executor::stream_event::Punctuation>,
+}
+
 /// Drive the fused `Merge.mode: interleave` arm when every direct
 /// predecessor is a `PlanNode::Source` whose receiver is parked in
 /// `ctx.source_records`. Takes ownership of each predecessor's
@@ -1887,29 +1911,32 @@ pub(crate) fn finalize_node_rooted_windows(
 /// crossbeam's randomized ready-pick matches; no snapshot/baseline test
 /// asserts a specific order on this path.
 ///
-/// `streaming_sender` is `Some` iff the executor matched a fused
+/// Document-boundary punctuations arriving on the per-Source channels are
+/// collected as records stream through, then reconciled once at close via
+/// [`crate::executor::stream_event::reconcile_document_boundaries`] — the
+/// same cross-input fold the non-fused Merge arm runs: one `DocumentOpen`
+/// per document on first sighting, one `DocumentClose` once every input
+/// that opened a document has closed it. A fused Merge's predecessors are
+/// all Sources with independently minted `DocumentId`s, so in practice
+/// each document is carried by one input and the fold is a pass-through
+/// dedup; running it anyway keeps the fused and non-fused arms on one
+/// boundary contract. The reconciled boundaries trail the records,
+/// matching the non-fused arm's tail emission — a downstream
+/// document-scoped operator (per-document Aggregate flush, Output
+/// finalize) then observes each boundary exactly once.
+///
+/// `streaming` is `Some` iff the executor matched a fused
 /// `Merge.interleave → single Output` chain against the streaming
 /// eligibility predicate (issue #72). In streaming mode this function
 /// pushes each canonicalized record through the bounded channel instead
 /// of accumulating into a Vec, applies live back-pressure end-to-end
 /// (writer slow → Merge `send` blocks → Sources' channels fill →
-/// ingest threads block), and returns an empty Vec at close. In
-/// non-streaming mode (`None`) it returns the accumulated
-/// `Vec<(Record, u64)>` that the Merge arm then teed into
-/// `node_buffers` for downstream consumers.
-/// Streaming handoff bundle for the fused `Merge.interleave` arm: the
-/// bounded-channel sender to the writer thread, the slot's per-batch
-/// charge handle, and the flush batch size. Present only when a single
-/// streaming-eligible Output downstream of the Merge installed its sender;
-/// absent on the materialized path (the arm accumulates a full `merged`
-/// Vec instead). Bundled into one struct so the arm's signature stays
-/// under the argument-count lint.
-pub(crate) struct MergeStreamHandoff<'a> {
-    pub(crate) sender: crossbeam_channel::Sender<crate::executor::stream_event::StreamEvent>,
-    pub(crate) charge: &'a crate::executor::batch_handoff::StreamingChargeHandle,
-    pub(crate) batch_size: usize,
-}
-
+/// ingest threads block), emits the reconciled boundaries through the
+/// same channel at the tail, and returns an empty [`FusedMergeOutput`]
+/// at close. In materialized mode (`None`) the returned
+/// [`FusedMergeOutput`] carries the accumulated records and the
+/// reconciled boundaries, which the Merge arm admits into `node_buffers`
+/// for downstream consumers.
 pub(crate) fn merge_fused_interleave(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
@@ -1917,7 +1944,7 @@ pub(crate) fn merge_fused_interleave(
     sorted_preds: &[NodeIndex],
     merge_output_schema: Option<&Arc<Schema>>,
     streaming: Option<MergeStreamHandoff<'_>>,
-) -> Result<Vec<(Record, u64)>, PipelineError> {
+) -> Result<FusedMergeOutput, PipelineError> {
     // Per-predecessor state: the source's plan-time schema, its
     // engine-stamped tail mapping, its `Arc<str>` name (used for
     // the per-source running counter and the
@@ -1973,6 +2000,11 @@ pub(crate) fn merge_fused_interleave(
     let merge_schema_arc = merge_output_schema.cloned();
     let has_record_seed = !ctx.record_var_seed.is_empty();
     let mut merged: Vec<(Record, u64)> = Vec::new();
+    // Document-boundary punctuations arriving on the Source channels collect
+    // here and reconcile once at close, mirroring the non-fused Merge arm's
+    // collect-then-dedup pass. Punctuations are O(1) per document, so this
+    // stays tiny next to the record stream.
+    let mut collected_puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
     // Streaming-mode batch accumulator: records collect into one
     // `EventBatch` and flush through the slot's charge handle once the
     // batch fills, so the fused Merge participates in per-batch arbitrator
@@ -2070,16 +2102,15 @@ pub(crate) fn merge_fused_interleave(
                     .expect("select op_index maps to an active receiver"),
             )
             .ok();
-        // Fused merge path: punctuations from the per-Source live
-        // channels are currently consumed here. Forwarding them
-        // through the streaming-output channel with multi-input dedup
-        // (Merge-style barrier counter) requires per-source state on
-        // this select loop and lands as a follow-up — file under #91
-        // backlog. The non-fused Merge arm already deduplicates
-        // punctuations via the `all_puncts` collect-then-dedup pass.
+        // A document-boundary punctuation off a Source channel is collected
+        // for the close-time reconcile rather than forwarded inline; only
+        // records flow into the per-record pipeline below.
         let item: Option<(Record, u64)> = match item {
             Some(crate::executor::stream_event::StreamEvent::Record(r, rn)) => Some((r, rn)),
-            Some(crate::executor::stream_event::StreamEvent::Punctuation(_)) => continue,
+            Some(crate::executor::stream_event::StreamEvent::Punctuation(p)) => {
+                collected_puncts.push(p);
+                continue;
+            }
             None => None,
         };
         match item {
@@ -2100,8 +2131,13 @@ pub(crate) fn merge_fused_interleave(
                 }
                 per_source_counts[i] += 1;
                 // Re-canonicalize onto the Merge's output schema so
-                // downstream operators hit `Arc::ptr_eq` regardless
-                // of which Source produced the record.
+                // downstream operators hit `Arc::ptr_eq` regardless of which
+                // Source produced the record. The rebuild carries the
+                // record's document context across, so a downstream
+                // per-document operator still buckets each row by the
+                // document its Source opened — otherwise the rebuilt row
+                // would carry the synthetic sentinel id and every document's
+                // `DocumentClose` would flush an empty bucket.
                 if let Some(merge_schema) = merge_schema_arc.as_ref() {
                     check_input_schema(
                         merge_schema,
@@ -2110,8 +2146,10 @@ pub(crate) fn merge_fused_interleave(
                         "merge",
                         &state.source_name_string,
                     )?;
+                    let doc_ctx = Arc::clone(rec.doc_ctx());
                     let values = rec.values().to_vec();
                     rec = Record::new(Arc::clone(merge_schema), values);
+                    rec.set_doc_ctx(doc_ctx);
                 }
                 match stream_batch.as_mut() {
                     // Streaming: accumulate into the current batch and flush
@@ -2147,16 +2185,43 @@ pub(crate) fn merge_fused_interleave(
         }
     }
 
-    // Flush the trailing partial batch (streaming mode only). The
-    // streaming sender then drops with this function's frame, disconnecting
-    // the writer thread's `recv` loop and triggering its flush.
+    // Flush the trailing partial record batch (streaming mode only) before
+    // the boundary punctuations, so the reconciled closes trail every record.
     if let Some(batch) = stream_batch.take()
         && !batch.is_empty()
     {
         flush_stream_batch(batch)?;
     }
 
-    Ok(merged)
+    // Reconcile the collected boundaries down to one open + one close per
+    // document (the non-fused Merge arm's cross-input fold). In streaming
+    // mode emit them through the same bounded channel at the tail and
+    // return an empty result; the sender then drops with this frame,
+    // disconnecting the writer thread's `recv` loop and triggering its
+    // flush. In materialized mode hand the records and the reconciled
+    // boundaries back to the Merge arm, which admits both into the node
+    // buffer.
+    let deduped_puncts =
+        crate::executor::stream_event::reconcile_document_boundaries(collected_puncts);
+    if streaming.is_some() {
+        if !deduped_puncts.is_empty() {
+            let mut batch =
+                crate::executor::batch_handoff::EventBatch::with_capacity(deduped_puncts.len());
+            for p in deduped_puncts {
+                batch.push_punctuation(p);
+            }
+            flush_stream_batch(batch)?;
+        }
+        return Ok(FusedMergeOutput {
+            records: Vec::new(),
+            puncts: Vec::new(),
+        });
+    }
+
+    Ok(FusedMergeOutput {
+        records: merged,
+        puncts: deduped_puncts,
+    })
 }
 
 /// Drive a `PlanNode::Transform` whose sole upstream is a

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -150,10 +150,10 @@ pub(crate) fn dispatch_merge(
     let mut nonfused_sender: Option<
         crossbeam_channel::Sender<crate::executor::stream_event::StreamEvent>,
     > = None;
-    let (merged, fused_deduped_puncts): (
-        Vec<(Record, u64)>,
-        Vec<crate::executor::stream_event::Punctuation>,
-    ) = if fused_mode {
+    let FusedMergeOutput {
+        records: merged,
+        puncts: fused_deduped_puncts,
+    } = if fused_mode {
         let handoff = match (streaming_sender, merge_charge.as_ref()) {
             (Some(sender), Some(charge)) => Some(MergeStreamHandoff {
                 sender,
@@ -162,15 +162,14 @@ pub(crate) fn dispatch_merge(
             }),
             _ => None,
         };
-        let FusedMergeOutput { records, puncts } = merge_fused_interleave(
+        merge_fused_interleave(
             ctx,
             current_dag,
             name,
             &sorted_preds,
             merge_output_schema.as_ref(),
             handoff,
-        )?;
-        (records, puncts)
+        )?
     } else {
         nonfused_sender = streaming_sender;
         let total: usize = sorted_preds
@@ -279,7 +278,10 @@ pub(crate) fn dispatch_merge(
                 }
             }
         }
-        (merged, Vec::new())
+        FusedMergeOutput {
+            records: merged,
+            puncts: Vec::new(),
+        }
     };
 
     // Reconcile boundaries across every Merge input: one `DocumentOpen`

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -15,9 +15,9 @@ use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
-    ExecutorContext, MergeStreamHandoff, admit_node_buffer, drain_node_buffer_slot,
-    finalize_node_rooted_windows, merge_fused_interleave, node_buffer_spill_allowed,
-    stream_linear_producer_emit, tee_emit_to_region_input_buffers,
+    ExecutorContext, FusedMergeOutput, MergeStreamHandoff, admit_node_buffer,
+    drain_node_buffer_slot, finalize_node_rooted_windows, merge_fused_interleave,
+    node_buffer_spill_allowed, stream_linear_producer_emit, tee_emit_to_region_input_buffers,
 };
 use crate::executor::schema_check::check_input_schema;
 use clinker_plan::error::PipelineError;
@@ -116,13 +116,12 @@ pub(crate) fn dispatch_merge(
             _ => false,
         });
 
-    // Punctuation collection state hoisted above the if-else so
-    // the dedup pass below the merge body can read it. The
-    // fused-mode merge_fused_interleave path does not yet
-    // forward punctuations (a follow-up will route them
-    // through merge_fused_interleave's recv loop); the else
-    // branch's drain logic fills `all_puncts` from each input
-    // NodeBuffer.
+    // Raw document-boundary punctuations drained from each non-fused input
+    // NodeBuffer; the cross-input fold below the merge body reconciles them.
+    // The fused path's inputs are live Source channels rather than
+    // NodeBuffers, so it collects and reconciles its own boundaries inside
+    // `merge_fused_interleave`, leaves `all_puncts` empty, and returns the
+    // already-reconciled set.
     let mut all_puncts: Vec<crate::executor::stream_event::Punctuation> = Vec::new();
 
     // Streaming-Output handoff: if a single Output downstream of
@@ -151,7 +150,10 @@ pub(crate) fn dispatch_merge(
     let mut nonfused_sender: Option<
         crossbeam_channel::Sender<crate::executor::stream_event::StreamEvent>,
     > = None;
-    let merged: Vec<(Record, u64)> = if fused_mode {
+    let (merged, fused_deduped_puncts): (
+        Vec<(Record, u64)>,
+        Vec<crate::executor::stream_event::Punctuation>,
+    ) = if fused_mode {
         let handoff = match (streaming_sender, merge_charge.as_ref()) {
             (Some(sender), Some(charge)) => Some(MergeStreamHandoff {
                 sender,
@@ -160,14 +162,15 @@ pub(crate) fn dispatch_merge(
             }),
             _ => None,
         };
-        merge_fused_interleave(
+        let FusedMergeOutput { records, puncts } = merge_fused_interleave(
             ctx,
             current_dag,
             name,
             &sorted_preds,
             merge_output_schema.as_ref(),
             handoff,
-        )?
+        )?;
+        (records, puncts)
     } else {
         nonfused_sender = streaming_sender;
         let total: usize = sorted_preds
@@ -276,7 +279,7 @@ pub(crate) fn dispatch_merge(
                 }
             }
         }
-        merged
+        (merged, Vec::new())
     };
 
     // Reconcile boundaries across every Merge input: one `DocumentOpen`
@@ -284,8 +287,14 @@ pub(crate) fn dispatch_merge(
     // every input that opened a document has closed it. A document
     // carried by a single input branch forwards its close after that
     // branch's close, so a Merge of distinct single-document sources
-    // lets each document flush independently downstream.
-    let deduped_puncts = crate::executor::stream_event::reconcile_document_boundaries(all_puncts);
+    // lets each document flush independently downstream. The fused arm
+    // already ran this fold inside `merge_fused_interleave`, so reuse its
+    // reconciled set; the non-fused arm folds the raw `all_puncts` here.
+    let deduped_puncts = if fused_mode {
+        fused_deduped_puncts
+    } else {
+        crate::executor::stream_event::reconcile_document_boundaries(all_puncts)
+    };
 
     // Non-fused streaming path: the predecessors' slots are
     // already drained into the full `merged` Vec, so this does not

--- a/crates/clinker-exec/tests/aggregate_per_document_flush.rs
+++ b/crates/clinker-exec/tests/aggregate_per_document_flush.rs
@@ -11,11 +11,27 @@
 //! no-document / single-document control proves the dominant path is
 //! unchanged, a tiny memory budget exercises the spilling strategy across
 //! a document boundary, the streaming-ingest path is covered via a fused
-//! producer, and `concat` / seeded-`interleave` Merges of two
-//! single-document sources prove a non-fused Merge forwards each source's
-//! per-document close, so each source document flushes independently
-//! downstream — even when a seeded interleave delivers their records
-//! non-contiguously.
+//! producer, and `concat` / seeded-`interleave` / unseeded-`interleave`
+//! Merges of two single-document sources prove every Merge mode forwards
+//! each source's per-document close, so each source document flushes
+//! independently downstream, even when a seeded interleave delivers their
+//! records non-contiguously.
+//!
+//! The unseeded interleave is the FUSED all-Source path: with no
+//! `interleave_seed`, the Merge takes ownership of its Source receivers and
+//! runs a `crossbeam_channel::Select` over them, whereas the seeded sibling
+//! stays non-fused so its deterministic schedule survives over a
+//! pre-buffered Vec. The fused arm collects the per-Source document
+//! boundaries off the live channels and reconciles them at close, the same
+//! cross-input fold the non-fused arm runs over pre-buffered input
+//! punctuations, so a fused Merge forwards per-document closes too.
+//!
+//! No streaming fused `Merge.interleave -> single Output` boundary test
+//! lives here: an Output consumes document punctuations at finalize and
+//! never writes them into the CSV body, so a fused-streaming boundary is
+//! not observable in the writer's output. The materialized fused case
+//! below (an Aggregate downstream of the Merge) is where forwarding the
+//! boundary changes observable output, so that is the regression guard.
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -558,5 +574,137 @@ nodes:
         "a seeded interleave is non-fused, so it forwards each source's \
          per-document close → per-document flush (x=3 from sa; x=2,y=1 from \
          sb), regardless of round-robin arrival order",
+    );
+}
+
+/// An UNSEEDED `interleave` Merge of two distinct-document Sources takes the
+/// fused all-Source path: the Merge owns the Source receivers and runs a
+/// `crossbeam_channel::Select` over the live channels rather than draining
+/// pre-buffered input slots. The fused arm collects each Source's document
+/// boundaries off its channel and reconciles them at close — the same
+/// cross-input fold the non-fused arm runs — then admits the reconciled
+/// closes into its node buffer trailing the records, so the downstream
+/// per-document Aggregate flushes each Source's document independently.
+///
+/// This is the regression guard for the fused path. With boundaries dropped
+/// on the fused arm (the historical behavior), no `DocumentClose` reaches
+/// the Aggregate until end-of-input, so it folds both documents into a
+/// single `x,5` + `y,1`. Forwarding the reconciled boundaries splits the
+/// fold per document: `x,3` from sa's document and `x,2` + `y,1` from sb's.
+/// The split is impossible without forwarding, so the body assertion alone
+/// pins the fix; the explicit fused-path assertion below removes any doubt
+/// that the run actually took the fused arm rather than an accidental
+/// non-fused one.
+#[test]
+fn fused_interleave_merge_forwards_per_source_document_close() {
+    let yaml = r#"
+pipeline:
+  name: fused_interleave_merge_agg
+nodes:
+  - type: source
+    name: sa
+    config:
+      name: sa
+      type: csv
+      path: ./sa.csv
+      schema:
+        - { name: category, type: string }
+  - type: source
+    name: sb
+    config:
+      name: sb
+      type: csv
+      path: ./sb.csv
+      schema:
+        - { name: category, type: string }
+  - type: merge
+    name: m
+    inputs: [sa, sb]
+    config:
+      mode: interleave
+  - type: aggregate
+    name: by_category
+    input: m
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+    let config = parse_config(yaml).expect("parse fused-interleave-merge pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile fused-interleave-merge pipeline");
+
+    // Prove this run takes the fused all-Source interleave arm: an unseeded
+    // interleave Merge whose every predecessor is a Source claims both
+    // Source receivers, so both names land in the fused set. The seeded
+    // sibling test, by contrast, has `interleave_seed` set and so produces
+    // an empty fused set. This is the same predicate the dispatcher consults
+    // at executor entry, so it can never drift from the runtime decision.
+    let (dag, _) =
+        clinker_exec::executor::PipelineExecutor::explain_plan_dag(&plan).expect("explain dag");
+    let fused =
+        clinker_plan::plan::execution::compute_merge_interleave_fused_sources(&dag, plan.config());
+    assert!(
+        fused.contains("sa") && fused.contains("sb"),
+        "an unseeded all-Source interleave Merge must fuse both Sources \
+         (so the fused merge_fused_interleave arm runs), got fused set: {fused:?}",
+    );
+
+    // sa: x×3 (one document); sb: x×2, y×1 (another document). The fused
+    // Merge reconciles each Source's per-document close and forwards it, so
+    // the Aggregate flushes per document: x=3 from sa's document, and x=2,
+    // y=1 from sb's document — never a folded x=5.
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([
+        (
+            "sa".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sa.csv",
+                Box::new(Cursor::new(b"category\nx\nx\nx\n".to_vec())),
+            ),
+        ),
+        (
+            "sb".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "sb.csv",
+                Box::new(Cursor::new(b"category\nx\nx\ny\n".to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run fused-interleave-merge pipeline");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    assert_eq!(
+        body,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "the fused interleave Merge forwards each Source's per-document close, \
+         so the Aggregate flushes per document (x=3 from sa; x=2,y=1 from sb), \
+         not a folded x=5",
     );
 }

--- a/docs/src/cookbook/aggregation.md
+++ b/docs/src/cookbook/aggregation.md
@@ -122,9 +122,11 @@ document and still emits a single aggregate. This holds **whether the
 Aggregate's upstream streams or materializes** its output — both flush
 per document.
 
-A `Merge` of distinct single-document sources now forwards each source's
-per-document close, so each source flushes its own roll-up. And
-per-document aggregation also works **after a `Combine`** on any join
+A `Merge` of distinct single-document sources forwards each source's
+per-document close on **every** mode — `concat`, seeded `interleave`, and
+the fused unseeded all-Source `interleave` fast path — so each source
+flushes its own roll-up. And per-document aggregation also works **after a
+`Combine`** on any join
 strategy — for example a driver `glob:` source joined to a lookup table,
 then a group-by Aggregate, yields one roll-up per driver document:
 
@@ -147,8 +149,7 @@ nodes:
 ```
 
 See [Envelopes & Document Context](../pipeline/envelope-and-doc-context.md#per-document-aggregation)
-for the boundary rules (including the one fused-interleave Merge exception
-that still folds distinct sources together).
+for the boundary rules across every `Merge` mode and `Combine` strategy.
 
 ### Strategy selection
 

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -204,18 +204,13 @@ sources now forwards **each** source document's close (each document has
 open-count == close-count == 1 on its single branch), so those sources
 flush **independently** downstream — one roll-up per source document,
 exactly as feeding each source to its own Aggregate would. This holds for
-`mode: concat`, `mode: interleave` over non-Source inputs, and `mode:
-interleave` with an explicit `interleave_seed`. The roll-up split holds
-**regardless of whether the Aggregate's upstream streams or materializes**
-its output — both paths flush per document.
+**every** `Merge` mode: `mode: concat`, `mode: interleave` over
+non-Source inputs, `mode: interleave` with an explicit `interleave_seed`,
+and the fused all-Source `mode: interleave` fast path with no seed. The
+roll-up split holds **regardless of whether the Aggregate's upstream
+streams or materializes** its output — both paths flush per document.
 
-The **one** exception is the fused all-Source `mode: interleave` fast
-path **without** a seed: it consumes punctuations inline and forwards no
-per-source close, so distinct single-document sources merged that way
-fold into one cross-source aggregate (the same result you would get with
-no envelopes at all). This is a known limitation; add an
-`interleave_seed` (or use `mode: concat`) to get per-document roll-ups. A
-`Combine` (join) carries reconciled boundaries on every strategy, so a
+A `Combine` (join) carries reconciled boundaries on every strategy, so a
 per-document Aggregate downstream of a join also rolls up per driver
 document.
 


### PR DESCRIPTION
## Summary

Document-aware sources emit inline document-boundary signals (a marker when a document opens and another when it closes) alongside body records. Downstream operators forward these so document-scoped logic — per-document aggregation flush, per-document output finalization — fires at the right point.

Every operator path forwarded these signals **except** the fused all-Source `Merge.mode: interleave` fast path (the one taken when an unseeded `interleave` Merge's predecessors are all sources, so the Merge owns their channels and runs a `Select` over them). That path consumed the boundaries without forwarding them, so a per-document Aggregate behind such a Merge never saw a document close until end-of-input and folded every source's documents into a single cross-document roll-up.

This change threads the boundaries through that path:

- The fused select loop now collects each source's boundary punctuations off its live channel and reconciles them once at close — the same cross-input fold (`reconcile_document_boundaries`) the non-fused Merge modes already use: one open per document on first sighting, one close once every input that opened a document has closed it.
- The reconciled boundaries trail the records, matching the other Merge modes' tail emission — in streaming mode they go out the bounded channel (chunked at the batch size, so a run spanning very many documents never builds one unbounded tail batch); in the materialized mode they ride in the node buffer the downstream operator drains.

It also fixes a latent bug this forwarding exposed: when the fused arm re-canonicalizes a record onto the Merge's output schema, the rebuild reset the record's document context to the synthetic sentinel. With boundaries now forwarded, every row would have bucketed under the sentinel id and each close would have flushed an empty bucket. The rebuild now carries the document context across, exactly as the non-fused arm already did.

## Behavior change

A `Merge` of distinct single-document sources now forwards each source's per-document close on **every** mode — `concat`, seeded `interleave`, and the fused unseeded all-Source `interleave` fast path — so each source flushes its own roll-up downstream. Previously the fused fast path was an exception that folded distinct sources together.

## Tests

Adds `fused_interleave_merge_forwards_per_source_document_close`: two single-document sources → an unseeded `interleave` Merge → a group-by Aggregate. It asserts the run actually takes the fused arm (via the same predicate the executor consults) and that the Aggregate flushes per document (`x=3` from one source; `x=2`, `y=1` from the other) rather than the folded `x=5` the old behavior produced. The existing `concat` and seeded-`interleave` per-document tests continue to pass.

## Docs

Updates the envelope/document-context and aggregation cookbook pages to drop the now-removed fused-interleave exception and state that every Merge mode forwards per-document boundaries.

Closes #191.