### PR TITLE
docs: refresh stale mdbook content against current engine

### DIFF
--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -352,7 +352,6 @@ impl<'de> Deserialize<'de> for PipelineNode {
                             "merge",
                             "combine",
                             "output",
-                            "state",
                             "composition",
                         ],
                     )),

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -125,7 +125,7 @@ pub struct RunArgs {
     /// Path to the pipeline YAML configuration file
     pub config: PathBuf,
 
-    /// Memory budget (supports K/M/G suffixes), default 256M
+    /// Memory budget (supports K/M/G suffixes), default 512M
     #[arg(long = "memory-limit", help_heading = "Execution")]
     pub mem_limit: Option<String>,
 
@@ -206,9 +206,9 @@ pub struct RunArgs {
 }
 
 impl RunArgs {
-    /// Resolve memory limit from CLI flag or default (256MB).
+    /// Resolve memory limit from CLI flag or default (512MB).
     pub fn memory_limit_bytes(&self) -> u64 {
-        parse_memory_limit_bytes(self.mem_limit.as_deref().or(Some("256M")))
+        parse_memory_limit_bytes(self.mem_limit.as_deref().or(Some("512M")))
     }
 
     /// Resolve batch_id from CLI flag or generate UUID v7.
@@ -2180,7 +2180,7 @@ mod tests {
     fn test_cli_run_default_memory_limit() {
         let cli = Cli::try_parse_from(["clinker", "run", "p.yaml"]).unwrap();
         match cli.command {
-            Commands::Run(args) => assert_eq!(args.memory_limit_bytes(), 256 * 1024 * 1024),
+            Commands::Run(args) => assert_eq!(args.memory_limit_bytes(), 512 * 1024 * 1024),
             _ => panic!("expected Run command"),
         }
     }

--- a/crates/cxl/src/builtins.rs
+++ b/crates/cxl/src/builtins.rs
@@ -335,10 +335,11 @@ impl BuiltinRegistry {
             },
         );
 
-        // ── Map (5) ── — `.keys`, `.values`, `.merge(map)`,
-        // `.set(key: string, value: any)`, `.remove_field(key: string)`.
-        // `keys` and `values` are zero-arg; `merge` / `set` /
-        // `remove_field` take a single argument plus an optional value.
+        // ── Map (6) ── — `.keys`, `.values`, `.merge(map)`,
+        // `.set(key: string, value: any)`, `.remove_field(key: string)`,
+        // `.unset(key: string)`. `keys` and `values` are zero-arg;
+        // `merge` / `set` / `remove_field` / `unset` take a single
+        // argument plus an optional value.
         methods.insert(
             "keys",
             BuiltinDef {

--- a/docs/explain/E150c.md
+++ b/docs/explain/E150c.md
@@ -44,7 +44,7 @@ yields a two-tier graph with referenced sources in tier 0 and primary
 sources in tier 1, so user-authored YAML cannot construct a
 tier-inverted geometry. E150c is wired as a guard against extensions
 that admit multi-tier inversions; the unit test at
-`crates/clinker-core/src/executor/tests/cross_source_window_topology.rs`
+`crates/clinker-exec/tests/cross_source_window_topology.rs`
 pins the predicate's behavior on a synthetically-constructed multi-tier
 input.
 

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -59,7 +59,9 @@ memory ceiling.
 ## Why Clinker?
 
 **Single binary, zero dependencies.** Download it, run it. No JVM, no Python,
-no package manager. Works on any Linux server out of the box.
+no package manager. Runs on Linux, macOS, and Windows out of the box — CI
+builds and tests on all three, and the spill, staging, and RSS-sampling
+layers have platform-specific paths so behavior is consistent across them.
 
 **Good neighbor on busy servers.** Clinker enforces a strict memory ceiling
 (default 512 MB) so it can run alongside JVM applications, databases, and other

--- a/docs/src/cxl/overview.md
+++ b/docs/src/cxl/overview.md
@@ -35,10 +35,11 @@ The operators `&&`, `||`, and `!` are **syntax errors** in CXL. Always use `and`
 
 CXL provides built-in namespaces for accessing pipeline state, metadata, and window functions. All system namespaces are prefixed with `$`:
 
-- `$pipeline.*` -- pipeline execution context (name, counters, provenance)
-- `$meta.*` -- per-record metadata
+- `$pipeline.*` -- pipeline execution context (name, counters, provenance) and pipeline-scope declared state
+- `$source.*` -- per-source context and source-scope declared state
+- `$record.*` -- per-record scoped state (travels with the record, never an output column)
 - `$window.*` -- window function calls
-- `$vars.*` -- user-defined pipeline variables
+- `$vars.*` -- static, channel-overridable configuration
 
 ```bash
 $ cxl eval -e 'emit name = $pipeline.name'

--- a/docs/src/cxl/statements.md
+++ b/docs/src/cxl/statements.md
@@ -96,19 +96,21 @@ distinct by field_name
 
 In a pipeline, `distinct` tracks values seen so far and drops records that have already been emitted with the same key.
 
-## emit meta
+## emit to a scoped namespace
 
-The `emit meta` statement writes a value to the `$meta.*` namespace -- per-record metadata that is not part of the output columns. Metadata can be read by downstream nodes via `$meta.field`.
-
-```
-emit meta quality_flag = if amount < 0 then "suspect" else "ok"
-```
-
-Access metadata downstream:
+An `emit` whose target is a `$pipeline.*`, `$source.*`, or `$record.*` name writes a producer-declared scoped variable instead of an output column. The variable must be listed in the writing Transform's `config.declares:` block. `$record.*` is the per-record store that travels with the record but never serializes as an output column.
 
 ```
-filter $meta.quality_flag == "ok"
+emit $record.quality_flag = if amount < 0 then "suspect" else "ok"
 ```
+
+Read it downstream via the same namespace:
+
+```
+filter $record.quality_flag == "ok"
+```
+
+See [Scoped Variables](../pipeline/variables.md) for the declaration model and the three scopes' lifetimes.
 
 ## trace
 

--- a/docs/src/cxl/system-variables.md
+++ b/docs/src/cxl/system-variables.md
@@ -96,27 +96,36 @@ emit currency = $vars.output_currency
 
 Variables provide a clean way to externalize configuration from CXL logic. Combined with [channels](../pipeline/channels.md), different variable sets can parameterize the same pipeline for different environments or clients.
 
-## $meta.* -- Per-record metadata
+## $record.* -- Per-record scoped state
 
-Metadata is a per-record key-value store that travels with the record through the pipeline but is not part of the output columns. Write to it with `emit meta`; read from it with `$meta.field`.
+`$record.*` is a per-record key-value store that travels with the record through the pipeline but never serializes as an output column. It is the mechanism for tagging records with quality flags, routing hints, or audit information that should not appear in the final output unless explicitly re-emitted as a regular column.
 
-### Writing metadata
+Each `$record` variable is declared in the writing Transform's `config.declares:` block (`scope: record`) and written from that Transform's CXL:
+
+### Writing record state
+
+```yaml
+- type: transform
+  name: classify
+  input: orders
+  config:
+    declares:
+      - { name: quality, scope: record, type: string }
+    cxl: |
+      emit order_id = order_id
+      emit $record.quality = if amount < 0 then "suspect" else "ok"
+```
+
+### Reading record state
+
+Any downstream node reads it via `$record.<key>`:
 
 ```
-emit meta quality = if amount < 0 then "suspect" else "ok"
-emit meta source_system = "legacy_erp"
+filter $record.quality == "ok"
+emit audit_quality = $record.quality
 ```
 
-### Reading metadata
-
-Downstream nodes can read metadata:
-
-```
-filter $meta.quality == "ok"
-emit audit_system = $meta.source_system
-```
-
-Metadata is useful for tagging records with quality flags, routing hints, or audit information that should not appear in the final output unless explicitly emitted.
+See [Scoped Variables](../pipeline/variables.md) for the full declaration model and the pipeline / source / record lifetimes.
 
 ## now -- Current time
 
@@ -166,7 +175,7 @@ pipeline:
         emit tax = amount * $vars.tax_rate
         emit total = amount * (1 - discount) + tax
         emit processed_at = now
-        emit meta source_file = $source.file
+        emit source_file = $source.file
         emit pipeline_run = $pipeline.execution_id
 
     - name: output

--- a/docs/src/getting-started/concepts.md
+++ b/docs/src/getting-started/concepts.md
@@ -96,17 +96,29 @@ CXL uses `and`, `or`, and `not` for boolean logic -- not `&&` or `||`. String
 concatenation uses `+`. Conditional expressions use
 `if ... then ... else ...` syntax.
 
-System namespaces use a `$` prefix: `$pipeline.*`, `$window.*`, `$meta.*`.
-These provide access to pipeline metadata, window function state, and record
-metadata respectively.
+System namespaces use a `$` prefix: `$pipeline.*`, `$source.*`, `$record.*`,
+`$window.*`, and `$vars.*`. These provide access to pipeline and source
+context, per-record scoped state, window function state, and static
+configuration respectively.
 
 ## Per-record evaluation and the memory budget
 
-Within a run, records flow through the pipeline **one at a time**. Clinker
-does not load an entire file into memory before processing it. A source reads
-one record, pushes it through the downstream nodes, and then reads the next.
-This is what "streaming" means in Clinker -- row-by-row evaluation inside a
-finite batch job, not Flink-style unbounded stream processing.
+Within a run, stateless operators evaluate records **one at a time**:
+a CXL block sees exactly one record, with no table-level context and no
+per-record state carried across records. Clinker does not load an entire
+file into memory before processing it. This is what "streaming" means in
+Clinker -- row-by-row evaluation inside a finite batch job, not Flink-style
+unbounded stream processing.
+
+"One at a time" describes the *evaluation* model, not the transport. For
+efficiency, records move between stages in bounded batches (default 2048
+events, tunable per stage or pipeline-wide via
+[`batch_size`](../ops/memory.md#streaming-batch-size-batch_size)) rather
+than as individual messages -- but each record is still evaluated
+independently against the CXL block. The batch is a handoff unit, not a
+window: an operator never needs the whole batch to process any single
+record. (Blocking operators -- Aggregate, sort, grace-hash Combine -- are
+the exception that *do* accumulate across records; see below.)
 
 Per-record evaluation keeps **per-row** memory usage bounded for the
 stateless parts of the graph (Transform, Route, Merge, most Combine

--- a/docs/src/ops/cli-reference.md
+++ b/docs/src/ops/cli-reference.md
@@ -20,7 +20,7 @@ clinker run [OPTIONS] <CONFIG>
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--memory-limit <SIZE>` | `256M` | Memory budget for the execution. Accepts binary (1024-based) `K`/`M`/`G` suffixes (`K` = 1024 bytes, `M` = 1024², `G` = 1024³); a bare integer is bytes. When the limit is approached, aggregation operators spill to disk rather than crashing. CLI value overrides any `memory.limit` set in the YAML. |
+| `--memory-limit <SIZE>` | `512M` | Memory budget for the execution. Accepts binary (1024-based) `K`/`M`/`G` suffixes (`K` = 1024 bytes, `M` = 1024², `G` = 1024³); a bare integer is bytes. When the limit is approached, aggregation operators spill to disk rather than crashing. CLI value overrides any `memory.limit` set in the YAML. |
 | `--threads <N>` | number of CPUs | Size of the thread pool used for parallel node execution. |
 | `--error-threshold <N>` | `0` (unlimited) | Maximum number of records routed to the dead-letter queue before the pipeline aborts. `0` means no limit -- the pipeline will run to completion regardless of DLQ volume. |
 | `--batch-id <ID>` | UUID v7 | Custom execution identifier. Appears in metrics output and log lines. Use a meaningful value (e.g. `daily-2026-04-11`) for correlation across retries. |

--- a/docs/src/ops/metrics.md
+++ b/docs/src/ops/metrics.md
@@ -28,12 +28,14 @@ When metrics are enabled, each execution writes one JSON file to the spool direc
 
 ## Metrics schema
 
-Each metrics file follows schema version 1:
+Each metrics file follows schema version 3. The collector rejects spool
+files written under an older schema version, so upgrading clinker across a
+schema bump means draining the spool first.
 
 ```json
 {
   "execution_id": "01912345-6789-7abc-def0-123456789abc",
-  "schema_version": 1,
+  "schema_version": 3,
   "pipeline_name": "customer_etl",
   "config_path": "/opt/clinker/pipelines/daily_etl.yaml",
   "hostname": "prod-etl-01",
@@ -43,14 +45,26 @@ Each metrics file follows schema version 1:
   "exit_code": 0,
   "records_total": 50000,
   "records_ok": 49950,
+  "records_written": 49950,
   "records_dlq": 50,
-  "execution_mode": "streaming",
+  "execution_mode": "Streaming",
   "peak_rss_bytes": 134217728,
   "thread_count": 4,
   "input_files": ["./data/customers.csv"],
   "output_files": ["./output/enriched.csv"],
   "dlq_path": "./output/errors.csv",
-  "error": null
+  "error": null,
+  "retraction": {
+    "groups_recomputed": 0,
+    "partitions_dispatched": 0,
+    "iterations": 0,
+    "degrade_fallback_count": 0,
+    "synthetic_ck_columns_emitted_total": 0,
+    "synthetic_ck_fanout_lookups_total": 0,
+    "synthetic_ck_fanout_rows_expanded_total": 0
+  },
+  "per_source_record_counts": { "customers": 50000 },
+  "per_source_dlq_counts": { "customers": 50 }
 }
 ```
 
@@ -59,7 +73,7 @@ Each metrics file follows schema version 1:
 | Field | Type | Description |
 |-------|------|-------------|
 | `execution_id` | string | UUID v7 or custom `--batch-id` value |
-| `schema_version` | integer | Always `1` for this release |
+| `schema_version` | integer | Schema version of this payload; currently `3` |
 | `pipeline_name` | string | The `name` from the pipeline YAML |
 | `config_path` | string | Absolute path to the config file |
 | `hostname` | string | Machine hostname |
@@ -67,16 +81,29 @@ Each metrics file follows schema version 1:
 | `finished_at` | string | ISO 8601 UTC timestamp |
 | `duration_ms` | integer | Wall-clock duration in milliseconds |
 | `exit_code` | integer | Process exit code (see [Exit Codes](exit-codes.md)) |
-| `records_total` | integer | Total records read from all sources |
-| `records_ok` | integer | Records that reached an output node |
+| `records_total` | integer | Total records read from the primary source |
+| `records_ok` | integer | Distinct source records that reached at least one output. Under inclusive Route fan-out one input matching N branches counts once |
+| `records_written` | integer | Total writes across all sinks. Equals `records_ok` for single-output exclusive pipelines; exceeds it under inclusive Route fan-out or multiple Output sinks |
 | `records_dlq` | integer | Records routed to the dead-letter queue |
-| `execution_mode` | string | `streaming` or `batch` |
-| `peak_rss_bytes` | integer | Maximum resident set size during execution |
+| `execution_mode` | string | DAG-derived execution summary: `Streaming` (no full-stage materialization required) or `TwoPass` (a blocking stage forces an accumulation pass) |
+| `peak_rss_bytes` | integer/null | Peak resident set size in bytes, sampled across chunk boundaries on Linux, macOS, and Windows. `null` on platforms where RSS sampling is unavailable |
 | `thread_count` | integer | Thread pool size used |
 | `input_files` | array | Paths to all source files |
 | `output_files` | array | Paths to all output files written |
 | `dlq_path` | string/null | Path to the DLQ file, or null if none |
-| `error` | string/null | Error message on failure, or null on success |
+| `error` | string/null | Error message on exit 1/3/4, or null on success (exit 0) and partial success (exit 2) |
+| `retraction` | object | Correlation-key retraction counters (see below). All-zero on strict pipelines, which never enter the relaxed loop |
+| `per_source_record_counts` | object | Ingest record count per Source node, keyed by node name |
+| `per_source_dlq_counts` | object | DLQ entry count per Source node; sources with zero DLQ entries are absent |
+
+The `retraction` object carries the relaxed correlation-key retraction
+orchestrator's counters: `groups_recomputed`, `partitions_dispatched`,
+`iterations`, `degrade_fallback_count`,
+`synthetic_ck_columns_emitted_total`, `synthetic_ck_fanout_lookups_total`,
+and `synthetic_ck_fanout_rows_expanded_total`. Every field is `0` on
+strict pipelines and on relaxed pipelines that never trigger a retraction.
+See [Correlation Keys](../pipeline/correlation-keys.md) for the underlying
+mechanism.
 
 ## Collecting metrics
 

--- a/docs/src/pipeline/channels.md
+++ b/docs/src/pipeline/channels.md
@@ -79,7 +79,7 @@ Source overrides are keyed by source-node name (`vars.source.<src>.<var>`). Adds
 
 ### Reserved-system fields
 
-Each scope has a small set of reserved field names that the engine populates (e.g. `$pipeline.execution_id`, `$source.path`, `$source.row`, `$pipeline.start_time`). Channels cannot shadow these — attempting it produces **E110**, naming the offending scope and field. The full lists live in `crates/clinker-core/src/config/mod.rs` (`RESERVED_PIPELINE_NAMES`, `RESERVED_SOURCE_NAMES`, `RESERVED_RECORD_NAMES`); `$vars.*` has no reserved subset.
+Each scope has a small set of reserved field names that the engine populates (e.g. `$pipeline.execution_id`, `$source.path`, `$source.row`, `$pipeline.start_time`). Channels cannot shadow these — attempting it produces **E110**, naming the offending scope and field. The full lists live in `crates/clinker-plan/src/config/pipeline.rs` (`RESERVED_PIPELINE_NAMES`, `RESERVED_SOURCE_NAMES`, `RESERVED_RECORD_NAMES`); `$vars.*` has no reserved subset.
 
 ### Composition-target channels
 

--- a/docs/src/pipeline/output.md
+++ b/docs/src/pipeline/output.md
@@ -105,26 +105,6 @@ Set to `false` to omit the CSV header row.
 
 When `false`, null values are written as empty strings. When `true`, nulls are preserved in the output format's native null representation (e.g., `null` in JSON).
 
-## Metadata inclusion
-
-Control whether per-record `$meta.*` metadata fields appear in output:
-
-```yaml
-    include_metadata: all       # Include all metadata fields
-```
-
-```yaml
-    include_metadata: none      # Default -- strip all metadata
-```
-
-```yaml
-    include_metadata:
-      - source_file             # Include only listed metadata keys
-      - source_row
-```
-
-Metadata fields are prefixed with `meta.` in the output.
-
 ## Output format options
 
 ### CSV

--- a/docs/src/pipeline/variables.md
+++ b/docs/src/pipeline/variables.md
@@ -2,10 +2,11 @@
 
 Clinker's scoped-variable system lets a pipeline read and write
 named values at three lifetimes: the pipeline run, the source, and
-the record. Variables are **declared statically** at pipeline top
-with their type and scope, **read inline** from CXL via the `$pipeline.*`,
-`$source.*`, and `$record.*` namespaces, and **written exclusively**
-by a dedicated `state` node.
+the record. Each variable is **declared on the Transform that writes
+it** via that Transform's `declares:` block (type, scope, optional
+default), **written** by the same Transform's CXL with
+`emit $<scope>.<name> = ...`, and **read inline** from any downstream
+node via the `$pipeline.*`, `$source.*`, and `$record.*` namespaces.
 
 ## The three scopes
 
@@ -15,40 +16,51 @@ by a dedicated `state` node.
 | `source`   | One per source file (`Arc<str>`-keyed)    | Per source-file   | `$source.<key>`         |
 | `record`   | A single record as it flows through nodes | Per record        | `$record.<key>`         |
 
-`$record.<key>` is a separate namespace from `$meta.<key>`. Metadata
-is written via `emit $meta.x = ...` from a transform and survives only
-to the immediate downstream operator. Record-scope vars survive the
-whole row pipeline (every transform along the row's path can read
-them) but never serialize as output columns unless explicitly emitted
-as a regular column.
+Record-scope variables are the per-record private store: every transform
+along the row's path can read them, but they never serialize as output
+columns unless explicitly re-emitted as a regular column. They are written
+with `emit $record.<key> = ...` from a transform that declares them.
 
 ## Declaring variables
 
-Every scoped variable must be declared in the pipeline's top-level
-`vars:` block, named, scoped, typed, and optionally given a default:
+A scoped variable is declared on the Transform that writes it, in that
+Transform's `config.declares:` list. Each entry is named, scoped, typed,
+and optionally given a default that satisfies reads firing before the
+writer has run:
+
+```yaml
+- type: transform
+  name: enrich
+  input: orders
+  config:
+    declares:
+      - { name: cutoff_date,  scope: pipeline, type: date,   default: "2024-01-01" }
+      - { name: ingest_label, scope: source,   type: string, default: "prod" }
+      - { name: fuzzy_score,  scope: record,   type: float }
+    cxl: |
+      emit id = id
+      emit $pipeline.cutoff_date = "2024-01-01"
+      emit $source.ingest_label = $source.file.file_stem()
+      emit $record.fuzzy_score = fuzzy_match(name, $pipeline.canonical_name)
+```
+
+Allowed types: `int`, `float`, `string`, `bool`, `date`, `date_time`.
+
+Each `(scope, name)` pair must be declared on exactly one Transform —
+the same pair declared on two Transforms is rejected at config-validation
+time, ahead of compilation. `$pipeline`, `$source`, and `$record` are flat
+shared namespaces; declare each name once and read it from every consumer.
+
+The pipeline's top-level `vars:` block is a **separate, flat** registry
+for static configuration read via `$vars.<key>` — it does not carry the
+nested `pipeline:` / `source:` / `record:` scopes:
 
 ```yaml
 pipeline:
   name: order_processing
   vars:
-    pipeline:
-      cutoff_date:
-        type: date
-        default: "2024-01-01"
-      fuzzy_threshold:
-        type: float
-        default: 0.85
-    source:
-      batch_id:
-        type: string
-      ingestion_label:
-        type: string
-    record:
-      fuzzy_score:
-        type: float
+    fuzzy_threshold: { type: float, default: 0.85 }   # read as $vars.fuzzy_threshold
 ```
-
-Allowed types: `int`, `float`, `string`, `bool`, `date`, `date_time`.
 
 Built-in members of each scope (`$source.file`, `$source.row`,
 `$source.path`, `$source.count`, `$source.batch`,
@@ -78,9 +90,9 @@ that Source's input stream closes:
 Pipelines that previously used `$source.count` as a streaming
 denominator (e.g. `value / $source.count`) will now see `Null` from
 that division on mid-stream records. If you need a streaming row
-counter, declare a `scope: source` variable and increment it from a
-`state` writer — that gives you a running count instead of waiting
-for the final.
+counter, declare a `scope: source` variable on a Transform and increment
+it from that Transform's CXL — that gives you a running count instead of
+waiting for the final.
 
 ## Reading variables
 
@@ -102,44 +114,47 @@ Reads of undeclared keys are rejected with **E200** (CXL name
 resolution failed) at compile time, with a "did you mean" suggestion
 that scans the declared registry.
 
-## Writing variables: the `state` node
+## Writing variables
 
-The only way to mutate a scoped variable is a dedicated `state`
-node. The node is a **pass-through** for records — its input record
-forwards unchanged on the output edge — but evaluates its `set:`
-assignments and writes the results into the appropriate scope-keyed
-runtime registry.
+A scoped variable is written by the Transform that declares it: list the
+variable in the Transform's `declares:` block and assign it from the same
+Transform's CXL with `emit $<scope>.<name> = <expr>`. The Transform still
+processes records normally — declaring and writing a scoped var is
+additive to its ordinary `emit`/`filter` logic.
 
 ```yaml
-- type: state
+- type: transform
   name: capture_header
   input: salesforce_in
   config:
-    scope: source
-    set:
-      - var: batch_id
-        cxl: "first(this.batch)"
-      - var: ingestion_label
-        cxl: "$source.file.file_stem()"
+    declares:
+      - { name: batch_id,        scope: source, type: string }
+      - { name: ingestion_label, scope: source, type: string }
+    cxl: |
+      emit id = id
+      emit $source.batch_id = batch
+      emit $source.ingestion_label = $source.file.file_stem()
 
-- type: state
+- type: transform
   name: row_score
   input: enrich
   config:
-    scope: record
-    set:
-      - var: fuzzy_score
-        cxl: "fuzzy_match(this.name, $pipeline.canonical_name)"
+    declares:
+      - { name: fuzzy_score, scope: record, type: float }
+    cxl: |
+      emit id = id
+      emit $record.fuzzy_score = fuzzy_match(name, $pipeline.canonical_name)
 ```
 
-Inline mutation from a regular transform (`emit $pipeline.x = ...`)
-is a parse error. The dedicated-node design keeps the dependency
-between writers and readers visible at plan time.
+An `emit $<scope>.<name>` write to a variable the Transform does **not**
+declare is rejected at compile time. Requiring the `declares:` entry keeps
+the dependency between writers and readers visible at plan time.
 
 ## Init phase: pre-runtime population
 
-A state node may declare `phase: init` to run **to completion**
-before any runtime-phase node sees a record:
+A Transform may set `phase: init` to run **to completion** before any
+runtime-phase node sees a record — useful for populating a `$pipeline.*`
+or `$source.*` value from a config source:
 
 ```yaml
 - type: source
@@ -159,22 +174,23 @@ before any runtime-phase node sees a record:
     cxl: |
       emit cap = max(cutoff)
 
-- type: state
+- type: transform
   name: precompute_cutoff
   input: max_agg
   config:
-    scope: pipeline
     phase: init
-    set:
-      - var: cutoff_date
-        cxl: "cap"
+    declares:
+      - { name: cutoff_date, scope: pipeline, type: int }
+    cxl: |
+      emit cap = cap
+      emit $pipeline.cutoff_date = cap
 ```
 
 Init-phase nodes **must be terminal** — no runtime-phase node may
-consume from an init-phase state node. (Init-phase state nodes can
-chain through init-only descendants for compositions.) Use disjoint
-Sources for init vs runtime when you need both, since a Source shared
-between an init and a runtime branch only feeds the init pass.
+consume from an init-phase Transform. (Init-phase nodes can chain
+through init-only descendants for compositions.) Use disjoint Sources
+for init vs runtime when you need both, since a Source shared between
+an init and a runtime branch only feeds the init pass.
 
 ## Compile-time validation
 
@@ -188,7 +204,7 @@ registry, and every cross-DAG flow is verified against the topology.
 | E109 | Channel targets a composition but carries `vars:` overrides.           |
 | E110 | Channel var name shadows a reserved system field for that scope.       |
 | E111 | Channel `vars.source.<src>` references an unknown source-node name.    |
-| E164 | An init-phase state node has a runtime descendant.                     |
+| E164 | An init-phase Transform has a runtime descendant.                      |
 | E171 | A reader is not a transitive DAG descendant of its writer.             |
 | E172 | Bare `$source.<custom>` read downstream of a Merge or Combine.         |
 | E173 | Composition body reads a parent scoped var without opting in.          |
@@ -269,10 +285,11 @@ These are intentional non-features:
 - **No persistence across runs.** State is in-memory only. A pipeline
   run starts with declaration defaults; the writes don't survive
   the process.
-- **No inline `emit $pipeline.x` writes.** Convenience-style
-  mutation from a transform body is forbidden — empirical evidence
-  from comparable engines shows it leads to race conditions and
-  hidden DAG dependencies.
+- **No undeclared writes.** A Transform may only write a scoped
+  variable it lists in `declares:`; an `emit $pipeline.x` to an
+  undeclared name is a compile error. Requiring the declaration keeps
+  every writer visible at plan time and the writer→reader dependency
+  explicit in the DAG.
 - **No dynamic var creation.** The set of variables is closed at
   plan time, by design. This bounds memory and makes the validation
   matrix above tractable.


### PR DESCRIPTION
Audit pass over the user-facing book. Corrects claims that drifted
from the code:

- Platform: replace "any Linux server" with Linux/macOS/Windows, which
  CI builds and tests and which the spill/staging/RSS layers support.
- Per-record model: clarify that "one record at a time" is the
  evaluation semantics; inter-stage transport moves bounded batches
  (default 2048 events, tunable via batch_size).
- Metrics schema: bump documented version 1 -> 3, add the records_written,
  retraction, and per_source_* fields, and correct execution_mode values
  (Streaming / TwoPass) and peak_rss_bytes nullability.
- Scoped variables: the dedicated `state` node no longer exists. Rewrite
  variables.md around Transform `declares:` + `emit $<scope>.<name>`,
  with `phase: init` on the Transform. Fix the flat `vars:` (static
  $vars.*) vs scoped-var declaration model.
- Metadata: the `$meta.*` namespace and `emit meta` statement were
  removed; replace with `$record.*` scoped state across overview,
  statements, system-variables, concepts, and variables. Drop the
  output `include_metadata` section (no such config field).
- Fix two stale `clinker-core` crate paths (now clinker-plan /
  clinker-exec) in channels.md and the E150c explainer.