### PR TITLE
format: recombine a split EDIFACT UNB date/time before locating the control reference (#408)

### DIFF
--- a/crates/clinker-format/src/edifact/mod.rs
+++ b/crates/clinker-format/src/edifact/mod.rs
@@ -46,10 +46,12 @@ const UNB_LEADING_COMPOSITES: usize = 4;
 
 /// Wire index of the canonical S004 (date/time of preparation) slot in a
 /// `UNB` segment: the fourth and last of the mandatory leading
-/// composites, immediately ahead of the control reference. An empty
-/// element here is the structural marker that the date/time has been
-/// padded, which is what shifts the control reference past its canonical
-/// slot in a doubly-degenerate header (see [`unb_control_candidates`]).
+/// composites, immediately ahead of the control reference. Its content is
+/// the structural marker for the two header divergences that shift the
+/// control reference past its canonical slot: an empty element here marks
+/// the doubly-degenerate padded shape, and a bare date token here (with a
+/// bare time in the next slot) marks a split date/time (see
+/// [`unb_control_candidates`]).
 const UNB_S004_INDEX: usize = UNB_LEADING_COMPOSITES - 1;
 
 /// Locate the interchange control reference (UNB data element 0020) by
@@ -82,35 +84,99 @@ pub(crate) fn unb_control_reference(elements: &[String]) -> Option<&str> {
 /// reference (0020), in order of decreasing likelihood, so the reader can
 /// confirm which one the `UNZ` trailer echoes.
 ///
-/// The first candidate is the canonical one — the first non-empty element
-/// after the four mandatory leading composites. A second candidate exists
-/// only for the *doubly-degenerate* header that the first-non-empty rule
-/// cannot resolve on its own: when the S004 (date/time) slot is empty, a
-/// producer that also emits a date-only S004 places it where 0020 would
-/// normally sit, so the date occupies the canonical slot and the true
-/// control reference is the next non-empty element. This shape is
-/// byte-indistinguishable from a conformant header whose optional S005
-/// recipient reference is present, so position alone cannot choose
-/// between them — only the `UNZ` echo can. The reader therefore treats
-/// both as candidates and accepts whichever the trailer echoes,
-/// validating against the segment structure rather than guessing from the
-/// data shape of the candidate (which would risk misreading a reference
-/// that merely looks like a date).
+/// The reference is the first non-empty element after the leading
+/// composite group. Two producer divergences shift it past its canonical
+/// slot, and each is resolved before the first-non-empty rule runs:
+///
+/// - **Split S004 date/time.** A header that transmits S004 as two
+///   element-separated parts (a bare date, then a bare time) instead of
+///   the conformant single `date:time` composite pushes 0020 one slot
+///   later. [`s004_date_time_is_split`] recognises that shape
+///   deterministically, so the time part is consumed as part of the
+///   leading group rather than mistaken for the control reference — a
+///   single, unambiguous location, not an extra candidate.
+/// - **Empty padding ahead of a date-only S004.** A *doubly-degenerate*
+///   header that leaves the S004 slot empty and places a date-only S004
+///   where 0020 would sit is byte-indistinguishable from a conformant
+///   header whose optional S005 recipient reference is present. Position
+///   alone cannot choose between the date and the next element, and
+///   sniffing the candidate's data shape would risk misreading a
+///   reference that merely looks like a date, so both are offered as
+///   candidates and the `UNZ` echo disambiguates.
 ///
 /// At most two candidates are yielded: the canonical slot and the
-/// single-position shift the documented degeneracies can produce. An
+/// single-position shift the empty-padding degeneracy can produce. An
 /// echo matching neither is a genuine mismatch.
 fn unb_control_candidates(elements: &[String]) -> impl Iterator<Item = &str> {
+    // A split date/time consumes one extra leading element (the time
+    // part), so the reference sits one slot later. Recombining it shifts
+    // the whole leading group rather than offering an extra candidate,
+    // since the recombination is deterministic.
+    let leading = if s004_date_time_is_split(elements) {
+        UNB_LEADING_COMPOSITES + 1
+    } else {
+        UNB_LEADING_COMPOSITES
+    };
+    // An empty S004 slot marks the doubly-degenerate shape, where the
+    // canonical slot and the slot after it are both plausible and only the
+    // trailer can choose. A split date/time is mutually exclusive with it:
+    // the S004 slot then holds a bare date, not an empty pad.
     let s004_padded = elements.get(UNB_S004_INDEX).is_some_and(|e| e.is_empty());
     elements
         .iter()
-        .skip(UNB_LEADING_COMPOSITES)
+        .skip(leading)
         .map(String::as_str)
         .filter(|e| !e.is_empty())
         // The primary candidate is the first non-empty element after the
         // leading composites; the shifted candidate is the next one, and
         // only when the empty S004 slot marks the doubly-degenerate shape.
         .take(if s004_padded { 2 } else { 1 })
+}
+
+/// Whether the `UNB` S004 date/time of preparation is transmitted as two
+/// separate data elements — a bare date in the S004 slot, then a bare
+/// time in the next slot — rather than the conformant single composite
+/// element `date:time`.
+///
+/// The split pushes the interchange control reference one slot later, so
+/// recognising it is a prerequisite for counting element positions
+/// correctly. The rule is deterministic and content-grounded rather than
+/// a loose "looks like data" sniff: it fires only when the S004 slot holds
+/// a bare date token (all digits, `YYMMDD` or `CCYYMMDD`) carrying no
+/// component separator — so it is *not* already a `date:time` composite —
+/// and the immediately following slot holds a bare EDIFACT time token (all
+/// digits, `HHMM` or `HHMMSS`). A genuine control reference whose value
+/// happens to be all digits is not mistaken for a split time unless the
+/// S004 slot is itself a bare date of the matching width, and even then
+/// the `UNZ` echo check still rejects a trailer that contradicts the
+/// recombined header.
+fn s004_date_time_is_split(elements: &[String]) -> bool {
+    let Some(date) = elements.get(UNB_S004_INDEX) else {
+        return false;
+    };
+    // The bare-date-token test also excludes a conformant composite: a
+    // joined `date:time` carries a component separator, so it is neither
+    // all-digits nor of date-token width and never matches.
+    if !is_edifact_date_token(date) {
+        return false;
+    }
+    elements
+        .get(UNB_S004_INDEX + 1)
+        .is_some_and(|time| is_edifact_time_token(time))
+}
+
+/// Whether `s` is a bare EDIFACT date token: all ASCII digits and either
+/// six (`YYMMDD`) or eight (`CCYYMMDD`) characters wide, the two date
+/// forms the S004 date component takes.
+fn is_edifact_date_token(s: &str) -> bool {
+    matches!(s.len(), 6 | 8) && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Whether `s` is a bare EDIFACT time token: all ASCII digits and either
+/// four (`HHMM`) or six (`HHMMSS`) characters wide, the two time forms the
+/// S004 time component takes.
+fn is_edifact_time_token(s: &str) -> bool {
+    matches!(s.len(), 4 | 6) && s.bytes().all(|b| b.is_ascii_digit())
 }
 
 /// Whether a `UNZ` control-reference echo matches the control reference
@@ -133,4 +199,111 @@ pub(crate) fn unz_echo_matches_unb(unb_elements: &[String], unz_echo: &str) -> b
     // A header with no control-reference candidate has nothing for the
     // trailer to contradict, so the echo is vacuously valid.
     candidates.peek().is_none() || candidates.any(|c| c == unz_echo)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn els(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn conformant_header_locates_reference_at_canonical_slot() {
+        let e = els(&["UNOA:1", "SENDER", "RECEIVER", "240101:1200", "REF1"]);
+        assert_eq!(unb_control_reference(&e), Some("REF1"));
+        assert!(unz_echo_matches_unb(&e, "REF1"));
+        assert!(!unz_echo_matches_unb(&e, "1200"));
+    }
+
+    #[test]
+    fn empty_padding_shifts_reference_one_slot() {
+        // S004 is populated; an empty optional element sits ahead of the
+        // reference, shifting it to index 5.
+        let e = els(&["UNOA:1", "S", "R", "240101:1200", "", "REF1"]);
+        assert_eq!(unb_control_reference(&e), Some("REF1"));
+        assert!(unz_echo_matches_unb(&e, "REF1"));
+    }
+
+    #[test]
+    fn split_date_time_recombines_before_locating_reference() {
+        // S004 split across two elements (date, then time) pushes the true
+        // reference REF1 to index 5; the time part 1200 must not be taken
+        // as the control reference.
+        let e = els(&["UNOA:1", "SENDER", "RECEIVER", "240101", "1200", "REF1"]);
+        assert!(s004_date_time_is_split(&e));
+        assert_eq!(unb_control_reference(&e), Some("REF1"));
+        assert!(unz_echo_matches_unb(&e, "REF1"));
+        // A trailer echoing the time part is a genuine mismatch — the split
+        // recombination is deterministic, not a candidate-widening.
+        assert!(!unz_echo_matches_unb(&e, "1200"));
+    }
+
+    #[test]
+    fn split_date_time_with_eight_digit_date_and_six_digit_time() {
+        // CCYYMMDD date plus HHMMSS time — the wider S004 forms still split.
+        let e = els(&["UNOA:1", "S", "R", "20240101", "120000", "REF1"]);
+        assert!(s004_date_time_is_split(&e));
+        assert_eq!(unb_control_reference(&e), Some("REF1"));
+    }
+
+    #[test]
+    fn conformant_joined_date_time_is_not_treated_as_split() {
+        // The composite carries a component separator, so it is already one
+        // element and nothing recombines.
+        let e = els(&["UNOA:1", "S", "R", "240101:1200", "REF1"]);
+        assert!(!s004_date_time_is_split(&e));
+        assert_eq!(unb_control_reference(&e), Some("REF1"));
+    }
+
+    #[test]
+    fn date_only_s004_without_a_following_time_is_not_a_split() {
+        // A bare date in S004 followed by a non-time reference is a
+        // date-only S004, not a split; the reference is the next element.
+        let e = els(&["UNOA:1", "S", "R", "240101", "REF1"]);
+        assert!(!s004_date_time_is_split(&e));
+        assert_eq!(unb_control_reference(&e), Some("REF1"));
+    }
+
+    #[test]
+    fn non_date_s004_followed_by_four_digit_reference_is_not_a_split() {
+        // A populated non-date S004 (already a conformant single date here
+        // would carry a colon; a genuinely odd S004 that is not a bare date
+        // token) must not trigger recombination even when the next element
+        // is four digits.
+        let e = els(&["UNOA:1", "S", "R", "240101:1200", "1234"]);
+        assert!(!s004_date_time_is_split(&e));
+        assert_eq!(unb_control_reference(&e), Some("1234"));
+    }
+
+    #[test]
+    fn doubly_degenerate_padded_header_is_not_misread_as_split() {
+        // Empty S004 pad plus a date-only S004 at the canonical slot: the
+        // empty-padding path owns this shape, not the split path. Both the
+        // date and the next element are candidates so the UNZ echo chooses.
+        let e = els(&["UNOA:1", "SENDER", "RECEIVER", "", "240101", "REF9"]);
+        assert!(!s004_date_time_is_split(&e));
+        assert!(unz_echo_matches_unb(&e, "REF9"));
+        assert!(unz_echo_matches_unb(&e, "240101"));
+        assert!(!unz_echo_matches_unb(&e, "WRONG"));
+    }
+
+    #[test]
+    fn date_token_widths_are_six_or_eight_digits_only() {
+        assert!(is_edifact_date_token("240101"));
+        assert!(is_edifact_date_token("20240101"));
+        assert!(!is_edifact_date_token("2401")); // too short
+        assert!(!is_edifact_date_token("2401011")); // odd width
+        assert!(!is_edifact_date_token("24010a")); // non-digit
+    }
+
+    #[test]
+    fn time_token_widths_are_four_or_six_digits_only() {
+        assert!(is_edifact_time_token("1200"));
+        assert!(is_edifact_time_token("120000"));
+        assert!(!is_edifact_time_token("12")); // too short
+        assert!(!is_edifact_time_token("12000")); // odd width
+        assert!(!is_edifact_time_token("12o0")); // non-digit
+    }
 }

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -653,6 +653,40 @@ mod tests {
     }
 
     #[test]
+    fn split_date_time_unb_locates_control_ref_past_the_time_part() {
+        // The UNB transmits S004 date/time as two separate elements
+        // (date "240101" at index 3, time "1200" at index 4) instead of
+        // the conformant single composite "240101:1200". That split pushes
+        // the true control reference "REF1" to index 5. Without
+        // recombining the date/time the locator would take the time "1200"
+        // as the reference and spuriously reject this internally consistent
+        // interchange (UNZ correctly echoes "REF1").
+        let data = "UNB+UNOA:1+SENDER+RECEIVER+240101+1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF1'";
+        let recs = collect(data);
+        assert_eq!(recs.len(), 2); // UNH, BGM — no spurious rejection
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("BGM".into())));
+    }
+
+    #[test]
+    fn split_date_time_unb_still_rejects_genuine_unz_mismatch() {
+        // The split-date/time recombination must not become a wildcard: a
+        // UNZ that echoes the time part "1200" instead of the true
+        // reference "REF1" is still a genuine mismatch.
+        let data = "UNB+UNOA:1+SENDER+RECEIVER+240101+1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+1200'";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected control ref mismatch for split date/time header"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("does not echo the UNB")));
+    }
+
+    #[test]
     fn doubly_degenerate_unb_still_rejects_genuine_unz_mismatch() {
         // The doubly-degenerate shape must not become a wildcard: a UNZ
         // that echoes neither the canonical-slot date "240101" nor the

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -712,6 +712,53 @@ mod tests {
     }
 
     #[test]
+    fn unz_echoes_control_ref_past_split_date_time() {
+        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use indexmap::IndexMap;
+
+        // A UNB whose S004 date/time is transmitted as two separate
+        // elements (date "240101" at index 3, time "1200" at index 4)
+        // rather than the conformant single "240101:1200" composite. The
+        // true control reference "REF1" sits at index 5. Reconstructing the
+        // header from the stashed element list must keep the split verbatim,
+        // and the UNZ echo must skip the time part to name the real
+        // reference so the output validates on re-read.
+        let s = schema();
+        let raw = RecVal::Array(vec![
+            RecVal::String("UNOA:1".into()),
+            RecVal::String("SENDER".into()),
+            RecVal::String("RECEIVER".into()),
+            RecVal::String("240101".into()),
+            RecVal::String("1200".into()),
+            RecVal::String("REF1".into()),
+        ]);
+        let mut unb: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        unb.insert(super::RAW_ELEMENTS_KEY.into(), raw);
+        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        sections.insert("unb".into(), RecVal::Map(Box::new(unb)));
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
+        record.set_doc_ctx(ctx);
+
+        let cfg = EdifactWriterConfig {
+            interchange_from_doc: Some("unb".into()),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let out = write_all(cfg, &[record], &s);
+        assert!(
+            out.starts_with("UNB+UNOA:1+SENDER+RECEIVER+240101+1200+REF1'"),
+            "split date/time UNB not reconstructed verbatim: {out}"
+        );
+        // UNZ echoes the real reference, not the time part "1200".
+        assert!(out.contains("UNZ+1+REF1'"), "{out}");
+    }
+
+    #[test]
     fn una_emitted_when_enabled() {
         let s = schema();
         let mut cfg = literal_config();

--- a/docs/src/pipeline/edifact.md
+++ b/docs/src/pipeline/edifact.md
@@ -255,3 +255,17 @@ have no source `UNB` section to echo.
   single empty-padding shapes re-emit with the correct reference; only
   this simultaneous double degeneracy carries the limitation, and it is
   rare in practice.
+- **Split date/time vs. a short numeric control reference.** The
+  deterministic split-recombination rule reads a bare date token (all
+  digits, six or eight wide) in the S004 slot followed by a bare time
+  token (all digits, four or six wide) as a split date/time, joining the
+  two into one slot before locating data element 0020. A header that
+  genuinely places a bare date-only S004 immediately ahead of a short
+  all-numeric control reference of exactly four or six digits is
+  byte-identical to that split, so the reference is mis-located as the
+  time component and the recombined date/time absorbs it. This is the
+  read-side counterpart of the deterministic tradeoff: position alone
+  cannot distinguish the two, and a content-shape sniff was rejected as
+  over-broad. The conformant single `date:time` composite, a date-only
+  S004 followed by a non-numeric or differently-sized reference, and an
+  empty (rather than date-only) S004 slot are all unaffected.

--- a/docs/src/pipeline/edifact.md
+++ b/docs/src/pipeline/edifact.md
@@ -149,6 +149,18 @@ the fifth position) therefore validates and round-trips correctly: the
 reader reads the real reference and the writer echoes the same one into
 `UNZ`, so the trailer never contradicts its own header.
 
+The S004 date/time of preparation is conformantly a single element with
+a date component and a time component joined by the component separator
+(`240101:1200`). Some producers transmit it as two element-separated
+parts instead — a bare date `240101`, then a bare time `1200` — which
+pushes the control reference one position later. The reader recombines
+that split into its logical S004 slot before locating data element 0020,
+recognising it deterministically: a bare date token (all digits, six or
+eight wide) carrying no component separator in the S004 position,
+followed by a bare time token (all digits, four or six wide). It then
+skips both as the single date/time slot, so the control reference is
+read from the correct position and the round-trip echoes it into `UNZ`.
+
 A header that is degenerate in two ways at once — an empty date/time
 slot *and* a date-only date/time element placed where the control
 reference would normally sit — leaves two equally-plausible positions
@@ -230,3 +242,16 @@ have no source `UNB` section to echo.
   cannot be divided across files. An `edifact` output combined with a
   `split:` block is rejected at config-validation time (diagnostic
   `E323`) rather than emitting a structurally corrupt interchange.
+- **Doubly-degenerate header on re-emit.** The reader resolves the
+  doubly-degenerate shape (an empty date/time slot plus a date-only
+  date/time at the canonical control-reference position) against the
+  `UNZ` echo, which is available only on read. The writer reconstructs
+  the header before the trailer is computed and has no echo to consult,
+  so it cannot tell the date-only date/time apart from the control
+  reference and echoes the first candidate (the date). A read → write
+  round-trip of such a header still validates on re-read — the emitted
+  `UNZ` matches one of the same plausible positions — but names the date
+  rather than the true reference in the trailer. The split date/time and
+  single empty-padding shapes re-emit with the correct reference; only
+  this simultaneous double degeneracy carries the limitation, and it is
+  rare in practice.


### PR DESCRIPTION
## Summary

A producer can split the UNB S004 date/time of preparation across two element-separated elements (a bare date, then a bare time) instead of one composite element. When that happens, the element-position count used to locate the interchange control reference (data element 0020) is off by one, so the wrong element is read as the control reference.

This detects the split deterministically — a bare 6/8-digit date token in the S004 slot immediately followed by a bare 4/6-digit time token — and recombines it into its logical S004 slot before locating the control reference, so the reference is counted correctly. It extends the existing candidate-location machinery rather than forking a second locator, and the split path is mutually exclusive with the empty-slot (doubly-degenerate) case so each keeps its own resolution. The fix is shared by reader and writer, so split interchanges round-trip self-consistently.

## Behavior & limits

All existing EDIFACT tests stay green; new unit + reader + writer tests cover the split read (no false control-reference mismatch), genuine-mismatch rejection, and byte-faithful writer reconstruction. The accepted, issue-sanctioned ambiguity (a date-only S004 followed by a short all-numeric control reference is byte-identical to a split, and is interpreted as a split) is documented on both the read and write sides in the EDIFACT limitations docs. The remaining doubly-degenerate *writer* residual (writer reconstructs before the trailer is known) is tracked in #472.

Closes #408.