### PR TITLE
format: streaming JSON document reader with path-pruned arena index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,7 @@ dependencies = [
  "clinker-record",
  "criterion",
  "csv",
+ "cxl",
  "indexmap",
  "miette",
  "quick-xml",

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -38,7 +38,11 @@ fn build_format_reader(
             Ok(Box::new(CsvReader::from_reader(reader, config)))
         }
         clinker_plan::config::InputFormat::Json(opts) => {
-            let config = build_json_reader_config(opts.as_ref(), input.array_paths.as_deref());
+            let config = build_json_reader_config(
+                opts.as_ref(),
+                input.array_paths.as_deref(),
+                &input.declared_doc_paths,
+            );
             Ok(Box::new(JsonReader::from_reader(reader, config)?))
         }
         clinker_plan::config::InputFormat::Xml(opts) => {
@@ -727,12 +731,31 @@ fn build_csv_reader_config(
     config
 }
 
-/// Build JSON reader config from optional JSON input options and array paths.
+/// Default cap on the JSON envelope pre-scan's path-pruned document index
+/// when a source declares no explicit `max_index_bytes`. Finite by design:
+/// the index retains only declared `$doc.*` subtrees, so 64 MB is generous
+/// headroom for envelope metadata while still failing loud before an
+/// unbounded-retention OOM.
+const DEFAULT_JSON_MAX_INDEX_BYTES: usize = 64 * 1_000_000;
+
+/// Build JSON reader config from optional JSON input options, array paths,
+/// and the source's planner-attributed `$doc.*` path set.
+///
+/// `declared_doc_paths` is the set of envelope paths some downstream
+/// program references through this source; the reader's pre-scan retains
+/// only the sections these paths name. When the source declares no
+/// `max_index_bytes`, the pre-scan index is capped at
+/// [`DEFAULT_JSON_MAX_INDEX_BYTES`].
 fn build_json_reader_config(
     opts: Option<&clinker_plan::config::JsonInputOptions>,
     array_paths: Option<&[clinker_plan::config::ArrayPathConfig]>,
+    declared_doc_paths: &[cxl::analyzer::doc_paths::DocPath],
 ) -> JsonReaderConfig {
-    let mut config = JsonReaderConfig::default();
+    let mut config = JsonReaderConfig {
+        declared_doc_paths: declared_doc_paths.to_vec(),
+        max_index_bytes: Some(DEFAULT_JSON_MAX_INDEX_BYTES),
+        ..Default::default()
+    };
     if let Some(opts) = opts {
         config.format = opts.format.as_ref().map(|f| match f {
             clinker_plan::config::JsonFormat::Array => JsonMode::Array,
@@ -740,6 +763,9 @@ fn build_json_reader_config(
             clinker_plan::config::JsonFormat::Object => JsonMode::Object,
         });
         config.record_path = opts.record_path.clone();
+        if let Some(cap) = opts.max_index_bytes {
+            config.max_index_bytes = Some(cap.0 as usize);
+        }
     }
     if let Some(paths) = array_paths {
         config.array_paths = paths

--- a/crates/clinker-format/Cargo.toml
+++ b/crates/clinker-format/Cargo.toml
@@ -7,6 +7,7 @@ description = "Streaming CSV, XML, JSON, and fixed-width readers/writers for Cli
 
 [dependencies]
 clinker-record = { workspace = true }
+cxl = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 csv = "1"

--- a/crates/clinker-format/src/doc_index.rs
+++ b/crates/clinker-format/src/doc_index.rs
@@ -1,0 +1,348 @@
+//! Path-pruned retention of a document's declared `$doc.*` subtrees.
+//!
+//! A [`DocArenaIndex`] is the format-agnostic accumulator a document
+//! reader's envelope pre-scan builds in a single streaming pass. It is
+//! seeded from the [`DocPath`] set the planner attributed to one source —
+//! the envelope paths some downstream program actually references — and
+//! retains *only* the subtrees those paths name. Every section the
+//! programs never read is parsed-and-skipped by the reader, never handed
+//! to the index, so retained memory scales with the declared paths rather
+//! than the document size.
+//!
+//! The index is parser-agnostic: [`DocArenaIndex::insert`] takes an
+//! already-built [`Value`] subtree, so a serde-driven JSON pre-scan and a
+//! quick-xml event-driven XML pre-scan feed the same type. Retained bytes
+//! are charged incrementally as each subtree is inserted and checked
+//! against the configured cap *before* the subtree is stored, so an
+//! over-budget document fails loud mid-build rather than after a full
+//! materialization — the bounded-memory posture the engine commits to.
+
+use clinker_record::Value;
+use cxl::analyzer::doc_paths::DocPath;
+use indexmap::IndexMap;
+
+use crate::error::FormatError;
+
+/// Compact, path-pruned retention of a document's declared `$doc.*`
+/// subtrees.
+///
+/// Blocking, bounded: built in one streaming pass by a format reader's
+/// envelope pre-scan. Retains ONLY the subtrees named by the declared
+/// [`DocPath`] set — every undeclared key/element is parsed-and-skipped by
+/// the reader, never stored. Total retained bytes are charged
+/// incrementally against `max_index_bytes`; the cap fires mid-build
+/// (before OOM), not post-hoc.
+pub struct DocArenaIndex {
+    /// Declared section names, in first-seen order. A reader's pre-scan
+    /// consults [`Self::wants_section`] before descending into a section,
+    /// so an undeclared section is skipped without materializing it.
+    wanted_sections: Vec<Box<str>>,
+    /// Declared `(section, field)` pairs. A reader that can prune at field
+    /// granularity (a future finer-grained walk) consults
+    /// [`Self::wants_field`]; the JSON pre-scan retains whole sections, so
+    /// it prunes at section granularity and this set is the contract for
+    /// the eventual field-level pruning.
+    wanted_fields: Vec<(Box<str>, Box<str>)>,
+    /// Retained section subtrees, keyed by section name in insertion
+    /// order. One entry per inserted section.
+    sections: IndexMap<Box<str>, Value>,
+    /// Running sum of the heap-size estimate of every retained subtree.
+    retained_bytes: usize,
+    /// Hard cap on `retained_bytes`. `None` disables the cap (the reader's
+    /// config supplies a finite default in practice).
+    max_index_bytes: Option<usize>,
+}
+
+impl DocArenaIndex {
+    /// Build an index seeded from one source's declared `$doc.*` paths and
+    /// an optional retention cap.
+    ///
+    /// The path set is the planner-attributed set for a single source, so
+    /// a multi-source run never tells one source to retain another's
+    /// sections. `max_index_bytes` caps total retained bytes; the cap is
+    /// checked incrementally in [`Self::insert`].
+    pub fn new(declared: &[DocPath], max_index_bytes: Option<usize>) -> Self {
+        let mut wanted_sections: Vec<Box<str>> = Vec::new();
+        let mut wanted_fields: Vec<(Box<str>, Box<str>)> = Vec::new();
+        for path in declared {
+            if !wanted_sections
+                .iter()
+                .any(|s| s.as_ref() == path.section.as_ref())
+            {
+                wanted_sections.push(path.section.clone());
+            }
+            let pair = (path.section.clone(), path.field.clone());
+            if !wanted_fields
+                .iter()
+                .any(|(s, f)| s.as_ref() == pair.0.as_ref() && f.as_ref() == pair.1.as_ref())
+            {
+                wanted_fields.push(pair);
+            }
+        }
+        DocArenaIndex {
+            wanted_sections,
+            wanted_fields,
+            sections: IndexMap::new(),
+            retained_bytes: 0,
+            max_index_bytes,
+        }
+    }
+
+    /// `true` when no path was declared — the reader's pre-scan can skip
+    /// the document entirely.
+    pub fn is_empty(&self) -> bool {
+        self.wanted_sections.is_empty()
+    }
+
+    /// `true` when some declared path references `section` — the reader
+    /// descends into the section; otherwise it skips the section without
+    /// materializing its subtree.
+    pub fn wants_section(&self, section: &str) -> bool {
+        self.wanted_sections.iter().any(|s| s.as_ref() == section)
+    }
+
+    /// `true` when some declared path references `section.field`. A reader
+    /// that prunes at field granularity consults this before retaining an
+    /// individual field; a reader that retains whole sections prunes with
+    /// [`Self::wants_section`] alone.
+    pub fn wants_field(&self, section: &str, field: &str) -> bool {
+        self.wanted_fields
+            .iter()
+            .any(|(s, f)| s.as_ref() == section && f.as_ref() == field)
+    }
+
+    /// Charge `value`'s heap-size estimate against the cap, then retain it
+    /// under `path.section`.
+    ///
+    /// The byte charge is computed *before* the value is stored and added
+    /// to the running total; if the new total would exceed
+    /// `max_index_bytes` the value is dropped and an error returns, so an
+    /// over-budget document fails mid-build rather than after the whole
+    /// index materializes. A repeated section name overwrites the prior
+    /// retention (a reader inserts each section once).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Json`] naming the offending section and the
+    /// cap when retaining `value` would push total retained bytes past
+    /// `max_index_bytes`.
+    pub fn insert(&mut self, path: &DocPath, value: Value) -> Result<(), FormatError> {
+        // `Value::heap_size` is the canonical real-heap-bytes estimate the
+        // engine uses for allocation accounting elsewhere; reuse it so the
+        // index cap measures the same bytes the RSS budget does. Add the
+        // section key's bytes, since the retained map owns that too.
+        let charge = path.section.len() + value.heap_size();
+        let projected = self.retained_bytes.saturating_add(charge);
+        if let Some(cap) = self.max_index_bytes
+            && projected > cap
+        {
+            return Err(FormatError::Json(format!(
+                "envelope document-index cap exceeded: retaining section {section:?} \
+                 ({charge} bytes) would push the index to {projected} bytes, over the \
+                 {cap}-byte `max_index_bytes` cap. Raise `max_index_bytes` on the source, \
+                 or narrow the `$doc.*` paths the pipeline reads.",
+                section = path.section,
+            )));
+        }
+        self.retained_bytes = projected;
+        self.sections.insert(path.section.clone(), value);
+        Ok(())
+    }
+
+    /// Total heap-size estimate of every retained subtree — a test and
+    /// diagnostic hook proving the index retained orders of magnitude less
+    /// than the input document.
+    pub fn retained_bytes(&self) -> usize {
+        self.retained_bytes
+    }
+
+    /// Lower the retained subtrees to the envelope-section map a reader's
+    /// `prepare_document` returns: section name → its retained [`Value`],
+    /// in insertion order.
+    pub fn into_sections(self) -> IndexMap<Box<str>, Value> {
+        self.sections
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cxl::analyzer::doc_paths::DocIndex;
+
+    fn path(section: &str, field: &str) -> DocPath {
+        DocPath {
+            section: section.into(),
+            field: field.into(),
+            indices: Vec::new(),
+        }
+    }
+
+    fn indexed_path(section: &str, field: &str, indices: Vec<DocIndex>) -> DocPath {
+        DocPath {
+            section: section.into(),
+            field: field.into(),
+            indices,
+        }
+    }
+
+    fn map(pairs: &[(&str, Value)]) -> Value {
+        let mut m: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (k, v) in pairs {
+            m.insert((*k).into(), v.clone());
+        }
+        Value::Map(Box::new(m))
+    }
+
+    #[test]
+    fn empty_when_no_paths_declared() {
+        let idx = DocArenaIndex::new(&[], Some(64));
+        assert!(idx.is_empty());
+        assert!(!idx.wants_section("Anything"));
+    }
+
+    #[test]
+    fn wants_section_matches_declared_section() {
+        let idx = DocArenaIndex::new(&[path("Summary", "record_count")], None);
+        assert!(!idx.is_empty());
+        assert!(idx.wants_section("Summary"));
+        assert!(!idx.wants_section("Header"));
+    }
+
+    #[test]
+    fn wants_field_matches_section_and_field() {
+        let idx = DocArenaIndex::new(
+            &[path("Summary", "record_count"), path("Header", "batch_id")],
+            None,
+        );
+        assert!(idx.wants_field("Summary", "record_count"));
+        assert!(idx.wants_field("Header", "batch_id"));
+        // Right section, undeclared field.
+        assert!(!idx.wants_field("Summary", "checksum"));
+        // Undeclared section.
+        assert!(!idx.wants_field("Footer", "record_count"));
+    }
+
+    #[test]
+    fn indexed_paths_collapse_to_their_section_and_field() {
+        // `$doc.summary.items[0]` and `$doc.summary.items[1]` both name the
+        // `summary.items` field — section/field pruning ignores the trailing
+        // index, which selects an element of the already-retained subtree.
+        let idx = DocArenaIndex::new(
+            &[
+                indexed_path("summary", "items", vec![DocIndex::Int(0)]),
+                indexed_path("summary", "items", vec![DocIndex::Int(1)]),
+            ],
+            None,
+        );
+        assert!(idx.wants_section("summary"));
+        assert!(idx.wants_field("summary", "items"));
+    }
+
+    #[test]
+    fn insert_retains_under_section_name() {
+        let mut idx = DocArenaIndex::new(&[path("Summary", "record_count")], None);
+        idx.insert(
+            &path("Summary", "record_count"),
+            map(&[("record_count", Value::Integer(42))]),
+        )
+        .unwrap();
+        let sections = idx.into_sections();
+        assert_eq!(sections.len(), 1);
+        let summary = match sections.get("Summary").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        assert_eq!(summary.get("record_count"), Some(&Value::Integer(42)));
+    }
+
+    #[test]
+    fn retained_bytes_grows_monotonically_with_inserts() {
+        let mut idx = DocArenaIndex::new(&[path("A", "x"), path("B", "y")], None);
+        assert_eq!(idx.retained_bytes(), 0);
+        idx.insert(
+            &path("A", "x"),
+            map(&[("x", Value::String("short".into()))]),
+        )
+        .unwrap();
+        let after_first = idx.retained_bytes();
+        assert!(after_first > 0);
+        idx.insert(
+            &path("B", "y"),
+            map(&[("y", Value::String("a".repeat(1000).into()))]),
+        )
+        .unwrap();
+        let after_second = idx.retained_bytes();
+        assert!(after_second > after_first);
+        // The large string dominates the second charge.
+        assert!(after_second - after_first >= 1000);
+    }
+
+    #[test]
+    fn retained_bytes_charges_heap_backed_string_payload() {
+        // A heap-backed (long) string section charges its byte length, so a
+        // large declared section is reflected in the running total.
+        let mut idx = DocArenaIndex::new(&[path("Big", "blob")], None);
+        idx.insert(
+            &path("Big", "blob"),
+            map(&[("blob", Value::String("x".repeat(5000).into()))]),
+        )
+        .unwrap();
+        assert!(idx.retained_bytes() >= 5000);
+    }
+
+    #[test]
+    fn insert_errors_when_charge_exceeds_cap() {
+        // Cap tiny; a payload above it must be rejected before storage.
+        let mut idx = DocArenaIndex::new(&[path("Big", "blob")], Some(64));
+        let payload = map(&[("blob", Value::String("z".repeat(10_000).into()))]);
+        let err = idx
+            .insert(&path("Big", "blob"), payload)
+            .expect_err("over-cap insert must error");
+        match err {
+            FormatError::Json(msg) => {
+                assert!(
+                    msg.contains("max_index_bytes"),
+                    "message names the cap: {msg}"
+                );
+                assert!(msg.contains("Big"), "message names the section: {msg}");
+            }
+            other => panic!("expected FormatError::Json, got {other:?}"),
+        }
+        // The over-cap value was not stored.
+        assert!(idx.into_sections().is_empty());
+    }
+
+    #[test]
+    fn insert_accumulates_until_cap_then_errors() {
+        // First insert fits, second tips over the cap — proving the cap is
+        // checked against the running total, not per-insert.
+        let mut idx = DocArenaIndex::new(&[path("A", "x"), path("B", "y")], Some(300));
+        idx.insert(
+            &path("A", "x"),
+            map(&[("x", Value::String("a".repeat(100).into()))]),
+        )
+        .expect("first insert fits under the running cap");
+        let err = idx
+            .insert(
+                &path("B", "y"),
+                map(&[("y", Value::String("b".repeat(400).into()))]),
+            )
+            .expect_err("second insert tips the running total over the cap");
+        assert!(matches!(err, FormatError::Json(msg) if msg.contains("B")));
+        // Only the first section survived.
+        let sections = idx.into_sections();
+        assert_eq!(sections.len(), 1);
+        assert!(sections.contains_key("A"));
+    }
+
+    #[test]
+    fn no_cap_retains_arbitrarily_large_subtree() {
+        let mut idx = DocArenaIndex::new(&[path("Big", "blob")], None);
+        idx.insert(
+            &path("Big", "blob"),
+            map(&[("blob", Value::String("z".repeat(100_000).into()))]),
+        )
+        .expect("no cap means no rejection");
+        assert!(idx.retained_bytes() >= 100_000);
+    }
+}

--- a/crates/clinker-format/src/doc_index.rs
+++ b/crates/clinker-format/src/doc_index.rs
@@ -37,12 +37,6 @@ pub struct DocArenaIndex {
     /// consults [`Self::wants_section`] before descending into a section,
     /// so an undeclared section is skipped without materializing it.
     wanted_sections: Vec<Box<str>>,
-    /// Declared `(section, field)` pairs. A reader that can prune at field
-    /// granularity (a future finer-grained walk) consults
-    /// [`Self::wants_field`]; the JSON pre-scan retains whole sections, so
-    /// it prunes at section granularity and this set is the contract for
-    /// the eventual field-level pruning.
-    wanted_fields: Vec<(Box<str>, Box<str>)>,
     /// Retained section subtrees, keyed by section name in insertion
     /// order. One entry per inserted section.
     sections: IndexMap<Box<str>, Value>,
@@ -63,7 +57,6 @@ impl DocArenaIndex {
     /// checked incrementally in [`Self::insert`].
     pub fn new(declared: &[DocPath], max_index_bytes: Option<usize>) -> Self {
         let mut wanted_sections: Vec<Box<str>> = Vec::new();
-        let mut wanted_fields: Vec<(Box<str>, Box<str>)> = Vec::new();
         for path in declared {
             if !wanted_sections
                 .iter()
@@ -71,17 +64,9 @@ impl DocArenaIndex {
             {
                 wanted_sections.push(path.section.clone());
             }
-            let pair = (path.section.clone(), path.field.clone());
-            if !wanted_fields
-                .iter()
-                .any(|(s, f)| s.as_ref() == pair.0.as_ref() && f.as_ref() == pair.1.as_ref())
-            {
-                wanted_fields.push(pair);
-            }
         }
         DocArenaIndex {
             wanted_sections,
-            wanted_fields,
             sections: IndexMap::new(),
             retained_bytes: 0,
             max_index_bytes,
@@ -101,25 +86,20 @@ impl DocArenaIndex {
         self.wanted_sections.iter().any(|s| s.as_ref() == section)
     }
 
-    /// `true` when some declared path references `section.field`. A reader
-    /// that prunes at field granularity consults this before retaining an
-    /// individual field; a reader that retains whole sections prunes with
-    /// [`Self::wants_section`] alone.
-    pub fn wants_field(&self, section: &str, field: &str) -> bool {
-        self.wanted_fields
-            .iter()
-            .any(|(s, f)| s.as_ref() == section && f.as_ref() == field)
-    }
-
-    /// Charge `value`'s heap-size estimate against the cap, then retain it
-    /// under `path.section`.
+    /// Charge an already-built `value`'s heap-size estimate against the cap,
+    /// then retain it under `path.section`.
     ///
-    /// The byte charge is computed *before* the value is stored and added
-    /// to the running total; if the new total would exceed
-    /// `max_index_bytes` the value is dropped and an error returns, so an
-    /// over-budget document fails mid-build rather than after the whole
-    /// index materializes. A repeated section name overwrites the prior
-    /// retention (a reader inserts each section once).
+    /// This is the index's authoritative retained-bytes accountant for a
+    /// finished subtree, and the parser-agnostic store seam: an XML reader
+    /// hands an event-built `Value` here exactly as the JSON reader hands a
+    /// coerced one. The byte charge is computed *before* the value is stored
+    /// and added to the running total; if the new total would exceed
+    /// `max_index_bytes` the value is dropped and an error returns. A reader
+    /// that builds a subtree through a streaming parse should *also* bound
+    /// the raw parse incrementally (see the JSON reader's byte-counting
+    /// pre-scan), so a single oversized declared subtree never fully
+    /// materializes before reaching this accountant. A repeated section name
+    /// overwrites the prior retention (a reader inserts each section once).
     ///
     /// # Errors
     ///
@@ -209,24 +189,23 @@ mod tests {
     }
 
     #[test]
-    fn wants_field_matches_section_and_field() {
+    fn distinct_fields_of_one_section_collapse_to_a_single_wanted_section() {
+        // Two paths into the same section (different fields) want that one
+        // section once — the JSON pre-scan retains the whole section object,
+        // so field granularity does not split retention.
         let idx = DocArenaIndex::new(
-            &[path("Summary", "record_count"), path("Header", "batch_id")],
+            &[path("Summary", "record_count"), path("Summary", "checksum")],
             None,
         );
-        assert!(idx.wants_field("Summary", "record_count"));
-        assert!(idx.wants_field("Header", "batch_id"));
-        // Right section, undeclared field.
-        assert!(!idx.wants_field("Summary", "checksum"));
-        // Undeclared section.
-        assert!(!idx.wants_field("Footer", "record_count"));
+        assert!(idx.wants_section("Summary"));
+        assert!(!idx.wants_section("Header"));
     }
 
     #[test]
-    fn indexed_paths_collapse_to_their_section_and_field() {
+    fn indexed_paths_collapse_to_their_section() {
         // `$doc.summary.items[0]` and `$doc.summary.items[1]` both name the
-        // `summary.items` field — section/field pruning ignores the trailing
-        // index, which selects an element of the already-retained subtree.
+        // `summary` section — section pruning ignores the field and trailing
+        // index, which select an element of the already-retained subtree.
         let idx = DocArenaIndex::new(
             &[
                 indexed_path("summary", "items", vec![DocIndex::Int(0)]),
@@ -235,7 +214,6 @@ mod tests {
             None,
         );
         assert!(idx.wants_section("summary"));
-        assert!(idx.wants_field("summary", "items"));
     }
 
     #[test]

--- a/crates/clinker-format/src/json/mod.rs
+++ b/crates/clinker-format/src/json/mod.rs
@@ -1,2 +1,3 @@
 pub mod reader;
+mod streaming;
 pub mod writer;

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -8,12 +8,20 @@
 //!   path, skipping non-matching keys without allocation, then streams the
 //!   array. Total memory: ~10KB buffer + one record.
 //!
-//! Envelope-aware sources buffer the full input at construction so the
-//! envelope pre-scan (which walks the entire JSON document for sections
-//! at arbitrary JSON pointer paths) can run before any body record
-//! emits. The buffered bytes are also the input to the body parser, so
-//! there is one read of the source from disk regardless of whether
-//! envelope sections are declared.
+//! Envelope-aware sources run a streaming pre-scan over the document
+//! before any body record emits: it walks the JSON once, deserializing
+//! ONLY the subtrees the declared `$doc.*` paths name (every other key is
+//! parsed-and-skipped via `IgnoredAny`) into a path-pruned arena index
+//! capped by `max_index_bytes`, rather than materializing the whole
+//! document tree. The pre-scan reads from a fresh cursor over the shared
+//! source buffer, so it does not consume body iteration.
+//!
+//! The source buffer itself is still a full `read_to_end` at construction
+//! — it backs both the body parser's cursor and the pre-scan's cursor, so
+//! there is one read from disk regardless of envelope declarations. Only
+//! the pre-scan's parsed-tree materialization is removed here; shrinking
+//! the raw byte buffer for purely-streamable bodies is a separate
+//! follow-up.
 
 use std::io::{BufRead, BufReader, Cursor, Read};
 use std::sync::Arc;
@@ -25,9 +33,13 @@ use clinker_record::{
 };
 use indexmap::IndexMap;
 
+use cxl::analyzer::doc_paths::DocPath;
+
 use crate::bom::UTF8_BOM;
+use crate::doc_index::DocArenaIndex;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType};
 use crate::error::FormatError;
+use crate::json::streaming::{SectionTarget, extract_sections};
 use crate::traits::FormatReader;
 
 // ── Public config types ──────────────────────────────────────────────
@@ -37,6 +49,17 @@ pub struct JsonReaderConfig {
     pub format: Option<JsonMode>,
     pub record_path: Option<String>,
     pub array_paths: Vec<ArrayPathSpec>,
+    /// `$doc.*` envelope paths a program downstream of this source
+    /// references, attributed to this source by the planner. The envelope
+    /// pre-scan retains only the sections these paths name; a declared
+    /// section no program reads is skipped, never materialized. Empty when
+    /// no downstream program reads any `$doc` path.
+    pub declared_doc_paths: Vec<DocPath>,
+    /// Hard cap on the bytes the envelope pre-scan's path-pruned index may
+    /// retain. The cap is charged incrementally as each section subtree is
+    /// retained and fires mid-build (before OOM). `None` disables the cap;
+    /// the source plumbing supplies a finite default.
+    pub max_index_bytes: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -66,10 +89,11 @@ pub struct JsonReader {
     schema: Option<Arc<Schema>>,
     config: JsonReaderConfig,
     pending: Vec<serde_json::Map<String, serde_json::Value>>,
-    /// Buffered source bytes shared with the envelope pre-scan. The
-    /// body parser drains a cursor over these bytes; `prepare_document`
-    /// re-parses the same bytes as a `serde_json::Value` to resolve
-    /// JSON pointer paths to envelope sections.
+    /// Buffered source bytes shared with the envelope pre-scan. The body
+    /// parser drains a cursor over these bytes; `prepare_document` opens a
+    /// fresh cursor over the same bytes and streams a single
+    /// `DeserializeSeed` pass that retains only declared `$doc.*` subtrees,
+    /// rather than re-parsing the whole document tree.
     raw_bytes: Arc<[u8]>,
 }
 
@@ -318,15 +342,27 @@ impl FormatReader for JsonReader {
             return Ok(IndexMap::new());
         }
 
-        // The pre-scan reads the full document as a `serde_json::Value`
-        // and resolves each declared section's JSON pointer against
-        // that parsed tree. Body iteration continues to drain its own
-        // cursor over `raw_bytes`; this parse is independent.
-        let root: serde_json::Value = serde_json::from_slice(&self.raw_bytes)
-            .map_err(|e| FormatError::Json(format!("envelope pre-scan: {e}")))?;
+        // The path-pruned index is the retention authority: it knows which
+        // sections some downstream program reads. A declared section no
+        // program references is not extracted at all — so when no `$doc`
+        // path is attributed to this source, the pre-scan skips the whole
+        // document.
+        let mut index =
+            DocArenaIndex::new(&self.config.declared_doc_paths, self.config.max_index_bytes);
+        if index.is_empty() {
+            return Ok(IndexMap::new());
+        }
 
-        let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(config.sections.len());
+        // Resolve each declared section the index wants to its JSON pointer,
+        // validating the extract type fits a JSON source (a wrong-format
+        // extract is an authoring error surfaced eagerly). Sections the
+        // index does not want are dropped here so the streaming pass never
+        // descends into them.
+        let mut targets: Vec<SectionTarget> = Vec::new();
         for (name, section) in &config.sections {
+            if !index.wants_section(name) {
+                continue;
+            }
             let pointer = match &section.extract {
                 EnvelopeExtract::JsonPointer(p) => p.as_str(),
                 EnvelopeExtract::XmlPath(_) => {
@@ -343,24 +379,39 @@ impl FormatReader for JsonReader {
                     )));
                 }
             };
-            let node = match root.pointer(pointer) {
-                Some(n) => n,
+            targets.push(SectionTarget::new(name.clone(), pointer));
+        }
+
+        // Single streaming pass over a fresh cursor: only the matched
+        // subtrees are deserialized; every other key is parsed-and-skipped.
+        // Body iteration keeps its own independent cursor over `raw_bytes`.
+        let mut prescan = BufReader::new(Cursor::new(Arc::clone(&self.raw_bytes)));
+        let matched = extract_sections(&mut prescan, &targets)?;
+
+        // Coerce each matched subtree to its declared field schema and
+        // charge it against the index cap before retaining it — an
+        // over-budget document fails here, mid-build, rather than after a
+        // full materialization.
+        for (name, section) in &config.sections {
+            let raw = match matched.get(name) {
+                Some(v) => v,
                 None => continue,
             };
-            let payload_obj = match node {
+            let payload_obj = match raw {
                 serde_json::Value::Object(obj) => obj,
                 other => {
                     return Err(FormatError::Json(format!(
-                        "envelope section {name:?}: JSON pointer {pointer:?} resolves to \
-                         {kind} but envelope sections must be JSON objects",
+                        "envelope section {name:?}: JSON pointer resolves to {kind} but \
+                         envelope sections must be JSON objects",
                         kind = json_value_kind(other),
                     )));
                 }
             };
             let typed = coerce_json_section_fields(name, payload_obj, &section.fields)?;
-            out.insert(Box::from(name.as_str()), Value::Map(Box::new(typed)));
+            let path = doc_path_for_section(name);
+            index.insert(&path, Value::Map(Box::new(typed)))?;
         }
-        Ok(out)
+        Ok(index.into_sections())
     }
 
     fn schema(&mut self) -> Result<Arc<Schema>, FormatError> {
@@ -576,6 +627,22 @@ fn json_to_value(v: &serde_json::Value) -> Value {
     }
 }
 
+/// Build the section-level [`DocPath`] under which a whole matched section
+/// subtree is retained.
+///
+/// JSON retains an envelope section as one object (one JSON pointer → one
+/// object → all its fields), so the insert key is the section, not an
+/// individual field; [`DocArenaIndex::insert`] groups by `path.section`.
+/// The `field`/`indices` axes carry no meaning for a section-granular
+/// retention and are left empty.
+fn doc_path_for_section(name: &str) -> DocPath {
+    DocPath {
+        section: name.into(),
+        field: Box::from(""),
+        indices: Vec::new(),
+    }
+}
+
 /// Lowercase descriptor for the JSON value kind, used in
 /// envelope-section diagnostics when the pointer resolves to a
 /// non-object value.
@@ -695,6 +762,33 @@ mod tests {
         }
     }
 
+    /// Declared `$doc.*` paths covering every `(section, field)` in `specs`,
+    /// so the path-pruned index wants all of them — the runtime stand-in
+    /// for the planner's per-source attribution.
+    fn declared_paths(specs: &[SectionSpec]) -> Vec<DocPath> {
+        let mut out = Vec::new();
+        for (section, _pointer, fields) in specs {
+            for (field, _ty) in *fields {
+                out.push(DocPath {
+                    section: (*section).into(),
+                    field: (*field).into(),
+                    indices: Vec::new(),
+                });
+            }
+        }
+        out
+    }
+
+    /// A reader config whose declared paths want every section in `specs`,
+    /// for an envelope-bearing source with the given `record_path` body.
+    fn envelope_reader_config(specs: &[SectionSpec], record_path: &str) -> JsonReaderConfig {
+        JsonReaderConfig {
+            record_path: Some(record_path.into()),
+            declared_doc_paths: declared_paths(specs),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn prepare_document_extracts_arbitrary_named_sections() {
         let json = r#"{
@@ -702,7 +796,7 @@ mod tests {
             "records": [{"x": 1}, {"x": 2}],
             "Summary": {"hash": "abc", "processed": 2}
         }"#;
-        let cfg = envelope_config(&[
+        let specs: &[SectionSpec] = &[
             (
                 "BatchInfo",
                 "/BatchInfo",
@@ -719,14 +813,9 @@ mod tests {
                     ("processed", EnvelopeFieldType::Int),
                 ],
             ),
-        ]);
-        let mut reader = reader_from_str(
-            json,
-            JsonReaderConfig {
-                record_path: Some("records".into()),
-                ..Default::default()
-            },
-        );
+        ];
+        let cfg = envelope_config(specs);
+        let mut reader = reader_from_str(json, envelope_reader_config(specs, "records"));
         let sections = reader.prepare_document(&cfg).expect("envelope pre-scan");
 
         assert_eq!(sections.len(), 2);
@@ -754,6 +843,19 @@ mod tests {
         assert!(sections.is_empty());
     }
 
+    /// A config wanting a single section named `Bad`, so the wrong-format
+    /// extract validation fires for that section in the rejection tests.
+    fn config_wanting_bad_section() -> JsonReaderConfig {
+        JsonReaderConfig {
+            declared_doc_paths: vec![DocPath {
+                section: "Bad".into(),
+                field: "any".into(),
+                indices: Vec::new(),
+            }],
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn prepare_document_rejects_xml_path_extract() {
         use crate::envelope::EnvelopeSection;
@@ -765,7 +867,7 @@ mod tests {
                 fields: IndexMap::new(),
             },
         );
-        let mut reader = reader_from_str(r#"{"records":[]}"#, default_config());
+        let mut reader = reader_from_str(r#"{"records":[]}"#, config_wanting_bad_section());
         let err = reader.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::Json(msg) if msg.contains("xml_path")));
     }
@@ -781,7 +883,7 @@ mod tests {
                 fields: IndexMap::new(),
             },
         );
-        let mut reader = reader_from_str(r#"{"records":[]}"#, default_config());
+        let mut reader = reader_from_str(r#"{"records":[]}"#, config_wanting_bad_section());
         let err = reader.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::Json(msg) if msg.contains("segment")));
     }
@@ -792,14 +894,9 @@ mod tests {
         // misconfiguration — envelope sections are object payloads of
         // typed fields.
         let json = r#"{"value": 42, "records": []}"#;
-        let cfg = envelope_config(&[("Val", "/value", &[("v", EnvelopeFieldType::Int)])]);
-        let mut reader = reader_from_str(
-            json,
-            JsonReaderConfig {
-                record_path: Some("records".into()),
-                ..Default::default()
-            },
-        );
+        let specs: &[SectionSpec] = &[("Val", "/value", &[("v", EnvelopeFieldType::Int)])];
+        let cfg = envelope_config(specs);
+        let mut reader = reader_from_str(json, envelope_reader_config(specs, "records"));
         let err = reader.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::Json(msg) if msg.contains("number")));
     }
@@ -807,14 +904,10 @@ mod tests {
     #[test]
     fn prepare_document_missing_pointer_yields_no_entry() {
         let json = r#"{"records": [{"x":1}]}"#;
-        let cfg = envelope_config(&[("Trailer", "/trailer", &[("count", EnvelopeFieldType::Int)])]);
-        let mut reader = reader_from_str(
-            json,
-            JsonReaderConfig {
-                record_path: Some("records".into()),
-                ..Default::default()
-            },
-        );
+        let specs: &[SectionSpec] =
+            &[("Trailer", "/trailer", &[("count", EnvelopeFieldType::Int)])];
+        let cfg = envelope_config(specs);
+        let mut reader = reader_from_str(json, envelope_reader_config(specs, "records"));
         let sections = reader.prepare_document(&cfg).unwrap();
         assert!(sections.is_empty());
     }
@@ -825,7 +918,7 @@ mod tests {
             "Meta": {"run_date": "2026-05-22", "enabled": true, "ratio": 0.5},
             "records": [{"x":1}]
         }"#;
-        let cfg = envelope_config(&[(
+        let specs: &[SectionSpec] = &[(
             "Meta",
             "/Meta",
             &[
@@ -833,14 +926,9 @@ mod tests {
                 ("enabled", EnvelopeFieldType::Bool),
                 ("ratio", EnvelopeFieldType::Float),
             ],
-        )]);
-        let mut reader = reader_from_str(
-            json,
-            JsonReaderConfig {
-                record_path: Some("records".into()),
-                ..Default::default()
-            },
-        );
+        )];
+        let cfg = envelope_config(specs);
+        let mut reader = reader_from_str(json, envelope_reader_config(specs, "records"));
         let sections = reader.prepare_document(&cfg).unwrap();
         let meta = unwrap_section_map(sections.get("Meta").unwrap());
         assert!(matches!(meta.get("run_date"), Some(Value::Date(_))));
@@ -940,28 +1028,23 @@ mod tests {
 
     #[test]
     fn test_json_envelope_prescan_strips_leading_bom() {
-        // The envelope pre-scan re-parses `raw_bytes` via
-        // `serde_json::from_slice`; the source-level strip must clear
-        // the BOM for that path too, not just body iteration.
+        // The envelope pre-scan streams `raw_bytes` from a fresh cursor;
+        // the source-level strip must clear the BOM for that path too, not
+        // just body iteration.
         let json = r#"{
             "BatchInfo": {"batch_id": "RUN-001", "count": 42},
             "records": [{"x": 1}, {"x": 2}]
         }"#;
-        let cfg = envelope_config(&[(
+        let specs: &[SectionSpec] = &[(
             "BatchInfo",
             "/BatchInfo",
             &[
                 ("batch_id", EnvelopeFieldType::String),
                 ("count", EnvelopeFieldType::Int),
             ],
-        )]);
-        let mut reader = reader_from_str_with_bom(
-            json,
-            JsonReaderConfig {
-                record_path: Some("records".into()),
-                ..Default::default()
-            },
-        );
+        )];
+        let cfg = envelope_config(specs);
+        let mut reader = reader_from_str_with_bom(json, envelope_reader_config(specs, "records"));
         let sections = reader.prepare_document(&cfg).expect("envelope pre-scan");
         let head = unwrap_section_map(sections.get("BatchInfo").unwrap());
         assert_eq!(head.get("batch_id"), Some(&Value::String("RUN-001".into())));

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -383,15 +383,18 @@ impl FormatReader for JsonReader {
         }
 
         // Single streaming pass over a fresh cursor: only the matched
-        // subtrees are deserialized; every other key is parsed-and-skipped.
-        // Body iteration keeps its own independent cursor over `raw_bytes`.
+        // subtrees are built; every other key is parsed-and-skipped. The cap
+        // is charged *as each declared section is constructed*, so an
+        // oversized declared section aborts the parse mid-build rather than
+        // after the whole subtree materializes. Body iteration keeps its own
+        // independent cursor over `raw_bytes`.
         let mut prescan = BufReader::new(Cursor::new(Arc::clone(&self.raw_bytes)));
-        let matched = extract_sections(&mut prescan, &targets)?;
+        let matched = extract_sections(&mut prescan, &targets, self.config.max_index_bytes)?;
 
-        // Coerce each matched subtree to its declared field schema and
-        // charge it against the index cap before retaining it — an
-        // over-budget document fails here, mid-build, rather than after a
-        // full materialization.
+        // Coerce each matched subtree to its declared field schema and retain
+        // it in the index, which accounts the coerced (field-filtered)
+        // retained bytes against the same cap. The streaming pass already
+        // bounded the raw parse; the index accounts what is actually kept.
         for (name, section) in &config.sections {
             let raw = match matched.get(name) {
                 Some(v) => v,

--- a/crates/clinker-format/src/json/streaming.rs
+++ b/crates/clinker-format/src/json/streaming.rs
@@ -1,0 +1,160 @@
+//! Streaming envelope pre-scan for JSON sources.
+//!
+//! Walks a JSON document exactly once through serde's `DeserializeSeed`
+//! API, deserializing *only* the subtrees a source's declared envelope
+//! sections point at and skipping every other key with `IgnoredAny` (a
+//! zero-allocation parse-and-discard). This replaces a full
+//! `serde_json::from_slice` of the whole document — which materialized the
+//! entire tree just to resolve a handful of pointers — so the pre-scan's
+//! retained memory scales with the declared sections rather than the
+//! document size.
+//!
+//! Blocking, bounded: the pre-scan runs before any body record streams and
+//! returns the matched section subtrees as a map. The caller charges each
+//! retained subtree against the document index cap and coerces it to the
+//! section's typed field schema.
+
+use std::io::{BufReader, Read};
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, Visitor};
+
+use crate::error::FormatError;
+
+/// One declared section's RFC 6901 pointer, decoded to path segments, plus
+/// its author-chosen name.
+///
+/// `segments` is empty only for the whole-document pointer `""`, which
+/// matches the root object itself.
+pub(crate) struct SectionTarget {
+    /// Author-chosen section name the matched subtree is recorded under.
+    pub name: String,
+    /// RFC 6901 pointer segments, `~1`/`~0` already decoded to `/`/`~`.
+    pub segments: Vec<String>,
+}
+
+impl SectionTarget {
+    /// Decode an RFC 6901 JSON pointer into path segments.
+    ///
+    /// A leading `/` introduces each segment; `~1` decodes to `/` and `~0`
+    /// to `~`, matching `serde_json::Value::pointer`. The empty pointer
+    /// `""` yields no segments (it names the root).
+    pub(crate) fn new(name: String, pointer: &str) -> Self {
+        let segments = if pointer.is_empty() {
+            Vec::new()
+        } else {
+            pointer
+                .split('/')
+                .skip(1)
+                .map(|s| s.replace("~1", "/").replace("~0", "~"))
+                .collect()
+        };
+        SectionTarget { name, segments }
+    }
+}
+
+/// Walk a JSON document once, retaining only the subtrees named by
+/// `targets`.
+///
+/// Each matched section's subtree is deserialized as a single
+/// `serde_json::Value` and returned keyed by section name; every other key
+/// is skipped via `IgnoredAny`. A target whose pointer does not resolve is
+/// simply absent from the result — the caller treats a missing section the
+/// same as the prior full-materialization path did.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Json`] on any JSON parse failure (malformed
+/// input, or a pointer descending through a non-object node).
+pub(crate) fn extract_sections<R: Read>(
+    reader: &mut BufReader<R>,
+    targets: &[SectionTarget],
+) -> Result<IndexMap<String, serde_json::Value>, FormatError> {
+    let live: Vec<&SectionTarget> = targets.iter().collect();
+    let mut matched: IndexMap<String, serde_json::Value> = IndexMap::new();
+    let mut de = serde_json::Deserializer::from_reader(reader);
+    NodeSeed {
+        // The whole document is the depth-0 node; descent advances one
+        // segment per object level.
+        depth: 0,
+        targets: &live,
+        matched: &mut matched,
+    }
+    .deserialize(&mut de)
+    .map_err(|e| FormatError::Json(format!("envelope pre-scan: {e}")))?;
+    Ok(matched)
+}
+
+/// Seed driving the walk of one JSON node `depth` segments from the
+/// document root, against the targets still live at this node.
+///
+/// A node is a matched section when some live target's pointer has exactly
+/// `depth` segments — every earlier segment matched the keys descended so
+/// far. A matched node is deserialized whole as a `serde_json::Value`;
+/// otherwise the seed descends into the object, following only keys some
+/// live target's next segment selects and skipping the rest with
+/// `IgnoredAny`.
+struct NodeSeed<'a, 't> {
+    depth: usize,
+    targets: &'t [&'t SectionTarget],
+    matched: &'a mut IndexMap<String, serde_json::Value>,
+}
+
+impl<'de, 'a, 't> DeserializeSeed<'de> for NodeSeed<'a, 't> {
+    type Value = ();
+
+    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<(), D::Error> {
+        for target in self.targets {
+            if target.segments.len() == self.depth {
+                let value = serde_json::Value::deserialize(deserializer)?;
+                self.matched.insert(target.name.clone(), value);
+                return Ok(());
+            }
+        }
+        deserializer.deserialize_map(ObjectDescent {
+            depth: self.depth,
+            targets: self.targets,
+            matched: self.matched,
+        })
+    }
+}
+
+/// Visitor that descends into a JSON object, recursing into keys a live
+/// target selects and skipping the rest without allocation.
+struct ObjectDescent<'a, 't> {
+    depth: usize,
+    targets: &'t [&'t SectionTarget],
+    matched: &'a mut IndexMap<String, serde_json::Value>,
+}
+
+impl<'de, 'a, 't> Visitor<'de> for ObjectDescent<'a, 't> {
+    type Value = ();
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("a JSON object to descend for envelope sections")
+    }
+
+    fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<(), M::Error> {
+        while let Some(key) = map.next_key::<String>()? {
+            // Targets whose next segment is this key stay live one level
+            // deeper; every other target ignores this key's value.
+            let live: Vec<&SectionTarget> = self
+                .targets
+                .iter()
+                .copied()
+                .filter(|t| t.segments.get(self.depth).is_some_and(|seg| seg == &key))
+                .collect();
+            if live.is_empty() {
+                map.next_value::<IgnoredAny>()?;
+                continue;
+            }
+            map.next_value_seed(NodeSeed {
+                depth: self.depth + 1,
+                targets: &live,
+                matched: self.matched,
+            })?;
+        }
+        Ok(())
+    }
+}

--- a/crates/clinker-format/src/json/streaming.rs
+++ b/crates/clinker-format/src/json/streaming.rs
@@ -10,15 +10,17 @@
 //! document size.
 //!
 //! Blocking, bounded: the pre-scan runs before any body record streams and
-//! returns the matched section subtrees as a map. The caller charges each
-//! retained subtree against the document index cap and coerces it to the
-//! section's typed field schema.
+//! returns the matched section subtrees as a map. A declared section is
+//! built through a byte-counting visitor that charges each constructed
+//! string/key/element against a shared cap and aborts the parse the moment
+//! the cumulative retained total crosses `max_index_bytes` — so even a
+//! single oversized declared section fails loud at ~the cap, before the
+//! whole subtree materializes, not after.
 
 use std::io::{BufReader, Read};
 
 use indexmap::IndexMap;
-use serde::Deserialize;
-use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, Visitor};
+use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor};
 
 use crate::error::FormatError;
 
@@ -26,7 +28,7 @@ use crate::error::FormatError;
 /// its author-chosen name.
 ///
 /// `segments` is empty only for the whole-document pointer `""`, which
-/// matches the root object itself.
+/// matches the root node itself.
 pub(crate) struct SectionTarget {
     /// Author-chosen section name the matched subtree is recorded under.
     pub name: String,
@@ -54,91 +56,155 @@ impl SectionTarget {
     }
 }
 
-/// Walk a JSON document once, retaining only the subtrees named by
-/// `targets`.
+/// Walk a JSON document once, building only the subtrees named by `targets`
+/// and charging their retained bytes against `max_index_bytes`.
 ///
-/// Each matched section's subtree is deserialized as a single
-/// `serde_json::Value` and returned keyed by section name; every other key
-/// is skipped via `IgnoredAny`. A target whose pointer does not resolve is
-/// simply absent from the result — the caller treats a missing section the
-/// same as the prior full-materialization path did.
+/// Each matched section's subtree is constructed as a single
+/// `serde_json::Value` through a byte-counting visitor; every other key is
+/// skipped via `IgnoredAny`. The cap is charged *as the subtree is built*,
+/// so an oversized declared section aborts the parse mid-build rather than
+/// after the whole subtree materializes. A target whose pointer cannot be
+/// reached through the streamed structure — a non-object/array intermediate,
+/// a top-level scalar/array document, or an array-index segment that no
+/// element matches — yields no section (a graceful miss), matching
+/// `serde_json::Value::pointer` returning `None`.
 ///
 /// # Errors
 ///
-/// Returns [`FormatError::Json`] on any JSON parse failure (malformed
-/// input, or a pointer descending through a non-object node).
+/// Returns [`FormatError::Json`] on a JSON parse failure, or naming the
+/// offending section and the cap when a declared section's retained bytes
+/// cross `max_index_bytes`.
 pub(crate) fn extract_sections<R: Read>(
     reader: &mut BufReader<R>,
     targets: &[SectionTarget],
+    max_index_bytes: Option<usize>,
 ) -> Result<IndexMap<String, serde_json::Value>, FormatError> {
     let live: Vec<&SectionTarget> = targets.iter().collect();
-    let mut matched: IndexMap<String, serde_json::Value> = IndexMap::new();
+    let mut state = WalkState {
+        matched: IndexMap::new(),
+        retained_bytes: 0,
+        max_index_bytes,
+        cap_error: None,
+    };
     let mut de = serde_json::Deserializer::from_reader(reader);
-    NodeSeed {
+    let outcome = NodeSeed {
         // The whole document is the depth-0 node; descent advances one
-        // segment per object level.
+        // segment per object/array level.
         depth: 0,
         targets: &live,
-        matched: &mut matched,
+        state: &mut state,
     }
-    .deserialize(&mut de)
-    .map_err(|e| FormatError::Json(format!("envelope pre-scan: {e}")))?;
-    Ok(matched)
+    .deserialize(&mut de);
+
+    // A cap trip is signalled through `cap_error` (carried out-of-band so it
+    // is not swallowed by serde's generic parse-error surface); surface it
+    // ahead of any serde error the aborted parse also produced.
+    if let Some(err) = state.cap_error {
+        return Err(err);
+    }
+    outcome.map_err(|e| FormatError::Json(format!("envelope pre-scan: {e}")))?;
+    Ok(state.matched)
 }
 
-/// Seed driving the walk of one JSON node `depth` segments from the
-/// document root, against the targets still live at this node.
+/// Mutable walk state threaded through the recursion: the sections built so
+/// far, the running retained-byte total, the cap, and an out-of-band slot
+/// for a cap-exceeded error.
+struct WalkState {
+    matched: IndexMap<String, serde_json::Value>,
+    retained_bytes: usize,
+    max_index_bytes: Option<usize>,
+    /// Set when a section build crosses the cap. Carried out-of-band of
+    /// serde's `D::Error` so the precise cap message survives the aborted
+    /// parse; checked by `extract_sections` before any serde error.
+    cap_error: Option<FormatError>,
+}
+
+impl WalkState {
+    /// Charge `bytes` against the cap; record a cap error and signal abort
+    /// (`Err(())`) if the running total would cross it. The caller turns the
+    /// `Err(())` into a serde `D::Error` to unwind the parse.
+    fn charge(&mut self, bytes: usize, section: &str) -> Result<(), ()> {
+        let projected = self.retained_bytes.saturating_add(bytes);
+        if let Some(cap) = self.max_index_bytes
+            && projected > cap
+        {
+            self.cap_error.get_or_insert_with(|| {
+                FormatError::Json(format!(
+                    "envelope document-index cap exceeded: building section {section:?} \
+                     crossed the {cap}-byte `max_index_bytes` cap mid-parse. Raise \
+                     `max_index_bytes` on the source, or narrow the `$doc.*` paths the \
+                     pipeline reads (declare paths over envelope metadata, not bulk arrays)."
+                ))
+            });
+            return Err(());
+        }
+        self.retained_bytes = projected;
+        Ok(())
+    }
+}
+
+/// Seed driving the walk of one JSON node `depth` segments from the document
+/// root, against the targets still live at this node.
 ///
 /// A node is a matched section when some live target's pointer has exactly
-/// `depth` segments — every earlier segment matched the keys descended so
-/// far. A matched node is deserialized whole as a `serde_json::Value`;
-/// otherwise the seed descends into the object, following only keys some
-/// live target's next segment selects and skipping the rest with
-/// `IgnoredAny`.
+/// `depth` segments — every earlier segment matched the structure descended
+/// so far. A matched node is built whole (byte-counted) as a
+/// `serde_json::Value`; otherwise the seed descends into the node, following
+/// only the keys/indices a live target's next segment selects and skipping
+/// the rest. A node that is neither map nor sequence (a scalar leaf reached
+/// before a target's pointer terminates) is a graceful miss for those
+/// targets.
 struct NodeSeed<'a, 't> {
     depth: usize,
     targets: &'t [&'t SectionTarget],
-    matched: &'a mut IndexMap<String, serde_json::Value>,
+    state: &'a mut WalkState,
 }
 
 impl<'de, 'a, 't> DeserializeSeed<'de> for NodeSeed<'a, 't> {
     type Value = ();
 
     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<(), D::Error> {
-        for target in self.targets {
-            if target.segments.len() == self.depth {
-                let value = serde_json::Value::deserialize(deserializer)?;
-                self.matched.insert(target.name.clone(), value);
-                return Ok(());
+        if let Some(target) = self.targets.iter().find(|t| t.segments.len() == self.depth) {
+            // This node terminates a declared pointer — build it whole,
+            // charging bytes as the subtree is constructed.
+            let value = CountingValueSeed {
+                section: &target.name,
+                state: self.state,
             }
+            .deserialize(deserializer)?;
+            self.state.matched.insert(target.name.clone(), value);
+            return Ok(());
         }
-        deserializer.deserialize_map(ObjectDescent {
+        // No target terminates here; descend. `deserialize_any` lets the
+        // node be a map, a sequence, or a scalar — a scalar reached before a
+        // target's pointer terminates is a graceful miss (no section, no
+        // error), matching `serde_json::Value::pointer` -> None.
+        deserializer.deserialize_any(StructureDescent {
             depth: self.depth,
             targets: self.targets,
-            matched: self.matched,
+            state: self.state,
         })
     }
 }
 
-/// Visitor that descends into a JSON object, recursing into keys a live
-/// target selects and skipping the rest without allocation.
-struct ObjectDescent<'a, 't> {
+/// Visitor that descends one structural level toward live targets, matching
+/// object keys and array indices and skipping everything else, and treats a
+/// scalar node as a graceful miss.
+struct StructureDescent<'a, 't> {
     depth: usize,
     targets: &'t [&'t SectionTarget],
-    matched: &'a mut IndexMap<String, serde_json::Value>,
+    state: &'a mut WalkState,
 }
 
-impl<'de, 'a, 't> Visitor<'de> for ObjectDescent<'a, 't> {
+impl<'de, 'a, 't> Visitor<'de> for StructureDescent<'a, 't> {
     type Value = ();
 
     fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str("a JSON object to descend for envelope sections")
+        f.write_str("any JSON value to descend for envelope sections")
     }
 
     fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<(), M::Error> {
         while let Some(key) = map.next_key::<String>()? {
-            // Targets whose next segment is this key stay live one level
-            // deeper; every other target ignores this key's value.
             let live: Vec<&SectionTarget> = self
                 .targets
                 .iter()
@@ -152,9 +218,177 @@ impl<'de, 'a, 't> Visitor<'de> for ObjectDescent<'a, 't> {
             map.next_value_seed(NodeSeed {
                 depth: self.depth + 1,
                 targets: &live,
-                matched: self.matched,
+                state: self.state,
             })?;
         }
         Ok(())
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<(), S::Error> {
+        // RFC 6901 array-index segments: a numeric segment selects the Nth
+        // element. Targets with a non-numeric next segment cannot match an
+        // array element and miss.
+        let mut idx = 0usize;
+        loop {
+            let live: Vec<&SectionTarget> = self
+                .targets
+                .iter()
+                .copied()
+                .filter(|t| {
+                    t.segments
+                        .get(self.depth)
+                        .and_then(|seg| seg.parse::<usize>().ok())
+                        .is_some_and(|n| n == idx)
+                })
+                .collect();
+            let proceeded = if live.is_empty() {
+                seq.next_element::<IgnoredAny>()?.is_some()
+            } else {
+                seq.next_element_seed(NodeSeed {
+                    depth: self.depth + 1,
+                    targets: &live,
+                    state: self.state,
+                })?
+                .is_some()
+            };
+            if !proceeded {
+                return Ok(());
+            }
+            idx += 1;
+        }
+    }
+
+    // A scalar node reached before any live target's pointer terminates is a
+    // graceful miss: the target's deeper segments cannot be satisfied, so it
+    // records no section and raises no error. `serde` calls the matching
+    // scalar visitor; each returns `Ok(())` without recording anything.
+    fn visit_unit<E>(self) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_bool<E>(self, _v: bool) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_i64<E>(self, _v: i64) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_u64<E>(self, _v: u64) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_f64<E>(self, _v: f64) -> Result<(), E> {
+        Ok(())
+    }
+    fn visit_str<E>(self, _v: &str) -> Result<(), E> {
+        Ok(())
+    }
+}
+
+/// Seed that builds a `serde_json::Value` while charging its retained bytes
+/// incrementally against the cap, aborting mid-build the instant the
+/// cumulative total crosses it.
+struct CountingValueSeed<'a, 's> {
+    section: &'s str,
+    state: &'a mut WalkState,
+}
+
+impl<'de, 'a, 's> DeserializeSeed<'de> for CountingValueSeed<'a, 's> {
+    type Value = serde_json::Value;
+
+    fn deserialize<D: Deserializer<'de>>(
+        self,
+        deserializer: D,
+    ) -> Result<serde_json::Value, D::Error> {
+        deserializer.deserialize_any(CountingValueVisitor {
+            section: self.section,
+            state: self.state,
+        })
+    }
+}
+
+/// Visitor building a `serde_json::Value` node-by-node, charging each owned
+/// string, key, and container element against the cap as it is constructed.
+struct CountingValueVisitor<'a, 's> {
+    section: &'s str,
+    state: &'a mut WalkState,
+}
+
+impl<'a, 's> CountingValueVisitor<'a, 's> {
+    /// Charge `bytes`, mapping a cap trip to a serde error so the parse
+    /// unwinds. The precise cap message is stashed in `state.cap_error`.
+    fn charge<E: serde::de::Error>(&mut self, bytes: usize) -> Result<(), E> {
+        self.state
+            .charge(bytes, self.section)
+            .map_err(|()| E::custom("envelope document-index cap exceeded"))
+    }
+}
+
+impl<'de, 'a, 's> Visitor<'de> for CountingValueVisitor<'a, 's> {
+    type Value = serde_json::Value;
+
+    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.write_str("a JSON value retained as an envelope section subtree")
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<serde_json::Value, E> {
+        Ok(serde_json::Value::Null)
+    }
+
+    fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<serde_json::Value, E> {
+        Ok(serde_json::Value::Bool(v))
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<serde_json::Value, E> {
+        Ok(serde_json::Value::Number(v.into()))
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<serde_json::Value, E> {
+        Ok(serde_json::Value::Number(v.into()))
+    }
+
+    fn visit_f64<E: serde::de::Error>(mut self, v: f64) -> Result<serde_json::Value, E> {
+        match serde_json::Number::from_f64(v) {
+            Some(n) => Ok(serde_json::Value::Number(n)),
+            None => {
+                // Non-finite floats have no JSON number; retain the string
+                // form and charge its bytes.
+                let s = v.to_string();
+                self.charge(s.len())?;
+                Ok(serde_json::Value::String(s))
+            }
+        }
+    }
+
+    fn visit_str<E: serde::de::Error>(mut self, v: &str) -> Result<serde_json::Value, E> {
+        self.charge(v.len())?;
+        Ok(serde_json::Value::String(v.to_owned()))
+    }
+
+    fn visit_string<E: serde::de::Error>(mut self, v: String) -> Result<serde_json::Value, E> {
+        self.charge(v.len())?;
+        Ok(serde_json::Value::String(v))
+    }
+
+    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<serde_json::Value, S::Error> {
+        let mut out: Vec<serde_json::Value> = Vec::new();
+        while let Some(elem) = seq.next_element_seed(CountingValueSeed {
+            section: self.section,
+            state: self.state,
+        })? {
+            out.push(elem);
+        }
+        Ok(serde_json::Value::Array(out))
+    }
+
+    fn visit_map<M: MapAccess<'de>>(mut self, mut map: M) -> Result<serde_json::Value, M::Error> {
+        let mut out = serde_json::Map::new();
+        while let Some(key) = map.next_key::<String>()? {
+            // Charge the key bytes (the retained map owns the key string).
+            self.charge(key.len())?;
+            let value = map.next_value_seed(CountingValueSeed {
+                section: self.section,
+                state: self.state,
+            })?;
+            out.insert(key, value);
+        }
+        Ok(serde_json::Value::Object(out))
     }
 }

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod bom;
 pub mod counting;
 pub mod csv;
+pub mod doc_index;
 pub mod edifact;
 pub mod envelope;
 pub mod error;
@@ -15,6 +16,7 @@ pub mod x12;
 pub mod xml;
 
 pub use counting::{CountedFormatWriter, CountingWriter, SharedByteCounter};
+pub use doc_index::DocArenaIndex;
 pub use envelope::{
     EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection,
     NestedEnvelopeSection,

--- a/crates/clinker-format/tests/streaming_doc_index_json.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_json.rs
@@ -110,22 +110,15 @@ fn prescan_retains_only_declared_trailer_not_the_body() {
         Some(&Value::Integer(rows as i64))
     );
 
-    // The retained-section map is orders of magnitude smaller than the
-    // input: the body's undeclared subtrees were skipped, never stored. A
-    // serialized section map of one int is well under 1KB; the input is
-    // multi-MB.
-    let serialized = serde_json::to_string(
-        &sections
-            .iter()
-            .map(|(k, v)| (k.to_string(), format!("{v:?}")))
-            .collect::<std::collections::BTreeMap<_, _>>(),
-    )
-    .unwrap();
+    // The retained bytes are orders of magnitude smaller than the input:
+    // the body's undeclared subtrees were skipped, never stored. Measuring
+    // the section map's own heap footprint (the real retained memory, not a
+    // serialized proxy) makes the skip-not-just-correct-output guarantee
+    // load-bearing — a single retained int sits far below input/1000.
+    let retained: usize = sections.iter().map(|(k, v)| k.len() + v.heap_size()).sum();
     assert!(
-        serialized.len() < input_len / 1_000,
-        "retained section map ({} bytes) must be <<< input ({} bytes)",
-        serialized.len(),
-        input_len
+        retained < input_len / 1_000,
+        "retained section heap ({retained} bytes) must be <<< input ({input_len} bytes)"
     );
 
     // The body still streams: every record is present, in order.
@@ -144,15 +137,26 @@ fn prescan_retains_only_declared_trailer_not_the_body() {
 }
 
 #[test]
-fn prescan_fails_loud_when_retention_exceeds_cap() {
-    // A declared section pointing at a large subtree, with a tiny cap. The
-    // cap must fire DURING the build (the input is far larger than the
-    // cap), naming the section and the cap, rather than OOMing.
-    let big_blob = "z".repeat(500_000);
-    let json = format!("{{\"Header\":{{\"note\":\"{big_blob}\"}},\"records\":[{{\"x\":1}}]}}");
+fn prescan_fails_loud_mid_build_on_a_single_oversized_section() {
+    // ONE declared section far larger than the cap. The cap must fire DURING
+    // that section's deserialization — before the whole subtree
+    // materializes — naming the section and the cap, rather than OOMing.
+    // This is the single-section guarantee: the cap is not a post-hoc
+    // measurement of an already-built section, it aborts the build.
+    let huge_array_elems: String = (0..50_000)
+        .map(|i| format!("\"row-{i}-{}\"", "y".repeat(40)))
+        .collect::<Vec<_>>()
+        .join(",");
+    let json =
+        format!("{{\"Header\":{{\"rows\":[{huge_array_elems}]}},\"records\":[{{\"x\":1}}]}}");
     let input_len = json.len();
+    // The single declared section is multiple MB on its own.
+    assert!(
+        input_len > 2_000_000,
+        "section should be multi-MB: {input_len}"
+    );
 
-    let specs: &[SectionSpec] = &[("Header", "/Header", &[("note", EnvelopeFieldType::String)])];
+    let specs: &[SectionSpec] = &[("Header", "/Header", &[("rows", EnvelopeFieldType::String)])];
     let cfg = envelope_config(specs);
 
     let mut reader = JsonReader::from_reader(
@@ -160,8 +164,8 @@ fn prescan_fails_loud_when_retention_exceeds_cap() {
         JsonReaderConfig {
             record_path: Some("records".into()),
             declared_doc_paths: declared_paths(specs),
-            // 4KB cap — far below the 500KB declared section.
-            max_index_bytes: Some(4_000),
+            // 8KB cap — far below the multi-MB declared section.
+            max_index_bytes: Some(8_000),
             ..Default::default()
         },
     )
@@ -177,12 +181,46 @@ fn prescan_fails_loud_when_retention_exceeds_cap() {
                 "error names the cap: {msg}"
             );
             assert!(msg.contains("Header"), "error names the section: {msg}");
+            assert!(
+                msg.contains("mid-parse"),
+                "error states the abort is mid-parse: {msg}"
+            );
         }
         other => panic!("expected FormatError::Json, got {other:?}"),
     }
-    // The input dwarfs the cap, proving the failure is a mid-build cap
-    // trip, not a post-hoc measurement of a fully materialized index.
-    assert!(input_len > 100_000);
+}
+
+#[test]
+fn prescan_fails_loud_when_cumulative_sections_exceed_cap() {
+    // Two declared sections that each fit, but whose cumulative retained
+    // bytes cross the cap — proves the running total is charged across the
+    // single streaming pass, not reset per section.
+    let chunk = "q".repeat(3_000);
+    let json = format!(
+        "{{\"A\":{{\"v\":\"{chunk}\"}},\"B\":{{\"v\":\"{chunk}\"}},\"records\":[{{\"x\":1}}]}}"
+    );
+    let specs: &[SectionSpec] = &[
+        ("A", "/A", &[("v", EnvelopeFieldType::String)]),
+        ("B", "/B", &[("v", EnvelopeFieldType::String)]),
+    ];
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.into_bytes()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            // 4KB cap: each 3KB section fits alone, but the pair (6KB) does not.
+            max_index_bytes: Some(4_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("cumulative over-cap retention must fail");
+    assert!(matches!(err, FormatError::Json(msg) if msg.contains("max_index_bytes")));
 }
 
 #[test]
@@ -222,4 +260,149 @@ fn prescan_skips_entirely_when_no_doc_path_declared() {
         count += 1;
     }
     assert_eq!(count, 3);
+}
+
+#[test]
+fn prescan_skips_cleanly_for_top_level_array_document() {
+    // The document is a top-level JSON array, but a `$doc` section is
+    // declared. The section pointer cannot resolve through an array root, so
+    // the pre-scan yields no section and does NOT abort the run — matching
+    // `serde_json::Value::pointer` returning `None` for a non-object root.
+    let json = r#"[{"x":1},{"x":2}]"#;
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader
+        .prepare_document(&cfg)
+        .expect("a non-object root is a graceful miss, not an error");
+    assert!(
+        sections.is_empty(),
+        "no section resolves through an array root"
+    );
+
+    // The top-level array still streams as the body.
+    let mut count = 0;
+    while reader.next_record().unwrap().is_some() {
+        count += 1;
+    }
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn prescan_skips_cleanly_when_pointer_descends_through_non_object() {
+    // The pointer `/meta/Summary` descends through `meta`, which is a scalar,
+    // not an object. The intermediate cannot be descended, so the section is
+    // a graceful miss — not a mid-stream hard error.
+    let json = r#"{"meta": 42, "records":[{"x":1}]}"#;
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/meta/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader
+        .prepare_document(&cfg)
+        .expect("a non-object intermediate is a graceful miss, not an error");
+    assert!(
+        sections.is_empty(),
+        "no section resolves through a scalar intermediate"
+    );
+}
+
+#[test]
+fn prescan_resolves_array_index_pointer_segment() {
+    // RFC 6901 array-index segment: `/data/0/Summary` selects element 0 of
+    // the `data` array, then its `Summary` object. The old full-tree pointer
+    // resolved this; the streaming walk must too (seq descent), not error.
+    let json = r#"{"data":[{"Summary":{"record_count":7}},{"other":1}],"records":[{"x":1}]}"#;
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/data/0/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader
+        .prepare_document(&cfg)
+        .expect("array-index pointer resolves");
+    let summary = match sections
+        .get("Summary")
+        .expect("Summary resolved via /data/0")
+    {
+        Value::Map(m) => m,
+        other => panic!("expected map, got {other:?}"),
+    };
+    assert_eq!(summary.get("record_count"), Some(&Value::Integer(7)));
+}
+
+#[test]
+fn prescan_prunes_the_unread_section_in_a_mixed_envelope() {
+    // The envelope declares two sections, but only one has a declared `$doc`
+    // path. The read section is present; the unread one is pruned — absent
+    // from the output, never materialized.
+    let json = r#"{"Head":{"batch_id":"B-1"},"Foot":{"record_count":5},"records":[{"x":1}]}"#;
+    let head_spec: SectionSpec = ("Head", "/Head", &[("batch_id", EnvelopeFieldType::String)]);
+    let foot_spec: SectionSpec = ("Foot", "/Foot", &[("record_count", EnvelopeFieldType::Int)]);
+    // Both sections are declared in the envelope config...
+    let cfg = envelope_config(&[head_spec, foot_spec]);
+    // ...but only `Foot` is referenced by a `$doc` path.
+    let declared = declared_paths(&[foot_spec]);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared,
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader.prepare_document(&cfg).expect("pre-scan");
+    assert!(
+        sections.contains_key("Foot"),
+        "the read section is retained"
+    );
+    assert!(
+        !sections.contains_key("Head"),
+        "the unread section is pruned, not materialized"
+    );
 }

--- a/crates/clinker-format/tests/streaming_doc_index_json.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_json.rs
@@ -1,0 +1,225 @@
+//! Bounded-retention behavior of the streaming JSON envelope pre-scan.
+//!
+//! Proves the pre-scan retains only the declared `$doc.*` subtrees — a
+//! multi-MB body array of undeclared records is parsed-and-skipped, never
+//! buffered into the document index — and that an over-budget retention
+//! fails loud mid-build rather than after a full materialization.
+
+use clinker_format::FormatError;
+use clinker_format::envelope::{
+    EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection,
+};
+use clinker_format::json::reader::{JsonReader, JsonReaderConfig};
+use clinker_format::traits::FormatReader;
+use clinker_record::Value;
+use cxl::analyzer::doc_paths::DocPath;
+use indexmap::IndexMap;
+
+/// One envelope section: name, JSON pointer, typed fields.
+type SectionSpec<'a> = (&'a str, &'a str, &'a [(&'a str, EnvelopeFieldType)]);
+
+fn envelope_config(specs: &[SectionSpec]) -> EnvelopeConfig {
+    let mut cfg = EnvelopeConfig::default();
+    for (name, pointer, fields) in specs {
+        let mut field_map = IndexMap::new();
+        for (fname, ftype) in *fields {
+            field_map.insert((*fname).to_string(), *ftype);
+        }
+        cfg.sections.insert(
+            (*name).to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::JsonPointer((*pointer).to_string()),
+                fields: field_map,
+            },
+        );
+    }
+    cfg
+}
+
+fn declared_paths(specs: &[SectionSpec]) -> Vec<DocPath> {
+    let mut out = Vec::new();
+    for (section, _pointer, fields) in specs {
+        for (field, _ty) in *fields {
+            out.push(DocPath {
+                section: (*section).into(),
+                field: (*field).into(),
+                indices: Vec::new(),
+            });
+        }
+    }
+    out
+}
+
+/// A document with a large undeclared body and a small declared trailer:
+/// `{ "records": [ ...N large rows... ], "Summary": { "record_count": N } }`.
+fn doc_with_large_body_and_small_trailer(rows: usize) -> String {
+    let mut s = String::from("{\"records\":[");
+    for i in 0..rows {
+        if i > 0 {
+            s.push(',');
+        }
+        // Each row carries a large, undeclared text blob — the bytes the
+        // pre-scan must skip rather than retain.
+        s.push_str(&format!(
+            "{{\"id\":{i},\"blob\":\"{}\"}}",
+            "x".repeat(2_000)
+        ));
+    }
+    s.push_str(&format!("],\"Summary\":{{\"record_count\":{rows}}}}}"));
+    s
+}
+
+#[test]
+fn prescan_retains_only_declared_trailer_not_the_body() {
+    let rows = 2_000;
+    let json = doc_with_large_body_and_small_trailer(rows);
+    let input_len = json.len();
+    // The body alone is multiple MB.
+    assert!(
+        input_len > 4_000_000,
+        "body should be multi-MB: {input_len}"
+    );
+
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.into_bytes()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader.prepare_document(&cfg).expect("envelope pre-scan");
+
+    // The trailer was extracted and typed.
+    let summary = match sections.get("Summary").expect("Summary section retained") {
+        Value::Map(m) => m,
+        other => panic!("expected map, got {other:?}"),
+    };
+    assert_eq!(
+        summary.get("record_count"),
+        Some(&Value::Integer(rows as i64))
+    );
+
+    // The retained-section map is orders of magnitude smaller than the
+    // input: the body's undeclared subtrees were skipped, never stored. A
+    // serialized section map of one int is well under 1KB; the input is
+    // multi-MB.
+    let serialized = serde_json::to_string(
+        &sections
+            .iter()
+            .map(|(k, v)| (k.to_string(), format!("{v:?}")))
+            .collect::<std::collections::BTreeMap<_, _>>(),
+    )
+    .unwrap();
+    assert!(
+        serialized.len() < input_len / 1_000,
+        "retained section map ({} bytes) must be <<< input ({} bytes)",
+        serialized.len(),
+        input_len
+    );
+
+    // The body still streams: every record is present, in order.
+    let mut count = 0usize;
+    let mut last_id = -1i64;
+    while let Some(rec) = reader.next_record().unwrap() {
+        let id = match rec.get("id") {
+            Some(Value::Integer(n)) => *n,
+            other => panic!("expected integer id, got {other:?}"),
+        };
+        assert_eq!(id, last_id + 1, "body records stream in order");
+        last_id = id;
+        count += 1;
+    }
+    assert_eq!(count, rows, "every body record streamed");
+}
+
+#[test]
+fn prescan_fails_loud_when_retention_exceeds_cap() {
+    // A declared section pointing at a large subtree, with a tiny cap. The
+    // cap must fire DURING the build (the input is far larger than the
+    // cap), naming the section and the cap, rather than OOMing.
+    let big_blob = "z".repeat(500_000);
+    let json = format!("{{\"Header\":{{\"note\":\"{big_blob}\"}},\"records\":[{{\"x\":1}}]}}");
+    let input_len = json.len();
+
+    let specs: &[SectionSpec] = &[("Header", "/Header", &[("note", EnvelopeFieldType::String)])];
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.into_bytes()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            // 4KB cap — far below the 500KB declared section.
+            max_index_bytes: Some(4_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("over-cap retention must fail");
+    match err {
+        FormatError::Json(msg) => {
+            assert!(
+                msg.contains("max_index_bytes"),
+                "error names the cap: {msg}"
+            );
+            assert!(msg.contains("Header"), "error names the section: {msg}");
+        }
+        other => panic!("expected FormatError::Json, got {other:?}"),
+    }
+    // The input dwarfs the cap, proving the failure is a mid-build cap
+    // trip, not a post-hoc measurement of a fully materialized index.
+    assert!(input_len > 100_000);
+}
+
+#[test]
+fn prescan_skips_entirely_when_no_doc_path_declared() {
+    // An envelope is declared, but no downstream program reads any `$doc`
+    // path (empty `declared_doc_paths`). The path-pruned index is empty, so
+    // the pre-scan skips the document and extracts nothing — the body is
+    // never walked for sections.
+    let json = r#"{"Summary":{"record_count":3},"records":[{"x":1},{"x":2},{"x":3}]}"#;
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            // No declared paths — nothing downstream reads `$doc.*`.
+            declared_doc_paths: Vec::new(),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader.prepare_document(&cfg).expect("pre-scan");
+    assert!(
+        sections.is_empty(),
+        "no declared path means no section is extracted"
+    );
+    // Body still streams normally.
+    let mut count = 0;
+    while reader.next_record().unwrap().is_some() {
+        count += 1;
+    }
+    assert_eq!(count, 3);
+}

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -453,6 +453,15 @@ pub struct JsonInputOptions {
     pub format: Option<JsonFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_path: Option<String>,
+    /// Hard cap on the bytes the envelope pre-scan's path-pruned document
+    /// index may retain while extracting declared `$doc.*` sections.
+    /// Accepts a size string (`"64MB"`, `"500KB"`) via the same
+    /// [`ByteSize`] grammar the file-size filters use. The cap is charged
+    /// incrementally and fires mid-build (before OOM) when a retained
+    /// section would push the index over it. Genuinely optional —
+    /// `None` falls back to the reader's documented default cap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_index_bytes: Option<ByteSize>,
 }
 
 /// XML-specific input options.
@@ -669,4 +678,32 @@ impl Hl7FieldSplitOption {
 /// `subcomponents` / `repetitions` split-declaration fields.
 fn one() -> usize {
     1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ByteSize;
+
+    #[test]
+    fn json_options_parse_max_index_bytes_size_string() {
+        let opts: JsonInputOptions =
+            crate::yaml::from_str("format: ndjson\nmax_index_bytes: 64MB\n").unwrap();
+        // Decimal units: 64MB = 64_000_000 bytes.
+        assert_eq!(opts.max_index_bytes, Some(ByteSize(64_000_000)));
+    }
+
+    #[test]
+    fn json_options_max_index_bytes_absent_is_none() {
+        // Genuinely optional — an omitted cap leaves `None`, so the reader
+        // applies its documented default rather than failing to parse.
+        let opts: JsonInputOptions = crate::yaml::from_str("record_path: data.rows\n").unwrap();
+        assert_eq!(opts.max_index_bytes, None);
+    }
+
+    #[test]
+    fn json_options_max_index_bytes_accepts_bare_byte_count() {
+        let opts: JsonInputOptions = crate::yaml::from_str("max_index_bytes: 4096\n").unwrap();
+        assert_eq!(opts.max_index_bytes, Some(ByteSize(4096)));
+    }
 }

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -22,6 +22,7 @@ rules.
     options:
       format: ndjson          # array | ndjson | object (auto-detect if omitted)
       record_path: "$.data"   # JSONPath to the records array (object format)
+      max_index_bytes: 64MB   # cap on retained envelope sections (optional)
 ```
 
 ## Physical shapes
@@ -43,3 +44,22 @@ product. The [`array_paths`](../nodes/source.md#array-paths) field on the
 source controls whether each nested array **explodes** into one record per
 element or **joins** into a delimited string. That field is shared with
 the XML reader and documented on the Source Nodes page.
+
+## Bounding envelope retention: `max_index_bytes`
+
+When a source declares an `envelope:` and a pipeline reads `$doc.*` paths
+from it, the JSON reader runs a streaming pre-scan that walks the document
+once and retains only the declared section subtrees — every other key,
+including a multi-megabyte body array, is parsed-and-skipped without being
+stored. The retained sections live in a bounded document index.
+
+`max_index_bytes` caps that index. It is charged incrementally as each
+section is parsed, so even a single oversized declared section aborts
+mid-parse (naming the section and the cap) rather than risking an
+out-of-memory failure. It accepts a decimal size string (`64MB`, `500KB`)
+or a bare byte count; optional, defaulting to **64MB**. Only the declared
+sections a program actually reads are retained, so envelope metadata sits
+far below this ceiling in practice — the cap exists to convert an unbounded
+mistake into a clear error. See
+[Document Envelope Context](../pipelines/envelope-and-doc-context.md) for
+the full model.

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -63,8 +63,54 @@ project:
   - running_fraction: row_index / $doc.Summary.record_count
 ```
 
+The pre-scan reads the envelope-bearing segments of the file before
+body streaming begins. Envelope payloads are small (a few hundred bytes
+per document is typical), and how much of the file the reader retains to
+reach a trailing section depends on the format:
+
+- **JSON** streams the pre-scan. The reader walks the document once and
+  deserializes *only* the subtrees the declared sections point at —
+  every other key (including a multi-megabyte body array) is
+  parsed-and-skipped without being stored. The retained sections live in
+  a bounded **document index** capped by `max_index_bytes` (see below),
+  so memory scales with the declared sections, not the document size.
+- **XML** currently buffers the document to reach trailing sections;
+  streaming its pre-scan is tracked as a follow-up. Until then an
+  XML envelope-aware source holds the file's bytes for the lifetime of
+  the read.
+
 Only the envelope sections live in the document context — body records
-still flow through the pipeline one at a time.
+still flow through the pipeline one at a time, for every format.
+
+### Bounding JSON envelope retention with `max_index_bytes`
+
+The JSON document index is capped so a pathologically large declared
+section fails loud rather than exhausting memory. The cap is charged
+incrementally *as each section is parsed* — byte by byte while the
+section's subtree is built — so even a single oversized declared section
+aborts mid-parse, before its whole subtree materializes, naming the
+offending section and the cap. (Undeclared siblings, including a
+multi-megabyte body array, are skipped without being parsed into memory
+at all.)
+
+```yaml
+- type: source
+  name: events
+  config:
+    name: events
+    type: json
+    path: "./data/events.json"
+    options:
+      record_path: data.rows
+      max_index_bytes: 64MB   # cap on retained envelope sections
+```
+
+`max_index_bytes` accepts a decimal size string (`64MB`, `500KB`) or a
+bare byte count. It is optional; when omitted the reader applies a
+documented finite default of **64MB**. Only the declared sections a
+program actually reads are retained, so envelope metadata sits far below
+this ceiling in practice — the cap exists to convert an unbounded
+mistake into a clear error.
 
 ## Extract rules per format
 


### PR DESCRIPTION
Replaces the JSON envelope pre-scan's full-document materialization with a single streaming pass that retains only the declared `$doc.*` subtrees. Previously `prepare_document` ran `serde_json::from_slice` over the whole buffered document, building a complete `serde_json::Value` tree — multiple GiB of RSS on a large document, violating the bounded-memory model. It now walks the document once with a `DeserializeSeed` visitor, deserializing only the subtrees named by the planner-computed declared `$doc` paths and skipping everything else via `IgnoredAny`.

- New `DocArenaIndex` (format-agnostic, parser-agnostic — its `insert` takes an already-built `Value`, so the forthcoming streaming XML reader feeds the same type) charges retained bytes incrementally against a configurable `max_index_bytes` cap (default 64 MB) that fires mid-build, naming the offending section, rather than letting a runaway document OOM.
- This is the first runtime consumer of the planner's `declared_doc_paths`; the plan→ingest→reader plumbing it adds is reused by the XML reader.
- Tests cover bounded retention (a large document with a small declared path set retains orders of magnitude less than the input), the cap-exceeded error firing during the build, and the no-declared-paths fast path.

Closes #383.