### PR TITLE
format: SWIFT MT writer with block-structure round-trip output

### DIFF
--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -83,6 +83,7 @@
 //! | `E339`      | error    | `hl7` output combined with byte-limit `split` (a batch/file envelope is one indivisible FHS..FTS structure) |
 //! | `E340`      | error    | A `$doc.<section>.<field>` access is indexed by a non-literal expression, so its declared document path cannot be resolved at compile time |
 //! | `E341`      | error    | A `$doc.<section>.<field>` access names an envelope section or field a feeding XML/JSON source does not declare |
+//! | `E342`      | error    | `swift` output combined with byte-limit `split` (a SWIFT MT message is one indivisible brace-balanced `{1:..}..{5:..}` envelope) |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -14,6 +14,7 @@ use clinker_format::fixed_width::writer::{FixedWidthWriter, FixedWidthWriterConf
 use clinker_format::hl7::writer::{Hl7Writer, Hl7WriterConfig};
 use clinker_format::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
 use clinker_format::splitting::{OversizeGroupPolicy, SplitPolicy, SplittingWriter, WriterFactory};
+use clinker_format::swift::writer::{SwiftWriter, SwiftWriterConfig};
 use clinker_format::traits::FormatWriter;
 use clinker_format::x12::Charset;
 use clinker_format::x12::writer::{X12Writer, X12WriterConfig};
@@ -159,6 +160,21 @@ fn build_hl7_writer_config(
         file_header_from_doc: opts.and_then(|o| o.file_header_from_doc.clone()),
         batch_header: opts.and_then(|o| o.batch_header.clone()),
         segment_newline: opts.and_then(|o| o.segment_newline).unwrap_or(true),
+    }
+}
+
+fn build_swift_writer_config(
+    opts: Option<&clinker_plan::config::SwiftOutputOptions>,
+) -> SwiftWriterConfig {
+    SwiftWriterConfig {
+        basic_header: opts.and_then(|o| o.basic_header.clone()),
+        basic_header_from_doc: opts.and_then(|o| o.basic_header_from_doc.clone()),
+        app_header: opts.and_then(|o| o.app_header.clone()),
+        app_header_from_doc: opts.and_then(|o| o.app_header_from_doc.clone()),
+        user_header: opts.and_then(|o| o.user_header.clone()),
+        user_header_from_doc: opts.and_then(|o| o.user_header_from_doc.clone()),
+        trailer: opts.and_then(|o| o.trailer.clone()),
+        trailer_from_doc: opts.and_then(|o| o.trailer_from_doc.clone()),
     }
 }
 
@@ -315,6 +331,16 @@ fn build_writer_factory(
                     counting_writer,
                     schema,
                     hl7_config.clone(),
+                )))
+            })
+        }
+        OutputFormat::Swift(opts) => {
+            let swift_config = build_swift_writer_config(opts.as_ref());
+            Box::new(move |counting_writer, schema| {
+                Ok(Box::new(SwiftWriter::new(
+                    counting_writer,
+                    schema,
+                    swift_config.clone(),
                 )))
             })
         }

--- a/crates/clinker-exec/tests/swift_pipeline.rs
+++ b/crates/clinker-exec/tests/swift_pipeline.rs
@@ -1,4 +1,4 @@
-//! End-to-end SWIFT MT ingestion.
+//! End-to-end SWIFT MT ingestion and emission.
 //!
 //! Covers: (1) a SWIFT source surfaces its service blocks (1/2/3/5) as
 //! file-level `$doc` envelope sections on every block-4 body record, proving
@@ -6,7 +6,11 @@
 //! block-4 `:tag:value` line streams as one `[block, tag, value]` record;
 //! (3) a header-only message still produces a balanced document level with a
 //! clean drain; (4) a malformed message (unbalanced brace / missing `-}`
-//! trailer) surfaces as a clean run failure rather than a panic.
+//! trailer) surfaces as a clean run failure rather than a panic; (5) a
+//! SWIFT → SWIFT → SWIFT round-trip re-frames the block structure and
+//! reproduces every field value byte-faithfully (interior braces, mid-line
+//! `-}`, folded continuations, and interior blank lines survive); (6) the
+//! `swift`+`split` combination is rejected at config time (diagnostic `E342`).
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -333,6 +337,254 @@ nodes:
         err.contains("truncated") || err.contains("SWIFT"),
         "error should name the SWIFT block failure: {err}"
     );
+}
+
+/// Build a SWIFT source → SWIFT output round-trip pipeline that declares an
+/// envelope section per service block the fixture carries and echoes each one
+/// back through the writer's matching `*_from_doc` option. Only the blocks the
+/// message actually carries are declared — the reader's pre-scan rejects a
+/// section over an absent block, so a fixture without (say) block 2 must not
+/// declare an `app` section.
+fn swift_round_trip_yaml(blocks: &[(&str, u8, &str)]) -> String {
+    let mut sections = String::new();
+    let mut options = String::new();
+    for (section, block_id, option) in blocks {
+        sections.push_str(&format!(
+            "          {section}:\n            extract: {{ segment: \"{block_id}\" }}\n"
+        ));
+        options.push_str(&format!("        {option}: {section}\n"));
+    }
+    format!(
+        r#"
+pipeline:
+  name: swift_round_trip
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      envelope:
+        sections:
+{sections}      schema:
+        - {{ name: block, type: string }}
+        - {{ name: tag, type: string }}
+        - {{ name: value, type: string }}
+  - type: output
+    name: out
+    input: message
+    config:
+      name: out
+      type: swift
+      path: out.swift
+      options:
+{options}"#
+    )
+}
+
+/// Feed a SWIFT message through SWIFT → SWIFT (block-structure reconstruction)
+/// using the given per-block section/option mapping, then re-read the
+/// reconstructed output through SWIFT → CSV, returning the reconstructed SWIFT
+/// bytes and the `block,tag,value` CSV rows so a test can assert the field
+/// stream round-trips in order.
+fn swift_to_swift_then_csv(fixture: &str, blocks: &[(&str, u8, &str)]) -> (String, String) {
+    let yaml = swift_round_trip_yaml(blocks);
+    let (_report, swift_out) =
+        run(&yaml, "message", fixture, "in.swift", "out").expect("swift -> swift round-trip");
+
+    let csv_yaml = r#"
+pipeline:
+  name: swift_to_csv
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: output
+    name: out
+    input: message
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+"#;
+    let (_report, csv_out) = run(csv_yaml, "message", &swift_out, "rt.swift", "out")
+        .expect("reconstructed swift -> csv");
+    (swift_out, csv_out)
+}
+
+/// Extract the `tag` column (CSV field index 1 of `block,tag,value`) from each
+/// re-read body row, in order.
+fn csv_tag_column(csv_out: &str) -> Vec<&str> {
+    csv_out
+        .lines()
+        .map(|l| l.split(',').nth(1).unwrap_or(""))
+        .collect()
+}
+
+#[test]
+fn swift_round_trip_reparses_identically() {
+    // The reconstructed output re-frames the full envelope in order, and the
+    // re-read tag stream matches the source's block-4 fields exactly.
+    let (swift_out, csv_out) = swift_to_swift_then_csv(
+        &mt103(),
+        &[
+            ("basic", 1, "basic_header_from_doc"),
+            ("app", 2, "app_header_from_doc"),
+            ("user", 3, "user_header_from_doc"),
+            ("trailer", 5, "trailer_from_doc"),
+        ],
+    );
+
+    // Service blocks re-framed in order: {1:}{2:}{3:{108:}} then block 4,
+    // then {5:}. Block 3's nested sub-block re-emits byte-for-byte.
+    assert!(
+        swift_out.starts_with(
+            "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}{3:{108:MSGREF12345}}{4:\r\n"
+        ),
+        "envelope framing wrong: {swift_out:?}"
+    );
+    assert!(
+        swift_out.ends_with("-}{5:{CHK:1234567890AB}}"),
+        "trailer framing wrong: {swift_out:?}"
+    );
+
+    // The re-read tag column round-trips in order.
+    assert_eq!(
+        csv_tag_column(&csv_out),
+        vec!["20", "23B", "32A"],
+        "csv was: {csv_out}"
+    );
+}
+
+#[test]
+fn swift_mt940_repeated_tags_round_trip() {
+    // Repeated :61:/:86: statement lines re-emit in arrival order; the re-read
+    // tag stream preserves both repeats. MT940 carries only blocks 1 and 2.
+    let (_swift_out, csv_out) = swift_to_swift_then_csv(
+        &mt940(),
+        &[
+            ("basic", 1, "basic_header_from_doc"),
+            ("app", 2, "app_header_from_doc"),
+        ],
+    );
+    assert_eq!(
+        csv_tag_column(&csv_out),
+        vec!["20", "25", "28C", "60F", "61", "86", "61", "86", "62F"],
+        "csv was: {csv_out}"
+    );
+}
+
+#[test]
+fn swift_interior_block4_braces_dashes_blanks_round_trip() {
+    // The load-bearing faithfulness test: a value carrying an interior brace
+    // (`:79:A{B`), a mid-line `-}` (`:79:SEE-}NOTE`), and an interior blank
+    // line in a `:77E:` value must all reproduce byte-identically on re-read.
+    // Block-4 free text is opaque, so the writer escapes nothing and the
+    // reader re-parses each value unchanged.
+    let fixture = "{1:F01BANKBEBBAXXX0000000000}\
+        {4:\r\n:79:A{B\r\n:79:SEE-}NOTE\r\n:77E:LINE1\r\n\r\nLINE3\r\n:86:PLAIN\r\n-}";
+
+    // Round-trip SWIFT -> SWIFT, then read the reconstructed output back
+    // through a SWIFT reader and assert each value is byte-identical to the
+    // value the original reader produced. The fixture carries only block 1.
+    let (swift_out, _csv) =
+        swift_to_swift_then_csv(fixture, &[("basic", 1, "basic_header_from_doc")]);
+
+    // Read both the original fixture and the reconstructed output through the
+    // reader and compare their (tag, value) streams field-for-field.
+    let read_fields = |data: &str| -> Vec<(String, Option<String>)> {
+        use clinker_format::swift::reader::{SwiftReader, SwiftReaderConfig};
+        use clinker_format::traits::FormatReader;
+        use clinker_record::Value;
+        let mut r = SwiftReader::new(
+            Cursor::new(data.as_bytes().to_vec()),
+            SwiftReaderConfig::default(),
+        );
+        let mut out = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            let tag = match rec.get("tag") {
+                Some(Value::String(s)) => s.to_string(),
+                other => panic!("unexpected tag: {other:?}"),
+            };
+            let value = match rec.get("value") {
+                Some(Value::String(s)) => Some(s.to_string()),
+                Some(Value::Null) | None => None,
+                other => panic!("unexpected value: {other:?}"),
+            };
+            out.push((tag, value));
+        }
+        out
+    };
+
+    let original = read_fields(fixture);
+    let reconstructed = read_fields(&swift_out);
+    assert_eq!(
+        original, reconstructed,
+        "field stream not byte-faithful after round-trip"
+    );
+
+    // Spot-check the load-bearing values survive verbatim.
+    assert!(
+        original
+            .iter()
+            .any(|(t, v)| t == "79" && v.as_deref() == Some("SEE-}NOTE")),
+        "mid-line dash-brace value missing: {original:?}"
+    );
+    assert!(
+        original
+            .iter()
+            .any(|(t, v)| t == "77E" && v.as_deref() == Some("LINE1\n\nLINE3")),
+        "interior blank line value missing: {original:?}"
+    );
+    assert!(
+        original
+            .iter()
+            .any(|(t, v)| t == "79" && v.as_deref() == Some("A{B")),
+        "interior brace value missing: {original:?}"
+    );
+}
+
+#[test]
+fn swift_output_with_split_is_rejected_at_config_time() {
+    // A SWIFT MT message is one indivisible brace-balanced envelope; byte-limit
+    // splitting would finalize block 4 mid-stream. The combination must fail
+    // config validation, not run and emit a corrupt message.
+    let yaml = r#"
+pipeline:
+  name: swift_split
+nodes:
+  - type: source
+    name: message
+    config:
+      name: message
+      type: swift
+      glob: ./*.swift
+      schema:
+        - { name: block, type: string }
+        - { name: tag, type: string }
+        - { name: value, type: string }
+  - type: output
+    name: out
+    input: message
+    config:
+      name: out
+      type: swift
+      path: out.swift
+      split:
+        max_bytes: 1024
+"#;
+    let err = parse_config(yaml).expect_err("swift + split must fail config validation");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("E342"), "expected E342 diagnostic, got: {msg}");
 }
 
 #[test]

--- a/crates/clinker-exec/tests/swift_pipeline.rs
+++ b/crates/clinker-exec/tests/swift_pipeline.rs
@@ -8,9 +8,10 @@
 //! clean drain; (4) a malformed message (unbalanced brace / missing `-}`
 //! trailer) surfaces as a clean run failure rather than a panic; (5) a
 //! SWIFT → SWIFT → SWIFT round-trip re-frames the block structure and
-//! reproduces every field value byte-faithfully (interior braces, mid-line
-//! `-}`, folded continuations, and interior blank lines survive); (6) the
-//! `swift`+`split` combination is rejected at config time (diagnostic `E342`).
+//! reproduces every field value byte-faithfully through the writer's executor
+//! path — multi-line continuation values, interior braces, mid-line `-}`, and
+//! interior blank lines all survive; (6) the `swift`+`split` combination is
+//! rejected at config time (diagnostic `E342`).
 
 use std::collections::HashMap;
 use std::io::Cursor;
@@ -483,6 +484,82 @@ fn swift_mt940_repeated_tags_round_trip() {
     );
 }
 
+/// Read a SWIFT message through the reader and collect its block-4
+/// `(tag, value)` field stream, with each value's folded continuation breaks
+/// intact. Used to assert value faithfulness through a round-trip.
+fn read_swift_fields(data: &str) -> Vec<(String, Option<String>)> {
+    use clinker_format::swift::reader::{SwiftReader, SwiftReaderConfig};
+    use clinker_format::traits::FormatReader;
+    use clinker_record::Value;
+    let mut r = SwiftReader::new(
+        Cursor::new(data.as_bytes().to_vec()),
+        SwiftReaderConfig::default(),
+    );
+    let mut out = Vec::new();
+    while let Some(rec) = r.next_record().unwrap() {
+        let tag = match rec.get("tag") {
+            Some(Value::String(s)) => s.to_string(),
+            other => panic!("unexpected tag: {other:?}"),
+        };
+        let value = match rec.get("value") {
+            Some(Value::String(s)) => Some(s.to_string()),
+            Some(Value::Null) | None => None,
+            other => panic!("unexpected value: {other:?}"),
+        };
+        out.push((tag, value));
+    }
+    out
+}
+
+#[test]
+fn swift_round_trip_preserves_multiline_values_through_writer() {
+    // The tag-column round-trip tests use fixtures with no folded continuation
+    // values, so value faithfulness through the SWIFT WRITER's executor path
+    // is otherwise unverified. This fixture carries a multi-line `:50K:`
+    // ordering-customer block and a `:77E:` narrative with an interior blank
+    // line, both of which fold continuation breaks into one value. Round-trip
+    // SWIFT -> SWIFT through the executor, then re-read the writer's output and
+    // assert every (tag, value) — values included — survives byte-faithfully.
+    let fixture = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}\
+        {4:\r\n:20:REF12345\r\n:32A:240101USD1000,00\r\n\
+        :50K:/12345678\r\nJOHN DOE\r\n123 MAIN ST\r\n\
+        :77E:NARRATIVE LINE ONE\r\n\r\nNARRATIVE LINE THREE\r\n-}";
+
+    let (swift_out, _csv) = swift_to_swift_then_csv(
+        fixture,
+        &[
+            ("basic", 1, "basic_header_from_doc"),
+            ("app", 2, "app_header_from_doc"),
+        ],
+    );
+
+    let original = read_swift_fields(fixture);
+    let reconstructed = read_swift_fields(&swift_out);
+    assert_eq!(
+        original, reconstructed,
+        "value stream not byte-faithful through the writer pipeline"
+    );
+
+    // Spot-check that the multi-line values specifically survived, not just
+    // the single-line ones — the folded continuation breaks are the point.
+    assert_eq!(
+        original
+            .iter()
+            .find(|(t, _)| t == "50K")
+            .and_then(|(_, v)| v.as_deref()),
+        Some("/12345678\nJOHN DOE\n123 MAIN ST"),
+        "multi-line :50K: value lost: {original:?}"
+    );
+    assert_eq!(
+        original
+            .iter()
+            .find(|(t, _)| t == "77E")
+            .and_then(|(_, v)| v.as_deref()),
+        Some("NARRATIVE LINE ONE\n\nNARRATIVE LINE THREE"),
+        "interior-blank-line :77E: value lost: {original:?}"
+    );
+}
+
 #[test]
 fn swift_interior_block4_braces_dashes_blanks_round_trip() {
     // The load-bearing faithfulness test: a value carrying an interior brace
@@ -499,34 +576,8 @@ fn swift_interior_block4_braces_dashes_blanks_round_trip() {
     let (swift_out, _csv) =
         swift_to_swift_then_csv(fixture, &[("basic", 1, "basic_header_from_doc")]);
 
-    // Read both the original fixture and the reconstructed output through the
-    // reader and compare their (tag, value) streams field-for-field.
-    let read_fields = |data: &str| -> Vec<(String, Option<String>)> {
-        use clinker_format::swift::reader::{SwiftReader, SwiftReaderConfig};
-        use clinker_format::traits::FormatReader;
-        use clinker_record::Value;
-        let mut r = SwiftReader::new(
-            Cursor::new(data.as_bytes().to_vec()),
-            SwiftReaderConfig::default(),
-        );
-        let mut out = Vec::new();
-        while let Some(rec) = r.next_record().unwrap() {
-            let tag = match rec.get("tag") {
-                Some(Value::String(s)) => s.to_string(),
-                other => panic!("unexpected tag: {other:?}"),
-            };
-            let value = match rec.get("value") {
-                Some(Value::String(s)) => Some(s.to_string()),
-                Some(Value::Null) | None => None,
-                other => panic!("unexpected value: {other:?}"),
-            };
-            out.push((tag, value));
-        }
-        out
-    };
-
-    let original = read_fields(fixture);
-    let reconstructed = read_fields(&swift_out);
+    let original = read_swift_fields(fixture);
+    let reconstructed = read_swift_fields(&swift_out);
     assert_eq!(
         original, reconstructed,
         "field stream not byte-faithful after round-trip"

--- a/crates/clinker-format/src/swift/mod.rs
+++ b/crates/clinker-format/src/swift/mod.rs
@@ -1,4 +1,4 @@
-//! SWIFT MT (FIN) message reader.
+//! SWIFT MT (FIN) message reader/writer pair.
 //!
 //! A SWIFT MT message is a sequence of brace-balanced blocks
 //! `{1:...}{2:...}{3:...}{4:...-}{5:...}`. Block 1 is the basic header, block
@@ -15,15 +15,45 @@
 //! hand-rolled on brace depth rather than reusing the shared segment
 //! tokenizer. Only the block-4 tag-line layer resembles a terminator scan.
 //!
-//! This module maps one block-4 `:tag:value` line to one
+//! The reader maps one block-4 `:tag:value` line to one
 //! [`crate::traits::FormatReader`] record under a static positional schema
 //! (`block`, `tag`, `value`) — the same one-line-one-record shape as the X12
 //! and HL7 readers, so memory scales O(1) with message size. The service
 //! blocks (1/2/3/5) are consumed by the reader to serve file-level `$doc`
 //! envelope sections and drive one balanced message-level document level;
 //! they are never emitted as body records.
+//!
+//! The writer inverts the reader exactly: it re-frames the service blocks
+//! `{<id>:<body>}` (body verbatim, no escaping) around the block-4 records it
+//! re-emits as `:tag:value` lines, closing block 4 with the line-anchored
+//! `-}` trailer. Block-4 free text is opaque, so values are written with zero
+//! escaping; the reader strips exactly the structural separators the writer
+//! re-adds, making the reader → writer → reader round-trip byte-faithful.
 
 pub mod reader;
 mod tokenizer;
+pub mod writer;
 
 pub use reader::{SwiftReader, SwiftReaderConfig};
+pub use writer::{SwiftWriter, SwiftWriterConfig};
+
+/// The default `$doc` section name for the basic header (block 1) when the
+/// source declares no `envelope:` mapping for it. User-chosen names override
+/// it; the engine reserves none — this is a stable label, not a keyword.
+pub(crate) const DEFAULT_BASIC_HEADER_SECTION: &str = "basic_header";
+
+/// The default `$doc` section name for the application header (block 2).
+pub(crate) const DEFAULT_APP_HEADER_SECTION: &str = "app_header";
+
+/// The default `$doc` section name for the user header (block 3).
+pub(crate) const DEFAULT_USER_HEADER_SECTION: &str = "user_header";
+
+/// The default `$doc` section name for the trailer (block 5).
+pub(crate) const DEFAULT_TRAILER_SECTION: &str = "trailer";
+
+/// The `body` field name a service block's verbatim text surfaces under
+/// inside its `$doc` section. SWIFT service blocks carry free-form text (a
+/// header string, nested `{sub:tag}` blocks), so the whole block body is one
+/// addressable field rather than positional elements. The reader writes it;
+/// the writer reads it back to echo a service block from `$doc`.
+pub(crate) const BODY_FIELD: &str = "body";

--- a/crates/clinker-format/src/swift/reader.rs
+++ b/crates/clinker-format/src/swift/reader.rs
@@ -33,6 +33,10 @@ use crate::error::FormatError;
 use crate::swift::tokenizer::{
     BlockTokenizer, ParsedBlock, ParsedBlock4Line, TEXT_BLOCK_ID, split_block4,
 };
+use crate::swift::{
+    BODY_FIELD, DEFAULT_APP_HEADER_SECTION, DEFAULT_BASIC_HEADER_SECTION, DEFAULT_TRAILER_SECTION,
+    DEFAULT_USER_HEADER_SECTION,
+};
 use crate::traits::FormatReader;
 
 /// Default ceiling on the number of block-4 field lines a single message may
@@ -40,26 +44,6 @@ use crate::traits::FormatReader;
 /// guidance rather than streaming an unbounded body. A real MT message is
 /// well under this; the cap exists only as a corruption guard.
 const DEFAULT_MAX_FIELDS: usize = 10_000;
-
-/// The default `$doc` section name for the basic header (block 1) when the
-/// source declares no `envelope:` mapping for it. User-chosen names override
-/// it; the engine reserves none — this is a stable label, not a keyword.
-const DEFAULT_BASIC_HEADER_SECTION: &str = "basic_header";
-
-/// The default `$doc` section name for the application header (block 2).
-const DEFAULT_APP_HEADER_SECTION: &str = "app_header";
-
-/// The default `$doc` section name for the user header (block 3).
-const DEFAULT_USER_HEADER_SECTION: &str = "user_header";
-
-/// The default `$doc` section name for the trailer (block 5).
-const DEFAULT_TRAILER_SECTION: &str = "trailer";
-
-/// The `body` field name a service block's verbatim text surfaces under
-/// inside its `$doc` section. SWIFT service blocks carry free-form text (a
-/// header string, nested `{sub:tag}` blocks), so the whole block body is one
-/// addressable field rather than positional elements.
-const BODY_FIELD: &str = "body";
 
 /// Configuration for the SWIFT reader.
 pub struct SwiftReaderConfig {

--- a/crates/clinker-format/src/swift/writer.rs
+++ b/crates/clinker-format/src/swift/writer.rs
@@ -1,0 +1,654 @@
+//! SWIFT MT message writer.
+//!
+//! Reconstructs a single SWIFT MT envelope around emitted block-4 records:
+//! the service blocks 1/2/3 (echoed from `$doc` sections or written from
+//! literal config), then block 4 (`{4:` … `-}`) framing the `:tag:value`
+//! lines re-emitted from the record stream, then the optional block 5
+//! trailer. The writer inverts the reader exactly — the reader strips the
+//! structural separators (braces, the leading `:`, the `-}` trailer, the
+//! line breaks) and keeps every other byte; the writer re-adds exactly those
+//! separators and nothing else. Block-4 free text is opaque, so values are
+//! written with **zero** escaping, making the reader → writer → reader
+//! round-trip byte-faithful even for values that carry `{`, `}`, or a
+//! mid-line `-}` as literal data.
+//!
+//! Record columns map by name: `block`, `tag`, `value`. Only `tag`/`value`
+//! become block-4 lines; `block` is the constant `4` discriminator (a record
+//! whose `block` is not `4` is rejected, since service blocks never arrive as
+//! records — they ride the document context).
+//!
+//! Memory model: streaming and O(1) in held state — only the open/finalized
+//! flags are retained, never a buffered message. A SWIFT message is a single
+//! indivisible envelope, so `flush` is the sole end-of-stream finalizer: it
+//! closes block 4 and writes the optional trailer exactly once. Byte-limit
+//! file splitting (which would flush — and thus finalize — mid-stream) is
+//! rejected for SWIFT outputs at config-validation time, so this writer is
+//! only ever flushed at true end of stream.
+
+use std::io::Write;
+use std::sync::Arc;
+
+use clinker_record::{Record, Schema, Value};
+
+use crate::error::FormatError;
+use crate::swift::BODY_FIELD;
+use crate::swift::tokenizer::TEXT_BLOCK_ID;
+use crate::traits::FormatWriter;
+
+/// One service block's source: a literal config body wins; otherwise the
+/// body is echoed from the named `$doc` section; otherwise the block is
+/// omitted.
+struct ServiceBlock {
+    /// The numeric block id (`1`, `2`, `3`, `5`).
+    id: u8,
+    /// Literal block body written verbatim. Takes precedence over `from_doc`.
+    literal: Option<String>,
+    /// Name of a `$doc` section to echo the block body from (read under the
+    /// shared `body` field). Used only when `literal` is unset.
+    from_doc: Option<String>,
+}
+
+/// Configuration for the SWIFT writer.
+///
+/// Each service block (1/2/3/5) is either written from a literal body, echoed
+/// from a user-declared `$doc` section, or omitted. The `*_from_doc` options
+/// name the section the user declared on the source — never an engine
+/// built-in; the engine reserves no section name.
+#[derive(Clone, Default)]
+pub struct SwiftWriterConfig {
+    /// Literal block-1 (basic header) body. Takes precedence over
+    /// `basic_header_from_doc`.
+    pub basic_header: Option<String>,
+    /// Name of a `$doc` section to echo the block-1 body from.
+    pub basic_header_from_doc: Option<String>,
+    /// Literal block-2 (application header) body. Takes precedence over
+    /// `app_header_from_doc`.
+    pub app_header: Option<String>,
+    /// Name of a `$doc` section to echo the block-2 body from.
+    pub app_header_from_doc: Option<String>,
+    /// Literal block-3 (user header) body. Takes precedence over
+    /// `user_header_from_doc`.
+    pub user_header: Option<String>,
+    /// Name of a `$doc` section to echo the block-3 body from.
+    pub user_header_from_doc: Option<String>,
+    /// Literal block-5 (trailer) body. Takes precedence over
+    /// `trailer_from_doc`.
+    pub trailer: Option<String>,
+    /// Name of a `$doc` section to echo the block-5 body from.
+    pub trailer_from_doc: Option<String>,
+}
+
+/// Streaming SWIFT MT message writer.
+///
+/// Holds the resolved `block`/`tag`/`value` column indices, the service-block
+/// configuration, and the open/finalized flags. Block-4 lines stream one
+/// record at a time; the envelope is opened on the first record and closed
+/// by `flush`.
+pub struct SwiftWriter<W: Write> {
+    writer: W,
+    config: SwiftWriterConfig,
+    block_idx: Option<usize>,
+    tag_idx: Option<usize>,
+    value_idx: Option<usize>,
+    /// `true` once the headers and the `{4:` opener have been written, so
+    /// later records skip straight to their `:tag:value` line.
+    header_written: bool,
+    /// The resolved block-5 trailer body, captured during the header phase
+    /// (when the first record's document context is available) and written by
+    /// `flush` after block 4 closes. `None` when no trailer is configured. A
+    /// `trailer_from_doc` echo must read the document context, which only a
+    /// record carries — so the trailer is resolved up front, not at flush.
+    trailer_body: Option<String>,
+    /// `true` once `flush` has closed block 4 and written the trailer, so a
+    /// repeat `flush` is a no-op.
+    finalized: bool,
+}
+
+impl<W: Write> SwiftWriter<W> {
+    /// Build a writer over a sink with the given schema and config. The
+    /// `block`, `tag`, and `value` columns are resolved to positional indices
+    /// once; the body lines stream one record at a time thereafter.
+    pub fn new(writer: W, schema: Arc<Schema>, config: SwiftWriterConfig) -> Self {
+        let mut block_idx = None;
+        let mut tag_idx = None;
+        let mut value_idx = None;
+        for (i, col) in schema.columns().iter().enumerate() {
+            match &**col {
+                "block" => block_idx = Some(i),
+                "tag" => tag_idx = Some(i),
+                "value" => value_idx = Some(i),
+                _ => {}
+            }
+        }
+        Self {
+            writer,
+            config,
+            block_idx,
+            tag_idx,
+            value_idx,
+            header_written: false,
+            trailer_body: None,
+            finalized: false,
+        }
+    }
+
+    /// Re-emit the service blocks 1/2/3 in order and open block 4 on the first
+    /// record. Each service block is `{<id>:<body>}` with its body verbatim
+    /// (block 3's nested `{108:...}` re-emitted byte-for-byte, no escaping);
+    /// an omitted block writes nothing. Block 4 is opened with `{4:` and the
+    /// `\r\n` that frames its first line, mirroring the reader's framing.
+    fn write_header(&mut self, record: &Record) -> Result<(), FormatError> {
+        if self.header_written {
+            return Ok(());
+        }
+        self.header_written = true;
+
+        for block in self.service_blocks_1_2_3() {
+            if let Some(body) = self.resolve_block_body(&block, record)? {
+                self.write_service_block(block.id, &body)?;
+            }
+        }
+        // Resolve the trailer now, while the record's document context is in
+        // hand; `flush` writes the stashed body after block 4 closes (it has
+        // no record to echo a `trailer_from_doc` section from).
+        self.trailer_body = self.resolve_block_body(&self.trailer_block(), record)?;
+        // Open the message-text block. `{4:` then the framing `\r\n`, so the
+        // first `:tag:value` line begins its own line and the closing `-}`
+        // trailer the writer appends at flush is line-anchored.
+        self.writer.write_all(b"{4:\r\n").map_err(FormatError::Io)?;
+        Ok(())
+    }
+
+    /// The service blocks the header phase emits, in wire order (1, 2, 3).
+    /// Block 5 (the trailer) is written by `flush`, after block 4 closes.
+    fn service_blocks_1_2_3(&self) -> [ServiceBlock; 3] {
+        [
+            ServiceBlock {
+                id: 1,
+                literal: self.config.basic_header.clone(),
+                from_doc: self.config.basic_header_from_doc.clone(),
+            },
+            ServiceBlock {
+                id: 2,
+                literal: self.config.app_header.clone(),
+                from_doc: self.config.app_header_from_doc.clone(),
+            },
+            ServiceBlock {
+                id: 3,
+                literal: self.config.user_header.clone(),
+                from_doc: self.config.user_header_from_doc.clone(),
+            },
+        ]
+    }
+
+    /// The block-5 trailer source (literal or echoed from `$doc`).
+    fn trailer_block(&self) -> ServiceBlock {
+        ServiceBlock {
+            id: 5,
+            literal: self.config.trailer.clone(),
+            from_doc: self.config.trailer_from_doc.clone(),
+        }
+    }
+
+    /// Resolve a service block's body: the literal config wins; otherwise echo
+    /// the body verbatim from the named `$doc` section under the shared `body`
+    /// field; otherwise `None` (the block is omitted).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Swift`] when `from_doc` names a section the
+    /// record's document context does not carry — a writer pointed at a
+    /// section the source never declared.
+    fn resolve_block_body(
+        &self,
+        block: &ServiceBlock,
+        record: &Record,
+    ) -> Result<Option<String>, FormatError> {
+        if let Some(literal) = &block.literal {
+            return Ok(Some(literal.clone()));
+        }
+        let Some(section) = &block.from_doc else {
+            return Ok(None);
+        };
+        let ctx = record.doc_ctx();
+        let value = ctx.get_section_field(section, BODY_FIELD).ok_or_else(|| {
+            FormatError::Swift(format!(
+                "block {id} echo names `$doc` section {section:?}, but the record's document \
+                 context carries no `{BODY_FIELD}` field for it. Ensure the source declares an \
+                 envelope section of the same name over block {id} (e.g. \
+                 `extract: {{ segment: \"{id}\" }}`).",
+                id = block.id,
+            ))
+        })?;
+        Ok(Some(value_to_field(
+            &value,
+            &format!("{section}.{BODY_FIELD}"),
+        )?))
+    }
+
+    /// Write one service block as `{<id>:<body>}` with the body verbatim.
+    /// SWIFT block bodies (including block 3/5 nested `{sub:tag}` sub-blocks)
+    /// are opaque, so no byte is escaped — the reader kept them verbatim and
+    /// the writer re-frames them verbatim.
+    fn write_service_block(&mut self, id: u8, body: &str) -> Result<(), FormatError> {
+        self.writer.write_all(b"{").map_err(FormatError::Io)?;
+        self.writer
+            .write_all(id.to_string().as_bytes())
+            .map_err(FormatError::Io)?;
+        self.writer.write_all(b":").map_err(FormatError::Io)?;
+        self.writer
+            .write_all(body.as_bytes())
+            .map_err(FormatError::Io)?;
+        self.writer.write_all(b"}").map_err(FormatError::Io)?;
+        Ok(())
+    }
+
+    /// Re-emit one block-4 record as a `:tag:value\r\n` line. A record whose
+    /// `block` column is not the constant `4` is rejected — service blocks
+    /// ride the document context, never the record stream. The value is
+    /// written verbatim (interior continuation breaks, blank lines, braces,
+    /// and mid-line `-}` reproduced as data), since block-4 free text is
+    /// opaque.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Swift`] when the record carries no `tag`, a
+    /// `block` value other than `4`, or [`FormatError::UnserializableMapValue`]
+    /// when `tag`/`value` hold a `Value::Map`/`Value::Array`.
+    fn write_body_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        let values = record.values();
+
+        if let Some(idx) = self.block_idx
+            && let Some(v) = values.get(idx)
+        {
+            let block = value_to_field(v, "block")?;
+            // An empty/null `block` is treated as the message-text block —
+            // a Transform that projects only `tag`/`value` need not restamp
+            // the discriminator the reader set. A non-empty `block` must parse
+            // to the text-block id; comparing the parsed number ties the check
+            // to TEXT_BLOCK_ID without allocating its string form per record.
+            if !block.is_empty() && block.parse::<u8>() != Ok(TEXT_BLOCK_ID) {
+                return Err(FormatError::Swift(format!(
+                    "record carries block {block:?}, but the SWIFT writer emits only block-4 \
+                     message-text lines as records (block \"4\"). Service blocks (1/2/3/5) are \
+                     written from the writer's header/trailer options or echoed from `$doc`, not \
+                     from the record stream."
+                )));
+            }
+        }
+
+        let tag = match self.tag_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_field(v, "tag")?,
+            None => String::new(),
+        };
+        if tag.is_empty() {
+            return Err(FormatError::Swift(
+                "record carries no `tag`; every SWIFT block-4 line needs a field tag to write \
+                 (`:tag:value`)"
+                    .into(),
+            ));
+        }
+        let value = match self.value_idx.and_then(|i| values.get(i)) {
+            Some(v) => value_to_field(v, "value")?,
+            None => String::new(),
+        };
+
+        self.writer.write_all(b":").map_err(FormatError::Io)?;
+        self.writer
+            .write_all(tag.as_bytes())
+            .map_err(FormatError::Io)?;
+        self.writer.write_all(b":").map_err(FormatError::Io)?;
+        self.writer
+            .write_all(value.as_bytes())
+            .map_err(FormatError::Io)?;
+        self.writer.write_all(b"\r\n").map_err(FormatError::Io)?;
+        Ok(())
+    }
+}
+
+impl<W: Write + Send> FormatWriter for SwiftWriter<W> {
+    fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        self.write_header(record)?;
+        self.write_body_record(record)
+    }
+
+    fn flush(&mut self) -> Result<(), FormatError> {
+        if self.finalized {
+            return Ok(());
+        }
+        self.finalized = true;
+        // A header-only output (no records) still frames a valid empty
+        // message: open block 4 so the `-}` trailer below closes a real
+        // block. The first-record header phase is skipped when no record
+        // arrived, so open it here from no record context — only the
+        // literal-config service blocks can appear in that case.
+        if !self.header_written {
+            self.header_written = true;
+            for block in self.service_blocks_1_2_3() {
+                if let Some(body) = block.literal {
+                    self.write_service_block(block.id, &body)?;
+                }
+            }
+            // No record means no document context, so only a literal trailer
+            // can frame block 5 in a zero-record output.
+            self.trailer_body = self.config.trailer.clone();
+            self.writer.write_all(b"{4:\r\n").map_err(FormatError::Io)?;
+        }
+        // Close block 4 with the line-anchored `-}` trailer: the last body
+        // line ended with `\r\n`, so `-}` begins its own line and the reader
+        // recognizes it as the trailer rather than data.
+        self.writer.write_all(b"-}").map_err(FormatError::Io)?;
+        // Re-emit the trailer (block 5) after block 4 closes from the body
+        // resolved during the header phase (literal config or a
+        // `trailer_from_doc` echo of the first record's document context).
+        if let Some(body) = self.trailer_body.take() {
+            self.write_service_block(5, &body)?;
+        }
+        self.writer.flush().map_err(FormatError::Io)?;
+        Ok(())
+    }
+}
+
+/// Render a `Value` to SWIFT field text. `Null` renders as the empty string;
+/// scalars render via their natural string form. A `Value::Map` or
+/// `Value::Array` has no scalar SWIFT representation, so it raises rather than
+/// silently emitting an empty field — mirroring the other formats' explicit
+/// posture for non-scalar payloads.
+fn value_to_field(value: &Value, column: &str) -> Result<String, FormatError> {
+    let text = match value {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Integer(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.to_string(),
+        Value::Date(d) => d.to_string(),
+        Value::DateTime(dt) => dt.to_string(),
+        Value::Map(_) | Value::Array(_) => {
+            return Err(FormatError::UnserializableMapValue {
+                format: "swift",
+                column: column.to_string(),
+            });
+        }
+    };
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::swift::{
+        DEFAULT_APP_HEADER_SECTION, DEFAULT_BASIC_HEADER_SECTION, DEFAULT_TRAILER_SECTION,
+        DEFAULT_USER_HEADER_SECTION,
+    };
+    use clinker_record::{DocumentContext, DocumentId};
+    use indexmap::IndexMap;
+    use std::io::Cursor;
+
+    /// A `[block, tag, value]` schema, the one the reader emits.
+    fn schema() -> Arc<Schema> {
+        let cols: Vec<Box<str>> = vec!["block".into(), "tag".into(), "value".into()];
+        Arc::new(Schema::new(cols))
+    }
+
+    fn record(schema: &Arc<Schema>, block: &str, tag: &str, value: &str) -> Record {
+        let values = vec![
+            Value::String(block.into()),
+            Value::String(tag.into()),
+            Value::String(value.into()),
+        ];
+        Record::new(Arc::clone(schema), values)
+    }
+
+    fn write_all(config: SwiftWriterConfig, records: &[Record], schema: &Arc<Schema>) -> String {
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(Cursor::new(&mut buf), Arc::clone(schema), config);
+        for r in records {
+            w.write_record(r).unwrap();
+        }
+        w.flush().unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    /// Build a document context exposing each named service-block section
+    /// under the shared `body` field, the shape the reader produces.
+    fn doc_ctx(sections: &[(&str, &str)]) -> Arc<DocumentContext> {
+        let mut out: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (name, body) in sections {
+            let mut fields: IndexMap<Box<str>, Value> = IndexMap::new();
+            fields.insert(BODY_FIELD.into(), Value::String((*body).into()));
+            out.insert(Box::from(*name), Value::Map(Box::new(fields)));
+        }
+        Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("a.swift"),
+            out,
+        ))
+    }
+
+    #[test]
+    fn block4_tag_line_reconstructed() {
+        let s = schema();
+        let rec = record(&s, "4", "20", "REFERENCE12345");
+        let out = write_all(SwiftWriterConfig::default(), &[rec], &s);
+        assert!(out.contains(":20:REFERENCE12345\r\n"), "{out}");
+        // The message-text block opens and closes around the line.
+        assert!(out.starts_with("{4:\r\n"), "{out}");
+        assert!(out.ends_with("-}"), "{out}");
+    }
+
+    #[test]
+    fn multiline_value_reproduces_continuation() {
+        // A folded continuation value (`/12345678\nJOHN DOE`) re-emits with the
+        // interior line break intact so a re-read folds it back identically.
+        let s = schema();
+        let rec = record(&s, "4", "50K", "/12345678\nJOHN DOE");
+        let out = write_all(SwiftWriterConfig::default(), &[rec], &s);
+        assert!(out.contains(":50K:/12345678\nJOHN DOE\r\n"), "{out}");
+    }
+
+    #[test]
+    fn interior_blank_line_in_value_survives() {
+        let s = schema();
+        let rec = record(&s, "4", "77E", "LINE1\n\nLINE3");
+        let out = write_all(SwiftWriterConfig::default(), &[rec], &s);
+        assert!(out.contains(":77E:LINE1\n\nLINE3\r\n"), "{out}");
+    }
+
+    #[test]
+    fn interior_brace_in_value_written_verbatim() {
+        // Block-4 free text is opaque — a `}` or `{` in a value is data,
+        // written with zero escaping.
+        let s = schema();
+        let recs = [
+            record(&s, "4", "79", "REF}WITHBRACE"),
+            record(&s, "4", "86", "A{B"),
+        ];
+        let out = write_all(SwiftWriterConfig::default(), &recs, &s);
+        assert!(out.contains(":79:REF}WITHBRACE\r\n"), "{out}");
+        assert!(out.contains(":86:A{B\r\n"), "{out}");
+    }
+
+    #[test]
+    fn block4_trailer_line_anchored() {
+        // The `-}` trailer begins its own line: the last body line ends with
+        // `\r\n`, so `-}` is preceded by a line break, not mid-line.
+        let s = schema();
+        let rec = record(&s, "4", "20", "REF");
+        let out = write_all(SwiftWriterConfig::default(), &[rec], &s);
+        assert!(out.ends_with(":20:REF\r\n-}"), "{out}");
+    }
+
+    #[test]
+    fn service_blocks_echoed_from_doc() {
+        // A record carrying a document context with the four service-block
+        // sections frames `{1:}{2:}{3:}` + block 4 + `{5:}` in order; block 3's
+        // nested sub-block re-emits verbatim.
+        let s = schema();
+        let mut rec = record(&s, "4", "20", "REF");
+        rec.set_doc_ctx(doc_ctx(&[
+            (DEFAULT_BASIC_HEADER_SECTION, "F01BANKBEBBAXXX0000000000"),
+            (DEFAULT_APP_HEADER_SECTION, "I103BANKDEFFXXXXN"),
+            (DEFAULT_USER_HEADER_SECTION, "{108:MSGREF12345}"),
+            (DEFAULT_TRAILER_SECTION, "{CHK:1234567890AB}"),
+        ]));
+        let config = SwiftWriterConfig {
+            basic_header_from_doc: Some(DEFAULT_BASIC_HEADER_SECTION.into()),
+            app_header_from_doc: Some(DEFAULT_APP_HEADER_SECTION.into()),
+            user_header_from_doc: Some(DEFAULT_USER_HEADER_SECTION.into()),
+            trailer_from_doc: Some(DEFAULT_TRAILER_SECTION.into()),
+            ..Default::default()
+        };
+        let out = write_all(config, &[rec], &s);
+        let expected = "{1:F01BANKBEBBAXXX0000000000}{2:I103BANKDEFFXXXXN}\
+            {3:{108:MSGREF12345}}{4:\r\n:20:REF\r\n-}{5:{CHK:1234567890AB}}";
+        assert_eq!(out, expected, "framing wrong");
+    }
+
+    #[test]
+    fn literal_header_wins_over_doc() {
+        let s = schema();
+        let mut rec = record(&s, "4", "20", "REF");
+        rec.set_doc_ctx(doc_ctx(&[(DEFAULT_BASIC_HEADER_SECTION, "FROMDOC")]));
+        let config = SwiftWriterConfig {
+            basic_header: Some("LITERAL1".into()),
+            basic_header_from_doc: Some(DEFAULT_BASIC_HEADER_SECTION.into()),
+            ..Default::default()
+        };
+        let out = write_all(config, &[rec], &s);
+        assert!(out.starts_with("{1:LITERAL1}{4:"), "{out}");
+        assert!(!out.contains("FROMDOC"), "{out}");
+    }
+
+    #[test]
+    fn flush_idempotent() {
+        let s = schema();
+        let rec = record(&s, "4", "20", "REF");
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&s),
+            SwiftWriterConfig {
+                trailer: Some("{CHK:AB}".into()),
+                ..Default::default()
+            },
+        );
+        w.write_record(&rec).unwrap();
+        w.flush().unwrap();
+        w.flush().unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out.matches("-}").count(), 1, "trailer written twice: {out}");
+        assert_eq!(
+            out.matches("{5:").count(),
+            1,
+            "block 5 written twice: {out}"
+        );
+    }
+
+    #[test]
+    fn non_block4_record_errors() {
+        let s = schema();
+        let rec = record(&s, "1", "20", "REF");
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&s),
+            SwiftWriterConfig::default(),
+        );
+        let err = w.write_record(&rec).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Swift(m) if m.contains("block-4")),
+            "expected a block-4 rejection, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn empty_block_column_defaults_to_block4() {
+        // A Transform that projects only tag/value (no block restamp) writes
+        // its lines as block-4 fields rather than being rejected.
+        let s = schema();
+        let rec = record(&s, "", "20", "REF");
+        let out = write_all(SwiftWriterConfig::default(), &[rec], &s);
+        assert!(out.contains(":20:REF\r\n"), "{out}");
+    }
+
+    #[test]
+    fn missing_tag_errors() {
+        let s = schema();
+        let rec = Record::new(
+            Arc::clone(&s),
+            vec![
+                Value::String("4".into()),
+                Value::Null,
+                Value::String("v".into()),
+            ],
+        );
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&s),
+            SwiftWriterConfig::default(),
+        );
+        let err = w.write_record(&rec).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Swift(m) if m.contains("no `tag`")),
+            "expected a missing-tag error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn map_value_in_value_column_errors() {
+        let s = schema();
+        let mut nested: IndexMap<Box<str>, Value> = IndexMap::new();
+        nested.insert("k".into(), Value::String("v".into()));
+        let rec = Record::new(
+            Arc::clone(&s),
+            vec![
+                Value::String("4".into()),
+                Value::String("20".into()),
+                Value::Map(Box::new(nested)),
+            ],
+        );
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&s),
+            SwiftWriterConfig::default(),
+        );
+        let err = w.write_record(&rec).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::UnserializableMapValue { format: "swift", column } if column == "value"),
+            "expected UnserializableMapValue for value, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn from_doc_naming_absent_section_errors() {
+        let s = schema();
+        let rec = record(&s, "4", "20", "REF");
+        let config = SwiftWriterConfig {
+            basic_header_from_doc: Some("nope".into()),
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(Cursor::new(&mut buf), Arc::clone(&s), config);
+        let err = w.write_record(&rec).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Swift(m) if m.contains("no `body` field")),
+            "expected an absent-section error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn zero_records_frames_empty_message() {
+        // A header-only output still frames a valid empty message: literal
+        // service blocks plus an empty block 4 closed by `-}`.
+        let s = schema();
+        let config = SwiftWriterConfig {
+            basic_header: Some("F01X".into()),
+            trailer: Some("{CHK:AB}".into()),
+            ..Default::default()
+        };
+        let out = write_all(config, &[], &s);
+        assert_eq!(out, "{1:F01X}{4:\r\n-}{5:{CHK:AB}}", "{out}");
+    }
+}

--- a/crates/clinker-format/src/swift/writer.rs
+++ b/crates/clinker-format/src/swift/writer.rs
@@ -7,10 +7,18 @@
 //! trailer. The writer inverts the reader exactly — the reader strips the
 //! structural separators (braces, the leading `:`, the `-}` trailer, the
 //! line breaks) and keeps every other byte; the writer re-adds exactly those
-//! separators and nothing else. Block-4 free text is opaque, so values are
-//! written with **zero** escaping, making the reader → writer → reader
-//! round-trip byte-faithful even for values that carry `{`, `}`, or a
-//! mid-line `-}` as literal data.
+//! separators and nothing else. Block-4 free text is opaque and has no escape
+//! mechanism, so values are written verbatim, making the
+//! reader → writer → reader round-trip byte-faithful even for values that
+//! carry `{`, `}`, or a mid-line `-}` as literal data.
+//!
+//! Verbatim emission is faithful for any value the reader can produce. The
+//! few shapes that unescaped block-4 text cannot represent — a folded
+//! continuation line beginning with the line-anchored `-}` terminator or with
+//! a `:` tag marker — only arise when a value is built from arbitrary records
+//! (CSV/JSON → Transform → SWIFT), never from the reader. Rather than emit
+//! silently-corrupt output, the writer rejects such a value with a clear
+//! error (see `reject_unrepresentable_value`).
 //!
 //! Record columns map by name: `block`, `tag`, `value`. Only `tag`/`value`
 //! become block-4 lines; `block` is the constant `4` discriminator (a record
@@ -246,15 +254,18 @@ impl<W: Write> SwiftWriter<W> {
     /// Re-emit one block-4 record as a `:tag:value\r\n` line. A record whose
     /// `block` column is not the constant `4` is rejected — service blocks
     /// ride the document context, never the record stream. The value is
-    /// written verbatim (interior continuation breaks, blank lines, braces,
-    /// and mid-line `-}` reproduced as data), since block-4 free text is
-    /// opaque.
+    /// written verbatim — interior braces and a mid-line `-}` reproduce as
+    /// data — *unless* the shape is unrepresentable in unescaped block-4 free
+    /// text (see [`reject_unrepresentable_value`]), in which case the record
+    /// is rejected rather than emitted as silently-corrupt output.
     ///
     /// # Errors
     ///
     /// Returns [`FormatError::Swift`] when the record carries no `tag`, a
-    /// `block` value other than `4`, or [`FormatError::UnserializableMapValue`]
-    /// when `tag`/`value` hold a `Value::Map`/`Value::Array`.
+    /// `block` value other than `4`, a `value` whose continuation line begins
+    /// with the block terminator (`-}`) or a tag marker (`:`), or
+    /// [`FormatError::UnserializableMapValue`] when `tag`/`value` hold a
+    /// `Value::Map`/`Value::Array`.
     fn write_body_record(&mut self, record: &Record) -> Result<(), FormatError> {
         let values = record.values();
 
@@ -292,6 +303,7 @@ impl<W: Write> SwiftWriter<W> {
             Some(v) => value_to_field(v, "value")?,
             None => String::new(),
         };
+        reject_unrepresentable_value(&tag, &value)?;
 
         self.writer.write_all(b":").map_err(FormatError::Io)?;
         self.writer
@@ -347,6 +359,49 @@ impl<W: Write + Send> FormatWriter for SwiftWriter<W> {
         self.writer.flush().map_err(FormatError::Io)?;
         Ok(())
     }
+}
+
+/// Reject a block-4 value whose folded continuation lines cannot be framed
+/// faithfully in unescaped block-4 free text.
+///
+/// Block 4 has no escape mechanism, so the writer emits values verbatim. A
+/// value written as `:tag:value\r\n` splits back on its interior `\n` line
+/// breaks on re-read: each continuation line (a line after the first, which
+/// rides directly after `:tag:`) becomes its own physical block-4 line. A
+/// continuation line that begins with `-}` re-reads as the line-anchored
+/// block-4 terminator (closing the block early — truncation), and one that
+/// begins with `:` re-reads as a spurious new `:tag:` field. The reader can
+/// never *produce* such a value, so a reader → writer round-trip is safe; but
+/// a value built from arbitrary records (CSV/JSON → Transform → SWIFT) can,
+/// and emitting it verbatim would write silently-corrupt output. Fail loud
+/// instead.
+///
+/// The first line of the value is exempt: it is preceded by the `:tag:`
+/// marker on the wire, so it can never be mistaken for a fresh tag or the
+/// terminator.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Swift`] naming the offending continuation line.
+fn reject_unrepresentable_value(tag: &str, value: &str) -> Result<(), FormatError> {
+    for line in value.split('\n').skip(1) {
+        let starts_with_trailer = line.starts_with("-}");
+        if starts_with_trailer || line.starts_with(':') {
+            let marker = if starts_with_trailer {
+                "the block terminator `-}`"
+            } else {
+                "a tag marker `:`"
+            };
+            return Err(FormatError::Swift(format!(
+                "SWIFT block-4 field `:{tag}:` has a continuation line {line:?} beginning with \
+                 {marker}. Block-4 free text has no escape mechanism, so a value line that starts \
+                 with `-}}` (the block terminator) or `:` (a field-tag marker) cannot be written \
+                 back faithfully — it would re-read as an early block close or a spurious field. \
+                 Rewrite the value so no continuation line begins with `-}}` or `:`."
+            )));
+        }
+    }
+    Ok(())
 }
 
 /// Render a `Value` to SWIFT field text. `Null` renders as the empty string;
@@ -569,6 +624,58 @@ mod tests {
         let rec = record(&s, "", "20", "REF");
         let out = write_all(SwiftWriterConfig::default(), &[rec], &s);
         assert!(out.contains(":20:REF\r\n"), "{out}");
+    }
+
+    #[test]
+    fn continuation_line_starting_with_trailer_errors() {
+        // A folded continuation line beginning with the line-anchored `-}`
+        // would re-read as an early block close — unrepresentable in
+        // unescaped block-4 text, so the writer fails loud rather than
+        // emitting truncated output. Such a value can only come from an
+        // arbitrary-record source, never the reader.
+        let s = schema();
+        let rec = record(&s, "4", "77E", "LINE1\n-}EVIL");
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&s),
+            SwiftWriterConfig::default(),
+        );
+        let err = w.write_record(&rec).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Swift(m) if m.contains("block terminator")),
+            "expected a block-terminator rejection, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn continuation_line_starting_with_tag_marker_errors() {
+        // A folded continuation line beginning with `:` would re-read as a
+        // spurious new `:tag:` field — unrepresentable, so reject it.
+        let s = schema();
+        let rec = record(&s, "4", "86", "NARRATIVE\n:99:NOTAFIELD");
+        let mut buf = Vec::new();
+        let mut w = SwiftWriter::new(
+            Cursor::new(&mut buf),
+            Arc::clone(&s),
+            SwiftWriterConfig::default(),
+        );
+        let err = w.write_record(&rec).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Swift(m) if m.contains("tag marker")),
+            "expected a tag-marker rejection, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn first_value_line_may_start_with_marker() {
+        // The first line of the value rides directly after the `:tag:` marker
+        // on the wire, so it can begin with `:` or `-}` without ambiguity —
+        // only *continuation* lines (after a fold) are constrained.
+        let s = schema();
+        let rec = record(&s, "4", "20", ":STARTSWITHCOLON");
+        let out = write_all(SwiftWriterConfig::default(), &[rec], &s);
+        assert!(out.contains(":20::STARTSWITHCOLON\r\n"), "{out}");
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/format.rs
+++ b/crates/clinker-plan/src/config/format.rs
@@ -56,6 +56,7 @@ impl OutputFormat {
             OutputFormat::Edifact(_) => "edifact",
             OutputFormat::X12(_) => "x12",
             OutputFormat::Hl7(_) => "hl7",
+            OutputFormat::Swift(_) => "swift",
         }
     }
 }
@@ -71,6 +72,7 @@ pub enum OutputFormat {
     Edifact(Option<EdifactOutputOptions>),
     X12(Option<X12OutputOptions>),
     Hl7(Option<Hl7OutputOptions>),
+    Swift(Option<SwiftOutputOptions>),
 }
 
 /// Supported format types.

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -291,3 +291,47 @@ pub struct Hl7OutputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub segment_newline: Option<bool>,
 }
+
+/// SWIFT MT output options.
+///
+/// The writer re-emits the block-4 `:tag:value` lines from the record stream
+/// and re-frames the single SWIFT envelope around them: the service blocks
+/// 1/2/3 first, then block 4, then the optional block-5 trailer. Each service
+/// block is written from a literal body or echoed from a user-declared `$doc`
+/// section (the `*_from_doc` options name the section the user wrote on the
+/// source — the engine reserves no section name). Block-4 free text is opaque,
+/// so values are written verbatim with no escaping, making the
+/// reader → writer → reader round-trip byte-faithful.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct SwiftOutputOptions {
+    /// Literal block-1 (basic header) body written verbatim. Takes precedence
+    /// over `basic_header_from_doc` when both are set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub basic_header: Option<String>,
+    /// Name of a `$doc` section to echo the block-1 body from, for round-trip
+    /// header reconstruction.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub basic_header_from_doc: Option<String>,
+    /// Literal block-2 (application header) body. Takes precedence over
+    /// `app_header_from_doc`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_header: Option<String>,
+    /// Name of a `$doc` section to echo the block-2 body from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_header_from_doc: Option<String>,
+    /// Literal block-3 (user header) body, including any nested `{sub:tag}`
+    /// content written verbatim. Takes precedence over `user_header_from_doc`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_header: Option<String>,
+    /// Name of a `$doc` section to echo the block-3 body from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_header_from_doc: Option<String>,
+    /// Literal block-5 (trailer) body, written after block 4 closes. Takes
+    /// precedence over `trailer_from_doc`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trailer: Option<String>,
+    /// Name of a `$doc` section to echo the block-5 body from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trailer_from_doc: Option<String>,
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3031,6 +3031,11 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                 "hl7",
                 "an HL7 v2 batch/file envelope is a single FHS..FTS structure",
             )),
+            OutputFormat::Swift(_) => Some((
+                "E342",
+                "swift",
+                "a SWIFT MT message is a single brace-balanced {1:..}..{5:..} envelope",
+            )),
             OutputFormat::Csv(_)
             | OutputFormat::Json(_)
             | OutputFormat::Xml(_)

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -233,6 +233,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E339" => Some(include_str!("../../../../docs/explain/E339.md")),
         "E340" => Some(include_str!("../../../../docs/explain/E340.md")),
         "E341" => Some(include_str!("../../../../docs/explain/E341.md")),
+        "E342" => Some(include_str!("../../../../docs/explain/E342.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -446,8 +447,8 @@ mod tests {
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
-            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E15Y",
-            "W101", "W302", "W305", "W306",
+            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
+            "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -1991,7 +1991,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E341, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E342, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/docs/explain/E342.md
+++ b/docs/explain/E342.md
@@ -1,0 +1,89 @@
+# Error E342: swift output cannot be combined with split
+
+## What it means
+
+An `Output` node declares the `swift` format and also carries a byte-limit
+`split:` block. The two are mutually exclusive: a SWIFT MT message is a single
+brace-balanced envelope — `{1:..}{2:..}{3:..}{4:..-}{5:..}` — whose service
+blocks frame one message-text block. The writer opens that envelope on the
+first record and closes it (the `-}` block-4 trailer plus the optional `{5:..}`
+trailer block) only at end of stream. Byte-limit file splitting finalizes the
+writer mid-stream, which would seal the message after the first split's
+records and then emit later `:tag:value` lines outside any block-4 frame,
+producing a structurally corrupt message that still reports run success.
+
+Rather than emit corruption, clinker rejects the combination at
+config-validation time.
+
+```
+[E342] output 'swift_out': `swift` output cannot be combined with `split` — a
+SWIFT MT message is a single brace-balanced {1:..}..{5:..} envelope and cannot
+be divided across files; remove the `split` block or choose a splittable format
+```
+
+## Example
+
+```yaml
+# Rejected: a SWIFT MT envelope cannot be split across files.
+nodes:
+  - type: output
+    name: swift_out
+    input: messages
+    config:
+      name: swift_out
+      type: swift
+      path: out/message.swift
+      split:
+        max_bytes: 1048576
+```
+
+```yaml
+# Corrected (option A): drop the split block; write one message envelope.
+nodes:
+  - type: output
+    name: swift_out
+    input: messages
+    config:
+      name: swift_out
+      type: swift
+      path: out/message.swift
+```
+
+```yaml
+# Corrected (option B): partition upstream and run one invocation per
+# partition, so each run produces its own complete message.
+#   for f in inputs/*.csv; do clinker run pipeline.yaml --var input="$f"; done
+```
+
+## How to fix
+
+1. **Remove the `split:` block** from the `swift` output. A single run then
+   writes one complete message envelope.
+
+2. **Choose a splittable format** (`csv`, `json`, `xml`, `fixed_width`) if the
+   byte-limit splitting is the requirement and the SWIFT block structure is
+   not.
+
+3. **Partition the input and invoke per partition** if you need multiple output
+   files: split the source by file or key upstream and run clinker once per
+   partition, so each invocation emits its own self-contained message.
+
+## Technical context
+
+The SWIFT writer reconstructs the single message envelope around emitted
+block-4 records: it writes the service blocks 1/2/3 from configuration (literal
+or echoed from `$doc`), opens block 4 with `{4:`, re-emits each `:tag:value`
+line, and on `flush()` closes block 4 with the line-anchored `-}` trailer and
+writes the optional `{5:..}` trailer block. That finalization is the only point
+at which the message is well-formed. A byte-limit `split` flushes (and
+therefore finalizes) the writer whenever the per-file cap is reached, so any
+records after the first split boundary would be written outside the sealed
+envelope. Because no valid SWIFT message can span files, the validator rejects
+the pairing up front.
+
+## See also
+
+- E323 (`edifact` output combined with byte-limit `split`)
+- E338 (`x12` output combined with byte-limit `split`)
+- E339 (`hl7` output combined with byte-limit `split`)
+- "SWIFT MT Format" in the pipeline reference

--- a/docs/user/src/formats/swift.md
+++ b/docs/user/src/formats/swift.md
@@ -1,15 +1,12 @@
 # SWIFT MT Format
 
-Clinker reads SWIFT MT (FIN) messages alongside CSV, JSON, XML,
+Clinker reads and writes SWIFT MT (FIN) messages alongside CSV, JSON, XML,
 fixed-width, EDIFACT, X12, and HL7 v2. A SWIFT MT message is a finite file
 built from brace-balanced blocks. The reader streams the message body one
 field at a time and surfaces the service blocks as document-envelope
-sections.
-
-> **Reader only.** This page documents reading SWIFT MT into Clinker. A
-> SWIFT MT *writer* (reconstructing the block structure around emitted
-> records) lands separately; until then a SWIFT source pairs with any other
-> output format (CSV, JSON, …).
+sections; the writer inverts the reader exactly, re-framing the block
+structure around emitted records so a read → write → read round-trip is
+byte-faithful.
 
 ## Block structure
 
@@ -156,10 +153,69 @@ rather than producing garbled records:
 A header-only message (no block 4, or an empty block 4) is valid: it
 produces no body records and drains cleanly.
 
+## Writing SWIFT MT
+
+A SWIFT Output node inverts the reader exactly. It re-emits each block-4
+record as a `:tag:value` line and re-frames the single message envelope
+around them: the service blocks 1/2/3 first, then block 4 (`{4:` … `-}`),
+then the optional block-5 trailer. Block-4 free text is opaque, so values are
+written **verbatim with no escaping** — an interior `{`, `}`, a mid-line `-}`,
+a folded continuation break, and an interior blank line all reproduce as data.
+The reader strips exactly the structural separators (braces, the leading `:`,
+the `-}` trailer, the line breaks) and keeps every other byte; the writer
+re-adds exactly those separators and nothing else, so a read → write → read
+round-trip returns byte-identical field values.
+
+Records map by the `tag` and `value` columns. The `block` column is the
+constant `4` discriminator (an empty `block` is treated as block 4, so a
+Transform that projects only `tag`/`value` writes fine); a record carrying a
+`block` other than `4` is rejected, because service blocks are never emitted
+as records — they ride the document context.
+
+```yaml
+nodes:
+  - type: output
+    name: out
+    input: messages
+    config:
+      name: out
+      type: swift
+      path: ./out/message.swift
+      options:
+        basic_header_from_doc: basic
+        app_header_from_doc: app
+        user_header_from_doc: user
+        trailer_from_doc: trailer
+```
+
+Each service block is written from a literal body or echoed from a
+user-declared `$doc` section:
+
+| Option                   | Meaning                                                          |
+| ------------------------ | ---------------------------------------------------------------- |
+| `basic_header`           | Literal block-1 body, written verbatim as `{1:<body>}`.          |
+| `basic_header_from_doc`  | Name of a `$doc` section to echo the block-1 body from.          |
+| `app_header`             | Literal block-2 body.                                            |
+| `app_header_from_doc`    | Name of a `$doc` section to echo the block-2 body from.          |
+| `user_header`            | Literal block-3 body (nested `{sub:tag}` content kept verbatim). |
+| `user_header_from_doc`   | Name of a `$doc` section to echo the block-3 body from.          |
+| `trailer`                | Literal block-5 body, written after block 4 closes.             |
+| `trailer_from_doc`       | Name of a `$doc` section to echo the block-5 body from.          |
+
+The `*_from_doc` options name the section the user declared on the **source**
+— the engine reserves no section name. A literal `*_header` wins over its
+`*_from_doc` companion when both are set; a service block with neither is
+omitted. The `_from_doc` echo reads the block body verbatim from the section's
+`body` field — the same single-field shape the reader writes — so a SWIFT
+source's service blocks (declared as `segment` envelope sections) round-trip
+unchanged when their section names are passed back to the writer here.
+
+A SWIFT MT message is a single indivisible envelope, so a `swift` output
+cannot be combined with a byte-limit `split:` block — the pairing is rejected
+at config-validation time (diagnostic `E342`).
+
 ## Limitations
 
-- **Reader only.** A SWIFT MT writer lands separately; today a SWIFT source
-  pairs with any other output format.
 - **UTF-8 only.** SWIFT MT messages are decoded as UTF-8; a non-UTF-8 block
   body is rejected explicitly rather than corrupted silently.
 - **Field-content parsing.** The reader exposes each `:tag:value` line as a

--- a/docs/user/src/formats/swift.md
+++ b/docs/user/src/formats/swift.md
@@ -210,6 +210,25 @@ omitted. The `_from_doc` echo reads the block body verbatim from the section's
 source's service blocks (declared as `segment` envelope sections) round-trip
 unchanged when their section names are passed back to the writer here.
 
+The document context that carries the `$doc` sections rides on each body
+record, so the `*_from_doc` echoes require at least one block-4 record to
+read from. A document with **zero** block-4 records emits a valid empty
+message — `{4:` immediately closed by `-}` — wrapped only by the
+**literal-configured** service blocks (`basic_header`, `app_header`,
+`user_header`, `trailer`); the `*_from_doc` echoes are skipped because no
+record carries the document context. Use the literal options when a
+zero-record output must still emit its service blocks.
+
+Block-4 free text has no escape mechanism, so values are written verbatim.
+Almost any value round-trips faithfully, but two shapes are unrepresentable
+when the value is built from arbitrary records (CSV/JSON → Transform →
+SWIFT): a value whose continuation line — a line after a folded line break —
+begins with the block terminator `-}` (which would re-read as an early block
+close) or with a `:` tag marker (which would re-read as a spurious field).
+The writer rejects such a value with a clear error rather than emitting
+silently-corrupt output. Values read from a SWIFT source can never take these
+shapes, so a read → write → read round-trip is always safe.
+
 A SWIFT MT message is a single indivisible envelope, so a `swift` output
 cannot be combined with a byte-limit `split:` block — the pairing is rejected
 at config-validation time (diagnostic `E342`).


### PR DESCRIPTION
Completes the SWIFT MT format pair by adding the writer, so messages round-trip (read → write → read byte-faithful). It reconstructs the brace-balanced block structure from records plus their document-context envelope sections: service blocks 1/2/3 and the trailer are re-emitted from the user-named `$doc` sections in order, and block 4's `:tag:value` lines are re-emitted from the body records. Block-4 free text is written verbatim with no escaping — interior braces, mid-line dashes, and interior blank continuation lines are reproduced exactly — and the text block closes on a line-anchored trailer, mirroring the reader.

- Registered as `OutputFormat::Swift`; splitting a SWIFT output is rejected at plan time (a SWIFT message is a single indivisible envelope) with a dedicated diagnostic.
- The reader's block-id model and default section-name constants are now shared (promoted to crate-visible) rather than duplicated.
- Round-trip tests on MT103 and MT940 (including repeated `:61:`/`:86:` tags and a message carrying interior block-4 braces, a mid-line dash-brace, and an interior blank line) assert byte-identical reconstruction. Zero new dependencies.

Closes #485. Closes #381.