### PR TITLE
engine: document-level dead-letter policy — reject an entire document on any record failure

### DIFF
--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -84,6 +84,7 @@
 //! | `E340`      | error    | A `$doc.<section>.<field>` access is indexed by a non-literal expression, so its declared document path cannot be resolved at compile time |
 //! | `E341`      | error    | A `$doc.<section>.<field>` access names an envelope section or field a feeding XML/JSON source does not declare |
 //! | `E342`      | error    | `swift` output combined with byte-limit `split` (a SWIFT MT message is one indivisible brace-balanced `{1:..}..{5:..}` envelope) |
+//! | `E343`      | error    | A per-source-file output template (`{source_file}` / `{source_path}`) combined with a source declaring `dlq_granularity: document` (a buffered-and-flushed document is incompatible with per-record file fan-out) |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-core-types/src/dlq.rs
+++ b/crates/clinker-core-types/src/dlq.rs
@@ -27,6 +27,17 @@ pub enum DlqErrorCategory {
     /// One entry per group with `trigger: true` plus collaterals for the
     /// other buffered records of the same group.
     GroupSizeExceeded,
+    /// Collateral entry emitted for a non-failing record in a document the
+    /// engine dead-lettered because some other record (or, in a later
+    /// build, an envelope/checksum validation) failed under a source's
+    /// `dlq_granularity: document` policy. The sibling root-cause entry
+    /// carries `trigger: true` and the original failure category; every
+    /// other record of the same document carries `trigger: false` and this
+    /// category. Each collateral counts toward the DLQ rate denominator —
+    /// a rejected N-record document contributes N entries — mirroring the
+    /// `Correlated` collateral precedent. Emitted only by the per-document
+    /// reject path in the Output dispatch arm.
+    DocumentRejected,
     /// Record arrived at a time-windowed aggregate after the window
     /// covering its event-time had already closed
     /// (`window_end + allowed_lateness < min_across_sources`). Routed
@@ -76,6 +87,7 @@ impl DlqErrorCategory {
             Self::AggregateFinalize => "aggregate_finalize",
             Self::Correlated => "correlated",
             Self::GroupSizeExceeded => "group_size_exceeded",
+            Self::DocumentRejected => "document_rejected",
             Self::LateRecord => "late_record",
             Self::ExpansionLimitExceeded => "expansion_limit_exceeded",
             Self::CombineOutputRow => "combine_output_row",
@@ -142,6 +154,10 @@ mod tests {
         assert_eq!(
             DlqErrorCategory::GroupSizeExceeded.as_str(),
             "group_size_exceeded"
+        );
+        assert_eq!(
+            DlqErrorCategory::DocumentRejected.as_str(),
+            "document_rejected"
         );
         assert_eq!(DlqErrorCategory::LateRecord.as_str(), "late_record");
         assert_eq!(

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -386,9 +386,27 @@ pub(crate) fn dispatch_transform_eval_error(
     if routed {
         return Ok(());
     }
-    let source_name = source_name_arc_of(&record);
     let triggering_field = eval_err.triggering_field.clone();
     let triggering_value = eval_err.triggering_value();
+    // Under `dlq_granularity: document`, a failure here condemns the whole
+    // document: mark it failed (capturing this record as the root cause)
+    // instead of dead-lettering only the failing record. The Output arm
+    // emits the trigger + collateral entries at the document's close.
+    let marked = crate::executor::document_dlq::record_error_to_document_buffer_if_doc_dlq(
+        ctx,
+        &record,
+        row_num,
+        category,
+        eval_err.to_string(),
+        stage.clone(),
+        None,
+        triggering_field.clone(),
+        triggering_value.clone(),
+    );
+    if marked {
+        return Ok(());
+    }
+    let source_name = source_name_arc_of(&record);
     push_dlq(
         ctx,
         DlqEntry {
@@ -762,6 +780,16 @@ pub(crate) struct ExecutorContext<'a> {
     /// buffering is disabled. Read by the Output arm before admitting
     /// a record into the buffer to detect overflow at admission time.
     pub(crate) correlation_max_group_buffer: u64,
+
+    /// Run-scoped document-level DLQ state. `Some` iff at least one source
+    /// declares `dlq_granularity: document` — the Output arm then drives a
+    /// per-document buffer (flush clean / reject dirty at each
+    /// `DocumentClose`, peak = concurrently-open documents, spillable under
+    /// budget), and upstream Transform / Route failures mark the failing
+    /// record's document here instead of pushing a per-record DLQ entry.
+    /// `None` otherwise; every record streams through per-record DLQ
+    /// semantics with zero overhead.
+    pub(crate) document_dlq: Option<crate::executor::document_dlq::DocumentDlqState>,
 
     /// Per-aggregate retained state for nodes whose `group_by` omits a
     /// correlation-key field. Populated by the Aggregate dispatch arm

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -1,0 +1,1130 @@
+//! Document-level dead-lettering for sources declaring
+//! `dlq_granularity: document`.
+//!
+//! Under the default `record` granularity a record failure dead-letters
+//! only that record; under `document` it dead-letters the entire document
+//! the failing record belongs to. The shape mirrors the correlation-group
+//! commit (buffer-until-boundary, flush clean / DLQ dirty, trigger /
+//! collateral split) but the memory model is the per-document Aggregate
+//! flush: records buffer per document and each document's bucket DROPS at
+//! its boundary, so a closed document's records leave RAM before the next
+//! file opens. A buffered bucket SPILLS to disk under the shared
+//! [`crate::pipeline::memory::MemoryArbitrator`] budget rather than OOM-ing,
+//! every bucket registering its own consumer the same way the Aggregate
+//! per-document tables do.
+//!
+//! ## Document grain
+//!
+//! The document is the OUTERMOST envelope level — the source file (an EDI
+//! interchange, a batch file with header/trailer). A nested-envelope format
+//! (X12 ISA → GS → ST) stamps each record with its innermost level's id,
+//! but every level of one file shares the file's `source_file` Arc, so the
+//! buffer keys on `source_file`: a failure anywhere in the file rejects the
+//! whole file, and a record arriving between two nested-level boundaries
+//! still belongs to its file's bucket. A flat single-level file (CSV, JSON,
+//! plain XML) has innermost == outermost == the file, so the grain is the
+//! file there too. The file's bucket decides when its OUTERMOST close
+//! arrives — tracked by per-file envelope depth returning to zero (nested
+//! closes leave the file open) — or at end-of-input for an unterminated
+//! file.
+//!
+//! ## Streaming
+//!
+//! Streaming is disabled pipeline-wide when any source declares the
+//! `document` granularity (see `PipelineConfig::any_source_has_document_dlq`):
+//! per-document buffering at the Output arm needs the materialized
+//! `DocumentClose` punctuation the streaming-Output / streaming-ingest
+//! short-circuits would otherwise consume out of band.
+//!
+//! ## DLQ rate
+//!
+//! The rate counts per entry: a rejected N-record document emits one
+//! `trigger: true` root cause plus N-1 `trigger: false` collateral entries,
+//! each counting toward the rate denominator — so a rejected 1000-record
+//! document contributes 1000 to the DLQ rate, matching the correlation
+//! collateral precedent.
+//!
+//! ## Spill correctness
+//!
+//! Document identity survives spilling end to end. The driver's own
+//! per-document bucket keys records by `source_file` BEFORE spilling them,
+//! and appends only its in-memory tail to a new chunk so repeated spills are
+//! O(total records), not O(records²). Upstream is covered too: a record's
+//! document context — including the `source_file` the grain keys on — now
+//! rides through the shared record-spill format, so a record arriving via an
+//! UPSTREAM node-buffer that spilled keeps its file identity and is still
+//! governed by the policy.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use clinker_record::{DocumentId, Record};
+
+use crate::executor::dispatch::{
+    ExecutorContext, MERGED_SOURCE_FILE, push_dlq, source_file_arc_of, source_name_arc_of,
+};
+use crate::executor::node_buffer::NodeBuffer;
+use crate::executor::stream_event::StreamEvent;
+use crate::executor::{DlqEntry, build_format_writer};
+use crate::projection::project_output_from_record;
+use clinker_plan::config::OutputConfig;
+use clinker_plan::error::PipelineError;
+
+/// Identity of one document the policy operates on: its source file (the
+/// outermost envelope level). Every record and boundary of a file shares
+/// this `Arc<str>`, so it is the grain a failure rejects at.
+type DocKey = Arc<str>;
+
+/// Root-cause failure captured for a document the first time one of its
+/// records (or an out-of-band validation) fails. Replayed as the single
+/// `trigger: true` DLQ entry when the document is rejected.
+struct DocTrigger {
+    source_row: u64,
+    category: clinker_core_types::dlq::DlqErrorCategory,
+    error_message: String,
+    original_record: Record,
+    stage: Option<String>,
+    route: Option<String>,
+    source_name: Arc<str>,
+    triggering_field: Option<Arc<str>>,
+    triggering_value: Option<clinker_record::Value>,
+}
+
+/// Run-scoped document-DLQ state: which sources opt into the policy, the
+/// failed-document set with each document's captured root-cause trigger,
+/// and the run-scoped dedup set that keeps a duplicate close from
+/// re-emitting a document's reject entries.
+///
+/// `Some(..)` on [`ExecutorContext::document_dlq`] iff at least one source
+/// declares `dlq_granularity: document`; `None` otherwise (the dominant
+/// per-record path, zero overhead). The per-document RECORD buffers live in
+/// the Output arm's single invocation (a local driver), not here. Only the
+/// cross-stage failure marks and the reject dedup are run-scoped, because an
+/// upstream Transform / Route failure must be visible to the Output at the
+/// document's close.
+pub(crate) struct DocumentDlqState {
+    /// Source-node names declaring `dlq_granularity: document`. A record is
+    /// governed by the policy only when its originating source is in this
+    /// set; records from `record`-granularity sources in the same run
+    /// stream through untouched.
+    doc_sources: HashSet<Arc<str>>,
+    /// Documents marked failed, keyed by source file, with the root-cause
+    /// trigger captured at the FIRST failure. Run-scoped so an upstream
+    /// failure (Transform / Route, before any Output) is visible to every
+    /// Output at the document's close.
+    failed: HashMap<DocKey, DocTrigger>,
+    /// Records of a failed document that ALSO failed (the 2nd, 3rd, … failure
+    /// in the same document), keyed by source file. Only the first failure
+    /// becomes the trigger; a later failing record never reaches an Output
+    /// (it was suppressed at its Transform / Route failure site), so it is
+    /// captured here and emitted as a `DocumentRejected` collateral at the
+    /// document's reject — preserving the invariant that every record of a
+    /// rejected N-record document contributes exactly one DLQ entry.
+    extra_collaterals: HashMap<DocKey, Vec<(Record, u64)>>,
+    /// Documents whose reject DLQ entries have already been emitted. A
+    /// duplicate close (fan-in dedup escapee, malformed input) finds the key
+    /// here and emits nothing more.
+    rejected: HashSet<DocKey>,
+}
+
+impl DocumentDlqState {
+    /// Build the run-scoped state from the set of document-granularity
+    /// source names. Empty marks / dedup — the first marked failure
+    /// populates them.
+    pub(crate) fn new(doc_sources: HashSet<Arc<str>>) -> Self {
+        Self {
+            doc_sources,
+            failed: HashMap::new(),
+            extra_collaterals: HashMap::new(),
+            rejected: HashSet::new(),
+        }
+    }
+
+    /// The document key (source file) `record` is governed by under the
+    /// `document` policy, or `None` when it is not governed: its originating
+    /// source declares the policy, it carries a real (non-synthetic)
+    /// document id, AND it carries a concrete source file (the key). A
+    /// `SYNTHETIC`-id or file-less record (a no-document source, an
+    /// in-pipeline synthesis, a post-Combine merged-lineage row) has no
+    /// document to reject, so it falls back to per-record DLQ semantics.
+    /// Returning the key — rather than a bool plus a second
+    /// `source_file_arc_of` at the call site — builds the file Arc once per
+    /// governed record.
+    fn governing_key(&self, record: &Record) -> Option<DocKey> {
+        if record.doc_ctx().id() == DocumentId::SYNTHETIC
+            || !self.doc_sources.contains(&source_name_arc_of(record))
+        {
+            return None;
+        }
+        let file = source_file_arc_of(record);
+        is_concrete_file(&file).then_some(file)
+    }
+}
+
+/// A source-file Arc identifies a real document only when it names a
+/// concrete file — not the empty stamp or the `<merged>` sentinel a
+/// fan-in (Combine / post-aggregate) record carries.
+fn is_concrete_file(file: &Arc<str>) -> bool {
+    !file.is_empty() && file.as_ref() != MERGED_SOURCE_FILE.as_ref()
+}
+
+/// Mark a document failed and capture its root-cause trigger, returning
+/// `true` iff the failure was absorbed into the document-DLQ state (the
+/// caller must NOT also push a per-record DLQ entry). Returns `false` when
+/// the buffer is inactive or the record is not under the `document` policy,
+/// signaling the caller to take its per-record DLQ path.
+///
+/// The first failure for a document wins the trigger slot; later failures
+/// of the same document are swallowed (the document is already doomed), so
+/// the trigger always names the earliest root cause. Mirrors
+/// `record_error_to_buffer_if_grouped`, the correlation-buffer sibling.
+///
+/// This is the routable reject-document seam: `category` is parameterized,
+/// so a non-record-eval validator (an envelope / checksum check that
+/// condemns the whole document without any one record being at fault)
+/// passes its own category and a representative document record here to mark
+/// the document failed — it need not be a CXL-eval failure. The engine
+/// reserves [`clinker_core_types::dlq::DlqErrorCategory::DocumentRejected`]
+/// for the `trigger: false` collateral siblings; the trigger carries
+/// whatever `category` the caller supplies.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn record_error_to_document_buffer_if_doc_dlq(
+    ctx: &mut ExecutorContext<'_>,
+    record: &Record,
+    row_num: u64,
+    category: clinker_core_types::dlq::DlqErrorCategory,
+    error_message: String,
+    stage: Option<String>,
+    route: Option<String>,
+    triggering_field: Option<Arc<str>>,
+    triggering_value: Option<clinker_record::Value>,
+) -> bool {
+    let Some(state) = ctx.document_dlq.as_ref() else {
+        return false;
+    };
+    let Some(key) = state.governing_key(record) else {
+        return false;
+    };
+    let source_name = source_name_arc_of(record);
+    mark_document_failed(
+        ctx,
+        key,
+        DocTrigger {
+            source_row: row_num,
+            category,
+            error_message,
+            original_record: record.clone(),
+            stage,
+            route,
+            source_name,
+            triggering_field,
+            triggering_value,
+        },
+    );
+    true
+}
+
+/// Mark document `key` failed by `trigger`. The FIRST failure becomes the
+/// document's root-cause trigger; a later failure of an already-failed
+/// document stashes its record as an extra collateral (the trigger slot is
+/// taken), so that record still contributes a `DocumentRejected` entry at
+/// the document's reject rather than vanishing — every record of a rejected
+/// document is accounted for as the trigger or a collateral.
+fn mark_document_failed(ctx: &mut ExecutorContext<'_>, key: DocKey, trigger: DocTrigger) {
+    let Some(state) = ctx.document_dlq.as_mut() else {
+        return;
+    };
+    match state.failed.entry(key.clone()) {
+        std::collections::hash_map::Entry::Vacant(v) => {
+            v.insert(trigger);
+        }
+        std::collections::hash_map::Entry::Occupied(_) => {
+            state
+                .extra_collaterals
+                .entry(key)
+                .or_default()
+                .push((trigger.original_record, trigger.source_row));
+        }
+    }
+}
+
+/// One per-document record bucket inside the Output-arm driver: a spillable
+/// [`NodeBuffer`] charged against the shared arbitrator through its own
+/// consumer, plus the live envelope depth for the file. The bucket drops at
+/// the file's outermost close (depth back to zero) or at end-of-input.
+struct DocBucket {
+    buffer: NodeBuffer,
+    consumer_id: crate::pipeline::memory::ConsumerId,
+    handle: Arc<crate::pipeline::memory::ConsumerHandle>,
+    /// Envelope nesting depth for this file: incremented on each
+    /// `DocumentOpen` carrying the file, decremented on each
+    /// `DocumentClose`. The file's outermost close is the one that returns
+    /// this to zero; a nested-level close leaves it positive.
+    depth: i64,
+}
+
+/// Per-Output-invocation driver for the `document` granularity: buffers
+/// each record into its file's spillable bucket and, when the file's
+/// outermost close arrives (envelope depth back to zero) or at end-of-input,
+/// flushes the file clean to this Output's writer or rejects it to the DLQ.
+/// The bucket drops on decision, so per-document peak memory falls — peak is
+/// the concurrently-open files.
+///
+/// Blocking at the document grain: a buffered record is not written until
+/// its file's outermost close decides the file clean. The writer is opened
+/// lazily on the first clean record and reused across this arm's document
+/// decisions, then flushed at the driver's end.
+pub(crate) struct DocumentDlqDriver<'cfg> {
+    output_name: String,
+    out_cfg: &'cfg OutputConfig,
+    cxl_emit_names: Option<Vec<String>>,
+    /// Per-file spillable buckets, dropped at each file's outermost close.
+    buckets: HashMap<DocKey, DocBucket>,
+    /// Files already flushed clean / rejected this invocation, so a record
+    /// or close arriving after a file is decided does not silently vanish:
+    /// a late record for a decided-clean file writes through (it would have
+    /// flushed); a late record for a decided-failed file dead-letters as a
+    /// collateral; a duplicate close is a no-op.
+    decided: HashSet<DocKey>,
+    /// The Output's writer, opened on the first clean record and reused
+    /// across this arm's document decisions. `None` until then.
+    writer: Option<Box<dyn clinker_format::FormatWriter>>,
+    arbitrator: Arc<crate::pipeline::memory::MemoryArbitrator>,
+    spill_root: Arc<std::path::Path>,
+    spill_compress: clinker_plan::config::CompressMode,
+    batch_size: usize,
+    ok_count: u64,
+    records_written: u64,
+}
+
+impl<'cfg> DocumentDlqDriver<'cfg> {
+    /// Build the driver for one Output arm invocation. `cxl_emit_names`
+    /// drives `include_unmapped: false` projection; `None`/empty keeps the
+    /// upstream passthrough.
+    pub(crate) fn new(
+        ctx: &ExecutorContext<'_>,
+        output_name: &str,
+        out_cfg: &'cfg OutputConfig,
+        cxl_emit_names: Vec<String>,
+    ) -> Self {
+        let cxl_emit_names = if cxl_emit_names.is_empty() {
+            None
+        } else {
+            Some(cxl_emit_names)
+        };
+        Self {
+            output_name: output_name.to_string(),
+            out_cfg,
+            cxl_emit_names,
+            buckets: HashMap::new(),
+            decided: HashSet::new(),
+            writer: None,
+            arbitrator: Arc::clone(&ctx.memory_budget),
+            spill_root: Arc::clone(&ctx.spill_root_path),
+            spill_compress: ctx.spill_compress,
+            batch_size: ctx.batch_size,
+            ok_count: 0,
+            records_written: 0,
+        }
+    }
+
+    /// Borrow (building on first sight) the bucket for file `key`. The
+    /// arbitrator is passed in so the caller's other `&self` fields stay
+    /// free of the `&mut self.buckets` borrow this returns.
+    fn bucket_for<'a>(
+        buckets: &'a mut HashMap<DocKey, DocBucket>,
+        arbitrator: &crate::pipeline::memory::MemoryArbitrator,
+        key: &DocKey,
+    ) -> &'a mut DocBucket {
+        buckets.entry(Arc::clone(key)).or_insert_with(|| {
+            let handle = crate::pipeline::memory::ConsumerHandle::new();
+            let consumer_id = arbitrator.register_consumer(Arc::new(
+                crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+            ));
+            DocBucket {
+                buffer: NodeBuffer::Memory(Vec::new()),
+                consumer_id,
+                handle,
+                depth: 0,
+            }
+        })
+    }
+
+    /// Buffer one record into its file's bucket, charging and spilling the
+    /// bucket under budget pressure.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces a spill-cap-exceeded [`PipelineError`] when admitting the
+    /// bucket would push cumulative spill past the configured ceiling.
+    fn buffer_record(
+        &mut self,
+        key: &DocKey,
+        record: Record,
+        row_num: u64,
+    ) -> Result<(), PipelineError> {
+        let column_count = record.schema().column_count();
+        let bucket = Self::bucket_for(&mut self.buckets, &self.arbitrator, key);
+        bucket.buffer.push(record, row_num);
+        bucket
+            .handle
+            .set_bytes(bucket.buffer.estimated_memory_bytes());
+        self.arbitrator.sample_peak_consumer_usage();
+        if self.arbitrator.should_spill() {
+            spill_bucket_in_place(
+                bucket,
+                &self.arbitrator,
+                &self.output_name,
+                self.spill_root.as_ref(),
+                self.spill_compress,
+                self.batch_size,
+                column_count,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Decide file `key`: flush it clean to the writer or, if its run-scoped
+    /// failed mark is set, reject it. Drops the bucket and marks the file
+    /// decided. Idempotent — a second decision for the same file is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces writer-build / write / flush failures, spill-drain decode
+    /// errors, and any DLQ-rate error from a reject as a [`PipelineError`].
+    fn decide_document(
+        &mut self,
+        ctx: &mut ExecutorContext<'_>,
+        key: &DocKey,
+    ) -> Result<(), PipelineError> {
+        if !self.decided.insert(Arc::clone(key)) {
+            return Ok(());
+        }
+        let bucket = self.buckets.remove(key);
+        let is_failed = ctx
+            .document_dlq
+            .as_ref()
+            .is_some_and(|s| s.failed.contains_key(key));
+        if is_failed {
+            reject_document_now(ctx, key, bucket)
+        } else {
+            self.flush_clean(ctx, bucket)
+        }
+    }
+
+    /// Write a clean document's buffered (possibly spilled) records through
+    /// this Output's writer, opening it on first use. Unregisters the
+    /// bucket's arbitrator consumer.
+    fn flush_clean(
+        &mut self,
+        ctx: &mut ExecutorContext<'_>,
+        bucket: Option<DocBucket>,
+    ) -> Result<(), PipelineError> {
+        let Some(bucket) = bucket else {
+            return Ok(());
+        };
+        let DocBucket {
+            buffer,
+            consumer_id,
+            handle,
+            ..
+        } = bucket;
+        handle.set_bytes(0);
+        let cxl_emit_names_opt: Option<&[String]> = self.cxl_emit_names.as_deref();
+
+        let mut projected: Vec<Record> = Vec::with_capacity(buffer.len_hint());
+        // Drain in ARRIVAL order. The success sink is order-sensitive, and a
+        // bucket that spilled and then kept a resident mem tail
+        // (`NodeBuffer::Mixed`) has its NEWEST records in the mem tail —
+        // `NodeBuffer::drain` yields mem-first, which would write the
+        // post-spill tail ahead of the pre-spill body. Emitting the spill
+        // chunks (older) before the resident tail (newer) restores arrival
+        // order. (The reject path's DLQ order is not contractual, so it
+        // drains directly.)
+        for item in drain_records_in_arrival_order(buffer) {
+            let (record, row_num) = item?;
+            projected.push(project_output_from_record(
+                &record,
+                self.out_cfg,
+                cxl_emit_names_opt,
+            ));
+            if ctx.ok_source_rows.insert(row_num) {
+                self.ok_count += 1;
+            }
+            self.records_written += 1;
+        }
+        self.arbitrator.unregister_consumer(consumer_id);
+
+        self.write_projected(ctx, &projected);
+        Ok(())
+    }
+
+    /// Write a non-governed record straight through to this Output's writer,
+    /// counting it toward `ok_count` / `records_written` exactly as the
+    /// per-record Output path does. Used for records a `record`-policy
+    /// source (or in-pipeline synthesis) routes to a document-DLQ Output,
+    /// and for a late record arriving after its file already flushed clean.
+    fn write_through(&mut self, ctx: &mut ExecutorContext<'_>, record: Record, row_num: u64) {
+        let projected =
+            project_output_from_record(&record, self.out_cfg, self.cxl_emit_names.as_deref());
+        if ctx.ok_source_rows.insert(row_num) {
+            self.ok_count += 1;
+        }
+        self.records_written += 1;
+        self.write_projected(ctx, std::slice::from_ref(&projected));
+    }
+
+    /// Write a batch of already-projected records through this Output's
+    /// writer, opening it lazily on first use. Errors land in the context's
+    /// error sink rather than short-circuiting, matching the per-record
+    /// Output path.
+    fn write_projected(&mut self, ctx: &mut ExecutorContext<'_>, projected: &[Record]) {
+        if projected.is_empty() {
+            return;
+        }
+        if self.writer.is_none() {
+            let Some(raw_writer) = ctx.writers.remove(&self.output_name) else {
+                // No writer registered for this Output (a dry-run or a
+                // sibling already took it): nothing to write to.
+                return;
+            };
+            let output_schema = Arc::clone(projected[0].schema());
+            match build_format_writer(self.out_cfg, raw_writer, output_schema) {
+                Ok(w) => self.writer = Some(w),
+                Err(e) => {
+                    ctx.output_errors.push(e);
+                    return;
+                }
+            }
+        }
+        let writer = self.writer.as_mut().expect("writer opened above");
+        for record in projected {
+            let write_result = {
+                let _guard = ctx.write_timer.guard();
+                writer.write_record(record)
+            };
+            if let Err(e) = write_result {
+                ctx.output_errors.push(e.into());
+                break;
+            }
+        }
+    }
+
+    /// Handle one governed record: buffer it into its open file's bucket, or
+    /// — when its file was already decided (a record arriving after its
+    /// file's close, e.g. an upstream interleave) — route it to match the
+    /// file's verdict so it never silently vanishes. A late record for a
+    /// clean file writes through; a late record for a failed file
+    /// dead-letters as a `DocumentRejected` collateral.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces buffering spill errors and DLQ-rate errors as a [`PipelineError`].
+    fn admit_governed(
+        &mut self,
+        ctx: &mut ExecutorContext<'_>,
+        key: DocKey,
+        record: Record,
+        row_num: u64,
+    ) -> Result<(), PipelineError> {
+        if self.decided.contains(&key) {
+            let is_failed = ctx
+                .document_dlq
+                .as_ref()
+                .is_some_and(|s| s.failed.contains_key(&key));
+            if is_failed {
+                push_document_collateral(ctx, &key, record, row_num)?;
+            } else {
+                self.write_through(ctx, record, row_num);
+            }
+            return Ok(());
+        }
+        self.buffer_record(&key, record, row_num)
+    }
+
+    /// Drive the Output arm's full drained event stream: buffer each record
+    /// into its file's bucket and, on each file's outermost close (envelope
+    /// depth back to zero), flush-or-reject it; then decide any file whose
+    /// outermost close never arrived (malformed / unterminated input) on the
+    /// same clean-vs-failed axis. Finishes by flushing the writer and
+    /// folding the run counters back into `ctx`.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces buffering, flushing, and reject errors as a [`PipelineError`].
+    pub(crate) fn run(
+        mut self,
+        ctx: &mut ExecutorContext<'_>,
+        events: impl IntoIterator<Item = StreamEvent>,
+    ) -> Result<(), PipelineError> {
+        use crate::executor::stream_event::PunctuationKind;
+        for event in events {
+            match event {
+                StreamEvent::Record(record, row_num) => {
+                    // A governed record buffers under its file's policy; a
+                    // non-governed one (synthetic id, file-less, or a
+                    // `record`-policy source feeding the same Output) writes
+                    // straight through, exactly as a per-record Output does.
+                    let key = ctx
+                        .document_dlq
+                        .as_ref()
+                        .and_then(|s| s.governing_key(&record));
+                    match key {
+                        Some(key) => self.admit_governed(ctx, key, record, row_num)?,
+                        None => self.write_through(ctx, record, row_num),
+                    }
+                }
+                StreamEvent::Punctuation(p) => {
+                    let file = Arc::clone(p.source_file());
+                    if !is_concrete_file(&file) {
+                        continue;
+                    }
+                    match p.kind() {
+                        PunctuationKind::DocumentOpen => {
+                            // Track envelope nesting per file so only the
+                            // OUTERMOST close (depth back to zero) decides
+                            // the file. A bucket may not exist yet for a
+                            // header-only file that has emitted no record;
+                            // create it so the open/close balance is counted.
+                            Self::bucket_for(&mut self.buckets, &self.arbitrator, &file).depth += 1;
+                        }
+                        PunctuationKind::DocumentClose => {
+                            let outermost = match self.buckets.get_mut(&file) {
+                                Some(b) => {
+                                    b.depth -= 1;
+                                    b.depth <= 0
+                                }
+                                // No live bucket: either already decided, or
+                                // a close with no tracked open (malformed) —
+                                // treat as the file's terminal close.
+                                None => true,
+                            };
+                            if outermost {
+                                self.decide_document(ctx, &file)?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // End-of-input drain: any file whose outermost close never arrived
+        // (a malformed / unterminated document) decides on the same
+        // clean-vs-failed axis as one closed in stream — a failed one
+        // rejects with its collaterals, a clean one flushes. Deterministic
+        // order keeps emit / write ordering stable across runs.
+        let mut remaining: Vec<DocKey> = self.buckets.keys().cloned().collect();
+        remaining.sort_unstable();
+        for key in remaining {
+            self.decide_document(ctx, &key)?;
+        }
+
+        if let Some(mut writer) = self.writer.take() {
+            let flush_result = {
+                let _guard = ctx.write_timer.guard();
+                writer.flush()
+            };
+            if let Err(e) = flush_result {
+                ctx.output_errors.push(e.into());
+            }
+        }
+        ctx.counters.ok_count += self.ok_count;
+        ctx.counters.records_written += self.records_written;
+        ctx.records_emitted += self.records_written;
+        Ok(())
+    }
+}
+
+impl Drop for DocumentDlqDriver<'_> {
+    fn drop(&mut self) {
+        // A `?`-early-return out of `run` leaves buckets live; unregister
+        // every surviving consumer so an error exit cannot strand a charge
+        // in the arbitrator's registry. Mirrors `RegisteredTables`' guard.
+        for (_, bucket) in self.buckets.drain() {
+            self.arbitrator.unregister_consumer(bucket.consumer_id);
+        }
+    }
+}
+
+/// End-of-DAG sweep: reject every failed document the run never emitted —
+/// a document marked failed upstream whose close never arrived AND whose
+/// records were all suppressed before any Output (so no Output-arm bucket
+/// carried them). Emits the captured root-cause trigger with no collaterals,
+/// once each. Runs once after every Output arm so a document whose records
+/// DID reach an Output (and was rejected there with its collaterals) is
+/// already in `rejected` and is skipped. A no-op when the document-DLQ
+/// buffer is inactive.
+///
+/// # Errors
+///
+/// Surfaces any DLQ-rate error a trigger push trips as a [`PipelineError`].
+pub(crate) fn reject_unclosed_failed_documents(
+    ctx: &mut ExecutorContext<'_>,
+) -> Result<(), PipelineError> {
+    let Some(state) = ctx.document_dlq.as_ref() else {
+        return Ok(());
+    };
+    let mut pending: Vec<DocKey> = state
+        .failed
+        .keys()
+        .filter(|k| !state.rejected.contains(*k))
+        .cloned()
+        .collect();
+    pending.sort_unstable();
+    for key in pending {
+        reject_document_now(ctx, &key, None)?;
+    }
+    Ok(())
+}
+
+/// Drain a clean document's bucket records in ARRIVAL order — spill chunks
+/// (older) first, then the resident in-memory tail (newer).
+///
+/// [`NodeBuffer::drain`] yields the in-memory events BEFORE the spill chunks,
+/// which is correct for an inter-stage slot (whose mem tail is the
+/// pre-spill head) but inverted for a document-DLQ bucket: a bucket that
+/// spilled and then accumulated a resident tail under relaxed pressure
+/// (`NodeBuffer::Mixed`) holds its NEWEST records in the mem tail. The
+/// success sink is order-sensitive, so this splits the bucket and re-orders
+/// to arrival sequence. Spill rows stream from disk lazily; a decode failure
+/// surfaces as a `PipelineError` item.
+fn drain_records_in_arrival_order(
+    buffer: NodeBuffer,
+) -> impl Iterator<Item = Result<(Record, u64), PipelineError>> {
+    let SpilledRemainder {
+        mem_records,
+        chunks,
+        ..
+    } = peel_mem_tail(buffer);
+    // The chunks alone re-form a `Spilled` buffer whose drain yields each
+    // chunk's records in chunk (= arrival) order; the resident tail follows.
+    let chunk_records = NodeBuffer::Spilled {
+        chunks,
+        pending_puncts: Vec::new(),
+    }
+    .drain()
+    .filter_map(|event| match event {
+        Ok(StreamEvent::Record(r, rn)) => Some(Ok((r, rn))),
+        Ok(StreamEvent::Punctuation(_)) => None,
+        Err(e) => Some(Err(e)),
+    });
+    chunk_records.chain(mem_records.into_iter().map(Ok))
+}
+
+/// A [`NodeBuffer`] split into its in-memory records, its already-on-disk
+/// spill chunks, and its trailing punctuations — the shape
+/// [`spill_bucket_in_place`] needs to append a new chunk without reading any
+/// existing chunk back from disk.
+struct SpilledRemainder {
+    mem_records: Vec<(Record, u64)>,
+    chunks: Vec<(crate::pipeline::spill::SpillFile<u64>, u64)>,
+    puncts: Vec<crate::executor::stream_event::Punctuation>,
+}
+
+/// Split `buffer` into its in-memory records, its on-disk spill chunks, and
+/// its trailing punctuations. Records and puncts in the mem tail separate
+/// (puncts never spill); spill chunks pass through untouched.
+fn peel_mem_tail(buffer: NodeBuffer) -> SpilledRemainder {
+    let (mem_events, chunks, mut puncts) = match buffer {
+        NodeBuffer::Memory(events) => (events, Vec::new(), Vec::new()),
+        NodeBuffer::Spilled {
+            chunks,
+            pending_puncts,
+        } => (Vec::new(), chunks, pending_puncts),
+        NodeBuffer::Mixed {
+            mem,
+            spills,
+            pending_puncts,
+        } => (mem, spills, pending_puncts),
+    };
+    let mut mem_records: Vec<(Record, u64)> = Vec::with_capacity(mem_events.len());
+    for event in mem_events {
+        match event {
+            StreamEvent::Record(r, rn) => mem_records.push((r, rn)),
+            StreamEvent::Punctuation(p) => puncts.push(p),
+        }
+    }
+    SpilledRemainder {
+        mem_records,
+        chunks,
+        puncts,
+    }
+}
+
+/// Flush only a bucket's in-memory tail to a NEW spill chunk, APPENDING it
+/// to any chunks the bucket already holds, and charge the file against the
+/// arbitrator's spill quota.
+///
+/// Peeling off only the mem tail (rather than draining the whole buffer and
+/// re-spilling every prior chunk) keeps repeated spills under sustained
+/// memory pressure O(total records), not O(records²): existing on-disk
+/// chunks stay on disk untouched. Punctuations never spill — they ride in
+/// `pending_puncts` and drain at the document tail.
+fn spill_bucket_in_place(
+    bucket: &mut DocBucket,
+    arbitrator: &crate::pipeline::memory::MemoryArbitrator,
+    output_name: &str,
+    spill_root: &std::path::Path,
+    spill_compress: clinker_plan::config::CompressMode,
+    batch_size: usize,
+    column_count: usize,
+) -> Result<(), PipelineError> {
+    // Peel only the in-memory portion off the bucket, leaving any existing
+    // spill chunks on disk untouched (no read-back). The mem-tail records
+    // become a new chunk appended after them.
+    let SpilledRemainder {
+        mem_records,
+        mut chunks,
+        puncts,
+    } = peel_mem_tail(std::mem::replace(
+        &mut bucket.buffer,
+        NodeBuffer::Memory(Vec::new()),
+    ));
+    if mem_records.is_empty() {
+        // Nothing new to flush — restore the buffer unchanged.
+        bucket.buffer = NodeBuffer::Spilled {
+            chunks,
+            pending_puncts: puncts,
+        };
+        return Ok(());
+    }
+
+    let compress = spill_compress.resolve_for_schema(column_count, batch_size as u64);
+    if let Some((file, count)) = crate::executor::node_buffer_spill::spill_node_buffer(
+        mem_records,
+        Some(spill_root),
+        compress,
+    )? {
+        let file_bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
+        if arbitrator.record_spill_bytes(output_name, file_bytes) {
+            return Err(PipelineError::spill_cap_exceeded(
+                output_name,
+                arbitrator.max_spill_bytes(),
+                file_bytes,
+                arbitrator.cumulative_spill_bytes(),
+            ));
+        }
+        chunks.push((file, count));
+    }
+    // The mem tail is now on disk; the bucket's live in-memory bytes are
+    // zero (only spill chunks remain).
+    bucket.handle.set_bytes(0);
+    bucket.buffer = NodeBuffer::Spilled {
+        chunks,
+        pending_puncts: puncts,
+    };
+    Ok(())
+}
+
+/// Emit one `DocumentRejected` collateral for a single late record that
+/// arrived after its document was already decided-failed. Counts toward the
+/// DLQ rate like every other collateral.
+fn push_document_collateral(
+    ctx: &mut ExecutorContext<'_>,
+    key: &DocKey,
+    record: Record,
+    row_num: u64,
+) -> Result<(), PipelineError> {
+    let source_name = source_name_arc_of(&record);
+    push_dlq(
+        ctx,
+        DlqEntry {
+            source_row: row_num,
+            category: clinker_core_types::dlq::DlqErrorCategory::DocumentRejected,
+            error_message: format!("document {key:?} rejected: a sibling record failed"),
+            original_record: record,
+            stage: Some("document_dlq".to_string()),
+            route: None,
+            trigger: false,
+            source_name,
+            triggering_field: None,
+            triggering_value: None,
+        },
+    )
+}
+
+/// Emit the reject DLQ entries for failed document `key`, once per document
+/// run-scoped: the captured root-cause trigger (`trigger: true`, its
+/// original category) followed by a `DocumentRejected` collateral
+/// (`trigger: false`) for every other buffered record of the document.
+/// Every emitted entry counts toward the DLQ rate. Drops the document's
+/// trigger and its bucket.
+fn reject_document_now(
+    ctx: &mut ExecutorContext<'_>,
+    key: &DocKey,
+    bucket: Option<DocBucket>,
+) -> Result<(), PipelineError> {
+    let already_rejected = {
+        let state = ctx
+            .document_dlq
+            .as_mut()
+            .expect("document_dlq is Some — checked by caller");
+        !state.rejected.insert(Arc::clone(key))
+    };
+    if already_rejected {
+        // Already rejected (duplicate close): release any bucket this caller
+        // handed in so its consumer does not leak, and emit nothing more.
+        if let Some(bucket) = bucket {
+            bucket.handle.set_bytes(0);
+            ctx.memory_budget.unregister_consumer(bucket.consumer_id);
+        }
+        return Ok(());
+    }
+    let (trigger, extra_collaterals) = {
+        let state = ctx
+            .document_dlq
+            .as_mut()
+            .expect("document_dlq is Some — checked above");
+        (
+            state.failed.remove(key),
+            state.extra_collaterals.remove(key).unwrap_or_default(),
+        )
+    };
+
+    // Collect this document's collateral rows out of the bucket before any
+    // `push_dlq` borrows `ctx` mutably. Dedup collateral by `(source_name,
+    // row_num)` so a fan-out that routed one source row to several Outputs
+    // emits one collateral, not N — the same identity the correlation
+    // collateral walk dedups on. The trigger's own row is seeded into the
+    // seen set so the root-cause record is never also a collateral.
+    let mut seen: HashSet<(Arc<str>, u64)> = HashSet::new();
+    if let Some(t) = trigger.as_ref() {
+        seen.insert((Arc::clone(&t.source_name), t.source_row));
+    }
+    let mut collaterals: Vec<(Record, u64, Arc<str>)> = Vec::new();
+    // A non-first failing record of this document was suppressed at its
+    // failure site (it never reached an Output bucket), so emit it as a
+    // collateral here. Added before the bucket walk so a record that
+    // somehow appears in both is deduped to one entry.
+    for (record, row_num) in extra_collaterals {
+        let source_name = source_name_arc_of(&record);
+        if seen.insert((Arc::clone(&source_name), row_num)) {
+            collaterals.push((record, row_num, source_name));
+        }
+    }
+    if let Some(bucket) = bucket {
+        let DocBucket {
+            buffer,
+            consumer_id,
+            handle,
+            ..
+        } = bucket;
+        handle.set_bytes(0);
+        for event in buffer.drain() {
+            if let StreamEvent::Record(record, row_num) = event? {
+                let source_name = source_name_arc_of(&record);
+                if seen.insert((Arc::clone(&source_name), row_num)) {
+                    collaterals.push((record, row_num, source_name));
+                }
+            }
+        }
+        ctx.memory_budget.unregister_consumer(consumer_id);
+    }
+
+    if let Some(t) = trigger {
+        push_dlq(
+            ctx,
+            DlqEntry {
+                source_row: t.source_row,
+                category: t.category,
+                error_message: t.error_message,
+                original_record: t.original_record,
+                stage: t.stage,
+                route: t.route,
+                trigger: true,
+                source_name: t.source_name,
+                triggering_field: t.triggering_field,
+                triggering_value: t.triggering_value,
+            },
+        )?;
+    }
+    for (record, row_num, source_name) in collaterals {
+        push_dlq(
+            ctx,
+            DlqEntry {
+                source_row: row_num,
+                category: clinker_core_types::dlq::DlqErrorCategory::DocumentRejected,
+                error_message: format!("document {key:?} rejected: a sibling record failed"),
+                original_record: record,
+                stage: Some("document_dlq".to_string()),
+                route: None,
+                trigger: false,
+                source_name,
+                triggering_field: None,
+                triggering_value: None,
+            },
+        )?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::{Schema, Value};
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec!["id".into(), "value".into()]))
+    }
+
+    fn rec(s: &Arc<Schema>, id: i64, value: i64) -> Record {
+        Record::new(
+            Arc::clone(s),
+            vec![Value::Integer(id), Value::Integer(value)],
+        )
+    }
+
+    /// A per-document bucket that spills to disk round-trips every record
+    /// and row number through the drain — the path both the clean flush and
+    /// the reject collateral walk take over a spilled bucket. Drives
+    /// [`spill_bucket_in_place`] directly so the bucket's OWN spill is
+    /// exercised in isolation from any upstream node-buffer spill (the
+    /// upstream-spill document-identity gap is tracked at
+    /// <https://github.com/rustpunk/clinker/issues/195>).
+    #[test]
+    fn bucket_spill_round_trips_records_and_row_numbers() {
+        let s = schema();
+        // A tiny budget so the registered consumer's reported bytes cross
+        // the soft limit; the bucket then spills to disk.
+        let arbitrator = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
+            64,
+            0.5,
+            Box::new(crate::pipeline::memory::NoOpPolicy),
+        ));
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let consumer_id = arbitrator.register_consumer(Arc::new(
+            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+        ));
+        let mut bucket = DocBucket {
+            buffer: NodeBuffer::Memory(Vec::new()),
+            consumer_id,
+            handle,
+            depth: 1,
+        };
+
+        let n: u64 = 64;
+        for i in 0..n {
+            bucket
+                .buffer
+                .push(rec(&s, i as i64, (i * 10) as i64), 1000 + i);
+        }
+
+        spill_bucket_in_place(
+            &mut bucket,
+            &arbitrator,
+            "out",
+            tmp.path(),
+            clinker_plan::config::CompressMode::default(),
+            8,
+            s.column_count(),
+        )
+        .expect("bucket spills cleanly");
+
+        // The bucket is now disk-backed: its in-memory tail is empty.
+        assert!(
+            matches!(bucket.buffer, NodeBuffer::Spilled { .. }),
+            "the over-budget bucket promoted to a spilled buffer"
+        );
+
+        // Drain reproduces every record and row number in order — the exact
+        // loop the reject / flush paths run over a spilled bucket.
+        let mut drained: Vec<(i64, i64, u64)> = Vec::new();
+        for event in bucket.buffer.drain() {
+            if let StreamEvent::Record(record, row_num) = event.expect("spill drains cleanly") {
+                let id = match &record.values()[0] {
+                    Value::Integer(v) => *v,
+                    other => panic!("unexpected id value: {other:?}"),
+                };
+                let value = match &record.values()[1] {
+                    Value::Integer(v) => *v,
+                    other => panic!("unexpected value: {other:?}"),
+                };
+                drained.push((id, value, row_num));
+            }
+        }
+        arbitrator.unregister_consumer(consumer_id);
+
+        let expected: Vec<(i64, i64, u64)> = (0..n)
+            .map(|i| (i as i64, (i * 10) as i64, 1000 + i))
+            .collect();
+        assert_eq!(
+            drained, expected,
+            "every spilled record and row number round-trips in order"
+        );
+    }
+
+    /// A clean document whose bucket SPILLED and then accumulated a resident
+    /// in-memory tail (a `Mixed` buffer — memory pressure relaxed mid-
+    /// document) is drained to the success sink in ARRIVAL order: the spilled
+    /// head first, then the resident tail. `NodeBuffer::drain` alone would
+    /// invert this (mem tail first), corrupting intra-document output order;
+    /// `drain_records_in_arrival_order` restores it.
+    #[test]
+    fn clean_mixed_bucket_drains_in_arrival_order() {
+        let s = schema();
+        let arbitrator = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
+            64,
+            0.5,
+            Box::new(crate::pipeline::memory::NoOpPolicy),
+        ));
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let consumer_id = arbitrator.register_consumer(Arc::new(
+            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+        ));
+        let mut bucket = DocBucket {
+            buffer: NodeBuffer::Memory(Vec::new()),
+            consumer_id,
+            handle,
+            depth: 1,
+        };
+
+        // Arrival order: rows 0..32 (the head) then rows 32..40 (the tail).
+        // Push and spill the head, then push the tail so the bucket ends in
+        // `Mixed` (spill chunk + resident mem tail) — the state a spilled
+        // document whose pressure relaxed reaches.
+        for i in 0..32u64 {
+            bucket
+                .buffer
+                .push(rec(&s, i as i64, (i * 10) as i64), 100 + i);
+        }
+        spill_bucket_in_place(
+            &mut bucket,
+            &arbitrator,
+            "out",
+            tmp.path(),
+            clinker_plan::config::CompressMode::default(),
+            8,
+            s.column_count(),
+        )
+        .expect("head spills");
+        for i in 32..40u64 {
+            bucket
+                .buffer
+                .push(rec(&s, i as i64, (i * 10) as i64), 100 + i);
+        }
+        assert!(
+            matches!(bucket.buffer, NodeBuffer::Mixed { .. }),
+            "after spilling then pushing more, the bucket is Mixed"
+        );
+
+        // The naive `NodeBuffer::drain` would yield the tail (mem) first.
+        // Arrival-order drain must yield the head (spilled) first.
+        let DocBucket {
+            buffer,
+            consumer_id,
+            ..
+        } = bucket;
+        let rows: Vec<u64> = drain_records_in_arrival_order(buffer)
+            .map(|item| item.expect("drains cleanly").1)
+            .collect();
+        arbitrator.unregister_consumer(consumer_id);
+
+        let expected: Vec<u64> = (100..140).collect();
+        assert_eq!(
+            rows, expected,
+            "the clean Mixed bucket drains in arrival order (spilled head, then resident tail)"
+        );
+    }
+}

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -10,6 +10,7 @@ mod context;
 pub(crate) mod correlation_dispatch;
 pub(crate) mod dispatch;
 mod dlq;
+pub(crate) mod document_dlq;
 mod ingest;
 pub(crate) mod merge_dispatch;
 pub mod node_buffer;
@@ -1162,6 +1163,28 @@ impl PipelineExecutor {
                 (None, 0)
             };
 
+        // Document-level DLQ state. `Some(..)` iff at least one source
+        // declares `dlq_granularity: document`; the set carries those
+        // sources' names so a record's policy is resolved from its
+        // engine-stamped `$source.name` at the Output / error site. Like
+        // correlation buffering, it disables the streaming fast-paths
+        // pipeline-wide (the per-document Output buffer needs the
+        // materialized `DocumentClose` punctuation the streaming
+        // short-circuits would consume out of band).
+        let any_document_dlq = config.any_source_has_document_dlq();
+        let document_dlq = if any_document_dlq {
+            let doc_sources: HashSet<Arc<str>> = source_configs
+                .iter()
+                .filter(|s| s.dlq_granularity == clinker_plan::config::DlqGranularity::Document)
+                .map(|s| Arc::from(s.name.as_str()))
+                .collect();
+            Some(crate::executor::document_dlq::DocumentDlqState::new(
+                doc_sources,
+            ))
+        } else {
+            None
+        };
+
         // Pre-seed each declared source's slot at `None` so the Source
         // dispatch arm can flip to `Some(n)` at receiver close.
         // [`MERGED_SOURCE_NAME`] gets its own slot; populated when
@@ -1219,7 +1242,7 @@ impl PipelineExecutor {
         let streaming_aggregate_ingest_edges: HashMap<
             petgraph::graph::NodeIndex,
             petgraph::graph::NodeIndex,
-        > = if config.any_source_has_correlation_key() {
+        > = if config.any_source_has_correlation_key() || any_document_dlq {
             HashMap::new()
         } else {
             clinker_plan::plan::execution::compute_streaming_aggregate_ingest_edges(
@@ -1241,7 +1264,7 @@ impl PipelineExecutor {
         let streaming_combine_probe_edges: HashMap<
             petgraph::graph::NodeIndex,
             petgraph::graph::NodeIndex,
-        > = if config.any_source_has_correlation_key() {
+        > = if config.any_source_has_correlation_key() || any_document_dlq {
             HashMap::new()
         } else {
             clinker_plan::plan::execution::compute_streaming_combine_probe_edges(
@@ -1398,6 +1421,7 @@ impl PipelineExecutor {
             memory_budget,
             correlation_buffers,
             correlation_max_group_buffer,
+            document_dlq,
             relaxed_aggregator_states: HashMap::new(),
             relaxed_aggregator_degrade: Vec::new(),
             commit_step_path: dispatch::CommitStepPath::NotSelected,
@@ -1541,10 +1565,21 @@ impl PipelineExecutor {
         // a failure, so swallow it here (the interruption is recorded in
         // `ctx.interrupted` and surfaced through the report) and let the
         // run finish draining. Every other walk error still propagates.
-        match walk_result {
-            Ok(()) => {}
-            Err(PipelineError::Interrupted) => {}
+        let walk_completed = match walk_result {
+            Ok(()) => true,
+            Err(PipelineError::Interrupted) => false,
             Err(other) => return Err(other),
+        };
+
+        // Document-level DLQ terminal sweep. The walk's Output arms already
+        // flushed-or-rejected every document whose close arrived or whose
+        // records reached an Output; this rejects the residue — documents
+        // marked failed upstream whose close was lost AND whose records were
+        // all suppressed before any Output — emitting their trigger entry
+        // once each. Skipped on an interrupted run, which is a graceful stop
+        // rather than a completed drain.
+        if walk_completed {
+            crate::executor::document_dlq::reject_unclosed_failed_documents(&mut ctx)?;
         }
 
         // Top-scope teardown: the run has drained, so unregister every

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -51,6 +51,17 @@ pub(crate) fn dispatch_output(
     if ctx.streaming_output_nodes.contains(&node_idx) {
         return Ok(());
     }
+    // Document-level DLQ short-circuit. When any source declares
+    // `dlq_granularity: document`, this Output's records are decided
+    // per-document: buffered until each `DocumentClose`, then flushed clean
+    // to the writer or rejected (trigger + collateral) to the DLQ. The
+    // driver consumes the INTERLEAVED event stream (records + closes in
+    // order), so this path reads the boundary the records-only `drain_split`
+    // below discards — an additive read of the same buffer, not a change to
+    // the records-vs-puncts split contract every other operator relies on.
+    if ctx.document_dlq.is_some() {
+        return dispatch_output_document_dlq(ctx, current_dag, node_idx, name);
+    }
     // Get input records: check own buffer first (Route
     // nodes store records at the successor's index), then
     // fall back to predecessor buffers.
@@ -285,6 +296,90 @@ pub(crate) fn dispatch_output(
     }
 
     Ok(())
+}
+
+/// Execute the `Output` arm under document-level DLQ. Drains this Output's
+/// input as the INTERLEAVED record + `DocumentClose` event stream and hands
+/// it to a [`crate::executor::document_dlq::DocumentDlqDriver`], which
+/// buffers each record per document and, at each close, flushes the
+/// document clean to the writer or rejects it (trigger + collateral) to the
+/// DLQ. Blocking at the document grain — a buffered record is not written
+/// until its close decides the document clean; peak memory is the
+/// concurrently-open documents, spillable under budget.
+fn dispatch_output_document_dlq(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    name: &str,
+) -> Result<(), PipelineError> {
+    let events = drain_output_input_events(ctx, current_dag, node_idx)?;
+
+    if let Some(expected) = current_dag.graph[node_idx]
+        .expected_input_schema_in(current_dag)
+        .cloned()
+    {
+        let upstream_name = current_dag
+            .graph
+            .neighbors_directed(node_idx, Direction::Incoming)
+            .next()
+            .map(|i| current_dag.graph[i].name().to_string())
+            .unwrap_or_default();
+        for event in &events {
+            if let crate::executor::stream_event::StreamEvent::Record(record, _) = event {
+                check_input_schema(&expected, record.schema(), name, "output", &upstream_name)?;
+            }
+        }
+    }
+
+    let out_cfg = ctx
+        .output_configs
+        .iter()
+        .find(|o| o.name == *name)
+        .unwrap_or(ctx.primary_output);
+    let cxl_emit_names = current_dag.graph[node_idx].cxl_emit_names_in(current_dag);
+    let driver =
+        crate::executor::document_dlq::DocumentDlqDriver::new(ctx, name, out_cfg, cxl_emit_names);
+    driver.run(ctx, events)
+}
+
+/// Drain this Output's input buffer as the INTERLEAVED `StreamEvent`
+/// stream, preserving record/`DocumentClose` ordering — the boundary the
+/// records-only `drain_split` path discards. Mirrors the predecessor-
+/// selection logic of the per-record path (own slot first, then the last-
+/// consumer predecessor drain, then a memory clone for multi-consumer
+/// fan-out), reading events rather than records so the document-DLQ driver
+/// can act on each close. Multi-consumer fan-out slots are never spilled
+/// (`node_buffer_spill_allowed` returns false for them), so the
+/// `clone_memory_only` branch never reaches a spilled buffer here.
+fn drain_output_input_events(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+) -> Result<Vec<crate::executor::stream_event::StreamEvent>, PipelineError> {
+    use crate::executor::stream_event::StreamEvent;
+
+    if let Some(own_buf) = drain_node_buffer_slot(ctx, node_idx) {
+        return own_buf.drain().collect();
+    }
+    let predecessors: Vec<NodeIndex> = current_dag
+        .graph
+        .neighbors_directed(node_idx, Direction::Incoming)
+        .collect();
+    for p in predecessors {
+        let remaining_consumers = current_dag
+            .graph
+            .neighbors_directed(p, Direction::Outgoing)
+            .filter(|&succ| succ > node_idx)
+            .count();
+        if remaining_consumers == 0 {
+            if let Some(nb) = drain_node_buffer_slot(ctx, p) {
+                return nb.drain().collect();
+            }
+        } else if let Some(cloned) = ctx.node_buffers.get(&p).map(|nb| nb.clone_memory_only()) {
+            return Ok(cloned);
+        }
+    }
+    Ok(Vec::<StreamEvent>::new())
 }
 
 /// The Output node's resolved write target plus the run-scoped writer

--- a/crates/clinker-exec/src/executor/route_dispatch.rs
+++ b/crates/clinker-exec/src/executor/route_dispatch.rs
@@ -184,10 +184,26 @@ pub(crate) fn dispatch_route(
                         stage.clone(),
                         None,
                     );
-                    if !routed {
+                    let triggering_field = route_err.triggering_field.clone();
+                    let triggering_value = route_err.triggering_value();
+                    // Under `dlq_granularity: document`, a route-eval failure
+                    // condemns the whole document — mark it failed (capturing
+                    // this record as the root cause) so the Output emits the
+                    // trigger + collateral entries at the document's close.
+                    let marked = !routed
+                        && crate::executor::document_dlq::record_error_to_document_buffer_if_doc_dlq(
+                            ctx,
+                            &record,
+                            rn,
+                            clinker_core_types::dlq::DlqErrorCategory::TypeCoercionFailure,
+                            route_err.to_string(),
+                            stage.clone(),
+                            None,
+                            triggering_field.clone(),
+                            triggering_value.clone(),
+                        );
+                    if !routed && !marked {
                         let source_name = source_name_arc_of(&record);
-                        let triggering_field = route_err.triggering_field.clone();
-                        let triggering_value = route_err.triggering_value();
                         push_dlq(
                             ctx,
                             DlqEntry {

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -76,6 +76,15 @@ impl Punctuation {
         self.doc_ctx.id()
     }
 
+    /// Source file the marked document belongs to. Every envelope level of
+    /// one file (the file-level document and each nested level) shares the
+    /// same `source_file` Arc, so this identifies the OUTERMOST (file /
+    /// interchange) document a nested-level boundary sits inside — the grain
+    /// the per-document DLQ rejects at.
+    pub fn source_file(&self) -> &Arc<str> {
+        self.doc_ctx.source_file()
+    }
+
     /// What boundary the punctuation marks.
     pub fn kind(&self) -> PunctuationKind {
         self.kind

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -63,7 +63,11 @@ pub(super) fn compute_streaming_output_specs(
 
     // Pipeline-wide correlation buffering disables streaming for every
     // Output — the CorrelationCommit terminal owns the actual writes.
-    if config.any_source_has_correlation_key() {
+    // Document-level DLQ disables it for the same structural reason: the
+    // per-document Output buffer flushes or rejects each document at its
+    // materialized `DocumentClose`, which a streaming-Output thread would
+    // consume out of band before the buffer could decide the document.
+    if config.any_source_has_correlation_key() || config.any_source_has_document_dlq() {
         return Vec::new();
     }
 

--- a/crates/clinker-exec/tests/document_dlq.rs
+++ b/crates/clinker-exec/tests/document_dlq.rs
@@ -1,0 +1,671 @@
+//! Document-level DLQ tests for `dlq_granularity: document`.
+//!
+//! Locks the load-bearing semantics: one record failure dead-letters the
+//! WHOLE document (root-cause trigger + `document_rejected` collaterals,
+//! each entry counting toward the DLQ rate), clean documents in the same
+//! run stream through intact, the default `record` policy is unchanged, a
+//! single large document is rejected atomically, the document grain is the
+//! OUTERMOST envelope level (a nested-envelope failure rejects the whole
+//! interchange, not just the inner transaction set), and the policy is
+//! rejected at compile time when combined with per-source-file output
+//! fan-out.
+//!
+//! Most tests use a multi-file CSV glob (each file is one flat document)
+//! the way the per-document Aggregate flush tests do; the nested-grain test
+//! drives a multi-level X12 interchange (ISA → GS → ST) so the
+//! outermost-grain decision is observable.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{DlqEntry, PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+use clinker_record::PipelineCounters;
+
+/// A `validate` transform coerces `value` to an int, so a non-numeric cell
+/// triggers a per-record eval failure. The source's `dlq_granularity`
+/// is templated so the same pipeline drives both the `document` and the
+/// default `record` policy.
+fn validate_yaml(dlq_granularity: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: doc_dlq
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      dlq_granularity: {dlq_granularity}
+      files:
+        on_no_match: skip
+      schema:
+        - {{ name: id, type: string }}
+        - {{ name: value, type: string }}
+  - type: transform
+    name: validate
+    input: events
+    config:
+      cxl: |
+        emit id = id
+        emit val = value.to_int()
+  - type: output
+    name: out
+    input: validate
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#
+    )
+}
+
+/// Run the validate pipeline over a set of in-memory CSV files, each fed as
+/// a distinct `FileSlot` (hence a distinct document). Returns the run
+/// counters, the DLQ entries, and the success-sink body lines.
+fn run_doc_dlq(
+    dlq_granularity: &str,
+    files: &[(&str, &str)],
+) -> (PipelineCounters, Vec<DlqEntry>, Vec<String>) {
+    let yaml = validate_yaml(dlq_granularity);
+    let config = parse_config(&yaml).expect("parse document-dlq pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile document-dlq pipeline");
+
+    let slots: Vec<FileSlot> = files
+        .iter()
+        .map(|(name, body)| {
+            FileSlot::new(
+                PathBuf::from(*name),
+                Box::new(Cursor::new(body.as_bytes().to_vec())),
+            )
+        })
+        .collect();
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run document-dlq pipeline");
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    (report.counters, report.dlq_entries, body)
+}
+
+#[test]
+fn one_fail_rejects_whole_document() {
+    // Document A has three records, one of which (`a2`) fails int coercion.
+    // The whole document is dead-lettered: one trigger plus two
+    // `document_rejected` collaterals, and zero records of document A reach
+    // the success sink.
+    let (counters, dlq_entries, body) = run_doc_dlq(
+        "document",
+        &[("a.csv", "id,value\na1,100\na2,bad\na3,300\n")],
+    );
+
+    assert_eq!(
+        counters.dlq_count, 3,
+        "all 3 records of the failing document are dead-lettered"
+    );
+    assert_eq!(
+        counters.ok_count, 0,
+        "no record of the rejected document emits"
+    );
+    assert_eq!(dlq_entries.len(), 3);
+
+    let triggers = dlq_entries.iter().filter(|e| e.trigger).count();
+    let collaterals = dlq_entries.iter().filter(|e| !e.trigger).count();
+    assert_eq!(triggers, 1, "exactly one root-cause trigger");
+    assert_eq!(collaterals, 2, "two collateral siblings");
+
+    for e in dlq_entries.iter().filter(|e| !e.trigger) {
+        assert_eq!(
+            e.category,
+            clinker_core_types::dlq::DlqErrorCategory::DocumentRejected,
+            "collateral carries the document_rejected category"
+        );
+    }
+    assert!(
+        body.is_empty(),
+        "no record of the rejected document reaches the success sink, got {body:?}"
+    );
+}
+
+#[test]
+fn multiple_failing_records_all_accounted_for() {
+    // A document with TWO failing records (`a2`, `a4`) plus three clean ones.
+    // The first failure is the trigger; every OTHER record — the second
+    // failing record AND every clean sibling — is a collateral. The invariant
+    // is that a rejected N-record document contributes exactly N entries, so a
+    // non-first failing record must not vanish from both sink and DLQ.
+    let (counters, dlq_entries, body) = run_doc_dlq(
+        "document",
+        &[(
+            "a.csv",
+            "id,value\na1,100\na2,bad\na3,300\na4,nope\na5,500\n",
+        )],
+    );
+
+    assert_eq!(
+        counters.dlq_count, 5,
+        "all 5 records of the document are accounted for as DLQ entries"
+    );
+    assert_eq!(dlq_entries.len(), 5);
+    assert_eq!(
+        counters.ok_count, 0,
+        "no record of the rejected document emits"
+    );
+
+    let triggers = dlq_entries.iter().filter(|e| e.trigger).count();
+    let collaterals = dlq_entries.iter().filter(|e| !e.trigger).count();
+    assert_eq!(
+        triggers, 1,
+        "exactly one root-cause trigger (the FIRST failure), even with two failing records"
+    );
+    assert_eq!(
+        collaterals, 4,
+        "the second failing record and all three clean siblings are collaterals"
+    );
+    for e in dlq_entries.iter().filter(|e| !e.trigger) {
+        assert_eq!(
+            e.category,
+            clinker_core_types::dlq::DlqErrorCategory::DocumentRejected,
+            "every collateral — failing or clean — carries the document_rejected category"
+        );
+    }
+    // Every source row 1..=5 appears exactly once across all entries: no row
+    // is dropped and none is double-counted.
+    let mut rows: Vec<u64> = dlq_entries.iter().map(|e| e.source_row).collect();
+    rows.sort_unstable();
+    assert_eq!(
+        rows,
+        vec![1, 2, 3, 4, 5],
+        "every source row is accounted for exactly once"
+    );
+    assert!(
+        body.is_empty(),
+        "no record of the rejected document reaches the success sink, got {body:?}"
+    );
+}
+
+#[test]
+fn clean_documents_stream_through() {
+    // Document A fails on `a2`; document B is all-valid. B reaches the
+    // success sink intact; `ok_count` counts only B's records.
+    let (counters, dlq_entries, body) = run_doc_dlq(
+        "document",
+        &[
+            ("a.csv", "id,value\na1,100\na2,bad\na3,300\n"),
+            ("b.csv", "id,value\nb1,400\nb2,500\n"),
+        ],
+    );
+
+    assert_eq!(
+        counters.dlq_count, 3,
+        "document A's 3 records dead-lettered"
+    );
+    assert_eq!(counters.ok_count, 2, "only document B's 2 records emit");
+    assert_eq!(
+        body,
+        vec!["b1,400,400".to_string(), "b2,500,500".to_string()],
+        "the clean document streams through intact"
+    );
+    assert!(
+        !body.iter().any(|r| r.starts_with("a")),
+        "no record of the rejected document A reaches the sink"
+    );
+    assert_eq!(dlq_entries.len(), 3);
+}
+
+#[test]
+fn record_level_policy_unchanged() {
+    // The same input under the default `record` policy: only the failing
+    // record (`a2`) is dead-lettered; its document siblings stream. No
+    // document-level rejection, no regression.
+    let (counters, dlq_entries, body) =
+        run_doc_dlq("record", &[("a.csv", "id,value\na1,100\na2,bad\na3,300\n")]);
+
+    assert_eq!(counters.dlq_count, 1, "only the failing record is DLQ'd");
+    assert_eq!(counters.ok_count, 2, "the two valid siblings stream");
+    assert_eq!(dlq_entries.len(), 1);
+    assert!(
+        dlq_entries[0].trigger,
+        "the failing record is its own root cause"
+    );
+    assert_ne!(
+        dlq_entries[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::DocumentRejected,
+        "no document_rejected category under the record policy"
+    );
+    assert_eq!(
+        body,
+        vec!["a1,100,100".to_string(), "a3,300,300".to_string()],
+        "the valid siblings reach the sink under the record policy"
+    );
+}
+
+#[test]
+fn all_clean_emits_nothing_to_dlq() {
+    // A control: every document valid → zero DLQ, every record streams.
+    let (counters, dlq_entries, body) = run_doc_dlq(
+        "document",
+        &[
+            ("a.csv", "id,value\na1,100\na2,200\n"),
+            ("b.csv", "id,value\nb1,300\n"),
+        ],
+    );
+    assert_eq!(counters.dlq_count, 0);
+    assert_eq!(dlq_entries.len(), 0);
+    assert_eq!(counters.ok_count, 3, "all three records stream");
+    assert_eq!(
+        body,
+        vec![
+            "a1,100,100".to_string(),
+            "a2,200,200".to_string(),
+            "b1,300,300".to_string()
+        ],
+    );
+}
+
+#[test]
+fn large_document_rejects_every_record() {
+    // A single large document (200 valid records + 1 failing tail record,
+    // one file, no internal boundary until EOF) is the worst-case shape the
+    // per-document buffer must hold and reject atomically: one trigger plus
+    // 200 collaterals, EACH counting toward the DLQ rate (a rejected
+    // N-record document contributes N to the rate), and nothing reaches the
+    // success sink. Proves the per-document buffering scales past a couple
+    // of records and the whole-document reject is complete.
+    let mut doc = String::from("id,value\n");
+    for i in 0..200 {
+        doc.push_str(&format!("r{i},{i}\n"));
+    }
+    doc.push_str("bad,not_an_int\n");
+
+    let yaml = validate_yaml("document");
+    let config = parse_config(&yaml).expect("parse large-document pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile large-document pipeline");
+
+    let slots = vec![FileSlot::new(
+        PathBuf::from("big.csv"),
+        Box::new(Cursor::new(doc.as_bytes().to_vec())),
+    )];
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run large-document pipeline");
+
+    assert_eq!(
+        report.counters.dlq_count, 201,
+        "one trigger + 200 collaterals: every record of the rejected document \
+         counts toward the DLQ rate"
+    );
+    assert_eq!(report.counters.ok_count, 0);
+    let output = buf.as_string();
+    let body: Vec<&str> = output.lines().skip(1).collect();
+    assert!(
+        body.is_empty(),
+        "no record of the rejected document reaches the sink, got {body:?}"
+    );
+}
+
+/// The canonical 106-byte ISA header, interchange control number
+/// `000000001` (`*` element, `:` sub-element, `~` terminator).
+const ISA: &str = "ISA*00*          *00*          *ZZ*SENDER         \
+    *ZZ*RECEIVER       *240101*1200*U*00401*000000001*0*P*:~";
+
+/// A single X12 interchange (one ISA..IEA / one file) holding TWO
+/// transaction sets in one functional group. The FIRST set's `BEG` segment
+/// carries a non-numeric first element (`XX`); the SECOND set is clean. A
+/// Transform coerces that element to an int, so the first set fails — and
+/// under the outermost (interchange) grain the WHOLE interchange, including
+/// the clean second set whose records arrive AFTER the first set's close,
+/// is dead-lettered.
+fn two_set_interchange(first_begin_e01: &str) -> String {
+    format!(
+        "{ISA}\
+        GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+        ST*850*0001~\
+        BEG*{first_begin_e01}*NE*PO12345**20240101~\
+        PO1*1*10*EA*9.99~\
+        SE*4*0001~\
+        ST*850*0002~\
+        BEG*00*NE*PO67890**20240102~\
+        PO1*2*20*EA*1.99~\
+        SE*4*0002~\
+        GE*2*1~\
+        IEA*1*000000001~"
+    )
+}
+
+const X12_DOC_DLQ_YAML: &str = r#"
+pipeline:
+  name: x12_doc_dlq
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      dlq_granularity: document
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: e01, type: string }
+  - type: transform
+    name: validate
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit v = e01.to_int()
+  - type: output
+    name: out
+    input: validate
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+/// Run an X12 interchange fixture through the document-DLQ pipeline,
+/// returning the run counters and the success-sink body line count.
+fn run_x12_doc_dlq(fixture: &str) -> (PipelineCounters, Vec<DlqEntry>, usize) {
+    let config = parse_config(X12_DOC_DLQ_YAML).expect("parse x12 document-dlq pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile x12 document-dlq pipeline");
+
+    let file = FileSlot::new(
+        PathBuf::from("po.x12"),
+        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "interchange".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run x12 document-dlq pipeline");
+    let body_lines = report.counters.ok_count.try_into().unwrap_or(usize::MAX);
+    (report.counters, report.dlq_entries, body_lines)
+}
+
+#[test]
+fn nested_envelope_failure_rejects_whole_interchange() {
+    // A failure in the FIRST transaction set rejects the WHOLE interchange
+    // (the outermost / file grain), including the clean SECOND set whose
+    // records arrive after the first set's inner close — the document is
+    // not decided until the interchange's outermost close. This pins both
+    // the outermost grain and robustness to a record arriving after an
+    // inner-level boundary.
+    let (counters, dlq_entries, _) = run_x12_doc_dlq(&two_set_interchange("XX"));
+
+    assert_eq!(counters.ok_count, 0, "the whole interchange is rejected");
+    assert!(
+        counters.dlq_count >= 2,
+        "the interchange's records across BOTH sets dead-letter, not just \
+         the failing first set's: {}",
+        counters.dlq_count
+    );
+    let triggers = dlq_entries.iter().filter(|e| e.trigger).count();
+    assert_eq!(
+        triggers, 1,
+        "exactly one root-cause trigger for the interchange"
+    );
+    assert!(
+        dlq_entries
+            .iter()
+            .filter(|e| !e.trigger)
+            .all(|e| e.category == clinker_core_types::dlq::DlqErrorCategory::DocumentRejected),
+        "every collateral carries the document_rejected category"
+    );
+}
+
+#[test]
+fn nested_envelope_clean_interchange_streams_through() {
+    // A control: every transaction set in the interchange is valid, so the
+    // whole interchange streams to the sink with no DLQ entries.
+    let (counters, dlq_entries, ok) = run_x12_doc_dlq(&two_set_interchange("00"));
+    assert_eq!(
+        counters.dlq_count, 0,
+        "a clean interchange emits no DLQ entries"
+    );
+    assert_eq!(dlq_entries.len(), 0);
+    assert!(ok > 0, "the clean interchange's records reach the sink");
+}
+
+#[test]
+fn document_dlq_with_per_source_file_fanout_is_rejected_at_compile_time() {
+    // Document-level DLQ buffers each document and flushes it to one writer;
+    // per-source-file fan-out routes each record to a file-keyed writer. The
+    // two are mutually exclusive, so the combination is rejected at compile
+    // time (E343) rather than silently dropping every clean document.
+    let yaml = r#"
+pipeline:
+  name: doc_dlq_fanout
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      dlq_granularity: document
+      schema:
+        - { name: id, type: string }
+  - type: output
+    name: out
+    input: events
+    config:
+      name: out
+      type: csv
+      path: "out/{source_file}.csv"
+"#;
+    // The combination is rejected during config validation (which runs at
+    // parse time), before the plan is built.
+    let err =
+        parse_config(yaml).expect_err("document-DLQ + per-source-file fan-out must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("E343"),
+        "expected the E343 document-DLQ + fan-out rejection, got: {msg}"
+    );
+}
+
+#[test]
+fn upstream_spill_still_rejects_whole_document() {
+    // Regression guard for the document-DLQ + record-spill combination.
+    // The inter-stage buffer feeding the Output is forced to disk under a
+    // tight memory budget; the Output reloads those records from the spill
+    // BEFORE deciding each document. Because a record's document context —
+    // including the source file the grain keys on — now survives the spill
+    // round-trip, a document one record of which fails is still rejected
+    // whole even when its other records passed through a spilling stage:
+    // every record dead-letters and none reach the success sink.
+    //
+    // RSS-gated: without an RSS reading the buffer stays in memory and never
+    // spills, so skip rather than assert a false negative (matching the
+    // existing soft-spill coverage).
+    if clinker_exec::pipeline::memory::rss_bytes().is_none() {
+        return;
+    }
+
+    // One large document: many records with a long free-text field (so the
+    // inter-stage buffer is heap-dominated and crosses the spill floor),
+    // plus one record whose `value` is non-numeric and fails int coercion.
+    let note = "free-text customer note that comfortably exceeds the inline boundary";
+    let mut doc = String::from("id,value,note\n");
+    const ROWS: usize = 4_000;
+    for i in 0..ROWS {
+        doc.push_str(&format!("r{i},{i},{note} #{i}\n"));
+    }
+    doc.push_str(&format!("bad,not_an_int,{note} #bad\n"));
+
+    let yaml = r#"
+pipeline:
+  name: doc_dlq_spill
+  memory: { limit: "1M", backpressure: spill }
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      dlq_granularity: document
+      files:
+        on_no_match: skip
+      schema:
+        - { name: id, type: string }
+        - { name: value, type: string }
+        - { name: note, type: string }
+  - type: transform
+    name: validate
+    input: events
+    config:
+      cxl: |
+        emit id = id
+        emit note = note
+        emit val = value.to_int()
+  - type: output
+    name: out
+    input: validate
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+    let config = parse_config(yaml).expect("parse upstream-spill pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile upstream-spill pipeline");
+
+    let slots = vec![FileSlot::new(
+        PathBuf::from("big.csv"),
+        Box::new(Cursor::new(doc.as_bytes().to_vec())),
+    )];
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run upstream-spill pipeline");
+
+    // An UPSTREAM stage must actually have spilled — otherwise this guards
+    // nothing about the document-context-through-spill round-trip. Per-stage
+    // spill bytes are keyed by the spilling node's name; the document-DLQ
+    // driver's own bucket spill is keyed by the Output node ("out"), so a
+    // non-"out" spilling stage is the inter-stage buffer feeding the Output
+    // (the producer that drains its records to disk before the Output
+    // reloads them). Pinning the upstream stage keeps a future regression in
+    // the doc-context-through-spill round-trip from slipping past a driver-
+    // only spill.
+    let upstream_spilled: u64 = report
+        .per_stage_spill_bytes
+        .iter()
+        .filter(|(node, _)| node.as_str() != "out")
+        .map(|(_, &bytes)| bytes)
+        .sum();
+    assert!(
+        upstream_spilled > 0,
+        "an upstream inter-stage buffer must spill under the 1 MiB budget so \
+         the Output reloads records from disk; per-stage spill = {:?}",
+        report.per_stage_spill_bytes
+    );
+
+    // The whole document is rejected despite the upstream spill: every
+    // record dead-letters (one trigger + collaterals) and none reaches the
+    // sink. If the spill had dropped document identity, the reloaded
+    // records would be treated as non-governed and streamed to the sink.
+    assert_eq!(
+        report.counters.ok_count, 0,
+        "no record of the rejected document reaches the sink across the spill"
+    );
+    let trigger_count = report.dlq_entries.iter().filter(|e| e.trigger).count();
+    assert_eq!(trigger_count, 1, "exactly one root-cause trigger");
+    assert_eq!(
+        report.counters.dlq_count as usize,
+        ROWS + 1,
+        "every record of the document dead-letters across the spill round-trip"
+    );
+    let body: Vec<String> = buf.as_string().lines().skip(1).map(String::from).collect();
+    assert!(
+        body.is_empty(),
+        "the success sink is empty — the whole document was rejected, got {} rows",
+        body.len()
+    );
+}

--- a/crates/clinker-plan/src/config/discovery.rs
+++ b/crates/clinker-plan/src/config/discovery.rs
@@ -456,6 +456,7 @@ mod tests {
             files: None,
             watermark: None,
             envelope: None,
+            dlq_granularity: crate::config::DlqGranularity::Record,
             declared_doc_paths: Vec::new(),
             schema: None,
             schema_overrides: None,

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -237,6 +237,17 @@ impl PipelineConfig {
         self.source_bodies().any(|b| b.correlation_key.is_some())
     }
 
+    /// Whether any source declares `dlq_granularity: document`. Drives the
+    /// runtime document-DLQ buffer setup and gates the streaming fast-paths
+    /// off pipeline-wide, mirroring `any_source_has_correlation_key` —
+    /// per-document buffering at the Output arm needs the materialized
+    /// `DocumentClose` punctuation the streaming-Output / streaming-ingest
+    /// short-circuits would otherwise consume out of band.
+    pub fn any_source_has_document_dlq(&self) -> bool {
+        self.source_configs()
+            .any(|s| s.dlq_granularity == DlqGranularity::Document)
+    }
+
     /// Public iterator over output nodes.
     pub fn output_configs(&self) -> impl Iterator<Item = &OutputConfig> + '_ {
         self.nodes.iter().filter_map(|n| match &n.value {
@@ -3037,6 +3048,37 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                  remove the `split` block or choose a splittable format",
                 name = output.name,
             )));
+        }
+    }
+
+    // Document-level DLQ cannot coexist with per-source-file fan-out output.
+    // Under `dlq_granularity: document` the engine buffers each document and
+    // decides flush-vs-reject at its boundary, opening ONE writer for the
+    // Output; a per-source-file fan-out (`{source_file}` / `{source_path}`
+    // in the path template over a multi-file source) instead routes each
+    // record to a writer keyed by its own file. The two writer models are
+    // mutually exclusive — a buffered-then-flushed document cannot also be
+    // streamed per-record to a file-keyed writer — so reject the
+    // combination up front rather than silently dropping every clean
+    // document (the fan-out writer registry is keyed differently than the
+    // single writer the document buffer flushes to).
+    if config.any_source_has_document_dlq() {
+        for output in config.output_configs() {
+            let Ok(template) = crate::config::path_template::PathTemplate::parse(&output.path)
+            else {
+                continue;
+            };
+            if template.has_per_record_tokens() {
+                return Err(ConfigError::Validation(format!(
+                    "[E343] output '{name}': a per-source-file output template \
+                     (`{{source_file}}` / `{{source_path}}`) cannot be combined with a \
+                     source declaring `dlq_granularity: document` — document-level \
+                     dead-lettering buffers each document and flushes it to a single \
+                     writer, which is incompatible with per-record file fan-out; use a \
+                     single output path, or set `dlq_granularity: record`",
+                    name = output.name,
+                )));
+            }
         }
     }
 

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -70,6 +70,18 @@ pub struct SourceConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub envelope: Option<clinker_format::EnvelopeConfig>,
 
+    /// Granularity at which a record failure dead-letters under the
+    /// `continue` / `best_effort` error strategies: `record` (the default)
+    /// DLQs only the failing record and streams its siblings, while
+    /// `document` dead-letters the entire document any record of which
+    /// fails. Per-source because only a document-aware source carries an
+    /// envelope and document boundaries (see `envelope` above), so the
+    /// knob lives next to that declaration. A genuinely-optional new field
+    /// — `#[serde(default)]` selects `record` when omitted, preserving
+    /// every existing pipeline's behavior.
+    #[serde(default)]
+    pub dlq_granularity: DlqGranularity,
+
     /// `$doc.<section>.<field>` envelope paths a program downstream of
     /// THIS source actually references, collected at compile time by
     /// `cxl::analyzer::doc_paths` and attributed per source: a path lands
@@ -114,6 +126,32 @@ pub struct SourceConfig {
     /// Kiln IDE metadata: stage notes + field annotations. Ignored by the engine.
     #[serde(default, rename = "_notes", skip_serializing_if = "Option::is_none")]
     pub notes: Option<serde_json::Value>,
+}
+
+/// Per-source dead-letter granularity under `continue` / `best_effort`.
+///
+/// Selects whether a record failure dead-letters just the failing record
+/// or the whole document it belongs to. Has no effect under `fail_fast`,
+/// where the first failure aborts the run regardless. A pure policy enum —
+/// it carries no state and imposes no memory cost itself; the runtime cost
+/// of `Document` is the per-document record buffer the executor holds open
+/// only for currently-open documents (peak = concurrently-open documents,
+/// not total input), which spills to disk under memory pressure.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DlqGranularity {
+    /// Dead-letter only the failing record; its document's other records
+    /// stream through unaffected. The default — every pre-existing pipeline
+    /// behaves this way.
+    #[default]
+    Record,
+    /// Dead-letter the entire document any record of which fails. The
+    /// failing record becomes the root-cause DLQ entry (`trigger: true`,
+    /// original category); every sibling becomes a collateral entry
+    /// (`trigger: false`, `DocumentRejected` category). Each entry counts
+    /// toward the DLQ rate, so a rejected N-record document contributes N
+    /// to the rate denominator.
+    Document,
 }
 
 /// Event-time watermark declaration on a `SourceConfig`.

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -234,6 +234,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E340" => Some(include_str!("../../../../docs/explain/E340.md")),
         "E341" => Some(include_str!("../../../../docs/explain/E341.md")),
         "E342" => Some(include_str!("../../../../docs/explain/E342.md")),
+        "E343" => Some(include_str!("../../../../docs/explain/E343.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -448,7 +449,7 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E15Y", "W101", "W302", "W305", "W306",
+            "E343", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -1991,7 +1991,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E342, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E343, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/docs/explain/E343.md
+++ b/docs/explain/E343.md
@@ -1,0 +1,105 @@
+# Error E343: per-source-file output cannot be combined with document-level DLQ
+
+## What it means
+
+A source declares `dlq_granularity: document` and an `Output` node's path
+template references a per-record token (`{source_file}` or `{source_path}`)
+over a multi-file source. The two writer models are mutually exclusive:
+
+- **Document-level DLQ** buffers every record of a document, then at the
+  document's boundary either flushes the whole document to **one** writer
+  (clean) or dead-letters it (any record failed). The decision is made per
+  document, so the records cannot be written until the boundary is reached.
+- **Per-source-file fan-out** instead routes each record, as it arrives, to a
+  writer keyed by that record's own source file.
+
+A document that is buffered and only flushed (or rejected) at its boundary
+cannot also be streamed per-record to a file-keyed writer. Rather than
+silently drop every clean document — the fan-out writer registry is keyed by
+source file, not the single writer the document buffer flushes to — clinker
+rejects the combination at config-validation time.
+
+```
+[E343] output 'per_file_out': a per-source-file output template
+(`{source_file}` / `{source_path}`) cannot be combined with a source declaring
+`dlq_granularity: document` — document-level dead-lettering buffers each
+document and flushes it to a single writer, which is incompatible with
+per-record file fan-out; use a single output path, or set
+`dlq_granularity: record`
+```
+
+## Example
+
+```yaml
+# Rejected: document-level DLQ + per-source-file fan-out.
+nodes:
+  - source: claims
+    type: x12
+    glob: ./claims/*.edi
+    dlq_granularity: document
+  - output: per_file_out
+    input: claims
+    format: csv
+    path: out/{source_file}.csv      # per-record fan-out token
+```
+
+```yaml
+# Corrected (option A): one output path; each document flushes or is rejected
+# whole.
+nodes:
+  - source: claims
+    type: x12
+    glob: ./claims/*.edi
+    dlq_granularity: document
+  - output: combined_out
+    input: claims
+    format: csv
+    path: out/claims.csv
+```
+
+```yaml
+# Corrected (option B): keep per-source-file fan-out under the default
+# per-record granularity (only the failing record is dead-lettered).
+nodes:
+  - source: claims
+    type: x12
+    glob: ./claims/*.edi
+    dlq_granularity: record          # the default
+  - output: per_file_out
+    input: claims
+    format: csv
+    path: out/{source_file}.csv
+```
+
+## How to fix
+
+1. **Use a single output path** — drop the `{source_file}` / `{source_path}`
+   token. Each document is then flushed (clean) or rejected (any failure) to
+   the one writer, and the document-level policy holds.
+
+2. **Set `dlq_granularity: record`** on the source if per-source-file fan-out
+   is the requirement and whole-document rejection is not — only the failing
+   record is dead-lettered, and its document's other records fan out normally.
+
+3. **Partition upstream and invoke per partition** if you need both
+   per-file output and whole-document rejection: run one invocation per file
+   so each run produces its own output file and its own document decision.
+
+## Technical context
+
+Document-level dead-lettering buffers each document's records until its
+boundary, then opens one writer for the Output and flushes the whole document
+(clean) or routes every record to the dead-letter queue (any failure). The CLI
+pre-opens that single writer in the standard writer registry. Per-source-file
+fan-out instead pre-opens a separate writer per discovered source file, held in
+a distinct file-keyed registry, and the dispatcher routes each record to the
+writer matching its `$source.file` stamp. The document buffer flushes to the
+single registry, never the file-keyed one, so combining the two would write a
+clean document's records to a writer that was never opened — they would be
+silently dropped. The validator rejects the pairing up front so the loss never
+reaches a run.
+
+## See also
+
+- "Document-level DLQ" in the error-handling reference
+- Correlation keys (`correlation_key`), the cross-file grouping analogue

--- a/docs/user/src/pipelines/error-handling.md
+++ b/docs/user/src/pipelines/error-handling.md
@@ -90,6 +90,7 @@ The `_cxl_dlq_error_category` column contains one of these values:
 | `aggregate_finalize` | An aggregate function failed during finalization |
 | `correlated` | A non-failing record was DLQ'd as collateral because another record in its correlation group failed |
 | `group_size_exceeded` | A correlation-key group exceeded the configured `max_group_buffer` limit |
+| `document_rejected` | A non-failing record was DLQ'd as collateral because another record in its document failed under a source's `dlq_granularity: document` policy |
 | `late_record` | A record arrived at a time-windowed aggregate after its event-time window had already closed |
 | `expansion_limit_exceeded` | A transform's `emit each` fan-out produced more output records than its `max_expansion` ceiling allows |
 | `combine_output_row` | A Combine output-stage eval failed for one driver row (probe-key, residual, or matched / `on_miss: null_fields` body); the entry carries the contributing-build lineage and rewinds both the driver and matched build source's rollback cursor. Routed to the DLQ under `continue` / `best_effort` across every Combine join mode; `fail_fast` propagates the eval error |
@@ -135,6 +136,41 @@ Limit the number of records buffered per correlation group:
 ```
 
 Groups exceeding this limit are DLQ'd entirely with a `group_size_exceeded` summary entry.
+
+### Document-level DLQ
+
+By default a record failure dead-letters only that record (`dlq_granularity: record`). A source can instead reject the **entire document** any record of which fails, by declaring the granularity per source:
+
+```yaml
+nodes:
+  - type: source
+    name: claims
+    config:
+      name: claims
+      type: x12
+      glob: ./claims/*.edi
+      dlq_granularity: document   # record (default) | document
+```
+
+Under `dlq_granularity: document` and the `continue` / `best_effort` strategies, when any record of a document fails:
+
+- the failing record becomes the **root-cause** DLQ entry (`_cxl_dlq_trigger = true`, carrying its original error category);
+- every other record of the same document becomes a **collateral** entry (`_cxl_dlq_trigger = false`, category `document_rejected`);
+- **no** record of that document reaches the success sink.
+
+Clean documents in the same run stream through untouched, and records from sibling sources still on the default `record` granularity keep per-record semantics — the policy is per source.
+
+This is the document-shaped analogue of [correlation keys](#correlation-key): use it when partial processing of a document (an EDI interchange, a batch file with a header/trailer) is worse than rejecting the whole document. Unlike correlation keys, which group across files by a key value, document-level DLQ scopes rejection to a single document's records.
+
+**Document grain.** The document is the **outermost** level — the source file. For a flat format (CSV, JSON, plain XML) each input file is one document. For a nested-envelope format (an X12 `ISA → GS → ST` interchange, an EDIFACT `UNB → UNG → UNH`) the document is the whole **interchange / file**, not an inner functional group or transaction set: a failure anywhere in the interchange rejects the entire interchange, including the transaction sets that validated cleanly. Reject the inner-level grain instead by partitioning the input so each interchange is its own file is not currently offered — the grain is fixed at the file.
+
+**DLQ rate.** Every emitted entry — the trigger and each collateral — counts toward the DLQ-rate denominator the [type error threshold](#type-error-threshold) circuit breaker measures, matching the correlated-collateral precedent. A rejected 1000-record document contributes 1000 entries, so size any `type_error_threshold` with whole-document rejection in mind.
+
+**Memory.** The engine buffers each open document's records until its boundary, then flushes the document clean to the sink or rejects it and drops the buffer. Peak memory scales with the **concurrently-open** documents, not the total input; a single very large document spills its buffer to disk under the run's memory budget rather than holding everything in RAM. See [Streaming vs blocking](../ops/streaming-vs-blocking.md) for the spill model.
+
+**Output restriction.** Document-level DLQ flushes each whole document to a single output writer, so it cannot be combined with a [per-source-file output](../nodes/output.md) (a `{source_file}` / `{source_path}` path template over a multi-file source). The two are rejected together at compile time (E343); use a single output path, or set `dlq_granularity: record` if per-file output is the requirement.
+
+**Spilling stages.** Document identity survives memory pressure end to end. The per-document buffer identifies each document before buffering and spills under the memory budget, and a blocking stage (Sort, hash Aggregate, grace-hash Combine) between the source and the output preserves each record's document context — including the source file the grain keys on — across its own spill round-trip. A document whose records pass through a spilling stage is therefore still grouped and rejected as one document under memory pressure, exactly as it would be in memory.
 
 ## Exit codes
 


### PR DESCRIPTION
Adds a per-source `dlq_granularity: { record | document }` policy (default `record`, unchanged behavior). Under `document`, when any record in a document fails, the whole document is dead-lettered: the failing record is recorded as the root-cause and every sibling record of that document as collateral (a new `document_rejected` category), and nothing from that document reaches the sink. Clean documents stream through intact; sources left on the default `record` policy are unaffected, as is the per-record path.

Memory model mirrors the per-document aggregate flush rather than the whole-run correlation buffer: each open document is buffered in a spillable per-document buffer charged against the shared memory arbitrator, flushed-or-rejected at its document-close boundary, then dropped — so peak memory scales with the number of concurrently-open documents, not the whole input, and a single large document spills its buffer rather than growing unbounded. Upstream record failures (in a Transform or Route) mark the document so the decision is applied when its buffer flushes. The dead-letter rate counts each emitted entry (a rejected N-record document contributes N), consistent with the existing correlated-rejection behavior.

A known limitation is documented and tracked separately: if an *upstream* buffer spills, records currently lose their document association across the spill round-trip, which affects document-level grouping in general; that is being addressed in the document-envelope-context spill work.

Closes #97.