### PR TITLE
format: SWIFT MT reader with block-structure envelope mapping

### DIFF
--- a/crates/clinker-benchmarks/src/format_mapping.rs
+++ b/crates/clinker-benchmarks/src/format_mapping.rs
@@ -10,6 +10,7 @@ pub enum FormatMappingError {
     UnsupportedEdifact,
     UnsupportedX12,
     UnsupportedHl7,
+    UnsupportedSwift,
 }
 
 impl std::fmt::Display for FormatMappingError {
@@ -26,6 +27,9 @@ impl std::fmt::Display for FormatMappingError {
             }
             Self::UnsupportedHl7 => {
                 f.write_str("HL7 format has no benchmark DataFormat equivalent")
+            }
+            Self::UnsupportedSwift => {
+                f.write_str("SWIFT format has no benchmark DataFormat equivalent")
             }
         }
     }
@@ -44,6 +48,7 @@ pub fn input_format_to_data_format(input: &InputFormat) -> Result<DataFormat, Fo
         InputFormat::Edifact(_) => Err(FormatMappingError::UnsupportedEdifact),
         InputFormat::X12(_) => Err(FormatMappingError::UnsupportedX12),
         InputFormat::Hl7(_) => Err(FormatMappingError::UnsupportedHl7),
+        InputFormat::Swift(_) => Err(FormatMappingError::UnsupportedSwift),
         InputFormat::Json(opts) => {
             let json_fmt = opts.as_ref().and_then(|o| o.format.as_ref());
             match json_fmt {

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -1007,24 +1007,29 @@ nodes:
         unreachable!("source node present")
     }
 
-    /// Drive `drive_record_source` over the script and return the ordered
-    /// stream of records and document boundaries the driver emitted.
-    fn drive(steps: Vec<Step>) -> Vec<Observed> {
+    /// Drive `drive_record_source` over a pathless source and collect the
+    /// ordered raw stream the driver emitted. The reader (scripted stand-in
+    /// or a real format reader) is small relative to the channel capacity, so
+    /// the driver runs to completion on this thread and drops the sender,
+    /// after which the receiver drains cleanly. Each caller projects the
+    /// returned `StreamEvent`s into the boundary/record shape it asserts on.
+    fn drive_to_stream_events(reader: Box<dyn crate::source::RecordSource>) -> Vec<StreamEvent> {
         let src_cfg = pathless_source_config();
-        let reader: Box<dyn crate::source::RecordSource> = Box::new(ScriptedReader::new(steps));
         let handle = crate::pipeline::memory::ConsumerHandle::new();
         let (stream, rx) = crate::executor::source_stream::SourceIngestChannel::new(
             crate::executor::source_stream::SourceIngestChannel::DEFAULT_CAPACITY,
             handle,
         );
-
-        // The script is far smaller than the channel capacity, so the
-        // driver never blocks on a full channel; it runs to completion on
-        // this thread and drops the sender, after which the receiver
-        // drains cleanly.
         drive_record_source(src_cfg, reader, stream, None).expect("drive");
+        rx.iter().collect()
+    }
 
-        rx.iter()
+    /// Drive the script and return the ordered stream of records and document
+    /// boundaries the driver emitted.
+    fn drive(steps: Vec<Step>) -> Vec<Observed> {
+        let reader: Box<dyn crate::source::RecordSource> = Box::new(ScriptedReader::new(steps));
+        drive_to_stream_events(reader)
+            .into_iter()
             .map(|ev| match ev {
                 StreamEvent::Record(rec, _) => match rec.values()[0] {
                     Value::Integer(id) => Observed::Record(id),
@@ -1139,5 +1144,92 @@ nodes:
             "header-only interchange has no body records"
         );
         assert_eq!(observed.len(), 4);
+    }
+
+    /// One observed event from driving a real [`FormatReader`], with records
+    /// projected to a chosen string column so a per-record assertion can name
+    /// which record landed where in the boundary stream.
+    #[derive(Debug, PartialEq, Eq)]
+    enum ObservedTagged {
+        Open,
+        Close,
+        Record(String),
+    }
+
+    /// Drive a real [`FormatReader`] (not the scripted stand-in) through the
+    /// shared ingest loop and return the ordered stream of document
+    /// boundaries and records, each record projected to its named string
+    /// column. Pins the exact interleaving of `DocumentOpen`/`DocumentClose`
+    /// punctuations with body records that the driver emits.
+    fn drive_format_reader(
+        reader: Box<dyn FormatReader>,
+        record_column: &str,
+    ) -> Vec<ObservedTagged> {
+        let src_reader: Box<dyn crate::source::RecordSource> = Box::new(reader);
+        drive_to_stream_events(src_reader)
+            .into_iter()
+            .map(|ev| match ev {
+                StreamEvent::Record(rec, _) => {
+                    let tag = match rec.get(record_column) {
+                        Some(Value::String(s)) => s.to_string(),
+                        other => panic!("record column {record_column:?} not a string: {other:?}"),
+                    };
+                    ObservedTagged::Record(tag)
+                }
+                StreamEvent::Punctuation(p) => match p.kind() {
+                    PunctuationKind::DocumentOpen => ObservedTagged::Open,
+                    PunctuationKind::DocumentClose => ObservedTagged::Close,
+                },
+            })
+            .collect()
+    }
+
+    #[test]
+    fn swift_message_close_follows_its_last_record() {
+        // A SWIFT message's CloseLevel must be applied AFTER the message's
+        // last body record, not before it: the driver drains
+        // `take_envelope_events` and applies each boundary before pushing the
+        // record that pull returned, so a close queued alongside the final
+        // record-bearing pull would strand that record outside its own
+        // document level. This locks the close onto the terminal `Ok(None)`
+        // pull so every body record stays inside the message document.
+        let mt103 = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}\
+            {4:\r\n:20:REF1\r\n:23B:CRED\r\n:32A:240101USD100,00\r\n-}";
+        let reader: Box<dyn FormatReader> = Box::new(SwiftReader::new(
+            std::io::Cursor::new(mt103.as_bytes().to_vec()),
+            SwiftReaderConfig::default(),
+        ));
+        let observed = drive_format_reader(reader, "tag");
+        // File document opens, the message level opens, all three block-4
+        // records stream, THEN the message and file levels close. The third
+        // record (`32A`) must precede the message `Close`.
+        assert_eq!(
+            observed,
+            vec![
+                ObservedTagged::Open, // file-level document
+                ObservedTagged::Open, // message level
+                ObservedTagged::Record("20".to_string()),
+                ObservedTagged::Record("23B".to_string()),
+                ObservedTagged::Record("32A".to_string()),
+                ObservedTagged::Close, // message level — after the last record
+                ObservedTagged::Close, // file-level document
+            ],
+            "the message Close must follow its last body record"
+        );
+        // Pin the invariant directly: the last record precedes the first
+        // Close. A regression that queues the close on the final
+        // record-bearing pull would place a Close before the `32A` record.
+        let last_record = observed
+            .iter()
+            .rposition(|o| matches!(o, ObservedTagged::Record(_)))
+            .expect("at least one record");
+        let first_close = observed
+            .iter()
+            .position(|o| *o == ObservedTagged::Close)
+            .expect("at least one close");
+        assert!(
+            last_record < first_close,
+            "every body record must precede the message close; got {observed:?}"
+        );
     }
 }

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -13,6 +13,7 @@ use clinker_format::hl7::reader::{Hl7Reader, Hl7ReaderConfig};
 use clinker_format::json::reader::{
     ArrayPathMode, ArrayPathSpec, JsonMode, JsonReader, JsonReaderConfig,
 };
+use clinker_format::swift::reader::{SwiftReader, SwiftReaderConfig};
 use clinker_format::traits::FormatReader;
 use clinker_format::x12::Charset;
 use clinker_format::x12::reader::{X12Reader, X12ReaderConfig};
@@ -60,6 +61,10 @@ fn build_format_reader(
         clinker_plan::config::InputFormat::Hl7(opts) => {
             let config = build_hl7_reader_config(opts.as_ref());
             Ok(Box::new(Hl7Reader::new(reader, config)))
+        }
+        clinker_plan::config::InputFormat::Swift(opts) => {
+            let config = build_swift_reader_config(opts.as_ref());
+            Ok(Box::new(SwiftReader::new(reader, config)))
         }
     }
 }
@@ -862,6 +867,18 @@ fn build_hl7_reader_config(
                 })
                 .collect();
         }
+    }
+    config
+}
+
+fn build_swift_reader_config(
+    opts: Option<&clinker_plan::config::SwiftInputOptions>,
+) -> SwiftReaderConfig {
+    let mut config = SwiftReaderConfig::default();
+    if let Some(opts) = opts
+        && let Some(max) = opts.max_fields
+    {
+        config.max_fields = max;
     }
     config
 }

--- a/crates/clinker-exec/tests/swift_pipeline.rs
+++ b/crates/clinker-exec/tests/swift_pipeline.rs
@@ -334,3 +334,43 @@ nodes:
         "error should name the SWIFT block failure: {err}"
     );
 }
+
+#[test]
+fn swift_max_fields_option_caps_block4_field_count() {
+    // The source's `max_fields` option flows through to the reader. A message
+    // carrying more block-4 fields than the configured cap fails the run with
+    // a precise error naming the option — exercising the
+    // options -> build_swift_reader_config -> reader path end-to-end.
+    let over_cap = "{1:F01BANKBEBBAXXX0000000000}\
+        {4:\r\n:20:ONE\r\n:21:TWO\r\n:22:THREE\r\n-}";
+    let yaml = r#"
+pipeline:
+  name: swift_max_fields
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      options:
+        max_fields: 2
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: output
+    name: out
+    input: message
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = run(yaml, "message", over_cap, "big.swift", "out")
+        .expect_err("an over-cap message must fail the run");
+    assert!(
+        err.contains("max_fields") || err.contains("SWIFT"),
+        "error should name the field-count cap: {err}"
+    );
+}

--- a/crates/clinker-exec/tests/swift_pipeline.rs
+++ b/crates/clinker-exec/tests/swift_pipeline.rs
@@ -1,0 +1,336 @@
+//! End-to-end SWIFT MT ingestion.
+//!
+//! Covers: (1) a SWIFT source surfaces its service blocks (1/2/3/5) as
+//! file-level `$doc` envelope sections on every block-4 body record, proving
+//! the message-level document context flows through the executor; (2) each
+//! block-4 `:tag:value` line streams as one `[block, tag, value]` record;
+//! (3) a header-only message still produces a balanced document level with a
+//! clean drain; (4) a malformed message (unbalanced brace / missing `-}`
+//! trailer) surfaces as a clean run failure rather than a panic.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// A single-customer-credit-transfer MT103 with all five blocks: basic
+/// header (1), application header (2), user header (3) with a nested
+/// service-id sub-block, the message text (4), and a trailer (5). Every
+/// block-4 field is one physical line so a CSV body row maps one-to-one.
+fn mt103() -> String {
+    "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}\
+     {3:{108:MSGREF12345}}\
+     {4:\r\n:20:REFERENCE12345\r\n:23B:CRED\r\n:32A:240101USD1000,00\r\n-}\
+     {5:{CHK:1234567890AB}}"
+        .to_string()
+}
+
+/// An MT940 statement with repeated `:61:` / `:86:` block-4 tags — one record
+/// per statement line. Exercises repeated block-4 tags streaming in order.
+fn mt940() -> String {
+    "{1:F01BANKBEBBAXXX0000000000}{2:I940BANKDEFFXXXXN}\
+     {4:\r\n:20:STMT001\r\n:25:12345678\r\n:28C:1/1\r\n\
+     :60F:C240101USD5000,00\r\n\
+     :61:2401010101D100,00NTRFREF1//BANK1\r\n:86:PAYMENT ONE\r\n\
+     :61:2401020102C200,00NTRFREF2//BANK2\r\n:86:PAYMENT TWO\r\n\
+     :62F:C240102USD5100,00\r\n-}"
+        .to_string()
+}
+
+fn run(
+    yaml: &str,
+    source_name: &str,
+    fixture: &str,
+    file_name: &str,
+    out_name: &str,
+) -> Result<(clinker_exec::executor::ExecutionReport, String), String> {
+    let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
+    let plan = config
+        .compile(&CompileContext::default())
+        .map_err(|e| format!("compile: {e:?}"))?;
+
+    let file = FileSlot::new(
+        PathBuf::from(file_name),
+        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        source_name.to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        out_name.to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .map_err(|e| format!("run: {e:?}"))?;
+    Ok((
+        report,
+        String::from_utf8_lossy(&buf.contents()).into_owned(),
+    ))
+}
+
+#[test]
+fn swift_source_surfaces_service_blocks_as_doc_sections() {
+    // Every block-4 body record carries the message-level document context,
+    // whose declared sections expose the service blocks. The Transform reads
+    // one field from each declared block:
+    //   block 1 (basic header) under `basic`,
+    //   block 2 (application header) under `app`,
+    //   block 3 (user header, with its nested sub-block) under `user`,
+    //   block 5 (trailer) under `tlr`.
+    let yaml = r#"
+pipeline:
+  name: swift_envelope
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      envelope:
+        sections:
+          basic:
+            extract: { segment: "1" }
+          app:
+            extract: { segment: "2" }
+          user:
+            extract: { segment: "3" }
+          tlr:
+            extract: { segment: "5" }
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: transform
+    name: tag
+    input: message
+    config:
+      cxl: |
+        emit tag = tag
+        emit basic = $doc.basic.body
+        emit app = $doc.app.body
+        emit user = $doc.user.body
+        emit tlr = $doc.tlr.body
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+      include_unmapped: false
+"#;
+    let (report, output) =
+        run(yaml, "message", &mt103(), "po.swift", "out").expect("run swift pipeline");
+    // Three block-4 fields: :20:, :23B:, :32A:.
+    assert_eq!(report.counters.total_count, 3, "output was: {output}");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 3, "3 body rows, no header; got: {output}");
+    for row in &lines {
+        // Every body row resolves all four declared service-block sections.
+        assert!(
+            row.contains("F01BANKBEBBAXXX0000000000"),
+            "row missing $doc.basic.body: {row}"
+        );
+        assert!(
+            row.contains("I103BANKDEFFXXXXN"),
+            "row missing $doc.app.body: {row}"
+        );
+        // Block 3 keeps its nested {108:...} sub-block verbatim.
+        assert!(
+            row.contains("{108:MSGREF12345}"),
+            "row missing $doc.user.body: {row}"
+        );
+        assert!(
+            row.contains("{CHK:1234567890AB}"),
+            "row missing $doc.tlr.body: {row}"
+        );
+    }
+    // First body record is the :20: reference field's tag.
+    assert!(lines[0].starts_with("20,"), "first row: {}", lines[0]);
+}
+
+#[test]
+fn swift_block4_tag_lines_stream_as_records() {
+    // Each block-4 `:tag:value` line becomes one record carrying the tag and
+    // value; the constant `block` column stamps `4` on every body row.
+    let yaml = r#"
+pipeline:
+  name: swift_body
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: transform
+    name: tag
+    input: message
+    config:
+      cxl: |
+        emit block = block
+        emit tag = tag
+        emit value = value
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+"#;
+    let (report, output) =
+        run(yaml, "message", &mt940(), "stmt.swift", "out").expect("run mt940 pipeline");
+    // MT940 carries nine block-4 fields (including two repeated :61:/:86:).
+    assert_eq!(report.counters.total_count, 9, "output was: {output}");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let rows: Vec<&str> = output.lines().collect();
+    assert_eq!(rows.len(), 9, "9 body rows, no header; got: {output}");
+    // Every row stamps the block-4 id and carries its tag/value.
+    for row in &rows {
+        assert!(row.starts_with("4,"), "block column wrong in row: {row}");
+    }
+    // The first statement-line tag (:61:) streams with its value (CSV quotes
+    // the comma-bearing amount, so match on the embedded content).
+    assert!(
+        rows[4].starts_with("4,61,") && rows[4].contains("2401010101D100,00NTRFREF1//BANK1"),
+        "first :61: row: {}",
+        rows[4]
+    );
+    // The second :61: streams as a distinct record.
+    assert!(
+        rows[6].starts_with("4,61,") && rows[6].contains("2401020102C200,00NTRFREF2//BANK2"),
+        "second :61: row: {}",
+        rows[6]
+    );
+}
+
+#[test]
+fn swift_header_only_message_drains_clean() {
+    // A header/trailer-only message (no block 4) emits no body records and
+    // still drains cleanly — the balanced message-level document open/close
+    // pair must not corrupt the document-context stack or panic.
+    let header_only = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}{5:{CHK:ABC}}";
+    let yaml = r#"
+pipeline:
+  name: swift_header_only
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: output
+    name: out
+    input: message
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let (report, output) = run(yaml, "message", header_only, "hdr.swift", "out")
+        .expect("header-only message must drain cleanly");
+    assert_eq!(report.counters.total_count, 0, "no body records: {output}");
+    assert_eq!(report.counters.dlq_count, 0);
+}
+
+#[test]
+fn swift_unbalanced_block_fails_the_run() {
+    // Block 2 never closes — an unbalanced brace the reader surfaces as a
+    // clean run failure, not a panic.
+    let bad = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN";
+    let yaml = r#"
+pipeline:
+  name: swift_bad_brace
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: output
+    name: out
+    input: message
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = run(yaml, "message", bad, "bad.swift", "out")
+        .expect_err("unbalanced brace must fail the run");
+    assert!(
+        err.contains("truncated") || err.contains("SWIFT"),
+        "error should name the SWIFT block failure: {err}"
+    );
+}
+
+#[test]
+fn swift_missing_block4_trailer_fails_the_run() {
+    // Block 4 with no `-}` trailer runs to EOF unbalanced — a truncation the
+    // reader surfaces cleanly.
+    let bad = "{1:F01BANKBEBBAXXX0000000000}{4:\r\n:20:REF\r\n";
+    let yaml = r#"
+pipeline:
+  name: swift_bad_trailer
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: output
+    name: out
+    input: message
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = run(yaml, "message", bad, "bad.swift", "out")
+        .expect_err("missing block-4 trailer must fail the run");
+    assert!(
+        err.contains("truncated") || err.contains("SWIFT"),
+        "error should name the SWIFT block failure: {err}"
+    );
+}

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -28,6 +28,11 @@ pub enum FormatError {
     /// constraint (missing/truncated MSH header, BTS/FTS count mismatch,
     /// unbalanced batch/file envelope, truncation, non-UTF-8 charset).
     Hl7(String),
+    /// A SWIFT MT parse or malformed-block failure. Carries a precise
+    /// message naming the offending block or constraint (unbalanced brace,
+    /// missing/non-numeric block id, missing `-}` block-4 trailer,
+    /// malformed `:tag:value` line, truncation, non-UTF-8 message).
+    Swift(String),
     InvalidRecord {
         row: u64,
         message: String,
@@ -74,6 +79,7 @@ impl fmt::Display for FormatError {
             Self::Edifact(msg) => write!(f, "EDIFACT error: {msg}"),
             Self::X12(msg) => write!(f, "X12 error: {msg}"),
             Self::Hl7(msg) => write!(f, "HL7 error: {msg}"),
+            Self::Swift(msg) => write!(f, "SWIFT error: {msg}"),
             Self::InvalidRecord { row, message } => {
                 write!(f, "invalid record at row {row}: {message}")
             }

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -9,6 +9,7 @@ pub mod hl7;
 pub mod json;
 pub(crate) mod segment_tokenizer;
 pub mod splitting;
+pub mod swift;
 pub mod traits;
 pub mod x12;
 pub mod xml;

--- a/crates/clinker-format/src/swift/mod.rs
+++ b/crates/clinker-format/src/swift/mod.rs
@@ -1,0 +1,27 @@
+//! SWIFT MT (FIN) message reader.
+//!
+//! A SWIFT MT message is a sequence of brace-balanced blocks
+//! `{1:...}{2:...}{3:...}{4:...-}{5:...}`. Block 1 is the basic header, block
+//! 2 the application header, block 3 the (optional) user header, block 4 the
+//! message text, and block 5 the (optional) trailer. Blocks 3 and 5 may
+//! carry nested `{tag:value}` sub-blocks; block 4 holds the message body as a
+//! run of `:tag:value` lines closed by a `-}` trailer rather than a bare
+//! brace, because its free text may contain a literal `}`.
+//!
+//! Unlike the flat EDI formats (HL7 v2, X12, EDIFACT) SWIFT framing is
+//! brace-balanced, not terminator-delimited, so the block framer is
+//! hand-rolled on brace depth rather than reusing the shared segment
+//! tokenizer. Only the block-4 tag-line layer resembles a terminator scan.
+//!
+//! This module maps one block-4 `:tag:value` line to one
+//! [`crate::traits::FormatReader`] record under a static positional schema
+//! (`block`, `tag`, `value`) — the same one-line-one-record shape as the X12
+//! and HL7 readers, so memory scales O(1) with message size. The service
+//! blocks (1/2/3/5) are consumed by the reader to serve file-level `$doc`
+//! envelope sections and drive one balanced message-level document level;
+//! they are never emitted as body records.
+
+pub mod reader;
+mod tokenizer;
+
+pub use reader::{SwiftReader, SwiftReaderConfig};

--- a/crates/clinker-format/src/swift/mod.rs
+++ b/crates/clinker-format/src/swift/mod.rs
@@ -4,9 +4,11 @@
 //! `{1:...}{2:...}{3:...}{4:...-}{5:...}`. Block 1 is the basic header, block
 //! 2 the application header, block 3 the (optional) user header, block 4 the
 //! message text, and block 5 the (optional) trailer. Blocks 3 and 5 may
-//! carry nested `{tag:value}` sub-blocks; block 4 holds the message body as a
-//! run of `:tag:value` lines closed by a `-}` trailer rather than a bare
-//! brace, because its free text may contain a literal `}`.
+//! carry nested `{tag:value}` sub-blocks tracked by brace depth; block 4
+//! holds the message body as opaque line-structured free text whose values
+//! legitimately contain `{`, `}`, and even `-}`, so it is not brace-counted
+//! at all — it closes only on a line-anchored `-}` trailer (a `-}` that
+//! begins a line).
 //!
 //! Unlike the flat EDI formats (HL7 v2, X12, EDIFACT) SWIFT framing is
 //! brace-balanced, not terminator-delimited, so the block framer is

--- a/crates/clinker-format/src/swift/reader.rs
+++ b/crates/clinker-format/src/swift/reader.rs
@@ -99,15 +99,9 @@ pub struct SwiftReader<R: Read> {
     /// The block-4 field lines, framed at first body pull and drained one
     /// record per `next_record`.
     body_lines: std::collections::VecDeque<ParsedBlock4Line>,
-    /// `true` once the message-level `OpenLevel` has been queued.
+    /// `true` once the message-level `OpenLevel` has been queued, so the
+    /// matching `CloseLevel` is queued exactly once at end-of-message.
     level_open: bool,
-    /// `true` once the matching `CloseLevel` has been queued, so it is queued
-    /// exactly once — on the final record-bearing pull (the moment the body
-    /// is known drained), not the trailing `Ok(None)` pull. Queuing it with
-    /// the last record means a multi-file wrapper forwards the precise close
-    /// before it advances to the next file, rather than relying on the
-    /// driver's file-boundary stack sweep.
-    level_closed: bool,
     /// Nested-envelope events queued during the most recent `next_record`,
     /// drained by the driver via [`FormatReader::take_envelope_events`].
     pending_events: Vec<EnvelopeEvent>,
@@ -129,7 +123,6 @@ impl<R: Read> SwiftReader<R> {
             trailer: None,
             body_lines: std::collections::VecDeque::new(),
             level_open: false,
-            level_closed: false,
             pending_events: Vec::new(),
             done: false,
         }
@@ -197,8 +190,17 @@ impl<R: Read> SwiftReader<R> {
     }
 
     /// Pull the next body record, queuing the message-level `OpenLevel`
-    /// before the first record and the matching `CloseLevel` the moment the
-    /// body is known drained. Returns `None` at clean end of message.
+    /// before the first record and the matching `CloseLevel` once the body is
+    /// drained. Returns `None` at clean end of message.
+    ///
+    /// The `CloseLevel` rides the terminal `Ok(None)` pull, not the final
+    /// record-bearing one: the source ingest driver drains
+    /// [`FormatReader::take_envelope_events`] and applies each boundary
+    /// *before* it pushes the record that pull returned, so a close queued
+    /// alongside the last record would be applied ahead of that record and
+    /// strand it outside its own document level. Queuing on the `None` pull
+    /// keeps every body record inside the message level and the close after
+    /// the message's last record.
     fn pull_next(&mut self) -> Result<Option<Record>, FormatError> {
         if !self.level_open {
             // One message = one nested document level wrapping the block-4
@@ -210,24 +212,14 @@ impl<R: Read> SwiftReader<R> {
             });
             self.level_open = true;
         }
-        let record = self
-            .body_lines
-            .pop_front()
-            .map(|line| self.body_record(&line));
-        // Close the level the instant the body is drained — on the final
-        // record-bearing pull (`body_lines` now empty) for a message with a
-        // body, or immediately for a header-only message. Queuing the
-        // `CloseLevel` with the last record (rather than on the trailing
-        // `Ok(None)` pull) means a multi-file source forwards the precise
-        // close before the wrapper advances to the next file.
-        if !self.level_closed && self.body_lines.is_empty() {
-            self.pending_events.push(EnvelopeEvent::CloseLevel);
-            self.level_closed = true;
+        match self.body_lines.pop_front() {
+            Some(line) => Ok(Some(self.body_record(&line))),
+            None => {
+                self.pending_events.push(EnvelopeEvent::CloseLevel);
+                self.done = true;
+                Ok(None)
+            }
         }
-        if record.is_none() {
-            self.done = true;
-        }
-        Ok(record)
     }
 
     /// Map one block-4 field line to a `[block, tag, value]` record. `block`

--- a/crates/clinker-format/src/swift/reader.rs
+++ b/crates/clinker-format/src/swift/reader.rs
@@ -1,0 +1,643 @@
+//! SWIFT MT message reader.
+//!
+//! Streaming, row-at-a-time over the message-text block: each `:tag:value`
+//! line of block 4 becomes one [`Record`] with a static positional schema
+//! `[block, tag, value]`. The service blocks (`1` basic header, `2`
+//! application header, `3` user header, `5` trailer) are consumed by the
+//! reader to drive the message-level document context and serve file-level
+//! `$doc` sections; they are never emitted as body records. This mirrors the
+//! one-segment-one-record shape of the X12 and HL7 readers, so memory scales
+//! O(1) with message size — only the block currently being framed is held.
+//!
+//! A SWIFT MT message is a single envelope: the service blocks are extracted
+//! in a one-time pre-scan and surface as file-level `$doc` sections via
+//! [`FormatReader::prepare_document`], and one message-level
+//! `OpenLevel`/`CloseLevel` pair brackets the block-4 body records so the
+//! driver's document-context stack stays balanced. A header-only message
+//! (no block 4, or an empty block 4) still produces the balanced
+//! open/close pair with no records between.
+//!
+//! Structural separators (braces, the leading `:`, the `-}` trailer, the
+//! line breaks) are kept out of the stored field values; the writer
+//! re-frames them, so the reader → writer → reader round-trip is
+//! byte-faithful.
+
+use std::io::{BufReader, Read};
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+use indexmap::IndexMap;
+
+use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract};
+use crate::error::FormatError;
+use crate::swift::tokenizer::{
+    BlockTokenizer, ParsedBlock, ParsedBlock4Line, TEXT_BLOCK_ID, split_block4,
+};
+use crate::traits::FormatReader;
+
+/// Default ceiling on the number of block-4 field lines a single message may
+/// carry. A message with more `:tag:value` lines than this is rejected with
+/// guidance rather than streaming an unbounded body. A real MT message is
+/// well under this; the cap exists only as a corruption guard.
+const DEFAULT_MAX_FIELDS: usize = 10_000;
+
+/// The default `$doc` section name for the basic header (block 1) when the
+/// source declares no `envelope:` mapping for it. User-chosen names override
+/// it; the engine reserves none — this is a stable label, not a keyword.
+const DEFAULT_BASIC_HEADER_SECTION: &str = "basic_header";
+
+/// The default `$doc` section name for the application header (block 2).
+const DEFAULT_APP_HEADER_SECTION: &str = "app_header";
+
+/// The default `$doc` section name for the user header (block 3).
+const DEFAULT_USER_HEADER_SECTION: &str = "user_header";
+
+/// The default `$doc` section name for the trailer (block 5).
+const DEFAULT_TRAILER_SECTION: &str = "trailer";
+
+/// The `body` field name a service block's verbatim text surfaces under
+/// inside its `$doc` section. SWIFT service blocks carry free-form text (a
+/// header string, nested `{sub:tag}` blocks), so the whole block body is one
+/// addressable field rather than positional elements.
+const BODY_FIELD: &str = "body";
+
+/// Configuration for the SWIFT reader.
+pub struct SwiftReaderConfig {
+    /// Maximum number of block-4 field lines a single message may carry. A
+    /// message exceeding this is rejected rather than streamed unbounded.
+    pub max_fields: usize,
+}
+
+impl Default for SwiftReaderConfig {
+    fn default() -> Self {
+        Self {
+            max_fields: DEFAULT_MAX_FIELDS,
+        }
+    }
+}
+
+/// Streaming SWIFT MT message reader.
+///
+/// Holds the block framer, the static `[block, tag, value]` schema, the
+/// service blocks captured during the one-time pre-scan, and the queue of
+/// envelope events the source ingest driver drains after each `next_record`.
+/// The block-4 field lines are framed once at the first body pull and
+/// streamed one record at a time.
+pub struct SwiftReader<R: Read> {
+    tokenizer: BlockTokenizer<BufReader<R>>,
+    schema: Arc<Schema>,
+    max_fields: usize,
+    initialized: bool,
+    /// Block 1 (basic header) body, captured in the pre-scan.
+    basic_header: Option<String>,
+    /// Block 2 (application header) body.
+    app_header: Option<String>,
+    /// Block 3 (user header) body, which may carry nested sub-blocks.
+    user_header: Option<String>,
+    /// Block 5 (trailer) body, which may carry nested sub-blocks.
+    trailer: Option<String>,
+    /// The block-4 field lines, framed at first body pull and drained one
+    /// record per `next_record`.
+    body_lines: std::collections::VecDeque<ParsedBlock4Line>,
+    /// `true` once the message-level `OpenLevel` has been queued, so the
+    /// matching `CloseLevel` is queued exactly once at end-of-stream.
+    level_open: bool,
+    /// Nested-envelope events queued during the most recent `next_record`,
+    /// drained by the driver via [`FormatReader::take_envelope_events`].
+    pending_events: Vec<EnvelopeEvent>,
+    done: bool,
+}
+
+impl<R: Read> SwiftReader<R> {
+    /// Build a reader over any `Read` source. Block framing and the
+    /// service-block pre-scan are deferred to the first read.
+    pub fn new(reader: R, config: SwiftReaderConfig) -> Self {
+        Self {
+            tokenizer: BlockTokenizer::new(BufReader::new(reader)),
+            schema: build_schema(),
+            max_fields: config.max_fields,
+            initialized: false,
+            basic_header: None,
+            app_header: None,
+            user_header: None,
+            trailer: None,
+            body_lines: std::collections::VecDeque::new(),
+            level_open: false,
+            pending_events: Vec::new(),
+            done: false,
+        }
+    }
+
+    /// Frame every block of the message once: stash the service blocks
+    /// (1/2/3/5) for envelope serving and split block 4 into its field lines
+    /// for streaming. A SWIFT message is bounded and small, so framing all
+    /// blocks up front holds only the (small) service-block bodies plus the
+    /// block-4 line list — not the whole input stream. Idempotent.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Swift`] on a malformed block (unbalanced brace,
+    /// bad id, missing `-}` trailer, malformed `:tag:value` line), a repeated
+    /// block id, or a block-4 line count past `max_fields`.
+    fn ensure_initialized(&mut self) -> Result<(), FormatError> {
+        if self.initialized {
+            return Ok(());
+        }
+        self.initialized = true;
+
+        while let Some(block) = self.tokenizer.read_block()? {
+            self.absorb_block(block)?;
+        }
+        Ok(())
+    }
+
+    /// Route one framed block to its service-block slot or split it into body
+    /// field lines. Rejects a repeated block id and a block-4 line count past
+    /// the configured ceiling.
+    fn absorb_block(&mut self, block: ParsedBlock) -> Result<(), FormatError> {
+        let ParsedBlock { id, body } = block;
+        match id {
+            1 => set_once(&mut self.basic_header, body, 1)?,
+            2 => set_once(&mut self.app_header, body, 2)?,
+            3 => set_once(&mut self.user_header, body, 3)?,
+            TEXT_BLOCK_ID => {
+                if !self.body_lines.is_empty() {
+                    return Err(FormatError::Swift(
+                        "a second SWIFT block 4 appeared; a message carries at most one \
+                         message-text block"
+                            .into(),
+                    ));
+                }
+                let lines = split_block4(&body)?;
+                if lines.len() > self.max_fields {
+                    return Err(FormatError::Swift(format!(
+                        "SWIFT message text carries {} fields, exceeding the configured \
+                         max_fields of {}; raise the source's `max_fields` option",
+                        lines.len(),
+                        self.max_fields
+                    )));
+                }
+                self.body_lines = lines.into();
+            }
+            5 => set_once(&mut self.trailer, body, 5)?,
+            other => {
+                return Err(FormatError::Swift(format!(
+                    "unsupported SWIFT block id {other}; expected one of 1, 2, 3, 4, 5"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Pull the next body record, queuing the message-level `OpenLevel`
+    /// before the first record and the matching `CloseLevel` once the body is
+    /// drained. Returns `None` at clean end of message.
+    fn pull_next(&mut self) -> Result<Option<Record>, FormatError> {
+        if !self.level_open {
+            // One message = one nested document level wrapping the block-4
+            // records. Open it once, before the first record (or, for a
+            // header-only message, immediately before the close) so the
+            // driver's document stack always balances.
+            self.pending_events.push(EnvelopeEvent::OpenLevel {
+                sections: IndexMap::new(),
+            });
+            self.level_open = true;
+        }
+        match self.body_lines.pop_front() {
+            Some(line) => Ok(Some(self.body_record(&line))),
+            None => {
+                self.pending_events.push(EnvelopeEvent::CloseLevel);
+                self.done = true;
+                Ok(None)
+            }
+        }
+    }
+
+    /// Map one block-4 field line to a `[block, tag, value]` record. `block`
+    /// is the constant `4` (the message-text block id), so downstream CXL can
+    /// distinguish body lines from any future block-keyed record shape.
+    fn body_record(&self, line: &ParsedBlock4Line) -> Record {
+        let values = vec![
+            Value::String(TEXT_BLOCK_ID.to_string().as_str().into()),
+            Value::String(line.tag.as_str().into()),
+            string_or_null(&line.value),
+        ];
+        Record::new(Arc::clone(&self.schema), values)
+    }
+
+    /// Build the file-level `$doc` sections from the captured service blocks,
+    /// honoring the source's declared section names where given and falling
+    /// back to the stable default labels otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Swift`] when a declared section's extract rule
+    /// is not a `segment` rule (an `xml_path`/`json_pointer` against a SWIFT
+    /// source) or names a block the message does not carry.
+    fn serve_sections(
+        &self,
+        config: &EnvelopeConfig,
+    ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
+        let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(config.sections.len());
+        for (name, section) in &config.sections {
+            let block_id = match &section.extract {
+                EnvelopeExtract::Segment(id) => id.as_str(),
+                EnvelopeExtract::XmlPath(_) | EnvelopeExtract::JsonPointer(_) => {
+                    return Err(FormatError::Swift(format!(
+                        "envelope section {name:?}: declared a non-`segment` extract against a \
+                         SWIFT source. Use `segment` with the block id (e.g. \
+                         `extract: {{ segment: \"1\" }}`) for SWIFT envelope sections."
+                    )));
+                }
+            };
+            let body = self.block_body_for(block_id).ok_or_else(|| {
+                FormatError::Swift(format!(
+                    "envelope section {name:?}: block {block_id:?} is not a service block this \
+                     message carries. Declare a section over block 1, 2, 3, or 5; block 4 is the \
+                     message-text body streamed as records."
+                ))
+            })?;
+            out.insert(Box::from(name.as_str()), block_section_value(body));
+        }
+        Ok(out)
+    }
+
+    /// Look up a service block's captured body by the user-facing id string,
+    /// accepting either the numeric id (`"1"`) or the default section label
+    /// (`"basic_header"`) so a `segment` extract can name a block either way.
+    fn block_body_for(&self, id: &str) -> Option<&str> {
+        match id {
+            "1" | DEFAULT_BASIC_HEADER_SECTION => self.basic_header.as_deref(),
+            "2" | DEFAULT_APP_HEADER_SECTION => self.app_header.as_deref(),
+            "3" | DEFAULT_USER_HEADER_SECTION => self.user_header.as_deref(),
+            "5" | DEFAULT_TRAILER_SECTION => self.trailer.as_deref(),
+            _ => None,
+        }
+    }
+}
+
+impl<R: Read + Send> FormatReader for SwiftReader<R> {
+    fn schema(&mut self) -> Result<Arc<Schema>, FormatError> {
+        Ok(Arc::clone(&self.schema))
+    }
+
+    fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
+        if self.done {
+            return Ok(None);
+        }
+        self.ensure_initialized()?;
+        self.pull_next()
+    }
+
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+
+    fn prepare_document(
+        &mut self,
+        config: &EnvelopeConfig,
+    ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
+        if config.is_empty() {
+            return Ok(IndexMap::new());
+        }
+        self.ensure_initialized()?;
+        self.serve_sections(config)
+    }
+}
+
+/// Set a service-block slot exactly once, rejecting a repeated block id (two
+/// `{1:...}` headers in one message, for instance).
+fn set_once(slot: &mut Option<String>, body: String, id: u8) -> Result<(), FormatError> {
+    if slot.is_some() {
+        return Err(FormatError::Swift(format!(
+            "a second SWIFT block {id} appeared; each service block occurs at most once per \
+             message"
+        )));
+    }
+    *slot = Some(body);
+    Ok(())
+}
+
+/// Wrap a service block's verbatim body in a single-field `$doc` section map
+/// under the [`BODY_FIELD`] key. SWIFT service blocks carry free-form text
+/// (a header string, nested `{sub:tag}` blocks), so the whole body is one
+/// addressable field rather than positional elements.
+fn block_section_value(body: &str) -> Value {
+    let mut fields: IndexMap<Box<str>, Value> = IndexMap::with_capacity(1);
+    fields.insert(Box::from(BODY_FIELD), string_or_null(body));
+    Value::Map(Box::new(fields))
+}
+
+/// Build the static `[block, tag, value]` schema. All columns are
+/// string-typed; tag and value text is stored verbatim so the round-trip is
+/// lossless.
+fn build_schema() -> Arc<Schema> {
+    let columns: Vec<Box<str>> = vec![Box::from("block"), Box::from("tag"), Box::from("value")];
+    Arc::new(Schema::new(columns))
+}
+
+/// Map a string to a `Value`: empty text becomes `Null` so an absent or blank
+/// value is uniformly null at the schema slot.
+fn string_or_null(s: &str) -> Value {
+    if s.is_empty() {
+        Value::Null
+    } else {
+        Value::String(s.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope::EnvelopeSection;
+    use std::io::Cursor;
+
+    /// A minimal single-customer-credit-transfer MT103 with all five blocks.
+    const MT103: &str = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}\
+        {3:{108:MSGREF12345}}\
+        {4:\r\n:20:REFERENCE12345\r\n:23B:CRED\r\n:32A:240101USD1000,00\r\n\
+        :59:/98765432\r\nJANE SMITH\r\n-}\
+        {5:{CHK:1234567890AB}}";
+
+    fn reader(data: &str) -> SwiftReader<Cursor<Vec<u8>>> {
+        SwiftReader::new(
+            Cursor::new(data.as_bytes().to_vec()),
+            SwiftReaderConfig::default(),
+        )
+    }
+
+    fn collect(data: &str) -> Vec<Record> {
+        let mut r = reader(data);
+        let mut out = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            out.push(rec);
+        }
+        out
+    }
+
+    #[test]
+    fn one_record_per_block4_tag_line() {
+        let recs = collect(MT103);
+        // :20:, :23B:, :32A:, :59: are the four block-4 fields.
+        assert_eq!(recs.len(), 4);
+        assert_eq!(recs[0].get("tag"), Some(&Value::String("20".into())));
+        assert_eq!(
+            recs[0].get("value"),
+            Some(&Value::String("REFERENCE12345".into()))
+        );
+        assert_eq!(recs[2].get("tag"), Some(&Value::String("32A".into())));
+        assert_eq!(
+            recs[2].get("value"),
+            Some(&Value::String("240101USD1000,00".into()))
+        );
+    }
+
+    #[test]
+    fn block_column_stamped_with_text_block_id() {
+        let recs = collect(MT103);
+        for rec in &recs {
+            assert_eq!(rec.get("block"), Some(&Value::String("4".into())));
+        }
+    }
+
+    #[test]
+    fn service_blocks_never_emitted_as_records() {
+        let recs = collect(MT103);
+        // Only block-4 tags appear; no header/trailer text.
+        for rec in &recs {
+            let tag = rec.get("tag").unwrap();
+            assert!(matches!(tag, Value::String(s) if !s.contains("F01")));
+        }
+    }
+
+    #[test]
+    fn multiline_continuation_value_folds() {
+        let recs = collect(MT103);
+        let f59 = recs
+            .iter()
+            .find(|r| matches!(r.get("tag"), Some(Value::String(s)) if &**s == "59"));
+        let f59 = f59.unwrap();
+        assert_eq!(
+            f59.get("value"),
+            Some(&Value::String("/98765432\nJANE SMITH".into()))
+        );
+    }
+
+    #[test]
+    fn balanced_open_close_for_message() {
+        let mut r = reader(MT103);
+        let mut opens = 0;
+        let mut closes = 0;
+        loop {
+            let more = r.next_record().unwrap().is_some();
+            for ev in r.take_envelope_events() {
+                match ev {
+                    EnvelopeEvent::OpenLevel { .. } => opens += 1,
+                    EnvelopeEvent::CloseLevel => closes += 1,
+                }
+            }
+            if !more {
+                break;
+            }
+        }
+        assert_eq!(opens, 1, "one message-level OpenLevel");
+        assert_eq!(closes, 1, "one matching CloseLevel");
+    }
+
+    #[test]
+    fn header_only_message_still_balances() {
+        // No block 4 at all — a header/trailer-only message must still emit a
+        // balanced OpenLevel/CloseLevel pair with no records between.
+        let data = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}{5:{CHK:ABC}}";
+        let mut r = reader(data);
+        assert!(r.next_record().unwrap().is_none(), "no body records");
+        let events = r.take_envelope_events();
+        let opens = events
+            .iter()
+            .filter(|e| matches!(e, EnvelopeEvent::OpenLevel { .. }))
+            .count();
+        let closes = events
+            .iter()
+            .filter(|e| matches!(e, EnvelopeEvent::CloseLevel))
+            .count();
+        assert_eq!(opens, 1);
+        assert_eq!(closes, 1);
+    }
+
+    #[test]
+    fn prepare_document_serves_service_blocks_by_block_id() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "basic".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("1".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        cfg.sections.insert(
+            "user".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("3".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(MT103);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let basic = match sections.get("basic").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        assert_eq!(
+            basic.get("body"),
+            Some(&Value::String("F01BANKBEBBAXXX0000000000".into()))
+        );
+        let user = match sections.get("user").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        // Block 3 keeps its nested sub-block verbatim in the body field.
+        assert_eq!(
+            user.get("body"),
+            Some(&Value::String("{108:MSGREF12345}".into()))
+        );
+        // The body still streams after the pre-scan.
+        let recs: Vec<_> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(recs.len(), 4);
+    }
+
+    #[test]
+    fn prepare_document_accepts_default_section_label_id() {
+        // A `segment: "trailer"` extract resolves block 5 by its default
+        // label, not just its numeric id.
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "tlr".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("trailer".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(MT103);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let tlr = match sections.get("tlr").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        assert_eq!(
+            tlr.get("body"),
+            Some(&Value::String("{CHK:1234567890AB}".into()))
+        );
+    }
+
+    #[test]
+    fn prepare_document_rejects_block4_section() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "bad".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::Segment("4".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(MT103);
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("not a service block")));
+    }
+
+    #[test]
+    fn prepare_document_rejects_xml_path_extract() {
+        let mut cfg = EnvelopeConfig::default();
+        cfg.sections.insert(
+            "bad".to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::XmlPath("/doc".to_string()),
+                fields: IndexMap::new(),
+            },
+        );
+        let mut r = reader(MT103);
+        let err = r.prepare_document(&cfg).unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("non-`segment`")));
+    }
+
+    #[test]
+    fn unbalanced_brace_errors_cleanly() {
+        // Block 2 never closes; the framer surfaces a truncation error rather
+        // than panicking.
+        let data = "{1:F01X}{2:I103BANKDEFFXXXXN";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected a truncation error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("truncated")));
+    }
+
+    #[test]
+    fn missing_block4_trailer_errors_cleanly() {
+        let data = "{1:F01X}{4:\r\n:20:REF\r\n";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected a truncation error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("truncated")));
+    }
+
+    #[test]
+    fn repeated_block_id_errors() {
+        let data = "{1:F01X}{1:F01Y}{4:\r\n:20:REF\r\n-}";
+        let mut r = reader(data);
+        let err = loop {
+            match r.next_record() {
+                Ok(Some(_)) => continue,
+                Ok(None) => panic!("expected a repeated-block error"),
+                Err(e) => break e,
+            }
+        };
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("second SWIFT block 1")));
+    }
+
+    /// An MT940 statement carries repeated `:61:` / `:86:` block-4 tags — one
+    /// record per statement line. The reader streams every repeat in order.
+    #[test]
+    fn mt940_repeated_tags_stream_as_records() {
+        let mt940 = "{1:F01BANKBEBBAXXX0000000000}{2:I940BANKDEFFXXXXN}\
+            {4:\r\n:20:STMT001\r\n:25:12345678\r\n:28C:1/1\r\n\
+            :60F:C240101USD5000,00\r\n\
+            :61:2401010101D100,00NTRFREF1//BANK1\r\n:86:PAYMENT ONE\r\n\
+            :61:2401020102C200,00NTRFREF2//BANK2\r\n:86:PAYMENT TWO\r\n\
+            :62F:C240102USD5100,00\r\n-}";
+        let recs = collect(mt940);
+        let tags: Vec<String> = recs
+            .iter()
+            .filter_map(|r| match r.get("tag") {
+                Some(Value::String(s)) => Some(s.to_string()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            tags,
+            vec!["20", "25", "28C", "60F", "61", "86", "61", "86", "62F"]
+        );
+        // Both :61: lines stream with their distinct values.
+        let sixty_ones: Vec<&Record> = recs
+            .iter()
+            .filter(|r| matches!(r.get("tag"), Some(Value::String(s)) if &**s == "61"))
+            .collect();
+        assert_eq!(sixty_ones.len(), 2);
+        assert_eq!(
+            sixty_ones[0].get("value"),
+            Some(&Value::String("2401010101D100,00NTRFREF1//BANK1".into()))
+        );
+        assert_eq!(
+            sixty_ones[1].get("value"),
+            Some(&Value::String("2401020102C200,00NTRFREF2//BANK2".into()))
+        );
+    }
+}

--- a/crates/clinker-format/src/swift/reader.rs
+++ b/crates/clinker-format/src/swift/reader.rs
@@ -99,9 +99,15 @@ pub struct SwiftReader<R: Read> {
     /// The block-4 field lines, framed at first body pull and drained one
     /// record per `next_record`.
     body_lines: std::collections::VecDeque<ParsedBlock4Line>,
-    /// `true` once the message-level `OpenLevel` has been queued, so the
-    /// matching `CloseLevel` is queued exactly once at end-of-stream.
+    /// `true` once the message-level `OpenLevel` has been queued.
     level_open: bool,
+    /// `true` once the matching `CloseLevel` has been queued, so it is queued
+    /// exactly once — on the final record-bearing pull (the moment the body
+    /// is known drained), not the trailing `Ok(None)` pull. Queuing it with
+    /// the last record means a multi-file wrapper forwards the precise close
+    /// before it advances to the next file, rather than relying on the
+    /// driver's file-boundary stack sweep.
+    level_closed: bool,
     /// Nested-envelope events queued during the most recent `next_record`,
     /// drained by the driver via [`FormatReader::take_envelope_events`].
     pending_events: Vec<EnvelopeEvent>,
@@ -123,6 +129,7 @@ impl<R: Read> SwiftReader<R> {
             trailer: None,
             body_lines: std::collections::VecDeque::new(),
             level_open: false,
+            level_closed: false,
             pending_events: Vec::new(),
             done: false,
         }
@@ -190,8 +197,8 @@ impl<R: Read> SwiftReader<R> {
     }
 
     /// Pull the next body record, queuing the message-level `OpenLevel`
-    /// before the first record and the matching `CloseLevel` once the body is
-    /// drained. Returns `None` at clean end of message.
+    /// before the first record and the matching `CloseLevel` the moment the
+    /// body is known drained. Returns `None` at clean end of message.
     fn pull_next(&mut self) -> Result<Option<Record>, FormatError> {
         if !self.level_open {
             // One message = one nested document level wrapping the block-4
@@ -203,14 +210,24 @@ impl<R: Read> SwiftReader<R> {
             });
             self.level_open = true;
         }
-        match self.body_lines.pop_front() {
-            Some(line) => Ok(Some(self.body_record(&line))),
-            None => {
-                self.pending_events.push(EnvelopeEvent::CloseLevel);
-                self.done = true;
-                Ok(None)
-            }
+        let record = self
+            .body_lines
+            .pop_front()
+            .map(|line| self.body_record(&line));
+        // Close the level the instant the body is drained — on the final
+        // record-bearing pull (`body_lines` now empty) for a message with a
+        // body, or immediately for a header-only message. Queuing the
+        // `CloseLevel` with the last record (rather than on the trailing
+        // `Ok(None)` pull) means a multi-file source forwards the precise
+        // close before the wrapper advances to the next file.
+        if !self.level_closed && self.body_lines.is_empty() {
+            self.pending_events.push(EnvelopeEvent::CloseLevel);
+            self.level_closed = true;
         }
+        if record.is_none() {
+            self.done = true;
+        }
+        Ok(record)
     }
 
     /// Map one block-4 field line to a `[block, tag, value]` record. `block`

--- a/crates/clinker-format/src/swift/tokenizer.rs
+++ b/crates/clinker-format/src/swift/tokenizer.rs
@@ -1,0 +1,466 @@
+//! SWIFT MT block framer and block-4 tag-line splitter.
+//!
+//! A SWIFT MT message is a sequence of brace-balanced blocks
+//! `{1:...}{2:...}{3:...}{4:...-}{5:...}`. Each top-level block opens with
+//! `{`, carries a numeric block id and a colon, then a body, and closes with
+//! the matching `}`. The body of blocks 3 and 5 may itself contain nested
+//! `{tag:value}` sub-blocks (e.g. `{3:{108:REF}}`), so the framer tracks
+//! brace depth rather than scanning for the first `}`. Block 4 — the message
+//! text block — is special: its body is a run of `:tag:value` lines and it is
+//! closed by the literal `-}` trailer rather than a bare brace.
+//!
+//! Unlike the flat EDI tokenizers (HL7/X12/EDIFACT) this framing is not
+//! terminator-delimited, so the block framer is hand-rolled on brace depth.
+//! Only the block-4 tag-line layer resembles a terminator scan: it splits the
+//! block-4 body into [`ParsedBlock4Line`] entries on the `\r\n` / `\n` line
+//! breaks that separate `:tag:value` lines.
+//!
+//! Structural separators (braces, the leading `:`, the `-}` trailer, the line
+//! breaks) are kept out of the stored field values so a record carries clean
+//! tag/value data; the writer re-frames them, keeping the reader → writer →
+//! reader round-trip byte-faithful.
+//!
+//! Memory model: the framer reads one top-level block at a time into a
+//! bounded scratch buffer. A hard per-block byte cap turns an unbalanced or
+//! missing-brace stream (truncated / corrupt input) into an error rather than
+//! letting the buffer grow without limit.
+
+use std::io::BufRead;
+
+use crate::error::FormatError;
+
+/// Hard ceiling on a single top-level block's raw byte length. A real SWIFT
+/// block 4 (the largest) is well under a few hundred kilobytes; this cap
+/// exists only so a stream with an unbalanced brace fails fast instead of
+/// buffering the whole input into one "block".
+pub(crate) const MAX_BLOCK_BYTES: usize = 1024 * 1024;
+
+/// The SWIFT block-4 trailer. Block 4 carries free `:tag:value` text whose
+/// values may include a bare `}`, so it is closed by this two-byte sequence
+/// rather than a single brace.
+const BLOCK4_TRAILER: &[u8] = b"-}";
+
+/// The numeric id of the message-text block (block 4), the only block whose
+/// body is split into per-line records.
+pub(crate) const TEXT_BLOCK_ID: u8 = 4;
+
+/// One top-level SWIFT block: its numeric id and its raw body text.
+///
+/// `body` is the content between the `{n:` header and the closing `}` (or the
+/// `-}` trailer for block 4), with the structural braces and the `-}` trailer
+/// stripped but every interior byte — including the nested `{tag:value}`
+/// sub-blocks of blocks 3 and 5 — kept verbatim. The block-4 body still
+/// carries its `:tag:value` line structure, which [`split_block4`] resolves.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedBlock {
+    /// The numeric block id (`1`, `2`, `3`, `4`, `5`).
+    pub id: u8,
+    /// The block body with the framing braces / `-}` trailer removed.
+    pub body: String,
+}
+
+/// One `:tag:value` line of a block-4 message-text body.
+///
+/// `tag` is the SWIFT field tag without its surrounding colons (`20`, `32A`,
+/// `61`); `value` is the field text, with any continuation lines that do not
+/// begin a new `:tag:` joined back in verbatim (multi-line `:86:` narrative,
+/// for instance, keeps its embedded line breaks). The writer re-frames the
+/// `:tag:value\r\n` wire shape from these, so the round-trip is byte-faithful.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ParsedBlock4Line {
+    /// The field tag without its surrounding colons.
+    pub tag: String,
+    /// The field value, continuation lines folded in verbatim.
+    pub value: String,
+}
+
+/// Streaming SWIFT MT block framer.
+///
+/// Wraps a buffered source and yields one top-level [`ParsedBlock`] at a time
+/// by tracking brace depth (and the block-4 `-}` trailer). The whole message
+/// is never buffered — only the block currently being framed.
+pub(crate) struct BlockTokenizer<R: BufRead> {
+    reader: R,
+}
+
+impl<R: BufRead> BlockTokenizer<R> {
+    /// Build a tokenizer over a buffered source.
+    pub(crate) fn new(reader: R) -> Self {
+        Self { reader }
+    }
+
+    /// Read the next top-level block, or `None` at a clean end of stream.
+    ///
+    /// Inter-block whitespace (`\r`/`\n`/spaces producers add for
+    /// readability) is skipped before the opening `{`. The block id is the
+    /// digit run between `{` and the first `:`; the body is the brace-balanced
+    /// (or `-}`-terminated, for block 4) content that follows.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Swift`] when the next non-whitespace byte is not
+    /// an opening brace, the block id is missing or non-numeric, the body
+    /// exceeds [`MAX_BLOCK_BYTES`] without closing, or the stream ends before
+    /// the block's closing brace / `-}` trailer (an unbalanced or truncated
+    /// message).
+    pub(crate) fn read_block(&mut self) -> Result<Option<ParsedBlock>, FormatError> {
+        if !self.skip_inter_block_whitespace()? {
+            return Ok(None);
+        }
+        let raw = self.read_balanced_block()?;
+        parse_block(&raw)
+    }
+
+    /// Consume inter-block whitespace up to the next byte that could open a
+    /// block. Returns `false` at a clean end of stream (no further block),
+    /// `true` when a non-whitespace byte is waiting.
+    fn skip_inter_block_whitespace(&mut self) -> Result<bool, FormatError> {
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                return Ok(false);
+            }
+            let consumed = buf
+                .iter()
+                .take_while(|&&b| b == b'\r' || b == b'\n' || b == b' ' || b == b'\t')
+                .count();
+            if consumed == 0 {
+                // A non-whitespace byte is at the front of the buffer.
+                return Ok(true);
+            }
+            self.reader.consume(consumed);
+        }
+    }
+
+    /// Read one top-level block's raw bytes including the framing braces.
+    ///
+    /// The first byte must be `{`. Brace depth tracks nested sub-blocks; the
+    /// block closes when depth returns to zero on a `}`. Block 4 is detected
+    /// by its `{4:` header and instead closes on the `-}` trailer at depth 1,
+    /// because its free `:tag:value` text may carry a bare `}` that is data,
+    /// not a frame.
+    fn read_balanced_block(&mut self) -> Result<Vec<u8>, FormatError> {
+        let mut raw: Vec<u8> = Vec::new();
+        let mut depth: usize = 0;
+        let mut is_text_block = false;
+        let mut header_seen = false;
+
+        loop {
+            let buf = self.reader.fill_buf()?;
+            if buf.is_empty() {
+                return Err(FormatError::Swift(format!(
+                    "SWIFT block truncated: reached end of input before the block's closing \
+                     brace (read {} bytes, brace depth {depth})",
+                    raw.len()
+                )));
+            }
+            let mut consumed = 0;
+            let mut finished = false;
+            for &b in buf {
+                consumed += 1;
+                raw.push(b);
+
+                if !header_seen {
+                    if raw.len() == 1 && b != b'{' {
+                        return Err(FormatError::Swift(format!(
+                            "SWIFT message must begin with an opening brace '{{', found {:?}",
+                            b as char
+                        )));
+                    }
+                    if b == b':' {
+                        // The `{4:` header marks the message-text block, whose
+                        // free-text body is closed by the `-}` trailer.
+                        is_text_block = raw.starts_with(b"{4:");
+                        header_seen = true;
+                    }
+                }
+
+                match b {
+                    b'{' => depth += 1,
+                    // The message-text block closes only on the `-}` trailer
+                    // (a bare `}` there is free-text data); every other block
+                    // closes on a bare `}`. In both cases the opening `{`
+                    // counted, so the close drops depth toward zero.
+                    b'}' if !is_text_block || raw.ends_with(BLOCK4_TRAILER) => {
+                        depth -= 1;
+                        if depth == 0 {
+                            finished = true;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            self.reader.consume(consumed);
+
+            if raw.len() > MAX_BLOCK_BYTES {
+                return Err(FormatError::Swift(format!(
+                    "SWIFT block exceeded the {MAX_BLOCK_BYTES}-byte cap without a closing \
+                     brace; the message is malformed or has an unbalanced brace"
+                )));
+            }
+            if finished {
+                return Ok(raw);
+            }
+        }
+    }
+}
+
+/// Parse one raw top-level block (`{n:body}` or `{4:body-}`) into its id and
+/// body, stripping the framing braces and the block-4 `-}` trailer.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Swift`] when the block is not brace-framed, has no
+/// `:` after the id, or carries a missing/non-numeric/out-of-range block id.
+fn parse_block(raw: &[u8]) -> Result<Option<ParsedBlock>, FormatError> {
+    if raw.first() != Some(&b'{') || raw.last() != Some(&b'}') {
+        return Err(FormatError::Swift(
+            "SWIFT block is not enclosed in braces; expected '{n:...}'".into(),
+        ));
+    }
+    let inner = &raw[1..raw.len() - 1];
+    let colon = inner.iter().position(|&b| b == b':').ok_or_else(|| {
+        FormatError::Swift("SWIFT block has no ':' after the block id; expected '{n:...}'".into())
+    })?;
+    let id_bytes = &inner[..colon];
+    if id_bytes.is_empty() || !id_bytes.iter().all(u8::is_ascii_digit) {
+        return Err(FormatError::Swift(format!(
+            "SWIFT block id {:?} is not a number; expected a numeric block id (1-5)",
+            String::from_utf8_lossy(id_bytes)
+        )));
+    }
+    let id: u8 = std::str::from_utf8(id_bytes)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| {
+            FormatError::Swift(format!(
+                "SWIFT block id {:?} is out of range; expected 1-5",
+                String::from_utf8_lossy(id_bytes)
+            ))
+        })?;
+    let mut body_bytes = &inner[colon + 1..];
+    // Block 4's body keeps its `:tag:value` lines but loses the `-}` trailer.
+    if id == TEXT_BLOCK_ID && body_bytes.ends_with(b"-") {
+        body_bytes = &body_bytes[..body_bytes.len() - 1];
+    }
+    let body = String::from_utf8(body_bytes.to_vec()).map_err(|e| {
+        FormatError::Swift(format!(
+            "SWIFT block {id} body is not valid UTF-8: {e}. Non-UTF-8 SWIFT messages are not \
+             supported"
+        ))
+    })?;
+    Ok(Some(ParsedBlock { id, body }))
+}
+
+/// Split a block-4 body into its `:tag:value` lines.
+///
+/// Each line of the form `:tag:value` begins a new field; a line that does
+/// not begin with `:` is a continuation of the current field's value and is
+/// folded back in verbatim (its leading line break preserved) so multi-line
+/// narrative fields round-trip. Leading/trailing line breaks framing the
+/// block body are insignificant and dropped.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Swift`] when a `:tag:` opener has no second colon
+/// closing the tag, or carries an empty tag — a malformed message-text line.
+pub(crate) fn split_block4(body: &str) -> Result<Vec<ParsedBlock4Line>, FormatError> {
+    let mut lines: Vec<ParsedBlock4Line> = Vec::new();
+    // Split on line breaks; a `:tag:value` line opens a field, a non-`:` line
+    // continues the current field's value. The line breaks that bracket the
+    // block body (the `\r\n` after the `{4:` opener and before the `-}`
+    // trailer) and any blank lines between fields are insignificant framing,
+    // so an empty segment is skipped rather than folded — folding it would
+    // append a spurious trailing newline to the preceding field's value.
+    for segment in body.split('\n') {
+        let segment = segment.strip_suffix('\r').unwrap_or(segment);
+        if segment.is_empty() {
+            continue;
+        }
+        if let Some(rest) = segment.strip_prefix(':') {
+            let tag_end = rest.find(':').ok_or_else(|| {
+                FormatError::Swift(format!(
+                    "SWIFT block-4 line {segment:?} has no ':' closing the field tag; expected \
+                     ':tag:value'"
+                ))
+            })?;
+            let tag = &rest[..tag_end];
+            if tag.is_empty() {
+                return Err(FormatError::Swift(format!(
+                    "SWIFT block-4 line {segment:?} has an empty field tag; expected ':tag:value'"
+                )));
+            }
+            let value = &rest[tag_end + 1..];
+            lines.push(ParsedBlock4Line {
+                tag: tag.to_string(),
+                value: value.to_string(),
+            });
+        } else if let Some(last) = lines.last_mut() {
+            // A continuation line of the current field's value. Re-join the
+            // line break the split removed so the value is byte-faithful.
+            last.value.push('\n');
+            last.value.push_str(segment);
+        } else {
+            return Err(FormatError::Swift(format!(
+                "SWIFT block-4 body opens with a continuation line {segment:?} before any \
+                 ':tag:value' field"
+            )));
+        }
+    }
+    Ok(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::BufReader;
+    use std::io::Cursor;
+
+    /// A minimal single-customer-credit-transfer MT103: basic header,
+    /// application header, user header with a nested service-id sub-block, the
+    /// message text block, and a trailer block.
+    const MT103: &str = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}\
+        {3:{108:MSGREF12345}}\
+        {4:\r\n:20:REFERENCE12345\r\n:23B:CRED\r\n:32A:240101USD1000,00\r\n\
+        :50K:/12345678\r\nJOHN DOE\r\n:59:/98765432\r\nJANE SMITH\r\n-}\
+        {5:{CHK:1234567890AB}}";
+
+    fn tok(data: &str) -> BlockTokenizer<BufReader<Cursor<Vec<u8>>>> {
+        BlockTokenizer::new(BufReader::new(Cursor::new(data.as_bytes().to_vec())))
+    }
+
+    fn collect_blocks(data: &str) -> Vec<ParsedBlock> {
+        let mut t = tok(data);
+        let mut out = Vec::new();
+        while let Some(block) = t.read_block().unwrap() {
+            out.push(block);
+        }
+        out
+    }
+
+    #[test]
+    fn frames_all_five_blocks_of_an_mt103() {
+        let blocks = collect_blocks(MT103);
+        let ids: Vec<u8> = blocks.iter().map(|b| b.id).collect();
+        assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+        assert_eq!(blocks[0].body, "F01BANKBEBBAXXX0000000000");
+        assert_eq!(blocks[1].body, "I103BANKDEFFXXXXN");
+    }
+
+    #[test]
+    fn nested_subblock_in_block3_stays_intact() {
+        let blocks = collect_blocks(MT103);
+        // Block 3 keeps its nested {108:...} sub-block verbatim.
+        assert_eq!(blocks[2].id, 3);
+        assert_eq!(blocks[2].body, "{108:MSGREF12345}");
+    }
+
+    #[test]
+    fn nested_subblock_in_block5_stays_intact() {
+        let blocks = collect_blocks(MT103);
+        assert_eq!(blocks[4].id, 5);
+        assert_eq!(blocks[4].body, "{CHK:1234567890AB}");
+    }
+
+    #[test]
+    fn block4_terminated_by_dash_brace_not_bare_brace() {
+        let blocks = collect_blocks(MT103);
+        let block4 = &blocks[3];
+        assert_eq!(block4.id, 4);
+        // The `-}` trailer is stripped; the `:tag:value` lines remain.
+        assert!(block4.body.contains(":20:REFERENCE12345"));
+        assert!(!block4.body.contains("-}"));
+    }
+
+    #[test]
+    fn block4_split_yields_one_line_per_tag() {
+        let blocks = collect_blocks(MT103);
+        let lines = split_block4(&blocks[3].body).unwrap();
+        let tags: Vec<&str> = lines.iter().map(|l| l.tag.as_str()).collect();
+        assert_eq!(tags, vec!["20", "23B", "32A", "50K", "59"]);
+        assert_eq!(lines[0].value, "REFERENCE12345");
+        assert_eq!(lines[2].value, "240101USD1000,00");
+    }
+
+    #[test]
+    fn block4_folds_multiline_continuation_values() {
+        let blocks = collect_blocks(MT103);
+        let lines = split_block4(&blocks[3].body).unwrap();
+        // :50K: carries an account line then a name continuation line.
+        let f50k = lines.iter().find(|l| l.tag == "50K").unwrap();
+        assert_eq!(f50k.value, "/12345678\nJOHN DOE");
+        let f59 = lines.iter().find(|l| l.tag == "59").unwrap();
+        assert_eq!(f59.value, "/98765432\nJANE SMITH");
+    }
+
+    #[test]
+    fn missing_trailing_newline_still_frames() {
+        // No trailing whitespace after the final block.
+        let data = "{1:F01X}{4:\r\n:20:REF\r\n-}";
+        let blocks = collect_blocks(data);
+        assert_eq!(blocks.len(), 2);
+        let lines = split_block4(&blocks[1].body).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].tag, "20");
+        assert_eq!(lines[0].value, "REF");
+    }
+
+    #[test]
+    fn truncated_open_brace_errors() {
+        let data = "{1:F01X}{2:I103";
+        let mut t = tok(data);
+        let _ = t.read_block().unwrap(); // block 1
+        let err = t.read_block().unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("truncated")));
+    }
+
+    #[test]
+    fn missing_block4_trailer_errors() {
+        // Block 4 with no `-}` trailer runs to EOF unbalanced.
+        let data = "{1:F01X}{4:\r\n:20:REF\r\n";
+        let mut t = tok(data);
+        let _ = t.read_block().unwrap();
+        let err = t.read_block().unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("truncated")));
+    }
+
+    #[test]
+    fn non_brace_start_errors() {
+        let data = "garbage";
+        let mut t = tok(data);
+        let err = t.read_block().unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("opening brace")));
+    }
+
+    #[test]
+    fn non_numeric_block_id_errors() {
+        let data = "{X:body}";
+        let mut t = tok(data);
+        let err = t.read_block().unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("not a number")));
+    }
+
+    #[test]
+    fn block4_bare_brace_in_value_is_data_not_a_close() {
+        // A `}` inside block-4 free text must not close the block early; only
+        // `-}` does. Here a value carries a literal `}`.
+        let data = "{4:\r\n:20:REF}WITHBRACE\r\n-}";
+        let blocks = collect_blocks(data);
+        assert_eq!(blocks.len(), 1);
+        let lines = split_block4(&blocks[0].body).unwrap();
+        assert_eq!(lines[0].value, "REF}WITHBRACE");
+    }
+
+    #[test]
+    fn block4_line_without_closing_tag_colon_errors() {
+        let err = split_block4(":20").unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("closing the field tag")));
+    }
+
+    #[test]
+    fn block4_empty_tag_errors() {
+        let err = split_block4("::value").unwrap_err();
+        assert!(matches!(err, FormatError::Swift(m) if m.contains("empty field tag")));
+    }
+}

--- a/crates/clinker-format/src/swift/tokenizer.rs
+++ b/crates/clinker-format/src/swift/tokenizer.rs
@@ -134,11 +134,16 @@ impl<R: BufRead> BlockTokenizer<R> {
 
     /// Read one top-level block's raw bytes including the framing braces.
     ///
-    /// The first byte must be `{`. Brace depth tracks nested sub-blocks; the
-    /// block closes when depth returns to zero on a `}`. Block 4 is detected
-    /// by its `{4:` header and instead closes on the `-}` trailer at depth 1,
-    /// because its free `:tag:value` text may carry a bare `}` that is data,
-    /// not a frame.
+    /// The first byte must be `{`. A non-text block (1/2/3/5) closes on the
+    /// brace that returns depth to zero, so its nested `{tag:value}`
+    /// sub-blocks are tracked by depth. The message-text block (`{4:`) is
+    /// different: its body is opaque line-structured free text — a SWIFT
+    /// field value (a `:77E:` envelope, a `:79:` narrative, an `:86:`
+    /// information line) legitimately carries `{`, `}`, and even `-}` as
+    /// data. So once the `{4:` header is seen, brace counting stops entirely
+    /// and the block closes only on a line-anchored `-}` trailer: a `-}` that
+    /// begins a line (preceded by `\r\n`/`\n`, or at the very start of the
+    /// body). Every interior `{`/`}`/non-anchored `-}` byte is data.
     fn read_balanced_block(&mut self) -> Result<Vec<u8>, FormatError> {
         let mut raw: Vec<u8> = Vec::new();
         let mut depth: usize = 0;
@@ -169,19 +174,29 @@ impl<R: BufRead> BlockTokenizer<R> {
                     }
                     if b == b':' {
                         // The `{4:` header marks the message-text block, whose
-                        // free-text body is closed by the `-}` trailer.
+                        // free-text body is opaque from here on.
                         is_text_block = raw.starts_with(b"{4:");
                         header_seen = true;
+                        // Block 4's opening `{` is the only structural brace;
+                        // it counted toward depth, and the line-anchored `-}`
+                        // trailer is what closes it.
+                        continue;
                     }
+                }
+
+                if is_text_block {
+                    // Opaque free text: close only on a line-anchored `-}`
+                    // trailer. Interior braces and non-anchored `-}` are data.
+                    if b == b'}' && ends_with_line_anchored_trailer(&raw) {
+                        finished = true;
+                        break;
+                    }
+                    continue;
                 }
 
                 match b {
                     b'{' => depth += 1,
-                    // The message-text block closes only on the `-}` trailer
-                    // (a bare `}` there is free-text data); every other block
-                    // closes on a bare `}`. In both cases the opening `{`
-                    // counted, so the close drops depth toward zero.
-                    b'}' if !is_text_block || raw.ends_with(BLOCK4_TRAILER) => {
+                    b'}' => {
                         depth -= 1;
                         if depth == 0 {
                             finished = true;
@@ -204,6 +219,30 @@ impl<R: BufRead> BlockTokenizer<R> {
             }
         }
     }
+}
+
+/// Whether the accumulated block-4 bytes end in a line-anchored `-}` trailer:
+/// a `-}` that begins a line. The trailer is line-anchored when the byte
+/// immediately before the `-` is a line break (`\n` after a CRLF, or a lone
+/// `\r`) or the `-}` sits at the very start of the block body (right after
+/// the `{4:` header — an empty message-text block). A `-}` mid-line
+/// (e.g. `:79:SEE-}NOTE`) is data, not a frame boundary, so it is not
+/// anchored.
+fn ends_with_line_anchored_trailer(raw: &[u8]) -> bool {
+    let Some(before_trailer) = raw.len().checked_sub(BLOCK4_TRAILER.len()) else {
+        return false;
+    };
+    if &raw[before_trailer..] != BLOCK4_TRAILER {
+        return false;
+    }
+    // The trailer begins its own line when the byte before the `-` is a line
+    // break, or the `-}` sits at the body start (right after the three-byte
+    // `{4:` header — an empty message-text block).
+    const HEADER_LEN: usize = "{4:".len();
+    if before_trailer == HEADER_LEN {
+        return true;
+    }
+    matches!(raw.get(before_trailer - 1), Some(b'\n') | Some(b'\r'))
 }
 
 /// Parse one raw top-level block (`{n:body}` or `{4:body-}`) into its id and
@@ -255,29 +294,32 @@ fn parse_block(raw: &[u8]) -> Result<Option<ParsedBlock>, FormatError> {
 
 /// Split a block-4 body into its `:tag:value` lines.
 ///
-/// Each line of the form `:tag:value` begins a new field; a line that does
-/// not begin with `:` is a continuation of the current field's value and is
-/// folded back in verbatim (its leading line break preserved) so multi-line
-/// narrative fields round-trip. Leading/trailing line breaks framing the
-/// block body are insignificant and dropped.
+/// Each line of the form `:tag:value` begins a new field; any line that does
+/// not begin with `:` continues the current field's value, **including a
+/// blank line** — a blank line inside a multi-line narrative (`:77E:`,
+/// `:79:`) is part of the value and is folded in verbatim so the
+/// read → write → read round-trip is byte-faithful. The single line break
+/// that frames the body (the `\r\n` between the last field and the `-}`
+/// trailer) is structural and dropped; leading blank lines before the first
+/// field are likewise insignificant framing.
 ///
 /// # Errors
 ///
 /// Returns [`FormatError::Swift`] when a `:tag:` opener has no second colon
 /// closing the tag, or carries an empty tag — a malformed message-text line.
 pub(crate) fn split_block4(body: &str) -> Result<Vec<ParsedBlock4Line>, FormatError> {
+    // The body ends with the structural line break that precedes the `-}`
+    // trailer. Drop exactly that one break so its trailing empty segment is
+    // not folded as a spurious blank continuation onto the final field; an
+    // interior blank line inside a field still survives the split below.
+    let body = body
+        .strip_suffix('\n')
+        .map(|b| b.strip_suffix('\r').unwrap_or(b))
+        .unwrap_or(body);
+
     let mut lines: Vec<ParsedBlock4Line> = Vec::new();
-    // Split on line breaks; a `:tag:value` line opens a field, a non-`:` line
-    // continues the current field's value. The line breaks that bracket the
-    // block body (the `\r\n` after the `{4:` opener and before the `-}`
-    // trailer) and any blank lines between fields are insignificant framing,
-    // so an empty segment is skipped rather than folded — folding it would
-    // append a spurious trailing newline to the preceding field's value.
     for segment in body.split('\n') {
         let segment = segment.strip_suffix('\r').unwrap_or(segment);
-        if segment.is_empty() {
-            continue;
-        }
         if let Some(rest) = segment.strip_prefix(':') {
             let tag_end = rest.find(':').ok_or_else(|| {
                 FormatError::Swift(format!(
@@ -297,16 +339,19 @@ pub(crate) fn split_block4(body: &str) -> Result<Vec<ParsedBlock4Line>, FormatEr
                 value: value.to_string(),
             });
         } else if let Some(last) = lines.last_mut() {
-            // A continuation line of the current field's value. Re-join the
-            // line break the split removed so the value is byte-faithful.
+            // A continuation line of the current field's value (blank or not).
+            // Re-join the line break the split removed so the value — and any
+            // interior blank line within it — is byte-faithful.
             last.value.push('\n');
             last.value.push_str(segment);
-        } else {
+        } else if !segment.is_empty() {
             return Err(FormatError::Swift(format!(
                 "SWIFT block-4 body opens with a continuation line {segment:?} before any \
                  ':tag:value' field"
             )));
         }
+        // A leading blank segment before the first field is structural
+        // whitespace (the `\r\n` after the `{4:` opener) — skipped silently.
     }
     Ok(lines)
 }
@@ -444,12 +489,56 @@ mod tests {
     #[test]
     fn block4_bare_brace_in_value_is_data_not_a_close() {
         // A `}` inside block-4 free text must not close the block early; only
-        // `-}` does. Here a value carries a literal `}`.
+        // a line-anchored `-}` does. Here a value carries a literal `}`.
         let data = "{4:\r\n:20:REF}WITHBRACE\r\n-}";
         let blocks = collect_blocks(data);
         assert_eq!(blocks.len(), 1);
         let lines = split_block4(&blocks[0].body).unwrap();
         assert_eq!(lines[0].value, "REF}WITHBRACE");
+    }
+
+    #[test]
+    fn block4_open_brace_in_value_is_data_not_counted() {
+        // A `{` inside a block-4 field value (legitimate in `:79:`/`:77E:`
+        // narrative) must NOT inflate brace depth — block 4 is opaque free
+        // text, so the real `-}` still closes it. A `{`-counting framer would
+        // reject this whole message as truncated.
+        let data = "{1:F01X}{4:\r\n:79:A{B\r\n:86:C{D{E\r\n-}";
+        let blocks = collect_blocks(data);
+        assert_eq!(blocks.len(), 2);
+        let lines = split_block4(&blocks[1].body).unwrap();
+        assert_eq!(lines[0].tag, "79");
+        assert_eq!(lines[0].value, "A{B");
+        assert_eq!(lines[1].tag, "86");
+        assert_eq!(lines[1].value, "C{D{E");
+    }
+
+    #[test]
+    fn block4_mid_line_dash_brace_is_data_not_a_close() {
+        // A `-}` in the MIDDLE of a value (not beginning a line) is data, not
+        // the trailer; only a line-anchored `-}` closes the block. The block
+        // must continue past the mid-line `-}` to its real line-anchored one.
+        let data = "{4:\r\n:79:SEE-}NOTE\r\n:86:MORE\r\n-}";
+        let blocks = collect_blocks(data);
+        assert_eq!(blocks.len(), 1);
+        let lines = split_block4(&blocks[0].body).unwrap();
+        assert_eq!(lines.len(), 2, "block must not close at a mid-line trailer");
+        assert_eq!(lines[0].tag, "79");
+        assert_eq!(lines[0].value, "SEE-}NOTE");
+        assert_eq!(lines[1].tag, "86");
+        assert_eq!(lines[1].value, "MORE");
+    }
+
+    #[test]
+    fn block4_interior_blank_line_in_value_survives() {
+        // A blank line WITHIN a multi-line narrative value is part of the
+        // value, not framing — it must fold in so the round-trip is faithful.
+        let data = "{4:\r\n:77E:LINE1\r\n\r\nLINE3\r\n-}";
+        let blocks = collect_blocks(data);
+        let lines = split_block4(&blocks[0].body).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].tag, "77E");
+        assert_eq!(lines[0].value, "LINE1\n\nLINE3");
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/format.rs
+++ b/crates/clinker-plan/src/config/format.rs
@@ -18,6 +18,7 @@ pub enum InputFormat {
     Edifact(Option<EdifactInputOptions>),
     X12(Option<X12InputOptions>),
     Hl7(Option<Hl7InputOptions>),
+    Swift(Option<SwiftInputOptions>),
 }
 
 impl InputFormat {
@@ -31,6 +32,7 @@ impl InputFormat {
             InputFormat::Edifact(_) => "edifact",
             InputFormat::X12(_) => "x12",
             InputFormat::Hl7(_) => "hl7",
+            InputFormat::Swift(_) => "swift",
         }
     }
 

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -615,6 +615,18 @@ pub struct Hl7InputOptions {
     pub split_fields: Option<Vec<Hl7FieldSplitOption>>,
 }
 
+/// SWIFT MT input options.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct SwiftInputOptions {
+    /// Maximum number of block-4 `:tag:value` field lines a single message
+    /// may carry. A message exceeding this is rejected with guidance rather
+    /// than streamed unbounded — a corruption guard, since a real MT message
+    /// is well under it. Defaults to 10000.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_fields: Option<usize>,
+}
+
 /// One opt-in HL7 composite-field split declaration.
 ///
 /// Names the positional field to explode and the column width on each

--- a/crates/clinker-schema/src/validate.rs
+++ b/crates/clinker-schema/src/validate.rs
@@ -133,6 +133,10 @@ fn validate_input(
         InputFormat::Edifact(_) => schema.metadata.format == crate::model::SourceFormat::Edifact,
         InputFormat::X12(_) => schema.metadata.format == crate::model::SourceFormat::X12,
         InputFormat::Hl7(_) => schema.metadata.format == crate::model::SourceFormat::Hl7,
+        // SWIFT MT sources stream a static `[block, tag, value]` schema rather
+        // than a declared `.schema.yaml` format, so there is no schema-format
+        // token to match against (the same posture fixed-width takes).
+        InputFormat::Swift(_) => false,
     };
 
     if !format_matches {

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
 - [EDIFACT Format](pipeline/edifact.md)
 - [X12 Format](pipeline/x12.md)
 - [HL7 v2 Format](pipeline/hl7.md)
+- [SWIFT MT Format](pipeline/swift.md)
 - [Network Sources (REST)](pipeline/source-network.md)
 - [Auto-Widen & Schema Drift](pipeline/auto-widen.md)
 - [Transform Nodes](pipeline/transform.md)

--- a/docs/src/pipeline/swift.md
+++ b/docs/src/pipeline/swift.md
@@ -32,12 +32,14 @@ parent block rather than mistaken for top-level blocks.
 
 ### The `-}` text-block trailer
 
-Block 4 is special. Its body is free `:tag:value` text whose values may
-contain a literal `}`, so it is closed by the two-byte `-}` trailer rather
-than a bare brace. The reader closes block 4 only on `-}`; a `}` inside the
-message text is treated as data, not a frame boundary. Both the framing
-braces and the `-}` trailer are stripped from the stored values, so a record
-carries clean tag/value data.
+Block 4 is special. Its body is opaque line-structured free text — a field
+value (a `:77E:` envelope, a `:79:` narrative, an `:86:` information line)
+legitimately contains `{`, `}`, and even `-}` as data. So the reader does
+**not** brace-count inside block 4: it closes the block only on a
+*line-anchored* `-}` trailer — a `-}` that begins a line. An interior `{`,
+`}`, or a `-}` in the middle of a value is data, not a frame boundary. Both
+the framing braces and the closing `-}` trailer are stripped from the stored
+values, so a record carries clean tag/value data.
 
 ### Whitespace between blocks
 
@@ -57,11 +59,13 @@ readers use, so memory scales O(1) with message size:
 | `tag`   | The SWIFT field tag without its surrounding colons (`20`, `32A`, `61`) |
 | `value` | The field value, with continuation lines folded in verbatim   |
 
-A multi-line field (a `:50K:` ordering-customer block, a `:86:` narrative)
-keeps its continuation lines: any line of block 4 that does not begin a new
-`:tag:` is folded into the current field's value with its line break
-preserved. A repeated tag (the `:61:` / `:86:` statement lines of an MT940,
-for instance) streams as one record per occurrence, in order.
+A multi-line field (a `:50K:` ordering-customer block, a `:77E:` / `:86:`
+narrative) keeps its continuation lines: any line of block 4 that does not
+begin a new `:tag:` is folded into the current field's value with its line
+break preserved — including a blank line **inside** the value, so a narrative
+with an internal blank line round-trips faithfully. A repeated tag (the
+`:61:` / `:86:` statement lines of an MT940, for instance) streams as one
+record per occurrence, in order.
 
 The service blocks (`1`, `2`, `3`, `5`) are consumed by the reader to serve
 envelope sections and drive the message-level document context — they are

--- a/docs/src/pipeline/swift.md
+++ b/docs/src/pipeline/swift.md
@@ -1,0 +1,166 @@
+# SWIFT MT Format
+
+Clinker reads SWIFT MT (FIN) messages alongside CSV, JSON, XML,
+fixed-width, EDIFACT, X12, and HL7 v2. A SWIFT MT message is a finite file
+built from brace-balanced blocks. The reader streams the message body one
+field at a time and surfaces the service blocks as document-envelope
+sections.
+
+> **Reader only.** This page documents reading SWIFT MT into Clinker. A
+> SWIFT MT *writer* (reconstructing the block structure around emitted
+> records) lands separately; until then a SWIFT source pairs with any other
+> output format (CSV, JSON, …).
+
+## Block structure
+
+A SWIFT MT message is a sequence of top-level blocks, each `{n:...}` where
+`n` is a numeric block id:
+
+| Block | Role                | Contents                                          |
+| ----- | ------------------- | ------------------------------------------------- |
+| `1`   | Basic header        | A fixed header string (application id, BIC, …)    |
+| `2`   | Application header  | Input/output direction, message type, recipient   |
+| `3`   | User header         | Optional; may carry nested `{tag:value}` sub-blocks |
+| `4`   | Message text        | The message body — a run of `:tag:value` fields    |
+| `5`   | Trailer             | Optional; may carry nested `{tag:value}` sub-blocks |
+
+Unlike the flat delimiter-structured EDI formats (HL7, X12, EDIFACT), SWIFT
+framing is **brace-balanced** rather than terminator-delimited. The reader
+tracks brace depth to find each top-level block, so the nested sub-blocks of
+blocks 3 and 5 (for example `{3:{108:MSGREF}}`) are kept intact inside their
+parent block rather than mistaken for top-level blocks.
+
+### The `-}` text-block trailer
+
+Block 4 is special. Its body is free `:tag:value` text whose values may
+contain a literal `}`, so it is closed by the two-byte `-}` trailer rather
+than a bare brace. The reader closes block 4 only on `-}`; a `}` inside the
+message text is treated as data, not a frame boundary. Both the framing
+braces and the `-}` trailer are stripped from the stored values, so a record
+carries clean tag/value data.
+
+### Whitespace between blocks
+
+Producers insert CR/LF (and the `\r\n` that separates block-4 fields) for
+readability. Inter-block whitespace is insignificant and is skipped; the
+line breaks inside block 4 delimit the `:tag:value` fields.
+
+## Record shape
+
+Each `:tag:value` line of block 4 becomes one record under a fixed
+positional schema — the same one-line-one-record model the X12 and HL7
+readers use, so memory scales O(1) with message size:
+
+| Column  | Meaning                                                       |
+| ------- | ------------------------------------------------------------- |
+| `block` | The block id the line came from (always `4` for body fields)  |
+| `tag`   | The SWIFT field tag without its surrounding colons (`20`, `32A`, `61`) |
+| `value` | The field value, with continuation lines folded in verbatim   |
+
+A multi-line field (a `:50K:` ordering-customer block, a `:86:` narrative)
+keeps its continuation lines: any line of block 4 that does not begin a new
+`:tag:` is folded into the current field's value with its line break
+preserved. A repeated tag (the `:61:` / `:86:` statement lines of an MT940,
+for instance) streams as one record per occurrence, in order.
+
+The service blocks (`1`, `2`, `3`, `5`) are consumed by the reader to serve
+envelope sections and drive the message-level document context — they are
+never emitted as body records.
+
+```yaml
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: swift
+      glob: ./inbox/*.swift
+      options:
+        max_fields: 20000   # raise the block-4 field ceiling for large messages
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+```
+
+The `max_fields` option caps the number of block-4 field lines a single
+message may carry (default 10000). A message exceeding it is rejected with
+guidance rather than streamed unbounded — a corruption guard, since a real
+MT message is well under the cap.
+
+## Envelope sections over the service blocks
+
+A SWIFT MT message is a single envelope: the four service blocks are
+extracted in a one-time pre-scan and surface as file-level `$doc` sections,
+exposing each block's text to CXL as `$doc.<section>.body`. One message-level
+document level brackets the body records, so a body record sees the enclosing
+message's headers through one `$doc.<section>.body` lookup.
+
+Declare the sections on the source with the `segment` extract rule naming the
+block id. The whole block body surfaces under the field name `body`, because
+a SWIFT service block carries free-form text (a header string, nested
+`{sub:tag}` blocks) rather than positional elements:
+
+```yaml
+envelope:
+  sections:
+    basic:
+      extract: { segment: "1" }   # block 1, the basic header
+    app:
+      extract: { segment: "2" }   # block 2, the application header
+    user:
+      extract: { segment: "3" }   # block 3, the user header (nested sub-blocks kept verbatim)
+    trailer:
+      extract: { segment: "5" }   # block 5, the trailer
+```
+
+A Transform on any body record can read every enclosing block at once:
+
+```cxl
+emit tag       = tag
+emit value     = value
+emit basic_hdr = $doc.basic.body     # block 1 header string
+emit app_hdr   = $doc.app.body       # block 2 header string
+emit user_hdr  = $doc.user.body      # block 3 body, nested {108:...} kept verbatim
+```
+
+The section names are entirely your choice — the engine reserves none. A
+`segment` extract may name a block either by its numeric id (`"1"`, `"3"`) or
+by the stable default label (`"basic_header"`, `"app_header"`,
+`"user_header"`, `"trailer"`); both resolve the same block.
+
+Block 4 is the message-text body streamed as records, not an envelope
+section — a `segment: "4"` extract is rejected at startup. An `xml_path` or
+`json_pointer` extract against a SWIFT source is likewise rejected, because
+those rules belong to the tree formats.
+
+## Malformed-message handling
+
+The reader fails the run with a precise `SWIFT` error rather than panicking
+on a structurally broken message:
+
+- **Unbalanced brace** — a block that never closes (or whose brace depth
+  never returns to zero) is a truncation error naming the offending block.
+- **Missing `-}` trailer** — a block 4 that runs to end of input without its
+  `-}` trailer is a truncation error.
+- **Missing or non-numeric block id** — a block without a numeric id after
+  the `{` (or with no `:` separating the id from the body) is rejected.
+- **Malformed `:tag:value` line** — a block-4 line with no second colon
+  closing the tag, or an empty tag, is rejected.
+- **Repeated service block** — a second `{1:...}` (or any repeated service
+  block) in one message is rejected.
+
+A header-only message (no block 4, or an empty block 4) is valid: it
+produces no body records and drains cleanly, with the message-level document
+level still opening and closing in balance.
+
+## Limitations
+
+- **Reader only.** A SWIFT MT writer lands separately; today a SWIFT source
+  pairs with any other output format.
+- **UTF-8 only.** SWIFT MT messages are decoded as UTF-8; a non-UTF-8 block
+  body is rejected explicitly rather than corrupted silently.
+- **Field-content parsing.** The reader exposes each `:tag:value` line as a
+  `tag`/`value` pair verbatim. Parsing a field's internal structure (the
+  sub-fields of a `:32A:` value-date/currency/amount, say) is a CXL concern
+  downstream of the source, not a reader responsibility.


### PR DESCRIPTION
Adds a streaming SWIFT MT (FIN) reader in `clinker-format`, alongside the existing CSV/JSON/XML/fixed-width and EDI (X12/EDIFACT/HL7) readers.

SWIFT MT messages are brace-balanced blocks: `{1:...}` basic header, `{2:...}` application header, `{3:...}` user header, `{4:...-}` text block of `:tag:value` lines, `{5:...}` trailer. The block framer is hand-rolled on brace depth (SWIFT is block/tag-line structured, not delimiter-segment structured, so it does not reuse the EDI segment tokenizer), which keeps the nested `{tag:value}` sub-blocks of blocks 3/5 intact and closes block 4 on its `-}` trailer.

- Each block-4 `:tag:value` line becomes one record under a static `[block, tag, value]` schema (one line → one record, O(1) streaming memory).
- Service blocks 1/2/3/5 are served as file-level `$doc` sections through `prepare_document`, bracketed by one balanced message-level envelope open/close.
- Registered as `InputFormat::Swift` with a `FormatError::Swift` variant; the new enum variant's exhaustive-match obligations are completed in the schema validator and benchmark format map.
- Reader-only: structural separators are kept verbatim so the writer (filed separately) can reconstruct losslessly. MX / ISO 20022 is out of scope (it is XML, covered by the XML reader). Zero new dependencies.

Fixtures cover MT103 (single customer credit transfer) and MT940 (statement with repeated block-4 tags); tests assert block→`$doc` mapping, block-4 tag→record extraction, balanced envelopes, and clean errors on malformed blocks.

Closes #484.