### PR TITLE
format: declare names and field schemas for X12 GS and ST envelope levels (#414)

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -820,6 +820,8 @@ fn build_x12_reader_config(
         if let Some(encoding) = opts.encoding.as_deref() {
             config.charset = parse_x12_charset(encoding)?;
         }
+        config.group_section = opts.group_section.clone();
+        config.set_section = opts.set_section.clone();
     }
     Ok(config)
 }

--- a/crates/clinker-exec/tests/x12_pipeline.rs
+++ b/crates/clinker-exec/tests/x12_pipeline.rs
@@ -170,6 +170,74 @@ nodes:
 }
 
 #[test]
+fn x12_source_exposes_declared_nested_section_names_typed() {
+    // The source names the GS level `grp` (with the functional id `e01`
+    // typed as a string and the group control `e06` typed as an int) and
+    // the ST level `txn` (the set id `e01` typed as an int). A Transform
+    // reads the nested fields under those chosen names — proving the GS/ST
+    // levels are addressable as `$doc.<chosen>.<field>` with coerced types,
+    // exactly like the declared ISA section.
+    let yaml = r#"
+pipeline:
+  name: x12_nested_decl
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      options:
+        group_section:
+          name: grp
+          fields:
+            e01: string
+            e06: int
+        set_section:
+          name: txn
+          fields:
+            e01: int
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit gs_id = $doc.grp.e01
+        emit gs_ctrl = $doc.grp.e06
+        emit st_id = $doc.txn.e01
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: false
+      include_header: false
+"#;
+    let (report, output) = run(yaml, "interchange", &purchase_order(), "po.x12", "out")
+        .expect("run nested-section pipeline");
+    assert_eq!(report.counters.total_count, 3, "output was: {output}");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // Columns in emit order: seg, gs_id (GS01), gs_ctrl (GS06), st_id (ST01).
+    // GS01 functional id "PO", GS06 group control "1" (coerced int prints
+    // as "1"), ST01 set id "850" (coerced int) resolve on every body row
+    // under the author's chosen section names.
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 3, "3 body rows, no header; got: {output}");
+    for row in &lines {
+        let cols: Vec<&str> = row.split(',').collect();
+        assert_eq!(cols[1], "PO", "gs_id (GS01) wrong in row: {row}");
+        assert_eq!(cols[2], "1", "gs_ctrl (GS06) wrong in row: {row}");
+        assert_eq!(cols[3], "850", "st_id (ST01) wrong in row: {row}");
+    }
+}
+
+#[test]
 fn x12_round_trip_reparses_identically() {
     // Source parses X12 and writes X12, reconstructing the three-tier
     // envelope from the echoed ISA `$doc` section plus a literal GS header.

--- a/crates/clinker-format/src/envelope.rs
+++ b/crates/clinker-format/src/envelope.rs
@@ -112,6 +112,34 @@ pub enum EnvelopeExtract {
     Segment(String),
 }
 
+/// A user-declared section for a *nested* envelope level that has no
+/// pre-scan declaration point.
+///
+/// The file-level envelope (X12 `ISA`, EDIFACT `UNB`, HL7 `FHS`) is
+/// declared through [`EnvelopeSection`] before body streaming, because a
+/// bounded header pre-scan resolves it. The nested tiers — X12's `GS`
+/// functional group and `ST` transaction set — exist only mid-file, so a
+/// reader cannot resolve them at pre-scan time and instead names them when
+/// it crosses each boundary. This carries the author's chosen section
+/// name and the typed `fields` schema the reader coerces the level's
+/// positional elements into, so `$doc.<name>.<field>` exposes typed,
+/// addressable fields instead of untyped positional `eNN` strings. The
+/// `extract` rule is implied by the level (the GS or ST segment), so only
+/// the name and field schema are declared.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct NestedEnvelopeSection {
+    /// The section name `$doc.<name>.<field>` resolves under for this
+    /// level. User-chosen — the engine reserves none.
+    pub name: String,
+    /// Typed field schema, keyed by the level's positional element name
+    /// (`e01`, `e02`, …). Drives the runtime coercion of each declared
+    /// element to its type; undeclared elements are dropped from the
+    /// typed view (the section schema is the contract).
+    #[serde(default)]
+    pub fields: IndexMap<String, EnvelopeFieldType>,
+}
+
 /// Field type vocabulary mirrored from CXL's typechecker — small
 /// closed set sufficient for envelope-section authoring.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -16,6 +16,7 @@ pub mod xml;
 pub use counting::{CountedFormatWriter, CountingWriter, SharedByteCounter};
 pub use envelope::{
     EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection,
+    NestedEnvelopeSection,
 };
 pub use error::FormatError;
 pub use traits::{FormatReader, FormatWriter};

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -31,7 +31,9 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
-use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, coerce_section_fields};
+use crate::envelope::{
+    EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, NestedEnvelopeSection, coerce_section_fields,
+};
 use crate::error::FormatError;
 use crate::traits::FormatReader;
 use crate::x12::RAW_ELEMENTS_KEY;
@@ -59,6 +61,18 @@ pub struct X12ReaderConfig {
     /// and defaults to UTF-8; a non-UTF-8 interchange (e.g. Latin-1 high
     /// bytes in free-text fields) declares the matching encoding.
     pub charset: Charset,
+    /// Optional user-declared name + typed field schema for the `GS`
+    /// functional-group nested level. When set, the reader surfaces the
+    /// group under the chosen section name with its declared elements
+    /// coerced to their types. When `None`, the group surfaces under the
+    /// default `functional_group` section keyed by untyped positional
+    /// `eNN` strings.
+    pub group_section: Option<NestedEnvelopeSection>,
+    /// Optional user-declared name + typed field schema for the `ST`
+    /// transaction-set nested level, mirroring `group_section`. When
+    /// `None`, the set surfaces under the default `transaction_set`
+    /// section keyed by untyped positional `eNN` strings.
+    pub set_section: Option<NestedEnvelopeSection>,
 }
 
 impl Default for X12ReaderConfig {
@@ -66,6 +80,8 @@ impl Default for X12ReaderConfig {
         Self {
             max_elements: DEFAULT_MAX_ELEMENTS,
             charset: Charset::default(),
+            group_section: None,
+            set_section: None,
         }
     }
 }
@@ -99,6 +115,12 @@ pub struct X12Reader<R: Read> {
     /// Nested-envelope events queued during the most recent `next_record`,
     /// drained by the driver via [`FormatReader::take_envelope_events`].
     pending_events: Vec<EnvelopeEvent>,
+    /// User-declared name + typed schema for the `GS` level, applied when
+    /// opening each functional group. `None` keeps the positional default.
+    group_section: Option<NestedEnvelopeSection>,
+    /// User-declared name + typed schema for the `ST` level, applied when
+    /// opening each transaction set. `None` keeps the positional default.
+    set_section: Option<NestedEnvelopeSection>,
     done: bool,
 }
 
@@ -141,6 +163,8 @@ impl<R: Read> X12Reader<R> {
             group_count: 0,
             interchange_closed: false,
             pending_events: Vec::new(),
+            group_section: config.group_section,
+            set_section: config.set_section,
             done: false,
         }
     }
@@ -260,9 +284,9 @@ impl<R: Read> X12Reader<R> {
             set_count: 0,
         });
         self.group_count += 1;
-        self.pending_events.push(EnvelopeEvent::OpenLevel {
-            sections: group_sections(gs),
-        });
+        let sections = nested_sections(gs, self.group_section.as_ref(), DEFAULT_GROUP_SECTION)?;
+        self.pending_events
+            .push(EnvelopeEvent::OpenLevel { sections });
         Ok(())
     }
 
@@ -326,9 +350,9 @@ impl<R: Read> X12Reader<R> {
         if let Some(group) = self.open_group.as_mut() {
             group.set_count += 1;
         }
-        self.pending_events.push(EnvelopeEvent::OpenLevel {
-            sections: set_sections(st),
-        });
+        let sections = nested_sections(st, self.set_section.as_ref(), DEFAULT_SET_SECTION)?;
+        self.pending_events
+            .push(EnvelopeEvent::OpenLevel { sections });
         Ok(())
     }
 
@@ -474,12 +498,7 @@ impl<R: Read + Send> FormatReader for X12Reader<R> {
                      validated by the reader, not exposed as $doc fields."
                 )));
             }
-            let raw: Vec<(String, String)> = self
-                .isa_elements
-                .iter()
-                .enumerate()
-                .map(|(i, e)| (positional_key(i), e.clone()))
-                .collect();
+            let raw = positional_pairs(&self.isa_elements);
             let mut typed =
                 coerce_section_fields(raw, &section.fields).map_err(FormatError::X12)?;
             // Stash the complete, ordered ISA element list under an
@@ -501,35 +520,58 @@ impl<R: Read + Send> FormatReader for X12Reader<R> {
     }
 }
 
-/// Build the `GS` functional-group `$doc` sections under a fixed
-/// `functional_group` name keyed by positional `eNN` elements.
+/// Section name the `GS` functional group surfaces under when the source
+/// declares no name of its own.
+const DEFAULT_GROUP_SECTION: &str = "functional_group";
+
+/// Section name the `ST` transaction set surfaces under when the source
+/// declares no name of its own.
+const DEFAULT_SET_SECTION: &str = "transaction_set";
+
+/// Build the `$doc` sections for a nested `GS`/`ST` level.
 ///
 /// A nested level surfaces its header through the document context exactly
-/// as the file-level `ISA` does, so a `$doc.functional_group.e06`
-/// reference resolves to the group control number on every record inside
-/// the group.
-fn group_sections(gs: &ParsedSegment) -> IndexMap<Box<str>, Value> {
-    positional_section("functional_group", &gs.elements)
-}
-
-/// Build the `ST` transaction-set `$doc` sections under a fixed
-/// `transaction_set` name keyed by positional `eNN` elements.
-fn set_sections(st: &ParsedSegment) -> IndexMap<Box<str>, Value> {
-    positional_section("transaction_set", &st.elements)
-}
-
-/// Build a single-named `$doc` section whose fields are the segment's
-/// positional elements (`e01`, `e02`, …). Used for the nested `GS`/`ST`
-/// levels, which carry their whole header verbatim rather than a
-/// user-declared field schema.
-fn positional_section(name: &str, elements: &[String]) -> IndexMap<Box<str>, Value> {
-    let mut fields: IndexMap<Box<str>, Value> = IndexMap::with_capacity(elements.len());
-    for (i, e) in elements.iter().enumerate() {
-        fields.insert(positional_key(i).into_boxed_str(), string_or_null(e));
-    }
+/// as the file-level `ISA` does. When the source declares a section name
+/// and typed `fields` schema for the level, the segment's positional
+/// elements are coerced to the declared types under the chosen name — so
+/// `$doc.<chosen>.<field>` resolves to a typed value. With no declaration,
+/// the level surfaces under `default_name` keyed by untyped positional
+/// `eNN` strings, the same behavior every X12 source had before nested
+/// declarations existed.
+///
+/// # Errors
+///
+/// Returns a [`FormatError::X12`] if a declared element fails coercion to
+/// its declared type (the wire value cannot be parsed as the field's type).
+fn nested_sections(
+    segment: &ParsedSegment,
+    declared: Option<&NestedEnvelopeSection>,
+    default_name: &str,
+) -> Result<IndexMap<Box<str>, Value>, FormatError> {
     let mut sections: IndexMap<Box<str>, Value> = IndexMap::with_capacity(1);
-    sections.insert(Box::from(name), Value::Map(Box::new(fields)));
-    sections
+    match declared {
+        Some(section) => {
+            // Coerce the level's positional elements through the declared
+            // field schema, exactly as the file-level ISA section does, so
+            // a declared GS/ST field is typed the same way a declared ISA
+            // field is.
+            let raw = positional_pairs(&segment.elements);
+            let typed = coerce_section_fields(raw, &section.fields).map_err(FormatError::X12)?;
+            sections.insert(
+                Box::from(section.name.as_str()),
+                Value::Map(Box::new(typed)),
+            );
+        }
+        None => {
+            let mut fields: IndexMap<Box<str>, Value> =
+                IndexMap::with_capacity(segment.elements.len());
+            for (i, e) in segment.elements.iter().enumerate() {
+                fields.insert(positional_key(i).into_boxed_str(), string_or_null(e));
+            }
+            sections.insert(Box::from(default_name), Value::Map(Box::new(fields)));
+        }
+    }
+    Ok(sections)
 }
 
 /// Parse a trailer control count, naming the segment and field on failure.
@@ -558,6 +600,17 @@ fn build_schema(max_elements: usize) -> Arc<Schema> {
 /// Positional element column name for element index `i`: `e01`, `e02`, …
 fn positional_key(i: usize) -> String {
     format!("e{:02}", i + 1)
+}
+
+/// Pair each element with its positional key (`e01`, `e02`, …) for
+/// [`coerce_section_fields`], the raw input shape both the file-level `ISA`
+/// section and a declared nested `GS`/`ST` section coerce against.
+fn positional_pairs(elements: &[String]) -> Vec<(String, String)> {
+    elements
+        .iter()
+        .enumerate()
+        .map(|(i, e)| (positional_key(i), e.clone()))
+        .collect()
 }
 
 /// Map an element string to a `Value`: empty text becomes `Null` so an
@@ -717,6 +770,146 @@ mod tests {
         };
         assert_eq!(set.get("e01"), Some(&Value::String("850".into())));
         assert_eq!(set.get("e02"), Some(&Value::String("0001".into())));
+    }
+
+    /// Build a [`NestedEnvelopeSection`] from a chosen name and a list of
+    /// `(positional element, declared type)` field declarations.
+    fn nested_section(name: &str, fields: &[(&str, EnvelopeFieldType)]) -> NestedEnvelopeSection {
+        let mut field_map = IndexMap::new();
+        for (k, ty) in fields {
+            field_map.insert((*k).to_string(), *ty);
+        }
+        NestedEnvelopeSection {
+            name: name.to_string(),
+            fields: field_map,
+        }
+    }
+
+    /// The first body record's two `OpenLevel` events carry the GS section
+    /// (index 0) and the ST section (index 1).
+    fn first_open_levels(mut r: X12Reader<Cursor<Vec<u8>>>) -> Vec<IndexMap<Box<str>, Value>> {
+        let _ = r.next_record().unwrap().unwrap();
+        r.take_envelope_events()
+            .into_iter()
+            .filter_map(|e| match e {
+                EnvelopeEvent::OpenLevel { sections } => Some(sections),
+                EnvelopeEvent::CloseLevel => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn declared_group_and_set_sections_surface_under_chosen_names_typed() {
+        // A source naming the GS level `group` with a numeric control field
+        // and the ST level `txn` with a numeric id and string control sees
+        // both levels under those names, each element coerced to its
+        // declared type rather than a positional `eNN` string.
+        let config = X12ReaderConfig {
+            group_section: Some(nested_section("group", &[("e06", EnvelopeFieldType::Int)])),
+            set_section: Some(nested_section(
+                "txn",
+                &[
+                    ("e01", EnvelopeFieldType::Int),
+                    ("e02", EnvelopeFieldType::String),
+                ],
+            )),
+            ..Default::default()
+        };
+        let r = X12Reader::new(Cursor::new(interchange().into_bytes()), config);
+        let levels = first_open_levels(r);
+        assert_eq!(levels.len(), 2, "GS and ST each open one level");
+
+        let group = match levels[0].get("group").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected group map, got {other:?}"),
+        };
+        // GS06 (group control number "1") coerces to an integer.
+        assert_eq!(group.get("e06"), Some(&Value::Integer(1)));
+        // The default `functional_group` name is NOT used when a name is
+        // declared.
+        assert!(levels[0].get("functional_group").is_none());
+
+        let txn = match levels[1].get("txn").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected txn map, got {other:?}"),
+        };
+        // ST01 (set id "850") coerces to an integer; ST02 stays a string.
+        assert_eq!(txn.get("e01"), Some(&Value::Integer(850)));
+        assert_eq!(txn.get("e02"), Some(&Value::String("0001".into())));
+        assert!(levels[1].get("transaction_set").is_none());
+    }
+
+    #[test]
+    fn undeclared_nested_levels_keep_positional_default_names() {
+        // With no declaration the GS/ST levels surface under the default
+        // `functional_group` / `transaction_set` names keyed by untyped
+        // positional `eNN` strings — the pre-declaration behavior.
+        let levels = first_open_levels(reader(&interchange()));
+        assert_eq!(levels.len(), 2);
+        assert!(levels[0].get("functional_group").is_some());
+        assert!(levels[1].get("transaction_set").is_some());
+        let group = match levels[0].get("functional_group").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // Untyped: the group control number stays a string.
+        assert_eq!(group.get("e06"), Some(&Value::String("1".into())));
+    }
+
+    #[test]
+    fn declaring_only_the_group_section_leaves_the_set_positional() {
+        // The two levels are declared independently: naming only the GS
+        // level types it while the ST level keeps the positional default.
+        let config = X12ReaderConfig {
+            group_section: Some(nested_section("grp", &[("e01", EnvelopeFieldType::String)])),
+            ..Default::default()
+        };
+        let r = X12Reader::new(Cursor::new(interchange().into_bytes()), config);
+        let levels = first_open_levels(r);
+        assert!(levels[0].get("grp").is_some());
+        assert!(levels[0].get("functional_group").is_none());
+        // The undeclared ST level still uses the default name.
+        assert!(levels[1].get("transaction_set").is_some());
+    }
+
+    #[test]
+    fn undeclared_elements_are_dropped_from_a_declared_section() {
+        // A declared field schema is the contract: only declared elements
+        // surface, so an element the schema omits is absent from the typed
+        // view even though it is on the wire.
+        let config = X12ReaderConfig {
+            set_section: Some(nested_section("txn", &[("e01", EnvelopeFieldType::String)])),
+            ..Default::default()
+        };
+        let r = X12Reader::new(Cursor::new(interchange().into_bytes()), config);
+        let levels = first_open_levels(r);
+        let txn = match levels[1].get("txn").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        assert_eq!(txn.get("e01"), Some(&Value::String("850".into())));
+        // ST02 is on the wire but undeclared, so it is not in the section.
+        assert!(txn.get("e02").is_none());
+    }
+
+    #[test]
+    fn declared_section_coercion_failure_errors() {
+        // Declaring a non-numeric element as an integer fails the read with
+        // a coercion error, the same way a mistyped ISA field does.
+        let config = X12ReaderConfig {
+            group_section: Some(nested_section(
+                // GS01 is the functional id code "PO" — not an integer.
+                "grp",
+                &[("e01", EnvelopeFieldType::Int)],
+            )),
+            ..Default::default()
+        };
+        let mut r = X12Reader::new(Cursor::new(interchange().into_bytes()), config);
+        let err = r.next_record().unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("cannot coerce")),
+            "expected a coercion error, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -578,6 +578,22 @@ pub struct X12InputOptions {
     /// precise error naming it.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub encoding: Option<String>,
+    /// Optional user-declared section name and typed field schema for the
+    /// `GS` functional-group nested envelope level. The interchange header
+    /// (`ISA`) is declared through `envelope:` because a bounded pre-scan
+    /// resolves it; the `GS` group exists only mid-file, so its name and
+    /// schema are declared here and applied when the reader crosses each
+    /// group boundary. When absent the group surfaces under the default
+    /// `functional_group` section keyed by untyped positional `eNN`
+    /// strings, unchanged from before this option existed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_section: Option<clinker_format::NestedEnvelopeSection>,
+    /// Optional user-declared section name and typed field schema for the
+    /// `ST` transaction-set nested envelope level, mirroring
+    /// `group_section`. When absent the set surfaces under the default
+    /// `transaction_set` section keyed by untyped positional `eNN` strings.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub set_section: Option<clinker_format::NestedEnvelopeSection>,
 }
 
 /// HL7 v2 input options.

--- a/docs/src/pipeline/envelope-and-doc-context.md
+++ b/docs/src/pipeline/envelope-and-doc-context.md
@@ -261,6 +261,30 @@ innermost wins for records inside it — the same shadowing rule a nested
 scope follows in any language. Picking distinct per-level names (as above)
 keeps every level independently visible.
 
+The reader-supplied default names are not the only option: an X12 source
+can name the `GS` and `ST` levels itself and give each a typed field
+schema, so a nested level is addressable under a chosen name with coerced
+fields exactly like the declared `ISA` section. The declaration lives on
+the source's `options` (not the `envelope:` block, which is reserved for
+the pre-scannable file-level header), and each nested level is named
+independently:
+
+```yaml
+type: x12
+options:
+  group_section:
+    name: functional_group       # your choice — the engine reserves no name
+    fields: { e06: int }         # GS06 group control number, typed
+  set_section:
+    name: transaction_set        # your choice
+    fields: { e01: int }         # ST01 transaction-set id, typed
+```
+
+Omit a level's declaration and it falls back to its reader-supplied
+default name keyed by untyped positional `eNN` strings. See
+[X12 Format](x12.md#naming-and-typing-the-nested-levels) for the full
+reference.
+
 Boundaries nest correctly through the pipeline: each level opens before
 the records inside it and closes after them, in strict innermost-first
 order. A level that fans in through several branches is still reconciled

--- a/docs/src/pipeline/x12.md
+++ b/docs/src/pipeline/x12.md
@@ -154,7 +154,48 @@ emit gs06  = $doc.functional_group.e06  # group control number (GS06)
 emit st02  = $doc.transaction_set.e02   # set control number (ST02)
 ```
 
-Only the `ISA` header is extractable as a *declared* envelope section.
+### Naming and typing the nested levels
+
+The `ISA` header is declared through `envelope:` because a bounded pre-scan
+resolves it before any body streams. The `GS` group and `ST` set exist
+only mid-file, so they cannot be declared the same way — instead, name them
+and give them a typed field schema under the X12 source's `options`. The
+reader applies the declaration each time it crosses a group or set
+boundary, so `$doc.<your-name>.<field>` exposes the level's elements under
+the name you chose, coerced to the types you declared — the same way a
+declared `ISA` field is typed and coerced:
+
+```yaml
+type: x12
+options:
+  group_section:
+    name: functional_group   # your choice — the engine reserves no name
+    fields:
+      e01: string            # GS01 functional identifier code
+      e06: int               # GS06 group control number
+  set_section:
+    name: transaction_set    # your choice
+    fields:
+      e01: int               # ST01 transaction-set identifier code
+      e02: string            # ST02 set control number
+```
+
+```cxl
+emit functional_id = $doc.functional_group.e01   # typed string
+emit group_control = $doc.functional_group.e06    # typed int
+emit txn_type      = $doc.transaction_set.e01     # typed int
+```
+
+The two levels are declared independently — name one, both, or neither. A
+declared field schema is the contract: only the elements it lists surface
+in the typed section, and an element the wire carries but the schema omits
+is absent from `$doc`. An element that cannot coerce to its declared type
+(declaring the alphabetic `GS01` code as an `int`, say) fails the run with
+a precise error. Omit a level's declaration and it keeps its default name
+(`functional_group` / `transaction_set`) keyed by untyped positional `eNN`
+strings, unchanged from before this option existed.
+
+Only the `ISA` header is extractable through the `envelope:` block.
 Trailer segments (`SE`, `GE`, `IEA`) arrive after the body they close and
 cannot become `$doc` fields without buffering the whole interchange — their
 control counts are instead validated inline by the reader (see below). A


### PR DESCRIPTION
## Summary

Lets an X12 source declare a user-chosen section name and a typed field schema for the GS (functional group) and ST (transaction set) nested envelope levels, so `$doc.<chosen>.<field>` exposes coerced, typed fields the same way the file-level ISA section already does. Undeclared levels keep the prior default names (`functional_group` / `transaction_set`) with untyped positional `eNN` strings — existing pipelines are unaffected.

## Design

A new `NestedEnvelopeSection { name, fields }` config (the level implies the GS/ST tag, so no `extract` is needed). The X12 reader's two fixed-name section helpers are replaced by a single `nested_sections` that coerces declared fields through the existing `coerce_section_fields` machinery — the same path the ISA section uses — or falls back to positional defaults when undeclared. Section names are user-defined; the engine assumes no specific names. Declared field types drive runtime coercion (`$doc.*` remains CXL `Any` at compile time, consistent with the ISA precedent).

## Tests & docs

Five reader unit tests cover typed declared fields, the positional default fallback, partial (group-only) declaration, the schema-as-contract field drop, and coercion-failure errors; an end-to-end test declares nested sections in YAML and reads the coerced typed fields through the executor. `docs/src/pipeline/x12.md` and `envelope-and-doc-context.md` document declaring and typing the nested levels.

Closes #414.