### PR TITLE
format: disambiguate a doubly-degenerate EDIFACT UNB control reference (#407)

### DIFF
--- a/crates/clinker-format/src/edifact/mod.rs
+++ b/crates/clinker-format/src/edifact/mod.rs
@@ -44,6 +44,14 @@ pub(crate) const RAW_ELEMENTS_KEY: &str = "$raw";
 /// this count.
 const UNB_LEADING_COMPOSITES: usize = 4;
 
+/// Wire index of the canonical S004 (date/time of preparation) slot in a
+/// `UNB` segment: the fourth and last of the mandatory leading
+/// composites, immediately ahead of the control reference. An empty
+/// element here is the structural marker that the date/time has been
+/// padded, which is what shifts the control reference past its canonical
+/// slot in a doubly-degenerate header (see [`unb_control_candidates`]).
+const UNB_S004_INDEX: usize = UNB_LEADING_COMPOSITES - 1;
+
 /// Locate the interchange control reference (UNB data element 0020) by
 /// its defined position in the segment structure rather than a fixed
 /// absolute index.
@@ -59,17 +67,72 @@ const UNB_LEADING_COMPOSITES: usize = 4;
 /// internally consistent interchange and the writer echoes the wrong
 /// element into `UNZ`.
 ///
-/// Both the reader and the writer call this so the located reference is
-/// identical on read and on re-emit, keeping a round-tripped header and
-/// trailer self-consistent. The control reference 0020 is a mandatory,
-/// non-empty element, so the rule is: the first non-empty element at or
-/// after the canonical position (the count of leading composites).
-/// Returns `None` only for a degenerate header with no such element,
-/// which disables the `UNZ`-echo check rather than failing the parse.
+/// Returns the primary positional candidate: the first non-empty element
+/// at or after the canonical position (the count of leading composites).
+/// The writer uses this as the reference it echoes into `UNZ` when it
+/// reconstructs a header from a `$doc` section, since at write time there
+/// is no trailer to consult. `None` only for a degenerate header with no
+/// such element, which disables the writer's echo rather than fabricating
+/// one.
 pub(crate) fn unb_control_reference(elements: &[String]) -> Option<&str> {
+    unb_control_candidates(elements).next()
+}
+
+/// Yield the structurally-plausible positions for the interchange control
+/// reference (0020), in order of decreasing likelihood, so the reader can
+/// confirm which one the `UNZ` trailer echoes.
+///
+/// The first candidate is the canonical one — the first non-empty element
+/// after the four mandatory leading composites. A second candidate exists
+/// only for the *doubly-degenerate* header that the first-non-empty rule
+/// cannot resolve on its own: when the S004 (date/time) slot is empty, a
+/// producer that also emits a date-only S004 places it where 0020 would
+/// normally sit, so the date occupies the canonical slot and the true
+/// control reference is the next non-empty element. This shape is
+/// byte-indistinguishable from a conformant header whose optional S005
+/// recipient reference is present, so position alone cannot choose
+/// between them — only the `UNZ` echo can. The reader therefore treats
+/// both as candidates and accepts whichever the trailer echoes,
+/// validating against the segment structure rather than guessing from the
+/// data shape of the candidate (which would risk misreading a reference
+/// that merely looks like a date).
+///
+/// At most two candidates are yielded: the canonical slot and the
+/// single-position shift the documented degeneracies can produce. An
+/// echo matching neither is a genuine mismatch.
+fn unb_control_candidates(elements: &[String]) -> impl Iterator<Item = &str> {
+    let s004_padded = elements.get(UNB_S004_INDEX).is_some_and(|e| e.is_empty());
     elements
         .iter()
+        .enumerate()
         .skip(UNB_LEADING_COMPOSITES)
-        .map(String::as_str)
-        .find(|e| !e.is_empty())
+        .filter(|(_, e)| !e.is_empty())
+        .map(|(i, e)| (i, e.as_str()))
+        // The primary candidate is the first non-empty element after the
+        // leading composites; the shifted candidate is the next one, and
+        // only when the empty S004 slot marks the doubly-degenerate shape.
+        .take(if s004_padded { 2 } else { 1 })
+        .map(|(_, e)| e)
+}
+
+/// Whether a `UNZ` control-reference echo matches the control reference
+/// the `UNB` declares, validating structurally against the segment.
+///
+/// The `UNB` header is parsed before the trailer is available, so the
+/// reader cannot resolve a doubly-degenerate header's control reference
+/// from the header alone (the canonical slot and the next slot are both
+/// plausible). The `UNZ` echo is the structural disambiguator: a valid
+/// interchange echoes its true control reference, so the echo confirms
+/// which candidate slot holds 0020. The check passes when the echo equals
+/// any structurally-plausible candidate (see [`unb_control_candidates`])
+/// and fails otherwise — a corrupt or out-of-sync trailer.
+///
+/// A header with no candidate at all (a degenerate `UNB` with no non-empty
+/// element after the leading composites) has no control reference to echo,
+/// so any echo passes — there is nothing to contradict.
+pub(crate) fn unz_echo_matches_unb(unb_elements: &[String], unz_echo: &str) -> bool {
+    let mut candidates = unb_control_candidates(unb_elements).peekable();
+    // A header with no control-reference candidate has nothing for the
+    // trailer to contradict, so the echo is vacuously valid.
+    candidates.peek().is_none() || candidates.any(|c| c == unz_echo)
 }

--- a/crates/clinker-format/src/edifact/mod.rs
+++ b/crates/clinker-format/src/edifact/mod.rs
@@ -104,15 +104,13 @@ fn unb_control_candidates(elements: &[String]) -> impl Iterator<Item = &str> {
     let s004_padded = elements.get(UNB_S004_INDEX).is_some_and(|e| e.is_empty());
     elements
         .iter()
-        .enumerate()
         .skip(UNB_LEADING_COMPOSITES)
-        .filter(|(_, e)| !e.is_empty())
-        .map(|(i, e)| (i, e.as_str()))
+        .map(String::as_str)
+        .filter(|e| !e.is_empty())
         // The primary candidate is the first non-empty element after the
         // leading composites; the shifted candidate is the next one, and
         // only when the empty S004 slot marks the doubly-degenerate shape.
         .take(if s004_padded { 2 } else { 1 })
-        .map(|(_, e)| e)
 }
 
 /// Whether a `UNZ` control-reference echo matches the control reference

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -22,7 +22,7 @@ use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
 use crate::edifact::tokenizer::{ParsedSegment, SegmentTokenizer, split_segment};
-use crate::edifact::{RAW_ELEMENTS_KEY, unb_control_reference};
+use crate::edifact::{RAW_ELEMENTS_KEY, unz_echo_matches_unb};
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::traits::FormatReader;
@@ -59,12 +59,10 @@ pub struct EdifactReader<R: Read> {
     schema: Arc<Schema>,
     max_elements: usize,
     initialized: bool,
-    /// Raw `UNB` data elements, stashed at init for envelope serving.
+    /// Raw `UNB` data elements, stashed at init for envelope serving and
+    /// for structurally validating the `UNZ` control-reference echo once
+    /// the trailer arrives.
     unb_elements: Vec<String>,
-    /// `UNB` interchange control reference (data element 0020), located
-    /// structurally after the mandatory leading composites and echoed by
-    /// `UNZ` for round-trip integrity validation.
-    unb_control_ref: Option<String>,
     /// State of the message currently being streamed, if any.
     open_message: Option<OpenMessage>,
     /// Count of `UNH` messages seen, checked against `UNZ`.
@@ -96,7 +94,6 @@ impl<R: Read> EdifactReader<R> {
             max_elements: config.max_elements,
             initialized: false,
             unb_elements: Vec::new(),
-            unb_control_ref: None,
             open_message: None,
             message_count: 0,
             interchange_closed: false,
@@ -105,8 +102,8 @@ impl<R: Read> EdifactReader<R> {
     }
 
     /// Consume the optional `UNA` and the mandatory `UNB`, stashing the
-    /// interchange control reference and the `UNB` data elements for
-    /// envelope serving. Idempotent.
+    /// `UNB` data elements for envelope serving and for the deferred
+    /// control-reference validation against the `UNZ` trailer. Idempotent.
     fn ensure_initialized(&mut self) -> Result<(), FormatError> {
         if self.initialized {
             return Ok(());
@@ -124,12 +121,11 @@ impl<R: Read> EdifactReader<R> {
                 parsed.tag
             )));
         }
-        // Locate the interchange control reference structurally — after
-        // the four mandatory leading composites — rather than at a fixed
-        // index, so an empty optional element ahead of it does not cause
-        // the wrong element to be read. Absence in a degenerate header
-        // disables the UNZ-echo check rather than failing the parse.
-        self.unb_control_ref = unb_control_reference(&parsed.elements).map(str::to_owned);
+        // Stash the full element list; the control reference is resolved
+        // structurally against the UNZ echo at interchange close, not from
+        // the header alone — a doubly-degenerate UNB (empty date/time slot
+        // plus a date-only date/time) leaves two plausible control-reference
+        // positions that only the trailer can disambiguate.
         self.unb_elements = parsed.elements;
         Ok(())
     }
@@ -289,14 +285,19 @@ impl<R: Read> EdifactReader<R> {
                 self.message_count
             )));
         }
-        if let Some(expected) = &self.unb_control_ref {
-            let echoed = unz.elements.get(1).map(|s| s.as_str()).unwrap_or("");
-            if echoed != expected {
-                return Err(FormatError::Edifact(format!(
-                    "UNZ control reference {echoed:?} does not echo the UNB reference \
-                     {expected:?}"
-                )));
-            }
+        // Validate the control-reference echo against the UNB structure
+        // rather than a single pre-chosen index: the echo confirms which
+        // of the plausible control-reference slots holds 0020, so a
+        // doubly-degenerate header (empty date/time slot plus a date-only
+        // date/time, which shifts the reference one slot) is accepted when
+        // the trailer echoes the true reference, while a genuinely
+        // out-of-sync trailer still fails.
+        let echoed = unz.elements.get(1).map(|s| s.as_str()).unwrap_or("");
+        if !unz_echo_matches_unb(&self.unb_elements, echoed) {
+            return Err(FormatError::Edifact(format!(
+                "UNZ control reference {echoed:?} does not echo the UNB interchange \
+                 control reference"
+            )));
         }
         self.interchange_closed = true;
         Ok(())
@@ -628,6 +629,41 @@ mod tests {
             match r.next_record() {
                 Ok(Some(_)) => continue,
                 Ok(None) => panic!("expected control ref mismatch for shifted reference"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("does not echo the UNB")));
+    }
+
+    #[test]
+    fn doubly_degenerate_unb_resolves_control_ref_to_intended_element() {
+        // A header degenerate in two ways at once: the S004 date/time slot
+        // (index 3) is an empty pad AND a date-only S004 "240101" sits at
+        // the canonical control-reference slot (index 4), shifting the true
+        // reference "REF9" to index 5. Locating the reference by the first
+        // non-empty element after the leading composites would pick the
+        // date "240101"; the structural check accepts the UNZ echo of the
+        // real reference at the shifted slot, so this internally consistent
+        // interchange validates instead of being spuriously rejected.
+        let data = "UNB+UNOA:1+SENDER+RECEIVER++240101+REF9'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF9'";
+        let recs = collect(data);
+        assert_eq!(recs.len(), 2); // UNH, BGM — no spurious rejection
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("BGM".into())));
+    }
+
+    #[test]
+    fn doubly_degenerate_unb_still_rejects_genuine_unz_mismatch() {
+        // The doubly-degenerate shape must not become a wildcard: a UNZ
+        // that echoes neither the canonical-slot date "240101" nor the
+        // shifted true reference "REF9" is still a genuine mismatch.
+        let data = "UNB+UNOA:1+SENDER+RECEIVER++240101+REF9'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+WRONGREF'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected control ref mismatch for doubly-degenerate header"),
                 Err(e) => break e,
             }
         };

--- a/docs/src/pipeline/edifact.md
+++ b/docs/src/pipeline/edifact.md
@@ -149,6 +149,17 @@ the fifth position) therefore validates and round-trips correctly: the
 reader reads the real reference and the writer echoes the same one into
 `UNZ`, so the trailer never contradicts its own header.
 
+A header that is degenerate in two ways at once — an empty date/time
+slot *and* a date-only date/time element placed where the control
+reference would normally sit — leaves two equally-plausible positions
+for data element 0020 that the header alone cannot tell apart (the shape
+is byte-identical to a conformant header whose optional recipient
+reference is present). The reader resolves this against the `UNZ`
+control-reference echo: 0020 is the candidate position the trailer
+echoes, so a self-consistent interchange of this shape validates and the
+intended control reference is identified, while a trailer that echoes
+neither plausible position is still rejected as a mismatch.
+
 A missing `UNZ` at end of input is a truncation error; content after the
 `UNZ` trailer is rejected.
 


### PR DESCRIPTION
## Summary

An EDIFACT interchange's control reference lives in the UNB segment's element S005/0020 — normally the first non-empty element after the leading composites. But a *doubly-degenerate* UNB header (an empty S004 date/time slot followed by a date-only value at the canonical position) shifts the true reference one element later, and that byte layout is indistinguishable from a conformant header that simply carries an optional recipient reference. No header-only positional rule can disambiguate the two without sniffing the data shape (e.g. guessing whether a value "looks like" a date), which is fragile and explicitly undesirable.

## Fix

Resolve the ambiguity using the structural anchor the reader already validates: the **UNZ trailer's control-reference echo**. The reader builds the small candidate set (the canonical slot, plus the single shifted slot only when the empty S004 marks the degenerate shape) and accepts whichever candidate the UNZ trailer echoes — while still rejecting a trailer that echoes neither (a genuine structural mismatch). Conformant, non-degenerate headers resolve exactly as before — no behavior change for the common case — and nothing buffers the whole interchange (validation happens when the reader reaches UNZ at close, consistent with the streaming model).

## Notes

- A rare residual remains on the *writer* side: reconstructing a doubly-degenerate UNB from a raw envelope has no trailer to anchor on at write time, so it echoes the positional candidate. The output still round-trips structurally; the deeper date/time-recombination handling is tracked in #408. This is documented in-code.

Closes #407.