### PR TITLE
format: opt-in HL7 v2 composite field splitting (#437)

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
 use clinker_format::edifact::reader::{EdifactReader, EdifactReaderConfig};
 use clinker_format::fixed_width::reader::{FixedWidthReader, FixedWidthReaderConfig};
+use clinker_format::hl7::Hl7FieldSplit;
 use clinker_format::hl7::reader::{Hl7Reader, Hl7ReaderConfig};
 use clinker_format::json::reader::{
     ArrayPathMode, ArrayPathSpec, JsonMode, JsonReader, JsonReaderConfig,
@@ -823,10 +824,27 @@ fn build_hl7_reader_config(
     opts: Option<&clinker_plan::config::Hl7InputOptions>,
 ) -> Hl7ReaderConfig {
     let mut config = Hl7ReaderConfig::default();
-    if let Some(opts) = opts
-        && let Some(max) = opts.max_fields
-    {
-        config.max_fields = max;
+    if let Some(opts) = opts {
+        if let Some(max) = opts.max_fields {
+            config.max_fields = max;
+        }
+        if let Some(splits) = &opts.split_fields {
+            // Config validation already rejected an unparseable `field` name,
+            // a position past `max_fields`, and a zero axis width, so a field
+            // that fails to parse here is dropped defensively rather than
+            // surfaced — the split simply contributes no columns.
+            config.split_fields = splits
+                .iter()
+                .filter_map(|s| {
+                    s.field_position().map(|field_index| Hl7FieldSplit {
+                        field_index,
+                        repetitions: s.repetitions,
+                        components: s.components,
+                        subcomponents: s.subcomponents,
+                    })
+                })
+                .collect();
+        }
     }
     config
 }

--- a/crates/clinker-exec/tests/hl7_pipeline.rs
+++ b/crates/clinker-exec/tests/hl7_pipeline.rs
@@ -6,7 +6,9 @@
 //! pipeline re-emits the MSH/body segments (escaping field data) and
 //! re-parses identically; (3) the `hl7`+`split` combination is rejected at
 //! config time (diagnostic `E339`); (4) a batch/file envelope surfaces
-//! file-level `$doc` fields and a BTS count mismatch fails the run.
+//! file-level `$doc` fields and a BTS count mismatch fails the run;
+//! (5) opt-in composite-field splitting exposes component columns to CXL and
+//! re-assembles them byte-identically on an HL7→HL7 round-trip.
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -369,5 +371,196 @@ nodes:
     assert!(
         err.contains("BTS batch message count mismatch") || err.contains("HL7"),
         "error should name the HL7 count failure: {err}"
+    );
+}
+
+#[test]
+fn hl7_split_fields_expose_component_columns_to_cxl() {
+    // Splitting MSH-9 (f08) into two components lets a Transform read the
+    // message code and trigger event without CXL string-splitting. PID-3
+    // (f03) splits into four components so the patient id and assigning
+    // authority surface separately.
+    let yaml = r#"
+pipeline:
+  name: hl7_split_read
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      options:
+        split_fields:
+          - { field: f08, components: 2 }
+          - { field: f03, components: 5 }
+      schema:
+        - { name: seg_id, type: string }
+        - { name: f08_c1, type: string }
+        - { name: f08_c2, type: string }
+        - { name: f03_c1, type: string }
+  - type: transform
+    name: tag
+    input: messages
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit code = f08_c1
+        emit trigger = f08_c2
+        emit patid = f03_c1
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+"#;
+    let (report, output) =
+        run(yaml, "messages", &adt_a01(), "adt.hl7", "out").expect("run split read");
+    assert_eq!(report.counters.dlq_count, 0);
+    // The MSH row resolves the message code/trigger from the split f08.
+    let msh_row = output
+        .lines()
+        .find(|l| l.starts_with("MSH,"))
+        .expect("MSH row present");
+    assert!(msh_row.contains("ADT"), "MSH-9.1 message code: {msh_row}");
+    assert!(msh_row.contains("A01"), "MSH-9.2 trigger event: {msh_row}");
+    // The PID row resolves the patient id from the split f03.
+    let pid_row = output
+        .lines()
+        .find(|l| l.starts_with("PID,"))
+        .expect("PID row present");
+    assert!(
+        pid_row.contains("PATID123"),
+        "PID-3.1 patient id: {pid_row}"
+    );
+}
+
+#[test]
+fn hl7_split_field_round_trips_byte_identically() {
+    // An HL7→HL7 pipeline that splits PID-3 (f03) into four components must
+    // re-assemble the exact composite on output — the `^` separators are
+    // reinserted verbatim, never escaped — so the re-emitted PID-3 is
+    // byte-identical to the source and a re-parse reproduces it.
+    let yaml = r#"
+pipeline:
+  name: hl7_split_round_trip
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      options:
+        split_fields:
+          - { field: f03, components: 5 }
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: hl7
+      path: out.hl7
+      include_unmapped: true
+      options:
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "messages", &adt_a01(), "adt.hl7", "out").expect("run split round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // PID-3 (`PATID123^^^HOSP^MR`) re-assembles byte-identically from its
+    // four split component columns; no component separator became an `\S\`.
+    assert!(
+        output.contains("PID|1||PATID123^^^HOSP^MR"),
+        "split PID-3 not byte-identical on round-trip: {output}"
+    );
+    assert!(
+        !output.contains("\\S\\"),
+        "component separator wrongly escaped on output: {output}"
+    );
+
+    // Re-parse the output (no split) to prove the wire field is intact.
+    let reparse_yaml = r#"
+pipeline:
+  name: hl7_split_reparse
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      schema:
+        - { name: seg_id, type: string }
+        - { name: f03, type: string }
+  - type: transform
+    name: tag
+    input: messages
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit f3 = f03
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+"#;
+    let (reparse_report, reparse_csv) =
+        run(reparse_yaml, "messages", &output, "echo.hl7", "out").expect("re-parse round-trip");
+    assert_eq!(reparse_report.counters.dlq_count, 0);
+    // The PID row carries the re-assembled composite verbatim.
+    let pid_row = reparse_csv
+        .lines()
+        .find(|l| l.starts_with("PID,"))
+        .expect("PID row present");
+    assert!(
+        pid_row.contains("PATID123^^^HOSP^MR"),
+        "re-parsed PID-3 wrong: {pid_row}"
+    );
+}
+
+#[test]
+fn hl7_split_field_past_max_fields_is_rejected_at_config_time() {
+    // A split naming a position past `max_fields` is unreachable; reject it
+    // at config validation rather than silently dropping the column.
+    let yaml = r#"
+pipeline:
+  name: hl7_split_overflow
+nodes:
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      glob: ./*.hl7
+      options:
+        max_fields: 4
+        split_fields:
+          - { field: f08, components: 2 }
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = parse_config(yaml).expect_err("split past max_fields must fail config validation");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("max_fields") && msg.contains("f08"),
+        "expected a max_fields overflow naming f08, got: {msg}"
     );
 }

--- a/crates/clinker-format/src/hl7/field_split.rs
+++ b/crates/clinker-format/src/hl7/field_split.rs
@@ -1,0 +1,560 @@
+//! Opt-in HL7 v2 composite-field splitting.
+//!
+//! The positional reader keeps every field verbatim by default, so a
+//! composite field such as the message type `ADT^A01` rides inside one
+//! `fNN` column with its component separator intact. Some consumers want
+//! component-level access (the message code `MSH-9.1` vs the trigger event
+//! `MSH-9.2`) without writing CXL string-splitting downstream. A source may
+//! therefore opt one or more fields into structural splitting: the reader
+//! explodes the named field into per-repetition / per-component /
+//! per-sub-component columns, and the writer re-assembles the exact wire
+//! field from them.
+//!
+//! HL7 nests three structural axes inside a field, from outermost to
+//! innermost: repetitions (`~`), components (`^`), and sub-components (`&`).
+//! A split declaration fixes the column width on each axis (how many
+//! repetitions / components / sub-components to expose), so the record
+//! schema stays static — it never varies with per-record data. A field
+//! whose data carries more structure on any axis than the declaration
+//! reserves is rejected with guidance rather than silently truncated,
+//! mirroring the `max_fields` overflow posture.
+//!
+//! ## Column naming
+//!
+//! Split columns name the path from the field down to a leaf with the
+//! axis letters `r` (repetition), `c` (component), and `s` (sub-component),
+//! all 1-based. The default axis index (1) is elided so the common
+//! component-only case stays clean, and the writer defaults a missing axis
+//! back to 1:
+//!
+//! | Declaration (`reps`,`comps`,`subs`) | Columns for `f08`                 |
+//! | ----------------------------------- | --------------------------------- |
+//! | `1, 2, 1`                           | `f08_c1`, `f08_c2`                 |
+//! | `1, 1, 2`                           | `f08_c1_s1`, `f08_c1_s2`          |
+//! | `2, 1, 1`                           | `f08_r1_c1`, `f08_r2_c1`          |
+//!
+//! The grammar is self-describing: the writer parses any structured `fNN_…`
+//! column name back to its `(field, repetition, component, sub-component)`
+//! coordinate without consulting the source split declaration, so an
+//! HL7→HL7 round-trip re-assembles correctly from the column names alone.
+//!
+//! ## Round-trip fidelity
+//!
+//! Explode and re-assemble are exact inverses: the reader splits on the
+//! discovered separators and the writer re-joins on them verbatim, never
+//! escaping `^`/`~`/`&`. A split → re-assemble round-trip therefore yields
+//! the byte-identical wire field, exactly as the verbatim positional model
+//! does for an unsplit field.
+
+use crate::error::FormatError;
+use crate::hl7::tokenizer::{Delimiters, decode_escapes};
+
+/// A resolved split declaration for one field position.
+///
+/// `field_index` is the 1-based wire field position (the `NN` of `fNN`,
+/// e.g. `8` for `f08`). The three counts fix how many columns each
+/// structural axis contributes; each is at least 1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Hl7FieldSplit {
+    /// 1-based wire field position to explode (`f08` → 8).
+    pub field_index: usize,
+    /// Number of repetition columns to expose (the `~` axis). At least 1.
+    pub repetitions: usize,
+    /// Number of component columns to expose (the `^` axis). At least 1.
+    pub components: usize,
+    /// Number of sub-component columns to expose (the `&` axis). At least 1.
+    pub subcomponents: usize,
+}
+
+impl Hl7FieldSplit {
+    /// The total number of leaf columns this declaration contributes:
+    /// `repetitions × components × subcomponents`.
+    pub(crate) fn column_count(&self) -> usize {
+        self.repetitions * self.components * self.subcomponents
+    }
+
+    /// The column names this declaration contributes, in stable iteration
+    /// order (repetition-major, then component, then sub-component). The
+    /// order matches [`Self::split_value`] so a reader can zip names to
+    /// values.
+    pub(crate) fn column_names(&self) -> Vec<String> {
+        let mut names = Vec::with_capacity(self.column_count());
+        for r in 1..=self.repetitions {
+            for c in 1..=self.components {
+                for s in 1..=self.subcomponents {
+                    names.push(self.column_name(r, c, s));
+                }
+            }
+        }
+        names
+    }
+
+    /// The column name for the leaf at 1-based `(repetition, component,
+    /// sub-component)`. The default index (1) on the repetition and
+    /// sub-component axes is elided; the component axis is always present so
+    /// the name is never a bare `fNN` that would collide with the verbatim
+    /// positional column.
+    fn column_name(&self, rep: usize, comp: usize, sub: usize) -> String {
+        let mut name = format!("f{:02}", self.field_index);
+        if self.repetitions > 1 {
+            name.push_str(&format!("_r{rep}"));
+        }
+        name.push_str(&format!("_c{comp}"));
+        if self.subcomponents > 1 {
+            name.push_str(&format!("_s{sub}"));
+        }
+        name
+    }
+
+    /// Explode a *raw* (still-escaped) field value into its decoded leaf
+    /// values in the same order as [`Self::column_names`]. An absent leaf
+    /// (the data carries fewer repetitions / components / sub-components than
+    /// declared, or an empty segment) yields `None`; a present leaf yields
+    /// its decoded text.
+    ///
+    /// The split runs on the raw bytes so the structural `~`/`^`/`&`
+    /// separators bound the leaves before [`decode_escapes`] turns an escaped
+    /// `\S\` into a literal `^` *inside* a leaf — splitting the decoded value
+    /// would wrongly treat that data `^` as a component boundary. Each leaf
+    /// is then decoded through the shared escape decoder, so the escape rules
+    /// stay in one place.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Hl7`] when the field data carries more
+    /// structure on any axis than the declaration reserves — splitting it
+    /// would drop the overflow, so the reader rejects it with guidance to
+    /// widen the split width, mirroring the `max_fields` overflow posture.
+    pub(crate) fn split_value(
+        &self,
+        raw_value: &str,
+        delims: &Delimiters,
+    ) -> Result<Vec<Option<String>>, FormatError> {
+        let repetitions = split_on(raw_value, delims.repetition as char);
+        if repetitions.len() > self.repetitions {
+            return Err(self.overflow("repetition", repetitions.len(), self.repetitions));
+        }
+        let mut out = Vec::with_capacity(self.column_count());
+        for r in 0..self.repetitions {
+            let rep = repetitions.get(r).copied();
+            let components = rep.map(|t| split_on(t, delims.component as char));
+            if let Some(comps) = &components
+                && comps.len() > self.components
+            {
+                return Err(self.overflow("component", comps.len(), self.components));
+            }
+            for c in 0..self.components {
+                let comp = components.as_ref().and_then(|cs| cs.get(c).copied());
+                let subs = comp.map(|t| split_on(t, delims.subcomponent as char));
+                if let Some(ss) = &subs
+                    && ss.len() > self.subcomponents
+                {
+                    return Err(self.overflow("sub-component", ss.len(), self.subcomponents));
+                }
+                for s in 0..self.subcomponents {
+                    let leaf = subs.as_ref().and_then(|ss| ss.get(s).copied());
+                    out.push(leaf.map(|raw| decode_escapes(raw.as_bytes(), delims)));
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Build an overflow error naming the axis and the offending counts.
+    fn overflow(&self, axis: &str, found: usize, declared: usize) -> FormatError {
+        FormatError::Hl7(format!(
+            "split field f{:02} carries {found} {axis}s, exceeding the configured {axis} width \
+             of {declared}; raise the field's `{axis}s` split count or leave the field unsplit",
+            self.field_index
+        ))
+    }
+}
+
+/// Split a string on a single-byte separator into its parts, preserving
+/// empty parts (`A^^C` → `["A", "", "C"]`). A field with no separator is a
+/// single part.
+fn split_on(value: &str, sep: char) -> Vec<&str> {
+    value.split(sep).collect()
+}
+
+/// A structured split column resolved to its wire coordinate.
+///
+/// Parsed from a column name by [`parse_split_column`]; consumed by the
+/// writer to re-assemble each `fNN` wire field from its leaf columns. All
+/// indices are 1-based.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SplitCoord {
+    /// 1-based wire field position (`f08_c2` → 8).
+    pub field_index: usize,
+    /// 1-based repetition index (the `r` axis; defaults to 1 when elided).
+    pub repetition: usize,
+    /// 1-based component index (the `c` axis; always present).
+    pub component: usize,
+    /// 1-based sub-component index (the `s` axis; defaults to 1 when elided).
+    pub subcomponent: usize,
+}
+
+/// Parse a structured split column name (`f08_c2`, `f03_r2_c1_s3`) into its
+/// wire coordinate, or `None` when the name is not a split column.
+///
+/// A split column is `f` + the field digits + a mandatory `_c<n>` component
+/// segment, with an optional leading `_r<n>` repetition segment and an
+/// optional trailing `_s<n>` sub-component segment, each 1-based and at
+/// least 1. The grammar is the exact inverse of
+/// [`Hl7FieldSplit::column_name`], so the writer recovers the coordinate
+/// without consulting the source split declaration.
+pub(crate) fn parse_split_column(name: &str) -> Option<SplitCoord> {
+    let rest = name.strip_prefix('f')?;
+    // The field index runs up to the first axis underscore.
+    let (field_digits, mut tail) = match rest.find('_') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => return None,
+    };
+    let field_index = parse_index(field_digits)?;
+
+    let mut repetition = 1;
+    let mut component = None;
+    let mut subcomponent = 1;
+
+    if let Some(after) = tail.strip_prefix("_r") {
+        let (digits, next) = split_axis(after);
+        repetition = parse_index(digits)?;
+        tail = next;
+    }
+    if let Some(after) = tail.strip_prefix("_c") {
+        let (digits, next) = split_axis(after);
+        component = Some(parse_index(digits)?);
+        tail = next;
+    }
+    if let Some(after) = tail.strip_prefix("_s") {
+        let (digits, next) = split_axis(after);
+        subcomponent = parse_index(digits)?;
+        tail = next;
+    }
+    // A trailing remainder means the name carries an axis segment out of
+    // order or an unknown axis letter — not a split column this writer maps.
+    if !tail.is_empty() {
+        return None;
+    }
+    Some(SplitCoord {
+        field_index,
+        repetition,
+        component: component?,
+        subcomponent,
+    })
+}
+
+/// Split an axis segment's leading digit run from any following `_`-prefixed
+/// segment. `2_c1` → (`2`, `_c1`); `1` → (`1`, ``).
+fn split_axis(after: &str) -> (&str, &str) {
+    let end = after
+        .bytes()
+        .position(|b| !b.is_ascii_digit())
+        .unwrap_or(after.len());
+    (&after[..end], &after[end..])
+}
+
+/// Parse a 1-based axis index: a non-empty all-ASCII-digit run that is at
+/// least 1. Rejects `0` and an empty run so a malformed name is not a split
+/// column.
+fn parse_index(digits: &str) -> Option<usize> {
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let n: usize = digits.parse().ok()?;
+    (n >= 1).then_some(n)
+}
+
+/// Re-assemble a field's wire text from its split leaf coordinates.
+///
+/// `leaves` pairs each leaf's coordinate with its text; the field is rebuilt
+/// by joining sub-components on `&`, components on `^`, and repetitions on
+/// `~`, with trailing empty segments on every axis trimmed so the
+/// re-assembled field carries no fabricated separators — exactly the bytes
+/// the reader split. The separators are written verbatim (never escaped),
+/// preserving round-trip fidelity.
+pub(crate) fn reassemble_field(leaves: &[(SplitCoord, String)], delims: &Delimiters) -> String {
+    // Bucket leaves into a [repetition][component][subcomponent] grid sized
+    // to the maximum coordinate seen, then trim empties per axis.
+    let max_rep = leaves.iter().map(|(c, _)| c.repetition).max().unwrap_or(1);
+    let max_comp = leaves.iter().map(|(c, _)| c.component).max().unwrap_or(1);
+    let max_sub = leaves
+        .iter()
+        .map(|(c, _)| c.subcomponent)
+        .max()
+        .unwrap_or(1);
+
+    let mut grid = vec![vec![vec![String::new(); max_sub]; max_comp]; max_rep];
+    for (coord, text) in leaves {
+        grid[coord.repetition - 1][coord.component - 1][coord.subcomponent - 1] = text.clone();
+    }
+
+    let component_sep = delims.component as char;
+    let subcomponent_sep = delims.subcomponent as char;
+    let repetition_sep = delims.repetition as char;
+
+    let reps: Vec<String> = grid
+        .into_iter()
+        .map(|components| {
+            let comps: Vec<String> = components
+                .into_iter()
+                .map(|subs| join_trimmed(subs, subcomponent_sep))
+                .collect();
+            join_trimmed(comps, component_sep)
+        })
+        .collect();
+    join_trimmed(reps, repetition_sep)
+}
+
+/// Join parts on a separator after dropping trailing empty parts, so no
+/// fabricated trailing separator survives. An all-empty list joins to the
+/// empty string.
+fn join_trimmed(mut parts: Vec<String>, sep: char) -> String {
+    while matches!(parts.last(), Some(s) if s.is_empty()) {
+        parts.pop();
+    }
+    parts.join(&sep.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn delims() -> Delimiters {
+        Delimiters::default_set()
+    }
+
+    fn split(field_index: usize, reps: usize, comps: usize, subs: usize) -> Hl7FieldSplit {
+        Hl7FieldSplit {
+            field_index,
+            repetitions: reps,
+            components: comps,
+            subcomponents: subs,
+        }
+    }
+
+    #[test]
+    fn component_columns_named_cleanly() {
+        let s = split(8, 1, 2, 1);
+        assert_eq!(s.column_names(), vec!["f08_c1", "f08_c2"]);
+    }
+
+    #[test]
+    fn subcomponent_columns_carry_s_axis() {
+        let s = split(3, 1, 1, 2);
+        assert_eq!(s.column_names(), vec!["f03_c1_s1", "f03_c1_s2"]);
+    }
+
+    #[test]
+    fn repetition_columns_carry_r_axis() {
+        let s = split(3, 2, 1, 1);
+        assert_eq!(s.column_names(), vec!["f03_r1_c1", "f03_r2_c1"]);
+    }
+
+    #[test]
+    fn full_grid_orders_rep_comp_sub() {
+        let s = split(3, 2, 2, 2);
+        assert_eq!(
+            s.column_names(),
+            vec![
+                "f03_r1_c1_s1",
+                "f03_r1_c1_s2",
+                "f03_r1_c2_s1",
+                "f03_r1_c2_s2",
+                "f03_r2_c1_s1",
+                "f03_r2_c1_s2",
+                "f03_r2_c2_s1",
+                "f03_r2_c2_s2",
+            ]
+        );
+    }
+
+    #[test]
+    fn split_value_explodes_components() {
+        let s = split(8, 1, 2, 1);
+        let leaves = s.split_value("ADT^A01", &delims()).unwrap();
+        assert_eq!(leaves, vec![Some("ADT".to_owned()), Some("A01".to_owned())]);
+    }
+
+    #[test]
+    fn split_value_pads_absent_leaves_with_none() {
+        // Field has one component; the second declared column is absent.
+        let s = split(8, 1, 2, 1);
+        let leaves = s.split_value("ADT", &delims()).unwrap();
+        assert_eq!(leaves, vec![Some("ADT".to_owned()), None]);
+    }
+
+    #[test]
+    fn split_value_keeps_empty_interior_component() {
+        // `PATID^^^MRN` has empty interior components that must survive.
+        let s = split(3, 1, 4, 1);
+        let leaves = s.split_value("PATID^^^MRN", &delims()).unwrap();
+        assert_eq!(
+            leaves,
+            vec![
+                Some("PATID".to_owned()),
+                Some(String::new()),
+                Some(String::new()),
+                Some("MRN".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn split_value_explodes_subcomponents() {
+        let s = split(3, 1, 1, 2);
+        let leaves = s.split_value("A&B", &delims()).unwrap();
+        assert_eq!(leaves, vec![Some("A".to_owned()), Some("B".to_owned())]);
+    }
+
+    #[test]
+    fn split_value_explodes_repetitions() {
+        let s = split(3, 2, 1, 1);
+        let leaves = s.split_value("ID1~ID2", &delims()).unwrap();
+        assert_eq!(leaves, vec![Some("ID1".to_owned()), Some("ID2".to_owned())]);
+    }
+
+    #[test]
+    fn escaped_component_separator_does_not_split() {
+        // `A\S\B` is a single component carrying a literal `^` in data; it
+        // must stay one leaf and decode to `A^B`, not split into two.
+        let s = split(8, 1, 2, 1);
+        let leaves = s.split_value("A\\S\\B", &delims()).unwrap();
+        assert_eq!(leaves, vec![Some("A^B".to_owned()), None]);
+    }
+
+    #[test]
+    fn leaf_decodes_escaped_field_separator() {
+        // A `\F\` inside a component decodes to a literal `|` in the leaf.
+        let s = split(8, 1, 1, 1);
+        let leaves = s.split_value("a\\F\\b", &delims()).unwrap();
+        assert_eq!(leaves, vec![Some("a|b".to_owned())]);
+    }
+
+    #[test]
+    fn component_overflow_errors() {
+        let s = split(8, 1, 1, 1);
+        let err = s.split_value("ADT^A01", &delims()).unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("component")));
+    }
+
+    #[test]
+    fn repetition_overflow_errors() {
+        let s = split(3, 1, 1, 1);
+        let err = s.split_value("ID1~ID2", &delims()).unwrap_err();
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("repetition")));
+    }
+
+    #[test]
+    fn parse_component_column() {
+        assert_eq!(
+            parse_split_column("f08_c2"),
+            Some(SplitCoord {
+                field_index: 8,
+                repetition: 1,
+                component: 2,
+                subcomponent: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_full_path_column() {
+        assert_eq!(
+            parse_split_column("f03_r2_c1_s3"),
+            Some(SplitCoord {
+                field_index: 3,
+                repetition: 2,
+                component: 1,
+                subcomponent: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_rejects_plain_positional_column() {
+        // A bare `fNN` is the verbatim positional column, not a split leaf.
+        assert_eq!(parse_split_column("f08"), None);
+    }
+
+    #[test]
+    fn parse_rejects_missing_component_axis() {
+        // A name with a repetition but no component axis is not a leaf.
+        assert_eq!(parse_split_column("f03_r2"), None);
+    }
+
+    #[test]
+    fn parse_rejects_index_zero() {
+        assert_eq!(parse_split_column("f08_c0"), None);
+    }
+
+    #[test]
+    fn parse_rejects_unknown_trailing_axis() {
+        assert_eq!(parse_split_column("f08_c1_x2"), None);
+    }
+
+    #[test]
+    fn reassemble_components() {
+        let leaves = vec![
+            (coord(8, 1, 1, 1), "ADT".to_owned()),
+            (coord(8, 1, 2, 1), "A01".to_owned()),
+        ];
+        assert_eq!(reassemble_field(&leaves, &delims()), "ADT^A01");
+    }
+
+    #[test]
+    fn reassemble_preserves_empty_interior_components() {
+        let leaves = vec![
+            (coord(3, 1, 1, 1), "PATID".to_owned()),
+            (coord(3, 1, 2, 1), String::new()),
+            (coord(3, 1, 3, 1), String::new()),
+            (coord(3, 1, 4, 1), "MRN".to_owned()),
+        ];
+        assert_eq!(reassemble_field(&leaves, &delims()), "PATID^^^MRN");
+    }
+
+    #[test]
+    fn reassemble_trims_trailing_empty_components() {
+        let leaves = vec![
+            (coord(8, 1, 1, 1), "ADT".to_owned()),
+            (coord(8, 1, 2, 1), String::new()),
+        ];
+        // The trailing empty component is trimmed — no fabricated `^`.
+        assert_eq!(reassemble_field(&leaves, &delims()), "ADT");
+    }
+
+    #[test]
+    fn reassemble_repetitions_and_subcomponents() {
+        let leaves = vec![
+            (coord(3, 1, 1, 1), "A".to_owned()),
+            (coord(3, 1, 1, 2), "B".to_owned()),
+            (coord(3, 2, 1, 1), "C".to_owned()),
+        ];
+        assert_eq!(reassemble_field(&leaves, &delims()), "A&B~C");
+    }
+
+    fn coord(field_index: usize, rep: usize, comp: usize, sub: usize) -> SplitCoord {
+        SplitCoord {
+            field_index,
+            repetition: rep,
+            component: comp,
+            subcomponent: sub,
+        }
+    }
+
+    #[test]
+    fn explode_reassemble_round_trips() {
+        // A full grid of declared widths must explode and re-assemble to the
+        // byte-identical original, with the discovered separators verbatim.
+        let s = split(3, 2, 3, 2);
+        let original = "PATID&X^^MRN~ALT&Y^^MR";
+        let leaves = s.split_value(original, &delims()).unwrap();
+        let names = s.column_names();
+        let paired: Vec<(SplitCoord, String)> = names
+            .iter()
+            .zip(leaves)
+            .filter_map(|(name, leaf)| leaf.map(|text| (parse_split_column(name).unwrap(), text)))
+            .collect();
+        assert_eq!(reassemble_field(&paired, &delims()), original);
+    }
+}

--- a/crates/clinker-format/src/hl7/mod.rs
+++ b/crates/clinker-format/src/hl7/mod.rs
@@ -22,6 +22,12 @@
 //! writer mirrors this, reconstructing the envelope around emitted records
 //! and recomputing every count.
 //!
+//! A field is kept verbatim by default (its `^`/`~`/`&` structure rides
+//! inside one column), but a source may opt one or more fields into
+//! structural splitting via [`Hl7FieldSplit`]: the reader explodes the field
+//! into per-repetition / per-component / per-sub-component columns and the
+//! writer re-assembles the exact wire field from them.
+//!
 //! The optional envelope tiers surface as nested document-context levels:
 //! an `FHS` file header is the file-level document (extracted in the
 //! one-time pre-scan), and each `BHS` batch and `MSH` message opens a
@@ -33,10 +39,12 @@
 //! (so `$doc` envelope sections over `FHS` cost O(FHS)); the body streams
 //! one segment at a time. The whole file is never buffered.
 
+mod field_split;
 pub mod reader;
 mod tokenizer;
 pub mod writer;
 
+pub use field_split::Hl7FieldSplit;
 pub use reader::{Hl7Reader, Hl7ReaderConfig};
 pub use writer::{Hl7Writer, Hl7WriterConfig};
 

--- a/crates/clinker-format/src/hl7/reader.rs
+++ b/crates/clinker-format/src/hl7/reader.rs
@@ -42,7 +42,10 @@ use indexmap::IndexMap;
 use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::hl7::RAW_FIELDS_KEY;
-use crate::hl7::tokenizer::{ParsedSegment, SegmentTokenizer, split_segment};
+use crate::hl7::field_split::Hl7FieldSplit;
+use crate::hl7::tokenizer::{
+    Delimiters, ParsedSegment, SegmentTokenizer, raw_field, split_segment,
+};
 use crate::traits::FormatReader;
 
 /// Default ceiling on the number of positional field columns the record
@@ -72,12 +75,20 @@ pub struct Hl7ReaderConfig {
     /// Number of positional `fNN` field columns on the record schema. A
     /// body segment with more data fields than this is rejected.
     pub max_fields: usize,
+    /// Opt-in composite-field splits. Each entry explodes one positional
+    /// field into per-repetition / per-component / per-sub-component
+    /// columns, replacing the verbatim `fNN` column with the structured
+    /// columns; the writer re-assembles the wire field from them. Empty by
+    /// default, so the positional model is byte-identical to today unless a
+    /// split is declared.
+    pub split_fields: Vec<Hl7FieldSplit>,
 }
 
 impl Default for Hl7ReaderConfig {
     fn default() -> Self {
         Self {
             max_fields: DEFAULT_MAX_FIELDS,
+            split_fields: Vec::new(),
         }
     }
 }
@@ -94,6 +105,11 @@ pub struct Hl7Reader<R: Read> {
     tokenizer: SegmentTokenizer<BufReader<R>>,
     schema: Arc<Schema>,
     max_fields: usize,
+    /// The ordered field-column layout: each positional field is either kept
+    /// verbatim as one `fNN` column or exploded into its split-leaf columns.
+    /// Built once from the config so `body_record` maps every segment the
+    /// same way.
+    field_layout: Vec<FieldGroup>,
     initialized: bool,
     /// The first segment, read during delimiter discovery and held until
     /// the body stream consumes it (an `MSH` is emitted, an `FHS`/`BHS`
@@ -122,6 +138,45 @@ pub struct Hl7Reader<R: Read> {
     done: bool,
 }
 
+/// One positional field's place in the record schema: kept verbatim as a
+/// single `fNN` column, or exploded into its split-leaf columns.
+///
+/// The layout is the single source of both the column list (for the schema)
+/// and the per-segment value mapping (in `body_record`), so the reader and
+/// its schema never disagree on which columns a split field contributes.
+enum FieldGroup {
+    /// A field kept whole at its 1-based wire position, as `fNN`.
+    Verbatim { position: usize },
+    /// A field exploded per its split declaration.
+    Split(Hl7FieldSplit),
+}
+
+impl FieldGroup {
+    /// The schema column names this group contributes, in column order.
+    fn column_names(&self) -> Vec<String> {
+        match self {
+            FieldGroup::Verbatim { position } => vec![positional_key(position - 1)],
+            FieldGroup::Split(split) => split.column_names(),
+        }
+    }
+}
+
+/// Build the ordered field-column layout from the field width and the split
+/// declarations: positions `1..=max_fields`, with each declared split
+/// replacing its verbatim `fNN` slot. A split naming a position outside the
+/// `max_fields` range is dropped here — the plan-config layer validates the
+/// in-range invariant with source spans before the reader is built.
+fn build_field_layout(max_fields: usize, splits: &[Hl7FieldSplit]) -> Vec<FieldGroup> {
+    let mut layout = Vec::with_capacity(max_fields);
+    for position in 1..=max_fields {
+        match splits.iter().find(|s| s.field_index == position) {
+            Some(split) => layout.push(FieldGroup::Split(*split)),
+            None => layout.push(FieldGroup::Verbatim { position }),
+        }
+    }
+    layout
+}
+
 /// Per-batch validation state for the batch currently open.
 struct OpenBatch {
     /// Count of messages (`MSH`) seen in this batch, checked against the
@@ -143,11 +198,13 @@ impl<R: Read> Hl7Reader<R> {
     /// configuration. Delimiter discovery and the first-segment read are
     /// deferred to the first call.
     pub fn new(reader: R, config: Hl7ReaderConfig) -> Self {
-        let schema = build_schema(config.max_fields);
+        let field_layout = build_field_layout(config.max_fields, &config.split_fields);
+        let schema = build_schema(&field_layout);
         Self {
             tokenizer: SegmentTokenizer::new(BufReader::new(reader)),
             schema,
             max_fields: config.max_fields,
+            field_layout,
             initialized: false,
             pending_segment: None,
             fhs_fields: Vec::new(),
@@ -232,7 +289,7 @@ impl<R: Read> Hl7Reader<R> {
                 "BTS" => self.close_batch(&segment)?,
                 "MSH" => {
                     self.open_message(&segment);
-                    let record = self.body_record(&segment)?;
+                    let record = self.body_record(&raw, &segment)?;
                     return Ok(Some(record));
                 }
                 _ => {
@@ -242,7 +299,7 @@ impl<R: Read> Hl7Reader<R> {
                             segment.tag
                         )));
                     }
-                    let record = self.body_record(&segment)?;
+                    let record = self.body_record(&raw, &segment)?;
                     return Ok(Some(record));
                 }
             }
@@ -383,10 +440,12 @@ impl<R: Read> Hl7Reader<R> {
 
     /// Map a parsed segment to a positional [`Record`] under the static
     /// schema. `seg_id`, `set_ref`, and `set_type` are stamped from the
-    /// open message; the data fields fill `f01..`. Absent trailing fields
-    /// stay `Value::Null`; a field count past `max_fields` errors with
-    /// guidance.
-    fn body_record(&self, segment: &ParsedSegment) -> Result<Record, FormatError> {
+    /// open message; the data fields follow the field layout — verbatim
+    /// fields fill one `fNN` column each, split fields explode into their
+    /// structured columns. Absent fields and leaves stay `Value::Null`; a
+    /// field count past `max_fields`, or a split field whose structure
+    /// overflows its declared width, errors with guidance.
+    fn body_record(&self, raw: &str, segment: &ParsedSegment) -> Result<Record, FormatError> {
         if segment.fields.len() > self.max_fields {
             return Err(FormatError::Hl7(format!(
                 "segment {:?} carries {} data fields, exceeding the configured max_fields of {}; \
@@ -400,18 +459,52 @@ impl<R: Read> Hl7Reader<R> {
             Some(msg) => (msg.control_id.clone(), msg.message_type.clone()),
             None => (String::new(), String::new()),
         };
+        let delims = self.tokenizer.delimiters();
 
-        let mut values: Vec<Value> = Vec::with_capacity(3 + self.max_fields);
+        let mut values: Vec<Value> = Vec::with_capacity(3 + self.schema.columns().len());
         values.push(Value::String(segment.tag.as_str().into()));
         values.push(string_or_null(&set_ref));
         values.push(string_or_null(&set_type));
-        for i in 0..self.max_fields {
-            match segment.fields.get(i) {
-                Some(f) => values.push(string_or_null(f)),
-                None => values.push(Value::Null),
-            }
+        for group in &self.field_layout {
+            self.push_field_group(raw, segment, group, &delims, &mut values)?;
         }
         Ok(Record::new(Arc::clone(&self.schema), values))
+    }
+
+    /// Append a field group's values to a record's value list: one cell for a
+    /// verbatim field (the decoded value, or `Null` when absent), or one cell
+    /// per leaf for a split field. A split reads the *raw* field text (re-cut
+    /// from the original segment string) so an escaped separator stays inside
+    /// its leaf rather than being mistaken for a structural boundary.
+    fn push_field_group(
+        &self,
+        raw: &str,
+        segment: &ParsedSegment,
+        group: &FieldGroup,
+        delims: &Delimiters,
+        values: &mut Vec<Value>,
+    ) -> Result<(), FormatError> {
+        match group {
+            FieldGroup::Verbatim { position } => match segment.fields.get(position - 1) {
+                Some(f) => values.push(string_or_null(f)),
+                None => values.push(Value::Null),
+            },
+            FieldGroup::Split(split) => {
+                let leaves = match raw_field(raw, delims, split.field_index) {
+                    Some(raw_text) => split.split_value(&raw_text, delims)?,
+                    // The split field is absent on this segment (a shorter
+                    // segment than the split position): every leaf is null.
+                    None => vec![None; split.column_count()],
+                };
+                for leaf in leaves {
+                    values.push(match leaf {
+                        Some(text) => string_or_null(&text),
+                        None => Value::Null,
+                    });
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -544,16 +637,20 @@ fn parse_optional_count(
     }
 }
 
-/// Build the static positional schema `[seg_id, set_ref, set_type,
-/// f01..f<max>]`. All columns are string-typed; field text is stored
-/// verbatim (escapes decoded) so the round-trip is lossless.
-fn build_schema(max_fields: usize) -> Arc<Schema> {
-    let mut columns: Vec<Box<str>> = Vec::with_capacity(3 + max_fields);
+/// Build the static positional schema `[seg_id, set_ref, set_type, <field
+/// columns>]` from the field layout. A verbatim field contributes one `fNN`
+/// column; a split field contributes its structured leaf columns in place of
+/// `fNN`. All columns are string-typed; field text is stored verbatim
+/// (escapes decoded) so the round-trip is lossless.
+fn build_schema(layout: &[FieldGroup]) -> Arc<Schema> {
+    let mut columns: Vec<Box<str>> = Vec::with_capacity(3 + layout.len());
     columns.push(Box::from("seg_id"));
     columns.push(Box::from("set_ref"));
     columns.push(Box::from("set_type"));
-    for i in 0..max_fields {
-        columns.push(positional_key(i).into_boxed_str());
+    for group in layout {
+        for name in group.column_names() {
+            columns.push(name.into_boxed_str());
+        }
     }
     Arc::new(Schema::new(columns))
 }
@@ -603,6 +700,37 @@ mod tests {
             out.push(rec);
         }
         out
+    }
+
+    fn reader_with_splits(
+        data: &str,
+        split_fields: Vec<Hl7FieldSplit>,
+    ) -> Hl7Reader<Cursor<Vec<u8>>> {
+        Hl7Reader::new(
+            Cursor::new(data.as_bytes().to_vec()),
+            Hl7ReaderConfig {
+                max_fields: DEFAULT_MAX_FIELDS,
+                split_fields,
+            },
+        )
+    }
+
+    fn collect_with_splits(data: &str, split_fields: Vec<Hl7FieldSplit>) -> Vec<Record> {
+        let mut r = reader_with_splits(data, split_fields);
+        let mut out = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            out.push(rec);
+        }
+        out
+    }
+
+    fn split(field_index: usize, reps: usize, comps: usize, subs: usize) -> Hl7FieldSplit {
+        Hl7FieldSplit {
+            field_index,
+            repetitions: reps,
+            components: comps,
+            subcomponents: subs,
+        }
     }
 
     #[test]
@@ -856,7 +984,10 @@ mod tests {
         let data = format!("{MSH}\rZZZ|a|b|c|d|e");
         let mut r = Hl7Reader::new(
             Cursor::new(data.into_bytes()),
-            Hl7ReaderConfig { max_fields: 2 },
+            Hl7ReaderConfig {
+                max_fields: 2,
+                split_fields: Vec::new(),
+            },
         );
         let err = loop {
             match r.next_record() {
@@ -866,6 +997,75 @@ mod tests {
             }
         };
         assert!(matches!(err, FormatError::Hl7(m) if m.contains("max_fields")));
+    }
+
+    #[test]
+    fn split_replaces_verbatim_column_with_components() {
+        // Splitting MSH-9 (f08) into two components exposes the message code
+        // and trigger event as separate columns; the verbatim `f08` is gone.
+        let recs = collect_with_splits(&adt_message(), vec![split(8, 1, 2, 1)]);
+        let msh = &recs[0];
+        assert_eq!(msh.get("f08_c1"), Some(&Value::String("ADT".into())));
+        assert_eq!(msh.get("f08_c2"), Some(&Value::String("A01".into())));
+        // The whole-field column is replaced by the split columns.
+        assert_eq!(msh.get("f08"), None);
+        // Neighboring fields are untouched and keep their verbatim columns.
+        assert_eq!(msh.get("f07"), Some(&Value::Null)); // MSH-8 empty
+        assert_eq!(msh.get("f09"), Some(&Value::String("MSG001".into())));
+    }
+
+    #[test]
+    fn split_applies_to_every_segment_positionally() {
+        // A split on f03 explodes field 3 of *every* segment, not just MSH.
+        // PID-3 here is `PATID^^^MRN`; EVN-3 is absent.
+        let recs = collect_with_splits(&adt_message(), vec![split(3, 1, 4, 1)]);
+        let pid = &recs[2];
+        assert_eq!(pid.get("f03_c1"), Some(&Value::String("PATID".into())));
+        assert_eq!(pid.get("f03_c2"), Some(&Value::Null)); // empty component
+        assert_eq!(pid.get("f03_c3"), Some(&Value::Null));
+        assert_eq!(pid.get("f03_c4"), Some(&Value::String("MRN".into())));
+        // EVN has no field 3 — every leaf is null.
+        let evn = &recs[1];
+        assert_eq!(evn.get("f03_c1"), Some(&Value::Null));
+        assert_eq!(evn.get("f03_c4"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn split_default_behavior_unchanged_without_declaration() {
+        // With no split declared, the field stays verbatim — byte-identical
+        // to the positional model.
+        let recs = collect(&adt_message());
+        assert_eq!(
+            recs[2].get("f03"),
+            Some(&Value::String("PATID^^^MRN".into()))
+        );
+    }
+
+    #[test]
+    fn split_component_overflow_errors() {
+        // f08 carries two components; declaring one is an overflow.
+        let mut r = reader_with_splits(&adt_message(), vec![split(8, 1, 1, 1)]);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected component overflow"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Hl7(m) if m.contains("component")));
+    }
+
+    #[test]
+    fn split_on_escaped_separator_keeps_one_component() {
+        // A field carrying an escaped component separator (`\S\`) is one
+        // component of literal data, not two — the split must run on the raw
+        // bytes before the escape decodes to a `^`.
+        let data = format!("{MSH}\rOBX|1|TX|note||CODE\\S\\TEXT");
+        let recs = collect_with_splits(&data, vec![split(5, 1, 2, 1)]);
+        let obx = &recs[1];
+        // The whole escaped value decodes into one component.
+        assert_eq!(obx.get("f05_c1"), Some(&Value::String("CODE^TEXT".into())));
+        assert_eq!(obx.get("f05_c2"), Some(&Value::Null));
     }
 
     fn fhs_section(fields: &[(&str, EnvelopeFieldType)]) -> EnvelopeConfig {
@@ -1009,5 +1209,64 @@ mod tests {
             Some(&Value::String("PATID^^^MRN~ALT^^^MR".into()))
         );
         assert_eq!(recs2[2].get("f05"), Some(&Value::String("a|b".into())));
+    }
+
+    /// A split composite field must re-assemble byte-identically on write:
+    /// reader explodes the field into component columns, the writer rejoins
+    /// them on the discovered separator (verbatim, never escaped), and a
+    /// re-read reproduces the same components.
+    #[test]
+    fn split_field_reassembles_byte_identically_on_round_trip() {
+        use crate::hl7::writer::{Hl7Writer, Hl7WriterConfig};
+        use crate::traits::FormatWriter;
+
+        // Split MSH-9 (f08) into two components and PID-3 (f03) into four.
+        let splits = vec![split(8, 1, 2, 1), split(3, 1, 4, 1)];
+        let input = format!("{MSH}\rPID|1||PATID^^^MRN");
+
+        let body_recs = collect_with_splits(&input, splits.clone());
+        assert_eq!(body_recs.len(), 2); // MSH, PID
+        assert_eq!(
+            body_recs[0].get("f08_c1"),
+            Some(&Value::String("ADT".into()))
+        );
+        assert_eq!(
+            body_recs[0].get("f08_c2"),
+            Some(&Value::String("A01".into()))
+        );
+        assert_eq!(
+            body_recs[1].get("f03_c1"),
+            Some(&Value::String("PATID".into()))
+        );
+        assert_eq!(
+            body_recs[1].get("f03_c4"),
+            Some(&Value::String("MRN".into()))
+        );
+
+        // Re-emit: the writer re-assembles the split columns into the exact
+        // wire fields, separators verbatim.
+        let schema = reader_with_splits(&input, splits.clone()).schema().unwrap();
+        let out = {
+            let mut buf = Vec::new();
+            let mut w = Hl7Writer::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                Hl7WriterConfig::default(),
+            );
+            for rec in &body_recs {
+                w.write_record(rec).unwrap();
+            }
+            w.flush().unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+        // MSH-9 and PID-3 are reconstructed byte-identically; no `\S\` escape.
+        assert!(out.contains("|ADT^A01|"), "MSH-9 reassembly wrong: {out}");
+        assert!(out.contains("PID|1||PATID^^^MRN\r"), "PID-3 wrong: {out}");
+        assert!(!out.contains("\\S\\"), "component separator escaped: {out}");
+
+        // Re-read with the same splits: the components come back identical.
+        let recs2 = collect_with_splits(&out, splits);
+        assert_eq!(recs2[1].get("f03_c4"), Some(&Value::String("MRN".into())));
+        assert_eq!(recs2[0].get("f08_c2"), Some(&Value::String("A01".into())));
     }
 }

--- a/crates/clinker-format/src/hl7/tokenizer.rs
+++ b/crates/clinker-format/src/hl7/tokenizer.rs
@@ -356,12 +356,35 @@ pub(crate) fn split_segment(raw: &str, delims: &Delimiters) -> ParsedSegment {
     ParsedSegment { tag, fields }
 }
 
+/// Return the *raw* (still-escaped) text of one data field by its 1-based
+/// wire position, or `None` when the segment has no such field.
+///
+/// Composite-field splitting consults this for the few split positions only:
+/// the split must run on the raw separators before [`decode_escapes`] turns
+/// an escaped `\S\` into a literal `^` that is data, not a component
+/// boundary. The common no-split path never calls it, so the verbatim
+/// positional decode pays nothing extra. The first part is the tag, so wire
+/// field `position` is part index `position` (the tag occupies index 0).
+pub(crate) fn raw_field(raw: &str, delims: &Delimiters, position: usize) -> Option<String> {
+    let field = delims.field;
+    raw.as_bytes()
+        .split(|&b| b == field)
+        .nth(position)
+        .map(|part| String::from_utf8_lossy(part).into_owned())
+}
+
 /// Decode HL7 `\X\` escape sequences in a field's bytes into their literal
 /// delimiter byte. A recognized sequence (`\F\ \S\ \T\ \R\ \E\`) is
 /// replaced with the byte it names; an unrecognized or unterminated escape
 /// run is kept verbatim, so application escapes (`\.br\`, `\Xdd..\`) and
 /// malformed input survive rather than silently dropping data.
-fn decode_escapes(bytes: &[u8], delims: &Delimiters) -> String {
+///
+/// Composite-field splitting splits the raw (still-escaped) field on the
+/// structural separators first, then decodes each leaf through this same
+/// function — so an escaped `\S\` (a literal `^` in data, not a component
+/// boundary) decodes to a `^` inside one leaf rather than wrongly splitting
+/// the field. Sharing this one decoder keeps the escape rules unforked.
+pub(crate) fn decode_escapes(bytes: &[u8], delims: &Delimiters) -> String {
     let escape = delims.escape;
     if !bytes.contains(&escape) {
         return String::from_utf8_lossy(bytes).into_owned();

--- a/crates/clinker-format/src/hl7/writer.rs
+++ b/crates/clinker-format/src/hl7/writer.rs
@@ -34,6 +34,7 @@ use clinker_record::{Record, Schema, Value};
 
 use crate::error::FormatError;
 use crate::hl7::RAW_FIELDS_KEY;
+use crate::hl7::field_split::{SplitCoord, parse_split_column, reassemble_field};
 use crate::hl7::tokenizer::Delimiters;
 use crate::traits::FormatWriter;
 
@@ -69,6 +70,11 @@ pub struct Hl7Writer<W: Write> {
     /// slot, so a gapped (`f01, f03`) or reordered schema maps values to
     /// the positions the names declare.
     field_columns: Vec<FieldColumn>,
+    /// Split-leaf columns (`f08_c1`, `f03_r2_c1_s3`, …) resolved to their
+    /// wire coordinate. Each contributes one leaf to its field's
+    /// re-assembled wire value; the field position is taken from the
+    /// coordinate, not declaration order.
+    split_columns: Vec<SplitColumnRef>,
     seg_id_idx: Option<usize>,
     header_written: bool,
     finalized: bool,
@@ -95,6 +101,17 @@ struct FieldColumn {
     schema_index: usize,
 }
 
+/// A schema split-leaf column (`f08_c1`) resolved to its wire coordinate and
+/// the schema index its value is read from.
+struct SplitColumnRef {
+    /// The `(field, repetition, component, sub-component)` coordinate.
+    coord: SplitCoord,
+    /// The column name (`f08_c1`) — used verbatim in error messages.
+    name: String,
+    /// Index into the record's value list.
+    schema_index: usize,
+}
+
 impl<W: Write> Hl7Writer<W> {
     /// Build a writer over a sink with the given schema and config. The
     /// schema's `seg_id` and `fNN` columns are resolved to positional
@@ -102,6 +119,7 @@ impl<W: Write> Hl7Writer<W> {
     /// `MSH` record itself, so they need no separate index.
     pub fn new(writer: W, schema: Arc<Schema>, config: Hl7WriterConfig) -> Self {
         let mut field_columns = Vec::new();
+        let mut split_columns = Vec::new();
         let mut seg_id_idx = None;
         for (i, col) in schema.columns().iter().enumerate() {
             match &**col {
@@ -111,7 +129,17 @@ impl<W: Write> Hl7Writer<W> {
                 // so they are not mapped to wire fields here.
                 "set_ref" | "set_type" => {}
                 name => {
-                    if let Some(position) = field_position(name) {
+                    // A structured split-leaf name (`f08_c1`) re-assembles
+                    // into its field; a plain `fNN` maps to its wire slot.
+                    // The two grammars are disjoint — `field_position`
+                    // rejects any name with a non-digit after `f`.
+                    if let Some(coord) = parse_split_column(name) {
+                        split_columns.push(SplitColumnRef {
+                            coord,
+                            name: name.to_string(),
+                            schema_index: i,
+                        });
+                    } else if let Some(position) = field_position(name) {
                         field_columns.push(FieldColumn {
                             position,
                             name: name.to_string(),
@@ -122,11 +150,13 @@ impl<W: Write> Hl7Writer<W> {
             }
         }
         field_columns.sort_by_key(|c| c.position);
+        split_columns.sort_by_key(|c| c.coord.field_index);
         Self {
             writer,
             config,
             delims: Delimiters::default_set(),
             field_columns,
+            split_columns,
             seg_id_idx,
             header_written: false,
             finalized: false,
@@ -237,18 +267,22 @@ impl<W: Write> Hl7Writer<W> {
         Ok(())
     }
 
-    /// Collect a record's `fNN` columns into wire-position order, filling
-    /// any gap left by a missing position with an empty field, then
-    /// trimming trailing empties so no fabricated delimiters appear.
+    /// Collect a record's field columns into wire-position order, filling any
+    /// gap left by a missing position with an empty field, then trimming
+    /// trailing empties so no fabricated delimiters appear.
+    ///
+    /// A verbatim `fNN` column sets its wire field directly. A split field's
+    /// leaf columns (`f08_c1`, …) are re-assembled into the wire field at
+    /// their shared position by joining on the component / sub-component /
+    /// repetition separators — the exact inverse of the reader's split, so an
+    /// HL7→HL7 round-trip is byte-faithful.
     fn record_fields(&self, record: &Record) -> Result<Vec<String>, FormatError> {
         let values = record.values();
-        let max_position = self
-            .field_columns
-            .iter()
-            .map(|c| c.position)
-            .max()
-            .unwrap_or(0);
+        let max_verbatim = self.field_columns.iter().map(|c| c.position).max();
+        let max_split = self.split_columns.iter().map(|c| c.coord.field_index).max();
+        let max_position = max_verbatim.max(max_split).unwrap_or(0);
         let mut fields: Vec<String> = vec![String::new(); max_position];
+
         for col in &self.field_columns {
             let text = match values.get(col.schema_index) {
                 Some(v) => value_to_field(v, &col.name)?,
@@ -256,6 +290,30 @@ impl<W: Write> Hl7Writer<W> {
             };
             fields[col.position - 1] = text;
         }
+
+        // Re-assemble each split field from its leaf columns. The leaves of
+        // one field share a `field_index`; `split_columns` is sorted by it,
+        // so contiguous runs belong to the same field.
+        let mut start = 0;
+        while start < self.split_columns.len() {
+            let field_index = self.split_columns[start].coord.field_index;
+            let mut end = start;
+            let mut leaves: Vec<(SplitCoord, String)> = Vec::new();
+            while end < self.split_columns.len()
+                && self.split_columns[end].coord.field_index == field_index
+            {
+                let col = &self.split_columns[end];
+                let text = match values.get(col.schema_index) {
+                    Some(v) => value_to_field(v, &col.name)?,
+                    None => String::new(),
+                };
+                leaves.push((col.coord, text));
+                end += 1;
+            }
+            fields[field_index - 1] = reassemble_field(&leaves, &self.delims);
+            start = end;
+        }
+
         while matches!(fields.last(), Some(s) if s.is_empty()) {
             fields.pop();
         }
@@ -274,8 +332,8 @@ impl<W: Write> Hl7Writer<W> {
             if !known {
                 return Err(FormatError::Hl7(format!(
                     "record column {name:?} has no HL7 mapping. The writer maps only `seg_id`, \
-                     `set_ref`, `set_type`, and positional `fNN` field columns; project the \
-                     record to those before output"
+                     `set_ref`, `set_type`, positional `fNN` field columns, and split-leaf \
+                     columns (`f08_c1`, `f03_r2_c1_s3`); project the record to those before output"
                 )));
             }
         }
@@ -399,10 +457,11 @@ impl<W: Write + Send> FormatWriter for Hl7Writer<W> {
     }
 }
 
-/// Whether a schema column name is a positional HL7 field column (`f01`,
-/// `f02`, …): an `f` followed by one or more ASCII digits.
+/// Whether a schema column name is a writable HL7 field column: a verbatim
+/// positional column (`f01`, `f02`, …) or a structured split-leaf column
+/// (`f08_c1`, `f03_r2_c1_s3`, …). Both map to a wire field.
 fn is_field_column(name: &str) -> bool {
-    field_position(name).is_some()
+    field_position(name).is_some() || parse_split_column(name).is_some()
 }
 
 /// Parse the 1-based wire field position from a column name. `f01` → 1,
@@ -752,5 +811,95 @@ mod tests {
         );
         let out = write_all(Hl7WriterConfig::default(), &[record], &schema);
         assert!(out.contains("PID|a||c\r"), "gapped mapping wrong: {out}");
+    }
+
+    #[test]
+    fn split_columns_reassemble_into_wire_field() {
+        // Component leaf columns re-join on the component separator at their
+        // shared wire position; the separator is verbatim, not escaped.
+        let cols: Vec<Box<str>> = vec![
+            "seg_id".into(),
+            "f01".into(),
+            "f03_c1".into(),
+            "f03_c2".into(),
+        ];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("PID".into()),
+                Value::String("1".into()),
+                Value::String("PATID".into()),
+                Value::String("MRN".into()),
+            ],
+        );
+        let out = write_all(Hl7WriterConfig::default(), &[record], &schema);
+        assert!(
+            out.contains("PID|1||PATID^MRN\r"),
+            "reassembly wrong: {out}"
+        );
+        assert!(!out.contains("\\S\\"), "component separator escaped: {out}");
+    }
+
+    #[test]
+    fn split_columns_trim_trailing_empty_components() {
+        // A trailing-empty component must not fabricate a `^` inside the
+        // re-assembled field. The split sits at wire field 3, so fields 1
+        // and 2 are empty (`PID|||…`), exactly as a verbatim `f03` would be.
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "f03_c1".into(), "f03_c2".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("PID".into()),
+                Value::String("PATID".into()),
+                Value::Null,
+            ],
+        );
+        let out = write_all(Hl7WriterConfig::default(), &[record], &schema);
+        assert!(out.contains("PID|||PATID\r"), "{out}");
+        assert!(!out.contains("PATID^"), "fabricated trailing sep: {out}");
+    }
+
+    #[test]
+    fn split_columns_reassemble_repetitions_and_subcomponents() {
+        let cols: Vec<Box<str>> = vec![
+            "seg_id".into(),
+            "f03_r1_c1_s1".into(),
+            "f03_r1_c1_s2".into(),
+            "f03_r2_c1_s1".into(),
+        ];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("PID".into()),
+                Value::String("A".into()),
+                Value::String("B".into()),
+                Value::String("C".into()),
+            ],
+        );
+        let out = write_all(Hl7WriterConfig::default(), &[record], &schema);
+        // Sub-components join on `&`, repetitions on `~`, at wire field 3.
+        assert!(out.contains("PID|||A&B~C\r"), "{out}");
+    }
+
+    #[test]
+    fn split_leaf_value_escapes_embedded_field_separator() {
+        // A literal field separator inside a split leaf is still escaped on
+        // output; only the structural component separator is verbatim.
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "f03_c1".into(), "f03_c2".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("PID".into()),
+                Value::String("a|b".into()),
+                Value::String("MRN".into()),
+            ],
+        );
+        let out = write_all(Hl7WriterConfig::default(), &[record], &schema);
+        // `a|b` → `a\F\b`, joined to `MRN` with a verbatim `^`, at wire field 3.
+        assert!(out.contains("PID|||a\\F\\b^MRN\r"), "{out}");
     }
 }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2581,6 +2581,10 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                 )));
             }
         }
+
+        if let InputFormat::Hl7(Some(opts)) = &input.format {
+            validate_hl7_split_fields(&input.name, opts)?;
+        }
     }
 
     // Single-envelope output formats wrap every record in one frame whose
@@ -2729,6 +2733,68 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         }
     }
 
+    Ok(())
+}
+
+/// Default `fNN` column count for an HL7 source when `max_fields` is unset,
+/// matching the reader's documented default. A split field must name a
+/// position within this range to be reachable.
+const HL7_DEFAULT_MAX_FIELDS: usize = 64;
+
+/// Validate an HL7 source's `split_fields` declarations: each names a
+/// reachable positional field (`fNN`, `1 <= N <= max_fields`) with at least
+/// one column on every structural axis, and no two splits target the same
+/// field.
+///
+/// # Errors
+///
+/// Returns [`ConfigError::Validation`] naming the offending split when a
+/// `field` is not a `fNN` name, names position 0 or a position past
+/// `max_fields`, declares a zero axis width, or duplicates another split's
+/// target field.
+fn validate_hl7_split_fields(source_name: &str, opts: &Hl7InputOptions) -> Result<(), ConfigError> {
+    let Some(splits) = &opts.split_fields else {
+        return Ok(());
+    };
+    let max_fields = opts.max_fields.unwrap_or(HL7_DEFAULT_MAX_FIELDS);
+    let mut seen: Vec<usize> = Vec::with_capacity(splits.len());
+    for split in splits {
+        let position = split.field_position().ok_or_else(|| {
+            ConfigError::Validation(format!(
+                "source '{source_name}': split field {:?} is not a positional `fNN` column name \
+                 (e.g. `f08`)",
+                split.field
+            ))
+        })?;
+        if position > max_fields {
+            return Err(ConfigError::Validation(format!(
+                "source '{source_name}': split field {:?} names position {position}, past the \
+                 configured max_fields of {max_fields}; raise `max_fields` or remove the split",
+                split.field
+            )));
+        }
+        for (axis, count) in [
+            ("components", split.components),
+            ("subcomponents", split.subcomponents),
+            ("repetitions", split.repetitions),
+        ] {
+            if count == 0 {
+                return Err(ConfigError::Validation(format!(
+                    "source '{source_name}': split field {:?} declares `{axis}: 0`; every axis \
+                     width must be at least 1",
+                    split.field
+                )));
+            }
+        }
+        if seen.contains(&position) {
+            return Err(ConfigError::Validation(format!(
+                "source '{source_name}': field {:?} is split more than once; declare each split \
+                 field at most once",
+                split.field
+            )));
+        }
+        seen.push(position);
+    }
     Ok(())
 }
 

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -579,4 +579,56 @@ pub struct Hl7InputOptions {
     /// guidance rather than silently truncated. Defaults to 64.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_fields: Option<usize>,
+    /// Opt-in composite-field splits. Each entry explodes one positional
+    /// field into per-component (and optionally per-sub-component /
+    /// per-repetition) columns, replacing the verbatim `fNN` column with the
+    /// structured columns; the writer re-assembles the wire field from them.
+    /// Absent by default, so the positional model is byte-identical to today
+    /// unless a split is declared.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub split_fields: Option<Vec<Hl7FieldSplitOption>>,
+}
+
+/// One opt-in HL7 composite-field split declaration.
+///
+/// Names the positional field to explode and the column width on each
+/// structural axis. The default index (1) on the repetition and
+/// sub-component axes is elided from the column names, so a component-only
+/// split yields clean `fNN_cC` columns.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Hl7FieldSplitOption {
+    /// The positional field column to explode (`f08`). The wire position is
+    /// parsed from the `fNN` suffix.
+    pub field: String,
+    /// Number of component columns to expose (the `^` axis). At least 1.
+    pub components: usize,
+    /// Number of sub-component columns to expose per component (the `&`
+    /// axis). Defaults to 1 (no sub-component explosion).
+    #[serde(default = "one")]
+    pub subcomponents: usize,
+    /// Number of repetition columns to expose (the `~` axis). Defaults to 1
+    /// (no repetition explosion).
+    #[serde(default = "one")]
+    pub repetitions: usize,
+}
+
+impl Hl7FieldSplitOption {
+    /// Parse the 1-based wire field position from `field` (`f08` → 8), or
+    /// `None` when it is not an `f`-prefixed digit run or names position 0.
+    /// Config validation rejects a `None` before the reader is built.
+    pub fn field_position(&self) -> Option<usize> {
+        let rest = self.field.strip_prefix('f')?;
+        if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        let position: usize = rest.parse().ok()?;
+        (position >= 1).then_some(position)
+    }
+}
+
+/// Default axis width: a single column. Used by the optional
+/// `subcomponents` / `repetitions` split-declaration fields.
+fn one() -> usize {
+    1
 }

--- a/docs/src/pipeline/hl7.md
+++ b/docs/src/pipeline/hl7.md
@@ -115,6 +115,72 @@ nodes:
         - { name: f01, type: string }
 ```
 
+## Component splitting (optional)
+
+By default a composite field rides inside one `fNN` column with its
+component (`^`), repetition (`~`), and sub-component (`&`) separators intact
+— the positional model deliberately works above component resolution. When
+you want component-level access (the message code `MSH-9.1` vs the trigger
+event `MSH-9.2`) without writing CXL string-splitting downstream, opt one or
+more fields into splitting with `split_fields`. The reader explodes the
+named field into structured columns, and an HL7 Output re-assembles the
+exact wire field from them, so an HL7→HL7 round-trip stays byte-identical.
+
+```yaml
+options:
+  split_fields:
+    - { field: f08, components: 2 }                       # MSH-9 → message code + trigger
+    - { field: f03, components: 5 }                       # PID-3 (CX) → its components
+    - { field: f04, components: 2, subcomponents: 3 }     # also expose sub-components
+    - { field: f13, components: 1, repetitions: 4 }       # repeating field → per-repetition
+```
+
+Each split fixes the column width on three structural axes: `components`
+(required, the `^` axis), `subcomponents` (default 1, the `&` axis), and
+`repetitions` (default 1, the `~` axis). The schema stays static — it never
+varies with per-record data. A field whose data carries more structure on
+any axis than the declaration reserves is rejected with guidance, the same
+posture as a `max_fields` overflow; raise the axis count or leave the field
+unsplit.
+
+The exploded columns name the path from the field down to a leaf with the
+axis letters `r`, `c`, `s`, all 1-based, eliding the default index (`1`) on
+the repetition and sub-component axes so the common component-only case
+stays clean:
+
+| Declaration                                | Columns for `f08`            |
+| ------------------------------------------ | ---------------------------- |
+| `components: 2`                            | `f08_c1`, `f08_c2`          |
+| `components: 1, subcomponents: 2`          | `f08_c1_s1`, `f08_c1_s2`    |
+| `components: 1, repetitions: 2`            | `f08_r1_c1`, `f08_r2_c1`    |
+
+The verbatim `fNN` column is replaced by the structured columns. Declare the
+exploded column names in the source `schema:` block (or rely on
+`on_unmapped`) the same way you would any other column:
+
+```yaml
+options:
+  split_fields:
+    - { field: f08, components: 2 }
+schema:
+  - { name: seg_id, type: string }
+  - { name: f08_c1, type: string }   # MSH-9.1 message code
+  - { name: f08_c2, type: string }   # MSH-9.2 trigger event
+```
+
+```cxl
+emit code    = f08_c1
+emit trigger = f08_c2
+```
+
+Splitting respects the escape rules: an escaped separator (e.g. `\S\`, a
+literal `^` in data) is **not** treated as a component boundary — the split
+runs on the raw bytes before the escape decodes, so the literal stays inside
+one component. On output the writer re-joins the leaves on the separators
+verbatim (never escaping `^`/`~`/`&`) and still escapes any field-separator,
+escape, or carriage-return byte inside a leaf, so the round-trip is
+byte-faithful.
+
 ## Envelope sections over the tiers
 
 The file header `FHS` is extractable as a file-level document envelope
@@ -174,8 +240,11 @@ stream, escaping any field data that carries a delimiter byte. Records map
 by the same positional columns (`seg_id`, `fNN`); trailing `null`/empty
 fields are trimmed so no fabricated delimiters appear, and a column the
 writer does not recognize is an error (project the record to the HL7
-columns first). The reader-stamped `set_ref`/`set_type` echoes and
-engine-internal `$`-namespaced columns are excluded automatically.
+columns first). Split-leaf columns (`f08_c1`, `f03_r2_c1_s3`) are recognized
+too — the writer groups them by field and re-assembles the wire value from
+the column names alone, so no output option is needed to round-trip a split
+source. The reader-stamped `set_ref`/`set_type` echoes and engine-internal
+`$`-namespaced columns are excluded automatically.
 
 ```yaml
 nodes:
@@ -220,10 +289,12 @@ no source `FHS` section to echo.
 
 - **Charset.** Field text is decoded as UTF-8. Non-UTF-8 messages are
   rejected explicitly rather than silently corrupted.
-- **Positional fields, not component trees.** Components, repetitions, and
-  sub-components ride inside one positional `fNN` field verbatim; the reader
-  decodes only the `\X\` delimiter escapes. Split a composite field with CXL
-  string operations downstream when component-level access is needed.
+- **Positional fields by default; opt-in component columns.** Components,
+  repetitions, and sub-components ride inside one positional `fNN` field
+  verbatim unless that field is named in `split_fields` (see *Component
+  splitting* above), in which case the reader explodes it into structured
+  columns and the writer re-assembles them. The reader always decodes the
+  `\X\` delimiter escapes regardless.
 - **HL7 v3 and FHIR are out of scope.** HL7 v3 is XML (use the `xml`
   format) and FHIR is JSON/REST (use the `json` format); this format
   handles HL7 v2.x pipe-and-hat encoding only.


### PR DESCRIPTION
## Summary

Adds an opt-in `split_fields` source option that explodes configurable HL7 v2 fields into per-repetition (`~`), per-component (`^`), and per-sub-component (`&`) columns, with the writer re-assembling the exact wire field. Off by default, so output is byte-identical to before.

## Design

- A new HL7-local split model (`field_split.rs`) maps a configured field (`fNN`) plus its component/sub-component/repetition counts to flat leaf columns, names them by axis coordinate, and provides split (read) and reassemble (write).
- **Escape-vs-structure ordering is the load-bearing correctness point:** splitting runs on the *raw* pre-decode field bytes and then decodes each leaf, because escape decoding turns `\S\` into a literal `^` indistinguishable from a structural component separator. An escaped separator therefore stays inside one component and never causes a spurious split.
- A split field **replaces** its verbatim `fNN` column (no parallel verbatim+split column), so there is a single write path; the writer re-joins on `^`/`~`/`&` verbatim (never escaping them) and reassembles purely from the schema column names.
- Config validation rejects non-`fNN` keys, positions past the field count, zero on any axis, and duplicate targets, each with a source-named diagnostic. Splitting is strictly row-at-a-time (bounded, no cross-record state).

## Tests & docs

The existing byte-faithful round-trip test stays green; a new round-trip test proves a split field re-emits the exact composite with no leaked escapes. ~20 unit tests cover the escape-safety ordering, trailing-empty trimming, column naming, and config validation. `docs/src/pipeline/hl7.md` documents the option, the three axes, the column-naming rules, and the escape-safety behavior.

Closes #437.