### PR TITLE
cxl,plan: collect $doc paths from Route branch predicates (#434)

### DIFF
--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -764,8 +764,10 @@ impl PipelineConfig {
         // residual filters / emit bodies and in composition-body
         // programs, all of which land in `artifacts.typed` under their
         // node name (body programs are inserted there by the recursive
-        // bind_schema pass). Missing any of them would drop a referenced
-        // path from the declared set.
+        // bind_schema pass). Combine `where:` predicates and Route branch
+        // conditions are typed into separate side-tables and chained in
+        // below. Missing any of them would drop a referenced path from the
+        // declared set.
         let doc_refs: Vec<(&str, &cxl::typecheck::pass::TypedProgram)> = artifacts
             .typed
             .iter()
@@ -779,6 +781,20 @@ impl PipelineConfig {
                     .combine_where_typed
                     .iter()
                     .map(|(name, tp)| (name.as_str(), tp.as_ref())),
+            )
+            // A Route's node-keyed `typed` entry is an empty body; its
+            // branch-condition programs live in a separate side-table, one
+            // per branch. Include each, keyed by the Route node name so the
+            // per-node source attribution stamps the path onto the Route's
+            // source(s) — a `$doc` access used only in a route condition
+            // would otherwise be dropped.
+            .chain(
+                artifacts
+                    .route_branch_typed
+                    .iter()
+                    .flat_map(|(name, programs)| {
+                        programs.iter().map(move |tp| (name.as_str(), tp.as_ref()))
+                    }),
             )
             .collect();
         let doc_path_set = cxl::analyzer::doc_paths::collect_doc_paths(&doc_refs);

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -65,6 +65,16 @@ pub struct CompileArtifacts {
     /// in a predicate (e.g. `l.amount > $doc.Head.cutoff`) is still
     /// reachable by the compile-time `$doc` path walk.
     pub combine_where_typed: HashMap<String, Arc<TypedProgram>>,
+    /// Per-Route branch-condition typed programs, keyed by Route node
+    /// name — one program per branch, in declaration order. A Route's
+    /// node-keyed `typed` entry is an empty body (the node carries no
+    /// `cxl:` projection); the branch conditions are otherwise compiled
+    /// straight to runtime evaluators and never land in `typed`. This
+    /// side-table retains them so a `$doc` access used ONLY in a route
+    /// condition (e.g. `amount > $doc.Head.cutoff`) is still reachable by
+    /// the compile-time `$doc` path walk and attributed to the Route's
+    /// source(s).
+    pub route_branch_typed: HashMap<String, Vec<Arc<TypedProgram>>>,
     /// All bound composition bodies, keyed by `CompositionBodyId`. The
     /// top-level pipeline is NOT in this map — it lives on
     /// `CompiledPlan.dag()` directly. Only body scopes are here.
@@ -1419,7 +1429,7 @@ fn bind_schema_inner(
                     Err(d) => diags.push(d),
                 }
             }
-            PipelineNode::Route { header, config: _ } => {
+            PipelineNode::Route { header, config } => {
                 if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
                     let cloned = upstream.clone();
                     if let Ok(mut empty) = typecheck_cxl(
@@ -1432,6 +1442,37 @@ fn bind_schema_inner(
                     ) {
                         empty.output_row = cloned.clone();
                         artifacts.typed.insert(name.clone(), Arc::new(empty));
+                    }
+                    // Type-check each branch condition into its own program
+                    // so the compile-time `$doc` walk can reach an envelope
+                    // path referenced ONLY in a route predicate. The
+                    // condition is a boolean expression; wrapping it in
+                    // `filter` mirrors how the runtime compiles it, giving a
+                    // `Statement::Filter` whose predicate the `$doc` walk
+                    // descends. A condition that fails to type-check is not
+                    // diagnosed here — that surfaces through the existing
+                    // route-compilation path — so only well-typed branches
+                    // contribute paths.
+                    let branch_programs: Vec<Arc<TypedProgram>> = config
+                        .conditions
+                        .values()
+                        .filter_map(|cond| {
+                            typecheck_cxl(
+                                &name,
+                                &format!("filter {}", cond.source),
+                                &cloned,
+                                AggregateMode::Row,
+                                span,
+                                &bind_ctx.scoped_vars,
+                            )
+                            .ok()
+                            .map(Arc::new)
+                        })
+                        .collect();
+                    if !branch_programs.is_empty() {
+                        artifacts
+                            .route_branch_typed
+                            .insert(name.clone(), branch_programs);
                     }
                     schema_by_name.insert(name, cloned);
                 }

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -282,6 +282,81 @@ nodes:
 }
 
 #[test]
+fn test_doc_path_in_route_branch_condition_is_collected() {
+    // A `$doc` access referenced ONLY in a Route branch condition must
+    // reach the declared path set. A Route's node-keyed typed program is
+    // an empty body and its branch conditions compile straight to runtime
+    // evaluators, so this exercises the route-branch side-table that feeds
+    // the all-programs walk. The path attributes to the Route's upstream
+    // source (the Route inherits its input's source set).
+    let yaml = r#"
+pipeline:
+  name: route_doc
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Head:
+            extract: { xml_path: "/doc/Head" }
+            fields:
+              cutoff: int
+      schema:
+        - { name: amount, type: int }
+  - type: route
+    name: split
+    input: payments
+    config:
+      mode: exclusive
+      conditions:
+        big: "amount > $doc.Head.cutoff"
+      default: small
+  - type: output
+    name: big_out
+    input: split.big
+    config:
+      name: big_out
+      type: csv
+      path: big.csv
+  - type: output
+    name: small_out
+    input: split.small
+    config:
+      name: small_out
+      type: csv
+      path: small.csv
+"#;
+    let config = parse_config(yaml).expect("parse route-doc pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile route-doc pipeline");
+    let dag = plan.dag();
+    let source = dag
+        .graph
+        .node_indices()
+        .find_map(|idx| match &dag.graph[idx] {
+            PlanNode::Source { resolved, .. } => resolved.as_ref(),
+            _ => None,
+        })
+        .expect("source node present with resolved payload");
+    assert!(
+        source
+            .source
+            .declared_doc_paths
+            .contains(&path("Head", "cutoff", vec![])),
+        "`$doc.Head.cutoff` used only in a route branch condition must reach the \
+         declared set, got {:?}",
+        source.source.declared_doc_paths
+    );
+}
+
+#[test]
 fn test_multi_source_paths_are_attributed_per_source() {
     // Two independent single-source chains read disjoint `$doc` paths.
     // Each source must carry ONLY the path its own downstream program


### PR DESCRIPTION
## Summary

The compile-time `$doc` path collection walked transforms, aggregates, Combine bodies and `where:` predicates, and composition bodies — but not Route branch conditions. A `$doc.<section>.<field>` referenced only inside a Route branch predicate was therefore dropped from the per-source declared set, so a reader pruning to declared paths would miss it.

This collects those paths, mirroring the existing Combine `where:` mechanism rather than forking the walker: a `route_branch_typed` side-table on the compile artifacts holds each Route branch condition type-checked as a `filter <cond>` program keyed by the Route node name, and those programs are chained into the same `$doc` collection so the per-source attribution lands each path on the Route's upstream source.

## Notes

The shared typed-AST visitor and the per-source attribution are reused unchanged. Only successfully-typed branch conditions are collected; plan-time diagnosis of malformed Route conditions (which still fail at runtime, as before) is tracked separately in #476. A test asserts a `$doc` path referenced only in a Route branch condition reaches its source's declared set.

Closes #434.