### PR TITLE
cxl: extract a shared typed-AST visitor for analyzer passes (#433)

### DIFF
--- a/crates/cxl/src/analyzer/doc_paths.rs
+++ b/crates/cxl/src/analyzer/doc_paths.rs
@@ -21,7 +21,8 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::ast::{Expr, LiteralValue, MatchArm, Statement, UnaryOp};
+use crate::analyzer::visitor::{Visitor, walk_expr};
+use crate::ast::{Expr, LiteralValue, UnaryOp};
 use crate::lexer::Span;
 use crate::typecheck::pass::{TypeDiagnostic, TypedProgram};
 
@@ -77,154 +78,69 @@ pub struct DocPathSet {
 /// deduplicated across all programs and returned in sorted order;
 /// unresolvable-index diagnostics are accumulated in walk order.
 pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
-    let mut paths: BTreeSet<DocPath> = BTreeSet::new();
-    let mut unresolvable: Vec<(String, TypeDiagnostic)> = Vec::new();
+    let mut collector = DocPathCollector::default();
     for (name, typed) in programs {
+        collector.node_name = name;
         for stmt in &typed.program.statements {
-            walk_statement(name, stmt, &mut paths, &mut unresolvable);
+            collector.visit_statement(stmt);
         }
     }
     DocPathSet {
-        paths: paths.into_iter().collect(),
-        unresolvable,
+        paths: collector.paths.into_iter().collect(),
+        unresolvable: collector.unresolvable,
     }
 }
 
-fn walk_statement(
-    node_name: &str,
-    stmt: &Statement,
-    paths: &mut BTreeSet<DocPath>,
-    unresolvable: &mut Vec<(String, TypeDiagnostic)>,
-) {
-    match stmt {
-        Statement::Let { expr, .. }
-        | Statement::Emit { expr, .. }
-        | Statement::ExprStmt { expr, .. } => walk_expr(node_name, expr, paths, unresolvable),
-        Statement::Filter { predicate, .. } => walk_expr(node_name, predicate, paths, unresolvable),
-        Statement::Trace { guard, message, .. } => {
-            if let Some(g) = guard {
-                walk_expr(node_name, g, paths, unresolvable);
-            }
-            walk_expr(node_name, message, paths, unresolvable);
-        }
-        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
-            walk_expr(node_name, source, paths, unresolvable);
-            for inner in body {
-                walk_statement(node_name, inner, paths, unresolvable);
-            }
-        }
-        Statement::Distinct { .. } | Statement::UseStmt { .. } => {}
-    }
-}
-
-/// Walk an expression, recording any `$doc` access it contains.
+/// Collects the `$doc` envelope paths a single program references, driving
+/// the shared typed-AST [`Visitor`] walk.
 ///
-/// A `$doc` access is the `DocAccess` node optionally wrapped in one or
-/// more `IndexAccess` layers (`$doc.s.f[0][1]`). When the whole stack of
-/// indices is literal, the path is recorded; the first non-literal index
-/// makes the access unresolvable. The walker recurses through every
-/// control-flow branch (`if`, `match`, `coalesce`, `emit_each` bodies),
-/// so a `$doc` access used only inside a conditional is still collected.
-fn walk_expr(
-    node_name: &str,
-    expr: &Expr,
-    paths: &mut BTreeSet<DocPath>,
-    unresolvable: &mut Vec<(String, TypeDiagnostic)>,
-) {
-    // An IndexAccess whose receiver chain bottoms out at a DocAccess is a
-    // `$doc` path with trailing indices — classify it as a unit rather
-    // than walking the DocAccess receiver as a bare access. Other
-    // IndexAccess shapes (`record_field[0]`) fall through to the generic
-    // recursion below.
-    if let Expr::IndexAccess { .. } = expr
-        && let Some(classified) = classify_doc_index_chain(expr)
-    {
-        match classified {
-            Ok(path) => {
-                paths.insert(path);
-            }
-            Err(diag) => unresolvable.push((node_name.to_string(), diag)),
-        }
-        return;
-    }
+/// Only `DocAccess` and `IndexAccess` carry `$doc` meaning, so those are
+/// the sole overrides — a `DocAccess` records a plain two-level path, and
+/// an `IndexAccess` whose receiver chain bottoms out at a `DocAccess`
+/// records a path with trailing index segments (or a diagnostic for a
+/// non-literal index). Every other node, including index chains that do
+/// not root at a `$doc` access, falls through to the default descent, so a
+/// `$doc` access nested in any control-flow branch or index expression is
+/// still collected.
+#[derive(Default)]
+struct DocPathCollector<'a> {
+    /// Name of the program currently being walked, so an unresolvable-index
+    /// diagnostic can be attributed to its node.
+    node_name: &'a str,
+    paths: BTreeSet<DocPath>,
+    unresolvable: Vec<(String, TypeDiagnostic)>,
+}
 
-    match expr {
-        Expr::DocAccess { section, field, .. } => {
-            paths.insert(DocPath {
+impl Visitor for DocPathCollector<'_> {
+    fn visit_expr(&mut self, expr: &Expr) {
+        // An IndexAccess whose receiver chain bottoms out at a DocAccess is
+        // a `$doc` path with trailing indices — classify it as a unit
+        // rather than descending into the DocAccess as a bare access. Other
+        // IndexAccess shapes (`record_field[0]`) fall through to the
+        // default descent below.
+        if let Expr::IndexAccess { .. } = expr
+            && let Some(classified) = classify_doc_index_chain(expr)
+        {
+            match classified {
+                Ok(path) => {
+                    self.paths.insert(path);
+                }
+                Err(diag) => self.unresolvable.push((self.node_name.to_string(), diag)),
+            }
+            return;
+        }
+
+        if let Expr::DocAccess { section, field, .. } = expr {
+            self.paths.insert(DocPath {
                 section: section.clone(),
                 field: field.clone(),
                 indices: Vec::new(),
             });
+            return;
         }
-        Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
-            walk_expr(node_name, lhs, paths, unresolvable);
-            walk_expr(node_name, rhs, paths, unresolvable);
-        }
-        Expr::Unary { operand, .. } => walk_expr(node_name, operand, paths, unresolvable),
-        Expr::MethodCall { receiver, args, .. } => {
-            walk_expr(node_name, receiver, paths, unresolvable);
-            for a in args {
-                walk_expr(node_name, a, paths, unresolvable);
-            }
-        }
-        Expr::Match { subject, arms, .. } => {
-            if let Some(s) = subject {
-                walk_expr(node_name, s, paths, unresolvable);
-            }
-            for arm in arms {
-                walk_match_arm(node_name, arm, paths, unresolvable);
-            }
-        }
-        Expr::IfThenElse {
-            condition,
-            then_branch,
-            else_branch,
-            ..
-        } => {
-            walk_expr(node_name, condition, paths, unresolvable);
-            walk_expr(node_name, then_branch, paths, unresolvable);
-            if let Some(e) = else_branch {
-                walk_expr(node_name, e, paths, unresolvable);
-            }
-        }
-        Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
-            for a in args {
-                walk_expr(node_name, a, paths, unresolvable);
-            }
-        }
-        Expr::IndexAccess {
-            receiver, index, ..
-        } => {
-            // Reached only for non-`$doc` index chains; recurse into both
-            // sides so a `$doc` access buried in the index expression
-            // (`arr[$doc.s.f]`) is still collected.
-            walk_expr(node_name, receiver, paths, unresolvable);
-            walk_expr(node_name, index, paths, unresolvable);
-        }
-        Expr::Closure { body, .. } => walk_expr(node_name, body, paths, unresolvable),
-        Expr::Literal { .. }
-        | Expr::FieldRef { .. }
-        | Expr::QualifiedFieldRef { .. }
-        | Expr::PipelineAccess { .. }
-        | Expr::VarsAccess { .. }
-        | Expr::SourceAccess { .. }
-        | Expr::QualifiedSourceAccess { .. }
-        | Expr::RecordAccess { .. }
-        | Expr::Now { .. }
-        | Expr::Wildcard { .. }
-        | Expr::AggSlot { .. }
-        | Expr::GroupKey { .. } => {}
-    }
-}
 
-fn walk_match_arm(
-    node_name: &str,
-    arm: &MatchArm,
-    paths: &mut BTreeSet<DocPath>,
-    unresolvable: &mut Vec<(String, TypeDiagnostic)>,
-) {
-    walk_expr(node_name, &arm.pattern, paths, unresolvable);
-    walk_expr(node_name, &arm.body, paths, unresolvable);
+        walk_expr(self, expr);
+    }
 }
 
 /// Classify an `IndexAccess` whose receiver chain bottoms out at a

--- a/crates/cxl/src/analyzer/mod.rs
+++ b/crates/cxl/src/analyzer/mod.rs
@@ -6,10 +6,13 @@
 
 use std::collections::HashSet;
 
-use crate::ast::{Expr, MatchArm, Statement};
+use crate::ast::{Expr, Statement};
 use crate::typecheck::pass::TypedProgram;
 
 pub mod doc_paths;
+pub mod visitor;
+
+use visitor::{Visitor, walk_expr};
 
 /// Which category of window function was called.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -74,30 +77,28 @@ pub struct AnalysisReport {
 /// `name`: the transform's name from config.
 /// `typed`: the compiled (parsed → resolved → type-checked) CXL program.
 pub fn analyze_transform(name: &str, typed: &TypedProgram) -> TransformAnalysis {
-    let mut window_calls = Vec::new();
-    let mut accessed_fields = HashSet::new();
-
     let has_distinct = typed
         .program
         .statements
         .iter()
         .any(|s| matches!(s, Statement::Distinct { .. }));
 
+    let mut collector = WindowCollector::default();
     for stmt in &typed.program.statements {
-        walk_statement(stmt, &mut window_calls, &mut accessed_fields);
+        collector.visit_statement(stmt);
     }
 
     // Distinct forces Sequential — mutable HashSet state cannot be parallelized.
     let parallelism_hint = if has_distinct {
         ParallelismHint::Sequential
     } else {
-        classify_parallelism(&window_calls)
+        classify_parallelism(&collector.window_calls)
     };
 
     TransformAnalysis {
         name: name.to_string(),
-        window_calls,
-        accessed_fields,
+        window_calls: collector.window_calls,
+        accessed_fields: collector.accessed_fields,
         parallelism_hint,
     }
 }
@@ -130,201 +131,126 @@ fn classify_parallelism(calls: &[WindowCallInfo]) -> ParallelismHint {
     ParallelismHint::IndexReading
 }
 
-// --- AST walkers ---
-
-fn walk_statement(stmt: &Statement, calls: &mut Vec<WindowCallInfo>, fields: &mut HashSet<String>) {
-    match stmt {
-        Statement::Let { expr, .. } => walk_expr(expr, calls, fields, None),
-        Statement::Emit { expr, .. } => walk_expr(expr, calls, fields, None),
-        Statement::Trace { guard, message, .. } => {
-            if let Some(g) = guard {
-                walk_expr(g, calls, fields, None);
-            }
-            walk_expr(message, calls, fields, None);
-        }
-        Statement::ExprStmt { expr, .. } => walk_expr(expr, calls, fields, None),
-        Statement::UseStmt { .. } => {}
-        Statement::Filter { predicate, .. } => walk_expr(predicate, calls, fields, None),
-        Statement::Distinct { .. } => {}
-        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
-            walk_expr(source, calls, fields, None);
-            for inner in body {
-                walk_statement(inner, calls, fields);
-            }
-        }
-    }
-}
-
-/// Walk an expression tree, collecting window calls and accessed fields.
+/// Collects every `window.*` call site and every field reference a
+/// transform's CXL reads, driving the shared typed-AST [`Visitor`] walk.
 ///
-/// `postfix_target`: when we're walking a postfix chain on a WindowCall result,
-/// this collects the field names accessed (e.g., `window.first().name` → "name").
-fn walk_expr(
-    expr: &Expr,
-    calls: &mut Vec<WindowCallInfo>,
-    fields: &mut HashSet<String>,
-    postfix_target: Option<&mut Vec<String>>,
-) {
-    match expr {
-        Expr::WindowCall { function, args, .. } => {
-            let category = match function.as_ref() {
-                "first" | "last" | "lag" | "lead" => WindowFunction::Positional,
-                "count" | "sum" | "avg" | "min" | "max" => WindowFunction::Aggregate,
-                "any" | "all" => WindowFunction::Iterable,
-                "collect" | "distinct" => WindowFunction::Collector,
-                _ => WindowFunction::Aggregate, // fallback
-            };
+/// Only the nodes that carry analysis meaning are overridden — `WindowCall`
+/// (records the call and its argument fields), `MethodCall` (detects a
+/// postfix field access on a window result, e.g. `window.first().name`),
+/// and `FieldRef` (every bare column the transform needs from the upstream
+/// record). Every other node falls through to the default descent.
+#[derive(Default)]
+struct WindowCollector {
+    window_calls: Vec<WindowCallInfo>,
+    accessed_fields: HashSet<String>,
+    /// Set while walking the receiver of a window-result method chain so a
+    /// field access in that chain attaches to the originating
+    /// `WindowCall`'s `postfix_fields`. `None` outside such a walk.
+    postfix_target: Option<Vec<String>>,
+}
 
-            // Extract field name arguments
-            let field_args: Vec<String> = args
-                .iter()
-                .filter_map(|arg| {
-                    if let Expr::FieldRef { name, .. } = arg {
-                        Some(name.to_string())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
+impl Visitor for WindowCollector {
+    fn visit_expr(&mut self, expr: &Expr) {
+        match expr {
+            Expr::WindowCall { function, args, .. } => {
+                let category = match function.as_ref() {
+                    "first" | "last" | "lag" | "lead" => WindowFunction::Positional,
+                    "count" | "sum" | "avg" | "min" | "max" => WindowFunction::Aggregate,
+                    "any" | "all" => WindowFunction::Iterable,
+                    "collect" | "distinct" => WindowFunction::Collector,
+                    _ => WindowFunction::Aggregate, // fallback
+                };
 
-            // Add field args to the accessed set
-            for f in &field_args {
-                fields.insert(f.clone());
-            }
+                let field_args: Vec<String> = args
+                    .iter()
+                    .filter_map(|arg| {
+                        if let Expr::FieldRef { name, .. } = arg {
+                            Some(name.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .collect();
 
-            // Walk args for nested expressions
-            for arg in args {
-                walk_expr(arg, calls, fields, None);
-            }
-
-            let call_info = WindowCallInfo {
-                function_name: function.clone(),
-                category,
-                field_args,
-                postfix_fields: Vec::new(), // filled by parent MethodCall if any
-            };
-            calls.push(call_info);
-        }
-
-        // MethodCall on a WindowCall result: `window.first().name` appears as
-        // MethodCall { receiver: WindowCall("first"), method: "name", args: [] }
-        // We need to detect when the receiver is a WindowCall and collect the method
-        // as a postfix field.
-        Expr::MethodCall {
-            receiver,
-            method,
-            args,
-            ..
-        } => {
-            // Check if receiver is a WindowCall (or chain leading to one)
-            if is_window_call_chain(receiver) {
-                // This method name is a field access on the window result
-                let field_name = method.to_string();
-                fields.insert(field_name.clone());
-
-                // Walk the receiver to collect the WindowCall itself
-                let mut postfix_fields = vec![field_name];
-                walk_expr(receiver, calls, fields, Some(&mut postfix_fields));
-
-                // Attach postfix fields to the last WindowCall we found
-                if let Some(last_call) = calls.last_mut() {
-                    last_call.postfix_fields.extend(postfix_fields);
+                for f in &field_args {
+                    self.accessed_fields.insert(f.clone());
                 }
-            } else {
-                // Normal method call — walk receiver and args
-                walk_expr(receiver, calls, fields, None);
+
+                // Argument sub-expressions never belong to the enclosing
+                // window-result postfix chain, so suspend any active target
+                // while descending into them.
+                let saved = self.postfix_target.take();
+                for arg in args {
+                    self.visit_expr(arg);
+                }
+                self.postfix_target = saved;
+
+                self.window_calls.push(WindowCallInfo {
+                    function_name: function.clone(),
+                    category,
+                    field_args,
+                    postfix_fields: Vec::new(), // filled by parent MethodCall if any
+                });
             }
 
-            for arg in args {
-                walk_expr(arg, calls, fields, None);
-            }
-        }
+            // `window.first().name` parses as
+            // MethodCall { receiver: WindowCall("first"), method: "name" }.
+            // When the receiver bottoms out at a window call, the method
+            // name is a field access on the window result — collect it and
+            // attach it to that call's postfix fields.
+            Expr::MethodCall {
+                receiver,
+                method,
+                args,
+                ..
+            } => {
+                if is_window_call_chain(receiver) {
+                    let field_name = method.to_string();
+                    self.accessed_fields.insert(field_name.clone());
 
-        // Field access. Any bare `FieldRef` means this transform needs
-        // the field from the upstream record at runtime — Option W's
-        // arena projection must include it, or the evaluator will read
-        // Null from a missing slot. This was a latent bug before the
-        // arena/DAG unification: the analyzer tracked only
-        // window-argument fields, so plain `emit f1 = f1` inside a
-        // window-using transform silently dropped f1.
-        //
-        // `postfix_target` is additionally collected for
-        // `window.first().name`-style access (so we can attach the
-        // postfix to the preceding WindowCall for aggregate-op dispatch).
-        Expr::FieldRef { name, .. } => {
-            fields.insert(name.to_string());
-            if let Some(postfix) = postfix_target {
-                postfix.push(name.to_string());
-            }
-        }
+                    let saved = self.postfix_target.replace(vec![field_name]);
+                    self.visit_expr(receiver);
+                    let postfix_fields = self.postfix_target.take().unwrap_or_default();
+                    self.postfix_target = saved;
 
-        // Recurse into all other expression types
-        Expr::Binary { lhs, rhs, .. } => {
-            walk_expr(lhs, calls, fields, None);
-            walk_expr(rhs, calls, fields, None);
-        }
-        Expr::Unary { operand, .. } => {
-            walk_expr(operand, calls, fields, None);
-        }
-        Expr::IfThenElse {
-            condition,
-            then_branch,
-            else_branch,
-            ..
-        } => {
-            walk_expr(condition, calls, fields, None);
-            walk_expr(then_branch, calls, fields, None);
-            if let Some(e) = else_branch {
-                walk_expr(e, calls, fields, None);
+                    if let Some(last_call) = self.window_calls.last_mut() {
+                        last_call.postfix_fields.extend(postfix_fields);
+                    }
+                } else {
+                    self.visit_expr(receiver);
+                }
+
+                let saved = self.postfix_target.take();
+                for arg in args {
+                    self.visit_expr(arg);
+                }
+                self.postfix_target = saved;
             }
-        }
-        Expr::Coalesce { lhs, rhs, .. } => {
-            walk_expr(lhs, calls, fields, None);
-            walk_expr(rhs, calls, fields, None);
-        }
-        Expr::Match { subject, arms, .. } => {
-            if let Some(s) = subject {
-                walk_expr(s, calls, fields, None);
+
+            // Any bare `FieldRef` means this transform needs the field from
+            // the upstream record at runtime — the arena projection must
+            // include it, or the evaluator reads Null from a missing slot.
+            // The analyzer therefore tracks every FieldRef, not just
+            // window-argument fields, so plain `emit f1 = f1` inside a
+            // window-using transform does not silently drop f1.
+            //
+            // While walking a window-result method chain, the field also
+            // attaches to that call's postfix fields for aggregate-op
+            // dispatch (`window.first().name`).
+            Expr::FieldRef { name, .. } => {
+                self.accessed_fields.insert(name.to_string());
+                if let Some(postfix) = self.postfix_target.as_mut() {
+                    postfix.push(name.to_string());
+                }
             }
-            for arm in arms {
-                walk_match_arm(arm, calls, fields);
-            }
+
+            _ => walk_expr(self, expr),
         }
-        Expr::AggCall { args, .. } => {
-            for arg in args {
-                walk_expr(arg, calls, fields, None);
-            }
-        }
-        Expr::IndexAccess {
-            receiver, index, ..
-        } => {
-            walk_expr(receiver, calls, fields, None);
-            walk_expr(index, calls, fields, None);
-        }
-        Expr::Closure { body, .. } => {
-            walk_expr(body, calls, fields, None);
-        }
-        Expr::Literal { .. }
-        | Expr::QualifiedFieldRef { .. }
-        | Expr::PipelineAccess { .. }
-        | Expr::VarsAccess { .. }
-        | Expr::SourceAccess { .. }
-        | Expr::QualifiedSourceAccess { .. }
-        | Expr::RecordAccess { .. }
-        | Expr::DocAccess { .. }
-        | Expr::Now { .. }
-        | Expr::Wildcard { .. }
-        | Expr::AggSlot { .. }
-        | Expr::GroupKey { .. } => {}
     }
 }
 
-fn walk_match_arm(arm: &MatchArm, calls: &mut Vec<WindowCallInfo>, fields: &mut HashSet<String>) {
-    walk_expr(&arm.pattern, calls, fields, None);
-    walk_expr(&arm.body, calls, fields, None);
-}
-
-/// Check if an expression is a WindowCall or a chain of method calls ending at a WindowCall.
+/// True when `expr` is a window call or a method-call chain bottoming out
+/// at one.
 fn is_window_call_chain(expr: &Expr) -> bool {
     match expr {
         Expr::WindowCall { .. } => true,

--- a/crates/cxl/src/analyzer/visitor.rs
+++ b/crates/cxl/src/analyzer/visitor.rs
@@ -1,0 +1,147 @@
+//! Shared typed-AST traversal for analyzer passes.
+//!
+//! A single set of `walk_*` functions enumerate every recursive edge in
+//! the [`Statement`] / [`Expr`] / [`MatchArm`] grammar exactly once. Each
+//! analyzer pass implements [`Visitor`], overriding only the nodes it
+//! inspects and delegating every other node to the shared walk via the
+//! default method bodies.
+//!
+//! The point of centralizing the recursion shape: a new expression or
+//! statement variant — or a change to which children an existing variant
+//! holds — is handled in one place here, so a pass cannot silently drop a
+//! sub-expression it never knew to descend into. Without this, every pass
+//! carried its own exhaustive match and a forgotten arm in one of them
+//! would quietly miss whatever lives beneath the new variant.
+//!
+//! The traversal mirrors syn's `Visit`: a [`Visitor`] method receives a
+//! node and is responsible for descending into that node's children by
+//! calling the matching free `walk_*` function (the default method body
+//! does exactly this). A pass that wants to *replace* a node's default
+//! descent — to treat a sub-tree as an indivisible unit, or to thread
+//! extra state through the children — overrides the method and chooses
+//! whether to call `walk_*` at all.
+
+use crate::ast::{Expr, MatchArm, Statement};
+
+/// A typed-AST traversal hook.
+///
+/// Default method bodies perform a full pre-order descent over the AST.
+/// Override `visit_expr` / `visit_statement` / `visit_match_arm` to act on
+/// specific nodes; call the matching `walk_*` free function from an
+/// override to continue the default descent into that node's children, or
+/// omit the call to prune the sub-tree.
+pub trait Visitor {
+    /// Visit one statement. The default descends into every expression and
+    /// nested-statement body the statement holds.
+    fn visit_statement(&mut self, stmt: &Statement) {
+        walk_statement(self, stmt);
+    }
+
+    /// Visit one expression. The default descends into every
+    /// sub-expression the variant holds.
+    fn visit_expr(&mut self, expr: &Expr) {
+        walk_expr(self, expr);
+    }
+
+    /// Visit one match arm. The default descends into the arm's pattern
+    /// and body expressions.
+    fn visit_match_arm(&mut self, arm: &MatchArm) {
+        walk_match_arm(self, arm);
+    }
+}
+
+/// Descend into a statement's children, dispatching each through the
+/// visitor. Covers every [`Statement`] variant; variants with no
+/// sub-expressions (`UseStmt`, `Distinct`) are terminal.
+pub fn walk_statement<V: Visitor + ?Sized>(visitor: &mut V, stmt: &Statement) {
+    match stmt {
+        Statement::Let { expr, .. }
+        | Statement::Emit { expr, .. }
+        | Statement::ExprStmt { expr, .. } => visitor.visit_expr(expr),
+        Statement::Filter { predicate, .. } => visitor.visit_expr(predicate),
+        Statement::Trace { guard, message, .. } => {
+            if let Some(g) = guard {
+                visitor.visit_expr(g);
+            }
+            visitor.visit_expr(message);
+        }
+        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
+            visitor.visit_expr(source);
+            for inner in body {
+                visitor.visit_statement(inner);
+            }
+        }
+        Statement::UseStmt { .. } | Statement::Distinct { .. } => {}
+    }
+}
+
+/// Descend into an expression's children, dispatching each through the
+/// visitor. Covers every [`Expr`] variant; leaf variants (literals,
+/// namespace accesses, `now`, wildcards, aggregate/group-key slots) hold
+/// no sub-expressions and are terminal.
+pub fn walk_expr<V: Visitor + ?Sized>(visitor: &mut V, expr: &Expr) {
+    match expr {
+        Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
+            visitor.visit_expr(lhs);
+            visitor.visit_expr(rhs);
+        }
+        Expr::Unary { operand, .. } => visitor.visit_expr(operand),
+        Expr::MethodCall { receiver, args, .. } => {
+            visitor.visit_expr(receiver);
+            for arg in args {
+                visitor.visit_expr(arg);
+            }
+        }
+        Expr::Match { subject, arms, .. } => {
+            if let Some(s) = subject {
+                visitor.visit_expr(s);
+            }
+            for arm in arms {
+                visitor.visit_match_arm(arm);
+            }
+        }
+        Expr::IfThenElse {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            visitor.visit_expr(condition);
+            visitor.visit_expr(then_branch);
+            if let Some(e) = else_branch {
+                visitor.visit_expr(e);
+            }
+        }
+        Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
+            for arg in args {
+                visitor.visit_expr(arg);
+            }
+        }
+        Expr::IndexAccess {
+            receiver, index, ..
+        } => {
+            visitor.visit_expr(receiver);
+            visitor.visit_expr(index);
+        }
+        Expr::Closure { body, .. } => visitor.visit_expr(body),
+        Expr::Literal { .. }
+        | Expr::FieldRef { .. }
+        | Expr::QualifiedFieldRef { .. }
+        | Expr::PipelineAccess { .. }
+        | Expr::VarsAccess { .. }
+        | Expr::SourceAccess { .. }
+        | Expr::QualifiedSourceAccess { .. }
+        | Expr::RecordAccess { .. }
+        | Expr::DocAccess { .. }
+        | Expr::Now { .. }
+        | Expr::Wildcard { .. }
+        | Expr::AggSlot { .. }
+        | Expr::GroupKey { .. } => {}
+    }
+}
+
+/// Descend into a match arm's pattern and body expressions.
+pub fn walk_match_arm<V: Visitor + ?Sized>(visitor: &mut V, arm: &MatchArm) {
+    visitor.visit_expr(&arm.pattern);
+    visitor.visit_expr(&arm.body);
+}


### PR DESCRIPTION
## Summary

The semantic analyzer and the `$doc`-path collector each hand-rolled their own pre-order walk over the typed AST (`walk_statement` / `walk_expr` / `walk_match_arm`), duplicating the descent across every `Statement` and `Expr` variant. A new expression or statement variant had to be wired into traversal in two places, and a missed edge silently dropped either an analyzer field reference or a declared `$doc` path.

This extracts one shared `Visitor` trait (`crates/cxl/src/analyzer/visitor.rs`, syn-style: default methods perform the full descent, an impl overrides only the nodes it inspects). Both consumers are now thin `Visitor` impls, and the two duplicated walks are deleted.

## Behavior

Behavior-preserving. The shared walker descends into exactly the union of edges both originals walked — verified by cross-checking the new match arms against both deleted copies (all 9 `Statement` and 23 `Expr` variants covered). The two behavior-sensitive special cases are reproduced exactly:

- the analyzer's window-result postfix-chain detection (`window.first(score).name`), via a `postfix_target` field that is suspended and restored across method-call argument descents to match the original's threading;
- the `$doc`-path collector's `IndexAccess` short-circuit (classify a `$doc` index chain as a unit, else fall through), so a non-`$doc` index like `arr[$doc.s.f]` still descends into both receiver and index and collects the inner path.

Net −11 lines; all cxl analyzer and `$doc`-path tests pass unchanged. Leaves the visitor extensible for the follow-up passes that will reuse it.

Closes #433.