### PR TITLE
engine: HL7 v2 format and compile-time $doc path analysis (#380, #382)

### DIFF
--- a/crates/clinker-benchmarks/src/format_mapping.rs
+++ b/crates/clinker-benchmarks/src/format_mapping.rs
@@ -9,6 +9,7 @@ pub enum FormatMappingError {
     UnsupportedJsonObject,
     UnsupportedEdifact,
     UnsupportedX12,
+    UnsupportedHl7,
 }
 
 impl std::fmt::Display for FormatMappingError {
@@ -22,6 +23,9 @@ impl std::fmt::Display for FormatMappingError {
             }
             Self::UnsupportedX12 => {
                 f.write_str("X12 format has no benchmark DataFormat equivalent")
+            }
+            Self::UnsupportedHl7 => {
+                f.write_str("HL7 format has no benchmark DataFormat equivalent")
             }
         }
     }
@@ -39,6 +43,7 @@ pub fn input_format_to_data_format(input: &InputFormat) -> Result<DataFormat, Fo
         InputFormat::FixedWidth(_) => Ok(DataFormat::FixedWidth),
         InputFormat::Edifact(_) => Err(FormatMappingError::UnsupportedEdifact),
         InputFormat::X12(_) => Err(FormatMappingError::UnsupportedX12),
+        InputFormat::Hl7(_) => Err(FormatMappingError::UnsupportedHl7),
         InputFormat::Json(opts) => {
             let json_fmt = opts.as_ref().and_then(|o| o.format.as_ref());
             match json_fmt {

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -81,7 +81,7 @@
 //! | `E323`      | error    | `edifact` output combined with byte-limit `split` (an interchange is one indivisible UNB..UNZ envelope) |
 //! | `E338`      | error    | `x12` output combined with byte-limit `split` (an interchange is one indivisible ISA..IEA envelope) |
 //! | `E339`      | error    | `hl7` output combined with byte-limit `split` (a batch/file envelope is one indivisible FHS..FTS structure) |
-//! | `E340`      | error    | A `$doc.<section>.<field>` access is indexed by a non-literal, so its declared document path cannot be resolved at compile time |
+//! | `E340`      | error    | A `$doc.<section>.<field>` access is indexed by a non-literal expression, so its declared document path cannot be resolved at compile time |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -80,6 +80,8 @@
 //! | `E322`      | error    | Two output destinations (Output nodes, or an Output node and a DLQ path) resolve to the same file |
 //! | `E323`      | error    | `edifact` output combined with byte-limit `split` (an interchange is one indivisible UNB..UNZ envelope) |
 //! | `E338`      | error    | `x12` output combined with byte-limit `split` (an interchange is one indivisible ISA..IEA envelope) |
+//! | `E339`      | error    | `hl7` output combined with byte-limit `split` (a batch/file envelope is one indivisible FHS..FTS structure) |
+//! | `E340`      | error    | A `$doc.<section>.<field>` access is indexed by a non-literal, so its declared document path cannot be resolved at compile time |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
 use clinker_format::edifact::reader::{EdifactReader, EdifactReaderConfig};
 use clinker_format::fixed_width::reader::{FixedWidthReader, FixedWidthReaderConfig};
+use clinker_format::hl7::reader::{Hl7Reader, Hl7ReaderConfig};
 use clinker_format::json::reader::{
     ArrayPathMode, ArrayPathSpec, JsonMode, JsonReader, JsonReaderConfig,
 };
@@ -53,6 +54,10 @@ fn build_format_reader(
         clinker_plan::config::InputFormat::X12(opts) => {
             let config = build_x12_reader_config(opts.as_ref());
             Ok(Box::new(X12Reader::new(reader, config)))
+        }
+        clinker_plan::config::InputFormat::Hl7(opts) => {
+            let config = build_hl7_reader_config(opts.as_ref());
+            Ok(Box::new(Hl7Reader::new(reader, config)))
         }
     }
 }
@@ -810,6 +815,18 @@ fn build_x12_reader_config(
         && let Some(max) = opts.max_elements
     {
         config.max_elements = max;
+    }
+    config
+}
+
+fn build_hl7_reader_config(
+    opts: Option<&clinker_plan::config::Hl7InputOptions>,
+) -> Hl7ReaderConfig {
+    let mut config = Hl7ReaderConfig::default();
+    if let Some(opts) = opts
+        && let Some(max) = opts.max_fields
+    {
+        config.max_fields = max;
     }
     config
 }

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -11,6 +11,7 @@ use clinker_format::counting::{CountedFormatWriter, CountingWriter, SharedByteCo
 use clinker_format::csv::writer::{CsvWriter, CsvWriterConfig, HeaderCapturingCsvWriter};
 use clinker_format::edifact::writer::{EdifactWriter, EdifactWriterConfig};
 use clinker_format::fixed_width::writer::{FixedWidthWriter, FixedWidthWriterConfig};
+use clinker_format::hl7::writer::{Hl7Writer, Hl7WriterConfig};
 use clinker_format::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
 use clinker_format::splitting::{OversizeGroupPolicy, SplitPolicy, SplittingWriter, WriterFactory};
 use clinker_format::traits::FormatWriter;
@@ -137,6 +138,18 @@ fn build_x12_writer_config(
         interchange_from_doc: opts.and_then(|o| o.interchange_from_doc.clone()),
         group_header: opts.and_then(|o| o.group_header.clone()),
         set_type: opts.and_then(|o| o.set_type.clone()),
+        segment_newline: opts.and_then(|o| o.segment_newline).unwrap_or(true),
+    }
+}
+
+fn build_hl7_writer_config(
+    opts: Option<&clinker_plan::config::Hl7OutputOptions>,
+) -> Hl7WriterConfig {
+    // `segment_newline` defaults to `true` (readable per-segment lines).
+    Hl7WriterConfig {
+        file_header: opts.and_then(|o| o.file_header.clone()),
+        file_header_from_doc: opts.and_then(|o| o.file_header_from_doc.clone()),
+        batch_header: opts.and_then(|o| o.batch_header.clone()),
         segment_newline: opts.and_then(|o| o.segment_newline).unwrap_or(true),
     }
 }
@@ -273,6 +286,16 @@ fn build_writer_factory(
                     counting_writer,
                     schema,
                     x12_config.clone(),
+                )))
+            })
+        }
+        OutputFormat::Hl7(opts) => {
+            let hl7_config = build_hl7_writer_config(opts.as_ref());
+            Box::new(move |counting_writer, schema| {
+                Ok(Box::new(Hl7Writer::new(
+                    counting_writer,
+                    schema,
+                    hl7_config.clone(),
                 )))
             })
         }

--- a/crates/clinker-exec/tests/hl7_pipeline.rs
+++ b/crates/clinker-exec/tests/hl7_pipeline.rs
@@ -181,6 +181,23 @@ nodes:
     assert!(output.contains("OBX|1|NM|"), "OBX1 missing: {output}");
     assert!(output.contains("OBX|2|NM|"), "OBX2 missing: {output}");
 
+    // Composite fields must survive byte-identically — their component '^'
+    // separators are part of the field structure and are NOT escaped on
+    // write. The PID-3 CX field and the OBX-3 CE field round-trip verbatim.
+    assert!(
+        output.contains("PID|1||PATID123^^^HOSP^MR"),
+        "composite PID-3 not byte-identical: {output}"
+    );
+    assert!(
+        output.contains("OBX|1|NM|WBC^White Blood Cell"),
+        "composite OBX-3 not byte-identical: {output}"
+    );
+    // No component separator may have been turned into an \S\ escape.
+    assert!(
+        !output.contains("\\S\\"),
+        "component separator wrongly escaped on output: {output}"
+    );
+
     // Feed the HL7 output back through a second pipeline (HL7 → CSV) to
     // prove it re-parses identically: the segment tags must round-trip.
     let reparse_yaml = r#"

--- a/crates/clinker-exec/tests/hl7_pipeline.rs
+++ b/crates/clinker-exec/tests/hl7_pipeline.rs
@@ -1,0 +1,356 @@
+//! End-to-end HL7 v2 ingestion and round-trip.
+//!
+//! Covers: (1) an HL7 source surfaces the message-level envelope as a
+//! `$doc` section on every body record, proving the nested-envelope nesting
+//! (`OpenLevel`/`CloseLevel`) flows through the executor; (2) an HL7→HL7
+//! pipeline re-emits the MSH/body segments (escaping field data) and
+//! re-parses identically; (3) the `hl7`+`split` combination is rejected at
+//! config time (diagnostic `E339`); (4) a batch/file envelope surfaces
+//! file-level `$doc` fields and a BTS count mismatch fails the run.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// A representative ADT^A01 (admit) message: MSH header, EVN event, PID
+/// patient, PV1 visit. Segments are CR-separated; the MSH declares the
+/// conventional `|^~\&` delimiters. The message control id is `ADT0001`.
+fn adt_a01() -> String {
+    [
+        "MSH|^~\\&|ADMIT|HOSP|REG|HOSP|20240101120000||ADT^A01|ADT0001|P|2.5",
+        "EVN|A01|20240101120000",
+        "PID|1||PATID123^^^HOSP^MR||DOE^JOHN^Q||19700101|M",
+        "PV1|1|I|WARD^101^A",
+    ]
+    .join("\r")
+}
+
+/// A representative ORU^R01 (observation result) message: MSH header, PID
+/// patient, OBR order, two OBX results. The message control id is `ORU0001`.
+fn oru_r01() -> String {
+    [
+        "MSH|^~\\&|LAB|HOSP|EHR|HOSP|20240102093000||ORU^R01|ORU0001|P|2.5",
+        "PID|1||PATID123^^^HOSP^MR||DOE^JOHN",
+        "OBR|1||LAB42|CBC^Complete Blood Count",
+        "OBX|1|NM|WBC^White Blood Cell||7.2|10*9/L|4.0-11.0|N",
+        "OBX|2|NM|HGB^Hemoglobin||14.1|g/dL|13.5-17.5|N",
+    ]
+    .join("\r")
+}
+
+fn run(
+    yaml: &str,
+    source_name: &str,
+    fixture: &str,
+    file_name: &str,
+    out_name: &str,
+) -> Result<(clinker_exec::executor::ExecutionReport, String), String> {
+    let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
+    let plan = config
+        .compile(&CompileContext::default())
+        .map_err(|e| format!("compile: {e:?}"))?;
+
+    let file = FileSlot::new(
+        PathBuf::from(file_name),
+        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        source_name.to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        out_name.to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .map_err(|e| format!("run: {e:?}"))?;
+    Ok((report, buf.as_string()))
+}
+
+#[test]
+fn hl7_source_surfaces_message_envelope_and_streams_segments() {
+    // Every body record carries the message-level document, whose
+    // `transaction_set` section exposes the MSH fields. A Transform reads
+    // the segment tag, the stamped control id (`set_ref`), and MSH-9
+    // (message type) via the `$doc.transaction_set.f08` positional field.
+    let yaml = r#"
+pipeline:
+  name: hl7_envelope
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: f01, type: string }
+  - type: transform
+    name: tag
+    input: messages
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit ctrl = set_ref
+        emit mtype = $doc.transaction_set.f08
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let (report, output) =
+        run(yaml, "messages", &adt_a01(), "adt.hl7", "out").expect("run hl7 pipeline");
+    // MSH, EVN, PID, PV1 are all body records.
+    assert_eq!(report.counters.total_count, 4, "output was: {output}");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 5, "header + 4 rows; got: {output}");
+    // Every body row carries the message control id and the message type
+    // resolved from the message-level $doc section.
+    for row in &lines[1..] {
+        assert!(row.contains("ADT0001"), "row missing set_ref: {row}");
+        assert!(
+            row.contains("ADT^A01"),
+            "row missing $doc.transaction_set.f08 (MSH-9): {row}"
+        );
+    }
+    // First body record is the MSH segment.
+    assert!(lines[1].starts_with("MSH,"), "first row: {}", lines[1]);
+}
+
+#[test]
+fn hl7_round_trip_reparses_identically() {
+    // Source parses HL7 and writes HL7, re-emitting the MSH and body
+    // segments. Re-parsing the output must yield the same segment tags in
+    // order, and an escaped field must survive the round-trip.
+    let yaml = r#"
+pipeline:
+  name: hl7_round_trip
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: hl7
+      path: out.hl7
+      include_unmapped: true
+      options:
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "messages", &oru_r01(), "oru.hl7", "out").expect("run round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // The re-emitted file opens with the original MSH and carries the two
+    // OBX result segments.
+    assert!(
+        output.starts_with("MSH|^~\\&|LAB|"),
+        "MSH echo wrong: {output}"
+    );
+    assert!(output.contains("OBX|1|NM|"), "OBX1 missing: {output}");
+    assert!(output.contains("OBX|2|NM|"), "OBX2 missing: {output}");
+
+    // Feed the HL7 output back through a second pipeline (HL7 → CSV) to
+    // prove it re-parses identically: the segment tags must round-trip.
+    let reparse_yaml = r#"
+pipeline:
+  name: hl7_reparse
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: tag
+    input: messages
+    config:
+      cxl: |
+        emit seg = seg_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+      include_header: false
+"#;
+    let (reparse_report, reparse_csv) =
+        run(reparse_yaml, "messages", &output, "echo.hl7", "out").expect("re-parse round-trip");
+    assert_eq!(reparse_report.counters.dlq_count, 0);
+    let tags: Vec<&str> = reparse_csv.lines().map(str::trim).collect();
+    assert_eq!(
+        tags,
+        vec!["MSH", "PID", "OBR", "OBX", "OBX"],
+        "round-trip segment tags; hl7 output was: {output}"
+    );
+}
+
+#[test]
+fn hl7_batch_envelope_surfaces_file_doc_and_validates_counts() {
+    // An FHS..FTS file wrapping a BHS..BTS batch of two messages. The FHS
+    // file header is extractable as a declared file-level `$doc` section;
+    // every body record resolves a field from it. The BTS/FTS counts match,
+    // so the run succeeds.
+    let msg2 = oru_r01().replace("ORU0001", "ORU0002");
+    let batched = format!(
+        "FHS|^~\\&|LAB|HOSP|EHR|HOSP|20240102|FILE7\r\
+         BHS|^~\\&|LAB|HOSP|EHR|HOSP|20240102|BATCH3\r\
+         {}\r{}\r\
+         BTS|2\r\
+         FTS|1",
+        adt_a01(),
+        msg2
+    );
+    let yaml = r#"
+pipeline:
+  name: hl7_batch
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      envelope:
+        sections:
+          file:
+            extract: { segment: "FHS" }
+            fields:
+              f07: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+  - type: transform
+    name: tag
+    input: messages
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit ctrl = set_ref
+        emit file_id = $doc.file.f07
+        emit batch_id = $doc.batch.f07
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+"#;
+    let (report, output) =
+        run(yaml, "messages", &batched, "batch.hl7", "out").expect("run batch envelope");
+    assert_eq!(report.counters.dlq_count, 0);
+    // ADT (MSH, EVN, PID, PV1 = 4) + ORU (MSH, PID, OBR, OBX, OBX = 5) = 9.
+    assert_eq!(report.counters.total_count, 9, "output was: {output}");
+    // Every row resolves the FHS file id (file-level $doc) and the BHS batch
+    // id (the nested batch-level $doc section, keyed positionally).
+    for row in output.lines() {
+        assert!(row.contains("FILE7"), "row missing $doc.file.f07: {row}");
+        assert!(row.contains("BATCH3"), "row missing $doc.batch.f07: {row}");
+    }
+}
+
+#[test]
+fn hl7_output_with_split_is_rejected_at_config_time() {
+    // A batch/file envelope is one FHS..FTS structure; byte-limit splitting
+    // would finalize it mid-stream. The combination must fail config
+    // validation, not run and emit a corrupt file.
+    let yaml = r#"
+pipeline:
+  name: hl7_split
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: hl7
+      path: out.hl7
+      options:
+        file_header: ["^~\\&", "LAB", "HOSP"]
+      split:
+        max_bytes: 1024
+"#;
+    let err = parse_config(yaml).expect_err("hl7 + split must fail config validation");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("E339"), "expected E339 diagnostic, got: {msg}");
+}
+
+#[test]
+fn hl7_bts_count_mismatch_fails_the_run() {
+    // The BTS trailer claims 9 messages where the batch has 1 — a
+    // truncation/corruption signal the reader surfaces as a run failure.
+    let bad = format!("BHS|^~\\&|LAB\r{}\rBTS|9", adt_a01());
+    let yaml = r#"
+pipeline:
+  name: hl7_bad_count
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let result = run(yaml, "messages", &bad, "bad.hl7", "out");
+    let err = result.expect_err("count mismatch must fail the run");
+    assert!(
+        err.contains("BTS batch message count mismatch") || err.contains("HL7"),
+        "error should name the HL7 count failure: {err}"
+    );
+}

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -23,6 +23,11 @@ pub enum FormatError {
     /// control-number echo mismatch, truncation, a delimiter byte in data
     /// that X12 cannot escape).
     X12(String),
+    /// An HL7 v2 parse, batch/file-count, or malformed-segment failure.
+    /// Carries a precise message naming the offending segment or
+    /// constraint (missing/truncated MSH header, BTS/FTS count mismatch,
+    /// unbalanced batch/file envelope, truncation, non-UTF-8 charset).
+    Hl7(String),
     InvalidRecord {
         row: u64,
         message: String,
@@ -68,6 +73,7 @@ impl fmt::Display for FormatError {
             Self::FixedWidth(msg) => write!(f, "fixed-width error: {msg}"),
             Self::Edifact(msg) => write!(f, "EDIFACT error: {msg}"),
             Self::X12(msg) => write!(f, "X12 error: {msg}"),
+            Self::Hl7(msg) => write!(f, "HL7 error: {msg}"),
             Self::InvalidRecord { row, message } => {
                 write!(f, "invalid record at row {row}: {message}")
             }

--- a/crates/clinker-format/src/hl7/mod.rs
+++ b/crates/clinker-format/src/hl7/mod.rs
@@ -1,0 +1,49 @@
+//! HL7 v2.x reader/writer pair (pipe-and-hat encoding).
+//!
+//! An HL7 v2 message is a flat, delimiter-structured stream of segments
+//! terminated by a carriage return. Each segment splits into a tag and
+//! data fields on the field separator; a field splits into components on
+//! the component separator, repetitions on the repetition separator, and
+//! sub-components on the sub-component separator. Unlike X12's fixed
+//! 106-byte `ISA`, HL7 declares its delimiters in the variable-length
+//! `MSH` header: the field separator is the single byte immediately after
+//! the `MSH` tag (`MSH-1`), and the encoding characters (`MSH-2`) are the
+//! four bytes that follow it — component (`^`), repetition (`~`), escape
+//! (`\`), and sub-component (`&`), in that fixed order. The segment
+//! terminator is always a carriage return (`\r`), never producer-chosen.
+//!
+//! This module maps one body segment to one [`crate::traits::FormatReader`]
+//! record under a static positional schema (`seg_id`, `set_ref`,
+//! `set_type`, `f01..`). The `MSH` header that opens a message **is**
+//! emitted as a body record (its fields carry the message's metadata);
+//! optional batch/file envelope segments (`BHS`/`BTS`, `FHS`/`FTS`) are
+//! consumed by the reader to validate batch/file counts inline and drive
+//! nested document levels — they are never emitted as body records. The
+//! writer mirrors this, reconstructing the envelope around emitted records
+//! and recomputing every count.
+//!
+//! The optional envelope tiers surface as nested document-context levels:
+//! an `FHS` file header is the file-level document (extracted in the
+//! one-time pre-scan), and each `BHS` batch and `MSH` message opens a
+//! nested level whose `$doc` sections layer over the enclosing tiers. All
+//! tiers are optional — a bare stream of `MSH` messages with no batch or
+//! file wrapping is a valid HL7 v2 file.
+//!
+//! Memory model: only the file header (`FHS`) is pre-scanned and retained
+//! (so `$doc` envelope sections over `FHS` cost O(FHS)); the body streams
+//! one segment at a time. The whole file is never buffered.
+
+pub mod reader;
+mod tokenizer;
+pub mod writer;
+
+pub use reader::{Hl7Reader, Hl7ReaderConfig};
+pub use writer::{Hl7Writer, Hl7WriterConfig};
+
+/// Engine-internal key under which the reader stashes the complete,
+/// ordered `MSH` data-field list in the `transaction_set` `$doc` section,
+/// for lossless writer reconstruction of an echoed `MSH` header. The `$`
+/// prefix marks it as engine-namespaced so it is not a user-declarable
+/// envelope field and never surfaces in CXL `$doc.<section>.<field>`
+/// typechecking.
+pub(crate) const RAW_FIELDS_KEY: &str = "$raw";

--- a/crates/clinker-format/src/hl7/reader.rs
+++ b/crates/clinker-format/src/hl7/reader.rs
@@ -1,0 +1,917 @@
+//! HL7 v2 file reader.
+//!
+//! Streaming, row-at-a-time: each segment of an HL7 v2 file becomes one
+//! [`Record`] with a static positional schema
+//! `[seg_id, set_ref, set_type, f01..f<max>]`. The `MSH` header that opens
+//! a message **is** emitted as a body record (its fields carry the
+//! message's metadata, and downstream CXL reads them positionally).
+//! Optional batch/file envelope segments (`FHS`/`FTS`, `BHS`/`BTS`) are
+//! consumed by the reader to drive nested document levels and validate
+//! batch/file counts inline; they are never emitted as body records.
+//!
+//! The optional envelope tiers map onto nested document-context levels: an
+//! `FHS` file header is the file-level document served by
+//! [`FormatReader::prepare_document`], and each `BHS` batch and `MSH`
+//! message opens a nested level via [`EnvelopeEvent`] the source ingest
+//! driver drains after each `next_record`. A `BHS` queues an `OpenLevel`
+//! carrying the batch's `$doc` section; an `MSH` queues a nested
+//! `OpenLevel` for the message and is then emitted. A message closes (its
+//! `CloseLevel` queued) when the next `MSH`, `BTS`, `FTS`, or end-of-input
+//! arrives — HL7 messages have no explicit per-message trailer segment, so
+//! the next header *is* the boundary. A `BTS` queues `CloseLevel` for the
+//! batch and a `FTS` ends the file-level document via the driver's
+//! end-of-input / file-transition sweep.
+//!
+//! All tiers are optional. A bare stream of `MSH` messages with no `FHS`
+//! or `BHS` wrapping is valid: each message still opens and closes its own
+//! nested level, and there is simply no file-level or batch-level section.
+//!
+//! Memory model: only the file header (`FHS`) is pre-scanned and retained,
+//! so `prepare_document` exposes the `FHS` fields as a `$doc` section with
+//! O(FHS) held memory. The body streams one segment at a time — the whole
+//! file is never buffered. Trailer counts (`BTS`/`FTS`) are validated as
+//! they arrive, not surfaced as envelope sections, because they follow the
+//! body they close.
+
+use std::io::{BufReader, Read};
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+use indexmap::IndexMap;
+
+use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, coerce_section_fields};
+use crate::error::FormatError;
+use crate::hl7::RAW_FIELDS_KEY;
+use crate::hl7::tokenizer::{ParsedSegment, SegmentTokenizer, split_segment};
+use crate::traits::FormatReader;
+
+/// Default ceiling on the number of positional field columns the record
+/// schema exposes. A segment carrying more data fields than this errors
+/// with guidance rather than silently truncating.
+const DEFAULT_MAX_FIELDS: usize = 64;
+
+/// The envelope segment tag `prepare_document` can extract as a `$doc`
+/// section. Only the file header `FHS` is resolvable from the bounded
+/// header pre-scan; `BHS` batches and `MSH` messages arrive mid-body and
+/// surface as nested document levels instead.
+const FHS_TAG: &str = "FHS";
+
+/// 1-based wire field position of the message type (`MSH-9`). The MSH
+/// off-by-one — the `MSH-1` field separator is implicit and `MSH-2`
+/// encoding characters is the first split field — puts `MSH-9` at field
+/// list index 7.
+const MSH_MESSAGE_TYPE_INDEX: usize = 7;
+
+/// 1-based wire field position of the message control id (`MSH-10`), the
+/// per-message reference carried on every record of the message. Field
+/// list index 8 under the MSH off-by-one.
+const MSH_CONTROL_ID_INDEX: usize = 8;
+
+/// Configuration for the HL7 reader.
+pub struct Hl7ReaderConfig {
+    /// Number of positional `fNN` field columns on the record schema. A
+    /// body segment with more data fields than this is rejected.
+    pub max_fields: usize,
+}
+
+impl Default for Hl7ReaderConfig {
+    fn default() -> Self {
+        Self {
+            max_fields: DEFAULT_MAX_FIELDS,
+        }
+    }
+}
+
+/// Streaming HL7 v2 file reader.
+///
+/// Holds the tokenizer, the static positional schema, the inline
+/// envelope-validation state for the optional file/batch/message tiers, and
+/// the queue of nested-envelope events the source ingest driver drains
+/// after each `next_record`. The `FHS` fields are stashed at
+/// initialization so [`FormatReader::prepare_document`] can serve an `FHS`
+/// envelope section without re-reading the source.
+pub struct Hl7Reader<R: Read> {
+    tokenizer: SegmentTokenizer<BufReader<R>>,
+    schema: Arc<Schema>,
+    max_fields: usize,
+    initialized: bool,
+    /// The first segment, read during delimiter discovery and held until
+    /// the body stream consumes it (an `MSH` is emitted, an `FHS`/`BHS`
+    /// drives the envelope).
+    pending_segment: Option<String>,
+    /// Raw `FHS` data fields, stashed at init when the file opens with a
+    /// file header, for envelope serving.
+    fhs_fields: Vec<String>,
+    /// State of the batch currently open, if any.
+    open_batch: Option<OpenBatch>,
+    /// State of the message currently streaming, if any.
+    open_message: Option<OpenMessage>,
+    /// `true` once the body stream has consumed the `FHS` header, so a
+    /// second `FHS` is an error. Set independently of `fhs_fields`, which
+    /// `prepare_document` may populate from a peek before the body stream
+    /// reaches the segment.
+    file_opened: bool,
+    /// Count of `BHS` batches seen, checked against `FTS01`.
+    batch_count: u64,
+    /// `true` once `FTS` has been consumed; any further segment is an
+    /// after-trailer-content error.
+    file_closed: bool,
+    /// Nested-envelope events queued during the most recent `next_record`,
+    /// drained by the driver via [`FormatReader::take_envelope_events`].
+    pending_events: Vec<EnvelopeEvent>,
+    done: bool,
+}
+
+/// Per-batch validation state for the batch currently open.
+struct OpenBatch {
+    /// Count of messages (`MSH`) seen in this batch, checked against the
+    /// `BTS01` batch message count.
+    message_count: u64,
+}
+
+/// Per-message state for the message currently streaming.
+struct OpenMessage {
+    /// `MSH-10` message control id, stamped on every record of the message
+    /// as `set_ref`.
+    control_id: String,
+    /// `MSH-9` message type, stamped on every record as `set_type`.
+    message_type: String,
+}
+
+impl<R: Read> Hl7Reader<R> {
+    /// Build a reader over any `Read` source with the given field-width
+    /// configuration. Delimiter discovery and the first-segment read are
+    /// deferred to the first call.
+    pub fn new(reader: R, config: Hl7ReaderConfig) -> Self {
+        let schema = build_schema(config.max_fields);
+        Self {
+            tokenizer: SegmentTokenizer::new(BufReader::new(reader)),
+            schema,
+            max_fields: config.max_fields,
+            initialized: false,
+            pending_segment: None,
+            fhs_fields: Vec::new(),
+            open_batch: None,
+            open_message: None,
+            file_opened: false,
+            batch_count: 0,
+            file_closed: false,
+            pending_events: Vec::new(),
+            done: false,
+        }
+    }
+
+    /// Read the first segment for delimiter discovery, stashing it as the
+    /// pending segment so the body stream consumes it. The first segment
+    /// resolves the delimiter set; whether it is `MSH`, `FHS`, or `BHS` is
+    /// decided when the body stream processes it. Idempotent.
+    fn ensure_initialized(&mut self) -> Result<(), FormatError> {
+        if self.initialized {
+            return Ok(());
+        }
+        self.initialized = true;
+        // The first segment must carry the MSH delimiter declaration. An
+        // FHS/BHS-led file still embeds an MSH for each message, but HL7
+        // requires the file's delimiters to match the first MSH; producers
+        // universally repeat the same encoding chars in FHS/BHS, so the
+        // tokenizer reads the field separator + encoding chars from the
+        // first segment regardless of its tag.
+        let first = self.tokenizer.read_first_segment()?;
+        self.pending_segment = Some(first);
+        Ok(())
+    }
+
+    /// Pull the next segment from the pending slot or the tokenizer.
+    fn next_raw(&mut self) -> Result<Option<String>, FormatError> {
+        if let Some(seg) = self.pending_segment.take() {
+            return Ok(Some(seg));
+        }
+        self.tokenizer.next_segment()
+    }
+
+    /// Pull the next service-or-body segment and advance the envelope
+    /// state. Returns the body record to emit, or `None` at clean
+    /// end-of-input. Envelope segments are consumed transparently (the loop
+    /// continues) so the caller only ever sees body records; envelope
+    /// boundaries crossed on the way are queued for the driver.
+    fn pull_next(&mut self) -> Result<Option<Record>, FormatError> {
+        loop {
+            let raw = match self.next_raw()? {
+                Some(s) => s,
+                None => {
+                    // End of input: close any still-open message, then the
+                    // batch if the file used a bare batch with no BTS.
+                    self.close_message_if_open();
+                    self.done = true;
+                    return Ok(None);
+                }
+            };
+            let delims = self.tokenizer.delimiters();
+            let segment = split_segment(&raw, &delims);
+
+            if self.file_closed {
+                return Err(FormatError::Hl7(format!(
+                    "segment {:?} found after the FTS file trailer; content past FTS is not \
+                     permitted",
+                    segment.tag
+                )));
+            }
+
+            match segment.tag.as_str() {
+                "FHS" => self.open_file(&segment)?,
+                "FTS" => self.close_file(&segment)?,
+                "BHS" => self.open_batch(&segment)?,
+                "BTS" => self.close_batch(&segment)?,
+                "MSH" => {
+                    self.open_message(&segment);
+                    let record = self.body_record(&segment)?;
+                    return Ok(Some(record));
+                }
+                _ => {
+                    if self.open_message.is_none() {
+                        return Err(FormatError::Hl7(format!(
+                            "body segment {:?} appeared before any MSH message header",
+                            segment.tag
+                        )));
+                    }
+                    let record = self.body_record(&segment)?;
+                    return Ok(Some(record));
+                }
+            }
+        }
+    }
+
+    /// Open the file-level document on an `FHS` segment, stashing its fields
+    /// for `prepare_document`. The `FHS` is the file-level document served
+    /// by the driver's pre-scan, so it queues no nested event. The
+    /// `file_opened` flag — not the presence of `fhs_fields`, which a
+    /// `prepare_document` peek may have populated first — guards against a
+    /// genuine second `FHS`.
+    fn open_file(&mut self, fhs: &ParsedSegment) -> Result<(), FormatError> {
+        if self.file_opened || self.batch_count > 0 || self.open_message.is_some() {
+            return Err(FormatError::Hl7(
+                "a second FHS file header appeared, or one followed batch/message content; \
+                 a file carries at most one FHS, before any batch or message"
+                    .into(),
+            ));
+        }
+        self.fhs_fields = fhs.fields.clone();
+        self.file_opened = true;
+        Ok(())
+    }
+
+    /// Validate and close the file against its `FTS` trailer. `FTS-1`
+    /// (field index 0) is the file batch count.
+    fn close_file(&mut self, fts: &ParsedSegment) -> Result<(), FormatError> {
+        self.close_message_if_open();
+        if self.open_batch.is_some() {
+            return Err(FormatError::Hl7(
+                "FTS file trailer arrived before the last batch's BTS".into(),
+            ));
+        }
+        // FTS-1 is optional in practice; validate it only when present.
+        if let Some(claimed) = parse_optional_count(fts.fields.first(), "FTS", "file batch count")?
+            && claimed != self.batch_count
+        {
+            return Err(FormatError::Hl7(format!(
+                "FTS file batch count mismatch: trailer claims {claimed}, file contains \
+                 {} batches",
+                self.batch_count
+            )));
+        }
+        self.file_closed = true;
+        Ok(())
+    }
+
+    /// Open a batch on a `BHS` segment, queuing the batch's `OpenLevel` so
+    /// the driver opens a nested document context.
+    fn open_batch(&mut self, bhs: &ParsedSegment) -> Result<(), FormatError> {
+        self.close_message_if_open();
+        if self.open_batch.is_some() {
+            return Err(FormatError::Hl7(
+                "BHS opened a new batch before the previous batch's BTS trailer; batches must \
+                 be BHS..BTS balanced"
+                    .into(),
+            ));
+        }
+        self.open_batch = Some(OpenBatch { message_count: 0 });
+        self.batch_count += 1;
+        self.pending_events.push(EnvelopeEvent::OpenLevel {
+            sections: positional_section("batch", &bhs.fields),
+        });
+        Ok(())
+    }
+
+    /// Validate and close the open batch against its `BTS` trailer, queuing
+    /// a `CloseLevel`. `BTS-1` (field index 0) is the batch message count.
+    fn close_batch(&mut self, bts: &ParsedSegment) -> Result<(), FormatError> {
+        self.close_message_if_open();
+        let batch = self
+            .open_batch
+            .take()
+            .ok_or_else(|| FormatError::Hl7("BTS trailer with no open BHS batch".into()))?;
+        if let Some(claimed) =
+            parse_optional_count(bts.fields.first(), "BTS", "batch message count")?
+            && claimed != batch.message_count
+        {
+            return Err(FormatError::Hl7(format!(
+                "BTS batch message count mismatch: trailer claims {claimed}, batch contains \
+                 {} messages",
+                batch.message_count
+            )));
+        }
+        self.pending_events.push(EnvelopeEvent::CloseLevel);
+        Ok(())
+    }
+
+    /// Open a message on an `MSH` segment, queuing a nested `OpenLevel` and
+    /// tallying it against the open batch. The previous message (if any) is
+    /// closed first — HL7 has no per-message trailer, so the next `MSH` is
+    /// the boundary.
+    fn open_message(&mut self, msh: &ParsedSegment) {
+        self.close_message_if_open();
+        let message_type = msh
+            .fields
+            .get(MSH_MESSAGE_TYPE_INDEX)
+            .cloned()
+            .unwrap_or_default();
+        let control_id = msh
+            .fields
+            .get(MSH_CONTROL_ID_INDEX)
+            .cloned()
+            .unwrap_or_default();
+        if let Some(batch) = self.open_batch.as_mut() {
+            batch.message_count += 1;
+        }
+        self.pending_events.push(EnvelopeEvent::OpenLevel {
+            sections: message_section(msh),
+        });
+        self.open_message = Some(OpenMessage {
+            control_id,
+            message_type,
+        });
+    }
+
+    /// Close the open message (if any), queuing its `CloseLevel`. A no-op
+    /// when no message is open. Called on the next `MSH`/`BHS`/`BTS`/`FTS`
+    /// and at end-of-input.
+    fn close_message_if_open(&mut self) {
+        if self.open_message.take().is_some() {
+            self.pending_events.push(EnvelopeEvent::CloseLevel);
+        }
+    }
+
+    /// Map a parsed segment to a positional [`Record`] under the static
+    /// schema. `seg_id`, `set_ref`, and `set_type` are stamped from the
+    /// open message; the data fields fill `f01..`. Absent trailing fields
+    /// stay `Value::Null`; a field count past `max_fields` errors with
+    /// guidance.
+    fn body_record(&self, segment: &ParsedSegment) -> Result<Record, FormatError> {
+        if segment.fields.len() > self.max_fields {
+            return Err(FormatError::Hl7(format!(
+                "segment {:?} carries {} data fields, exceeding the configured max_fields of {}; \
+                 raise the source's `max_fields` option",
+                segment.tag,
+                segment.fields.len(),
+                self.max_fields
+            )));
+        }
+        let (set_ref, set_type) = match self.open_message.as_ref() {
+            Some(msg) => (msg.control_id.clone(), msg.message_type.clone()),
+            None => (String::new(), String::new()),
+        };
+
+        let mut values: Vec<Value> = Vec::with_capacity(3 + self.max_fields);
+        values.push(Value::String(segment.tag.as_str().into()));
+        values.push(string_or_null(&set_ref));
+        values.push(string_or_null(&set_type));
+        for i in 0..self.max_fields {
+            match segment.fields.get(i) {
+                Some(f) => values.push(string_or_null(f)),
+                None => values.push(Value::Null),
+            }
+        }
+        Ok(Record::new(Arc::clone(&self.schema), values))
+    }
+}
+
+impl<R: Read + Send> FormatReader for Hl7Reader<R> {
+    fn schema(&mut self) -> Result<Arc<Schema>, FormatError> {
+        Ok(Arc::clone(&self.schema))
+    }
+
+    fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
+        if self.done {
+            return Ok(None);
+        }
+        self.ensure_initialized()?;
+        self.pull_next()
+    }
+
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+
+    fn prepare_document(
+        &mut self,
+        config: &EnvelopeConfig,
+    ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
+        if config.is_empty() {
+            return Ok(IndexMap::new());
+        }
+        self.ensure_initialized()?;
+        // The FHS header (if present) is the only declared-envelope-section
+        // source. It is the first segment only when the file opens with a
+        // file header; peek the pending segment to populate `fhs_fields`
+        // before serving, without consuming a body record.
+        if self.fhs_fields.is_empty()
+            && let Some(pending) = self.pending_segment.as_ref()
+        {
+            let delims = self.tokenizer.delimiters();
+            let parsed = split_segment(pending, &delims);
+            if parsed.tag == "FHS" {
+                self.fhs_fields = parsed.fields;
+            }
+        }
+
+        let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(config.sections.len());
+        for (name, section) in &config.sections {
+            let segment_tag = match &section.extract {
+                EnvelopeExtract::Segment(tag) => tag.as_str(),
+                EnvelopeExtract::XmlPath(_) | EnvelopeExtract::JsonPointer(_) => {
+                    return Err(FormatError::Hl7(format!(
+                        "envelope section {name:?}: declared a non-`segment` extract against an \
+                         HL7 source. Use `segment` (e.g. `extract: {{ segment: \"FHS\" }}`) for \
+                         HL7 envelope sections."
+                    )));
+                }
+            };
+            if segment_tag != FHS_TAG {
+                return Err(FormatError::Hl7(format!(
+                    "envelope section {name:?}: segment {segment_tag:?} is not extractable as a \
+                     file-level $doc section. Only the file header `FHS` is available from the \
+                     header pre-scan; `BHS` batches and `MSH` messages surface as nested document \
+                     levels, and trailer segments (`BTS`/`FTS`) are validated by the reader, not \
+                     exposed as $doc fields."
+                )));
+            }
+            if self.fhs_fields.is_empty() {
+                return Err(FormatError::Hl7(format!(
+                    "envelope section {name:?}: declared a `segment: \"FHS\"` extract, but the \
+                     file has no FHS file header. A bare MSH-led HL7 file has no file-level \
+                     envelope; remove the section or wrap the messages in an FHS..FTS file."
+                )));
+            }
+            let raw: Vec<(String, String)> = self
+                .fhs_fields
+                .iter()
+                .enumerate()
+                .map(|(i, f)| (positional_key(i), f.clone()))
+                .collect();
+            let typed = coerce_section_fields(raw, &section.fields).map_err(FormatError::Hl7)?;
+            out.insert(Box::from(name.as_str()), Value::Map(Box::new(typed)));
+        }
+        Ok(out)
+    }
+}
+
+/// Build the `MSH` message-level `$doc` section under a fixed
+/// `transaction_set` name keyed by positional `fNN` fields, plus the raw
+/// field list under the engine-internal key for lossless writer
+/// reconstruction of an echoed `MSH` header.
+fn message_section(msh: &ParsedSegment) -> IndexMap<Box<str>, Value> {
+    let mut sections = positional_section("transaction_set", &msh.fields);
+    if let Some(Value::Map(fields)) = sections.get_mut("transaction_set") {
+        let raw: Vec<Value> = msh
+            .fields
+            .iter()
+            .map(|f| Value::String(f.as_str().into()))
+            .collect();
+        fields.insert(Box::from(RAW_FIELDS_KEY), Value::Array(raw));
+    }
+    sections
+}
+
+/// Build a single-named `$doc` section whose fields are the segment's
+/// positional fields (`f01`, `f02`, …). Used for the nested `BHS`/`MSH`
+/// levels, which carry their whole header verbatim rather than a
+/// user-declared field schema.
+fn positional_section(name: &str, fields: &[String]) -> IndexMap<Box<str>, Value> {
+    let mut payload: IndexMap<Box<str>, Value> = IndexMap::with_capacity(fields.len());
+    for (i, f) in fields.iter().enumerate() {
+        payload.insert(positional_key(i).into_boxed_str(), string_or_null(f));
+    }
+    let mut sections: IndexMap<Box<str>, Value> = IndexMap::with_capacity(1);
+    sections.insert(Box::from(name), Value::Map(Box::new(payload)));
+    sections
+}
+
+/// Parse an optional trailer count: `None`/empty field disables the check,
+/// a non-numeric field is an error naming the segment and count.
+fn parse_optional_count(
+    raw: Option<&String>,
+    segment: &str,
+    field: &str,
+) -> Result<Option<u64>, FormatError> {
+    match raw {
+        None => Ok(None),
+        Some(text) if text.trim().is_empty() => Ok(None),
+        Some(text) => {
+            text.trim().parse().map(Some).map_err(|_| {
+                FormatError::Hl7(format!("{segment} {field} {text:?} is not a number"))
+            })
+        }
+    }
+}
+
+/// Build the static positional schema `[seg_id, set_ref, set_type,
+/// f01..f<max>]`. All columns are string-typed; field text is stored
+/// verbatim (escapes decoded) so the round-trip is lossless.
+fn build_schema(max_fields: usize) -> Arc<Schema> {
+    let mut columns: Vec<Box<str>> = Vec::with_capacity(3 + max_fields);
+    columns.push(Box::from("seg_id"));
+    columns.push(Box::from("set_ref"));
+    columns.push(Box::from("set_type"));
+    for i in 0..max_fields {
+        columns.push(positional_key(i).into_boxed_str());
+    }
+    Arc::new(Schema::new(columns))
+}
+
+/// Positional field column name for field index `i`: `f01`, `f02`, …
+fn positional_key(i: usize) -> String {
+    format!("f{:02}", i + 1)
+}
+
+/// Map a field string to a `Value`: empty text becomes `Null` so an absent
+/// or blank field is uniformly null at the schema slot.
+fn string_or_null(s: &str) -> Value {
+    if s.is_empty() {
+        Value::Null
+    } else {
+        Value::String(s.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::{EnvelopeFieldType, EnvelopeSection};
+    use std::io::Cursor;
+
+    /// A minimal MSH header with the conventional `|^~\&` delimiters,
+    /// message type `ADT^A01`, control id `MSG001`.
+    const MSH: &str =
+        "MSH|^~\\&|SENDAPP|SENDFAC|RCVAPP|RCVFAC|20240101120000||ADT^A01|MSG001|P|2.5";
+
+    /// A bare single message (no batch/file envelope): MSH, EVN, PID, PV1.
+    fn adt_message() -> String {
+        format!("{MSH}\rEVN|A01|20240101120000\rPID|1||PATID^^^MRN||DOE^JOHN\rPV1|1|I")
+    }
+
+    fn reader(data: &str) -> Hl7Reader<Cursor<Vec<u8>>> {
+        Hl7Reader::new(
+            Cursor::new(data.as_bytes().to_vec()),
+            Hl7ReaderConfig::default(),
+        )
+    }
+
+    fn collect(data: &str) -> Vec<Record> {
+        let mut r = reader(data);
+        let mut out = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            out.push(rec);
+        }
+        out
+    }
+
+    #[test]
+    fn one_record_per_segment_including_msh() {
+        let recs = collect(&adt_message());
+        // MSH, EVN, PID, PV1 are all body records.
+        assert_eq!(recs.len(), 4);
+        assert_eq!(recs[0].get("seg_id"), Some(&Value::String("MSH".into())));
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("EVN".into())));
+        assert_eq!(recs[2].get("seg_id"), Some(&Value::String("PID".into())));
+        assert_eq!(recs[3].get("seg_id"), Some(&Value::String("PV1".into())));
+    }
+
+    #[test]
+    fn msh_off_by_one_field_positions() {
+        let recs = collect(&adt_message());
+        let msh = &recs[0];
+        // MSH-2 (encoding chars) is f01, kept verbatim.
+        assert_eq!(msh.get("f01"), Some(&Value::String("^~\\&".into())));
+        // MSH-3 (sending app) is f02.
+        assert_eq!(msh.get("f02"), Some(&Value::String("SENDAPP".into())));
+        // MSH-9 (message type) is f08.
+        assert_eq!(msh.get("f08"), Some(&Value::String("ADT^A01".into())));
+        // MSH-10 (control id) is f09.
+        assert_eq!(msh.get("f09"), Some(&Value::String("MSG001".into())));
+    }
+
+    #[test]
+    fn set_ref_and_type_stamped_on_every_record() {
+        let recs = collect(&adt_message());
+        for rec in &recs {
+            assert_eq!(rec.get("set_ref"), Some(&Value::String("MSG001".into())));
+            assert_eq!(rec.get("set_type"), Some(&Value::String("ADT^A01".into())));
+        }
+    }
+
+    #[test]
+    fn envelope_segments_never_emitted_as_body() {
+        let batched = format!("FHS|^~\\&|SENDAPP\rBHS|^~\\&|SENDAPP\r{MSH}\rPID|1\rBTS|1\rFTS|1");
+        let recs = collect(&batched);
+        for rec in &recs {
+            let seg = rec.get("seg_id").unwrap();
+            assert!(
+                !matches!(seg, Value::String(s) if matches!(&**s, "FHS" | "FTS" | "BHS" | "BTS"))
+            );
+        }
+        // MSH and PID are the only body records.
+        assert_eq!(recs.len(), 2);
+    }
+
+    #[test]
+    fn absent_trailing_fields_are_null() {
+        let recs = collect(&adt_message());
+        // EVN has 2 fields (A01, timestamp); f03.. are null.
+        assert_eq!(recs[1].get("f03"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn nested_events_open_message_for_bare_msh() {
+        let mut r = reader(&adt_message());
+        let _first = r.next_record().unwrap().unwrap(); // MSH
+        let events = r.take_envelope_events();
+        assert_eq!(events.len(), 1, "MSH opens one message level");
+        assert!(matches!(events[0], EnvelopeEvent::OpenLevel { .. }));
+    }
+
+    #[test]
+    fn nested_events_close_message_at_end() {
+        let mut r = reader(&adt_message());
+        while r.next_record().unwrap().is_some() {
+            let _ = r.take_envelope_events();
+        }
+        // The terminal next_record closes the message level.
+        let trailing = r.take_envelope_events();
+        assert_eq!(trailing.len(), 1, "the message closes at end-of-input");
+        assert!(matches!(trailing[0], EnvelopeEvent::CloseLevel));
+    }
+
+    #[test]
+    fn message_section_exposes_msh_fields() {
+        let mut r = reader(&adt_message());
+        let _ = r.next_record().unwrap().unwrap();
+        let events = r.take_envelope_events();
+        let EnvelopeEvent::OpenLevel { sections } = &events[0] else {
+            panic!("expected message OpenLevel");
+        };
+        let set = match sections.get("transaction_set").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // MSH-9 (message type) is f08; MSH-10 (control id) is f09.
+        assert_eq!(set.get("f08"), Some(&Value::String("ADT^A01".into())));
+        assert_eq!(set.get("f09"), Some(&Value::String("MSG001".into())));
+    }
+
+    #[test]
+    fn multi_message_bare_stream_closes_each_message() {
+        let m2 = MSH.replace("MSG001", "MSG002");
+        let data = format!("{MSH}\rPID|1\r{m2}\rPID|2");
+        let mut r = reader(&data);
+        // MSH(1)
+        let _ = r.next_record().unwrap().unwrap();
+        assert_eq!(r.take_envelope_events().len(), 1); // open msg 1
+        // PID|1
+        let _ = r.next_record().unwrap().unwrap();
+        assert!(r.take_envelope_events().is_empty());
+        // MSH(2) closes msg 1 and opens msg 2.
+        let _ = r.next_record().unwrap().unwrap();
+        let evs = r.take_envelope_events();
+        assert_eq!(evs.len(), 2);
+        assert!(matches!(evs[0], EnvelopeEvent::CloseLevel));
+        assert!(matches!(evs[1], EnvelopeEvent::OpenLevel { .. }));
+    }
+
+    #[test]
+    fn batch_nesting_opens_batch_then_message() {
+        let data = format!("BHS|^~\\&|SENDAPP\r{MSH}\rPID|1\rBTS|1");
+        let mut r = reader(&data);
+        let _ = r.next_record().unwrap().unwrap(); // MSH
+        let events = r.take_envelope_events();
+        // BHS opens the batch, MSH opens the message.
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0], EnvelopeEvent::OpenLevel { .. }));
+        assert!(matches!(events[1], EnvelopeEvent::OpenLevel { .. }));
+    }
+
+    #[test]
+    fn bts_message_count_mismatch_errors() {
+        let data = format!("BHS|^~\\&|S\r{MSH}\rPID|1\rBTS|9");
+        let mut r = reader(&data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected count mismatch"),
+                Err(e) => break e,
+            }
+        };
+        assert!(
+            matches!(err, FormatError::Hl7(m) if m.contains("BTS batch message count mismatch"))
+        );
+    }
+
+    #[test]
+    fn fts_batch_count_mismatch_errors() {
+        let data = format!("FHS|^~\\&|S\rBHS|^~\\&|S\r{MSH}\rPID|1\rBTS|1\rFTS|9");
+        let mut r = reader(&data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected file batch count mismatch"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("FTS file batch count mismatch")));
+    }
+
+    #[test]
+    fn empty_count_disables_the_check() {
+        // BTS with no count field validates clean.
+        let data = format!("BHS|^~\\&|S\r{MSH}\rPID|1\rBTS");
+        let recs = collect(&data);
+        assert_eq!(recs.len(), 2);
+    }
+
+    #[test]
+    fn content_after_fts_errors() {
+        let data = format!("FHS|^~\\&|S\r{MSH}\rPID|1\rFTS|0\rPID|99");
+        let mut r = reader(&data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected after-trailer error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("after the FTS")));
+    }
+
+    #[test]
+    fn body_before_any_header_errors() {
+        // A file whose first segment is an ordinary body segment (no
+        // MSH/FHS/BHS header) is malformed; the tokenizer rejects it at
+        // delimiter discovery.
+        let data = "PID|1||X\rNTE|note";
+        let mut r = reader(data);
+        let err = r.next_record().unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("must begin with an MSH")));
+    }
+
+    #[test]
+    fn max_fields_overflow_errors_with_guidance() {
+        let data = format!("{MSH}\rZZZ|a|b|c|d|e");
+        let mut r = Hl7Reader::new(
+            Cursor::new(data.into_bytes()),
+            Hl7ReaderConfig { max_fields: 2 },
+        );
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected field overflow"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("max_fields")));
+    }
+
+    fn fhs_section(fields: &[(&str, EnvelopeFieldType)]) -> EnvelopeConfig {
+        let mut cfg = EnvelopeConfig::default();
+        let mut field_map = IndexMap::new();
+        for (k, ty) in fields {
+            field_map.insert((*k).to_string(), *ty);
+        }
+        cfg.sections.insert(
+            "file".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("FHS".to_string()),
+                fields: field_map,
+            },
+        );
+        cfg
+    }
+
+    #[test]
+    fn prepare_document_extracts_fhs_fields_typed() {
+        let file =
+            format!("FHS|^~\\&|SENDAPP|SENDFAC|RCVAPP|RCVFAC|20240101|FILE42\r{MSH}\rPID|1\rFTS|0");
+        let cfg = fhs_section(&[("f07", EnvelopeFieldType::String)]);
+        let mut r = reader(&file);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let file_doc = match sections.get("file").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // FHS-8 (file name / id) is f07 under the off-by-one.
+        assert_eq!(file_doc.get("f07"), Some(&Value::String("FILE42".into())));
+        // Body still streams after the header pre-scan.
+        let recs: Vec<_> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(recs.len(), 2); // MSH, PID
+    }
+
+    #[test]
+    fn prepare_document_rejects_non_fhs_segment() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "batch".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("BHS".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(&adt_message());
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("not extractable")));
+    }
+
+    #[test]
+    fn prepare_document_rejects_xml_path_extract() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "bad".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::XmlPath("/doc".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(&adt_message());
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("non-`segment`")));
+    }
+
+    #[test]
+    fn prepare_document_rejects_fhs_section_when_file_has_no_fhs() {
+        // A bare MSH-led file has no FHS; declaring an FHS section is a
+        // config-against-data mistake the reader surfaces.
+        let cfg = fhs_section(&[("f07", EnvelopeFieldType::String)]);
+        let mut r = reader(&adt_message());
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("no FHS file header")));
+    }
+
+    /// Full reader → `$doc` → writer → reader round-trip exercising the MSH
+    /// header reconstruction, the message-level envelope, and escape
+    /// re-encoding.
+    #[test]
+    fn reader_doc_writer_round_trip_preserves_msh_and_escapes() {
+        use crate::hl7::writer::{Hl7Writer, Hl7WriterConfig};
+        use crate::traits::FormatWriter;
+        use clinker_record::{DocumentContext, DocumentId};
+
+        // An OBX field carries a literal '|' that arrives escaped as \F\.
+        let input = format!("{MSH}\rPID|1||PATID\rOBX|1|TX|note||a\\F\\b");
+
+        let mut r = reader(&input);
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 3); // MSH, PID, OBX
+        // The decoded OBX value is clean (no wire escape).
+        assert_eq!(body_recs[2].get("f05"), Some(&Value::String("a|b".into())));
+
+        // Attach a document context (no FHS section; the message-level MSH
+        // is rebuilt from the record stream) and re-emit through the writer.
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("adt.hl7"),
+            IndexMap::new(),
+        ));
+        let schema = r.schema().unwrap();
+        let out = {
+            let mut buf = Vec::new();
+            let mut w = Hl7Writer::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                Hl7WriterConfig::default(),
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+
+        // The MSH header is re-emitted and the literal '|' is re-escaped.
+        assert!(out.starts_with("MSH|^~\\&|"), "{out}");
+        assert!(out.contains("OBX|1|TX|note||a\\F\\b"), "{out}");
+
+        // Re-read the emitted file: the decoded value matches.
+        let recs2 = collect(&out);
+        assert_eq!(recs2.len(), 3);
+        assert_eq!(recs2[2].get("f05"), Some(&Value::String("a|b".into())));
+    }
+}

--- a/crates/clinker-format/src/hl7/reader.rs
+++ b/crates/clinker-format/src/hl7/reader.rs
@@ -199,9 +199,17 @@ impl<R: Read> Hl7Reader<R> {
             let raw = match self.next_raw()? {
                 Some(s) => s,
                 None => {
-                    // End of input: close any still-open message, then the
-                    // batch if the file used a bare batch with no BTS.
+                    // End of input. Close every still-open level so the
+                    // queued envelope events balance: first any open message
+                    // (which has no trailer — EOF is its natural boundary),
+                    // then an open batch whose `BTS` the file omitted. HL7
+                    // batch/file trailers are advisory and real files
+                    // frequently drop them, so a missing `BTS`/`FTS` at EOF
+                    // is a clean close, not a truncation error; the optional
+                    // count check only runs when a trailer is actually
+                    // present.
                     self.close_message_if_open();
+                    self.close_batch_if_open();
                     self.done = true;
                     return Ok(None);
                 }
@@ -357,6 +365,18 @@ impl<R: Read> Hl7Reader<R> {
     /// and at end-of-input.
     fn close_message_if_open(&mut self) {
         if self.open_message.take().is_some() {
+            self.pending_events.push(EnvelopeEvent::CloseLevel);
+        }
+    }
+
+    /// Close the open batch (if any) without a `BTS` count check, queuing
+    /// its `CloseLevel`. A no-op when no batch is open. Used at end-of-input
+    /// for a batch whose `BTS` trailer the file omitted, so the queued
+    /// `OpenLevel`/`CloseLevel` events stay balanced. An explicit `BTS`
+    /// trailer goes through [`Self::close_batch`] instead, which also
+    /// validates the optional message count.
+    fn close_batch_if_open(&mut self) {
+        if self.open_batch.take().is_some() {
             self.pending_events.push(EnvelopeEvent::CloseLevel);
         }
     }
@@ -709,6 +729,65 @@ mod tests {
         assert!(matches!(events[1], EnvelopeEvent::OpenLevel { .. }));
     }
 
+    /// Drain every envelope event a reader produces across the whole stream,
+    /// including the terminal end-of-input `next_record`.
+    fn drain_all_events(data: &str) -> Vec<EnvelopeEvent> {
+        let mut r = reader(data);
+        let mut events = Vec::new();
+        loop {
+            match r.next_record().unwrap() {
+                Some(_) => events.extend(r.take_envelope_events()),
+                None => {
+                    events.extend(r.take_envelope_events());
+                    break;
+                }
+            }
+        }
+        events
+    }
+
+    fn count_open_close(events: &[EnvelopeEvent]) -> (usize, usize) {
+        let opens = events
+            .iter()
+            .filter(|e| matches!(e, EnvelopeEvent::OpenLevel { .. }))
+            .count();
+        let closes = events
+            .iter()
+            .filter(|e| matches!(e, EnvelopeEvent::CloseLevel))
+            .count();
+        (opens, closes)
+    }
+
+    #[test]
+    fn unterminated_batch_at_eof_still_balances_events() {
+        // A BHS-opened batch (and its MSH message) with no BTS/FTS at EOF —
+        // a common shape for HL7 batch files that drop the advisory trailers.
+        // The reader must close both the message and the batch at EOF so the
+        // OpenLevel/CloseLevel events stay balanced; an unbalanced batch
+        // OpenLevel would leave the driver's document stack open forever.
+        let data = format!("BHS|^~\\&|S\r{MSH}\rPID|1");
+        let events = drain_all_events(&data);
+        let (opens, closes) = count_open_close(&events);
+        assert_eq!(opens, 2, "BHS + MSH each open one level");
+        assert_eq!(
+            closes, opens,
+            "every opened level must close by EOF; events: {events:?}"
+        );
+    }
+
+    #[test]
+    fn unterminated_batch_with_trailer_still_balances_events() {
+        // The same batch with its BTS/FTS present must balance identically.
+        let data = format!("FHS|^~\\&|S\rBHS|^~\\&|S\r{MSH}\rPID|1\rBTS|1\rFTS|1");
+        let events = drain_all_events(&data);
+        let (opens, closes) = count_open_close(&events);
+        assert_eq!(
+            opens, 2,
+            "BHS + MSH each open one level (FHS is file-level)"
+        );
+        assert_eq!(closes, opens, "events: {events:?}");
+    }
+
     #[test]
     fn bts_message_count_mismatch_errors() {
         let data = format!("BHS|^~\\&|S\r{MSH}\rPID|1\rBTS|9");
@@ -872,12 +951,21 @@ mod tests {
         use crate::traits::FormatWriter;
         use clinker_record::{DocumentContext, DocumentId};
 
-        // An OBX field carries a literal '|' that arrives escaped as \F\.
-        let input = format!("{MSH}\rPID|1||PATID\rOBX|1|TX|note||a\\F\\b");
+        // PID-3 is a real composite CX field with four components and a
+        // repetition (`~`); the OBX field carries a literal '|' that arrives
+        // escaped as \F\. The composite/repetition structure must round-trip
+        // byte-identically (kept verbatim), while the escaped '|' decodes and
+        // re-escapes.
+        let input = format!("{MSH}\rPID|1||PATID^^^MRN~ALT^^^MR\rOBX|1|TX|note||a\\F\\b");
 
         let mut r = reader(&input);
         let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
         assert_eq!(body_recs.len(), 3); // MSH, PID, OBX
+        // PID-3 is kept verbatim (components and repetition intact).
+        assert_eq!(
+            body_recs[1].get("f03"),
+            Some(&Value::String("PATID^^^MRN~ALT^^^MR".into()))
+        );
         // The decoded OBX value is clean (no wire escape).
         assert_eq!(body_recs[2].get("f05"), Some(&Value::String("a|b".into())));
 
@@ -905,13 +993,21 @@ mod tests {
             String::from_utf8(buf).unwrap()
         };
 
-        // The MSH header is re-emitted and the literal '|' is re-escaped.
+        // The MSH header is re-emitted, the composite PID-3 is byte-identical
+        // (its component '^' and repetition '~' separators are NOT escaped),
+        // and the literal '|' is re-escaped.
         assert!(out.starts_with("MSH|^~\\&|"), "{out}");
+        assert!(out.contains("PID|1||PATID^^^MRN~ALT^^^MR\r"), "{out}");
         assert!(out.contains("OBX|1|TX|note||a\\F\\b"), "{out}");
 
-        // Re-read the emitted file: the decoded value matches.
+        // Re-read the emitted file: the composite survives and the decoded
+        // value matches.
         let recs2 = collect(&out);
         assert_eq!(recs2.len(), 3);
+        assert_eq!(
+            recs2[1].get("f03"),
+            Some(&Value::String("PATID^^^MRN~ALT^^^MR".into()))
+        );
         assert_eq!(recs2[2].get("f05"), Some(&Value::String("a|b".into())));
     }
 }

--- a/crates/clinker-format/src/hl7/tokenizer.rs
+++ b/crates/clinker-format/src/hl7/tokenizer.rs
@@ -1,0 +1,572 @@
+//! HL7 v2 segment tokenizer: MSH-driven delimiter discovery and
+//! escape-aware splitting.
+//!
+//! An HL7 v2 file is a flat byte stream of segments terminated by a
+//! carriage return. Each segment splits into a tag and data fields on the
+//! field separator; a field splits into components on the component
+//! separator, repetitions on the repetition separator, and sub-components
+//! on the sub-component separator. The delimiters are declared in the
+//! `MSH` header rather than assumed: the field separator is the single
+//! byte immediately after the `MSH` tag (`MSH-1`), and the four encoding
+//! characters (`MSH-2`) are the bytes that follow — component, repetition,
+//! escape, sub-component — up to the next field separator.
+//!
+//! The escape character introduces an escape sequence `\X\`, where `X`
+//! names a delimiter (`F` field, `S` component, `T` sub-component, `R`
+//! repetition, `E` escape itself). The reader decodes these into their
+//! literal data byte so downstream consumers see clean data; the writer
+//! re-escapes on output, so a reader → writer → reader round-trip is
+//! byte-faithful. Component, repetition, and sub-component separators are
+//! *not* split or decoded — field text keeps them verbatim, so a composite
+//! field `A^B^C` stays one field string. The positional field model
+//! deliberately works above component resolution.
+//!
+//! Memory model: the tokenizer reads one segment at a time from a buffered
+//! source into a bounded scratch buffer. A hard per-segment byte cap turns
+//! a missing terminator (truncated / corrupt input) into an error rather
+//! than letting the buffer grow without limit.
+
+use std::io::{BufRead, Read};
+
+use crate::error::FormatError;
+
+/// Hard ceiling on a single segment's raw byte length. A real HL7 segment
+/// is well under a few kilobytes; this cap exists only so a stream with no
+/// carriage-return terminator fails fast instead of buffering the whole
+/// file into one "segment".
+pub(crate) const MAX_SEGMENT_BYTES: usize = 256 * 1024;
+
+/// The HL7 segment terminator. Always a carriage return — never
+/// producer-chosen, unlike the field/encoding delimiters.
+const SEGMENT_TERMINATOR: u8 = b'\r';
+
+/// The four HL7 service delimiters discovered from the `MSH` header (the
+/// field separator plus the four encoding characters).
+///
+/// The component, repetition, and sub-component separators are stored but
+/// never split on at the tokenizer level: field text is kept verbatim, so
+/// a composite or repeating field rides inside one field string intact.
+/// Only the escape character is interpreted, because that is what
+/// distinguishes a delimiter byte from literal data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Delimiters {
+    /// Field separator (`MSH-1`), between fields of a segment.
+    pub field: u8,
+    /// Component separator (first encoding char), within a field.
+    pub component: u8,
+    /// Repetition separator (second encoding char), within a field.
+    pub repetition: u8,
+    /// Escape character (third encoding char), introducing a `\X\`
+    /// escape sequence.
+    pub escape: u8,
+    /// Sub-component separator (fourth encoding char), within a component.
+    pub subcomponent: u8,
+}
+
+impl Delimiters {
+    /// The conventional HL7 v2 default delimiter set — field `|`,
+    /// component `^`, repetition `~`, escape `\`, sub-component `&`. Used
+    /// as a placeholder before the `MSH` header is read and as the writer's
+    /// default when no header dictates otherwise.
+    pub(crate) fn default_set() -> Self {
+        Self {
+            field: b'|',
+            component: b'^',
+            repetition: b'~',
+            escape: b'\\',
+            subcomponent: b'&',
+        }
+    }
+}
+
+/// Streaming HL7 segment reader.
+///
+/// Wraps a buffered source and yields one raw segment string at a time
+/// (terminator stripped, inter-segment newline whitespace stripped). The
+/// delimiters are discovered once from the `MSH` header on the first read.
+pub(crate) struct SegmentTokenizer<R: Read> {
+    reader: R,
+    delimiters: Delimiters,
+    initialized: bool,
+}
+
+impl<R: BufRead> SegmentTokenizer<R> {
+    /// Build a tokenizer over a buffered source. Delimiter discovery is
+    /// deferred to the first [`Self::read_first_segment`] call so the `MSH`
+    /// header scan and the first segment read share one pass.
+    pub(crate) fn new(reader: R) -> Self {
+        Self {
+            reader,
+            delimiters: Delimiters::default_set(),
+            initialized: false,
+        }
+    }
+
+    /// The active delimiter set, valid only after the first read has
+    /// resolved the `MSH` header.
+    pub(crate) fn delimiters(&self) -> Delimiters {
+        self.delimiters
+    }
+
+    /// Consume any inter-segment newline whitespace (`\r`/`\n`) that some
+    /// producers add between segments for readability. Stops at the first
+    /// byte that could begin a segment tag.
+    fn skip_inter_segment_whitespace(&mut self) -> Result<(), FormatError> {
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                return Ok(());
+            }
+            let mut consumed = 0;
+            for &b in buf {
+                if b == b'\r' || b == b'\n' {
+                    consumed += 1;
+                } else {
+                    break;
+                }
+            }
+            if consumed == 0 {
+                return Ok(());
+            }
+            self.reader.consume(consumed);
+        }
+    }
+
+    /// Read the first segment — an `MSH` message header, or an `FHS` file
+    /// header or `BHS` batch header that wraps it — resolving the delimiter
+    /// set from it and returning the raw segment text.
+    ///
+    /// All three header segments share the same delimiter-declaring layout:
+    /// the field separator is the single byte after the three-character tag,
+    /// and the four encoding characters follow it up to the next field
+    /// separator. HL7 requires a file's `FHS`/`BHS` encoding characters to
+    /// match its messages' `MSH`, so reading them from whichever header
+    /// leads the file yields the same delimiter set. The reader's
+    /// `ensure_initialized` guards against a second call, so this runs
+    /// exactly once before any [`Self::next_segment`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Hl7`] when the stream does not begin with an
+    /// `MSH`/`FHS`/`BHS` header carrying at least the field separator and
+    /// four encoding characters (a non-HL7 or truncated stream leaves the
+    /// delimiter set undefined, so nothing downstream can be tokenized).
+    pub(crate) fn read_first_segment(&mut self) -> Result<String, FormatError> {
+        self.skip_inter_segment_whitespace()?;
+
+        // The header's delimiters are not yet known, so the first segment is
+        // read up to the fixed carriage-return terminator without any escape
+        // interpretation: the escape character itself is declared inside
+        // this very segment.
+        let raw = self.read_raw_until_terminator()?.ok_or_else(|| {
+            FormatError::Hl7(
+                "empty input: no header segment found; the file is empty or not HL7 v2".into(),
+            )
+        })?;
+
+        let starts_with_header =
+            raw.starts_with(b"MSH") || raw.starts_with(b"FHS") || raw.starts_with(b"BHS");
+        if !starts_with_header {
+            return Err(FormatError::Hl7(format!(
+                "HL7 v2 file must begin with an MSH, FHS, or BHS header segment, found {:?}",
+                String::from_utf8_lossy(&raw[..3.min(raw.len())])
+            )));
+        }
+        // After the tag: byte 3 is the field separator, bytes 4..8 are the
+        // encoding characters (component, repetition, escape, sub-component).
+        // The encoding-characters field ends at the next field separator, so
+        // it must be at least four bytes wide.
+        if raw.len() < 8 {
+            return Err(FormatError::Hl7(format!(
+                "truncated HL7 header: need a three-character tag plus a field separator and four \
+                 encoding characters (8 bytes), read {}",
+                raw.len()
+            )));
+        }
+        let field = raw[3];
+        let encoding = &raw[4..8];
+        self.delimiters = Delimiters {
+            field,
+            component: encoding[0],
+            repetition: encoding[1],
+            escape: encoding[2],
+            subcomponent: encoding[3],
+        };
+        self.initialized = true;
+
+        let text = String::from_utf8(raw).map_err(|e| {
+            FormatError::Hl7(format!(
+                "MSH header is not valid UTF-8: {e}. Non-UTF-8 charsets are not supported"
+            ))
+        })?;
+        Ok(text)
+    }
+
+    /// Read the next raw segment (carriage-return-delimited), or `None` at
+    /// clean end of stream.
+    ///
+    /// The terminator byte is consumed but not returned. An escape sequence
+    /// `\X\` is passed through verbatim (the escape char is not a segment
+    /// boundary); decoding into literal data happens in [`split_segment`].
+    /// Inter-segment newlines are dropped; an embedded escape sequence
+    /// inside a field is preserved.
+    pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
+        debug_assert!(
+            self.initialized,
+            "read_first_segment must run before next_segment"
+        );
+        self.skip_inter_segment_whitespace()?;
+        let raw = match self.read_raw_until_terminator()? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
+        let text = String::from_utf8(raw).map_err(|e| {
+            FormatError::Hl7(format!(
+                "segment is not valid UTF-8: {e}. Non-UTF-8 charsets are not supported"
+            ))
+        })?;
+        Ok(Some(text))
+    }
+
+    /// Read raw bytes up to (and consuming) the next carriage-return
+    /// terminator. Returns `None` at a clean end of stream (empty pending
+    /// buffer). A non-empty buffer at EOF is treated as a final segment
+    /// whose trailing terminator the producer omitted — accepted rather
+    /// than rejected, because HL7 producers commonly drop the last CR.
+    ///
+    /// The escape character is never interpreted here: a `\X\` sequence
+    /// passes through verbatim because the terminator is the fixed carriage
+    /// return, and HL7 escape decoding happens later in [`split_segment`].
+    fn read_raw_until_terminator(&mut self) -> Result<Option<Vec<u8>>, FormatError> {
+        let mut raw: Vec<u8> = Vec::new();
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                if raw.is_empty() {
+                    return Ok(None);
+                }
+                // A final segment with no trailing CR is the common HL7
+                // shape; strip surrounding newlines and accept it.
+                return Ok(Some(strip_edge_whitespace(&raw)));
+            }
+
+            let mut consumed = 0;
+            let mut finished = false;
+            for &b in buf {
+                consumed += 1;
+                if b == SEGMENT_TERMINATOR {
+                    finished = true;
+                    break;
+                }
+                raw.push(b);
+            }
+            self.reader.consume(consumed);
+
+            if raw.len() > MAX_SEGMENT_BYTES {
+                return Err(FormatError::Hl7(format!(
+                    "segment exceeded the {MAX_SEGMENT_BYTES}-byte cap without a carriage-return \
+                     terminator; the file is malformed or not HL7 v2"
+                )));
+            }
+
+            if finished {
+                return Ok(Some(strip_edge_whitespace(&raw)));
+            }
+        }
+    }
+}
+
+/// Drop a line-feed that brackets a raw segment body. HL7 segments end in
+/// a bare carriage return, but producers (and CRLF-normalizing transports)
+/// often add a line feed; that whitespace is insignificant, so it is
+/// trimmed from the segment edges. Interior bytes are left intact.
+fn strip_edge_whitespace(raw: &[u8]) -> Vec<u8> {
+    let start = raw
+        .iter()
+        .position(|&b| b != b'\r' && b != b'\n')
+        .unwrap_or(raw.len());
+    let end = raw
+        .iter()
+        .rposition(|&b| b != b'\r' && b != b'\n')
+        .map(|p| p + 1)
+        .unwrap_or(start);
+    raw[start..end].to_vec()
+}
+
+/// A parsed segment: its tag plus its decoded data fields.
+///
+/// Escape sequences are decoded into their literal data byte here, so a
+/// field value carries clean data (a `\F\` on the wire becomes a literal
+/// field-separator byte in the value). Downstream consumers — CSV/JSON
+/// output, CXL string predicates, `$doc` fields — therefore see the data
+/// the HL7 producer meant, never the wire escapes. The writer re-escapes
+/// on output, so the reader → writer → reader round-trip is byte-faithful.
+///
+/// Component, repetition, and sub-component separators are *not* decoded or
+/// split: field text keeps them verbatim, so a composite field `A^B^C`
+/// stays one field string and a repeating field rides inside one string
+/// intact. Only the escape mechanism is interpreted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedSegment {
+    pub tag: String,
+    pub fields: Vec<String>,
+}
+
+/// Split a raw segment string into its tag and decoded field values on the
+/// field separator, honoring the escape character.
+///
+/// The tag is the first part; the remainder are data fields. The header
+/// segments (`MSH`/`FHS`/`BHS`) are special: their field-separator-1 *is*
+/// the delimiter, and their encoding-characters field (field index 0)
+/// carries the component/repetition/escape/sub-component bytes verbatim —
+/// those bytes are not interpreted as escapes there, so the
+/// encoding-characters field round-trips intact. For every other field, an
+/// escape sequence `\X\` decodes to the literal delimiter byte it names
+/// (`\F\` → field, `\S\` → component, `\T\` → sub-component, `\R\` →
+/// repetition, `\E\` → escape); an unrecognized or unterminated sequence is
+/// kept verbatim so no data is lost.
+pub(crate) fn split_segment(raw: &str, delims: &Delimiters) -> ParsedSegment {
+    let field = delims.field;
+    let bytes = raw.as_bytes();
+
+    // Split on the field separator first (the field separator never appears
+    // unescaped inside field data — a literal one is written `\F\`).
+    let mut raw_parts: Vec<&[u8]> = Vec::new();
+    let mut start = 0;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == field {
+            raw_parts.push(&bytes[start..i]);
+            start = i + 1;
+        }
+    }
+    raw_parts.push(&bytes[start..]);
+
+    // A delimiter-declaring header carries the escape character as literal
+    // data in its encoding-characters field rather than as an escape
+    // introducer, so that field is kept verbatim.
+    let is_header = raw.starts_with("MSH") || raw.starts_with("FHS") || raw.starts_with("BHS");
+    let mut parts = raw_parts.into_iter();
+    let tag = parts
+        .next()
+        .map(|t| String::from_utf8_lossy(t).into_owned())
+        .unwrap_or_default();
+    let fields: Vec<String> = parts
+        .enumerate()
+        .map(|(idx, part)| {
+            if is_header && idx == 0 {
+                String::from_utf8_lossy(part).into_owned()
+            } else {
+                decode_escapes(part, delims)
+            }
+        })
+        .collect();
+
+    ParsedSegment { tag, fields }
+}
+
+/// Decode HL7 `\X\` escape sequences in a field's bytes into their literal
+/// delimiter byte. A recognized sequence (`\F\ \S\ \T\ \R\ \E\`) is
+/// replaced with the byte it names; an unrecognized or unterminated escape
+/// run is kept verbatim, so application escapes (`\.br\`, `\Xdd..\`) and
+/// malformed input survive rather than silently dropping data.
+fn decode_escapes(bytes: &[u8], delims: &Delimiters) -> String {
+    let escape = delims.escape;
+    if !bytes.contains(&escape) {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != escape {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        }
+        // Look for a closing escape byte to delimit the sequence.
+        if let Some(end_rel) = bytes[i + 1..].iter().position(|&b| b == escape) {
+            let inner = &bytes[i + 1..i + 1 + end_rel];
+            if let Some(byte) = escape_to_delimiter(inner, delims) {
+                out.push(byte);
+                i = i + 1 + end_rel + 1;
+                continue;
+            }
+            // Recognized escape framing but an application sequence we do
+            // not decode (e.g. `\.br\`): keep the whole run verbatim.
+            out.push(escape);
+            i += 1;
+            continue;
+        }
+        // No closing escape byte: a dangling escape char is literal data.
+        out.push(escape);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+/// Map a delimiter-escape sequence body (the bytes between the two escape
+/// characters) to the literal delimiter byte it names, or `None` for any
+/// sequence that is not one of the five standard delimiter escapes.
+fn escape_to_delimiter(inner: &[u8], delims: &Delimiters) -> Option<u8> {
+    match inner {
+        b"F" => Some(delims.field),
+        b"S" => Some(delims.component),
+        b"T" => Some(delims.subcomponent),
+        b"R" => Some(delims.repetition),
+        b"E" => Some(delims.escape),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// A minimal MSH header with the conventional `|^~\&` delimiters.
+    const MSH: &str =
+        "MSH|^~\\&|SENDAPP|SENDFAC|RCVAPP|RCVFAC|20240101120000||ADT^A01|MSG001|P|2.5";
+
+    fn tok(data: &[u8]) -> SegmentTokenizer<Cursor<Vec<u8>>> {
+        SegmentTokenizer::new(Cursor::new(data.to_vec()))
+    }
+
+    #[test]
+    fn msh_header_declares_delimiters() {
+        let data = format!("{MSH}\rPID|1||PATID");
+        let mut t = tok(data.as_bytes());
+        let header = t.read_first_segment().unwrap();
+        let d = t.delimiters();
+        assert_eq!(d.field, b'|');
+        assert_eq!(d.component, b'^');
+        assert_eq!(d.repetition, b'~');
+        assert_eq!(d.escape, b'\\');
+        assert_eq!(d.subcomponent, b'&');
+        let parsed = split_segment(&header, &d);
+        assert_eq!(parsed.tag, "MSH");
+        // MSH-2 (encoding chars) is field index 0, kept verbatim.
+        assert_eq!(parsed.fields[0], "^~\\&");
+        // MSH-9 (message type) is field index 7 (the MSH off-by-one).
+        assert_eq!(parsed.fields[7], "ADT^A01");
+        // MSH-10 (message control id) is field index 8.
+        assert_eq!(parsed.fields[8], "MSG001");
+    }
+
+    #[test]
+    fn custom_delimiters_discovered_from_msh() {
+        // Field '#', component '@', repetition '*', escape '/', subcomponent '$'.
+        let msh = "MSH#@*/$#SENDAPP#SENDFAC#RCVAPP#RCVFAC#202401##ADT@A01#M1#P#2.5";
+        let data = format!("{msh}\r");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let d = t.delimiters();
+        assert_eq!(d.field, b'#');
+        assert_eq!(d.component, b'@');
+        assert_eq!(d.repetition, b'*');
+        assert_eq!(d.escape, b'/');
+        assert_eq!(d.subcomponent, b'$');
+    }
+
+    #[test]
+    fn next_segment_after_msh_reads_pid() {
+        let data = format!("{MSH}\rPID|1||PATID^^^MRN");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let pid = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&pid, &t.delimiters());
+        assert_eq!(parsed.tag, "PID");
+        assert_eq!(parsed.fields[0], "1");
+        // Composite field kept verbatim above component resolution.
+        assert_eq!(parsed.fields[2], "PATID^^^MRN");
+    }
+
+    #[test]
+    fn escape_sequences_decode_into_clean_values() {
+        // OBX field carries an escaped field separator, escaped component
+        // separator, and an escaped escape character.
+        let data = format!("{MSH}\rOBX|1|TX|note||a\\F\\b\\S\\c\\E\\d");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let obx = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&obx, &t.delimiters());
+        assert_eq!(parsed.tag, "OBX");
+        // \F\ -> '|', \S\ -> '^', \E\ -> '\'.
+        assert_eq!(parsed.fields[4], "a|b^c\\d");
+    }
+
+    #[test]
+    fn unrecognized_escape_kept_verbatim() {
+        // \.br\ is a formatting escape this positional reader does not
+        // decode; it must survive verbatim, not be dropped.
+        let data = format!("{MSH}\rNTE|1||line one\\.br\\line two");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let nte = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&nte, &t.delimiters());
+        assert_eq!(parsed.fields[2], "line one\\.br\\line two");
+    }
+
+    #[test]
+    fn newlines_between_segments_stripped() {
+        let data = format!("{MSH}\r\nPID|1\r\nNTE|2\r\n");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let pid = t.next_segment().unwrap().unwrap();
+        assert_eq!(pid, "PID|1");
+        let nte = t.next_segment().unwrap().unwrap();
+        assert_eq!(nte, "NTE|2");
+        assert!(t.next_segment().unwrap().is_none());
+    }
+
+    #[test]
+    fn final_segment_without_terminator_accepted() {
+        // HL7 producers commonly omit the trailing CR on the last segment.
+        let data = format!("{MSH}\rPID|1");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let pid = t.next_segment().unwrap().unwrap();
+        assert_eq!(pid, "PID|1");
+        assert!(t.next_segment().unwrap().is_none());
+    }
+
+    #[test]
+    fn empty_input_errors() {
+        let mut t = tok(b"");
+        let err = t.read_first_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("empty input")));
+    }
+
+    #[test]
+    fn non_msh_start_errors() {
+        let mut t = tok(b"PID|1||X\r");
+        let err = t.read_first_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("must begin with an MSH")));
+    }
+
+    #[test]
+    fn truncated_msh_errors() {
+        let mut t = tok(b"MSH|^\r");
+        let err = t.read_first_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("truncated HL7 header")));
+    }
+
+    #[test]
+    fn unterminated_segment_hits_byte_cap() {
+        let data = format!("{MSH}\r{}", "A".repeat(MAX_SEGMENT_BYTES + 10));
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("cap")));
+    }
+
+    #[test]
+    fn msh_split_across_buffer_boundaries() {
+        use std::io::BufReader;
+        let data = format!("{MSH}\rPID|1");
+        let inner = Cursor::new(data.into_bytes());
+        let buffered = BufReader::with_capacity(8, inner);
+        let mut t = SegmentTokenizer::new(buffered);
+        let header = t.read_first_segment().unwrap();
+        assert!(header.starts_with("MSH"));
+        assert_eq!(t.delimiters().field, b'|');
+    }
+}

--- a/crates/clinker-format/src/hl7/tokenizer.rs
+++ b/crates/clinker-format/src/hl7/tokenizer.rs
@@ -185,6 +185,42 @@ impl<R: BufRead> SegmentTokenizer<R> {
         }
         let field = raw[3];
         let encoding = &raw[4..8];
+        // The five service delimiters must be mutually distinct. A short
+        // MSH-2 (e.g. `MSH|^~\|...`, which omits the sub-component char)
+        // leaves `raw[7]` pointing at the next field separator, so a naive
+        // read would set `subcomponent == field` and silently corrupt every
+        // split. The byte after the four encoding characters (`raw[8]`, when
+        // present) must be the field separator that ends MSH-2; reject a
+        // header where it is not, or where any two delimiters collide.
+        let delims = [field, encoding[0], encoding[1], encoding[2], encoding[3]];
+        for (a, &da) in delims.iter().enumerate() {
+            for &db in &delims[a + 1..] {
+                if da == db {
+                    return Err(FormatError::Hl7(format!(
+                        "HL7 header declares colliding delimiters: the field separator and the \
+                         four encoding characters (component, repetition, escape, sub-component) \
+                         must be five distinct bytes, found {:?}. A short MSH-2 that omits an \
+                         encoding character is the usual cause.",
+                        String::from_utf8_lossy(&raw[3..8])
+                    )));
+                }
+            }
+        }
+        // A conformant MSH-2 ends at the next field separator. If the byte
+        // after the four encoding characters is present and is not the field
+        // separator, the encoding-characters field is longer than four bytes
+        // (an unsupported extended encoding set), which would misalign every
+        // later field.
+        if let Some(&after) = raw.get(8)
+            && after != field
+        {
+            return Err(FormatError::Hl7(format!(
+                "HL7 header MSH-2 encoding-characters field is not the expected four bytes \
+                 terminated by the field separator; found {:?} after the four encoding \
+                 characters. Extended encoding sets are not supported.",
+                after as char
+            )));
+        }
         self.delimiters = Delimiters {
             field,
             component: encoding[0],
@@ -390,6 +426,15 @@ fn decode_escapes(bytes: &[u8], delims: &Delimiters) -> String {
                 i = i + 1 + end_rel + 1;
                 continue;
             }
+            // A `\Xhh..\` hexadecimal escape encodes raw data bytes (the
+            // form the writer uses to escape an embedded carriage return so
+            // it cannot split a segment). Decode it back to those bytes so
+            // the round-trip is faithful.
+            if let Some(mut decoded) = decode_hex_escape(inner) {
+                out.append(&mut decoded);
+                i = i + 1 + end_rel + 1;
+                continue;
+            }
             // Recognized escape framing but an application sequence we do
             // not decode (e.g. `\.br\`): keep the whole run verbatim.
             out.push(escape);
@@ -415,6 +460,25 @@ fn escape_to_delimiter(inner: &[u8], delims: &Delimiters) -> Option<u8> {
         b"E" => Some(delims.escape),
         _ => None,
     }
+}
+
+/// Decode an HL7 `\Xhh..\` hexadecimal escape body (the bytes between the
+/// two escape characters, beginning with `X`) to the raw bytes it encodes.
+/// Returns `None` when the body is not an `X` followed by an even-length run
+/// of ASCII hex digits, so a non-hex application escape keeps its
+/// verbatim-passthrough behavior.
+fn decode_hex_escape(inner: &[u8]) -> Option<Vec<u8>> {
+    let hex = inner.strip_prefix(b"X")?;
+    if hex.is_empty() || !hex.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(hex.len() / 2);
+    for pair in hex.chunks_exact(2) {
+        let hi = (pair[0] as char).to_digit(16)?;
+        let lo = (pair[1] as char).to_digit(16)?;
+        out.push((hi * 16 + lo) as u8);
+    }
+    Some(out)
 }
 
 #[cfg(test)]
@@ -568,5 +632,63 @@ mod tests {
         let header = t.read_first_segment().unwrap();
         assert!(header.starts_with("MSH"));
         assert_eq!(t.delimiters().field, b'|');
+    }
+
+    #[test]
+    fn short_msh2_collides_with_field_separator_and_is_rejected() {
+        // `MSH|^~\|...` has a three-character MSH-2 (`^~\`, no sub-component)
+        // followed by the field separator. A naive `raw[4..8]` read would set
+        // the sub-component separator to the field separator `|`, silently
+        // corrupting every split. The collision must be rejected.
+        let mut t = tok(b"MSH|^~\\|SENDAPP|SENDFAC|RCVAPP|RCVFAC|202401||ADT^A01|M1|P|2.5\r");
+        let err = t.read_first_segment().unwrap_err();
+        assert!(
+            matches!(err, FormatError::Hl7(m) if m.contains("colliding delimiters")),
+            "expected a colliding-delimiter rejection"
+        );
+    }
+
+    #[test]
+    fn duplicate_encoding_chars_rejected() {
+        // Two encoding characters equal to each other (`^` repeated) is also
+        // a collision the parser must reject.
+        let mut t = tok(b"MSH|^^\\&|SENDAPP|SENDFAC|R|R|202401||ADT^A01|M1|P|2.5\r");
+        let err = t.read_first_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("colliding delimiters")));
+    }
+
+    #[test]
+    fn extended_msh2_beyond_four_chars_rejected() {
+        // A MSH-2 wider than four bytes before the field separator is an
+        // unsupported extended encoding set; rejecting it avoids silently
+        // misaligning every later field.
+        let mut t = tok(b"MSH|^~\\&#|SENDAPP|SENDFAC|R|R|202401||ADT^A01|M1|P|2.5\r");
+        let err = t.read_first_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("not the expected four bytes")));
+    }
+
+    #[test]
+    fn hex_escape_decodes_to_raw_byte() {
+        // A `\X0D\` hex escape decodes back to a literal carriage return —
+        // the form the writer uses to escape an embedded CR so it cannot
+        // split a segment.
+        let data = format!("{MSH}\rNTE|1||a\\X0D\\b");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let nte = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&nte, &t.delimiters());
+        assert_eq!(parsed.fields[2], "a\rb");
+    }
+
+    #[test]
+    fn malformed_hex_escape_kept_verbatim() {
+        // A non-hex `\X..\` body is not a valid hex escape and is preserved
+        // verbatim rather than dropped.
+        let data = format!("{MSH}\rNTE|1||a\\XZZ\\b");
+        let mut t = tok(data.as_bytes());
+        let _ = t.read_first_segment().unwrap();
+        let nte = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&nte, &t.delimiters());
+        assert_eq!(parsed.fields[2], "a\\XZZ\\b");
     }
 }

--- a/crates/clinker-format/src/hl7/writer.rs
+++ b/crates/clinker-format/src/hl7/writer.rs
@@ -1,0 +1,661 @@
+//! HL7 v2 file writer.
+//!
+//! Reconstructs an HL7 v2 file around emitted body records: an optional
+//! `FHS` file header (literal config fields or echoed from a `$doc`
+//! section), an optional `BHS` batch header, the `MSH..` messages
+//! themselves (re-emitted from the record stream), and — when an envelope
+//! was configured — closing `BTS`/`FTS` trailers with recomputed counts.
+//! Record columns map positionally: `seg_id` is the segment tag, `f01..`
+//! are the data fields. Field data is escaped on output and decoded by the
+//! reader, so a reader → writer → reader round-trip is byte-faithful even
+//! for values that carry delimiter characters as literal data.
+//!
+//! HL7 messages have no per-message trailer segment — the next `MSH` (or a
+//! batch/file trailer, or end of input) is the message boundary — so the
+//! writer simply re-emits each segment in order, tracking message and batch
+//! counts for the optional `BTS`/`FTS` trailers. The `MSH` header segment
+//! arrives as a body record (the reader emits it), so the writer writes it
+//! verbatim rather than synthesizing one; its `MSH-2` encoding-characters
+//! field is written without escaping, mirroring the reader's verbatim
+//! treatment.
+//!
+//! Memory model: streaming and O(1) in held state — only the current
+//! message and batch counts are retained. `flush` is the single
+//! end-of-stream finalizer: it writes the `BTS`/`FTS` trailers (when an
+//! envelope was opened) exactly once. A file is one envelope, so byte-limit
+//! file splitting (which would flush — and thus finalize — mid-stream) is
+//! rejected for HL7 outputs at config-validation time; this writer is
+//! therefore only ever flushed at true end of stream.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+
+use crate::error::FormatError;
+use crate::hl7::RAW_FIELDS_KEY;
+use crate::hl7::tokenizer::Delimiters;
+use crate::traits::FormatWriter;
+
+/// Configuration for the HL7 writer.
+#[derive(Clone, Default)]
+pub struct Hl7WriterConfig {
+    /// Literal `FHS` data fields written verbatim as a file header. When
+    /// set, the writer opens the file with an `FHS` and closes it with an
+    /// `FTS`. Takes precedence over `file_header_from_doc`.
+    pub file_header: Option<Vec<String>>,
+    /// Name of a `$doc` section to echo the `FHS` fields from (the reader's
+    /// positional `FHS` envelope section), enabling round-trip file-header
+    /// reconstruction. Used only when `file_header` is unset.
+    pub file_header_from_doc: Option<String>,
+    /// Literal `BHS` data fields written verbatim as a batch header. When
+    /// set, the writer wraps the messages in a `BHS..BTS` batch.
+    pub batch_header: Option<Vec<String>>,
+    /// Write a newline after each segment's carriage-return terminator for
+    /// readability. The YAML option default is `true`, applied by the
+    /// config builder; the plain `Default` for this struct leaves it
+    /// `false`, so a caller constructing the config directly sets it.
+    pub segment_newline: bool,
+}
+
+/// Streaming HL7 v2 file writer.
+pub struct Hl7Writer<W: Write> {
+    writer: W,
+    config: Hl7WriterConfig,
+    delims: Delimiters,
+    /// Wire field columns keyed by the 1-based position parsed from the
+    /// column name (`f01` → 1), each paired with its schema index. The
+    /// numeric suffix — not schema-declaration order — determines the wire
+    /// slot, so a gapped (`f01, f03`) or reordered schema maps values to
+    /// the positions the names declare.
+    field_columns: Vec<FieldColumn>,
+    seg_id_idx: Option<usize>,
+    header_written: bool,
+    finalized: bool,
+    /// `true` once an `FHS` file header was emitted, so `flush` writes the
+    /// matching `FTS`.
+    file_open: bool,
+    /// `true` once a `BHS` batch header was emitted, so `flush` writes the
+    /// matching `BTS`.
+    batch_open: bool,
+    /// Count of `MSH` messages written, for the `BTS01` batch message count.
+    message_count: u64,
+    /// Count of `BHS` batches written, for the `FTS01` file batch count.
+    batch_count: u64,
+}
+
+/// A schema `fNN` field column resolved to its wire position and the schema
+/// index its value is read from.
+struct FieldColumn {
+    /// 1-based wire field position parsed from the `fNN` suffix.
+    position: usize,
+    /// The column name (`f01`) — used verbatim in error messages.
+    name: String,
+    /// Index into the record's value list.
+    schema_index: usize,
+}
+
+impl<W: Write> Hl7Writer<W> {
+    /// Build a writer over a sink with the given schema and config. The
+    /// schema's `seg_id` and `fNN` columns are resolved to positional
+    /// indices once. The `set_ref` / `set_type` columns are read from the
+    /// `MSH` record itself, so they need no separate index.
+    pub fn new(writer: W, schema: Arc<Schema>, config: Hl7WriterConfig) -> Self {
+        let mut field_columns = Vec::new();
+        let mut seg_id_idx = None;
+        for (i, col) in schema.columns().iter().enumerate() {
+            match &**col {
+                "seg_id" => seg_id_idx = Some(i),
+                // set_ref / set_type are reader-stamped echoes of MSH
+                // fields; the MSH record carries the authoritative values,
+                // so they are not mapped to wire fields here.
+                "set_ref" | "set_type" => {}
+                name => {
+                    if let Some(position) = field_position(name) {
+                        field_columns.push(FieldColumn {
+                            position,
+                            name: name.to_string(),
+                            schema_index: i,
+                        });
+                    }
+                }
+            }
+        }
+        field_columns.sort_by_key(|c| c.position);
+        Self {
+            writer,
+            config,
+            delims: Delimiters::default_set(),
+            field_columns,
+            seg_id_idx,
+            header_written: false,
+            finalized: false,
+            file_open: false,
+            batch_open: false,
+            message_count: 0,
+            batch_count: 0,
+        }
+    }
+
+    /// Emit the optional `FHS` file header and `BHS` batch header on the
+    /// first record.
+    fn write_header(&mut self, record: &Record) -> Result<(), FormatError> {
+        if self.header_written {
+            return Ok(());
+        }
+        self.header_written = true;
+
+        if let Some(fhs) = self.resolve_file_header(record)? {
+            self.write_segment("FHS", &fhs, true)?;
+            self.file_open = true;
+        }
+        if let Some(bhs) = self.config.batch_header.clone() {
+            self.write_segment("BHS", &bhs, true)?;
+            self.batch_open = true;
+            self.batch_count += 1;
+        }
+        Ok(())
+    }
+
+    /// Resolve the optional `FHS` fields: the literal config list wins;
+    /// otherwise echo from the named `$doc` section; otherwise `None` (a
+    /// bare MSH-led file with no file envelope).
+    fn resolve_file_header(&self, record: &Record) -> Result<Option<Vec<String>>, FormatError> {
+        if let Some(literal) = &self.config.file_header {
+            return Ok(Some(literal.clone()));
+        }
+        if let Some(section) = &self.config.file_header_from_doc {
+            let ctx = record.doc_ctx();
+            if let Some(Value::Array(raw)) = ctx.get_section_field(section, RAW_FIELDS_KEY) {
+                let fields = raw
+                    .iter()
+                    .enumerate()
+                    .map(|(i, v)| value_to_field(v, &format!("{section}.f{:02}", i + 1)))
+                    .collect::<Result<Vec<_>, _>>()?;
+                return Ok(Some(fields));
+            }
+            // Fallback: walk the declared positional `f01, f02, …` keys.
+            let mut fields: Vec<String> = Vec::new();
+            for i in 0.. {
+                let key = format!("f{:02}", i + 1);
+                match ctx.get_section_field(section, &key) {
+                    Some(v) => fields.push(value_to_field(&v, &format!("{section}.{key}"))?),
+                    None => break,
+                }
+            }
+            if fields.is_empty() {
+                return Err(FormatError::Hl7(format!(
+                    "file_header_from_doc names section {section:?}, but the record's document \
+                     context carries no FHS fields for it. Ensure the source declares a \
+                     `segment: \"FHS\"` envelope section of the same name."
+                )));
+            }
+            return Ok(Some(fields));
+        }
+        Ok(None)
+    }
+
+    /// Map a body record to its segment tag and field list, then write it.
+    /// An `MSH` segment is counted as a message and its `MSH-2`
+    /// encoding-characters field is written verbatim; other segments are
+    /// written with their field data escaped.
+    fn write_body_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        self.reject_unknown_columns(record)?;
+        let values = record.values();
+        let seg_id = match self.seg_id_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_field(v, "seg_id")?,
+            None => String::new(),
+        };
+        if seg_id.is_empty() {
+            return Err(FormatError::Hl7(
+                "record carries no `seg_id`; every HL7 record needs a segment tag to write".into(),
+            ));
+        }
+
+        // Batch/file headers and trailers are reconstructed by the writer
+        // from config, so an envelope segment that rode through the record
+        // stream is not re-emitted; an MSH still drives the message count.
+        if matches!(seg_id.as_str(), "FHS" | "FTS" | "BHS" | "BTS") {
+            return Ok(());
+        }
+
+        let is_msh = seg_id == "MSH";
+        if is_msh {
+            self.message_count += 1;
+        }
+        let fields = self.record_fields(record)?;
+        self.write_segment(&seg_id, &fields, is_msh)?;
+        Ok(())
+    }
+
+    /// Collect a record's `fNN` columns into wire-position order, filling
+    /// any gap left by a missing position with an empty field, then
+    /// trimming trailing empties so no fabricated delimiters appear.
+    fn record_fields(&self, record: &Record) -> Result<Vec<String>, FormatError> {
+        let values = record.values();
+        let max_position = self
+            .field_columns
+            .iter()
+            .map(|c| c.position)
+            .max()
+            .unwrap_or(0);
+        let mut fields: Vec<String> = vec![String::new(); max_position];
+        for col in &self.field_columns {
+            let text = match values.get(col.schema_index) {
+                Some(v) => value_to_field(v, &col.name)?,
+                None => String::new(),
+            };
+            fields[col.position - 1] = text;
+        }
+        while matches!(fields.last(), Some(s) if s.is_empty()) {
+            fields.pop();
+        }
+        Ok(fields)
+    }
+
+    /// Reject a record carrying a user column the writer does not map.
+    /// Engine-namespaced columns (`$`-prefixed) and the reader-stamped
+    /// `set_ref`/`set_type` echoes are excluded from the check.
+    fn reject_unknown_columns(&self, record: &Record) -> Result<(), FormatError> {
+        for (name, _) in record.iter_user_fields() {
+            if name.starts_with('$') {
+                continue;
+            }
+            let known = matches!(name, "seg_id" | "set_ref" | "set_type") || is_field_column(name);
+            if !known {
+                return Err(FormatError::Hl7(format!(
+                    "record column {name:?} has no HL7 mapping. The writer maps only `seg_id`, \
+                     `set_ref`, `set_type`, and positional `fNN` field columns; project the \
+                     record to those before output"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Write one segment: tag, field separator, escaped fields joined by the
+    /// field separator, carriage-return terminator, optional newline.
+    ///
+    /// A header segment (`is_header`) carries its encoding-characters field
+    /// (field index 0) verbatim — escaping it would corrupt the delimiter
+    /// declaration. All other field data is escaped so a delimiter byte in
+    /// data round-trips as an HL7 escape sequence rather than corrupting the
+    /// segment.
+    fn write_segment(
+        &mut self,
+        tag: &str,
+        fields: &[String],
+        is_header: bool,
+    ) -> Result<(), FormatError> {
+        self.writer
+            .write_all(tag.as_bytes())
+            .map_err(FormatError::Io)?;
+        for (idx, field) in fields.iter().enumerate() {
+            self.writer
+                .write_all(&[self.delims.field])
+                .map_err(FormatError::Io)?;
+            if is_header && idx == 0 {
+                self.writer
+                    .write_all(field.as_bytes())
+                    .map_err(FormatError::Io)?;
+            } else {
+                self.write_escaped(field)?;
+            }
+        }
+        self.writer.write_all(b"\r").map_err(FormatError::Io)?;
+        if self.config.segment_newline {
+            self.writer.write_all(b"\n").map_err(FormatError::Io)?;
+        }
+        Ok(())
+    }
+
+    /// Write a field, escaping each structural delimiter byte as its HL7
+    /// escape sequence (`|`→`\F\`, `^`→`\S\`, `&`→`\T\`, `~`→`\R\`,
+    /// `\`→`\E\`). The component, repetition, and sub-component separators
+    /// are escaped too, mirroring the reader's decode: the reader keeps them
+    /// verbatim inside a field only when they arrived verbatim, so a value
+    /// that decoded *from* an escape must be re-escaped to round-trip.
+    fn write_escaped(&mut self, field: &str) -> Result<(), FormatError> {
+        for &b in field.as_bytes() {
+            let escape: Option<&[u8]> = if b == self.delims.escape {
+                Some(b"E")
+            } else if b == self.delims.field {
+                Some(b"F")
+            } else if b == self.delims.component {
+                Some(b"S")
+            } else if b == self.delims.subcomponent {
+                Some(b"T")
+            } else if b == self.delims.repetition {
+                Some(b"R")
+            } else {
+                None
+            };
+            match escape {
+                Some(code) => {
+                    self.writer
+                        .write_all(&[self.delims.escape])
+                        .map_err(FormatError::Io)?;
+                    self.writer.write_all(code).map_err(FormatError::Io)?;
+                    self.writer
+                        .write_all(&[self.delims.escape])
+                        .map_err(FormatError::Io)?;
+                }
+                None => self.writer.write_all(&[b]).map_err(FormatError::Io)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write + Send> FormatWriter for Hl7Writer<W> {
+    fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        self.write_header(record)?;
+        self.write_body_record(record)
+    }
+
+    fn flush(&mut self) -> Result<(), FormatError> {
+        if self.finalized {
+            return Ok(());
+        }
+        self.finalized = true;
+        // Close the batch then the file with recomputed counts, but only if
+        // a header was opened — a bare MSH-led output writes no trailers.
+        if self.batch_open {
+            let count = self.message_count.to_string();
+            self.write_segment("BTS", &[count], false)?;
+            self.batch_open = false;
+        }
+        if self.file_open {
+            let count = self.batch_count.to_string();
+            self.write_segment("FTS", &[count], false)?;
+            self.file_open = false;
+        }
+        self.writer.flush().map_err(FormatError::Io)?;
+        Ok(())
+    }
+}
+
+/// Whether a schema column name is a positional HL7 field column (`f01`,
+/// `f02`, …): an `f` followed by one or more ASCII digits.
+fn is_field_column(name: &str) -> bool {
+    field_position(name).is_some()
+}
+
+/// Parse the 1-based wire field position from a column name. `f01` → 1,
+/// `f12` → 12. Returns `None` when the name is not an `f`-prefixed digit
+/// run or names position 0 (`f00`, which has no wire slot).
+fn field_position(name: &str) -> Option<usize> {
+    let rest = name.strip_prefix('f')?;
+    if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let position: usize = rest.parse().ok()?;
+    (position >= 1).then_some(position)
+}
+
+/// Render a `Value` to HL7 field text. `Null` renders as the empty string
+/// (an absent field); scalars render via their natural string form. A
+/// `Value::Map` or `Value::Array` has no scalar HL7 field representation,
+/// so it raises rather than silently emitting an empty cell — mirroring the
+/// other formats' explicit-error posture for non-scalar payloads.
+fn value_to_field(value: &Value, column: &str) -> Result<String, FormatError> {
+    let text = match value {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Integer(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.to_string(),
+        Value::Date(d) => d.to_string(),
+        Value::DateTime(dt) => dt.to_string(),
+        Value::Map(_) | Value::Array(_) => {
+            return Err(FormatError::UnserializableMapValue {
+                format: "hl7",
+                column: column.to_string(),
+            });
+        }
+    };
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// A schema with `seg_id`, `set_ref`, `set_type`, and `f01..f10`.
+    fn schema() -> Arc<Schema> {
+        let mut cols: Vec<Box<str>> = vec!["seg_id".into(), "set_ref".into(), "set_type".into()];
+        for i in 1..=10 {
+            cols.push(format!("f{i:02}").into_boxed_str());
+        }
+        Arc::new(Schema::new(cols))
+    }
+
+    fn record(schema: &Arc<Schema>, seg: &str, fields: &[&str]) -> Record {
+        let mut values = vec![Value::String(seg.into()), Value::Null, Value::Null];
+        for i in 0..10 {
+            match fields.get(i) {
+                Some(f) if !f.is_empty() => values.push(Value::String((*f).into())),
+                _ => values.push(Value::Null),
+            }
+        }
+        Record::new(Arc::clone(schema), values)
+    }
+
+    fn write_all(config: Hl7WriterConfig, records: &[Record], schema: &Arc<Schema>) -> String {
+        let mut buf = Vec::new();
+        let mut w = Hl7Writer::new(Cursor::new(&mut buf), Arc::clone(schema), config);
+        for r in records {
+            w.write_record(r).unwrap();
+        }
+        w.flush().unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn msh_and_body_segments_written_verbatim() {
+        let s = schema();
+        let msh = record(
+            &s,
+            "MSH",
+            &["^~\\&", "SENDAPP", "", "", "", "", "", "ADT^A01", "MSG001"],
+        );
+        let pid = record(&s, "PID", &["1", "", "PATID"]);
+        let out = write_all(Hl7WriterConfig::default(), &[msh, pid], &s);
+        // The MSH-2 encoding chars are written verbatim (not escaped).
+        assert!(out.starts_with("MSH|^~\\&|SENDAPP|"), "{out}");
+        // PID writes positionally.
+        assert!(out.contains("PID|1||PATID\r"), "{out}");
+        // No trailers without an envelope config.
+        assert!(!out.contains("FTS"), "{out}");
+        assert!(!out.contains("BTS"), "{out}");
+    }
+
+    #[test]
+    fn field_data_is_escaped_on_output() {
+        let s = schema();
+        // An OBX value carries literal '|', '^', and '\' bytes.
+        let msh = record(&s, "MSH", &["^~\\&", "S"]);
+        let obx = record(&s, "OBX", &["1", "TX", "note", "", "a|b^c\\d"]);
+        let out = write_all(Hl7WriterConfig::default(), &[msh, obx], &s);
+        // '|' -> \F\, '^' -> \S\, '\' -> \E\.
+        assert!(out.contains("a\\F\\b\\S\\c\\E\\d"), "{out}");
+    }
+
+    #[test]
+    fn trailing_nulls_not_padded() {
+        let s = schema();
+        let msh = record(&s, "MSH", &["^~\\&", "S"]);
+        let pid = record(&s, "PID", &["1"]);
+        let out = write_all(Hl7WriterConfig::default(), &[msh, pid], &s);
+        // PID has one field; no trailing '|' delimiters.
+        assert!(out.contains("PID|1\r"), "{out}");
+        assert!(!out.contains("PID|1|"), "{out}");
+    }
+
+    #[test]
+    fn file_and_batch_envelope_reconstructed_with_counts() {
+        let s = schema();
+        let msh1 = record(
+            &s,
+            "MSH",
+            &["^~\\&", "S", "", "", "", "", "", "ADT^A01", "M1"],
+        );
+        let pid1 = record(&s, "PID", &["1"]);
+        let msh2 = record(
+            &s,
+            "MSH",
+            &["^~\\&", "S", "", "", "", "", "", "ADT^A01", "M2"],
+        );
+        let pid2 = record(&s, "PID", &["2"]);
+        let cfg = Hl7WriterConfig {
+            file_header: Some(vec!["^~\\&".into(), "SENDAPP".into()]),
+            batch_header: Some(vec!["^~\\&".into(), "SENDAPP".into()]),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[msh1, pid1, msh2, pid2], &s);
+        assert!(out.starts_with("FHS|^~\\&|SENDAPP\r"), "{out}");
+        assert!(out.contains("BHS|^~\\&|SENDAPP\r"), "{out}");
+        // Two messages -> BTS|2; one batch -> FTS|1.
+        assert!(out.contains("BTS|2\r"), "{out}");
+        assert!(out.contains("FTS|1\r"), "{out}");
+    }
+
+    #[test]
+    fn file_header_echoed_from_doc_section() {
+        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use indexmap::IndexMap;
+
+        let s = schema();
+        let raw = RecVal::Array(vec![
+            RecVal::String("^~\\&".into()),
+            RecVal::String("SENDAPP".into()),
+            RecVal::String("FILE9".into()),
+        ]);
+        let mut file_doc: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        file_doc.insert(super::RAW_FIELDS_KEY.into(), raw);
+        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        sections.insert("file".into(), RecVal::Map(Box::new(file_doc)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("a.hl7"),
+            sections,
+        ));
+
+        let mut msh = record(
+            &s,
+            "MSH",
+            &["^~\\&", "S", "", "", "", "", "", "ADT^A01", "M1"],
+        );
+        msh.set_doc_ctx(ctx);
+
+        let cfg = Hl7WriterConfig {
+            file_header_from_doc: Some("file".into()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[msh], &s);
+        assert!(out.starts_with("FHS|^~\\&|SENDAPP|FILE9\r"), "{out}");
+        // One message, zero batches -> FTS|0.
+        assert!(out.contains("FTS|0\r"), "{out}");
+    }
+
+    #[test]
+    fn unrecognized_column_errors_by_name() {
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "amount".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::String("PID".into()), Value::String("99".into())],
+        );
+        let mut buf = Vec::new();
+        let mut w = Hl7Writer::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&schema),
+            Hl7WriterConfig::default(),
+        );
+        let err = w.write_record(&record).unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("amount")));
+    }
+
+    #[test]
+    fn engine_stamped_columns_excluded() {
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "f01".into(), "$source.file".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let values = vec![
+            Value::String("PID".into()),
+            Value::String("1".into()),
+            Value::String("/tmp/a.hl7".into()),
+        ];
+        let record = Record::new(Arc::clone(&schema), values);
+        let out = write_all(Hl7WriterConfig::default(), &[record], &schema);
+        assert!(out.contains("PID|1\r"), "{out}");
+        assert!(!out.contains("/tmp/a.hl7"), "{out}");
+    }
+
+    #[test]
+    fn map_value_in_field_column_errors_by_name() {
+        use indexmap::IndexMap;
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "f01".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let mut nested: IndexMap<Box<str>, Value> = IndexMap::new();
+        nested.insert("k".into(), Value::String("v".into()));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::String("PID".into()), Value::Map(Box::new(nested))],
+        );
+        let mut buf = Vec::new();
+        let mut w = Hl7Writer::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&schema),
+            Hl7WriterConfig::default(),
+        );
+        let err = w.write_record(&record).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::UnserializableMapValue { format: "hl7", column } if column == "f01"),
+            "expected UnserializableMapValue for f01, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn flush_finalize_idempotent() {
+        let s = schema();
+        let msh = record(&s, "MSH", &["^~\\&", "S"]);
+        let mut buf = Vec::new();
+        let cfg = Hl7WriterConfig {
+            file_header: Some(vec!["^~\\&".into(), "S".into()]),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let mut w = Hl7Writer::new(Cursor::new(&mut buf), Arc::clone(&s), cfg);
+        w.write_record(&msh).unwrap();
+        w.flush().unwrap();
+        w.flush().unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out.matches("FTS").count(), 1, "{out}");
+    }
+
+    #[test]
+    fn zero_records_writes_nothing() {
+        let s = schema();
+        let out = write_all(Hl7WriterConfig::default(), &[], &s);
+        assert!(out.is_empty(), "{out}");
+    }
+
+    #[test]
+    fn gapped_field_columns_map_by_position() {
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "f01".into(), "f03".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("PID".into()),
+                Value::String("a".into()),
+                Value::String("c".into()),
+            ],
+        );
+        let out = write_all(Hl7WriterConfig::default(), &[record], &schema);
+        assert!(out.contains("PID|a||c\r"), "gapped mapping wrong: {out}");
+    }
+}

--- a/crates/clinker-format/src/hl7/writer.rs
+++ b/crates/clinker-format/src/hl7/writer.rs
@@ -174,13 +174,22 @@ impl<W: Write> Hl7Writer<W> {
                     .collect::<Result<Vec<_>, _>>()?;
                 return Ok(Some(fields));
             }
-            // Fallback: walk the declared positional `f01, f02, …` keys.
+            // Fallback: collect the declared positional `f01, f02, …` keys
+            // into wire order. A gapped section (e.g. `f01` and `f03`
+            // present, `f02` absent) must not truncate at the gap — pad the
+            // missing slot with an empty field and keep the later values at
+            // the positions their keys declare, mirroring how `record_fields`
+            // maps body records. `DocumentContext` exposes only point
+            // lookups, so the scan runs to a fixed ceiling that comfortably
+            // exceeds any real FHS/BHS header width.
+            const HEADER_FIELD_SCAN_LIMIT: usize = 99;
             let mut fields: Vec<String> = Vec::new();
-            for i in 0.. {
+            for i in 0..HEADER_FIELD_SCAN_LIMIT {
                 let key = format!("f{:02}", i + 1);
-                match ctx.get_section_field(section, &key) {
-                    Some(v) => fields.push(value_to_field(&v, &format!("{section}.{key}"))?),
-                    None => break,
+                if let Some(v) = ctx.get_section_field(section, &key) {
+                    // Pad any skipped lower positions before placing this one.
+                    fields.resize(i, String::new());
+                    fields.push(value_to_field(&v, &format!("{section}.{key}"))?);
                 }
             }
             if fields.is_empty() {
@@ -309,24 +318,39 @@ impl<W: Write> Hl7Writer<W> {
         Ok(())
     }
 
-    /// Write a field, escaping each structural delimiter byte as its HL7
-    /// escape sequence (`|`→`\F\`, `^`→`\S\`, `&`→`\T\`, `~`→`\R\`,
-    /// `\`→`\E\`). The component, repetition, and sub-component separators
-    /// are escaped too, mirroring the reader's decode: the reader keeps them
-    /// verbatim inside a field only when they arrived verbatim, so a value
-    /// that decoded *from* an escape must be re-escaped to round-trip.
+    /// Write a field, escaping only the bytes the reader would otherwise
+    /// misread as structure: the field separator (`|` → `\F\`), the escape
+    /// character itself (`\` → `\E\`), and the segment terminator (carriage
+    /// return → `\X0D\`).
+    ///
+    /// The component (`^`), repetition (`~`), and sub-component (`&`)
+    /// separators are written **verbatim**, mirroring the reader, which keeps
+    /// them as a field's internal composite/repetition structure rather than
+    /// decoding them. Escaping them here would collapse a composite field
+    /// like `PATID^^^MRN` into a single component of escaped literals,
+    /// destroying the structure; leaving them verbatim makes the
+    /// reader → writer → reader round-trip byte-faithful, exactly as the X12
+    /// writer leaves its sub-element separator verbatim.
     fn write_escaped(&mut self, field: &str) -> Result<(), FormatError> {
         for &b in field.as_bytes() {
+            // The carriage return is the segment terminator; a scalar field
+            // value normally cannot contain it, but escape it defensively as
+            // the numeric `\X0D\` form so an embedded CR cannot split a
+            // segment.
+            if b == b'\r' {
+                self.writer
+                    .write_all(&[self.delims.escape])
+                    .map_err(FormatError::Io)?;
+                self.writer.write_all(b"X0D").map_err(FormatError::Io)?;
+                self.writer
+                    .write_all(&[self.delims.escape])
+                    .map_err(FormatError::Io)?;
+                continue;
+            }
             let escape: Option<&[u8]> = if b == self.delims.escape {
                 Some(b"E")
             } else if b == self.delims.field {
                 Some(b"F")
-            } else if b == self.delims.component {
-                Some(b"S")
-            } else if b == self.delims.subcomponent {
-                Some(b"T")
-            } else if b == self.delims.repetition {
-                Some(b"R")
             } else {
                 None
             };
@@ -472,14 +496,49 @@ mod tests {
     }
 
     #[test]
-    fn field_data_is_escaped_on_output() {
+    fn only_field_and_escape_chars_are_escaped() {
         let s = schema();
-        // An OBX value carries literal '|', '^', and '\' bytes.
+        // An OBX value carries a literal field separator '|', a component
+        // separator '^', and a literal escape char '\'. Only the field
+        // separator and the escape char are escaped; the component separator
+        // is part of the field's composite structure and is left verbatim,
+        // mirroring the reader (which keeps it verbatim) and the X12 writer.
         let msh = record(&s, "MSH", &["^~\\&", "S"]);
         let obx = record(&s, "OBX", &["1", "TX", "note", "", "a|b^c\\d"]);
         let out = write_all(Hl7WriterConfig::default(), &[msh, obx], &s);
-        // '|' -> \F\, '^' -> \S\, '\' -> \E\.
-        assert!(out.contains("a\\F\\b\\S\\c\\E\\d"), "{out}");
+        assert!(out.contains("a\\F\\b^c\\E\\d"), "{out}");
+        // The component separator must not be escaped to \S\.
+        assert!(
+            !out.contains("\\S\\"),
+            "component separator wrongly escaped: {out}"
+        );
+    }
+
+    #[test]
+    fn composite_field_round_trips_verbatim() {
+        // A composite CX field (`PATID^^^^MRN`) read verbatim by the reader
+        // must re-emit byte-identically — escaping the component separators
+        // would collapse it into one component of escaped literals.
+        let s = schema();
+        let msh = record(&s, "MSH", &["^~\\&", "S"]);
+        let pid = record(&s, "PID", &["1", "", "PATID^^^^MRN"]);
+        let out = write_all(Hl7WriterConfig::default(), &[msh, pid], &s);
+        assert!(out.contains("PID|1||PATID^^^^MRN\r"), "{out}");
+    }
+
+    #[test]
+    fn embedded_carriage_return_is_hex_escaped() {
+        // A scalar value carrying a carriage return cannot be written raw —
+        // it would split the segment. It is escaped as the numeric \X0D\
+        // form, which the reader decodes back to a literal CR.
+        let s = schema();
+        let msh = record(&s, "MSH", &["^~\\&", "S"]);
+        let nte = record(&s, "NTE", &["1", "", "a\rb"]);
+        let out = write_all(Hl7WriterConfig::default(), &[msh, nte], &s);
+        assert!(out.contains("a\\X0D\\b"), "{out}");
+        // The raw CR must not appear inside the field (only as the segment
+        // terminator after the field).
+        assert!(!out.contains("a\rb"), "raw CR leaked into field: {out}");
     }
 
     #[test]
@@ -559,6 +618,42 @@ mod tests {
         assert!(out.starts_with("FHS|^~\\&|SENDAPP|FILE9\r"), "{out}");
         // One message, zero batches -> FTS|0.
         assert!(out.contains("FTS|0\r"), "{out}");
+    }
+
+    #[test]
+    fn gapped_doc_header_fallback_pads_missing_positions() {
+        // The positional-key fallback (no `$raw` array present) must not stop
+        // at the first missing `fNN` key: with `f01` and `f03` declared but
+        // `f02` absent, the FHS header must carry an empty field at position 2
+        // rather than truncating at the gap.
+        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use indexmap::IndexMap;
+
+        let s = schema();
+        let mut file_doc: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        file_doc.insert("f01".into(), RecVal::String("^~\\&".into()));
+        // f02 deliberately absent — the gap.
+        file_doc.insert("f03".into(), RecVal::String("FILE9".into()));
+        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        sections.insert("file".into(), RecVal::Map(Box::new(file_doc)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("a.hl7"),
+            sections,
+        ));
+
+        let mut msh = record(&s, "MSH", &["^~\\&", "S"]);
+        msh.set_doc_ctx(ctx);
+
+        let cfg = Hl7WriterConfig {
+            file_header_from_doc: Some("file".into()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[msh], &s);
+        // FHS-2 encoding chars, then an empty FHS-3, then FILE9 at FHS-4 —
+        // the gap is preserved as an empty field, not collapsed.
+        assert!(out.starts_with("FHS|^~\\&||FILE9\r"), "{out}");
     }
 
     #[test]

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -5,6 +5,7 @@ pub mod edifact;
 pub mod envelope;
 pub mod error;
 pub mod fixed_width;
+pub mod hl7;
 pub mod json;
 pub mod splitting;
 pub mod traits;

--- a/crates/clinker-plan/src/config/discovery.rs
+++ b/crates/clinker-plan/src/config/discovery.rs
@@ -456,6 +456,7 @@ mod tests {
             files: None,
             watermark: None,
             envelope: None,
+            declared_doc_paths: Vec::new(),
             schema: None,
             schema_overrides: None,
             array_paths: None,

--- a/crates/clinker-plan/src/config/format.rs
+++ b/crates/clinker-plan/src/config/format.rs
@@ -17,6 +17,7 @@ pub enum InputFormat {
     FixedWidth(Option<FixedWidthInputOptions>),
     Edifact(Option<EdifactInputOptions>),
     X12(Option<X12InputOptions>),
+    Hl7(Option<Hl7InputOptions>),
 }
 
 impl InputFormat {
@@ -29,6 +30,7 @@ impl InputFormat {
             InputFormat::FixedWidth(_) => "fixed_width",
             InputFormat::Edifact(_) => "edifact",
             InputFormat::X12(_) => "x12",
+            InputFormat::Hl7(_) => "hl7",
         }
     }
 
@@ -51,6 +53,7 @@ impl OutputFormat {
             OutputFormat::FixedWidth(_) => "fixed_width",
             OutputFormat::Edifact(_) => "edifact",
             OutputFormat::X12(_) => "x12",
+            OutputFormat::Hl7(_) => "hl7",
         }
     }
 }
@@ -65,6 +68,7 @@ pub enum OutputFormat {
     FixedWidth(Option<FixedWidthOutputOptions>),
     Edifact(Option<EdifactOutputOptions>),
     X12(Option<X12OutputOptions>),
+    Hl7(Option<Hl7OutputOptions>),
 }
 
 /// Supported format types.

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -248,3 +248,34 @@ pub struct X12OutputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_newline: Option<bool>,
 }
+
+/// HL7 v2 output options.
+///
+/// The writer re-emits the `MSH` and body segments from the record stream
+/// and optionally wraps them in batch/file envelopes. An `FHS` file header
+/// comes from `file_header` (literal fields) or, when that is unset, is
+/// echoed from the `$doc` section named by `file_header_from_doc` for
+/// round-trip reconstruction; a `BHS` batch header comes from
+/// `batch_header`. When either envelope is configured the writer recomputes
+/// the closing `BTS`/`FTS` counts.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Hl7OutputOptions {
+    /// Literal `FHS` file-header fields written verbatim. Takes precedence
+    /// over `file_header_from_doc` when both are set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_header: Option<Vec<String>>,
+    /// Name of a `$doc` section to echo the `FHS` fields from (the reader's
+    /// positional `FHS` envelope section), enabling round-trip file-header
+    /// reconstruction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file_header_from_doc: Option<String>,
+    /// Literal `BHS` batch-header fields written verbatim. When set, the
+    /// writer wraps the messages in a `BHS..BTS` batch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch_header: Option<Vec<String>>,
+    /// Write a newline after each segment's carriage-return terminator for
+    /// readability. Defaults to `true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segment_newline: Option<bool>,
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -755,6 +755,24 @@ impl PipelineConfig {
             })
             .collect();
         let report = cxl::analyzer::analyze_all(&compiled_refs);
+
+        // Collect the `$doc` envelope paths every program references, so
+        // each lowered Source carries its declared document-path set for
+        // the reader. An access indexed by a non-literal cannot be
+        // resolved to a static path — surface E340 against the node and
+        // abort, since the declared set would otherwise be incomplete.
+        let doc_path_set = cxl::analyzer::doc_paths::collect_doc_paths(&compiled_refs);
+        if !doc_path_set.unresolvable.is_empty() {
+            for d in &doc_path_set.unresolvable {
+                diags.push(Diagnostic::error(
+                    "E340",
+                    d.message.clone(),
+                    LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+                ));
+            }
+            return Err(diags);
+        }
+        let declared_doc_paths = doc_path_set.paths;
         // Keep an analysis-by-name index so we can surface the analysis
         // alongside its matching entry regardless of filter order.
         let mut analysis_by_name: HashMap<String, &cxl::analyzer::TransformAnalysis> =
@@ -859,6 +877,7 @@ impl PipelineConfig {
                 analysis: analysis_by_name.get(name.as_str()).copied(),
                 window_config: entry_idx.and_then(|i| window_configs[i].as_ref()),
                 primary_source: primary_source.as_str(),
+                declared_doc_paths: &declared_doc_paths,
             };
             let plan_node =
                 lower_node_to_plan_node(node, &name, span, &artifacts, &lowering_ctx, &mut diags);
@@ -1904,6 +1923,11 @@ pub(crate) struct LoweringCtx<'a> {
     pub analysis: Option<&'a cxl::analyzer::TransformAnalysis>,
     pub window_config: Option<&'a AnalyticWindowSpec>,
     pub primary_source: &'a str,
+    /// `$doc` envelope paths collected across the pipeline's programs,
+    /// surfaced onto each lowered `Source` node's `SourceConfig`. Empty
+    /// for the body-node lowering path (`LoweringCtx::default()`) — only
+    /// the top-level compile path collects and threads these.
+    pub declared_doc_paths: &'a [cxl::analyzer::doc_paths::DocPath],
 }
 
 /// Lower a single `PipelineNode` into its `PlanNode` counterpart.
@@ -1985,15 +2009,25 @@ pub(crate) fn lower_node_to_plan_node(
     };
 
     match node {
-        PipelineNode::Source { config, .. } => Some(PlanNode::Source {
-            name: name.to_string(),
-            span,
-            resolved: Some(Box::new(PlanSourcePayload {
-                source: config.source.clone(),
-                validated_path: None,
-            })),
-            output_schema: schema_from_bound(name),
-        }),
+        PipelineNode::Source { config, .. } => {
+            let mut source = config.source.clone();
+            // Stamp the pipeline-wide `$doc` path set onto this source so
+            // a document reader can learn the declared path set before
+            // reading input. A `$doc` access carries no source qualifier,
+            // so the whole set is attached to every source; single-source
+            // document pipelines (the common case) thus see exactly their
+            // own paths.
+            source.declared_doc_paths = ctx.declared_doc_paths.to_vec();
+            Some(PlanNode::Source {
+                name: name.to_string(),
+                span,
+                resolved: Some(Box::new(PlanSourcePayload {
+                    source,
+                    validated_path: None,
+                })),
+                output_schema: schema_from_bound(name),
+            })
+        }
         PipelineNode::Transform { config, .. } => {
             // Missing typed program means bind_schema hit a CXL error
             // (E108, E200, etc.) on this node — skip lowering.
@@ -2537,6 +2571,26 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                  an X12 interchange is a single ISA..IEA envelope and cannot be \
                  divided across files; remove the `split` block or choose a splittable \
                  format",
+                output.name
+            )));
+        }
+    }
+
+    // An HL7 v2 file with a batch/file envelope is likewise a single
+    // FHS..FTS / BHS..BTS structure whose trailer counts are recomputed and
+    // written only at end of stream. Byte-limit file splitting flushes (and
+    // therefore finalizes) the writer mid-stream, sealing the file after the
+    // first split and emitting later messages after the FTS trailer. There
+    // is no meaningful way to split one HL7 file envelope across files, so
+    // reject the combination up front rather than emit a structurally
+    // corrupt file that still reports run success.
+    for output in config.output_configs() {
+        if matches!(output.format, OutputFormat::Hl7(_)) && output.split.is_some() {
+            return Err(ConfigError::Validation(format!(
+                "[E339] output '{}': `hl7` output cannot be combined with `split` — \
+                 an HL7 v2 batch/file envelope is a single FHS..FTS structure and \
+                 cannot be divided across files; remove the `split` block or choose a \
+                 splittable format",
                 output.name
             )));
         }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -758,17 +758,57 @@ impl PipelineConfig {
 
         // Collect the `$doc` envelope paths every program references, so
         // each lowered Source carries its declared document-path set for
-        // the reader. An access indexed by a non-literal cannot be
-        // resolved to a static path — surface E340 against the node and
-        // abort, since the declared set would otherwise be incomplete.
-        let doc_path_set = cxl::analyzer::doc_paths::collect_doc_paths(&compiled_refs);
+        // the reader. The walk covers EVERY typed program in the compile
+        // artifacts — not just the `entries` subset that feeds the
+        // analyzer — because `$doc` is valid in Combine predicates /
+        // residual filters / emit bodies and in composition-body
+        // programs, all of which land in `artifacts.typed` under their
+        // node name (body programs are inserted there by the recursive
+        // bind_schema pass). Missing any of them would drop a referenced
+        // path from the declared set.
+        let doc_refs: Vec<(&str, &cxl::typecheck::pass::TypedProgram)> = artifacts
+            .typed
+            .iter()
+            .map(|(name, tp)| (name.as_str(), tp.as_ref()))
+            // A Combine's node-keyed `typed` entry holds only its `cxl:`
+            // body; its `where:` predicate program lives in a separate
+            // side-table, so include those too — a `$doc` access used only
+            // in a predicate would otherwise be dropped.
+            .chain(
+                artifacts
+                    .combine_where_typed
+                    .iter()
+                    .map(|(name, tp)| (name.as_str(), tp.as_ref())),
+            )
+            .collect();
+        let doc_path_set = cxl::analyzer::doc_paths::collect_doc_paths(&doc_refs);
         if !doc_path_set.unresolvable.is_empty() {
-            for d in &doc_path_set.unresolvable {
-                diags.push(Diagnostic::error(
+            // Anchor each diagnostic at the offending node's source line.
+            // Top-level node lines come from the saphyr-captured YAML
+            // position; a composition-body node (not present in
+            // `self.nodes`) falls back to a synthetic span.
+            let node_line: HashMap<&str, u32> = self
+                .nodes
+                .iter()
+                .filter_map(|sp| {
+                    let line = sp.referenced.line();
+                    (line > 0).then(|| (sp.value.name(), line as u32))
+                })
+                .collect();
+            for (node_name, d) in &doc_path_set.unresolvable {
+                let primary = match node_line.get(node_name.as_str()) {
+                    Some(&line) => Span::line_only(line),
+                    None => Span::SYNTHETIC,
+                };
+                let mut diag = Diagnostic::error(
                     "E340",
                     d.message.clone(),
-                    LabeledSpan::primary(Span::SYNTHETIC, String::new()),
-                ));
+                    LabeledSpan::primary(primary, String::new()),
+                );
+                if let Some(help) = &d.help {
+                    diag = diag.with_help(help.clone());
+                }
+                diags.push(diag);
             }
             return Err(diags);
         }

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -70,6 +70,16 @@ pub struct SourceConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub envelope: Option<clinker_format::EnvelopeConfig>,
 
+    /// `$doc.<section>.<field>` envelope paths the pipeline's CXL
+    /// programs actually reference, collected at compile time by
+    /// `cxl::analyzer::doc_paths`. Empty for sources whose downstream
+    /// programs read no `$doc` paths. Document readers consult this set
+    /// to skip extracting declared sections no program consumes. Derived
+    /// by the planner — never author-written — so it is excluded from
+    /// serialized config.
+    #[serde(skip)]
+    pub declared_doc_paths: Vec<cxl::analyzer::doc_paths::DocPath>,
+
     /// Format-layer schema pointer (e.g. fixed-width field layouts).
     /// Distinct from the CXL-type-level `SourceBody.schema` declared
     /// at the parent `SourceBody` scope — this one points at on-disk
@@ -558,4 +568,15 @@ pub struct X12InputOptions {
     /// with guidance rather than silently truncated. Defaults to 32.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_elements: Option<usize>,
+}
+
+/// HL7 v2 input options.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Hl7InputOptions {
+    /// Number of positional `fNN` field columns on the record schema. A
+    /// segment carrying more data fields than this is rejected with
+    /// guidance rather than silently truncated. Defaults to 64.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_fields: Option<usize>,
 }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -57,6 +57,14 @@ pub const MAX_COMPOSITION_DEPTH: u32 = 50;
 #[derive(Debug, Default, Clone)]
 pub struct CompileArtifacts {
     pub typed: HashMap<String, Arc<TypedProgram>>,
+    /// Per-Combine `where:` predicate typed programs, keyed by combine
+    /// node name. The node-keyed `typed` map stores only a Combine's
+    /// `cxl:` body; the `where:` predicate is decomposed into
+    /// `combine_predicates` and otherwise discarded as a standalone
+    /// program. This side-table retains it so a `$doc` access used ONLY
+    /// in a predicate (e.g. `l.amount > $doc.Head.cutoff`) is still
+    /// reachable by the compile-time `$doc` path walk.
+    pub combine_where_typed: HashMap<String, Arc<TypedProgram>>,
     /// All bound composition bodies, keyed by `CompositionBodyId`. The
     /// top-level pipeline is NOT in this map — it lives on
     /// `CompiledPlan.dag()` directly. Only body scopes are here.
@@ -3069,6 +3077,10 @@ fn bind_combine(
             return;
         }
     };
+
+    artifacts
+        .combine_where_typed
+        .insert(name.to_string(), Arc::clone(&typed_where));
 
     // Post-walk for E304 (unknown / 3-part qualified refs in where).
     let e304_before = diags.iter().filter(|d| d.code == "E304").count();

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -230,6 +230,8 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E336" => Some(include_str!("../../../../docs/explain/E336.md")),
         "E337" => Some(include_str!("../../../../docs/explain/E337.md")),
         "E338" => Some(include_str!("../../../../docs/explain/E338.md")),
+        "E339" => Some(include_str!("../../../../docs/explain/E339.md")),
+        "E340" => Some(include_str!("../../../../docs/explain/E340.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -433,8 +435,8 @@ mod tests {
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
-            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E15Y", "W101", "W302", "W305",
-            "W306",
+            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E15Y", "W101",
+            "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -114,10 +114,12 @@ fn test_pipeline_with_no_doc_access_has_empty_path_set() {
 }
 
 #[test]
-fn test_dynamic_doc_index_aborts_compile_with_e339() {
+fn test_dynamic_doc_index_aborts_compile_with_e340_at_node_span() {
     // `$doc.Summary.total[amount]` indexes a `$doc` access by a record
     // field, so the declared path cannot be resolved at compile time.
-    // The compile must abort with E340.
+    // The compile must abort with E340, and the diagnostic must anchor
+    // at the offending node's source (a non-synthetic span) and carry
+    // the help text — not a bare synthetic span with the message alone.
     let yaml = r#"
 pipeline:
   name: dynamic_doc_index
@@ -156,8 +158,205 @@ nodes:
     let config = parse_config(yaml).expect("parse dynamic-index pipeline");
     let result = config.compile(&CompileContext::default());
     let err = result.expect_err("dynamic `$doc` index must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E340")
+        .unwrap_or_else(|| panic!("expected an E340 diagnostic, got: {err:?}"));
+    // The primary span points into the source (a real line), not the
+    // pre-interning synthetic sentinel.
+    assert_ne!(
+        diag.primary.span,
+        clinker_core_types::span::Span::SYNTHETIC,
+        "E340 primary span must not be the synthetic sentinel"
+    );
     assert!(
-        err.iter().any(|d| d.code == "E340"),
-        "expected an E340 diagnostic, got: {err:?}"
+        diag.primary.span.synthetic_line_number().is_some(),
+        "E340 primary span must carry the offending node's source line"
+    );
+    assert!(diag.help.is_some(), "E340 must carry help text");
+}
+
+#[test]
+fn test_negative_literal_doc_index_compiles() {
+    // A negated integer literal is a static from-end index, so the path
+    // is resolvable and the compile succeeds.
+    let paths = compile_and_read_source_paths(&["emit amount = amount
+emit last = $doc.Summary.total[-1]"]);
+    assert_eq!(
+        paths,
+        vec![path("Summary", "total", vec![DocIndex::Int(-1)])]
+    );
+}
+
+#[test]
+fn test_doc_path_in_combine_predicate_is_collected() {
+    // A `$doc` access inside a Combine `where:` predicate must reach the
+    // declared path set — Combine programs are not in the analyzer's
+    // `entries` subset, so this exercises the all-programs walk.
+    let yaml = r#"
+pipeline:
+  name: combine_doc
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: xml
+      glob: ./l/*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Head:
+            extract: { xml_path: "/doc/Head" }
+            fields:
+              cutoff: int
+      schema:
+        - { name: id, type: int }
+        - { name: amount, type: int }
+  - type: source
+    name: right
+    config:
+      name: right
+      type: csv
+      path: right.csv
+      schema:
+        - { name: id, type: int }
+        - { name: label, type: string }
+  - type: combine
+    name: joined
+    input:
+      l: left
+      r: right
+    config:
+      where: "l.id == r.id and l.amount > $doc.Head.cutoff"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit id = l.id
+        emit label = r.label
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse combine-doc pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile combine-doc pipeline");
+    let dag = plan.dag();
+    // Both sources carry the pipeline-wide set (the known
+    // over-attachment); assert the Combine-predicate path reached it.
+    let any_source_has_path = dag.graph.node_indices().any(|idx| {
+        matches!(&dag.graph[idx], PlanNode::Source { resolved: Some(r), .. }
+            if r.source.declared_doc_paths.contains(&path("Head", "cutoff", vec![])))
+    });
+    assert!(
+        any_source_has_path,
+        "`$doc.Head.cutoff` used in the Combine predicate must reach the declared set"
+    );
+}
+
+#[test]
+fn test_doc_path_in_composition_body_is_collected() {
+    // A `$doc` access inside a `.comp.yaml` body transform must reach the
+    // declared path set. Body programs live in `artifacts.composition_*`
+    // / the shared typed map, separate from the top-level `entries`
+    // subset, so this exercises the all-programs walk across the
+    // composition boundary. The envelope is declared on the PARENT source
+    // (the document context flows into the body via the input port).
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    std::fs::write(
+        comp_dir.join("doc_body.comp.yaml"),
+        r#"_compose:
+  name: doc_body
+  inputs:
+    inp:
+      schema:
+        - { name: amount, type: int }
+  outputs:
+    out: tagged
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: tagged
+    input: inp
+    config:
+      cxl: |
+        emit amount = amount
+        emit cutoff = $doc.Head.cutoff
+"#,
+    )
+    .expect("write comp");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    let yaml = r#"
+pipeline:
+  name: composition_doc
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Head:
+            extract: { xml_path: "/doc/Head" }
+            fields:
+              cutoff: int
+      schema:
+        - { name: amount, type: int }
+  - type: composition
+    name: body
+    input: payments
+    use: ../compositions/doc_body.comp.yaml
+    inputs:
+      inp: payments
+  - type: output
+    name: out
+    input: body
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+    let config = parse_config(yaml).expect("parse composition-doc pipeline");
+    let ctx = crate::config::CompileContext::with_pipeline_dir(
+        workspace.path(),
+        std::path::PathBuf::from("pipelines"),
+    );
+    let compiled = config
+        .compile(&ctx)
+        .expect("compile composition-doc pipeline");
+    let dag = compiled.dag();
+    let source = dag
+        .graph
+        .node_indices()
+        .find_map(|idx| match &dag.graph[idx] {
+            PlanNode::Source { resolved, .. } => resolved.as_ref(),
+            _ => None,
+        })
+        .expect("parent source present");
+    assert!(
+        source
+            .source
+            .declared_doc_paths
+            .contains(&path("Head", "cutoff", vec![])),
+        "`$doc.Head.cutoff` used in the composition body must reach the declared set, got {:?}",
+        source.source.declared_doc_paths
     );
 }

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -1,0 +1,163 @@
+//! End-to-end surfacing of the compile-time `$doc` path set.
+//!
+//! `cxl::analyzer::doc_paths` collects every `$doc.<section>.<field>` the
+//! pipeline's programs reference; `PipelineConfig::compile` stamps that
+//! set onto each lowered `Source` node's `SourceConfig`. These tests pin
+//! the plan-build wiring: the path set reaches the Source, and a `$doc`
+//! access indexed by a non-literal aborts the compile with E340.
+
+use cxl::analyzer::doc_paths::{DocIndex, DocPath};
+
+use crate::config::{CompileContext, parse_config};
+use crate::plan::execution::PlanNode;
+
+/// Compile a document-aware pipeline whose two transforms read distinct
+/// `$doc` paths, and return the path set stamped on the single Source.
+fn compile_and_read_source_paths(transforms_cxl: &[&str]) -> Vec<DocPath> {
+    let mut yaml = String::from(
+        r#"
+pipeline:
+  name: doc_paths_demo
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          BatchInfo:
+            extract: { xml_path: "/doc/BatchInfo" }
+            fields:
+              batch_id: string
+          Summary:
+            extract: { xml_path: "/doc/Summary" }
+            fields:
+              total: int
+      schema:
+        - { name: amount, type: int }
+"#,
+    );
+    let mut prev = "payments".to_string();
+    for (i, cxl) in transforms_cxl.iter().enumerate() {
+        let name = format!("t{i}");
+        yaml.push_str(&format!(
+            "  - type: transform\n    name: {name}\n    input: {prev}\n    config:\n      cxl: |\n",
+        ));
+        for line in cxl.lines() {
+            yaml.push_str(&format!("        {line}\n"));
+        }
+        prev = name;
+    }
+    yaml.push_str(&format!(
+        "  - type: output\n    name: out\n    input: {prev}\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+    ));
+
+    let config = parse_config(&yaml).expect("parse doc-paths pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile doc-paths pipeline");
+
+    let dag = plan.dag();
+    let source = dag
+        .graph
+        .node_indices()
+        .find_map(|idx| match &dag.graph[idx] {
+            PlanNode::Source { resolved, .. } => resolved.as_ref(),
+            _ => None,
+        })
+        .expect("source node present with resolved payload");
+    source.source.declared_doc_paths.clone()
+}
+
+fn path(section: &str, field: &str, indices: Vec<DocIndex>) -> DocPath {
+    DocPath {
+        section: section.into(),
+        field: field.into(),
+        indices,
+    }
+}
+
+#[test]
+fn test_doc_paths_surface_onto_source() {
+    let paths = compile_and_read_source_paths(&[
+        "emit amount = amount\nemit batch = $doc.BatchInfo.batch_id",
+        "emit amount = amount\nemit total = $doc.Summary.total",
+    ]);
+    // Sorted by (section, field): BatchInfo precedes Summary.
+    assert_eq!(
+        paths,
+        vec![
+            path("BatchInfo", "batch_id", vec![]),
+            path("Summary", "total", vec![]),
+        ]
+    );
+}
+
+#[test]
+fn test_doc_path_used_only_in_conditional_still_surfaces() {
+    // The `$doc` access lives only inside an `if` branch — the analyzer
+    // must still collect it, so the Source must still carry it.
+    let paths = compile_and_read_source_paths(&[
+        "emit amount = amount\nemit batch = if amount > 0 then $doc.BatchInfo.batch_id else \"none\"",
+    ]);
+    assert_eq!(paths, vec![path("BatchInfo", "batch_id", vec![])]);
+}
+
+#[test]
+fn test_pipeline_with_no_doc_access_has_empty_path_set() {
+    let paths = compile_and_read_source_paths(&["emit amount = amount + 1"]);
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn test_dynamic_doc_index_aborts_compile_with_e339() {
+    // `$doc.Summary.total[amount]` indexes a `$doc` access by a record
+    // field, so the declared path cannot be resolved at compile time.
+    // The compile must abort with E340.
+    let yaml = r#"
+pipeline:
+  name: dynamic_doc_index
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Summary:
+            extract: { xml_path: "/doc/Summary" }
+            fields:
+              total: int
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: t0
+    input: payments
+    config:
+      cxl: |
+        emit amount = amount
+        emit picked = $doc.Summary.total[amount]
+  - type: output
+    name: out
+    input: t0
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse dynamic-index pipeline");
+    let result = config.compile(&CompileContext::default());
+    let err = result.expect_err("dynamic `$doc` index must fail to compile");
+    assert!(
+        err.iter().any(|d| d.code == "E340"),
+        "expected an E340 diagnostic, got: {err:?}"
+    );
+}

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -3,6 +3,7 @@ mod ck_lattice;
 mod dag;
 mod dedup_node_rooted;
 mod deferred_region;
+mod doc_paths;
 mod explain_buffer_class;
 mod explain_polish;
 mod plan_time_window_root;

--- a/crates/clinker-schema/src/model.rs
+++ b/crates/clinker-schema/src/model.rs
@@ -61,6 +61,7 @@ pub enum SourceFormat {
     Parquet,
     Edifact,
     X12,
+    Hl7,
 }
 
 impl SourceFormat {
@@ -75,6 +76,7 @@ impl SourceFormat {
             Self::Parquet => "parquet",
             Self::Edifact => "edifact",
             Self::X12 => "x12",
+            Self::Hl7 => "hl7",
         }
     }
 
@@ -87,6 +89,7 @@ impl SourceFormat {
             Self::Parquet => FormatCategory::Parquet,
             Self::Edifact => FormatCategory::Edifact,
             Self::X12 => FormatCategory::X12,
+            Self::Hl7 => FormatCategory::Hl7,
         }
     }
 }
@@ -100,6 +103,7 @@ pub enum FormatCategory {
     Parquet,
     Edifact,
     X12,
+    Hl7,
 }
 
 /// A single field in a schema.

--- a/crates/clinker-schema/src/validate.rs
+++ b/crates/clinker-schema/src/validate.rs
@@ -132,6 +132,7 @@ fn validate_input(
         InputFormat::FixedWidth(_) => false, // No schema format match for fixed-width yet
         InputFormat::Edifact(_) => schema.metadata.format == crate::model::SourceFormat::Edifact,
         InputFormat::X12(_) => schema.metadata.format == crate::model::SourceFormat::X12,
+        InputFormat::Hl7(_) => schema.metadata.format == crate::model::SourceFormat::Hl7,
     };
 
     if !format_matches {

--- a/crates/cxl/src/analyzer/doc_paths.rs
+++ b/crates/cxl/src/analyzer/doc_paths.rs
@@ -1,0 +1,479 @@
+//! Compile-time `$doc` path analysis.
+//!
+//! Walks the typed AST of every CXL-bearing node and collects the set of
+//! `$doc.<section>.<field>` envelope paths the pipeline's programs
+//! actually reference, including trailing index accesses
+//! (`$doc.section.items[0]`). Document readers consult this set to learn,
+//! before reading any input, which declared envelope paths a run will
+//! consume — a declared section the programs never read need not be
+//! extracted.
+//!
+//! A `$doc` access is statically resolvable iff its section, field, and
+//! every trailing index are literals. The CXL grammar guarantees the
+//! section and field are always literal identifiers (the parser rejects a
+//! one-level `$doc.foo`), so the only dynamic axis is an index expression
+//! computed from runtime data (`$doc.section.items[some_field]`). Such an
+//! access is reported as an unresolvable path with a fail-fast diagnostic
+//! carrying the offending index span; the declared-path set cannot name a
+//! row-dependent element.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::ast::{Expr, LiteralValue, MatchArm, Statement};
+use crate::lexer::Span;
+use crate::typecheck::pass::{TypeDiagnostic, TypedProgram};
+
+/// One trailing index segment on a `$doc` path.
+///
+/// `$doc.section.items[0]["k"]` carries `[Int(0), Key("k")]`. Only
+/// literal indices are representable — a computed index makes the whole
+/// access unresolvable and is reported as a diagnostic instead.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum DocIndex {
+    /// Integer array index, e.g. `items[0]`.
+    Int(i64),
+    /// String map key, e.g. `meta["run_date"]`.
+    Key(Box<str>),
+}
+
+/// A statically-resolved `$doc` envelope path referenced by some program.
+///
+/// `section` and `field` are the two literal levels every `$doc` access
+/// carries; `indices` holds any trailing literal index segments in order.
+/// Ordered by `(section, field, indices)` so the collected set has a
+/// deterministic iteration order independent of program walk order.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct DocPath {
+    /// Envelope section name (`$doc.<section>.…`).
+    pub section: Box<str>,
+    /// Field within the section (`$doc.section.<field>`).
+    pub field: Box<str>,
+    /// Trailing literal index segments, outermost first.
+    pub indices: Vec<DocIndex>,
+}
+
+/// The result of [`collect_doc_paths`]: every statically-resolved `$doc`
+/// path the programs reference, deduplicated and deterministically
+/// ordered, plus a fail-fast diagnostic for each `$doc` access that could
+/// not be statically resolved.
+#[derive(Debug, Clone, Default)]
+pub struct DocPathSet {
+    /// Deduplicated, sorted declared paths.
+    pub paths: Vec<DocPath>,
+    /// One diagnostic per `$doc` access whose index is not a literal.
+    pub unresolvable: Vec<TypeDiagnostic>,
+}
+
+/// Collect the `$doc` path set referenced across a set of typed programs.
+///
+/// Each tuple is `(node_name, typed_program)`; the node name is unused
+/// today but kept to mirror [`super::analyze_all`]'s signature and to let
+/// a future caller attribute a path to its referencing node. Paths are
+/// deduplicated across all programs and returned in sorted order;
+/// unresolvable-index diagnostics are accumulated in walk order.
+pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
+    let mut paths: BTreeSet<DocPath> = BTreeSet::new();
+    let mut unresolvable: Vec<TypeDiagnostic> = Vec::new();
+    for (_name, typed) in programs {
+        for stmt in &typed.program.statements {
+            walk_statement(stmt, &mut paths, &mut unresolvable);
+        }
+    }
+    DocPathSet {
+        paths: paths.into_iter().collect(),
+        unresolvable,
+    }
+}
+
+fn walk_statement(
+    stmt: &Statement,
+    paths: &mut BTreeSet<DocPath>,
+    unresolvable: &mut Vec<TypeDiagnostic>,
+) {
+    match stmt {
+        Statement::Let { expr, .. }
+        | Statement::Emit { expr, .. }
+        | Statement::ExprStmt { expr, .. } => walk_expr(expr, paths, unresolvable),
+        Statement::Filter { predicate, .. } => walk_expr(predicate, paths, unresolvable),
+        Statement::Trace { guard, message, .. } => {
+            if let Some(g) = guard {
+                walk_expr(g, paths, unresolvable);
+            }
+            walk_expr(message, paths, unresolvable);
+        }
+        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
+            walk_expr(source, paths, unresolvable);
+            for inner in body {
+                walk_statement(inner, paths, unresolvable);
+            }
+        }
+        Statement::Distinct { .. } | Statement::UseStmt { .. } => {}
+    }
+}
+
+/// Walk an expression, recording any `$doc` access it contains.
+///
+/// A `$doc` access is the `DocAccess` node optionally wrapped in one or
+/// more `IndexAccess` layers (`$doc.s.f[0][1]`). When the whole stack of
+/// indices is literal, the path is recorded; the first non-literal index
+/// makes the access unresolvable. The walker recurses through every
+/// control-flow branch (`if`, `match`, `coalesce`, `emit_each` bodies),
+/// so a `$doc` access used only inside a conditional is still collected.
+fn walk_expr(expr: &Expr, paths: &mut BTreeSet<DocPath>, unresolvable: &mut Vec<TypeDiagnostic>) {
+    // An IndexAccess whose receiver chain bottoms out at a DocAccess is a
+    // `$doc` path with trailing indices — classify it as a unit rather
+    // than walking the DocAccess receiver as a bare access. Other
+    // IndexAccess shapes (`record_field[0]`) fall through to the generic
+    // recursion below.
+    if let Expr::IndexAccess { .. } = expr
+        && let Some(classified) = classify_doc_index_chain(expr)
+    {
+        match classified {
+            Ok(path) => {
+                paths.insert(path);
+            }
+            Err(diag) => unresolvable.push(diag),
+        }
+        return;
+    }
+
+    match expr {
+        Expr::DocAccess { section, field, .. } => {
+            paths.insert(DocPath {
+                section: section.clone(),
+                field: field.clone(),
+                indices: Vec::new(),
+            });
+        }
+        Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
+            walk_expr(lhs, paths, unresolvable);
+            walk_expr(rhs, paths, unresolvable);
+        }
+        Expr::Unary { operand, .. } => walk_expr(operand, paths, unresolvable),
+        Expr::MethodCall { receiver, args, .. } => {
+            walk_expr(receiver, paths, unresolvable);
+            for a in args {
+                walk_expr(a, paths, unresolvable);
+            }
+        }
+        Expr::Match { subject, arms, .. } => {
+            if let Some(s) = subject {
+                walk_expr(s, paths, unresolvable);
+            }
+            for arm in arms {
+                walk_match_arm(arm, paths, unresolvable);
+            }
+        }
+        Expr::IfThenElse {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            walk_expr(condition, paths, unresolvable);
+            walk_expr(then_branch, paths, unresolvable);
+            if let Some(e) = else_branch {
+                walk_expr(e, paths, unresolvable);
+            }
+        }
+        Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
+            for a in args {
+                walk_expr(a, paths, unresolvable);
+            }
+        }
+        Expr::IndexAccess {
+            receiver, index, ..
+        } => {
+            // Reached only for non-`$doc` index chains; recurse into both
+            // sides so a `$doc` access buried in the index expression
+            // (`arr[$doc.s.f]`) is still collected.
+            walk_expr(receiver, paths, unresolvable);
+            walk_expr(index, paths, unresolvable);
+        }
+        Expr::Closure { body, .. } => walk_expr(body, paths, unresolvable),
+        Expr::Literal { .. }
+        | Expr::FieldRef { .. }
+        | Expr::QualifiedFieldRef { .. }
+        | Expr::PipelineAccess { .. }
+        | Expr::VarsAccess { .. }
+        | Expr::SourceAccess { .. }
+        | Expr::QualifiedSourceAccess { .. }
+        | Expr::RecordAccess { .. }
+        | Expr::Now { .. }
+        | Expr::Wildcard { .. }
+        | Expr::AggSlot { .. }
+        | Expr::GroupKey { .. } => {}
+    }
+}
+
+fn walk_match_arm(
+    arm: &MatchArm,
+    paths: &mut BTreeSet<DocPath>,
+    unresolvable: &mut Vec<TypeDiagnostic>,
+) {
+    walk_expr(&arm.pattern, paths, unresolvable);
+    walk_expr(&arm.body, paths, unresolvable);
+}
+
+/// Classify an `IndexAccess` whose receiver chain bottoms out at a
+/// `DocAccess`.
+///
+/// Returns:
+/// - `None` — not a `$doc` index chain (the receiver is something else);
+///   the caller falls back to generic recursion.
+/// - `Some(Ok(path))` — every index in the chain is literal.
+/// - `Some(Err(diag))` — some index is a computed expression, so the path
+///   is unresolvable; the diagnostic points at that index's span.
+fn classify_doc_index_chain(expr: &Expr) -> Option<Result<DocPath, TypeDiagnostic>> {
+    // First descend the receiver chain to its root WITHOUT judging the
+    // indices. Only once the root is confirmed to be a `$doc` access do
+    // the index expressions matter — `region[$doc.s.f]` has a `$doc`
+    // node in INDEX position, not as the indexed receiver, so it is not a
+    // `$doc` path chain and must fall through to generic recursion (which
+    // collects the `$doc` access inside the index expression).
+    let mut indexed_exprs: Vec<&Expr> = Vec::new();
+    let mut cursor = expr;
+    let (section, field) = loop {
+        match cursor {
+            Expr::IndexAccess {
+                receiver, index, ..
+            } => {
+                indexed_exprs.push(index);
+                cursor = receiver;
+            }
+            Expr::DocAccess { section, field, .. } => break (section, field),
+            // Receiver chain does not bottom out at a `$doc` access — not
+            // a `$doc` path. Let generic recursion handle it.
+            _ => return None,
+        }
+    };
+
+    // Root is a `$doc` access. Validate the indices outermost-first (the
+    // chain was collected innermost-first, so reverse). The first
+    // non-literal index makes the whole path unresolvable.
+    let mut indices = Vec::with_capacity(indexed_exprs.len());
+    for index in indexed_exprs.into_iter().rev() {
+        match literal_index(index) {
+            Some(seg) => indices.push(seg),
+            None => return Some(Err(diag_dynamic_doc_index(index.span()))),
+        }
+    }
+    Some(Ok(DocPath {
+        section: section.clone(),
+        field: field.clone(),
+        indices,
+    }))
+}
+
+/// Extract a literal index segment, or `None` if the index is computed.
+///
+/// Only integer and string literals are valid `$doc` index segments;
+/// every other literal kind (float, bool, date, null) is rejected as
+/// non-indexable so it surfaces the same fail-fast diagnostic as a
+/// computed index.
+fn literal_index(index: &Expr) -> Option<DocIndex> {
+    match index {
+        Expr::Literal {
+            value: LiteralValue::Int(n),
+            ..
+        } => Some(DocIndex::Int(*n)),
+        Expr::Literal {
+            value: LiteralValue::String(s),
+            ..
+        } => Some(DocIndex::Key(s.clone())),
+        _ => None,
+    }
+}
+
+fn diag_dynamic_doc_index(span: Span) -> TypeDiagnostic {
+    TypeDiagnostic {
+        span,
+        message: "a `$doc` access must index by a literal — this index is computed at \
+                  runtime, so the declared document path cannot be resolved at compile time"
+            .to_string(),
+        help: Some(
+            "index the envelope path with an integer or string literal \
+             (`$doc.section.items[0]` / `$doc.section.meta[\"run_date\"]`)"
+                .to_string(),
+        ),
+        related_span: None,
+        is_warning: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lexer::Span;
+    use crate::parser::Parser;
+    use crate::resolve::pass::resolve_program;
+    use crate::typecheck::pass::type_check;
+    use crate::typecheck::row::Row;
+
+    /// Compile CXL source to a `TypedProgram` for the path analyzer.
+    /// The schema is empty and field references resolve against a fixed
+    /// set — sufficient because the pass only inspects `$doc` accesses.
+    fn compile(source: &str) -> TypedProgram {
+        let parsed = Parser::parse(source);
+        assert!(
+            parsed.errors.is_empty(),
+            "parse errors: {:?}",
+            parsed.errors
+        );
+        let fields: Vec<&str> = vec!["idx", "amount", "region"];
+        let resolved = resolve_program(parsed.ast, &fields, parsed.node_count).unwrap();
+        let schema = Row::closed(indexmap::IndexMap::new(), Span::new(0, 0));
+        type_check(resolved, &schema).unwrap()
+    }
+
+    fn collect(source: &str) -> DocPathSet {
+        let typed = compile(source);
+        collect_doc_paths(&[("t", &typed)])
+    }
+
+    fn path(section: &str, field: &str, indices: Vec<DocIndex>) -> DocPath {
+        DocPath {
+            section: section.into(),
+            field: field.into(),
+            indices,
+        }
+    }
+
+    #[test]
+    fn test_collects_plain_two_level_path() {
+        let set = collect("emit batch = $doc.Head.batch_id");
+        assert!(set.unresolvable.is_empty());
+        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+    }
+
+    #[test]
+    fn test_collects_multiple_distinct_paths_sorted() {
+        let set = collect(
+            "emit a = $doc.Foot.record_count\n\
+             emit b = $doc.Head.batch_id",
+        );
+        assert!(set.unresolvable.is_empty());
+        // BTreeSet ordering is by (section, field): Foot precedes Head.
+        assert_eq!(
+            set.paths,
+            vec![
+                path("Foot", "record_count", vec![]),
+                path("Head", "batch_id", vec![]),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_dedups_identical_paths_across_statements() {
+        let set = collect(
+            "emit a = $doc.Head.batch_id\n\
+             emit b = $doc.Head.batch_id + 1",
+        );
+        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+    }
+
+    #[test]
+    fn test_collects_literal_int_index() {
+        let set = collect("emit first = $doc.summary.items[0]");
+        assert!(set.unresolvable.is_empty());
+        assert_eq!(
+            set.paths,
+            vec![path("summary", "items", vec![DocIndex::Int(0)])]
+        );
+    }
+
+    #[test]
+    fn test_collects_literal_string_index() {
+        let set = collect("emit run = $doc.meta.props[\"run_date\"]");
+        assert!(set.unresolvable.is_empty());
+        assert_eq!(
+            set.paths,
+            vec![path(
+                "meta",
+                "props",
+                vec![DocIndex::Key("run_date".into())]
+            )]
+        );
+    }
+
+    #[test]
+    fn test_collects_nested_index_chain() {
+        let set = collect("emit deep = $doc.summary.rows[2][\"k\"]");
+        assert!(set.unresolvable.is_empty());
+        assert_eq!(
+            set.paths,
+            vec![path(
+                "summary",
+                "rows",
+                vec![DocIndex::Int(2), DocIndex::Key("k".into())]
+            )]
+        );
+    }
+
+    #[test]
+    fn test_collects_path_used_only_in_if_branch() {
+        // The `$doc` access lives only inside the then-branch of an `if`.
+        // Conditional-only usage must still be collected.
+        let set = collect("emit v = if region == \"x\" then $doc.Head.batch_id else 0");
+        assert!(set.unresolvable.is_empty());
+        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+    }
+
+    #[test]
+    fn test_collects_path_used_only_in_match_arm() {
+        let set = collect(
+            "emit v = match region {\n\
+             \"x\" => $doc.Foot.record_count,\n\
+             _ => 0,\n\
+             }",
+        );
+        assert!(set.unresolvable.is_empty());
+        assert_eq!(set.paths, vec![path("Foot", "record_count", vec![])]);
+    }
+
+    #[test]
+    fn test_collects_path_inside_index_expression() {
+        // `$doc` appears as the index of an unrelated array access.
+        let set = collect("emit v = region[$doc.Head.offset]");
+        assert!(set.unresolvable.is_empty());
+        assert_eq!(set.paths, vec![path("Head", "offset", vec![])]);
+    }
+
+    #[test]
+    fn test_dynamic_index_is_unresolvable_with_span() {
+        // `idx` is a record field, not a literal — the `$doc` element it
+        // selects cannot be named at compile time.
+        let src = "emit v = $doc.summary.items[idx]";
+        let set = collect(src);
+        assert!(
+            set.paths.is_empty(),
+            "no path is recorded for an unresolvable access"
+        );
+        assert_eq!(set.unresolvable.len(), 1);
+        let diag = &set.unresolvable[0];
+        // The span must point at the offending index expression `idx`,
+        // not the whole access.
+        let snippet = &src[diag.span.start as usize..diag.span.end as usize];
+        assert_eq!(snippet, "idx");
+        assert!(!diag.is_warning);
+    }
+
+    #[test]
+    fn test_resolvable_and_unresolvable_coexist() {
+        let set = collect(
+            "emit a = $doc.Head.batch_id\n\
+             emit b = $doc.summary.items[region]",
+        );
+        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+        assert_eq!(set.unresolvable.len(), 1);
+    }
+
+    #[test]
+    fn test_no_doc_access_yields_empty_set() {
+        let set = collect("emit v = amount + 1");
+        assert!(set.paths.is_empty());
+        assert!(set.unresolvable.is_empty());
+    }
+}

--- a/crates/cxl/src/analyzer/doc_paths.rs
+++ b/crates/cxl/src/analyzer/doc_paths.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{Expr, LiteralValue, MatchArm, Statement};
+use crate::ast::{Expr, LiteralValue, MatchArm, Statement, UnaryOp};
 use crate::lexer::Span;
 use crate::typecheck::pass::{TypeDiagnostic, TypedProgram};
 
@@ -62,8 +62,11 @@ pub struct DocPath {
 pub struct DocPathSet {
     /// Deduplicated, sorted declared paths.
     pub paths: Vec<DocPath>,
-    /// One diagnostic per `$doc` access whose index is not a literal.
-    pub unresolvable: Vec<TypeDiagnostic>,
+    /// One entry per `$doc` access whose index is not a literal. The
+    /// `String` is the name of the program's node so the caller can anchor
+    /// a plan-level diagnostic at that node; the [`TypeDiagnostic`] carries
+    /// the precise offending-index span and help.
+    pub unresolvable: Vec<(String, TypeDiagnostic)>,
 }
 
 /// Collect the `$doc` path set referenced across a set of typed programs.
@@ -75,10 +78,10 @@ pub struct DocPathSet {
 /// unresolvable-index diagnostics are accumulated in walk order.
 pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
     let mut paths: BTreeSet<DocPath> = BTreeSet::new();
-    let mut unresolvable: Vec<TypeDiagnostic> = Vec::new();
-    for (_name, typed) in programs {
+    let mut unresolvable: Vec<(String, TypeDiagnostic)> = Vec::new();
+    for (name, typed) in programs {
         for stmt in &typed.program.statements {
-            walk_statement(stmt, &mut paths, &mut unresolvable);
+            walk_statement(name, stmt, &mut paths, &mut unresolvable);
         }
     }
     DocPathSet {
@@ -88,25 +91,26 @@ pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
 }
 
 fn walk_statement(
+    node_name: &str,
     stmt: &Statement,
     paths: &mut BTreeSet<DocPath>,
-    unresolvable: &mut Vec<TypeDiagnostic>,
+    unresolvable: &mut Vec<(String, TypeDiagnostic)>,
 ) {
     match stmt {
         Statement::Let { expr, .. }
         | Statement::Emit { expr, .. }
-        | Statement::ExprStmt { expr, .. } => walk_expr(expr, paths, unresolvable),
-        Statement::Filter { predicate, .. } => walk_expr(predicate, paths, unresolvable),
+        | Statement::ExprStmt { expr, .. } => walk_expr(node_name, expr, paths, unresolvable),
+        Statement::Filter { predicate, .. } => walk_expr(node_name, predicate, paths, unresolvable),
         Statement::Trace { guard, message, .. } => {
             if let Some(g) = guard {
-                walk_expr(g, paths, unresolvable);
+                walk_expr(node_name, g, paths, unresolvable);
             }
-            walk_expr(message, paths, unresolvable);
+            walk_expr(node_name, message, paths, unresolvable);
         }
         Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
-            walk_expr(source, paths, unresolvable);
+            walk_expr(node_name, source, paths, unresolvable);
             for inner in body {
-                walk_statement(inner, paths, unresolvable);
+                walk_statement(node_name, inner, paths, unresolvable);
             }
         }
         Statement::Distinct { .. } | Statement::UseStmt { .. } => {}
@@ -121,7 +125,12 @@ fn walk_statement(
 /// makes the access unresolvable. The walker recurses through every
 /// control-flow branch (`if`, `match`, `coalesce`, `emit_each` bodies),
 /// so a `$doc` access used only inside a conditional is still collected.
-fn walk_expr(expr: &Expr, paths: &mut BTreeSet<DocPath>, unresolvable: &mut Vec<TypeDiagnostic>) {
+fn walk_expr(
+    node_name: &str,
+    expr: &Expr,
+    paths: &mut BTreeSet<DocPath>,
+    unresolvable: &mut Vec<(String, TypeDiagnostic)>,
+) {
     // An IndexAccess whose receiver chain bottoms out at a DocAccess is a
     // `$doc` path with trailing indices — classify it as a unit rather
     // than walking the DocAccess receiver as a bare access. Other
@@ -134,7 +143,7 @@ fn walk_expr(expr: &Expr, paths: &mut BTreeSet<DocPath>, unresolvable: &mut Vec<
             Ok(path) => {
                 paths.insert(path);
             }
-            Err(diag) => unresolvable.push(diag),
+            Err(diag) => unresolvable.push((node_name.to_string(), diag)),
         }
         return;
     }
@@ -148,22 +157,22 @@ fn walk_expr(expr: &Expr, paths: &mut BTreeSet<DocPath>, unresolvable: &mut Vec<
             });
         }
         Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
-            walk_expr(lhs, paths, unresolvable);
-            walk_expr(rhs, paths, unresolvable);
+            walk_expr(node_name, lhs, paths, unresolvable);
+            walk_expr(node_name, rhs, paths, unresolvable);
         }
-        Expr::Unary { operand, .. } => walk_expr(operand, paths, unresolvable),
+        Expr::Unary { operand, .. } => walk_expr(node_name, operand, paths, unresolvable),
         Expr::MethodCall { receiver, args, .. } => {
-            walk_expr(receiver, paths, unresolvable);
+            walk_expr(node_name, receiver, paths, unresolvable);
             for a in args {
-                walk_expr(a, paths, unresolvable);
+                walk_expr(node_name, a, paths, unresolvable);
             }
         }
         Expr::Match { subject, arms, .. } => {
             if let Some(s) = subject {
-                walk_expr(s, paths, unresolvable);
+                walk_expr(node_name, s, paths, unresolvable);
             }
             for arm in arms {
-                walk_match_arm(arm, paths, unresolvable);
+                walk_match_arm(node_name, arm, paths, unresolvable);
             }
         }
         Expr::IfThenElse {
@@ -172,15 +181,15 @@ fn walk_expr(expr: &Expr, paths: &mut BTreeSet<DocPath>, unresolvable: &mut Vec<
             else_branch,
             ..
         } => {
-            walk_expr(condition, paths, unresolvable);
-            walk_expr(then_branch, paths, unresolvable);
+            walk_expr(node_name, condition, paths, unresolvable);
+            walk_expr(node_name, then_branch, paths, unresolvable);
             if let Some(e) = else_branch {
-                walk_expr(e, paths, unresolvable);
+                walk_expr(node_name, e, paths, unresolvable);
             }
         }
         Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
             for a in args {
-                walk_expr(a, paths, unresolvable);
+                walk_expr(node_name, a, paths, unresolvable);
             }
         }
         Expr::IndexAccess {
@@ -189,10 +198,10 @@ fn walk_expr(expr: &Expr, paths: &mut BTreeSet<DocPath>, unresolvable: &mut Vec<
             // Reached only for non-`$doc` index chains; recurse into both
             // sides so a `$doc` access buried in the index expression
             // (`arr[$doc.s.f]`) is still collected.
-            walk_expr(receiver, paths, unresolvable);
-            walk_expr(index, paths, unresolvable);
+            walk_expr(node_name, receiver, paths, unresolvable);
+            walk_expr(node_name, index, paths, unresolvable);
         }
-        Expr::Closure { body, .. } => walk_expr(body, paths, unresolvable),
+        Expr::Closure { body, .. } => walk_expr(node_name, body, paths, unresolvable),
         Expr::Literal { .. }
         | Expr::FieldRef { .. }
         | Expr::QualifiedFieldRef { .. }
@@ -209,12 +218,13 @@ fn walk_expr(expr: &Expr, paths: &mut BTreeSet<DocPath>, unresolvable: &mut Vec<
 }
 
 fn walk_match_arm(
+    node_name: &str,
     arm: &MatchArm,
     paths: &mut BTreeSet<DocPath>,
-    unresolvable: &mut Vec<TypeDiagnostic>,
+    unresolvable: &mut Vec<(String, TypeDiagnostic)>,
 ) {
-    walk_expr(&arm.pattern, paths, unresolvable);
-    walk_expr(&arm.body, paths, unresolvable);
+    walk_expr(node_name, &arm.pattern, paths, unresolvable);
+    walk_expr(node_name, &arm.body, paths, unresolvable);
 }
 
 /// Classify an `IndexAccess` whose receiver chain bottoms out at a
@@ -269,10 +279,11 @@ fn classify_doc_index_chain(expr: &Expr) -> Option<Result<DocPath, TypeDiagnosti
 
 /// Extract a literal index segment, or `None` if the index is computed.
 ///
-/// Only integer and string literals are valid `$doc` index segments;
-/// every other literal kind (float, bool, date, null) is rejected as
-/// non-indexable so it surfaces the same fail-fast diagnostic as a
-/// computed index.
+/// Accepts an integer literal, a unary-negated integer literal
+/// (`items[-1]` — a static from-end index), or a string-key literal.
+/// Every other shape (a field reference, an arithmetic expression, a
+/// float/bool/date/null literal) is non-literal and makes the path
+/// unresolvable.
 fn literal_index(index: &Expr) -> Option<DocIndex> {
     match index {
         Expr::Literal {
@@ -283,6 +294,20 @@ fn literal_index(index: &Expr) -> Option<DocIndex> {
             value: LiteralValue::String(s),
             ..
         } => Some(DocIndex::Key(s.clone())),
+        // `items[-1]` parses as `Unary{Neg, Literal(Int)}` — still a
+        // static index, so resolve it rather than rejecting it as
+        // "computed".
+        Expr::Unary {
+            op: UnaryOp::Neg,
+            operand,
+            ..
+        } => match operand.as_ref() {
+            Expr::Literal {
+                value: LiteralValue::Int(n),
+                ..
+            } => Some(DocIndex::Int(-*n)),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -290,11 +315,13 @@ fn literal_index(index: &Expr) -> Option<DocIndex> {
 fn diag_dynamic_doc_index(span: Span) -> TypeDiagnostic {
     TypeDiagnostic {
         span,
-        message: "a `$doc` access must index by a literal — this index is computed at \
-                  runtime, so the declared document path cannot be resolved at compile time"
+        message: "a `$doc` access must be indexed by a literal, but this index is a \
+                  non-literal expression, so the declared document path cannot be \
+                  resolved at compile time"
             .to_string(),
         help: Some(
-            "index the envelope path with an integer or string literal \
+            "index the envelope path with an integer literal (including a \
+             negative such as `[-1]`) or a string-key literal \
              (`$doc.section.items[0]` / `$doc.section.meta[\"run_date\"]`)"
                 .to_string(),
         ),
@@ -452,12 +479,50 @@ mod tests {
             "no path is recorded for an unresolvable access"
         );
         assert_eq!(set.unresolvable.len(), 1);
-        let diag = &set.unresolvable[0];
+        let (node, diag) = &set.unresolvable[0];
+        // The diagnostic is tagged with the program's node name so a
+        // plan-level caller can anchor a node-level span.
+        assert_eq!(node, "t");
         // The span must point at the offending index expression `idx`,
         // not the whole access.
         let snippet = &src[diag.span.start as usize..diag.span.end as usize];
         assert_eq!(snippet, "idx");
         assert!(!diag.is_warning);
+    }
+
+    #[test]
+    fn test_negative_literal_index_is_resolved() {
+        // `items[-1]` parses as a unary-negated integer literal — a
+        // static from-end index, so the path resolves rather than being
+        // flagged unresolvable.
+        let set = collect("emit last = $doc.summary.items[-1]");
+        assert!(
+            set.unresolvable.is_empty(),
+            "a negated integer literal is a static index"
+        );
+        assert_eq!(
+            set.paths,
+            vec![path("summary", "items", vec![DocIndex::Int(-1)])]
+        );
+    }
+
+    #[test]
+    fn test_unresolvable_message_does_not_claim_runtime_for_static_forms() {
+        // A field-reference index is genuinely non-literal; the message
+        // must describe it as a non-literal expression, never as a
+        // specific runtime claim that would be false for a static `-1`.
+        let set = collect("emit v = $doc.summary.items[region]");
+        assert_eq!(set.unresolvable.len(), 1);
+        let (_node, diag) = &set.unresolvable[0];
+        assert!(
+            diag.message.contains("non-literal expression"),
+            "message should describe the index as a non-literal expression: {}",
+            diag.message
+        );
+        assert!(
+            diag.help.as_deref().unwrap_or("").contains("[-1]"),
+            "help should mention that a negative literal is accepted"
+        );
     }
 
     #[test]

--- a/crates/cxl/src/analyzer/mod.rs
+++ b/crates/cxl/src/analyzer/mod.rs
@@ -9,6 +9,8 @@ use std::collections::HashSet;
 use crate::ast::{Expr, MatchArm, Statement};
 use crate::typecheck::pass::TypedProgram;
 
+pub mod doc_paths;
+
 /// Which category of window function was called.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WindowFunction {

--- a/docs/explain/E339.md
+++ b/docs/explain/E339.md
@@ -1,0 +1,81 @@
+# Error E339: hl7 output cannot be combined with split
+
+## What it means
+
+An `Output` node declares the `hl7` format and also carries a byte-limit
+`split:` block. The two are mutually exclusive: an HL7 v2 batch or file is a
+single nested envelope — `FHS..FTS` wraps `BHS..BTS` batches, each wrapping
+`MSH`-led messages — whose trailer counts (`BTS` message count, `FTS` batch
+count) are recomputed and written only at end of stream. Byte-limit file
+splitting finalizes the writer mid-stream, which would seal the file after the
+first split's records and then emit later messages — and their fresh `MSH`
+headers — after the `FTS` trailer, producing a structurally corrupt batch that
+still reports run success.
+
+Rather than emit corruption, clinker rejects the combination at
+config-validation time.
+
+```
+E339 output 'hl7_out': `hl7` output cannot be combined with `split` — a
+batch/file envelope is one indivisible FHS..FTS structure and cannot be divided
+across files; remove the `split` block or choose a splittable format
+```
+
+## Example
+
+```yaml
+# Rejected: a batch/file envelope cannot be split across files.
+nodes:
+  - output: hl7_out
+    input: messages
+    format: hl7
+    path: out/messages.hl7
+    split:
+      max_bytes: 1048576
+```
+
+```yaml
+# Corrected (option A): drop the split block; write one batch/file.
+nodes:
+  - output: hl7_out
+    input: messages
+    format: hl7
+    path: out/messages.hl7
+```
+
+```yaml
+# Corrected (option B): partition upstream and run one invocation per
+# partition, so each run produces its own complete batch/file.
+#   for f in inputs/*.csv; do clinker run pipeline.yaml --var input="$f"; done
+```
+
+## How to fix
+
+1. **Remove the `split:` block** from the `hl7` output. A single run then
+   writes one complete batch/file.
+
+2. **Choose a splittable format** (`csv`, `json`, `xml`, `fixed_width`) if the
+   byte-limit splitting is the requirement and the HL7 batch envelope is not.
+
+3. **Partition the input and invoke per partition** if you need multiple output
+   files: split the source by file or key upstream and run clinker once per
+   partition, so each invocation emits its own self-contained batch/file.
+
+## Technical context
+
+The HL7 writer optionally reconstructs the batch envelope around emitted
+records: it writes `FHS`/`BHS` from configuration (literal or echoed from
+`$doc`), re-emits each `MSH`-led message, and on `flush()` writes the `BTS`
+trailer with the recomputed message count and the `FTS` trailer with the
+recomputed batch count. That finalization is the only point at which the
+batch/file is well-formed. A byte-limit `split` flushes (and therefore
+finalizes) the writer whenever the per-file cap is reached, so any messages
+after the first split boundary would be written outside the sealed envelope.
+Because no valid batch can span files, the validator rejects the pairing up
+front.
+
+## See also
+
+- E323 (`edifact` output combined with byte-limit `split`)
+- E338 (`x12` output combined with byte-limit `split`)
+- "HL7 v2 Format" in the pipeline reference

--- a/docs/explain/E339.md
+++ b/docs/explain/E339.md
@@ -16,8 +16,8 @@ Rather than emit corruption, clinker rejects the combination at
 config-validation time.
 
 ```
-E339 output 'hl7_out': `hl7` output cannot be combined with `split` — a
-batch/file envelope is one indivisible FHS..FTS structure and cannot be divided
+[E339] output 'hl7_out': `hl7` output cannot be combined with `split` — an HL7
+v2 batch/file envelope is a single FHS..FTS structure and cannot be divided
 across files; remove the `split` block or choose a splittable format
 ```
 

--- a/docs/explain/E340.md
+++ b/docs/explain/E340.md
@@ -11,13 +11,16 @@ A path whose index is computed at run time cannot be named in that static set,
 so the path the reader must extract is unknown until evaluation — too late for a
 reader that prunes its parse to the declared paths.
 
+A negative integer literal such as `[-1]` (an index from the end) is a
+compile-time constant and **is** accepted; only a genuinely non-literal index
+expression is rejected.
+
 Rather than read the whole document defensively, clinker rejects the
 non-resolvable path at config-validation time.
 
 ```
-E340 transform 'enrich': a `$doc` path indexed by a non-literal cannot be
-resolved to a declared document path at compile time; index `$doc` values with
-a literal `[n]` or `["key"]`
+a `$doc` access must be indexed by a literal, but this index is a non-literal
+expression, so the declared document path cannot be resolved at compile time
 ```
 
 ## Example
@@ -32,17 +35,19 @@ nodes:
 ```
 
 ```yaml
-# Corrected (option A): index with a literal.
+# Corrected (option A): index with a literal (integer, negative, or string key).
 nodes:
   - transform: enrich
     input: orders
     cxl: |
       emit first_line = $doc.summary.items[0]
+      emit last_line  = $doc.summary.items[-1]
 ```
 
 ```yaml
-# Corrected (option B): extract the whole declared array, then index it in a
-# downstream expression over the record's own fields.
+# Corrected (option B): bind the declared array to a `let`, then apply the
+# dynamic index to that binding — the declared path is `$doc.summary.items`,
+# which resolves statically, and the run-time index applies to an ordinary value.
 nodes:
   - transform: enrich
     input: orders
@@ -53,24 +58,27 @@ nodes:
 
 ## How to fix
 
-1. **Use a literal index** (`[0]`, `["total"]`) so the document path is fully
-   known at compile time.
+1. **Use a literal index** — an integer (`[0]`), a negative integer (`[-1]`),
+   or a string key (`["total"]`) — so the document path is fully known at
+   compile time.
 
 2. **Bind the declared array or map to a `let`** and apply the dynamic index to
-   that binding instead of to the `$doc` access directly — the declared path is
+   that binding instead of to the `$doc` access directly. The declared path is
    then `$doc.summary.items`, which resolves statically, and the run-time index
    applies to an ordinary value.
 
 ## Technical context
 
-Compile-time `$doc` path analysis walks every typed program and records each
-`$doc.<section>.<field>` access, including trailing literal index segments
-(`[0]`, `["k"]`), into the source configuration's declared path set. The section
-and field are always literal — the grammar admits only `$doc.section.field` —
-so the sole dynamic axis is an index expression. When an index is not an integer
-or string literal, the access cannot contribute a concrete path to the set, and
-the analysis fails fast with the offending index's source span rather than
-silently widening the reader to the entire envelope.
+Compile-time `$doc` path analysis walks every typed program — Transform,
+Aggregate, Route, Combine predicates and bodies, and composition bodies — and
+records each `$doc.<section>.<field>` access, including trailing literal index
+segments (`[0]`, `[-1]`, `["k"]`), into the source configuration's declared path
+set. The section and field are always literal — the grammar admits only
+`$doc.section.field` — so the sole dynamic axis is an index expression. When an
+index is not an integer or string literal (a negated literal still counts as a
+literal), the access cannot contribute a concrete path to the set, and the
+analysis fails fast with the offending index's source span rather than silently
+widening the reader to the entire envelope.
 
 ## See also
 

--- a/docs/explain/E340.md
+++ b/docs/explain/E340.md
@@ -1,0 +1,77 @@
+# Error E340: $doc path indexed by a non-literal cannot be resolved
+
+## What it means
+
+A program addresses a document envelope value with `$doc.<section>.<field>` and
+then indexes it with a non-literal subscript — for example
+`$doc.summary.items[row_field]`, where the index is a record field rather than a
+constant. The compiler collects every `$doc` path a pipeline declares so a
+document reader knows the full set of envelope paths before it reads any input.
+A path whose index is computed at run time cannot be named in that static set,
+so the path the reader must extract is unknown until evaluation — too late for a
+reader that prunes its parse to the declared paths.
+
+Rather than read the whole document defensively, clinker rejects the
+non-resolvable path at config-validation time.
+
+```
+E340 transform 'enrich': a `$doc` path indexed by a non-literal cannot be
+resolved to a declared document path at compile time; index `$doc` values with
+a literal `[n]` or `["key"]`
+```
+
+## Example
+
+```yaml
+# Rejected: the index is a record field, not a constant.
+nodes:
+  - transform: enrich
+    input: orders
+    cxl: |
+      emit first_line = $doc.summary.items[line_no]
+```
+
+```yaml
+# Corrected (option A): index with a literal.
+nodes:
+  - transform: enrich
+    input: orders
+    cxl: |
+      emit first_line = $doc.summary.items[0]
+```
+
+```yaml
+# Corrected (option B): extract the whole declared array, then index it in a
+# downstream expression over the record's own fields.
+nodes:
+  - transform: enrich
+    input: orders
+    cxl: |
+      let lines = $doc.summary.items
+      emit picked = lines[line_no]
+```
+
+## How to fix
+
+1. **Use a literal index** (`[0]`, `["total"]`) so the document path is fully
+   known at compile time.
+
+2. **Bind the declared array or map to a `let`** and apply the dynamic index to
+   that binding instead of to the `$doc` access directly — the declared path is
+   then `$doc.summary.items`, which resolves statically, and the run-time index
+   applies to an ordinary value.
+
+## Technical context
+
+Compile-time `$doc` path analysis walks every typed program and records each
+`$doc.<section>.<field>` access, including trailing literal index segments
+(`[0]`, `["k"]`), into the source configuration's declared path set. The section
+and field are always literal — the grammar admits only `$doc.section.field` —
+so the sole dynamic axis is an index expression. When an index is not an integer
+or string literal, the access cannot contribute a concrete path to the set, and
+the analysis fails fast with the offending index's source span rather than
+silently widening the reader to the entire envelope.
+
+## See also
+
+- "Envelopes & Document Context" in the pipeline reference

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
 - [Source Nodes](pipeline/source.md)
 - [EDIFACT Format](pipeline/edifact.md)
 - [X12 Format](pipeline/x12.md)
+- [HL7 v2 Format](pipeline/hl7.md)
 - [Network Sources (REST)](pipeline/source-network.md)
 - [Auto-Widen & Schema Drift](pipeline/auto-widen.md)
 - [Transform Nodes](pipeline/transform.md)

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -89,6 +89,7 @@ Each section declares how the reader locates its payload:
 | JSON    | `json_pointer`   | RFC 6901 pointer, e.g. `/Head`                   |
 | EDIFACT | `segment`        | A service-segment tag — only `UNB`               |
 | X12     | `segment`        | A service-segment tag — only `ISA` (GS/ST surface as nested levels) |
+| HL7 v2  | `segment`        | A header-segment tag — only `FHS` (BHS/MSH surface as nested levels) |
 
 Declaring an `xml_path` section against a JSON source (or vice versa),
 or a `segment` extract against XML/JSON, is a configuration error and
@@ -223,6 +224,15 @@ implements this: an **interchange** (ISA/IEA) contains one or more
 sets** (ST/SE), each containing the records. A single file can carry
 multiple interchanges back to back. See [X12 Format](x12.md) for the full
 reference.
+
+HL7 v2 is the second multi-level format: an optional **file** (`FHS`/`FTS`)
+contains optional **batches** (`BHS`/`BTS`), each containing one or more
+**messages** (`MSH..`), each containing the segment records. The tiers map
+onto the same nested levels — the `FHS` file header is a declared
+`segment: "FHS"` section, while the `BHS` batch and the `MSH` message
+surface automatically as the reader-supplied sections `batch` and
+`transaction_set`. Every tier is optional, so a bare `MSH`-led file simply
+opens one message level. See [HL7 v2 Format](hl7.md) for the full reference.
 
 A reader for such a format opens and closes each nested level as it
 crosses the corresponding envelope boundary mid-file. Each level

--- a/docs/src/pipeline/hl7.md
+++ b/docs/src/pipeline/hl7.md
@@ -1,0 +1,233 @@
+# HL7 v2 Format
+
+Clinker reads and writes HL7 v2.x pipe-and-hat messages alongside CSV,
+JSON, XML, fixed-width, EDIFACT, and X12. An HL7 v2 file is a finite stream
+of carriage-return-terminated segments. The smallest unit is one message,
+which always begins with an `MSH` (message header) segment; messages may
+optionally be wrapped in a `BHS..BTS` batch and an `FHS..FTS` file
+envelope. The reader streams one segment at a time and the writer re-emits
+the segments, optionally reconstructing the batch/file envelopes.
+
+The optional envelope tiers surface as nested document-context levels: an
+`FHS` file header becomes the file-level `$doc` document, and each `BHS`
+batch and `MSH` message opens a nested level whose `$doc` sections layer
+over the enclosing tiers. A body record therefore sees every enclosing
+tier's fields through one `$doc.<section>.<field>` lookup. All tiers are
+optional — a bare stream of `MSH` messages with no batch or file wrapping
+is a valid HL7 v2 file.
+
+## Delimiters and the MSH header
+
+HL7 declares its delimiters in the `MSH` header rather than assuming a
+fixed set. The byte immediately after the `MSH` tag is the field separator
+(`MSH-1`), and the four bytes that follow are the encoding characters
+(`MSH-2`), in this fixed order:
+
+| Role                  | Source in MSH-2          | Conventional byte |
+| --------------------- | ------------------------ | ----------------- |
+| Component separator   | first encoding character | `^`               |
+| Repetition separator  | second encoding char     | `~`               |
+| Escape character      | third encoding char      | `\`               |
+| Sub-component sep.    | fourth encoding char     | `&`               |
+
+The reader reads these bytes from the header, so a message that uses the
+conventional `|^~\&` or any other producer-chosen delimiters parses
+correctly. The segment terminator is **always** a carriage return
+(`0x0D`) — unlike the field and encoding delimiters, it is never
+producer-chosen.
+
+When a file opens with an `FHS` or `BHS` header instead of `MSH`, the
+delimiters are read from that header; HL7 requires the file's `FHS`/`BHS`
+encoding characters to match its messages' `MSH`.
+
+### The MSH off-by-one
+
+`MSH-1` *is* the field separator, so it is implicit — it never appears as a
+data field. When the `MSH` segment is split on the field separator, the
+encoding-characters field (`MSH-2`) is the first data field. As a result,
+for any `MSH` field number N ≥ 2, the positional column is `f<N-1>`:
+`MSH-2` is `f01`, the sending application `MSH-3` is `f02`, the message
+type `MSH-9` is `f08`, and the message control id `MSH-10` is `f09`. The
+same off-by-one applies to `FHS` and `BHS`.
+
+### Escape sequences
+
+Field data escapes a literal delimiter character with an escape sequence
+`\X\`, where `X` names the delimiter: `\F\` field separator, `\S\`
+component separator, `\T\` sub-component separator, `\R\` repetition
+separator, `\E\` the escape character itself. The reader decodes these into
+their literal data byte, so downstream consumers — CSV/JSON output, CXL
+string predicates, `$doc` fields — see clean data, never the wire escapes.
+The writer re-escapes any delimiter byte in field data on output, so the
+reader → writer → reader round-trip is byte-faithful.
+
+An application escape the positional reader does not decode (e.g. the
+formatting escape `\.br\`) is kept verbatim rather than dropped, so no data
+is lost.
+
+The component, repetition, and sub-component separators inside a field
+(e.g. the `^` in a composite `PATID^^^HOSP^MR`) are kept as part of the
+field's text and are not split — the positional field model works above
+component resolution, so a composite field round-trips unchanged.
+
+### Newlines between segments
+
+Some producers (and CRLF-normalizing transports) add a line feed after each
+carriage-return terminator. Those bytes are insignificant and are stripped
+between segments. A producer that omits the trailing carriage return on the
+final segment is accepted — that shape is common in practice.
+
+## Record shape
+
+Each segment becomes one record under a fixed positional schema:
+
+| Column     | Meaning                                                       |
+| ---------- | ------------------------------------------------------------- |
+| `seg_id`   | The segment tag (`MSH`, `PID`, `OBX`, …)                      |
+| `set_ref`  | The enclosing message's control id (`MSH-10`)                |
+| `set_type` | The enclosing message's type (`MSH-9`, e.g. `ADT^A01`)       |
+| `f01`, `f02`, … | The segment's positional data fields                    |
+
+The `MSH` header segment **is** emitted as a body record (its `seg_id` is
+`MSH`), carrying the message's fields positionally. Batch/file envelope
+segments (`FHS`, `FTS`, `BHS`, `BTS`) are consumed by the reader to drive
+the document levels and validate counts — they are never emitted as body
+records.
+
+The number of `fNN` columns is controlled by the source `max_fields`
+option (default 64). A segment carrying more data fields than that is
+rejected with guidance rather than silently truncated. Absent trailing
+fields read as `null`.
+
+```yaml
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./inbox/*.hl7
+      options:
+        max_fields: 128       # widen the positional schema for large OBX segments
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: f01, type: string }
+```
+
+## Envelope sections over the tiers
+
+The file header `FHS` is extractable as a file-level document envelope
+section, exposing its positional fields to CXL as `$doc.<section>.<field>`.
+Use the `segment` extract rule with the field names matching the positional
+keys `f01`, `f02`, … :
+
+```yaml
+envelope:
+  sections:
+    file:
+      extract: { segment: "FHS" }
+      fields:
+        f07: string          # file name / id (FHS-8 under the off-by-one)
+```
+
+The `BHS` batch and the `MSH` message surface automatically as the nested
+`$doc` sections `batch` and `transaction_set`, each keyed by positional
+`fNN` fields — no envelope declaration is needed for them. A Transform on
+any body record can read all available tiers at once:
+
+```cxl
+emit file_id  = $doc.file.f07            # FHS file id (declared section)
+emit batch_id = $doc.batch.f07           # BHS batch id (auto section)
+emit mtype    = $doc.transaction_set.f08 # MSH-9 message type (auto section)
+emit ctrl     = $doc.transaction_set.f09 # MSH-10 control id (auto section)
+```
+
+Only the `FHS` header is extractable as a *declared* envelope section, and
+only when the file actually opens with one; a bare `MSH`-led file has no
+file-level envelope, so declaring an `FHS` section against it is rejected at
+startup. Trailer segments (`BTS`, `FTS`) arrive after the body they close
+and cannot become `$doc` fields without buffering the whole file — their
+counts are instead validated inline by the reader (see below). A `segment`
+extract naming any tag other than `FHS`, or an `xml_path` / `json_pointer`
+extract against an HL7 source, is rejected at startup.
+
+## Control-count validation
+
+The reader validates the structural integrity claims carried in the
+batch/file trailers as they arrive, failing the run on a mismatch (a
+truncation or corruption signal):
+
+- **`BTS` batch message count (`BTS-1`)** — must equal the number of `MSH`
+  messages in the batch. An empty `BTS-1` disables the check (the count is
+  optional in practice).
+- **`FTS` file batch count (`FTS-1`)** — must equal the number of `BHS`
+  batches in the file. An empty `FTS-1` disables the check.
+
+Content after the `FTS` file trailer is rejected. A bare `MSH`-led file
+needs no trailers and validates with no count checks.
+
+## Writing HL7
+
+An HL7 Output node re-emits the `MSH` and body segments from the record
+stream, escaping any field data that carries a delimiter byte. Records map
+by the same positional columns (`seg_id`, `fNN`); trailing `null`/empty
+fields are trimmed so no fabricated delimiters appear, and a column the
+writer does not recognize is an error (project the record to the HL7
+columns first). The reader-stamped `set_ref`/`set_type` echoes and
+engine-internal `$`-namespaced columns are excluded automatically.
+
+```yaml
+nodes:
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: hl7
+      path: ./out/result.hl7
+      options:
+        file_header: ["^~\\&", "LAB", "HOSP", "EHR", "HOSP", "20240102", "FILE7"]
+        batch_header: ["^~\\&", "LAB", "HOSP", "EHR", "HOSP", "20240102", "BATCH3"]
+        segment_newline: true
+```
+
+Output options:
+
+| Option                  | Meaning                                                                |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `file_header`           | Literal `FHS` fields; opens an `FHS..FTS` file envelope.               |
+| `file_header_from_doc`  | Name of a `$doc` section to echo the `FHS` fields from (round-trip).   |
+| `batch_header`          | Literal `BHS` fields; wraps the messages in a `BHS..BTS` batch.        |
+| `segment_newline`       | Write a newline after each segment terminator (default `true`).        |
+
+When a file or batch header is configured, the writer recomputes the `BTS`
+batch message count and the `FTS` file batch count and emits the trailers
+at end of stream, so the output passes its own count validation on re-read.
+The `MSH-2` encoding-characters field of each header is written verbatim so
+the delimiter declaration round-trips. With no header options set, the
+writer emits a bare stream of messages with no batch/file envelope.
+
+`file_header_from_doc` echoes the `FHS` header from a record's document
+context. That context is populated by a source's `FHS` envelope section
+(declare a `segment: "FHS"` envelope section on the source) and travels
+with every body record through the pipeline. The reader stashes the
+complete, ordered `FHS` field list, so the reconstructed header is
+faithful. Supply `file_header` literal fields instead when the records have
+no source `FHS` section to echo.
+
+## Limitations
+
+- **Charset.** Field text is decoded as UTF-8. Non-UTF-8 messages are
+  rejected explicitly rather than silently corrupted.
+- **Positional fields, not component trees.** Components, repetitions, and
+  sub-components ride inside one positional `fNN` field verbatim; the reader
+  decodes only the `\X\` delimiter escapes. Split a composite field with CXL
+  string operations downstream when component-level access is needed.
+- **HL7 v3 and FHIR are out of scope.** HL7 v3 is XML (use the `xml`
+  format) and FHIR is JSON/REST (use the `json` format); this format
+  handles HL7 v2.x pipe-and-hat encoding only.
+- **Output splitting.** A batch/file envelope is a single `FHS..FTS`
+  structure and cannot be divided across files. An `hl7` output combined
+  with a `split:` block is rejected at config-validation time (diagnostic
+  `E339`) rather than emitting a structurally corrupt file.

--- a/docs/src/pipeline/output.md
+++ b/docs/src/pipeline/output.md
@@ -14,7 +14,7 @@ Output nodes write processed records to files. They are the terminal nodes of a 
     path: "./output/result.csv"
 ```
 
-The `type:` field selects the output format: `csv`, `json`, `xml`, `fixed_width`, `edifact`, or `x12`. The `edifact` and `x12` writers reconstruct their EDI interchange envelopes around emitted records; see [EDIFACT Format](edifact.md) and [X12 Format](x12.md).
+The `type:` field selects the output format: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`, or `hl7`. The `edifact` and `x12` writers reconstruct their EDI interchange envelopes around emitted records; the `hl7` writer re-emits HL7 v2 segments and optionally wraps them in batch/file envelopes. See [EDIFACT Format](edifact.md), [X12 Format](x12.md), and [HL7 v2 Format](hl7.md).
 
 ## Field control
 
@@ -65,7 +65,7 @@ Set `include_correlation_keys: true` to surface the shadow columns in the writer
 
 ### Writer rejection of `Value::Map` payloads
 
-CSV, XML, fixed-width, EDIFACT, and X12 writers refuse records carrying a `Value::Map` payload at any column slot, raising `FormatError::UnserializableMapValue { format, column }`. JSON serializes `Value::Map` natively as a nested object.
+CSV, XML, fixed-width, EDIFACT, X12, and HL7 writers refuse records carrying a `Value::Map` payload at any column slot, raising `FormatError::UnserializableMapValue { format, column }`. JSON serializes `Value::Map` natively as a nested object.
 
 The typical cause is a `$widened` sidecar reaching a non-JSON writer because the Output node set `include_unmapped: false`. See [Auto-Widen & Schema Drift -> Writer rejection](auto-widen.md#writer-rejection-of-valuemap-payloads) for the rejection contract and remediation routes.
 
@@ -217,6 +217,33 @@ interchange is a single envelope, so an `edifact` output cannot be
 combined with a `split:` block — the combination is rejected at
 config-validation time (`E323`). See [EDIFACT Format](edifact.md) for the
 full option reference, the record schema, and the round-trip semantics.
+
+### HL7 v2
+
+```yaml
+- type: output
+  name: hl7_out
+  input: messages
+  config:
+    name: hl7_out
+    type: hl7
+    path: "./out/result.hl7"
+    options:
+      file_header: ["^~\\&", "LAB", "HOSP", "EHR", "HOSP", "20240102", "FILE7"]
+      batch_header: ["^~\\&", "LAB", "HOSP", "EHR", "HOSP", "20240102", "BATCH3"]
+      segment_newline: true
+```
+
+The HL7 writer re-emits the `MSH` and body segments from the record
+stream, escaping any field data that carries a delimiter character (`|` →
+`\F\`, `^` → `\S\`, and so on). When a `file_header` (or
+`file_header_from_doc`) or `batch_header` is configured the writer wraps the
+messages in an `FHS..FTS` file or `BHS..BTS` batch and recomputes the
+closing `BTS`/`FTS` counts. A batch/file envelope is a single structure, so
+an `hl7` output cannot be combined with a `split:` block — the combination
+is rejected at config-validation time (`E339`). See
+[HL7 v2 Format](hl7.md) for the full option reference, the record schema,
+the MSH off-by-one, and the round-trip semantics.
 
 ## Sort order
 

--- a/docs/src/pipeline/source.md
+++ b/docs/src/pipeline/source.md
@@ -80,7 +80,7 @@ shares repeated values instead of storing each copy independently.
 A source declaration has two independent layers:
 
 - **Transport** (`transport:`) selects *where* the records come from. The only transport today is `file` — read bytes from the filesystem, resolved through one of the file matchers (`path` / `glob` / `regex` / `paths`). `transport:` is optional and defaults to `file`, so a source that omits it reads from disk exactly as before.
-- **Format** (`type:`) selects *how* the bytes decode into records: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`.
+- **Format** (`type:`) selects *how* the bytes decode into records: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`, `hl7`.
 
 ```yaml
 - type: source
@@ -98,7 +98,7 @@ A `file` transport requires **exactly one** file matcher (`path`, `glob`, `regex
 
 ## Format types
 
-The `type:` field inside `config:` selects the on-disk format. Supported values: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`.
+The `type:` field inside `config:` selects the on-disk format. Supported values: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`, `hl7`.
 
 The `edifact` format reads UN/EDIFACT interchanges; it has its own
 reference page covering the segment-record schema, delimiter discovery,
@@ -112,6 +112,12 @@ The `x12` format reads ANSI ASC X12 interchanges with their three-tier
 `ISA..IEA` → `GS..GE` → `ST..SE` envelope, surfacing all three tiers as
 nested `$doc` sections. It shares the same `max_elements` input option and
 has its own reference page. See [X12 Format](x12.md).
+
+The `hl7` format reads HL7 v2.x pipe-and-hat messages with MSH-driven
+delimiter discovery and optional batch/file (`BHS..BTS`, `FHS..FTS`)
+envelopes that surface as nested `$doc` levels. Its input option is
+`max_fields` (default 64) — the number of positional `fNN` field columns on
+the record schema. See [HL7 v2 Format](hl7.md).
 
 ### CSV
 


### PR DESCRIPTION
## Summary

Two document-shape additions, landed together as one wave.

### HL7 v2 reader/writer (#380)

A hand-rolled `hl7` format pair in `clinker-format`, alongside csv/json/xml/fixed-width and the EDI siblings (X12, EDIFACT). MSH-driven delimiter discovery, segments as records, and FHS/BHS and BTS/FTS batch envelopes mapped onto document-context levels (`$doc.file` / `$doc.batch` / `$doc.transaction_set`).

- **Round-trip fidelity.** Composite (`^`), repetition (`~`), and sub-component (`&`) separators are kept verbatim as a field's internal structure; the writer escapes only the field separator (`\F\`), the escape character (`\E\`), and an embedded carriage return (`\X0D\` hex), with the matching reader-side `\Xhh\` decode — so a read→write round trip is byte-faithful (a composite like `PATID^^^MRN` survives intact).
- **Envelope integrity.** BTS/FTS trailer counts are recomputed only at end of stream, so `hl7` output combined with byte-limit `split` is rejected up front (**E339**) rather than sealing a batch mid-stream. A batch left untrailed at EOF closes cleanly with balanced envelope events. MSH-2 encoding-character collisions are rejected.
- HL7 v3 and FHIR are out of scope (v3 is XML; FHIR is JSON/REST). No new crate dependency.

### Compile-time `$doc` path analysis (#382)

A static pass over **every** typed program — transforms, aggregates, route predicates, Combine predicates and bodies, and composition bodies — collects each `$doc.<section>.<field>` access (including literal, negative-literal, and string-key index segments) and surfaces the declared path set on each source configuration at plan-build time, so a document reader knows its full envelope path set before reading input.

A `$doc` access indexed by a genuinely non-literal expression cannot be named in that static set, so it fails fast at compile time with the offending index's source span (**E340**). The streaming JSON/XML readers and eval-time index resolution build on this set.

## Tests

HL7: 54 unit tests (delimiter discovery, MSH off-by-one, escape/hex decode, composite round-trip, envelope nesting, count validation, MSH-2 collision rejection) plus 5 end-to-end pipeline tests over ADT/ORU fixtures. `$doc`: 16 cxl-crate unit tests (nested/indexed/conditional-only paths, negative-literal index, unresolvable-index span) plus 7 plan-layer tests proving collection from transforms, Combine predicates, and composition bodies, and the E340 fail-fast.

## Docs

A new `docs/src/pipeline/hl7.md` reference page, envelope/document-context and format-overview updates, and `explain --code` entries for E339 and E340.

Closes #380.
Closes #382.

🤖 Generated with [Claude Code](https://claude.com/claude-code)