### PR TITLE
format: share a segment tokenizer across the EDI readers (#438)

### DIFF
--- a/crates/clinker-format/src/edifact/tokenizer.rs
+++ b/crates/clinker-format/src/edifact/tokenizer.rs
@@ -16,6 +16,9 @@
 use std::io::{BufRead, Read};
 
 use crate::error::FormatError;
+use crate::segment_tokenizer::{
+    SegmentFraming, TrailingSegment, read_raw_segment, skip_inter_segment_whitespace,
+};
 
 /// Hard ceiling on a single segment's raw byte length. A real EDIFACT
 /// segment is well under a kilobyte; this cap exists only so a stream
@@ -119,32 +122,21 @@ impl<R: BufRead> SegmentTokenizer<R> {
             };
             self.delimiters = delimiters;
             self.reader.consume(9);
-            self.skip_inter_segment_whitespace()?;
+            skip_inter_segment_whitespace(&mut self.reader)?;
         }
         Ok(())
     }
 
-    /// Consume CR/LF (and surrounding spaces/tabs) that some producers
-    /// insert between segments for readability. Stops at the first byte
-    /// that could begin a segment tag.
-    fn skip_inter_segment_whitespace(&mut self) -> Result<(), FormatError> {
-        loop {
-            let buf = self.reader.fill_buf()?;
-            if buf.is_empty() {
-                return Ok(());
-            }
-            let mut consumed = 0;
-            for &b in buf {
-                if b == b'\r' || b == b'\n' {
-                    consumed += 1;
-                } else {
-                    break;
-                }
-            }
-            if consumed == 0 {
-                return Ok(());
-            }
-            self.reader.consume(consumed);
+    /// EDIFACT segment framing: the terminator discovered from `UNA` (or the
+    /// Level-A default), the release character that escapes an embedded
+    /// terminator, and a terminator-less final segment rejected as a
+    /// truncated interchange.
+    fn framing(&self) -> SegmentFraming {
+        SegmentFraming {
+            terminator: self.delimiters.terminator,
+            release: Some(self.delimiters.release),
+            max_segment_bytes: MAX_SEGMENT_BYTES,
+            trailing: TrailingSegment::RejectUnterminated,
         }
     }
 
@@ -157,92 +149,37 @@ impl<R: BufRead> SegmentTokenizer<R> {
     /// dropped; CR/LF inside an element is preserved.
     pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
         self.initialize()?;
-        self.skip_inter_segment_whitespace()?;
+        skip_inter_segment_whitespace(&mut self.reader)?;
 
-        let terminator = self.delimiters.terminator;
-        let release = self.delimiters.release;
-
-        let mut raw: Vec<u8> = Vec::new();
-        let mut pending_release = false;
-
-        loop {
-            let buf = self.reader.fill_buf()?;
-            if buf.is_empty() {
-                // EOF. A non-empty pending buffer means a final segment
-                // with no terminator — truncation, not a clean end.
-                if raw.is_empty() {
-                    return Ok(None);
-                }
-                return Err(FormatError::Edifact(format!(
-                    "unterminated final segment ({} bytes read with no segment terminator); \
-                     the interchange is truncated",
-                    raw.len()
-                )));
-            }
-
-            let mut consumed = 0;
-            let mut finished = false;
-            for &b in buf {
-                consumed += 1;
-                if pending_release {
-                    // The previous byte was an unescaped release char;
-                    // this byte is literal regardless of its role.
-                    raw.push(release);
-                    raw.push(b);
-                    pending_release = false;
-                    continue;
-                }
-                if b == release {
-                    pending_release = true;
-                    continue;
-                }
-                if b == terminator {
-                    finished = true;
-                    break;
-                }
-                raw.push(b);
-            }
-            self.reader.consume(consumed);
-
-            if raw.len() > MAX_SEGMENT_BYTES {
-                return Err(FormatError::Edifact(format!(
+        let framing = self.framing();
+        let raw = match read_raw_segment(
+            &mut self.reader,
+            &framing,
+            || {
+                FormatError::Edifact(format!(
                     "segment exceeded the {MAX_SEGMENT_BYTES}-byte cap without a terminator; \
                      the interchange is malformed or the segment terminator is misconfigured"
-                )));
-            }
+                ))
+            },
+            |read| {
+                FormatError::Edifact(format!(
+                    "unterminated final segment ({read} bytes read with no segment terminator); \
+                     the interchange is truncated"
+                ))
+            },
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
 
-            if finished {
-                if pending_release {
-                    // Dangling release char with nothing to escape.
-                    raw.push(release);
-                }
-                let segment = strip_edge_whitespace(&raw);
-                let text = String::from_utf8(segment).map_err(|e| {
-                    FormatError::Edifact(format!(
-                        "segment is not valid UTF-8: {e}. Non-UTF-8 charsets \
-                         (UNOA/UNOB/Latin-1 high bytes) are not supported"
-                    ))
-                })?;
-                return Ok(Some(text));
-            }
-        }
+        let text = String::from_utf8(raw).map_err(|e| {
+            FormatError::Edifact(format!(
+                "segment is not valid UTF-8: {e}. Non-UTF-8 charsets \
+                 (UNOA/UNOB/Latin-1 high bytes) are not supported"
+            ))
+        })?;
+        Ok(Some(text))
     }
-}
-
-/// Drop CR/LF that bracket a raw segment body. Interior CR/LF is left
-/// intact — only the readability newlines a producer wraps around the
-/// terminator are insignificant.
-fn strip_edge_whitespace(raw: &[u8]) -> Vec<u8> {
-    let start = raw
-        .iter()
-        .position(|&b| b != b'\r' && b != b'\n')
-        .unwrap_or(raw.len());
-    let end = raw
-        .iter()
-        .rposition(|&b| b != b'\r' && b != b'\n')
-        .map(|p| p + 1)
-        .unwrap_or(start);
-    raw[start..end].to_vec()
 }
 
 /// A parsed segment: its tag plus its decoded data elements.

--- a/crates/clinker-format/src/hl7/tokenizer.rs
+++ b/crates/clinker-format/src/hl7/tokenizer.rs
@@ -29,6 +29,9 @@
 use std::io::{BufRead, Read};
 
 use crate::error::FormatError;
+use crate::segment_tokenizer::{
+    SegmentFraming, TrailingSegment, read_raw_segment, skip_inter_segment_whitespace,
+};
 
 /// Hard ceiling on a single segment's raw byte length. A real HL7 segment
 /// is well under a few kilobytes; this cap exists only so a stream with no
@@ -39,6 +42,17 @@ pub(crate) const MAX_SEGMENT_BYTES: usize = 256 * 1024;
 /// The HL7 segment terminator. Always a carriage return — never
 /// producer-chosen, unlike the field/encoding delimiters.
 const SEGMENT_TERMINATOR: u8 = b'\r';
+
+/// HL7 segment framing: the fixed carriage-return terminator, no release
+/// character (escape decoding happens later in [`split_segment`], not at the
+/// framing layer), and a terminator-less final segment accepted because HL7
+/// producers commonly drop the last carriage return.
+const FRAMING: SegmentFraming = SegmentFraming {
+    terminator: SEGMENT_TERMINATOR,
+    release: None,
+    max_segment_bytes: MAX_SEGMENT_BYTES,
+    trailing: TrailingSegment::AcceptUnterminated,
+};
 
 /// The four HL7 service delimiters discovered from the `MSH` header (the
 /// field separator plus the four encoding characters).
@@ -108,30 +122,6 @@ impl<R: BufRead> SegmentTokenizer<R> {
         self.delimiters
     }
 
-    /// Consume any inter-segment newline whitespace (`\r`/`\n`) that some
-    /// producers add between segments for readability. Stops at the first
-    /// byte that could begin a segment tag.
-    fn skip_inter_segment_whitespace(&mut self) -> Result<(), FormatError> {
-        loop {
-            let buf = self.reader.fill_buf()?;
-            if buf.is_empty() {
-                return Ok(());
-            }
-            let mut consumed = 0;
-            for &b in buf {
-                if b == b'\r' || b == b'\n' {
-                    consumed += 1;
-                } else {
-                    break;
-                }
-            }
-            if consumed == 0 {
-                return Ok(());
-            }
-            self.reader.consume(consumed);
-        }
-    }
-
     /// Read the first segment — an `MSH` message header, or an `FHS` file
     /// header or `BHS` batch header that wraps it — resolving the delimiter
     /// set from it and returning the raw segment text.
@@ -152,7 +142,7 @@ impl<R: BufRead> SegmentTokenizer<R> {
     /// four encoding characters (a non-HL7 or truncated stream leaves the
     /// delimiter set undefined, so nothing downstream can be tokenized).
     pub(crate) fn read_first_segment(&mut self) -> Result<String, FormatError> {
-        self.skip_inter_segment_whitespace()?;
+        skip_inter_segment_whitespace(&mut self.reader)?;
 
         // The header's delimiters are not yet known, so the first segment is
         // read up to the fixed carriage-return terminator without any escape
@@ -251,7 +241,7 @@ impl<R: BufRead> SegmentTokenizer<R> {
             self.initialized,
             "read_first_segment must run before next_segment"
         );
-        self.skip_inter_segment_whitespace()?;
+        skip_inter_segment_whitespace(&mut self.reader)?;
         let raw = match self.read_raw_until_terminator()? {
             Some(bytes) => bytes,
             None => return Ok(None),
@@ -274,59 +264,25 @@ impl<R: BufRead> SegmentTokenizer<R> {
     /// passes through verbatim because the terminator is the fixed carriage
     /// return, and HL7 escape decoding happens later in [`split_segment`].
     fn read_raw_until_terminator(&mut self) -> Result<Option<Vec<u8>>, FormatError> {
-        let mut raw: Vec<u8> = Vec::new();
-        loop {
-            let buf = self.reader.fill_buf()?;
-            if buf.is_empty() {
-                if raw.is_empty() {
-                    return Ok(None);
-                }
-                // A final segment with no trailing CR is the common HL7
-                // shape; strip surrounding newlines and accept it.
-                return Ok(Some(strip_edge_whitespace(&raw)));
-            }
-
-            let mut consumed = 0;
-            let mut finished = false;
-            for &b in buf {
-                consumed += 1;
-                if b == SEGMENT_TERMINATOR {
-                    finished = true;
-                    break;
-                }
-                raw.push(b);
-            }
-            self.reader.consume(consumed);
-
-            if raw.len() > MAX_SEGMENT_BYTES {
-                return Err(FormatError::Hl7(format!(
+        // HL7 accepts a terminator-less final segment, so the truncation
+        // constructor is unreachable under this framing policy.
+        read_raw_segment(
+            &mut self.reader,
+            &FRAMING,
+            || {
+                FormatError::Hl7(format!(
                     "segment exceeded the {MAX_SEGMENT_BYTES}-byte cap without a carriage-return \
                      terminator; the file is malformed or not HL7 v2"
-                )));
-            }
-
-            if finished {
-                return Ok(Some(strip_edge_whitespace(&raw)));
-            }
-        }
+                ))
+            },
+            |read| {
+                FormatError::Hl7(format!(
+                    "unterminated final HL7 segment ({read} bytes read with no carriage-return \
+                     terminator)"
+                ))
+            },
+        )
     }
-}
-
-/// Drop a line-feed that brackets a raw segment body. HL7 segments end in
-/// a bare carriage return, but producers (and CRLF-normalizing transports)
-/// often add a line feed; that whitespace is insignificant, so it is
-/// trimmed from the segment edges. Interior bytes are left intact.
-fn strip_edge_whitespace(raw: &[u8]) -> Vec<u8> {
-    let start = raw
-        .iter()
-        .position(|&b| b != b'\r' && b != b'\n')
-        .unwrap_or(raw.len());
-    let end = raw
-        .iter()
-        .rposition(|&b| b != b'\r' && b != b'\n')
-        .map(|p| p + 1)
-        .unwrap_or(start);
-    raw[start..end].to_vec()
 }
 
 /// A parsed segment: its tag plus its decoded data fields.

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod fixed_width;
 pub mod hl7;
 pub mod json;
+pub(crate) mod segment_tokenizer;
 pub mod splitting;
 pub mod traits;
 pub mod x12;

--- a/crates/clinker-format/src/segment_tokenizer.rs
+++ b/crates/clinker-format/src/segment_tokenizer.rs
@@ -1,0 +1,197 @@
+//! Shared segment-framing scaffolding for the flat EDI readers (HL7 v2,
+//! ANSI ASC X12, UN/EDIFACT).
+//!
+//! All three formats are byte streams of terminator-delimited segments with
+//! the same low-level framing concerns: producers sprinkle inter-segment
+//! `\r`/`\n` for readability, a single segment must not grow without bound
+//! when a terminator goes missing, and the readability newlines that bracket
+//! a raw segment body are insignificant. Only the *policy* differs between
+//! formats — the terminator byte, whether a release character escapes an
+//! embedded terminator, the byte cap, and what an EOF with bytes still
+//! pending means (a producer that dropped the final terminator versus a
+//! truncated stream). This module owns the framing loop and lets each format
+//! supply its policy, so a fix or a cap change lands in one place instead of
+//! drifting across three copies.
+//!
+//! Escape/release *decoding* and delimiter *discovery* stay in each format's
+//! own tokenizer: this layer never inspects field structure, it only finds
+//! segment boundaries. HL7 composite (`^`), repetition (`~`), and
+//! sub-component (`&`) separators therefore pass through framing untouched.
+
+use std::io::BufRead;
+
+use crate::error::FormatError;
+
+/// What a clean end-of-stream with bytes still pending means for a format.
+///
+/// HL7 producers commonly drop the trailing carriage return on the final
+/// segment, so a non-empty pending buffer at EOF is a legitimate last
+/// segment. X12 and EDIFACT require every segment to carry its terminator,
+/// so the same condition is a truncated interchange.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TrailingSegment {
+    /// Accept a terminator-less final segment as the producer's last record.
+    AcceptUnterminated,
+    /// Reject a terminator-less final segment as truncation.
+    RejectUnterminated,
+}
+
+/// The per-format framing policy consumed by [`read_raw_segment`].
+///
+/// Carries the resolved terminator byte (fixed for HL7, discovered from the
+/// header for X12/EDIFACT), the optional release character that escapes an
+/// embedded terminator (EDIFACT only), the per-segment byte cap, and how to
+/// treat an unterminated final segment.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SegmentFraming {
+    /// The byte that ends a segment.
+    pub terminator: u8,
+    /// A release character that, immediately preceding the terminator (or any
+    /// byte), makes that byte literal data rather than a boundary. `None` for
+    /// formats with no release mechanism (HL7, X12).
+    pub release: Option<u8>,
+    /// Hard ceiling on a single segment's raw byte length, so a missing
+    /// terminator fails fast instead of buffering the whole stream.
+    pub max_segment_bytes: usize,
+    /// Whether a terminator-less final segment is the producer's last record
+    /// or a truncation error.
+    pub trailing: TrailingSegment,
+}
+
+/// Consume any inter-segment newline whitespace (`\r`/`\n`) that producers
+/// add between segments for readability. Stops at the first byte that could
+/// begin a segment tag.
+///
+/// # Errors
+///
+/// Propagates an I/O error from the underlying buffered reader as
+/// [`FormatError::Io`].
+pub(crate) fn skip_inter_segment_whitespace<R: BufRead>(reader: &mut R) -> Result<(), FormatError> {
+    loop {
+        let buf = reader.fill_buf()?;
+        if buf.is_empty() {
+            return Ok(());
+        }
+        let mut consumed = 0;
+        for &b in buf {
+            if b == b'\r' || b == b'\n' {
+                consumed += 1;
+            } else {
+                break;
+            }
+        }
+        if consumed == 0 {
+            return Ok(());
+        }
+        reader.consume(consumed);
+    }
+}
+
+/// Drop the line-feed and carriage-return bytes that bracket a raw segment
+/// body. EDI segments end in a single terminator byte, but producers (and
+/// CRLF-normalizing transports) wrap readability newlines around it; that
+/// whitespace is insignificant, so it is trimmed from the segment edges.
+/// Interior bytes are left intact.
+fn strip_edge_whitespace(raw: &[u8]) -> Vec<u8> {
+    let start = raw
+        .iter()
+        .position(|&b| b != b'\r' && b != b'\n')
+        .unwrap_or(raw.len());
+    let end = raw
+        .iter()
+        .rposition(|&b| b != b'\r' && b != b'\n')
+        .map(|p| p + 1)
+        .unwrap_or(start);
+    raw[start..end].to_vec()
+}
+
+/// Read raw bytes up to (and consuming) the next unescaped terminator,
+/// returning the edge-trimmed segment body or `None` at a clean end of
+/// stream.
+///
+/// The terminator byte is consumed but not returned. When the framing policy
+/// names a release character, a release byte makes the byte that follows it
+/// literal data — both bytes are retained verbatim — so an escaped terminator
+/// does not split the segment; the release mechanism is therefore preserved
+/// for the format's own splitter to decode later. A release with nothing to
+/// escape at the segment boundary is kept as literal data.
+///
+/// The caller supplies two error constructors so each format raises its own
+/// [`FormatError`] variant with a precise message: `cap_error` for a segment
+/// that exceeds the byte cap with no terminator, and `truncation_error` for
+/// an unterminated final segment under [`TrailingSegment::RejectUnterminated`].
+/// `truncation_error` receives the count of bytes read so far.
+///
+/// # Errors
+///
+/// Returns the `cap_error` result when a segment exceeds
+/// [`SegmentFraming::max_segment_bytes`] without a terminator, the
+/// `truncation_error` result on an unterminated final segment when the policy
+/// rejects one, or [`FormatError::Io`] on an underlying read failure.
+pub(crate) fn read_raw_segment<R: BufRead>(
+    reader: &mut R,
+    framing: &SegmentFraming,
+    cap_error: impl FnOnce() -> FormatError,
+    truncation_error: impl FnOnce(usize) -> FormatError,
+) -> Result<Option<Vec<u8>>, FormatError> {
+    let terminator = framing.terminator;
+    let release = framing.release;
+
+    let mut raw: Vec<u8> = Vec::new();
+    // Holds the release byte when the previous input byte was an unescaped
+    // release char, so the byte that follows it is taken as literal data.
+    let mut pending_release: Option<u8> = None;
+
+    loop {
+        let buf = reader.fill_buf()?;
+        if buf.is_empty() {
+            // A release char dangling at EOF has nothing to escape and no
+            // following byte to carry, so the segment ends exactly at the
+            // bytes already accumulated — the dangling release is dropped,
+            // never counted toward an empty-vs-pending decision.
+            if raw.is_empty() {
+                return Ok(None);
+            }
+            return match framing.trailing {
+                TrailingSegment::AcceptUnterminated => Ok(Some(strip_edge_whitespace(&raw))),
+                TrailingSegment::RejectUnterminated => Err(truncation_error(raw.len())),
+            };
+        }
+
+        let mut consumed = 0;
+        let mut finished = false;
+        for &b in buf {
+            consumed += 1;
+            if let Some(rel) = pending_release.take() {
+                // The previous byte was an unescaped release char; this byte
+                // is literal regardless of its delimiter role. Both bytes are
+                // kept verbatim so the format's splitter can decode the escape.
+                raw.push(rel);
+                raw.push(b);
+                continue;
+            }
+            if release == Some(b) {
+                pending_release = Some(b);
+                continue;
+            }
+            if b == terminator {
+                finished = true;
+                break;
+            }
+            raw.push(b);
+        }
+        reader.consume(consumed);
+
+        if raw.len() > framing.max_segment_bytes {
+            return Err(cap_error());
+        }
+
+        // A terminator is reached only when no release escape is pending (the
+        // escape branch above consumes the byte after a release before any
+        // terminator test), so the finished segment never carries a dangling
+        // release here.
+        if finished {
+            return Ok(Some(strip_edge_whitespace(&raw)));
+        }
+    }
+}

--- a/crates/clinker-format/src/x12/tokenizer.rs
+++ b/crates/clinker-format/src/x12/tokenizer.rs
@@ -28,6 +28,9 @@
 use std::io::{BufRead, Read};
 
 use crate::error::FormatError;
+use crate::segment_tokenizer::{
+    SegmentFraming, TrailingSegment, read_raw_segment, skip_inter_segment_whitespace,
+};
 
 /// Hard ceiling on a single segment's raw byte length. A real X12 segment
 /// is well under a kilobyte; this cap exists only so a stream with no
@@ -106,30 +109,6 @@ impl<R: BufRead> SegmentTokenizer<R> {
         self.delimiters
     }
 
-    /// Consume CR/LF (and surrounding spaces/tabs producers sometimes add)
-    /// between segments for readability. Stops at the first byte that
-    /// could begin a segment tag.
-    fn skip_inter_segment_whitespace(&mut self) -> Result<(), FormatError> {
-        loop {
-            let buf = self.reader.fill_buf()?;
-            if buf.is_empty() {
-                return Ok(());
-            }
-            let mut consumed = 0;
-            for &b in buf {
-                if b == b'\r' || b == b'\n' {
-                    consumed += 1;
-                } else {
-                    break;
-                }
-            }
-            if consumed == 0 {
-                return Ok(());
-            }
-            self.reader.consume(consumed);
-        }
-    }
-
     /// Read and consume the fixed 106-byte `ISA` header, returning its raw
     /// bytes and resolving the delimiter set from it.
     ///
@@ -181,8 +160,20 @@ impl<R: BufRead> SegmentTokenizer<R> {
         self.initialized = true;
         // Drop the trailing terminator (and any CR/LF a producer wrote
         // after it) so the next read starts cleanly at GS.
-        self.skip_inter_segment_whitespace()?;
+        skip_inter_segment_whitespace(&mut self.reader)?;
         Ok(header)
+    }
+
+    /// X12 segment framing: the terminator discovered from the `ISA` header,
+    /// no release character (X12 has no escape mechanism), and a
+    /// terminator-less final segment rejected as a truncated interchange.
+    fn framing(&self) -> SegmentFraming {
+        SegmentFraming {
+            terminator: self.delimiters.terminator,
+            release: None,
+            max_segment_bytes: MAX_SEGMENT_BYTES,
+            trailing: TrailingSegment::RejectUnterminated,
+        }
     }
 
     /// Read the next raw segment (terminator-delimited), or `None` at
@@ -197,72 +188,36 @@ impl<R: BufRead> SegmentTokenizer<R> {
             self.initialized,
             "read_isa_header must run before next_segment"
         );
-        self.skip_inter_segment_whitespace()?;
+        skip_inter_segment_whitespace(&mut self.reader)?;
 
-        let terminator = self.delimiters.terminator;
-        let mut raw: Vec<u8> = Vec::new();
-
-        loop {
-            let buf = self.reader.fill_buf()?;
-            if buf.is_empty() {
-                // EOF. A non-empty pending buffer means a final segment
-                // with no terminator — truncation, not a clean end.
-                if raw.is_empty() {
-                    return Ok(None);
-                }
-                return Err(FormatError::X12(format!(
-                    "unterminated final segment ({} bytes read with no segment terminator); \
-                     the interchange is truncated",
-                    raw.len()
-                )));
-            }
-
-            let mut consumed = 0;
-            let mut finished = false;
-            for &b in buf {
-                consumed += 1;
-                if b == terminator {
-                    finished = true;
-                    break;
-                }
-                raw.push(b);
-            }
-            self.reader.consume(consumed);
-
-            if raw.len() > MAX_SEGMENT_BYTES {
-                return Err(FormatError::X12(format!(
+        let framing = self.framing();
+        let raw = match read_raw_segment(
+            &mut self.reader,
+            &framing,
+            || {
+                FormatError::X12(format!(
                     "segment exceeded the {MAX_SEGMENT_BYTES}-byte cap without a terminator; \
                      the interchange is malformed or the segment terminator is misconfigured"
-                )));
-            }
+                ))
+            },
+            |read| {
+                FormatError::X12(format!(
+                    "unterminated final segment ({read} bytes read with no segment terminator); \
+                     the interchange is truncated"
+                ))
+            },
+        )? {
+            Some(bytes) => bytes,
+            None => return Ok(None),
+        };
 
-            if finished {
-                let segment = strip_edge_whitespace(&raw);
-                let text = String::from_utf8(segment).map_err(|e| {
-                    FormatError::X12(format!(
-                        "segment is not valid UTF-8: {e}. Non-UTF-8 charsets are not supported"
-                    ))
-                })?;
-                return Ok(Some(text));
-            }
-        }
+        let text = String::from_utf8(raw).map_err(|e| {
+            FormatError::X12(format!(
+                "segment is not valid UTF-8: {e}. Non-UTF-8 charsets are not supported"
+            ))
+        })?;
+        Ok(Some(text))
     }
-}
-
-/// Drop CR/LF that bracket a raw segment body. Interior CR/LF is left
-/// intact — only the readability newlines a producer wraps around the
-/// terminator are insignificant.
-fn strip_edge_whitespace(raw: &[u8]) -> Vec<u8> {
-    let start = raw
-        .iter()
-        .position(|&b| b != b'\r' && b != b'\n')
-        .unwrap_or(raw.len());
-    let end = raw
-        .iter()
-        .rposition(|&b| b != b'\r' && b != b'\n')
-        .map(|p| p + 1)
-        .unwrap_or(start);
-    raw[start..end].to_vec()
 }
 
 /// A parsed segment: its tag plus its data elements.


### PR DESCRIPTION
## Summary

The HL7 v2, X12, and EDIFACT readers each carried a near-identical `SegmentTokenizer`: the same terminator-delimited segment-reading loop, inter-segment whitespace skipping, and byte-cap enforcement, copy-pasted three times and free to drift. This extracts that framing logic into one shared module (`crates/clinker-format/src/segment_tokenizer.rs`) that all three readers consume.

## Design — one helper, three thin consumers

The shared module owns the framing loop (`read_raw_segment`), whitespace handling, and a small `SegmentFraming` policy struct (terminator byte, optional release/escape byte, byte cap, and an accept-vs-reject decision for an unterminated trailing segment). Each reader passes its own policy and supplies its own error constructors, so format-specific concerns stay local:

- **HL7**: fixed `\r` terminator, accept an unterminated final segment (producers often drop the last CR).
- **X12**: terminator discovered from the ISA header, reject an unterminated final segment as truncation.
- **EDIFACT**: terminator discovered from the UNA service string, release-escape handling, reject unterminated.

Delimiter discovery (MSH/ISA/UNA parsing) and escape/release *decoding* remain entirely format-local — only the generic segment framing is shared. The three duplicated loops, three `skip_inter_segment_whitespace` copies, and three `strip_edge_whitespace` copies are fully deleted, not shimmed.

## Behavior

Behavior-preserving. HL7 composite (`^`), repetition (`~`), and sub-component (`&`) separators pass through the framing layer byte-for-byte (they are never the segment terminator and HL7 declares no release char), so all HL7 escape decoding stays in the untouched HL7 path. The byte-faithful reader→writer→reader round-trip test stays green, as do the X12/EDIFACT truncation and byte-cap tests. Net +314 / −268 lines; the three readers shed ~150 lines of duplication.

Closes #438.