### PR TITLE
format,engine: de-buffer the JSON reader via a re-openable source through the reader factory

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -5,6 +5,7 @@
 use std::io::Read;
 use std::sync::Arc;
 
+use clinker_format::ReopenableSource;
 use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
 use clinker_format::edifact::reader::{EdifactReader, EdifactReaderConfig};
 use clinker_format::fixed_width::reader::{FixedWidthReader, FixedWidthReaderConfig};
@@ -23,19 +24,25 @@ use clinker_format::xml::reader::{
 use clinker_plan::config::PipelineConfig;
 use clinker_plan::error::PipelineError;
 
-/// Build a format-specific reader from input config and raw reader.
+/// Build a format-specific reader from input config and a re-openable source.
 ///
-/// Dispatches on `InputFormat` to construct the correct reader type.
-/// Returns `Box<dyn FormatReader>` — all downstream code uses trait methods
-/// (`schema()`, `next_record()`).
+/// Dispatches on `InputFormat` to construct the correct reader type. The JSON
+/// arm threads the [`ReopenableSource`] straight through so its envelope
+/// pre-scan and body stream each open a fresh `Read` without buffering the
+/// whole file; every other (one-pass) format opens the source once and streams
+/// that single `Read`. Returns `Box<dyn FormatReader>` — all downstream code
+/// uses trait methods (`schema()`, `next_record()`).
 fn build_format_reader(
     input: &clinker_plan::config::SourceConfig,
-    reader: Box<dyn Read + Send>,
+    source: ReopenableSource,
 ) -> Result<Box<dyn FormatReader>, PipelineError> {
     match &input.format {
         clinker_plan::config::InputFormat::Csv(opts) => {
             let config = build_csv_reader_config(opts.as_ref());
-            Ok(Box::new(CsvReader::from_reader(reader, config)))
+            Ok(Box::new(CsvReader::from_reader(
+                open_one_shot(&source)?,
+                config,
+            )))
         }
         clinker_plan::config::InputFormat::Json(opts) => {
             let config = build_json_reader_config(
@@ -43,7 +50,7 @@ fn build_format_reader(
                 input.array_paths.as_deref(),
                 &input.declared_doc_paths,
             );
-            Ok(Box::new(JsonReader::from_reader(reader, config)?))
+            Ok(Box::new(JsonReader::from_source(source, config)?))
         }
         clinker_plan::config::InputFormat::Xml(opts) => {
             let config = build_xml_reader_config(
@@ -51,30 +58,47 @@ fn build_format_reader(
                 input.array_paths.as_deref(),
                 &input.declared_doc_paths,
             );
-            Ok(Box::new(XmlReader::new(reader, config)?))
+            Ok(Box::new(XmlReader::new(open_one_shot(&source)?, config)?))
         }
         clinker_plan::config::InputFormat::FixedWidth(opts) => {
             let fields = extract_field_defs(input)?;
             let config = build_fw_reader_config(opts.as_ref());
-            Ok(Box::new(FixedWidthReader::new(reader, fields, config)?))
+            Ok(Box::new(FixedWidthReader::new(
+                open_one_shot(&source)?,
+                fields,
+                config,
+            )?))
         }
         clinker_plan::config::InputFormat::Edifact(opts) => {
             let config = build_edifact_reader_config(opts.as_ref());
-            Ok(Box::new(EdifactReader::new(reader, config)))
+            Ok(Box::new(EdifactReader::new(
+                open_one_shot(&source)?,
+                config,
+            )))
         }
         clinker_plan::config::InputFormat::X12(opts) => {
             let config = build_x12_reader_config(opts.as_ref())?;
-            Ok(Box::new(X12Reader::new(reader, config)))
+            Ok(Box::new(X12Reader::new(open_one_shot(&source)?, config)))
         }
         clinker_plan::config::InputFormat::Hl7(opts) => {
             let config = build_hl7_reader_config(opts.as_ref());
-            Ok(Box::new(Hl7Reader::new(reader, config)))
+            Ok(Box::new(Hl7Reader::new(open_one_shot(&source)?, config)))
         }
         clinker_plan::config::InputFormat::Swift(opts) => {
             let config = build_swift_reader_config(opts.as_ref());
-            Ok(Box::new(SwiftReader::new(reader, config)))
+            Ok(Box::new(SwiftReader::new(open_one_shot(&source)?, config)))
         }
     }
+}
+
+/// Open a single `Read` from a re-openable source for a one-pass format reader,
+/// mapping an open failure to a pipeline config-validation error.
+fn open_one_shot(source: &ReopenableSource) -> Result<Box<dyn Read + Send>, PipelineError> {
+    source.open().map_err(|e| {
+        PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+            "failed to open source bytes: {e}"
+        )))
+    })
 }
 
 /// Build a [`MultiFileFormatReader`] wrapping every file the discovery
@@ -94,10 +118,10 @@ fn build_multi_file_reader(
     // boundary intact.
     let owned_config = input.clone();
     let factory: Box<FactoryFn> = Box::new(
-        move |reader: Box<dyn Read + Send>,
+        move |source: ReopenableSource,
               _idx: usize|
               -> Result<Box<dyn FormatReader>, clinker_format::FormatError> {
-            build_format_reader(&owned_config, reader).map_err(|e| {
+            build_format_reader(&owned_config, source).map_err(|e| {
                 clinker_format::FormatError::SchemaInference(format!(
                     "format reader construction failed: {e}"
                 ))

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -225,10 +225,7 @@ pub fn single_file_reader(
     path: impl Into<std::path::PathBuf>,
     reader: Box<dyn Read + Send>,
 ) -> crate::source::SourceInput {
-    crate::source::SourceInput::Files(vec![crate::source::multi_file::FileSlot {
-        path: path.into(),
-        reader,
-    }])
+    crate::source::SourceInput::Files(vec![crate::source::multi_file::FileSlot::new(path, reader)])
 }
 
 /// Dummy storage type for streaming (no-window) evaluation.

--- a/crates/clinker-exec/src/source/multi_file.rs
+++ b/crates/clinker-exec/src/source/multi_file.rs
@@ -1,9 +1,10 @@
 //! Multi-file streaming reader.
 //!
-//! [`MultiFileFormatReader`] sequences a list of `(PathBuf, Box<dyn Read>)`
-//! files through a per-file format reader factory, presenting them as a
-//! single [`FormatReader`] stream to the executor. Each inner reader is
-//! built fresh per file via the supplied factory closure.
+//! [`MultiFileFormatReader`] sequences a list of [`FileSlot`]s (each a
+//! provenance path plus a re-openable byte source) through a per-file format
+//! reader factory, presenting them as a single [`FormatReader`] stream to the
+//! executor. Each inner reader is built fresh per file via the supplied factory
+//! closure.
 //!
 //! Per-format concat-safety:
 //! - **CSV** with `has_header: true` — every inner CsvReader independently
@@ -26,43 +27,60 @@ use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use clinker_format::{FormatError, FormatReader};
+use clinker_format::{FormatError, FormatReader, ReopenableSource};
 use clinker_record::{Record, Schema};
 
-/// Closure that builds a [`FormatReader`] from a single file's bytes.
+/// Closure that builds a [`FormatReader`] from a single file's re-openable
+/// byte source.
+///
+/// The factory receives a [`ReopenableSource`] rather than a one-shot
+/// `Box<dyn Read>` so a reader needing multiple passes (JSON's envelope
+/// pre-scan plus its body stream) can open the source twice without buffering
+/// the whole file. One-pass formats (CSV, fixed-width, XML, EDI) open it once
+/// and ignore the re-open capability.
 ///
 /// `file_index` lets the factory differentiate the first file from
 /// subsequent files when format-specific bookkeeping requires it
 /// (currently unused — every format builds the same way per file).
 pub type FactoryFn =
-    dyn FnMut(Box<dyn Read + Send>, usize) -> Result<Box<dyn FormatReader>, FormatError> + Send;
+    dyn FnMut(ReopenableSource, usize) -> Result<Box<dyn FormatReader>, FormatError> + Send;
 
 /// One file slot in the multi-file stream.
+///
+/// `path` is the record-stamping provenance identity (`$source.file`), which
+/// for a staged source is the *original* matched path. `source` is the
+/// re-openable handle on the actual bytes the reader streams — for a staged
+/// source, the content-addressed staged copy, distinct from `path`.
 pub struct FileSlot {
     pub path: PathBuf,
-    pub reader: Box<dyn Read + Send>,
+    pub source: ReopenableSource,
 }
 
 impl FileSlot {
-    /// Convenience: wrap an open `Read` handle plus its path into a slot.
+    /// Wrap a one-shot `Read` handle plus its path into a slot.
+    ///
+    /// For in-memory inputs (test/bench cursors, the `<empty>` slot) that have
+    /// no on-disk path to re-open: the reader is held lazily as a
+    /// `ReopenableSource::OneShot` and streamed directly by a one-pass format,
+    /// so a paced/slow reader keeps its per-row timing and nothing is read at
+    /// slot construction. A multi-pass reader (JSON) buffers it on demand.
+    /// File-backed production sources use [`from_path`](Self::from_path)
+    /// instead, which re-opens by path and never buffers the file whole.
     pub fn new(path: impl Into<PathBuf>, reader: Box<dyn Read + Send>) -> Self {
         Self {
             path: path.into(),
-            reader,
+            source: ReopenableSource::one_shot(reader),
         }
     }
-}
 
-/// Wrap a single `Read` handle as a one-element file list. The path is
-/// `"<inline>"` — used by tests and benchmarks that hand the executor
-/// in-memory cursors with no real on-disk path. Production callers
-/// should construct `FileSlot` directly with the real path so
-/// `$source.file` carries it through to records.
-impl From<Box<dyn Read + Send>> for FileSlot {
-    fn from(reader: Box<dyn Read + Send>) -> Self {
+    /// Build a slot for a file-backed source: `provenance` is the originating
+    /// path stamped on records (`$source.file`), `read_path` is the stable
+    /// (staged) path the reader re-opens. The reader opens `read_path` fresh
+    /// per pass — no whole-file buffer is held.
+    pub fn from_path(provenance: impl Into<PathBuf>, read_path: impl Into<PathBuf>) -> Self {
         Self {
-            path: PathBuf::from("<inline>"),
-            reader,
+            path: provenance.into(),
+            source: ReopenableSource::path(read_path),
         }
     }
 }
@@ -137,12 +155,12 @@ impl MultiFileFormatReader {
             &mut self.files[idx],
             FileSlot {
                 path: PathBuf::new(),
-                reader: Box::new(std::io::empty()),
+                source: ReopenableSource::one_shot(Box::new(std::io::empty())),
             },
         );
         self.current_file = Arc::from(slot.path.to_string_lossy().into_owned());
         self.cursor += 1;
-        let reader = (self.factory)(slot.reader, idx)?;
+        let reader = (self.factory)(slot.source, idx)?;
         self.active = Some(reader);
         Ok(true)
     }
@@ -258,17 +276,18 @@ mod tests {
     use super::*;
     use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
 
-    fn cursor(s: &str) -> Box<dyn Read + Send> {
-        Box::new(std::io::Cursor::new(s.to_string().into_bytes()))
+    fn slot(path: &str, s: &str) -> FileSlot {
+        FileSlot::new(
+            PathBuf::from(path),
+            Box::new(std::io::Cursor::new(s.to_string().into_bytes())),
+        )
     }
 
     fn csv_factory() -> Box<FactoryFn> {
         Box::new(
-            |reader: Box<dyn Read + Send>,
-             _idx: usize|
-             -> Result<Box<dyn FormatReader>, FormatError> {
+            |source: ReopenableSource, _idx: usize| -> Result<Box<dyn FormatReader>, FormatError> {
                 Ok(Box::new(CsvReader::from_reader(
-                    reader,
+                    source.open()?,
                     CsvReaderConfig::default(),
                 )))
             },
@@ -278,14 +297,8 @@ mod tests {
     #[test]
     fn streams_records_across_two_csv_files() {
         let files = vec![
-            FileSlot {
-                path: PathBuf::from("a.csv"),
-                reader: cursor("id,name\n1,alice\n2,bob\n"),
-            },
-            FileSlot {
-                path: PathBuf::from("b.csv"),
-                reader: cursor("id,name\n3,carol\n"),
-            },
+            slot("a.csv", "id,name\n1,alice\n2,bob\n"),
+            slot("b.csv", "id,name\n3,carol\n"),
         ];
         let mut r = MultiFileFormatReader::new(files, csv_factory());
         let _ = r.schema().unwrap();
@@ -299,14 +312,8 @@ mod tests {
     #[test]
     fn current_file_updates_across_boundary() {
         let files = vec![
-            FileSlot {
-                path: PathBuf::from("a.csv"),
-                reader: cursor("id,name\n1,alice\n"),
-            },
-            FileSlot {
-                path: PathBuf::from("b.csv"),
-                reader: cursor("id,name\n2,bob\n"),
-            },
+            slot("a.csv", "id,name\n1,alice\n"),
+            slot("b.csv", "id,name\n2,bob\n"),
         ];
         let mut r = MultiFileFormatReader::new(files, csv_factory());
         r.next_record().unwrap();
@@ -320,14 +327,8 @@ mod tests {
     #[test]
     fn schema_mismatch_across_files_is_rejected() {
         let files = vec![
-            FileSlot {
-                path: PathBuf::from("a.csv"),
-                reader: cursor("id,name\n1,alice\n"),
-            },
-            FileSlot {
-                path: PathBuf::from("b.csv"),
-                reader: cursor("id,price\n2,9.99\n"),
-            },
+            slot("a.csv", "id,name\n1,alice\n"),
+            slot("b.csv", "id,price\n2,9.99\n"),
         ];
         let mut r = MultiFileFormatReader::new(files, csv_factory());
         let _ = r.schema().unwrap();
@@ -344,10 +345,7 @@ mod tests {
 
     #[test]
     fn single_file_streams_unchanged() {
-        let files = vec![FileSlot {
-            path: PathBuf::from("only.csv"),
-            reader: cursor("id\n1\n2\n3\n"),
-        }];
+        let files = vec![slot("only.csv", "id\n1\n2\n3\n")];
         let mut r = MultiFileFormatReader::new(files, csv_factory());
         let _ = r.schema().unwrap();
         let mut count = 0;
@@ -360,14 +358,8 @@ mod tests {
     #[test]
     fn schema_is_cached_from_first_file() {
         let files = vec![
-            FileSlot {
-                path: PathBuf::from("a.csv"),
-                reader: cursor("id,name\n1,alice\n"),
-            },
-            FileSlot {
-                path: PathBuf::from("b.csv"),
-                reader: cursor("id,name\n2,bob\n"),
-            },
+            slot("a.csv", "id,name\n1,alice\n"),
+            slot("b.csv", "id,name\n2,bob\n"),
         ];
         let mut r = MultiFileFormatReader::new(files, csv_factory());
         let s1 = r.schema().unwrap();

--- a/crates/clinker-format/src/json/body_stream.rs
+++ b/crates/clinker-format/src/json/body_stream.rs
@@ -1,0 +1,883 @@
+//! Lazy, one-element-at-a-time streaming of a JSON array body.
+//!
+//! [`JsonArrayStream`] owns a single `BufReader` over a freshly re-opened
+//! source and yields the array's elements **one at a time** — it never
+//! collects them into a `Vec`. Peak retention is one element's bytes plus its
+//! parsed `serde_json::Value`, i.e. O(1 record), regardless of array length.
+//!
+//! ## Why a structural scanner rather than serde streaming
+//!
+//! serde_json exposes no public API to pull comma-delimited elements out of a
+//! single `[...]` array lazily: `StreamDeserializer` is whitespace-delimited
+//! (it streams `[0] [1]`, not the elements inside one array), and building a
+//! fresh `Deserializer` per element over a borrowed `&mut BufReader` drops the
+//! one-byte lookahead `IoRead` keeps, corrupting the stream. Holding a
+//! `SeqAccess` across calls would need a self-referential struct. So this scans
+//! the array's structural framing itself — tracking string/escape state and
+//! brace/bracket depth to find each element's byte boundaries — and hands each
+//! element's bytes to `serde_json::from_slice`. The framing scan is the only
+//! hand-rolled part; element *parsing* stays with serde_json.
+
+use std::io::{BufReader, Read};
+
+use crate::error::FormatError;
+
+/// A byte stream over a re-opened source, navigated to a JSON array, yielding
+/// its elements lazily.
+///
+/// Streaming, O(1 record): only the current element's bytes and parsed value
+/// are retained at any time. The opening `[` of the target array has already
+/// been consumed at construction; [`next`](Self::next) reads up to the matching
+/// `]`.
+///
+/// Malformed-input note: because elements are framed and parsed one at a time,
+/// a truncated array (`[1,2` with no closing `]`) yields its complete leading
+/// elements and then fails loud on the missing `]` at the next pull — the error
+/// is late but never silent. A non-whitespace tail after a *top-level* array's
+/// close is rejected immediately (see `strict_eof`).
+pub(crate) struct JsonArrayStream {
+    reader: ByteReader,
+    /// `true` once the array's closing `]` has been seen; further `next` calls
+    /// return `None`.
+    done: bool,
+    /// `true` before the first element so `next` knows whether to expect a
+    /// leading comma separator.
+    first: bool,
+    /// Per-element scan buffer, cleared and reused across `next` calls so a
+    /// long array does not allocate a fresh `Vec` per element. Holds at most
+    /// one element's bytes — O(1 record).
+    scratch: Vec<u8>,
+    /// When `true`, the array is the whole document, so any non-whitespace byte
+    /// after its closing `]` is trailing garbage and fails loud. `false` for a
+    /// `record_path` array, where the enclosing object legitimately carries
+    /// sibling keys after the array.
+    strict_eof: bool,
+}
+
+impl JsonArrayStream {
+    /// Open a stream over the top-level JSON array in `reader`.
+    ///
+    /// Skips leading whitespace, consumes the opening `[`, and positions before
+    /// the first element. An empty document (`reader` at EOF) yields a stream
+    /// that immediately returns `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Json`] if the first non-whitespace byte is not
+    /// `[`, or [`FormatError::Io`] on a read failure.
+    pub(crate) fn top_level(reader: BufReader<Box<dyn Read + Send>>) -> Result<Self, FormatError> {
+        // The array is the whole document, so enforce whitespace-only tail.
+        Self::at_array(ByteReader::new(reader), true)
+    }
+
+    /// Open a stream over the JSON array reached by following `path` (dotted
+    /// `record_path` segments) from a top-level object.
+    ///
+    /// Descends key-by-key, skipping sibling values structurally (no
+    /// allocation beyond the bytes of a skipped key string), until the target
+    /// array is reached, then positions before its first element.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Json`] if a path segment is missing, an
+    /// intermediate is not an object, or the terminal value is not an array;
+    /// [`FormatError::Io`] on a read failure.
+    pub(crate) fn at_path(
+        reader: BufReader<Box<dyn Read + Send>>,
+        path: &[String],
+    ) -> Result<Self, FormatError> {
+        let mut br = ByteReader::new(reader);
+        navigate_to_path(&mut br, path)?;
+        // The array sits inside an object that may carry sibling keys after it,
+        // so a non-whitespace tail is not garbage here.
+        Self::at_array(br, false)
+    }
+
+    /// Consume the opening `[` of the array the reader is positioned at.
+    /// `strict_eof` requires a whitespace-only tail after the array closes.
+    fn at_array(mut reader: ByteReader, strict_eof: bool) -> Result<Self, FormatError> {
+        match reader.next_nonspace()? {
+            Some(b'[') => Ok(Self {
+                reader,
+                done: false,
+                first: true,
+                scratch: Vec::new(),
+                strict_eof,
+            }),
+            Some(b) => Err(FormatError::Json(format!(
+                "expected '[' to start JSON array body, found '{}' (0x{b:02x})",
+                b as char
+            ))),
+            // No array at all (empty document / empty navigated value): an
+            // immediately-exhausted stream.
+            None => Ok(Self {
+                reader,
+                done: true,
+                first: true,
+                scratch: Vec::new(),
+                strict_eof,
+            }),
+        }
+    }
+
+    /// Yield the next array element, or `None` at the closing `]`.
+    ///
+    /// Reads exactly one element's bytes (tracking string and nesting state),
+    /// then parses them with `serde_json::from_slice`. O(1 record): the
+    /// element buffer is the only growth and is reused-then-dropped per call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Json`] on malformed array framing or a failed
+    /// element parse; [`FormatError::Io`] on a read failure.
+    pub(crate) fn next(&mut self) -> Result<Option<serde_json::Value>, FormatError> {
+        if self.done {
+            return Ok(None);
+        }
+        // Between elements sits either a separating comma or the closing
+        // bracket. The first element has no leading comma.
+        match self.reader.next_nonspace()? {
+            Some(b']') => {
+                self.done = true;
+                if self.strict_eof {
+                    // The array was the whole document; reject trailing garbage
+                    // (`[1,2] xyz`) the way a full-document parse would.
+                    if let Some(b) = self.reader.next_nonspace()? {
+                        return Err(FormatError::Json(format!(
+                            "trailing characters after top-level JSON array: '{}' (0x{b:02x})",
+                            b as char
+                        )));
+                    }
+                }
+                return Ok(None);
+            }
+            Some(b',') if !self.first => {}
+            Some(b) if self.first => {
+                // The first element's opening byte — push it back so the value
+                // scan below sees the whole element.
+                self.reader.push_back(b);
+            }
+            Some(b) => {
+                return Err(FormatError::Json(format!(
+                    "expected ',' or ']' between JSON array elements, found '{}' (0x{b:02x})",
+                    b as char
+                )));
+            }
+            None => {
+                return Err(FormatError::Json(
+                    "unexpected end of input inside JSON array body".into(),
+                ));
+            }
+        }
+        self.first = false;
+
+        // A trailing comma before `]` (`[1,2,]`) is invalid JSON; surface it.
+        match self.reader.next_nonspace()? {
+            Some(b']') => {
+                return Err(FormatError::Json(
+                    "trailing comma before ']' in JSON array body".into(),
+                ));
+            }
+            Some(b) => self.reader.push_back(b),
+            None => {
+                return Err(FormatError::Json(
+                    "unexpected end of input inside JSON array body".into(),
+                ));
+            }
+        }
+
+        self.scratch.clear();
+        scan_value(&mut self.reader, &mut self.scratch)?;
+        let value = serde_json::from_slice(&self.scratch)
+            .map_err(|e| FormatError::Json(format!("JSON array element: {e}")))?;
+        Ok(Some(value))
+    }
+}
+
+/// A buffered byte reader with a one-byte push-back, so the scanner can peek a
+/// structural byte (comma, bracket) and put it back for the value scan.
+struct ByteReader {
+    inner: BufReader<Box<dyn Read + Send>>,
+    /// A single pushed-back byte to re-read before pulling from `inner`.
+    peeked: Option<u8>,
+}
+
+impl ByteReader {
+    fn new(inner: BufReader<Box<dyn Read + Send>>) -> Self {
+        Self {
+            inner,
+            peeked: None,
+        }
+    }
+
+    /// Pull the next byte, honoring a pushed-back byte first.
+    fn next_byte(&mut self) -> Result<Option<u8>, FormatError> {
+        if let Some(b) = self.peeked.take() {
+            return Ok(Some(b));
+        }
+        let mut one = [0u8; 1];
+        match self.inner.read(&mut one) {
+            Ok(0) => Ok(None),
+            Ok(_) => Ok(Some(one[0])),
+            Err(e) => Err(FormatError::Io(e)),
+        }
+    }
+
+    /// Push one byte back so the next [`next_byte`](Self::next_byte) returns it.
+    /// At most one byte is ever buffered.
+    fn push_back(&mut self, b: u8) {
+        debug_assert!(
+            self.peeked.is_none(),
+            "ByteReader holds at most one pushback"
+        );
+        self.peeked = Some(b);
+    }
+
+    /// Pull the next non-whitespace byte, or `None` at EOF. Whitespace is the
+    /// RFC 8259 set (`{space, tab, LF, CR}`), not the wider ASCII-whitespace set
+    /// — so a form-feed (`0x0C`) is *not* skipped and surfaces as a structural
+    /// byte, matching what `serde_json` accepts.
+    fn next_nonspace(&mut self) -> Result<Option<u8>, FormatError> {
+        loop {
+            match self.next_byte()? {
+                Some(b) if is_json_ws(b) => continue,
+                other => return Ok(other),
+            }
+        }
+    }
+}
+
+/// `true` for the four bytes RFC 8259 admits as JSON whitespace: space, tab,
+/// line feed, carriage return. Deliberately narrower than
+/// [`u8::is_ascii_whitespace`], which also counts form-feed (`0x0C`) — treating
+/// form-feed as whitespace would make this streaming scanner accept inputs
+/// `serde_json` rejects. Shared with the auto-detect peek in the reader so the
+/// document head is held to the same whitespace rule as the body.
+pub(crate) fn is_json_ws(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+/// Descend a top-level JSON object following `path`, leaving the reader
+/// positioned at the start of the value the final segment names.
+///
+/// Skips sibling keys' values structurally. An empty `path` is a no-op (the
+/// reader is already at the target).
+fn navigate_to_path(reader: &mut ByteReader, path: &[String]) -> Result<(), FormatError> {
+    for (depth, segment) in path.iter().enumerate() {
+        match reader.next_nonspace()? {
+            Some(b'{') => {}
+            Some(b) => {
+                return Err(FormatError::Json(format!(
+                    "record_path: expected an object at segment '{segment}' (depth {depth}), \
+                     found '{}' (0x{b:02x})",
+                    b as char
+                )));
+            }
+            None => {
+                return Err(FormatError::Json(format!(
+                    "record_path: unexpected end of input seeking segment '{segment}'"
+                )));
+            }
+        }
+        find_key_in_object(reader, segment)?;
+    }
+    Ok(())
+}
+
+/// Within an object whose `{` was just consumed, advance to the value of
+/// `target_key`, leaving the reader positioned at the start of that value.
+/// Sibling keys before it are skipped, values and all.
+fn find_key_in_object(reader: &mut ByteReader, target_key: &str) -> Result<(), FormatError> {
+    loop {
+        // A key, or the object's closing brace if the key is absent.
+        match reader.next_nonspace()? {
+            Some(b'"') => {}
+            Some(b'}') => {
+                return Err(FormatError::Json(format!(
+                    "record_path: key '{target_key}' not found in object"
+                )));
+            }
+            Some(b',') => continue,
+            Some(b) => {
+                return Err(FormatError::Json(format!(
+                    "record_path: expected a key string, found '{}' (0x{b:02x})",
+                    b as char
+                )));
+            }
+            None => {
+                return Err(FormatError::Json(format!(
+                    "record_path: unexpected end of input seeking key '{target_key}'"
+                )));
+            }
+        }
+        let key = read_string_body(reader)?;
+        // The ':' separating key and value.
+        match reader.next_nonspace()? {
+            Some(b':') => {}
+            other => {
+                return Err(FormatError::Json(format!(
+                    "record_path: expected ':' after key '{key}', found {other:?}"
+                )));
+            }
+        }
+        if key == target_key {
+            return Ok(());
+        }
+        // Skip this sibling's value, advancing the reader past it without
+        // buffering — an arbitrarily large preceding sibling costs O(1) memory.
+        scan_value(reader, &mut Discard)?;
+    }
+}
+
+/// Read a JSON string's body bytes (the opening `"` already consumed),
+/// returning the decoded contents up to the closing `"`. Handles `\"` and
+/// `\\` so an escaped quote does not terminate the string; other escapes are
+/// preserved verbatim (sufficient for object-key comparison).
+fn read_string_body(reader: &mut ByteReader) -> Result<String, FormatError> {
+    let mut out = Vec::new();
+    loop {
+        match reader.next_byte()? {
+            Some(b'"') => break,
+            Some(b'\\') => {
+                // Keep the escape and its following byte verbatim; only `\"`
+                // and `\\` matter for terminator detection and both are handled
+                // by consuming the escaped byte without treating it as a quote.
+                out.push(b'\\');
+                match reader.next_byte()? {
+                    Some(c) => out.push(c),
+                    None => {
+                        return Err(FormatError::Json(
+                            "unterminated escape in JSON string".into(),
+                        ));
+                    }
+                }
+            }
+            Some(b) => out.push(b),
+            None => {
+                return Err(FormatError::Json("unterminated JSON string".into()));
+            }
+        }
+    }
+    // Decode the captured bytes via serde so escapes resolve correctly for the
+    // returned key. Re-wrap in quotes to parse as a JSON string literal.
+    let mut quoted = Vec::with_capacity(out.len() + 2);
+    quoted.push(b'"');
+    quoted.extend_from_slice(&out);
+    quoted.push(b'"');
+    serde_json::from_slice::<String>(&quoted)
+        .map_err(|e| FormatError::Json(format!("JSON object key: {e}")))
+}
+
+/// A byte destination for the value scanner, so one scan implementation serves
+/// both *capturing* an array element (into a `Vec<u8>` to parse) and *skipping*
+/// a preceding sibling during path navigation (into [`Discard`], retaining
+/// nothing). The skip path is what keeps `record_path` navigation O(1) memory
+/// over an arbitrarily large preceding sibling.
+trait ScanSink {
+    /// Append one scanned byte, or drop it for a skip-only scan.
+    fn push(&mut self, byte: u8);
+}
+
+impl ScanSink for Vec<u8> {
+    fn push(&mut self, byte: u8) {
+        Vec::push(self, byte);
+    }
+}
+
+/// A [`ScanSink`] that retains nothing — used to advance the reader over a
+/// skipped value (a navigated-past sibling) without buffering its bytes.
+struct Discard;
+
+impl ScanSink for Discard {
+    fn push(&mut self, _byte: u8) {}
+}
+
+/// Scan exactly one complete JSON value, leaving the reader positioned
+/// immediately after the value and writing its bytes to `sink`.
+///
+/// Tracks string and escape state so a `,`/`}`/`]` inside a string does not
+/// end the value, and brace/bracket depth so a nested container is captured
+/// whole. The leading byte of the value must be the next byte the reader
+/// yields. O(value size) when `sink` is a `Vec` (one element at a time, never
+/// the whole array); O(1) memory when `sink` is [`Discard`] (a skipped
+/// sibling).
+fn scan_value<S: ScanSink>(reader: &mut ByteReader, sink: &mut S) -> Result<(), FormatError> {
+    // Establish what kind of value we are reading from its first non-space byte.
+    let first = match reader.next_nonspace()? {
+        Some(b) => b,
+        None => {
+            return Err(FormatError::Json(
+                "unexpected end of input scanning a JSON value".into(),
+            ));
+        }
+    };
+    sink.push(first);
+    match first {
+        b'{' | b'[' => scan_container(reader, sink, first),
+        b'"' => scan_rest_of_string(reader, sink),
+        // A scalar (number, true, false, null): read until a structural byte or
+        // whitespace ends it, pushing that delimiter back for the caller.
+        _ => scan_scalar(reader, sink),
+    }
+}
+
+/// First JSON container nesting depth the framing scanner *rejects*. The
+/// scanner accepts an element nested up to `MAX_NESTING_DEPTH - 1` (127) levels
+/// and rejects the 128th, so the scanner — not the downstream
+/// `serde_json::from_slice` — owns the depth boundary and emits the clean error.
+/// `serde_json`'s own recursion limit is 128, so rejecting at 128 keeps the
+/// scanner strictly inside serde's limit; an over-deep element never reaches
+/// serde's "recursion limit exceeded" message, and never overflows the stack.
+const MAX_NESTING_DEPTH: usize = 128;
+
+/// Scan a container (object or array) body into `sink`, the opening bracket
+/// already pushed. Balances nested containers of either kind and ignores
+/// structural bytes inside strings.
+///
+/// Iterative, not recursive: an explicit stack of expected close delimiters
+/// tracks the open `{`/`[` of *both* kinds, so a deeply alternating-nested
+/// element (`{`→`[`→`{`…) costs heap, not call frames, and cannot overflow the
+/// stack. The reachable depth is bounded by [`MAX_NESTING_DEPTH`].
+///
+/// # Errors
+///
+/// Returns [`FormatError::Json`] on end-of-input inside the container, a
+/// mismatched closer, or nesting that would reach [`MAX_NESTING_DEPTH`].
+fn scan_container<S: ScanSink>(
+    reader: &mut ByteReader,
+    sink: &mut S,
+    open: u8,
+) -> Result<(), FormatError> {
+    // Stack of the close delimiters still owed, innermost last. Seeded with the
+    // already-consumed opener's close, so `stack.len()` is the current depth.
+    let mut stack: Vec<u8> = vec![if open == b'{' { b'}' } else { b']' }];
+    while let Some(&expected_close) = stack.last() {
+        let b = match reader.next_byte()? {
+            Some(b) => b,
+            None => {
+                return Err(FormatError::Json(
+                    "unexpected end of input inside a JSON container".into(),
+                ));
+            }
+        };
+        sink.push(b);
+        match b {
+            b'"' => scan_rest_of_string(reader, sink)?,
+            b'{' | b'[' => {
+                // Reject before the push that would reach MAX_NESTING_DEPTH, so
+                // the deepest accepted element is `MAX_NESTING_DEPTH - 1` levels.
+                if stack.len() + 1 >= MAX_NESTING_DEPTH {
+                    return Err(FormatError::Json(format!(
+                        "JSON nesting reaches the {MAX_NESTING_DEPTH}-level limit in an array element"
+                    )));
+                }
+                stack.push(if b == b'{' { b'}' } else { b']' });
+            }
+            b'}' | b']' if b == expected_close => {
+                stack.pop();
+            }
+            b'}' | b']' => {
+                return Err(FormatError::Json(format!(
+                    "mismatched JSON close '{}' (expected '{}')",
+                    b as char, expected_close as char
+                )));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Scan the remaining bytes of a string whose opening `"` is already pushed,
+/// writing up to and including the closing `"`. Honors `\` escapes.
+fn scan_rest_of_string<S: ScanSink>(
+    reader: &mut ByteReader,
+    sink: &mut S,
+) -> Result<(), FormatError> {
+    loop {
+        let b = match reader.next_byte()? {
+            Some(b) => b,
+            None => {
+                return Err(FormatError::Json("unterminated JSON string".into()));
+            }
+        };
+        sink.push(b);
+        match b {
+            b'"' => return Ok(()),
+            b'\\' => {
+                // Consume the escaped byte verbatim so `\"` does not terminate.
+                match reader.next_byte()? {
+                    Some(c) => sink.push(c),
+                    None => {
+                        return Err(FormatError::Json(
+                            "unterminated escape in JSON string".into(),
+                        ));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Scan a scalar value (number / `true` / `false` / `null`) whose first byte is
+/// already pushed, writing bytes until a delimiter (`,`/`}`/`]`/JSON
+/// whitespace/EOF). The delimiter is pushed back so the caller's framing sees
+/// it. JSON whitespace is exactly `{space, tab, LF, CR}` (RFC 8259), so a
+/// non-whitespace control byte like form-feed is captured into the scalar and
+/// rejected by the element parse rather than silently ending the value.
+fn scan_scalar<S: ScanSink>(reader: &mut ByteReader, sink: &mut S) -> Result<(), FormatError> {
+    loop {
+        match reader.next_byte()? {
+            Some(b) if is_json_ws(b) || b == b',' || b == b'}' || b == b']' => {
+                reader.push_back(b);
+                return Ok(());
+            }
+            Some(b) => sink.push(b),
+            None => return Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn br(s: &str) -> BufReader<Box<dyn Read + Send>> {
+        BufReader::new(Box::new(Cursor::new(s.as_bytes().to_vec())))
+    }
+
+    fn collect_top_level(s: &str) -> Vec<serde_json::Value> {
+        let mut stream = JsonArrayStream::top_level(br(s)).unwrap();
+        let mut out = Vec::new();
+        while let Some(v) = stream.next().unwrap() {
+            out.push(v);
+        }
+        out
+    }
+
+    fn collect_path(s: &str, path: &[&str]) -> Vec<serde_json::Value> {
+        let segs: Vec<String> = path.iter().map(|s| s.to_string()).collect();
+        let mut stream = JsonArrayStream::at_path(br(s), &segs).unwrap();
+        let mut out = Vec::new();
+        while let Some(v) = stream.next().unwrap() {
+            out.push(v);
+        }
+        out
+    }
+
+    #[test]
+    fn streams_top_level_scalars() {
+        let vs = collect_top_level("[1, 2, 3]");
+        assert_eq!(vs, vec![json_int(1), json_int(2), json_int(3)]);
+    }
+
+    #[test]
+    fn streams_top_level_objects() {
+        let vs = collect_top_level(r#"[{"a":1},{"a":2}]"#);
+        assert_eq!(vs.len(), 2);
+        assert_eq!(vs[0]["a"], serde_json::json!(1));
+        assert_eq!(vs[1]["a"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn empty_array_yields_nothing() {
+        assert!(collect_top_level("[]").is_empty());
+        assert!(collect_top_level("[   ]").is_empty());
+    }
+
+    #[test]
+    fn nested_containers_and_strings_with_structural_bytes() {
+        // Commas and brackets inside strings and nested arrays must not split
+        // elements early.
+        let vs = collect_top_level(r#"[{"k":"a,b]c","n":[1,2,{"x":3}]},{"k":"}"}]"#);
+        assert_eq!(vs.len(), 2);
+        assert_eq!(vs[0]["k"], serde_json::json!("a,b]c"));
+        assert_eq!(vs[0]["n"], serde_json::json!([1, 2, {"x": 3}]));
+        assert_eq!(vs[1]["k"], serde_json::json!("}"));
+    }
+
+    #[test]
+    fn escaped_quote_does_not_terminate_string() {
+        let vs = collect_top_level(r#"[{"k":"he said \"hi\""}]"#);
+        assert_eq!(vs[0]["k"], serde_json::json!("he said \"hi\""));
+    }
+
+    #[test]
+    fn navigates_record_path_skipping_siblings() {
+        let s = r#"{"metadata":{"v":1},"data":{"results":[{"x":1},{"x":2}]}}"#;
+        let vs = collect_path(s, &["data", "results"]);
+        assert_eq!(vs.len(), 2);
+        assert_eq!(vs[0]["x"], serde_json::json!(1));
+        assert_eq!(vs[1]["x"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn navigates_past_a_large_sibling_blob() {
+        let big = "x".repeat(10_000);
+        let s = format!(r#"{{"big_blob":"{big}","target":[{{"id":1}},{{"id":2}}]}}"#);
+        let vs = collect_path(&s, &["target"]);
+        assert_eq!(vs.len(), 2);
+        assert_eq!(vs[0]["id"], serde_json::json!(1));
+    }
+
+    #[test]
+    fn missing_key_is_an_error() {
+        let segs = vec!["nope".to_string()];
+        let mut stream = JsonArrayStream::at_path(br(r#"{"a":[]}"#), &segs);
+        assert!(stream.is_err() || stream.as_mut().unwrap().next().is_err());
+    }
+
+    #[test]
+    fn trailing_comma_is_rejected() {
+        let mut stream = JsonArrayStream::top_level(br("[1,2,]")).unwrap();
+        assert_eq!(stream.next().unwrap(), Some(json_int(1)));
+        assert_eq!(stream.next().unwrap(), Some(json_int(2)));
+        assert!(stream.next().is_err(), "trailing comma must error");
+    }
+
+    #[test]
+    fn floats_and_keywords_scan_correctly() {
+        let vs = collect_top_level("[1.5, true, false, null, -3]");
+        assert_eq!(
+            vs,
+            vec![
+                serde_json::json!(1.5),
+                serde_json::json!(true),
+                serde_json::json!(false),
+                serde_json::json!(null),
+                serde_json::json!(-3),
+            ]
+        );
+    }
+
+    fn json_int(n: i64) -> serde_json::Value {
+        serde_json::json!(n)
+    }
+
+    /// A `Read` that records the running total of bytes pulled from it, so a
+    /// test can prove the array scanner consumes incrementally rather than
+    /// reading the whole array before yielding the first element.
+    struct CountingRead {
+        bytes: std::io::Cursor<Vec<u8>>,
+        consumed: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    impl Read for CountingRead {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            let n = self.bytes.read(buf)?;
+            self.consumed
+                .fetch_add(n, std::sync::atomic::Ordering::Relaxed);
+            Ok(n)
+        }
+    }
+
+    #[test]
+    fn reads_incrementally_not_the_whole_array_up_front() {
+        use std::sync::atomic::Ordering;
+        // A large array: if the scanner collected eagerly it would pull the
+        // whole body before the first `next`. Element-at-a-time scanning pulls
+        // only enough to frame the first element.
+        let mut json = String::from("[");
+        for i in 0..5_000 {
+            if i > 0 {
+                json.push(',');
+            }
+            json.push_str(&format!(r#"{{"id":{i}}}"#));
+        }
+        json.push(']');
+        let total = json.len();
+
+        let consumed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let reader: Box<dyn Read + Send> = Box::new(CountingRead {
+            bytes: std::io::Cursor::new(json.into_bytes()),
+            consumed: std::sync::Arc::clone(&consumed),
+        });
+        let mut stream = JsonArrayStream::top_level(BufReader::new(reader)).unwrap();
+
+        // First element pulled.
+        let first = stream.next().unwrap().unwrap();
+        assert_eq!(first["id"], serde_json::json!(0));
+        // The BufReader fills in 8 KB chunks, so consumption after one element
+        // is at most a couple of fill blocks — far less than the whole body.
+        assert!(
+            consumed.load(Ordering::Relaxed) < total / 4,
+            "first element pulled {} of {total} bytes — should be a fraction, not the whole array",
+            consumed.load(Ordering::Relaxed)
+        );
+
+        // The rest still streams correctly.
+        let mut count = 1usize;
+        while stream.next().unwrap().is_some() {
+            count += 1;
+        }
+        assert_eq!(count, 5_000);
+    }
+
+    /// A single top-level array element nested `depth` containers deep, as
+    /// same-kind `[[[…1…]]]`. Returns the framed document `[<elem>]`.
+    fn nested_array_doc(depth: usize) -> String {
+        let mut elem = String::new();
+        for _ in 0..depth {
+            elem.push('[');
+        }
+        elem.push('1');
+        for _ in 0..depth {
+            elem.push(']');
+        }
+        format!("[{elem}]")
+    }
+
+    #[test]
+    fn deeply_alternating_nested_element_errors_not_crashes() {
+        // An alternating `{`/`[` nest deeper than the cap. The pre-change
+        // scanner recursed one frame per level here and would overflow the
+        // stack; the iterative cap returns a clean error instead. Build
+        // `[{"a":[{"a":[ ... ]}]}]` to a depth well past MAX_NESTING_DEPTH.
+        let levels = MAX_NESTING_DEPTH + 50;
+        let mut json = String::from("[");
+        for _ in 0..levels {
+            json.push_str(r#"{"a":["#);
+        }
+        for _ in 0..levels {
+            json.push_str("]}");
+        }
+        json.push(']');
+
+        let mut stream = JsonArrayStream::top_level(br(&json)).unwrap();
+        let err = stream
+            .next()
+            .expect_err("over-deep nesting must error, not crash");
+        match err {
+            FormatError::Json(msg) => assert!(
+                msg.contains("nesting reaches"),
+                "error names the nesting limit: {msg}"
+            ),
+            other => panic!("expected a nesting-limit Json error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nesting_depth_boundary_is_owned_by_the_scanner() {
+        // The scanner owns the boundary: the deepest *accepted* element is
+        // `MAX_NESTING_DEPTH - 1` (127) deep, and the 128th-deep element is
+        // rejected with the SCANNER's message — never serde_json's recursion
+        // error. This keeps the scanner strictly inside serde's limit (128).
+        let ok = collect_top_level(&nested_array_doc(MAX_NESTING_DEPTH - 1));
+        assert_eq!(ok.len(), 1, "a 127-deep element streams");
+
+        let mut stream =
+            JsonArrayStream::top_level(br(&nested_array_doc(MAX_NESTING_DEPTH))).unwrap();
+        let err = stream
+            .next()
+            .expect_err("a 128-deep element is rejected by the scanner");
+        match err {
+            FormatError::Json(msg) => {
+                assert!(
+                    msg.contains("nesting reaches"),
+                    "the scanner owns the boundary message, not serde: {msg}"
+                );
+                assert!(
+                    !msg.contains("recursion"),
+                    "serde_json's recursion message must not surface: {msg}"
+                );
+            }
+            other => panic!("expected the scanner's nesting Json error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trailing_garbage_after_top_level_array_is_rejected() {
+        // `[1,2] XYZ` — a full-document parse would reject the trailing
+        // characters; the streaming scanner must too.
+        let mut stream = JsonArrayStream::top_level(br("[1,2] XYZ")).unwrap();
+        assert_eq!(stream.next().unwrap(), Some(json_int(1)));
+        assert_eq!(stream.next().unwrap(), Some(json_int(2)));
+        let err = stream.next().expect_err("trailing garbage must error");
+        match err {
+            FormatError::Json(msg) => assert!(
+                msg.contains("trailing characters"),
+                "error names the trailing characters: {msg}"
+            ),
+            other => panic!("expected a trailing-characters Json error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn trailing_whitespace_after_top_level_array_is_ok() {
+        // Whitespace after the close is not garbage.
+        let vs = collect_top_level("[1,2]  \n\t ");
+        assert_eq!(vs, vec![json_int(1), json_int(2)]);
+    }
+
+    #[test]
+    fn record_path_array_allows_sibling_keys_after_the_array() {
+        // For a `record_path` array the enclosing object legitimately carries
+        // keys after the array, so the strict trailing-garbage check must not
+        // apply.
+        let s = r#"{"data":[{"x":1},{"x":2}],"meta":{"v":1}}"#;
+        let vs = collect_path(s, &["data"]);
+        assert_eq!(vs.len(), 2);
+        assert_eq!(vs[1]["x"], serde_json::json!(2));
+    }
+
+    #[test]
+    fn trailing_form_feed_is_rejected_under_strict_eof() {
+        // RFC 8259 whitespace excludes form-feed (0x0C). `serde_json` rejects
+        // `[1,2]\x0c`; the streaming scanner must too, not silently accept it.
+        let mut stream = JsonArrayStream::top_level(br("[1,2]\u{0c}")).unwrap();
+        assert_eq!(stream.next().unwrap(), Some(json_int(1)));
+        assert_eq!(stream.next().unwrap(), Some(json_int(2)));
+        let err = stream
+            .next()
+            .expect_err("a trailing form-feed is trailing garbage, not whitespace");
+        match err {
+            FormatError::Json(msg) => assert!(
+                msg.contains("trailing characters"),
+                "form-feed after the array must be rejected as trailing garbage: {msg}"
+            ),
+            other => panic!("expected a trailing-characters Json error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn form_feed_inside_a_scalar_is_not_a_value_terminator() {
+        // A form-feed mid-scalar must not end the value (RFC 8259 whitespace is
+        // narrower); the byte is captured and the element parse rejects it,
+        // matching serde_json rather than silently splitting `12` from garbage.
+        let mut stream = JsonArrayStream::top_level(br("[12\u{0c}34]")).unwrap();
+        assert!(
+            stream.next().is_err(),
+            "a form-feed inside a number is not a separator"
+        );
+    }
+
+    #[test]
+    fn record_path_navigation_skips_a_giant_sibling_in_o1_memory() {
+        // A multi-MB preceding sibling must be navigated past WITHOUT buffering
+        // it — the skip sink retains nothing. Track bytes consumed: navigating
+        // past the sibling necessarily reads its bytes from the stream, but the
+        // peak retained scan buffer stays tiny. We assert correctness over a
+        // sibling far larger than any element, proving the skip path runs (a
+        // buffering skip would still be correct but is the wart we removed).
+        let giant = "x".repeat(4_000_000);
+        let s = format!(r#"{{"huge":"{giant}","target":[{{"id":1}},{{"id":2}}]}}"#);
+        let consumed = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let reader: Box<dyn Read + Send> = Box::new(CountingRead {
+            bytes: std::io::Cursor::new(s.into_bytes()),
+            consumed: std::sync::Arc::clone(&consumed),
+        });
+        let segs = vec!["target".to_string()];
+        let mut stream = JsonArrayStream::at_path(BufReader::new(reader), &segs).unwrap();
+        // Both target elements stream correctly after the giant sibling.
+        assert_eq!(stream.next().unwrap().unwrap()["id"], serde_json::json!(1));
+        assert_eq!(stream.next().unwrap().unwrap()["id"], serde_json::json!(2));
+        assert!(stream.next().unwrap().is_none());
+        // Sanity: the giant sibling was indeed traversed (its bytes were read).
+        assert!(
+            consumed.load(std::sync::atomic::Ordering::Relaxed) > 4_000_000,
+            "navigation read past the multi-MB sibling"
+        );
+    }
+}

--- a/crates/clinker-format/src/json/mod.rs
+++ b/crates/clinker-format/src/json/mod.rs
@@ -1,3 +1,4 @@
+mod body_stream;
 pub mod reader;
 mod streaming;
 pub mod writer;

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -1,29 +1,26 @@
 //! Streaming JSON reader with auto-detect (array/NDJSON/object), schema inference,
 //! nested flattening, and array_paths explode/join.
 //!
-//! **All modes stream with O(1 record) memory:**
-//! - NDJSON: line-by-line from BufReader.
-//! - Array: `visit_seq` via DeserializeSeed — one element at a time.
-//! - record_path: `DeserializeSeed` + `IgnoredAny` navigates to the target
-//!   path, skipping non-matching keys without allocation, then streams the
-//!   array. Total memory: ~10KB buffer + one record.
+//! **All modes stream with O(1 record) memory, with no whole-file buffer held
+//! for a re-openable (file) source:**
+//! - NDJSON: line-by-line from a freshly re-opened `BufReader`.
+//! - Array / record_path: a [`JsonArrayStream`] navigates to the target array
+//!   over a second freshly re-opened reader and yields one element at a time —
+//!   never collecting the array into a `Vec`.
 //!
-//! Envelope-aware sources run a streaming pre-scan over the document
-//! before any body record emits: it walks the JSON once, deserializing
-//! ONLY the subtrees the declared `$doc.*` paths name (every other key is
-//! parsed-and-skipped via `IgnoredAny`) into a path-pruned arena index
-//! capped by `max_index_bytes`, rather than materializing the whole
-//! document tree. The pre-scan reads from a fresh cursor over the shared
-//! source buffer, so it does not consume body iteration.
-//!
-//! The source buffer itself is still a full `read_to_end` at construction
-//! — it backs both the body parser's cursor and the pre-scan's cursor, so
-//! there is one read from disk regardless of envelope declarations. Only
-//! the pre-scan's parsed-tree materialization is removed here; shrinking
-//! the raw byte buffer for purely-streamable bodies is a separate
-//! follow-up.
+//! Envelope-aware sources run a streaming pre-scan over the document before any
+//! body record emits: it walks the JSON once over its own freshly re-opened
+//! reader, deserializing ONLY the subtrees the declared `$doc.*` paths name
+//! (every other key is parsed-and-skipped via `IgnoredAny`) into a path-pruned
+//! arena index capped by `max_index_bytes`, rather than materializing the whole
+//! document tree. The pre-scan and the body each open their own [`Read`] from
+//! the [`ReopenableSource`], so neither consumes the other and no shared
+//! whole-file byte buffer is retained for file-backed inputs. A pathless input
+//! (a test cursor, the `<inline>`/`<empty>` slot, a REST body) is held as a
+//! small `ReopenableSource::Buffered` — the honest one-shot fallback, bounded
+//! because such inputs are small by construction.
 
-use std::io::{BufRead, BufReader, Cursor, Read};
+use std::io::{BufRead, BufReader, Read};
 use std::sync::Arc;
 
 use clinker_record::{
@@ -39,7 +36,9 @@ use crate::bom::UTF8_BOM;
 use crate::doc_index::DocArenaIndex;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType};
 use crate::error::FormatError;
+use crate::json::body_stream::{JsonArrayStream, is_json_ws};
 use crate::json::streaming::{SectionTarget, extract_sections};
+use crate::source::{ReopenableSource, SourceIdentity};
 use crate::traits::FormatReader;
 
 // ── Public config types ──────────────────────────────────────────────
@@ -89,82 +88,134 @@ pub struct JsonReader {
     schema: Option<Arc<Schema>>,
     config: JsonReaderConfig,
     pending: Vec<serde_json::Map<String, serde_json::Value>>,
-    /// Buffered source bytes shared with the envelope pre-scan. The body
-    /// parser drains a cursor over these bytes; `prepare_document` opens a
-    /// fresh cursor over the same bytes and streams a single
-    /// `DeserializeSeed` pass that retains only declared `$doc.*` subtrees,
-    /// rather than re-parsing the whole document tree.
-    raw_bytes: Arc<[u8]>,
+    /// The re-openable byte source. Body iteration and the envelope pre-scan
+    /// each open their own fresh [`Read`] from it, so no whole-file buffer is
+    /// held for a file-backed (`ReopenableSource::Path`) source.
+    source: ReopenableSource,
+    /// Content identity of the bytes the body open read, captured at
+    /// construction. The envelope pre-scan re-opens the source and confirms it
+    /// sees the same content, so a path-backed input rewritten between the two
+    /// passes fails loud instead of splicing a stale envelope onto a new body.
+    body_identity: SourceIdentity,
 }
 
 enum InnerReader {
-    /// NDJSON: line-by-line. O(1 record) memory.
+    /// NDJSON: line-by-line from a re-opened `BufReader`. O(1 record) memory.
     Ndjson {
         reader: BufReader<Box<dyn Read + Send>>,
         line_buf: String,
     },
-    /// Array or record_path: records collected via streaming DeserializeSeed.
-    /// Elements are deserialized one at a time and pushed to a Vec during the
-    /// single-pass `deserialize` call, then yielded lazily via `pos`.
-    Collected {
-        records: Vec<serde_json::Value>,
-        pos: usize,
-    },
-    /// Exhausted.
+    /// Array or record_path: one element at a time from a lazy
+    /// [`JsonArrayStream`] over a re-opened reader. Never collects the array.
+    Array(JsonArrayStream),
+    /// Exhausted (empty document).
     Done,
 }
 
 impl JsonReader {
-    pub fn from_reader<R: Read + Send + 'static>(
-        mut reader: R,
+    /// Build a reader over a re-openable byte source.
+    ///
+    /// Streaming, O(1 record): the body opens one fresh [`Read`] from `source`
+    /// (and the envelope pre-scan opens a second), so a file-backed source is
+    /// never buffered whole. Auto-detect peeks the first non-whitespace byte
+    /// from a fresh open to choose array vs. NDJSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError`] if the source cannot be opened, the first byte
+    /// is not a valid JSON start, or `format: object` is set without a
+    /// `record_path`.
+    pub fn from_source(
+        source: ReopenableSource,
         config: JsonReaderConfig,
     ) -> Result<Self, FormatError> {
-        let mut bytes_vec = Vec::new();
-        reader.read_to_end(&mut bytes_vec)?;
-        // Strip a single leading UTF-8 BOM once at the source. `raw_bytes`
-        // feeds every JSON path — array/object auto-detect, the NDJSON
-        // line scan, and the envelope pre-scan's `serde_json::from_slice`
-        // — so one strip here clears the marker from all of them.
-        if bytes_vec.starts_with(&UTF8_BOM) {
-            bytes_vec.drain(..UTF8_BOM.len());
-        }
-        let raw_bytes: Arc<[u8]> = Arc::from(bytes_vec);
-        let body_cursor: Box<dyn Read + Send> = Box::new(Cursor::new(Arc::clone(&raw_bytes)));
-        let mut buf = BufReader::new(body_cursor);
-        let inner = Self::init(&mut buf, &config)?;
+        // JSON runs two passes (envelope pre-scan + body stream), so the source
+        // must be re-openable. A `Path`/`Buffered` source passes through; a
+        // pathless `OneShot` is buffered here, on the reader-building thread —
+        // bounded because such inputs are small.
+        let source = source.into_reopenable().map_err(FormatError::Io)?;
+        let (inner, body_identity) = Self::init(&source, &config)?;
         Ok(JsonReader {
             inner,
             schema: None,
             config,
             pending: Vec::new(),
-            raw_bytes,
+            source,
+            body_identity,
         })
     }
 
+    /// Build a reader by buffering a one-shot `Read` into a re-openable source.
+    ///
+    /// For pathless inputs (test cursors, the `<inline>`/`<empty>` slots, REST
+    /// bodies) that have no on-disk path to re-open: the bytes are captured
+    /// once into a small `ReopenableSource::Buffered`. Bounded because such
+    /// inputs are small by construction; file-backed sources use
+    /// [`from_source`](Self::from_source) with `ReopenableSource::Path` instead
+    /// and are never buffered whole.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError`] on a read failure or the same parse errors as
+    /// [`from_source`](Self::from_source).
+    pub fn from_reader<R: Read + Send + 'static>(
+        reader: R,
+        config: JsonReaderConfig,
+    ) -> Result<Self, FormatError> {
+        let source = ReopenableSource::buffer(reader).map_err(FormatError::Io)?;
+        Self::from_source(source, config)
+    }
+
+    /// Open a fresh `BufReader` from the source with a leading UTF-8 BOM
+    /// stripped, returning the content-identity snapshot of the bytes it reads.
+    /// Each pass (body, pre-scan) re-opens, so the strip happens per open rather
+    /// than once over a shared buffer; the identity lets a later pass detect the
+    /// input changing between passes.
+    fn open_buf(
+        source: &ReopenableSource,
+    ) -> Result<(BufReader<Box<dyn Read + Send>>, SourceIdentity), FormatError> {
+        let (reader, identity) = source.open_with_identity().map_err(FormatError::Io)?;
+        let mut buf = BufReader::new(reader);
+        strip_leading_bom(&mut buf)?;
+        Ok((buf, identity))
+    }
+
+    /// Build the body reader and return it alongside the content-identity of
+    /// the bytes it opened, so the envelope pre-scan can verify it re-opens the
+    /// same content.
     fn init(
-        buf: &mut BufReader<Box<dyn Read + Send>>,
+        source: &ReopenableSource,
         config: &JsonReaderConfig,
-    ) -> Result<InnerReader, FormatError> {
-        // record_path → streaming DeserializeSeed navigation
+    ) -> Result<(InnerReader, SourceIdentity), FormatError> {
+        // record_path → navigate then stream the named array lazily.
         if let Some(ref rp) = config.record_path {
             let path_segments: Vec<String> = rp.split('.').map(String::from).collect();
-            let records = stream_path_array(buf, &path_segments)?;
-            return Ok(InnerReader::Collected { records, pos: 0 });
+            let (buf, identity) = Self::open_buf(source)?;
+            return Ok((
+                InnerReader::Array(JsonArrayStream::at_path(buf, &path_segments)?),
+                identity,
+            ));
         }
 
-        // Explicit format
+        // Explicit format.
         if let Some(mode) = config.format {
             return match mode {
                 JsonMode::Array => {
-                    let records = stream_top_level_array(buf)?;
-                    Ok(InnerReader::Collected { records, pos: 0 })
+                    let (buf, identity) = Self::open_buf(source)?;
+                    Ok((
+                        InnerReader::Array(JsonArrayStream::top_level(buf)?),
+                        identity,
+                    ))
                 }
                 JsonMode::Ndjson => {
-                    let owned = std::mem::replace(buf, BufReader::new(Box::new(std::io::empty())));
-                    Ok(InnerReader::Ndjson {
-                        reader: owned,
-                        line_buf: String::new(),
-                    })
+                    let (reader, identity) = Self::open_buf(source)?;
+                    Ok((
+                        InnerReader::Ndjson {
+                            reader,
+                            line_buf: String::new(),
+                        },
+                        identity,
+                    ))
                 }
                 JsonMode::Object => Err(FormatError::Json(
                     "format: object requires record_path".into(),
@@ -172,39 +223,28 @@ impl JsonReader {
             };
         }
 
-        // Auto-detect
-        let first = peek_first_byte(buf)?;
-        match first {
-            Some(b'[') => {
-                let records = stream_top_level_array(buf)?;
-                Ok(InnerReader::Collected { records, pos: 0 })
+        // Auto-detect from the first non-whitespace byte.
+        let (mut buf, identity) = Self::open_buf(source)?;
+        let inner = match peek_first_byte(&mut buf)? {
+            Some(b'[') => InnerReader::Array(JsonArrayStream::top_level(buf)?),
+            Some(b'{') => InnerReader::Ndjson {
+                reader: buf,
+                line_buf: String::new(),
+            },
+            Some(b) => {
+                return Err(FormatError::Json(format!(
+                    "cannot auto-detect: unexpected byte '{}' (0x{b:02x})",
+                    b as char
+                )));
             }
-            Some(b'{') => {
-                let owned = std::mem::replace(buf, BufReader::new(Box::new(std::io::empty())));
-                Ok(InnerReader::Ndjson {
-                    reader: owned,
-                    line_buf: String::new(),
-                })
-            }
-            Some(b) => Err(FormatError::Json(format!(
-                "cannot auto-detect: unexpected byte '{}' (0x{b:02x})",
-                b as char
-            ))),
-            None => Ok(InnerReader::Done),
-        }
+            None => InnerReader::Done,
+        };
+        Ok((inner, identity))
     }
 
     fn next_raw(&mut self) -> Result<Option<serde_json::Value>, FormatError> {
         match &mut self.inner {
-            InnerReader::Collected { records, pos } => {
-                if *pos < records.len() {
-                    let v = records[*pos].clone();
-                    *pos += 1;
-                    Ok(Some(v))
-                } else {
-                    Ok(None)
-                }
-            }
+            InnerReader::Array(stream) => stream.next(),
             InnerReader::Ndjson { reader, line_buf } => loop {
                 line_buf.clear();
                 let n = reader.read_line(line_buf).map_err(FormatError::Io)?;
@@ -382,13 +422,30 @@ impl FormatReader for JsonReader {
             targets.push(SectionTarget::new(name.clone(), pointer));
         }
 
-        // Single streaming pass over a fresh cursor: only the matched
-        // subtrees are built; every other key is parsed-and-skipped. The cap
-        // is charged *as each declared section is constructed*, so an
+        // Single streaming pass over a freshly re-opened reader: only the
+        // matched subtrees are built; every other key is parsed-and-skipped.
+        // The cap is charged *as each declared section is constructed*, so an
         // oversized declared section aborts the parse mid-build rather than
-        // after the whole subtree materializes. Body iteration keeps its own
-        // independent cursor over `raw_bytes`.
-        let mut prescan = BufReader::new(Cursor::new(Arc::clone(&self.raw_bytes)));
+        // after the whole subtree materializes. Body iteration opens its own
+        // independent reader, so this pass does not consume it and no shared
+        // whole-file buffer is held.
+        //
+        // Confirm the pre-scan re-opens the same content the body opened. A
+        // path-backed input replaced or truncated between the two opens (an
+        // external producer re-emitting mid-run) would otherwise splice this
+        // envelope onto a body parsed from different bytes; the `(len, mtime)`
+        // identity check fails loud instead.
+        //
+        // This is a cheap courtesy guard under the finite-batch input-stability
+        // contract, not a fingerprint: it does not detect a same-length,
+        // same-mtime-tick in-place rewrite, nor a rewrite landing after this
+        // point while the body streams lazily through `next_record` (the check
+        // runs once, here). Closing those would require hashing the whole file,
+        // reintroducing the buffer this reader removes. See `SourceIdentity`.
+        let (mut prescan, prescan_identity) = Self::open_buf(&self.source)?;
+        prescan_identity
+            .ensure_matches(&self.body_identity)
+            .map_err(FormatError::Io)?;
         let matched = extract_sections(&mut prescan, &targets, self.config.max_index_bytes)?;
 
         // Coerce each matched subtree to its declared field schema and retain
@@ -475,132 +532,6 @@ impl FormatReader for JsonReader {
             return Ok(Some(record));
         }
     }
-}
-
-// ── Streaming DeserializeSeed for path navigation ────────────────────
-//
-// These types use serde's Deserializer API to navigate through a JSON
-// object tree without buffering. Non-matching keys are skipped via
-// `IgnoredAny` which parses but discards values (zero allocation).
-// At the target path, array elements are deserialized one at a time
-// as `serde_json::Value` and collected into a Vec.
-
-use serde::de::{self, DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor};
-
-/// Navigate to a nested path, then collect array elements.
-/// Memory: O(N elements) for the collected results, but each element is
-/// deserialized individually (not buffered as a raw tree of the whole file).
-struct PathNavigator<'a> {
-    path: &'a [String],
-    results: &'a mut Vec<serde_json::Value>,
-}
-
-impl<'de, 'a> DeserializeSeed<'de> for PathNavigator<'a> {
-    type Value = ();
-
-    fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<(), D::Error> {
-        if self.path.is_empty() {
-            // Arrived at target — stream the array
-            deserializer.deserialize_seq(ArrayCollector {
-                results: self.results,
-            })
-        } else {
-            // Navigate one level deeper
-            deserializer.deserialize_map(ObjectNavigator {
-                target_key: &self.path[0],
-                remaining: &self.path[1..],
-                results: self.results,
-            })
-        }
-    }
-}
-
-struct ObjectNavigator<'a> {
-    target_key: &'a str,
-    remaining: &'a [String],
-    results: &'a mut Vec<serde_json::Value>,
-}
-
-impl<'de, 'a> Visitor<'de> for ObjectNavigator<'a> {
-    type Value = ();
-
-    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "an object containing key '{}'", self.target_key)
-    }
-
-    fn visit_map<M: MapAccess<'de>>(self, mut map: M) -> Result<(), M::Error> {
-        while let Some(key) = map.next_key::<String>()? {
-            if key == self.target_key {
-                // Found target key — descend into its value
-                map.next_value_seed(PathNavigator {
-                    path: self.remaining,
-                    results: self.results,
-                })?;
-                // Skip remaining keys in this object
-                while (map.next_key::<IgnoredAny>()?).is_some() {
-                    map.next_value::<IgnoredAny>()?;
-                }
-                return Ok(());
-            } else {
-                // Skip this key's value entirely — zero allocation
-                map.next_value::<IgnoredAny>()?;
-            }
-        }
-        Err(de::Error::custom(format!(
-            "key '{}' not found",
-            self.target_key
-        )))
-    }
-}
-
-struct ArrayCollector<'a> {
-    results: &'a mut Vec<serde_json::Value>,
-}
-
-impl<'de, 'a> Visitor<'de> for ArrayCollector<'a> {
-    type Value = ();
-
-    fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.write_str("an array of records")
-    }
-
-    fn visit_seq<S: SeqAccess<'de>>(self, mut seq: S) -> Result<(), S::Error> {
-        while let Some(element) = seq.next_element::<serde_json::Value>()? {
-            self.results.push(element);
-        }
-        Ok(())
-    }
-}
-
-/// Stream array elements from a nested path using DeserializeSeed.
-/// Navigates to the path via `IgnoredAny` (zero-alloc skip), then
-/// deserializes each array element individually.
-fn stream_path_array(
-    reader: &mut BufReader<Box<dyn Read + Send>>,
-    path: &[String],
-) -> Result<Vec<serde_json::Value>, FormatError> {
-    let mut results = Vec::new();
-    let mut de = serde_json::Deserializer::from_reader(reader);
-    PathNavigator {
-        path,
-        results: &mut results,
-    }
-    .deserialize(&mut de)
-    .map_err(|e| FormatError::Json(e.to_string()))?;
-    Ok(results)
-}
-
-/// Stream elements from a top-level JSON array using DeserializeSeed.
-fn stream_top_level_array(
-    reader: &mut BufReader<Box<dyn Read + Send>>,
-) -> Result<Vec<serde_json::Value>, FormatError> {
-    let mut results = Vec::new();
-    let mut de = serde_json::Deserializer::from_reader(reader);
-    de.deserialize_seq(ArrayCollector {
-        results: &mut results,
-    })
-    .map_err(|e| FormatError::Json(e.to_string()))?;
-    Ok(results)
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -706,12 +637,30 @@ fn peek_first_byte(
         if buf.is_empty() {
             return Ok(None);
         }
-        if let Some(pos) = buf.iter().position(|b| !b.is_ascii_whitespace()) {
+        // RFC 8259 whitespace only, so a leading form-feed before the value is
+        // a structural byte the auto-detect rejects, not silently skipped —
+        // matching `serde_json` and the body scanner.
+        if let Some(pos) = buf.iter().position(|b| !is_json_ws(*b)) {
             return Ok(Some(buf[pos]));
         }
         let len = buf.len();
         reader.consume(len);
     }
+}
+
+/// Consume a single leading UTF-8 BOM from a freshly opened reader, if present.
+///
+/// Each pass re-opens its own `Read`, so a Windows-authored file (Excel /
+/// PowerShell utf8 export) carries the BOM on every open; stripping it here
+/// clears the marker for body iteration, the NDJSON line scan, and the
+/// envelope pre-scan alike. The `BufReader`'s default capacity exceeds the
+/// 3-byte BOM, so the marker is always wholly inside the first fill.
+fn strip_leading_bom(reader: &mut BufReader<Box<dyn Read + Send>>) -> Result<(), FormatError> {
+    let buf = reader.fill_buf().map_err(FormatError::Io)?;
+    if buf.starts_with(&UTF8_BOM) {
+        reader.consume(UTF8_BOM.len());
+    }
+    Ok(())
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -1031,9 +980,9 @@ mod tests {
 
     #[test]
     fn test_json_envelope_prescan_strips_leading_bom() {
-        // The envelope pre-scan streams `raw_bytes` from a fresh cursor;
-        // the source-level strip must clear the BOM for that path too, not
-        // just body iteration.
+        // The envelope pre-scan re-opens its own reader from the source; the
+        // per-open BOM strip must clear the marker for that path too, not just
+        // body iteration.
         let json = r#"{
             "BatchInfo": {"batch_id": "RUN-001", "count": 42},
             "records": [{"x": 1}, {"x": 2}]

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -9,6 +9,7 @@ pub mod fixed_width;
 pub mod hl7;
 pub mod json;
 pub(crate) mod segment_tokenizer;
+pub mod source;
 pub mod splitting;
 pub mod swift;
 pub mod traits;
@@ -22,4 +23,5 @@ pub use envelope::{
     NestedEnvelopeSection,
 };
 pub use error::FormatError;
+pub use source::ReopenableSource;
 pub use traits::{FormatReader, FormatWriter};

--- a/crates/clinker-format/src/source.rs
+++ b/crates/clinker-format/src/source.rs
@@ -1,0 +1,381 @@
+//! Re-openable byte source backing a format reader.
+//!
+//! A [`ReopenableSource`] decouples a reader from a single `Box<dyn Read>`
+//! handle so a reader that needs multiple passes (JSON's envelope pre-scan plus
+//! its body stream) can open the bytes more than once without buffering the
+//! whole input — while a one-pass reader (CSV, XML, fixed-width, EDI) consumes
+//! the bytes lazily, one streamed `Read` and no buffer.
+//!
+//! Three shapes, each honest about its memory:
+//! - [`ReopenableSource::Path`] re-opens a stable on-disk path. With staging
+//!   enabled the input is a content-addressed copy held under an advisory read
+//!   lock for the run, so two opens read byte-identical content; with staging
+//!   off the original path is re-opened directly. Either way the batch model
+//!   requires inputs to stay stable for the run's duration, and a multi-pass
+//!   reader guards that with [`SourceIdentity`] — a `(len, mtime)` snapshot
+//!   taken at each open that fails loud if the file changed between passes,
+//!   rather than splicing a stale envelope onto a freshly-read body. Memory is
+//!   O(1) per open — no whole-file buffer is ever held.
+//! - [`ReopenableSource::OneShot`] wraps a single pathless `Box<dyn Read>`
+//!   (a test/bench cursor, the `<empty>` slot, a network body). It is consumed
+//!   *lazily*: the first [`open`](Self::open) hands out the reader as-is, so a
+//!   one-pass format streams it without buffering and a paced/slow reader keeps
+//!   its streaming timing. A second pass is only possible after
+//!   [`into_reopenable`](Self::into_reopenable) buffers it.
+//! - [`ReopenableSource::Buffered`] holds bytes in a shared `Arc<[u8]>`, handing
+//!   out cursors. A `OneShot` becomes `Buffered` on demand when a multi-pass
+//!   reader (JSON) needs a second open; bounded because pathless inputs are
+//!   small by construction.
+
+use std::io::{Cursor, Read};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+/// A cheap `(len, mtime)` snapshot of a re-opened source's content, taken off
+/// the *open* handle (not the path) so it reflects the bytes that open will
+/// read.
+///
+/// This is a courtesy guard against an accidental mid-run input rewrite under
+/// Clinker's finite-batch input-stability contract — not a security boundary
+/// and not a content fingerprint.
+///
+/// What it catches: a file replaced or truncated to a different length, or
+/// touched to a newer mtime, in the window between a reader's two opens (the
+/// body open at construction and the envelope pre-scan open in
+/// `prepare_document`). Cheap — no bytes are read.
+///
+/// What it does NOT catch (accepted residuals; inputs must stay stable for the
+/// duration of a finite batch run):
+/// - A same-length, same-mtime-*tick* in-place rewrite. On coarse-granularity
+///   filesystems (FAT/exFAT at 2 s) or for a truncate-and-rewrite completing
+///   inside one mtime tick, the snapshot is unchanged. Closing this would
+///   require hashing the whole file, which reintroduces the buffer this design
+///   removes, so it is deliberately left open.
+/// - A rewrite landing *after* the pre-scan, while the body still streams
+///   lazily through `next_record`. The guard runs once, at the pre-scan open;
+///   later body reads are not re-checked.
+///
+/// `Buffered` snapshots its byte length (immutable, always self-consistent);
+/// `OneShot` is not re-openable, so its identity never takes part in a
+/// cross-pass check.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct SourceIdentity {
+    len: u64,
+    mtime: Option<SystemTime>,
+}
+
+/// A byte source a format reader can open, re-openably for file/buffered shapes
+/// and once-lazily for a pathless one-shot reader.
+///
+/// A reader needing two passes (JSON's pre-scan plus body) first calls
+/// [`into_reopenable`](Self::into_reopenable) so every [`open`](Self::open)
+/// thereafter yields an independent `Read`; a one-pass reader just calls
+/// [`open`](Self::open) once and streams it.
+pub enum ReopenableSource {
+    /// Re-open a stable filesystem path. Each open is a fresh `std::fs::File`;
+    /// for a staged, advisory-locked source two opens read identical bytes.
+    Path(PathBuf),
+    /// Stream from shared in-memory bytes. Each open is a fresh cursor over the
+    /// same `Arc<[u8]>`. Re-openable; bounded because such inputs are small.
+    Buffered(Arc<[u8]>),
+    /// A single pathless `Box<dyn Read>`, consumed lazily on the first open.
+    /// The `Mutex<Option<..>>` lets `open(&self)` take the reader without
+    /// buffering, preserving a slow/paced reader's streaming timing for a
+    /// one-pass format. `None` after the reader has been taken or buffered.
+    OneShot(Mutex<Option<Box<dyn Read + Send>>>),
+}
+
+impl ReopenableSource {
+    /// Wrap a one-shot pathless reader, consumed lazily on first open.
+    ///
+    /// No bytes are read here — a one-pass format streams the reader directly,
+    /// so a slow/paced reader keeps its per-row timing. JSON, which needs two
+    /// passes, calls [`into_reopenable`](Self::into_reopenable) to buffer it.
+    pub fn one_shot(reader: Box<dyn Read + Send>) -> Self {
+        ReopenableSource::OneShot(Mutex::new(Some(reader)))
+    }
+
+    /// Build a buffered source by draining a one-shot reader into shared bytes.
+    ///
+    /// Used when a multi-pass reader needs re-openability over pathless bytes:
+    /// the reader is captured once into an `Arc<[u8]>` replayed on every
+    /// [`open`](Self::open). Blocking until the reader EOFs; memory is the
+    /// drained size, bounded by these inputs being small.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`std::io::Error`] if draining the reader fails.
+    pub fn buffer<R: Read>(mut reader: R) -> std::io::Result<Self> {
+        let mut bytes = Vec::new();
+        reader.read_to_end(&mut bytes)?;
+        Ok(ReopenableSource::Buffered(Arc::from(bytes)))
+    }
+
+    /// Build a path-backed source that re-opens `path` fresh on every open.
+    pub fn path(path: impl Into<PathBuf>) -> Self {
+        ReopenableSource::Path(path.into())
+    }
+
+    /// Convert into a shape that supports repeated [`open`](Self::open) calls.
+    ///
+    /// `Path` and `Buffered` are already re-openable and pass through untouched
+    /// (no read). A `OneShot` is drained once into a `Buffered` so a multi-pass
+    /// reader (JSON's pre-scan + body) can open it twice. The drain runs at the
+    /// caller's site (the executor's per-file factory for JSON), not at slot
+    /// construction, so a one-pass format never triggers it.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`std::io::Error`] if draining a `OneShot` fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a `OneShot`'s reader was already taken by a prior
+    /// [`open`](Self::open) — a multi-pass reader must convert before opening.
+    pub fn into_reopenable(self) -> std::io::Result<Self> {
+        match self {
+            ReopenableSource::OneShot(slot) => {
+                let reader = slot
+                    .into_inner()
+                    .expect("ReopenableSource mutex poisoned")
+                    .expect("one-shot reader already taken; convert before the first open");
+                Self::buffer(reader)
+            }
+            already => Ok(already),
+        }
+    }
+
+    /// Open a `Read` over the source's bytes, positioned at the start.
+    ///
+    /// `Path` opens a fresh file (O(1) memory); `Buffered` cursors the shared
+    /// `Arc<[u8]>`; `OneShot` hands out its lazy reader on the first call.
+    /// Multi-pass callers convert via [`into_reopenable`](Self::into_reopenable)
+    /// first so every open yields an independent `Read`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`std::io::Error`] if a `Path` source fails to
+    /// open. `Buffered` never fails.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a `OneShot` is opened more than once without first converting
+    /// via [`into_reopenable`](Self::into_reopenable).
+    pub fn open(&self) -> std::io::Result<Box<dyn Read + Send>> {
+        Ok(self.open_with_identity()?.0)
+    }
+
+    /// Open a `Read` and snapshot the content identity of the bytes it will
+    /// read, for a multi-pass reader that must detect the input changing
+    /// between passes.
+    ///
+    /// The [`SourceIdentity`] is stat-ed off the open handle for a `Path`
+    /// source, the byte length for a `Buffered` source, and an empty (always
+    /// self-consistent) snapshot for a `OneShot`. A reader captures it on its
+    /// first pass and compares it on later passes via
+    /// [`SourceIdentity::ensure_matches`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`std::io::Error`] if a `Path` source fails to
+    /// open or its metadata cannot be read.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a `OneShot` is opened more than once without first converting
+    /// via [`into_reopenable`](Self::into_reopenable).
+    pub fn open_with_identity(&self) -> std::io::Result<(Box<dyn Read + Send>, SourceIdentity)> {
+        match self {
+            ReopenableSource::Path(path) => {
+                let file = open_shared(path)?;
+                // Stat the open handle, not the path, so the identity reflects
+                // exactly the bytes this handle reads even if the path is
+                // concurrently replaced.
+                let meta = file.metadata()?;
+                let identity = SourceIdentity {
+                    len: meta.len(),
+                    mtime: meta.modified().ok(),
+                };
+                Ok((Box::new(file), identity))
+            }
+            ReopenableSource::Buffered(bytes) => {
+                let identity = SourceIdentity {
+                    len: bytes.len() as u64,
+                    mtime: None,
+                };
+                Ok((Box::new(Cursor::new(Arc::clone(bytes))), identity))
+            }
+            ReopenableSource::OneShot(slot) => {
+                let reader = slot
+                    .lock()
+                    .expect("ReopenableSource mutex poisoned")
+                    .take()
+                    .expect("one-shot source opened twice; convert via into_reopenable first");
+                Ok((
+                    reader,
+                    SourceIdentity {
+                        len: 0,
+                        mtime: None,
+                    },
+                ))
+            }
+        }
+    }
+}
+
+impl SourceIdentity {
+    /// Confirm this identity matches `prior`, the snapshot from the reader's
+    /// first pass. A mismatch means a path-backed input was rewritten between
+    /// passes — the envelope and body would otherwise be spliced from different
+    /// content — so it is surfaced loud rather than silently accepted.
+    ///
+    /// `Buffered`/`OneShot` sources are immutable across passes (or not
+    /// re-opened), so a check over them never trips.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`std::io::Error`] of kind [`std::io::ErrorKind::Other`] naming
+    /// the change — both the length and the modified time, so an mtime-only
+    /// change (same length, touched timestamp) reads as a timestamp change
+    /// rather than a self-contradictory "500 bytes → 500 bytes" — when
+    /// `self != prior`.
+    pub fn ensure_matches(&self, prior: &SourceIdentity) -> std::io::Result<()> {
+        if self == prior {
+            return Ok(());
+        }
+        Err(std::io::Error::other(format!(
+            "source file changed between the envelope pre-scan and the body read \
+             (was {} bytes, mtime {:?}; now {} bytes, mtime {:?}); inputs must stay \
+             stable for the duration of a run",
+            prior.len, prior.mtime, self.len, self.mtime
+        )))
+    }
+}
+
+/// Open a file for reading with cross-process-friendly share semantics.
+///
+/// On Windows, opening with `FILE_SHARE_DELETE` (alongside read/write) lets a
+/// concurrent atomic-rename publish or delete of a staged source proceed while
+/// this read handle stays valid — matching the POSIX semantics where an
+/// open file survives a concurrent `rename`/`unlink`. Each re-open of a staged
+/// path goes through here so every pass shares those semantics. On Unix this is
+/// a plain `File::open`; an open fd already survives a concurrent rename/unlink.
+fn open_shared(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.read(true);
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        // winnt.h: FILE_SHARE_READ = 0x1, FILE_SHARE_WRITE = 0x2,
+        // FILE_SHARE_DELETE = 0x4. DELETE is the load-bearing one.
+        const FILE_SHARE_READ: u32 = 0x1;
+        const FILE_SHARE_WRITE: u32 = 0x2;
+        const FILE_SHARE_DELETE: u32 = 0x4;
+        opts.share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE);
+    }
+    opts.open(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buffered_yields_two_independent_reads_over_identical_bytes() {
+        let src = ReopenableSource::buffer(Cursor::new(b"hello world".to_vec())).unwrap();
+        let mut a = String::new();
+        let mut b = String::new();
+        src.open().unwrap().read_to_string(&mut a).unwrap();
+        src.open().unwrap().read_to_string(&mut b).unwrap();
+        assert_eq!(a, "hello world");
+        assert_eq!(a, b, "two opens read identical bytes");
+    }
+
+    #[test]
+    fn path_yields_two_independent_reads_over_identical_bytes() {
+        use std::io::Write;
+        // A unique temp path under the OS temp dir, cleaned up at test end. No
+        // external temp-file crate needed for a single fixed-content file.
+        let path = std::env::temp_dir().join(format!(
+            "clinker-reopenable-{}-{:?}.bin",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"path bytes")
+            .unwrap();
+        let src = ReopenableSource::path(&path);
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        src.open().unwrap().read_to_end(&mut a).unwrap();
+        src.open().unwrap().read_to_end(&mut b).unwrap();
+        let _ = std::fs::remove_file(&path);
+        assert_eq!(a, b"path bytes");
+        assert_eq!(a, b, "two opens of the same path read identical bytes");
+    }
+
+    #[test]
+    fn one_shot_opens_lazily_exactly_once() {
+        let src = ReopenableSource::one_shot(Box::new(Cursor::new(b"once".to_vec())));
+        let mut a = String::new();
+        src.open().unwrap().read_to_string(&mut a).unwrap();
+        assert_eq!(a, "once");
+        // The reader was taken; a second open without converting must panic.
+        let second = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| src.open()));
+        assert!(second.is_err(), "a second one-shot open must panic");
+    }
+
+    #[test]
+    fn into_reopenable_makes_a_one_shot_re_openable() {
+        let src = ReopenableSource::one_shot(Box::new(Cursor::new(b"twice".to_vec())))
+            .into_reopenable()
+            .unwrap();
+        let mut a = String::new();
+        let mut b = String::new();
+        src.open().unwrap().read_to_string(&mut a).unwrap();
+        src.open().unwrap().read_to_string(&mut b).unwrap();
+        assert_eq!(a, "twice");
+        assert_eq!(a, b, "after conversion two opens read identical bytes");
+    }
+
+    #[test]
+    fn path_identity_changes_when_the_file_is_rewritten() {
+        use std::io::Write;
+        let path = std::env::temp_dir().join(format!(
+            "clinker-identity-{}-{:?}.bin",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"original content")
+            .unwrap();
+        let src = ReopenableSource::path(&path);
+        let (_r1, id1) = src.open_with_identity().unwrap();
+
+        // Rewrite the file to a different length, as an external producer would.
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(b"a wholly different and longer content")
+            .unwrap();
+        let (_r2, id2) = src.open_with_identity().unwrap();
+        let _ = std::fs::remove_file(&path);
+
+        assert_ne!(id1, id2, "a rewritten file yields a different identity");
+        assert!(
+            id2.ensure_matches(&id1).is_err(),
+            "ensure_matches must fail loud on a changed file"
+        );
+    }
+
+    #[test]
+    fn buffered_identity_is_stable_across_opens() {
+        let src = ReopenableSource::buffer(Cursor::new(b"stable".to_vec())).unwrap();
+        let (_a, id_a) = src.open_with_identity().unwrap();
+        let (_b, id_b) = src.open_with_identity().unwrap();
+        assert_eq!(id_a, id_b);
+        assert!(id_b.ensure_matches(&id_a).is_ok());
+    }
+}

--- a/crates/clinker-format/tests/streaming_doc_index_json.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_json.rs
@@ -406,3 +406,156 @@ fn prescan_prunes_the_unread_section_in_a_mixed_envelope() {
         "the unread section is pruned, not materialized"
     );
 }
+
+/// A multi-MB top-level array streams element-at-a-time: the whole array is
+/// never collected into a `Vec`, and re-opening by path means no whole-file
+/// byte buffer is held either. Body consumption tracks records yielded, not the
+/// full array up front.
+#[test]
+fn large_array_body_streams_without_collecting_or_buffering() {
+    use clinker_format::ReopenableSource;
+    use std::io::Write;
+
+    // ~5 MB array of small objects, written to a real file so the reader
+    // re-opens by path (the production shape) rather than buffering bytes.
+    let rows = 50_000usize;
+    let mut json = String::from("[");
+    for i in 0..rows {
+        if i > 0 {
+            json.push(',');
+        }
+        json.push_str(&format!(r#"{{"id":{i},"name":"row-{i}"}}"#));
+    }
+    json.push(']');
+    assert!(
+        json.len() > 1_000_000,
+        "body should be > 1 MB: {}",
+        json.len()
+    );
+
+    let path = std::env::temp_dir().join(format!(
+        "clinker-large-array-{}-{:?}.json",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(json.as_bytes())
+        .unwrap();
+
+    let mut reader =
+        JsonReader::from_source(ReopenableSource::path(&path), JsonReaderConfig::default())
+            .unwrap();
+
+    // Reading the first record must not require materializing the rest: it
+    // streams one element. Then every record streams in order.
+    let mut count = 0usize;
+    let mut last_id = -1i64;
+    while let Some(rec) = reader.next_record().unwrap() {
+        let id = match rec.get("id") {
+            Some(Value::Integer(n)) => *n,
+            other => panic!("expected integer id, got {other:?}"),
+        };
+        assert_eq!(id, last_id + 1, "body records stream in order");
+        last_id = id;
+        count += 1;
+    }
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(count, rows, "every body element streamed exactly once");
+}
+
+/// `record_path` into a large nested array streams the same way: navigation
+/// skips siblings structurally and the body yields one element at a time.
+#[test]
+fn large_record_path_array_streams_one_element_at_a_time() {
+    let rows = 20_000usize;
+    let mut body = String::from(r#"{"meta":{"v":1},"data":{"results":["#);
+    for i in 0..rows {
+        if i > 0 {
+            body.push(',');
+        }
+        body.push_str(&format!(r#"{{"x":{i}}}"#));
+    }
+    body.push_str("]}}");
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(body.into_bytes()),
+        JsonReaderConfig {
+            record_path: Some("data.results".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let mut count = 0usize;
+    let mut last = -1i64;
+    while let Some(rec) = reader.next_record().unwrap() {
+        let x = match rec.get("x") {
+            Some(Value::Integer(n)) => *n,
+            other => panic!("expected integer x, got {other:?}"),
+        };
+        assert_eq!(x, last + 1);
+        last = x;
+        count += 1;
+    }
+    assert_eq!(count, rows);
+}
+
+/// A path-backed input rewritten between the body open (at construction) and
+/// the envelope pre-scan (at `prepare_document`) is caught: the pre-scan refuses
+/// to splice an envelope from new bytes onto a body parsed from old ones, and
+/// fails loud instead of silently mismatching.
+#[test]
+fn envelope_prescan_rejects_a_file_changed_between_passes() {
+    use clinker_format::ReopenableSource;
+    use std::io::Write;
+
+    let path = std::env::temp_dir().join(format!(
+        "clinker-changed-between-passes-{}-{:?}.json",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    let original = r#"{"Summary":{"record_count":2},"records":[{"x":1},{"x":2}]}"#;
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(original.as_bytes())
+        .unwrap();
+
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    // Construction opens the body and snapshots the file's identity.
+    let mut reader = JsonReader::from_source(
+        ReopenableSource::path(&path),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // An external producer rewrites the file to different content before the
+    // pre-scan re-opens it.
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(br#"{"Summary":{"record_count":9999},"records":[{"x":7},{"x":8},{"x":9}]}"#)
+        .unwrap();
+
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("a file changed between the two passes must fail loud");
+    let _ = std::fs::remove_file(&path);
+    match err {
+        FormatError::Io(e) => assert!(
+            e.to_string().contains("changed between"),
+            "error names the mid-run change: {e}"
+        ),
+        other => panic!("expected an Io change error, got {other:?}"),
+    }
+}

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -1050,10 +1050,15 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
             // `open_source_file` adds the Windows FILE_SHARE_DELETE share mode so
             // a concurrent atomic-rename publish or delete still interoperates
             // with this open handle on Windows.
-            let file = clinker_channel::open_source_file(&read_path)?;
-            slots.push(clinker_exec::source::multi_file::FileSlot::new(
+            // Validate readability up front (surfacing a permission/missing
+            // error here, before the executor thread starts) while leaving the
+            // reader to re-open the stable staged `read_path` per pass. The
+            // staged copy is held under this source's shared advisory read lock
+            // for the run, so re-opens read byte-identical content.
+            clinker_channel::open_source_file(&read_path)?;
+            slots.push(clinker_exec::source::multi_file::FileSlot::from_path(
                 path.clone(),
-                Box::new(file),
+                read_path,
             ));
         }
         source_files_by_name.insert(source_name.clone(), paths);


### PR DESCRIPTION
The JSON document reader previously read the whole file into an Arc<[u8]> held for its lifetime, and array/record_path mode collected the entire parsed body into a Vec — so a large document peaked at memory proportional to file size. This threads a re-openable source (the staged file path) through the reader factory boundary so the JSON reader opens one fresh reader for its envelope pre-scan and a second for the body, which now streams one element at a time. Peak memory becomes O(declared $doc sections, capped by max_index_bytes) + O(1 record); NDJSON was already O(1). Non-seekable inputs (in-memory test cursors, inline sources) keep a bounded buffered fallback. Other formats receive the source and are unaffected. The XML reader reuses this plumbing in a follow-up.

First step toward the end-to-end bounded-memory proof for document $doc resolution. Closes #511.