### PR TITLE
engine: preserve document envelope context across record spill round-trips

### DIFF
--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -4,12 +4,26 @@
 //!
 //! ```text
 //! [tag:  format byte — 0x00 uncompressed, 0x01 LZ4 frame]
-//! [body: a stream of records, each prefixed by a 4-byte LE length and
-//!        encoded as a postcard-serialized `Record` (RecordPayload shape);
-//!        raw when the tag is 0x00, inside an LZ4 frame when 0x01]
+//! [body: a stream of frames, each prefixed by a 4-byte LE length covering a
+//!        1-byte discriminator plus the frame body; raw when the tag is 0x00,
+//!        inside an LZ4 frame when 0x01:
+//!          0x00 record pair  — postcard `RecordPayload`
+//!          0x01 context intern — postcard `DocumentContext`]
 //! [footer: magic u32 LE | version u16 LE | hash_bits u8 |
 //!          partition_id u16 LE | record_count u64 LE]
 //! ```
+//!
+//! Document envelope context is interned per file, mirroring the inter-stage
+//! [`SpillWriter`](crate::pipeline::spill::SpillWriter): the first record
+//! carrying a non-synthetic [`DocumentId`] is preceded by a one-time context
+//! frame, and every record frame carries only its `doc_id`. On read a
+//! `HashMap<DocumentId, Arc<DocumentContext>>` is built incrementally and each
+//! record clones the shared `Arc` — `O(distinct documents)` context frames and
+//! one `Arc` per document on reload, never per record. The synthetic document
+//! is never interned; a synthetic `doc_id` resolves to the process-wide
+//! synthetic singleton, and a non-synthetic `doc_id` with no interned context
+//! is a corrupt-file error. `record_count` in the footer counts record frames
+//! only — context frames are not records.
 //!
 //! The leading format tag records the workspace `[storage.spill] compress`
 //! decision (see [`clinker_plan::config::CompressMode`]) so the reader
@@ -30,6 +44,7 @@
 //! records via postcard. A 64MB per-record byte budget bounds reader
 //! allocations against malformed input.
 
+use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -39,7 +54,9 @@ use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 
 use clinker_plan::SpillError;
 use clinker_plan::error::PipelineError;
-use clinker_record::{Record, RecordPayload, Schema};
+use clinker_record::{
+    DocumentContext, DocumentId, Record, RecordPayload, Schema, synthetic_document_context,
+};
 
 /// On-disk format tag for an uncompressed grace spill body: the postcard
 /// record stream is written raw, with no LZ4 frame.
@@ -48,6 +65,14 @@ const FORMAT_TAG_UNCOMPRESSED: u8 = 0x00;
 const FORMAT_TAG_LZ4: u8 = 0x01;
 /// Byte length of the leading format tag.
 const TAG_SIZE: u64 = 1;
+
+/// Frame discriminator for a record pair: the body is a postcard
+/// [`RecordPayload`].
+const FRAME_RECORD_PAIR: u8 = 0x00;
+/// Frame discriminator for a document-context intern: the body is a postcard
+/// [`DocumentContext`], emitted on the first sight of a non-synthetic
+/// [`DocumentId`].
+const FRAME_CONTEXT_INTERN: u8 = 0x01;
 
 /// Record-stream sink for a grace spill body: either a raw buffered file
 /// writer (uncompressed) or an LZ4 frame encoder wrapping one. Mirrors the
@@ -186,8 +211,11 @@ pub(crate) fn grace_spill_error(e: GraceSpillError, node: &str, detail: &str) ->
 /// no string handling.
 pub(crate) const GRACE_SPILL_MAGIC: u32 = 0x434C_4B47;
 
-/// Format revision. Bump when the on-disk layout changes incompatibly.
-pub(crate) const GRACE_SPILL_VERSION: u16 = 1;
+/// Format revision. Bump when the on-disk layout changes incompatibly. The
+/// body now carries discriminator-tagged frames (record pair vs context
+/// intern) and per-document context interning, which the prior format did
+/// not, so a reader must reject the older layout outright.
+pub(crate) const GRACE_SPILL_VERSION: u16 = 2;
 
 /// Maximum single-record postcard byte length the reader will allocate
 /// for. Larger length prefixes are treated as corruption and surfaced as
@@ -215,16 +243,27 @@ pub(crate) struct SpillHeader {
 ///
 /// Owns a body sink — a raw buffered file writer or an LZ4 frame encoder
 /// over one, chosen from the resolved compression decision and recorded in
-/// the leading format tag. `write_record` postcard-encodes the record and
-/// emits a length-prefixed body chunk. `finish` finalizes the body, appends
-/// the raw footer, and returns the file path; the caller takes ownership of
-/// cleanup via the surrounding `tempfile::TempDir`.
+/// the leading format tag. `write_record` interns each new document's
+/// context once, then postcard-encodes the record and emits a
+/// discriminator-tagged, length-prefixed body frame. `finish` finalizes the
+/// body, appends the raw footer, and returns the file path; the caller takes
+/// ownership of cleanup via the surrounding `tempfile::TempDir`.
+///
+/// Memory model: streaming — frames are flushed one at a time. The only
+/// retained state is `seen_docs`, an `O(distinct documents)` set bounding
+/// context interning to one frame per document.
 pub(crate) struct GraceSpillWriter {
     sink: GraceSpillSink,
     path: PathBuf,
     hash_bits: u8,
     partition_id: u16,
+    /// Counts record-pair frames only; context-intern frames are not
+    /// records and are excluded from the footer's `record_count`.
     record_count: u64,
+    /// Documents already interned in this partition file, so each
+    /// non-synthetic [`DocumentId`] emits exactly one context frame
+    /// (`O(distinct documents)`), never one per record.
+    seen_docs: HashSet<DocumentId>,
 }
 
 impl GraceSpillWriter {
@@ -309,28 +348,49 @@ impl GraceSpillWriter {
             hash_bits,
             partition_id,
             record_count: 0,
+            seen_docs: HashSet::new(),
         })
     }
 
-    /// Append one record to the partition body.
-    pub(crate) fn write_record(&mut self, record: &Record) -> Result<(), GraceSpillError> {
-        let rv = record.record_var_pairs();
-        let payload = RecordPayload {
-            values: record.values().to_vec(),
-            record_vars: if rv.is_empty() { None } else { Some(rv) },
-        };
-        let bytes =
-            postcard::to_stdvec(&payload).map_err(|e| std::io::Error::other(e.to_string()))?;
-        let len = u32::try_from(bytes.len())
-            .map_err(|_| std::io::Error::other("grace spill: record exceeds u32 byte length"))?;
-        // Classify a write fault against the partition directory so an
-        // `ENOSPC` mid-stream surfaces as `DiskFull` (E321), not internal Io.
+    /// Write one discriminator-tagged, length-prefixed body frame: a 4-byte
+    /// LE length covering the 1-byte `discriminator` plus `body`, then the
+    /// discriminator, then the body. Classifies a write fault against the
+    /// partition directory so an `ENOSPC` mid-stream surfaces as `DiskFull`
+    /// (E321), not an internal `Io`.
+    fn write_frame(&mut self, discriminator: u8, body: &[u8]) -> Result<(), GraceSpillError> {
+        let len = u32::try_from(body.len() + 1)
+            .map_err(|_| std::io::Error::other("grace spill: frame exceeds u32 byte length"))?;
         if let Err(e) = self.sink.write_all(&len.to_le_bytes()) {
             return Err(self.classify_io(e));
         }
-        if let Err(e) = self.sink.write_all(&bytes) {
+        if let Err(e) = self.sink.write_all(&[discriminator]) {
             return Err(self.classify_io(e));
         }
+        if let Err(e) = self.sink.write_all(body) {
+            return Err(self.classify_io(e));
+        }
+        Ok(())
+    }
+
+    /// Append one record to the partition body.
+    ///
+    /// Emits the record's document context as a one-time intern frame the
+    /// first time its non-synthetic [`DocumentId`] is seen, before the
+    /// record frame, so the reader's table is populated before the record
+    /// references it. The synthetic document is never interned.
+    pub(crate) fn write_record(&mut self, record: &Record) -> Result<(), GraceSpillError> {
+        let doc_ctx = record.doc_ctx();
+        let doc_id = doc_ctx.id();
+        if doc_id != DocumentId::SYNTHETIC && self.seen_docs.insert(doc_id) {
+            let ctx_bytes = postcard::to_stdvec(doc_ctx.as_ref())
+                .map_err(|e| std::io::Error::other(e.to_string()))?;
+            self.write_frame(FRAME_CONTEXT_INTERN, &ctx_bytes)?;
+        }
+
+        let payload = RecordPayload::from_record(record);
+        let bytes =
+            postcard::to_stdvec(&payload).map_err(|e| std::io::Error::other(e.to_string()))?;
+        self.write_frame(FRAME_RECORD_PAIR, &bytes)?;
         self.record_count += 1;
         Ok(())
     }
@@ -366,6 +426,7 @@ impl GraceSpillWriter {
             hash_bits,
             partition_id,
             record_count,
+            seen_docs: _,
         } = self;
         let mut file = sink.into_file().map_err(&classify)?;
         // Seek to current end and append footer; the body (raw or LZ4 frame)
@@ -389,12 +450,22 @@ impl GraceSpillWriter {
 /// Validates the footer magic + version on `open`, then dispatches the body
 /// source on the leading format tag (raw vs LZ4). Yields records via
 /// `Iterator` until either the body stream returns EOF or the recorded
-/// `record_count` is exhausted.
+/// `record_count` record frames are exhausted; context-intern frames are
+/// consumed in between to populate the per-document interning table.
+///
+/// Memory model: streaming — one frame is decoded per `next` call. The only
+/// retained state is `doc_table`, the per-file `DocumentId → Arc` table built
+/// from context frames (`O(distinct documents)`); each record clones its
+/// document's shared `Arc`.
 pub(crate) struct GraceSpillReader {
     source: GraceSpillSource,
     schema: Arc<Schema>,
     header: SpillHeader,
     records_read: u64,
+    /// Per-file envelope-context interning table, populated by context
+    /// frames and read by record frames so every record of a document
+    /// shares one `Arc`.
+    doc_table: HashMap<DocumentId, Arc<DocumentContext>>,
     len_buf: [u8; 4],
 }
 
@@ -467,12 +538,39 @@ impl GraceSpillReader {
             schema,
             header,
             records_read: 0,
+            doc_table: HashMap::new(),
             len_buf: [0u8; 4],
         })
     }
 
     pub(crate) fn header(&self) -> &SpillHeader {
         &self.header
+    }
+
+    /// Decode a context-intern frame into one shared `Arc<DocumentContext>`
+    /// and key it into the per-file table by the document's id.
+    fn intern_context(&mut self, body: &[u8]) -> std::io::Result<()> {
+        let ctx: DocumentContext =
+            postcard::from_bytes(body).map_err(|e| std::io::Error::other(e.to_string()))?;
+        self.doc_table.insert(ctx.id(), Arc::new(ctx));
+        Ok(())
+    }
+
+    /// Reattach a decoded record's shared envelope context. A synthetic
+    /// `doc_id` resolves to the process-wide singleton; a non-synthetic
+    /// `doc_id` absent from the interning table is a corrupt-file error,
+    /// never a silent synthetic fallback.
+    fn doc_ctx_for(&self, doc_id: DocumentId) -> std::io::Result<Arc<DocumentContext>> {
+        if doc_id == DocumentId::SYNTHETIC {
+            Ok(synthetic_document_context())
+        } else {
+            self.doc_table.get(&doc_id).map(Arc::clone).ok_or_else(|| {
+                std::io::Error::other(format!(
+                    "grace spill: record references document {doc_id:?} with no interned \
+                     context frame; file is corrupt"
+                ))
+            })
+        }
     }
 }
 
@@ -483,36 +581,65 @@ impl Iterator for GraceSpillReader {
         if self.records_read >= self.header.record_count {
             return None;
         }
-        match self.source.read_exact(&mut self.len_buf) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
-                // Stream ended before the recorded record_count was
-                // reached — surface as an error rather than silently
-                // truncating, so callers don't lose rows on a corrupted
-                // partition file.
+        // Drive past context-intern frames — they populate the doc table but
+        // are not records — until a record-pair frame yields a `Record`.
+        loop {
+            match self.source.read_exact(&mut self.len_buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    // Stream ended before the recorded record_count was
+                    // reached — surface as an error rather than silently
+                    // truncating, so callers don't lose rows on a corrupted
+                    // partition file.
+                    return Some(Err(std::io::Error::other(format!(
+                        "grace spill: unexpected EOF after {} of {} records",
+                        self.records_read, self.header.record_count
+                    ))));
+                }
+                Err(e) => return Some(Err(e)),
+            }
+            let len = u32::from_le_bytes(self.len_buf) as usize;
+            if len > GRACE_SPILL_MAX_RECORD_BYTES {
                 return Some(Err(std::io::Error::other(format!(
-                    "grace spill: unexpected EOF after {} of {} records",
-                    self.records_read, self.header.record_count
+                    "grace spill: frame length {len} exceeds {GRACE_SPILL_MAX_RECORD_BYTES} byte cap"
                 ))));
             }
-            Err(e) => return Some(Err(e)),
+            if len == 0 {
+                return Some(Err(std::io::Error::other(
+                    "grace spill: frame length 0 (missing discriminator); file is corrupt",
+                )));
+            }
+            let mut buf = vec![0u8; len];
+            if let Err(e) = self.source.read_exact(&mut buf) {
+                return Some(Err(e));
+            }
+            let (discriminator, body) = (buf[0], &buf[1..]);
+            match discriminator {
+                FRAME_CONTEXT_INTERN => {
+                    if let Err(e) = self.intern_context(body) {
+                        return Some(Err(e));
+                    }
+                    // Loop to the next frame.
+                }
+                FRAME_RECORD_PAIR => {
+                    let payload: RecordPayload = match postcard::from_bytes(body) {
+                        Ok(p) => p,
+                        Err(e) => return Some(Err(std::io::Error::other(e.to_string()))),
+                    };
+                    let doc_ctx = match self.doc_ctx_for(payload.doc_id) {
+                        Ok(c) => c,
+                        Err(e) => return Some(Err(e)),
+                    };
+                    self.records_read += 1;
+                    return Some(Ok(payload.into_record(Arc::clone(&self.schema), doc_ctx)));
+                }
+                other => {
+                    return Some(Err(std::io::Error::other(format!(
+                        "grace spill: unknown frame discriminator {other:#04x}; file is corrupt"
+                    ))));
+                }
+            }
         }
-        let len = u32::from_le_bytes(self.len_buf) as usize;
-        if len > GRACE_SPILL_MAX_RECORD_BYTES {
-            return Some(Err(std::io::Error::other(format!(
-                "grace spill: record length {len} exceeds {GRACE_SPILL_MAX_RECORD_BYTES} byte cap"
-            ))));
-        }
-        let mut buf = vec![0u8; len];
-        if let Err(e) = self.source.read_exact(&mut buf) {
-            return Some(Err(e));
-        }
-        let payload: RecordPayload = match postcard::from_bytes(&buf) {
-            Ok(p) => p,
-            Err(e) => return Some(Err(std::io::Error::other(e.to_string()))),
-        };
-        self.records_read += 1;
-        Some(Ok(payload.into_record(Arc::clone(&self.schema))))
     }
 }
 
@@ -549,6 +676,7 @@ impl Read for BoundedRead {
 mod tests {
     use super::*;
     use clinker_record::Value;
+    use indexmap::IndexMap;
     use tempfile::TempDir;
 
     fn schema() -> Arc<Schema> {
@@ -560,6 +688,24 @@ mod tests {
             Arc::clone(s),
             vec![Value::Integer(id), Value::String(v.into())],
         )
+    }
+
+    /// Build a `DocumentContext` with a single `Head` section carrying a
+    /// nested `Value::Map`, exercising the recursive `Value` path through
+    /// the interned context frame.
+    fn doc_ctx(seed: i64, file: &str) -> Arc<DocumentContext> {
+        let mut head = IndexMap::new();
+        head.insert(
+            Box::from("batch_id"),
+            Value::String(format!("RUN-{seed:03}").into()),
+        );
+        let mut sections = IndexMap::new();
+        sections.insert(Box::from("Head"), Value::Map(Box::new(head)));
+        Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from(file),
+            sections,
+        ))
     }
 
     /// LZ4 frame magic number, little-endian `0x184D2204` — the four bytes a
@@ -776,5 +922,123 @@ mod tests {
                 .contains("became unavailable mid-run"),
             "{pipeline_err}"
         );
+    }
+
+    // A document's envelope context (id, nested-Map section, non-empty
+    // source_file) survives the grace spill round-trip under both body
+    // formats.
+    #[test]
+    fn grace_roundtrip_preserves_doc_ctx() {
+        for compress in [true, false] {
+            let dir = TempDir::new().unwrap();
+            let s = schema();
+            let doc = doc_ctx(1, "claims/run-001.xml");
+            let mut w = GraceSpillWriter::new(dir.path(), 4, 0, compress).unwrap();
+            let mut rec = record(&s, 1, "a");
+            rec.set_doc_ctx(Arc::clone(&doc));
+            w.write_record(&rec).unwrap();
+            let (path, _) = w.finish().unwrap();
+
+            let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
+            assert_eq!(
+                reader.header().record_count,
+                1,
+                "footer record_count counts record frames only (compress={compress})"
+            );
+            let recs: Vec<Record> = reader.map(|r| r.unwrap()).collect();
+            assert_eq!(recs.len(), 1, "compress={compress}");
+            let ctx = recs[0].doc_ctx();
+            assert_eq!(ctx.id(), doc.id(), "compress={compress}");
+            assert_eq!(ctx.source_file().as_ref(), "claims/run-001.xml");
+            assert_eq!(
+                ctx.get_section_field("Head", "batch_id"),
+                Some(Value::String("RUN-001".into())),
+                "compress={compress}"
+            );
+        }
+    }
+
+    // Every record of one document re-hydrates the SAME shared Arc — one
+    // allocation per document on reload.
+    #[test]
+    fn grace_shares_one_arc_per_document() {
+        let dir = TempDir::new().unwrap();
+        let s = schema();
+        let doc = doc_ctx(2, "batch.xml");
+        let mut w = GraceSpillWriter::new(dir.path(), 4, 0, true).unwrap();
+        for i in 0..3 {
+            let mut rec = record(&s, i, "x");
+            rec.set_doc_ctx(Arc::clone(&doc));
+            w.write_record(&rec).unwrap();
+        }
+        let (path, _) = w.finish().unwrap();
+        let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
+        let recs: Vec<Record> = reader.map(|r| r.unwrap()).collect();
+        assert_eq!(recs.len(), 3);
+        let first = recs[0].doc_ctx();
+        for r in &recs[1..] {
+            assert!(
+                Arc::ptr_eq(first, r.doc_ctx()),
+                "all records of one document must share one re-hydrated Arc",
+            );
+        }
+    }
+
+    // A synthetic-context record interns no context frame and re-hydrates to
+    // the process-wide synthetic singleton.
+    #[test]
+    fn grace_synthetic_doc_ctx_roundtrips_as_synthetic() {
+        let dir = TempDir::new().unwrap();
+        let s = schema();
+        let mut w = GraceSpillWriter::new(dir.path(), 4, 0, true).unwrap();
+        // record() leaves the default synthetic context attached.
+        w.write_record(&record(&s, 1, "syn")).unwrap();
+        let (path, _) = w.finish().unwrap();
+        let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
+        let recs: Vec<Record> = reader.map(|r| r.unwrap()).collect();
+        assert_eq!(recs.len(), 1);
+        assert!(
+            Arc::ptr_eq(recs[0].doc_ctx(), &synthetic_document_context()),
+            "synthetic doc_id must re-hydrate to the shared singleton",
+        );
+        assert_eq!(recs[0].doc_ctx().id(), DocumentId::SYNTHETIC);
+    }
+
+    // The interning table is O(distinct documents): K documents over N
+    // records emit exactly K context frames, and each document's records
+    // share one Arc while distinct documents get distinct Arcs.
+    #[test]
+    fn grace_interning_table_is_o_distinct_docs() {
+        let dir = TempDir::new().unwrap();
+        let s = schema();
+        const DOCS: i64 = 3;
+        const RECS_PER_DOC: usize = 10;
+        let docs: Vec<Arc<DocumentContext>> = (0..DOCS)
+            .map(|d| doc_ctx(d + 1, &format!("doc-{d}.xml")))
+            .collect();
+        let mut w = GraceSpillWriter::new(dir.path(), 4, 0, false).unwrap();
+        for doc in &docs {
+            for i in 0..RECS_PER_DOC {
+                let mut rec = record(&s, i as i64, "r");
+                rec.set_doc_ctx(Arc::clone(doc));
+                w.write_record(&rec).unwrap();
+            }
+        }
+        let (path, _) = w.finish().unwrap();
+        let reader = GraceSpillReader::open(&path, Arc::clone(&s)).unwrap();
+        // Footer counts record frames only — context frames excluded.
+        assert_eq!(
+            reader.header().record_count as usize,
+            DOCS as usize * RECS_PER_DOC,
+        );
+        let recs: Vec<Record> = reader.map(|r| r.unwrap()).collect();
+        assert_eq!(recs.len(), DOCS as usize * RECS_PER_DOC);
+        let doc_a = recs[0].doc_ctx();
+        let doc_b = recs[RECS_PER_DOC].doc_ctx();
+        assert!(
+            !Arc::ptr_eq(doc_a, doc_b),
+            "distinct docs get distinct Arcs"
+        );
+        assert!(Arc::ptr_eq(doc_a, recs[RECS_PER_DOC - 1].doc_ctx()));
     }
 }

--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -41,8 +41,10 @@
 //!
 //! Reader path validates the footer magic and version, then opens a
 //! decode stream over the body (matching the format tag) and yields
-//! records via postcard. A 64MB per-record byte budget bounds reader
-//! allocations against malformed input.
+//! records via postcard. A per-frame byte cap
+//! ([`SPILL_MAX_FRAME_BYTES`](crate::pipeline::spill::SPILL_MAX_FRAME_BYTES),
+//! shared with the inter-stage spill reader) bounds reader allocations
+//! against a malformed length prefix on either frame kind.
 
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
@@ -52,6 +54,7 @@ use std::sync::Arc;
 
 use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 
+use crate::pipeline::spill::SPILL_MAX_FRAME_BYTES;
 use clinker_plan::SpillError;
 use clinker_plan::error::PipelineError;
 use clinker_record::{
@@ -216,11 +219,6 @@ pub(crate) const GRACE_SPILL_MAGIC: u32 = 0x434C_4B47;
 /// intern) and per-document context interning, which the prior format did
 /// not, so a reader must reject the older layout outright.
 pub(crate) const GRACE_SPILL_VERSION: u16 = 2;
-
-/// Maximum single-record postcard byte length the reader will allocate
-/// for. Larger length prefixes are treated as corruption and surfaced as
-/// `io::Error` rather than driving a runaway allocation.
-pub(crate) const GRACE_SPILL_MAX_RECORD_BYTES: usize = 64 * 1024 * 1024;
 
 /// Footer byte size: 4 (magic) + 2 (version) + 1 (hash_bits) +
 /// 2 (partition_id) + 8 (record_count) = 17 bytes.
@@ -599,9 +597,9 @@ impl Iterator for GraceSpillReader {
                 Err(e) => return Some(Err(e)),
             }
             let len = u32::from_le_bytes(self.len_buf) as usize;
-            if len > GRACE_SPILL_MAX_RECORD_BYTES {
+            if len > SPILL_MAX_FRAME_BYTES {
                 return Some(Err(std::io::Error::other(format!(
-                    "grace spill: frame length {len} exceeds {GRACE_SPILL_MAX_RECORD_BYTES} byte cap"
+                    "grace spill: frame length {len} exceeds {SPILL_MAX_FRAME_BYTES} byte cap"
                 ))));
             }
             if len == 0 {

--- a/crates/clinker-exec/src/pipeline/spill.rs
+++ b/crates/clinker-exec/src/pipeline/spill.rs
@@ -18,8 +18,26 @@
 //!   Then a record stream (raw when uncompressed, inside an LZ4 frame when
 //!   compressed):
 //!     Line 0: JSON array of column names (schema header)
-//!     Line 1..N: postcard-encoded `(RecordPayload, P)` pairs, length-prefixed
-//!                as a 4-byte little-endian u32 before each record.
+//!     Line 1..N: a sequence of length-prefixed frames. Each frame is a
+//!                4-byte little-endian u32 byte length, then a 1-byte frame
+//!                discriminator, then the frame body:
+//!                  `0x00` record pair — postcard `(RecordPayload, P)`.
+//!                  `0x01` context intern — postcard `DocumentContext`.
+//!
+//! Document envelope context is interned per file, not inlined per record.
+//! The first time a record carrying a non-synthetic [`DocumentId`] is
+//! written, the writer emits that document's context frame **before** the
+//! record's pair frame; every later record of the same document carries
+//! only its `doc_id` (a `u64`) in the `RecordPayload`. On read the context
+//! frames build a `HashMap<DocumentId, Arc<DocumentContext>>` incrementally
+//! and each record clones the shared `Arc` keyed by its `doc_id`. This is
+//! bounded-memory: `O(distinct documents in file)` context frames, never
+//! `O(records)`, and exactly one `Arc<DocumentContext>` per document on
+//! reload. [`DocumentId::SYNTHETIC`] is never interned — a synthetic
+//! `doc_id` resolves on read to the process-wide
+//! [`synthetic_document_context`] singleton; a non-synthetic `doc_id`
+//! absent from the table is a corrupt-file decode error, not a silent
+//! synthetic fallback.
 //!
 //! The leading tag lets the reader dispatch on the on-disk format without
 //! the writer's compression choice having to travel out-of-band. The choice
@@ -31,6 +49,7 @@
 //! manifest written once per file. Record bodies use postcard for compact
 //! binary encoding of `Value`s and the per-record metadata map.
 
+use std::collections::{HashMap, HashSet};
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
@@ -40,7 +59,9 @@ use lz4_flex::frame::{FrameDecoder, FrameEncoder};
 use serde::{Serialize, de::DeserializeOwned};
 use tempfile::NamedTempFile;
 
-use clinker_record::{Record, RecordPayload, Schema};
+use clinker_record::{
+    DocumentContext, DocumentId, Record, RecordPayload, Schema, synthetic_document_context,
+};
 
 use clinker_plan::SpillError;
 
@@ -49,6 +70,14 @@ use clinker_plan::SpillError;
 const FORMAT_TAG_UNCOMPRESSED: u8 = 0x00;
 /// On-disk format tag for an LZ4-frame-compressed spill file.
 const FORMAT_TAG_LZ4: u8 = 0x01;
+
+/// Frame discriminator for a record pair: the body is a postcard
+/// `(RecordPayload, P)` tuple.
+const FRAME_RECORD_PAIR: u8 = 0x00;
+/// Frame discriminator for a document-context intern: the body is a postcard
+/// [`DocumentContext`], emitted on the first sight of a non-synthetic
+/// [`DocumentId`] in the stream.
+const FRAME_CONTEXT_INTERN: u8 = 0x01;
 
 /// Record-stream sink for a spill file: either a raw buffered writer
 /// (uncompressed) or an LZ4 frame encoder wrapping one. Both expose
@@ -104,13 +133,25 @@ impl SpillSink {
 /// Writes (record, payload) pairs to a spill file, optionally LZ4-compressed.
 ///
 /// A 1-byte format tag is written first, then the schema as a JSON header
-/// line, then each record as a 4-byte little-endian length prefix followed by
-/// a postcard-encoded `(RecordPayload, P)` tuple. The `compress` flag at
-/// construction selects the LZ4 or raw record stream and is recorded in the
-/// tag so [`SpillReader`] dispatches without out-of-band state.
+/// line, then a sequence of length-prefixed, discriminator-tagged frames:
+/// each record becomes a record-pair frame holding a postcard
+/// `(RecordPayload, P)` tuple, and the first record of each non-synthetic
+/// document is preceded by a one-time context-intern frame holding that
+/// document's [`DocumentContext`]. The `compress` flag at construction
+/// selects the LZ4 or raw record stream and is recorded in the tag so
+/// [`SpillReader`] dispatches without out-of-band state.
+///
+/// Memory model: streaming — records are encoded and flushed one at a time.
+/// The only retained state is `seen_docs`, an `O(distinct documents)` set
+/// that bounds context interning to one frame per document.
 pub struct SpillWriter<P> {
     sink: SpillSink,
     schema: Arc<Schema>,
+    /// Documents whose context frame has already been emitted, so each
+    /// non-synthetic [`DocumentId`] is interned exactly once per file. Holds
+    /// at most one entry per distinct document in the stream
+    /// (`O(distinct documents)`), never one per record.
+    seen_docs: HashSet<DocumentId>,
     /// Directory the spill file lives in, retained so a mid-stream write or
     /// finalize fault can be classified against it: an `ENOSPC` becomes
     /// `SpillError::DiskFull` and a directory-level fault becomes
@@ -183,32 +224,51 @@ impl<P: Serialize> SpillWriter<P> {
         Ok(SpillWriter {
             sink,
             schema,
+            seen_docs: HashSet::new(),
             spill_dir: resolved_dir,
             _payload: PhantomData,
         })
     }
 
-    /// Serialize one (record, payload) pair.
-    ///
-    /// Each pair is written as a 4-byte little-endian length prefix
-    /// followed by a postcard-encoded `(RecordPayload, P)` tuple.
-    pub fn write_pair(&mut self, record: &Record, payload: &P) -> Result<(), SpillError> {
-        let rv = record.record_var_pairs();
-        let rec_payload = RecordPayload {
-            values: record.values().to_vec(),
-            record_vars: if rv.is_empty() { None } else { Some(rv) },
-        };
-        let bytes = postcard::to_stdvec(&(&rec_payload, payload))?;
-        let len = bytes.len() as u32;
-        // Classify a write fault against the spill directory so an `ENOSPC`
-        // mid-stream surfaces as `DiskFull` (E321), not a generic `Io`.
+    /// Write one length-prefixed, discriminator-tagged frame: a 4-byte
+    /// little-endian length covering the 1-byte `discriminator` plus
+    /// `body`, then the discriminator, then the body. Classifies a write
+    /// fault against the spill directory so an `ENOSPC` mid-stream surfaces
+    /// as `DiskFull` (E321), not a generic `Io`.
+    fn write_frame(&mut self, discriminator: u8, body: &[u8]) -> Result<(), SpillError> {
+        let len = (body.len() + 1) as u32;
         self.sink
             .write_all(&len.to_le_bytes())
             .map_err(|e| SpillError::from_spill_dir_io(&self.spill_dir, e))?;
         self.sink
-            .write_all(&bytes)
+            .write_all(&[discriminator])
+            .map_err(|e| SpillError::from_spill_dir_io(&self.spill_dir, e))?;
+        self.sink
+            .write_all(body)
             .map_err(|e| SpillError::from_spill_dir_io(&self.spill_dir, e))?;
         Ok(())
+    }
+
+    /// Serialize one (record, payload) pair.
+    ///
+    /// On the first sight of a record's non-synthetic [`DocumentId`], a
+    /// one-time context-intern frame carrying its [`DocumentContext`] is
+    /// emitted *before* the record-pair frame, so the reader's interning
+    /// table is populated before any record references it. The record's
+    /// `RecordPayload` then carries only the `doc_id`, never the full
+    /// context. The synthetic document is never interned — it resolves on
+    /// read to the shared synthetic singleton.
+    pub fn write_pair(&mut self, record: &Record, payload: &P) -> Result<(), SpillError> {
+        let doc_ctx = record.doc_ctx();
+        let doc_id = doc_ctx.id();
+        if doc_id != DocumentId::SYNTHETIC && self.seen_docs.insert(doc_id) {
+            let ctx_bytes = postcard::to_stdvec(doc_ctx.as_ref())?;
+            self.write_frame(FRAME_CONTEXT_INTERN, &ctx_bytes)?;
+        }
+
+        let rec_payload = RecordPayload::from_record(record);
+        let bytes = postcard::to_stdvec(&(&rec_payload, payload))?;
+        self.write_frame(FRAME_RECORD_PAIR, &bytes)
     }
 
     /// Convenience: write a record with the unit payload `()`.
@@ -264,6 +324,7 @@ impl<P: DeserializeOwned> SpillFile<P> {
         let mut reader = SpillReader {
             source,
             schema: Arc::clone(&self.schema),
+            doc_table: HashMap::new(),
             len_buf: [0u8; 4],
             _payload: PhantomData,
         };
@@ -335,9 +396,19 @@ impl BufRead for SpillSource {
 
 /// Reads (record, payload) pairs from a spill file, dispatching on the file's
 /// format tag for the compressed or uncompressed record stream.
+///
+/// Memory model: streaming — one frame is decoded per `next` call. The only
+/// retained state is `doc_table`, the per-file `DocumentId → Arc` interning
+/// table built incrementally from context frames; it holds one `Arc` per
+/// distinct document (`O(distinct documents)`), and every record of a
+/// document clones that shared `Arc` rather than decoding the context again.
 pub struct SpillReader<P> {
     source: SpillSource,
     schema: Arc<Schema>,
+    /// Per-file envelope-context interning table. A context-intern frame
+    /// decodes its [`DocumentContext`] into exactly one `Arc` here; every
+    /// later record carrying that `DocumentId` clones the shared `Arc`.
+    doc_table: HashMap<DocumentId, Arc<DocumentContext>>,
     len_buf: [u8; 4],
     _payload: PhantomData<P>,
 }
@@ -346,25 +417,78 @@ impl<P: DeserializeOwned> Iterator for SpillReader<P> {
     type Item = Result<(Record, P), SpillError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Read 4-byte length prefix
-        match self.source.read_exact(&mut self.len_buf) {
-            Ok(()) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return None,
-            Err(e) => return Some(Err(SpillError::Io(e))),
+        // Drive past any context-intern frames — they populate the doc
+        // table but yield no record — until a record-pair frame produces a
+        // `(Record, P)`, or the stream ends.
+        loop {
+            // Read 4-byte length prefix.
+            match self.source.read_exact(&mut self.len_buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return None,
+                Err(e) => return Some(Err(SpillError::Io(e))),
+            }
+            let len = u32::from_le_bytes(self.len_buf) as usize;
+            if len == 0 {
+                // A frame is at minimum its 1-byte discriminator; a zero
+                // length is structurally impossible from `write_frame`.
+                return Some(Err(SpillError::InvalidSchema(
+                    "spill frame length 0 (missing discriminator); file is corrupt".to_string(),
+                )));
+            }
+            let mut buf = vec![0u8; len];
+            if let Err(e) = self.source.read_exact(&mut buf) {
+                return Some(Err(SpillError::Io(e)));
+            }
+            let (discriminator, body) = (buf[0], &buf[1..]);
+            match discriminator {
+                FRAME_CONTEXT_INTERN => {
+                    if let Err(e) = self.intern_context(body) {
+                        return Some(Err(e));
+                    }
+                    // Loop to the next frame.
+                }
+                FRAME_RECORD_PAIR => return Some(self.parse_pair(body)),
+                other => {
+                    return Some(Err(SpillError::InvalidSchema(format!(
+                        "unknown spill frame discriminator {other:#04x}; file is corrupt"
+                    ))));
+                }
+            }
         }
-        let len = u32::from_le_bytes(self.len_buf) as usize;
-        let mut buf = vec![0u8; len];
-        if let Err(e) = self.source.read_exact(&mut buf) {
-            return Some(Err(SpillError::Io(e)));
-        }
-        Some(self.parse_pair(&buf))
     }
 }
 
 impl<P: DeserializeOwned> SpillReader<P> {
+    /// Decode a context-intern frame into one shared `Arc<DocumentContext>`
+    /// and insert it into the per-file table keyed by the document's id.
+    fn intern_context(&mut self, body: &[u8]) -> Result<(), SpillError> {
+        let ctx: DocumentContext = postcard::from_bytes(body)?;
+        self.doc_table.insert(ctx.id(), Arc::new(ctx));
+        Ok(())
+    }
+
+    /// Decode a record-pair frame and reattach the document's shared
+    /// context. A synthetic `doc_id` resolves to the process-wide synthetic
+    /// singleton; a non-synthetic `doc_id` absent from the interning table
+    /// is a corrupt-file error (a record frame must always be preceded by
+    /// its document's context frame), never a silent synthetic fallback.
     fn parse_pair(&self, buf: &[u8]) -> Result<(Record, P), SpillError> {
         let (rec_payload, payload): (RecordPayload, P) = postcard::from_bytes(buf)?;
-        let record = rec_payload.into_record(Arc::clone(&self.schema));
+        let doc_ctx = if rec_payload.doc_id == DocumentId::SYNTHETIC {
+            synthetic_document_context()
+        } else {
+            match self.doc_table.get(&rec_payload.doc_id) {
+                Some(ctx) => Arc::clone(ctx),
+                None => {
+                    return Err(SpillError::InvalidSchema(format!(
+                        "spill record references document {:?} with no interned context frame; \
+                         file is corrupt",
+                        rec_payload.doc_id
+                    )));
+                }
+            }
+        };
+        let record = rec_payload.into_record(Arc::clone(&self.schema), doc_ctx);
         Ok((record, payload))
     }
 }
@@ -373,6 +497,7 @@ impl<P: DeserializeOwned> SpillReader<P> {
 mod tests {
     use super::*;
     use clinker_record::Value;
+    use indexmap::IndexMap;
 
     fn test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
@@ -380,6 +505,26 @@ mod tests {
             "amount".into(),
             "active".into(),
         ]))
+    }
+
+    /// Build a `DocumentContext` with the given id, file, and a single
+    /// `Head` section carrying `(batch_id, total)` — a typical envelope
+    /// shape with a nested `Value::Map` payload exercising the recursive
+    /// `Value` path through the context frame.
+    fn make_doc_ctx(id_seed: i64, file: &str) -> Arc<DocumentContext> {
+        let mut head = IndexMap::new();
+        head.insert(
+            Box::from("batch_id"),
+            Value::String(format!("RUN-{id_seed:03}").into()),
+        );
+        head.insert("total".into(), Value::Integer(id_seed * 10));
+        let mut sections = IndexMap::new();
+        sections.insert(Box::from("Head"), Value::Map(Box::new(head)));
+        Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from(file),
+            sections,
+        ))
     }
 
     fn make_record(schema: &Arc<Schema>, name: &str, amount: i64, active: bool) -> Record {
@@ -714,5 +859,265 @@ mod tests {
             rendered.contains("became unavailable mid-run"),
             "{rendered}"
         );
+    }
+
+    // A document's envelope context (id, sections including a nested
+    // Value::Map, and a non-empty source_file) must survive the spill
+    // round-trip identically under both the compressed and uncompressed
+    // body format.
+    #[test]
+    fn spill_roundtrip_preserves_doc_ctx() {
+        for compress in [true, false] {
+            let schema = test_schema();
+            let doc = make_doc_ctx(1, "payments/run-001.xml");
+            let mut writer: SpillWriter<()> =
+                SpillWriter::new(Arc::clone(&schema), None, compress).unwrap();
+            let mut rec = make_record(&schema, "Alice", 100, true);
+            rec.set_doc_ctx(Arc::clone(&doc));
+            writer.write_record(&rec).unwrap();
+
+            let spill_file = writer.finish().unwrap();
+            let records: Vec<Record> = spill_file.reader().unwrap().map(|r| r.unwrap().0).collect();
+            assert_eq!(records.len(), 1, "compress={compress}");
+            let ctx = records[0].doc_ctx();
+            assert_eq!(ctx.id(), doc.id(), "compress={compress}");
+            assert_eq!(
+                ctx.source_file().as_ref(),
+                "payments/run-001.xml",
+                "source_file must survive (compress={compress})"
+            );
+            assert_eq!(
+                ctx.get_section_field("Head", "batch_id"),
+                Some(Value::String("RUN-001".into())),
+                "section field must survive (compress={compress})"
+            );
+            assert_eq!(
+                ctx.get_section_field("Head", "total"),
+                Some(Value::Integer(10)),
+                "compress={compress}"
+            );
+        }
+    }
+
+    // Every record of one document re-hydrates the SAME shared
+    // `Arc<DocumentContext>` — one allocation per document on reload, not
+    // per record. `Arc::ptr_eq` across all three records of the document
+    // proves the interning table hands back a single shared Arc.
+    #[test]
+    fn spill_shares_one_arc_per_document() {
+        let schema = test_schema();
+        let doc = make_doc_ctx(2, "claims/batch.xml");
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, true).unwrap();
+        for i in 0..3 {
+            let mut rec = make_record(&schema, &format!("row{i}"), i, true);
+            rec.set_doc_ctx(Arc::clone(&doc));
+            writer.write_record(&rec).unwrap();
+        }
+        let spill_file = writer.finish().unwrap();
+        let records: Vec<Record> = spill_file.reader().unwrap().map(|r| r.unwrap().0).collect();
+        assert_eq!(records.len(), 3);
+        let first = records[0].doc_ctx();
+        for rec in &records[1..] {
+            assert!(
+                Arc::ptr_eq(first, rec.doc_ctx()),
+                "all records of one document must share one re-hydrated Arc",
+            );
+        }
+    }
+
+    // A synthetic-context record interns no context frame and re-hydrates
+    // to the process-wide synthetic singleton (ptr_eq to the live
+    // singleton), so in-pipeline-synthesized records cost zero context
+    // frames on spill.
+    #[test]
+    fn spill_synthetic_doc_ctx_roundtrips_as_synthetic() {
+        let schema = test_schema();
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, true).unwrap();
+        // make_record leaves the default synthetic context attached.
+        writer
+            .write_record(&make_record(&schema, "syn", 1, false))
+            .unwrap();
+        let spill_file = writer.finish().unwrap();
+
+        // No context-intern frame is emitted for the synthetic document:
+        // exactly one frame (the record pair) lands in the body.
+        assert_eq!(
+            count_body_frames(&spill_file),
+            1,
+            "synthetic document must intern no context frame",
+        );
+
+        let records: Vec<Record> = spill_file.reader().unwrap().map(|r| r.unwrap().0).collect();
+        assert_eq!(records.len(), 1);
+        assert!(
+            Arc::ptr_eq(records[0].doc_ctx(), &synthetic_document_context()),
+            "synthetic doc_id must re-hydrate to the shared singleton",
+        );
+        assert_eq!(records[0].doc_ctx().id(), DocumentId::SYNTHETIC);
+    }
+
+    // The interning table is `O(distinct documents)`, not `O(records)`: N
+    // records spread over K distinct documents emit exactly K context
+    // frames (plus N record frames), regardless of how many records each
+    // document carries.
+    #[test]
+    fn spill_interning_table_is_o_distinct_docs() {
+        let schema = test_schema();
+        const DOCS: usize = 3;
+        const RECS_PER_DOC: usize = 20;
+        let docs: Vec<Arc<DocumentContext>> = (0..DOCS)
+            .map(|d| make_doc_ctx(d as i64 + 1, &format!("doc-{d}.xml")))
+            .collect();
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, false).unwrap();
+        for doc in &docs {
+            for i in 0..RECS_PER_DOC {
+                let mut rec = make_record(&schema, "r", i as i64, true);
+                rec.set_doc_ctx(Arc::clone(doc));
+                writer.write_record(&rec).unwrap();
+            }
+        }
+        let spill_file = writer.finish().unwrap();
+
+        let (ctx_frames, rec_frames) = count_frames_by_kind(&spill_file);
+        assert_eq!(ctx_frames, DOCS, "exactly one context frame per document");
+        assert_eq!(
+            rec_frames,
+            DOCS * RECS_PER_DOC,
+            "one record frame per record",
+        );
+
+        // Each document's records share that document's single Arc, and the
+        // three documents' Arcs are mutually distinct.
+        let records: Vec<Record> = spill_file.reader().unwrap().map(|r| r.unwrap().0).collect();
+        assert_eq!(records.len(), DOCS * RECS_PER_DOC);
+        let doc_a = records[0].doc_ctx();
+        let doc_b = records[RECS_PER_DOC].doc_ctx();
+        assert!(
+            !Arc::ptr_eq(doc_a, doc_b),
+            "distinct docs get distinct Arcs"
+        );
+        assert!(Arc::ptr_eq(doc_a, records[RECS_PER_DOC - 1].doc_ctx()));
+    }
+
+    // A non-synthetic record whose context frame never landed is a
+    // corrupt-file decode error, never a silent synthetic fallback. Build a
+    // valid spill, then strip its leading context-intern frame so the
+    // record references an absent document.
+    #[test]
+    fn spill_missing_context_frame_is_decode_error() {
+        let schema = test_schema();
+        let doc = make_doc_ctx(9, "lone.xml");
+        // Uncompressed so the body frames are byte-addressable for surgery.
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, false).unwrap();
+        let mut rec = make_record(&schema, "z", 1, true);
+        rec.set_doc_ctx(Arc::clone(&doc));
+        writer.write_record(&rec).unwrap();
+        let spill_file = writer.finish().unwrap();
+
+        // The on-disk layout is: [tag][schema line\n][ctx frame][record frame].
+        // Drop the context frame, keeping tag + schema + record frame, so the
+        // record's doc_id has no interned context.
+        let raw = std::fs::read(spill_file.path()).unwrap();
+        let nl = raw.iter().position(|&b| b == b'\n').unwrap();
+        let header = &raw[..=nl];
+        let mut rest = &raw[nl + 1..];
+        // First frame is the context intern: skip its 4-byte length + body.
+        let ctx_len = u32::from_le_bytes(rest[..4].try_into().unwrap()) as usize;
+        assert_eq!(rest[4], FRAME_CONTEXT_INTERN, "first body frame is context");
+        rest = &rest[4 + ctx_len..];
+        let mut surgical = Vec::with_capacity(header.len() + rest.len());
+        surgical.extend_from_slice(header);
+        surgical.extend_from_slice(rest);
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), &surgical).unwrap();
+        // Re-open through a hand-built SpillFile pointing at the surgical file.
+        let file = std::fs::File::open(tmp.path()).unwrap();
+        drop(file);
+        // Decode via a fresh reader over the surgical bytes.
+        let err = decode_surgical(tmp.path(), &schema)
+            .expect_err("a record with no interned context must be a decode error");
+        match err {
+            SpillError::InvalidSchema(msg) => assert!(
+                msg.contains("no interned context frame"),
+                "expected corrupt-context message, got: {msg}"
+            ),
+            other => panic!("expected InvalidSchema, got {other:?}"),
+        }
+    }
+
+    /// Count every length-prefixed frame in a finished spill file's body,
+    /// transparently handling the LZ4 / raw body. Used by the interning
+    /// tests to assert the frame budget without depending on reader logic.
+    fn count_body_frames(spill_file: &SpillFile<()>) -> usize {
+        let (ctx, rec) = count_frames_by_kind(spill_file);
+        ctx + rec
+    }
+
+    /// Decode a spill file's body frames and tally `(context_frames,
+    /// record_frames)`. Reads the leading format tag and schema line the
+    /// same way `SpillFile::reader` does, then walks the frame stream.
+    fn count_frames_by_kind(spill_file: &SpillFile<()>) -> (usize, usize) {
+        let mut file = std::fs::File::open(spill_file.path()).unwrap();
+        let mut tag = [0u8; 1];
+        file.read_exact(&mut tag).unwrap();
+        let mut source: Box<dyn BufRead> = match tag[0] {
+            FORMAT_TAG_LZ4 => Box::new(BufReader::new(FrameDecoder::new(file))),
+            FORMAT_TAG_UNCOMPRESSED => Box::new(BufReader::new(file)),
+            other => panic!("unknown tag {other:#04x}"),
+        };
+        let mut schema_line = String::new();
+        source.read_line(&mut schema_line).unwrap();
+        let (mut ctx, mut rec) = (0usize, 0usize);
+        let mut len_buf = [0u8; 4];
+        loop {
+            match source.read_exact(&mut len_buf) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => break,
+                Err(e) => panic!("read error: {e}"),
+            }
+            let len = u32::from_le_bytes(len_buf) as usize;
+            let mut buf = vec![0u8; len];
+            source.read_exact(&mut buf).unwrap();
+            match buf[0] {
+                FRAME_CONTEXT_INTERN => ctx += 1,
+                FRAME_RECORD_PAIR => rec += 1,
+                other => panic!("unknown frame discriminator {other:#04x}"),
+            }
+        }
+        (ctx, rec)
+    }
+
+    /// Open a raw spill file at `path` (uncompressed) and decode it through
+    /// the production `SpillReader` frame loop, returning the first decode
+    /// error encountered. Mirrors `SpillFile::reader` without needing a
+    /// `SpillFile` handle (the surgical file isn't one).
+    fn decode_surgical(path: &Path, schema: &Arc<Schema>) -> Result<Vec<Record>, SpillError> {
+        let mut file = std::fs::File::open(path)?;
+        let mut tag = [0u8; 1];
+        file.read_exact(&mut tag)?;
+        let source = match tag[0] {
+            FORMAT_TAG_UNCOMPRESSED => SpillSource::Uncompressed(BufReader::new(file)),
+            FORMAT_TAG_LZ4 => SpillSource::Lz4(BufReader::new(FrameDecoder::new(file))),
+            other => {
+                return Err(SpillError::InvalidSchema(format!(
+                    "unknown tag {other:#04x}"
+                )));
+            }
+        };
+        let mut reader: SpillReader<()> = SpillReader {
+            source,
+            schema: Arc::clone(schema),
+            doc_table: HashMap::new(),
+            len_buf: [0u8; 4],
+            _payload: PhantomData,
+        };
+        let mut schema_line = String::new();
+        reader.source.read_line(&mut schema_line)?;
+        reader.map(|r| r.map(|(rec, ())| rec)).collect()
     }
 }

--- a/crates/clinker-exec/src/pipeline/spill.rs
+++ b/crates/clinker-exec/src/pipeline/spill.rs
@@ -79,6 +79,14 @@ const FRAME_RECORD_PAIR: u8 = 0x00;
 /// [`DocumentId`] in the stream.
 const FRAME_CONTEXT_INTERN: u8 = 0x01;
 
+/// Upper bound on a single spill frame's on-disk byte length. A length
+/// prefix exceeding this is treated as corruption and surfaced as a clean
+/// decode error *before* any allocation, so a garbage prefix can't drive an
+/// unbounded `vec![0u8; len]` and OOM the process. Applies to both frame
+/// kinds (record pair and context intern). The grace-hash spill reader
+/// shares this cap for parity.
+pub(crate) const SPILL_MAX_FRAME_BYTES: usize = 64 * 1024 * 1024;
+
 /// Record-stream sink for a spill file: either a raw buffered writer
 /// (uncompressed) or an LZ4 frame encoder wrapping one. Both expose
 /// `io::Write` for the schema header and per-record bodies; the variant is
@@ -434,6 +442,16 @@ impl<P: DeserializeOwned> Iterator for SpillReader<P> {
                 return Some(Err(SpillError::InvalidSchema(
                     "spill frame length 0 (missing discriminator); file is corrupt".to_string(),
                 )));
+            }
+            if len > SPILL_MAX_FRAME_BYTES {
+                // A length prefix past the cap is corruption — reject before
+                // allocating `len` bytes so a garbage prefix can't OOM the
+                // process. Covers both the record-pair and context-intern
+                // frames, which share this read.
+                return Some(Err(SpillError::InvalidSchema(format!(
+                    "spill frame length {len} exceeds {SPILL_MAX_FRAME_BYTES} byte cap; \
+                     file is corrupt"
+                ))));
             }
             let mut buf = vec![0u8; len];
             if let Err(e) = self.source.read_exact(&mut buf) {
@@ -1048,6 +1066,67 @@ mod tests {
             ),
             other => panic!("expected InvalidSchema, got {other:?}"),
         }
+    }
+
+    // A garbage length prefix on either frame kind must be rejected as a
+    // clean decode error BEFORE the `vec![0u8; len]` allocation, so a
+    // corrupt prefix can't drive an unbounded allocation and OOM the
+    // process — the same cap the grace-hash reader enforces. The first body
+    // frame's 4-byte length prefix is overwritten with an over-cap value in
+    // place (no oversized buffer is materialized), then the reader must
+    // surface the cap error rather than attempting the allocation. Covers
+    // both the context-intern frame (doc-attached record opens with one) and
+    // the record-pair frame (synthetic record opens with one).
+    fn assert_over_cap_first_frame_rejected(spill_file: &SpillFile<()>, schema: &Arc<Schema>) {
+        let mut raw = std::fs::read(spill_file.path()).unwrap();
+        let nl = raw.iter().position(|&b| b == b'\n').unwrap();
+        // Overwrite the first body frame's 4-byte LE length prefix with an
+        // over-cap value. The cap check must fire on this prefix before any
+        // `vec![0u8; len]`, so the (absent) oversized body is never read.
+        let over_cap = (SPILL_MAX_FRAME_BYTES as u32) + 1;
+        raw[nl + 1..nl + 5].copy_from_slice(&over_cap.to_le_bytes());
+
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), &raw).unwrap();
+        let err = decode_surgical(tmp.path(), schema).expect_err(
+            "an over-cap frame length prefix must be a decode error, not an allocation",
+        );
+        match err {
+            SpillError::InvalidSchema(msg) => assert!(
+                msg.contains("exceeds") && msg.contains("byte cap"),
+                "expected over-cap message, got: {msg}"
+            ),
+            other => panic!("expected InvalidSchema, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn spill_over_cap_context_frame_length_is_decode_error_not_oom() {
+        let schema = test_schema();
+        // A doc-attached record opens the body with a context-intern frame.
+        // Uncompressed so the first frame's length prefix sits at a fixed
+        // offset right after the JSON schema header line.
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, false).unwrap();
+        let mut rec = make_record(&schema, "a", 1, true);
+        rec.set_doc_ctx(make_doc_ctx(5, "big.xml"));
+        writer.write_record(&rec).unwrap();
+        let spill_file = writer.finish().unwrap();
+        assert_over_cap_first_frame_rejected(&spill_file, &schema);
+    }
+
+    #[test]
+    fn spill_over_cap_record_frame_length_is_decode_error_not_oom() {
+        let schema = test_schema();
+        // A synthetic-context record interns no context frame, so the first
+        // body frame is the record pair.
+        let mut writer: SpillWriter<()> =
+            SpillWriter::new(Arc::clone(&schema), None, false).unwrap();
+        writer
+            .write_record(&make_record(&schema, "a", 1, true))
+            .unwrap();
+        let spill_file = writer.finish().unwrap();
+        assert_over_cap_first_frame_rejected(&spill_file, &schema);
     }
 
     /// Count every length-prefixed frame in a finished spill file's body,

--- a/crates/clinker-exec/tests/aggregate_per_document_flush.rs
+++ b/crates/clinker-exec/tests/aggregate_per_document_flush.rs
@@ -243,6 +243,150 @@ fn spilling_strategy_flushes_per_document_across_boundary() {
     }
 }
 
+/// Per-document identity must survive an UPSTREAM record spill, not just the
+/// Aggregate's own accumulator spill. A multi-document CSV source fans out
+/// through a Route whose materialized branch `node_buffers` spill records to
+/// disk under a 1 MiB budget (the RSS-soft predicate from
+/// `route_fanout_soft_spill.rs`), then those re-hydrated records feed a
+/// per-document `count(*)` Aggregate. If the document context were lost on
+/// the record-half spill round-trip, every post-spill record would re-hydrate
+/// to the SYNTHETIC document and the per-document flush would fold all
+/// documents into a single cross-document group set. The per-document counts
+/// holding across the spill is the end-to-end proof that `doc_ctx` survived.
+const UPSTREAM_SPILL_YAML: &str = r#"
+pipeline:
+  name: per_doc_upstream_spill
+  memory: { limit: "1M", backpressure: spill }
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - { name: category, type: string }
+        - { name: payload, type: string }
+  - type: route
+    name: split
+    input: events
+    config:
+      mode: exclusive
+      conditions:
+        keep: "true"
+      default: drop
+  - type: aggregate
+    name: by_category
+    input: split.keep
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+
+#[test]
+fn per_document_identity_survives_upstream_record_spill() {
+    // RSS-based spill predicate: with no RSS reading the upstream node_buffer
+    // never spills, so the record-half round-trip under test never fires.
+    // Skip rather than assert a false negative.
+    if clinker_exec::pipeline::memory::rss_bytes().is_none() {
+        return;
+    }
+
+    // Two documents (one CSV file each). Document A: category x×400, y×200.
+    // Document B: category x×300. A wide `payload` column inflates per-row
+    // node_buffer charge so the Route branch slot crosses the RSS soft floor
+    // and spills its records through the inter-stage SpillWriter.
+    let wide = "p".repeat(64);
+    let mut doc_a = String::from("category,payload\n");
+    for _ in 0..400 {
+        doc_a.push_str(&format!("x,{wide}\n"));
+    }
+    for _ in 0..200 {
+        doc_a.push_str(&format!("y,{wide}\n"));
+    }
+    let mut doc_b = String::from("category,payload\n");
+    for _ in 0..300 {
+        doc_b.push_str(&format!("x,{wide}\n"));
+    }
+
+    let config = parse_config(UPSTREAM_SPILL_YAML).expect("parse upstream-spill pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile upstream-spill pipeline");
+
+    let slots = vec![
+        FileSlot::new(
+            PathBuf::from("a.csv"),
+            Box::new(Cursor::new(doc_a.into_bytes())),
+        ),
+        FileSlot::new(
+            PathBuf::from("b.csv"),
+            Box::new(Cursor::new(doc_b.into_bytes())),
+        ),
+    ];
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run upstream-spill pipeline");
+    assert_eq!(report.counters.dlq_count, 0, "no DLQ entries expected");
+
+    // Fail loudly if the run stopped spilling — the test's whole point is to
+    // exercise the upstream record-spill round-trip, so a zero here means the
+    // assertion below would pass vacuously.
+    assert!(
+        report.cumulative_spill_bytes > 0,
+        "upstream node_buffer must have spilled records under the 1 MiB budget; \
+         cumulative_spill_bytes = {}",
+        report.cumulative_spill_bytes,
+    );
+
+    let output = buf.as_string();
+    let mut body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
+    body.sort();
+    // Per-document flush: document A keeps x=400, y=200; document B keeps a
+    // SEPARATE x=300 — never a folded x=700 that a SYNTHETIC collapse would
+    // produce.
+    assert_eq!(
+        body,
+        vec![
+            "x,300".to_string(),
+            "x,400".to_string(),
+            "y,200".to_string()
+        ],
+        "each document's counts must stay attributed across the upstream record \
+         spill (x=400,y=200 for doc A; x=300 for doc B), with no cross-document \
+         fold into a synthetic document",
+    );
+}
+
 /// A fused `Source → Transform` feeding a strict hash Aggregate is
 /// certified for the streaming-ingest substrate: the aggregate drives
 /// `add_record` off a bounded channel rather than draining a charged

--- a/crates/clinker-exec/tests/envelope_doc_context_test.rs
+++ b/crates/clinker-exec/tests/envelope_doc_context_test.rs
@@ -127,3 +127,147 @@ fn envelope_sections_available_on_every_body_record() {
         );
     }
 }
+
+/// `$doc.<section>.<field>` must resolve correctly even when the body record
+/// carrying that context has round-tripped through an upstream record spill.
+/// A Route fans the envelope source's body out through a materialized branch
+/// whose `node_buffers` spill records to disk under a 1 MiB budget (the
+/// RSS-soft predicate from `route_fanout_soft_spill.rs`); the downstream
+/// Transform then reads `$doc.BatchInfo.batch_id` off the re-hydrated records.
+/// If the envelope context were dropped on the spill round-trip, the spilled
+/// records would re-hydrate to the empty synthetic context and `$doc.*` would
+/// resolve to null — so a non-null, correct value on every spilled body row
+/// is the end-to-end proof the interned context survived.
+const SPILL_ENVELOPE_YAML: &str = r#"
+pipeline:
+  name: envelope_spill
+  memory: { limit: "1M", backpressure: spill }
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          BatchInfo:
+            extract: { xml_path: "/doc/BatchInfo" }
+            fields:
+              batch_id: string
+          Summary:
+            extract: { xml_path: "/doc/Summary" }
+            fields:
+              total: int
+      schema:
+        - { name: amount, type: int }
+        - { name: pad, type: string }
+  - type: route
+    name: split
+    input: payments
+    config:
+      mode: exclusive
+      conditions:
+        keep: "true"
+      default: drop
+  - type: transform
+    name: tag
+    input: split.keep
+    config:
+      cxl: |
+        emit amount = amount
+        emit batch = $doc.BatchInfo.batch_id
+        emit declared_total = $doc.Summary.total
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn doc_context_resolves_after_upstream_record_spill() {
+    // RSS-based spill predicate: without RSS reading the upstream
+    // node_buffer never spills, so the round-trip under test never fires.
+    if clinker_exec::pipeline::memory::rss_bytes().is_none() {
+        return;
+    }
+
+    // One document, many body rows with a wide `pad` column so the Route
+    // branch slot crosses the RSS soft floor and spills its records through
+    // the inter-stage SpillWriter. The envelope sections live once per
+    // document, interned a single time on spill regardless of row count.
+    const ROWS: usize = 1_500;
+    let pad = "z".repeat(64);
+    let mut xml =
+        String::from("<doc>\n  <BatchInfo><batch_id>RUN-777</batch_id></BatchInfo>\n  <records>\n");
+    for i in 0..ROWS {
+        xml.push_str(&format!(
+            "    <record><amount>{i}</amount><pad>{pad}</pad></record>\n"
+        ));
+    }
+    xml.push_str(&format!(
+        "  </records>\n  <Summary><total>{ROWS}</total></Summary>\n</doc>"
+    ));
+
+    let config = parse_config(SPILL_ENVELOPE_YAML).expect("parse spill-envelope pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile spill-envelope pipeline");
+
+    let file = FileSlot::new(
+        PathBuf::from("payments.xml"),
+        Box::new(Cursor::new(xml.into_bytes())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "payments".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run spill-envelope pipeline");
+    assert_eq!(report.counters.total_count as usize, ROWS, "all body rows");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    // Fail loudly if the run stopped spilling — otherwise the $doc assertion
+    // below would pass without ever exercising the spill round-trip.
+    assert!(
+        report.cumulative_spill_bytes > 0,
+        "upstream node_buffer must have spilled records under the 1 MiB budget; \
+         cumulative_spill_bytes = {}",
+        report.cumulative_spill_bytes,
+    );
+
+    // Every output row resolves the head section (batch_id) and tail section
+    // (total) off its re-hydrated record — the in-memory baseline value,
+    // never the synthetic-context null a dropped context would yield.
+    let output = buf.as_string();
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), ROWS + 1, "header + {ROWS} data rows");
+    for (i, row) in lines[1..].iter().enumerate() {
+        assert!(
+            row.contains("RUN-777"),
+            "row {i} lost $doc.BatchInfo.batch_id across the spill round-trip: {row}"
+        );
+        assert!(
+            row.contains(&format!(",{ROWS}")),
+            "row {i} lost $doc.Summary.total across the spill round-trip: {row}"
+        );
+    }
+}

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -14,6 +14,10 @@
 
 use crate::value::Value;
 use indexmap::IndexMap;
+use serde::de::{self, SeqAccess, Visitor};
+use serde::ser::SerializeTuple;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -25,7 +29,13 @@ use std::sync::{Arc, OnceLock};
 /// boundary down to one downstream emission, and by the Aggregate's
 /// per-document group flush to walk its open documents in a stable order.
 /// `Ord` follows allocation order: a document opened earlier sorts first.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+///
+/// The `Serialize`/`Deserialize` impls are transparent over the inner
+/// `u64`, so a spilled record's `doc_id` keys the per-file interning
+/// table by the original numeric identity — never re-minted on read.
+/// [`DocumentId::SYNTHETIC`] (`0`) round-trips as `0`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
 pub struct DocumentId(u64);
 
 impl DocumentId {
@@ -128,6 +138,82 @@ impl DocumentContext {
             // means the reader emitted a non-Map payload.
             _ => None,
         }
+    }
+}
+
+// ── Spill codec ─────────────────────────────────────────────────────────────
+//
+// A `DocumentContext` is interned once per spill file (one frame per distinct
+// `DocumentId`), so its codec is hand-written rather than derived for two
+// reasons: `IndexMap` has no insertion-order-preserving serde impl, and the
+// `Arc<str>` source file must collapse to its bytes on the wire and rebuild as
+// a fresh `Arc<str>` on read (the in-memory `Arc` identity does not — and need
+// not — survive the spill boundary; see the module-level note on per-document
+// re-hydration). The shape is a 3-tuple mirroring `Value::Map`'s pair-vec
+// encoding so section insertion order is preserved exactly:
+//   (DocumentId, source_file: &str, sections: Vec<(&str, &Value)>)
+// On read each `(String, Value)` pair re-inserts in order into a fresh
+// `IndexMap`, and the source file rebuilds via `Arc::from`.
+
+impl Serialize for DocumentContext {
+    /// Serializes this context as `(id, source_file, ordered section pairs)`.
+    ///
+    /// Used only by the spill interning path, which writes one context frame
+    /// per distinct document per file (`O(distinct documents)`, never
+    /// `O(records)`). Section order is preserved by emitting the `IndexMap`
+    /// as an ordered pair vector, matching the `Value::Map` codec.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let pairs: Vec<(&str, &Value)> =
+            self.sections.iter().map(|(k, v)| (k.as_ref(), v)).collect();
+        let mut tup = serializer.serialize_tuple(3)?;
+        tup.serialize_element(&self.id)?;
+        tup.serialize_element(self.source_file.as_ref())?;
+        tup.serialize_element(&pairs)?;
+        tup.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for DocumentContext {
+    /// Reconstructs a context from `(id, source_file, ordered section pairs)`.
+    ///
+    /// Rebuilds the `source_file` as a fresh `Arc<str>` and re-inserts the
+    /// section pairs into a new `IndexMap` in wire order, so a document's
+    /// section ordering survives a spill round-trip. The rebuilt `Arc<str>`
+    /// is a distinct allocation from the live ingest stream's — equality is
+    /// by content, not pointer identity.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct ContextVisitor;
+
+        impl<'de> Visitor<'de> for ContextVisitor {
+            type Value = DocumentContext;
+
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "a (DocumentId, source_file, sections) tuple")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<DocumentContext, A::Error> {
+                let id: DocumentId = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
+                let source_file: std::string::String = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
+                let pairs: Vec<(std::string::String, Value)> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                let mut sections = IndexMap::with_capacity(pairs.len());
+                for (k, v) in pairs {
+                    sections.insert(k.into_boxed_str(), v);
+                }
+                Ok(DocumentContext {
+                    id,
+                    source_file: Arc::from(source_file.as_str()),
+                    sections,
+                })
+            }
+        }
+
+        deserializer.deserialize_tuple(3, ContextVisitor)
     }
 }
 
@@ -302,5 +388,78 @@ mod tests {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<DocumentContext>();
         assert_send_sync::<Arc<DocumentContext>>();
+    }
+
+    #[test]
+    fn document_id_serde_is_transparent_over_u64() {
+        // The id is the interning-table key on a spill round-trip; it must
+        // encode as the bare inner u64 so a record's doc_id reloads to the
+        // same numeric identity it spilled with.
+        let id = DocumentId::next();
+        let bytes = postcard::to_stdvec(&id).unwrap();
+        let raw = postcard::to_stdvec(&id.0).unwrap();
+        assert_eq!(bytes, raw, "DocumentId must encode identically to its u64");
+        let back: DocumentId = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(back, id);
+
+        // SYNTHETIC (0) round-trips as 0, never re-minted.
+        let syn = postcard::to_stdvec(&DocumentId::SYNTHETIC).unwrap();
+        let syn_back: DocumentId = postcard::from_bytes(&syn).unwrap();
+        assert_eq!(syn_back, DocumentId::SYNTHETIC);
+    }
+
+    #[test]
+    fn document_context_serde_preserves_id_file_and_section_order() {
+        // Sections inserted z, a, m — insertion order must survive the wire,
+        // mirroring the Value::Map pair-vec codec. A nested Value::Map inside
+        // a section exercises the recursive Value path through the frame.
+        let mut sections = IndexMap::new();
+        sections.insert(
+            Box::from("z_section"),
+            make_section(&[("k", Value::String("zv".into()))]),
+        );
+        sections.insert(
+            Box::from("a_section"),
+            make_section(&[
+                ("count", Value::Integer(7)),
+                (
+                    "nested",
+                    Value::Map(Box::new({
+                        let mut inner = IndexMap::new();
+                        inner.insert(Box::from("deep"), Value::Bool(true));
+                        inner
+                    })),
+                ),
+            ]),
+        );
+        sections.insert(Box::from("m_section"), make_section(&[]));
+        let id = DocumentId::next();
+        let ctx = DocumentContext::new(id, Arc::from("payments/run-001.xml"), sections);
+
+        let bytes = postcard::to_stdvec(&ctx).unwrap();
+        let back: DocumentContext = postcard::from_bytes(&bytes).unwrap();
+
+        assert_eq!(back.id(), id);
+        assert_eq!(back.source_file().as_ref(), "payments/run-001.xml");
+        // Section names survive in insertion order, not sorted order.
+        let names: Vec<&str> = back.sections.keys().map(|k| k.as_ref()).collect();
+        assert_eq!(names, vec!["z_section", "a_section", "m_section"]);
+        // Field values, including a nested Value::Map, survive intact.
+        assert_eq!(
+            back.get_section_field("z_section", "k"),
+            Some(Value::String("zv".into()))
+        );
+        assert_eq!(
+            back.get_section_field("a_section", "count"),
+            Some(Value::Integer(7))
+        );
+        assert_eq!(
+            back.get_section_field("a_section", "nested"),
+            Some(Value::Map(Box::new({
+                let mut inner = IndexMap::new();
+                inner.insert(Box::from("deep"), Value::Bool(true));
+                inner
+            })))
+        );
     }
 }

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -1,4 +1,4 @@
-use crate::document_context::{DocumentContext, synthetic_document_context};
+use crate::document_context::{DocumentContext, DocumentId, synthetic_document_context};
 use crate::resolver::FieldResolver;
 use crate::schema::Schema;
 use crate::value::Value;
@@ -47,9 +47,14 @@ pub struct Record {
 /// Wire payload for a [`Record`] in binary spill streams.
 ///
 /// Schema is not embedded — the spill stream writes the schema once in
-/// a header line, so each record body carries only positional values
-/// and optional per-record `$record.<key>` scoped variables. Callers
-/// reconstruct a full `Record` via [`RecordPayload::into_record`].
+/// a header line, so each record body carries only positional values,
+/// optional per-record `$record.<key>` scoped variables, and the
+/// [`DocumentId`] keying its envelope context. The full
+/// [`DocumentContext`] is **not** inlined per record: the spill writer
+/// interns one context frame per distinct document per file, and
+/// [`RecordPayload::into_record`] reattaches the shared `Arc` looked up
+/// by this `doc_id`. So the per-record cost is one `u64`, and reload
+/// memory is `O(distinct documents)`, never `O(records)`.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct RecordPayload {
     /// Positional field values in schema column order.
@@ -57,34 +62,46 @@ pub struct RecordPayload {
     /// Per-record `$record.<key>` user-declared scoped variables, or
     /// `None` if the record has none.
     pub record_vars: Option<Vec<(Box<str>, Value)>>,
+    /// Identity of this record's envelope document. Keys the spill file's
+    /// per-document interning table on read; [`DocumentId::SYNTHETIC`] maps
+    /// to the process-wide synthetic context singleton.
+    pub doc_id: DocumentId,
 }
 
 impl RecordPayload {
-    /// Reconstruct a [`Record`] from this payload using a caller-supplied schema.
-    pub fn into_record(self, schema: Arc<Schema>) -> Record {
+    /// Capture a record's wire payload: its positional values, any
+    /// `$record.<key>` scoped variables, and its envelope [`DocumentId`].
+    ///
+    /// The schema and full document context are dropped here — the spill
+    /// stream writes the schema once in its header and interns the context
+    /// once per document — so a payload is exactly what each record body
+    /// must carry. Both spill encoders (the inter-stage `SpillWriter` and
+    /// the grace-hash twin) build their payload through this one place.
+    pub fn from_record(record: &Record) -> Self {
+        let rv = record.record_var_pairs();
+        RecordPayload {
+            values: record.values().to_vec(),
+            record_vars: if rv.is_empty() { None } else { Some(rv) },
+            doc_id: record.doc_ctx().id(),
+        }
+    }
+
+    /// Reconstruct a [`Record`] from this payload, attaching the
+    /// caller-supplied schema and the shared envelope context.
+    ///
+    /// `doc_ctx` is the single `Arc<DocumentContext>` the spill reader
+    /// re-hydrated for this payload's `doc_id`; every record of one
+    /// document clones that same `Arc` (refcount bump only, no per-record
+    /// context copy).
+    pub fn into_record(self, schema: Arc<Schema>, doc_ctx: Arc<DocumentContext>) -> Record {
         let mut record = Record::new(schema, self.values);
         if let Some(rv_pairs) = self.record_vars {
             for (k, v) in rv_pairs {
                 let _ = record.set_record_var(&k, v);
             }
         }
+        record.set_doc_ctx(doc_ctx);
         record
-    }
-}
-
-impl Serialize for Record {
-    /// Serializes this record as a [`RecordPayload`] (values + record_vars).
-    ///
-    /// The schema is not included in the wire output. Callers that need
-    /// schema information must write it separately (e.g., as a header line)
-    /// and supply it on deserialization via [`RecordPayload::into_record`].
-    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let rv = self.record_var_pairs();
-        RecordPayload {
-            values: self.values.clone(),
-            record_vars: if rv.is_empty() { None } else { Some(rv) },
-        }
-        .serialize(serializer)
     }
 }
 
@@ -387,6 +404,25 @@ mod tests {
             record_vars: _,
             doc_ctx: _,
         } = rec;
+    }
+
+    /// Structural assertion: `RecordPayload` carries exactly `values`,
+    /// `record_vars`, and `doc_id` — the wire shape of a spilled record.
+    /// `doc_id` (not the full context) keeps the per-record spill cost a
+    /// single `u64`; adding or renaming a field fails compilation, so a
+    /// silent widening of the per-record payload can't slip in.
+    #[test]
+    fn test_record_payload_struct_has_exactly_values_record_vars_doc_id() {
+        let payload = RecordPayload {
+            values: vec![Value::Null; 5],
+            record_vars: None,
+            doc_id: DocumentId::SYNTHETIC,
+        };
+        let RecordPayload {
+            values: _,
+            record_vars: _,
+            doc_id: _,
+        } = payload;
     }
 
     #[test]


### PR DESCRIPTION
Records carry document envelope context (document id, envelope sections, source file) used by $doc.* resolution and per-document operators. The shared record spill format previously serialized only values and record variables, so a spilled-and-reloaded record came back with an empty synthetic document context — silently breaking per-document aggregation, document-level routing, and $doc.* lookups whenever an upstream buffer spilled under memory pressure.

Each spill file now interns its documents: the first time a document id is seen, that document's context is written once as a tagged frame ahead of the record; on read, all records of one document re-hydrate a single shared context (one Arc per document, not per record). Retained context memory is O(distinct documents in the file), not O(records). The synthetic (no-document) context is never interned and resolves to the shared singleton; a record referencing an un-interned context is a decode error rather than a silent fallback. Applied identically to the inter-stage/sort spill format and the grace-hash spill twin.

Verified: a spill round-trip preserves the document id, sections (including nested maps), and source file under both compressed and uncompressed formats; all records of one document share one re-hydrated context; per-document aggregation and $doc.* resolution stay correct across an upstream spill.

Closes #195.