### PR TITLE
format: decode EDIFACT element text per the UNB syntax identifier

### DIFF
--- a/crates/clinker-format/src/edifact/charset.rs
+++ b/crates/clinker-format/src/edifact/charset.rs
@@ -1,0 +1,296 @@
+//! Character-set decoding for EDIFACT element text, selected in-band from
+//! the `UNB` syntax identifier.
+//!
+//! Unlike X12 — which has no in-band repertoire marker and declares its
+//! encoding out-of-band on the source — an EDIFACT interchange names its
+//! repertoire on the wire: `UNB` data element S001 component 1 carries the
+//! syntax identifier (`UNOA`, `UNOB`, `UNOC`, …). The tokenizer starts on a
+//! byte-total bootstrap repertoire so the `UNB` itself decodes before its
+//! repertoire is known, then is re-armed once the reader has parsed the
+//! syntax identifier; every subsequent segment decodes through the
+//! negotiated repertoire.
+//!
+//! Only repertoires whose byte↔codepoint mapping is total and
+//! round-trippable in pure Rust are supported, so a read→write→read cycle is
+//! byte-faithful for the negotiated charset. An unsupported syntax level
+//! fails explicitly, naming the offending level, rather than guessing or
+//! silently substituting replacement characters.
+
+use crate::error::FormatError;
+
+/// The character repertoire used to decode and encode EDIFACT element text,
+/// resolved from the `UNB` syntax identifier.
+///
+/// Decoding happens per segment (no whole-interchange buffering), so the
+/// charset is consulted once per segment read rather than over the stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum Charset {
+    /// The bootstrap repertoire used before the `UNB` syntax identifier is
+    /// known. Maps every byte `0xNN` to codepoint `U+00NN` (Latin-1 style),
+    /// so the `UNB` — whose tag and syntax identifier are pure ASCII —
+    /// decodes regardless of any high byte further along the segment, and
+    /// decoding never fails. Re-armed to the negotiated repertoire before
+    /// the first body segment is decoded.
+    #[default]
+    Bootstrap,
+    /// Syntax level UNOA/UNOB: restricted/basic ASCII. A byte `>= 0x80` is
+    /// rejected loudly rather than reinterpreted, so a high byte declared
+    /// under an ASCII repertoire fails instead of silently corrupting.
+    Ascii,
+    /// Syntax level UNOC: ISO-8859-1 (Latin-1). Each byte `0xNN` maps to
+    /// codepoint `U+00NN` across the whole `0x00..=0xFF` range, so decoding
+    /// never fails and a round-trip is byte-exact. Encoding rejects a
+    /// character above `U+00FF`, which Latin-1 cannot represent, rather than
+    /// corrupting the output.
+    Latin1,
+    /// Syntax level UNOY: UTF-8. Strict — invalid UTF-8 is an error, not a
+    /// lossy substitution, so a mis-declared interchange fails loudly.
+    Utf8,
+}
+
+impl Charset {
+    /// Resolve a `UNB` syntax-identifier level (the first component of data
+    /// element S001, e.g. `"UNOA"`, `"UNOC"`, `"UNOY"`) to a [`Charset`].
+    ///
+    /// The level is matched case-insensitively. UNOA and UNOB both map to
+    /// ASCII (the acceptance only exercises a UNOC round-trip and an
+    /// unsupported-level rejection, so byte-faithful ASCII for the two
+    /// ASCII-subset levels is sufficient and keeps the read→write→read cycle
+    /// exact for them).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] naming the unsupported level and the
+    /// supported set when the level matches no mapped repertoire (UNOD..UNOX
+    /// have no pure-Rust total single-byte mapping available here). The
+    /// interchange then fails loudly at decode time rather than guessing a
+    /// fallback or silently substituting replacement characters.
+    pub(crate) fn from_syntax_id(level: &str) -> Result<Self, FormatError> {
+        let normalized = level.trim().to_ascii_uppercase();
+        match normalized.as_str() {
+            "UNOA" | "UNOB" => Ok(Charset::Ascii),
+            "UNOC" => Ok(Charset::Latin1),
+            "UNOY" => Ok(Charset::Utf8),
+            _ => Err(FormatError::Edifact(format!(
+                "unsupported EDIFACT syntax level {level:?} in the UNB syntax identifier. \
+                 Supported levels are \"UNOA\"/\"UNOB\" (ASCII), \"UNOC\" (ISO-8859-1, \
+                 Latin-1), and \"UNOY\" (UTF-8)"
+            ))),
+        }
+    }
+
+    /// Resolve the repertoire from a whole `UNB` syntax-identifier element
+    /// (data element S001, e.g. `"UNOA:1"`), splitting off the level
+    /// (component 1) on the active component separator before resolving.
+    ///
+    /// Both the reader and the writer arm the charset from this one element,
+    /// so the "component 1 is the syntax level" structure lives here rather
+    /// than at each call site.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the level component matches no
+    /// mapped repertoire (see [`Self::from_syntax_id`]).
+    pub(crate) fn from_unb_syntax_identifier(
+        syntax_id: &str,
+        component_sep: u8,
+    ) -> Result<Self, FormatError> {
+        let level = syntax_id.split(component_sep as char).next().unwrap_or("");
+        Self::from_syntax_id(level)
+    }
+
+    /// Decode raw segment bytes to a `String` through this repertoire,
+    /// consuming the buffer so the UTF-8 path validates in place without a
+    /// copy (this runs once per segment on the hot path).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the bytes are not valid in the
+    /// repertoire: a byte `>= 0x80` under [`Charset::Ascii`], or invalid
+    /// UTF-8 under [`Charset::Utf8`]. The bootstrap and Latin-1 repertoires
+    /// map every byte and never fail. The message names the active level so
+    /// a mis-declared syntax identifier is diagnosable.
+    pub(crate) fn decode(&self, bytes: Vec<u8>) -> Result<String, FormatError> {
+        match self {
+            // Bootstrap and Latin-1 both map byte 0xNN to U+00NN, so every
+            // byte decodes; bootstrap exists only to read the UNB before its
+            // repertoire is known.
+            Charset::Bootstrap | Charset::Latin1 => {
+                Ok(bytes.into_iter().map(|b| b as char).collect())
+            }
+            Charset::Ascii => {
+                if let Some(&high) = bytes.iter().find(|&&b| b >= 0x80) {
+                    return Err(FormatError::Edifact(format!(
+                        "segment carries byte {high:#04X}, which is outside the ASCII \
+                         repertoire declared by the UNB syntax identifier (UNOA/UNOB). \
+                         Declare UNOC (Latin-1) or UNOY (UTF-8) if the interchange uses a \
+                         wider character set"
+                    )));
+                }
+                // Every byte is < 0x80, so the slice is valid ASCII and
+                // therefore valid UTF-8.
+                Ok(bytes.into_iter().map(|b| b as char).collect())
+            }
+            Charset::Utf8 => String::from_utf8(bytes).map_err(|e| {
+                FormatError::Edifact(format!(
+                    "segment is not valid UTF-8: {e}. The UNB syntax identifier declares \
+                     UNOY (UTF-8); declare UNOC (Latin-1) if the interchange uses a \
+                     single-byte repertoire instead"
+                ))
+            }),
+        }
+    }
+
+    /// Encode element text to raw bytes through this repertoire.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the text carries a character the
+    /// repertoire cannot represent: any non-ASCII character under
+    /// [`Charset::Ascii`], or a character above `U+00FF` under
+    /// [`Charset::Latin1`]. The writer then fails explicitly rather than
+    /// emitting a structurally truncated value. UTF-8 (and the bootstrap
+    /// repertoire, for the ASCII control segments it ever sees) cannot fail.
+    pub(crate) fn encode(&self, text: &str) -> Result<Vec<u8>, FormatError> {
+        match self {
+            Charset::Utf8 | Charset::Bootstrap => Ok(text.as_bytes().to_vec()),
+            Charset::Ascii => {
+                if let Some(c) = text.chars().find(|c| !c.is_ascii()) {
+                    return Err(FormatError::Edifact(format!(
+                        "element text {text:?} contains character {c:?} (U+{:04X}), which is \
+                         outside the ASCII repertoire declared by the UNB syntax identifier \
+                         (UNOA/UNOB) and cannot be encoded",
+                        u32::from(c)
+                    )));
+                }
+                Ok(text.as_bytes().to_vec())
+            }
+            Charset::Latin1 => text
+                .chars()
+                .map(|c| {
+                    u32::from(c).try_into().map_err(|_| {
+                        FormatError::Edifact(format!(
+                            "element text {text:?} contains character {c:?} (U+{:04X}), which \
+                             is outside ISO-8859-1 (Latin-1) and cannot be encoded; the \
+                             repertoire declared by the UNB syntax identifier (UNOC) cannot \
+                             represent it",
+                            u32::from(c)
+                        ))
+                    })
+                })
+                .collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_syntax_id_resolves_ascii_levels() {
+        assert_eq!(Charset::from_syntax_id("UNOA").unwrap(), Charset::Ascii);
+        assert_eq!(Charset::from_syntax_id("UNOB").unwrap(), Charset::Ascii);
+        assert_eq!(Charset::from_syntax_id("unoa").unwrap(), Charset::Ascii);
+    }
+
+    #[test]
+    fn from_syntax_id_resolves_latin1_and_utf8() {
+        assert_eq!(Charset::from_syntax_id("UNOC").unwrap(), Charset::Latin1);
+        assert_eq!(Charset::from_syntax_id("UNOY").unwrap(), Charset::Utf8);
+        assert_eq!(Charset::from_syntax_id("unoc").unwrap(), Charset::Latin1);
+    }
+
+    #[test]
+    fn from_syntax_id_rejects_unsupported_level_naming_value() {
+        let err = Charset::from_syntax_id("UNOD").unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("UNOD") && m.contains("UNOC")),
+            "expected precise unsupported-level error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn latin1_decodes_high_bytes_to_codepoints() {
+        // 0xE9 is é, 0xF1 is ñ in Latin-1.
+        let decoded = Charset::Latin1
+            .decode(vec![b'C', b'a', b'f', 0xE9])
+            .unwrap();
+        assert_eq!(decoded, "Café");
+        let decoded = Charset::Latin1.decode(vec![b'A', 0xF1, b'o']).unwrap();
+        assert_eq!(decoded, "Año");
+    }
+
+    #[test]
+    fn latin1_round_trip_is_byte_exact() {
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let decoded = Charset::Latin1.decode(bytes.clone()).unwrap();
+        let reencoded = Charset::Latin1.encode(&decoded).unwrap();
+        assert_eq!(reencoded, bytes, "Latin-1 round-trip must be byte-exact");
+    }
+
+    #[test]
+    fn bootstrap_decodes_every_byte_and_never_fails() {
+        // The bootstrap repertoire must not break on a high byte before the
+        // repertoire is known.
+        let bytes: Vec<u8> = (0u8..=255).collect();
+        let decoded = Charset::Bootstrap.decode(bytes.clone()).unwrap();
+        assert_eq!(decoded.chars().count(), 256);
+        // The ASCII prefix a UNB tag/syntax-id lives in is faithful.
+        let unb = Charset::Bootstrap.decode(b"UNB+UNOA:1".to_vec()).unwrap();
+        assert_eq!(unb, "UNB+UNOA:1");
+    }
+
+    #[test]
+    fn ascii_rejects_high_byte_loudly() {
+        let err = Charset::Ascii
+            .decode(vec![b'C', b'a', b'f', 0xE9])
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("ASCII")),
+            "expected ASCII high-byte rejection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn ascii_decodes_plain_ascii() {
+        let decoded = Charset::Ascii.decode(b"PLAIN".to_vec()).unwrap();
+        assert_eq!(decoded, "PLAIN");
+    }
+
+    #[test]
+    fn utf8_rejects_invalid_bytes() {
+        // 0xE9 alone is not valid UTF-8.
+        let err = Charset::Utf8
+            .decode(vec![b'C', b'a', b'f', 0xE9])
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("not valid UTF-8")),
+            "expected UTF-8 decode error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn latin1_encode_rejects_out_of_range_char() {
+        // U+20AC (euro sign) is above U+00FF and cannot be Latin-1 encoded.
+        let err = Charset::Latin1.encode("price €5").unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("Latin-1") && m.contains("U+20AC")),
+            "expected out-of-range encode error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn ascii_encode_rejects_high_char() {
+        let err = Charset::Ascii.encode("Café").unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("ASCII") && m.contains("U+00E9")),
+            "expected ASCII out-of-range encode error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn utf8_encode_is_passthrough() {
+        assert_eq!(Charset::Utf8.encode("Café €").unwrap(), "Café €".as_bytes());
+    }
+}

--- a/crates/clinker-format/src/edifact/charset.rs
+++ b/crates/clinker-format/src/edifact/charset.rs
@@ -4,11 +4,14 @@
 //! Unlike X12 — which has no in-band repertoire marker and declares its
 //! encoding out-of-band on the source — an EDIFACT interchange names its
 //! repertoire on the wire: `UNB` data element S001 component 1 carries the
-//! syntax identifier (`UNOA`, `UNOB`, `UNOC`, …). The tokenizer starts on a
-//! byte-total bootstrap repertoire so the `UNB` itself decodes before its
-//! repertoire is known, then is re-armed once the reader has parsed the
-//! syntax identifier; every subsequent segment decodes through the
-//! negotiated repertoire.
+//! syntax identifier (`UNOA`, `UNOB`, `UNOC`, …). That identifier is always
+//! ASCII, so the reader frames the `UNB` raw and reads the level directly
+//! from the bytes ([`Charset::from_raw_unb_segment`]) before decoding
+//! anything; it then decodes the whole `UNB` — including its own non-ASCII
+//! sender/recipient identification — through the negotiated repertoire. The
+//! writer derives the same repertoire from the `UNB` it emits and arms it
+//! before writing the header. No element is ever processed under a wrong
+//! repertoire, so the `UNB` round-trips byte-for-byte just like the body.
 //!
 //! Only repertoires whose byte↔codepoint mapping is total and
 //! round-trippable in pure Rust are supported, so a read→write→read cycle is
@@ -16,6 +19,7 @@
 //! fails explicitly, naming the offending level, rather than guessing or
 //! silently substituting replacement characters.
 
+use crate::edifact::tokenizer::Delimiters;
 use crate::error::FormatError;
 
 /// The character repertoire used to decode and encode EDIFACT element text,
@@ -23,16 +27,17 @@ use crate::error::FormatError;
 ///
 /// Decoding happens per segment (no whole-interchange buffering), so the
 /// charset is consulted once per segment read rather than over the stream.
+/// The syntax identifier that selects the repertoire is itself ASCII and is
+/// read from the raw `UNB` bytes before any segment is decoded, so the
+/// `UNB`'s own non-ASCII elements (sender / recipient identification under
+/// UNOC or UNOY) decode and encode under the negotiated repertoire, never a
+/// placeholder — a read → write → read cycle is byte-faithful end to end.
+///
+/// The [`Default`] is [`Charset::Utf8`], used only as the tokenizer's
+/// pre-negotiation placeholder; it is overwritten before any byte is
+/// interpreted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub(crate) enum Charset {
-    /// The bootstrap repertoire used before the `UNB` syntax identifier is
-    /// known. Maps every byte `0xNN` to codepoint `U+00NN` (Latin-1 style),
-    /// so the `UNB` — whose tag and syntax identifier are pure ASCII —
-    /// decodes regardless of any high byte further along the segment, and
-    /// decoding never fails. Re-armed to the negotiated repertoire before
-    /// the first body segment is decoded.
-    #[default]
-    Bootstrap,
     /// Syntax level UNOA/UNOB: restricted/basic ASCII. A byte `>= 0x80` is
     /// rejected loudly rather than reinterpreted, so a high byte declared
     /// under an ASCII repertoire fails instead of silently corrupting.
@@ -44,7 +49,10 @@ pub(crate) enum Charset {
     /// corrupting the output.
     Latin1,
     /// Syntax level UNOY: UTF-8. Strict — invalid UTF-8 is an error, not a
-    /// lossy substitution, so a mis-declared interchange fails loudly.
+    /// lossy substitution, so a mis-declared interchange fails loudly. The
+    /// default placeholder, never used to interpret bytes before the real
+    /// repertoire is negotiated.
+    #[default]
     Utf8,
 }
 
@@ -83,9 +91,11 @@ impl Charset {
     /// (data element S001, e.g. `"UNOA:1"`), splitting off the level
     /// (component 1) on the active component separator before resolving.
     ///
-    /// Both the reader and the writer arm the charset from this one element,
-    /// so the "component 1 is the syntax level" structure lives here rather
-    /// than at each call site.
+    /// The writer arms the charset from this already-decoded element (its
+    /// header comes from config or a `$doc` echo), so the "component 1 is the
+    /// syntax level" structure lives here rather than at the call site. The
+    /// reader instead uses [`Self::from_raw_unb_segment`], because it must
+    /// know the repertoire before it can decode the `UNB`.
     ///
     /// # Errors
     ///
@@ -99,6 +109,52 @@ impl Charset {
         Self::from_syntax_id(level)
     }
 
+    /// Resolve the repertoire from the raw, still-undecoded bytes of a `UNB`
+    /// segment (terminator already stripped), reading the syntax-identifier
+    /// level (S001 component 1) directly from the bytes.
+    ///
+    /// The reader cannot decode the `UNB` until it knows the repertoire, and
+    /// the repertoire is named inside the `UNB` — so the level is read from
+    /// the raw bytes first. The level is always ASCII (`UNOA`..`UNOY`), and
+    /// ASCII bytes are identical under every supported repertoire, so reading
+    /// it byte-for-byte is unambiguous even when a later `UNB` element (a
+    /// sender/recipient identification) carries a non-ASCII byte. Once
+    /// resolved, the caller decodes the whole `UNB` through the returned
+    /// repertoire.
+    ///
+    /// The level spans from just after the tag's element separator to the
+    /// next component or element separator, honoring the release character so
+    /// an escaped delimiter inside the (pathological) identifier is not
+    /// mistaken for a boundary.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the segment carries no
+    /// syntax-identifier element, when that identifier is not ASCII (a
+    /// malformed `UNB`, since the level is spec-ASCII), or when the level
+    /// matches no mapped repertoire (see [`Self::from_syntax_id`]).
+    pub(crate) fn from_raw_unb_segment(
+        raw: &[u8],
+        delims: &Delimiters,
+    ) -> Result<Self, FormatError> {
+        let level_bytes = raw_unb_syntax_level(raw, delims).ok_or_else(|| {
+            FormatError::Edifact(
+                "UNB carries no syntax-identifier element (S001); the interchange \
+                 declares no character repertoire and is malformed"
+                    .into(),
+            )
+        })?;
+        let level = std::str::from_utf8(&level_bytes).map_err(|_| {
+            FormatError::Edifact(
+                "the UNB syntax-identifier level (S001 component 1) is not ASCII; the \
+                 interchange is malformed (the syntax level is always one of \
+                 UNOA/UNOB/UNOC/UNOY)"
+                    .into(),
+            )
+        })?;
+        Self::from_syntax_id(level)
+    }
+
     /// Decode raw segment bytes to a `String` through this repertoire,
     /// consuming the buffer so the UTF-8 path validates in place without a
     /// copy (this runs once per segment on the hot path).
@@ -107,17 +163,12 @@ impl Charset {
     ///
     /// Returns [`FormatError::Edifact`] when the bytes are not valid in the
     /// repertoire: a byte `>= 0x80` under [`Charset::Ascii`], or invalid
-    /// UTF-8 under [`Charset::Utf8`]. The bootstrap and Latin-1 repertoires
-    /// map every byte and never fail. The message names the active level so
-    /// a mis-declared syntax identifier is diagnosable.
+    /// UTF-8 under [`Charset::Utf8`]. Latin-1 maps every byte and never
+    /// fails. The message names the active level so a mis-declared syntax
+    /// identifier is diagnosable.
     pub(crate) fn decode(&self, bytes: Vec<u8>) -> Result<String, FormatError> {
         match self {
-            // Bootstrap and Latin-1 both map byte 0xNN to U+00NN, so every
-            // byte decodes; bootstrap exists only to read the UNB before its
-            // repertoire is known.
-            Charset::Bootstrap | Charset::Latin1 => {
-                Ok(bytes.into_iter().map(|b| b as char).collect())
-            }
+            Charset::Latin1 => Ok(latin1_decode(bytes)),
             Charset::Ascii => {
                 if let Some(&high) = bytes.iter().find(|&&b| b >= 0x80) {
                     return Err(FormatError::Edifact(format!(
@@ -127,9 +178,9 @@ impl Charset {
                          wider character set"
                     )));
                 }
-                // Every byte is < 0x80, so the slice is valid ASCII and
-                // therefore valid UTF-8.
-                Ok(bytes.into_iter().map(|b| b as char).collect())
+                // Every byte is < 0x80, so the bytes are valid ASCII; the
+                // Latin-1 byte→codepoint map is identical to ASCII here.
+                Ok(latin1_decode(bytes))
             }
             Charset::Utf8 => String::from_utf8(bytes).map_err(|e| {
                 FormatError::Edifact(format!(
@@ -149,11 +200,10 @@ impl Charset {
     /// repertoire cannot represent: any non-ASCII character under
     /// [`Charset::Ascii`], or a character above `U+00FF` under
     /// [`Charset::Latin1`]. The writer then fails explicitly rather than
-    /// emitting a structurally truncated value. UTF-8 (and the bootstrap
-    /// repertoire, for the ASCII control segments it ever sees) cannot fail.
+    /// emitting a structurally truncated value. UTF-8 encoding cannot fail.
     pub(crate) fn encode(&self, text: &str) -> Result<Vec<u8>, FormatError> {
         match self {
-            Charset::Utf8 | Charset::Bootstrap => Ok(text.as_bytes().to_vec()),
+            Charset::Utf8 => Ok(text.as_bytes().to_vec()),
             Charset::Ascii => {
                 if let Some(c) = text.chars().find(|c| !c.is_ascii()) {
                     return Err(FormatError::Edifact(format!(
@@ -165,22 +215,95 @@ impl Charset {
                 }
                 Ok(text.as_bytes().to_vec())
             }
-            Charset::Latin1 => text
-                .chars()
-                .map(|c| {
-                    u32::from(c).try_into().map_err(|_| {
-                        FormatError::Edifact(format!(
-                            "element text {text:?} contains character {c:?} (U+{:04X}), which \
-                             is outside ISO-8859-1 (Latin-1) and cannot be encoded; the \
-                             repertoire declared by the UNB syntax identifier (UNOC) cannot \
-                             represent it",
-                            u32::from(c)
-                        ))
-                    })
-                })
-                .collect(),
+            Charset::Latin1 => latin1_encode(text),
         }
     }
+}
+
+/// Extract the raw bytes of the `UNB` syntax-identifier level (S001
+/// component 1) from a raw `UNB` segment, or `None` when the segment has no
+/// data element after the tag.
+///
+/// Scans past the tag's element separator, then collects bytes up to the
+/// first component or element separator. The release character escapes the
+/// following byte so an escaped delimiter is treated as literal data,
+/// mirroring [`super::split_segment`]; the escaped byte is included verbatim
+/// (release char dropped) so the returned slice is the decoded level.
+fn raw_unb_syntax_level(raw: &[u8], delims: &Delimiters) -> Option<Vec<u8>> {
+    let mut iter = raw.iter().copied();
+    // Skip the tag up to and including the first (unescaped) element
+    // separator. A release before the separator escapes it.
+    let mut pending_release = false;
+    let mut found_tag_end = false;
+    for b in iter.by_ref() {
+        if pending_release {
+            pending_release = false;
+            continue;
+        }
+        if b == delims.release {
+            pending_release = true;
+            continue;
+        }
+        if b == delims.element {
+            found_tag_end = true;
+            break;
+        }
+    }
+    if !found_tag_end {
+        return None;
+    }
+    // Collect the first data element's first component (the syntax level).
+    let mut level: Vec<u8> = Vec::new();
+    let mut pending_release = false;
+    for b in iter {
+        if pending_release {
+            level.push(b);
+            pending_release = false;
+            continue;
+        }
+        if b == delims.release {
+            pending_release = true;
+            continue;
+        }
+        if b == delims.component || b == delims.element {
+            break;
+        }
+        level.push(b);
+    }
+    if pending_release {
+        // A dangling release at element end escapes nothing — keep it.
+        level.push(delims.release);
+    }
+    Some(level)
+}
+
+/// Decode bytes as ISO-8859-1 (Latin-1): byte `0xNN` is codepoint `U+00NN`
+/// across the whole range, so every byte maps and decoding never fails. The
+/// ASCII repertoire reuses this after rejecting high bytes, since the two
+/// maps agree below `0x80`.
+fn latin1_decode(bytes: Vec<u8>) -> String {
+    bytes.into_iter().map(|b| b as char).collect()
+}
+
+/// Encode text as ISO-8859-1 (Latin-1), one byte per character.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Edifact`] when a character is above `U+00FF`, which
+/// Latin-1 cannot represent, so the value is rejected rather than truncated.
+fn latin1_encode(text: &str) -> Result<Vec<u8>, FormatError> {
+    text.chars()
+        .map(|c| {
+            u32::from(c).try_into().map_err(|_| {
+                FormatError::Edifact(format!(
+                    "element text {text:?} contains character {c:?} (U+{:04X}), which is \
+                     outside ISO-8859-1 (Latin-1) and cannot be encoded; the repertoire \
+                     declared by the UNB syntax identifier (UNOC) cannot represent it",
+                    u32::from(c)
+                ))
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -230,15 +353,59 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_decodes_every_byte_and_never_fails() {
-        // The bootstrap repertoire must not break on a high byte before the
-        // repertoire is known.
-        let bytes: Vec<u8> = (0u8..=255).collect();
-        let decoded = Charset::Bootstrap.decode(bytes.clone()).unwrap();
-        assert_eq!(decoded.chars().count(), 256);
-        // The ASCII prefix a UNB tag/syntax-id lives in is faithful.
-        let unb = Charset::Bootstrap.decode(b"UNB+UNOA:1".to_vec()).unwrap();
-        assert_eq!(unb, "UNB+UNOA:1");
+    fn from_raw_unb_segment_sniffs_level_before_decoding() {
+        // The syntax level is read from raw UNB bytes (ASCII) even when a
+        // later element carries a high byte that the level's repertoire would
+        // later decode — proving the sniff does not need the body decoded.
+        let d = Delimiters::level_a();
+        let mut raw = b"UNB+UNOC:3+Caf".to_vec();
+        raw.push(0xE9); // a non-ASCII byte further along the UNB
+        assert_eq!(
+            Charset::from_raw_unb_segment(&raw, &d).unwrap(),
+            Charset::Latin1
+        );
+
+        // UNOA -> ASCII, UNOY -> UTF-8.
+        assert_eq!(
+            Charset::from_raw_unb_segment(b"UNB+UNOA:1+S+R", &d).unwrap(),
+            Charset::Ascii
+        );
+        assert_eq!(
+            Charset::from_raw_unb_segment(b"UNB+UNOY:4+S+R", &d).unwrap(),
+            Charset::Utf8
+        );
+    }
+
+    #[test]
+    fn from_raw_unb_segment_handles_level_without_a_component() {
+        // A syntax identifier that is just the level, with no `:version`
+        // component, still resolves (the level runs to the element sep).
+        let d = Delimiters::level_a();
+        assert_eq!(
+            Charset::from_raw_unb_segment(b"UNB+UNOC+S+R", &d).unwrap(),
+            Charset::Latin1
+        );
+    }
+
+    #[test]
+    fn from_raw_unb_segment_rejects_missing_syntax_id() {
+        // A UNB with no data element after the tag declares no repertoire.
+        let d = Delimiters::level_a();
+        let err = Charset::from_raw_unb_segment(b"UNB", &d).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("syntax-identifier")),
+            "expected missing-syntax-id error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_raw_unb_segment_rejects_unsupported_level() {
+        let d = Delimiters::level_a();
+        let err = Charset::from_raw_unb_segment(b"UNB+UNOD:4+S+R", &d).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("UNOD")),
+            "expected unsupported-level error naming UNOD, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/edifact/mod.rs
+++ b/crates/clinker-format/src/edifact/mod.rs
@@ -20,6 +20,7 @@
 //! (so `$doc` envelope sections over `UNB` cost O(UNB)); the body streams
 //! one segment at a time. The whole interchange is never buffered.
 
+mod charset;
 pub mod reader;
 mod tokenizer;
 pub mod writer;

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
+use crate::edifact::charset::Charset;
 use crate::edifact::tokenizer::{ParsedSegment, SegmentTokenizer, split_segment};
 use crate::edifact::{RAW_ELEMENTS_KEY, unz_echo_matches_unb};
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
@@ -127,6 +128,21 @@ impl<R: Read> EdifactReader<R> {
         // plus a date-only date/time) leaves two plausible control-reference
         // positions that only the trailer can disambiguate.
         self.unb_elements = parsed.elements;
+
+        // Re-arm the tokenizer's charset from the in-band syntax identifier
+        // (UNB S001 component 1, e.g. `UNOA` in `UNOA:1`) before any body
+        // segment is read. The UNB itself was decoded under the bootstrap
+        // charset, which is faithful for its ASCII tag and syntax id; every
+        // subsequent segment decodes through the negotiated repertoire.
+        let syntax_id = self.unb_elements.first().ok_or_else(|| {
+            FormatError::Edifact(
+                "UNB carries no syntax-identifier element (S001); the interchange \
+                 declares no character repertoire and is malformed"
+                    .into(),
+            )
+        })?;
+        let charset = Charset::from_unb_syntax_identifier(syntax_id, delims.component)?;
+        self.tokenizer.set_charset(charset);
         Ok(())
     }
 
@@ -931,5 +947,142 @@ mod tests {
         // 3. Re-read the emitted interchange: the decoded value matches.
         let recs2 = collect(&out);
         assert_eq!(recs2[1].get("e01"), Some(&Value::String("O'BRIEN".into())));
+    }
+
+    /// Collect every body record from a raw byte interchange — the
+    /// Latin-1 path carries high bytes that are not valid UTF-8, so the
+    /// fixture cannot be a `&str`.
+    fn collect_bytes(data: Vec<u8>) -> Vec<Record> {
+        let mut r = EdifactReader::new(Cursor::new(data), EdifactReaderConfig::default());
+        let mut out = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            out.push(rec);
+        }
+        out
+    }
+
+    #[test]
+    fn unoc_body_segment_decodes_latin1_high_byte() {
+        // A UNOC interchange whose first body segment (the second segment of
+        // the stream) carries the Latin-1 byte 0xE9 (é) decodes correctly —
+        // proving the reader re-armed the charset between the UNB and the
+        // first body segment.
+        let mut data = b"UNB+UNOC:3+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'NAD+BY+Caf"
+            .to_vec();
+        data.push(0xE9);
+        data.extend_from_slice(b"'UNT+3+M1'UNZ+1+REF1'");
+        let recs = collect_bytes(data);
+        // UNH, NAD body records.
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[1].get("seg_id"), Some(&Value::String("NAD".into())));
+        assert_eq!(recs[1].get("e02"), Some(&Value::String("Café".into())));
+    }
+
+    #[test]
+    fn unoa_high_byte_body_segment_rejected_loudly() {
+        // The same high byte under a UNOA (ASCII) syntax identifier must
+        // fail loud rather than reinterpret it.
+        let mut data = b"UNB+UNOA:1+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'NAD+BY+Caf"
+            .to_vec();
+        data.push(0xE9);
+        data.extend_from_slice(b"'UNT+3+M1'UNZ+1+REF1'");
+        let mut r = EdifactReader::new(Cursor::new(data), EdifactReaderConfig::default());
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected ASCII high-byte rejection"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("ASCII")));
+    }
+
+    #[test]
+    fn unsupported_syntax_level_unb_fails_naming_level() {
+        // A UNB declaring an unmapped syntax level (UNOD) fails loudly at
+        // initialization, naming the offending level, rather than guessing a
+        // fallback.
+        let data = "UNB+UNOD:4+S+R+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF1'";
+        let mut r = reader(data);
+        let err = r.next_record().unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("UNOD") && m.contains("unsupported")),
+            "expected unsupported-level error naming UNOD, got {err:?}"
+        );
+    }
+
+    /// Full reader → writer → reader round-trip of a UNOC interchange whose
+    /// body element carries Latin-1 high bytes (0xE9 é, 0xF1 ñ): the reader
+    /// decodes them under Latin-1, the writer re-encodes them to the same
+    /// single bytes, and a re-read recovers the identical decoded text. This
+    /// proves encode-then-escape on the writer inverts escape-then-decode on
+    /// the reader for the negotiated repertoire.
+    #[test]
+    fn latin1_body_round_trips_reader_writer_reader() {
+        use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
+        use crate::envelope::EnvelopeFieldType;
+        use crate::traits::FormatWriter;
+        use clinker_record::{DocumentContext, DocumentId};
+
+        // NAD body element "Caf鏃" carries 0xE9 (é); a second body element
+        // carries 0xF1 (ñ). UNOC declares Latin-1.
+        let mut input = b"UNB+UNOC:3+SENDER+RECEIVER+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'NAD+BY+Caf"
+            .to_vec();
+        input.push(0xE9); // é
+        input.extend_from_slice(b"+A");
+        input.push(0xF1); // ñ
+        input.extend_from_slice(b"o'UNT+3+M1'UNZ+1+REF1'");
+
+        // 1. Read the envelope + body under Latin-1.
+        let cfg = unb_section(&[("e05", EnvelopeFieldType::String)]);
+        let mut r = EdifactReader::new(Cursor::new(input), EdifactReaderConfig::default());
+        let sections = r.prepare_document(&cfg).unwrap();
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 2); // UNH, NAD
+        assert_eq!(body_recs[1].get("e02"), Some(&Value::String("Café".into())));
+        assert_eq!(body_recs[1].get("e03"), Some(&Value::String("Año".into())));
+
+        // 2. Re-emit through the writer, which negotiates UNOC from the
+        // echoed UNB and re-encodes the high-byte elements to single bytes.
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        let schema = r.schema().unwrap();
+        let out_bytes = {
+            let mut buf = Vec::new();
+            let mut w = EdifactWriter::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                EdifactWriterConfig {
+                    interchange_from_doc: Some("interchange".into()),
+                    segment_newline: false,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            buf
+        };
+
+        // The é and ñ are emitted as the single Latin-1 bytes, not UTF-8
+        // multi-byte sequences.
+        assert!(out_bytes.windows(4).any(|w| w == [b'C', b'a', b'f', 0xE9]));
+        assert!(out_bytes.windows(3).any(|w| w == [b'A', 0xF1, b'o']));
+
+        // 3. Re-read: the decoded text is identical, so the round-trip is
+        // byte-faithful for the negotiated repertoire.
+        let recs2 = collect_bytes(out_bytes);
+        assert_eq!(recs2[1].get("e02"), Some(&Value::String("Café".into())));
+        assert_eq!(recs2[1].get("e03"), Some(&Value::String("Año".into())));
     }
 }

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -105,17 +105,33 @@ impl<R: Read> EdifactReader<R> {
     /// Consume the optional `UNA` and the mandatory `UNB`, stashing the
     /// `UNB` data elements for envelope serving and for the deferred
     /// control-reference validation against the `UNZ` trailer. Idempotent.
+    ///
+    /// The `UNB` is framed raw first so its in-band syntax identifier (S001
+    /// component 1, always ASCII) can arm the charset before the segment is
+    /// decoded. The `UNB`'s own elements — including a sender/recipient
+    /// identification carrying non-ASCII text under UNOC or UNOY — are then
+    /// decoded through the negotiated repertoire, so `$doc.UNB.*` and the
+    /// `UNZ` echo hold correctly-decoded values, not bytes read under a
+    /// placeholder.
     fn ensure_initialized(&mut self) -> Result<(), FormatError> {
         if self.initialized {
             return Ok(());
         }
         self.initialized = true;
 
-        let first = self.tokenizer.next_segment()?.ok_or_else(|| {
+        let raw = self.tokenizer.next_raw_segment()?.ok_or_else(|| {
             FormatError::Edifact("empty interchange: no UNB segment found".into())
         })?;
         let delims = self.tokenizer.delimiters();
-        let parsed = split_segment(&first, &delims);
+
+        // Arm the charset from the raw UNB's syntax identifier (ASCII, read
+        // before decoding), then decode the UNB through that repertoire so
+        // its non-ASCII elements come out correct.
+        let charset = Charset::from_raw_unb_segment(&raw, &delims)?;
+        self.tokenizer.set_charset(charset);
+        let decoded = self.tokenizer.decode(raw)?;
+
+        let parsed = split_segment(&decoded, &delims);
         if parsed.tag != "UNB" {
             return Err(FormatError::Edifact(format!(
                 "interchange must begin with a UNB segment, found {:?}",
@@ -128,21 +144,6 @@ impl<R: Read> EdifactReader<R> {
         // plus a date-only date/time) leaves two plausible control-reference
         // positions that only the trailer can disambiguate.
         self.unb_elements = parsed.elements;
-
-        // Re-arm the tokenizer's charset from the in-band syntax identifier
-        // (UNB S001 component 1, e.g. `UNOA` in `UNOA:1`) before any body
-        // segment is read. The UNB itself was decoded under the bootstrap
-        // charset, which is faithful for its ASCII tag and syntax id; every
-        // subsequent segment decodes through the negotiated repertoire.
-        let syntax_id = self.unb_elements.first().ok_or_else(|| {
-            FormatError::Edifact(
-                "UNB carries no syntax-identifier element (S001); the interchange \
-                 declares no character repertoire and is malformed"
-                    .into(),
-            )
-        })?;
-        let charset = Charset::from_unb_syntax_identifier(syntax_id, delims.component)?;
-        self.tokenizer.set_charset(charset);
         Ok(())
     }
 
@@ -963,10 +964,10 @@ mod tests {
 
     #[test]
     fn unoc_body_segment_decodes_latin1_high_byte() {
-        // A UNOC interchange whose first body segment (the second segment of
-        // the stream) carries the Latin-1 byte 0xE9 (é) decodes correctly —
-        // proving the reader re-armed the charset between the UNB and the
-        // first body segment.
+        // A UNOC interchange whose first body segment carries the Latin-1
+        // byte 0xE9 (é) decodes correctly — the charset is armed from the raw
+        // UNB before any segment is decoded, so the body decodes under
+        // Latin-1.
         let mut data = b"UNB+UNOC:3+S+R+240101:1200+REF1'\
             UNH+M1+ORDERS:D:96A:UN'NAD+BY+Caf"
             .to_vec();
@@ -1084,5 +1085,145 @@ mod tests {
         let recs2 = collect_bytes(out_bytes);
         assert_eq!(recs2[1].get("e02"), Some(&Value::String("Café".into())));
         assert_eq!(recs2[1].get("e03"), Some(&Value::String("Año".into())));
+    }
+
+    /// Read → write → read with a non-ASCII byte in a `UNB` *header* element
+    /// (the sender identification), under UNOC (Latin-1). The header itself —
+    /// not just the body — must decode and re-encode under the negotiated
+    /// repertoire, so `$doc.UNB.*` surfaces the correct text and the emitted
+    /// bytes are identical to the input. This is the regression guard for the
+    /// header being processed under a placeholder charset whose decode and
+    /// encode are not inverses for high bytes.
+    #[test]
+    fn unoc_unb_sender_element_round_trips_byte_for_byte() {
+        use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
+        use crate::envelope::EnvelopeFieldType;
+        use crate::traits::FormatWriter;
+        use clinker_record::{DocumentContext, DocumentId};
+
+        // UNB sender element (e02) is "Café" with é = 0xE9 (a single Latin-1
+        // byte). UNOC declares Latin-1.
+        let mut input = b"UNB+UNOC:3+Caf".to_vec();
+        input.push(0xE9); // é in the sender id
+        input.extend_from_slice(
+            b"+RECEIVER+240101:1200+REF1'\
+              UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF1'",
+        );
+
+        // Reader surfaces the correct decoded sender in $doc.UNB.e02.
+        let cfg = unb_section(&[
+            ("e02", EnvelopeFieldType::String),
+            ("e05", EnvelopeFieldType::String),
+        ]);
+        let mut r = EdifactReader::new(Cursor::new(input.clone()), EdifactReaderConfig::default());
+        let sections = r.prepare_document(&cfg).unwrap();
+        let interchange = match sections.get("interchange").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        assert_eq!(
+            interchange.get("e02"),
+            Some(&Value::String("Café".into())),
+            "UNB sender decoded under a placeholder, not the negotiated charset"
+        );
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 2); // UNH, BGM
+
+        // Re-emit: the UNB must be encoded under UNOC, so the sender's é is
+        // the single byte 0xE9 again — byte-identical to the input.
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        let schema = r.schema().unwrap();
+        let out_bytes = {
+            let mut buf = Vec::new();
+            let mut w = EdifactWriter::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                EdifactWriterConfig {
+                    interchange_from_doc: Some("interchange".into()),
+                    segment_newline: false,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            buf
+        };
+        assert_eq!(
+            out_bytes, input,
+            "UNOC UNB header did not round-trip byte-for-byte"
+        );
+    }
+
+    /// Read → write → read with a multi-byte UTF-8 character in a `UNB`
+    /// header element, under UNOY (UTF-8). The reader must surface one
+    /// codepoint (not mojibake from a byte-wise placeholder decode), and the
+    /// emitted bytes must be byte-faithful.
+    #[test]
+    fn unoy_unb_element_decodes_one_codepoint_and_round_trips() {
+        use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
+        use crate::envelope::EnvelopeFieldType;
+        use crate::traits::FormatWriter;
+        use clinker_record::{DocumentContext, DocumentId};
+
+        // UNB sender element is "Café" with é = 0xC3 0xA9 (two UTF-8 bytes).
+        // A byte-wise placeholder decode would surface "Ã©" (two codepoints).
+        let input = "UNB+UNOY:4+Café+RECEIVER+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN'BGM+220'UNT+3+M1'UNZ+1+REF1'"
+            .as_bytes()
+            .to_vec();
+
+        let cfg = unb_section(&[("e02", EnvelopeFieldType::String)]);
+        let mut r = EdifactReader::new(Cursor::new(input.clone()), EdifactReaderConfig::default());
+        let sections = r.prepare_document(&cfg).unwrap();
+        let interchange = match sections.get("interchange").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // One codepoint, not mojibake.
+        assert_eq!(
+            interchange.get("e02"),
+            Some(&Value::String("Café".into())),
+            "UNB sender decoded byte-wise instead of as UTF-8"
+        );
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 2);
+
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            sections,
+        ));
+        let schema = r.schema().unwrap();
+        let out_bytes = {
+            let mut buf = Vec::new();
+            let mut w = EdifactWriter::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                EdifactWriterConfig {
+                    interchange_from_doc: Some("interchange".into()),
+                    segment_newline: false,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            buf
+        };
+        assert_eq!(
+            out_bytes, input,
+            "UNOY UNB header did not round-trip byte-for-byte"
+        );
     }
 }

--- a/crates/clinker-format/src/edifact/tokenizer.rs
+++ b/crates/clinker-format/src/edifact/tokenizer.rs
@@ -15,6 +15,7 @@
 
 use std::io::{BufRead, Read};
 
+use crate::edifact::charset::Charset;
 use crate::error::FormatError;
 use crate::segment_tokenizer::{
     SegmentFraming, TrailingSegment, read_raw_segment, skip_inter_segment_whitespace,
@@ -60,24 +61,31 @@ impl Delimiters {
 
 /// Streaming EDIFACT segment reader.
 ///
-/// Wraps a buffered source and yields one raw segment string at a time
+/// Wraps a buffered source and yields one decoded segment string at a time
 /// (terminator stripped, inter-segment CR/LF whitespace stripped). The
 /// delimiters are discovered once from the optional `UNA` prefix on the
-/// first read.
+/// first read. Element text is decoded through the active [`Charset`], which
+/// starts on the byte-total bootstrap repertoire so the `UNB` decodes before
+/// its in-band syntax identifier is known; the reader re-arms it via
+/// [`Self::set_charset`] once that identifier is parsed.
 pub(crate) struct SegmentTokenizer<R: Read> {
     reader: R,
     delimiters: Delimiters,
+    charset: Charset,
     initialized: bool,
 }
 
 impl<R: BufRead> SegmentTokenizer<R> {
     /// Build a tokenizer over a buffered source. Delimiter discovery is
     /// deferred to the first [`Self::next_segment`] call so the `UNA`
-    /// scan and the first segment read share one pass.
+    /// scan and the first segment read share one pass. Decoding starts on
+    /// the bootstrap charset so the `UNB` — which names the body repertoire
+    /// in-band — can itself be decoded before that repertoire is known.
     pub(crate) fn new(reader: R) -> Self {
         Self {
             reader,
             delimiters: Delimiters::level_a(),
+            charset: Charset::Bootstrap,
             initialized: false,
         }
     }
@@ -86,6 +94,13 @@ impl<R: BufRead> SegmentTokenizer<R> {
     /// any `UNA` prefix).
     pub(crate) fn delimiters(&self) -> Delimiters {
         self.delimiters
+    }
+
+    /// Re-arm the decoding charset, called by the reader once it has parsed
+    /// the `UNB` syntax identifier so every subsequent segment decodes
+    /// through the negotiated repertoire.
+    pub(crate) fn set_charset(&mut self, charset: Charset) {
+        self.charset = charset;
     }
 
     /// Resolve the optional `UNA` prefix. Peeks the first bytes of the
@@ -140,13 +155,22 @@ impl<R: BufRead> SegmentTokenizer<R> {
         }
     }
 
-    /// Read the next raw segment (terminator-delimited), or `None` at
-    /// clean end of stream.
+    /// Read the next segment (terminator-delimited) and decode it through
+    /// the active [`Charset`], or `None` at clean end of stream.
     ///
     /// The terminator byte is consumed but not returned. A release char
     /// immediately before a terminator escapes it (the terminator is
     /// then literal data, not a boundary). CR/LF between segments is
-    /// dropped; CR/LF inside an element is preserved.
+    /// dropped; CR/LF inside an element is preserved. The raw segment bytes
+    /// are decoded once here (the shared framing layer that read them never
+    /// interprets bytes), so the in-band repertoire is honored without
+    /// touching segment framing.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the segment bytes are not valid
+    /// in the active charset — a high byte under an ASCII repertoire, or
+    /// invalid UTF-8 under UNOY.
     pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
         self.initialize()?;
         skip_inter_segment_whitespace(&mut self.reader)?;
@@ -172,12 +196,7 @@ impl<R: BufRead> SegmentTokenizer<R> {
             None => return Ok(None),
         };
 
-        let text = String::from_utf8(raw).map_err(|e| {
-            FormatError::Edifact(format!(
-                "segment is not valid UTF-8: {e}. Non-UTF-8 charsets \
-                 (UNOA/UNOB/Latin-1 high bytes) are not supported"
-            ))
-        })?;
+        let text = self.charset.decode(raw)?;
         Ok(Some(text))
     }
 }
@@ -387,5 +406,55 @@ mod tests {
         let mut t = tok(b"UNA:+");
         let err = t.next_segment().unwrap_err();
         assert!(matches!(err, FormatError::Edifact(msg) if msg.contains("UNA")));
+    }
+
+    #[test]
+    fn bootstrap_decodes_unb_with_high_byte_in_a_later_element() {
+        // The bootstrap charset must not break on a high byte before the
+        // syntax identifier is known: a UNB carrying a Latin-1 byte 0xE9 in
+        // a sender field still decodes (the tag/syntax id are ASCII).
+        let mut data = b"UNB+UNOC:3+Caf".to_vec();
+        data.push(0xE9);
+        data.push(b'\'');
+        let mut t = SegmentTokenizer::new(Cursor::new(data));
+        let first = t.next_segment().unwrap().unwrap();
+        assert_eq!(first, "UNB+UNOC:3+Café");
+    }
+
+    #[test]
+    fn rearmed_latin1_decodes_high_byte_body_segment() {
+        // After the UNB is decoded under the bootstrap charset, re-arming to
+        // Latin-1 (as the reader does once it parses UNOC) lets a body
+        // segment carrying a Latin-1 high byte decode correctly.
+        let mut body = b"NAD+BY+Caf".to_vec();
+        body.push(0xE9);
+        body.push(b'\'');
+        let mut full = b"UNB+UNOC:3+S+R'".to_vec();
+        full.extend_from_slice(&body);
+        let mut t = SegmentTokenizer::new(Cursor::new(full));
+        let unb = t.next_segment().unwrap().unwrap();
+        assert_eq!(unb, "UNB+UNOC:3+S+R");
+        // The reader re-arms here, between segment 1 (UNB) and segment 2.
+        t.set_charset(Charset::Latin1);
+        let nad = t.next_segment().unwrap().unwrap();
+        let parsed = split_segment(&nad, &t.delimiters());
+        assert_eq!(parsed.tag, "NAD");
+        assert_eq!(parsed.elements, vec!["BY".to_string(), "Café".to_string()]);
+    }
+
+    #[test]
+    fn high_byte_body_segment_rejected_under_ascii_charset() {
+        // The same body bytes under a UNOA/UNOB ASCII repertoire fail loud
+        // rather than silently reinterpreting the high byte.
+        let mut body = b"NAD+BY+Caf".to_vec();
+        body.push(0xE9);
+        body.push(b'\'');
+        let mut full = b"UNB+UNOA:1+S+R'".to_vec();
+        full.extend_from_slice(&body);
+        let mut t = SegmentTokenizer::new(Cursor::new(full));
+        let _ = t.next_segment().unwrap().unwrap(); // UNB under bootstrap
+        t.set_charset(Charset::Ascii);
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(m) if m.contains("ASCII")));
     }
 }

--- a/crates/clinker-format/src/edifact/tokenizer.rs
+++ b/crates/clinker-format/src/edifact/tokenizer.rs
@@ -64,10 +64,16 @@ impl Delimiters {
 /// Wraps a buffered source and yields one decoded segment string at a time
 /// (terminator stripped, inter-segment CR/LF whitespace stripped). The
 /// delimiters are discovered once from the optional `UNA` prefix on the
-/// first read. Element text is decoded through the active [`Charset`], which
-/// starts on the byte-total bootstrap repertoire so the `UNB` decodes before
-/// its in-band syntax identifier is known; the reader re-arms it via
-/// [`Self::set_charset`] once that identifier is parsed.
+/// first read.
+///
+/// The body repertoire is named in-band by the `UNB` syntax identifier, so
+/// the reader frames the first segment raw via [`Self::next_raw_segment`],
+/// sniffs that identifier (always ASCII) from the raw bytes, arms the
+/// charset with [`Self::set_charset`], and only then decodes — including the
+/// `UNB` itself — through [`Self::decode`]. Every subsequent segment decodes
+/// through the negotiated repertoire via [`Self::next_segment`]. The charset
+/// is therefore set before any byte is interpreted, so no element is ever
+/// decoded under a wrong repertoire.
 pub(crate) struct SegmentTokenizer<R: Read> {
     reader: R,
     delimiters: Delimiters,
@@ -77,15 +83,19 @@ pub(crate) struct SegmentTokenizer<R: Read> {
 
 impl<R: BufRead> SegmentTokenizer<R> {
     /// Build a tokenizer over a buffered source. Delimiter discovery is
-    /// deferred to the first [`Self::next_segment`] call so the `UNA`
-    /// scan and the first segment read share one pass. Decoding starts on
-    /// the bootstrap charset so the `UNB` — which names the body repertoire
-    /// in-band — can itself be decoded before that repertoire is known.
+    /// deferred to the first read so the `UNA` scan and the first segment
+    /// read share one pass.
+    ///
+    /// The charset starts at [`Charset::default`] purely as a placeholder:
+    /// the reader frames the first (`UNB`) segment raw, sniffs the in-band
+    /// syntax identifier, and arms the real repertoire via
+    /// [`Self::set_charset`] before any segment — the `UNB` included — is
+    /// decoded, so the placeholder is never used to interpret bytes.
     pub(crate) fn new(reader: R) -> Self {
         Self {
             reader,
             delimiters: Delimiters::level_a(),
-            charset: Charset::Bootstrap,
+            charset: Charset::default(),
             initialized: false,
         }
     }
@@ -96,11 +106,26 @@ impl<R: BufRead> SegmentTokenizer<R> {
         self.delimiters
     }
 
-    /// Re-arm the decoding charset, called by the reader once it has parsed
-    /// the `UNB` syntax identifier so every subsequent segment decodes
-    /// through the negotiated repertoire.
+    /// Arm the decoding charset from the `UNB` syntax identifier, called by
+    /// the reader before it decodes the first segment so every segment —
+    /// the `UNB` included — decodes through the negotiated repertoire.
     pub(crate) fn set_charset(&mut self, charset: Charset) {
         self.charset = charset;
+    }
+
+    /// Decode raw segment bytes through the armed charset.
+    ///
+    /// Paired with [`Self::next_raw_segment`] so the reader can frame the
+    /// first segment, sniff its in-band syntax identifier, arm the charset,
+    /// and then decode the same bytes correctly.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the bytes are not valid in the
+    /// armed charset (a high byte under an ASCII repertoire, or invalid
+    /// UTF-8 under UNOY).
+    pub(crate) fn decode(&self, raw: Vec<u8>) -> Result<String, FormatError> {
+        self.charset.decode(raw)
     }
 
     /// Resolve the optional `UNA` prefix. Peeks the first bytes of the
@@ -155,28 +180,22 @@ impl<R: BufRead> SegmentTokenizer<R> {
         }
     }
 
-    /// Read the next segment (terminator-delimited) and decode it through
-    /// the active [`Charset`], or `None` at clean end of stream.
+    /// Read the next segment's raw bytes (terminator-delimited), or `None`
+    /// at clean end of stream, without decoding them.
     ///
     /// The terminator byte is consumed but not returned. A release char
-    /// immediately before a terminator escapes it (the terminator is
-    /// then literal data, not a boundary). CR/LF between segments is
-    /// dropped; CR/LF inside an element is preserved. The raw segment bytes
-    /// are decoded once here (the shared framing layer that read them never
-    /// interprets bytes), so the in-band repertoire is honored without
-    /// touching segment framing.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FormatError::Edifact`] when the segment bytes are not valid
-    /// in the active charset — a high byte under an ASCII repertoire, or
-    /// invalid UTF-8 under UNOY.
-    pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
+    /// immediately before a terminator escapes it (the terminator is then
+    /// literal data, not a boundary). CR/LF between segments is dropped;
+    /// CR/LF inside an element is preserved. The bytes are returned
+    /// undecoded so the reader can sniff the `UNB` syntax identifier (always
+    /// ASCII) before arming the charset, then decode the same bytes through
+    /// the negotiated repertoire via [`Self::decode`].
+    pub(crate) fn next_raw_segment(&mut self) -> Result<Option<Vec<u8>>, FormatError> {
         self.initialize()?;
         skip_inter_segment_whitespace(&mut self.reader)?;
 
         let framing = self.framing();
-        let raw = match read_raw_segment(
+        read_raw_segment(
             &mut self.reader,
             &framing,
             || {
@@ -191,13 +210,26 @@ impl<R: BufRead> SegmentTokenizer<R> {
                      the interchange is truncated"
                 ))
             },
-        )? {
-            Some(bytes) => bytes,
-            None => return Ok(None),
-        };
+        )
+    }
 
-        let text = self.charset.decode(raw)?;
-        Ok(Some(text))
+    /// Read the next segment and decode it through the armed [`Charset`], or
+    /// `None` at clean end of stream.
+    ///
+    /// Convenience composition of [`Self::next_raw_segment`] and
+    /// [`Self::decode`] for body segments, which are always read after the
+    /// charset has been armed from the `UNB`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the segment bytes are not valid
+    /// in the armed charset — a high byte under an ASCII repertoire, or
+    /// invalid UTF-8 under UNOY.
+    pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
+        match self.next_raw_segment()? {
+            Some(raw) => Ok(Some(self.decode(raw)?)),
+            None => Ok(None),
+        }
     }
 }
 
@@ -409,33 +441,38 @@ mod tests {
     }
 
     #[test]
-    fn bootstrap_decodes_unb_with_high_byte_in_a_later_element() {
-        // The bootstrap charset must not break on a high byte before the
-        // syntax identifier is known: a UNB carrying a Latin-1 byte 0xE9 in
-        // a sender field still decodes (the tag/syntax id are ASCII).
+    fn raw_unb_decodes_high_byte_element_under_negotiated_charset() {
+        // The UNB is framed raw, the ASCII syntax id is sniffed to arm the
+        // charset, and only then is the UNB decoded — so a non-ASCII byte in
+        // a UNB sender element decodes under the negotiated repertoire, not a
+        // placeholder. 0xE9 under UNOC (Latin-1) is é.
         let mut data = b"UNB+UNOC:3+Caf".to_vec();
         data.push(0xE9);
         data.push(b'\'');
         let mut t = SegmentTokenizer::new(Cursor::new(data));
-        let first = t.next_segment().unwrap().unwrap();
+        let raw = t.next_raw_segment().unwrap().unwrap();
+        let charset = Charset::from_raw_unb_segment(&raw, &t.delimiters()).unwrap();
+        assert_eq!(charset, Charset::Latin1);
+        t.set_charset(charset);
+        let first = t.decode(raw).unwrap();
         assert_eq!(first, "UNB+UNOC:3+Café");
     }
 
     #[test]
-    fn rearmed_latin1_decodes_high_byte_body_segment() {
-        // After the UNB is decoded under the bootstrap charset, re-arming to
-        // Latin-1 (as the reader does once it parses UNOC) lets a body
-        // segment carrying a Latin-1 high byte decode correctly.
+    fn armed_latin1_decodes_high_byte_body_segment() {
+        // After the UNB is read raw and the charset armed to Latin-1, a body
+        // segment carrying a Latin-1 high byte decodes correctly.
         let mut body = b"NAD+BY+Caf".to_vec();
         body.push(0xE9);
         body.push(b'\'');
         let mut full = b"UNB+UNOC:3+S+R'".to_vec();
         full.extend_from_slice(&body);
         let mut t = SegmentTokenizer::new(Cursor::new(full));
-        let unb = t.next_segment().unwrap().unwrap();
-        assert_eq!(unb, "UNB+UNOC:3+S+R");
-        // The reader re-arms here, between segment 1 (UNB) and segment 2.
-        t.set_charset(Charset::Latin1);
+        let raw = t.next_raw_segment().unwrap().unwrap();
+        let charset = Charset::from_raw_unb_segment(&raw, &t.delimiters()).unwrap();
+        t.set_charset(charset);
+        assert_eq!(t.decode(raw).unwrap(), "UNB+UNOC:3+S+R");
+        // The body segment now decodes under the armed Latin-1 charset.
         let nad = t.next_segment().unwrap().unwrap();
         let parsed = split_segment(&nad, &t.delimiters());
         assert_eq!(parsed.tag, "NAD");
@@ -452,8 +489,11 @@ mod tests {
         let mut full = b"UNB+UNOA:1+S+R'".to_vec();
         full.extend_from_slice(&body);
         let mut t = SegmentTokenizer::new(Cursor::new(full));
-        let _ = t.next_segment().unwrap().unwrap(); // UNB under bootstrap
-        t.set_charset(Charset::Ascii);
+        let raw = t.next_raw_segment().unwrap().unwrap();
+        let charset = Charset::from_raw_unb_segment(&raw, &t.delimiters()).unwrap();
+        assert_eq!(charset, Charset::Ascii);
+        t.set_charset(charset);
+        let _ = t.decode(raw).unwrap(); // UNB is ASCII, decodes fine
         let err = t.next_segment().unwrap_err();
         assert!(matches!(err, FormatError::Edifact(m) if m.contains("ASCII")));
     }

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 
 use clinker_record::{Record, Schema, Value};
 
+use crate::edifact::charset::Charset;
 use crate::edifact::tokenizer::Delimiters;
 use crate::edifact::{RAW_ELEMENTS_KEY, unb_control_reference};
 use crate::error::FormatError;
@@ -58,6 +59,11 @@ pub struct EdifactWriter<W: Write> {
     writer: W,
     config: EdifactWriterConfig,
     delims: Delimiters,
+    /// Repertoire element text is encoded through, negotiated from the
+    /// resolved `UNB` syntax identifier when the header is written. Starts on
+    /// the byte-total bootstrap charset so the `UNB` (whose tag and syntax id
+    /// are ASCII) emits before the repertoire is known.
+    charset: Charset,
     /// Wire element columns keyed by the 1-based position parsed from the
     /// column name (`e01` → 1), each paired with its schema index. The
     /// numeric suffix — not schema-declaration order — determines the wire
@@ -127,6 +133,7 @@ impl<W: Write> EdifactWriter<W> {
             writer,
             config,
             delims: Delimiters::level_a(),
+            charset: Charset::Bootstrap,
             element_columns,
             seg_id_idx,
             msg_ref_idx,
@@ -167,6 +174,22 @@ impl<W: Write> EdifactWriter<W> {
         }
 
         let unb_elements = self.resolve_unb_elements(record)?;
+        // Negotiate the encoding repertoire from the resolved syntax
+        // identifier (UNB S001 component 1, e.g. `UNOC` in `UNOC:3`) before
+        // emitting any segment, so element text is encoded through the same
+        // repertoire the reader decodes under and the round-trip is
+        // byte-faithful. The UNB itself emits under the bootstrap charset,
+        // which is faithful for its ASCII content, then every subsequent
+        // body segment encodes through the negotiated repertoire.
+        let syntax_id = unb_elements.first().ok_or_else(|| {
+            FormatError::Edifact(
+                "the resolved UNB header carries no syntax-identifier element (S001), \
+                 so no character repertoire can be negotiated; supply a UNB whose first \
+                 element names a syntax level (e.g. `UNOC:3`)"
+                    .into(),
+            )
+        })?;
+        let charset = Charset::from_unb_syntax_identifier(syntax_id, self.delims.component)?;
         // Echo the same control reference into the UNZ trailer that the
         // reader validates against, located structurally (after the
         // mandatory leading composites) so an empty optional element in
@@ -176,6 +199,9 @@ impl<W: Write> EdifactWriter<W> {
             .unwrap_or_default()
             .to_owned();
         self.write_segment("UNB", &unb_elements)?;
+        // Re-arm only after the UNB has emitted (it goes out under the
+        // bootstrap charset, which is faithful for its ASCII content).
+        self.charset = charset;
         Ok(())
     }
 
@@ -407,8 +433,16 @@ impl<W: Write> EdifactWriter<W> {
         Ok(())
     }
 
-    /// Write one element, prefixing each service character that would
-    /// otherwise be read as a delimiter with the release character.
+    /// Encode one element through the negotiated repertoire, then write the
+    /// encoded bytes prefixing each service character that would otherwise
+    /// be read as a delimiter with the release character.
+    ///
+    /// Encoding runs *before* escaping so the release escapes apply to the
+    /// wire bytes the reader will see: a Latin-1 byte that happens to equal
+    /// the element separator `+` or the terminator `'` must still be escaped,
+    /// which a pre-encode escape pass over the UTF-8 source could miss. This
+    /// inverts the reader's escape-then-decode order exactly, so a
+    /// reader→writer→reader cycle is byte-faithful for the negotiated charset.
     ///
     /// Escaped: the segment terminator, the element separator, and the
     /// release character itself. The component separator is *not* escaped
@@ -416,11 +450,19 @@ impl<W: Write> EdifactWriter<W> {
     /// composite structure (mirroring the reader, which keeps unescaped
     /// component separators verbatim), so composite elements like
     /// `UNOA:1` re-emit unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Edifact`] when the element text carries a
+    /// character the negotiated repertoire cannot represent (a non-ASCII
+    /// character under UNOA/UNOB, or a character above `U+00FF` under UNOC),
+    /// so an unrepresentable value is rejected rather than emitted truncated.
     fn write_escaped_element(&mut self, element: &str) -> Result<(), FormatError> {
         let release = self.delims.release;
         let terminator = self.delims.terminator;
         let separator = self.delims.element;
-        for &b in element.as_bytes() {
+        let encoded = self.charset.encode(element)?;
+        for &b in &encoded {
             if b == release || b == terminator || b == separator {
                 self.writer.write_all(&[release]).map_err(FormatError::Io)?;
             }
@@ -1007,6 +1049,122 @@ mod tests {
         assert!(
             out.contains("BGM+first+second'"),
             "reordered mapping wrong: {out}"
+        );
+    }
+
+    /// A UNOC interchange config: the syntax identifier declares Latin-1, so
+    /// the writer encodes element text through the single-byte repertoire.
+    fn unoc_config() -> EdifactWriterConfig {
+        EdifactWriterConfig {
+            interchange: Some(vec![
+                "UNOC:3".into(),
+                "S".into(),
+                "R".into(),
+                "240101:1200".into(),
+                "REF1".into(),
+            ]),
+            segment_newline: false,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn unoc_encodes_high_byte_element_to_single_latin1_byte() {
+        // Under UNOC the writer encodes "Café" with é as the single Latin-1
+        // byte 0xE9, not the two-byte UTF-8 sequence.
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&s), unoc_config());
+        w.write_record(&body(&s, "NAD", "M1", "ORDERS", &["Café"]))
+            .unwrap();
+        w.flush().unwrap();
+        // The body element bytes are "Caf" + 0xE9, escaped as needed.
+        assert!(
+            buf.windows(4).any(|w| w == [b'C', b'a', b'f', 0xE9]),
+            "é was not encoded to the single Latin-1 byte 0xE9: {buf:?}"
+        );
+        // No UTF-8 two-byte sequence for é (0xC3 0xA9) appears.
+        assert!(
+            !buf.windows(2).any(|w| w == [0xC3, 0xA9]),
+            "é leaked as a UTF-8 sequence: {buf:?}"
+        );
+    }
+
+    #[test]
+    fn unoc_latin1_byte_equal_to_delimiter_is_release_escaped() {
+        // A Latin-1 codepoint that encodes to a byte equal to a service
+        // delimiter must still be release-escaped on the encoded bytes. The
+        // element separator '+' is 0x2B; encode-then-escape is what makes a
+        // data byte 0x2B survive as ?+ rather than splitting the element.
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&s), unoc_config());
+        // U+002B is '+', which round-trips through Latin-1 to byte 0x2B.
+        w.write_record(&body(&s, "BGM", "M1", "ORDERS", &["A+B"]))
+            .unwrap();
+        w.flush().unwrap();
+        // "A?+B" — the data '+' is escaped, the element is not split.
+        assert!(
+            buf.windows(5).any(|w| w == b"A?+B'"),
+            "data '+' was not release-escaped under UNOC: {buf:?}"
+        );
+    }
+
+    #[test]
+    fn unoc_rejects_char_outside_latin1() {
+        // A euro sign (U+20AC) is above U+00FF and has no Latin-1 byte; the
+        // writer must reject it, not truncate.
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&s), unoc_config());
+        let err = w
+            .write_record(&body(&s, "FTX", "M1", "ORDERS", &["price €5"]))
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("Latin-1") && m.contains("U+20AC")),
+            "expected out-of-range encode rejection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unoa_rejects_non_ascii_element() {
+        // Under a UNOA (ASCII) header a non-ASCII element is rejected loudly.
+        let s = schema();
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&s), literal_config());
+        let err = w
+            .write_record(&body(&s, "NAD", "M1", "ORDERS", &["Café"]))
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("ASCII")),
+            "expected ASCII encode rejection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unsupported_syntax_level_header_errors_naming_level() {
+        // A literal UNB declaring an unmapped syntax level fails when the
+        // header is written, naming the offending level.
+        let s = schema();
+        let cfg = EdifactWriterConfig {
+            interchange: Some(vec![
+                "UNOD:4".into(),
+                "S".into(),
+                "R".into(),
+                "240101:1200".into(),
+                "REF1".into(),
+            ]),
+            segment_newline: false,
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut w = EdifactWriter::new(Cursor::new(&mut buf), Arc::clone(&s), cfg);
+        let err = w
+            .write_record(&body(&s, "BGM", "M1", "ORDERS", &["220"]))
+            .unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Edifact(m) if m.contains("UNOD") && m.contains("unsupported")),
+            "expected unsupported-level header error, got {err:?}"
         );
     }
 

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -60,9 +60,11 @@ pub struct EdifactWriter<W: Write> {
     config: EdifactWriterConfig,
     delims: Delimiters,
     /// Repertoire element text is encoded through, negotiated from the
-    /// resolved `UNB` syntax identifier when the header is written. Starts on
-    /// the byte-total bootstrap charset so the `UNB` (whose tag and syntax id
-    /// are ASCII) emits before the repertoire is known.
+    /// resolved `UNB` syntax identifier and armed before the `UNB` is
+    /// emitted, so the header's own elements encode under it. Holds the
+    /// [`Charset::default`] placeholder until `write_header` arms it; the
+    /// placeholder is never used to encode, since no segment is written
+    /// before the header.
     charset: Charset,
     /// Wire element columns keyed by the 1-based position parsed from the
     /// column name (`e01` → 1), each paired with its schema index. The
@@ -133,7 +135,7 @@ impl<W: Write> EdifactWriter<W> {
             writer,
             config,
             delims: Delimiters::level_a(),
-            charset: Charset::Bootstrap,
+            charset: Charset::default(),
             element_columns,
             seg_id_idx,
             msg_ref_idx,
@@ -175,12 +177,12 @@ impl<W: Write> EdifactWriter<W> {
 
         let unb_elements = self.resolve_unb_elements(record)?;
         // Negotiate the encoding repertoire from the resolved syntax
-        // identifier (UNB S001 component 1, e.g. `UNOC` in `UNOC:3`) before
-        // emitting any segment, so element text is encoded through the same
-        // repertoire the reader decodes under and the round-trip is
-        // byte-faithful. The UNB itself emits under the bootstrap charset,
-        // which is faithful for its ASCII content, then every subsequent
-        // body segment encodes through the negotiated repertoire.
+        // identifier (UNB S001 component 1, e.g. `UNOC` in `UNOC:3`) and arm
+        // it BEFORE the UNB is emitted, so the UNB's own elements — including
+        // a sender/recipient identification carrying non-ASCII text under
+        // UNOC or UNOY — encode through the negotiated repertoire and invert
+        // the reader's decode exactly. The syntax identifier itself is ASCII,
+        // so it encodes identically regardless.
         let syntax_id = unb_elements.first().ok_or_else(|| {
             FormatError::Edifact(
                 "the resolved UNB header carries no syntax-identifier element (S001), \
@@ -189,7 +191,7 @@ impl<W: Write> EdifactWriter<W> {
                     .into(),
             )
         })?;
-        let charset = Charset::from_unb_syntax_identifier(syntax_id, self.delims.component)?;
+        self.charset = Charset::from_unb_syntax_identifier(syntax_id, self.delims.component)?;
         // Echo the same control reference into the UNZ trailer that the
         // reader validates against, located structurally (after the
         // mandatory leading composites) so an empty optional element in
@@ -199,9 +201,6 @@ impl<W: Write> EdifactWriter<W> {
             .unwrap_or_default()
             .to_owned();
         self.write_segment("UNB", &unb_elements)?;
-        // Re-arm only after the UNB has emitted (it goes out under the
-        // bootstrap charset, which is faithful for its ASCII content).
-        self.charset = charset;
         Ok(())
     }
 

--- a/docs/src/pipeline/edifact.md
+++ b/docs/src/pipeline/edifact.md
@@ -243,12 +243,15 @@ without any configuration.
 | `UNOY`             | UTF-8; invalid byte sequences are an error      |
 
 Decoding stays streaming and per-segment — the interchange is never
-buffered whole. The `UNB` itself is decoded byte-for-byte before its
-syntax identifier is known (its tag and identifier are ASCII), then the
-repertoire is armed before the first body segment, so a `UNOC`
-interchange whose body carries Latin-1 high bytes (for example accented
-characters in free-text name or address fields) parses without error and
-the decoded element text matches the source bytes under Latin-1.
+buffered whole. The syntax identifier is itself ASCII, so it is read
+straight from the raw `UNB` bytes before any text is decoded; the `UNB`
+and every body segment are then decoded through the negotiated
+repertoire. The `UNB`'s own sender and recipient identification elements
+may legitimately carry non-ASCII text under `UNOC` or `UNOY`, and they
+decode (and re-encode on output) under that repertoire too — so a `UNOC`
+interchange whose header or body carries Latin-1 high bytes (for example
+accented characters in a party name) parses without error, surfaces the
+correct text in `$doc.UNB.*`, and round-trips byte-for-byte.
 
 The repertoire is enforced loudly. A `UNOA`/`UNOB` interchange whose body
 carries a high byte fails ("outside the ASCII repertoire") rather than

--- a/docs/src/pipeline/edifact.md
+++ b/docs/src/pipeline/edifact.md
@@ -226,11 +226,43 @@ middle element is empty and the user declares only the fields they care
 about. Supply `interchange` literal elements instead when the records
 have no source `UNB` section to echo.
 
+## Character set
+
+EDIFACT names its body character repertoire **in-band**: the `UNB`
+header's syntax identifier (data element S001, component 1 — the `UNOA`
+in `UNOA:1`) declares the repertoire for the whole interchange. There is
+therefore **no `encoding` option** on an EDIFACT source or sink; the
+reader discovers the repertoire from the `UNB` and the writer re-derives
+it from the `UNB` it emits, so a read → write round-trip is byte-faithful
+without any configuration.
+
+| `UNB` syntax level | Repertoire                                      |
+| ------------------ | ----------------------------------------------- |
+| `UNOA`, `UNOB`     | ASCII; a byte `>= 0x80` is an error             |
+| `UNOC`             | ISO-8859-1 (Latin-1), one byte per character    |
+| `UNOY`             | UTF-8; invalid byte sequences are an error      |
+
+Decoding stays streaming and per-segment — the interchange is never
+buffered whole. The `UNB` itself is decoded byte-for-byte before its
+syntax identifier is known (its tag and identifier are ASCII), then the
+repertoire is armed before the first body segment, so a `UNOC`
+interchange whose body carries Latin-1 high bytes (for example accented
+characters in free-text name or address fields) parses without error and
+the decoded element text matches the source bytes under Latin-1.
+
+The repertoire is enforced loudly. A `UNOA`/`UNOB` interchange whose body
+carries a high byte fails ("outside the ASCII repertoire") rather than
+silently reinterpreting it; a `UNOY` interchange with invalid UTF-8 fails
+("not valid UTF-8"); and a `UNB` declaring an unsupported syntax level
+(`UNOD`..`UNOX`) fails at startup with a precise error naming the level,
+never falling back to a guessed encoding or substituting replacement
+characters. On output the writer encodes element text through the same
+repertoire the `UNB` declares; a character the repertoire cannot
+represent (a non-ASCII character under `UNOA`/`UNOB`, or a codepoint above
+`U+00FF` under `UNOC`) is rejected rather than emitted truncated.
+
 ## Limitations
 
-- **Charset.** Element text is decoded as UTF-8. Non-UTF-8 interchanges
-  (UNOA/UNOB/Latin-1 high bytes) are rejected explicitly rather than
-  silently corrupted.
 - **Functional groups.** A single `UNB..UNZ` interchange is supported;
   `UNG`/`UNE` functional-group segments are rejected with a precise
   error.


### PR DESCRIPTION
EDIFACT names its body character repertoire in-band: the UNB header's syntax identifier (data element S001, e.g. `UNOA` in `UNOA:1`) declares the encoding for the whole interchange. The reader and writer previously assumed UTF-8 and rejected any non-UTF-8 interchange. This decodes element text per the declared repertoire instead, with no source/sink option needed (the encoding is read from the wire).

A crate-private `Charset` is resolved from the syntax identifier:

- `UNOA`/`UNOB` → ASCII (a byte ≥ 0x80 is an error, not reinterpreted)
- `UNOC` → ISO-8859-1 (Latin-1), one byte per character
- `UNOY` → UTF-8
- `UNOD`..`UNOX` → fail loud, naming the level (no new dependency, no guessed fallback, no replacement characters)

The tokenizer starts on a byte-total bootstrap repertoire so the UNB itself decodes before its repertoire is known; the reader re-arms the charset from the parsed syntax identifier before reading any body segment, and the writer re-derives it from the UNB it emits. Element encoding runs before release-escaping, so a single byte equal to a service delimiter is still escaped — exactly inverting the reader's escape-then-decode order. A read → write → read cycle is byte-faithful for the negotiated charset.

This mirrors the equivalent X12 work, with the key difference that EDIFACT's repertoire is in-band (discovered from the UNB) rather than configured out-of-band.

Closes #403.