### PR TITLE
format: emit one X12 functional group per group_ref discriminator (#413)

### DIFF
--- a/crates/clinker-exec/tests/x12_pipeline.rs
+++ b/crates/clinker-exec/tests/x12_pipeline.rs
@@ -332,6 +332,129 @@ nodes:
 }
 
 #[test]
+fn x12_output_emits_multiple_functional_groups() {
+    // A two-group source interchange is projected so the functional-group
+    // control number becomes a `group_ref` discriminator, then written back
+    // as X12. The writer must reopen a GS..GE group per discriminator,
+    // recompute each GE transaction-set count, and re-parse cleanly — proving
+    // multi-group output, not a single GS wrapping every set.
+    let multi = format!(
+        "{ISA}\
+        GS*PO*S*R*20240101*1200*1*X*004010~\
+        ST*850*0001~BEG*00*NE*A**20240101~SE*3*0001~\
+        ST*850*0002~BEG*00*NE*B**20240101~SE*3*0002~\
+        GE*2*1~\
+        GS*PO*S*R*20240101*1300*2*X*004010~\
+        ST*850*0003~BEG*00*NE*C**20240101~SE*3*0003~\
+        GE*1*2~\
+        IEA*2*000000001~"
+    );
+    let yaml = r#"
+pipeline:
+  name: x12_multi_out
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: set_type, type: string }
+        - { name: e01, type: string }
+        - { name: e02, type: string }
+        - { name: e03, type: string }
+        - { name: e04, type: string }
+  - type: transform
+    name: regroup
+    input: interchange
+    config:
+      cxl: |
+        emit seg_id = seg_id
+        emit group_ref = $doc.functional_group.e06
+        emit set_ref = set_ref
+        emit set_type = set_type
+        emit e01 = e01
+        emit e02 = e02
+        emit e03 = e03
+        emit e04 = e04
+  - type: output
+    name: out
+    input: regroup
+    config:
+      name: out
+      type: x12
+      path: out.x12
+      include_unmapped: true
+      options:
+        interchange: ["00", "          ", "00", "          ", "ZZ", "SENDER         ", "ZZ", "RECEIVER       ", "240101", "1200", "U", "00401", "000000001", "0", "P", ":"]
+        group_header: ["PO", "S", "R", "20240101", "1200", "1", "X", "004010"]
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "interchange", &multi, "multi.x12", "out").expect("run multi-group output");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // Two functional groups, each echoing its source control number, with a
+    // per-group transaction-set count (first holds two sets, second one), and
+    // the IEA claiming both groups.
+    assert_eq!(output.matches("GS*").count(), 2, "output was: {output}");
+    assert_eq!(output.matches("GE*").count(), 2, "output was: {output}");
+    assert!(output.contains("GE*2*1~"), "first group GE wrong: {output}");
+    assert!(
+        output.contains("GE*1*2~"),
+        "second group GE wrong: {output}"
+    );
+    assert!(
+        output.contains("IEA*2*000000001~"),
+        "IEA count wrong: {output}"
+    );
+
+    // The reconstructed multi-group interchange re-parses without error and
+    // streams every body segment in order across both groups.
+    let reparse_yaml = r#"
+pipeline:
+  name: x12_multi_reparse
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+      include_header: false
+"#;
+    let (reparse_report, reparse_csv) =
+        run(reparse_yaml, "interchange", &output, "echo.x12", "out")
+            .expect("re-parse multi-group round-trip");
+    assert_eq!(reparse_report.counters.dlq_count, 0);
+    let tags: Vec<&str> = reparse_csv.lines().map(str::trim).collect();
+    assert_eq!(
+        tags,
+        vec!["ST", "BEG", "ST", "BEG", "ST", "BEG"],
+        "round-trip body tags across both groups; x12 output was: {output}"
+    );
+}
+
+#[test]
 fn x12_output_with_split_is_rejected_at_config_time() {
     // An interchange is one three-tier envelope; byte-limit splitting would
     // finalize it mid-stream. The combination must fail config validation,

--- a/crates/clinker-format/src/x12/writer.rs
+++ b/crates/clinker-format/src/x12/writer.rs
@@ -2,10 +2,18 @@
 //!
 //! Reconstructs the three-tier interchange envelope around emitted body
 //! records: an `ISA` header (literal config elements or echoed from a
-//! `$doc` section), one `GS..GE` functional group, `ST..SE` transaction
-//! sets grouped on the `set_ref` column, and a closing `IEA`. Record
-//! columns map positionally — `seg_id` is the segment tag, `e01..` are the
-//! data elements.
+//! `$doc` section), `GS..GE` functional groups grouped on the optional
+//! `group_ref` column, `ST..SE` transaction sets grouped on the `set_ref`
+//! column, and a closing `IEA`. Record columns map positionally — `seg_id`
+//! is the segment tag, `e01..` are the data elements.
+//!
+//! A record stream carrying several distinct `group_ref` values writes one
+//! `GS..GE` functional group per value inside the single `ISA..IEA`
+//! interchange — a `PO` group of purchase orders and an `IN` group of
+//! invoices, say, share one envelope. With no `group_ref` column the whole
+//! stream collapses to a single functional group, byte-identical to a
+//! stream whose `group_ref` never changes; the `group_ref` grouping is the
+//! exact analog of how `set_ref` drives `ST..SE` boundaries one tier down.
 //!
 //! X12 has **no** release/escape character: a data value carrying a
 //! delimiter byte (the element separator, the sub-element separator, or
@@ -14,14 +22,14 @@
 //! a precise error naming the offending column.
 //!
 //! Memory model: streaming and O(1) in held state — only the currently
-//! open transaction set's segment count, the functional group's set count,
-//! and the interchange group count are retained. `flush` is the single
-//! end-of-stream finalizer: it closes the open set, the group, and writes
-//! the `IEA` trailer with recomputed counts, exactly once. An interchange
-//! is one envelope, so byte-limit file splitting (which would flush — and
-//! thus finalize — mid-stream) is rejected for X12 outputs at
-//! config-validation time; this writer is therefore only ever flushed at
-//! true end of stream.
+//! open transaction set's segment count, the open functional group's set
+//! count and control number, and the interchange group count are retained.
+//! `flush` is the single end-of-stream finalizer: it closes the open set,
+//! the open group, and writes the `IEA` trailer with recomputed counts,
+//! exactly once. An interchange is one envelope, so byte-limit file
+//! splitting (which would flush — and thus finalize — mid-stream) is
+//! rejected for X12 outputs at config-validation time; this writer is
+//! therefore only ever flushed at true end of stream.
 
 use std::io::Write;
 use std::sync::Arc;
@@ -93,18 +101,15 @@ pub struct X12Writer<W: Write> {
     seg_id_idx: Option<usize>,
     set_ref_idx: Option<usize>,
     set_type_idx: Option<usize>,
+    group_ref_idx: Option<usize>,
     header_written: bool,
     finalized: bool,
     /// `ISA13` interchange control number, echoed in the `IEA02` trailer.
     isa_control_number: String,
-    /// `GS06` group control number for the single open functional group.
-    group_control_number: String,
-    /// Count of `ST` transaction sets written, for the `GE01` count.
-    set_count: u64,
     /// Count of `GS` functional groups written, for the `IEA01` count.
     group_count: u64,
     open_set: Option<OpenSet>,
-    group_open: bool,
+    open_group: Option<OpenGroup>,
 }
 
 /// A schema `eNN` element column resolved to its wire position and the
@@ -128,20 +133,38 @@ struct OpenSet {
     segment_count: u64,
 }
 
+/// State for the functional group currently being written. Carried per
+/// group so the closing `GE01` reflects only the sets inside *this* group,
+/// not the interchange-wide running total — the multi-group analog of how
+/// [`OpenSet`] scopes the `SE01` segment count to a single set.
+struct OpenGroup {
+    /// The record-level `group_ref` value that opened the group, or empty
+    /// when the stream carries no `group_ref` column. A non-empty value
+    /// closes the group and opens a new one when it changes.
+    group_ref: String,
+    /// `GS06` group control number echoed by `GE02`.
+    control_number: String,
+    /// `ST` transaction sets opened in this group so far, for the `GE01`
+    /// count and for deriving anonymous set control numbers within it.
+    set_count: u64,
+}
+
 impl<W: Write> X12Writer<W> {
     /// Build a writer over a sink with the given schema and config. The
-    /// schema's `seg_id` / `set_ref` / `set_type` / `eNN` columns are
-    /// resolved to positional indices once.
+    /// schema's `seg_id` / `set_ref` / `set_type` / `group_ref` / `eNN`
+    /// columns are resolved to positional indices once.
     pub fn new(writer: W, schema: Arc<Schema>, config: X12WriterConfig) -> Self {
         let mut element_columns = Vec::new();
         let mut seg_id_idx = None;
         let mut set_ref_idx = None;
         let mut set_type_idx = None;
+        let mut group_ref_idx = None;
         for (i, col) in schema.columns().iter().enumerate() {
             match &**col {
                 "seg_id" => seg_id_idx = Some(i),
                 "set_ref" => set_ref_idx = Some(i),
                 "set_type" => set_type_idx = Some(i),
+                "group_ref" => group_ref_idx = Some(i),
                 name => {
                     if let Some(position) = element_position(name) {
                         element_columns.push(ElementColumn {
@@ -162,19 +185,21 @@ impl<W: Write> X12Writer<W> {
             seg_id_idx,
             set_ref_idx,
             set_type_idx,
+            group_ref_idx,
             header_written: false,
             finalized: false,
             isa_control_number: String::new(),
-            group_control_number: String::new(),
-            set_count: 0,
             group_count: 0,
             open_set: None,
-            group_open: false,
+            open_group: None,
         }
     }
 
-    /// Emit the `ISA` interchange header and the `GS` functional-group
-    /// header on the first record.
+    /// Emit the `ISA` interchange header on the first record. The first
+    /// `GS` functional group opens lazily on the first body segment, driven
+    /// by that record's `group_ref`, exactly as the first `ST` set does — so
+    /// the group control number can echo a discriminator the header has not
+    /// yet seen.
     fn write_header(&mut self, record: &Record) -> Result<(), FormatError> {
         if self.header_written {
             return Ok(());
@@ -191,7 +216,6 @@ impl<W: Write> X12Writer<W> {
         // writer keeps the element separator and terminator at their
         // defaults so the header is self-consistent on re-read.
         self.write_segment("ISA", &isa_elements)?;
-        self.open_functional_group()?;
         Ok(())
     }
 
@@ -242,9 +266,14 @@ impl<W: Write> X12Writer<W> {
         ))
     }
 
-    /// Open the single functional group from the configured `group_header`,
-    /// recomputing its `GS06` control number.
-    fn open_functional_group(&mut self) -> Result<(), FormatError> {
+    /// Open a functional group from the configured `group_header`,
+    /// recomputing its `GS06` control number. A non-empty `group_ref` echoes
+    /// as the control number (the discriminator *is* the group identity, the
+    /// `GS06`/`GE02` analog of how a non-empty `set_ref` echoes as `ST02`);
+    /// an empty `group_ref` falls back to the sequential group ordinal so a
+    /// stream without a `group_ref` column keeps the single-group `1, 2, …`
+    /// numbering unchanged.
+    fn open_functional_group(&mut self, group_ref: &str) -> Result<(), FormatError> {
         let header = self.config.group_header.clone().ok_or_else(|| {
             FormatError::X12(
                 "no functional-group header configured: set the writer's `group_header` \
@@ -253,24 +282,53 @@ impl<W: Write> X12Writer<W> {
             )
         })?;
         self.group_count += 1;
+        let control_number = if group_ref.is_empty() {
+            self.group_count.to_string()
+        } else {
+            group_ref.to_string()
+        };
         // GS06 (element index 5) is the group control number; recompute it
         // so it is unique per group and echoed correctly by GE.
-        self.group_control_number = self.group_count.to_string();
         let mut gs = header;
-        set_or_push(&mut gs, 5, self.group_control_number.clone());
+        set_or_push(&mut gs, 5, control_number.clone());
         self.write_segment("GS", &gs)?;
-        self.group_open = true;
+        self.open_group = Some(OpenGroup {
+            group_ref: group_ref.to_string(),
+            control_number,
+            set_count: 0,
+        });
         Ok(())
     }
 
+    /// Open a new `GS` functional group (closing any previous one) when the
+    /// `group_ref` changes, or open the first group. A record with an empty
+    /// `group_ref` joins the current group; if none is open, it opens the
+    /// sole group — so a stream with no `group_ref` column produces exactly
+    /// one `GS..GE`, byte-identical to the single-group output.
+    fn transition_group(&mut self, group_ref: &str) -> Result<(), FormatError> {
+        let need_new = match &self.open_group {
+            None => true,
+            Some(open) => !group_ref.is_empty() && open.group_ref != *group_ref,
+        };
+        if !need_new {
+            return Ok(());
+        }
+        self.close_functional_group()?;
+        self.open_functional_group(group_ref)
+    }
+
     /// Map a body record to its segment tag and element list, then write
-    /// it, opening or closing `ST..SE` transaction sets on `set_ref`
-    /// transitions.
+    /// it, opening or closing `GS..GE` functional groups on `group_ref`
+    /// transitions and `ST..SE` transaction sets on `set_ref` transitions.
     fn write_body_record(&mut self, record: &Record) -> Result<(), FormatError> {
         self.reject_unknown_columns(record)?;
         let values = record.values();
         let seg_id = match self.seg_id_idx.and_then(|i| values.get(i)) {
             Some(v) => value_to_element(v, "seg_id")?,
+            None => String::new(),
+        };
+        let group_ref = match self.group_ref_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_element(v, "group_ref")?,
             None => String::new(),
         };
         let set_ref = match self.set_ref_idx.and_then(|i| values.get(i)) {
@@ -281,6 +339,11 @@ impl<W: Write> X12Writer<W> {
             Some(v) => value_to_element(v, "set_type")?,
             None => String::new(),
         };
+
+        // The group boundary is the outer tier, so it transitions first: a
+        // group change closes the open set then the open group before
+        // opening the new group, which the next `transition_set` populates.
+        self.transition_group(&group_ref)?;
 
         // Service segments embedded in the record stream are skipped — the
         // writer reconstructs envelopes itself, so an ISA/GS/ST/SE/GE/IEA
@@ -327,13 +390,21 @@ impl<W: Write> X12Writer<W> {
                     .into(),
             ));
         };
+        // Anonymous sets number from the *open group's* set count, so the
+        // generated `ST02` control numbers restart per group rather than
+        // running interchange-wide. A set is always opened inside a group —
+        // `transition_group` has run for this record — so the group is open
+        // here; `unwrap_or(0)` keeps the path total in the unreachable case.
+        let group_set_count = self.open_group.as_ref().map(|g| g.set_count).unwrap_or(0);
         let control_number = if set_ref.is_empty() {
-            format!("{:04}", self.set_count + 1)
+            format!("{:04}", group_set_count + 1)
         } else {
             set_ref.to_string()
         };
         self.write_segment("ST", &[resolved_type, control_number.clone()])?;
-        self.set_count += 1;
+        if let Some(group) = self.open_group.as_mut() {
+            group.set_count += 1;
+        }
         self.open_set = Some(OpenSet {
             control_number,
             segment_count: 1,
@@ -351,18 +422,15 @@ impl<W: Write> X12Writer<W> {
         Ok(())
     }
 
-    /// Close the open functional group with its recomputed `GE` trailer
-    /// (transaction-set count, group control-number echo).
+    /// Close the open functional group with its recomputed `GE` trailer:
+    /// `GE01` is the count of transaction sets in *this* group (not the
+    /// interchange-wide total), `GE02` echoes the group control number. Any
+    /// transaction set still open is closed first, since `SE` always
+    /// precedes the enclosing `GE`.
     fn close_functional_group(&mut self) -> Result<(), FormatError> {
-        if self.group_open {
-            self.group_open = false;
-            self.write_segment(
-                "GE",
-                &[
-                    self.set_count.to_string(),
-                    self.group_control_number.clone(),
-                ],
-            )?;
+        self.close_open_set()?;
+        if let Some(group) = self.open_group.take() {
+            self.write_segment("GE", &[group.set_count.to_string(), group.control_number])?;
         }
         Ok(())
     }
@@ -403,13 +471,13 @@ impl<W: Write> X12Writer<W> {
             if name.starts_with('$') {
                 continue;
             }
-            let known =
-                matches!(name, "seg_id" | "set_ref" | "set_type") || is_element_column(name);
+            let known = matches!(name, "seg_id" | "set_ref" | "set_type" | "group_ref")
+                || is_element_column(name);
             if !known {
                 return Err(FormatError::X12(format!(
                     "record column {name:?} has no X12 mapping. The writer maps only \
-                     `seg_id`, `set_ref`, `set_type`, and positional `eNN` element \
-                     columns; project the record to those before output"
+                     `seg_id`, `set_ref`, `set_type`, `group_ref`, and positional `eNN` \
+                     element columns; project the record to those before output"
                 )));
             }
         }
@@ -489,7 +557,8 @@ impl<W: Write + Send> FormatWriter for X12Writer<W> {
             return Ok(());
         }
         self.finalized = true;
-        self.close_open_set()?;
+        // Closing the group cascades to close any open transaction set
+        // first, so the SE/GE ordering holds at end of stream too.
         self.close_functional_group()?;
         // Only write IEA if a header was actually emitted; a writer that
         // saw zero records produces nothing rather than a bare trailer.
@@ -929,6 +998,179 @@ mod tests {
         let s = schema();
         let out = write_all(literal_config(), &[], &s);
         assert!(out.is_empty(), "{out}");
+    }
+
+    /// Schema with a `group_ref` discriminator column ahead of `set_ref`,
+    /// for the multi-functional-group output tests.
+    fn grouped_schema() -> Arc<Schema> {
+        let mut cols: Vec<Box<str>> = vec![
+            "seg_id".into(),
+            "group_ref".into(),
+            "set_ref".into(),
+            "set_type".into(),
+        ];
+        for i in 1..=4 {
+            cols.push(format!("e{i:02}").into_boxed_str());
+        }
+        Arc::new(Schema::new(cols))
+    }
+
+    /// Body record carrying a `group_ref` value alongside `set_ref` /
+    /// `set_type`, mirroring [`body`] but with the group discriminator.
+    fn grouped_body(
+        schema: &Arc<Schema>,
+        seg: &str,
+        group_ref: &str,
+        set_ref: &str,
+        set_type: &str,
+        els: &[&str],
+    ) -> Record {
+        let string_or_null = |s: &str| {
+            if s.is_empty() {
+                Value::Null
+            } else {
+                Value::String(s.into())
+            }
+        };
+        let mut values = vec![
+            Value::String(seg.into()),
+            string_or_null(group_ref),
+            string_or_null(set_ref),
+            string_or_null(set_type),
+        ];
+        for i in 0..4 {
+            match els.get(i) {
+                Some(e) => values.push(Value::String((*e).into())),
+                None => values.push(Value::Null),
+            }
+        }
+        Record::new(Arc::clone(schema), values)
+    }
+
+    #[test]
+    fn group_ref_transition_opens_a_second_functional_group() {
+        let s = grouped_schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                grouped_body(&s, "BEG", "PO", "0001", "850", &["a"]),
+                grouped_body(&s, "INV", "IN", "0002", "810", &["b"]),
+            ],
+            &s,
+        );
+        // Two distinct group_ref values → two GS..GE groups in one ISA..IEA.
+        assert_eq!(out.matches("GS*").count(), 2, "{out}");
+        assert_eq!(out.matches("GE*").count(), 2, "{out}");
+        // GS06 echoes the discriminator; each GE claims its own single set
+        // and echoes the matching control number.
+        assert!(
+            out.contains("GS*PO*SENDER*RECEIVER*20240101*1200*PO*X*004010~"),
+            "{out}"
+        );
+        assert!(
+            out.contains("GS*PO*SENDER*RECEIVER*20240101*1200*IN*X*004010~"),
+            "{out}"
+        );
+        assert!(out.contains("GE*1*PO~"), "first group GE wrong: {out}");
+        assert!(out.contains("GE*1*IN~"), "second group GE wrong: {out}");
+        // IEA claims both functional groups.
+        assert!(out.contains("IEA*2*000000001~"), "{out}");
+    }
+
+    #[test]
+    fn ge_counts_are_per_group_not_interchange_wide() {
+        // First group holds two sets, second holds one. Each GE01 must
+        // reflect only its own group's sets, not the running total.
+        let s = grouped_schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                grouped_body(&s, "BEG", "PO", "0001", "850", &["a"]),
+                grouped_body(&s, "BEG", "PO", "0002", "850", &["b"]),
+                grouped_body(&s, "INV", "IN", "0003", "810", &["c"]),
+            ],
+            &s,
+        );
+        // First group: 2 sets; second group: 1 set.
+        assert!(
+            out.contains("GE*2*PO~"),
+            "first GE should claim 2 sets: {out}"
+        );
+        assert!(
+            out.contains("GE*1*IN~"),
+            "second GE should claim 1 set: {out}"
+        );
+        assert!(out.contains("IEA*2*000000001~"), "{out}");
+    }
+
+    #[test]
+    fn empty_group_ref_keeps_one_group_byte_identical() {
+        // A `group_ref` column whose value never changes (here always empty)
+        // must collapse to exactly one GS..GE, identical to a stream with no
+        // group_ref column at all.
+        let grouped = grouped_schema();
+        let with_group = write_all(
+            literal_config(),
+            &[
+                grouped_body(&grouped, "BEG", "", "0001", "850", &["a"]),
+                grouped_body(&grouped, "PO1", "", "0001", "850", &["b"]),
+            ],
+            &grouped,
+        );
+        let plain = schema();
+        let without_group = write_all(
+            literal_config(),
+            &[
+                body(&plain, "BEG", "0001", "850", &["a"]),
+                body(&plain, "PO1", "0001", "850", &["b"]),
+            ],
+            &plain,
+        );
+        assert_eq!(
+            with_group, without_group,
+            "empty group_ref must produce byte-identical output to no group_ref column"
+        );
+        assert_eq!(with_group.matches("GS*").count(), 1, "{with_group}");
+        assert!(with_group.contains("GE*1*1~"), "{with_group}");
+    }
+
+    #[test]
+    fn anonymous_set_numbers_restart_per_group() {
+        // With no set_ref but distinct group_ref values, each group's
+        // generated ST02 control number restarts at 0001 within its group.
+        let cols: Vec<Box<str>> = vec!["seg_id".into(), "group_ref".into()];
+        let schema = Arc::new(Schema::new(cols));
+        let rec = |seg: &str, group: &str| {
+            Record::new(
+                Arc::clone(&schema),
+                vec![Value::String(seg.into()), Value::String(group.into())],
+            )
+        };
+        let mut cfg = literal_config();
+        cfg.set_type = Some("850".into());
+        let out = write_all(cfg, &[rec("BEG", "PO"), rec("INV", "IN")], &schema);
+        // Each group opens an anonymous set numbered from that group's count.
+        assert_eq!(out.matches("ST*850*0001~").count(), 2, "{out}");
+        assert!(out.contains("GE*1*PO~"), "{out}");
+        assert!(out.contains("GE*1*IN~"), "{out}");
+    }
+
+    #[test]
+    fn group_ref_column_is_accepted_not_rejected() {
+        // The group discriminator is a recognized control column, never an
+        // unmapped user field.
+        let s = grouped_schema();
+        let out = write_all(
+            literal_config(),
+            &[grouped_body(&s, "BEG", "PO", "0001", "850", &["00"])],
+            &s,
+        );
+        assert!(out.contains("BEG*00~"), "{out}");
+        // group_ref drives the group, it is never emitted as a data element.
+        assert!(
+            !out.contains("*PO*PO*"),
+            "group_ref leaked into a segment: {out}"
+        );
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -219,8 +219,13 @@ pub struct EdifactOutputOptions {
 /// header comes from `interchange` (literal elements) or, when that is
 /// unset, is echoed from the `$doc` section named by `interchange_from_doc`
 /// for round-trip reconstruction. The `GS` functional-group header comes
-/// from `group_header`; transaction sets are grouped on the `set_ref`
-/// column, and the `SE`/`GE`/`IEA` control counts are recomputed.
+/// from `group_header`. Functional groups are grouped on the optional
+/// `group_ref` column and transaction sets on the `set_ref` column, so a
+/// stream carrying several distinct `group_ref` values writes one `GS..GE`
+/// group per value inside the single interchange (with no `group_ref`
+/// column the whole stream is one functional group). The `SE`/`GE`/`IEA`
+/// control counts are recomputed per set, per group, and for the
+/// interchange respectively.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct X12OutputOptions {

--- a/docs/src/pipeline/x12.md
+++ b/docs/src/pipeline/x12.md
@@ -64,6 +64,13 @@ schema:
 | `set_type` | The transaction set identifier code (`ST01`, e.g. `850`)     |
 | `e01`, `e02`, … | The segment's positional data elements                  |
 
+The reader does not stamp the enclosing functional-group control number as
+a column; it surfaces through `$doc.functional_group.e06` (see [Envelope
+sections over the three tiers](#envelope-sections-over-the-three-tiers)). An
+optional `group_ref` column drives multi-group **output** — project it from
+that `$doc` field when reconstructing several functional groups (see
+[Writing X12](#writing-x12)).
+
 Service segments (`ISA`, `IEA`, `GS`, `GE`, `SE`) are consumed by the
 reader to drive the envelope and validation — they are never emitted as
 body records. The `ST` segment that opens a transaction set **is** emitted
@@ -177,10 +184,11 @@ A missing `IEA` at end of input is a truncation error; content after the
 
 An X12 Output node reconstructs the three-tier envelope around emitted
 records. Records map by the same positional columns (`seg_id`, `set_ref`,
-`set_type`, `eNN`); trailing `null`/empty elements are trimmed so no
-fabricated delimiters appear, and a column the writer does not recognize is
-an error (project the record to the X12 columns first). Engine-internal
-`$`-namespaced columns are excluded automatically.
+`set_type`, `eNN`, and the optional `group_ref`); trailing `null`/empty
+elements are trimmed so no fabricated delimiters appear, and a column the
+writer does not recognize is an error (project the record to the X12
+columns first). Engine-internal `$`-namespaced columns are excluded
+automatically.
 
 ```yaml
 nodes:
@@ -207,17 +215,62 @@ Output options:
 | ----------------------- | ---------------------------------------------------------------------- |
 | `interchange`           | Literal `ISA` data elements (the 16 fixed-width ISA fields).           |
 | `interchange_from_doc`  | Name of a `$doc` section to echo the `ISA` elements from (round-trip). |
-| `group_header`          | Literal `GS01..GS08` elements (`GS06` control number recomputed).      |
+| `group_header`          | Literal `GS01..GS08` elements (`GS06` control number recomputed per group). |
 | `set_type`              | Fallback `ST01` set type when a record carries no `set_type` value.    |
 | `segment_newline`       | Write a newline after each segment terminator (default `true`).        |
 | `encoding`              | Character set element text is encoded through (default `utf-8`).        |
 
 Consecutive records are grouped into `ST..SE` transaction sets on `set_ref`
-transitions, and all sets are wrapped in a single `GS..GE` functional
-group. The writer recomputes the `SE` segment count, the `GE`
-transaction-set count, and the `IEA` functional-group count, and echoes the
-set, group, and interchange control numbers, so the output passes its own
-count validation on re-read.
+transitions and into `GS..GE` functional groups on `group_ref` transitions
+— the group discriminator is the outer-tier analog of `set_ref`. The writer
+recomputes the `SE` segment count, the per-group `GE` transaction-set count,
+and the `IEA` functional-group count, and echoes the set, group, and
+interchange control numbers, so the output passes its own count validation
+on re-read.
+
+### Multiple functional groups
+
+A real interchange can carry several functional groups — purchase orders
+(`PO`) and invoices (`IN`) in one `ISA..IEA`, each in its own `GS..GE` with
+a distinct functional identifier code. Project a `group_ref` column and the
+writer opens a fresh `GS..GE` group every time its value changes, echoing
+that value as the group control number (`GS06`/`GE02`) and recomputing each
+group's own `GE01` transaction-set count. With no `group_ref` column the
+whole stream collapses to one functional group, byte-identical to the
+single-group shape, so the column is opt-in. To split a source interchange
+into the same groups it arrived in, project `group_ref` from
+`$doc.functional_group.e06`:
+
+```yaml
+nodes:
+  - type: transform
+    name: regroup
+    input: orders
+    config:
+      cxl: |
+        emit seg_id    = seg_id
+        emit group_ref = $doc.functional_group.e06   # functional group control number (GS06)
+        emit set_ref   = set_ref
+        emit set_type  = set_type
+        emit e01       = e01
+        # … remaining eNN columns …
+  - type: output
+    name: out
+    input: regroup
+    config:
+      name: out
+      type: x12
+      path: ./out/result.x12
+      options:
+        interchange_from_doc: interchange
+        group_header: ["PO", "SENDER", "RECEIVER", "20240101", "1200", "1", "X", "004010"]
+```
+
+Records that share a `group_ref` value must arrive consecutively, exactly as
+records sharing a `set_ref` must: the writer streams and closes a group the
+moment the discriminator changes, so an interleaved stream would reopen a
+group it already closed. Sort upstream by `group_ref` (then `set_ref`) when
+the record order does not already guarantee it.
 
 `interchange_from_doc` echoes the header from a record's document context.
 That context is populated by a source's `ISA` envelope section (declare a
@@ -237,9 +290,10 @@ have no source `ISA` section to echo.
 - **No escape character.** X12 has no release mechanism, so a data value
   that contains a delimiter byte is rejected on output rather than
   corrupting the interchange.
-- **One functional group on output.** The writer wraps all transaction sets
-  in a single `GS..GE` functional group; the reader handles any number of
-  groups on input. A multi-group output shape requires multiple runs.
+- **Consecutive grouping.** Both `GS..GE` functional groups (`group_ref`)
+  and `ST..SE` transaction sets (`set_ref`) close the moment their
+  discriminator changes, so records sharing a value must arrive together;
+  sort upstream when the source order does not already guarantee it.
 - **Output splitting.** An interchange is a single `ISA..IEA` envelope and
   cannot be divided across files. An `x12` output combined with a `split:`
   block is rejected at config-validation time (diagnostic `E338`) rather


### PR DESCRIPTION
## Summary

The X12 writer wrapped every transaction set in a single `GS..GE` functional group. Real X12 interchanges carry multiple functional groups within one `ISA..IEA` envelope. The writer now emits a new `GS..GE` group whenever a record-level `group_ref` discriminator column changes — the outer-tier analog of how the existing `set_ref` column drives `ST..SE` transaction-set boundaries.

## Design

This extends the existing per-set envelope-recomputation rather than forking it: an `OpenGroup { group_ref, control_number, set_count }` mirrors the existing `OpenSet`. `GE01` counts only the current group's transaction sets, `GS06`/`GE02` echo the discriminator, and `IEA01` counts all groups. Group opening is lazy (driven by the first body record's `group_ref`, so the control number can echo a value the ISA header hasn't seen), group close cascades to close any open set first, and anonymous `ST02` numbering restarts per group. The old single-group state is fully replaced, not shimmed alongside.

## Behavior

With no `group_ref` column (or a single group), output is byte-identical to before, including the sequential `1, 2, …` group numbering (empty `group_ref` falls back to the ordinal). New unit tests assert per-group `GE01`, interchange-wide `IEA01`, byte-identical single-group framing, and anonymous-set restart; an end-to-end test round-trips a two-group source through the executor to multi-group X12 and back.

The `group_ref` value is a record column the user projects (e.g. from `$doc.functional_group.e06`); no config plumbing is needed since the writer resolves it from the schema like `set_ref`.

Closes #413.