### PR TITLE
engine: Reshape node — per-correlation-group synthesis and trigger-row mutation (#387)

### DIFF
--- a/crates/clinker-core-types/src/dlq.rs
+++ b/crates/clinker-core-types/src/dlq.rs
@@ -2,10 +2,9 @@
 //! stage-label helpers shared between the executor (which constructs DLQ
 //! entries) and the CLI sink (which writes them out).
 
-/// All 12 DLQ error categories per spec §10.4.
-///
-/// Passed from the error site — no string matching. Each error path
-/// constructs the correct variant at the point of failure.
+/// DLQ error categories. Passed from the error site — no string
+/// matching. Each error path constructs the correct variant at the
+/// point of failure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DlqErrorCategory {
     MissingRequiredField,
@@ -55,6 +54,14 @@ pub enum DlqErrorCategory {
     /// grace-hash, and sort-merge kernels all route an output-eval failure
     /// here under `Continue` / `BestEffort`.
     CombineOutputRow,
+    /// Two Reshape rules wrote the same field on the same correlation-
+    /// group row at runtime (a content-dependent collision the
+    /// compile-time static-overlap check could not prove). The whole
+    /// correlation group rolls back per `CorrelationCommit` semantics —
+    /// no synthesized or mutated rows from that group reach output.
+    /// Stage label `reshape:<node>:<rule_a>+<rule_b>` names the colliding
+    /// rule pair.
+    MutationConflict,
 }
 
 impl DlqErrorCategory {
@@ -72,8 +79,16 @@ impl DlqErrorCategory {
             Self::LateRecord => "late_record",
             Self::ExpansionLimitExceeded => "expansion_limit_exceeded",
             Self::CombineOutputRow => "combine_output_row",
+            Self::MutationConflict => "mutation_conflict",
         }
     }
+}
+
+/// Stage label helper for Reshape mutation-conflict DLQ entries. Names
+/// the colliding rule pair so a reader scanning the DLQ can identify
+/// which two rules wrote the same field on the same row.
+pub fn stage_reshape_mutation_conflict(node: &str, rule_a: &str, rule_b: &str) -> String {
+    format!("reshape:{node}:{rule_a}+{rule_b}")
 }
 
 /// Stage label helper for aggregate-transform DLQ entries.
@@ -136,6 +151,18 @@ mod tests {
         assert_eq!(
             DlqErrorCategory::CombineOutputRow.as_str(),
             "combine_output_row"
+        );
+        assert_eq!(
+            DlqErrorCategory::MutationConflict.as_str(),
+            "mutation_conflict"
+        );
+    }
+
+    #[test]
+    fn test_stage_reshape_mutation_conflict_helper() {
+        assert_eq!(
+            stage_reshape_mutation_conflict("backfill", "fix_a", "fix_b"),
+            "reshape:backfill:fix_a+fix_b"
         );
     }
 

--- a/crates/clinker-exec/src/dlq.rs
+++ b/crates/clinker-exec/src/dlq.rs
@@ -184,7 +184,8 @@ fn dlq_user_columns(schema: &Schema) -> impl Iterator<Item = (usize, &str)> {
             Some(FieldMetadata::WidenedSidecar)
             | Some(FieldMetadata::SourceFile)
             | Some(FieldMetadata::SourceName)
-            | Some(FieldMetadata::SourceEventTime) => None,
+            | Some(FieldMetadata::SourceEventTime)
+            | Some(FieldMetadata::ReshapeAudit) => None,
             Some(FieldMetadata::SourceCorrelation { .. })
             | Some(FieldMetadata::AggregateGroupIndex { .. })
             | None => Some((i, c.as_ref())),

--- a/crates/clinker-exec/src/executor/commit/detect.rs
+++ b/crates/clinker-exec/src/executor/commit/detect.rs
@@ -224,13 +224,14 @@ pub(crate) fn detect_retract_scope(
                     Some(FieldMetadata::WidenedSidecar)
                     | Some(FieldMetadata::SourceFile)
                     | Some(FieldMetadata::SourceName)
-                    | Some(FieldMetadata::SourceEventTime) => {
-                        // The `auto_widen` sidecar and the
-                        // `$source.file` / `$source.name` /
-                        // `$source.event_time` lineage stamps carry no
-                        // correlation linkage — they ride alongside the
-                        // CK lattice but the retract walk routes through
-                        // `$ck.*` columns only.
+                    | Some(FieldMetadata::SourceEventTime)
+                    | Some(FieldMetadata::ReshapeAudit) => {
+                        // The `auto_widen` sidecar, the `$source.file` /
+                        // `$source.name` / `$source.event_time` lineage
+                        // stamps, and the `$meta.*` Reshape audit stamps
+                        // carry no correlation linkage — they ride
+                        // alongside the CK lattice but the retract walk
+                        // routes through `$ck.*` columns only.
                     }
                     None => {}
                 }

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -285,6 +285,7 @@ pub(crate) fn buffer_key_for_record(record: &Record, row_num: u64) -> Vec<GroupB
             | Some(FieldMetadata::SourceFile)
             | Some(FieldMetadata::SourceName)
             | Some(FieldMetadata::SourceEventTime)
+            | Some(FieldMetadata::ReshapeAudit)
             | None => {}
         }
     }
@@ -1618,6 +1619,7 @@ pub(crate) fn build_engine_stamped_tail(target: &Arc<Schema>) -> Vec<(usize, Box
             | Some(clinker_record::FieldMetadata::SourceFile)
             | Some(clinker_record::FieldMetadata::SourceName)
             | Some(clinker_record::FieldMetadata::SourceEventTime)
+            | Some(clinker_record::FieldMetadata::ReshapeAudit)
             | None => None,
         })
         .collect()
@@ -2700,6 +2702,10 @@ pub(crate) fn dispatch_plan_node(
 
         PlanNode::Output { .. } => {
             crate::executor::output_dispatch::dispatch_output(ctx, current_dag, node_idx, &node)?;
+        }
+
+        PlanNode::Reshape { .. } => {
+            crate::executor::reshape_dispatch::dispatch_reshape(ctx, current_dag, node_idx, &node)?;
         }
 
         PlanNode::Composition { .. } => {

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod node_buffer_spill;
 pub(crate) mod output_dispatch;
 mod params;
 mod registry;
+pub(crate) mod reshape_dispatch;
 mod route;
 pub(crate) mod route_dispatch;
 mod schema_check;

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -261,9 +261,7 @@ fn process_group(
     // Conflict: the whole correlation group rolls back. No output row from
     // this group reaches the buffer.
     if let Some(c) = conflict {
-        return dlq_group_conflict(
-            ctx, node_name, &c.rule_a, &c.rule_b, &c.field, &c.record, c.row_num,
-        );
+        return dlq_group_conflict(ctx, node_name, &c);
     }
 
     // No conflict: emit originals (with staged mutations + audit stamps)
@@ -283,22 +281,24 @@ fn process_group(
 /// Push a `MutationConflict` DLQ entry for the colliding row and roll the
 /// whole group back. Returns `Ok(())` so the caller skips emitting this
 /// group's rows.
-#[allow(clippy::too_many_arguments)]
 fn dlq_group_conflict(
     ctx: &mut ExecutorContext<'_>,
     node_name: &str,
-    rule_a: &str,
-    rule_b: &str,
-    field: &str,
-    record: &Record,
-    row_num: u64,
+    conflict: &MutationConflict,
 ) -> Result<(), PipelineError> {
+    let MutationConflict {
+        rule_a,
+        rule_b,
+        field,
+        record,
+        row_num,
+    } = conflict;
     let stage = stage_reshape_mutation_conflict(node_name, rule_a, rule_b);
     let source_name = source_name_arc_of(record);
     push_dlq(
         ctx,
         DlqEntry {
-            source_row: row_num,
+            source_row: *row_num,
             category: DlqErrorCategory::MutationConflict,
             error_message: format!(
                 "reshape {node_name:?}: rules {rule_a:?} and {rule_b:?} both write field \
@@ -309,7 +309,7 @@ fn dlq_group_conflict(
             route: None,
             trigger: true,
             source_name,
-            triggering_field: Some(Arc::from(field)),
+            triggering_field: Some(Arc::from(field.as_str())),
             triggering_value: None,
         },
     )

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -10,9 +10,9 @@
 //! # Memory model
 //!
 //! The whole input materializes into per-group buffers before any output
-//! row leaves — group observation must see the complete group. Disk-spill
-//! governance for these buffers lands with the follow-on memory work; this
-//! arm accumulates in memory bounded by the correlation group cap.
+//! row leaves — group observation must see the complete group. There is no
+//! group-size cap and no disk spill yet: this arm accumulates everything in
+//! memory. Bounded-memory governance (spill, group caps) is follow-on work.
 //!
 //! # No-cascade contract
 //!
@@ -245,7 +245,15 @@ fn process_group(
             if let Some(synth) = rule.synth.as_mut() {
                 let mut new_row = match synth.copy_from {
                     CopyFrom::Trigger => clone_into_schema(record, output_schema),
-                    CopyFrom::None => Record::new(Arc::clone(output_schema), Vec::new()),
+                    // Born sized to the full output schema (upstream cols +
+                    // the three `$meta.*` audit cols) so each override lands
+                    // in its schema-indexed slot. Binding guarantees a
+                    // `copy_from: none` rule overrides every user column, so
+                    // no `Null` survives below.
+                    CopyFrom::None => Record::new(
+                        Arc::clone(output_schema),
+                        vec![Value::Null; output_schema.column_count()],
+                    ),
                 };
                 for (field, evaluator) in synth.overrides.iter_mut() {
                     let value = eval_scalar(evaluator, &eval_ctx, record, field)

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -1,0 +1,544 @@
+//! `PlanNode::Reshape` dispatch arm.
+//!
+//! Per-correlation-group synthesis and trigger-row mutation. Blocking
+//! grouping operator: it drains the predecessor's full output, groups
+//! records by `partition_by`, optionally orders each group by `order_by`,
+//! and per rule mutates the rows whose `when` predicate fires while
+//! synthesizing new rows derived from those trigger rows. The dispatcher's
+//! `Reshape` arm is a single delegating call into [`dispatch_reshape`].
+//!
+//! # Memory model
+//!
+//! The whole input materializes into per-group buffers before any output
+//! row leaves — group observation must see the complete group. Disk-spill
+//! governance for these buffers lands with the follow-on memory work; this
+//! arm accumulates in memory bounded by the correlation group cap.
+//!
+//! # No-cascade contract
+//!
+//! Every rule observes the **original** group snapshot. A row mutated by
+//! rule A is not re-observed by rule B; conflicting writes are detected and
+//! the whole group is rolled back rather than silently order-dependent.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use clinker_record::{GroupByKey, Record, Value};
+use cxl::eval::{EvalContext, EvalResult, ProgramEvaluator};
+use cxl::typecheck::{QualifiedField, Row, Type};
+use petgraph::graph::NodeIndex;
+
+use crate::executor::DlqEntry;
+use crate::executor::dispatch::{
+    ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
+    push_dlq, source_file_arc_of, source_name_arc_of, tee_emit_to_region_input_buffers,
+};
+use clinker_core_types::dlq::{DlqErrorCategory, stage_reshape_mutation_conflict};
+use clinker_plan::config::pipeline_node::{
+    CopyFrom, RESHAPE_MUTATED_BY_COLUMN, RESHAPE_SYNTHESIZED_BY_COLUMN, RESHAPE_SYNTHETIC_COLUMN,
+    ReshapeBody,
+};
+use clinker_plan::config::{SortField, SortOrder};
+use clinker_plan::error::PipelineError;
+use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
+
+use crate::executor::NullStorage;
+
+/// A compiled rule: the trigger predicate plus the per-field mutation and
+/// synthesis assignment evaluators, all built against the live input
+/// schema at dispatch time (the same condition-compile seam Route uses).
+struct CompiledRule {
+    name: String,
+    /// `filter <when>` — `Emit` iff the row is a trigger row.
+    when: ProgramEvaluator,
+    /// `mutate.set` field → `emit <field> = <expr>` evaluator.
+    set: Vec<(String, ProgramEvaluator)>,
+    /// Present iff the rule synthesizes rows.
+    synth: Option<CompiledSynth>,
+}
+
+/// Compiled synthesis action.
+struct CompiledSynth {
+    copy_from: CopyFrom,
+    /// `overrides` field → `emit <field> = <expr>` evaluator.
+    overrides: Vec<(String, ProgramEvaluator)>,
+}
+
+/// A detected runtime mutation conflict: two rules wrote the same field on
+/// the same group row. Captured as owned data so the DLQ push (which needs
+/// `&mut ExecutorContext`) runs after the eval context's immutable borrow
+/// is released.
+struct MutationConflict {
+    rule_a: String,
+    rule_b: String,
+    field: String,
+    record: Record,
+    row_num: u64,
+}
+
+/// Execute the `Reshape` arm for `node_idx`. Drains the predecessor,
+/// groups by `partition_by`, applies each rule's mutation and synthesis
+/// per group, routes mutation conflicts to the DLQ (rolling back the whole
+/// group), and emits originals (mutated, audit-stamped) followed by
+/// synthesized rows. Blocking: the full input materializes before the
+/// first output row leaves.
+pub(crate) fn dispatch_reshape(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    node: &PlanNode,
+) -> Result<(), PipelineError> {
+    let PlanNode::Reshape {
+        ref name,
+        ref config,
+        ref output_schema,
+        ..
+    } = *node
+    else {
+        unreachable!("dispatch_reshape called with non-Reshape node");
+    };
+
+    let pred = single_predecessor(current_dag, node_idx, "reshape", name)?;
+    let (input, input_puncts): (
+        Vec<(Record, u64)>,
+        Vec<crate::executor::stream_event::Punctuation>,
+    ) = match drain_node_buffer_slot(ctx, pred) {
+        Some(nb) => nb.drain_split()?,
+        None => (Vec::new(), Vec::new()),
+    };
+
+    if input.is_empty() {
+        tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &[])?;
+        let nb = admit_node_buffer(
+            ctx,
+            name,
+            node_idx,
+            Vec::new(),
+            input_puncts,
+            node_buffer_spill_allowed(current_dag, node_idx),
+        )?;
+        ctx.node_buffers.insert(node_idx, nb);
+        return Ok(());
+    }
+
+    // Compile every rule's predicate / assignment program against the live
+    // input schema. The schema is uniform across a node_buffer slot, so the
+    // first record's schema drives the typecheck row.
+    let input_schema = input[0].0.schema().clone();
+    let mut rules = compile_rules(name, config, &input_schema)?;
+
+    // Group records by `partition_by`, preserving first-seen group order
+    // and within-group arrival order. Each entry is `(record, row_num)`.
+    let mut group_order: Vec<Vec<GroupByKey>> = Vec::new();
+    let mut groups: HashMap<Vec<GroupByKey>, Vec<(Record, u64)>> = HashMap::new();
+    for (record, row_num) in input {
+        let key = partition_key(&record, &config.partition_by);
+        groups
+            .entry(key.clone())
+            .or_insert_with(|| {
+                group_order.push(key.clone());
+                Vec::new()
+            })
+            .push((record, row_num));
+    }
+
+    let mut out: Vec<(Record, u64)> = Vec::new();
+    for key in &group_order {
+        let mut group = groups.remove(key).expect("group key present in order");
+        if !config.order_by.is_empty() {
+            sort_group(&mut group, &config.order_by);
+        }
+        process_group(ctx, name, &mut rules, output_schema, group, &mut out)?;
+    }
+
+    tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out)?;
+    let nb = admit_node_buffer(
+        ctx,
+        name,
+        node_idx,
+        out,
+        input_puncts,
+        node_buffer_spill_allowed(current_dag, node_idx),
+    )?;
+    ctx.node_buffers.insert(node_idx, nb);
+    Ok(())
+}
+
+/// Apply every rule to one group against its original snapshot, detect
+/// cross-rule mutation conflicts, and append the group's output rows.
+///
+/// On a mutation conflict the whole group rolls back: a `MutationConflict`
+/// DLQ entry is pushed for the colliding row and no output row from this
+/// group reaches the buffer (matching the correlation-group atomicity
+/// contract).
+fn process_group(
+    ctx: &mut ExecutorContext<'_>,
+    node_name: &str,
+    rules: &mut [CompiledRule],
+    output_schema: &Arc<clinker_record::Schema>,
+    group: Vec<(Record, u64)>,
+    out: &mut Vec<(Record, u64)>,
+) -> Result<(), PipelineError> {
+    // Per original row: accumulated field writes (field → (value, rule
+    // name)). A second write to an already-written field by a different
+    // rule is a conflict; the stored rule name names the prior writer.
+    let mut mutations: Vec<HashMap<String, (Value, String)>> =
+        (0..group.len()).map(|_| HashMap::new()).collect();
+    // Per original row: the rule labels that mutated it, for the
+    // `$meta.mutated_by` audit stamp.
+    let mut mutated_by: Vec<Vec<String>> = (0..group.len()).map(|_| Vec::new()).collect();
+    // Synthesized rows accumulated across rules: `(record, source_row_num)`.
+    let mut synthesized: Vec<(Record, u64)> = Vec::new();
+    // First detected cross-rule mutation conflict, captured as owned data
+    // so the whole group can roll back to the DLQ once the immutable
+    // `ctx` borrow held by the eval context is released.
+    let mut conflict: Option<MutationConflict> = None;
+
+    'rules: for rule in rules.iter_mut() {
+        for (row_idx, (record, row_num)) in group.iter().enumerate() {
+            // Per-record evaluation context carries the record's own
+            // source attribution and envelope. The Arcs live for the
+            // record's loop iteration so the borrowing `EvalContext` is
+            // valid across every rule-program eval below.
+            let source_file = source_file_arc_of(record);
+            let source_name = source_name_arc_of(record);
+            let eval_ctx =
+                ctx.eval_ctx_for_record(&source_file, &source_name, *row_num, record.doc_ctx());
+
+            // `when` predicate: a trigger row emits.
+            let triggered = matches!(
+                rule.when
+                    .eval_record::<NullStorage>(&eval_ctx, record, None)
+                    .map_err(|e| reshape_eval_error(node_name, &rule.name, "when", e))?,
+                EvalResult::Emit { .. } | EvalResult::EmitMany { .. }
+            );
+            if !triggered {
+                continue;
+            }
+
+            // Mutation: evaluate each `set` expression and stage the write.
+            let mut rule_mutated_this_row = false;
+            for (field, evaluator) in rule.set.iter_mut() {
+                let value = eval_scalar(evaluator, &eval_ctx, record, field)
+                    .map_err(|e| reshape_eval_error(node_name, &rule.name, field, e))?;
+                if let Some((_, prior_rule)) = mutations[row_idx].get(field) {
+                    // Content-dependent collision two rules could not be
+                    // proven disjoint at compile time. Capture the conflict
+                    // and stop — the whole group rolls back to the DLQ.
+                    conflict = Some(MutationConflict {
+                        rule_a: prior_rule.clone(),
+                        rule_b: rule.name.clone(),
+                        field: field.clone(),
+                        record: record.clone(),
+                        row_num: *row_num,
+                    });
+                    break 'rules;
+                }
+                mutations[row_idx].insert(field.clone(), (value, rule.name.clone()));
+                rule_mutated_this_row = true;
+            }
+            if rule_mutated_this_row {
+                mutated_by[row_idx].push(rule_label(node_name, &rule.name));
+            }
+
+            // Synthesis: derive a new row from this trigger row.
+            if let Some(synth) = rule.synth.as_mut() {
+                let mut new_row = match synth.copy_from {
+                    CopyFrom::Trigger => clone_into_schema(record, output_schema),
+                    CopyFrom::None => Record::new(Arc::clone(output_schema), Vec::new()),
+                };
+                for (field, evaluator) in synth.overrides.iter_mut() {
+                    let value = eval_scalar(evaluator, &eval_ctx, record, field)
+                        .map_err(|e| reshape_eval_error(node_name, &rule.name, field, e))?;
+                    new_row.set(field, value);
+                }
+                stamp_audit(&mut new_row, true, &rule_label(node_name, &rule.name), &[]);
+                synthesized.push((new_row, *row_num));
+            }
+        }
+    }
+
+    // Conflict: the whole correlation group rolls back. No output row from
+    // this group reaches the buffer.
+    if let Some(c) = conflict {
+        return dlq_group_conflict(
+            ctx, node_name, &c.rule_a, &c.rule_b, &c.field, &c.record, c.row_num,
+        );
+    }
+
+    // No conflict: emit originals (with staged mutations + audit stamps)
+    // followed by synthesized rows, preserving within-group order.
+    for (row_idx, (record, row_num)) in group.into_iter().enumerate() {
+        let mut row = clone_into_schema(&record, output_schema);
+        for (field, (value, _)) in mutations[row_idx].drain() {
+            row.set(&field, value);
+        }
+        stamp_audit(&mut row, false, "", &mutated_by[row_idx]);
+        out.push((row, row_num));
+    }
+    out.append(&mut synthesized);
+    Ok(())
+}
+
+/// Push a `MutationConflict` DLQ entry for the colliding row and roll the
+/// whole group back. Returns `Ok(())` so the caller skips emitting this
+/// group's rows.
+#[allow(clippy::too_many_arguments)]
+fn dlq_group_conflict(
+    ctx: &mut ExecutorContext<'_>,
+    node_name: &str,
+    rule_a: &str,
+    rule_b: &str,
+    field: &str,
+    record: &Record,
+    row_num: u64,
+) -> Result<(), PipelineError> {
+    let stage = stage_reshape_mutation_conflict(node_name, rule_a, rule_b);
+    let source_name = source_name_arc_of(record);
+    push_dlq(
+        ctx,
+        DlqEntry {
+            source_row: row_num,
+            category: DlqErrorCategory::MutationConflict,
+            error_message: format!(
+                "reshape {node_name:?}: rules {rule_a:?} and {rule_b:?} both write field \
+                 {field:?} on the same row — the correlation group is rolled back"
+            ),
+            original_record: record.clone(),
+            stage: Some(stage),
+            route: None,
+            trigger: true,
+            source_name,
+            triggering_field: Some(Arc::from(field)),
+            triggering_value: None,
+        },
+    )
+}
+
+/// Evaluate a single-`emit` scalar program and extract the assigned value.
+fn eval_scalar(
+    evaluator: &mut ProgramEvaluator,
+    eval_ctx: &EvalContext<'_>,
+    record: &Record,
+    field: &str,
+) -> Result<Value, cxl::eval::EvalError> {
+    match evaluator.eval_record::<NullStorage>(eval_ctx, record, None)? {
+        EvalResult::Emit { mut fields, .. } => {
+            Ok(fields.shift_remove(field).unwrap_or(Value::Null))
+        }
+        EvalResult::EmitMany { .. } | EvalResult::Skip(_) => Ok(Value::Null),
+    }
+}
+
+/// Compile each rule's `when` / `set` / `overrides` CXL against `schema`.
+fn compile_rules(
+    node_name: &str,
+    config: &ReshapeBody,
+    schema: &Arc<clinker_record::Schema>,
+) -> Result<Vec<CompiledRule>, PipelineError> {
+    let type_cols: indexmap::IndexMap<QualifiedField, Type> = schema
+        .columns()
+        .iter()
+        .map(|c| (QualifiedField::bare(c.as_ref()), Type::Any))
+        .collect();
+    let row = Row::closed(type_cols, cxl::lexer::Span::new(0, 0));
+    let field_refs: Vec<&str> = schema.columns().iter().map(|c| c.as_ref()).collect();
+
+    let mut compiled = Vec::with_capacity(config.rules.len());
+    for rule in &config.rules {
+        let when = compile_program(
+            node_name,
+            &rule.name,
+            "when",
+            &format!("filter {}", rule.when.source),
+            &row,
+            &field_refs,
+        )?;
+        let mut set = Vec::new();
+        if let Some(mutate) = &rule.mutate {
+            for (field, value) in &mutate.set {
+                let prog = compile_program(
+                    node_name,
+                    &rule.name,
+                    field,
+                    &format!("emit {field} = {}", value.source),
+                    &row,
+                    &field_refs,
+                )?;
+                set.push((field.clone(), prog));
+            }
+        }
+        let synth = match &rule.synthesize {
+            None => None,
+            Some(s) => {
+                let mut overrides = Vec::new();
+                for (field, value) in &s.overrides {
+                    let prog = compile_program(
+                        node_name,
+                        &rule.name,
+                        field,
+                        &format!("emit {field} = {}", value.source),
+                        &row,
+                        &field_refs,
+                    )?;
+                    overrides.push((field.clone(), prog));
+                }
+                Some(CompiledSynth {
+                    copy_from: s.copy_from,
+                    overrides,
+                })
+            }
+        };
+        compiled.push(CompiledRule {
+            name: rule.name.clone(),
+            when,
+            set,
+            synth,
+        });
+    }
+    Ok(compiled)
+}
+
+/// Parse → resolve → typecheck a single CXL fragment into a
+/// [`ProgramEvaluator`]. Type errors here are a planner invariant violation
+/// (bind_schema already typechecked the same fragment), so they surface as
+/// `PipelineError::Compilation`.
+fn compile_program(
+    node_name: &str,
+    rule_name: &str,
+    field: &str,
+    source: &str,
+    row: &Row,
+    field_refs: &[&str],
+) -> Result<ProgramEvaluator, PipelineError> {
+    let scoped_vars = cxl::resolve::ScopedVarsRegistry::default();
+    let make_err = |messages: Vec<String>| PipelineError::Compilation {
+        transform_name: format!("reshape:{node_name}:{rule_name}:{field}"),
+        messages,
+    };
+
+    let parse_result = cxl::parser::Parser::parse(source);
+    if !parse_result.errors.is_empty() {
+        return Err(make_err(
+            parse_result
+                .errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect(),
+        ));
+    }
+    let resolved = cxl::resolve::resolve_program_with_modules_and_vars(
+        parse_result.ast,
+        field_refs,
+        parse_result.node_count,
+        &std::collections::HashMap::new(),
+        &scoped_vars,
+    )
+    .map_err(|diags| make_err(diags.into_iter().map(|d| d.message).collect()))?;
+    let typed = cxl::typecheck::pass::type_check_with_mode_and_vars(
+        resolved,
+        row,
+        cxl::typecheck::pass::AggregateMode::Row,
+        &scoped_vars,
+    )
+    .map_err(|diags| {
+        make_err(
+            diags
+                .into_iter()
+                .filter(|d| !d.is_warning)
+                .map(|d| d.message)
+                .collect(),
+        )
+    })?;
+    Ok(ProgramEvaluator::new(Arc::new(typed), false))
+}
+
+/// Extract the `partition_by` key tuple from a record. Mirrors the
+/// correlation-buffer keying: an empty string and a null both map to
+/// `GroupByKey::Null` so a missing partition value groups consistently.
+fn partition_key(record: &Record, partition_by: &[String]) -> Vec<GroupByKey> {
+    partition_by
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| {
+            let v = record.get(f).unwrap_or(&Value::Null);
+            if v.is_null() || matches!(v, Value::String(s) if s.is_empty()) {
+                return GroupByKey::Null;
+            }
+            clinker_record::value_to_group_key(v, f, None, idx as u64)
+                .ok()
+                .flatten()
+                .unwrap_or(GroupByKey::Null)
+        })
+        .collect()
+}
+
+/// Sort a group in place by `order_by`, stable across equal keys (so
+/// arrival order breaks ties deterministically).
+fn sort_group(group: &mut [(Record, u64)], order_by: &[SortField]) {
+    group.sort_by(|(a, _), (b, _)| {
+        for sf in order_by {
+            let av = a.get(&sf.field).unwrap_or(&Value::Null);
+            let bv = b.get(&sf.field).unwrap_or(&Value::Null);
+            let ord = match (av, bv) {
+                (Value::Null, Value::Null) => std::cmp::Ordering::Equal,
+                // Nulls sort last regardless of direction (SQL convention).
+                (Value::Null, _) => std::cmp::Ordering::Greater,
+                (_, Value::Null) => std::cmp::Ordering::Less,
+                _ => av.partial_cmp(bv).unwrap_or(std::cmp::Ordering::Equal),
+            };
+            let ord = match sf.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            };
+            if ord != std::cmp::Ordering::Equal {
+                return ord;
+            }
+        }
+        std::cmp::Ordering::Equal
+    });
+}
+
+/// Re-key a record onto the (audit-widened) output schema, carrying every
+/// matching column value through and defaulting new columns to null.
+fn clone_into_schema(record: &Record, schema: &Arc<clinker_record::Schema>) -> Record {
+    let mut values = Vec::with_capacity(schema.column_count());
+    for col in schema.columns() {
+        values.push(record.get(col.as_ref()).cloned().unwrap_or(Value::Null));
+    }
+    Record::new(Arc::clone(schema), values)
+}
+
+/// Write the three `$meta.*` audit columns onto a row.
+fn stamp_audit(row: &mut Record, synthetic: bool, synthesized_by: &str, mutated_by: &[String]) {
+    row.set(RESHAPE_SYNTHETIC_COLUMN, Value::Bool(synthetic));
+    row.set(
+        RESHAPE_SYNTHESIZED_BY_COLUMN,
+        Value::String(synthesized_by.into()),
+    );
+    row.set(
+        RESHAPE_MUTATED_BY_COLUMN,
+        Value::String(mutated_by.join(",").into()),
+    );
+}
+
+/// `<node>:<rule>` audit label.
+fn rule_label(node_name: &str, rule_name: &str) -> String {
+    format!("{node_name}:{rule_name}")
+}
+
+/// Wrap a CXL eval error from a rule fragment as a hard pipeline error.
+/// Rule-fragment eval errors are setup-invariant violations (the fragment
+/// typechecked at bind time), so they abort rather than route to the DLQ.
+fn reshape_eval_error(
+    node_name: &str,
+    rule_name: &str,
+    field: &str,
+    e: cxl::eval::EvalError,
+) -> PipelineError {
+    PipelineError::Internal {
+        op: "reshape",
+        node: node_name.to_string(),
+        detail: format!("rule {rule_name:?} field {field:?} eval failed: {e}"),
+    }
+}

--- a/crates/clinker-exec/tests/reshape_pipeline.rs
+++ b/crates/clinker-exec/tests/reshape_pipeline.rs
@@ -294,3 +294,97 @@ nodes:
         "both rules apply against the original group state: {output}"
     );
 }
+
+/// A `synthesize` rule with `copy_from: none` that overrides every user
+/// column. The synthesized row is born from an all-null base, so every
+/// output value comes from an `overrides` expression. This exercises the
+/// `CopyFrom::None` dispatch path end-to-end — the path the compile-only
+/// `copy_from: none` validation tests never reach.
+const COPY_FROM_NONE_PIPELINE: &str = r#"
+pipeline:
+  name: reshape_copy_from_none
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: test.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: int }
+        - { name: label, type: string }
+  - type: reshape
+    name: emit_summary
+    input: rows
+    config:
+      partition_by: [id]
+      rules:
+        - name: summarize_big
+          when: "amount > 100"
+          synthesize:
+            copy_from: none
+            overrides:
+              id: "id"
+              amount: "amount * 2"
+              label: "'synthetic-summary'"
+  - type: output
+    name: out
+    input: emit_summary
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn copy_from_none_synthesizes_fully_overridden_row() {
+    // Group A's amount=150 (>100) fires the rule and synthesizes a brand-new
+    // row from an all-null base, every column supplied by an override:
+    // id=A (the trigger's), amount=300 (150*2), label='synthetic-summary'.
+    // Group B's amount=50 does not fire. Before the sizing fix, building the
+    // synthesized Record from an empty values Vec against the wider output
+    // schema (3 user cols + 3 `$meta.*` audit cols) tripped the
+    // `Record::new` length `debug_assert`, panicking this debug-build run.
+    let csv = "id,amount,label\n\
+               A,150,original\n\
+               B,50,original\n";
+    let (counters, dlq, output) = run_reshape(COPY_FROM_NONE_PIPELINE, csv).unwrap();
+
+    assert!(dlq.is_empty(), "no DLQ entries expected, got {dlq:?}");
+
+    let lines: Vec<&str> = output.lines().collect();
+    // The two originals pass through plus exactly one synthesized row.
+    let data_lines: Vec<&str> = lines
+        .iter()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .copied()
+        .collect();
+    assert_eq!(
+        data_lines.len(),
+        3,
+        "2 originals + 1 synthesized data row: {output}"
+    );
+
+    // The synthesized row carries every overridden value (none null): the
+    // trigger's id, the doubled amount, and the literal label.
+    assert!(
+        lines.iter().any(|l| l == &"A,300,synthetic-summary"),
+        "fully-overridden synthesized row must be present and non-null: {output}"
+    );
+
+    // Originals are untouched, and no audit column leaks into output.
+    assert!(lines.iter().any(|l| l == &"A,150,original"));
+    assert!(lines.iter().any(|l| l == &"B,50,original"));
+    assert!(
+        !output.contains("$meta."),
+        "$meta.* audit columns must not leak into default output: {output}"
+    );
+
+    // `ok_count` counts distinct source rows reaching output; the synthesized
+    // row borrows its trigger's identity, so both source rows count clean.
+    assert_eq!(counters.ok_count, 2, "both source rows emit clean");
+}

--- a/crates/clinker-exec/tests/reshape_pipeline.rs
+++ b/crates/clinker-exec/tests/reshape_pipeline.rs
@@ -1,0 +1,296 @@
+//! Reshape node integration tests.
+//!
+//! Exercises the per-correlation-group synthesis and trigger-row mutation
+//! arm end-to-end against in-memory CSV readers/writers: group synthesis,
+//! trigger-row mutation, the `$meta.*` audit stamps, the no-cascade
+//! contract, and mutation-conflict routing to the dead-letter queue with a
+//! whole-group rollback.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{DlqEntry, PipelineRunParams};
+use clinker_plan::error::PipelineError;
+use clinker_record::PipelineCounters;
+
+/// Run a single-source → reshape → single-output pipeline over `csv_input`,
+/// returning the run counters, DLQ entries, and the CSV output string.
+fn run_reshape(
+    yaml: &str,
+    csv_input: &str,
+) -> Result<(PipelineCounters, Vec<DlqEntry>, String), PipelineError> {
+    let config = clinker_plan::config::parse_config(yaml).expect("fixture pipeline must parse");
+    let params = PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let primary = config.source_configs().next().unwrap().name.clone();
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        primary,
+        clinker_exec::executor::single_file_reader(
+            "test.csv",
+            Box::new(std::io::Cursor::new(csv_input.as_bytes().to_vec())),
+        ),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        config.output_configs().next().unwrap().name.clone(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let report = common::run_config(&config, readers, writers, &params)?;
+    Ok((report.counters, report.dlq_entries, buf.as_string()))
+}
+
+/// SCD-Type-2 shape: per employee, a row whose `plan_start - plan_end`
+/// exceeds the one-year boundary (here 365) triggers a fix of its end date
+/// and the synthesis of a new boundary row.
+const SCD_PIPELINE: &str = r#"
+pipeline:
+  name: reshape_scd
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: plans
+    config:
+      name: plans
+      type: csv
+      path: test.csv
+      schema:
+        - { name: employee_id, type: string }
+        - { name: plan_start, type: int }
+        - { name: plan_end, type: int }
+        - { name: status, type: string }
+  - type: reshape
+    name: backfill
+    input: plans
+    config:
+      partition_by: [employee_id]
+      order_by:
+        - { field: plan_start, order: asc }
+      rules:
+        - name: fix_long_plan
+          when: "plan_start - plan_end > 365"
+          mutate:
+            set:
+              plan_end: "plan_start"
+          synthesize:
+            copy_from: trigger
+            overrides:
+              status: "'synthesized'"
+  - type: output
+    name: out
+    input: backfill
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn scd_type2_mutates_trigger_and_synthesizes_row() {
+    // Employee A has one long-gap row (1000 - 100 = 900 > 365) and one
+    // normal row. Employee B has only a normal row.
+    let csv = "employee_id,plan_start,plan_end,status\n\
+               A,100,90,baseline\n\
+               A,1000,100,baseline\n\
+               B,200,150,baseline\n";
+    let (counters, dlq, output) = run_reshape(SCD_PIPELINE, csv).unwrap();
+
+    assert!(dlq.is_empty(), "no DLQ entries expected, got {dlq:?}");
+    // `ok_count` counts distinct SOURCE rows reaching output; the
+    // synthesized row borrows its trigger's identity, so all 3 source
+    // rows count clean.
+    assert_eq!(counters.ok_count, 3, "all 3 source rows emit clean");
+
+    // The trigger row's end date is fixed to its start (1000), and a
+    // synthesized row carries status=synthesized. The output carries a
+    // header line plus 4 data rows (3 originals + 1 synthesized).
+    let data_lines: Vec<&str> = output.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        data_lines.len(),
+        4,
+        "3 originals + 1 synthesized data row: {output}"
+    );
+    let lines: Vec<&str> = output.lines().collect();
+    assert!(
+        lines.iter().any(|l| l.contains("1000,1000")),
+        "trigger row end date should be fixed to start: {output}"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("synthesized")),
+        "a synthesized row should be present: {output}"
+    );
+    // Audit columns stay out of the default writer surface.
+    assert!(
+        !output.contains("$meta."),
+        "$meta.* audit columns must not leak into default output: {output}"
+    );
+    // The untriggered rows are unchanged.
+    assert!(lines.iter().any(|l| l.contains("A,100,90,baseline")));
+    assert!(lines.iter().any(|l| l.contains("B,200,150,baseline")));
+}
+
+#[test]
+fn scd_idempotent_rerun_is_stable() {
+    // After the first reshape, the synthesized row plus the fixed trigger
+    // exist. Feeding the post-reshape state back in must not re-trigger:
+    // the fixed trigger now has plan_start - plan_end == 0, and the
+    // synthesized row likewise. Only genuinely long-gap rows fire.
+    let already_fixed = "employee_id,plan_start,plan_end,status\n\
+                         A,100,90,baseline\n\
+                         A,1000,1000,baseline\n\
+                         A,1000,1000,synthesized\n";
+    let (_, dlq, output) = run_reshape(SCD_PIPELINE, already_fixed).unwrap();
+    assert!(dlq.is_empty());
+    // No new synthesized row beyond the one already present.
+    let synth_count = output.lines().filter(|l| l.contains("synthesized")).count();
+    assert_eq!(
+        synth_count, 1,
+        "no rule should fire on an already-fixed group: {output}"
+    );
+}
+
+/// Two rules whose selectors overlap on content and both write the same
+/// field. Static overlap cannot prove disjointness, so the collision
+/// surfaces at runtime as a mutation conflict.
+const CONFLICT_PIPELINE: &str = r#"
+pipeline:
+  name: reshape_conflict
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: test.csv
+      schema:
+        - { name: gid, type: string }
+        - { name: amount, type: int }
+        - { name: tier, type: string }
+  - type: reshape
+    name: classify
+    input: rows
+    config:
+      partition_by: [gid]
+      rules:
+        - name: bump_high
+          when: "amount > 50"
+          mutate:
+            set:
+              tier: "'high'"
+        - name: bump_big
+          when: "amount > 80"
+          mutate:
+            set:
+              tier: "'big'"
+  - type: output
+    name: out
+    input: classify
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn mutation_conflict_dlqs_whole_group() {
+    // Group X: amount 100 fires BOTH rules on the same row → both write
+    // `tier` → MutationConflict → whole group rolls back. Group Y: amount
+    // 60 fires only `bump_high` → clean, emits.
+    let csv = "gid,amount,tier\n\
+               X,100,base\n\
+               X,30,base\n\
+               Y,60,base\n";
+    let (counters, dlq, output) = run_reshape(CONFLICT_PIPELINE, csv).unwrap();
+
+    assert_eq!(dlq.len(), 1, "exactly one MutationConflict DLQ entry");
+    assert_eq!(
+        dlq[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::MutationConflict
+    );
+    assert_eq!(
+        dlq[0].stage.as_deref(),
+        Some("reshape:classify:bump_high+bump_big"),
+        "stage label names the colliding rule pair"
+    );
+
+    // Group X produced no output (whole-group rollback); group Y emitted.
+    assert!(
+        !output.contains("X,"),
+        "conflicting group X must not reach output: {output}"
+    );
+    assert!(
+        output.contains("Y,60,high"),
+        "group Y emitted clean: {output}"
+    );
+    assert_eq!(counters.ok_count, 1, "only group Y's single row emitted");
+}
+
+#[test]
+fn no_cascade_rules_see_original_state() {
+    // `bump_high` rewrites tier to 'high' for amount>50; a second rule
+    // gated on tier=='base' must STILL fire on the same row, because rules
+    // observe the original group snapshot — not bump_high's effect. The
+    // two rules write different fields, so there is no conflict.
+    let yaml = r#"
+pipeline:
+  name: reshape_no_cascade
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: csv
+      path: test.csv
+      schema:
+        - { name: gid, type: string }
+        - { name: amount, type: int }
+        - { name: tier, type: string }
+        - { name: note, type: string }
+  - type: reshape
+    name: classify
+    input: rows
+    config:
+      partition_by: [gid]
+      rules:
+        - name: set_tier
+          when: "amount > 50"
+          mutate:
+            set:
+              tier: "'high'"
+        - name: note_base
+          when: "tier == 'base'"
+          mutate:
+            set:
+              note: "'was_base'"
+  - type: output
+    name: out
+    input: classify
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let csv = "gid,amount,tier,note\nX,100,base,\n";
+    let (_, dlq, output) = run_reshape(yaml, csv).unwrap();
+    assert!(dlq.is_empty(), "different fields → no conflict: {dlq:?}");
+    // Both rules fired against the original snapshot: tier=high AND
+    // note=was_base on the same row.
+    assert!(
+        output.contains("high") && output.contains("was_base"),
+        "both rules apply against the original group state: {output}"
+    );
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -737,6 +737,7 @@ impl PipelineConfig {
                 PipelineNode::Source { .. }
                 | PipelineNode::Output { .. }
                 | PipelineNode::Merge { .. }
+                | PipelineNode::Reshape { .. }
                 | PipelineNode::Composition { .. }
                 | PipelineNode::Combine { .. } => None,
             })
@@ -1066,6 +1067,7 @@ impl PipelineConfig {
                 PipelineNode::Transform { header, .. }
                 | PipelineNode::Aggregate { header, .. }
                 | PipelineNode::Route { header, .. }
+                | PipelineNode::Reshape { header, .. }
                 | PipelineNode::Output { header, .. } => {
                     wire(&input_full_reference(&header.input.value), None);
                 }
@@ -2076,6 +2078,7 @@ fn resolve_all_input_references(
             PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
+            | PipelineNode::Reshape { header, .. }
             | PipelineNode::Output { header, .. } => {
                 emit(consumer_name, None, &header.input);
             }
@@ -2431,6 +2434,11 @@ pub(crate) fn lower_node_to_plan_node(
                         builder.with_field_meta(col, FieldMetadata::source_name())
                     } else if col == crate::config::pipeline_node::SOURCE_EVENT_TIME_COLUMN {
                         builder.with_field_meta(col, FieldMetadata::source_event_time())
+                    } else if col == crate::config::pipeline_node::RESHAPE_SYNTHETIC_COLUMN
+                        || col == crate::config::pipeline_node::RESHAPE_SYNTHESIZED_BY_COLUMN
+                        || col == crate::config::pipeline_node::RESHAPE_MUTATED_BY_COLUMN
+                    {
+                        builder.with_field_meta(col, FieldMetadata::reshape_audit())
                     } else {
                         builder.with_field(col)
                     };
@@ -2721,6 +2729,22 @@ pub(crate) fn lower_node_to_plan_node(
                 decomposed_from: None,
                 output_schema: schema_from_bound(name),
                 resolved_column_map,
+            })
+        }
+        // Reshape lowers to PlanNode::Reshape carrying the parsed config
+        // and the audit-widened output schema. The executor compiles each
+        // rule's `when` / `set` / `overrides` CXL against the live input
+        // schema at dispatch time (the Route condition-compile seam), so no
+        // per-rule typed program is threaded through CompileArtifacts.
+        PipelineNode::Reshape { config, .. } => {
+            // A missing typed entry means bind_schema rejected the node
+            // (E200 on a rule predicate / assignment) — skip lowering.
+            artifacts.typed.get(name)?;
+            Some(crate::plan::execution::PlanNode::Reshape {
+                name: name.to_string(),
+                span,
+                config: config.clone(),
+                output_schema: schema_from_bound(name),
             })
         }
     }

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -115,6 +115,20 @@ pub enum PipelineNode {
         header: NodeHeader,
         config: OutputBody,
     },
+    /// Per-correlation-group record synthesis and trigger-row mutation.
+    ///
+    /// Groups records by `partition_by`, observes each group, and per
+    /// declarative rule mutates the rows whose state caused the rule to
+    /// fire and/or synthesizes new rows derived from those trigger rows.
+    /// Distinct from Aggregate (which reduces a group to one row),
+    /// Transform (0-or-1 record per input), and Combine (joins across
+    /// sources): Reshape produces new records derived from a group's
+    /// observed state while preserving the originals. Single output.
+    Reshape {
+        #[serde(flatten)]
+        header: NodeHeader,
+        config: ReshapeBody,
+    },
     /// Composition call-site node. Lowered to `PlanNode::Composition` in
     /// Stage 5; body nodes live in `CompileArtifacts.composition_bodies`
     /// keyed by the `body` handle.
@@ -336,6 +350,13 @@ impl<'de> Deserialize<'de> for PipelineNode {
                         let (header, config) = payload.into_variant_parts();
                         Ok(PipelineNode::Output { header, config })
                     }
+                    "reshape" => {
+                        let payload = ReshapePayload::deserialize(
+                            de::value::MapAccessDeserializer::new(dispatch),
+                        )?;
+                        let (header, config) = payload.into_variant_parts();
+                        Ok(PipelineNode::Reshape { header, config })
+                    }
                     "composition" => {
                         let payload = CompositionPayload::deserialize(
                             de::value::MapAccessDeserializer::new(dispatch),
@@ -352,6 +373,7 @@ impl<'de> Deserialize<'de> for PipelineNode {
                             "merge",
                             "combine",
                             "output",
+                            "reshape",
                             "composition",
                         ],
                     )),
@@ -510,6 +532,34 @@ impl OutputPayload {
     }
 }
 
+// ---- Reshape ---------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReshapePayload {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    input: crate::yaml::Spanned<crate::config::node_header::NodeInput>,
+    #[serde(default, rename = "_notes")]
+    notes: Option<serde_json::Value>,
+    config: ReshapeBody,
+}
+
+impl ReshapePayload {
+    fn into_variant_parts(self) -> (NodeHeader, ReshapeBody) {
+        (
+            NodeHeader {
+                name: self.name,
+                description: self.description,
+                input: self.input,
+                notes: self.notes,
+            },
+            self.config,
+        )
+    }
+}
+
 // ---- Merge -----------------------------------------------------------
 
 #[derive(Deserialize)]
@@ -622,6 +672,7 @@ impl PipelineNode {
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
             | PipelineNode::Output { header, .. }
+            | PipelineNode::Reshape { header, .. }
             | PipelineNode::Composition { header, .. } => &header.name,
             PipelineNode::Merge { header, .. } => &header.name,
             PipelineNode::Combine { header, .. } => &header.name,
@@ -638,6 +689,7 @@ impl PipelineNode {
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
             | PipelineNode::Output { header, .. }
+            | PipelineNode::Reshape { header, .. }
             | PipelineNode::Composition { header, .. } => Some(header.input.value.name()),
             PipelineNode::Source { .. }
             | PipelineNode::Merge { .. }
@@ -668,6 +720,7 @@ impl PipelineNode {
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
             | PipelineNode::Output { header, .. }
+            | PipelineNode::Reshape { header, .. }
             | PipelineNode::Composition { header, .. } => vec![header.input.value.name()],
             PipelineNode::Merge { header, .. } => {
                 header.inputs.iter().map(|i| i.value.name()).collect()
@@ -707,6 +760,7 @@ impl PipelineNode {
             PipelineNode::Merge { .. } => "merge",
             PipelineNode::Combine { .. } => "combine",
             PipelineNode::Output { .. } => "output",
+            PipelineNode::Reshape { .. } => "reshape",
             PipelineNode::Composition { .. } => "composition",
         }
     }
@@ -1238,6 +1292,100 @@ pub struct CombineBody {
 pub struct OutputBody {
     #[serde(flatten)]
     pub output: crate::config::OutputConfig,
+}
+
+/// Engine-stamped audit column set `true` on every record a Reshape
+/// rule synthesizes. Originals (including mutated trigger rows) carry
+/// `false`. Reserved `$meta.` prefix guarantees no collision with a
+/// user-declared column.
+pub const RESHAPE_SYNTHETIC_COLUMN: &str = "$meta.synthetic";
+
+/// Engine-stamped audit column naming the `<node>:<rule>` that
+/// synthesized a record. Empty string on non-synthetic records.
+pub const RESHAPE_SYNTHESIZED_BY_COLUMN: &str = "$meta.synthesized_by";
+
+/// Engine-stamped audit column accumulating the `<node>:<rule>` labels
+/// of every rule that mutated a record, comma-separated. Empty string
+/// on records no rule mutated.
+pub const RESHAPE_MUTATED_BY_COLUMN: &str = "$meta.mutated_by";
+
+/// Reshape variant body. A blocking grouping operator: it buffers each
+/// correlation group (keyed by `partition_by`), observes the whole
+/// group, then applies each rule's mutation and synthesis actions.
+///
+/// Rules see the **original** group state — later rules never observe
+/// earlier rules' effects (the no-cascade contract). To sequence
+/// dependent transformations, chain two Reshape nodes in the DAG.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReshapeBody {
+    /// Correlation-key fields. Records are grouped by the tuple of these
+    /// column values; every rule observes and acts within one group.
+    pub partition_by: Vec<String>,
+    /// Optional within-group ordering. When set, each group's rows are
+    /// sorted by these keys before rules run, so `order_by`-dependent
+    /// synthesis (e.g. copy-from-first) is deterministic.
+    #[serde(default)]
+    pub order_by: Vec<crate::config::SortField>,
+    /// Declarative rules applied per group. Evaluated in declaration
+    /// order, but all against the same original group snapshot.
+    pub rules: Vec<ReshapeRule>,
+}
+
+/// One declarative Reshape rule: a row-trigger predicate plus optional
+/// mutation and synthesis actions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ReshapeRule {
+    /// Rule name, used in `$meta.*` audit stamps and mutation-conflict
+    /// DLQ stage labels.
+    pub name: String,
+    /// CXL boolean predicate. A group row for which `when` evaluates
+    /// truthy is a **trigger row**: the rule's `mutate` rewrites it and
+    /// its `synthesize` derives new rows from it.
+    pub when: CxlSource,
+    /// Optional in-place mutation of trigger rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mutate: Option<MutateAction>,
+    /// Optional synthesis of new rows derived from trigger rows.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synthesize: Option<SynthesizeAction>,
+}
+
+/// In-place mutation of trigger rows: assign each field its CXL-evaluated
+/// new value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MutateAction {
+    /// Field → CXL scalar expression. Each expression evaluates against
+    /// the original trigger row; the result overwrites that field on the
+    /// row. Assigning a `partition_by` field is a compile error — group
+    /// identity must survive Reshape.
+    pub set: IndexMap<String, CxlSource>,
+}
+
+/// Synthesis of new rows derived from trigger rows.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SynthesizeAction {
+    /// Where the synthesized row's base column values come from.
+    pub copy_from: CopyFrom,
+    /// Field → CXL scalar expression applied on top of the copied base.
+    /// Evaluated against the trigger row. When `copy_from: none`, every
+    /// output column must appear here (enforced at compile time).
+    #[serde(default)]
+    pub overrides: IndexMap<String, CxlSource>,
+}
+
+/// Base-value source for a synthesized row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CopyFrom {
+    /// Copy every column value from the trigger row, then apply
+    /// `overrides`.
+    Trigger,
+    /// Start from an all-null row; `overrides` supplies every value.
+    None,
 }
 
 /// The scope a Transform's `declares:` entry writes to. Each scope is

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1158,6 +1158,19 @@ fn synthetic_typed_program(output_row: Row) -> TypedProgram {
     }
 }
 
+/// Borrowed inputs for binding one `PipelineNode::Reshape`.
+///
+/// Bundles the read-only node identity (name/config/upstream/span/vars)
+/// so `bind_reshape` keeps only the mutable sinks (diags/artifacts/schema
+/// map) as loose parameters, mirroring `CombineNodeBinding`.
+struct ReshapeNodeBinding<'a> {
+    name: &'a str,
+    config: &'a ReshapeBody,
+    upstream: &'a Row,
+    span: Span,
+    scoped_vars: &'a cxl::resolve::ScopedVarsRegistry,
+}
+
 /// Bind a `PipelineNode::Reshape`: validate `partition_by` against the
 /// upstream schema, typecheck each rule's `when` / `set` / `overrides`
 /// CXL against that schema, enforce the group-identity and synthesis
@@ -1173,17 +1186,19 @@ fn synthetic_typed_program(output_row: Row) -> TypedProgram {
 ///   survive Reshape;
 /// - `copy_from: none` requires every upstream column to appear in
 ///   `overrides`, so a synthesized row is never silently all-null.
-#[allow(clippy::too_many_arguments)]
 fn bind_reshape(
-    name: &str,
-    config: &ReshapeBody,
-    upstream: &Row,
-    span: Span,
-    scoped_vars: &cxl::resolve::ScopedVarsRegistry,
+    node: &ReshapeNodeBinding<'_>,
     diags: &mut Vec<Diagnostic>,
     artifacts: &mut CompileArtifacts,
     schema_by_name: &mut HashMap<String, Row>,
 ) {
+    let &ReshapeNodeBinding {
+        name,
+        config,
+        upstream,
+        span,
+        scoped_vars,
+    } = node;
     let mut ok = true;
 
     // `partition_by` fields must exist upstream.
@@ -1771,11 +1786,13 @@ fn bind_schema_inner(
                 if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
                     let upstream = upstream.clone();
                     bind_reshape(
-                        &name,
-                        config,
-                        &upstream,
-                        span,
-                        &bind_ctx.scoped_vars,
+                        &ReshapeNodeBinding {
+                            name: &name,
+                            config,
+                            upstream: &upstream,
+                            span,
+                            scoped_vars: &bind_ctx.scoped_vars,
+                        },
                         diags,
                         artifacts,
                         schema_by_name,

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -33,7 +33,8 @@ use crate::config::composition::{
 };
 use crate::config::node_header::CombineHeader;
 use crate::config::pipeline_node::{
-    CombineBody, MatchMode, OnUnmapped, PipelineNode, PropagateCkSpec, SchemaDecl,
+    CombineBody, CopyFrom, MatchMode, OnUnmapped, PipelineNode, PropagateCkSpec, ReshapeBody,
+    SchemaDecl,
 };
 use crate::plan::combine::{
     CombineInput, DecomposedPredicate, decompose_predicate, select_driving_input,
@@ -1157,6 +1158,219 @@ fn synthetic_typed_program(output_row: Row) -> TypedProgram {
     }
 }
 
+/// Bind a `PipelineNode::Reshape`: validate `partition_by` against the
+/// upstream schema, typecheck each rule's `when` / `set` / `overrides`
+/// CXL against that schema, enforce the group-identity and synthesis
+/// invariants, and publish the audit-widened output row.
+///
+/// Validation enforced here (compile errors, code E200):
+/// - every `partition_by` field exists upstream;
+/// - each rule's `when` predicate and every `set` / `overrides` value
+///   expression typechecks against the upstream row;
+/// - `set` targets must already exist upstream (Reshape mutates, it does
+///   not widen the user schema) and must not be a `partition_by` field or
+///   an engine-stamped `$`-namespaced column — group identity must
+///   survive Reshape;
+/// - `copy_from: none` requires every upstream column to appear in
+///   `overrides`, so a synthesized row is never silently all-null.
+#[allow(clippy::too_many_arguments)]
+fn bind_reshape(
+    name: &str,
+    config: &ReshapeBody,
+    upstream: &Row,
+    span: Span,
+    scoped_vars: &cxl::resolve::ScopedVarsRegistry,
+    diags: &mut Vec<Diagnostic>,
+    artifacts: &mut CompileArtifacts,
+    schema_by_name: &mut HashMap<String, Row>,
+) {
+    let mut ok = true;
+
+    // `partition_by` fields must exist upstream.
+    for pk in &config.partition_by {
+        if !upstream.has_field(pk) {
+            diags.push(
+                Diagnostic::error(
+                    "E200",
+                    format!(
+                        "reshape {name:?}: partition_by field {pk:?} is not present in the \
+                         upstream schema"
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                )
+                .with_help(
+                    "declare the column in the source's `schema:` block or emit it from an \
+                     upstream transform",
+                ),
+            );
+            ok = false;
+        }
+    }
+
+    // `order_by` fields must exist upstream.
+    for sf in &config.order_by {
+        if !upstream.has_field(&sf.field) {
+            diags.push(Diagnostic::error(
+                "E200",
+                format!(
+                    "reshape {name:?}: order_by field {:?} is not present in the upstream schema",
+                    sf.field
+                ),
+                LabeledSpan::primary(span, String::new()),
+            ));
+            ok = false;
+        }
+    }
+
+    // Per-rule predicate + assignment typechecks and invariants.
+    for rule in &config.rules {
+        // `when` predicate compiles as a row filter.
+        let when_src = format!("filter {}", rule.when.source);
+        if let Err(d) = typecheck_cxl(
+            &format!("{name}:{}:when", rule.name),
+            &when_src,
+            upstream,
+            AggregateMode::Row,
+            span,
+            scoped_vars,
+        ) {
+            diags.push(d);
+            ok = false;
+        }
+
+        if let Some(mutate) = &rule.mutate {
+            for (field, value) in &mutate.set {
+                // Group identity must survive Reshape: a `set` cannot
+                // target a partition key or an engine-stamped column.
+                if config.partition_by.iter().any(|p| p == field) {
+                    diags.push(
+                        Diagnostic::error(
+                            "E200",
+                            format!(
+                                "reshape {name:?} rule {:?}: mutate.set may not write \
+                                 partition_by field {field:?} — group identity must survive \
+                                 Reshape",
+                                rule.name
+                            ),
+                            LabeledSpan::primary(span, String::new()),
+                        )
+                        .with_help("drop this assignment, or partition on a different field"),
+                    );
+                    ok = false;
+                } else if field.starts_with('$') {
+                    diags.push(Diagnostic::error(
+                        "E200",
+                        format!(
+                            "reshape {name:?} rule {:?}: mutate.set may not write the \
+                             engine-stamped column {field:?}",
+                            rule.name
+                        ),
+                        LabeledSpan::primary(span, String::new()),
+                    ));
+                    ok = false;
+                } else if !upstream.has_field(field) {
+                    diags.push(
+                        Diagnostic::error(
+                            "E200",
+                            format!(
+                                "reshape {name:?} rule {:?}: mutate.set target {field:?} is not \
+                                 present in the upstream schema — Reshape mutates existing \
+                                 columns, it does not add new ones",
+                                rule.name
+                            ),
+                            LabeledSpan::primary(span, String::new()),
+                        )
+                        .with_help("emit the column from an upstream transform first"),
+                    );
+                    ok = false;
+                }
+                if let Err(d) = typecheck_cxl(
+                    &format!("{name}:{}:set.{field}", rule.name),
+                    &format!("emit {field} = {}", value.source),
+                    upstream,
+                    AggregateMode::Row,
+                    span,
+                    scoped_vars,
+                ) {
+                    diags.push(d);
+                    ok = false;
+                }
+            }
+        }
+
+        if let Some(synth) = &rule.synthesize {
+            // `copy_from: none` requires every upstream user column to be
+            // supplied by `overrides`, so a synthesized row is never
+            // silently all-null.
+            if synth.copy_from == CopyFrom::None {
+                for (qf, _) in upstream.fields() {
+                    let col = qf.name.as_ref();
+                    if col.starts_with('$') {
+                        continue;
+                    }
+                    if !synth.overrides.keys().any(|k| k == col) {
+                        diags.push(
+                            Diagnostic::error(
+                                "E200",
+                                format!(
+                                    "reshape {name:?} rule {:?}: synthesize with \
+                                     `copy_from: none` must override every column, but {col:?} \
+                                     is missing from `overrides`",
+                                    rule.name
+                                ),
+                                LabeledSpan::primary(span, String::new()),
+                            )
+                            .with_help(
+                                "add the column to `overrides`, or use `copy_from: trigger` to \
+                                 inherit the trigger row's values",
+                            ),
+                        );
+                        ok = false;
+                    }
+                }
+            }
+            for (field, value) in &synth.overrides {
+                if let Err(d) = typecheck_cxl(
+                    &format!("{name}:{}:override.{field}", rule.name),
+                    &format!("emit {field} = {}", value.source),
+                    upstream,
+                    AggregateMode::Row,
+                    span,
+                    scoped_vars,
+                ) {
+                    diags.push(d);
+                    ok = false;
+                }
+            }
+        }
+    }
+
+    if !ok {
+        return;
+    }
+
+    // Output row = upstream columns ++ the three `$meta.*` audit columns
+    // Reshape stamps on every output record.
+    let mut declared = upstream.declared_map().clone();
+    use crate::config::pipeline_node::{
+        RESHAPE_MUTATED_BY_COLUMN, RESHAPE_SYNTHESIZED_BY_COLUMN, RESHAPE_SYNTHETIC_COLUMN,
+    };
+    declared.insert(QualifiedField::bare(RESHAPE_SYNTHETIC_COLUMN), Type::Bool);
+    declared.insert(
+        QualifiedField::bare(RESHAPE_SYNTHESIZED_BY_COLUMN),
+        Type::String,
+    );
+    declared.insert(
+        QualifiedField::bare(RESHAPE_MUTATED_BY_COLUMN),
+        Type::String,
+    );
+    let out = Row::from_parts(declared, upstream.declared_span, upstream.tail.clone());
+    schema_by_name.insert(name.to_string(), out.clone());
+    artifacts
+        .typed
+        .insert(name.to_string(), Arc::new(synthetic_typed_program(out)));
+}
+
 // ─── Internal recursive bind_schema ─────────────────────────────────
 
 /// Internal recursive bind_schema. Walks nodes in topological order,
@@ -1551,6 +1765,21 @@ fn bind_schema_inner(
                     artifacts
                         .typed
                         .insert(name, Arc::new(synthetic_typed_program(row)));
+                }
+            }
+            PipelineNode::Reshape { header, config } => {
+                if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
+                    let upstream = upstream.clone();
+                    bind_reshape(
+                        &name,
+                        config,
+                        &upstream,
+                        span,
+                        &bind_ctx.scoped_vars,
+                        diags,
+                        artifacts,
+                        schema_by_name,
+                    );
                 }
             }
             // Phase Combine C.1.1 + C.1.2 + C.1.3 (single-pass arm).
@@ -1979,6 +2208,7 @@ fn bind_composition(
             PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
+            | PipelineNode::Reshape { header, .. }
             | PipelineNode::Output { header, .. } => {
                 let r = match &header.input.value {
                     crate::config::node_header::NodeInput::Single(s) => s.clone(),
@@ -2090,6 +2320,7 @@ fn bind_composition(
             | PipelineNode::Transform { header, .. }
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
+            | PipelineNode::Reshape { header, .. }
             | PipelineNode::Output { header, .. } => {
                 vec![match &header.input.value {
                     crate::config::node_header::NodeInput::Single(s) => s.clone(),

--- a/crates/clinker-plan/src/plan/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/deferred_region.rs
@@ -1037,6 +1037,18 @@ fn propagate_through_node_for_body(node: &PlanNode, set: &mut HashSet<String>) {
             // node itself is treated as a passthrough for the buffer
             // schema.
         }
+        PlanNode::Reshape { config, .. } => {
+            // Reshape observes the whole correlation group: it needs its
+            // partition_by and order_by columns retained in the buffer.
+            // Per-rule predicate/assignment column reads narrow further
+            // but the partition/order superset is sound.
+            for p in &config.partition_by {
+                set.insert(p.clone());
+            }
+            for sf in &config.order_by {
+                set.insert(sf.field.clone());
+            }
+        }
         PlanNode::Source { .. } | PlanNode::Output { .. } => {
             // Sources and Outputs are region boundaries; never visited
             // as upstream in the propagation walk.

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -1366,6 +1366,9 @@ impl ExecutionPlanDag {
                 PlanNode::Combine { .. } => {
                     out.push_str(&format!("  ◈ {}{line_suffix}\n", node.display_name()));
                 }
+                PlanNode::Reshape { .. } => {
+                    out.push_str(&format!("  ◇ {}{line_suffix}\n", node.display_name()));
+                }
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }
                 | PlanNode::Output { .. }
@@ -1486,6 +1489,11 @@ impl ExecutionPlanDag {
                     // `display_name()` carries the strategy/drive/build
                     // and predicate-shape suffix.
                     out.push_str(&format!("  ◈ {}{line_suffix}\n", node.display_name()));
+                }
+                PlanNode::Reshape { .. } => {
+                    // Sibling rendering: Reshape is a grouping operator;
+                    // it shares the `◇` glyph family with Aggregate.
+                    out.push_str(&format!("  ◇ {}{line_suffix}\n", node.display_name()));
                 }
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -893,9 +893,9 @@ pub(super) fn arbitration_class(node: &PlanNode) -> ArbitrationClass {
         // sink, Composition is a structural wrapper whose body nodes
         // carry their own classes, and CorrelationCommit's group buffer
         // is bounded by `max_group_buffer` rather than the arbitrator.
-        // Reshape buffers per-group state in memory bounded by the
-        // correlation group cap; its disk-spill governance lands with the
-        // follow-on memory work, so it registers no spillable consumer yet.
+        // Reshape buffers per-group state entirely in memory with no
+        // group-size cap; its disk-spill governance lands with the follow-on
+        // memory work, so it registers no spillable consumer yet.
         PlanNode::Transform { .. }
         | PlanNode::Route { .. }
         | PlanNode::Merge { .. }

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -172,6 +172,28 @@ pub enum PlanNode {
         #[serde(skip)]
         resolved: Option<Box<PlanOutputPayload>>,
     },
+    /// Per-correlation-group synthesis and trigger-row mutation.
+    ///
+    /// Blocking grouping operator: buffers each `partition_by` group,
+    /// observes it, then applies each rule's trigger-row mutation and
+    /// row synthesis. Single output. The executor compiles each rule's
+    /// `when` / `set` / `overrides` CXL against the live input schema at
+    /// dispatch time (mirroring the Route condition-compile seam), so the
+    /// plan node carries only the parsed `config` and the widened output
+    /// schema.
+    Reshape {
+        name: String,
+        #[serde(skip)]
+        span: Span,
+        /// Parsed Reshape configuration (`partition_by` / `order_by` /
+        /// `rules`). Consumed by the executor's reshape dispatch arm.
+        config: crate::config::pipeline_node::ReshapeBody,
+        /// Widened output schema: the upstream columns plus the three
+        /// `$meta.*` audit columns Reshape stamps. Populated by
+        /// `bind_schema`.
+        #[serde(skip)]
+        output_schema: Arc<Schema>,
+    },
     /// Planner-synthesized sort enforcer.
     ///
     /// Inserted by `ExecutionPlanDag::insert_enforcer_sorts` on edges feeding
@@ -406,6 +428,7 @@ impl PlanNode {
             | PlanNode::Route { name, .. }
             | PlanNode::Merge { name, .. }
             | PlanNode::Output { name, .. }
+            | PlanNode::Reshape { name, .. }
             | PlanNode::Sort { name, .. }
             | PlanNode::Aggregation { name, .. }
             | PlanNode::Composition { name, .. }
@@ -423,6 +446,7 @@ impl PlanNode {
             | PlanNode::Route { span, .. }
             | PlanNode::Merge { span, .. }
             | PlanNode::Output { span, .. }
+            | PlanNode::Reshape { span, .. }
             | PlanNode::Sort { span, .. }
             | PlanNode::Aggregation { span, .. }
             | PlanNode::Composition { span, .. }
@@ -467,6 +491,7 @@ impl PlanNode {
             PlanNode::Aggregation { output_schema, .. }
             | PlanNode::Combine { output_schema, .. }
             | PlanNode::Composition { output_schema, .. }
+            | PlanNode::Reshape { output_schema, .. }
             | PlanNode::Merge { output_schema, .. } => output_schema
                 .columns()
                 .iter()
@@ -501,6 +526,7 @@ impl PlanNode {
             | PlanNode::Aggregation { output_schema, .. }
             | PlanNode::Combine { output_schema, .. }
             | PlanNode::Composition { output_schema, .. }
+            | PlanNode::Reshape { output_schema, .. }
             | PlanNode::Merge { output_schema, .. } => Some(output_schema),
             PlanNode::Route { .. }
             | PlanNode::Output { .. }
@@ -589,6 +615,7 @@ impl PlanNode {
             PlanNode::Composition { .. } => "composition",
             PlanNode::Combine { .. } => "combine",
             PlanNode::CorrelationCommit { .. } => "correlation_commit",
+            PlanNode::Reshape { .. } => "reshape",
         }
     }
 
@@ -637,6 +664,13 @@ impl PlanNode {
             }
             PlanNode::Merge { name, .. } => format!("[merge] {name}"),
             PlanNode::Output { name, .. } => format!("[output] {name}"),
+            PlanNode::Reshape { name, config, .. } => {
+                format!(
+                    "[reshape] {name} partition_by=[{}] rules={}",
+                    config.partition_by.join(", "),
+                    config.rules.len()
+                )
+            }
             PlanNode::Sort { name, .. } => format!("[sort] {name}"),
             PlanNode::Aggregation { name, strategy, .. } => {
                 let s = match strategy {
@@ -859,10 +893,14 @@ pub(super) fn arbitration_class(node: &PlanNode) -> ArbitrationClass {
         // sink, Composition is a structural wrapper whose body nodes
         // carry their own classes, and CorrelationCommit's group buffer
         // is bounded by `max_group_buffer` rather than the arbitrator.
+        // Reshape buffers per-group state in memory bounded by the
+        // correlation group cap; its disk-spill governance lands with the
+        // follow-on memory work, so it registers no spillable consumer yet.
         PlanNode::Transform { .. }
         | PlanNode::Route { .. }
         | PlanNode::Merge { .. }
         | PlanNode::Output { .. }
+        | PlanNode::Reshape { .. }
         | PlanNode::Composition { .. }
         | PlanNode::CorrelationCommit { .. } => ArbitrationClass {
             spill_priority: None,
@@ -922,6 +960,7 @@ pub(super) fn writes_spill_files(node: &PlanNode) -> bool {
         | PlanNode::Route { .. }
         | PlanNode::Merge { .. }
         | PlanNode::Output { .. }
+        | PlanNode::Reshape { .. }
         | PlanNode::Composition { .. }
         | PlanNode::CorrelationCommit { .. } => false,
     }

--- a/crates/clinker-plan/src/plan/execution/scheduling.rs
+++ b/crates/clinker-plan/src/plan/execution/scheduling.rs
@@ -1020,6 +1020,23 @@ fn compute_one(
             }
         }
 
+        PlanNode::Reshape { .. } => {
+            // Reshape re-orders rows within each group (`order_by`) and
+            // injects synthesized rows, so no parent ordering survives;
+            // downstream sees an unordered stream. Group identity is
+            // preserved — `partition_by` must cover every visible CK
+            // field — so the parent CK set flows through unchanged.
+            NodeProperties {
+                ordering: Ordering {
+                    sort_order: None,
+                    provenance: OrderingProvenance::NoOrdering,
+                },
+                partitioning: parent_partitioning(),
+                ck_set: preserve_parent_ck_set(),
+                ..NodeProperties::unordered_single()
+            }
+        }
+
         PlanNode::Combine {
             name, propagate_ck, ..
         } => {

--- a/crates/clinker-plan/src/plan/tests/ck_lattice.rs
+++ b/crates/clinker-plan/src/plan/tests/ck_lattice.rs
@@ -965,6 +965,7 @@ fn assert_every_node_has_properties(plan: &crate::plan::execution::ExecutionPlan
                 PlanNode::Merge { .. } => "merge",
                 PlanNode::Combine { .. } => "combine",
                 PlanNode::Output { .. } => "output",
+                PlanNode::Reshape { .. } => "reshape",
                 PlanNode::Composition { .. } => "composition",
                 PlanNode::CorrelationCommit { .. } => "correlation_commit",
             }

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -7,5 +7,6 @@ mod doc_paths;
 mod explain_buffer_class;
 mod explain_polish;
 mod plan_time_window_root;
+mod reshape_validation;
 mod route_ports;
 mod watermark_validation;

--- a/crates/clinker-plan/src/plan/tests/reshape_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/reshape_validation.rs
@@ -1,0 +1,205 @@
+//! Plan-time validation for the Reshape node's `bind_schema` guards.
+//!
+//! Each guard rejects a malformed rule at compile time with an `E200`
+//! diagnostic. Because every guard shares the `E200` code, these tests
+//! pin the distinctive message substring each one produces, so a future
+//! edit that swaps two messages — or drops a guard entirely — fails here
+//! rather than letting a malformed pipeline plan silently.
+//!
+//! Guards covered (one negative path each):
+//! - `partition_by` names a field absent from the upstream schema.
+//! - `order_by` names a field absent from the upstream schema.
+//! - `mutate.set` writes a `partition_by` field (group identity must
+//!   survive Reshape).
+//! - `mutate.set` writes an engine-stamped `$`-prefixed column.
+//! - `mutate.set` targets a column absent from the upstream schema
+//!   (Reshape mutates existing columns, never adds new ones).
+//! - `synthesize` with `copy_from: none` fails to override every column.
+
+use crate::config::{CompileContext, parse_config};
+
+/// Compile `yaml`, expecting failure, and return `(code, message)` pairs.
+fn compile_diagnostics(yaml: &str) -> Vec<(String, String)> {
+    let config = parse_config(yaml).expect("parse_config");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("compile should fail");
+    diags
+        .iter()
+        .map(|d| (d.code.clone(), d.message.clone()))
+        .collect()
+}
+
+/// Assert that some emitted `E200` carries every substring in `needles`.
+fn assert_e200_contains(diags: &[(String, String)], needles: &[&str]) {
+    let found = diags
+        .iter()
+        .filter(|(code, _)| code == "E200")
+        .any(|(_, msg)| needles.iter().all(|n| msg.contains(n)));
+    assert!(
+        found,
+        "expected an E200 containing all of {needles:?}, got {diags:?}"
+    );
+}
+
+/// Wrap a reshape `config:` block in a source → reshape → output pipeline
+/// whose upstream schema is `id: string, amount: int, label: string` and
+/// whose partition key is `id`.
+fn pipeline_with_reshape_config(reshape_config: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: reshape_validation
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: id, type: string }}
+        - {{ name: amount, type: int }}
+        - {{ name: label, type: string }}
+  - type: reshape
+    name: rs
+    input: src
+    config:
+{reshape_config}
+  - type: output
+    name: out
+    input: rs
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+#[test]
+fn partition_by_unknown_field_rejected() {
+    let yaml = pipeline_with_reshape_config(
+        r#"      partition_by: [nonexistent]
+      rules:
+        - name: r
+          when: "amount > 0"
+          mutate:
+            set:
+              label: "'x'""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &[
+            "partition_by field",
+            "nonexistent",
+            "not present in the upstream schema",
+        ],
+    );
+}
+
+#[test]
+fn order_by_unknown_field_rejected() {
+    let yaml = pipeline_with_reshape_config(
+        r#"      partition_by: [id]
+      order_by:
+        - { field: nonexistent, order: asc }
+      rules:
+        - name: r
+          when: "amount > 0"
+          mutate:
+            set:
+              label: "'x'""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &[
+            "order_by field",
+            "nonexistent",
+            "not present in the upstream schema",
+        ],
+    );
+}
+
+#[test]
+fn mutate_set_partition_key_rejected() {
+    let yaml = pipeline_with_reshape_config(
+        r#"      partition_by: [id]
+      rules:
+        - name: r
+          when: "amount > 0"
+          mutate:
+            set:
+              id: "'reassigned'""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &[
+            "mutate.set may not write",
+            "partition_by field",
+            "group identity must survive",
+        ],
+    );
+}
+
+#[test]
+fn mutate_set_engine_stamped_column_rejected() {
+    let yaml = pipeline_with_reshape_config(
+        r#"      partition_by: [id]
+      rules:
+        - name: r
+          when: "amount > 0"
+          mutate:
+            set:
+              $meta.synthetic: "true""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &["mutate.set may not write the engine-stamped column"],
+    );
+}
+
+#[test]
+fn mutate_set_unknown_target_rejected() {
+    let yaml = pipeline_with_reshape_config(
+        r#"      partition_by: [id]
+      rules:
+        - name: r
+          when: "amount > 0"
+          mutate:
+            set:
+              nonexistent: "'x'""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &["mutate.set target", "nonexistent", "does not add new ones"],
+    );
+}
+
+#[test]
+fn synthesize_copy_from_none_missing_override_rejected() {
+    // `copy_from: none` starts all-null, so every user column (`amount`,
+    // `label`) must appear in `overrides`. Here only `amount` is supplied,
+    // so `label` is reported missing.
+    let yaml = pipeline_with_reshape_config(
+        r#"      partition_by: [id]
+      rules:
+        - name: r
+          when: "amount > 0"
+          synthesize:
+            copy_from: none
+            overrides:
+              id: "id"
+              amount: "amount""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &["copy_from: none", "must override every column", "label"],
+    );
+}

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -272,7 +272,8 @@ impl Record {
                 Some(FieldMetadata::WidenedSidecar)
                 | Some(FieldMetadata::SourceFile)
                 | Some(FieldMetadata::SourceName)
-                | Some(FieldMetadata::SourceEventTime) => false,
+                | Some(FieldMetadata::SourceEventTime)
+                | Some(FieldMetadata::ReshapeAudit) => false,
                 Some(FieldMetadata::SourceCorrelation { .. })
                 | Some(FieldMetadata::AggregateGroupIndex { .. })
                 | None => true,

--- a/crates/clinker-record/src/schema.rs
+++ b/crates/clinker-record/src/schema.rs
@@ -93,6 +93,12 @@ pub enum FieldMetadata {
     /// (https://github.com/rustpunk/clinker/issues/61) to assign each
     /// record to its window(s).
     SourceEventTime,
+    /// Reshape audit-stamp column (`$meta.synthetic`,
+    /// `$meta.synthesized_by`, `$meta.mutated_by`). Engine-written per
+    /// Reshape output record so the provenance of a synthesized or
+    /// mutated row is queryable downstream while staying out of the
+    /// default writer surface — mirroring the `$ck.*` posture.
+    ReshapeAudit,
 }
 
 impl FieldMetadata {
@@ -139,6 +145,12 @@ impl FieldMetadata {
     /// per-record value did not parse.
     pub fn source_event_time() -> Self {
         Self::SourceEventTime
+    }
+
+    /// Marks this column as a Reshape audit stamp (`$meta.synthetic` /
+    /// `$meta.synthesized_by` / `$meta.mutated_by`).
+    pub fn reshape_audit() -> Self {
+        Self::ReshapeAudit
     }
 
     /// True for every variant. The presence of [`FieldMetadata`] on a

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -23,6 +23,7 @@
 - [Route Nodes](pipeline/route.md)
 - [Merge Nodes](pipeline/merge.md)
 - [Combine Nodes](pipeline/combine.md)
+- [Reshape Nodes](pipeline/reshape.md)
 - [Output Nodes](pipeline/output.md)
 - [Error Handling & DLQ](pipeline/error-handling.md)
 - [Correlation Keys](pipeline/correlation-keys.md)

--- a/docs/src/pipeline/reshape.md
+++ b/docs/src/pipeline/reshape.md
@@ -112,4 +112,4 @@ Like the `$ck.*` correlation columns, these `$meta.*` columns stay out of the de
 
 ## Memory model
 
-Reshape accumulates per-group state in memory: a group must be fully buffered before its rules run. Group buffering is bounded by the correlation group cap (`error_handling.max_group_buffer`). Disk-spill governance for these buffers is part of Reshape's ongoing memory-management work.
+The whole input materializes in memory before any output row is emitted: Reshape groups every record, then runs each group's rules. There is no group-size cap and no disk spill yet — bounded-memory governance (spill, group caps, and hysteresis around the spill thresholds) is tracked as follow-on work.

--- a/docs/src/pipeline/reshape.md
+++ b/docs/src/pipeline/reshape.md
@@ -1,0 +1,115 @@
+# Reshape Nodes
+
+Reshape nodes observe a whole correlation group and, per group, **mutate** the rows whose state caused a rule to fire while **synthesizing** new rows derived from those trigger rows. They are the node for "look at everything an entity did, then fix one record and insert the record that should have been there" — work no other node can do:
+
+- **Aggregate** reduces a group to one summary row.
+- **Transform** emits 0 or 1 record per input record.
+- **Combine** joins records across sources.
+
+None of those produce new records derived from a group's observed state while preserving the originals. Reshape does.
+
+Reshape is a **blocking grouping operator**: it buffers every record of a group before any output row leaves, because a rule cannot decide what to synthesize until it has seen the whole group. It has a single output.
+
+## Basic structure
+
+```yaml
+- type: reshape
+  name: backfill_plans
+  input: plans
+  config:
+    partition_by: [employee_id]
+    order_by:
+      - { field: plan_start, order: asc }
+    rules:
+      - name: fix_long_plan_years
+        when: "plan_start - plan_end > 365"
+        mutate:
+          set:
+            plan_end: "plan_start"
+        synthesize:
+          copy_from: trigger
+          overrides:
+            status: "'synthesized'"
+```
+
+For each `employee_id` group, every row where `plan_start - plan_end > 365` (the trigger) has its `plan_end` rewritten and a new row synthesized from it with `status` overridden to `synthesized`.
+
+## `partition_by`
+
+A list of field names. Records sharing the same values for all `partition_by` fields form one group, and every rule observes and acts within a single group. This is the correlation key the operator reasons over.
+
+## `order_by`
+
+Optional. A list of sort fields (`{ field, order }`, where `order` is `asc` or `desc`) applied within each group before rules run, so order-dependent synthesis is deterministic. Nulls sort last. Arrival order breaks ties.
+
+## Rules
+
+Each entry in `rules:` is a declarative rule with a name, a trigger predicate, and optional mutation and synthesis actions. Rules are evaluated in declaration order — but every rule observes the **same original group snapshot** (see [No cascade](#no-cascade) below).
+
+### `when` — the trigger predicate
+
+`when` is a CXL boolean expression evaluated against each row in the group. A row for which `when` is true is a **trigger row** for that rule: its `mutate` rewrites it, and its `synthesize` derives new rows from it. CXL boolean operators are `and` / `or` / `not` (Clinker's expression language is not SQL).
+
+### `mutate` — in-place trigger-row mutation
+
+```yaml
+mutate:
+  set:
+    plan_end: "plan_start"
+    note: "concat(note, ' (corrected)')"
+```
+
+Each `set:` entry is `field: <CXL expression>`. The expression evaluates against the original trigger row and overwrites that field's value on the row.
+
+Two restrictions are enforced at compile time:
+
+- A `set:` target must already exist in the upstream schema. Reshape mutates existing columns; it does not add new ones. Emit the column from an upstream Transform first if you need it.
+- A `set:` may not write a `partition_by` field — group identity must survive Reshape.
+
+### `synthesize` — deriving new rows
+
+```yaml
+synthesize:
+  copy_from: trigger
+  overrides:
+    plan_date: "'2024-01-01'"
+    status: "'synthesized'"
+```
+
+For each trigger row, `synthesize` emits one new row:
+
+- `copy_from: trigger` — the new row starts as a copy of the trigger row's values, then `overrides` are applied on top.
+- `copy_from: none` — the new row starts all-null; `overrides` must supply every column (enforced at compile time, so a synthesized row is never silently empty).
+
+Each `overrides:` entry is `field: <CXL expression>`, evaluated against the trigger row.
+
+## No cascade
+
+**Every rule observes the original group state.** A row mutated by rule A is not re-observed by rule B, and rule B's `when` predicate sees the row's original values, not rule A's edits. This is a deliberate guarantee:
+
+- **Determinism** — cascade would make rule order silently change output.
+- **Single observation** — the group is observed once.
+
+To sequence dependent transformations, chain two Reshape nodes in the DAG so the second observes the first's output.
+
+## Mutation conflicts
+
+If two rules write the **same field** on the **same row**, that is a mutation conflict. Some conflicts are caught at compile time when the rules' selectors statically overlap; content-dependent collisions that cannot be proven at compile time are caught at runtime.
+
+A runtime conflict routes a dead-letter-queue entry under the `mutation_conflict` category, and the **whole correlation group rolls back** — none of that group's mutated or synthesized rows reach the output. The DLQ entry's stage label is `reshape:<node>:<rule_a>+<rule_b>`, naming the colliding rule pair. See [Error Handling & DLQ](error-handling.md).
+
+## Audit stamps
+
+Reshape stamps three engine-written columns on its output records so the provenance of a synthesized or mutated row is queryable downstream:
+
+| Column | Meaning |
+|--------|---------|
+| `$meta.synthetic` | `true` on a synthesized row, `false` on an original (including a mutated trigger row) |
+| `$meta.synthesized_by` | the `<node>:<rule>` that synthesized the row (empty on originals) |
+| `$meta.mutated_by` | comma-separated `<node>:<rule>` labels of every rule that mutated the row (empty if none) |
+
+Like the `$ck.*` correlation columns, these `$meta.*` columns stay out of the default writer output — they are available for downstream CXL and audit, not silently dumped into your output files.
+
+## Memory model
+
+Reshape accumulates per-group state in memory: a group must be fully buffered before its rules run. Group buffering is bounded by the correlation group cap (`error_handling.max_group_buffer`). Disk-spill governance for these buffers is part of Reshape's ongoing memory-management work.


### PR DESCRIPTION
## Summary

Adds a new `Reshape` pipeline node: a blocking grouping operator that observes a whole correlation group and, per declarative rule, mutates the trigger rows whose state fired the rule while synthesizing new rows derived from them. Single output. It is modeled on the existing Aggregate/Sort blocking template.

## Shape

A Reshape node declares `partition_by`, optional in-group `order_by`, and a list of `rules`. Each rule has a `when` trigger predicate and optional `mutate.set` (field assignments) and `synthesize` (new rows with `copy_from: trigger | none` plus `overrides`).

- **No-cascade contract:** every rule evaluates against the *original* group snapshot, so one rule's mutation never changes what a later rule sees.
- **Mutation conflicts:** if two rules write the same field of the same trigger row, the conflict is detected and the *whole* correlation group is rolled back to the DLQ (`MutationConflict` category) — no partial group is emitted.
- **Audit stamps:** synthesized/mutated rows carry `$meta.synthetic` / `$meta.synthesized_by` / `$meta.mutated_by`, hidden from default writer output (like other engine-stamped columns) but queryable downstream.
- **Binding validation:** partition/order fields must exist; `set` cannot write a partition key or an engine-stamped column; `copy_from: none` must override every column; rule predicates and assignments are type-checked. Each guard has a negative-path test.

## Memory

This is the Reshape **core**. The whole input materializes in memory before any output row is emitted — there is no group-size cap or disk spill yet; bounded-memory governance (spill, group caps, threshold hysteresis) is tracked as follow-on work in #388. The node's docs state this plainly.

## Tests & docs

Execution tests cover SCD-Type-2 mutate+synthesize, idempotent re-run, the no-cascade guarantee, and whole-group rollback on conflict; plan tests pin all six binding guards. `docs/src/pipeline/reshape.md` documents the node.

Closes #387.