### PR TITLE
format: decode X12 element text per the declared character set (#412)

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -13,6 +13,7 @@ use clinker_format::json::reader::{
     ArrayPathMode, ArrayPathSpec, JsonMode, JsonReader, JsonReaderConfig,
 };
 use clinker_format::traits::FormatReader;
+use clinker_format::x12::Charset;
 use clinker_format::x12::reader::{X12Reader, X12ReaderConfig};
 use clinker_format::xml::reader::{
     NamespaceMode, XmlArrayMode, XmlArrayPath, XmlReader, XmlReaderConfig,
@@ -52,7 +53,7 @@ fn build_format_reader(
             Ok(Box::new(EdifactReader::new(reader, config)))
         }
         clinker_plan::config::InputFormat::X12(opts) => {
-            let config = build_x12_reader_config(opts.as_ref());
+            let config = build_x12_reader_config(opts.as_ref())?;
             Ok(Box::new(X12Reader::new(reader, config)))
         }
         clinker_plan::config::InputFormat::Hl7(opts) => {
@@ -809,14 +810,28 @@ fn build_edifact_reader_config(
 
 fn build_x12_reader_config(
     opts: Option<&clinker_plan::config::X12InputOptions>,
-) -> X12ReaderConfig {
+) -> Result<X12ReaderConfig, PipelineError> {
     let mut config = X12ReaderConfig::default();
-    if let Some(opts) = opts
-        && let Some(max) = opts.max_elements
-    {
-        config.max_elements = max;
+    if let Some(opts) = opts {
+        if let Some(max) = opts.max_elements {
+            config.max_elements = max;
+        }
+        if let Some(encoding) = opts.encoding.as_deref() {
+            config.charset = parse_x12_charset(encoding)?;
+        }
     }
-    config
+    Ok(config)
+}
+
+/// Resolve a source-declared X12 `encoding` name to a [`Charset`], mapping
+/// an unsupported value to a config-validation error so the run fails at
+/// startup with the name the user must fix.
+fn parse_x12_charset(encoding: &str) -> Result<Charset, PipelineError> {
+    Charset::from_name(encoding).map_err(|e| {
+        PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+            "X12 source: {e}"
+        )))
+    })
 }
 
 fn build_hl7_reader_config(

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -15,6 +15,7 @@ use clinker_format::hl7::writer::{Hl7Writer, Hl7WriterConfig};
 use clinker_format::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
 use clinker_format::splitting::{OversizeGroupPolicy, SplitPolicy, SplittingWriter, WriterFactory};
 use clinker_format::traits::FormatWriter;
+use clinker_format::x12::Charset;
 use clinker_format::x12::writer::{X12Writer, X12WriterConfig};
 use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
 use clinker_plan::config::{OutputConfig, OutputFormat};
@@ -129,17 +130,24 @@ fn build_edifact_writer_config(
 
 fn build_x12_writer_config(
     opts: Option<&clinker_plan::config::X12OutputOptions>,
-) -> X12WriterConfig {
+) -> Result<X12WriterConfig, clinker_format::FormatError> {
     // `segment_newline` defaults to `true` (readable per-segment lines).
     // The struct literal expresses it up front so an unset option falls
-    // through to the documented default.
-    X12WriterConfig {
+    // through to the documented default. An unset `encoding` defaults to
+    // UTF-8; a declared one is resolved here so a bad name fails at writer
+    // construction rather than mid-stream.
+    let charset = match opts.and_then(|o| o.encoding.as_deref()) {
+        Some(name) => Charset::from_name(name)?,
+        None => Charset::default(),
+    };
+    Ok(X12WriterConfig {
         interchange: opts.and_then(|o| o.interchange.clone()),
         interchange_from_doc: opts.and_then(|o| o.interchange_from_doc.clone()),
         group_header: opts.and_then(|o| o.group_header.clone()),
         set_type: opts.and_then(|o| o.set_type.clone()),
         segment_newline: opts.and_then(|o| o.segment_newline).unwrap_or(true),
-    }
+        charset,
+    })
 }
 
 fn build_hl7_writer_config(
@@ -280,12 +288,23 @@ fn build_writer_factory(
             })
         }
         OutputFormat::X12(opts) => {
+            // Resolve the writer config (including charset) once here so the
+            // factory only clones an already-validated config and a bad
+            // `encoding` name surfaces deterministically, before any output
+            // bytes. For a non-split sink the factory runs at executor setup,
+            // so the error is a startup failure; for a split sink the
+            // SplittingWriter lazy-opens the factory, so it surfaces when the
+            // first per-split writer is built (at the first record) — still
+            // pre-output and never a corrupt interchange, just not at setup.
             let x12_config = build_x12_writer_config(opts.as_ref());
             Box::new(move |counting_writer, schema| {
+                let config = x12_config
+                    .as_ref()
+                    .map_err(|e| clinker_format::FormatError::X12(e.to_string()))?;
                 Ok(Box::new(X12Writer::new(
                     counting_writer,
                     schema,
-                    x12_config.clone(),
+                    config.clone(),
                 )))
             })
         }

--- a/crates/clinker-exec/tests/x12_pipeline.rs
+++ b/crates/clinker-exec/tests/x12_pipeline.rs
@@ -47,6 +47,21 @@ fn run(
     file_name: &str,
     out_name: &str,
 ) -> Result<(clinker_exec::executor::ExecutionReport, String), String> {
+    let (report, bytes) = run_bytes(yaml, source_name, fixture.as_bytes(), file_name, out_name)?;
+    Ok((report, String::from_utf8_lossy(&bytes).into_owned()))
+}
+
+/// Drive a pipeline over a raw-byte fixture, returning the report and the
+/// raw output bytes. Used for non-UTF-8 (charset) interchanges whose body
+/// bytes are not valid UTF-8, so the output must be compared byte-for-byte
+/// rather than as a `String`.
+fn run_bytes(
+    yaml: &str,
+    source_name: &str,
+    fixture: &[u8],
+    file_name: &str,
+    out_name: &str,
+) -> Result<(clinker_exec::executor::ExecutionReport, Vec<u8>), String> {
     let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
     let plan = config
         .compile(&CompileContext::default())
@@ -54,7 +69,7 @@ fn run(
 
     let file = FileSlot::new(
         PathBuf::from(file_name),
-        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+        Box::new(Cursor::new(fixture.to_vec())),
     );
     let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
         source_name.to_string(),
@@ -77,7 +92,7 @@ fn run(
 
     let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
         .map_err(|e| format!("run: {e:?}"))?;
-    Ok((report, buf.as_string()))
+    Ok((report, buf.contents()))
 }
 
 #[test]
@@ -384,5 +399,155 @@ nodes:
     assert!(
         err.contains("SE segment count mismatch") || err.contains("X12"),
         "error should name the X12 count failure: {err}"
+    );
+}
+
+/// Build a Latin-1 interchange whose body carries high bytes (`0xE9` é,
+/// `0xF1` ñ) in a free-text `N1` element. The bytes are not valid UTF-8.
+fn latin1_interchange_bytes() -> Vec<u8> {
+    let mut data = Vec::new();
+    data.extend_from_slice(ISA.as_bytes());
+    data.extend_from_slice(b"GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~");
+    data.extend_from_slice(b"ST*850*0001~");
+    // N1*BT*Caf\xE9 A\xF1o~
+    data.extend_from_slice(b"N1*BT*Caf");
+    data.push(0xE9);
+    data.extend_from_slice(b" A");
+    data.push(0xF1);
+    data.extend_from_slice(b"o~");
+    data.extend_from_slice(b"SE*3*0001~");
+    data.extend_from_slice(b"GE*1*1~");
+    data.extend_from_slice(b"IEA*1*000000001~");
+    data
+}
+
+#[test]
+fn x12_latin1_source_round_trips_byte_faithfully() {
+    // A source declaring `encoding: iso-8859-1` decodes the high-byte body
+    // without error; an X12 sink declaring the same encoding re-emits the
+    // interchange with byte-identical output.
+    let yaml = r#"
+pipeline:
+  name: x12_latin1_round_trip
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      options:
+        encoding: iso-8859-1
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields:
+              e13: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: set_type, type: string }
+        - { name: e01, type: string }
+        - { name: e02, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: x12
+      path: out.x12
+      include_unmapped: true
+      options:
+        interchange_from_doc: interchange
+        group_header: ["PO", "SENDER", "RECEIVER", "20240101", "1200", "1", "X", "004010"]
+        segment_newline: false
+        encoding: iso-8859-1
+"#;
+    let input = latin1_interchange_bytes();
+    let (report, output) =
+        run_bytes(yaml, "interchange", &input, "po.x12", "out").expect("run latin1 round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+    assert_eq!(
+        output, input,
+        "Latin-1 interchange must round-trip byte-for-byte"
+    );
+}
+
+#[test]
+fn x12_latin1_body_rejected_under_default_utf8() {
+    // Without the `encoding` option the reader assumes UTF-8 and rejects the
+    // high-byte body with a precise error rather than corrupting it.
+    let yaml = r#"
+pipeline:
+  name: x12_latin1_utf8_reject
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = run_bytes(
+        yaml,
+        "interchange",
+        &latin1_interchange_bytes(),
+        "po.x12",
+        "out",
+    )
+    .expect_err("non-UTF-8 body must fail under the default charset");
+    assert!(
+        err.contains("not valid UTF-8") || err.contains("X12"),
+        "error should name the UTF-8 decode failure: {err}"
+    );
+}
+
+#[test]
+fn x12_unsupported_encoding_fails_at_startup() {
+    // A source declaring an encoding the reader does not support fails the
+    // run with a precise error naming the unsupported value.
+    let yaml = r#"
+pipeline:
+  name: x12_bad_encoding
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      options:
+        encoding: shift_jis
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = run_bytes(
+        yaml,
+        "interchange",
+        &latin1_interchange_bytes(),
+        "po.x12",
+        "out",
+    )
+    .expect_err("unsupported encoding must fail the run");
+    assert!(
+        err.contains("shift_jis") && err.contains("iso-8859-1"),
+        "error should name the unsupported charset and the supported set: {err}"
     );
 }

--- a/crates/clinker-format/src/x12/charset.rs
+++ b/crates/clinker-format/src/x12/charset.rs
@@ -1,0 +1,189 @@
+//! Character-set decoding for X12 element text.
+//!
+//! X12 interchanges carry a declared character repertoire (the "basic" and
+//! "extended" sets are ASCII subsets; real-world trading-partner agreements
+//! also push Latin-1 high bytes through free-text name/address fields).
+//! Unlike EDIFACT's `UNB` syntax identifier, X12 has no in-band element that
+//! names the body repertoire, so the encoding is declared on the source and
+//! defaults to UTF-8.
+//!
+//! Only single-byte repertoires whose byte↔codepoint mapping is total and
+//! round-trippable in pure Rust are supported, so a read→write→read cycle is
+//! byte-faithful for the configured charset. An unsupported or unconfigured
+//! non-UTF-8 repertoire fails explicitly rather than guessing or silently
+//! substituting replacement characters.
+
+use crate::error::FormatError;
+
+/// The character repertoire used to decode and encode X12 element text.
+///
+/// Decoding happens per element (no whole-interchange buffering), so the
+/// charset is consulted once per segment split rather than over the stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Charset {
+    /// UTF-8 (the default). Strict: invalid UTF-8 is an error, not a
+    /// lossy substitution, so a mis-declared encoding fails loudly.
+    #[default]
+    Utf8,
+    /// ISO-8859-1 (Latin-1). Each byte `0xNN` maps to codepoint `U+00NN`
+    /// across the whole `0x00..=0xFF` range, so decoding never fails and a
+    /// round-trip is byte-exact. Encoding rejects a character above
+    /// `U+00FF`, which Latin-1 cannot represent, rather than corrupting the
+    /// output.
+    Latin1,
+}
+
+impl Charset {
+    /// Resolve a source-declared encoding name to a [`Charset`],
+    /// case-insensitively, accepting the common aliases for each repertoire.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::X12`] naming the unsupported value and the
+    /// supported set when the name matches no known repertoire, so a
+    /// mis-configured source fails at decode time with actionable guidance
+    /// rather than guessing.
+    pub fn from_name(name: &str) -> Result<Self, FormatError> {
+        // Match on a normalized form so `UTF-8`, `utf8`, `ISO-8859-1`,
+        // `iso8859-1`, `Latin-1`, and `latin1` all resolve.
+        let normalized: String = name
+            .chars()
+            .filter(|c| !matches!(c, '-' | '_' | ' '))
+            .map(|c| c.to_ascii_lowercase())
+            .collect();
+        match normalized.as_str() {
+            "utf8" => Ok(Charset::Utf8),
+            "iso88591" | "latin1" | "l1" => Ok(Charset::Latin1),
+            _ => Err(FormatError::X12(format!(
+                "unsupported X12 character set {name:?}. Supported encodings are \
+                 \"utf-8\" (the default) and \"iso-8859-1\" (Latin-1)"
+            ))),
+        }
+    }
+
+    /// Decode raw element bytes to a `String` through this repertoire,
+    /// consuming the buffer so the UTF-8 path validates in place without a
+    /// copy (this runs once per segment on the hot path).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::X12`] when the bytes are not valid in the
+    /// repertoire — only possible for [`Charset::Utf8`], since Latin-1 maps
+    /// every byte. The message names the configured charset so a
+    /// mis-declared encoding is diagnosable.
+    pub fn decode(&self, bytes: Vec<u8>) -> Result<String, FormatError> {
+        match self {
+            Charset::Utf8 => String::from_utf8(bytes).map_err(|e| {
+                FormatError::X12(format!(
+                    "segment is not valid UTF-8: {e}. Declare the source's character \
+                     set (e.g. `encoding: iso-8859-1`) if the interchange uses a \
+                     non-UTF-8 repertoire"
+                ))
+            }),
+            // Latin-1: byte 0xNN is codepoint U+00NN, so every byte decodes.
+            Charset::Latin1 => Ok(bytes.into_iter().map(|b| b as char).collect()),
+        }
+    }
+
+    /// Encode element text to raw bytes through this repertoire.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::X12`] for [`Charset::Latin1`] when the text
+    /// carries a character above `U+00FF` that Latin-1 cannot represent, so
+    /// the writer fails explicitly rather than emitting a structurally
+    /// truncated value. UTF-8 encoding never fails.
+    pub fn encode(&self, text: &str) -> Result<Vec<u8>, FormatError> {
+        match self {
+            Charset::Utf8 => Ok(text.as_bytes().to_vec()),
+            Charset::Latin1 => text
+                .chars()
+                .map(|c| {
+                    u32::from(c).try_into().map_err(|_| {
+                        FormatError::X12(format!(
+                            "element text {text:?} contains character {c:?} (U+{:04X}), which \
+                             is outside ISO-8859-1 (Latin-1) and cannot be encoded; the \
+                             configured charset cannot represent it",
+                            u32::from(c)
+                        ))
+                    })
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_name_resolves_utf8_aliases() {
+        assert_eq!(Charset::from_name("utf-8").unwrap(), Charset::Utf8);
+        assert_eq!(Charset::from_name("UTF8").unwrap(), Charset::Utf8);
+        assert_eq!(Charset::from_name("utf8").unwrap(), Charset::Utf8);
+    }
+
+    #[test]
+    fn from_name_resolves_latin1_aliases() {
+        assert_eq!(Charset::from_name("iso-8859-1").unwrap(), Charset::Latin1);
+        assert_eq!(Charset::from_name("ISO8859-1").unwrap(), Charset::Latin1);
+        assert_eq!(Charset::from_name("latin-1").unwrap(), Charset::Latin1);
+        assert_eq!(Charset::from_name("Latin1").unwrap(), Charset::Latin1);
+    }
+
+    #[test]
+    fn from_name_rejects_unsupported_with_precise_error() {
+        let err = Charset::from_name("shift_jis").unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("shift_jis") && m.contains("iso-8859-1")),
+            "expected precise unsupported-charset error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn latin1_decodes_high_bytes_to_codepoints() {
+        // 0xE9 is é, 0xF1 is ñ in Latin-1.
+        let decoded = Charset::Latin1
+            .decode(vec![b'C', b'a', b'f', 0xE9])
+            .unwrap();
+        assert_eq!(decoded, "Café");
+        let decoded = Charset::Latin1.decode(vec![b'A', 0xF1, b'o']).unwrap();
+        assert_eq!(decoded, "Año");
+    }
+
+    #[test]
+    fn latin1_round_trip_is_byte_exact() {
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let decoded = Charset::Latin1.decode(bytes.clone()).unwrap();
+        let reencoded = Charset::Latin1.encode(&decoded).unwrap();
+        assert_eq!(reencoded, bytes, "Latin-1 round-trip must be byte-exact");
+    }
+
+    #[test]
+    fn utf8_rejects_invalid_bytes() {
+        // 0xE9 alone is not valid UTF-8.
+        let err = Charset::Utf8
+            .decode(vec![b'C', b'a', b'f', 0xE9])
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("not valid UTF-8")),
+            "expected UTF-8 decode error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn latin1_encode_rejects_out_of_range_char() {
+        // U+20AC (euro sign) is above U+00FF and cannot be Latin-1 encoded.
+        let err = Charset::Latin1.encode("price €5").unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("Latin-1") && m.contains("U+20AC")),
+            "expected out-of-range encode error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn utf8_encode_is_passthrough() {
+        assert_eq!(Charset::Utf8.encode("Café €").unwrap(), "Café €".as_bytes());
+    }
+}

--- a/crates/clinker-format/src/x12/mod.rs
+++ b/crates/clinker-format/src/x12/mod.rs
@@ -28,10 +28,12 @@
 //! (so `$doc` envelope sections over `ISA` cost O(ISA)); the body streams
 //! one segment at a time. The whole interchange is never buffered.
 
+mod charset;
 pub mod reader;
 mod tokenizer;
 pub mod writer;
 
+pub use charset::Charset;
 pub use reader::{X12Reader, X12ReaderConfig};
 pub use writer::{X12Writer, X12WriterConfig};
 

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -35,6 +35,7 @@ use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, coerce_sec
 use crate::error::FormatError;
 use crate::traits::FormatReader;
 use crate::x12::RAW_ELEMENTS_KEY;
+use crate::x12::charset::Charset;
 use crate::x12::tokenizer::{ParsedSegment, SegmentTokenizer, split_isa, split_segment};
 
 /// Default ceiling on the number of positional element columns the record
@@ -53,12 +54,18 @@ pub struct X12ReaderConfig {
     /// Number of positional `eNN` element columns on the record schema. A
     /// body segment with more data elements than this is rejected.
     pub max_elements: usize,
+    /// Character set used to decode element text. X12 carries no in-band
+    /// element naming the body repertoire, so it is declared on the source
+    /// and defaults to UTF-8; a non-UTF-8 interchange (e.g. Latin-1 high
+    /// bytes in free-text fields) declares the matching encoding.
+    pub charset: Charset,
 }
 
 impl Default for X12ReaderConfig {
     fn default() -> Self {
         Self {
             max_elements: DEFAULT_MAX_ELEMENTS,
+            charset: Charset::default(),
         }
     }
 }
@@ -123,7 +130,7 @@ impl<R: Read> X12Reader<R> {
     pub fn new(reader: R, config: X12ReaderConfig) -> Self {
         let schema = build_schema(config.max_elements);
         Self {
-            tokenizer: SegmentTokenizer::new(BufReader::new(reader)),
+            tokenizer: SegmentTokenizer::new(BufReader::new(reader), config.charset),
             schema,
             max_elements: config.max_elements,
             initialized: false,
@@ -149,7 +156,7 @@ impl<R: Read> X12Reader<R> {
 
         let header = self.tokenizer.read_isa_header()?;
         let delims = self.tokenizer.delimiters();
-        let parsed = split_isa(&header, &delims);
+        let parsed = split_isa(&header, &delims, self.tokenizer.charset())?;
         // ISA13 (the interchange control number) is element index 12. It
         // is located structurally — the 13th element of the split header —
         // not by absolute byte offset, so producer padding quirks do not
@@ -842,7 +849,10 @@ mod tests {
         );
         let mut r = X12Reader::new(
             Cursor::new(data.into_bytes()),
-            X12ReaderConfig { max_elements: 2 },
+            X12ReaderConfig {
+                max_elements: 2,
+                ..Default::default()
+            },
         );
         let err = loop {
             match r.next_record() {
@@ -997,5 +1007,125 @@ mod tests {
         let recs2 = collect(&out);
         assert_eq!(recs2.len(), 3);
         assert_eq!(recs2[2].get("seg_id"), Some(&Value::String("PO1".into())));
+    }
+
+    /// A minimal interchange whose body carries Latin-1 high bytes (`0xE9`
+    /// for é, `0xF1` for ñ) in a free-text element. The bytes are not valid
+    /// UTF-8, so the default reader rejects them; the Latin-1 reader decodes
+    /// them to the matching codepoints.
+    fn latin1_interchange() -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(ISA.as_bytes());
+        data.extend_from_slice(b"GS*PO*S*R*20240101*1200*1*X*004010~");
+        data.extend_from_slice(b"ST*850*0001~");
+        // N1*BT*Caf\xE9 A\xF1o~ — a free-text name with two Latin-1 high bytes.
+        data.extend_from_slice(b"N1*BT*Caf");
+        data.push(0xE9);
+        data.extend_from_slice(b" A");
+        data.push(0xF1);
+        data.extend_from_slice(b"o~");
+        data.extend_from_slice(b"SE*3*0001~");
+        data.extend_from_slice(b"GE*1*1~");
+        data.extend_from_slice(b"IEA*1*000000001~");
+        data
+    }
+
+    fn reader_bytes(data: Vec<u8>, charset: Charset) -> X12Reader<Cursor<Vec<u8>>> {
+        X12Reader::new(
+            Cursor::new(data),
+            X12ReaderConfig {
+                charset,
+                ..Default::default()
+            },
+        )
+    }
+
+    #[test]
+    fn latin1_body_high_bytes_decode_to_codepoints() {
+        let mut r = reader_bytes(latin1_interchange(), Charset::Latin1);
+        let recs: Vec<_> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        // ST and N1 are body records.
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("N1".into())));
+        // The free-text element decodes through Latin-1: 0xE9→é, 0xF1→ñ.
+        assert_eq!(recs[1].get("e02"), Some(&Value::String("Café Año".into())));
+    }
+
+    #[test]
+    fn latin1_body_rejected_under_default_utf8() {
+        let mut r = reader_bytes(latin1_interchange(), Charset::Utf8);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected a UTF-8 decode error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::X12(m) if m.contains("not valid UTF-8")));
+    }
+
+    /// The headline acceptance: a Latin-1 interchange read with the matching
+    /// charset and re-written with it produces byte-identical output, and
+    /// the re-read body matches.
+    #[test]
+    fn latin1_read_write_read_is_byte_faithful() {
+        use crate::traits::{FormatReader, FormatWriter};
+        use crate::x12::writer::{X12Writer, X12WriterConfig};
+
+        let input = latin1_interchange();
+
+        // Read with the Latin-1 charset.
+        let mut r = reader_bytes(input.clone(), Charset::Latin1);
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        let schema = r.schema().unwrap();
+
+        // Re-emit through a Latin-1 writer with the literal ISA/GS headers,
+        // matching the input fixture so the bytes line up exactly.
+        let out: Vec<u8> = {
+            let mut buf = Vec::new();
+            let mut w = X12Writer::new(
+                Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                X12WriterConfig {
+                    interchange: Some(
+                        split_isa(
+                            ISA.as_bytes(),
+                            &crate::x12::tokenizer::Delimiters {
+                                element: b'*',
+                                subelement: b':',
+                                terminator: b'~',
+                            },
+                            Charset::Latin1,
+                        )
+                        .unwrap()
+                        .elements,
+                    ),
+                    group_header: Some(
+                        ["PO", "S", "R", "20240101", "1200", "1", "X", "004010"]
+                            .iter()
+                            .map(|s| s.to_string())
+                            .collect(),
+                    ),
+                    segment_newline: false,
+                    charset: Charset::Latin1,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                w.write_record(rec).unwrap();
+            }
+            w.flush().unwrap();
+            buf
+        };
+
+        // The output bytes equal the input bytes, including the two Latin-1
+        // high bytes — the round-trip never passed through UTF-8.
+        assert_eq!(out, input, "Latin-1 round-trip must be byte-faithful");
+
+        // Re-read the emitted bytes under Latin-1: the body decodes the same.
+        let mut r2 = reader_bytes(out, Charset::Latin1);
+        let recs2: Vec<_> = std::iter::from_fn(|| r2.next_record().unwrap()).collect();
+        assert_eq!(recs2.len(), 2);
+        assert_eq!(recs2[1].get("e02"), Some(&Value::String("Café Año".into())));
     }
 }

--- a/crates/clinker-format/src/x12/tokenizer.rs
+++ b/crates/clinker-format/src/x12/tokenizer.rs
@@ -31,6 +31,7 @@ use crate::error::FormatError;
 use crate::segment_tokenizer::{
     SegmentFraming, TrailingSegment, read_raw_segment, skip_inter_segment_whitespace,
 };
+use crate::x12::charset::Charset;
 
 /// Hard ceiling on a single segment's raw byte length. A real X12 segment
 /// is well under a kilobyte; this cap exists only so a stream with no
@@ -75,21 +76,25 @@ pub(crate) struct Delimiters {
 
 /// Streaming X12 segment reader.
 ///
-/// Wraps a buffered source and yields one raw segment string at a time
+/// Wraps a buffered source and yields one decoded segment string at a time
 /// (terminator stripped, inter-segment CR/LF whitespace stripped). The
 /// delimiters are discovered once from the fixed 106-byte `ISA` header on
-/// the first read.
+/// the first read; element text is decoded through the configured
+/// [`Charset`] (the shared framing layer never inspects bytes, so the
+/// charset policy stays X12-local here).
 pub(crate) struct SegmentTokenizer<R: Read> {
     reader: R,
     delimiters: Delimiters,
+    charset: Charset,
     initialized: bool,
 }
 
 impl<R: BufRead> SegmentTokenizer<R> {
-    /// Build a tokenizer over a buffered source. Delimiter discovery is
-    /// deferred to the first [`Self::next_segment`] call so the `ISA`
-    /// header scan and the first segment read share one pass.
-    pub(crate) fn new(reader: R) -> Self {
+    /// Build a tokenizer over a buffered source decoding element text
+    /// through `charset`. Delimiter discovery is deferred to the first
+    /// [`Self::next_segment`] call so the `ISA` header scan and the first
+    /// segment read share one pass.
+    pub(crate) fn new(reader: R, charset: Charset) -> Self {
         Self {
             reader,
             // A placeholder until the ISA is read; never used because the
@@ -99,6 +104,7 @@ impl<R: BufRead> SegmentTokenizer<R> {
                 subelement: b':',
                 terminator: b'~',
             },
+            charset,
             initialized: false,
         }
     }
@@ -107,6 +113,11 @@ impl<R: BufRead> SegmentTokenizer<R> {
     /// resolved the `ISA` header.
     pub(crate) fn delimiters(&self) -> Delimiters {
         self.delimiters
+    }
+
+    /// The charset element text is decoded through.
+    pub(crate) fn charset(&self) -> Charset {
+        self.charset
     }
 
     /// Read and consume the fixed 106-byte `ISA` header, returning its raw
@@ -176,13 +187,20 @@ impl<R: BufRead> SegmentTokenizer<R> {
         }
     }
 
-    /// Read the next raw segment (terminator-delimited), or `None` at
-    /// clean end of stream.
+    /// Read the next segment (terminator-delimited) and decode it through
+    /// the configured [`Charset`], or `None` at clean end of stream.
     ///
     /// The terminator byte is consumed but not returned. X12 has no
     /// release/escape mechanism, so every terminator byte is a segment
     /// boundary. CR/LF between segments is dropped; CR/LF inside an
-    /// element is preserved.
+    /// element is preserved. The raw segment bytes are decoded once here
+    /// (the shared framing layer that read them never interprets bytes), so
+    /// a non-UTF-8 charset is honored without touching segment framing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::X12`] when the segment bytes are not valid in
+    /// the configured charset (only possible under [`Charset::Utf8`]).
     pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
         debug_assert!(
             self.initialized,
@@ -211,11 +229,7 @@ impl<R: BufRead> SegmentTokenizer<R> {
             None => return Ok(None),
         };
 
-        let text = String::from_utf8(raw).map_err(|e| {
-            FormatError::X12(format!(
-                "segment is not valid UTF-8: {e}. Non-UTF-8 charsets are not supported"
-            ))
-        })?;
+        let text = self.charset.decode(raw)?;
         Ok(Some(text))
     }
 }
@@ -264,14 +278,24 @@ pub(crate) fn split_segment(raw: &str, delims: &Delimiters) -> ParsedSegment {
 }
 
 /// Split the fixed `ISA` header bytes into the `ISA` tag plus its 16 data
-/// elements on the discovered element separator.
+/// elements on the discovered element separator, decoding the header text
+/// through `charset`.
 ///
 /// The header is split structurally (on the element separator), not by
 /// absolute byte offset, so a consumer reads `ISA13` (the interchange
 /// control number) as element index 12 regardless of any producer
 /// padding quirk — mirroring the rest of the parser's
 /// locate-by-structure discipline.
-pub(crate) fn split_isa(header: &[u8], delims: &Delimiters) -> ParsedSegment {
+///
+/// # Errors
+///
+/// Returns [`FormatError::X12`] when the header bytes are not valid in
+/// `charset` (only possible under [`Charset::Utf8`]).
+pub(crate) fn split_isa(
+    header: &[u8],
+    delims: &Delimiters,
+    charset: Charset,
+) -> Result<ParsedSegment, FormatError> {
     // The header's final byte is the segment terminator; trim it so the
     // last element (ISA16) is not contaminated by it.
     let body = if header.last() == Some(&delims.terminator) {
@@ -279,12 +303,13 @@ pub(crate) fn split_isa(header: &[u8], delims: &Delimiters) -> ParsedSegment {
     } else {
         header
     };
-    let text = String::from_utf8_lossy(body).into_owned();
-    split_segment(&text, delims)
+    let text = charset.decode(body.to_vec())?;
+    Ok(split_segment(&text, delims))
 }
 
 /// Reassemble interior `current` bytes into a `String`. The input is a
-/// UTF-8-validated segment slice, so this is lossless.
+/// slice of an already-decoded (valid UTF-8) segment string, split on the
+/// single-byte element separator, so this reconstruction is lossless.
 fn bytes_to_string(bytes: &[u8]) -> String {
     String::from_utf8_lossy(bytes).into_owned()
 }
@@ -306,7 +331,7 @@ mod tests {
     }
 
     fn tok(data: &[u8]) -> SegmentTokenizer<Cursor<Vec<u8>>> {
-        SegmentTokenizer::new(Cursor::new(data.to_vec()))
+        SegmentTokenizer::new(Cursor::new(data.to_vec()), Charset::Utf8)
     }
 
     #[test]
@@ -318,7 +343,7 @@ mod tests {
         assert_eq!(d.element, b'*');
         assert_eq!(d.subelement, b':');
         assert_eq!(d.terminator, b'~');
-        let parsed = split_isa(&header, &d);
+        let parsed = split_isa(&header, &d, t.charset()).unwrap();
         assert_eq!(parsed.tag, "ISA");
         assert_eq!(parsed.elements.len(), 16, "ISA carries 16 elements");
         // ISA13 (interchange control number) is element index 12.
@@ -362,6 +387,54 @@ mod tests {
         let parsed = split_segment(&seg, &t.delimiters());
         assert_eq!(parsed.tag, "REF");
         assert_eq!(parsed.elements, vec!["ZZ".to_string(), "A:B:C".to_string()]);
+    }
+
+    #[test]
+    fn latin1_high_byte_element_decoded() {
+        // A REF segment whose element carries the Latin-1 byte 0xE9 (é)
+        // decodes under the Latin-1 charset but would be rejected as
+        // invalid UTF-8 under the default.
+        let mut data = isa_header().into_bytes();
+        data.extend_from_slice(b"REF*ZZ*Caf");
+        data.push(0xE9);
+        data.push(b'~');
+        let mut t = SegmentTokenizer::new(Cursor::new(data), Charset::Latin1);
+        let _ = t.read_isa_header().unwrap();
+        let seg = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&seg, &t.delimiters());
+        assert_eq!(parsed.tag, "REF");
+        assert_eq!(parsed.elements, vec!["ZZ".to_string(), "Café".to_string()]);
+    }
+
+    #[test]
+    fn latin1_isa_decode_consistent_with_segments() {
+        // A Latin-1 tokenizer decodes both the ISA header and the body
+        // through the same repertoire; the ASCII control header is
+        // unaffected and the high-byte body element decodes.
+        let mut data = isa_header().into_bytes();
+        data.extend_from_slice(b"REF*N1*A");
+        data.push(0xF1);
+        data.push(b'o');
+        data.push(b'~');
+        let mut t = SegmentTokenizer::new(Cursor::new(data), Charset::Latin1);
+        let header = t.read_isa_header().unwrap();
+        let isa = split_isa(&header, &t.delimiters(), t.charset()).unwrap();
+        assert_eq!(isa.elements[12], "000000001");
+        let seg = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&seg, &t.delimiters());
+        assert_eq!(parsed.elements, vec!["N1".to_string(), "Año".to_string()]);
+    }
+
+    #[test]
+    fn high_byte_element_rejected_under_utf8() {
+        let mut data = isa_header().into_bytes();
+        data.extend_from_slice(b"REF*ZZ*Caf");
+        data.push(0xE9);
+        data.push(b'~');
+        let mut t = SegmentTokenizer::new(Cursor::new(data), Charset::Utf8);
+        let _ = t.read_isa_header().unwrap();
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::X12(m) if m.contains("not valid UTF-8")));
     }
 
     #[test]
@@ -422,7 +495,7 @@ mod tests {
         let data = format!("{}GS*PO*S*R*20240101*1200*1*X*004010~", isa_header());
         let inner = Cursor::new(data.into_bytes());
         let buffered = BufReader::with_capacity(16, inner);
-        let mut t = SegmentTokenizer::new(buffered);
+        let mut t = SegmentTokenizer::new(buffered, Charset::Utf8);
         let header = t.read_isa_header().unwrap();
         assert_eq!(header.len(), ISA_LEN);
         assert_eq!(t.delimiters().element, b'*');

--- a/crates/clinker-format/src/x12/writer.rs
+++ b/crates/clinker-format/src/x12/writer.rs
@@ -31,6 +31,7 @@ use clinker_record::{Record, Schema, Value};
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
 use crate::x12::RAW_ELEMENTS_KEY;
+use crate::x12::charset::Charset;
 use crate::x12::tokenizer::Delimiters;
 
 /// Default X12 service delimiters used when no `ISA` header dictates
@@ -70,6 +71,11 @@ pub struct X12WriterConfig {
     /// plain `Default` for this struct leaves it `false`, so a caller
     /// constructing the config directly sets it explicitly.
     pub segment_newline: bool,
+    /// Character set element text is encoded through. Defaults to UTF-8; set
+    /// to match the reader's charset so a non-UTF-8 interchange round-trips
+    /// byte-faithfully. A character the charset cannot represent is rejected
+    /// rather than emitted truncated.
+    pub charset: Charset,
 }
 
 /// Streaming X12 interchange writer.
@@ -428,9 +434,11 @@ impl<W: Write> X12Writer<W> {
             self.writer
                 .write_all(&[self.delims.element])
                 .map_err(FormatError::Io)?;
-            self.writer
-                .write_all(element.as_bytes())
-                .map_err(FormatError::Io)?;
+            // Encode element text through the configured charset so a
+            // non-UTF-8 interchange round-trips byte-faithfully; a character
+            // the charset cannot represent is rejected, not truncated.
+            let encoded = self.config.charset.encode(element)?;
+            self.writer.write_all(&encoded).map_err(FormatError::Io)?;
         }
         self.writer
             .write_all(&[self.delims.terminator])

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -247,6 +247,13 @@ pub struct X12OutputOptions {
     /// Defaults to `true`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_newline: Option<bool>,
+    /// Character set element text is encoded through. Defaults to UTF-8; set
+    /// to match the source's `encoding` so a non-UTF-8 interchange
+    /// round-trips byte-faithfully. Supported values are `utf-8` and
+    /// `iso-8859-1` (Latin-1); a character the charset cannot represent is
+    /// rejected rather than emitted truncated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
 }
 
 /// HL7 v2 output options.

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -568,6 +568,13 @@ pub struct X12InputOptions {
     /// with guidance rather than silently truncated. Defaults to 32.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_elements: Option<usize>,
+    /// Character set the interchange body is decoded through. X12 carries
+    /// no in-band element naming the body repertoire, so it is declared
+    /// here and defaults to UTF-8. Supported values are `utf-8` and
+    /// `iso-8859-1` (Latin-1); an unsupported value is rejected with a
+    /// precise error naming it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
 }
 
 /// HL7 v2 input options.

--- a/docs/src/pipeline/x12.md
+++ b/docs/src/pipeline/x12.md
@@ -85,11 +85,39 @@ nodes:
       glob: ./inbox/*.x12
       options:
         max_elements: 48      # widen the positional schema for exotic segments
+        encoding: iso-8859-1  # decode body element text as Latin-1
       schema:
         - { name: seg_id, type: string }
         - { name: set_ref, type: string }
         - { name: e01, type: string }
 ```
+
+## Character set
+
+X12 carries no in-band element that names the body character repertoire
+(unlike EDIFACT's `UNB` syntax identifier). Element text is therefore
+decoded through the charset the source declares in its `encoding` option,
+defaulting to UTF-8. The `ISA` header's control fields are ASCII, so the
+declared charset affects only the body element text.
+
+| `encoding` value                         | Repertoire                              |
+| ---------------------------------------- | --------------------------------------- |
+| `utf-8` (default)                        | UTF-8; invalid bytes are an error       |
+| `iso-8859-1` (aliases `latin-1`, `latin1`) | ISO-8859-1 (Latin-1), one byte per char |
+
+Decoding stays streaming and per-element — the interchange is never
+buffered whole. An interchange whose body carries Latin-1 high bytes (for
+example accented characters in free-text name or address fields) parses
+without error once the source declares `encoding: iso-8859-1`, and the
+decoded element text matches the source bytes under Latin-1.
+
+A source that omits the option and meets non-UTF-8 bytes fails explicitly
+("segment is not valid UTF-8") rather than corrupting the data silently; a
+source that declares an unsupported encoding fails at startup with a
+precise error naming the value. On output, set the same `encoding` on the
+X12 sink so the round-trip is byte-faithful; a character the chosen charset
+cannot represent (for example a non-Latin-1 codepoint under `iso-8859-1`)
+is rejected rather than emitted truncated.
 
 ## Envelope sections over the three tiers
 
@@ -182,6 +210,7 @@ Output options:
 | `group_header`          | Literal `GS01..GS08` elements (`GS06` control number recomputed).      |
 | `set_type`              | Fallback `ST01` set type when a record carries no `set_type` value.    |
 | `segment_newline`       | Write a newline after each segment terminator (default `true`).        |
+| `encoding`              | Character set element text is encoded through (default `utf-8`).        |
 
 Consecutive records are grouped into `ST..SE` transaction sets on `set_ref`
 transitions, and all sets are wrapped in a single `GS..GE` functional
@@ -201,8 +230,10 @@ have no source `ISA` section to echo.
 
 ## Limitations
 
-- **Charset.** Element text is decoded as UTF-8. Non-UTF-8 interchanges are
-  rejected explicitly rather than silently corrupted.
+- **Charset.** Element text is decoded through the source's `encoding`
+  option (UTF-8 by default, or ISO-8859-1). An unsupported or
+  unconfigured-but-non-UTF-8 repertoire is rejected explicitly rather than
+  silently corrupted (see [Character set](#character-set) above).
 - **No escape character.** X12 has no release mechanism, so a data value
   that contains a delimiter byte is rejected on output rather than
   corrupting the interchange.


### PR DESCRIPTION
## Summary

X12 element text was decoded as UTF-8 unconditionally. Real X12 interchanges are exchanged in a declared character repertoire (basic/extended), which is not UTF-8. This decodes element bytes per a configured character set on read and re-encodes on write.

- A new X12-local `Charset` (UTF-8 default, ISO-8859-1/Latin-1), hand-rolled in pure Rust — **no new dependency**. Latin-1 decode is total and lossless; encode rejects characters outside the repertoire with a precise error.
- The charset is threaded through the X12 tokenizer/reader/writer; the shared segment-framing layer is untouched. The default UTF-8 path stays zero-copy (validates the segment bytes in place).
- A source/sink `encoding` option selects the charset; an unsupported value fails at startup (non-split path) naming the offending encoding, rather than silently falling back or mangling text.

## Tests

Charset unit tests (full 0x00–0xFF Latin-1 round-trip, strict UTF-8 rejection, out-of-range encode rejection), reader/tokenizer Latin-1 round-trips, and end-to-end `x12_pipeline` integration tests (byte-faithful Latin-1 source round-trip, UTF-8 rejection, unsupported-encoding startup failure). `docs/src/pipeline/x12.md` documents the option and supported values.

Closes #412.