### PR TITLE
cxl: nested unset(path) map method for arbitrary-depth deletion (#409)

### DIFF
--- a/crates/clinker-exec/tests/intra_record_closures.rs
+++ b/crates/clinker-exec/tests/intra_record_closures.rs
@@ -370,10 +370,13 @@ nodes:
 }
 
 /// Map builtins running inside a closure: `.keys()`, `.values()`,
-/// `.set()`, `.remove_field()`. The closure binding `it` is each
-/// element of the items array (a `Value::Map`); the builtins return
-/// new `Value::Map`/`Value::Array` per element, surfaced through the
-/// outer `.map` that wraps them.
+/// `.set()`, `.remove_field()`, and the nested-path `.unset()`. The
+/// closure binding `it` is each element of the items array (a
+/// `Value::Map`); the builtins return new `Value::Map`/`Value::Array`
+/// per element, surfaced through the outer `.map` that wraps them. The
+/// `.unset("meta.flag")` case proves the nested-path deletion parses,
+/// typechecks, compiles, and evaluates through a real pipeline — not
+/// just in the `cxl`-crate eval unit tests.
 #[test]
 fn ndjson_map_builtins_run_inside_array_closures() {
     let yaml = r#"
@@ -401,6 +404,7 @@ nodes:
         emit value_sets = items.map(it => it.values())
         emit enriched = items.map(it => it.set("region", "us-east"))
         emit slim = items.map(it => it.remove_field("internal_id"))
+        emit pruned = items.map(it => it.unset("meta.flag"))
   - type: output
     name: out
     input: derive
@@ -413,7 +417,7 @@ nodes:
       include_unmapped: false
       exclude: [items]
 "#;
-    let payload = br#"{"items":[{"sku":"a","price":10,"internal_id":"ix-1"},{"sku":"b","price":20,"internal_id":"ix-2"}]}
+    let payload = br#"{"items":[{"sku":"a","price":10,"internal_id":"ix-1","meta":{"flag":true,"keep":1}},{"sku":"b","price":20,"internal_id":"ix-2","meta":{"flag":true,"keep":1}}]}
 "#;
     let (_report, output) = run_with_payload(yaml, "rows.ndjson", payload);
     let line = output.lines().next().expect("at least one record");
@@ -457,6 +461,24 @@ nodes:
     assert!(
         first_slim.contains_key("sku"),
         ".remove_field preserved sku"
+    );
+    let pruned = parsed
+        .get("pruned")
+        .and_then(|v| v.as_array())
+        .expect("pruned array");
+    let first_meta = pruned[0]
+        .as_object()
+        .expect("pruned[0] is object")
+        .get("meta")
+        .and_then(|v| v.as_object())
+        .expect("pruned[0].meta is object");
+    assert!(
+        !first_meta.contains_key("flag"),
+        ".unset dropped the nested meta.flag end-to-end: {parsed}"
+    );
+    assert!(
+        first_meta.contains_key("keep"),
+        ".unset preserved the sibling meta.keep"
     );
 }
 

--- a/crates/cxl/src/builtins.rs
+++ b/crates/cxl/src/builtins.rs
@@ -399,6 +399,18 @@ impl BuiltinRegistry {
                 category: Category::Array,
             },
         );
+        methods.insert(
+            "unset",
+            BuiltinDef {
+                name: "unset",
+                receiver: TypeTag::Map,
+                args: vec![TypeTag::String],
+                min_args: 1,
+                max_args: Some(1),
+                return_type: TypeTag::Map,
+                category: Category::Array,
+            },
+        );
 
         // ── Conversion strict (6) ──
         let cs = |name: &'static str,

--- a/crates/cxl/src/eval/builtins_impl.rs
+++ b/crates/cxl/src/eval/builtins_impl.rs
@@ -867,7 +867,12 @@ fn map_unset_path(m: &indexmap::IndexMap<Box<str>, Value>, key: &str) -> Value {
 /// `.unset` is a no-op.
 fn unset_in(target: &mut Value, segs: &[PathSeg<'_>]) -> bool {
     let Some((head, rest)) = segs.split_first() else {
-        // An empty path addresses no leaf to delete.
+        // Unreachable in practice: `parse_set_path` always yields at least one
+        // segment, and the recursion below only descends with a non-empty
+        // `rest`, so `unset_in` never sees an empty path. Kept as a defensive
+        // no-op (no leaf to delete → receiver unchanged) rather than a panic.
+        // Deletion acts on the parent container, so — unlike `set_in` — there
+        // is no recurse-into-empty-base write step that would make this live.
         return false;
     };
     match (head, target) {

--- a/crates/cxl/src/eval/builtins_impl.rs
+++ b/crates/cxl/src/eval/builtins_impl.rs
@@ -681,6 +681,16 @@ pub fn dispatch_method(
             }
             _ => Value::Null,
         })),
+        "unset" => Ok(Some(match (receiver, args.first()) {
+            (Value::Map(m), Some(Value::String(key))) => {
+                // A bare key (no `.` / `[n]`) drops a top-level entry, mirroring
+                // `remove_field`. A dotted/indexed path descends to the addressed
+                // leaf and deletes it; see `map_unset_path` for the
+                // shift-on-array-remove and missing-path-is-a-no-op rules.
+                map_unset_path(m, key.as_str())
+            }
+            _ => Value::Null,
+        })),
 
         _ => Ok(None), // Unknown method
     }
@@ -811,6 +821,87 @@ fn set_in(target: &mut Value, segs: &[PathSeg<'_>], val: &Value) -> bool {
         },
         // Field-into-array, index-into-map, or any scalar where a container is
         // required: a hard type conflict.
+        _ => false,
+    }
+}
+
+// ── `.unset` path deletion ──────────────────────────────────
+//
+// `.unset` is the deletion counterpart to `.set`: it reuses the very same path
+// grammar (`parse_set_path`) to address one leaf and remove it. The contrasts
+// with `.set` are deliberate:
+//   * An array element is removed **and the tail shifts down** (jq `del`
+//     semantics) — the array shrinks by one. This is distinct from
+//     `set(path, null)`, which leaves a null hole.
+//   * A path that does not resolve — missing intermediate, missing final key,
+//     array index past the end, or a type conflict (a field segment into a
+//     non-map, an index segment into a non-array) — is a **no-op returning the
+//     receiver unchanged**, never `Null`. This mirrors `remove_field` returning
+//     the receiver unchanged when the key is absent, and is the opposite of
+//     `.set`, which yields `Null` on a conflicting path.
+// Like every map method it is copy-on-write: the receiver is never mutated.
+
+/// Deletes the leaf addressed by `key` within map `m`, returning a fresh
+/// `Value::Map`.
+///
+/// A malformed path string, or any path that does not resolve to an existing
+/// leaf, is a no-op: the receiver is returned unchanged (contrast `map_set_path`,
+/// which yields `Null` on a conflicting path). Array elements are removed with a
+/// down-shift so the array shrinks by one. The receiver is cloned before any
+/// edit, so the caller's binding is untouched.
+fn map_unset_path(m: &indexmap::IndexMap<Box<str>, Value>, key: &str) -> Value {
+    let Some(segs) = parse_set_path(key) else {
+        return Value::Map(Box::new(m.clone()));
+    };
+    let mut root = Value::Map(Box::new(m.clone()));
+    // The cloned `root` is the unchanged receiver whether or not `unset_in`
+    // deletes anything, so a no-op simply returns it as-is.
+    unset_in(&mut root, &segs);
+    root
+}
+
+/// Removes the leaf at path `segs` inside `target`, descending in place into the
+/// caller's already-cloned copy. Returns `true` when a leaf was actually deleted
+/// and `false` for any unresolved path (missing key, index past the end, or a
+/// type conflict), leaving `target` untouched in the `false` case so the whole
+/// `.unset` is a no-op.
+fn unset_in(target: &mut Value, segs: &[PathSeg<'_>]) -> bool {
+    let Some((head, rest)) = segs.split_first() else {
+        // An empty path addresses no leaf to delete.
+        return false;
+    };
+    match (head, target) {
+        (PathSeg::Field(name), Value::Map(map)) => {
+            if rest.is_empty() {
+                // `shift_remove` deletes the entry and preserves the order of the
+                // surviving keys; absence is a no-op.
+                map.shift_remove(*name).is_some()
+            } else {
+                match map.get_mut(*name) {
+                    Some(child) => unset_in(child, rest),
+                    None => false, // missing intermediate → no-op
+                }
+            }
+        }
+        (PathSeg::Index(idx), Value::Array(items)) => {
+            if rest.is_empty() {
+                if *idx < items.len() {
+                    // Remove-and-shift: the array shrinks by one (jq `del`),
+                    // distinct from `set(path, null)` leaving a hole.
+                    items.remove(*idx);
+                    true
+                } else {
+                    false // index past the end → no-op
+                }
+            } else {
+                match items.get_mut(*idx) {
+                    Some(child) => unset_in(child, rest),
+                    None => false, // index past the end → no-op
+                }
+            }
+        }
+        // Field-into-array, index-into-map, or a scalar where a container is
+        // required: a type conflict, so a no-op.
         _ => false,
     }
 }

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -1853,6 +1853,301 @@ mod intra_record {
     }
 
     #[test]
+    fn nested_unset_removes_leaf_preserving_siblings() {
+        let out = run(
+            "emit pruned = doc.unset(\"a.b\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "a",
+                    map(vec![("b", Value::Integer(1)), ("c", Value::Integer(2))]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("pruned"),
+                    Some(&map(vec![("a", map(vec![("c", Value::Integer(2))]))])),
+                    "unset must drop only the addressed leaf, keeping every sibling",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_array_element_removes_and_shifts() {
+        // `unset("items[0]")` deletes element 0 and shifts the tail down, so the
+        // array shrinks by one (jq `del` semantics). This is deliberately
+        // distinct from `set("items[0]", null)`, which would leave a null hole.
+        let out = run(
+            "emit shifted = doc.unset(\"items[0]\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "items",
+                    arr(vec![
+                        Value::Integer(10),
+                        Value::Integer(20),
+                        Value::Integer(30),
+                    ]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("shifted"),
+                    Some(&map(vec![(
+                        "items",
+                        arr(vec![Value::Integer(20), Value::Integer(30)]),
+                    )])),
+                    "array unset must remove-and-shift: length shrinks, order preserved, no null hole",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_leaf_reached_through_array_index() {
+        let out = run(
+            "emit r = doc.unset(\"items[1].sku\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "items",
+                    arr(vec![
+                        map(vec![("sku", Value::String("a".into()))]),
+                        map(vec![
+                            ("sku", Value::String("b".into())),
+                            ("qty", Value::Integer(3)),
+                        ]),
+                    ]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![(
+                        "items",
+                        arr(vec![
+                            map(vec![("sku", Value::String("a".into()))]),
+                            map(vec![("qty", Value::Integer(3))]),
+                        ]),
+                    )])),
+                    "unset descends through an array index to delete a nested map leaf",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_missing_final_key_is_noop_not_null() {
+        // The intermediate `a` exists but has no `z`. Unlike `.set` on a
+        // conflicting path (which returns null), `.unset` returns the receiver
+        // unchanged.
+        let out = run(
+            "emit r = doc.unset(\"a.z\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![("a", map(vec![("b", Value::Integer(1))]))]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![("a", map(vec![("b", Value::Integer(1))]))])),
+                    "missing final key is a no-op returning the receiver unchanged, not null",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_missing_intermediate_is_noop_not_null() {
+        // `a` is absent entirely, so the path cannot resolve; the receiver comes
+        // back unchanged rather than null.
+        let out = run(
+            "emit r = doc.unset(\"a.b\")",
+            &["doc"],
+            HashMap::from([("doc".into(), map(vec![("k", Value::Integer(1))]))]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![("k", Value::Integer(1))])),
+                    "missing intermediate is a no-op returning the receiver unchanged, not null",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_array_index_past_end_is_noop_not_null() {
+        // The contrast with `nested_set_array_index_past_end_returns_null`:
+        // `.set` past the end is null, but `.unset` past the end is a no-op that
+        // returns the receiver unchanged.
+        let out = run(
+            "emit r = doc.unset(\"items[5]\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "items",
+                    arr(vec![Value::Integer(10), Value::Integer(20)]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![(
+                        "items",
+                        arr(vec![Value::Integer(10), Value::Integer(20)]),
+                    )])),
+                    "array index past the end is a no-op for unset (returns receiver), unlike set which returns null",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_field_into_array_is_noop_not_null() {
+        // `items` is an array; a field segment against it is a type conflict.
+        // `.set` returns null here; `.unset` returns the receiver unchanged.
+        let out = run(
+            "emit r = doc.unset(\"items.name\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![("items", arr(vec![Value::Integer(1)]))]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![("items", arr(vec![Value::Integer(1)]))])),
+                    "field-into-array type conflict is a no-op for unset (returns receiver), unlike set which returns null",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_index_into_map_is_noop_not_null() {
+        // `a` is a map; an index segment against it is a type conflict. `.set`
+        // returns null here; `.unset` returns the receiver unchanged.
+        let out = run(
+            "emit r = doc.unset(\"a[0]\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![("a", map(vec![("b", Value::Integer(1))]))]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![("a", map(vec![("b", Value::Integer(1))]))])),
+                    "index-into-map type conflict is a no-op for unset (returns receiver), unlike set which returns null",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_does_not_mutate_receiver() {
+        // `.unset` is copy-on-write: emitting both the original and the pruned
+        // path must show the original untouched.
+        let out = run(
+            "emit before = doc\nemit after = doc.unset(\"a.b\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![(
+                    "a",
+                    map(vec![("b", Value::Integer(1)), ("c", Value::Integer(2))]),
+                )]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("before"),
+                    Some(&map(vec![(
+                        "a",
+                        map(vec![("b", Value::Integer(1)), ("c", Value::Integer(2))]),
+                    )])),
+                    "receiver must be untouched after unset (copy-on-write)",
+                );
+                assert_eq!(
+                    fields.get("after"),
+                    Some(&map(vec![("a", map(vec![("c", Value::Integer(2))]))])),
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn single_key_unset_behaves_like_remove_field() {
+        // A bare key reaches the top-level entry through the path grammar,
+        // matching `remove_field("region")` exactly.
+        let out = run(
+            "emit via_unset = doc.unset(\"region\")\nemit via_remove = doc.remove_field(\"region\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![
+                    ("region", Value::String("us-east".into())),
+                    ("tier", Value::String("gold".into())),
+                ]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                let expected = map(vec![("tier", Value::String("gold".into()))]);
+                assert_eq!(fields.get("via_unset"), Some(&expected));
+                assert_eq!(
+                    fields.get("via_unset"),
+                    fields.get("via_remove"),
+                    "single-segment unset must match remove_field for the same key",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn array_remove_returns_new_array_without_index() {
         let out = run(
             "emit val = nums.remove(1)",

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -1915,6 +1915,61 @@ mod intra_record {
     }
 
     #[test]
+    fn nested_unset_last_array_element_yields_empty_array() {
+        // Deleting the only element shrinks the array to empty — the
+        // remove-and-shift boundary where a hole-leaving impl or an off-by-one
+        // bound would surface.
+        let out = run(
+            "emit r = doc.unset(\"items[0]\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![("items", arr(vec![Value::Integer(10)]))]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![("items", arr(vec![]))])),
+                    "deleting the only array element yields an empty array, not a null hole",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_unset_removes_whole_submap_by_bare_key() {
+        // A bare key naming a container deletes the entire substructure, exactly
+        // like `remove_field` — the documented "prune a nested field" use case,
+        // through the same top-level `shift_remove` path a scalar key takes.
+        let out = run(
+            "emit r = doc.unset(\"a\")",
+            &["doc"],
+            HashMap::from([(
+                "doc".into(),
+                map(vec![
+                    ("a", map(vec![("b", Value::Integer(1))])),
+                    ("k", Value::Integer(2)),
+                ]),
+            )]),
+        )
+        .unwrap();
+        match out {
+            EvalResult::Emit { fields, .. } => {
+                assert_eq!(
+                    fields.get("r"),
+                    Some(&map(vec![("k", Value::Integer(2))])),
+                    "a bare key deletes the whole sub-map, not just scalar leaves",
+                );
+            }
+            other => panic!("expected Emit, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn nested_unset_leaf_reached_through_array_index() {
         let out = run(
             "emit r = doc.unset(\"items[1].sku\")",

--- a/docs/src/cookbook/intra-record-closures.md
+++ b/docs/src/cookbook/intra-record-closures.md
@@ -157,7 +157,7 @@ The first `set` overwrites the SKU of the first item; the second writes `ship.re
 
 - [Closures](../cxl/closures.md) -- the `it => body` form.
 - [Array Methods](../cxl/builtins-array.md) -- `filter`, `map`, `find`, `any`, `flat_map`, `remove`, `length`, `join`.
-- [Map Methods](../cxl/builtins-map.md) -- `keys`, `values`, `merge`, `set`, `remove_field`.
+- [Map Methods](../cxl/builtins-map.md) -- `keys`, `values`, `merge`, `set`, `remove_field`, `unset`.
 - [Nested Paths](../cxl/nested-paths.md) -- bracket-index and dotted-path navigation.
 - [Emit Each](../cxl/emit-each.md) -- the fan-out statement.
 - [Transform Nodes](../pipeline/transform.md) -- `max_expansion` and DLQ routing.

--- a/docs/src/cxl/builtins-map.md
+++ b/docs/src/cxl/builtins-map.md
@@ -1,6 +1,6 @@
 # Map Methods
 
-CXL provides five built-in methods for working with map values (key-value pairs). Maps arise naturally from JSON object inputs, from the [`set`](#setkey-string-value-any---map) builder below, and from upstream emits that produce nested structures.
+CXL provides six built-in methods for working with map values (key-value pairs). Maps arise naturally from JSON object inputs, from the [`set`](#setkey-string-value-any---map) builder below, and from upstream emits that produce nested structures.
 
 All map methods return new values -- they never mutate the receiver. This is copy-on-write semantics: chaining `.set` then `.remove_field` produces a fresh map at each step, leaving the upstream binding untouched.
 
@@ -87,6 +87,22 @@ Returns a new map without `key`. If the key was absent, the receiver is returned
 ```
 
 `slim` is `{"name":"Alice","tier":"gold"}`.
+
+### unset(key: String) -> Map
+
+Returns a new map with the entry addressed by `key` removed. `unset` is the deletion counterpart to [`set`](#setkey-string-value-any---map) and reuses the **same** dotted/indexed path grammar: dots separate map keys, a `[n]` suffix indexes an array. A bare key (no `.` or `[n]`) drops a top-level entry, exactly like `remove_field`.
+
+```yaml
+    cxl: |
+      emit pruned = profile.unset("address.city")
+      emit dropped = order.unset("items[0]")
+```
+
+- **Array element removes and shifts.** `unset("items[0]")` deletes element 0 and shifts the remaining elements down, so the array shrinks by one (matching jq `del`). This is deliberately distinct from `set("items[0]", null)`, which leaves a `null` hole — `unset` means *delete*.
+- **Missing or conflicting path is a no-op.** A path that does not resolve — a missing intermediate, a missing final key, an array index past the end, or a type conflict (a field segment against an array, an index segment against a map) — returns the receiver **unchanged**. This mirrors `remove_field` on an absent key, and is the opposite of `set`, which returns `null` on a conflicting path.
+- **Copy-on-write.** Like every map method, `unset` never mutates the receiver; the upstream binding is untouched.
+
+For `profile = {"name":"Alice","address":{"city":"LA","zip":"90001"}}`, `profile.unset("address.city")` is `{"name":"Alice","address":{"zip":"90001"}}` -- the sibling `zip` and the top-level `name` are preserved.
 
 ## Worked example: chained set + remove_field
 

--- a/docs/src/cxl/builtins.md
+++ b/docs/src/cxl/builtins.md
@@ -104,4 +104,5 @@ Builders and accessors for `Value::Map` payloads. All map methods return new map
 | `keys`, `values` | List map keys / values as arrays |
 | `merge` | Union of two maps (right wins on conflict) |
 | `set` | Insert / replace an entry, by single key or by a nested `a.b[0].c` path |
-| `remove_field` | Drop a single entry by key |
+| `remove_field` | Drop a single entry by top-level key |
+| `unset` | Delete an entry by single key or by a nested `a.b[0].c` path (array index removes-and-shifts; missing path is a no-op) |


### PR DESCRIPTION
## Summary

CXL's `set(path, value)` map method addresses a single leaf inside a nested document via a dotted/indexed path string (`order.set("items[0].sku", "A-100")`), but there was no symmetric deletion form. `remove_field(key)` removes only a top-level key by exact match; pruning a nested key or an array element required rebuilding the enclosing container by hand.

This adds a `unset(path)` map method:

- Accepts the **same** dotted/indexed path grammar as `set` (dots separate map keys, `[n]` indexes an array) by reusing `set`'s path parser.
- **Array elements are removed-and-shifted** — `unset("items[0]")` deletes the element and the array shrinks by one (matching jq's `del`), deliberately distinct from `set("items[0]", null)`, which would leave a null hole.
- A path that does not resolve — a missing intermediate, a missing final key, an array index past the end, or a type conflict — is a **no-op that returns the receiver unchanged** (never `null`), mirroring how `remove_field` returns the receiver unchanged when a key is absent. This is the deliberate behavioral contrast with `set`, which returns `null` on a conflicting path.
- Copy-on-write, like every other map method — the receiver is never mutated.

## Tests

Unit coverage in the `cxl` crate (12 cases): nested leaf deletion preserving siblings; array remove-and-shift (including deleting the only element down to an empty array); deletion through an array index into a nested map; deleting a whole sub-map by a bare key; the missing-intermediate / missing-final-key / index-past-end / type-conflict no-op cases (each asserting receiver-unchanged, not null); copy-on-write; and single-key equivalence to `remove_field`. An end-to-end pipeline test exercises a nested `unset("meta.flag")` inside an array closure, proving the path-addressed deletion parses, typechecks, compiles, and evaluates through a real pipeline.

## Docs

The Map Methods page documents `unset` alongside `set` and `remove_field`, calling out the remove-and-shift and no-op-returns-receiver contrasts; the builtins summary table and the cookbook cross-references are updated.

Closes #409.