### PR TITLE
engine: Cull node — per-correlation-group record removal with a removed_to side-output

### DIFF
--- a/crates/clinker-exec/src/aggregation/mod.rs
+++ b/crates/clinker-exec/src/aggregation/mod.rs
@@ -51,7 +51,7 @@ use clinker_record::group_key::value_to_group_key;
 use clinker_record::schema::Schema;
 use clinker_record::{GroupByKey, Record, Value};
 use cxl::ast::{BinOp, Expr, LiteralValue, UnaryOp};
-use cxl::eval::{CompiledScalar, EvalContext, EvalError, ProgramEvaluator};
+use cxl::eval::{CompiledScalar, EvalContext, EvalError, ProgramEvaluator, compare_values};
 use cxl::plan::{AggregateBinding, BindingArg, CompiledAggregate};
 
 use clinker_plan::error::PipelineError;
@@ -220,6 +220,24 @@ fn eval_binary(op: BinOp, l: Value, r: Value) -> Result<Value, AggregateEvalErro
         (BinOp::Div, Float(a), Integer(b)) => Float(a / b as f64),
         (BinOp::Eq, a, b) => Bool(a == b),
         (BinOp::Neq, a, b) => Bool(a != b),
+        // Ordered comparisons delegate to the same `compare_values` the row
+        // evaluator uses, so an aggregate boolean residual means exactly what
+        // it would in a Transform: `count(*) > 100`, `max(name) > 'M'`, and
+        // `min(event_date) >= '2020-01-01'` all order Int/Float/String/Date/
+        // DateTime identically. A null (or otherwise-incomparable) operand
+        // yields `None`, which maps to `false` here, matching the row
+        // evaluator's three-valued comparison (whose `matches!`-based
+        // `>=`/`<=` likewise treat an incomparable pair as false).
+        (BinOp::Gt, a, b) => Bool(compare_values(&a, &b) == Some(std::cmp::Ordering::Greater)),
+        (BinOp::Lt, a, b) => Bool(compare_values(&a, &b) == Some(std::cmp::Ordering::Less)),
+        (BinOp::Gte, a, b) => Bool(matches!(
+            compare_values(&a, &b),
+            Some(std::cmp::Ordering::Greater | std::cmp::Ordering::Equal)
+        )),
+        (BinOp::Lte, a, b) => Bool(matches!(
+            compare_values(&a, &b),
+            Some(std::cmp::Ordering::Less | std::cmp::Ordering::Equal)
+        )),
         (BinOp::And, Bool(a), Bool(b)) => Bool(a && b),
         (BinOp::Or, Bool(a), Bool(b)) => Bool(a || b),
         (_, Null, _) | (_, _, Null) => Null,

--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -1,0 +1,1134 @@
+//! `PlanNode::Cull` dispatch arm.
+//!
+//! Per-correlation-group record removal with a side-output port. Blocking
+//! grouping operator: it drains the predecessor's full output, groups
+//! records by `partition_by`, evaluates each rule's group-level
+//! `drop_group_when` predicate over the whole group, and routes every
+//! record of a dropped group to the `removed_to` output port while every
+//! record of an untriggered group flows to the main output port. The
+//! dispatcher's `Cull` arm is a single delegating call into
+//! [`dispatch_cull`].
+//!
+//! # Two output ports (not the DLQ)
+//!
+//! `removed_to` is a first-class producer-side output port, mirroring the
+//! Route fan-out seam — NOT the dead-letter queue. Removed records are not
+//! errors; they are valid rows the operator deliberately partitions onto a
+//! second stream (an audit sink, a reprocessing branch). The split is
+//! resolved off the live edge graph: each outgoing edge carries a
+//! [`producer_port`](clinker_plan::plan::execution::PlanEdge::producer_port)
+//! tag, so an edge tagged with the `removed_to` port name receives removed
+//! rows and every other edge (the bare main reference, tagged `None`)
+//! receives kept rows. Both ports carry the unchanged upstream schema —
+//! Cull does not widen. Per-port output volume is counted downstream at the
+//! Output nodes each port feeds (the same place Route's branch volumes are
+//! counted), not at this arm.
+//!
+//! # Memory model
+//!
+//! Blocking and grouped: the whole input materializes into per-group
+//! buffers before any output row leaves, because the group-level
+//! `drop_group_when` predicate is an aggregate property of the whole group
+//! and cannot be folded into a per-record keep/remove decision. The buffer
+//! is governed by the central
+//! [`MemoryArbitrator`](crate::pipeline::memory::MemoryArbitrator): a
+//! registered [`CullConsumer`] reports the live group-buffer bytes, and when
+//! the soft threshold trips the arm spills whole input records through a
+//! [`SpillWriter`], then re-splits the reloaded group at finalize. A single
+//! oversized group is spilled incrementally (sliced by the upper bits of
+//! each record's admission sequence) so the ingest-time resident peak stays
+//! bounded under skew. The consumer registers at priority `15` (between
+//! grace-hash and external sort) and cannot back-pressure: there is no
+//! upstream channel to gate once the predecessor has drained.
+//!
+//! The drop decision per group is computed by folding the same records
+//! through an in-memory aggregate over the predicate (group-by =
+//! `partition_by`); that aggregate state is O(groups) and is not spilled —
+//! only the raw buffered records (which dominate the footprint) spill.
+//!
+//! A single correlation group whose reloaded footprint exceeds the finalize
+//! budget fails loud with a [`PipelineError`] rather than risking an
+//! out-of-memory crash on reload.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use clinker_record::{GroupByKey, Record, Schema, SchemaBuilder, Value};
+use cxl::eval::ProgramEvaluator;
+use cxl::typecheck::{QualifiedField, Row, Type};
+use petgraph::Direction;
+use petgraph::graph::NodeIndex;
+use petgraph::visit::EdgeRef;
+
+use crate::executor::dispatch::{
+    ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
+    source_file_arc_of, source_name_arc_of,
+};
+use crate::pipeline::memory::{
+    ConsumerHandle, ConsumerSpillError, MemoryArbitrator, MemoryConsumer,
+};
+use crate::pipeline::spill::{SpillFile, SpillWriter};
+use clinker_plan::BudgetCategory;
+use clinker_plan::config::pipeline_node::CullBody;
+use clinker_plan::config::{SortField, SortOrder};
+use clinker_plan::error::PipelineError;
+use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
+
+/// Spill priority for the Cull group buffer: between grace-hash (`10`) and
+/// external sort (`20`), matching Reshape. A grouped record buffer is
+/// costlier to evict than grace partitions (reload re-splits the group) but
+/// cheaper than an external-sort merge. The plan-time mirror in
+/// `arbitration_class` returns the same constant.
+const CULL_SPILL_PRIORITY: i32 = 15;
+
+/// Maximum partition fan-out used to slice one oversized group across
+/// successive spill waves. 12 bits (4096 partitions) matches the grace-hash
+/// cap: beyond it, per-file overhead outweighs further skew reduction.
+const MAX_SKEW_PARTITION_BITS: u32 = 12;
+
+/// Synthetic output column the predicate aggregate emits the per-group
+/// removal decision into. A reserved `__cull_…__` name: the CXL parser
+/// rejects an `emit` to a `$`-namespaced column, so the synthetic emit
+/// target must be a plain identifier; the double-underscore bracketing keeps
+/// it out of any realistic user column space.
+const DROP_DECISION_COLUMN: &str = "__cull_drop_decision__";
+
+/// Arbitrator-facing wrapper over the Cull group buffer.
+///
+/// Blocking operator: reports the live group-buffer byte footprint through a
+/// shared [`ConsumerHandle`] and cannot back-pressure (no upstream channel
+/// remains once the predecessor has drained). On `try_spill` it flips the
+/// handle's spill-request flag; the dispatch loop reads it at the next
+/// grouping boundary and evicts resident groups to disk in-thread.
+struct CullConsumer {
+    handle: Arc<ConsumerHandle>,
+}
+
+impl CullConsumer {
+    fn new(handle: Arc<ConsumerHandle>) -> Self {
+        Self { handle }
+    }
+}
+
+impl MemoryConsumer for CullConsumer {
+    fn current_usage(&self) -> u64 {
+        self.handle.bytes()
+    }
+
+    fn spill_priority(&self) -> i32 {
+        CULL_SPILL_PRIORITY
+    }
+
+    fn try_spill(&self, target_bytes: u64) -> Result<u64, ConsumerSpillError> {
+        self.handle.request_spill();
+        let bytes = self.handle.bytes();
+        if bytes >= target_bytes {
+            Ok(bytes)
+        } else {
+            Err(ConsumerSpillError::BelowTarget {
+                target: target_bytes,
+                freed: bytes,
+            })
+        }
+    }
+
+    fn can_back_pressure(&self) -> bool {
+        false
+    }
+}
+
+/// Execute the `Cull` arm for `node_idx`. Drains the predecessor, groups by
+/// `partition_by`, evaluates each group's `drop_group_when` predicate over
+/// the whole group, and splits kept vs. removed records onto the main and
+/// `removed_to` output ports. Blocking: the full input materializes before
+/// the first output row leaves.
+pub(crate) fn dispatch_cull(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    node: &PlanNode,
+) -> Result<(), PipelineError> {
+    let PlanNode::Cull {
+        ref name,
+        ref config,
+        ref output_schema,
+        ..
+    } = *node
+    else {
+        unreachable!("dispatch_cull called with non-Cull node");
+    };
+
+    let pred = single_predecessor(current_dag, node_idx, "cull", name)?;
+    let (input, input_puncts): (
+        Vec<(Record, u64)>,
+        Vec<crate::executor::stream_event::Punctuation>,
+    ) = match drain_node_buffer_slot(ctx, pred) {
+        Some(nb) => nb.drain_split()?,
+        None => (Vec::new(), Vec::new()),
+    };
+
+    if input.is_empty() {
+        // Empty-input fast path returns BEFORE any consumer registers, so
+        // there is nothing to deregister: a `ConsumerId` left registered on
+        // an early return inflates the run's peak for every downstream stage.
+        // Both ports still receive the punctuation broadcast so each
+        // downstream subgraph sees the document boundaries.
+        emit_ports(
+            ctx,
+            current_dag,
+            node_idx,
+            name,
+            config,
+            Vec::new(),
+            Vec::new(),
+            input_puncts,
+        )?;
+        return Ok(());
+    }
+
+    // Register the group buffer with the arbitrator only after the
+    // empty-input guard, so the no-work path never leaks a consumer.
+    let handle = ConsumerHandle::new();
+    let consumer_id = ctx
+        .memory_budget
+        .register_consumer(Arc::new(CullConsumer::new(handle.clone())));
+
+    // Every exit path past this point must deregister `consumer_id`, so the
+    // grouping/finalize work runs inside a helper whose result is matched
+    // below — success and hard error both funnel through the single
+    // `unregister_consumer` call.
+    let result = run_cull_grouped(
+        ctx,
+        current_dag,
+        node_idx,
+        name,
+        config,
+        output_schema,
+        input,
+        input_puncts,
+        &handle,
+    );
+    ctx.memory_budget.unregister_consumer(consumer_id);
+    result
+}
+
+/// Group the drained input, spilling resident groups to disk under memory
+/// pressure, compute the per-group `drop_group_when` decision, then split
+/// each group's records (reloading spilled groups) onto the main and
+/// `removed_to` output ports.
+///
+/// Split out of [`dispatch_cull`] so the consumer deregistration there
+/// covers every exit — success and hard error both return through this
+/// function's `Result`.
+#[allow(clippy::too_many_arguments)]
+fn run_cull_grouped(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    name: &str,
+    config: &CullBody,
+    output_schema: &Arc<Schema>,
+    input: Vec<(Record, u64)>,
+    input_puncts: Vec<crate::executor::stream_event::Punctuation>,
+    handle: &Arc<ConsumerHandle>,
+) -> Result<(), PipelineError> {
+    // The schema is uniform across a node_buffer slot, so the first record's
+    // schema drives both the predicate aggregate compile and the spill
+    // schema.
+    let input_schema = input[0].0.schema().clone();
+
+    // Compute the per-group removal decision by folding every record through
+    // an in-memory aggregate over the OR of all rules' `drop_group_when`
+    // predicates (group-by = `partition_by`). The aggregate's per-group
+    // state is O(groups) and is not spilled — only the raw buffered records
+    // (which dominate the footprint) spill, below.
+    let drop_decisions = compute_drop_decisions(ctx, name, config, &input_schema, &input)?;
+
+    let spill_compress = ctx
+        .spill_compress
+        .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
+
+    let budget = Arc::clone(&ctx.memory_budget);
+    let spill_root = Arc::clone(&ctx.spill_root_path);
+
+    let mut buffer = CullGroupBuffer::new(Arc::clone(&input_schema), spill_compress);
+    for (record, row_num) in input {
+        let key = partition_key(name, &record, &config.partition_by)?;
+        buffer.push(key, record, row_num);
+        handle.set_bytes(buffer.resident_bytes() as u64);
+        // Poll for self-spill pressure at every admission. `should_spill_self`
+        // updates the peak and reports the soft-threshold crossing WITHOUT
+        // running the pausing arbitration round: Cull relieves pressure by
+        // spilling its OWN buffer in-thread, and that round can elect and
+        // pause a back-pressureable Source in a concurrent DAG branch that
+        // Cull never resumes — the deadlock the hash aggregator avoids the
+        // same way. `take_spill_request` still honors a spill nudge another
+        // stage's arbitration round set on this consumer.
+        if budget.should_spill_self() || handle.take_spill_request() {
+            buffer.spill_until_under_budget(name, &budget, &spill_root, handle)?;
+            handle.set_bytes(buffer.resident_bytes() as u64);
+        }
+    }
+
+    // Finalize: stream each group back in first-seen order (from memory when
+    // it never spilled, else reloaded from its spill files and restored to
+    // arrival order), then route every record of the group to the kept or
+    // removed bucket per the precomputed decision. The hard limit gates a
+    // single correlation group too large to observe whole.
+    let hard_limit = budget.hard_limit();
+    let mut kept: Vec<(Record, u64)> = Vec::new();
+    let mut removed: Vec<(Record, u64)> = Vec::new();
+    let group_order = buffer.take_group_order();
+    for key in group_order {
+        let mut group = buffer.take_group(name, &key, hard_limit)?;
+        handle.set_bytes(buffer.resident_bytes() as u64);
+        if !config.order_by.is_empty() {
+            sort_group(&mut group, &config.order_by);
+        }
+        // Every buffered group must have a computed decision: the decision
+        // aggregate is keyed by the same `partition_key`, over the same
+        // records, so a missing key is an internal invariant violation — fail
+        // loud rather than silently default a should-be-removed group to the
+        // main port.
+        let Some(&drop) = drop_decisions.get(&key) else {
+            return Err(PipelineError::Internal {
+                op: "cull",
+                node: name.to_string(),
+                detail: "a buffered correlation group has no computed removal decision — the \
+                         dispatch buffer and the decision aggregate diverged on the partition key"
+                    .to_string(),
+            });
+        };
+        if drop {
+            removed.append(&mut group);
+        } else {
+            kept.append(&mut group);
+        }
+    }
+
+    emit_ports(
+        ctx,
+        current_dag,
+        node_idx,
+        name,
+        config,
+        kept,
+        removed,
+        input_puncts,
+    )
+}
+
+/// Fold every input record through an in-memory aggregate over the OR of all
+/// rules' `drop_group_when` predicates and return a per-group removal
+/// decision keyed identically to the dispatch buffer.
+///
+/// The predicate program is `emit <decision> = (rule_1) or (rule_2) or …`,
+/// typechecked and run in aggregate context (group-by = `partition_by`), so
+/// an aggregate predicate such as `count(*) > 100` is well-formed. The
+/// finalized per-group record carries the group-by columns and the boolean
+/// decision; the decision map is keyed by `partition_key` over that record so
+/// it matches the dispatch buffer's group keys exactly.
+fn compute_drop_decisions(
+    ctx: &mut ExecutorContext<'_>,
+    name: &str,
+    config: &CullBody,
+    input_schema: &Arc<Schema>,
+    input: &[(Record, u64)],
+) -> Result<HashMap<Vec<GroupByKey>, bool>, PipelineError> {
+    use crate::aggregation::{AggregateStream, AggregatorConfig, SortRow};
+
+    let predicate_src = build_drop_predicate(config);
+    let compiled = compile_drop_aggregate(name, config, &predicate_src, input_schema)?;
+    let evaluator = ProgramEvaluator::new(Arc::clone(&compiled.typed), false);
+
+    // Output schema = partition-by columns ++ the boolean decision column.
+    // Spill schema is unused (the predicate aggregate runs in-memory: budget
+    // 0 disables the group-count cap and `spill_dir: None` keeps every group
+    // resident), but `AggregatorConfig` still requires a value.
+    let drop_output_schema: Arc<Schema> = config
+        .partition_by
+        .iter()
+        .map(|s| Box::<str>::from(s.as_str()))
+        .chain([Box::<str>::from(DROP_DECISION_COLUMN)])
+        .collect::<SchemaBuilder>()
+        .build();
+    let spill_schema: Arc<Schema> = config
+        .partition_by
+        .iter()
+        .map(|s| Box::<str>::from(s.as_str()))
+        .chain([Box::<str>::from("__acc_state")])
+        .collect::<SchemaBuilder>()
+        .build();
+
+    let handle = ConsumerHandle::new();
+    let mut stream = AggregateStream::for_node(
+        clinker_plan::plan::types::AggregateStrategy::Hash,
+        AggregatorConfig {
+            compiled: Arc::clone(&compiled.compiled),
+            evaluator,
+            output_schema: Arc::clone(&drop_output_schema),
+            spill_schema,
+            // In-memory only: the raw-record buffer carries the spill burden,
+            // and the aggregate state is O(groups) — never spilled.
+            memory_budget: 0,
+            spill_dir: None,
+            spill_compress: false,
+            transform_name: format!("cull:{name}"),
+            consumer_handle: handle,
+        },
+    )?;
+
+    let mut emitted: Vec<SortRow> = Vec::new();
+    for (record, row_num) in input {
+        let source_file = source_file_arc_of(record);
+        let source_name = source_name_arc_of(record);
+        let eval_ctx =
+            ctx.eval_ctx_for_record(&source_file, &source_name, *row_num, record.doc_ctx());
+        stream
+            .add_record(record, *row_num, &eval_ctx, &mut emitted)
+            .map_err(|e| cull_predicate_error(name, e))?;
+    }
+    let finalize_ctx = ctx.merged_eval_ctx();
+    stream
+        .finalize(&finalize_ctx, &mut emitted)
+        .map_err(|e| cull_predicate_error(name, e))?;
+
+    // Each finalized row carries the group-by columns and the decision.
+    // Re-derive the group key from those columns with the SAME `partition_key`
+    // the dispatch buffer uses, so a buffered group and its decision can never
+    // key differently. The finalized record's group-by columns hold the
+    // group's key values verbatim (the aggregate stamps each group-by column
+    // from its key tuple), so this reproduces the buffer key exactly.
+    let mut decisions: HashMap<Vec<GroupByKey>, bool> = HashMap::with_capacity(emitted.len());
+    for (record, _) in emitted {
+        let key = partition_key(name, &record, &config.partition_by)?;
+        let drop = matches!(record.get(DROP_DECISION_COLUMN), Some(Value::Bool(true)));
+        decisions.insert(key, drop);
+    }
+    Ok(decisions)
+}
+
+/// Compiled predicate aggregate: the deduplicated aggregate plan plus the
+/// typed program the evaluator lowers expression bindings against.
+struct CompiledDropAggregate {
+    compiled: Arc<cxl::plan::CompiledAggregate>,
+    typed: Arc<cxl::typecheck::TypedProgram>,
+}
+
+/// Build the OR-combined removal predicate `emit <decision> = (r1) or (r2) …`.
+/// A group is removed when any rule's `drop_group_when` predicate holds, so
+/// the per-group decision is the disjunction of every rule's predicate.
+fn build_drop_predicate(config: &CullBody) -> String {
+    let disjuncts: Vec<String> = config
+        .rules
+        .iter()
+        .map(|r| format!("({})", r.drop_group_when.source))
+        .collect();
+    // `bind_cull` rejects an empty `rules:` list, so a valid plan always has
+    // at least one disjunct; the empty fallback is defensive only (the
+    // executor compiles the predicate independently of bind-time validation).
+    let body = if disjuncts.is_empty() {
+        "false".to_string()
+    } else {
+        disjuncts.join(" or ")
+    };
+    format!("emit {DROP_DECISION_COLUMN} = {body}")
+}
+
+/// Parse → resolve → typecheck the predicate aggregate program in aggregate
+/// context (group-by = `partition_by`) and extract its aggregate plan.
+///
+/// Type errors here are a planner-invariant violation (`bind_cull` already
+/// typechecked each rule fragment), so they surface as
+/// [`PipelineError::Compilation`].
+fn compile_drop_aggregate(
+    name: &str,
+    config: &CullBody,
+    source: &str,
+    schema: &Arc<Schema>,
+) -> Result<CompiledDropAggregate, PipelineError> {
+    let make_err = |messages: Vec<String>| PipelineError::Compilation {
+        transform_name: format!("cull:{name}:drop_group_when"),
+        messages,
+    };
+
+    let type_cols: indexmap::IndexMap<QualifiedField, Type> = schema
+        .columns()
+        .iter()
+        .map(|c| (QualifiedField::bare(c.as_ref()), Type::Any))
+        .collect();
+    let row = Row::closed(type_cols, cxl::lexer::Span::new(0, 0));
+    let field_refs: Vec<&str> = schema.columns().iter().map(|c| c.as_ref()).collect();
+    let schema_names: Vec<String> = schema.columns().iter().map(|c| c.to_string()).collect();
+    let scoped_vars = cxl::resolve::ScopedVarsRegistry::default();
+
+    let parse_result = cxl::parser::Parser::parse(source);
+    if !parse_result.errors.is_empty() {
+        return Err(make_err(
+            parse_result
+                .errors
+                .iter()
+                .map(|e| e.message.clone())
+                .collect(),
+        ));
+    }
+    let resolved = cxl::resolve::resolve_program_with_modules_and_vars(
+        parse_result.ast,
+        &field_refs,
+        parse_result.node_count,
+        &std::collections::HashMap::new(),
+        &scoped_vars,
+    )
+    .map_err(|diags| make_err(diags.into_iter().map(|d| d.message).collect()))?;
+    let agg_mode = cxl::typecheck::pass::AggregateMode::GroupBy {
+        group_by_fields: config.partition_by.iter().cloned().collect(),
+    };
+    let typed =
+        cxl::typecheck::pass::type_check_with_mode_and_vars(resolved, &row, agg_mode, &scoped_vars)
+            .map_err(|diags| {
+                make_err(
+                    diags
+                        .into_iter()
+                        .filter(|d| !d.is_warning)
+                        .map(|d| d.message)
+                        .collect(),
+                )
+            })?;
+    let compiled = cxl::plan::extract_aggregates(&typed, &config.partition_by, &schema_names)
+        .map_err(|diags| make_err(diags.into_iter().map(|d| d.message).collect()))?;
+    Ok(CompiledDropAggregate {
+        compiled: Arc::new(compiled),
+        typed: Arc::new(typed),
+    })
+}
+
+/// Deliver the kept and removed record sets to their producer-side output
+/// ports. A successor whose incoming edge is tagged with the `removed_to` port
+/// draws removed rows; every other successor (the bare main reference, tagged
+/// `None`) draws kept rows.
+///
+/// Records are accumulated **per successor across both ports** before a single
+/// admission, so a node drawing from both ports lands the union in one slot —
+/// the second port's records never overwrite the first's (the per-successor
+/// accumulation Route uses for its branches).
+///
+/// Where the records land depends on how the successor reads its input. A
+/// single-output consumer (Transform / Output / Reshape / Cull) checks its own
+/// `node_buffers` slot first, so its records go there. A multi-input consumer
+/// (Merge / Combine) reads its *predecessor's* slot directly, so its records go
+/// into this Cull's own slot (`node_idx`) instead. Both ports broadcast
+/// `input_puncts` so each downstream subgraph drives its own per-document
+/// accumulators.
+#[allow(clippy::too_many_arguments)]
+fn emit_ports(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    name: &str,
+    config: &CullBody,
+    kept: Vec<(Record, u64)>,
+    removed: Vec<(Record, u64)>,
+    input_puncts: Vec<crate::executor::stream_event::Punctuation>,
+) -> Result<(), PipelineError> {
+    // Accumulate each successor's port-selected records keyed by successor
+    // index. The edge's `producer_port` tag is the source of truth:
+    // `Some(removed_to)` → removed rows, anything else (the untagged main
+    // reference) → kept rows. A record set is cloned into a successor's bucket
+    // only when that successor draws the matching port, so the bucket is the
+    // exact set the port selected; a node drawing both ports gets the union.
+    let removed_port = config.removed_to.as_str();
+    let mut succ_records: HashMap<NodeIndex, Vec<(Record, u64)>> = HashMap::new();
+    let mut succ_order: Vec<NodeIndex> = Vec::new();
+    for edge in current_dag
+        .graph
+        .edges_directed(node_idx, Direction::Outgoing)
+    {
+        let succ = edge.target();
+        if !succ_records.contains_key(&succ) {
+            succ_order.push(succ);
+        }
+        let bucket = succ_records.entry(succ).or_default();
+        match edge.weight().producer_port.as_deref() {
+            Some(port) if port == removed_port => bucket.extend(removed.iter().cloned()),
+            _ => bucket.extend(kept.iter().cloned()),
+        }
+    }
+
+    let cull_region_producer = current_dag.deferred_region_at(node_idx).map(|r| r.producer);
+    let active_body = ctx.window_runtime.active_stack.last().copied();
+    // Records destined for a predecessor-slot reader (Merge / Combine)
+    // accumulate into this Cull's own slot, where that consumer drains them.
+    let mut predecessor_slot: Vec<(Record, u64)> = Vec::new();
+    let mut wrote_predecessor_slot = false;
+    // Iterate in first-seen successor order so admission is deterministic.
+    for succ in succ_order {
+        let records = succ_records.remove(&succ).unwrap_or_default();
+        // Cross-region tee: a successor inside a deferred region this Cull is
+        // not in needs the port-selected records parked on the matching
+        // outgoing edge so the commit-time deferred dispatcher receives exactly
+        // them. In-region and non-deferred edges skip the tee; their
+        // `node_buffers` slot already covers them.
+        let succ_region_producer = current_dag.deferred_region_at(succ).map(|r| r.producer);
+        let crosses = match (cull_region_producer, succ_region_producer) {
+            (None, Some(_)) => true,
+            (Some(p), Some(t)) if p != t => true,
+            _ => false,
+        };
+        if crosses && let Some(edge) = current_dag.graph.find_edge(node_idx, succ) {
+            let row_bytes_each: u64 = records
+                .first()
+                .map(|(rec, _)| {
+                    (std::mem::size_of::<Value>() * rec.schema().column_count()
+                        + std::mem::size_of::<(Record, u64)>()) as u64
+                })
+                .unwrap_or(0);
+            for (record, rn) in &records {
+                // Fail loud if an oversized cross-region tee would blow the
+                // budget, mirroring the Route tee — parking unbounded records
+                // into `region_input_buffers` must not silently overshoot.
+                if row_bytes_each > 0 && ctx.memory_budget.should_abort() {
+                    return Err(PipelineError::MemoryBudgetExceeded {
+                        node: name.to_string(),
+                        used: ctx.memory_budget.peak_rss().unwrap_or(0),
+                        limit: ctx.memory_budget.hard_limit(),
+                        source: BudgetCategory::Arena,
+                        detail: Some("Cull cross-region tee admission".to_string()),
+                    });
+                }
+                ctx.region_input_buffers
+                    .entry((active_body, edge))
+                    .or_default()
+                    .push((record.clone(), *rn));
+            }
+        }
+        if reads_predecessor_slot(&current_dag.graph[succ]) {
+            // Merge / Combine drains its predecessor's slot, not its own, so
+            // its records join this Cull's slot (deduped across such
+            // successors into one accumulation — they all read the same slot).
+            predecessor_slot.extend(records);
+            wrote_predecessor_slot = true;
+        } else {
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                succ,
+                records,
+                input_puncts.clone(),
+                node_buffer_spill_allowed(current_dag, succ),
+            )?;
+            ctx.node_buffers.insert(succ, nb);
+        }
+    }
+    if wrote_predecessor_slot {
+        let nb = admit_node_buffer(
+            ctx,
+            name,
+            node_idx,
+            predecessor_slot,
+            input_puncts,
+            node_buffer_spill_allowed(current_dag, node_idx),
+        )?;
+        ctx.node_buffers.insert(node_idx, nb);
+    }
+    Ok(())
+}
+
+/// Whether `node` drains its *predecessor's* `node_buffers` slot rather than
+/// checking its own slot first. Merge and Combine read each predecessor slot
+/// directly; every other consumer (Transform / Output / Reshape / Cull / Sort
+/// / Aggregation) checks its own slot first, so a producer writes into the
+/// consumer's slot for those.
+fn reads_predecessor_slot(node: &PlanNode) -> bool {
+    matches!(node, PlanNode::Merge { .. } | PlanNode::Combine { .. })
+}
+
+// ---------------------------------------------------------------------
+// Per-group input buffer with arbitrator-driven spill.
+//
+// Mirrors the Reshape group buffer: holds every drained input record
+// grouped by `partition_by` in first-seen order, spilling whole resident
+// groups (or slices of one oversized group) to disk under memory pressure,
+// and reloading each group in arrival order at finalize.
+// ---------------------------------------------------------------------
+
+/// One buffered input record plus the two `u64`s the spill round-trip must
+/// preserve: a Cull-local admission sequence that orders the record within
+/// its group across a multi-source merge, and the upstream source row number
+/// carried through for output.
+struct BufferedRecord {
+    record: Record,
+    /// Cull-local monotonic admission sequence; the within-group sort key.
+    seq: u64,
+    /// Upstream source row number, carried through to the output ports.
+    row_num: u64,
+}
+
+/// Spill payload for a buffered Cull input record: the admission sequence and
+/// the source row number, both reconstructed on reload.
+type CullSpillPayload = (u64, u64);
+
+/// One group's buffered input records: a resident tail plus any slices
+/// already evicted to disk.
+struct CullGroupState {
+    resident: Vec<BufferedRecord>,
+    resident_bytes: usize,
+    spilled_bytes: usize,
+    spilled: Vec<SpillFile<CullSpillPayload>>,
+}
+
+impl CullGroupState {
+    fn new() -> Self {
+        Self {
+            resident: Vec::new(),
+            resident_bytes: 0,
+            spilled_bytes: 0,
+            spilled: Vec::new(),
+        }
+    }
+}
+
+/// Per-group input buffer with arbitrator-driven spill.
+///
+/// Holds every drained input record grouped by `partition_by` in first-seen
+/// order. Under memory pressure it evicts whole resident groups to disk
+/// largest-first; a single group too large to fit on its own is sliced by
+/// the upper bits of each record's admission sequence so successive waves
+/// spill fractions of the one group. At finalize each group is streamed back
+/// — resident records plus reloaded spill slices in arrival order — and split
+/// onto the output ports.
+struct CullGroupBuffer {
+    input_schema: Arc<Schema>,
+    compress: bool,
+    group_order: Vec<Vec<GroupByKey>>,
+    groups: HashMap<Vec<GroupByKey>, CullGroupState>,
+    resident_bytes: usize,
+    next_seq: u64,
+}
+
+impl CullGroupBuffer {
+    fn new(input_schema: Arc<Schema>, compress: bool) -> Self {
+        Self {
+            input_schema,
+            compress,
+            group_order: Vec::new(),
+            groups: HashMap::new(),
+            resident_bytes: 0,
+            next_seq: 0,
+        }
+    }
+
+    fn resident_bytes(&self) -> usize {
+        self.resident_bytes
+    }
+
+    /// Admit one record into its group, stamping a Cull-local admission
+    /// sequence and recording first-seen group order.
+    fn push(&mut self, key: Vec<GroupByKey>, record: Record, row_num: u64) {
+        let bytes = estimated_input_bytes(&record);
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        let order = &mut self.group_order;
+        let state = self.groups.entry(key.clone()).or_insert_with(|| {
+            order.push(key);
+            CullGroupState::new()
+        });
+        state.resident.push(BufferedRecord {
+            record,
+            seq,
+            row_num,
+        });
+        state.resident_bytes += bytes;
+        self.resident_bytes += bytes;
+    }
+
+    /// Take the first-seen group order, consuming it for the finalize drain.
+    fn take_group_order(&mut self) -> Vec<Vec<GroupByKey>> {
+        std::mem::take(&mut self.group_order)
+    }
+
+    /// Evict resident groups to disk, largest-first, until the resident
+    /// footprint drops back under the soft threshold. The stop condition keys
+    /// on the live, decreasing `resident_bytes` rather than the arbitrator's
+    /// monotonic `peak_rss` high-water, so under a budget below baseline RSS
+    /// it stops at the threshold instead of draining every group.
+    fn spill_until_under_budget(
+        &mut self,
+        node_name: &str,
+        budget: &MemoryArbitrator,
+        spill_root: &std::path::Path,
+        handle: &Arc<ConsumerHandle>,
+    ) -> Result<(), PipelineError> {
+        let soft = budget.spill_threshold_bytes() as usize;
+        while self.resident_bytes > soft {
+            let Some(key) = self.largest_resident_group() else {
+                break;
+            };
+            let resident_bytes = self.groups[&key].resident_bytes;
+            if resident_bytes > soft && soft > 0 {
+                self.spill_group_partitioned(node_name, budget, spill_root, &key, soft)?;
+            } else {
+                self.spill_group_whole(node_name, budget, spill_root, &key)?;
+            }
+            handle.set_bytes(self.resident_bytes as u64);
+        }
+        Ok(())
+    }
+
+    /// Key of the resident group holding the most in-memory bytes, or `None`
+    /// when every group is fully spilled.
+    fn largest_resident_group(&self) -> Option<Vec<GroupByKey>> {
+        self.groups
+            .iter()
+            .filter(|(_, s)| !s.resident.is_empty())
+            .max_by_key(|(_, s)| s.resident_bytes)
+            .map(|(k, _)| k.clone())
+    }
+
+    /// Evict one group's entire resident tail to a fresh spill file.
+    fn spill_group_whole(
+        &mut self,
+        node_name: &str,
+        budget: &MemoryArbitrator,
+        spill_root: &std::path::Path,
+        key: &[GroupByKey],
+    ) -> Result<(), PipelineError> {
+        let state = self
+            .groups
+            .get_mut(key)
+            .expect("spill target group present");
+        let records = std::mem::take(&mut state.resident);
+        let freed = std::mem::take(&mut state.resident_bytes);
+        self.resident_bytes -= freed;
+        let file = write_spill_slice(
+            node_name,
+            budget,
+            spill_root,
+            &self.input_schema,
+            self.compress,
+            records.iter(),
+        )?;
+        let state = self
+            .groups
+            .get_mut(key)
+            .expect("spill target group present");
+        state.spilled.push(file);
+        state.spilled_bytes += freed;
+        Ok(())
+    }
+
+    /// Slice one oversized group's resident tail across hash partitions,
+    /// spilling enough partitions to bring the group's resident footprint
+    /// under `soft`. The partition assignment uses the upper bits of each
+    /// record's admission sequence, so a single giant group is evicted in
+    /// fractions across successive waves and a duplicate-content group still
+    /// distributes evenly.
+    fn spill_group_partitioned(
+        &mut self,
+        node_name: &str,
+        budget: &MemoryArbitrator,
+        spill_root: &std::path::Path,
+        key: &[GroupByKey],
+        soft: usize,
+    ) -> Result<(), PipelineError> {
+        let state = self
+            .groups
+            .get_mut(key)
+            .expect("partition-spill target group present");
+        let resident = std::mem::take(&mut state.resident);
+        let total_bytes = std::mem::take(&mut state.resident_bytes);
+        self.resident_bytes -= total_bytes;
+
+        let parts_wanted = total_bytes.div_ceil(soft.max(1)).max(2);
+        let bits =
+            (usize::BITS - (parts_wanted - 1).leading_zeros()).clamp(1, MAX_SKEW_PARTITION_BITS);
+        let shift = 64 - bits;
+
+        let n = 1usize << bits;
+        let mut buckets: Vec<Vec<BufferedRecord>> = (0..n).map(|_| Vec::new()).collect();
+        let mut bucket_bytes: Vec<usize> = vec![0; n];
+        for buffered in resident {
+            // Partition on the admission sequence via the SplitMix64 finalizer:
+            // the sequence is dense, so it varies only in its low bits, but the
+            // slicer reads the upper bits — the finalizer spreads that low-bit
+            // variation across the whole word so buckets fill evenly.
+            let p = ((crate::sketch::splitmix64(buffered.seq) >> shift) as usize) & (n - 1);
+            bucket_bytes[p] += estimated_input_bytes(&buffered.record);
+            buckets[p].push(buffered);
+        }
+
+        let mut order: Vec<usize> = (0..n).collect();
+        order.sort_by_key(|&p| std::cmp::Reverse(bucket_bytes[p]));
+        let mut remaining: usize = bucket_bytes.iter().sum();
+        let mut spilled_files: Vec<SpillFile<CullSpillPayload>> = Vec::new();
+        for &p in &order {
+            if remaining <= soft || buckets[p].is_empty() {
+                continue;
+            }
+            let slice = std::mem::take(&mut buckets[p]);
+            remaining -= bucket_bytes[p];
+            let file = write_spill_slice(
+                node_name,
+                budget,
+                spill_root,
+                &self.input_schema,
+                self.compress,
+                slice.iter(),
+            )?;
+            spilled_files.push(file);
+        }
+
+        let tail: Vec<BufferedRecord> = buckets.into_iter().flatten().collect();
+        let spilled_now = total_bytes - remaining;
+        let state = self
+            .groups
+            .get_mut(key)
+            .expect("partition-spill target group present");
+        state.resident = tail;
+        state.resident_bytes = remaining;
+        state.spilled_bytes += spilled_now;
+        state.spilled.extend(spilled_files);
+        self.resident_bytes += remaining;
+        Ok(())
+    }
+
+    /// Reload one group's full record set in original arrival order.
+    ///
+    /// A group whose reloaded footprint (`resident_bytes + spilled_bytes`)
+    /// exceeds `hard_limit` cannot be observed within budget — the
+    /// `drop_group_when` decision needs the whole group — so finalize fails
+    /// loud rather than OOM on reload. A spilled group's records arrive in
+    /// spill-file then bucket order, so the merged group is re-sorted by the
+    /// Cull-local admission sequence (globally unique and monotonic in
+    /// arrival order, surviving a multi-source merge where source row numbers
+    /// collide) so it emits identically to a resident group.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PipelineError::Internal`] when a single correlation group's
+    /// reloaded footprint exceeds `hard_limit`, or when a spill file cannot be
+    /// read back.
+    fn take_group(
+        &mut self,
+        node_name: &str,
+        key: &[GroupByKey],
+        hard_limit: u64,
+    ) -> Result<Vec<(Record, u64)>, PipelineError> {
+        let state = self.groups.remove(key).expect("group key present in order");
+        self.resident_bytes -= state.resident_bytes;
+
+        let group_bytes = (state.resident_bytes + state.spilled_bytes) as u64;
+        if hard_limit > 0 && group_bytes > hard_limit {
+            return Err(cull_giant_group_error(node_name, group_bytes, hard_limit));
+        }
+
+        if state.spilled.is_empty() {
+            return Ok(state
+                .resident
+                .into_iter()
+                .map(|b| (b.record, b.row_num))
+                .collect());
+        }
+
+        let mut group: Vec<BufferedRecord> = Vec::new();
+        for file in &state.spilled {
+            let reader = file.reader().map_err(|e| cull_spill_error(node_name, e))?;
+            for pair in reader {
+                let (record, (seq, row_num)) = pair.map_err(|e| cull_spill_error(node_name, e))?;
+                group.push(BufferedRecord {
+                    record,
+                    seq,
+                    row_num,
+                });
+            }
+        }
+        group.extend(state.resident);
+        group.sort_by_key(|b| b.seq);
+        Ok(group.into_iter().map(|b| (b.record, b.row_num)).collect())
+    }
+}
+
+/// Write one input-record slice to a fresh spill file, charging its on-disk
+/// byte size against the arbitrator's per-stage and pipeline-wide spill
+/// totals so `--explain` calibration and the disk-spill cap both see it.
+fn write_spill_slice<'a>(
+    node_name: &str,
+    budget: &MemoryArbitrator,
+    spill_root: &std::path::Path,
+    input_schema: &Arc<Schema>,
+    compress: bool,
+    records: impl Iterator<Item = &'a BufferedRecord>,
+) -> Result<SpillFile<CullSpillPayload>, PipelineError> {
+    let mut writer: SpillWriter<CullSpillPayload> =
+        SpillWriter::new(Arc::clone(input_schema), Some(spill_root), compress)
+            .map_err(|e| cull_spill_error(node_name, e))?;
+    for buffered in records {
+        writer
+            .write_pair(&buffered.record, &(buffered.seq, buffered.row_num))
+            .map_err(|e| cull_spill_error(node_name, e))?;
+    }
+    let file = writer
+        .finish()
+        .map_err(|e| cull_spill_error(node_name, e))?;
+    let bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
+    budget.record_spill_bytes(node_name, bytes);
+    Ok(file)
+}
+
+/// One input record's estimated buffered footprint: heap bytes plus the
+/// owning [`BufferedRecord`] header overhead.
+fn estimated_input_bytes(record: &Record) -> usize {
+    record.estimated_heap_size() + std::mem::size_of::<BufferedRecord>()
+}
+
+/// Extract the `partition_by` key tuple from a record, using the **exact**
+/// construction the decision aggregate's internal grouping uses
+/// ([`value_to_group_key`] with `Ok(None) → GroupByKey::Null`).
+///
+/// Keying the dispatch buffer and the decision aggregate by the same function
+/// is load-bearing: any divergence (for example collapsing an empty string to
+/// `Null` here while the aggregate keeps it as a distinct `Str("")` group)
+/// would merge two groups in the buffer that the aggregate split — or vice
+/// versa — and the merged group would then be routed by whichever decision the
+/// `HashMap` happened to insert last. So this does not special-case empty
+/// strings: `account=""` and `account=null` are distinct groups in both the
+/// buffer and the aggregate, exactly as every other aggregate / correlation
+/// grouping in the engine treats them.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::Internal`] when a `partition_by` value cannot form
+/// a group key (a NaN, array, or map cell) — the same hard failure the
+/// aggregate raises, so the two keyings stay in lockstep rather than the buffer
+/// silently degrading a cell the aggregate rejects.
+fn partition_key(
+    node_name: &str,
+    record: &Record,
+    partition_by: &[String],
+) -> Result<Vec<GroupByKey>, PipelineError> {
+    partition_by
+        .iter()
+        .enumerate()
+        .map(|(idx, f)| {
+            let v = record.get(f).unwrap_or(&Value::Null);
+            match clinker_record::value_to_group_key(v, f, None, idx as u64) {
+                Ok(Some(gk)) => Ok(gk),
+                Ok(None) => Ok(GroupByKey::Null),
+                Err(e) => Err(PipelineError::Internal {
+                    op: "cull",
+                    node: node_name.to_string(),
+                    detail: format!("partition_by field {f:?} cannot form a group key: {e}"),
+                }),
+            }
+        })
+        .collect()
+}
+
+/// Sort a group in place by `order_by`, stable across equal keys (so arrival
+/// order breaks ties deterministically). Nulls sort last regardless of
+/// direction (SQL convention).
+fn sort_group(group: &mut [(Record, u64)], order_by: &[SortField]) {
+    group.sort_by(|(a, _), (b, _)| {
+        for sf in order_by {
+            let av = a.get(&sf.field).unwrap_or(&Value::Null);
+            let bv = b.get(&sf.field).unwrap_or(&Value::Null);
+            let ord = match (av, bv) {
+                (Value::Null, Value::Null) => std::cmp::Ordering::Equal,
+                (Value::Null, _) => std::cmp::Ordering::Greater,
+                (_, Value::Null) => std::cmp::Ordering::Less,
+                _ => av.partial_cmp(bv).unwrap_or(std::cmp::Ordering::Equal),
+            };
+            let ord = match sf.order {
+                SortOrder::Asc => ord,
+                SortOrder::Desc => ord.reverse(),
+            };
+            if ord != std::cmp::Ordering::Equal {
+                return ord;
+            }
+        }
+        std::cmp::Ordering::Equal
+    });
+}
+
+/// Wrap a spill read/write fault from the Cull group buffer as a hard
+/// pipeline error. Spill faults are I/O failures, not data errors, so they
+/// abort the run rather than route anywhere.
+fn cull_spill_error(node_name: &str, e: clinker_plan::SpillError) -> PipelineError {
+    PipelineError::Internal {
+        op: "cull",
+        node: node_name.to_string(),
+        detail: format!("group-buffer spill failed: {e}"),
+    }
+}
+
+/// Wrap a predicate-aggregate compile or eval fault as a hard pipeline error.
+/// `bind_cull` already typechecked each rule fragment, so a failure here is a
+/// setup-invariant violation that aborts the run.
+fn cull_predicate_error(node_name: &str, e: crate::aggregation::HashAggError) -> PipelineError {
+    PipelineError::Internal {
+        op: "cull",
+        node: node_name.to_string(),
+        detail: format!("drop_group_when predicate evaluation failed: {e}"),
+    }
+}
+
+/// Hard error for a single correlation group that exceeds the finalize memory
+/// budget. The `drop_group_when` decision needs the whole group observable at
+/// once, so a group bigger than the budget has no in-budget representation —
+/// fail loud rather than OOM on reload.
+fn cull_giant_group_error(node_name: &str, group_bytes: u64, hard_limit: u64) -> PipelineError {
+    PipelineError::Internal {
+        op: "cull",
+        node: node_name.to_string(),
+        detail: format!(
+            "a single Cull correlation group is ~{group_bytes} bytes, which exceeds the memory \
+             budget of {hard_limit} bytes. Cull evaluates its group-level removal predicate \
+             against the whole group at once, so a single group must fit the budget even though \
+             cross-group and ingest-time peaks spill to disk. Raise `memory.limit`, or partition \
+             the input so no one correlation group is this large."
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::Schema;
+
+    fn record(schema: &Arc<Schema>, account: Value) -> Record {
+        Record::new(Arc::clone(schema), vec![account])
+    }
+
+    // The decision aggregate groups by `value_to_group_key`, which keeps an
+    // empty string as a distinct `Str("")` key and maps only a true null to
+    // `Null`. The dispatch buffer MUST key identically, or an empty-string row
+    // and a null row would merge in one but split in the other, and the merged
+    // group would be routed by whichever decision the HashMap inserted last.
+    #[test]
+    fn partition_key_keeps_empty_string_distinct_from_null() {
+        let schema: Arc<Schema> = Arc::new(Schema::new(vec!["account".into()]));
+        let part = vec!["account".to_string()];
+
+        let empty = partition_key("c", &record(&schema, Value::String("".into())), &part).unwrap();
+        let null = partition_key("c", &record(&schema, Value::Null), &part).unwrap();
+        let nonempty =
+            partition_key("c", &record(&schema, Value::String("X".into())), &part).unwrap();
+
+        // Empty-string and null are DISTINCT keys (the divergence bug collapsed
+        // both to Null), and neither equals a non-empty string key.
+        assert_eq!(empty, vec![GroupByKey::Str("".into())]);
+        assert_eq!(null, vec![GroupByKey::Null]);
+        assert_ne!(empty, null);
+        assert_ne!(empty, nonempty);
+
+        // And the keys match the canonical aggregate construction exactly, so
+        // the buffer and the decision aggregate can never diverge.
+        let canon = |v: &Value| {
+            clinker_record::value_to_group_key(v, "account", None, 0)
+                .unwrap()
+                .map(|gk| vec![gk])
+                .unwrap_or_else(|| vec![GroupByKey::Null])
+        };
+        assert_eq!(empty, canon(&Value::String("".into())));
+        assert_eq!(null, canon(&Value::Null));
+    }
+}

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -2708,6 +2708,10 @@ pub(crate) fn dispatch_plan_node(
             crate::executor::reshape_dispatch::dispatch_reshape(ctx, current_dag, node_idx, &node)?;
         }
 
+        PlanNode::Cull { .. } => {
+            crate::executor::cull_dispatch::dispatch_cull(ctx, current_dag, node_idx, &node)?;
+        }
+
         PlanNode::Composition { .. } => {
             crate::executor::composition_dispatch::dispatch_composition(
                 ctx,

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod commit;
 pub(crate) mod composition_dispatch;
 mod context;
 pub(crate) mod correlation_dispatch;
+pub(crate) mod cull_dispatch;
 pub(crate) mod dispatch;
 mod dlq;
 mod ingest;

--- a/crates/clinker-exec/tests/aggregate_integration.rs
+++ b/crates/clinker-exec/tests/aggregate_integration.rs
@@ -883,3 +883,61 @@ nodes:
         "expected aggregate-rejects-scope-emit diagnostic, got:\n{combined}",
     );
 }
+
+#[test]
+fn test_e2e_aggregate_emit_comparison_residual() {
+    // An aggregate `emit` whose value is an ordered comparison over an
+    // aggregate — `count(*) > 1` (numeric) and `max(name) > 'M'` (string).
+    // These exercise the aggregate emit-residual evaluator's ordered
+    // comparison, the same code path a Cull `drop_group_when` uses, so the
+    // result means the same thing here as `>` does in a Transform.
+    let yaml = r#"
+pipeline:
+  name: agg_compare_residual
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: in.csv
+    schema:
+      - { name: team, type: string }
+      - { name: name, type: string }
+- type: aggregate
+  name: by_team
+  input: src
+  config:
+    group_by:
+    - team
+    cxl: 'emit team = team
+
+      emit multiple = count(*) > 1
+
+      emit late_name = max(name) > ''M''
+
+      '
+- type: output
+  name: out
+  input: by_team
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    // team alpha: Alice, Bob → count 2 (>1 true), max 'Bob' (< 'M', false).
+    // team zeta: Zoe → count 1 (>1 false), max 'Zoe' (> 'M', true).
+    let csv = "team,name\nalpha,Alice\nalpha,Bob\nzeta,Zoe\n";
+    let (report, output) = run_single(yaml, csv);
+    assert_eq!(report.dlq_entries.len(), 0, "no DLQ on comparison residual");
+    let lines = sorted_body_lines(&output);
+    // alpha,true,false  and  zeta,false,true
+    assert!(
+        lines.iter().any(|l| l == "alpha,true,false"),
+        "alpha: count(*)>1 true, max(name)>'M' false: {output}"
+    );
+    assert!(
+        lines.iter().any(|l| l == "zeta,false,true"),
+        "zeta: count(*)>1 false, max(name)>'M' true: {output}"
+    );
+}

--- a/crates/clinker-exec/tests/cull_explain_snapshot.rs
+++ b/crates/clinker-exec/tests/cull_explain_snapshot.rs
@@ -1,0 +1,84 @@
+//! Snapshot capture for the Cull node's `--explain` surface.
+//!
+//! Locks in the two-port topology a Cull renders: the main output port and
+//! the `removed_to` side-output port, plus the operator's blocking/spill
+//! arbitration annotation. The committed snapshot is the canonical text; any
+//! change to the explain body that flows through here is reviewed line-by-line
+//! in the `cargo insta review` diff before being accepted into the tree.
+
+use clinker_plan::config::{CompileContext, PipelineConfig, parse_config};
+
+fn render_explain(yaml: &str) -> String {
+    let config: PipelineConfig = parse_config(yaml).expect("parse_config");
+    let plan = config.compile(&CompileContext::default()).expect("compile");
+    let dag = plan.dag();
+    let artifacts = plan.artifacts();
+    dag.explain_text_with_artifacts(&config, artifacts)
+}
+
+/// A source → cull → (main output + audit side output) pipeline. The Cull
+/// removes any account group containing an `error` row, routing the whole
+/// group to the `removed` side output. `--explain` must render both output
+/// ports so the two-output topology is visible.
+#[test]
+fn explain_renders_cull_two_output_ports() {
+    let yaml = r#"
+pipeline:
+  name: cull_explain_demo
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: events.csv
+      schema:
+        - { name: account, type: string }
+        - { name: amount, type: int }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_bad
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: drop_error_groups
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+  - type: output
+    name: kept
+    input: drop_bad
+    config:
+      name: kept
+      type: csv
+      path: kept.csv
+  - type: output
+    name: audit
+    input: drop_bad.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
+    let text = render_explain(yaml);
+
+    // Sanity asserts on the two-port topology, independent of the snapshot:
+    // both the main and `removed` ports must appear, and the Cull's blocking
+    // spill annotation must be present.
+    assert!(
+        text.contains("FORK [cull] 'drop_bad'"),
+        "Cull must render as a two-port fork: {text}"
+    );
+    assert!(
+        text.contains("main → drop_bad"),
+        "the main output port must be rendered: {text}"
+    );
+    assert!(
+        text.contains("removed → drop_bad.removed"),
+        "the removed side-output port must be rendered: {text}"
+    );
+
+    insta::assert_snapshot!("explain_cull_two_output_ports", text);
+}

--- a/crates/clinker-exec/tests/cull_pipeline.rs
+++ b/crates/clinker-exec/tests/cull_pipeline.rs
@@ -1,0 +1,693 @@
+//! Cull node integration tests.
+//!
+//! Exercises the per-correlation-group record removal arm end-to-end against
+//! in-memory CSV readers/writers: the group-level `drop_group_when`
+//! predicate, the kept/removed split across the main and `removed_to`
+//! producer-side ports, the unchanged (unwidened) schema on both ports,
+//! bounded-memory spill under pressure, and idempotent re-run byte-equality.
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// The two rendered output streams of a Cull run: the main port (`main`) and
+/// the `removed_to` side-output port (`removed`), plus the run's cumulative
+/// on-disk spill volume.
+struct CullOutputs {
+    main: String,
+    removed: String,
+    cumulative_spill_bytes: u64,
+    dlq_count: usize,
+}
+
+/// Run a single-source → cull → (main output + audit output) pipeline over
+/// `csv_input`, returning both rendered output streams.
+fn run_cull(yaml: &str, csv_input: &str) -> CullOutputs {
+    let config = parse_config(yaml).expect("fixture pipeline must parse");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("fixture pipeline must compile");
+
+    let primary = config.source_configs().next().unwrap().name.clone();
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        primary,
+        clinker_exec::executor::single_file_reader(
+            "test.csv",
+            Box::new(std::io::Cursor::new(csv_input.as_bytes().to_vec())),
+        ),
+    )]);
+
+    let main_buf = SharedBuffer::new();
+    let removed_buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        (
+            "out".to_string(),
+            Box::new(main_buf.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+        (
+            "audit".to_string(),
+            Box::new(removed_buf.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+    ]);
+
+    let params = PipelineRunParams {
+        execution_id: "cull-test".to_string(),
+        batch_id: "cull-test".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("cull run");
+    CullOutputs {
+        main: main_buf.as_string(),
+        removed: removed_buf.as_string(),
+        cumulative_spill_bytes: report.cumulative_spill_bytes,
+        dlq_count: report.dlq_entries.len(),
+    }
+}
+
+/// Group-error cull: per account, a group containing any row whose status is
+/// `error` is removed (routed to the audit side output); clean groups flow to
+/// the main output. `sum(if status == 'error' then 1 else 0) > 0` is the
+/// group-level "any row is an error" predicate — CXL's bare aggregates are
+/// `sum/count/min/max/avg/collect`, so the disjunction is expressed via a
+/// summed indicator rather than a non-existent bare `any()`.
+const ERROR_CULL_PIPELINE: &str = r#"
+pipeline:
+  name: cull_errors
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: account, type: string }
+        - { name: amount, type: int }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_bad
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: drop_error_groups
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+  - type: output
+    name: out
+    input: drop_bad
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: drop_bad.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
+
+#[test]
+fn error_group_routed_to_removed_clean_group_to_main() {
+    // Account A has one `error` row → the whole A group is removed. Account B
+    // is clean → it flows to the main output.
+    let csv = "account,amount,status\n\
+               A,100,ok\n\
+               A,200,error\n\
+               B,300,ok\n\
+               B,400,ok\n";
+    let out = run_cull(ERROR_CULL_PIPELINE, csv);
+
+    assert_eq!(out.dlq_count, 0, "removed rows are not DLQ entries");
+
+    // Main output: only account B's two rows, none of A's.
+    let main_data: Vec<&str> = out.main.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        main_data.len(),
+        2,
+        "main carries B's two rows: {}",
+        out.main
+    );
+    assert!(out.main.contains("B,300,ok"));
+    assert!(out.main.contains("B,400,ok"));
+    assert!(
+        !out.main.contains("A,"),
+        "the error group must not reach the main output: {}",
+        out.main
+    );
+
+    // Removed output: both of account A's rows (including the clean one — the
+    // WHOLE group is removed when the predicate holds).
+    let removed_data: Vec<&str> = out
+        .removed
+        .lines()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert_eq!(
+        removed_data.len(),
+        2,
+        "removed carries both of A's rows: {}",
+        out.removed
+    );
+    assert!(out.removed.contains("A,100,ok"));
+    assert!(out.removed.contains("A,200,error"));
+    assert!(
+        !out.removed.contains("B,"),
+        "clean group B must not reach the removed output: {}",
+        out.removed
+    );
+}
+
+#[test]
+fn no_trigger_all_to_main_removed_empty() {
+    // No group contains an error → every row flows to the main output and the
+    // removed side output gets only a header (no data rows).
+    let csv = "account,amount,status\n\
+               A,100,ok\n\
+               B,200,ok\n";
+    let out = run_cull(ERROR_CULL_PIPELINE, csv);
+
+    assert_eq!(out.dlq_count, 0);
+    let main_data: Vec<&str> = out.main.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(main_data.len(), 2, "all rows flow to main: {}", out.main);
+    let removed_data: Vec<&str> = out
+        .removed
+        .lines()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert!(
+        removed_data.is_empty(),
+        "no group removed, so the removed output carries no data rows: {}",
+        out.removed
+    );
+}
+
+#[test]
+fn removed_port_carries_unwidened_schema() {
+    // Cull does not widen: the removed output's columns are exactly the input
+    // columns (account, amount, status) — no `$meta.*` or other engine
+    // column leaks onto either port.
+    let csv = "account,amount,status\n\
+               A,100,error\n";
+    let out = run_cull(ERROR_CULL_PIPELINE, csv);
+
+    let removed_header = out.removed.lines().next().unwrap_or("");
+    assert_eq!(
+        removed_header, "account,amount,status",
+        "the removed port carries the unchanged input schema: {removed_header:?}"
+    );
+    assert!(
+        !out.removed.contains("$"),
+        "no engine-stamped column may leak onto the removed port: {}",
+        out.removed
+    );
+}
+
+/// Count-threshold cull parameterized on the memory limit, with the `spill`
+/// backpressure policy so a sub-baseline limit forces the disk path. A group
+/// is removed when it holds more than 100 rows.
+fn count_cull_pipeline(memory_limit: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: cull_count_spill
+  memory: {{ limit: "{memory_limit}", backpressure: spill }}
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - {{ name: account, type: string }}
+        - {{ name: seq, type: int }}
+  - type: cull
+    name: drop_big
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: drop_large_groups
+          drop_group_when: "count(*) > 100"
+  - type: output
+    name: out
+    input: drop_big
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: drop_big.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#
+    )
+}
+
+/// Build a wide input: `small_groups` accounts with a handful of rows each,
+/// plus one "big" account with `big_rows` rows that trips the `count(*) > 100`
+/// removal predicate.
+fn count_input(small_groups: usize, big_rows: usize) -> String {
+    let mut csv = String::from("account,seq\n");
+    for g in 0..small_groups {
+        for r in 0..3 {
+            csv.push_str(&format!("small-{g:05},{r}\n"));
+        }
+    }
+    for r in 0..big_rows {
+        csv.push_str(&format!("BIG,{r}\n"));
+    }
+    csv
+}
+
+#[test]
+fn cull_spills_under_memory_pressure() {
+    // Many small groups plus one big group (150 rows, ~38 KB) that trips the
+    // `count(*) > 100` removal predicate. A 96K budget (≈77K soft) sits below
+    // the total raw-record footprint, so the cross-group resident peak trips
+    // the soft threshold and evicts small groups to disk, yet every single
+    // group — including the big one — still fits the finalize reload under the
+    // 96K hard limit (so this is the spill success path, not the fail-loud
+    // single-giant-group case). The output must be byte-identical to the same
+    // input run with an ample budget (spill is a memory strategy, never a data
+    // transform) AND the run must report on-disk spill volume.
+    let csv = count_input(200, 150);
+
+    let spilled = run_cull(&count_cull_pipeline("96K"), &csv);
+    let in_memory = run_cull(&count_cull_pipeline("512M"), &csv);
+
+    assert_eq!(spilled.dlq_count, 0, "spilling run produces no DLQ entries");
+    assert!(
+        spilled.cumulative_spill_bytes > 0,
+        "the 4K budget must force the disk spill path"
+    );
+    assert_eq!(
+        in_memory.cumulative_spill_bytes, 0,
+        "the 512M budget keeps everything in memory"
+    );
+
+    // Spill is transparent: identical split regardless of budget. Compare
+    // sorted line sets so any reordering across the spill round-trip is caught.
+    let mut spilled_main: Vec<&str> = spilled.main.lines().collect();
+    let mut memory_main: Vec<&str> = in_memory.main.lines().collect();
+    spilled_main.sort_unstable();
+    memory_main.sort_unstable();
+    assert_eq!(
+        spilled_main, memory_main,
+        "spilled main output must match the in-memory run"
+    );
+
+    let mut spilled_removed: Vec<&str> = spilled.removed.lines().collect();
+    let mut memory_removed: Vec<&str> = in_memory.removed.lines().collect();
+    spilled_removed.sort_unstable();
+    memory_removed.sort_unstable();
+    assert_eq!(
+        spilled_removed, memory_removed,
+        "spilled removed output must match the in-memory run"
+    );
+
+    // The BIG group (150 rows > 100) is removed; the 200 small groups (3 rows
+    // each = 600 rows) survive to the main output.
+    let main_data = spilled
+        .main
+        .lines()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .count();
+    assert_eq!(main_data, 600, "all 600 small-group rows survive to main");
+    let removed_data = spilled
+        .removed
+        .lines()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .count();
+    assert_eq!(removed_data, 150, "the 150-row BIG group is removed");
+    assert!(
+        !spilled.main.contains("BIG,"),
+        "the removed BIG group must not reach the main output"
+    );
+}
+
+#[test]
+fn idempotent_rerun_is_byte_stable() {
+    // Re-running Cull over its own main output must be a fixed point: the main
+    // output of run 1 contains only kept groups, none of which trip the
+    // removal predicate, so run 2 keeps all of them and removes nothing.
+    let csv = "account,amount,status\n\
+               A,100,ok\n\
+               A,200,error\n\
+               B,300,ok\n";
+    let first = run_cull(ERROR_CULL_PIPELINE, csv);
+    // Feed the first run's main output back in.
+    let second = run_cull(ERROR_CULL_PIPELINE, &first.main);
+    assert_eq!(
+        second.main, first.main,
+        "re-running over kept groups is a fixed point: {} vs {}",
+        first.main, second.main
+    );
+    let second_removed: Vec<&str> = second
+        .removed
+        .lines()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .collect();
+    assert!(
+        second_removed.is_empty(),
+        "no group is removed on the second pass: {}",
+        second.removed
+    );
+}
+
+/// A Cull whose `drop_group_when` uses ordered comparisons over non-numeric
+/// and nullable aggregates: a string `max(name) > 'M'`, a date
+/// `max(hired) >= '2020-01-01'`, and a group whose comparison operand is null.
+/// These exercise the aggregate residual evaluator's ordered comparison over
+/// String / Date / Null operands — the path that previously hard-errored.
+const TYPED_COMPARE_PIPELINE: &str = r#"
+pipeline:
+  name: cull_typed_compare
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: people
+    config:
+      name: people
+      type: csv
+      path: test.csv
+      schema:
+        - { name: team, type: string }
+        - { name: name, type: string }
+        - { name: hired, type: date }
+  - type: cull
+    name: drop_recent_or_late
+    input: people
+    config:
+      partition_by: [team]
+      removed_to: removed
+      rules:
+        # String ordering: a team whose lexically-greatest name sorts after 'M'.
+        - name: late_alphabet
+          drop_group_when: "max(name) > 'M'"
+        # Date ordering: a team whose most recent hire is in 2020 or later.
+        # `#YYYY-MM-DD#` is the CXL date-literal syntax, so both sides of the
+        # comparison are Dates (a string literal would be a type error).
+        - name: recent_hire
+          drop_group_when: "max(hired) >= #2020-01-01#"
+  - type: output
+    name: out
+    input: drop_recent_or_late
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: drop_recent_or_late.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
+
+#[test]
+fn ordered_comparison_over_string_date_and_null_operands() {
+    // team alpha: names Alice/Bob (max 'Bob' < 'M'), hires 2018/2019 (max
+    // < 2020) → kept. team zeta: name Zoe (> 'M') → removed by the string
+    // rule. team gamma: name Ann (< 'M') but hire 2021 (>= 2020) → removed by
+    // the date rule. team nullteam: a single row whose date is empty (null);
+    // `max(hired)` over the group is null, so `max(hired) >= '2020-01-01'`
+    // compares against null → false (three-valued), and `max(name) = 'Kit'`
+    // < 'M' → false, so the group is KEPT (a null aggregate operand must not
+    // hard-error and must not remove the group).
+    let csv = "team,name,hired\n\
+               alpha,Alice,2018-03-01\n\
+               alpha,Bob,2019-06-01\n\
+               zeta,Zoe,2017-01-01\n\
+               gamma,Ann,2021-09-01\n\
+               nullteam,Kit,\n";
+    let out = run_cull(TYPED_COMPARE_PIPELINE, csv);
+
+    assert_eq!(
+        out.dlq_count, 0,
+        "no null/typed comparison may DLQ or error"
+    );
+
+    // alpha and nullteam kept; zeta and gamma removed.
+    assert!(out.main.contains("alpha,Alice"), "alpha kept: {}", out.main);
+    assert!(
+        out.main.contains("nullteam,Kit"),
+        "the null-aggregate group is kept, not errored: {}",
+        out.main
+    );
+    assert!(
+        !out.main.contains("zeta,") && !out.main.contains("gamma,"),
+        "removed groups must not reach main: {}",
+        out.main
+    );
+    assert!(
+        out.removed.contains("zeta,Zoe"),
+        "zeta removed by the string `max(name) > 'M'` rule: {}",
+        out.removed
+    );
+    assert!(
+        out.removed.contains("gamma,Ann"),
+        "gamma removed by the date `max(hired) >= '2020-01-01'` rule: {}",
+        out.removed
+    );
+    assert!(
+        !out.removed.contains("nullteam,"),
+        "the null-aggregate group must not be removed: {}",
+        out.removed
+    );
+}
+
+/// A Cull partitioned on a JSON column that carries BOTH empty-string and null
+/// values. The dispatch buffer and the decision aggregate must key these as
+/// two distinct groups (not collapse both to null), and each group must get
+/// its own deterministic decision. JSON is used because a CSV empty cell is an
+/// empty string, never a true null — JSON distinguishes `""` from `null`.
+const EMPTY_NULL_PARTITION_PIPELINE: &str = r#"
+pipeline:
+  name: cull_empty_null_partition
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: json
+      path: test.json
+      schema:
+        - { name: account, type: string }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_errors
+    input: rows
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: any_error
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+  - type: output
+    name: out
+    input: drop_errors
+    config:
+      name: out
+      type: json
+      path: out.json
+  - type: output
+    name: audit
+    input: drop_errors.removed
+    config:
+      name: audit
+      type: json
+      path: audit.json
+"#;
+
+#[test]
+fn empty_string_and_null_partitions_are_distinct_deterministic_groups() {
+    // Three distinct partition groups:
+    //   account=""    → one row, status=error      → REMOVED
+    //   account=null  → one row, status=ok          → KEPT
+    //   account="A"   → one row, status=ok          → KEPT
+    // The empty-string and null groups MUST be treated separately: collapsing
+    // them (the divergence bug) would route both by one nondeterministic
+    // decision. Their decisions here differ, so a wrong merge is observable.
+    let json = r#"[
+        {"account": "", "status": "error"},
+        {"account": null, "status": "ok"},
+        {"account": "A", "status": "ok"}
+    ]"#;
+
+    let config = parse_config(EMPTY_NULL_PARTITION_PIPELINE).expect("parse");
+    let plan = config.compile(&CompileContext::default()).expect("compile");
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "rows".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "test.json",
+            Box::new(std::io::Cursor::new(json.as_bytes().to_vec())),
+        ),
+    )]);
+    let main_buf = SharedBuffer::new();
+    let removed_buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([
+        (
+            "out".to_string(),
+            Box::new(main_buf.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+        (
+            "audit".to_string(),
+            Box::new(removed_buf.clone()) as Box<dyn std::io::Write + Send>,
+        ),
+    ]);
+    let params = PipelineRunParams {
+        execution_id: "cull-empty-null".to_string(),
+        batch_id: "cull-empty-null".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("empty/null partition cull run");
+    assert!(report.dlq_entries.is_empty(), "no DLQ entries");
+
+    let main = main_buf.as_string();
+    let removed = removed_buf.as_string();
+
+    // The null and "A" groups are kept; the empty-string group is removed.
+    // The empty-string error row must NOT leak into main (which the
+    // empty↔null merge bug could cause by routing the merged group as "keep").
+    assert!(
+        removed.contains("\"error\""),
+        "the empty-string group (status=error) must be removed: removed={removed}"
+    );
+    assert!(
+        !main.contains("\"error\""),
+        "the error row must not reach main: main={main}"
+    );
+    // The null and "A" groups (both ok) are kept. Two kept rows total.
+    let ok_count = main.matches("\"ok\"").count();
+    assert_eq!(
+        ok_count, 2,
+        "the null-account and \"A\" groups are both kept: main={main}"
+    );
+}
+
+/// A single downstream node that draws from BOTH Cull ports must receive the
+/// union of kept + removed records. Here a Merge consumes `drop_bad`
+/// (main/kept) and `drop_bad.removed` (side/removed); the merged output must
+/// contain every input row exactly once. Before the per-successor
+/// accumulation fix, the second port's admission overwrote the first's, losing
+/// one port's records.
+const BOTH_PORTS_TO_ONE_SUCCESSOR_PIPELINE: &str = r#"
+pipeline:
+  name: cull_both_ports_one_successor
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: account, type: string }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_bad
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: any_error
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+  - type: merge
+    name: recombined
+    inputs: [drop_bad, drop_bad.removed]
+  - type: output
+    name: out
+    input: recombined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn one_successor_drawing_both_ports_receives_the_union() {
+    // Account A has an error → removed; account B is clean → kept. A Merge
+    // draws both Cull ports, so its output must carry all FOUR rows (both of
+    // A's removed rows + both of B's kept rows), each exactly once.
+    let csv = "account,status\n\
+               A,ok\n\
+               A,error\n\
+               B,ok\n\
+               B,ok\n";
+    let config = parse_config(BOTH_PORTS_TO_ONE_SUCCESSOR_PIPELINE).expect("parse");
+    let plan = config.compile(&CompileContext::default()).expect("compile");
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "test.csv",
+            Box::new(std::io::Cursor::new(csv.as_bytes().to_vec())),
+        ),
+    )]);
+    let out_buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(out_buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "cull-both-ports".to_string(),
+        batch_id: "cull-both-ports".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("both-ports merge run");
+    assert!(report.dlq_entries.is_empty(), "no DLQ entries");
+
+    let out = out_buf.as_string();
+    let data: Vec<&str> = out.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        data.len(),
+        4,
+        "the Merge of both Cull ports must carry all four rows (2 removed + 2 kept), \
+         not lose one port to an overwrite: {out}"
+    );
+    // Both A's (removed-port) rows AND both B's (main-port) rows are present.
+    assert_eq!(
+        out.matches("A,").count(),
+        2,
+        "both removed-port rows (account A) survive: {out}"
+    );
+    assert_eq!(
+        out.matches("B,").count(),
+        2,
+        "both main-port rows (account B) survive: {out}"
+    );
+}

--- a/crates/clinker-exec/tests/snapshots/cull_explain_snapshot__explain_cull_two_output_ports.snap
+++ b/crates/clinker-exec/tests/snapshots/cull_explain_snapshot__explain_cull_two_output_ports.snap
@@ -1,0 +1,88 @@
+---
+source: crates/clinker-exec/tests/cull_explain_snapshot.rs
+expression: text
+---
+=== Execution Plan ===
+
+Mode: Streaming
+Indices to build: 0
+Transforms: 0
+Output projections: 2
+DAG nodes: 4
+arbitration: BackPressurePreferred -> Priority
+
+Source DAG:
+  Tier 0: events
+
+=== Physical Properties ===
+
+source.events:
+  ordering: <none>
+  ordering_provenance: NoOrdering
+  partitioning: Single
+  partitioning_provenance: SingleStream
+  buffer: materialized
+  arbitration: spill_priority=N/A, can_back_pressure=true, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
+
+cull.drop_bad:
+  ordering: <none>
+  ordering_provenance: NoOrdering
+  partitioning: Single
+  partitioning_provenance: SingleStream
+  buffer: materialized
+  arbitration: spill_priority=15, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
+
+output.audit:
+  ordering: <none>
+  ordering_provenance: NoOrdering
+  partitioning: Single
+  partitioning_provenance: SingleStream
+  buffer: streaming
+  arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
+
+output.kept:
+  ordering: <none>
+  ordering_provenance: NoOrdering
+  partitioning: Single
+  partitioning_provenance: SingleStream
+  buffer: streaming
+  arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
+
+=== Buffer Edges ===
+
+edge source.events -> cull.drop_bad:
+  buffer: node_buffer (slot=0)
+  arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
+
+edge cull.drop_bad -> output.audit:
+  buffer: node_buffer (slot=1)
+  arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: cull)
+
+edge cull.drop_bad -> output.kept:
+  buffer: node_buffer (slot=1)
+  arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: cull)
+
+=== Estimated Spill Volume ===
+
+Estimated spill volume (per blocking stage):
+  [cull] drop_bad partition_by=[account] rules=1 removed_to=removed → unknown
+  Total (known stages): 0B (excludes stages whose volume is unknown at plan time — a network source, a missing or unreadable input, or a glob/regex matcher whose discovery fails)
+
+=== CXL Expressions ===
+
+=== Type Annotations ===
+
+
+=== Memory Budget ===
+
+Memory limit: default
+Worker threads: 4
+
+=== DAG Topology ===
+
+  ● [source] events (line:7)
+  ◆ FORK [cull] 'drop_bad' (line:17)
+  ├──> main → drop_bad
+  ├──> removed → drop_bad.removed
+  │ [output] audit (line:33)
+  │ [output] kept (line:26)

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -738,6 +738,7 @@ impl PipelineConfig {
                 | PipelineNode::Output { .. }
                 | PipelineNode::Merge { .. }
                 | PipelineNode::Reshape { .. }
+                | PipelineNode::Cull { .. }
                 | PipelineNode::Composition { .. }
                 | PipelineNode::Combine { .. } => None,
             })
@@ -1068,6 +1069,7 @@ impl PipelineConfig {
                 | PipelineNode::Aggregate { header, .. }
                 | PipelineNode::Route { header, .. }
                 | PipelineNode::Reshape { header, .. }
+                | PipelineNode::Cull { header, .. }
                 | PipelineNode::Output { header, .. } => {
                     wire(&input_full_reference(&header.input.value), None);
                 }
@@ -2079,6 +2081,7 @@ fn resolve_all_input_references(
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
             | PipelineNode::Reshape { header, .. }
+            | PipelineNode::Cull { header, .. }
             | PipelineNode::Output { header, .. } => {
                 emit(consumer_name, None, &header.input);
             }
@@ -2741,6 +2744,22 @@ pub(crate) fn lower_node_to_plan_node(
             // (E200 on a rule predicate / assignment) — skip lowering.
             artifacts.typed.get(name)?;
             Some(crate::plan::execution::PlanNode::Reshape {
+                name: name.to_string(),
+                span,
+                config: config.clone(),
+                output_schema: schema_from_bound(name),
+            })
+        }
+        // Cull lowers to PlanNode::Cull carrying the parsed config and the
+        // (unchanged) upstream output schema. The executor recompiles each
+        // rule's `drop_group_when` predicate against the live input schema
+        // at dispatch time, so no per-rule typed program is threaded
+        // through CompileArtifacts.
+        PipelineNode::Cull { config, .. } => {
+            // A missing typed entry means bind_schema rejected the node
+            // (E200 on a rule predicate / removed_to) — skip lowering.
+            artifacts.typed.get(name)?;
+            Some(crate::plan::execution::PlanNode::Cull {
                 name: name.to_string(),
                 span,
                 config: config.clone(),

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -129,6 +129,23 @@ pub enum PipelineNode {
         header: NodeHeader,
         config: ReshapeBody,
     },
+    /// Per-correlation-group record removal with a side-output port.
+    ///
+    /// Groups records by `partition_by`, evaluates a group-level
+    /// `drop_group_when` predicate over each whole group, and routes every
+    /// record of a dropped group to the `removed_to` output port while
+    /// untriggered groups flow to the main output port. Distinct from
+    /// Route (which fans out per-record on a row predicate) and from
+    /// Reshape (which mutates and synthesizes within a group): Cull removes
+    /// whole correlation groups based on an aggregate property of the
+    /// group, and emits the removed rows on a first-class producer-side
+    /// port rather than discarding them or routing to the DLQ. Both ports
+    /// carry the unchanged upstream schema — Cull does not widen.
+    Cull {
+        #[serde(flatten)]
+        header: NodeHeader,
+        config: CullBody,
+    },
     /// Composition call-site node. Lowered to `PlanNode::Composition` in
     /// Stage 5; body nodes live in `CompileArtifacts.composition_bodies`
     /// keyed by the `body` handle.
@@ -357,6 +374,13 @@ impl<'de> Deserialize<'de> for PipelineNode {
                         let (header, config) = payload.into_variant_parts();
                         Ok(PipelineNode::Reshape { header, config })
                     }
+                    "cull" => {
+                        let payload = CullPayload::deserialize(
+                            de::value::MapAccessDeserializer::new(dispatch),
+                        )?;
+                        let (header, config) = payload.into_variant_parts();
+                        Ok(PipelineNode::Cull { header, config })
+                    }
                     "composition" => {
                         let payload = CompositionPayload::deserialize(
                             de::value::MapAccessDeserializer::new(dispatch),
@@ -374,6 +398,7 @@ impl<'de> Deserialize<'de> for PipelineNode {
                             "combine",
                             "output",
                             "reshape",
+                            "cull",
                             "composition",
                         ],
                     )),
@@ -560,6 +585,34 @@ impl ReshapePayload {
     }
 }
 
+// ---- Cull ------------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CullPayload {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    input: crate::yaml::Spanned<crate::config::node_header::NodeInput>,
+    #[serde(default, rename = "_notes")]
+    notes: Option<serde_json::Value>,
+    config: CullBody,
+}
+
+impl CullPayload {
+    fn into_variant_parts(self) -> (NodeHeader, CullBody) {
+        (
+            NodeHeader {
+                name: self.name,
+                description: self.description,
+                input: self.input,
+                notes: self.notes,
+            },
+            self.config,
+        )
+    }
+}
+
 // ---- Merge -----------------------------------------------------------
 
 #[derive(Deserialize)]
@@ -673,6 +726,7 @@ impl PipelineNode {
             | PipelineNode::Route { header, .. }
             | PipelineNode::Output { header, .. }
             | PipelineNode::Reshape { header, .. }
+            | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => &header.name,
             PipelineNode::Merge { header, .. } => &header.name,
             PipelineNode::Combine { header, .. } => &header.name,
@@ -690,6 +744,7 @@ impl PipelineNode {
             | PipelineNode::Route { header, .. }
             | PipelineNode::Output { header, .. }
             | PipelineNode::Reshape { header, .. }
+            | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => Some(header.input.value.name()),
             PipelineNode::Source { .. }
             | PipelineNode::Merge { .. }
@@ -721,6 +776,7 @@ impl PipelineNode {
             | PipelineNode::Route { header, .. }
             | PipelineNode::Output { header, .. }
             | PipelineNode::Reshape { header, .. }
+            | PipelineNode::Cull { header, .. }
             | PipelineNode::Composition { header, .. } => vec![header.input.value.name()],
             PipelineNode::Merge { header, .. } => {
                 header.inputs.iter().map(|i| i.value.name()).collect()
@@ -761,6 +817,7 @@ impl PipelineNode {
             PipelineNode::Combine { .. } => "combine",
             PipelineNode::Output { .. } => "output",
             PipelineNode::Reshape { .. } => "reshape",
+            PipelineNode::Cull { .. } => "cull",
             PipelineNode::Composition { .. } => "composition",
         }
     }
@@ -1386,6 +1443,55 @@ pub enum CopyFrom {
     Trigger,
     /// Start from an all-null row; `overrides` supplies every value.
     None,
+}
+
+/// Cull variant body. A blocking grouping operator: it buffers each
+/// correlation group (keyed by `partition_by`), evaluates each rule's
+/// group-level `drop_group_when` predicate over the whole group, and
+/// routes every record of a triggered group to the `removed_to` side
+/// output while untriggered groups flow to the main output.
+///
+/// Cull does not widen — both the main and `removed_to` ports carry the
+/// unchanged upstream schema. The two ports are first-class producer-side
+/// outputs (the Route fan-out seam): the main output is referenced as the
+/// node name, the side output as `<cull>.<removed_to>`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CullBody {
+    /// Correlation-key fields. Records are grouped by the tuple of these
+    /// column values; every rule's predicate observes one whole group.
+    pub partition_by: Vec<String>,
+    /// Optional within-group ordering. Applied to each group before its
+    /// predicate runs, so an order-sensitive `drop_group_when` (e.g. one
+    /// reading the first or last row) is deterministic.
+    #[serde(default)]
+    pub order_by: Vec<crate::config::SortField>,
+    /// Declarative removal rules. A group is removed (routed to
+    /// `removed_to`) when any rule's `drop_group_when` predicate holds.
+    pub rules: Vec<CullRule>,
+    /// Name of the side-output port that carries removed groups' records.
+    /// Referenced downstream as `<cull>.<removed_to>`. Non-empty and
+    /// distinct from the main output (enforced at compile time).
+    pub removed_to: String,
+}
+
+/// One declarative Cull rule: a group-level removal predicate.
+///
+/// `drop_group_when` is a CXL boolean expression evaluated in **aggregate
+/// context** over the whole correlation group (group-by = `partition_by`), so
+/// it may use CXL's aggregate functions — `count(*)`, `sum(...)`, `min`/`max`,
+/// `avg`. CXL has no bare `any()` aggregate, so "remove the group if any row
+/// matches" is written `sum(if <cond> then 1 else 0) > 0`. When the predicate
+/// holds for a group, every record of that group is routed to the `removed_to`
+/// port.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CullRule {
+    /// Rule name, used in diagnostics.
+    pub name: String,
+    /// CXL boolean predicate evaluated in aggregate context over the
+    /// whole group. A group for which this holds is removed.
+    pub drop_group_when: CxlSource,
 }
 
 /// The scope a Transform's `declares:` entry writes to. Each scope is

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -33,8 +33,8 @@ use crate::config::composition::{
 };
 use crate::config::node_header::CombineHeader;
 use crate::config::pipeline_node::{
-    CombineBody, CopyFrom, MatchMode, OnUnmapped, PipelineNode, PropagateCkSpec, ReshapeBody,
-    SchemaDecl,
+    CombineBody, CopyFrom, CullBody, MatchMode, OnUnmapped, PipelineNode, PropagateCkSpec,
+    ReshapeBody, SchemaDecl,
 };
 use crate::plan::combine::{
     CombineInput, DecomposedPredicate, decompose_predicate, select_driving_input,
@@ -1456,6 +1456,173 @@ fn bind_reshape(
         .insert(name.to_string(), Arc::new(synthetic_typed_program(out)));
 }
 
+/// Borrowed inputs for binding one `PipelineNode::Cull`.
+///
+/// Bundles the read-only node identity (name/config/upstream/span/vars)
+/// so `bind_cull` keeps only the mutable sinks (diags/artifacts/schema
+/// map) as loose parameters, mirroring `ReshapeNodeBinding`.
+struct CullNodeBinding<'a> {
+    name: &'a str,
+    config: &'a CullBody,
+    upstream: &'a Row,
+    span: Span,
+    scoped_vars: &'a cxl::resolve::ScopedVarsRegistry,
+}
+
+/// Bind a `PipelineNode::Cull`: validate `partition_by` / `order_by`
+/// against the upstream schema, typecheck each rule's `drop_group_when`
+/// predicate in aggregate context, validate the `removed_to` port name,
+/// and publish the (unchanged) upstream row as the node's output.
+///
+/// Validation enforced here (compile errors, code E200):
+/// - every `partition_by` and `order_by` field exists upstream;
+/// - at least one removal rule is declared;
+/// - each rule's `drop_group_when` predicate typechecks against the
+///   upstream row in aggregate context (group-by = `partition_by`), so a
+///   group-level predicate like `count(*) > 100` is well-formed;
+/// - `removed_to` is non-empty and is not the node's own name (the main
+///   output port), so the two output ports are distinguishable.
+///
+/// Cull does not widen: both the main and `removed_to` output ports carry
+/// the unchanged upstream row, so the bound output schema equals upstream.
+fn bind_cull(
+    node: &CullNodeBinding<'_>,
+    diags: &mut Vec<Diagnostic>,
+    artifacts: &mut CompileArtifacts,
+    schema_by_name: &mut HashMap<String, Row>,
+) {
+    let &CullNodeBinding {
+        name,
+        config,
+        upstream,
+        span,
+        scoped_vars,
+    } = node;
+    let mut ok = true;
+
+    // `partition_by` fields must exist upstream.
+    for pk in &config.partition_by {
+        if !upstream.has_field(pk) {
+            diags.push(
+                Diagnostic::error(
+                    "E200",
+                    format!(
+                        "cull {name:?}: partition_by field {pk:?} is not present in the \
+                         upstream schema"
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                )
+                .with_help(
+                    "declare the column in the source's `schema:` block or emit it from an \
+                     upstream transform",
+                ),
+            );
+            ok = false;
+        }
+    }
+
+    // `order_by` fields must exist upstream.
+    for sf in &config.order_by {
+        if !upstream.has_field(&sf.field) {
+            diags.push(Diagnostic::error(
+                "E200",
+                format!(
+                    "cull {name:?}: order_by field {:?} is not present in the upstream schema",
+                    sf.field
+                ),
+                LabeledSpan::primary(span, String::new()),
+            ));
+            ok = false;
+        }
+    }
+
+    // `removed_to` names a distinct side-output port. An empty name has
+    // no resolvable edge, and reusing the node's own name would collide
+    // the side-output port with the main output, so both are rejected.
+    if config.removed_to.trim().is_empty() {
+        diags.push(
+            Diagnostic::error(
+                "E200",
+                format!("cull {name:?}: removed_to must name a non-empty side-output port"),
+                LabeledSpan::primary(span, String::new()),
+            )
+            .with_help(
+                "set `removed_to:` to the port name downstream nodes draw removed rows from",
+            ),
+        );
+        ok = false;
+    } else if config.removed_to == name {
+        diags.push(
+            Diagnostic::error(
+                "E200",
+                format!(
+                    "cull {name:?}: removed_to {:?} collides with the node's own name (the main \
+                     output port) — the two output ports must be distinguishable",
+                    config.removed_to
+                ),
+                LabeledSpan::primary(span, String::new()),
+            )
+            .with_help("rename `removed_to:` to a distinct port name"),
+        );
+        ok = false;
+    }
+
+    // A Cull with no removal rule never removes anything — it is a no-op
+    // operator with two ports, almost certainly an authoring mistake. Reject
+    // it rather than silently route every record to the main port.
+    if config.rules.is_empty() {
+        diags.push(
+            Diagnostic::error(
+                "E200",
+                format!("cull {name:?}: rules must contain at least one removal rule"),
+                LabeledSpan::primary(span, String::new()),
+            )
+            .with_help(
+                "add a rule with a `drop_group_when:` predicate, or remove the Cull node entirely",
+            ),
+        );
+        ok = false;
+    }
+
+    // Each rule's `drop_group_when` typechecks in aggregate context over the
+    // whole group (group-by = `partition_by`), so an aggregate predicate such
+    // as `count(*) > 100` or `sum(if status == 'error' then 1 else 0) > 0` is
+    // well-formed. The predicate is wrapped in a single `emit` so it
+    // typechecks through the same aggregate-mode path the Aggregate node uses;
+    // the bound result is discarded here (the executor recompiles per node at
+    // dispatch time, the Route condition-compile seam).
+    let agg_mode = AggregateMode::GroupBy {
+        group_by_fields: config.partition_by.iter().cloned().collect(),
+    };
+    for rule in &config.rules {
+        let drop_src = format!("emit __drop = {}", rule.drop_group_when.source);
+        if let Err(d) = typecheck_cxl(
+            &format!("{name}:{}:drop_group_when", rule.name),
+            &drop_src,
+            upstream,
+            agg_mode.clone(),
+            span,
+            scoped_vars,
+        ) {
+            diags.push(d);
+            ok = false;
+        }
+    }
+
+    if !ok {
+        return;
+    }
+
+    // Cull does not widen: both output ports carry the unchanged upstream
+    // row. Publish it as the node's output so downstream binding sees the
+    // identical schema on the main and `removed_to` ports.
+    let out = upstream.clone();
+    schema_by_name.insert(name.to_string(), out.clone());
+    artifacts
+        .typed
+        .insert(name.to_string(), Arc::new(synthetic_typed_program(out)));
+}
+
 // ─── Internal recursive bind_schema ─────────────────────────────────
 
 /// Internal recursive bind_schema. Walks nodes in topological order,
@@ -1857,6 +2024,23 @@ fn bind_schema_inner(
                     let upstream = upstream.clone();
                     bind_reshape(
                         &ReshapeNodeBinding {
+                            name: &name,
+                            config,
+                            upstream: &upstream,
+                            span,
+                            scoped_vars: &bind_ctx.scoped_vars,
+                        },
+                        diags,
+                        artifacts,
+                        schema_by_name,
+                    );
+                }
+            }
+            PipelineNode::Cull { header, config } => {
+                if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
+                    let upstream = upstream.clone();
+                    bind_cull(
+                        &CullNodeBinding {
                             name: &name,
                             config,
                             upstream: &upstream,
@@ -2296,6 +2480,7 @@ fn bind_composition(
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
             | PipelineNode::Reshape { header, .. }
+            | PipelineNode::Cull { header, .. }
             | PipelineNode::Output { header, .. } => {
                 let r = match &header.input.value {
                     crate::config::node_header::NodeInput::Single(s) => s.clone(),
@@ -2408,6 +2593,7 @@ fn bind_composition(
             | PipelineNode::Aggregate { header, .. }
             | PipelineNode::Route { header, .. }
             | PipelineNode::Reshape { header, .. }
+            | PipelineNode::Cull { header, .. }
             | PipelineNode::Output { header, .. } => {
                 vec![match &header.input.value {
                     crate::config::node_header::NodeInput::Single(s) => s.clone(),

--- a/crates/clinker-plan/src/plan/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/deferred_region.rs
@@ -1049,6 +1049,19 @@ fn propagate_through_node_for_body(node: &PlanNode, set: &mut HashSet<String>) {
                 set.insert(sf.field.clone());
             }
         }
+        PlanNode::Cull { config, .. } => {
+            // Cull observes the whole correlation group to evaluate its
+            // group-level removal predicate: it needs its partition_by and
+            // order_by columns retained in the buffer. The per-rule
+            // predicate column reads narrow further, but the partition/order
+            // superset is sound.
+            for p in &config.partition_by {
+                set.insert(p.clone());
+            }
+            for sf in &config.order_by {
+                set.insert(sf.field.clone());
+            }
+        }
         PlanNode::Source { .. } | PlanNode::Output { .. } => {
             // Sources and Outputs are region boundaries; never visited
             // as upstream in the propagation walk.

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -1369,6 +1369,17 @@ impl ExecutionPlanDag {
                 PlanNode::Reshape { .. } => {
                     out.push_str(&format!("  ◇ {}{line_suffix}\n", node.display_name()));
                 }
+                PlanNode::Cull { config, name, .. } => {
+                    // Fork rendering: Cull is a two-port producer like Route.
+                    // Show the main and side-output ports so the two-output
+                    // topology is visible in the plan.
+                    out.push_str(&format!("  ◆ FORK [cull] '{name}'{line_suffix}\n"));
+                    out.push_str(&format!("  ├──> main → {name}\n"));
+                    out.push_str(&format!(
+                        "  ├──> {removed} → {name}.{removed}\n",
+                        removed = config.removed_to
+                    ));
+                }
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }
                 | PlanNode::Output { .. }
@@ -1494,6 +1505,17 @@ impl ExecutionPlanDag {
                     // Sibling rendering: Reshape is a grouping operator;
                     // it shares the `◇` glyph family with Aggregate.
                     out.push_str(&format!("  ◇ {}{line_suffix}\n", node.display_name()));
+                }
+                PlanNode::Cull { config, name, .. } => {
+                    // Fork rendering: Cull is a two-port producer like Route,
+                    // so it gets the `◆ FORK` glyph and one line per output
+                    // port (main + the `removed_to` side output).
+                    out.push_str(&format!("  ◆ FORK [cull] '{name}'{line_suffix}\n"));
+                    out.push_str(&format!("  ├──> main → {name}\n"));
+                    out.push_str(&format!(
+                        "  ├──> {removed} → {name}.{removed}\n",
+                        removed = config.removed_to
+                    ));
                 }
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -194,6 +194,31 @@ pub enum PlanNode {
         #[serde(skip)]
         output_schema: Arc<Schema>,
     },
+    /// Per-correlation-group record removal with a side-output port.
+    ///
+    /// Blocking grouping operator: buffers each `partition_by` group,
+    /// evaluates each rule's group-level `drop_group_when` predicate over
+    /// the whole group, and routes every record of a dropped group to the
+    /// `removed_to` producer-side output port while untriggered groups flow
+    /// to the main output port. Cull does not widen — both ports carry the
+    /// unchanged upstream schema. The executor compiles each rule's
+    /// predicate against the live input schema at dispatch time (the Route
+    /// condition-compile seam), so the plan node carries only the parsed
+    /// `config` and the unchanged output schema.
+    Cull {
+        name: String,
+        #[serde(skip)]
+        span: Span,
+        /// Parsed Cull configuration (`partition_by` / `order_by` /
+        /// `rules` / `removed_to`). Consumed by the executor's cull
+        /// dispatch arm.
+        config: crate::config::pipeline_node::CullBody,
+        /// Output schema, equal to the upstream schema (Cull does not
+        /// widen). Both the main and `removed_to` ports carry it.
+        /// Populated by `bind_schema`.
+        #[serde(skip)]
+        output_schema: Arc<Schema>,
+    },
     /// Planner-synthesized sort enforcer.
     ///
     /// Inserted by `ExecutionPlanDag::insert_enforcer_sorts` on edges feeding
@@ -429,6 +454,7 @@ impl PlanNode {
             | PlanNode::Merge { name, .. }
             | PlanNode::Output { name, .. }
             | PlanNode::Reshape { name, .. }
+            | PlanNode::Cull { name, .. }
             | PlanNode::Sort { name, .. }
             | PlanNode::Aggregation { name, .. }
             | PlanNode::Composition { name, .. }
@@ -447,6 +473,7 @@ impl PlanNode {
             | PlanNode::Merge { span, .. }
             | PlanNode::Output { span, .. }
             | PlanNode::Reshape { span, .. }
+            | PlanNode::Cull { span, .. }
             | PlanNode::Sort { span, .. }
             | PlanNode::Aggregation { span, .. }
             | PlanNode::Composition { span, .. }
@@ -492,6 +519,7 @@ impl PlanNode {
             | PlanNode::Combine { output_schema, .. }
             | PlanNode::Composition { output_schema, .. }
             | PlanNode::Reshape { output_schema, .. }
+            | PlanNode::Cull { output_schema, .. }
             | PlanNode::Merge { output_schema, .. } => output_schema
                 .columns()
                 .iter()
@@ -527,6 +555,7 @@ impl PlanNode {
             | PlanNode::Combine { output_schema, .. }
             | PlanNode::Composition { output_schema, .. }
             | PlanNode::Reshape { output_schema, .. }
+            | PlanNode::Cull { output_schema, .. }
             | PlanNode::Merge { output_schema, .. } => Some(output_schema),
             PlanNode::Route { .. }
             | PlanNode::Output { .. }
@@ -616,6 +645,7 @@ impl PlanNode {
             PlanNode::Combine { .. } => "combine",
             PlanNode::CorrelationCommit { .. } => "correlation_commit",
             PlanNode::Reshape { .. } => "reshape",
+            PlanNode::Cull { .. } => "cull",
         }
     }
 
@@ -627,14 +657,15 @@ impl PlanNode {
     /// The named output ports this node emits to, or `None` when the node
     /// has a single unnamed output.
     ///
-    /// Producer-side counterpart to a node's named inputs. A `Route` emits
-    /// one output per branch plus its `default`; the dispatcher tags each
-    /// outgoing edge with the [`PlanEdge::producer_port`] it carries, so a
-    /// record assigned to branch `b` flows down exactly the edges tagged
-    /// `b`. The returned set is deduplicated and preserves branch
-    /// declaration order, appending `default` last when it is not already a
-    /// branch name. Every other variant returns `None` (single output).
-    /// Future multi-output operators add their own arm here.
+    /// Producer-side counterpart to a node's named inputs. Two variants emit
+    /// named ports: a `Route` emits one output per branch plus its `default`,
+    /// and a `Cull` emits `main` (kept groups) plus its `removed_to` port
+    /// (removed groups). The dispatcher tags each outgoing edge with the
+    /// [`PlanEdge::producer_port`] it carries, so a record assigned to port
+    /// `p` flows down exactly the edges tagged `p`. The Route set is
+    /// deduplicated and preserves branch declaration order, appending
+    /// `default` last when it is not already a branch name. Every other
+    /// variant returns `None` (single output).
     pub fn output_ports(&self) -> Option<Vec<&str>> {
         match self {
             PlanNode::Route {
@@ -646,6 +677,12 @@ impl PlanNode {
                 }
                 Some(ports)
             }
+            // Cull is the second producer-side multi-output operator: the
+            // main port carries kept groups, the `removed_to` port carries
+            // removed groups. A downstream node draws kept rows by
+            // referencing the node name (bare) and removed rows by
+            // referencing `<cull>.<removed_to>`.
+            PlanNode::Cull { config, .. } => Some(vec!["main", config.removed_to.as_str()]),
             _ => None,
         }
     }
@@ -669,6 +706,14 @@ impl PlanNode {
                     "[reshape] {name} partition_by=[{}] rules={}",
                     config.partition_by.join(", "),
                     config.rules.len()
+                )
+            }
+            PlanNode::Cull { name, config, .. } => {
+                format!(
+                    "[cull] {name} partition_by=[{}] rules={} removed_to={}",
+                    config.partition_by.join(", "),
+                    config.rules.len(),
+                    config.removed_to
                 )
             }
             PlanNode::Sort { name, .. } => format!("[sort] {name}"),
@@ -901,6 +946,18 @@ pub(super) fn arbitration_class(node: &PlanNode) -> ArbitrationClass {
             spill_priority: Some(15),
             can_back_pressure: false,
         },
+        // Cull buffers every input record per correlation group before any
+        // group-level `drop_group_when` predicate can decide keep-vs-remove
+        // (an aggregate property of the whole group cannot be folded
+        // incrementally into a keep/remove decision), then spills the raw
+        // input records via the same whole-record round-trip Reshape uses.
+        // Priority `15` matches Reshape — a grouped record buffer costlier
+        // to evict than grace partitions but cheaper than an external-sort
+        // merge. No upstream channel to gate, so it cannot back-pressure.
+        PlanNode::Cull { .. } => ArbitrationClass {
+            spill_priority: Some(15),
+            can_back_pressure: false,
+        },
         // Stateless or sink stages register no spillable consumer:
         // Transform / Route / Merge stream record-at-a-time, Output is a
         // sink, Composition is a structural wrapper whose body nodes
@@ -970,6 +1027,10 @@ pub(super) fn writes_spill_files(node: &PlanNode) -> bool {
         // the budget and re-runs synthesis on reload, so it writes real spill
         // files and must appear in the disk-spill projection surfaces.
         PlanNode::Reshape { .. } => true,
+        // Cull spills its raw per-group input records when the buffer trips
+        // the budget and re-splits on reload, so it writes real spill files
+        // and must appear in the disk-spill projection surfaces.
+        PlanNode::Cull { .. } => true,
         PlanNode::Source { .. }
         | PlanNode::Transform { .. }
         | PlanNode::Route { .. }

--- a/crates/clinker-plan/src/plan/execution/scheduling.rs
+++ b/crates/clinker-plan/src/plan/execution/scheduling.rs
@@ -1037,6 +1037,25 @@ fn compute_one(
             }
         }
 
+        PlanNode::Cull { .. } => {
+            // Cull removes whole correlation groups but neither reorders nor
+            // synthesizes rows; the records that survive keep their relative
+            // order. The buffer drains group-by-group, though, so the
+            // cross-group emission order is not the input order — emit
+            // `NoOrdering` rather than claiming preservation. Group identity
+            // is preserved (`partition_by` covers every visible CK field), so
+            // the parent CK set flows through unchanged on both output ports.
+            NodeProperties {
+                ordering: Ordering {
+                    sort_order: None,
+                    provenance: OrderingProvenance::NoOrdering,
+                },
+                partitioning: parent_partitioning(),
+                ck_set: preserve_parent_ck_set(),
+                ..NodeProperties::unordered_single()
+            }
+        }
+
         PlanNode::Combine {
             name, propagate_ck, ..
         } => {

--- a/crates/clinker-plan/src/plan/tests/ck_lattice.rs
+++ b/crates/clinker-plan/src/plan/tests/ck_lattice.rs
@@ -966,6 +966,7 @@ fn assert_every_node_has_properties(plan: &crate::plan::execution::ExecutionPlan
                 PlanNode::Combine { .. } => "combine",
                 PlanNode::Output { .. } => "output",
                 PlanNode::Reshape { .. } => "reshape",
+                PlanNode::Cull { .. } => "cull",
                 PlanNode::Composition { .. } => "composition",
                 PlanNode::CorrelationCommit { .. } => "correlation_commit",
             }

--- a/crates/clinker-plan/src/plan/tests/cull_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_validation.rs
@@ -1,0 +1,239 @@
+//! Plan-time validation for the Cull node's `bind_schema` guards.
+//!
+//! Each guard rejects a malformed Cull at compile time with an `E200`
+//! diagnostic. Because every guard shares the `E200` code, these tests pin
+//! the distinctive message substring each one produces, so a future edit
+//! that swaps two messages — or drops a guard entirely — fails here rather
+//! than letting a malformed pipeline plan silently.
+//!
+//! Guards covered (one negative path each):
+//! - `partition_by` names a field absent from the upstream schema.
+//! - `order_by` names a field absent from the upstream schema.
+//! - `removed_to` is empty.
+//! - `removed_to` collides with the node's own name (the main output port).
+//! - `drop_group_when` references a field absent from the upstream schema.
+
+use crate::config::{CompileContext, parse_config};
+
+/// Compile `yaml`, expecting failure, and return `(code, message)` pairs.
+fn compile_diagnostics(yaml: &str) -> Vec<(String, String)> {
+    let config = parse_config(yaml).expect("parse_config");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("compile should fail");
+    diags
+        .iter()
+        .map(|d| (d.code.clone(), d.message.clone()))
+        .collect()
+}
+
+/// Assert that some emitted `E200` carries every substring in `needles`.
+fn assert_e200_contains(diags: &[(String, String)], needles: &[&str]) {
+    let found = diags
+        .iter()
+        .filter(|(code, _)| code == "E200")
+        .any(|(_, msg)| needles.iter().all(|n| msg.contains(n)));
+    assert!(
+        found,
+        "expected an E200 containing all of {needles:?}, got {diags:?}"
+    );
+}
+
+/// Wrap a cull `config:` block in a source → cull → output pipeline whose
+/// upstream schema is `id: string, amount: int, status: string` and whose
+/// partition key is `id`. The main output draws from `cd` (bare) and the
+/// side output from `cd.removed` — but malformed fixtures here fail at
+/// bind time before the side-output wiring matters.
+fn pipeline_with_cull_config(cull_config: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: cull_validation
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: id, type: string }}
+        - {{ name: amount, type: int }}
+        - {{ name: status, type: string }}
+  - type: cull
+    name: cd
+    input: src
+    config:
+{cull_config}
+  - type: output
+    name: out
+    input: cd
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: cd.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#
+    )
+}
+
+#[test]
+fn partition_by_unknown_field_rejected() {
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [nonexistent]
+      removed_to: removed
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &[
+            "partition_by field",
+            "nonexistent",
+            "not present in the upstream schema",
+        ],
+    );
+}
+
+#[test]
+fn order_by_unknown_field_rejected() {
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [id]
+      order_by:
+        - { field: nonexistent, order: asc }
+      removed_to: removed
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &[
+            "order_by field",
+            "nonexistent",
+            "not present in the upstream schema",
+        ],
+    );
+}
+
+#[test]
+fn empty_removed_to_rejected() {
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [id]
+      removed_to: ""
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &["removed_to must name a non-empty side-output port"],
+    );
+}
+
+#[test]
+fn removed_to_colliding_with_node_name_rejected() {
+    // `removed_to: cd` collides with the node's own name (the main output
+    // port), so the two output ports would be indistinguishable.
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [id]
+      removed_to: cd
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(
+        &diags,
+        &[
+            "removed_to",
+            "collides with the node's own name",
+            "must be distinguishable",
+        ],
+    );
+}
+
+#[test]
+fn drop_group_when_unknown_field_rejected() {
+    // The predicate references a column absent from the upstream schema, so
+    // the aggregate-context typecheck fails.
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(nonexistent) > 0""#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    // The typecheck reports the unknown field; the exact wording comes from
+    // the CXL resolver, so pin the field name and the node label.
+    let found = diags
+        .iter()
+        .any(|(code, msg)| code == "E200" && msg.contains("nonexistent"));
+    assert!(
+        found,
+        "expected an E200 naming the unknown field `nonexistent`, got {diags:?}"
+    );
+}
+
+#[test]
+fn empty_rules_rejected() {
+    // A Cull with no removal rule never removes anything — a no-op two-port
+    // operator, almost certainly an authoring mistake — so it is rejected.
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [id]
+      removed_to: removed
+      rules: []"#,
+    );
+    let diags = compile_diagnostics(&yaml);
+    assert_e200_contains(&diags, &["rules must contain at least one removal rule"]);
+}
+
+#[test]
+fn well_formed_cull_compiles() {
+    // The happy path: a valid Cull with an aggregate `drop_group_when`
+    // predicate compiles, and both output ports wire (main → `out`, removed
+    // → `audit`).
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0""#,
+    );
+    let config = parse_config(&yaml).expect("parse_config");
+    config
+        .compile(&CompileContext::default())
+        .expect("a well-formed Cull pipeline must compile");
+}
+
+#[test]
+fn string_and_count_predicates_typecheck() {
+    // Ordered aggregate-boolean predicates over non-numeric aggregates
+    // (`max(status) > 'error'`) and over `count(*)` both typecheck — the
+    // aggregate residual evaluator orders strings the same way the row
+    // evaluator does, so these are well-formed group-level predicates.
+    let yaml = pipeline_with_cull_config(
+        r#"      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: lexical
+          drop_group_when: "max(status) > 'error'"
+        - name: big
+          drop_group_when: "count(*) > 3""#,
+    );
+    let config = parse_config(&yaml).expect("parse_config");
+    config
+        .compile(&CompileContext::default())
+        .expect("string and count aggregate predicates must typecheck");
+}

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -1,5 +1,6 @@
 mod ck_aligned_partition;
 mod ck_lattice;
+mod cull_validation;
 mod dag;
 mod dedup_node_rooted;
 mod deferred_region;

--- a/crates/cxl/src/eval/compiled.rs
+++ b/crates/cxl/src/eval/compiled.rs
@@ -1787,7 +1787,16 @@ fn values_equal(a: &Value, b: &Value) -> bool {
     }
 }
 
-fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
+/// Order two [`Value`]s with the row evaluator's comparison semantics, the
+/// single source of truth for `<` / `>` / `<=` / `>=` in CXL.
+///
+/// Orders `Int`/`Float` (mixed, via `f64`), `String` (lexicographic), `Date`,
+/// and `DateTime`. Returns `None` for any other pairing — a null operand, a
+/// bool, or a type mismatch — which every comparison call site maps to a
+/// false / null three-valued result. Shared by the row evaluator and the
+/// aggregate emit-residual evaluator so `max(name) > 'M'` means the same
+/// thing in a Transform, an Aggregate `emit`, and a Cull predicate.
+pub fn compare_values(a: &Value, b: &Value) -> Option<std::cmp::Ordering> {
     match (a, b) {
         (Value::Integer(x), Value::Integer(y)) => Some(x.cmp(y)),
         (Value::Float(x), Value::Float(y)) => x.partial_cmp(y),

--- a/crates/cxl/src/eval/mod.rs
+++ b/crates/cxl/src/eval/mod.rs
@@ -23,7 +23,7 @@ use crate::typecheck::pass::TypedProgram;
 
 use compiled::{CompiledProgram, EvalState};
 
-pub use compiled::{CompiledScalar, compile_scalar};
+pub use compiled::{CompiledScalar, compare_values, compile_scalar};
 pub use context::{Clock, EvalContext, FixedClock, StableEvalContext, WallClock};
 pub use error::{EvalError, EvalErrorKind, extract_triggering_value};
 

--- a/docs/user/src/SUMMARY.md
+++ b/docs/user/src/SUMMARY.md
@@ -29,6 +29,7 @@
 - [Combine Nodes](nodes/combine.md)
 - [Aggregate Nodes](nodes/aggregate.md)
 - [Reshape Nodes](nodes/reshape.md)
+- [Cull Nodes](nodes/cull.md)
 - [Output Nodes](nodes/output.md)
 
 # Source Formats
@@ -90,5 +91,6 @@
 - [Routing to Multiple Outputs](cookbook/routing.md)
 - [Aggregation & Rollups](cookbook/aggregation.md)
 - [Slowly-Changing Dimensions (SCD Type 2)](cookbook/scd-type2.md)
+- [Backfill, Then Cull for Review](cookbook/backfill-and-cull.md)
 - [File Splitting](cookbook/file-splitting.md)
 - [Intra-Record Closures](cookbook/intra-record-closures.md)

--- a/docs/user/src/cookbook/backfill-and-cull.md
+++ b/docs/user/src/cookbook/backfill-and-cull.md
@@ -1,0 +1,108 @@
+# Backfill, Then Cull for Review
+
+This recipe chains two grouping operators: a [Reshape](../nodes/reshape.md) node backfills each subject's history, then a [Cull](../nodes/cull.md) node sets aside whole subjects that need manual review — routing them to a second output stream instead of dropping them.
+
+It ships as a runnable pipeline at `examples/pipelines/employee_plan_backfill.yaml`.
+
+## The problem
+
+You have run an SCD-style backfill over each employee's benefit-plan history (closing over-long windows and synthesizing continuation rows). After backfilling, some employees end up with a large or otherwise unusual plan history that an analyst should eyeball before it lands in the clean dataset. You want two outputs:
+
+- a **clean** stream for the employees whose history looks fine, and
+- a **review** stream for the flagged employees — their records intact, not discarded, not errored.
+
+That is a per-group decision based on an aggregate property of the whole group ("this employee has more than three plan rows"), and the flagged records belong on a *second valid data stream*, not in the dead-letter queue. Cull fits exactly: it groups by `partition_by`, evaluates a group-level `drop_group_when` predicate, and emits removed groups on a first-class `removed_to` side-output port.
+
+## Input data
+
+`data/employee_plans.csv` — each employee's plan history, with start/end day-numbers:
+
+```csv
+employee_id,plan_start,plan_end,status
+E001,100,90,baseline
+E001,1000,100,baseline
+E002,200,150,baseline
+E003,50,40,baseline
+E003,300,250,baseline
+E003,600,550,baseline
+E003,900,850,baseline
+```
+
+`E001` has one over-long window (`1000 - 100 > 365`); `E003` has four plan rows.
+
+## The pipeline
+
+```yaml
+nodes:
+  - type: source
+    name: plans
+    config:
+      name: plans
+      type: csv
+      path: ./data/employee_plans.csv
+      schema:
+        - { name: employee_id, type: string }
+        - { name: plan_start, type: int }
+        - { name: plan_end, type: int }
+        - { name: status, type: string }
+
+  - type: reshape
+    name: backfill
+    input: plans
+    config:
+      partition_by: [employee_id]
+      order_by:
+        - { field: plan_start, order: asc }
+      rules:
+        - name: split_long_plan
+          when: "plan_start - plan_end > 365"
+          mutate:
+            set:
+              plan_end: "plan_start"
+          synthesize:
+            copy_from: trigger
+            overrides:
+              status: "'synthesized'"
+
+  - type: cull
+    name: flag_large_histories
+    input: backfill
+    config:
+      partition_by: [employee_id]
+      removed_to: review
+      rules:
+        - name: too_many_plans
+          drop_group_when: "count(*) > 3"
+
+  - type: output
+    name: out
+    input: flag_large_histories         # main port — kept employees
+    config: { name: out, type: csv, path: ./output/employee_plans_clean.csv }
+
+  - type: output
+    name: review
+    input: flag_large_histories.review  # side-output port — flagged employees
+    config: { name: review, type: csv, path: ./output/employee_plans_review.csv }
+```
+
+## How it works
+
+1. **Reshape (`backfill`)** groups by `employee_id` and, for the over-long window, closes it (`plan_end = plan_start`) and synthesizes a continuation row marked `status=synthesized`. `E001` gains a synthesized row, ending up with three rows.
+2. **Cull (`flag_large_histories`)** groups the backfilled rows by `employee_id` again and evaluates `count(*) > 3` over each whole group. `E003` has four rows, so the **whole `E003` group** is routed to the `review` side-output port; `E001` (three rows) and `E002` (one row) flow to the main output.
+3. **Two outputs** draw the two ports: `out` references the Cull node by name (the main port, kept employees); `review` references `flag_large_histories.review` (the side-output port, flagged employees).
+
+The main output (`employee_plans_clean.csv`) carries `E001` (with its synthesized continuation row) and `E002`; the review output (`employee_plans_review.csv`) carries all four of `E003`'s rows. Both streams carry the unchanged input schema — Cull does not widen, and the flagged records are valid rows on a normal data edge, never DLQ entries.
+
+## Expressing group-level conditions
+
+`drop_group_when` is an **aggregate** predicate over the whole group. CXL's bare aggregates are `sum` / `count` / `min` / `max` / `avg` / `collect` / `weighted_avg` — there is no bare `any()`. To flag a group when **any** row matches a condition, sum an indicator and compare to zero:
+
+```yaml
+rules:
+  # Flag the whole employee for review if any plan row is still flagged
+  # `status == 'error'` after backfill.
+  - name: any_error
+    drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+```
+
+See the [Cull node reference](../nodes/cull.md) for the full predicate vocabulary, the producer-side port model, and the bounded-memory spill behavior.

--- a/docs/user/src/nodes/cull.md
+++ b/docs/user/src/nodes/cull.md
@@ -1,0 +1,125 @@
+# Cull Nodes
+
+Cull nodes observe a whole correlation group and remove the entire group when a group-level predicate holds, routing the removed records to a **side-output port** instead of discarding them. They are the node for "look at everything an entity did, then set the whole entity aside for review or reprocessing" — work that operates on an aggregate property of a group, not on individual rows:
+
+- **Route** fans out *per record* on a row predicate.
+- **Reshape** mutates rows and synthesizes new ones *within* a group.
+- **Aggregate** reduces a group to one summary row.
+
+None of those remove a whole correlation group based on an aggregate property of the group and emit the removed rows on a second stream. Cull does.
+
+Cull is a **blocking grouping operator**: it buffers every record of a group before any output leaves, because a group-level predicate (e.g. "this group has more than 100 rows") cannot be decided until the whole group is seen. It has **two output ports**: the main port (kept groups) and the `removed_to` side-output port (removed groups).
+
+## Basic structure
+
+```yaml
+- type: cull
+  name: flag_large_histories
+  input: backfill
+  config:
+    partition_by: [employee_id]
+    removed_to: review
+    rules:
+      - name: too_many_plans
+        drop_group_when: "count(*) > 3"
+```
+
+For each `employee_id` group, if the group holds more than three rows the **whole group** is routed to the `review` side output; every other group flows to the main output.
+
+## `partition_by`
+
+A list of field names. Records sharing the same values for all `partition_by` fields form one group, and the removal predicate observes one whole group at a time. This is the correlation key the operator reasons over. `partition_by` must cover every visible correlation-key field so group identity is preserved on both output ports.
+
+## `order_by`
+
+Optional. A list of sort fields (`{ field, order }`, where `order` is `asc` or `desc`) applied within each group before its predicate runs, so an order-sensitive predicate is deterministic. Nulls sort last. Arrival order breaks ties.
+
+## Rules
+
+Each entry in `rules:` is a declarative removal rule with a name and a `drop_group_when` predicate. **A group is removed when any rule's predicate holds** (the rules are OR-combined).
+
+### `drop_group_when` — the group-level removal predicate
+
+`drop_group_when` is a CXL boolean expression evaluated in **aggregate context** over the whole group (group-by = `partition_by`). Because it is an aggregate expression, it uses CXL's aggregate functions:
+
+| Aggregate | Meaning |
+|-----------|---------|
+| `count(*)` | number of rows in the group |
+| `sum(<expr>)` | sum of an expression over the group |
+| `min(<expr>)` / `max(<expr>)` | minimum / maximum over the group |
+| `avg(<expr>)` | mean over the group |
+
+```yaml
+rules:
+  - name: too_many_plans
+    drop_group_when: "count(*) > 3"
+  - name: high_total
+    drop_group_when: "sum(amount) > 10000"
+```
+
+CXL's bare aggregate vocabulary is `sum` / `count` / `min` / `max` / `avg` / `collect` / `weighted_avg` — there is **no bare `any()` aggregate**. To express "remove the group if any row matches a condition", sum an indicator and compare to zero:
+
+```yaml
+rules:
+  - name: drop_error_groups
+    # Remove any account group containing at least one `error` row.
+    drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+```
+
+Ordered comparisons (`>`, `<`, `>=`, `<=`) work over every comparable aggregate type, not just numbers — the predicate uses the same comparison rules as a Transform. Numbers, strings, and dates all order:
+
+```yaml
+rules:
+  - name: late_alphabet
+    drop_group_when: "max(name) > 'M'"          # string ordering
+  - name: recent_hire
+    drop_group_when: "max(hired) >= #2020-01-01#" # date ordering (`#YYYY-MM-DD#` literal)
+```
+
+A group whose aggregate operand is null (for example `max(...)` over an all-null column) compares as false — a null operand never removes the group and never errors.
+
+## Output ports: main and `removed_to`
+
+Cull has two producer-side output ports, the same mechanism a [Route](route.md) uses for its branches — not the dead-letter queue. Removed records are **valid rows the operator deliberately partitions onto a second stream**, not errors.
+
+Downstream nodes draw from the two ports by reference:
+
+- The **main output** (kept groups) is referenced by the Cull node's bare name: `input: flag_large_histories`.
+- The **side output** (removed groups) is referenced as `<cull>.<removed_to>`: `input: flag_large_histories.review`.
+
+```yaml
+  - type: output
+    name: kept
+    input: flag_large_histories            # main port — kept groups
+    config: { name: kept, type: csv, path: kept.csv }
+
+  - type: output
+    name: review
+    input: flag_large_histories.review     # side-output port — removed groups
+    config: { name: review, type: csv, path: review.csv }
+```
+
+`removed_to` must be a non-empty name distinct from the Cull node's own name (enforced at compile time, so the two ports are always distinguishable).
+
+A single downstream node may draw from **both** ports — for example a [Merge](merge.md) recombining the kept and removed streams (`inputs: [flag_large_histories, flag_large_histories.review]`) — and receives the union of both ports' records.
+
+### `removed_to` is not the DLQ
+
+The `removed_to` port carries the **unchanged upstream schema** — Cull does not widen, and both ports emit exactly the input columns. Removed records are not `DlqEntry`s and never appear in the dead-letter queue or its counters; they flow down a normal data edge to whatever node draws the `removed_to` port (an audit sink, a reprocessing branch, another transform). Use the DLQ for *errors*; use a Cull side output for *valid records you want to handle separately*. See [Error Handling & DLQ](../pipelines/error-handling.md) for the error path.
+
+## Memory model
+
+Cull is a **blocking, grouped** operator: it groups every input record by `partition_by` before any record leaves, because the group-level `drop_group_when` predicate is an aggregate property of the whole group and cannot be folded into a per-record keep/remove decision. It therefore cannot stream — the full group set materializes before the first output row leaves.
+
+That per-group buffer is governed by the same central memory arbitrator every other blocking operator polls (see [Memory & Spill](../ops/memory.md)). As records are grouped, Cull tracks the live in-memory footprint and, whenever the run crosses the **soft** spill threshold (80% of `memory.limit` by default), it spills buffered groups to disk:
+
+- **What spills:** the **raw input records**. On reload at finalize, each group is re-split onto its output port exactly as it would have been without spilling, so the output is identical whether a group stayed resident or round-tripped through disk — including within-group row order, which is restored to arrival order after a reload. (The per-group removal decision is computed from an in-memory aggregate over the same records; that aggregate state is bounded by the group count and is never spilled — only the raw records spill.)
+- **Spill priority:** `15`, between grace-hash Combine (`10`) and external sort (`20`), matching Reshape. Cull **cannot back-pressure** — once its predecessor has drained there is no upstream channel to pause — so under memory pressure it always spills its own buffer in-thread rather than pausing a producer.
+- **Largest-first, stop at the threshold:** when the budget trips, Cull evicts the largest resident groups first and stops as soon as the resident footprint drops back under the soft threshold — it does not drain every group.
+- **Skew (one giant group):** a single correlation group whose resident tail alone exceeds the budget is spilled **incrementally** — sliced by the upper bits of each record's admission sequence — while smaller groups stay resident, so the ingest-time resident peak stays bounded even under one giant skewed group.
+
+The on-disk spill volume Cull produces is surfaced per stage in `clinker run --explain` (the **Estimated spill volume** and **Spill compression** sections) and, after a run, in the actual per-stage spill totals.
+
+### Limit: a single group must fit the finalize budget
+
+Cull evaluates its group-level predicate against the *whole* group at once, so even though cross-group and ingest-time peaks spill to disk, the finalize reload of one group needs that group to fit the memory budget. Skew slicing bounds the ingest peak, but a single correlation group larger than `memory.limit` has no in-budget representation. Rather than risk an out-of-memory crash, the run **fails loud** with a diagnostic naming the offending group's size. Raise `memory.limit`, or partition the input so no one correlation group is that large.

--- a/docs/user/src/nodes/index.md
+++ b/docs/user/src/nodes/index.md
@@ -22,6 +22,7 @@ nodes, and leaves at an Output:
 | [Combine](combine.md) | N-ary record combining with mixed predicates (equi + range + arbitrary CXL). | N → 1 | Blocking (build side) |
 | [Aggregate](aggregate.md) | Grouped or windowed reduction. | 1 → 1 | Blocking (or streaming when sorted) |
 | [Reshape](reshape.md) | Pivot / unpivot between wide and long record shapes. | 1 → 1 | Blocking |
+| [Cull](cull.md) | Per-correlation-group removal on a group-level predicate, with a `removed_to` side-output port. | 1 → 2 | Blocking |
 | [Output](output.md) | Writes records to a sink; the exit point. | 1 → 0 | Streaming |
 
 ## Streaming vs blocking

--- a/examples/pipelines/data/employee_plans.csv
+++ b/examples/pipelines/data/employee_plans.csv
@@ -1,0 +1,8 @@
+employee_id,plan_start,plan_end,status
+E001,100,90,baseline
+E001,1000,100,baseline
+E002,200,150,baseline
+E003,50,40,baseline
+E003,300,250,baseline
+E003,600,550,baseline
+E003,900,850,baseline

--- a/examples/pipelines/employee_plan_backfill.yaml
+++ b/examples/pipelines/employee_plan_backfill.yaml
@@ -1,0 +1,94 @@
+# Employee plan backfill, then cull the groups that need manual review.
+#
+# Stage 1 (Reshape): per employee (`employee_id` is the correlation group), a
+# plan row whose coverage window runs longer than one fiscal year
+# (`plan_start - plan_end > 365`) is an un-split SCD record. Reshape MUTATES
+# that trigger row to close its window at the start boundary and SYNTHESIZES a
+# continuation row marked `status=synthesized`.
+#
+# Stage 2 (Cull): after backfill, employees with a large plan history are
+# flagged for manual review. Cull groups the backfilled rows by `employee_id`
+# again and routes the WHOLE group of any employee with more than three plan
+# rows to the `review` side-output port; every other employee flows to the
+# main output. `removed_to` is a first-class producer-side output port (not the
+# dead-letter queue): the removed rows are valid records deliberately
+# partitioned onto a second audit stream.
+#
+# Both Reshape and Cull are blocking, grouped operators governed by the engine
+# memory budget — they spill their per-group buffers to disk under pressure and
+# re-run on reload, so the result is identical whether a group stayed resident
+# or round-tripped through disk.
+pipeline:
+  name: employee_plan_backfill
+
+nodes:
+  - type: source
+    name: plans
+    config:
+      name: plans
+      type: csv
+      path: ./data/employee_plans.csv
+      options:
+        has_header: true
+      schema:
+        - { name: employee_id, type: string }
+        - { name: plan_start, type: int }
+        - { name: plan_end, type: int }
+        - { name: status, type: string }
+
+  - type: reshape
+    name: backfill
+    input: plans
+    config:
+      partition_by: [employee_id]
+      order_by:
+        - { field: plan_start, order: asc }
+      rules:
+        - name: split_long_plan
+          when: "plan_start - plan_end > 365"
+          mutate:
+            set:
+              # Close the over-long window at its start boundary.
+              plan_end: "plan_start"
+          synthesize:
+            copy_from: trigger
+            overrides:
+              status: "'synthesized'"
+
+  - type: cull
+    name: flag_large_histories
+    input: backfill
+    config:
+      partition_by: [employee_id]
+      # The side-output port name. Downstream nodes draw removed rows by
+      # referencing `flag_large_histories.review`.
+      removed_to: review
+      rules:
+        # An employee with more than three plan rows after backfill is routed
+        # to manual review. CXL's bare aggregates are sum/count/min/max/avg/
+        # collect, so the group-level predicate is `count(*) > 3` (there is no
+        # bare `any()` aggregate — express "any row matches" as
+        # `sum(if <cond> then 1 else 0) > 0`).
+        - name: too_many_plans
+          drop_group_when: "count(*) > 3"
+
+  # Main output: employees with a manageable plan history.
+  - type: output
+    name: out
+    input: flag_large_histories
+    config:
+      name: out
+      type: csv
+      path: ./output/employee_plans_clean.csv
+
+  # Side output: employees flagged for manual review.
+  - type: output
+    name: review
+    input: flag_large_histories.review
+    config:
+      name: review
+      type: csv
+      path: ./output/employee_plans_review.csv
+
+error_handling:
+  strategy: continue


### PR DESCRIPTION
Adds the Cull node: per-correlation-group record removal. A group-level removal predicate (`drop_group_when`) is evaluated over each correlation group; when it holds, the whole group is routed to a first-class `removed_to` side-output port (distinct from the dead-letter queue), built on the producer-side port-tagged edges. Kept records flow to the main port; both ports carry the unchanged input schema. Cull is a blocking, spilling operator that mirrors Reshape's bounded-memory machinery (per-group buffer charged to the arbitrator, largest-first spill, incremental skew slicing, fail-loud on a single group exceeding the budget). `--explain` renders it as a two-port fork.

The aggregate-residual evaluator previously handled only equality on group-level predicates; it now also handles ordered comparisons (so `count(*) > 100` and `sum(...) > 0` work), which also benefits the Aggregate node. Includes validation, lowering, an `--explain` snapshot, a Reshape+Cull example pipeline, and node + cookbook documentation. The intra-group dedup rule (`keep_row_where`) is tracked separately as it requires a new ranking function.

Closes #390.