### PR TITLE
plan,engine: tag DAG edges with a producer-side output port; route by the tag (#389)

### DIFF
--- a/crates/clinker-exec/src/executor/route_dispatch.rs
+++ b/crates/clinker-exec/src/executor/route_dispatch.rs
@@ -87,77 +87,23 @@ pub(crate) fn dispatch_route(
         .neighbors_directed(node_idx, Direction::Outgoing)
         .collect();
 
-    // Build branch_name -> successor NodeIndex mapping.
+    // Map each branch output port to the successor(s) that draw from it.
     //
-    // Under the unified taxonomy, a
-    // `PlanNode::Route` is a first-class node named as the
-    // user wrote it in YAML (e.g. `classify_route`). Successors
-    // may be Transforms, Aggregates, Outputs, or Compositions —
-    // any node whose `input:` is declared as
-    // `<route_name>.<branch>` (NodeInput::Port form). We
-    // can't use `build_transform_specs` alone because it
-    // excludes Outputs and Compositions.
-    //
-    // Walk `config.nodes` once, read each node's
-    // `header.input`, match against `<route_parent>.<branch>`,
-    // and map the branch to the successor's NodeIndex.
-    let route_parent = name.strip_prefix("route_").unwrap_or(name);
-    let mut succ_by_name: HashMap<String, NodeIndex> = HashMap::new();
-    for &succ in &successors {
-        succ_by_name.insert(current_dag.graph[succ].name().to_string(), succ);
-    }
-    let mut branch_to_succ: HashMap<String, NodeIndex> = HashMap::new();
-    // Iterate either the body's input-ref table (when set
-    // by the body executor for the current walk) or the
-    // top-level config nodes. The shape is the same:
-    // `(consumer_name, input_ref)` pairs.
-    let mut name_input_pairs: Vec<(String, String)> = Vec::new();
-    if let Some(body_refs) = ctx.current_body_node_input_refs.as_ref() {
-        for (consumer, refs) in body_refs {
-            for r in refs {
-                name_input_pairs.push((consumer.clone(), r.clone()));
-            }
-        }
-    } else {
-        use clinker_plan::config::PipelineNode;
-        use clinker_plan::config::node_header::NodeInput;
-        for spanned in &ctx.config.nodes {
-            let (node_name, input_ref) = match &spanned.value {
-                PipelineNode::Transform { header, .. }
-                | PipelineNode::Aggregate { header, .. }
-                | PipelineNode::Route { header, .. }
-                | PipelineNode::Output { header, .. } => {
-                    let ir = match &header.input.value {
-                        NodeInput::Single(s) => s.clone(),
-                        NodeInput::Port { node, port } => format!("{node}.{port}"),
-                    };
-                    (header.name.clone(), ir)
-                }
-                _ => continue,
-            };
-            name_input_pairs.push((node_name, input_ref));
-        }
-    }
-    for (node_name, input_ref) in name_input_pairs {
-        // Port form: "<route>.<branch>" — branch name comes
-        // from the port suffix. Standard for named branches
-        // on routes with multiple downstream consumers per
-        // branch.
-        if let Some(branch) = input_ref.strip_prefix(&format!("{}.", route_parent))
-            && let Some(&succ) = succ_by_name.get(&node_name)
-        {
-            branch_to_succ.insert(branch.to_string(), succ);
-            continue;
-        }
-        // Bare form: `input: <route>` on an Output whose
-        // *name* matches a Route branch (or the Route
-        // `default:`). Conventional shorthand when each
-        // branch has exactly one downstream consumer and
-        // the consumer's name is the branch name.
-        if input_ref == route_parent
-            && let Some(&succ) = succ_by_name.get(&node_name)
-        {
-            branch_to_succ.insert(node_name.clone(), succ);
+    // The producer-port tag on each outgoing edge is the single source
+    // of truth: the planner stamps `PlanEdge.producer_port` with the
+    // branch (or `default`) name the consumer referenced as
+    // `<route>.<branch>`, so resolution is a direct walk of the live
+    // edge graph — no re-parsing of `config.nodes` input refs and no
+    // dependence on the route-name spelling. A branch may fan to more
+    // than one consumer, so each port maps to a `Vec` of successors.
+    use petgraph::visit::EdgeRef;
+    let mut branch_to_succ: HashMap<&str, Vec<NodeIndex>> = HashMap::new();
+    for edge in current_dag
+        .graph
+        .edges_directed(node_idx, Direction::Outgoing)
+    {
+        if let Some(port) = edge.weight().producer_port.as_deref() {
+            branch_to_succ.entry(port).or_default().push(edge.target());
         }
     }
 
@@ -209,11 +155,13 @@ pub(crate) fn dispatch_route(
             match route_result {
                 Ok(targets) => {
                     for target in &targets {
-                        if let Some(&succ) = branch_to_succ.get(target.as_str()) {
-                            branch_buffers
-                                .entry(succ)
-                                .or_default()
-                                .push((record.clone(), rn));
+                        if let Some(succs) = branch_to_succ.get(target.as_str()) {
+                            for &succ in succs {
+                                branch_buffers
+                                    .entry(succ)
+                                    .or_default()
+                                    .push((record.clone(), rn));
+                            }
                         }
                         // Exclusive mode: stop after first match
                         if mode == clinker_plan::config::RouteMode::Exclusive {

--- a/crates/clinker-exec/src/executor/tests/aggregation.rs
+++ b/crates/clinker-exec/src/executor/tests/aggregation.rs
@@ -201,6 +201,7 @@ nodes:
             PlanEdge {
                 dependency_type: DependencyType::Data,
                 port: None,
+                producer_port: None,
             },
         );
 

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_route_fanout.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_route_fanout.snap
@@ -76,8 +76,8 @@ edge route.classify_route -> output.high:
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: route)
 
 Route 'classify_route' (mode: exclusive):
-  Branch 'high' → output 'high'
-  Default: 'low' → output 'low'
+  Branch 'high' → output.high
+  Default: 'low' → output.low
 
 === CXL Expressions ===
 

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -937,19 +937,29 @@ impl PipelineConfig {
         }
         for spanned in &self.nodes {
             let node = &spanned.value;
-            let consumer_name = node.name();
-            let Some(&consumer_idx) = name_to_idx.get(consumer_name) else {
+            let consumer_name = node.name().to_string();
+            let Some(&consumer_idx) = name_to_idx.get(consumer_name.as_str()) else {
                 continue;
             };
             let mut wire = |producer_full: &str, port: Option<String>| {
                 let producer_key = strip_port_for_edge(producer_full);
                 if let Some(&producer_idx) = name_to_idx.get(producer_key) {
+                    // Tag the edge with the producer output port it draws
+                    // from so the dispatcher routes Route branches off the
+                    // live graph; `None` for single-output producers.
+                    let producer_port = resolve_producer_port(
+                        &graph[producer_idx],
+                        producer_full,
+                        producer_key,
+                        &consumer_name,
+                    );
                     graph.add_edge(
                         producer_idx,
                         consumer_idx,
                         PlanEdge {
                             dependency_type: DependencyType::Data,
                             port,
+                            producer_port,
                         },
                     );
                 }
@@ -1867,6 +1877,41 @@ fn input_full_reference(input: &node_header::NodeInput) -> String {
         node_header::NodeInput::Single(s) => s.clone(),
         node_header::NodeInput::Port { node, port } => format!("{node}.{port}"),
     }
+}
+
+/// Resolve the producer output port a consumer's edge draws from, given
+/// the producer node, the consumer's full input reference, the bare
+/// producer name, and the consumer's own name.
+///
+/// Two reference shapes select a port on a multi-output producer (today
+/// only `PlanNode::Route`, whose ports are its branches plus the default):
+///
+/// - Port form: `input: <route>.<branch>` — the suffix names the port.
+/// - Bare form: `input: <route>` on a consumer whose own *name* equals a
+///   branch (or the default). This shorthand reads as "this node IS the
+///   `<name>` branch": each branch has one consumer named for it.
+///
+/// Returns `None` for single-output producers, and for references that
+/// match neither shape (a suffix or consumer name that is not a declared
+/// port). Shared by the top-level and composition-body edge wiring so
+/// both scopes route Route branches off the live edge graph identically.
+pub(crate) fn resolve_producer_port(
+    producer: &crate::plan::execution::PlanNode,
+    producer_full: &str,
+    producer_key: &str,
+    consumer_name: &str,
+) -> Option<String> {
+    let ports = producer.output_ports()?;
+    if let Some(suffix) = producer_full
+        .strip_prefix(producer_key)
+        .and_then(|rest| rest.strip_prefix('.'))
+    {
+        return ports.contains(&suffix).then(|| suffix.to_string());
+    }
+    // Bare reference: the consumer's name selects the port.
+    ports
+        .contains(&consumer_name)
+        .then(|| consumer_name.to_string())
 }
 
 /// Unified input-reference resolution pass. Walks every node's

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1889,8 +1889,8 @@ fn bind_composition(
     }
     for spanned in &body_file.nodes {
         let n = &spanned.value;
-        let consumer_name = n.name();
-        let Some(&consumer_idx) = body_name_to_idx.get(consumer_name) else {
+        let consumer_name = n.name().to_string();
+        let Some(&consumer_idx) = body_name_to_idx.get(consumer_name.as_str()) else {
             continue;
         };
         let mut wire = |producer_full: &str, port: Option<String>| {
@@ -1900,12 +1900,23 @@ fn bind_composition(
             // graph edge — port seeding is handled at composition
             // entry by the executor through the live edge graph.
             if let Some(&producer_idx) = body_name_to_idx.get(producer_key) {
+                // Tag the producer output port a `<route>.<branch>` (or
+                // bare-name) reference draws from, mirroring the top-level
+                // wiring so the body executor routes Route branches off the
+                // live edge graph too.
+                let producer_port = crate::config::resolve_producer_port(
+                    &body_graph[producer_idx],
+                    producer_full,
+                    producer_key,
+                    &consumer_name,
+                );
                 body_graph.add_edge(
                     producer_idx,
                     consumer_idx,
                     PlanEdge {
                         dependency_type: DependencyType::Data,
                         port,
+                        producer_port,
                     },
                 );
             }

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -2052,6 +2052,7 @@ pub(crate) fn decompose_nary_combines(
                     PlanEdge {
                         dependency_type: DependencyType::Data,
                         port: None,
+                        producer_port: None,
                     },
                 );
             }
@@ -2062,6 +2063,7 @@ pub(crate) fn decompose_nary_combines(
                     PlanEdge {
                         dependency_type: DependencyType::Data,
                         port: None,
+                        producer_port: None,
                     },
                 );
             }

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -716,6 +716,7 @@ mod port_tag_guard_tests {
             PlanEdge {
                 dependency_type: DependencyType::Data,
                 port: Some("p".to_string()),
+                producer_port: None,
             },
         );
         let artifacts = CompileArtifacts::default();
@@ -738,6 +739,7 @@ mod port_tag_guard_tests {
             PlanEdge {
                 dependency_type: DependencyType::Data,
                 port: None,
+                producer_port: None,
             },
         );
         let artifacts = CompileArtifacts::default();
@@ -775,6 +777,7 @@ mod port_tag_guard_tests {
             PlanEdge {
                 dependency_type: DependencyType::Data,
                 port: None,
+                producer_port: None,
             },
         );
         let body = crate::plan::composition_body::BoundBody {

--- a/crates/clinker-plan/src/plan/execution/enforcer.rs
+++ b/crates/clinker-plan/src/plan/execution/enforcer.rs
@@ -115,17 +115,19 @@ impl ExecutionPlanDag {
             }
 
             // Locate and remove the direct Source→consumer edge, capturing
-            // its dependency type and consumer-side port for re-use on
-            // the rewritten edges. The port tag belongs to the
-            // sort→consumer hop (the consumer is unchanged); the
-            // source→sort hop has no port (Sort takes a single unnamed
-            // input).
+            // its dependency type and both port tags for re-use on the
+            // rewritten edges. Both tags belong to the sort→consumer hop:
+            // the consumer is unchanged, and the original producer is
+            // preserved upstream of the spliced Sort. The source→sort hop
+            // carries no port (Sort takes a single unnamed input and the
+            // Source emits a single unnamed output).
             let edge_id = self
                 .graph
                 .find_edge(source_idx, consumer_idx)
                 .expect("source parent must have outgoing edge to consumer");
             let dep_type = self.graph[edge_id].dependency_type;
             let consumer_port = self.graph[edge_id].port.clone();
+            let producer_port = self.graph[edge_id].producer_port.clone();
             self.graph.remove_edge(edge_id);
 
             // Planner-synthesized sort enforcer. No YAML node exists
@@ -146,6 +148,7 @@ impl ExecutionPlanDag {
                 PlanEdge {
                     dependency_type: dep_type,
                     port: None,
+                    producer_port: None,
                 },
             );
             self.graph.add_edge(
@@ -154,6 +157,7 @@ impl ExecutionPlanDag {
                 PlanEdge {
                     dependency_type: dep_type,
                     port: consumer_port,
+                    producer_port,
                 },
             );
         }
@@ -230,11 +234,11 @@ impl ExecutionPlanDag {
                 }
             }
 
-            // Capture (target, dep_type, port) for every outgoing edge — the
-            // port tag must survive the splice so a downstream
-            // composition's named-input edge keeps its tag on the new
-            // sort→target hop.
-            let outgoing: Vec<(NodeIndex, DependencyType, Option<String>)> = self
+            // Capture (target, dep_type, consumer_port, producer_port) for
+            // every outgoing edge — both port tags must survive the splice
+            // so a downstream composition's named-input edge keeps its tag
+            // and any producer output port stays on the new sort→target hop.
+            let outgoing: Vec<(NodeIndex, DependencyType, Option<String>, Option<String>)> = self
                 .graph
                 .edges_directed(source_idx, petgraph::Direction::Outgoing)
                 .map(|e| {
@@ -242,6 +246,7 @@ impl ExecutionPlanDag {
                         e.target(),
                         e.weight().dependency_type,
                         e.weight().port.clone(),
+                        e.weight().producer_port.clone(),
                     )
                 })
                 .collect();
@@ -251,7 +256,7 @@ impl ExecutionPlanDag {
 
             // Idempotent insertion guard: every outgoing edge already
             // lands on a CORRELATION_SORT_PREFIX Sort node — nothing to do.
-            if outgoing.iter().all(|(t, _, _)| {
+            if outgoing.iter().all(|(t, _, _, _)| {
                 matches!(&self.graph[*t], PlanNode::Sort { name, .. } if name.starts_with(CORRELATION_SORT_PREFIX))
             }) {
                 continue;
@@ -263,7 +268,7 @@ impl ExecutionPlanDag {
                 sort_fields,
             };
             let sort_idx = self.graph.add_node(sort_node);
-            for (target, dep_type, port) in outgoing {
+            for (target, dep_type, port, producer_port) in outgoing {
                 if target == sort_idx {
                     continue;
                 }
@@ -276,6 +281,7 @@ impl ExecutionPlanDag {
                     PlanEdge {
                         dependency_type: dep_type,
                         port,
+                        producer_port,
                     },
                 );
             }
@@ -285,6 +291,7 @@ impl ExecutionPlanDag {
                 PlanEdge {
                     dependency_type: DependencyType::Data,
                     port: None,
+                    producer_port: None,
                 },
             );
         }
@@ -361,6 +368,7 @@ impl ExecutionPlanDag {
                 PlanEdge {
                     dependency_type: DependencyType::Data,
                     port: None,
+                    producer_port: None,
                 },
             );
         }

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -580,15 +580,18 @@ impl ExecutionPlanDag {
             out.push('\n');
         }
 
-        // Show route info from graph nodes
-        for node in self.graph.node_weights() {
+        // Show route info from graph nodes. Each branch (and the default)
+        // is an output port; the consumers it feeds are resolved from the
+        // producer-port-tagged outgoing edges, so the rendering reflects
+        // the live topology rather than assuming one consumer per port.
+        for idx in self.graph.node_indices() {
             if let PlanNode::Route {
                 name,
                 mode,
                 branches,
                 default,
                 ..
-            } = node
+            } = &self.graph[idx]
             {
                 out.push_str(&format!(
                     "Route '{}' (mode: {}):\n",
@@ -600,13 +603,15 @@ impl ExecutionPlanDag {
                 ));
                 for branch_name in branches {
                     out.push_str(&format!(
-                        "  Branch '{}' → output '{}'\n",
-                        branch_name, branch_name
+                        "  Branch '{}' → {}\n",
+                        branch_name,
+                        self.render_route_port_targets(idx, branch_name),
                     ));
                 }
                 out.push_str(&format!(
-                    "  Default: '{}' → output '{}'\n\n",
-                    default, default
+                    "  Default: '{}' → {}\n\n",
+                    default,
+                    self.render_route_port_targets(idx, default),
                 ));
             }
         }
@@ -623,6 +628,28 @@ impl ExecutionPlanDag {
         self.render_retraction_section(&mut out, None);
 
         out
+    }
+
+    /// Render the `--explain` target list for one Route output port.
+    ///
+    /// Walks the route node's outgoing edges, selecting those whose
+    /// [`PlanEdge::producer_port`] equals `port`, and lists each target
+    /// node's id slug. A port with no consumer renders `(unconsumed)` so
+    /// an author who wired a branch to nothing sees it. Multiple consumers
+    /// of one port render comma-separated in graph-edge order.
+    fn render_route_port_targets(&self, route_idx: NodeIndex, port: &str) -> String {
+        use petgraph::visit::EdgeRef;
+        let targets: Vec<String> = self
+            .graph
+            .edges_directed(route_idx, petgraph::Direction::Outgoing)
+            .filter(|e| e.weight().producer_port.as_deref() == Some(port))
+            .map(|e| self.graph[e.target()].id_slug())
+            .collect();
+        if targets.is_empty() {
+            "(unconsumed)".to_string()
+        } else {
+            targets.join(", ")
+        }
     }
 
     /// Render the retraction-cost block for content-relaxed aggregates
@@ -1493,7 +1520,16 @@ impl ExecutionPlanDag {
                     petgraph::dot::Config::EdgeNoLabel,
                     petgraph::dot::Config::NodeNoLabel,
                 ],
-                &|_, edge| { format!(r#"label="{}""#, edge.weight().dependency_type.as_str()) },
+                &|_, edge| {
+                    // Append the producer output port (Route branch /
+                    // default) to the dependency-type label so the graph
+                    // shows which branch each edge carries.
+                    let dep = edge.weight().dependency_type.as_str();
+                    match edge.weight().producer_port.as_deref() {
+                        Some(port) => format!(r#"label="{}:{}""#, dep, dot_escape(port)),
+                        None => format!(r#"label="{}""#, dep),
+                    }
+                },
                 &|_, (_, node)| { format!(r#"label="{}""#, dot_escape(&node.display_name())) },
             )
         )
@@ -2292,6 +2328,7 @@ mod spill_projection_tests {
             PlanEdge {
                 dependency_type: DependencyType::Data,
                 port: None,
+                producer_port: None,
             },
         );
         dag.topo_order = vec![src_idx, sort_idx];

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -597,6 +597,32 @@ impl PlanNode {
         format!("{}.{}", self.type_tag(), self.name())
     }
 
+    /// The named output ports this node emits to, or `None` when the node
+    /// has a single unnamed output.
+    ///
+    /// Producer-side counterpart to a node's named inputs. A `Route` emits
+    /// one output per branch plus its `default`; the dispatcher tags each
+    /// outgoing edge with the [`PlanEdge::producer_port`] it carries, so a
+    /// record assigned to branch `b` flows down exactly the edges tagged
+    /// `b`. The returned set is deduplicated and preserves branch
+    /// declaration order, appending `default` last when it is not already a
+    /// branch name. Every other variant returns `None` (single output).
+    /// Future multi-output operators add their own arm here.
+    pub fn output_ports(&self) -> Option<Vec<&str>> {
+        match self {
+            PlanNode::Route {
+                branches, default, ..
+            } => {
+                let mut ports: Vec<&str> = branches.iter().map(String::as_str).collect();
+                if !ports.contains(&default.as_str()) {
+                    ports.push(default.as_str());
+                }
+                Some(ports)
+            }
+            _ => None,
+        }
+    }
+
     /// Human-readable label for DOT node annotations and text display.
     pub fn display_name(&self) -> String {
         match self {
@@ -698,14 +724,25 @@ impl DependencyType {
 
 /// Edge in the execution plan DAG.
 ///
-/// `port` carries the consumer-side port name when the edge feeds a
-/// node whose inputs are named (currently `PlanNode::Composition`). The
-/// dispatcher uses the live edge graph + port tag as the single source
-/// of truth for runtime port resolution: planner-injected nodes (e.g.,
-/// `inject_correlation_sort`'s synthetic Sort) reroute edges and carry
-/// the tag forward, so a downstream composition arm always reads its
-/// producer through the live graph rather than a frozen name snapshot.
-/// `None` for unnamed-input edges (every other consumer arm).
+/// An edge connects a producer output to a consumer input. Two
+/// independent port tags name the endpoints when either side carries
+/// more than one labelled stream:
+///
+/// - `producer_port` names which output of the producer this edge draws
+///   from. A node that emits multiple named output streams (today:
+///   `PlanNode::Route`, one output per branch plus the default) tags each
+///   outgoing edge with the output it carries. `None` means the producer
+///   has a single unnamed output (every other operator).
+/// - `port` (consumer-side) names which input of the consumer this edge
+///   feeds when the consumer takes named inputs (today:
+///   `PlanNode::Composition`). `None` otherwise.
+///
+/// The dispatcher uses the live edge graph + these tags as the single
+/// source of truth for runtime port resolution: planner-injected nodes
+/// (e.g., `inject_correlation_sort`'s synthetic Sort) reroute edges and
+/// carry both tags forward, so a downstream arm always reads its
+/// producer/consumer port through the live graph rather than a frozen
+/// name snapshot.
 #[derive(Debug, Clone, Serialize)]
 pub struct PlanEdge {
     pub dependency_type: DependencyType,
@@ -713,6 +750,14 @@ pub struct PlanEdge {
     /// `None` otherwise. Preserved across edge reroutes by every
     /// planner pass that splices intermediate nodes.
     pub port: Option<String>,
+    /// Producer-side output port this edge draws from when the producer
+    /// emits multiple named outputs (Route branches / default); `None`
+    /// for single-output producers. Preserved across edge reroutes by
+    /// every planner pass that splices an intermediate node: the spliced
+    /// node is a single-output passthrough, so the tag stays on the hop
+    /// leaving the original multi-output producer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub producer_port: Option<String>,
 }
 
 /// Plan-time projection of an operator's runtime arbitration parameters.

--- a/crates/clinker-plan/src/plan/extraction.rs
+++ b/crates/clinker-plan/src/plan/extraction.rs
@@ -456,6 +456,7 @@ mod tests {
         PlanEdge {
             dependency_type: DependencyType::Data,
             port: None,
+            producer_port: None,
         }
     }
 

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -7,4 +7,5 @@ mod doc_paths;
 mod explain_buffer_class;
 mod explain_polish;
 mod plan_time_window_root;
+mod route_ports;
 mod watermark_validation;

--- a/crates/clinker-plan/src/plan/tests/route_ports.rs
+++ b/crates/clinker-plan/src/plan/tests/route_ports.rs
@@ -1,0 +1,194 @@
+//! Producer-side output-port tagging on Route fan-out edges.
+//!
+//! A Route declares one named output port per branch plus its default.
+//! Each outgoing edge is tagged with [`crate::plan::execution::PlanEdge`]'s
+//! `producer_port` so the dispatcher routes records by output port off the
+//! live graph. These gates pin the tagging contract for both reference
+//! shapes a consumer can use to draw from a branch.
+
+use super::dag::parse_fixture;
+use crate::config::CompileContext;
+use crate::plan::execution::PlanNode;
+use petgraph::Direction;
+use petgraph::visit::EdgeRef;
+
+/// Compile a fixture and return the producer-port-tagged targets of the
+/// single Route node, as `(producer_port, consumer_id_slug)` pairs sorted
+/// for deterministic comparison. An untagged outgoing edge surfaces as a
+/// `None` producer port so a wiring regression is visible rather than
+/// silently dropped.
+fn route_port_targets(yaml: &str) -> Vec<(Option<String>, String)> {
+    let config = parse_fixture(yaml);
+    let dag = config
+        .compile(&CompileContext::default())
+        .expect("compile")
+        .dag()
+        .clone();
+    let route_idx = dag
+        .graph
+        .node_indices()
+        .find(|&i| matches!(dag.graph[i], PlanNode::Route { .. }))
+        .expect("fixture has a Route node");
+    let mut out: Vec<(Option<String>, String)> = dag
+        .graph
+        .edges_directed(route_idx, Direction::Outgoing)
+        .map(|e| {
+            (
+                e.weight().producer_port.clone(),
+                dag.graph[e.target()].id_slug(),
+            )
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+const SOURCE_AND_CLASSIFY: &str = r#"pipeline:
+  name: route_ports
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: string }
+  - type: transform
+    name: classify
+    input: orders
+    config:
+      cxl: |
+        emit id = id
+        emit amount = amount
+"#;
+
+/// Port-form references (`<route>.<branch>`) tag every Route outgoing
+/// edge with the branch — including the default — it draws from.
+#[test]
+fn port_form_references_tag_each_branch() {
+    let yaml = format!(
+        "{SOURCE_AND_CLASSIFY}{}",
+        r#"  - type: route
+    name: split
+    input: classify
+    config:
+      mode: exclusive
+      conditions:
+        high: "amount.to_int() > 100"
+      default: low
+  - type: output
+    name: high_out
+    input: split.high
+    config:
+      name: high_out
+      type: csv
+      path: high.csv
+  - type: output
+    name: low_out
+    input: split.low
+    config:
+      name: low_out
+      type: csv
+      path: low.csv
+"#
+    );
+
+    assert_eq!(
+        route_port_targets(&yaml),
+        vec![
+            (Some("high".to_string()), "output.high_out".to_string()),
+            (Some("low".to_string()), "output.low_out".to_string()),
+        ],
+    );
+}
+
+/// Bare references (`input: <route>`) on consumers whose own name equals a
+/// branch tag the edge with that branch — the one-consumer-per-branch
+/// shorthand, with the default reachable the same way.
+#[test]
+fn bare_name_references_tag_the_matching_branch() {
+    let yaml = format!(
+        "{SOURCE_AND_CLASSIFY}{}",
+        r#"  - type: route
+    name: split
+    input: classify
+    config:
+      mode: exclusive
+      conditions:
+        high: "amount.to_int() > 100"
+      default: low
+  - type: output
+    name: high
+    input: split
+    config:
+      name: high
+      type: csv
+      path: high.csv
+  - type: output
+    name: low
+    input: split
+    config:
+      name: low
+      type: csv
+      path: low.csv
+"#
+    );
+
+    assert_eq!(
+        route_port_targets(&yaml),
+        vec![
+            (Some("high".to_string()), "output.high".to_string()),
+            (Some("low".to_string()), "output.low".to_string()),
+        ],
+    );
+}
+
+/// A single branch consumed by more than one downstream node tags every
+/// such edge, so the dispatcher fans one branch to all its consumers.
+#[test]
+fn one_branch_fans_to_multiple_consumers() {
+    let yaml = format!(
+        "{SOURCE_AND_CLASSIFY}{}",
+        r#"  - type: route
+    name: split
+    input: classify
+    config:
+      mode: exclusive
+      conditions:
+        high: "amount.to_int() > 100"
+      default: low
+  - type: output
+    name: high_a
+    input: split.high
+    config:
+      name: high_a
+      type: csv
+      path: high_a.csv
+  - type: output
+    name: high_b
+    input: split.high
+    config:
+      name: high_b
+      type: csv
+      path: high_b.csv
+  - type: output
+    name: low_out
+    input: split.low
+    config:
+      name: low_out
+      type: csv
+      path: low.csv
+"#
+    );
+
+    assert_eq!(
+        route_port_targets(&yaml),
+        vec![
+            (Some("high".to_string()), "output.high_a".to_string()),
+            (Some("high".to_string()), "output.high_b".to_string()),
+            (Some("low".to_string()), "output.low_out".to_string()),
+        ],
+    );
+}


### PR DESCRIPTION
## Summary

Refactors Route fan-out onto a producer-side output-port abstraction on the execution-plan graph, replacing the previous scheme where the executor re-parsed each consumer's input reference and relied on a `route_`-prefixed node-name convention to identify branches.

- A `PlanEdge` now carries an optional `producer_port` tag — *which named output of the producer this edge draws from* — distinct from the existing consumer-side `port` (which input of the consumer an edge feeds, used by compositions).
- `PlanNode::output_ports()` declares a node's named outputs: a Route exposes its branch names plus its `default`; every other node has a single unnamed output. This is the extension point for future nodes that emit to multiple named ports.
- Route dispatch now reads the `producer_port` tag off outgoing edges instead of re-parsing config and matching name prefixes (−64 lines), and `--explain` / DOT output render each output port's resolved consumers.

## Behavior

Behavior-preserving — the existing branching and multi-output integration tests pass unchanged. One latent bug is fixed in passing: when a single Route branch fanned out to multiple consumers, the old single-entry branch→successor map silently kept only the last; dispatch now delivers to all of them (covered by a new multi-consumer test).

## Notes

The output-port abstraction is the foundation a producer-emits-to-multiple-named-ports node needs (e.g. a main output plus a side-output) — the port-tagged edges, `output_ports()`, and port-generic dispatch/rendering are all in place. The engine now matches the port model already described in the routing docs.

Closes #389.