### PR TITLE
cxl,plan: attribute collected $doc paths per source instead of pipeline-wide (#432)

### DIFF
--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -1983,6 +1983,16 @@ fn resolve_all_input_references(
 /// attributor unions these source sets across a path's referencing nodes
 /// to stamp each source with only the paths it actually delivers.
 ///
+/// This is a parallel walk to `bind_schema`'s `upstream_sources` map
+/// (which feeds the E156 time-window watermark guard). The two
+/// intentionally diverge: that walk unions every input unconditionally,
+/// whereas this one narrows a `Combine` to its driving input and resolves
+/// a `Composition` through its full `inputs:` port set. The semantics here
+/// model where a record's document context actually flows; the watermark
+/// walk models which sources can deliver records at all. Keep them in sync
+/// on the shared shape (Source-seeds-self, declaration-order topo walk,
+/// composition-body recursion) when either changes.
+///
 /// The top-level walk runs in declaration order, which Stage-3 validation
 /// proved topologically sound, so each node's source set is the union of
 /// its direct inputs' sets (Sources seed themselves).
@@ -1998,10 +2008,15 @@ fn resolve_all_input_references(
 /// program are keyed by the combine node's own name, so they share this
 /// driving-input source set with no extra handling.
 ///
-/// Composition bodies are isolated mini-DAGs whose nodes draw their
-/// records from the call-site `inputs:` port bindings; every body node
-/// (recursively, through nested compositions) inherits the union of the
-/// source sets feeding those ports. A body `$doc` access carries no port
+/// A `Composition` forwards the union of EVERY bound `inputs:` port's
+/// source set, not just its primary port. `direct_input_names` reports
+/// only `header.input` (the single primary port) for a composition, so a
+/// multi-port call (`inputs: { primary: a, reference: b }`) would drop the
+/// non-primary ports' sources — a downstream `$doc` read off the
+/// composition output must still see them. Composition bodies are isolated
+/// mini-DAGs whose nodes draw their records from the same call-site port
+/// bindings; every body node (recursively, through nested compositions)
+/// inherits the same port-union set. A body `$doc` access carries no port
 /// qualifier, so it could read any incoming port's source envelope — the
 /// union is the correct attribution.
 fn build_node_source_sets(
@@ -2056,6 +2071,23 @@ fn build_node_source_sets(
             .collect()
     };
 
+    // Union of the source sets feeding a composition's `inputs:` port
+    // bindings — the authoritative call-site connectivity. `header.input`
+    // (what `direct_input_names` reports for a Composition) names only the
+    // single primary port, so it must NOT be used for a multi-port
+    // composition: a downstream `$doc` read off the composition output, or
+    // a body `$doc` access, can resolve against any bound port's source.
+    let composition_call_site_sources =
+        |inputs: &IndexMap<String, String>,
+         sources: &HashMap<String, std::collections::BTreeSet<String>>|
+         -> std::collections::BTreeSet<String> {
+            let producers: Vec<&str> = inputs
+                .values()
+                .map(|upstream| upstream.split('.').next().unwrap_or(upstream))
+                .collect();
+            union_of(&producers, sources)
+        };
+
     for spanned in nodes {
         let name = spanned.value.name().to_string();
         let sources: std::collections::BTreeSet<String> = match &spanned.value {
@@ -2068,6 +2100,14 @@ fn build_node_source_sets(
             PipelineNode::Combine { .. } => combine_driver_upstream(&name)
                 .and_then(|driver| node_sources.get(&driver).cloned())
                 .unwrap_or_else(|| union_of(&spanned.value.direct_input_names(), &node_sources)),
+            // A composition forwards the union of EVERY bound input port's
+            // source set, not just its primary port — a downstream node
+            // reading `$doc` off the composition output can see any port's
+            // document context. This matches the body-node attribution
+            // below, which unions the same port sources.
+            PipelineNode::Composition { inputs, .. } => {
+                composition_call_site_sources(inputs, &node_sources)
+            }
             // Every other non-Source variant inherits the union of its
             // direct inputs' source sets.
             other => union_of(&other.direct_input_names(), &node_sources),
@@ -2076,18 +2116,12 @@ fn build_node_source_sets(
         // A composition's body nodes feed from the call-site `inputs:`
         // port bindings — union every bound port's source set so a body
         // `$doc` access is attributed to whichever input could supply its
-        // envelope. The port bindings are the authoritative call-site
-        // connectivity (`header.input` adds nothing beyond them).
-        if let PipelineNode::Composition { inputs, .. } = &spanned.value {
-            let call_site_sources: std::collections::BTreeSet<String> = inputs
-                .values()
-                .map(|upstream| upstream.split('.').next().unwrap_or(upstream))
-                .filter_map(|producer| node_sources.get(producer))
-                .flat_map(|s| s.iter().cloned())
-                .collect();
-            if let Some(&body_id) = artifacts.composition_body_assignments.get(&name) {
-                attribute_body(body_id, &call_site_sources, artifacts, &mut node_sources);
-            }
+        // envelope. That union is exactly the source set the Composition
+        // arm above computed into `sources`, so reuse it.
+        if let PipelineNode::Composition { .. } = &spanned.value
+            && let Some(&body_id) = artifacts.composition_body_assignments.get(&name)
+        {
+            attribute_body(body_id, &sources, artifacts, &mut node_sources);
         }
 
         node_sources.insert(name, sources);

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -812,7 +812,34 @@ impl PipelineConfig {
             }
             return Err(diags);
         }
-        let declared_doc_paths = doc_path_set.paths;
+        // Attribute each collected `$doc` path to the source(s) it flows
+        // from: trace every referencing node back through the DAG to its
+        // upstream Source set and stamp the path onto only those sources.
+        // A `$doc` access carries no source qualifier, so a multi-source
+        // run must not stamp the pipeline-wide union onto every source —
+        // a source would otherwise be told to extract envelope sections
+        // its own document never declares.
+        let node_sources = build_node_source_sets(&self.nodes, &artifacts);
+        let mut doc_paths_by_source: HashMap<String, std::collections::BTreeSet<_>> =
+            HashMap::new();
+        for (doc_path, nodes) in &doc_path_set.by_node {
+            for node_name in nodes {
+                let Some(sources) = node_sources.get(node_name) else {
+                    continue;
+                };
+                for source in sources {
+                    doc_paths_by_source
+                        .entry(source.clone())
+                        .or_default()
+                        .insert(doc_path.clone());
+                }
+            }
+        }
+        let declared_doc_paths: HashMap<String, Vec<cxl::analyzer::doc_paths::DocPath>> =
+            doc_paths_by_source
+                .into_iter()
+                .map(|(source, paths)| (source, paths.into_iter().collect()))
+                .collect();
         // Keep an analysis-by-name index so we can surface the analysis
         // alongside its matching entry regardless of filter order.
         let mut analysis_by_name: HashMap<String, &cxl::analyzer::TransformAnalysis> =
@@ -917,7 +944,7 @@ impl PipelineConfig {
                 analysis: analysis_by_name.get(name.as_str()).copied(),
                 window_config: entry_idx.and_then(|i| window_configs[i].as_ref()),
                 primary_source: primary_source.as_str(),
-                declared_doc_paths: &declared_doc_paths,
+                doc_paths_by_source: &declared_doc_paths,
             };
             let plan_node =
                 lower_node_to_plan_node(node, &name, span, &artifacts, &lowering_ctx, &mut diags);
@@ -1951,6 +1978,124 @@ fn resolve_all_input_references(
     }
 }
 
+/// Map every CXL-bearing node name — top-level and composition-body — to
+/// the set of upstream `Source` names that feed it. The `$doc` path
+/// attributor unions these source sets across a path's referencing nodes
+/// to stamp each source with only the paths it actually delivers.
+///
+/// The top-level walk runs in declaration order, which Stage-3 validation
+/// proved topologically sound, so each node's source set is the union of
+/// its direct inputs' sets (Sources seed themselves).
+///
+/// A `Combine` is the one node whose source set is NOT the union of its
+/// inputs: a joined record carries the DRIVING input's document context
+/// forward (the same per-driver-document rule a downstream Aggregate
+/// follows), and the predicate's `$doc` accesses likewise bind to the
+/// driving record's envelope. So a Combine's source set is the driving
+/// input's source set alone — using the union would tell the probe-side
+/// source to extract envelope sections only the driver's document
+/// declares. Both the Combine's `cxl:` body and its `where:` predicate
+/// program are keyed by the combine node's own name, so they share this
+/// driving-input source set with no extra handling.
+///
+/// Composition bodies are isolated mini-DAGs whose nodes draw their
+/// records from the call-site `inputs:` port bindings; every body node
+/// (recursively, through nested compositions) inherits the union of the
+/// source sets feeding those ports. A body `$doc` access carries no port
+/// qualifier, so it could read any incoming port's source envelope — the
+/// union is the correct attribution.
+fn build_node_source_sets(
+    nodes: &[Spanned<PipelineNode>],
+    artifacts: &crate::plan::bind_schema::CompileArtifacts,
+) -> HashMap<String, std::collections::BTreeSet<String>> {
+    use crate::plan::composition_body::CompositionBodyId;
+
+    let mut node_sources: HashMap<String, std::collections::BTreeSet<String>> = HashMap::new();
+
+    // Attribute every node in a composition body (recursively through
+    // nested bodies) to the call-site's source set.
+    fn attribute_body(
+        body_id: CompositionBodyId,
+        call_site_sources: &std::collections::BTreeSet<String>,
+        artifacts: &crate::plan::bind_schema::CompileArtifacts,
+        node_sources: &mut HashMap<String, std::collections::BTreeSet<String>>,
+    ) {
+        let Some(body) = artifacts.body_of(body_id) else {
+            return;
+        };
+        for body_node_name in body.name_to_idx.keys() {
+            node_sources
+                .entry(body_node_name.clone())
+                .or_default()
+                .extend(call_site_sources.iter().cloned());
+        }
+        for nested in &body.nested_body_ids {
+            attribute_body(*nested, call_site_sources, artifacts, node_sources);
+        }
+    }
+
+    // The driving input's upstream node name for a combine, if the
+    // planner picked one (combines that fail driver selection are absent).
+    let combine_driver_upstream = |combine_name: &str| -> Option<String> {
+        let qualifier = artifacts.combine_driving.get(combine_name)?;
+        let inputs = artifacts.combine_inputs.get(combine_name)?;
+        inputs
+            .get(qualifier)
+            .map(|ci| ci.upstream_name.as_ref().to_string())
+    };
+
+    // Union of the source sets feeding the named producers, resolved
+    // against the sets recorded for already-walked nodes.
+    let union_of = |producers: &[&str],
+                    sources: &HashMap<String, std::collections::BTreeSet<String>>|
+     -> std::collections::BTreeSet<String> {
+        producers
+            .iter()
+            .filter_map(|inp| sources.get(*inp))
+            .flat_map(|s| s.iter().cloned())
+            .collect()
+    };
+
+    for spanned in nodes {
+        let name = spanned.value.name().to_string();
+        let sources: std::collections::BTreeSet<String> = match &spanned.value {
+            PipelineNode::Source { .. } => std::iter::once(name.clone()).collect(),
+            // A joined record carries only the driving input's document
+            // context, so a Combine takes the driving input's source set —
+            // not the union of every input. Falls back to the input union
+            // when the planner could not pick a driver (the combine is then
+            // omitted from the DAG, so the set is unused either way).
+            PipelineNode::Combine { .. } => combine_driver_upstream(&name)
+                .and_then(|driver| node_sources.get(&driver).cloned())
+                .unwrap_or_else(|| union_of(&spanned.value.direct_input_names(), &node_sources)),
+            // Every other non-Source variant inherits the union of its
+            // direct inputs' source sets.
+            other => union_of(&other.direct_input_names(), &node_sources),
+        };
+
+        // A composition's body nodes feed from the call-site `inputs:`
+        // port bindings — union every bound port's source set so a body
+        // `$doc` access is attributed to whichever input could supply its
+        // envelope. The port bindings are the authoritative call-site
+        // connectivity (`header.input` adds nothing beyond them).
+        if let PipelineNode::Composition { inputs, .. } = &spanned.value {
+            let call_site_sources: std::collections::BTreeSet<String> = inputs
+                .values()
+                .map(|upstream| upstream.split('.').next().unwrap_or(upstream))
+                .filter_map(|producer| node_sources.get(producer))
+                .flat_map(|s| s.iter().cloned())
+                .collect();
+            if let Some(&body_id) = artifacts.composition_body_assignments.get(&name) {
+                attribute_body(body_id, &call_site_sources, artifacts, &mut node_sources);
+            }
+        }
+
+        node_sources.insert(name, sources);
+    }
+
+    node_sources
+}
+
 /// Cross-cutting inputs threaded into [`lower_node_to_plan_node`] for
 /// variants that need derived fields (Transform, Aggregate).
 ///
@@ -1967,16 +2112,38 @@ fn resolve_all_input_references(
 /// it requires the post-graph upstream `NodeIndex` for node-rooted
 /// windows. The Stage-5 lowering pass mutates the field in place
 /// after edges are wired and indices are deduplicated.
-#[derive(Default)]
 pub(crate) struct LoweringCtx<'a> {
     pub analysis: Option<&'a cxl::analyzer::TransformAnalysis>,
     pub window_config: Option<&'a AnalyticWindowSpec>,
     pub primary_source: &'a str,
-    /// `$doc` envelope paths collected across the pipeline's programs,
-    /// surfaced onto each lowered `Source` node's `SourceConfig`. Empty
-    /// for the body-node lowering path (`LoweringCtx::default()`) — only
-    /// the top-level compile path collects and threads these.
-    pub declared_doc_paths: &'a [cxl::analyzer::doc_paths::DocPath],
+    /// `$doc` envelope paths each source must extract, keyed by source
+    /// name. A path lands here only for the source(s) feeding a node that
+    /// references it — never the pipeline-wide union — so a multi-source
+    /// run does not tell a source to extract another source's envelope
+    /// sections. A source absent from the map (or mapped to an empty
+    /// vec) reads no `$doc` paths. Empty for the body-node lowering path
+    /// (`LoweringCtx::default()`) — only the top-level compile path
+    /// collects and threads these.
+    pub doc_paths_by_source: &'a HashMap<String, Vec<cxl::analyzer::doc_paths::DocPath>>,
+}
+
+/// Empty per-source `$doc` map backing [`LoweringCtx::default`] — the
+/// body-node lowering path carries no document-path attribution (the
+/// top-level compile path is the only collector), so its borrow points
+/// here rather than at a freshly-allocated map per call.
+static EMPTY_DOC_PATHS_BY_SOURCE: std::sync::LazyLock<
+    HashMap<String, Vec<cxl::analyzer::doc_paths::DocPath>>,
+> = std::sync::LazyLock::new(HashMap::new);
+
+impl Default for LoweringCtx<'_> {
+    fn default() -> Self {
+        LoweringCtx {
+            analysis: None,
+            window_config: None,
+            primary_source: "",
+            doc_paths_by_source: &EMPTY_DOC_PATHS_BY_SOURCE,
+        }
+    }
 }
 
 /// Lower a single `PipelineNode` into its `PlanNode` counterpart.
@@ -2060,13 +2227,17 @@ pub(crate) fn lower_node_to_plan_node(
     match node {
         PipelineNode::Source { config, .. } => {
             let mut source = config.source.clone();
-            // Stamp the pipeline-wide `$doc` path set onto this source so
-            // a document reader can learn the declared path set before
-            // reading input. A `$doc` access carries no source qualifier,
-            // so the whole set is attached to every source; single-source
-            // document pipelines (the common case) thus see exactly their
-            // own paths.
-            source.declared_doc_paths = ctx.declared_doc_paths.to_vec();
+            // Stamp only THIS source's `$doc` path set so a document
+            // reader can learn the declared path set before reading input.
+            // The set is attributed per source upstream — each path lands
+            // on exactly the source(s) feeding a node that references it,
+            // so a multi-source run never asks a source to extract another
+            // source's envelope sections.
+            source.declared_doc_paths = ctx
+                .doc_paths_by_source
+                .get(name)
+                .cloned()
+                .unwrap_or_default();
             Some(PlanNode::Source {
                 name: name.to_string(),
                 span,

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -70,13 +70,16 @@ pub struct SourceConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub envelope: Option<clinker_format::EnvelopeConfig>,
 
-    /// `$doc.<section>.<field>` envelope paths the pipeline's CXL
-    /// programs actually reference, collected at compile time by
-    /// `cxl::analyzer::doc_paths`. Empty for sources whose downstream
-    /// programs read no `$doc` paths. Document readers consult this set
-    /// to skip extracting declared sections no program consumes. Derived
-    /// by the planner — never author-written — so it is excluded from
-    /// serialized config.
+    /// `$doc.<section>.<field>` envelope paths a program downstream of
+    /// THIS source actually references, collected at compile time by
+    /// `cxl::analyzer::doc_paths` and attributed per source: a path lands
+    /// here only when a node feeding from this source reads it, never the
+    /// pipeline-wide union, so a multi-source run is not told to extract
+    /// another source's envelope sections. Empty for sources whose
+    /// downstream programs read no `$doc` paths. Document readers consult
+    /// this set to skip extracting declared sections no program consumes.
+    /// Derived by the planner — never author-written — so it is excluded
+    /// from serialized config.
     #[serde(skip)]
     pub declared_doc_paths: Vec<cxl::analyzer::doc_paths::DocPath>,
 

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1174,6 +1174,14 @@ fn bind_schema_inner(
     // aggregate guard (E156) below. A node's set is the union of its
     // input nodes' sets, so the check at an Aggregate sees every Source
     // that can deliver records to it through any path.
+    //
+    // `crate::config::pipeline::build_node_source_sets` is a parallel
+    // source-attribution walk over the same DAG, sharing this walk's shape
+    // (Source-seeds-self, declaration-order topo order, union of inputs).
+    // It intentionally diverges where document context — not mere
+    // reachability — matters: it narrows a `Combine` to its driving input
+    // and resolves a `Composition` through its full `inputs:` port set.
+    // Keep the shared shape in sync across both when either changes.
     let mut source_has_watermark: HashMap<String, bool> = HashMap::new();
     let mut upstream_sources: HashMap<String, HashSet<String>> = HashMap::new();
 

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -1,10 +1,12 @@
 //! End-to-end surfacing of the compile-time `$doc` path set.
 //!
 //! `cxl::analyzer::doc_paths` collects every `$doc.<section>.<field>` the
-//! pipeline's programs reference; `PipelineConfig::compile` stamps that
-//! set onto each lowered `Source` node's `SourceConfig`. These tests pin
-//! the plan-build wiring: the path set reaches the Source, and a `$doc`
-//! access indexed by a non-literal aborts the compile with E340.
+//! pipeline's programs reference, attributed to the referencing node;
+//! `PipelineConfig::compile` traces each path back through the DAG to its
+//! source(s) and stamps only those sources' `SourceConfig`. These tests
+//! pin the plan-build wiring: each path reaches exactly the source(s)
+//! feeding it (never the pipeline-wide union), and a `$doc` access
+//! indexed by a non-literal aborts the compile with E340.
 
 use cxl::analyzer::doc_paths::{DocIndex, DocPath};
 
@@ -249,16 +251,124 @@ nodes:
         .compile(&CompileContext::default())
         .expect("compile combine-doc pipeline");
     let dag = plan.dag();
-    // Both sources carry the pipeline-wide set (the known
-    // over-attachment); assert the Combine-predicate path reached it.
-    let any_source_has_path = dag.graph.node_indices().any(|idx| {
-        matches!(&dag.graph[idx], PlanNode::Source { resolved: Some(r), .. }
-            if r.source.declared_doc_paths.contains(&path("Head", "cutoff", vec![])))
-    });
+    let head_cutoff = path("Head", "cutoff", vec![]);
+    // A joined record carries the DRIVING input's document context, so a
+    // `$doc` access in the Combine predicate is attributed to the driver
+    // source only. `left` is declared first (the planner's declaration-
+    // order driver default) and is the source whose envelope declares
+    // `Head`. The probe-side `right` source — which has no envelope —
+    // must NOT be told to extract it.
+    let paths_for = |source_name: &str| -> Vec<DocPath> {
+        dag.graph
+            .node_indices()
+            .find_map(|idx| match &dag.graph[idx] {
+                PlanNode::Source {
+                    name,
+                    resolved: Some(r),
+                    ..
+                } if name == source_name => Some(r.source.declared_doc_paths.clone()),
+                _ => None,
+            })
+            .unwrap_or_default()
+    };
     assert!(
-        any_source_has_path,
-        "`$doc.Head.cutoff` used in the Combine predicate must reach the declared set"
+        paths_for("left").contains(&head_cutoff),
+        "the driving source `left` must carry the Combine-predicate `$doc` path"
     );
+    assert!(
+        !paths_for("right").contains(&head_cutoff),
+        "the probe source `right` must NOT carry the driver's `$doc` path"
+    );
+}
+
+#[test]
+fn test_multi_source_paths_are_attributed_per_source() {
+    // Two independent single-source chains read disjoint `$doc` paths.
+    // Each source must carry ONLY the path its own downstream program
+    // reads — never the pipeline-wide union — so a multi-source run does
+    // not tell a source to extract another source's envelope section.
+    let yaml = r#"
+pipeline:
+  name: multi_source_doc
+nodes:
+  - type: source
+    name: alpha
+    config:
+      name: alpha
+      type: xml
+      glob: ./a/*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          AHead:
+            extract: { xml_path: "/doc/AHead" }
+            fields:
+              a_batch: string
+      schema:
+        - { name: amount, type: int }
+  - type: source
+    name: beta
+    config:
+      name: beta
+      type: xml
+      glob: ./b/*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          BHead:
+            extract: { xml_path: "/doc/BHead" }
+            fields:
+              b_batch: string
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: tag_alpha
+    input: alpha
+    config:
+      cxl: |
+        emit amount = amount
+        emit a = $doc.AHead.a_batch
+  - type: transform
+    name: tag_beta
+    input: beta
+    config:
+      cxl: |
+        emit amount = amount
+        emit b = $doc.BHead.b_batch
+  - type: merge
+    name: merged
+    inputs: [tag_alpha, tag_beta]
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse multi-source pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile multi-source pipeline");
+    let dag = plan.dag();
+    let paths_for = |source_name: &str| -> Vec<DocPath> {
+        dag.graph
+            .node_indices()
+            .find_map(|idx| match &dag.graph[idx] {
+                PlanNode::Source {
+                    name,
+                    resolved: Some(r),
+                    ..
+                } if name == source_name => Some(r.source.declared_doc_paths.clone()),
+                _ => None,
+            })
+            .unwrap_or_default()
+    };
+    // `alpha` carries only its own section; `beta` only its own.
+    assert_eq!(paths_for("alpha"), vec![path("AHead", "a_batch", vec![])]);
+    assert_eq!(paths_for("beta"), vec![path("BHead", "b_batch", vec![])]);
 }
 
 #[test]

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -470,3 +470,136 @@ nodes:
         source.source.declared_doc_paths
     );
 }
+
+#[test]
+fn test_multi_port_composition_forwards_all_port_sources() {
+    // A composition with TWO bound input ports merges them and surfaces one
+    // output. A downstream node reading `$doc` off the composition output
+    // could see a record from EITHER port's source, so the path must be
+    // attributed to BOTH port sources — not just the primary `input:` port.
+    // The composition node forwards only `header.input` (the primary port)
+    // through the generic DAG-edge view, so this pins that the source
+    // attribution unions every `inputs:` port instead.
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    std::fs::write(
+        comp_dir.join("two_port.comp.yaml"),
+        r#"_compose:
+  name: two_port
+  inputs:
+    primary:
+      schema:
+        - { name: amount, type: int }
+    reference:
+      schema:
+        - { name: amount, type: int }
+  outputs:
+    out: merged
+  config_schema: {}
+
+nodes:
+  - type: merge
+    name: merged
+    inputs: [primary, reference]
+"#,
+    )
+    .expect("write comp");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    // Both sources declare the SAME envelope section so a `$doc.Shared.tag`
+    // read downstream of the merge typechecks regardless of which port's
+    // record is in hand.
+    let yaml = r#"
+pipeline:
+  name: multi_port_doc
+nodes:
+  - type: source
+    name: customers
+    config:
+      name: customers
+      type: xml
+      glob: ./c/*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Shared:
+            extract: { xml_path: "/doc/Shared" }
+            fields:
+              tag: string
+      schema:
+        - { name: amount, type: int }
+  - type: source
+    name: zip_lookup
+    config:
+      name: zip_lookup
+      type: xml
+      glob: ./z/*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Shared:
+            extract: { xml_path: "/doc/Shared" }
+            fields:
+              tag: string
+      schema:
+        - { name: amount, type: int }
+  - type: composition
+    name: combined
+    input: customers
+    use: ../compositions/two_port.comp.yaml
+    inputs:
+      primary: customers
+      reference: zip_lookup
+  - type: transform
+    name: tag
+    input: combined
+    config:
+      cxl: |
+        emit amount = amount
+        emit tag = $doc.Shared.tag
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse multi-port pipeline");
+    let ctx = crate::config::CompileContext::with_pipeline_dir(
+        workspace.path(),
+        std::path::PathBuf::from("pipelines"),
+    );
+    let compiled = config.compile(&ctx).expect("compile multi-port pipeline");
+    let dag = compiled.dag();
+    let paths_for = |source_name: &str| -> Vec<DocPath> {
+        dag.graph
+            .node_indices()
+            .find_map(|idx| match &dag.graph[idx] {
+                PlanNode::Source {
+                    name,
+                    resolved: Some(r),
+                    ..
+                } if name == source_name => Some(r.source.declared_doc_paths.clone()),
+                _ => None,
+            })
+            .unwrap_or_default()
+    };
+    let shared_tag = path("Shared", "tag", vec![]);
+    // The downstream `$doc` read must reach BOTH the primary (`customers`)
+    // and the non-primary (`zip_lookup`) port sources.
+    assert!(
+        paths_for("customers").contains(&shared_tag),
+        "primary port source `customers` must carry the downstream `$doc` path"
+    );
+    assert!(
+        paths_for("zip_lookup").contains(&shared_tag),
+        "non-primary port source `zip_lookup` must carry the downstream `$doc` path, got {:?}",
+        paths_for("zip_lookup")
+    );
+}

--- a/crates/cxl/src/analyzer/doc_paths.rs
+++ b/crates/cxl/src/analyzer/doc_paths.rs
@@ -1,12 +1,19 @@
 //! Compile-time `$doc` path analysis.
 //!
-//! Walks the typed AST of every CXL-bearing node and collects the set of
+//! Walks the typed AST of every CXL-bearing node and collects the
 //! `$doc.<section>.<field>` envelope paths the pipeline's programs
 //! actually reference, including trailing index accesses
-//! (`$doc.section.items[0]`). Document readers consult this set to learn,
-//! before reading any input, which declared envelope paths a run will
-//! consume — a declared section the programs never read need not be
-//! extracted.
+//! (`$doc.section.items[0]`), attributing each path to the node(s) that
+//! reference it. Document readers consult this set to learn, before
+//! reading any input, which declared envelope paths a run will consume —
+//! a declared section the programs never read need not be extracted.
+//!
+//! Attribution stops at the referencing node because a `$doc` access
+//! carries no source qualifier; the planner traces each node back through
+//! the DAG to its source(s) and stamps only those. A multi-source run
+//! must not tell every source to extract the pipeline-wide union, or a
+//! source would attempt to extract sections its own document never
+//! declares.
 //!
 //! A `$doc` access is statically resolvable iff its section, field, and
 //! every trailing index are literals. The CXL grammar guarantees the
@@ -17,7 +24,7 @@
 //! carrying the offending index span; the declared-path set cannot name a
 //! row-dependent element.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -56,13 +63,23 @@ pub struct DocPath {
 }
 
 /// The result of [`collect_doc_paths`]: every statically-resolved `$doc`
-/// path the programs reference, deduplicated and deterministically
-/// ordered, plus a fail-fast diagnostic for each `$doc` access that could
-/// not be statically resolved.
+/// path the programs reference, attributed to the node(s) that reference
+/// it, plus a fail-fast diagnostic for each `$doc` access that could not
+/// be statically resolved.
+///
+/// A `$doc` access carries no source qualifier, so attribution stops at
+/// the referencing node: the planner traces each node back through the
+/// DAG to the source(s) feeding it and stamps only those sources with the
+/// path. Stamping every source with the pipeline-wide union would tell a
+/// multi-source run to extract envelope sections a given source's own
+/// document never declares.
 #[derive(Debug, Clone, Default)]
 pub struct DocPathSet {
-    /// Deduplicated, sorted declared paths.
-    pub paths: Vec<DocPath>,
+    /// Each statically-resolved path mapped to the set of node names whose
+    /// program references it. The outer `BTreeMap` keys (paths) and inner
+    /// `BTreeSet` values (node names) are both ordered, so iteration is
+    /// deterministic independent of program walk order.
+    pub by_node: BTreeMap<DocPath, BTreeSet<String>>,
     /// One entry per `$doc` access whose index is not a literal. The
     /// `String` is the name of the program's node so the caller can anchor
     /// a plan-level diagnostic at that node; the [`TypeDiagnostic`] carries
@@ -70,13 +87,22 @@ pub struct DocPathSet {
     pub unresolvable: Vec<(String, TypeDiagnostic)>,
 }
 
-/// Collect the `$doc` path set referenced across a set of typed programs.
+impl DocPathSet {
+    /// The deduplicated, sorted set of every resolved path across all
+    /// nodes, discarding per-node attribution. Useful for callers that
+    /// only need the pipeline-wide path list (diagnostics, display).
+    pub fn all_paths(&self) -> Vec<DocPath> {
+        self.by_node.keys().cloned().collect()
+    }
+}
+
+/// Collect the `$doc` path set referenced across a set of typed programs,
+/// attributing each resolved path to the node(s) that reference it.
 ///
-/// Each tuple is `(node_name, typed_program)`; the node name is unused
-/// today but kept to mirror [`super::analyze_all`]'s signature and to let
-/// a future caller attribute a path to its referencing node. Paths are
-/// deduplicated across all programs and returned in sorted order;
-/// unresolvable-index diagnostics are accumulated in walk order.
+/// Each tuple is `(node_name, typed_program)`. A path referenced by
+/// multiple nodes is attributed to each of them, so the planner can union
+/// the source sets of every referencing node when stamping a source.
+/// Unresolvable-index diagnostics are accumulated in walk order.
 pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
     let mut collector = DocPathCollector::default();
     for (name, typed) in programs {
@@ -86,7 +112,7 @@ pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
         }
     }
     DocPathSet {
-        paths: collector.paths.into_iter().collect(),
+        by_node: collector.by_node,
         unresolvable: collector.unresolvable,
     }
 }
@@ -104,11 +130,22 @@ pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
 /// still collected.
 #[derive(Default)]
 struct DocPathCollector<'a> {
-    /// Name of the program currently being walked, so an unresolvable-index
-    /// diagnostic can be attributed to its node.
+    /// Name of the program currently being walked, so each collected path
+    /// — and each unresolvable-index diagnostic — is attributed to its
+    /// node.
     node_name: &'a str,
-    paths: BTreeSet<DocPath>,
+    by_node: BTreeMap<DocPath, BTreeSet<String>>,
     unresolvable: Vec<(String, TypeDiagnostic)>,
+}
+
+impl DocPathCollector<'_> {
+    /// Record a resolved path against the node currently being walked.
+    fn record(&mut self, path: DocPath) {
+        self.by_node
+            .entry(path)
+            .or_default()
+            .insert(self.node_name.to_string());
+    }
 }
 
 impl Visitor for DocPathCollector<'_> {
@@ -122,16 +159,14 @@ impl Visitor for DocPathCollector<'_> {
             && let Some(classified) = classify_doc_index_chain(expr)
         {
             match classified {
-                Ok(path) => {
-                    self.paths.insert(path);
-                }
+                Ok(path) => self.record(path),
                 Err(diag) => self.unresolvable.push((self.node_name.to_string(), diag)),
             }
             return;
         }
 
         if let Expr::DocAccess { section, field, .. } = expr {
-            self.paths.insert(DocPath {
+            self.record(DocPath {
                 section: section.clone(),
                 field: field.clone(),
                 indices: Vec::new(),
@@ -276,6 +311,14 @@ mod tests {
         collect_doc_paths(&[("t", &typed)])
     }
 
+    /// Sorted node names a path was attributed to.
+    fn attributed_to(set: &DocPathSet, p: &DocPath) -> Vec<String> {
+        set.by_node
+            .get(p)
+            .map(|nodes| nodes.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
     fn path(section: &str, field: &str, indices: Vec<DocIndex>) -> DocPath {
         DocPath {
             section: section.into(),
@@ -288,7 +331,10 @@ mod tests {
     fn test_collects_plain_two_level_path() {
         let set = collect("emit batch = $doc.Head.batch_id");
         assert!(set.unresolvable.is_empty());
-        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+        let p = path("Head", "batch_id", vec![]);
+        assert_eq!(set.all_paths(), vec![p.clone()]);
+        // The path is attributed to the single program's node.
+        assert_eq!(attributed_to(&set, &p), vec!["t".to_string()]);
     }
 
     #[test]
@@ -298,9 +344,9 @@ mod tests {
              emit b = $doc.Head.batch_id",
         );
         assert!(set.unresolvable.is_empty());
-        // BTreeSet ordering is by (section, field): Foot precedes Head.
+        // BTreeMap ordering is by (section, field): Foot precedes Head.
         assert_eq!(
-            set.paths,
+            set.all_paths(),
             vec![
                 path("Foot", "record_count", vec![]),
                 path("Head", "batch_id", vec![]),
@@ -314,7 +360,7 @@ mod tests {
             "emit a = $doc.Head.batch_id\n\
              emit b = $doc.Head.batch_id + 1",
         );
-        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+        assert_eq!(set.all_paths(), vec![path("Head", "batch_id", vec![])]);
     }
 
     #[test]
@@ -322,7 +368,7 @@ mod tests {
         let set = collect("emit first = $doc.summary.items[0]");
         assert!(set.unresolvable.is_empty());
         assert_eq!(
-            set.paths,
+            set.all_paths(),
             vec![path("summary", "items", vec![DocIndex::Int(0)])]
         );
     }
@@ -332,7 +378,7 @@ mod tests {
         let set = collect("emit run = $doc.meta.props[\"run_date\"]");
         assert!(set.unresolvable.is_empty());
         assert_eq!(
-            set.paths,
+            set.all_paths(),
             vec![path(
                 "meta",
                 "props",
@@ -346,7 +392,7 @@ mod tests {
         let set = collect("emit deep = $doc.summary.rows[2][\"k\"]");
         assert!(set.unresolvable.is_empty());
         assert_eq!(
-            set.paths,
+            set.all_paths(),
             vec![path(
                 "summary",
                 "rows",
@@ -361,7 +407,7 @@ mod tests {
         // Conditional-only usage must still be collected.
         let set = collect("emit v = if region == \"x\" then $doc.Head.batch_id else 0");
         assert!(set.unresolvable.is_empty());
-        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+        assert_eq!(set.all_paths(), vec![path("Head", "batch_id", vec![])]);
     }
 
     #[test]
@@ -373,7 +419,7 @@ mod tests {
              }",
         );
         assert!(set.unresolvable.is_empty());
-        assert_eq!(set.paths, vec![path("Foot", "record_count", vec![])]);
+        assert_eq!(set.all_paths(), vec![path("Foot", "record_count", vec![])]);
     }
 
     #[test]
@@ -381,7 +427,7 @@ mod tests {
         // `$doc` appears as the index of an unrelated array access.
         let set = collect("emit v = region[$doc.Head.offset]");
         assert!(set.unresolvable.is_empty());
-        assert_eq!(set.paths, vec![path("Head", "offset", vec![])]);
+        assert_eq!(set.all_paths(), vec![path("Head", "offset", vec![])]);
     }
 
     #[test]
@@ -391,7 +437,7 @@ mod tests {
         let src = "emit v = $doc.summary.items[idx]";
         let set = collect(src);
         assert!(
-            set.paths.is_empty(),
+            set.by_node.is_empty(),
             "no path is recorded for an unresolvable access"
         );
         assert_eq!(set.unresolvable.len(), 1);
@@ -417,7 +463,7 @@ mod tests {
             "a negated integer literal is a static index"
         );
         assert_eq!(
-            set.paths,
+            set.all_paths(),
             vec![path("summary", "items", vec![DocIndex::Int(-1)])]
         );
     }
@@ -447,14 +493,47 @@ mod tests {
             "emit a = $doc.Head.batch_id\n\
              emit b = $doc.summary.items[region]",
         );
-        assert_eq!(set.paths, vec![path("Head", "batch_id", vec![])]);
+        assert_eq!(set.all_paths(), vec![path("Head", "batch_id", vec![])]);
         assert_eq!(set.unresolvable.len(), 1);
     }
 
     #[test]
     fn test_no_doc_access_yields_empty_set() {
         let set = collect("emit v = amount + 1");
-        assert!(set.paths.is_empty());
+        assert!(set.by_node.is_empty());
         assert!(set.unresolvable.is_empty());
+    }
+
+    #[test]
+    fn test_attributes_each_path_to_its_referencing_node() {
+        // Two programs read disjoint `$doc` paths. Each path must be
+        // attributed to ONLY the node that references it — the foundation
+        // for stamping each source with just its own paths rather than the
+        // pipeline-wide union.
+        let a = compile("emit x = $doc.Head.batch_id");
+        let b = compile("emit y = $doc.Foot.record_count");
+        let set = collect_doc_paths(&[("node_a", &a), ("node_b", &b)]);
+
+        let head = path("Head", "batch_id", vec![]);
+        let foot = path("Foot", "record_count", vec![]);
+        assert_eq!(set.all_paths(), vec![foot.clone(), head.clone()]);
+        assert_eq!(attributed_to(&set, &head), vec!["node_a".to_string()]);
+        assert_eq!(attributed_to(&set, &foot), vec!["node_b".to_string()]);
+    }
+
+    #[test]
+    fn test_shared_path_is_attributed_to_every_referencing_node() {
+        // The same path read by two nodes is attributed to both, so the
+        // planner unions their source sets when stamping.
+        let a = compile("emit x = $doc.Head.batch_id");
+        let b = compile("emit y = $doc.Head.batch_id + 1");
+        let set = collect_doc_paths(&[("node_a", &a), ("node_b", &b)]);
+
+        let head = path("Head", "batch_id", vec![]);
+        assert_eq!(set.all_paths(), vec![head.clone()]);
+        assert_eq!(
+            attributed_to(&set, &head),
+            vec!["node_a".to_string(), "node_b".to_string()]
+        );
     }
 }

--- a/crates/cxl/src/analyzer/doc_paths.rs
+++ b/crates/cxl/src/analyzer/doc_paths.rs
@@ -87,11 +87,15 @@ pub struct DocPathSet {
     pub unresolvable: Vec<(String, TypeDiagnostic)>,
 }
 
+#[cfg(test)]
 impl DocPathSet {
     /// The deduplicated, sorted set of every resolved path across all
-    /// nodes, discarding per-node attribution. Useful for callers that
-    /// only need the pipeline-wide path list (diagnostics, display).
-    pub fn all_paths(&self) -> Vec<DocPath> {
+    /// nodes, discarding per-node attribution — a test convenience for
+    /// asserting against the flat path list. Production callers consume
+    /// the per-node attribution in `by_node` directly; a pipeline-wide
+    /// flat-list consumer (diagnostics / display) can promote this out of
+    /// the test gate when one lands.
+    fn all_paths(&self) -> Vec<DocPath> {
         self.by_node.keys().cloned().collect()
     }
 }


### PR DESCRIPTION
## Summary

The engine collected the union of every `$doc.<section>.<field>` path referenced anywhere in a pipeline and stamped that single pipeline-wide set onto **every** source. In a multi-source pipeline that over-attaches: a source would be told to extract document sections that are only referenced downstream of a *different* source. This attributes each collected path to the source(s) it actually flows from.

## What changed

- `$doc` path collection now returns per-node attribution (`DocPathSet.by_node`: path → the set of nodes that reference it) instead of a flat union, using the shared typed-AST visitor.
- A source-attribution pass walks each CXL-bearing node to its upstream source set (Source seeds itself; non-sources union their inputs; composition bodies recurse), then unions a path's referencing nodes' source sets and stamps each source with only its own paths.
  - A Combine attributes its `$doc` references to its **driving** input's source (a joined record carries the driver's document context).
  - A Composition forwards the union of **all** its bound input ports' sources (not just the primary `input:`), so a downstream `$doc` read after a multi-port composition reaches every contributing source.

## Tests

Multi-source attribution (each source gets only its own paths), composition-body paths attributing to the parent source, Combine driver-only attribution, and multi-port composition forwarding across all ports.

## Notes

A latent imprecision is documented and tracked (#467): the Combine attribution reads the bind-time driving input, which a runtime driver re-derived from row-count statistics could differ from. It is inert today (no reader consumes the per-source paths yet) and must be resolved before the first consumer lands. The two parallel source-attribution walks (this one and the watermark-guard walk) carry reciprocal cross-reference comments since they intentionally diverge.

Closes #432.