### PR TITLE
plan: validate $doc path references against the declared envelope schema (#435)

### DIFF
--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -82,6 +82,7 @@
 //! | `E338`      | error    | `x12` output combined with byte-limit `split` (an interchange is one indivisible ISA..IEA envelope) |
 //! | `E339`      | error    | `hl7` output combined with byte-limit `split` (a batch/file envelope is one indivisible FHS..FTS structure) |
 //! | `E340`      | error    | A `$doc.<section>.<field>` access is indexed by a non-literal expression, so its declared document path cannot be resolved at compile time |
+//! | `E341`      | error    | A `$doc.<section>.<field>` access names an envelope section or field a feeding XML/JSON source does not declare |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -798,21 +798,22 @@ impl PipelineConfig {
             )
             .collect();
         let doc_path_set = cxl::analyzer::doc_paths::collect_doc_paths(&doc_refs);
+        // Anchor each `$doc` diagnostic at the offending node's source line.
+        // Top-level node lines come from the saphyr-captured YAML position;
+        // a composition-body node (not present in `self.nodes`) falls back
+        // to a synthetic span. Shared by the E340 unresolvable-index pass
+        // and the E341 undeclared-path pass below.
+        let doc_node_line: HashMap<&str, u32> = self
+            .nodes
+            .iter()
+            .filter_map(|sp| {
+                let line = sp.referenced.line();
+                (line > 0).then(|| (sp.value.name(), line as u32))
+            })
+            .collect();
         if !doc_path_set.unresolvable.is_empty() {
-            // Anchor each diagnostic at the offending node's source line.
-            // Top-level node lines come from the saphyr-captured YAML
-            // position; a composition-body node (not present in
-            // `self.nodes`) falls back to a synthetic span.
-            let node_line: HashMap<&str, u32> = self
-                .nodes
-                .iter()
-                .filter_map(|sp| {
-                    let line = sp.referenced.line();
-                    (line > 0).then(|| (sp.value.name(), line as u32))
-                })
-                .collect();
             for (node_name, d) in &doc_path_set.unresolvable {
-                let primary = match node_line.get(node_name.as_str()) {
+                let primary = match doc_node_line.get(node_name.as_str()) {
                     Some(&line) => Span::line_only(line),
                     None => Span::SYNTHETIC,
                 };
@@ -856,6 +857,59 @@ impl PipelineConfig {
                 .into_iter()
                 .map(|(source, paths)| (source, paths.into_iter().collect()))
                 .collect();
+        // E341 — a `$doc.<section>.<field>` access must name a section and
+        // field the feeding source's envelope actually declares. Without
+        // this check a typo (`$doc.Summry.total` against a declared
+        // `Summary`) compiles silently and resolves to `Value::Null` at
+        // run time; the cxl typechecker cannot catch it because `$doc.*`
+        // types as `Any` with no envelope context in scope.
+        //
+        // Only XML and JSON sources are validated: their reader extracts
+        // exactly the declared sections, each with exactly the declared
+        // fields, so the `EnvelopeConfig` is the authoritative closed
+        // schema. Segment- and positional-based formats (X12, EDIFACT,
+        // HL7, fixed-width) synthesize multi-level sections and positional
+        // fields beyond the declared config — e.g. an X12 reader exposes
+        // `$doc.functional_group.*` and `$doc.transaction_set.*` the config
+        // never names — so a closed-schema check would false-positive on
+        // them and is skipped.
+        let source_by_name: HashMap<&str, &crate::config::SourceConfig> = source_configs
+            .iter()
+            .map(|s| (s.name.as_str(), s))
+            .collect();
+        for (doc_path, ref_nodes) in &doc_path_set.by_node {
+            for node_name in ref_nodes {
+                let Some(sources) = node_sources.get(node_name) else {
+                    continue;
+                };
+                for source_name in sources {
+                    let Some(source) = source_by_name.get(source_name.as_str()) else {
+                        continue;
+                    };
+                    if !envelope_schema_is_closed(&source.format) {
+                        continue;
+                    }
+                    let Some(problem) = undeclared_doc_path_problem(source, doc_path) else {
+                        continue;
+                    };
+                    let primary = match doc_node_line.get(node_name.as_str()) {
+                        Some(&line) => Span::line_only(line),
+                        None => Span::SYNTHETIC,
+                    };
+                    diags.push(
+                        Diagnostic::error(
+                            "E341",
+                            problem.message,
+                            LabeledSpan::primary(primary, String::new()),
+                        )
+                        .with_help(problem.help),
+                    );
+                }
+            }
+        }
+        if diags.iter().any(|d| d.code == "E341") {
+            return Err(diags);
+        }
         // Keep an analysis-by-name index so we can surface the analysis
         // alongside its matching entry regardless of filter order.
         let mut analysis_by_name: HashMap<String, &cxl::analyzer::TransformAnalysis> =
@@ -2036,6 +2090,74 @@ fn resolve_all_input_references(
                 }
             }
         }
+    }
+}
+
+/// Whether a source format's `EnvelopeConfig` is the complete, closed set
+/// of `$doc` sections and fields the reader can supply.
+///
+/// XML and JSON readers extract exactly the declared sections, each with
+/// exactly the declared fields, so a used `$doc` path naming anything the
+/// config omits is a genuine typo. Segment- and positional-based formats
+/// (X12, EDIFACT, HL7, fixed-width) synthesize multi-level envelope
+/// sections and positional fields beyond the declared config — an X12
+/// reader exposes `$doc.functional_group.*` / `$doc.transaction_set.*`
+/// the config never names — so their envelope is open and the closed-set
+/// `$doc` validation is skipped for them.
+fn envelope_schema_is_closed(format: &InputFormat) -> bool {
+    matches!(format, InputFormat::Xml(_) | InputFormat::Json(_))
+}
+
+/// A rejected `$doc` path against a closed envelope schema: the formatted
+/// diagnostic message plus its fix-it help text.
+struct UndeclaredDocPath {
+    message: String,
+    help: String,
+}
+
+/// Check one `$doc.<section>.<field>` path against a source's declared
+/// envelope, returning the diagnostic content when the path names an
+/// undeclared section or an undeclared field within a declared section.
+///
+/// Returns `None` when the path is fully declared. The caller has already
+/// confirmed the source's format carries a closed envelope schema, so an
+/// absent `envelope:` block means every `$doc` path is undeclared.
+fn undeclared_doc_path_problem(
+    source: &crate::config::SourceConfig,
+    doc_path: &cxl::analyzer::doc_paths::DocPath,
+) -> Option<UndeclaredDocPath> {
+    let section_name = &*doc_path.section;
+    let field_name = &*doc_path.field;
+    let source_name = &source.name;
+    let section = source
+        .envelope
+        .as_ref()
+        .and_then(|env| env.sections.get(section_name));
+    match section {
+        None => Some(UndeclaredDocPath {
+            message: format!(
+                "`$doc.{section_name}.{field_name}` references envelope section \
+                 '{section_name}', but source '{source_name}' declares no such section"
+            ),
+            help: format!(
+                "declare the section under the source's `envelope.sections`, or correct \
+                 the name to a declared section. Section names are user-chosen and \
+                 case-sensitive — '{section_name}' must match a key under \
+                 `envelope.sections` exactly"
+            ),
+        }),
+        Some(section) if !section.fields.contains_key(field_name) => Some(UndeclaredDocPath {
+            message: format!(
+                "`$doc.{section_name}.{field_name}` references field '{field_name}' in \
+                 envelope section '{section_name}', but source '{source_name}' declares no \
+                 such field in that section"
+            ),
+            help: format!(
+                "add '{field_name}' to `envelope.sections.{section_name}.fields`, or correct \
+                 the name to a declared field. Field names are case-sensitive"
+            ),
+        }),
+        Some(_) => None,
     }
 }
 

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -232,6 +232,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E338" => Some(include_str!("../../../../docs/explain/E338.md")),
         "E339" => Some(include_str!("../../../../docs/explain/E339.md")),
         "E340" => Some(include_str!("../../../../docs/explain/E340.md")),
+        "E341" => Some(include_str!("../../../../docs/explain/E341.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -425,6 +426,16 @@ mod tests {
     }
 
     #[test]
+    fn test_explain_code_e341_undeclared_doc_path() {
+        let doc = explain_code("E341").unwrap();
+        assert!(doc.contains("E341"));
+        // The doc must name the `$doc` namespace and tie the check to the
+        // source's declared envelope sections.
+        assert!(doc.contains("$doc"));
+        assert!(doc.contains("envelope"));
+    }
+
+    #[test]
     fn test_explain_code_unknown() {
         assert!(explain_code("E999").is_none());
     }
@@ -435,8 +446,8 @@ mod tests {
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
-            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E15Y", "W101",
-            "W302", "W305", "W306",
+            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E15Y",
+            "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -178,6 +178,165 @@ nodes:
     assert!(diag.help.is_some(), "E340 must carry help text");
 }
 
+/// Compile a single-transform XML pipeline whose source declares a
+/// `Summary { total: int }` envelope section, with the transform body
+/// supplied by the caller. Returns the compile result so a test can assert
+/// success or inspect the diagnostics.
+fn compile_with_summary_envelope(
+    transform_cxl: &str,
+) -> Result<crate::plan::CompiledPlan, Vec<clinker_core_types::Diagnostic>> {
+    let mut yaml = String::from(
+        r#"
+pipeline:
+  name: doc_validate_demo
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Summary:
+            extract: { xml_path: "/doc/Summary" }
+            fields:
+              total: int
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: t0
+    input: payments
+    config:
+      cxl: |
+"#,
+    );
+    for line in transform_cxl.lines() {
+        yaml.push_str(&format!("        {line}\n"));
+    }
+    yaml.push_str(
+        "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+    );
+    let config = parse_config(&yaml).expect("parse doc-validate pipeline");
+    config.compile(&CompileContext::default())
+}
+
+#[test]
+fn test_undeclared_doc_section_aborts_compile_with_e341() {
+    // `$doc.Summry.total` misspells the declared `Summary` section, so the
+    // path names a section the XML source does not declare. The compile
+    // must abort with E341 anchored at the referencing transform.
+    let err = compile_with_summary_envelope("emit amount = amount\nemit t = $doc.Summry.total")
+        .expect_err("an undeclared `$doc` section must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E341")
+        .unwrap_or_else(|| panic!("expected an E341 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("Summry"),
+        "E341 message must name the undeclared section: {}",
+        diag.message
+    );
+    assert!(
+        diag.primary.span.synthetic_line_number().is_some(),
+        "E341 primary span must carry the referencing node's source line"
+    );
+    assert!(diag.help.is_some(), "E341 must carry help text");
+}
+
+#[test]
+fn test_undeclared_doc_field_aborts_compile_with_e341() {
+    // `$doc.Summary.totl` names the declared `Summary` section but a field
+    // the section does not declare — a distinct typo from a bad section.
+    let err = compile_with_summary_envelope("emit amount = amount\nemit t = $doc.Summary.totl")
+        .expect_err("an undeclared `$doc` field must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E341")
+        .unwrap_or_else(|| panic!("expected an E341 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("totl") && diag.message.contains("Summary"),
+        "E341 message must name the undeclared field and its section: {}",
+        diag.message
+    );
+}
+
+#[test]
+fn test_declared_doc_path_does_not_trip_e341() {
+    // The fully-declared `$doc.Summary.total` must compile without E341.
+    let plan = compile_with_summary_envelope("emit amount = amount\nemit t = $doc.Summary.total")
+        .expect("a declared `$doc` path must compile");
+    // Sanity: the path still surfaces onto the source's declared set.
+    let dag = plan.dag();
+    let source = dag
+        .graph
+        .node_indices()
+        .find_map(|idx| match &dag.graph[idx] {
+            PlanNode::Source { resolved, .. } => resolved.as_ref(),
+            _ => None,
+        })
+        .expect("source node present");
+    assert!(
+        source
+            .source
+            .declared_doc_paths
+            .contains(&path("Summary", "total", vec![])),
+    );
+}
+
+#[test]
+fn test_undeclared_doc_path_against_segment_format_is_not_validated() {
+    // X12 (and the other segment/positional formats) synthesize envelope
+    // levels beyond the declared config — `$doc.functional_group.*` and
+    // `$doc.transaction_set.*` are reader-derived, not config-declared. The
+    // closed-schema E341 check must NOT fire for these, or every multi-level
+    // EDI pipeline would be rejected.
+    let yaml = r#"
+pipeline:
+  name: x12_doc_open
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      path: po.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields:
+              e13: string
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: t0
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit gs06 = $doc.functional_group.e06
+        emit st02 = $doc.transaction_set.e02
+  - type: output
+    name: out
+    input: t0
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse x12 pipeline");
+    let result = config.compile(&CompileContext::default());
+    if let Err(err) = &result {
+        assert!(
+            err.iter().all(|d| d.code != "E341"),
+            "segment-format `$doc` paths must not trip E341, got: {err:?}"
+        );
+    }
+}
+
 #[test]
 fn test_negative_literal_doc_index_compiles() {
     // A negated integer literal is a static from-end index, so the path

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -1991,7 +1991,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E338, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E341, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/docs/explain/E341.md
+++ b/docs/explain/E341.md
@@ -1,0 +1,93 @@
+# Error E341: $doc path references an undeclared envelope section or field
+
+## What it means
+
+A program reads `$doc.<section>.<field>` from a document envelope, but the source
+feeding that program declares no such section — or declares the section without
+that field. The most common cause is a typo: `$doc.Summry.total` against a
+declared `Summary` section, or `$doc.Summary.totl` against a declared `total`
+field. Section and field names are user-chosen and case-sensitive, so `Summary`
+and `summary` are different sections.
+
+The compiler attributes every `$doc` path to the source(s) that flow into the
+referencing node, then checks each path against that source's declared envelope
+schema. Without this check, an undeclared path compiles silently and resolves to
+`Value::Null` at run time, so the typo surfaces only as missing output data.
+
+This check applies to **XML** and **JSON** sources, whose readers extract exactly
+the sections and fields the `envelope:` block declares — the declaration is the
+complete, closed schema. Segment- and positional-based formats (X12, EDIFACT,
+HL7, fixed-width) synthesize extra envelope levels and positional fields beyond
+the declared config, so their envelope is open and is not checked this way.
+
+```
+`$doc.Summry.total` references envelope section 'Summry', but source 'payments'
+declares no such section
+```
+
+## Example
+
+```yaml
+# Rejected: the section name is misspelled — `Summry` vs the declared `Summary`.
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      glob: ./*.xml
+      envelope:
+        sections:
+          Summary:
+            extract: { xml_path: "/doc/Summary" }
+            fields:
+              total: int
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: tag
+    input: payments
+    config:
+      cxl: |
+        emit amount = amount
+        emit declared_total = $doc.Summry.total
+```
+
+```yaml
+# Corrected: the reference matches the declared section and field exactly.
+  - type: transform
+    name: tag
+    input: payments
+    config:
+      cxl: |
+        emit amount = amount
+        emit declared_total = $doc.Summary.total
+```
+
+## How to fix
+
+1. **Correct the name** so `$doc.<section>.<field>` matches a declared section and
+   field exactly, including case.
+
+2. **Declare the section or field** under the source's `envelope:` block if the
+   reference is intentional. Add the section under `envelope.sections`, and the
+   field under `envelope.sections.<section>.fields`, with the field's declared
+   type.
+
+## Technical context
+
+The cxl typechecker types every `$doc.<section>.<field>` access as `Any` — it has
+no envelope schema in scope, so it cannot reject an undeclared path on its own. The
+planner closes that gap: it collects every `$doc` path the pipeline's programs
+reference (Transform, Aggregate, Route conditions, Combine predicates and bodies,
+and composition bodies), traces each referencing node back through the DAG to the
+source(s) feeding it, and validates each path against that source's declared
+envelope. The check runs only for XML and JSON sources, because their readers
+extract exactly the declared sections and fields; for those formats the
+`envelope:` declaration is authoritative, so a path it omits is a genuine typo
+rather than a wire-derived section the config legitimately leaves untyped.
+
+## See also
+
+- "Envelopes & Document Context" in the pipeline reference
+- Error E340 — a `$doc` path indexed by a non-literal expression

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -165,6 +165,23 @@ follows the same missing-value convention as `$source.*` and
 simply absent from the context; any `$doc.<missing_section>.<field>`
 resolves to `null`.
 
+## Declared-path validation (XML and JSON)
+
+For XML and JSON sources, the `envelope:` block is the complete schema:
+the reader extracts exactly the sections and fields it declares. So a
+`$doc.<section>.<field>` reference that names a section the source does
+not declare — or a field the declared section does not declare — is
+almost always a typo (`$doc.Summry.total` against a declared `Summary`),
+and would otherwise resolve silently to `null`. clinker rejects it at
+compile time with error `E341`, pointing at the node that made the
+reference. Run `clinker explain --code E341` for the full write-up.
+
+Segment- and positional-based formats (X12, EDIFACT, HL7, fixed-width)
+synthesize extra envelope levels and positional fields beyond what the
+config declares — an X12 reader exposes `$doc.functional_group.*` and
+`$doc.transaction_set.*` the config never names — so their `$doc` paths
+are not checked this way.
+
 ## One document per file
 
 Each source file is its own document with its own envelope context.


### PR DESCRIPTION
## Summary

Adds a compile-time validation pass (diagnostic **E341**) that cross-checks every `$doc.<section>.<field>` path a pipeline references — now per-source-attributed, and including Route branch predicates and Combine/composition bodies — against the feeding source's declared envelope schema. A path naming an undeclared section, or an undeclared field within a declared section, is reported at compile time with a span anchored at the referencing node, instead of silently resolving to null at runtime.

## Scope

The check applies to formats whose envelope schema is **closed** — XML and JSON, where the reader extracts exactly the declared sections/fields. Segment/positional formats (X12, EDIFACT, HL7) synthesize multi-level envelope sections beyond the config (e.g. X12's `$doc.functional_group.*`), so a blanket check would false-positive on valid wire-derived paths; validating those against a format-specific vocabulary is tracked separately in #481. Section names are user-defined — never hardcoded.

## Wiring

E341 carries a registry row, a 5-section `docs/explain/E341.md` page (with the emitted message reproduced verbatim), an `explain` provenance arm + section-coverage test entry, and the CLI explain code-range hint. Tests cover an undeclared section, an undeclared field in a declared section, a valid path (no diagnostic), and a segment-format path (correctly not validated). The shared node→source-line map between the E340 and E341 passes was de-duplicated.

Closes #435.