### PR TITLE
format: streaming XML document reader with path-pruned arena index

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -46,7 +46,11 @@ fn build_format_reader(
             Ok(Box::new(JsonReader::from_reader(reader, config)?))
         }
         clinker_plan::config::InputFormat::Xml(opts) => {
-            let config = build_xml_reader_config(opts.as_ref(), input.array_paths.as_deref());
+            let config = build_xml_reader_config(
+                opts.as_ref(),
+                input.array_paths.as_deref(),
+                &input.declared_doc_paths,
+            );
             Ok(Box::new(XmlReader::new(reader, config)?))
         }
         clinker_plan::config::InputFormat::FixedWidth(opts) => {
@@ -783,12 +787,30 @@ fn build_json_reader_config(
     config
 }
 
-/// Build XML reader config from optional XML input options and array paths.
+/// Default cap on the XML envelope pre-scan's path-pruned document index
+/// when a source declares no explicit `max_index_bytes`. Finite by design:
+/// the index retains only declared `$doc.*` subtrees, so 64 MB is generous
+/// headroom for envelope metadata while still failing loud before an
+/// unbounded-retention OOM. Mirrors [`DEFAULT_JSON_MAX_INDEX_BYTES`].
+const DEFAULT_XML_MAX_INDEX_BYTES: usize = 64 * 1_000_000;
+
+/// Build XML reader config from optional XML input options, array paths, and
+/// the source's planner-attributed `$doc.*` path set.
+///
+/// `declared_doc_paths` is the set of envelope paths some downstream program
+/// references through this source; the reader's pre-scan retains only the
+/// sections these paths name. When the source declares no `max_index_bytes`,
+/// the pre-scan index is capped at [`DEFAULT_XML_MAX_INDEX_BYTES`].
 fn build_xml_reader_config(
     opts: Option<&clinker_plan::config::XmlInputOptions>,
     array_paths: Option<&[clinker_plan::config::ArrayPathConfig]>,
+    declared_doc_paths: &[cxl::analyzer::doc_paths::DocPath],
 ) -> XmlReaderConfig {
-    let mut config = XmlReaderConfig::default();
+    let mut config = XmlReaderConfig {
+        declared_doc_paths: declared_doc_paths.to_vec(),
+        max_index_bytes: Some(DEFAULT_XML_MAX_INDEX_BYTES),
+        ..Default::default()
+    };
     if let Some(opts) = opts {
         config.record_path = opts.record_path.clone();
         if let Some(ref prefix) = opts.attribute_prefix {
@@ -798,6 +820,9 @@ fn build_xml_reader_config(
             Some(clinker_plan::config::NamespaceHandling::Qualify) => NamespaceMode::Qualify,
             _ => NamespaceMode::Strip,
         };
+        if let Some(cap) = opts.max_index_bytes {
+            config.max_index_bytes = Some(cap.0 as usize);
+        }
     }
     if let Some(paths) = array_paths {
         config.array_paths = paths

--- a/crates/clinker-exec/tests/envelope_doc_context_json_test.rs
+++ b/crates/clinker-exec/tests/envelope_doc_context_json_test.rs
@@ -1,0 +1,135 @@
+//! End-to-end document-envelope ingestion for a JSON source: the source
+//! declares envelope sections at the document head and tail, the reader's
+//! streaming pre-scan extracts both before body streaming, and a downstream
+//! transform reads `$doc.<section>.<field>` on every body record — including
+//! the first row, proving the tail section was available up front.
+//!
+//! This is the JSON twin of `envelope_doc_context_test.rs`. It exercises the
+//! full planner → config → ingest → reader → transform → output path, so it
+//! also locks the runtime stamping of the per-source `$doc` path set onto the
+//! `PipelineConfig` source body (the set the executor's ingest reads): without
+//! that stamp the pre-scan prunes every section and `$doc.*` resolves empty.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+const YAML: &str = r#"
+pipeline:
+  name: envelope_demo_json
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          BatchInfo:
+            extract: { json_pointer: "/BatchInfo" }
+            fields:
+              batch_id: string
+          Summary:
+            extract: { json_pointer: "/Summary" }
+            fields:
+              total: int
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: tag
+    input: payments
+    config:
+      cxl: |
+        emit amount = amount
+        emit batch = $doc.BatchInfo.batch_id
+  - type: transform
+    name: tag2
+    input: tag
+    config:
+      cxl: |
+        emit amount = amount
+        emit batch = batch
+        emit declared_total = $doc.Summary.total
+  - type: output
+    name: out
+    input: tag2
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+const DOC_JSON: &str = r#"{
+  "BatchInfo": { "batch_id": "RUN-001" },
+  "records": [
+    { "amount": 10 },
+    { "amount": 20 },
+    { "amount": 30 }
+  ],
+  "Summary": { "total": 3 }
+}"#;
+
+#[test]
+fn json_envelope_sections_available_on_every_body_record() {
+    let config = parse_config(YAML).expect("parse envelope pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile envelope pipeline");
+
+    let file = FileSlot::new(
+        PathBuf::from("payments.json"),
+        Box::new(Cursor::new(DOC_JSON.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "payments".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run envelope pipeline");
+    assert_eq!(report.counters.total_count, 3, "three body records");
+    assert_eq!(report.counters.dlq_count, 0);
+
+    let output = buf.as_string();
+    let lines: Vec<&str> = output.lines().collect();
+    assert_eq!(lines.len(), 4, "header + 3 data rows; got: {output}");
+
+    // Head section (BatchInfo) and tail section (Summary) both resolve on
+    // EVERY body record — including the first, which proves the tail section
+    // was pre-scanned before body streaming began.
+    for (i, row) in lines[1..].iter().enumerate() {
+        assert!(
+            row.contains("RUN-001"),
+            "row {i} missing $doc.BatchInfo.batch_id: {row}"
+        );
+        // `declared_total` is the trailer's count, read on each body row —
+        // available mid-stream because the pre-scan pulled the tail section
+        // up front.
+        assert!(
+            row.contains(",3") || row.ends_with("3"),
+            "row {i} missing $doc.Summary.total: {row}"
+        );
+    }
+}

--- a/crates/clinker-format/src/xml/mod.rs
+++ b/crates/clinker-format/src/xml/mod.rs
@@ -1,2 +1,3 @@
 pub mod reader;
+mod streaming;
 pub mod writer;

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -4,12 +4,19 @@
 //! flattens nested elements with `.` separator, handles namespaces.
 //!
 //! The reader buffers its entire input at construction time into an
-//! `Arc<[u8]>` so the envelope pre-scan (run before any body record
-//! emits) and the body iteration can each parse from a fresh cursor
-//! over the same byte slice. ETL XML files are typically MB-scale; the
-//! buffering trade-off enables the locked "all `$doc.*` sections
-//! available throughout the body stream" semantics without re-opening
-//! the source mid-stream.
+//! `Arc<[u8]>` so the envelope pre-scan (run before any body record emits)
+//! and the body iteration can each parse from a fresh cursor over the same
+//! byte slice. That raw byte buffer is retained for the reader's lifetime —
+//! it backs both the body parser and the transient pre-scan cursor, so
+//! there is one read from disk regardless of envelope declarations.
+//!
+//! What the pre-scan removed is the full-tree *section materialization*, not
+//! the raw byte buffer: the envelope pre-scan no longer captures undeclared
+//! sections at all, and the retained payload of each declared section is
+//! bounded by `max_index_bytes`, charged incrementally so an oversized
+//! declared section aborts mid-parse before its subtree fully materializes.
+//! See [`crate::xml::streaming`] for the event-driven pruned-extraction
+//! pass.
 
 use std::io::{self, Cursor, Read};
 use std::sync::Arc;
@@ -20,9 +27,13 @@ use quick_xml::events::Event;
 
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
 
+use cxl::analyzer::doc_paths::DocPath;
+
+use crate::doc_index::DocArenaIndex;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::traits::FormatReader;
+use crate::xml::streaming::{SectionTarget, extract_sections};
 
 /// XML reader configuration.
 pub struct XmlReaderConfig {
@@ -30,6 +41,17 @@ pub struct XmlReaderConfig {
     pub attribute_prefix: String,
     pub namespace_handling: NamespaceMode,
     pub array_paths: Vec<XmlArrayPath>,
+    /// `$doc.*` envelope paths a program downstream of this source
+    /// references, attributed to this source by the planner. The envelope
+    /// pre-scan retains only the sections these paths name; a declared
+    /// section no program reads is skipped, never materialized. Empty when
+    /// no downstream program reads any `$doc` path.
+    pub declared_doc_paths: Vec<DocPath>,
+    /// Hard cap on the bytes the envelope pre-scan's path-pruned index may
+    /// retain. The cap is charged incrementally as each section's payload is
+    /// built and fires mid-parse (before OOM). `None` disables the cap; the
+    /// source plumbing supplies a finite default.
+    pub max_index_bytes: Option<usize>,
 }
 
 impl Default for XmlReaderConfig {
@@ -39,6 +61,8 @@ impl Default for XmlReaderConfig {
             attribute_prefix: "@".into(),
             namespace_handling: NamespaceMode::Strip,
             array_paths: vec![],
+            declared_doc_paths: Vec::new(),
+            max_index_bytes: None,
         }
     }
 }
@@ -64,14 +88,19 @@ pub enum XmlArrayMode {
 
 /// Streaming XML reader.
 ///
-/// Buffers its entire input at construction time into an `Arc<[u8]>`
-/// so two parsers can walk the same bytes: one transient parser for
-/// the envelope pre-scan, and one stateful parser for body record
-/// iteration. The trade-off — held memory equal to the source file's
-/// size while the reader exists — enables the locked
-/// "all `$doc.*` sections available throughout the body stream"
-/// semantics, since post-body envelope sections must be extracted
-/// before the first body record emits.
+/// Buffers its entire input at construction time into an `Arc<[u8]>` so two
+/// parsers can walk the same bytes: one transient parser for the envelope
+/// pre-scan, and one stateful parser for body record iteration. Holding the
+/// raw bytes makes every declared section available to every body record,
+/// since a post-body section must be extracted before the first record
+/// emits.
+///
+/// The envelope pre-scan no longer materializes undeclared sections, and
+/// each retained section's payload is bounded by `max_index_bytes` (charged
+/// incrementally, aborting mid-parse on an oversized section). The raw byte
+/// buffer itself remains — only the full-tree section materialization was
+/// removed — so held memory is the source file's size plus the bounded
+/// section payloads while the reader exists.
 pub struct XmlReader {
     bytes: Arc<[u8]>,
     parser: XmlParser<Cursor<Arc<[u8]>>>,
@@ -398,20 +427,30 @@ impl FormatReader for XmlReader {
             return Ok(IndexMap::new());
         }
 
-        // Compile each declared section's XmlPath into a path-segment
-        // vector once; a JsonPointer arrival means a config-for-wrong-
-        // format mistake and surfaces as a format error.
-        let mut sections: Vec<(Box<str>, Vec<String>, &crate::envelope::EnvelopeSection)> =
-            Vec::with_capacity(config.sections.len());
+        // The path-pruned index is the retention authority: it knows which
+        // sections some downstream program reads. A declared section no
+        // program references is not extracted at all — so when no `$doc`
+        // path is attributed to this source, the pre-scan skips the whole
+        // document.
+        let mut index =
+            DocArenaIndex::new(&self.config.declared_doc_paths, self.config.max_index_bytes);
+        if index.is_empty() {
+            return Ok(IndexMap::new());
+        }
+
+        // Compile only the wanted sections' XmlPaths into path-segment
+        // targets; a JsonPointer/Segment arrival means a config-for-wrong-
+        // format mistake and surfaces as a format error. Sections the index
+        // does not want are dropped here so the streaming pass never
+        // descends into them.
+        let mut targets: Vec<SectionTarget> = Vec::new();
         for (name, section) in &config.sections {
+            if !index.wants_section(name) {
+                continue;
+            }
             match &section.extract {
                 EnvelopeExtract::XmlPath(p) => {
-                    let segments: Vec<String> = p
-                        .trim_start_matches('/')
-                        .split('/')
-                        .map(String::from)
-                        .collect();
-                    sections.push((Box::from(name.as_str()), segments, section));
+                    targets.push(SectionTarget::new(Box::from(name.as_str()), p));
                 }
                 EnvelopeExtract::JsonPointer(_) => {
                     return Err(FormatError::Xml(format!(
@@ -429,82 +468,61 @@ impl FormatReader for XmlReader {
             }
         }
 
-        // Transient parser over a fresh cursor; the body parser's state
-        // remains untouched and starts streaming from byte 0 when
-        // `next_record` is first called.
-        let mut transient = XmlParser::from_reader(Cursor::new(Arc::clone(&self.bytes)));
-        transient.config_mut().trim_text(true);
-        let mut path_stack: Vec<String> = Vec::new();
-        let mut captured: IndexMap<Box<str>, IndexMap<Box<str>, Value>> = IndexMap::new();
-        let mut buf: Vec<u8> = Vec::new();
+        // Single streaming pass over a fresh cursor: only the matched
+        // subtrees are flattened; every unmatched element body is
+        // counted-and-dropped. The cap is charged *as each declared
+        // section's payload is built*, so an oversized declared section
+        // aborts the parse mid-subtree rather than after the whole subtree
+        // materializes. Body iteration keeps its own independent cursor over
+        // `self.bytes`.
+        let matched = extract_sections(
+            &self.bytes,
+            &targets,
+            &self.config.namespace_handling,
+            &self.config.attribute_prefix,
+            self.config.max_index_bytes,
+        )?;
 
-        loop {
-            buf.clear();
-            let event = transient
-                .read_event_into(&mut buf)
-                .map_err(|e| FormatError::Xml(e.to_string()))?;
-            match event {
-                Event::Start(ref e) => {
-                    let name = elem_name_static(&self.config.namespace_handling, &e.name());
-                    path_stack.push(name);
-                    if let Some((sec_name, _, section)) = sections
-                        .iter()
-                        .find(|(_, segs, _)| path_matches(&path_stack, segs))
-                    {
-                        let payload = read_section_payload(
-                            &mut transient,
-                            &mut buf,
-                            &self.config.namespace_handling,
-                            &self.config.attribute_prefix,
-                            path_stack.len(),
-                        )?;
-                        let typed = coerce_section_fields(payload, &section.fields)
-                            .map_err(FormatError::Xml)?;
-                        captured.insert(Box::from(&**sec_name), typed);
-                        // `read_section_payload` consumed the matched
-                        // subtree up to its closing `End`. Pop the
-                        // element off the path stack now since the
-                        // upcoming loop iteration will not see that
-                        // `End` event.
-                        path_stack.pop();
-                    }
-                }
-                Event::Empty(ref e) => {
-                    let name = elem_name_static(&self.config.namespace_handling, &e.name());
-                    path_stack.push(name);
-                    if let Some((sec_name, _, section)) = sections
-                        .iter()
-                        .find(|(_, segs, _)| path_matches(&path_stack, segs))
-                    {
-                        let mut payload: Vec<(String, String)> = Vec::new();
-                        let attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
-                        payload.extend(attrs);
-                        let typed = coerce_section_fields(payload, &section.fields)
-                            .map_err(FormatError::Xml)?;
-                        captured.insert(Box::from(&**sec_name), typed);
-                    }
-                    path_stack.pop();
-                }
-                Event::End(_) => {
-                    path_stack.pop();
-                }
-                Event::Eof => break,
-                _ => {}
-            }
+        // Coerce each matched payload to its declared field schema and retain
+        // it in the index, which accounts the coerced (field-filtered)
+        // retained bytes against the same cap. The streaming pass already
+        // bounded the raw parse; the index accounts what is actually kept.
+        for (name, payload) in matched {
+            let section = match config.sections.get(&*name) {
+                Some(s) => s,
+                None => continue,
+            };
+            let typed =
+                coerce_section_fields(payload, &section.fields).map_err(FormatError::Xml)?;
+            let path = doc_path_for_section(&name);
+            index.insert(&path, Value::Map(Box::new(typed)))?;
         }
-
-        // Convert the captured fields into the trait return shape:
-        // each section's payload is a `Value::Map`.
-        let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(captured.len());
-        for (sec_name, fields) in captured {
-            out.insert(sec_name, Value::Map(Box::new(fields)));
-        }
-        Ok(out)
+        Ok(index.into_sections())
     }
 }
 
-/// Extract element name without borrowing self.
-fn elem_name_static(ns: &NamespaceMode, qname: &quick_xml::name::QName) -> String {
+/// Build the section-level [`DocPath`] under which a whole matched section
+/// payload is retained.
+///
+/// XML retains an envelope section as one flattened map (one element subtree
+/// → one map of `$doc.<section>.<field>` values), so the insert key is the
+/// section, not an individual field; [`DocArenaIndex::insert`] groups by
+/// `path.section`. The `field`/`indices` axes carry no meaning for a
+/// section-granular retention and are left empty.
+fn doc_path_for_section(name: &str) -> DocPath {
+    DocPath {
+        section: name.into(),
+        field: Box::from(""),
+        indices: Vec::new(),
+    }
+}
+
+/// Resolve an element's name under the configured namespace policy.
+///
+/// `Strip` drops the namespace prefix (keeping the local name); `Qualify`
+/// keeps the full namespace-qualified name. Shared by body iteration and
+/// the envelope streaming pre-scan so both map element names identically.
+pub(crate) fn elem_name_static(ns: &NamespaceMode, qname: &quick_xml::name::QName) -> String {
     let local = qname.local_name();
     let bytes = match ns {
         NamespaceMode::Strip => local.as_ref(),
@@ -513,8 +531,12 @@ fn elem_name_static(ns: &NamespaceMode, qname: &quick_xml::name::QName) -> Strin
     String::from_utf8_lossy(bytes).into_owned()
 }
 
-/// Extract attributes without borrowing self.
-fn extract_attributes_static(
+/// Extract an element's attributes as `(prefixed_key, value)` pairs.
+///
+/// Each attribute key is prefixed with `prefix` (default `@`) so attributes
+/// and child elements never collide in the flattened field set. Shared by
+/// body iteration and the envelope streaming pre-scan.
+pub(crate) fn extract_attributes_static(
     prefix: &str,
     elem: &quick_xml::events::BytesStart,
 ) -> Result<Vec<(String, String)>, FormatError> {
@@ -529,94 +551,6 @@ fn extract_attributes_static(
         attrs.push((format!("{prefix}{key}"), val));
     }
     Ok(attrs)
-}
-
-/// Match the runtime descent stack against a declared section path.
-/// Both are taken as slices of element names; a section path is
-/// rooted at the document, so an exact-match (modulo length) wins.
-fn path_matches(stack: &[String], segs: &[String]) -> bool {
-    if stack.len() != segs.len() {
-        return false;
-    }
-    stack.iter().zip(segs.iter()).all(|(a, b)| a == b)
-}
-
-/// Read the subtree under the current `Start` element (already
-/// pushed onto the caller's `path_stack`) into a flat list of
-/// `(field_name, raw_string)` pairs. Mirrors `extract_record_fields`
-/// but operates on a transient envelope-scan parser and returns
-/// without touching the caller's body-iteration state.
-fn read_section_payload(
-    parser: &mut XmlParser<Cursor<Arc<[u8]>>>,
-    buf: &mut Vec<u8>,
-    ns: &NamespaceMode,
-    attr_prefix: &str,
-    section_depth: usize,
-) -> Result<Vec<(String, String)>, FormatError> {
-    let mut fields: Vec<(String, String)> = Vec::new();
-    let mut element_stack: Vec<String> = Vec::new();
-    let mut depth_here = section_depth;
-    loop {
-        buf.clear();
-        let event = parser
-            .read_event_into(buf)
-            .map_err(|e| FormatError::Xml(e.to_string()))?;
-        match event {
-            Event::Start(ref e) => {
-                depth_here += 1;
-                let name = elem_name_static(ns, &e.name());
-                element_stack.push(name);
-                let attrs = extract_attributes_static(attr_prefix, e)?;
-                let prefix = element_stack.join(".");
-                for (k, v) in attrs {
-                    fields.push((format!("{prefix}.{k}"), v));
-                }
-            }
-            Event::End(_) => {
-                depth_here -= 1;
-                if depth_here < section_depth {
-                    return Ok(fields);
-                }
-                element_stack.pop();
-            }
-            Event::Empty(ref e) => {
-                let name = elem_name_static(ns, &e.name());
-                let prefix = if element_stack.is_empty() {
-                    name.clone()
-                } else {
-                    format!("{}.{name}", element_stack.join("."))
-                };
-                fields.push((prefix.clone(), String::new()));
-                let attrs = extract_attributes_static(attr_prefix, e)?;
-                for (k, v) in attrs {
-                    fields.push((format!("{prefix}.{k}"), v));
-                }
-            }
-            Event::Text(ref t) => {
-                let text = t
-                    .unescape()
-                    .map_err(|e| FormatError::Xml(e.to_string()))?
-                    .into_owned();
-                if !text.is_empty() {
-                    let field_name = element_stack.join(".");
-                    if !field_name.is_empty() {
-                        fields.push((field_name, text));
-                    }
-                }
-            }
-            Event::CData(ref cd) => {
-                let text = String::from_utf8_lossy(cd.as_ref()).into_owned();
-                if !text.is_empty() {
-                    let field_name = element_stack.join(".");
-                    if !field_name.is_empty() {
-                        fields.push((field_name, text));
-                    }
-                }
-            }
-            Event::Eof => return Ok(fields),
-            _ => {}
-        }
-    }
 }
 
 /// Simple type inference from string values (same rules as JSON).
@@ -659,6 +593,47 @@ mod tests {
     /// `(section name, XPath, [(field name, type)])` for one envelope section.
     type SectionSpec<'a> = (&'a str, &'a str, &'a [(&'a str, EnvelopeFieldType)]);
 
+    /// Declared `$doc.*` paths covering every `(section, field)` in `specs`,
+    /// so the path-pruned index wants all of them — the runtime stand-in for
+    /// the planner's per-source attribution.
+    fn declared_paths(specs: &[SectionSpec]) -> Vec<DocPath> {
+        let mut out = Vec::new();
+        for (section, _xpath, fields) in specs {
+            for (field, _ty) in *fields {
+                out.push(DocPath {
+                    section: (*section).into(),
+                    field: (*field).into(),
+                    indices: Vec::new(),
+                });
+            }
+        }
+        out
+    }
+
+    /// A reader config over `record_path` whose declared paths want every
+    /// section in `specs`, for an envelope-bearing source.
+    fn envelope_reader_config(specs: &[SectionSpec], record_path: &str) -> XmlReaderConfig {
+        XmlReaderConfig {
+            record_path: Some(record_path.into()),
+            declared_doc_paths: declared_paths(specs),
+            ..Default::default()
+        }
+    }
+
+    /// A reader config wanting a single section named `Bad`, so the
+    /// wrong-format extract validation fires for that section.
+    fn config_wanting_bad_section(record_path: &str) -> XmlReaderConfig {
+        XmlReaderConfig {
+            record_path: Some(record_path.into()),
+            declared_doc_paths: vec![DocPath {
+                section: "Bad".into(),
+                field: "any".into(),
+                indices: Vec::new(),
+            }],
+            ..Default::default()
+        }
+    }
+
     fn envelope_config(sections: &[SectionSpec]) -> EnvelopeConfig {
         use crate::envelope::EnvelopeSection;
         let mut cfg = EnvelopeConfig::default();
@@ -696,7 +671,7 @@ mod tests {
             <records><record><x>1</x></record><record><x>2</x></record></records>
             <Summary><hash>abc</hash><processed>2</processed></Summary>
         </doc>"#;
-        let cfg = envelope_config(&[
+        let specs: &[SectionSpec] = &[
             (
                 "BatchInfo",
                 "/doc/BatchInfo",
@@ -713,9 +688,10 @@ mod tests {
                     ("processed", EnvelopeFieldType::Int),
                 ],
             ),
-        ]);
+        ];
+        let cfg = envelope_config(specs);
 
-        let mut reader = reader_from_str(xml, default_config_with_path("doc/records/record"));
+        let mut reader = reader_from_str(xml, envelope_reader_config(specs, "doc/records/record"));
         let sections = reader.prepare_document(&cfg).expect("envelope pre-scan");
 
         // Both sections present — the post-body section is available
@@ -760,7 +736,7 @@ mod tests {
                 fields: IndexMap::new(),
             },
         );
-        let mut reader = reader_from_str(xml, default_config_with_path("doc/a"));
+        let mut reader = reader_from_str(xml, config_wanting_bad_section("doc/a"));
         let err = reader.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::Xml(msg) if msg.contains("json_pointer")));
     }
@@ -777,7 +753,7 @@ mod tests {
                 fields: IndexMap::new(),
             },
         );
-        let mut reader = reader_from_str(xml, default_config_with_path("doc/a"));
+        let mut reader = reader_from_str(xml, config_wanting_bad_section("doc/a"));
         let err = reader.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::Xml(msg) if msg.contains("segment")));
     }
@@ -788,12 +764,13 @@ mod tests {
         // is absent from the returned map; CXL resolves missing
         // sections to `Value::Null`.
         let xml = r#"<doc><records><record><x>1</x></record></records></doc>"#;
-        let cfg = envelope_config(&[(
+        let specs: &[SectionSpec] = &[(
             "Trailer",
             "/doc/Trailer",
             &[("count", EnvelopeFieldType::Int)],
-        )]);
-        let mut reader = reader_from_str(xml, default_config_with_path("doc/records/record"));
+        )];
+        let cfg = envelope_config(specs);
+        let mut reader = reader_from_str(xml, envelope_reader_config(specs, "doc/records/record"));
         let sections = reader.prepare_document(&cfg).expect("scan ok");
         assert!(sections.is_empty());
     }
@@ -808,7 +785,7 @@ mod tests {
             </Meta>
             <records><record><x>1</x></record></records>
         </doc>"#;
-        let cfg = envelope_config(&[(
+        let specs: &[SectionSpec] = &[(
             "Meta",
             "/doc/Meta",
             &[
@@ -816,8 +793,9 @@ mod tests {
                 ("enabled", EnvelopeFieldType::Bool),
                 ("ratio", EnvelopeFieldType::Float),
             ],
-        )]);
-        let mut reader = reader_from_str(xml, default_config_with_path("doc/records/record"));
+        )];
+        let cfg = envelope_config(specs);
+        let mut reader = reader_from_str(xml, envelope_reader_config(specs, "doc/records/record"));
         let sections = reader.prepare_document(&cfg).expect("scan ok");
         let meta = unwrap_section_map(sections.get("Meta").unwrap());
         assert!(matches!(meta.get("run_date"), Some(Value::Date(_))));

--- a/crates/clinker-format/src/xml/streaming.rs
+++ b/crates/clinker-format/src/xml/streaming.rs
@@ -1,0 +1,283 @@
+//! Streaming envelope pre-scan for XML sources.
+//!
+//! Walks an XML document exactly once through quick-xml's pull parser,
+//! building a flat `(field, raw_string)` payload *only* for the subtrees a
+//! source's declared envelope sections point at and dropping every other
+//! element's body without allocating it. This replaces a full-tree capture
+//! of every declared section — which materialized each matched subtree
+//! before any cap could fire — so the pre-scan's retained memory scales
+//! with the declared sections rather than the document size.
+//!
+//! Unmatched elements are counted-and-dropped: quick-xml does not
+//! materialize the body of an element the walk never recurses into, so the
+//! only allocation per declared section happens inside
+//! [`read_section_payload`], which is called solely on a path match.
+//!
+//! Blocking, bounded: the pre-scan runs before any body record streams and
+//! returns the matched sections' flat payloads. A declared section's
+//! payload is built through a byte-counting accumulator that charges each
+//! retained field name + value against a shared cap and aborts the parse
+//! the moment the cumulative retained total crosses `max_index_bytes` — so
+//! even a single oversized declared section fails loud at ~the cap, before
+//! the whole subtree materializes, not after.
+
+use std::io::Cursor;
+use std::sync::Arc;
+
+use quick_xml::Reader as XmlParser;
+use quick_xml::events::Event;
+
+use crate::error::FormatError;
+use crate::xml::reader::{NamespaceMode, elem_name_static, extract_attributes_static};
+
+/// One matched section's name paired with its flat `(field, raw_string)`
+/// payload, as produced by [`extract_sections`].
+pub(crate) type MatchedSection = (Box<str>, Vec<(String, String)>);
+
+/// One declared section's slash-path, decoded to element-name segments,
+/// plus its author-chosen name.
+///
+/// A leading `/` is trimmed before splitting, so `/doc/Summary` and
+/// `doc/Summary` yield the same segments — matching the existing
+/// `prepare_document` segment compile.
+pub(crate) struct SectionTarget {
+    /// Author-chosen section name the matched payload is recorded under.
+    pub name: Box<str>,
+    /// Element-name path segments, rooted at the document element.
+    pub segments: Vec<String>,
+}
+
+impl SectionTarget {
+    /// Decode a slash-path into element-name segments, trimming a leading
+    /// `/` so a rooted path and an unrooted one compile identically.
+    pub(crate) fn new(name: Box<str>, path: &str) -> Self {
+        let segments = path
+            .trim_start_matches('/')
+            .split('/')
+            .map(String::from)
+            .collect();
+        SectionTarget { name, segments }
+    }
+}
+
+/// Walk an XML document once, building a flat payload only for the subtrees
+/// named by `targets` and charging their retained bytes against
+/// `max_index_bytes`.
+///
+/// Each matched section's subtree is flattened into `(field, raw_string)`
+/// pairs through a byte-counting accumulator; every unmatched element is
+/// counted-and-dropped without allocating its body. The cap is charged *as
+/// each pair is appended*, so an oversized declared section aborts the
+/// parse mid-subtree rather than after the whole subtree materializes. A
+/// target whose path never appears in the document yields no payload (a
+/// graceful miss), matching the absent-section convention.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Xml`] on an XML parse failure, or naming the
+/// offending section and the cap when a declared section's retained bytes
+/// cross `max_index_bytes` mid-parse.
+pub(crate) fn extract_sections(
+    bytes: &Arc<[u8]>,
+    targets: &[SectionTarget],
+    ns: &NamespaceMode,
+    attr_prefix: &str,
+    max_index_bytes: Option<usize>,
+) -> Result<Vec<MatchedSection>, FormatError> {
+    let mut parser = XmlParser::from_reader(Cursor::new(Arc::clone(bytes)));
+    parser.config_mut().trim_text(true);
+
+    let mut path_stack: Vec<String> = Vec::new();
+    let mut captured: Vec<MatchedSection> = Vec::new();
+    let mut charge = ByteCharge {
+        retained_bytes: 0,
+        max_index_bytes,
+    };
+    let mut buf: Vec<u8> = Vec::new();
+
+    loop {
+        buf.clear();
+        let event = parser
+            .read_event_into(&mut buf)
+            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        match event {
+            Event::Start(ref e) => {
+                let name = elem_name_static(ns, &e.name());
+                path_stack.push(name);
+                if let Some(target) = targets
+                    .iter()
+                    .find(|t| path_matches(&path_stack, &t.segments))
+                {
+                    let payload = read_section_payload(
+                        &mut parser,
+                        &mut buf,
+                        ns,
+                        attr_prefix,
+                        path_stack.len(),
+                        &target.name,
+                        &mut charge,
+                    )?;
+                    captured.push((target.name.clone(), payload));
+                    // `read_section_payload` consumed the matched subtree up
+                    // to its closing `End`; the upcoming loop iteration will
+                    // not see that `End`, so pop the element now.
+                    path_stack.pop();
+                }
+            }
+            Event::Empty(ref e) => {
+                let name = elem_name_static(ns, &e.name());
+                path_stack.push(name);
+                if let Some(target) = targets
+                    .iter()
+                    .find(|t| path_matches(&path_stack, &t.segments))
+                {
+                    let mut payload: Vec<(String, String)> = Vec::new();
+                    for (key, val) in extract_attributes_static(attr_prefix, e)? {
+                        charge.charge(key.len() + val.len(), &target.name)?;
+                        payload.push((key, val));
+                    }
+                    captured.push((target.name.clone(), payload));
+                }
+                path_stack.pop();
+            }
+            Event::End(_) => {
+                path_stack.pop();
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+
+    Ok(captured)
+}
+
+/// Running retained-byte total for the streaming pass, charged against the
+/// configured cap as each retained field is appended.
+struct ByteCharge {
+    retained_bytes: usize,
+    max_index_bytes: Option<usize>,
+}
+
+impl ByteCharge {
+    /// Charge `bytes` against the cap; abort with a [`FormatError::Xml`]
+    /// naming `section` and the cap when the running total would cross it.
+    fn charge(&mut self, bytes: usize, section: &str) -> Result<(), FormatError> {
+        let projected = self.retained_bytes.saturating_add(bytes);
+        if let Some(cap) = self.max_index_bytes
+            && projected > cap
+        {
+            return Err(FormatError::Xml(format!(
+                "envelope document-index cap exceeded: building section {section:?} \
+                 crossed the {cap}-byte `max_index_bytes` cap mid-parse. Raise \
+                 `max_index_bytes` on the source, or narrow the `$doc.*` paths the \
+                 pipeline reads (declare paths over envelope metadata, not bulk elements)."
+            )));
+        }
+        self.retained_bytes = projected;
+        Ok(())
+    }
+}
+
+/// Match the runtime descent stack against a declared section path. Both
+/// are element-name slices; a section path is rooted at the document, so an
+/// exact match (modulo length) wins.
+fn path_matches(stack: &[String], segs: &[String]) -> bool {
+    stack.len() == segs.len() && stack.iter().zip(segs.iter()).all(|(a, b)| a == b)
+}
+
+/// Read the subtree under the current `Start` element (already pushed onto
+/// the caller's `path_stack`) into a flat list of `(field_name, raw_string)`
+/// pairs, charging each retained pair against `charge` and aborting
+/// mid-subtree the instant the running total crosses the cap.
+///
+/// Produces the same flat payload the body record extractor does — same
+/// `.`-joined nested-element prefixes, attribute prefixing, and CData /
+/// text handling — so a declared section's output is byte-identical to the
+/// body reader's for the same element. Returns without touching the
+/// caller's body-iteration state.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Xml`] on a parse failure, or naming `section` and
+/// the cap when the retained bytes cross `max_index_bytes` mid-subtree.
+fn read_section_payload(
+    parser: &mut XmlParser<Cursor<Arc<[u8]>>>,
+    buf: &mut Vec<u8>,
+    ns: &NamespaceMode,
+    attr_prefix: &str,
+    section_depth: usize,
+    section: &str,
+    charge: &mut ByteCharge,
+) -> Result<Vec<(String, String)>, FormatError> {
+    let mut fields: Vec<(String, String)> = Vec::new();
+    let mut element_stack: Vec<String> = Vec::new();
+    let mut depth_here = section_depth;
+    loop {
+        buf.clear();
+        let event = parser
+            .read_event_into(buf)
+            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        match event {
+            Event::Start(ref e) => {
+                depth_here += 1;
+                let name = elem_name_static(ns, &e.name());
+                element_stack.push(name);
+                let attrs = extract_attributes_static(attr_prefix, e)?;
+                let prefix = element_stack.join(".");
+                for (k, v) in attrs {
+                    let key = format!("{prefix}.{k}");
+                    charge.charge(key.len() + v.len(), section)?;
+                    fields.push((key, v));
+                }
+            }
+            Event::End(_) => {
+                depth_here -= 1;
+                if depth_here < section_depth {
+                    return Ok(fields);
+                }
+                element_stack.pop();
+            }
+            Event::Empty(ref e) => {
+                let name = elem_name_static(ns, &e.name());
+                let prefix = if element_stack.is_empty() {
+                    name.clone()
+                } else {
+                    format!("{}.{name}", element_stack.join("."))
+                };
+                charge.charge(prefix.len(), section)?;
+                fields.push((prefix.clone(), String::new()));
+                let attrs = extract_attributes_static(attr_prefix, e)?;
+                for (k, v) in attrs {
+                    let key = format!("{prefix}.{k}");
+                    charge.charge(key.len() + v.len(), section)?;
+                    fields.push((key, v));
+                }
+            }
+            Event::Text(ref t) => {
+                let text = t
+                    .unescape()
+                    .map_err(|e| FormatError::Xml(e.to_string()))?
+                    .into_owned();
+                if !text.is_empty() {
+                    let field_name = element_stack.join(".");
+                    if !field_name.is_empty() {
+                        charge.charge(field_name.len() + text.len(), section)?;
+                        fields.push((field_name, text));
+                    }
+                }
+            }
+            Event::CData(ref cd) => {
+                let text = String::from_utf8_lossy(cd.as_ref()).into_owned();
+                if !text.is_empty() {
+                    let field_name = element_stack.join(".");
+                    if !field_name.is_empty() {
+                        charge.charge(field_name.len() + text.len(), section)?;
+                        fields.push((field_name, text));
+                    }
+                }
+            }
+            Event::Eof => return Ok(fields),
+            _ => {}
+        }
+    }
+}

--- a/crates/clinker-format/tests/streaming_doc_index_xml.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_xml.rs
@@ -1,0 +1,370 @@
+//! Bounded-retention behavior of the streaming XML envelope pre-scan.
+//!
+//! Proves the pre-scan retains only the declared `$doc.*` section subtrees —
+//! a multi-MB body of undeclared records is event-walked and dropped, never
+//! flattened into the document index — and that an over-budget retention
+//! fails loud mid-build rather than after a full materialization.
+
+use clinker_format::FormatError;
+use clinker_format::envelope::{
+    EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection,
+};
+use clinker_format::traits::FormatReader;
+use clinker_format::xml::reader::{XmlReader, XmlReaderConfig};
+use clinker_record::Value;
+use cxl::analyzer::doc_paths::DocPath;
+use indexmap::IndexMap;
+
+/// One envelope section: name, slash-path, typed fields.
+type SectionSpec<'a> = (&'a str, &'a str, &'a [(&'a str, EnvelopeFieldType)]);
+
+fn envelope_config(specs: &[SectionSpec]) -> EnvelopeConfig {
+    let mut cfg = EnvelopeConfig::default();
+    for (name, xpath, fields) in specs {
+        let mut field_map = IndexMap::new();
+        for (fname, ftype) in *fields {
+            field_map.insert((*fname).to_string(), *ftype);
+        }
+        cfg.sections.insert(
+            (*name).to_string(),
+            EnvelopeSection {
+                extract: EnvelopeExtract::XmlPath((*xpath).to_string()),
+                fields: field_map,
+            },
+        );
+    }
+    cfg
+}
+
+fn declared_paths(specs: &[SectionSpec]) -> Vec<DocPath> {
+    let mut out = Vec::new();
+    for (section, _xpath, fields) in specs {
+        for (field, _ty) in *fields {
+            out.push(DocPath {
+                section: (*section).into(),
+                field: (*field).into(),
+                indices: Vec::new(),
+            });
+        }
+    }
+    out
+}
+
+fn reader(xml: String, specs: &[SectionSpec], record_path: &str, cap: usize) -> XmlReader {
+    XmlReader::new(
+        std::io::Cursor::new(xml.into_bytes()),
+        XmlReaderConfig {
+            record_path: Some(record_path.into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(cap),
+            ..Default::default()
+        },
+    )
+    .expect("XML buffer read")
+}
+
+/// A document with a large undeclared body and a small declared trailer:
+/// `<doc><records>...N large records...</records><Summary>...</Summary></doc>`.
+fn doc_with_large_body_and_small_trailer(rows: usize) -> String {
+    let mut s = String::from("<doc><records>");
+    for i in 0..rows {
+        // Each record carries a large, undeclared text blob — the bytes the
+        // pre-scan must drop rather than retain.
+        s.push_str(&format!(
+            "<record><id>{i}</id><blob>{}</blob></record>",
+            "x".repeat(2_000)
+        ));
+    }
+    s.push_str(&format!(
+        "</records><Summary><record_count>{rows}</record_count></Summary></doc>"
+    ));
+    s
+}
+
+fn unwrap_map(value: &Value) -> &IndexMap<Box<str>, Value> {
+    match value {
+        Value::Map(m) => m,
+        other => panic!("expected map, got {other:?}"),
+    }
+}
+
+#[test]
+fn prescan_retains_only_declared_trailer_not_the_body() {
+    let rows = 2_000;
+    let xml = doc_with_large_body_and_small_trailer(rows);
+    let input_len = xml.len();
+    // The body alone is multiple MB.
+    assert!(
+        input_len > 4_000_000,
+        "body should be multi-MB: {input_len}"
+    );
+
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/doc/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = reader(xml, specs, "doc/records/record", 64 * 1_000_000);
+    let sections = reader.prepare_document(&cfg).expect("envelope pre-scan");
+
+    // The trailer was extracted and typed.
+    let summary = unwrap_map(sections.get("Summary").expect("Summary section retained"));
+    assert_eq!(
+        summary.get("record_count"),
+        Some(&Value::Integer(rows as i64))
+    );
+
+    // The retained bytes are orders of magnitude smaller than the input: the
+    // body's undeclared subtrees were dropped, never stored. Measuring the
+    // section map's own heap footprint (the real retained memory, not a
+    // serialized proxy) makes the skip-not-just-correct-output guarantee
+    // load-bearing — a single retained int sits far below input/1000.
+    let retained: usize = sections.iter().map(|(k, v)| k.len() + v.heap_size()).sum();
+    assert!(
+        retained < input_len / 1_000,
+        "retained section heap ({retained} bytes) must be <<< input ({input_len} bytes)"
+    );
+
+    // The body still streams: every record is present, in order.
+    let mut count = 0usize;
+    let mut last_id = -1i64;
+    while let Some(rec) = reader.next_record().unwrap() {
+        let id = match rec.get("id") {
+            Some(Value::Integer(n)) => *n,
+            other => panic!("expected integer id, got {other:?}"),
+        };
+        assert_eq!(id, last_id + 1, "body records stream in order");
+        last_id = id;
+        count += 1;
+    }
+    assert_eq!(count, rows, "every body record streamed");
+}
+
+#[test]
+fn prescan_fails_loud_mid_build_on_a_single_oversized_section() {
+    // ONE declared section far larger than the cap. The cap must fire DURING
+    // that section's flattening — before the whole subtree materializes —
+    // naming the section and the cap, rather than OOMing. This is the
+    // single-section guarantee: the cap aborts the build, it is not a
+    // post-hoc measurement of an already-built section.
+    let huge_body: String = (0..50_000)
+        .map(|i| format!("<row>row-{i}-{}</row>", "y".repeat(40)))
+        .collect();
+    let xml = format!(
+        "<doc><Header>{huge_body}</Header><records><record><x>1</x></record></records></doc>"
+    );
+    let input_len = xml.len();
+    // The single declared section is multiple MB on its own.
+    assert!(
+        input_len > 2_000_000,
+        "section should be multi-MB: {input_len}"
+    );
+
+    let specs: &[SectionSpec] = &[(
+        "Header",
+        "/doc/Header",
+        &[("row", EnvelopeFieldType::String)],
+    )];
+    let cfg = envelope_config(specs);
+
+    // 8KB cap — far below the multi-MB declared section.
+    let mut reader = reader(xml, specs, "doc/records/record", 8_000);
+
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("over-cap retention must fail");
+    match err {
+        FormatError::Xml(msg) => {
+            assert!(
+                msg.contains("max_index_bytes"),
+                "error names the cap: {msg}"
+            );
+            assert!(msg.contains("Header"), "error names the section: {msg}");
+            assert!(
+                msg.contains("mid-parse"),
+                "error states the abort is mid-parse: {msg}"
+            );
+        }
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
+#[test]
+fn prescan_fails_loud_when_cumulative_sections_exceed_cap() {
+    // Two declared sections that each fit, but whose cumulative retained
+    // bytes cross the cap — proves the running total is charged across the
+    // single streaming pass, not reset per section.
+    let chunk = "q".repeat(3_000);
+    let xml = format!(
+        "<doc><A><v>{chunk}</v></A><B><v>{chunk}</v></B>\
+         <records><record><x>1</x></record></records></doc>"
+    );
+    let specs: &[SectionSpec] = &[
+        ("A", "/doc/A", &[("v", EnvelopeFieldType::String)]),
+        ("B", "/doc/B", &[("v", EnvelopeFieldType::String)]),
+    ];
+    let cfg = envelope_config(specs);
+
+    // 4KB cap: each 3KB section fits alone, but the pair (6KB) does not.
+    let mut reader = reader(xml, specs, "doc/records/record", 4_000);
+
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("cumulative over-cap retention must fail");
+    assert!(matches!(err, FormatError::Xml(msg) if msg.contains("max_index_bytes")));
+}
+
+#[test]
+fn prescan_skips_entirely_when_no_doc_path_declared() {
+    // An envelope is declared, but no downstream program reads any `$doc`
+    // path (empty `declared_doc_paths`). The path-pruned index is empty, so
+    // the pre-scan skips the document and extracts nothing — the body is
+    // never walked for sections.
+    let xml = r#"<doc><Summary><record_count>3</record_count></Summary><records><record><x>1</x></record><record><x>2</x></record><record><x>3</x></record></records></doc>"#;
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/doc/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = XmlReader::new(
+        std::io::Cursor::new(xml.as_bytes().to_vec()),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            // No declared paths — nothing downstream reads `$doc.*`.
+            declared_doc_paths: Vec::new(),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .expect("XML buffer read");
+
+    let sections = reader.prepare_document(&cfg).expect("pre-scan");
+    assert!(
+        sections.is_empty(),
+        "no declared path means no section is extracted"
+    );
+    // Body still streams normally.
+    let mut count = 0;
+    while reader.next_record().unwrap().is_some() {
+        count += 1;
+    }
+    assert_eq!(count, 3);
+}
+
+#[test]
+fn prescan_skips_cleanly_for_absent_section() {
+    // A section the config declares but the XML doesn't carry is absent from
+    // the returned map and does NOT abort the run — CXL resolves a missing
+    // section to `Value::Null`.
+    let xml = r#"<doc><records><record><x>1</x></record></records></doc>"#.to_string();
+    let specs: &[SectionSpec] = &[(
+        "Trailer",
+        "/doc/Trailer",
+        &[("count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = reader(xml, specs, "doc/records/record", 64 * 1_000_000);
+    let sections = reader
+        .prepare_document(&cfg)
+        .expect("an absent section is a graceful miss, not an error");
+    assert!(
+        sections.is_empty(),
+        "no section resolves for an absent path"
+    );
+}
+
+#[test]
+fn prescan_skips_cleanly_when_path_traverses_non_matching_structure() {
+    // The declared path `/doc/meta/Summary` never appears — `meta` is not a
+    // child of `doc` in this document. The path simply never matches the
+    // descent stack, so the section is a graceful miss, not a hard error.
+    let xml = r#"<doc><other><Summary><record_count>7</record_count></Summary></other><records><record><x>1</x></record></records></doc>"#.to_string();
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/doc/meta/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = reader(xml, specs, "doc/records/record", 64 * 1_000_000);
+    let sections = reader
+        .prepare_document(&cfg)
+        .expect("a non-matching path is a graceful miss, not an error");
+    assert!(
+        sections.is_empty(),
+        "no section resolves through a non-matching structure"
+    );
+}
+
+#[test]
+fn prescan_prunes_the_unread_section_in_a_mixed_envelope() {
+    // The envelope declares two sections, but only one has a declared `$doc`
+    // path. The read section is present; the unread one is pruned — absent
+    // from the output, never materialized.
+    let xml = r#"<doc><Head><batch_id>B-1</batch_id></Head><Foot><record_count>5</record_count></Foot><records><record><x>1</x></record></records></doc>"#.to_string();
+    let head_spec: SectionSpec = (
+        "Head",
+        "/doc/Head",
+        &[("batch_id", EnvelopeFieldType::String)],
+    );
+    let foot_spec: SectionSpec = (
+        "Foot",
+        "/doc/Foot",
+        &[("record_count", EnvelopeFieldType::Int)],
+    );
+    // Both sections are declared in the envelope config...
+    let cfg = envelope_config(&[head_spec, foot_spec]);
+    // ...but only `Foot` is referenced by a `$doc` path.
+    let declared = declared_paths(&[foot_spec]);
+
+    let mut reader = XmlReader::new(
+        std::io::Cursor::new(xml.into_bytes()),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            declared_doc_paths: declared,
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .expect("XML buffer read");
+
+    let sections = reader.prepare_document(&cfg).expect("pre-scan");
+    assert!(
+        sections.contains_key("Foot"),
+        "the read section is retained"
+    );
+    assert!(
+        !sections.contains_key("Head"),
+        "the unread section is pruned, not materialized"
+    );
+}
+
+#[test]
+fn prescan_preserves_namespaces_attributes_and_cdata() {
+    // The streaming pre-scan must map element names, child attributes, and
+    // CData exactly as the body reader does: a namespace-stripped section
+    // element, an attribute on a child element (prefixed and `.`-joined),
+    // and a CData child payload all coerce into the declared section fields
+    // byte-identically to body extraction.
+    let xml = r#"<doc><ns:Meta><tag kind="run"></tag><note><![CDATA[a & b]]></note></ns:Meta><records><record><x>1</x></record></records></doc>"#.to_string();
+    let specs: &[SectionSpec] = &[(
+        "Meta",
+        "/doc/Meta",
+        &[
+            ("tag.@kind", EnvelopeFieldType::String),
+            ("note", EnvelopeFieldType::String),
+        ],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = reader(xml, specs, "doc/records/record", 64 * 1_000_000);
+    let sections = reader.prepare_document(&cfg).expect("pre-scan");
+    let meta = unwrap_map(sections.get("Meta").expect("Meta retained"));
+    assert_eq!(meta.get("tag.@kind"), Some(&Value::String("run".into())));
+    assert_eq!(meta.get("note"), Some(&Value::String("a & b".into())));
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -1015,7 +1015,6 @@ impl PipelineConfig {
                 analysis: analysis_by_name.get(name.as_str()).copied(),
                 window_config: entry_idx.and_then(|i| window_configs[i].as_ref()),
                 primary_source: primary_source.as_str(),
-                doc_paths_by_source: &declared_doc_paths,
             };
             let plan_node =
                 lower_node_to_plan_node(node, &name, span, &artifacts, &lowering_ctx, &mut diags);
@@ -1962,7 +1961,29 @@ impl PipelineConfig {
             return Err(diags);
         }
 
-        let plan = CompiledPlan::new(dag, self.clone(), artifacts);
+        // Stamp the runtime config's source bodies with their declared
+        // `$doc.*` path set. The executor's ingest path reads source configs
+        // from `PipelineConfig::source_configs` (the config nodes), so the
+        // envelope pre-scan only learns which sections a downstream program
+        // reads from this stamp. The attribution map is keyed by node
+        // identity (`header.name`), which can differ from the nested
+        // `config.name:`, so the lookup keys on `header.name` and writes onto
+        // that node's source body. A source no program reads a `$doc` path
+        // through keeps an empty set, which the reader treats as "skip the
+        // pre-scan entirely".
+        let mut runtime_config = self.clone();
+        for spanned in runtime_config.nodes.iter_mut() {
+            if let PipelineNode::Source {
+                header,
+                config: body,
+            } = &mut spanned.value
+                && let Some(paths) = declared_doc_paths.get(&header.name)
+            {
+                body.source.declared_doc_paths = paths.clone();
+            }
+        }
+
+        let plan = CompiledPlan::new(dag, runtime_config, artifacts);
         Ok((plan, diags))
     }
 }
@@ -2332,38 +2353,11 @@ fn build_node_source_sets(
 /// it requires the post-graph upstream `NodeIndex` for node-rooted
 /// windows. The Stage-5 lowering pass mutates the field in place
 /// after edges are wired and indices are deduplicated.
+#[derive(Default)]
 pub(crate) struct LoweringCtx<'a> {
     pub analysis: Option<&'a cxl::analyzer::TransformAnalysis>,
     pub window_config: Option<&'a AnalyticWindowSpec>,
     pub primary_source: &'a str,
-    /// `$doc` envelope paths each source must extract, keyed by source
-    /// name. A path lands here only for the source(s) feeding a node that
-    /// references it — never the pipeline-wide union — so a multi-source
-    /// run does not tell a source to extract another source's envelope
-    /// sections. A source absent from the map (or mapped to an empty
-    /// vec) reads no `$doc` paths. Empty for the body-node lowering path
-    /// (`LoweringCtx::default()`) — only the top-level compile path
-    /// collects and threads these.
-    pub doc_paths_by_source: &'a HashMap<String, Vec<cxl::analyzer::doc_paths::DocPath>>,
-}
-
-/// Empty per-source `$doc` map backing [`LoweringCtx::default`] — the
-/// body-node lowering path carries no document-path attribution (the
-/// top-level compile path is the only collector), so its borrow points
-/// here rather than at a freshly-allocated map per call.
-static EMPTY_DOC_PATHS_BY_SOURCE: std::sync::LazyLock<
-    HashMap<String, Vec<cxl::analyzer::doc_paths::DocPath>>,
-> = std::sync::LazyLock::new(HashMap::new);
-
-impl Default for LoweringCtx<'_> {
-    fn default() -> Self {
-        LoweringCtx {
-            analysis: None,
-            window_config: None,
-            primary_source: "",
-            doc_paths_by_source: &EMPTY_DOC_PATHS_BY_SOURCE,
-        }
-    }
 }
 
 /// Lower a single `PipelineNode` into its `PlanNode` counterpart.
@@ -2451,18 +2445,11 @@ pub(crate) fn lower_node_to_plan_node(
 
     match node {
         PipelineNode::Source { config, .. } => {
-            let mut source = config.source.clone();
-            // Stamp only THIS source's `$doc` path set so a document
-            // reader can learn the declared path set before reading input.
-            // The set is attributed per source upstream — each path lands
-            // on exactly the source(s) feeding a node that references it,
-            // so a multi-source run never asks a source to extract another
-            // source's envelope sections.
-            source.declared_doc_paths = ctx
-                .doc_paths_by_source
-                .get(name)
-                .cloned()
-                .unwrap_or_default();
+            // The `$doc` path set the reader extracts is stamped on the
+            // runtime `PipelineConfig` source body (see `compile_with_diagnostics`),
+            // which is what the executor's ingest path reads; the DAG payload
+            // does not carry it.
+            let source = config.source.clone();
             Some(PlanNode::Source {
                 name: name.to_string(),
                 span,

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -474,6 +474,15 @@ pub struct XmlInputOptions {
     pub attribute_prefix: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace_handling: Option<NamespaceHandling>,
+    /// Hard cap on the bytes the envelope pre-scan's path-pruned document
+    /// index may retain while extracting declared `$doc.*` sections.
+    /// Accepts a size string (`"64MB"`, `"500KB"`) via the same
+    /// [`ByteSize`] grammar the file-size filters use. The cap is charged
+    /// incrementally and fires mid-parse (before OOM) when a retained
+    /// section would push the index over it. Genuinely optional —
+    /// `None` falls back to the reader's documented default cap.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_index_bytes: Option<ByteSize>,
 }
 
 /// JSON input format mode (auto-detect if not specified).
@@ -704,6 +713,30 @@ mod tests {
     #[test]
     fn json_options_max_index_bytes_accepts_bare_byte_count() {
         let opts: JsonInputOptions = crate::yaml::from_str("max_index_bytes: 4096\n").unwrap();
+        assert_eq!(opts.max_index_bytes, Some(ByteSize(4096)));
+    }
+
+    #[test]
+    fn xml_options_parse_max_index_bytes_size_string() {
+        let opts: XmlInputOptions =
+            crate::yaml::from_str("record_path: doc/records/record\nmax_index_bytes: 64MB\n")
+                .unwrap();
+        // Decimal units: 64MB = 64_000_000 bytes.
+        assert_eq!(opts.max_index_bytes, Some(ByteSize(64_000_000)));
+    }
+
+    #[test]
+    fn xml_options_max_index_bytes_absent_is_none() {
+        // Genuinely optional — an omitted cap leaves `None`, so the reader
+        // applies its documented default rather than failing to parse.
+        let opts: XmlInputOptions =
+            crate::yaml::from_str("record_path: doc/records/record\n").unwrap();
+        assert_eq!(opts.max_index_bytes, None);
+    }
+
+    #[test]
+    fn xml_options_max_index_bytes_accepts_bare_byte_count() {
+        let opts: XmlInputOptions = crate::yaml::from_str("max_index_bytes: 4096\n").unwrap();
         assert_eq!(opts.max_index_bytes, Some(ByteSize(4096)));
     }
 }

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -11,7 +11,6 @@
 use cxl::analyzer::doc_paths::{DocIndex, DocPath};
 
 use crate::config::{CompileContext, parse_config};
-use crate::plan::execution::PlanNode;
 
 /// Compile a document-aware pipeline whose two transforms read distinct
 /// `$doc` paths, and return the path set stamped on the single Source.
@@ -63,16 +62,27 @@ nodes:
         .compile(&CompileContext::default())
         .expect("compile doc-paths pipeline");
 
-    let dag = plan.dag();
-    let source = dag
-        .graph
-        .node_indices()
-        .find_map(|idx| match &dag.graph[idx] {
-            PlanNode::Source { resolved, .. } => resolved.as_ref(),
+    // Read the live stamp off the runtime `PipelineConfig` source body — the
+    // set the executor's ingest path actually reads (the DAG payload does not
+    // carry it).
+    source_doc_paths(&plan, "payments")
+}
+
+/// The `$doc` path set stamped on the runtime source body named `source_name`
+/// (by node identity / `header.name`), as the executor's ingest path reads
+/// it. Returns an empty vec when no such source carries paths.
+fn source_doc_paths(plan: &crate::plan::CompiledPlan, source_name: &str) -> Vec<DocPath> {
+    use crate::config::pipeline_node::PipelineNode;
+    plan.config()
+        .nodes
+        .iter()
+        .find_map(|spanned| match &spanned.value {
+            PipelineNode::Source { header, config } if header.name == source_name => {
+                Some(config.source.declared_doc_paths.clone())
+            }
             _ => None,
         })
-        .expect("source node present with resolved payload");
-    source.source.declared_doc_paths.clone()
+        .unwrap_or_default()
 }
 
 fn path(section: &str, field: &str, indices: Vec<DocIndex>) -> DocPath {
@@ -96,6 +106,63 @@ fn test_doc_paths_surface_onto_source() {
             path("BatchInfo", "batch_id", vec![]),
             path("Summary", "total", vec![]),
         ]
+    );
+}
+
+#[test]
+fn test_doc_paths_surface_when_header_name_differs_from_config_name() {
+    // A Source whose node identity (`header.name`) differs from its nested
+    // `config.name:` is a shape the compiler accepts. The `$doc` attribution
+    // map is keyed by node identity, so the runtime stamp must look up by
+    // `header.name` and still land the path set on that node's source body —
+    // otherwise the pre-scan prunes every section and `$doc.*` resolves
+    // empty at run time.
+    let yaml = r#"
+pipeline:
+  name: divergent_name_doc
+nodes:
+  - type: source
+    name: node_identity
+    config:
+      name: config_name
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Summary:
+            extract: { xml_path: "/doc/Summary" }
+            fields:
+              total: int
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: t0
+    input: node_identity
+    config:
+      cxl: |
+        emit amount = amount
+        emit total = $doc.Summary.total
+  - type: output
+    name: out
+    input: t0
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse divergent-name pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile divergent-name pipeline");
+    // The stamp keys on node identity (`node_identity`), not the inner
+    // `config.name:` (`config_name`).
+    let paths = source_doc_paths(&plan, "node_identity");
+    assert_eq!(
+        paths,
+        vec![path("Summary", "total", vec![])],
+        "the `$doc` path must reach the source body keyed by node identity"
     );
 }
 
@@ -269,21 +336,7 @@ fn test_declared_doc_path_does_not_trip_e341() {
     let plan = compile_with_summary_envelope("emit amount = amount\nemit t = $doc.Summary.total")
         .expect("a declared `$doc` path must compile");
     // Sanity: the path still surfaces onto the source's declared set.
-    let dag = plan.dag();
-    let source = dag
-        .graph
-        .node_indices()
-        .find_map(|idx| match &dag.graph[idx] {
-            PlanNode::Source { resolved, .. } => resolved.as_ref(),
-            _ => None,
-        })
-        .expect("source node present");
-    assert!(
-        source
-            .source
-            .declared_doc_paths
-            .contains(&path("Summary", "total", vec![])),
-    );
+    assert!(source_doc_paths(&plan, "payments").contains(&path("Summary", "total", vec![])));
 }
 
 #[test]
@@ -409,7 +462,6 @@ nodes:
     let plan = config
         .compile(&CompileContext::default())
         .expect("compile combine-doc pipeline");
-    let dag = plan.dag();
     let head_cutoff = path("Head", "cutoff", vec![]);
     // A joined record carries the DRIVING input's document context, so a
     // `$doc` access in the Combine predicate is attributed to the driver
@@ -417,25 +469,12 @@ nodes:
     // order driver default) and is the source whose envelope declares
     // `Head`. The probe-side `right` source — which has no envelope —
     // must NOT be told to extract it.
-    let paths_for = |source_name: &str| -> Vec<DocPath> {
-        dag.graph
-            .node_indices()
-            .find_map(|idx| match &dag.graph[idx] {
-                PlanNode::Source {
-                    name,
-                    resolved: Some(r),
-                    ..
-                } if name == source_name => Some(r.source.declared_doc_paths.clone()),
-                _ => None,
-            })
-            .unwrap_or_default()
-    };
     assert!(
-        paths_for("left").contains(&head_cutoff),
+        source_doc_paths(&plan, "left").contains(&head_cutoff),
         "the driving source `left` must carry the Combine-predicate `$doc` path"
     );
     assert!(
-        !paths_for("right").contains(&head_cutoff),
+        !source_doc_paths(&plan, "right").contains(&head_cutoff),
         "the probe source `right` must NOT carry the driver's `$doc` path"
     );
 }
@@ -495,23 +534,11 @@ nodes:
     let plan = config
         .compile(&CompileContext::default())
         .expect("compile route-doc pipeline");
-    let dag = plan.dag();
-    let source = dag
-        .graph
-        .node_indices()
-        .find_map(|idx| match &dag.graph[idx] {
-            PlanNode::Source { resolved, .. } => resolved.as_ref(),
-            _ => None,
-        })
-        .expect("source node present with resolved payload");
+    let paths = source_doc_paths(&plan, "payments");
     assert!(
-        source
-            .source
-            .declared_doc_paths
-            .contains(&path("Head", "cutoff", vec![])),
+        paths.contains(&path("Head", "cutoff", vec![])),
         "`$doc.Head.cutoff` used only in a route branch condition must reach the \
-         declared set, got {:?}",
-        source.source.declared_doc_paths
+         declared set, got {paths:?}"
     );
 }
 
@@ -586,23 +613,15 @@ nodes:
     let plan = config
         .compile(&CompileContext::default())
         .expect("compile multi-source pipeline");
-    let dag = plan.dag();
-    let paths_for = |source_name: &str| -> Vec<DocPath> {
-        dag.graph
-            .node_indices()
-            .find_map(|idx| match &dag.graph[idx] {
-                PlanNode::Source {
-                    name,
-                    resolved: Some(r),
-                    ..
-                } if name == source_name => Some(r.source.declared_doc_paths.clone()),
-                _ => None,
-            })
-            .unwrap_or_default()
-    };
     // `alpha` carries only its own section; `beta` only its own.
-    assert_eq!(paths_for("alpha"), vec![path("AHead", "a_batch", vec![])]);
-    assert_eq!(paths_for("beta"), vec![path("BHead", "b_batch", vec![])]);
+    assert_eq!(
+        source_doc_paths(&plan, "alpha"),
+        vec![path("AHead", "a_batch", vec![])]
+    );
+    assert_eq!(
+        source_doc_paths(&plan, "beta"),
+        vec![path("BHead", "b_batch", vec![])]
+    );
 }
 
 #[test]
@@ -686,22 +705,10 @@ nodes:
     let compiled = config
         .compile(&ctx)
         .expect("compile composition-doc pipeline");
-    let dag = compiled.dag();
-    let source = dag
-        .graph
-        .node_indices()
-        .find_map(|idx| match &dag.graph[idx] {
-            PlanNode::Source { resolved, .. } => resolved.as_ref(),
-            _ => None,
-        })
-        .expect("parent source present");
+    let paths = source_doc_paths(&compiled, "payments");
     assert!(
-        source
-            .source
-            .declared_doc_paths
-            .contains(&path("Head", "cutoff", vec![])),
-        "`$doc.Head.cutoff` used in the composition body must reach the declared set, got {:?}",
-        source.source.declared_doc_paths
+        paths.contains(&path("Head", "cutoff", vec![])),
+        "`$doc.Head.cutoff` used in the composition body must reach the declared set, got {paths:?}"
     );
 }
 
@@ -810,30 +817,16 @@ nodes:
         std::path::PathBuf::from("pipelines"),
     );
     let compiled = config.compile(&ctx).expect("compile multi-port pipeline");
-    let dag = compiled.dag();
-    let paths_for = |source_name: &str| -> Vec<DocPath> {
-        dag.graph
-            .node_indices()
-            .find_map(|idx| match &dag.graph[idx] {
-                PlanNode::Source {
-                    name,
-                    resolved: Some(r),
-                    ..
-                } if name == source_name => Some(r.source.declared_doc_paths.clone()),
-                _ => None,
-            })
-            .unwrap_or_default()
-    };
     let shared_tag = path("Shared", "tag", vec![]);
     // The downstream `$doc` read must reach BOTH the primary (`customers`)
     // and the non-primary (`zip_lookup`) port sources.
     assert!(
-        paths_for("customers").contains(&shared_tag),
+        source_doc_paths(&compiled, "customers").contains(&shared_tag),
         "primary port source `customers` must carry the downstream `$doc` path"
     );
+    let zip_paths = source_doc_paths(&compiled, "zip_lookup");
     assert!(
-        paths_for("zip_lookup").contains(&shared_tag),
-        "non-primary port source `zip_lookup` must carry the downstream `$doc` path, got {:?}",
-        paths_for("zip_lookup")
+        zip_paths.contains(&shared_tag),
+        "non-primary port source `zip_lookup` must carry the downstream `$doc` path, got {zip_paths:?}"
     );
 }

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -22,6 +22,7 @@ rules.
       record_path: "//product"          # XPath to record elements
       attribute_prefix: "@"             # prefix for XML attribute fields
       namespace_handling: strip         # strip | qualify
+      max_index_bytes: 64MB             # cap on retained envelope sections (optional)
 ```
 
 ## Options
@@ -31,6 +32,7 @@ rules.
 | `record_path` | — | XPath selecting the elements that each become one record. |
 | `attribute_prefix` | `@` | Prefix that distinguishes an element's attributes from its child elements when both map to schema fields. |
 | `namespace_handling` | `strip` | `strip` removes namespace prefixes from element and attribute names; `qualify` preserves the namespace-qualified names. |
+| `max_index_bytes` | `64MB` | Cap on the bytes the envelope pre-scan retains while extracting declared `$doc.*` sections. |
 
 ## Nested arrays
 
@@ -39,3 +41,27 @@ When a record element contains repeated child elements, the
 controls whether each repetition **explodes** into its own record or
 **joins** into a delimited string. That field is shared with the JSON
 reader and documented on the Source Nodes page.
+
+## Bounding envelope retention: `max_index_bytes`
+
+When a source declares an `envelope:` and a pipeline reads `$doc.*` paths
+from it, the XML reader runs an event-driven streaming pre-scan that walks
+the document once and retains only the declared section subtrees — every
+other element, including a multi-megabyte body, is event-walked and dropped
+without being flattened into memory. The retained sections live in a bounded
+document index.
+
+`max_index_bytes` caps that index. It is charged incrementally as each
+section is built, so even a single oversized declared section aborts
+mid-parse (naming the section and the cap) rather than risking an
+out-of-memory failure. It accepts a decimal size string (`64MB`, `500KB`)
+or a bare byte count; optional, defaulting to **64MB**. Only the declared
+sections a program actually reads are retained, so envelope metadata sits
+far below this ceiling in practice — the cap exists to convert an unbounded
+mistake into a clear error.
+
+The reader still buffers the raw source bytes for the lifetime of the read
+(one disk read backs both the body parser and the pre-scan); the pre-scan
+no longer materializes the section subtrees themselves. See
+[Document Envelope Context](../pipelines/envelope-and-doc-context.md) for
+the full model.

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -73,25 +73,30 @@ reach a trailing section depends on the format:
   every other key (including a multi-megabyte body array) is
   parsed-and-skipped without being stored. The retained sections live in
   a bounded **document index** capped by `max_index_bytes` (see below),
-  so memory scales with the declared sections, not the document size.
-- **XML** currently buffers the document to reach trailing sections;
-  streaming its pre-scan is tracked as a follow-up. Until then an
-  XML envelope-aware source holds the file's bytes for the lifetime of
-  the read.
+  so retained section memory scales with the declared sections, not the
+  document size.
+- **XML** streams the pre-scan too. The reader event-walks the document
+  once and flattens *only* the declared section subtrees — every other
+  element, including a multi-megabyte body, is event-walked and dropped
+  without being materialized. The retained sections live in the same
+  bounded **document index** capped by `max_index_bytes`. The reader still
+  holds the file's raw bytes for the lifetime of the read (one disk read
+  backs both the body parser and the pre-scan), but the pre-scan no longer
+  materializes the undeclared section subtrees.
 
 Only the envelope sections live in the document context — body records
 still flow through the pipeline one at a time, for every format.
 
-### Bounding JSON envelope retention with `max_index_bytes`
+### Bounding envelope retention with `max_index_bytes`
 
-The JSON document index is capped so a pathologically large declared
-section fails loud rather than exhausting memory. The cap is charged
-incrementally *as each section is parsed* — byte by byte while the
-section's subtree is built — so even a single oversized declared section
-aborts mid-parse, before its whole subtree materializes, naming the
-offending section and the cap. (Undeclared siblings, including a
-multi-megabyte body array, are skipped without being parsed into memory
-at all.)
+For JSON and XML sources, the document index is capped so a
+pathologically large declared section fails loud rather than exhausting
+memory. The cap is charged incrementally *as each section is parsed* —
+byte by byte while the section's subtree is built — so even a single
+oversized declared section aborts mid-parse, before its whole subtree
+materializes, naming the offending section and the cap. (Undeclared
+siblings, including a multi-megabyte body, are skipped without being
+parsed into the index at all.)
 
 ```yaml
 - type: source
@@ -104,6 +109,9 @@ at all.)
       record_path: data.rows
       max_index_bytes: 64MB   # cap on retained envelope sections
 ```
+
+The same `max_index_bytes` option applies to an XML source's `options:`
+block, capping its envelope pre-scan identically.
 
 `max_index_bytes` accepts a decimal size string (`64MB`, `500KB`) or a
 bare byte count. It is optional; when omitted the reader applies a
@@ -130,6 +138,16 @@ fails fast when the source opens, rather than silently producing empty
 sections. CSV and fixed-width sources do not yet support envelope
 extraction; declaring envelope sections on those formats is a no-op
 today.
+
+### Network (REST) sources carry no `$doc` context
+
+A `rest` source pulls its records page by page over paginated HTTP — it
+has no single buffered document with head and tail sections, so it
+carries no envelope context. Any `$doc.<section>.<field>` read against a
+REST source resolves to `null`, even when the source declares an
+`envelope:` block. Envelope sections are a file-document concept; pull
+the document-level metadata into record fields through the API's own
+response shape (`record_path`, `array_paths`) instead.
 
 ### EDIFACT `segment` extract
 


### PR DESCRIPTION
Adds the streaming XML counterpart of the JSON document reader: the envelope pre-scan now walks the document once with quick-xml events, retaining only the declared $doc.* sections into the shared path-pruned arena index (reused unchanged), under the same incrementally-charged max_index_bytes cap that aborts mid-parse before a single oversized section materializes. Undeclared sections are parsed-and-skipped rather than buffered. Namespace, attribute, repeated-element, and CData handling match the existing XML mapping.

This also closes a cross-format runtime gap: the planner stamped the declared document paths onto the execution-graph source node but not onto the runtime config source bodies the executor actually reads, so at runtime the pre-scan saw no declared paths and pruned every section. The stamp is now applied format-agnostically, which restores the JSON streaming reader's runtime envelope path as well (its format-level tests passed the paths directly, so the gap was latent). A new end-to-end envelope test exercises the executor path.

Closes #384.