### PR TITLE
engine: document structural validation — dead-letter malformed EDI envelopes instead of aborting

### DIFF
--- a/crates/clinker-core-types/src/dlq.rs
+++ b/crates/clinker-core-types/src/dlq.rs
@@ -73,6 +73,20 @@ pub enum DlqErrorCategory {
     /// Stage label `reshape:<node>:<rule_a>+<rule_b>` names the colliding
     /// rule pair.
     MutationConflict,
+    /// An envelope structural-integrity check failed: a trailer segment's
+    /// declared count did not match the body the reader actually saw (X12
+    /// `SE`/`GE`/`IEA`, EDIFACT `UNT`/`UNZ`, HL7 `BTS`/`FTS`). The mismatch
+    /// is detected mid-stream when the trailer arrives — after the body
+    /// records it counts have already streamed — so under a source's
+    /// `dlq_granularity: document` policy it condemns the WHOLE source file:
+    /// this is the `trigger: true` root cause and every already-streamed
+    /// record of the same file becomes a `DocumentRejected` collateral, so
+    /// no record of a malformed envelope reaches the sink. Distinct from a
+    /// per-record eval failure — no single record is at fault; the document
+    /// as a whole is structurally invalid. Only emitted under the `document`
+    /// granularity opt-in; under the default `record` granularity a count
+    /// mismatch still aborts the run.
+    StructuralValidation,
 }
 
 impl DlqErrorCategory {
@@ -92,6 +106,7 @@ impl DlqErrorCategory {
             Self::ExpansionLimitExceeded => "expansion_limit_exceeded",
             Self::CombineOutputRow => "combine_output_row",
             Self::MutationConflict => "mutation_conflict",
+            Self::StructuralValidation => "structural_validation",
         }
     }
 }
@@ -171,6 +186,10 @@ mod tests {
         assert_eq!(
             DlqErrorCategory::MutationConflict.as_str(),
             "mutation_conflict"
+        );
+        assert_eq!(
+            DlqErrorCategory::StructuralValidation.as_str(),
+            "structural_validation"
         );
     }
 

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -2157,6 +2157,10 @@ pub(crate) fn merge_fused_interleave(
         let item: Option<(Record, u64)> = match item {
             Some(crate::executor::stream_event::StreamEvent::Record(r, rn)) => Some((r, rn)),
             Some(crate::executor::stream_event::StreamEvent::Punctuation(p)) => {
+                // A structural-count close condemns its whole file; mark it
+                // failed before the reconcile so the Output arm's per-file
+                // buffer rejects every already-streamed record of the file.
+                crate::executor::document_dlq::mark_structural_reject_if_present(ctx, &p);
                 collected_puncts.push(p);
                 continue;
             }
@@ -2508,6 +2512,11 @@ pub(crate) fn transform_fused_consume(
             let (record, rn) = match item {
                 Some(crate::executor::stream_event::StreamEvent::Record(r, rn)) => (r, rn),
                 Some(crate::executor::stream_event::StreamEvent::Punctuation(p)) => {
+                    // A structural-count close condemns its whole file; mark
+                    // it failed before forwarding so the Output arm's
+                    // per-file buffer rejects every already-streamed record
+                    // of the file at this close.
+                    crate::executor::document_dlq::mark_structural_reject_if_present(ctx, &p);
                     event_batcher.push_punctuation(p)?;
                     continue;
                 }

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -224,6 +224,38 @@ pub(crate) fn record_error_to_document_buffer_if_doc_dlq(
     true
 }
 
+/// Mark a document failed for an envelope structural-count failure if `p`
+/// is a file-level close carrying a [`crate::executor::stream_event::StructuralReject`]
+/// payload. A no-op for every ordinary boundary.
+///
+/// Called at every raw source-channel punctuation-drain site that holds
+/// `ctx` — the non-fused Source arm, the fused Source→Transform arm, and the
+/// fused Merge.interleave arm — so a structural-count failure condemns the
+/// whole file regardless of which fusion claimed the source receiver. The
+/// reject is keyed by the representative record's `$source.file` stamp, so
+/// the file grain is correct independent of the carrying close's level. The
+/// close still forwards downstream unchanged; #97's per-file Output buffer
+/// rejects every already-streamed record of the file at that close.
+pub(crate) fn mark_structural_reject_if_present(
+    ctx: &mut ExecutorContext<'_>,
+    p: &crate::executor::stream_event::Punctuation,
+) {
+    let Some(reject) = p.structural_reject() else {
+        return;
+    };
+    record_error_to_document_buffer_if_doc_dlq(
+        ctx,
+        &reject.record,
+        reject.row_num,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation,
+        reject.message.clone(),
+        Some("structural_validation".to_string()),
+        None,
+        None,
+        None,
+    );
+}
+
 /// Mark document `key` failed by `trigger`. The FIRST failure becomes the
 /// document's root-cause trigger; a later failure of an already-failed
 /// document stashes its record as an extra collateral (the trigger slot is

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -516,7 +516,83 @@ fn drive_record_source(
                     )?;
                     break;
                 }
-                Err(other) => return Err(other.into()),
+                Err(other) => {
+                    // An envelope trailer's declared count did not match the
+                    // body the reader streamed (X12 SE/GE/IEA, EDIFACT
+                    // UNT/UNZ, HL7 BTS/FTS). Under `dlq_granularity:
+                    // document` this condemns the WHOLE source file rather
+                    // than aborting the run: the count is only known here, at
+                    // the trailer, AFTER every body record it counts has
+                    // already streamed, so the document cannot be rejected
+                    // before its first record. Instead, tag the file's
+                    // close with a structural-reject payload carrying a
+                    // representative document record; the consumer-side
+                    // Source arm marks the file failed through the #97
+                    // reject seam, and #97's per-file Output buffer rejects
+                    // every already-streamed record of the file at its
+                    // close. Genuine corruption (truncation, bad delimiters,
+                    // control-number echo mismatch) is NOT a `StructuralCount`
+                    // and keeps aborting even under the opt-in.
+                    if other.is_structural_count()
+                        && src_cfg.dlq_granularity == clinker_plan::config::DlqGranularity::Document
+                    {
+                        let file_arc = src_reader
+                            .current_source_file()
+                            .cloned()
+                            .unwrap_or_else(|| Arc::clone(&static_source_file));
+                        // The document context the reject keys on. A malformed
+                        // file that streamed at least one body record has its
+                        // level stack open, so use the innermost level. A
+                        // ZERO-body malformed envelope (a trailer claiming a
+                        // count with no body segment — X12 `ISA … IEA*5~`,
+                        // EDIFACT `UNB … UNZ` with no `UNH`, HL7 `BHS`/`BTS`
+                        // with no `MSH`) never drained its queued `OpenLevel`
+                        // into the stack, so synthesize a file-level context
+                        // from the file grain instead. Either way the
+                        // representative record carries a real (non-synthetic)
+                        // document id and the file's `$source.file` stamp, so
+                        // the document-DLQ reject keys at the file grain.
+                        let doc_ctx = doc_stack.last().cloned().unwrap_or_else(|| {
+                            Arc::new(clinker_record::DocumentContext::new(
+                                clinker_record::DocumentId::next(),
+                                Arc::clone(&file_arc),
+                                indexmap::IndexMap::new(),
+                            ))
+                        });
+                        let rep_record = build_representative_record(
+                            &widened_schema,
+                            &doc_ctx,
+                            &file_arc,
+                            &source_name_arc,
+                        );
+                        let reject = crate::executor::stream_event::StructuralReject {
+                            record: rep_record,
+                            row_num: rn.saturating_add(1),
+                            message: other.to_string(),
+                        };
+                        emit_structural_reject_close(
+                            &mut stream,
+                            &mut doc_stack,
+                            &doc_ctx,
+                            reject,
+                        )?;
+                        // The trailer-count error fires at the file's closing
+                        // segment, so this file is fully consumed. Advance to
+                        // the next file of a multi-file source and keep
+                        // streaming — dead-lettering one malformed file must
+                        // not silently drop the clean files after it (that
+                        // would turn the prior loud run-abort into a silent
+                        // partial success). With the failed file's level stack
+                        // already drained above, the next record reopens a
+                        // fresh file-level document. A single-file source has
+                        // no next file, so this breaks at end-of-input.
+                        if src_reader.advance_to_next_file()? {
+                            continue;
+                        }
+                        break;
+                    }
+                    return Err(other.into());
+                }
             }
         }
         // Close every level still open at end-of-input, innermost first.
@@ -588,6 +664,84 @@ fn close_open_levels(
         )?;
     }
     Ok(())
+}
+
+/// Build a representative record for a document the ingest thread condemned
+/// for an envelope structural-count failure.
+///
+/// No single body record is at fault (the whole document is structurally
+/// invalid), so this synthesizes one onto the engine-widened schema: the
+/// body columns are `Null` and the three engine-stamped tail columns carry
+/// the file's `$source.file`, the source's `$source.name`, and a `Null`
+/// `$source.event_time`, mirroring the per-record widening in
+/// [`drive_record_source`]. The record carries the document's innermost
+/// context so its `source_file` stamp keys the document-DLQ reject at the
+/// correct file grain. It becomes the `trigger: true` root cause for the
+/// file's reject.
+fn build_representative_record(
+    widened_schema: &Arc<clinker_record::Schema>,
+    doc_ctx: &Arc<clinker_record::DocumentContext>,
+    file_arc: &Arc<str>,
+    source_name_arc: &Arc<str>,
+) -> clinker_record::Record {
+    let column_count = widened_schema.column_count();
+    // The three engine-stamped tail columns are the last three; every
+    // body column ahead of them is Null on this synthetic trigger row.
+    let mut values: Vec<clinker_record::Value> =
+        vec![clinker_record::Value::Null; column_count.saturating_sub(3)];
+    values.push(clinker_record::Value::from(file_arc.as_ref()));
+    values.push(clinker_record::Value::from(source_name_arc.as_ref()));
+    values.push(clinker_record::Value::Null);
+    let mut record = clinker_record::Record::new(Arc::clone(widened_schema), values);
+    record.set_doc_ctx(Arc::clone(doc_ctx));
+    record
+}
+
+/// Condemn the open document for an envelope structural-count failure: emit
+/// the innermost open level's `DocumentClose` carrying the structural-reject
+/// payload, then close every remaining open level (the file-level document
+/// and any enclosing nested levels) so the boundary stack stays balanced.
+///
+/// The reject payload rides the INNERMOST close because that is the level
+/// the trailer just failed; the consumer-side reject seam keys on the
+/// representative record's `$source.file` stamp, so the file grain is
+/// correct regardless of which level carries the payload. Draining the rest
+/// of the stack here keeps every `DocumentOpen` balanced by exactly one
+/// `DocumentClose`, the invariant downstream per-document consumers rely on.
+///
+/// When the stack is EMPTY — a zero-body malformed envelope whose queued
+/// `OpenLevel` never drained into the stack — the payload rides a standalone
+/// `DocumentClose` on the synthesized `synthesized_ctx` so the consumer-side
+/// Source arm still marks the file failed and emits its trigger (with no
+/// collaterals, since no record of the file streamed). The end-of-DAG sweep
+/// `reject_unclosed_failed_documents` then emits the trigger for that
+/// recordless document, so a zero-body malformed file still dead-letters.
+fn emit_structural_reject_close(
+    stream: &mut crate::executor::source_stream::SourceIngestChannel,
+    doc_stack: &mut Vec<Arc<clinker_record::DocumentContext>>,
+    synthesized_ctx: &Arc<clinker_record::DocumentContext>,
+    reject: crate::executor::stream_event::StructuralReject,
+) -> Result<(), PipelineError> {
+    match doc_stack.pop() {
+        Some(innermost) => {
+            push_doc_punctuation(
+                stream,
+                crate::executor::stream_event::Punctuation::structural_reject_close(
+                    innermost, reject,
+                ),
+            )?;
+        }
+        None => {
+            push_doc_punctuation(
+                stream,
+                crate::executor::stream_event::Punctuation::structural_reject_close(
+                    Arc::clone(synthesized_ctx),
+                    reject,
+                ),
+            )?;
+        }
+    }
+    close_open_levels(stream, doc_stack)
 }
 
 /// Open the file-level document for `file_arc`, closing the prior file's

--- a/crates/clinker-exec/src/executor/source_dispatch.rs
+++ b/crates/clinker-exec/src/executor/source_dispatch.rs
@@ -171,6 +171,10 @@ pub(crate) fn dispatch_source(
                     drained.push((rec, rn));
                 }
                 Some(crate::executor::stream_event::StreamEvent::Punctuation(p)) => {
+                    // Mark a structural-count close failed BEFORE forwarding it,
+                    // so the Output arm's per-file buffer rejects the file at
+                    // this close rather than flushing it.
+                    crate::executor::document_dlq::mark_structural_reject_if_present(ctx, &p);
                     drained_puncts.push(p);
                 }
                 None => break,

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -39,6 +39,32 @@ pub enum PunctuationKind {
     DocumentClose,
 }
 
+/// Structural-integrity failure a source reader detected at an envelope
+/// trailer (an X12 `SE`/`GE`/`IEA`, EDIFACT `UNT`/`UNZ`, or HL7 `BTS`/`FTS`
+/// count mismatch). Rides on the file-level [`PunctuationKind::DocumentClose`]
+/// the ingest thread emits for the condemned file.
+///
+/// The count is only known mid-stream — after every body record it counts
+/// has already streamed — so the ingest thread cannot reject the document
+/// before its first record. Instead it tags the document's close with this
+/// payload; the consumer-side Source dispatch arm reads it and marks the
+/// whole file failed through the document-DLQ reject seam, so #97's
+/// per-file Output buffer rejects every already-streamed record of the file
+/// at its close. The `record` is a representative body row of the document
+/// (widened, doc-context-stamped) that becomes the captured `trigger: true`
+/// root cause.
+#[derive(Debug, Clone)]
+pub struct StructuralReject {
+    /// A representative record of the condemned document — the engine-widened,
+    /// document-context-stamped row the reject seam captures as the
+    /// `trigger: true` root cause for the file's reject.
+    pub record: Record,
+    /// Source row number of the representative record, for DLQ attribution.
+    pub row_num: u64,
+    /// The precise count-mismatch message the reader built at the trailer.
+    pub message: String,
+}
+
 /// Document-boundary punctuation on the executor's record stream.
 ///
 /// Carries an `Arc<DocumentContext>` so operators reading the event can
@@ -48,16 +74,29 @@ pub enum PunctuationKind {
 /// from the same Arc that body records carried). The Arc clone is a
 /// refcount bump only; punctuations are O(1) per document, not per
 /// record.
+///
+/// A file-level `DocumentClose` may additionally carry a
+/// [`StructuralReject`] payload when the ingest thread condemned the file
+/// for an envelope count mismatch under `dlq_granularity: document`; every
+/// other punctuation leaves it `None`, so the structural-validation path
+/// adds zero cost to the dominant boundary-marking flow and stays invisible
+/// to operators that ignore it (they treat the close as an ordinary
+/// boundary).
 #[derive(Debug, Clone)]
 pub struct Punctuation {
     doc_ctx: Arc<DocumentContext>,
     kind: PunctuationKind,
+    structural_reject: Option<Box<StructuralReject>>,
 }
 
 impl Punctuation {
     /// Construct a punctuation for a given document context and kind.
     pub fn new(doc_ctx: Arc<DocumentContext>, kind: PunctuationKind) -> Self {
-        Self { doc_ctx, kind }
+        Self {
+            doc_ctx,
+            kind,
+            structural_reject: None,
+        }
     }
 
     /// Convenience: build a `DocumentOpen` punctuation.
@@ -68,6 +107,29 @@ impl Punctuation {
     /// Convenience: build a `DocumentClose` punctuation.
     pub fn document_close(doc_ctx: Arc<DocumentContext>) -> Self {
         Self::new(doc_ctx, PunctuationKind::DocumentClose)
+    }
+
+    /// Build a `DocumentClose` punctuation that condemns the document for an
+    /// envelope structural-count failure. The consumer-side Source dispatch
+    /// arm reads the [`StructuralReject`] payload and marks the file failed
+    /// via the document-DLQ reject seam before forwarding the close
+    /// downstream.
+    pub fn structural_reject_close(
+        doc_ctx: Arc<DocumentContext>,
+        reject: StructuralReject,
+    ) -> Self {
+        Self {
+            doc_ctx,
+            kind: PunctuationKind::DocumentClose,
+            structural_reject: Some(Box::new(reject)),
+        }
+    }
+
+    /// The structural-count reject payload this close carries, if any. `None`
+    /// for every normal boundary; `Some` only on the file-level close of a
+    /// document the ingest thread condemned for an envelope count mismatch.
+    pub fn structural_reject(&self) -> Option<&StructuralReject> {
+        self.structural_reject.as_deref()
     }
 
     /// Identity of the document this punctuation marks. Equality on
@@ -239,6 +301,39 @@ mod tests {
         };
         assert_eq!(rn, 42);
         assert_eq!(r.values()[0], Value::Integer(1));
+    }
+
+    #[test]
+    fn ordinary_close_carries_no_structural_reject() {
+        // The dominant boundary path leaves the structural-reject payload
+        // empty, so a structural-validation check on any close is a cheap None.
+        let ctx = doc_ctx();
+        let close = Punctuation::document_close(Arc::clone(&ctx));
+        assert!(close.structural_reject().is_none());
+        let open = Punctuation::document_open(ctx);
+        assert!(open.structural_reject().is_none());
+    }
+
+    #[test]
+    fn structural_reject_close_carries_payload_and_is_a_close() {
+        // A structural-reject close is a `DocumentClose` (so downstream
+        // per-document consumers treat it as an ordinary boundary) that
+        // additionally exposes its representative record, row, and message
+        // for the consumer-side reject seam.
+        let ctx = doc_ctx();
+        let reject = StructuralReject {
+            record: rec(7),
+            row_num: 42,
+            message: "SE segment count mismatch".to_string(),
+        };
+        let close = Punctuation::structural_reject_close(Arc::clone(&ctx), reject);
+        assert_eq!(close.kind(), PunctuationKind::DocumentClose);
+        let payload = close
+            .structural_reject()
+            .expect("a structural-reject close carries its payload");
+        assert_eq!(payload.row_num, 42);
+        assert_eq!(payload.record.values()[0], Value::Integer(7));
+        assert!(payload.message.contains("SE segment count mismatch"));
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -222,6 +222,12 @@ impl FormatReader for CoercingReader {
         // its envelope nesting.
         self.inner.take_envelope_events()
     }
+
+    fn advance_to_next_file(&mut self) -> Result<bool, FormatError> {
+        // File advancement is the inner multi-file reader's concern; coercion
+        // is per-record and stateless across files, so forward verbatim.
+        self.inner.advance_to_next_file()
+    }
 }
 
 /// Unwrap Nullable to get the inner type for coercion.

--- a/crates/clinker-exec/src/source/mod.rs
+++ b/crates/clinker-exec/src/source/mod.rs
@@ -81,6 +81,21 @@ pub trait RecordSource: Send {
     /// so it ignores the token. Network readers holding a live socket
     /// override this to bound cancellation latency.
     fn set_shutdown_token(&mut self, _token: crate::pipeline::shutdown::ShutdownToken) {}
+
+    /// Abandon the current file and advance to the next, returning `Ok(true)`
+    /// when a next file opened or `Ok(false)` when none remain. Mirrors
+    /// [`FormatReader::advance_to_next_file`]: the ingest driver calls this
+    /// after dead-lettering a whole file for a structural-count failure under
+    /// `dlq_granularity: document`, so a multi-file source keeps reading its
+    /// remaining files past the malformed one. The default returns `Ok(false)`
+    /// for single-file and pathless transports.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the next file's reader-construction or schema-mismatch error.
+    fn advance_to_next_file(&mut self) -> Result<bool, FormatError> {
+        Ok(false)
+    }
 }
 
 /// Byte-stream transports reach the row-yielding contract by delegating
@@ -110,6 +125,10 @@ impl RecordSource for Box<dyn FormatReader> {
 
     fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
         (**self).take_envelope_events()
+    }
+
+    fn advance_to_next_file(&mut self) -> Result<bool, FormatError> {
+        (**self).advance_to_next_file()
     }
 }
 

--- a/crates/clinker-exec/src/source/multi_file.rs
+++ b/crates/clinker-exec/src/source/multi_file.rs
@@ -269,6 +269,21 @@ impl FormatReader for MultiFileFormatReader {
             }
         }
     }
+
+    fn advance_to_next_file(&mut self) -> Result<bool, FormatError> {
+        // Drop the active (dead-lettered, trailer-reached) inner reader and
+        // open the next slot. A structural-count failure fires at the file's
+        // closing trailer, so the abandoned file is fully consumed — nothing
+        // unread is lost. Verify the new file's schema before its records
+        // flow, exactly as the EOF-driven advance in `next_record` does.
+        self.active = None;
+        if !self.advance()? {
+            return Ok(false);
+        }
+        let new_schema = self.active.as_mut().unwrap().schema()?;
+        self.assert_schema_match(&new_schema)?;
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -322,6 +337,54 @@ mod tests {
         r.next_record().unwrap();
         let after_second = r.current_file().to_string();
         assert!(after_second.ends_with("b.csv"));
+    }
+
+    #[test]
+    fn advance_to_next_file_abandons_current_and_opens_next() {
+        // `advance_to_next_file` drops the active file (skipping any of its
+        // unread records) and opens the next, updating `current_file`. This is
+        // the seam the ingest driver uses to keep streaming past a file it
+        // dead-lettered for a structural-count failure. Returns Ok(false) once
+        // no files remain.
+        let files = vec![
+            FileSlot {
+                path: PathBuf::from("a.csv"),
+                reader: cursor("id,name\n1,alice\n2,bob\n"),
+            },
+            FileSlot {
+                path: PathBuf::from("b.csv"),
+                reader: cursor("id,name\n3,carol\n"),
+            },
+        ];
+        let mut r = MultiFileFormatReader::new(files, csv_factory());
+        // Read one record of file a, then abandon a's remaining record (id=2).
+        assert!(r.next_record().unwrap().is_some());
+        assert!(r.current_file().to_string().ends_with("a.csv"));
+        assert!(
+            r.advance_to_next_file().unwrap(),
+            "a next file (b) opens, so advance reports true"
+        );
+        assert!(
+            r.current_file().to_string().ends_with("b.csv"),
+            "current_file moves to the next file after advancing"
+        );
+        // Only file b's record (carol) remains — a's unread tail (bob) is gone.
+        let mut remaining: Vec<String> = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            if let clinker_record::Value::String(s) = &rec.values()[1] {
+                remaining.push(s.as_str().to_string());
+            }
+        }
+        assert_eq!(
+            remaining,
+            vec!["carol".to_string()],
+            "file a's unread record was abandoned by the advance; only file b streams"
+        );
+        // No files remain, so a further advance reports false.
+        assert!(
+            !r.advance_to_next_file().unwrap(),
+            "advancing past the last file reports false"
+        );
     }
 
     #[test]

--- a/crates/clinker-exec/src/source/multi_file.rs
+++ b/crates/clinker-exec/src/source/multi_file.rs
@@ -347,14 +347,8 @@ mod tests {
         // dead-lettered for a structural-count failure. Returns Ok(false) once
         // no files remain.
         let files = vec![
-            FileSlot {
-                path: PathBuf::from("a.csv"),
-                reader: cursor("id,name\n1,alice\n2,bob\n"),
-            },
-            FileSlot {
-                path: PathBuf::from("b.csv"),
-                reader: cursor("id,name\n3,carol\n"),
-            },
+            slot("a.csv", "id,name\n1,alice\n2,bob\n"),
+            slot("b.csv", "id,name\n3,carol\n"),
         ];
         let mut r = MultiFileFormatReader::new(files, csv_factory());
         // Read one record of file a, then abandon a's remaining record (id=2).

--- a/crates/clinker-exec/tests/document_dlq.rs
+++ b/crates/clinker-exec/tests/document_dlq.rs
@@ -491,6 +491,722 @@ fn nested_envelope_clean_interchange_streams_through() {
     assert!(ok > 0, "the clean interchange's records reach the sink");
 }
 
+// --- Structural-count validation: malformed envelope → document DLQ ---
+
+/// An X12 document-DLQ pipeline whose source `dlq_granularity` is templated,
+/// so the same pipeline drives both the `document` opt-in and the default
+/// `record` policy for the structural-count tests.
+fn x12_structural_yaml(dlq_granularity: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: x12_structural
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      dlq_granularity: {dlq_granularity}
+      schema:
+        - {{ name: seg_id, type: string }}
+        - {{ name: set_ref, type: string }}
+        - {{ name: e01, type: string }}
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+/// One X12 interchange (one file) holding a single transaction set whose
+/// `SE01` segment count is templated — pass a wrong count to trip the SE
+/// structural-count check, the right count (`4`) for a clean control. Two
+/// body segments (`BEG`, `PO1`) stream as records BEFORE the SE trailer
+/// fires, so a reject has already-streamed records to dead-letter as
+/// collaterals.
+fn x12_se_count(se01: &str) -> String {
+    format!(
+        "{ISA}\
+        GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+        ST*850*0001~\
+        BEG*00*NE*PO12345**20240101~\
+        PO1*1*10*EA*9.99~\
+        SE*{se01}*0001~\
+        GE*1*1~\
+        IEA*1*000000001~"
+    )
+}
+
+/// Like [`x12_se_count`] but the `GE01` functional-group set count is
+/// templated (the right value is `1`). The SE trailer is correct so only the
+/// GE count can fail.
+fn x12_ge_count(ge01: &str) -> String {
+    format!(
+        "{ISA}\
+        GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+        ST*850*0001~\
+        BEG*00*NE*PO12345**20240101~\
+        PO1*1*10*EA*9.99~\
+        SE*4*0001~\
+        GE*{ge01}*1~\
+        IEA*1*000000001~"
+    )
+}
+
+/// Like [`x12_se_count`] but the `IEA01` interchange functional-group count
+/// is templated (the right value is `1`). SE and GE trailers are correct so
+/// only the IEA count can fail.
+fn x12_iea_count(iea01: &str) -> String {
+    format!(
+        "{ISA}\
+        GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+        ST*850*0001~\
+        BEG*00*NE*PO12345**20240101~\
+        PO1*1*10*EA*9.99~\
+        SE*4*0001~\
+        GE*1*1~\
+        IEA*{iea01}*000000001~"
+    )
+}
+
+/// A ZERO-body malformed interchange: an `ISA` header with NO functional
+/// group and an `IEA` claiming a nonzero group count. `close_interchange`
+/// fires the IEA structural-count error before any body record streams, so
+/// the failed file's level stack never opened — the document context for the
+/// reject must be synthesized from the file grain.
+fn x12_zero_body_iea_count(iea01: &str) -> String {
+    format!("{ISA}IEA*{iea01}*000000001~")
+}
+
+/// Run an X12 fixture through the structural-count pipeline at the given
+/// granularity, returning the full run `Result` so a test can assert either
+/// a successful document-DLQ run or a run-aborting error.
+fn run_x12_structural(
+    dlq_granularity: &str,
+    fixture: &str,
+) -> Result<clinker_exec::executor::ExecutionReport, clinker_plan::error::PipelineError> {
+    let yaml = x12_structural_yaml(dlq_granularity);
+    let config = parse_config(&yaml).expect("parse x12 structural pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile x12 structural pipeline");
+    let file = FileSlot::new(
+        PathBuf::from("po.x12"),
+        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "interchange".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+}
+
+/// Run several named X12 files as one multi-file glob source through the
+/// structural-count pipeline at the given granularity, returning the run
+/// `Result` plus the sorted success-sink body lines (each `seg_id,set_ref`).
+#[allow(clippy::type_complexity)]
+fn run_x12_structural_multi(
+    dlq_granularity: &str,
+    files: &[(&str, String)],
+) -> Result<
+    (clinker_exec::executor::ExecutionReport, Vec<String>),
+    clinker_plan::error::PipelineError,
+> {
+    let yaml = x12_structural_yaml(dlq_granularity);
+    let config = parse_config(&yaml).expect("parse x12 structural pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile x12 structural pipeline");
+    let slots: Vec<FileSlot> = files
+        .iter()
+        .map(|(name, body)| {
+            FileSlot::new(
+                PathBuf::from(*name),
+                Box::new(Cursor::new(body.as_bytes().to_vec())),
+            )
+        })
+        .collect();
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "interchange".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)?;
+    let mut body: Vec<String> = buf.as_string().lines().skip(1).map(String::from).collect();
+    body.sort();
+    Ok((report, body))
+}
+
+#[test]
+fn x12_multi_file_bad_in_the_middle_rejects_only_the_bad_file() {
+    // A multi-file glob source [good, bad (wrong SE count), good] under the
+    // `document` opt-in: dead-lettering the malformed middle file must NOT
+    // stop ingestion of the clean third file. The two good files stream to
+    // the sink and ONLY the bad file's records dead-letter — silently
+    // dropping the good tail (the way a `break`-the-source implementation
+    // would) is a data-loss regression on the prior loud run-abort.
+    let (report, body) = run_x12_structural_multi(
+        "document",
+        &[
+            ("a.x12", x12_se_count("4")),  // clean
+            ("b.x12", x12_se_count("99")), // malformed: wrong SE count
+            ("c.x12", x12_se_count("4")),  // clean — must still be read
+        ],
+    )
+    .expect("a malformed file dead-letters; the run does not abort");
+
+    // Both clean files reached the sink; the bad file contributed nothing.
+    assert!(
+        report.counters.ok_count > 0,
+        "the clean files' records reach the sink"
+    );
+    assert!(
+        !body.is_empty(),
+        "the clean files stream through, got an empty sink"
+    );
+    // Each clean single-set interchange emits the same body segments, so the
+    // good output is exactly double a single clean file's output.
+    let (single_clean, _) =
+        run_x12_structural_multi("document", &[("solo.x12", x12_se_count("4"))])
+            .expect("a single clean file runs");
+    assert_eq!(
+        report.counters.ok_count,
+        single_clean.counters.ok_count * 2,
+        "exactly the two clean files' records reach the sink — the third file \
+         was not silently dropped after the malformed second"
+    );
+
+    // Exactly one malformed file was dead-lettered: one StructuralValidation
+    // trigger, its message naming the bad file's count mismatch.
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(
+        triggers.len(),
+        1,
+        "exactly one file (the malformed middle one) is dead-lettered"
+    );
+    assert_eq!(
+        triggers[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("SE segment count mismatch"),
+        "got {:?}",
+        triggers[0].error_message
+    );
+}
+
+#[test]
+fn x12_zero_body_malformed_file_dead_letters() {
+    // A ZERO-body malformed interchange (an ISA with no functional group and
+    // an IEA claiming a nonzero count) dead-letters under the `document`
+    // opt-in rather than aborting — even though no body record ever streamed,
+    // so the file's level stack never opened. The reject's document context is
+    // synthesized from the file grain. One StructuralValidation trigger, no
+    // collaterals (no record of the file streamed), nothing at the sink.
+    let report = run_x12_structural("document", &x12_zero_body_iea_count("5"))
+        .expect("a zero-body malformed file dead-letters rather than aborting");
+    assert_eq!(report.counters.ok_count, 0, "no record reaches the sink");
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(
+        triggers.len(),
+        1,
+        "exactly one root-cause trigger for the zero-body malformed file"
+    );
+    assert_eq!(
+        triggers[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("IEA functional-group count mismatch"),
+        "got {:?}",
+        triggers[0].error_message
+    );
+    assert_eq!(
+        report.dlq_entries.iter().filter(|e| !e.trigger).count(),
+        0,
+        "a zero-body file has no already-streamed records, so no collaterals"
+    );
+}
+
+#[test]
+fn x12_zero_body_bad_then_good_continues() {
+    // The (A) regression guard: a glob [zero-body-bad, good] under the
+    // `document` opt-in must dead-letter the zero-body file AND keep reading
+    // the good file. Before the synthesized-context fix the empty level stack
+    // fell through to a loud run-abort, silently dropping the trailing good
+    // file.
+    let (report, body) = run_x12_structural_multi(
+        "document",
+        &[
+            ("bad.x12", x12_zero_body_iea_count("5")), // zero-body malformed
+            ("good.x12", x12_se_count("4")),           // clean — must still be read
+        ],
+    )
+    .expect("a zero-body malformed file dead-letters; the run does not abort");
+
+    assert!(
+        !body.is_empty() && report.counters.ok_count > 0,
+        "the good file after a zero-body malformed one still streams to the sink"
+    );
+    let (single_clean, _) =
+        run_x12_structural_multi("document", &[("solo.x12", x12_se_count("4"))])
+            .expect("a single clean file runs");
+    assert_eq!(
+        report.counters.ok_count, single_clean.counters.ok_count,
+        "exactly the one clean file's records reach the sink"
+    );
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(
+        triggers.len(),
+        1,
+        "only the zero-body file is dead-lettered"
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("IEA functional-group count mismatch"),
+        "got {:?}",
+        triggers[0].error_message
+    );
+}
+
+#[test]
+fn x12_multi_file_bad_first_then_good_continues() {
+    // [bad, good]: the malformed FIRST file dead-letters and the good second
+    // file streams. Guards the cursor-advance from the very first slot.
+    let (report, body) = run_x12_structural_multi(
+        "document",
+        &[
+            ("bad.x12", x12_se_count("99")),
+            ("good.x12", x12_se_count("4")),
+        ],
+    )
+    .expect("does not abort");
+    let (single_clean, _) =
+        run_x12_structural_multi("document", &[("solo.x12", x12_se_count("4"))])
+            .expect("a single clean file runs");
+    assert!(!body.is_empty(), "the good second file streams");
+    assert_eq!(
+        report.counters.ok_count, single_clean.counters.ok_count,
+        "exactly the one clean file's records reach the sink"
+    );
+    assert_eq!(
+        report.dlq_entries.iter().filter(|e| e.trigger).count(),
+        1,
+        "only the malformed first file is dead-lettered"
+    );
+}
+
+#[test]
+fn x12_multi_file_all_bad_dead_letters_each_and_emits_nothing() {
+    // [bad, bad]: every file is malformed — each dead-letters independently
+    // (two triggers) and nothing reaches the sink. The run still does NOT
+    // abort under the opt-in.
+    let (report, body) = run_x12_structural_multi(
+        "document",
+        &[("a.x12", x12_se_count("99")), ("b.x12", x12_ge_count("9"))],
+    )
+    .expect("does not abort even when every file is malformed");
+    assert_eq!(report.counters.ok_count, 0, "nothing reaches the sink");
+    assert!(body.is_empty());
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(
+        triggers.len(),
+        2,
+        "each malformed file is dead-lettered independently"
+    );
+    assert!(
+        triggers
+            .iter()
+            .all(|e| e.category == clinker_core_types::dlq::DlqErrorCategory::StructuralValidation),
+        "both triggers carry the structural_validation category"
+    );
+}
+
+#[test]
+fn x12_multi_file_bad_bad_good_streams_only_the_good() {
+    // [bad, bad, good]: two consecutive malformed files each dead-letter, and
+    // the trailing good file still streams — the advance is robust across
+    // back-to-back rejects.
+    let (report, body) = run_x12_structural_multi(
+        "document",
+        &[
+            ("a.x12", x12_se_count("99")),
+            ("b.x12", x12_iea_count("9")),
+            ("c.x12", x12_se_count("4")),
+        ],
+    )
+    .expect("does not abort");
+    let (single_clean, _) =
+        run_x12_structural_multi("document", &[("solo.x12", x12_se_count("4"))])
+            .expect("a single clean file runs");
+    assert!(!body.is_empty(), "the trailing good file streams");
+    assert_eq!(
+        report.counters.ok_count, single_clean.counters.ok_count,
+        "exactly the one clean file's records reach the sink"
+    );
+    assert_eq!(
+        report.dlq_entries.iter().filter(|e| e.trigger).count(),
+        2,
+        "both malformed files are dead-lettered"
+    );
+}
+
+#[test]
+fn x12_se_count_mismatch_rejects_whole_document() {
+    // A wrong SE segment count condemns the WHOLE interchange under the
+    // `document` opt-in: the body segments that already streamed dead-letter
+    // (one StructuralValidation trigger + DocumentRejected collaterals), and
+    // ZERO records reach the success sink. The trailer count is only known
+    // mid-stream, so the reject lands at the file's close — but no record of
+    // the malformed envelope is ever written out.
+    let report = run_x12_structural("document", &x12_se_count("99"))
+        .expect("structural-count failure dead-letters rather than aborting");
+
+    assert_eq!(
+        report.counters.ok_count, 0,
+        "no record of the malformed interchange reaches the sink"
+    );
+    assert!(
+        report.counters.dlq_count >= 1,
+        "the malformed interchange's already-streamed records dead-letter, got {}",
+        report.counters.dlq_count
+    );
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(triggers.len(), 1, "exactly one root-cause trigger");
+    assert_eq!(
+        triggers[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation,
+        "the trigger carries the structural_validation category"
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("SE segment count mismatch"),
+        "the trigger message names the count mismatch, got {:?}",
+        triggers[0].error_message
+    );
+    assert!(
+        report
+            .dlq_entries
+            .iter()
+            .filter(|e| !e.trigger)
+            .all(|e| e.category == clinker_core_types::dlq::DlqErrorCategory::DocumentRejected),
+        "every collateral carries the document_rejected category"
+    );
+}
+
+#[test]
+fn x12_ge_count_mismatch_rejects_at_file_grain() {
+    // A GE functional-group count mismatch rejects the whole source file
+    // (the outermost grain), not just the offending group.
+    let report = run_x12_structural("document", &x12_ge_count("9"))
+        .expect("GE count failure dead-letters rather than aborting");
+    assert_eq!(report.counters.ok_count, 0, "the whole file dead-letters");
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(triggers.len(), 1);
+    assert_eq!(
+        triggers[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("GE transaction-set count mismatch"),
+        "got {:?}",
+        triggers[0].error_message
+    );
+}
+
+#[test]
+fn x12_iea_count_mismatch_rejects_at_file_grain() {
+    // An IEA interchange-level count mismatch rejects the whole file.
+    let report = run_x12_structural("document", &x12_iea_count("9"))
+        .expect("IEA count failure dead-letters rather than aborting");
+    assert_eq!(report.counters.ok_count, 0, "the whole file dead-letters");
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(triggers.len(), 1);
+    assert_eq!(
+        triggers[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("IEA functional-group count mismatch"),
+        "got {:?}",
+        triggers[0].error_message
+    );
+}
+
+#[test]
+fn x12_clean_interchange_streams_under_structural_opt_in() {
+    // The control: a well-formed interchange under the same `document`
+    // opt-in streams normally with no DLQ entries — the opt-in only changes
+    // behavior on a malformed envelope.
+    let report = run_x12_structural("document", &x12_se_count("4"))
+        .expect("a clean interchange runs without error");
+    assert_eq!(
+        report.counters.dlq_count, 0,
+        "no DLQ entries for a clean file"
+    );
+    assert!(
+        report.counters.ok_count > 0,
+        "the clean interchange's records reach the sink"
+    );
+}
+
+#[test]
+fn x12_count_mismatch_aborts_under_record_granularity() {
+    // Without the opt-in (default `record` granularity) a structural-count
+    // mismatch still ABORTS the run — the document-DLQ behavior is gated on
+    // `dlq_granularity: document`.
+    let err = run_x12_structural("record", &x12_se_count("99"))
+        .expect_err("a count mismatch aborts the run under the default record policy");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("SE segment count mismatch"),
+        "the run aborts with the structural-count error, got {msg:?}"
+    );
+}
+
+#[test]
+fn x12_genuine_corruption_aborts_even_under_opt_in() {
+    // Genuine corruption that is NOT a count mismatch — here a segment
+    // appearing AFTER the IEA interchange trailer — keeps aborting even under
+    // the `document` opt-in. Only `StructuralCount` is reclassified to the
+    // document DLQ; structural corruption stays run-aborting.
+    let corrupt = format!(
+        "{ISA}\
+        GS*PO*SENDER*RECEIVER*20240101*1200*1*X*004010~\
+        ST*850*0001~\
+        BEG*00*NE*PO12345**20240101~\
+        PO1*1*10*EA*9.99~\
+        SE*4*0001~\
+        GE*1*1~\
+        IEA*1*000000001~\
+        ST*850*0002~"
+    );
+    let err = run_x12_structural("document", &corrupt)
+        .expect_err("post-trailer corruption aborts even under the document opt-in");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("after the IEA"),
+        "genuine corruption aborts with its own error, not a doc-DLQ reject, got {msg:?}"
+    );
+}
+
+/// Run an arbitrary fixture through a templated document-DLQ pipeline of the
+/// named `format`, returning the full run `Result`. Shared by the EDIFACT and
+/// HL7 structural-count tests so each format exercises the same disposition.
+fn run_structural(
+    format: &str,
+    dlq_granularity: &str,
+    file_name: &str,
+    fixture: &str,
+) -> Result<clinker_exec::executor::ExecutionReport, clinker_plan::error::PipelineError> {
+    let yaml = format!(
+        r#"
+pipeline:
+  name: structural
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: msgs
+    config:
+      name: msgs
+      type: {format}
+      glob: ./*.{format}
+      dlq_granularity: {dlq_granularity}
+      schema:
+        - {{ name: seg_id, type: string }}
+        - {{ name: set_ref, type: string }}
+  - type: output
+    name: out
+    input: msgs
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    );
+    let config = parse_config(&yaml).expect("parse structural pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile structural pipeline");
+    let file = FileSlot::new(
+        PathBuf::from(file_name),
+        Box::new(Cursor::new(fixture.as_bytes().to_vec())),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "msgs".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+}
+
+/// One ORDERS interchange whose `UNT` segment count is templated (the right
+/// count is `4`). `UNH`, `BGM`, `NAD` stream as body records before the UNT
+/// trailer fires.
+fn edifact_unt_count(unt_count: &str) -> String {
+    format!(
+        "UNB+UNOA:1+SENDER+RECEIVER+240101:1200+REF1'\
+         UNH+M1+ORDERS:D:96A:UN'\
+         BGM+220+PO12345+9'\
+         NAD+BY+5021376940009::9'\
+         UNT+{unt_count}+M1'\
+         UNZ+1+REF1'"
+    )
+}
+
+#[test]
+fn edifact_unt_count_mismatch_rejects_whole_document() {
+    // A wrong UNT segment count condemns the whole EDIFACT interchange under
+    // the `document` opt-in: the body segments dead-letter (StructuralValidation
+    // trigger + DocumentRejected collaterals) and no record reaches the sink.
+    let report = run_structural(
+        "edifact",
+        "document",
+        "po.edifact",
+        &edifact_unt_count("99"),
+    )
+    .expect("EDIFACT count failure dead-letters rather than aborting");
+    assert_eq!(report.counters.ok_count, 0, "no record reaches the sink");
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(triggers.len(), 1);
+    assert_eq!(
+        triggers[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("UNT segment count mismatch"),
+        "got {:?}",
+        triggers[0].error_message
+    );
+}
+
+#[test]
+fn edifact_clean_interchange_streams_under_opt_in() {
+    // The control: a well-formed UNT count streams normally under the same
+    // opt-in.
+    let report = run_structural("edifact", "document", "po.edifact", &edifact_unt_count("4"))
+        .expect("a clean EDIFACT interchange runs without error");
+    assert_eq!(report.counters.dlq_count, 0);
+    assert!(report.counters.ok_count > 0);
+}
+
+#[test]
+fn edifact_count_mismatch_aborts_under_record_granularity() {
+    // Without the opt-in, a UNT count mismatch still aborts the run.
+    let err = run_structural("edifact", "record", "po.edifact", &edifact_unt_count("99"))
+        .expect_err("a count mismatch aborts under the default record policy");
+    assert!(
+        format!("{err}").contains("UNT segment count mismatch"),
+        "got {err}"
+    );
+}
+
+/// An FHS..FTS file wrapping a BHS..BTS batch of two ADT messages whose
+/// `BTS` batch message count is templated (the right count is `2`). The two
+/// MSH-led messages stream as body records before the BTS trailer fires.
+fn hl7_bts_count(bts_count: &str) -> String {
+    let msh1 = "MSH|^~\\&|ADMIT|HOSP|REG|HOSP|20240101120000||ADT^A01|ADT0001|P|2.5";
+    let msh2 = "MSH|^~\\&|ADMIT|HOSP|REG|HOSP|20240101120100||ADT^A01|ADT0002|P|2.5";
+    format!(
+        "FHS|^~\\&|LAB|HOSP|EHR|HOSP|20240102|FILE7\r\
+         BHS|^~\\&|LAB|HOSP|EHR|HOSP|20240102|BATCH3\r\
+         {msh1}\rPID|1||PT1\r\
+         {msh2}\rPID|1||PT2\r\
+         BTS|{bts_count}\r\
+         FTS|1"
+    )
+}
+
+#[test]
+fn hl7_bts_count_mismatch_rejects_whole_document() {
+    // A wrong BTS batch message count condemns the whole HL7 file under the
+    // `document` opt-in: the streamed message segments dead-letter
+    // (StructuralValidation trigger + DocumentRejected collaterals) and no
+    // record reaches the sink.
+    let report = run_structural("hl7", "document", "batch.hl7", &hl7_bts_count("99"))
+        .expect("HL7 count failure dead-letters rather than aborting");
+    assert_eq!(report.counters.ok_count, 0, "no record reaches the sink");
+    let triggers: Vec<&DlqEntry> = report.dlq_entries.iter().filter(|e| e.trigger).collect();
+    assert_eq!(triggers.len(), 1);
+    assert_eq!(
+        triggers[0].category,
+        clinker_core_types::dlq::DlqErrorCategory::StructuralValidation
+    );
+    assert!(
+        triggers[0]
+            .error_message
+            .contains("BTS batch message count mismatch"),
+        "got {:?}",
+        triggers[0].error_message
+    );
+}
+
+#[test]
+fn hl7_count_mismatch_aborts_under_record_granularity() {
+    // Without the opt-in, a BTS count mismatch still aborts the run.
+    let err = run_structural("hl7", "record", "batch.hl7", &hl7_bts_count("99"))
+        .expect_err("a count mismatch aborts under the default record policy");
+    assert!(
+        format!("{err}").contains("BTS batch message count mismatch"),
+        "got {err}"
+    );
+}
+
 #[test]
 fn document_dlq_with_per_source_file_fanout_is_rejected_at_compile_time() {
     // Document-level DLQ buffers each document and flushes it to one writer;
@@ -528,6 +1244,44 @@ nodes:
     assert!(
         msg.contains("E343"),
         "expected the E343 document-DLQ + fan-out rejection, got: {msg}"
+    );
+}
+
+#[test]
+fn document_dlq_with_fail_fast_is_rejected_at_compile_time() {
+    // `dlq_granularity: document` keeps the run going past a bad document;
+    // `strategy: fail_fast` aborts on the first error. The two give
+    // contradictory dispositions, so the combination is rejected at config
+    // validation (E344) rather than silently ignoring the granularity field.
+    let yaml = r#"
+pipeline:
+  name: doc_dlq_fail_fast
+error_handling:
+  strategy: fail_fast
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      dlq_granularity: document
+      schema:
+        - { name: id, type: string }
+  - type: output
+    name: out
+    input: events
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err =
+        parse_config(yaml).expect_err("document-DLQ + fail_fast must be rejected as contradictory");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("E344"),
+        "expected the E344 document-DLQ + fail_fast rejection, got: {msg}"
     );
 }
 

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -257,7 +257,7 @@ impl<R: Read> EdifactReader<R> {
         // the UNT segment itself completes the count.
         let actual = msg.segment_count + 1;
         if claimed != actual {
-            return Err(FormatError::Edifact(format!(
+            return Err(FormatError::edifact_structural_count(format!(
                 "UNT segment count mismatch for message {:?}: trailer claims {claimed}, \
                  interchange contains {actual} (UNH..UNT inclusive)",
                 msg.reference
@@ -296,7 +296,7 @@ impl<R: Read> EdifactReader<R> {
                 ))
             })?;
         if claimed != self.message_count {
-            return Err(FormatError::Edifact(format!(
+            return Err(FormatError::edifact_structural_count(format!(
                 "UNZ message count mismatch: trailer claims {claimed}, interchange \
                  contains {} messages",
                 self.message_count
@@ -571,7 +571,9 @@ mod tests {
                 Err(e) => break e,
             }
         };
-        assert!(matches!(err, FormatError::Edifact(m) if m.contains("UNT segment count mismatch")));
+        assert!(
+            matches!(err, FormatError::StructuralCount { format: "EDIFACT", ref message } if message.contains("UNT segment count mismatch"))
+        );
     }
 
     #[test]
@@ -601,7 +603,9 @@ mod tests {
                 Err(e) => break e,
             }
         };
-        assert!(matches!(err, FormatError::Edifact(m) if m.contains("UNZ message count mismatch")));
+        assert!(
+            matches!(err, FormatError::StructuralCount { format: "EDIFACT", ref message } if message.contains("UNZ message count mismatch"))
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -33,6 +33,19 @@ pub enum FormatError {
     /// missing/non-numeric block id, missing `-}` block-4 trailer,
     /// malformed `:tag:value` line, truncation, non-UTF-8 message).
     Swift(String),
+    /// An envelope trailer's declared structural COUNT did not match the
+    /// body the reader streamed: X12 `SE`/`GE`/`IEA`, EDIFACT `UNT`/`UNZ`,
+    /// or HL7 `BTS`/`FTS`. Distinct from the format-specific variants above
+    /// (which also cover truncation, bad delimiters, and control-number echo
+    /// mismatches) so the executor can route ONLY a count mismatch to the
+    /// document-level DLQ under `dlq_granularity: document`, while genuine
+    /// corruption keeps aborting the run. `format` names the spec for the
+    /// DLQ stage label; `message` is the precise count-mismatch description
+    /// the reader built at the trailer.
+    StructuralCount {
+        format: &'static str,
+        message: String,
+    },
     InvalidRecord {
         row: u64,
         message: String,
@@ -80,6 +93,9 @@ impl fmt::Display for FormatError {
             Self::X12(msg) => write!(f, "X12 error: {msg}"),
             Self::Hl7(msg) => write!(f, "HL7 error: {msg}"),
             Self::Swift(msg) => write!(f, "SWIFT error: {msg}"),
+            Self::StructuralCount { format, message } => {
+                write!(f, "{format} structural count error: {message}")
+            }
             Self::InvalidRecord { row, message } => {
                 write!(f, "invalid record at row {row}: {message}")
             }
@@ -97,6 +113,42 @@ impl fmt::Display for FormatError {
                  user emitted a map explicitly, coerce to a scalar in CXL before the emit."
             ),
         }
+    }
+}
+
+impl FormatError {
+    /// Build a [`FormatError::StructuralCount`] for an X12 envelope
+    /// count mismatch (`SE`/`GE`/`IEA`).
+    pub fn x12_structural_count(message: impl Into<String>) -> Self {
+        Self::StructuralCount {
+            format: "X12",
+            message: message.into(),
+        }
+    }
+
+    /// Build a [`FormatError::StructuralCount`] for an EDIFACT envelope
+    /// count mismatch (`UNT`/`UNZ`).
+    pub fn edifact_structural_count(message: impl Into<String>) -> Self {
+        Self::StructuralCount {
+            format: "EDIFACT",
+            message: message.into(),
+        }
+    }
+
+    /// Build a [`FormatError::StructuralCount`] for an HL7 batch/file
+    /// envelope count mismatch (`BTS`/`FTS`).
+    pub fn hl7_structural_count(message: impl Into<String>) -> Self {
+        Self::StructuralCount {
+            format: "HL7",
+            message: message.into(),
+        }
+    }
+
+    /// `true` for a [`FormatError::StructuralCount`] — the only class the
+    /// executor reclassifies from run-aborting to document-DLQ under
+    /// `dlq_granularity: document`. Every other variant keeps aborting.
+    pub fn is_structural_count(&self) -> bool {
+        matches!(self, Self::StructuralCount { .. })
     }
 }
 

--- a/crates/clinker-format/src/hl7/reader.rs
+++ b/crates/clinker-format/src/hl7/reader.rs
@@ -338,7 +338,7 @@ impl<R: Read> Hl7Reader<R> {
         if let Some(claimed) = parse_optional_count(fts.fields.first(), "FTS", "file batch count")?
             && claimed != self.batch_count
         {
-            return Err(FormatError::Hl7(format!(
+            return Err(FormatError::hl7_structural_count(format!(
                 "FTS file batch count mismatch: trailer claims {claimed}, file contains \
                  {} batches",
                 self.batch_count
@@ -379,7 +379,7 @@ impl<R: Read> Hl7Reader<R> {
             parse_optional_count(bts.fields.first(), "BTS", "batch message count")?
             && claimed != batch.message_count
         {
-            return Err(FormatError::Hl7(format!(
+            return Err(FormatError::hl7_structural_count(format!(
                 "BTS batch message count mismatch: trailer claims {claimed}, batch contains \
                  {} messages",
                 batch.message_count
@@ -928,7 +928,7 @@ mod tests {
             }
         };
         assert!(
-            matches!(err, FormatError::Hl7(m) if m.contains("BTS batch message count mismatch"))
+            matches!(err, FormatError::StructuralCount { format: "HL7", ref message } if message.contains("BTS batch message count mismatch"))
         );
     }
 
@@ -943,7 +943,9 @@ mod tests {
                 Err(e) => break e,
             }
         };
-        assert!(matches!(err, FormatError::Hl7(m) if m.contains("FTS file batch count mismatch")));
+        assert!(
+            matches!(err, FormatError::StructuralCount { format: "HL7", ref message } if message.contains("FTS file batch count mismatch"))
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/traits.rs
+++ b/crates/clinker-format/src/traits.rs
@@ -66,6 +66,29 @@ pub trait FormatReader: Send {
     fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
         Vec::new()
     }
+
+    /// Abandon the file currently being read and advance to the next one,
+    /// returning `Ok(true)` when a next file was opened (and
+    /// [`Self::current_source_file`] now names it) or `Ok(false)` when no
+    /// files remain.
+    ///
+    /// The ingest driver calls this after dead-lettering a whole file for a
+    /// structural-integrity failure under `dlq_granularity: document`, to keep
+    /// reading the remaining files of a multi-file source instead of stopping
+    /// the source at the first malformed file. The structural-count failures
+    /// that trigger it fire at the file's closing trailer, so the abandoned
+    /// file is already fully consumed — no unread records of it are lost.
+    ///
+    /// Default impl returns `Ok(false)`: a single-file reader has no next file.
+    /// Wrappers holding an inner reader (`CoercingReader`) must delegate;
+    /// [`MultiFileFormatReader`](crate) overrides it to advance its file cursor.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces the next file's reader-construction or schema-mismatch error.
+    fn advance_to_next_file(&mut self) -> Result<bool, FormatError> {
+        Ok(false)
+    }
 }
 
 /// Streaming record writer. Consumes records one at a time.

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -305,7 +305,7 @@ impl<R: Read> X12Reader<R> {
         })?;
         let claimed = parse_count(ge.elements.first(), "GE", "transaction-set count")?;
         if claimed != group.set_count {
-            return Err(FormatError::X12(format!(
+            return Err(FormatError::x12_structural_count(format!(
                 "GE transaction-set count mismatch for group {:?}: trailer claims {claimed}, \
                  group contains {} transaction sets",
                 group.control_number, group.set_count
@@ -370,7 +370,7 @@ impl<R: Read> X12Reader<R> {
         // itself completes the count.
         let actual = set.segment_count + 1;
         if claimed != actual {
-            return Err(FormatError::X12(format!(
+            return Err(FormatError::x12_structural_count(format!(
                 "SE segment count mismatch for transaction set {:?}: trailer claims {claimed}, \
                  set contains {actual} (ST..SE inclusive)",
                 set.control_number
@@ -398,7 +398,7 @@ impl<R: Read> X12Reader<R> {
         }
         let claimed = parse_count(iea.elements.first(), "IEA", "functional-group count")?;
         if claimed != self.group_count {
-            return Err(FormatError::X12(format!(
+            return Err(FormatError::x12_structural_count(format!(
                 "IEA functional-group count mismatch: trailer claims {claimed}, interchange \
                  contains {} groups",
                 self.group_count
@@ -940,7 +940,9 @@ mod tests {
             ST*850*0001~BEG*00*NE*A**20240101~SE*9*0001~GE*1*1~IEA*1*000000001~"
         );
         let err = error_from(&data);
-        assert!(matches!(err, FormatError::X12(m) if m.contains("SE segment count mismatch")));
+        assert!(
+            matches!(err, FormatError::StructuralCount { format: "X12", ref message } if message.contains("SE segment count mismatch"))
+        );
     }
 
     #[test]
@@ -961,7 +963,7 @@ mod tests {
         );
         let err = error_from(&data);
         assert!(
-            matches!(err, FormatError::X12(m) if m.contains("GE transaction-set count mismatch"))
+            matches!(err, FormatError::StructuralCount { format: "X12", ref message } if message.contains("GE transaction-set count mismatch"))
         );
     }
 
@@ -983,7 +985,7 @@ mod tests {
         );
         let err = error_from(&data);
         assert!(
-            matches!(err, FormatError::X12(m) if m.contains("IEA functional-group count mismatch"))
+            matches!(err, FormatError::StructuralCount { format: "X12", ref message } if message.contains("IEA functional-group count mismatch"))
         );
     }
 

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3101,6 +3101,32 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         }
     }
 
+    // Document-level dead-lettering is in direct tension with `fail_fast`:
+    // `dlq_granularity: document` says "do not abort the run on a bad
+    // document — dead-letter it and keep processing", while `fail_fast` says
+    // "abort on the first error". Under `fail_fast` a per-record failure
+    // aborts before any document-DLQ disposition, AND a malformed-envelope
+    // structural-count failure would dead-letter-and-continue, so the two
+    // settings give contradictory dispositions for the same run. Reject the
+    // combination up front rather than silently no-op'ing a user-set field.
+    if config.any_source_has_document_dlq()
+        && config.error_handling.strategy == ErrorStrategy::FailFast
+    {
+        let source = config
+            .source_configs()
+            .find(|s| s.dlq_granularity == DlqGranularity::Document)
+            .map(|s| s.name.as_str())
+            .unwrap_or("");
+        return Err(ConfigError::Validation(format!(
+            "[E344] source '{source}': `dlq_granularity: document` cannot be combined \
+             with `error_handling.strategy: fail_fast` — document-level dead-lettering \
+             keeps the run going past a bad document, which contradicts fail-fast's \
+             abort-on-first-error. Use `strategy: continue` (or `best_effort`) with \
+             `dlq_granularity: document`, or set `dlq_granularity: record` to keep \
+             fail-fast"
+        )));
+    }
+
     // Validate the flat `vars:` block (`$vars.<key>` static config)
     if let Some(ref vars) = config.pipeline.vars {
         for (name, decl) in vars {

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -131,12 +131,15 @@ pub struct SourceConfig {
 /// Per-source dead-letter granularity under `continue` / `best_effort`.
 ///
 /// Selects whether a record failure dead-letters just the failing record
-/// or the whole document it belongs to. Has no effect under `fail_fast`,
-/// where the first failure aborts the run regardless. A pure policy enum —
-/// it carries no state and imposes no memory cost itself; the runtime cost
-/// of `Document` is the per-document record buffer the executor holds open
-/// only for currently-open documents (peak = concurrently-open documents,
-/// not total input), which spills to disk under memory pressure.
+/// or the whole document it belongs to. `Document` is incompatible with
+/// `error_handling.strategy: fail_fast` — document-level dead-lettering keeps
+/// the run going past a bad document, which contradicts fail-fast's
+/// abort-on-first-error, so the pairing is rejected at config-validation time
+/// (E344). A pure policy enum — it carries no state and imposes no memory cost
+/// itself; the runtime cost of `Document` is the per-document record buffer the
+/// executor holds open only for currently-open documents (peak =
+/// concurrently-open documents, not total input), which spills to disk under
+/// memory pressure.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum DlqGranularity {

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -235,6 +235,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E341" => Some(include_str!("../../../../docs/explain/E341.md")),
         "E342" => Some(include_str!("../../../../docs/explain/E342.md")),
         "E343" => Some(include_str!("../../../../docs/explain/E343.md")),
+        "E344" => Some(include_str!("../../../../docs/explain/E344.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -449,7 +450,7 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E15Y", "W101", "W302", "W305", "W306",
+            "E343", "E344", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -1996,7 +1996,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E343, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E344, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/docs/explain/E344.md
+++ b/docs/explain/E344.md
@@ -1,0 +1,108 @@
+# Error E344: document-level DLQ cannot be combined with fail_fast
+
+## What it means
+
+A source declares `dlq_granularity: document` while the pipeline's
+`error_handling.strategy` is `fail_fast` (the default). The two settings give
+contradictory dispositions for the same run:
+
+- **`fail_fast`** aborts the whole run on the first error — no dead-letter
+  queue, no partial output.
+- **`dlq_granularity: document`** does the opposite: it keeps the run going
+  past a bad document, dead-lettering that document's records (and, for a
+  malformed envelope, the whole file) while clean documents stream through.
+
+Under `fail_fast` a per-record failure aborts before any document-level
+dead-lettering can apply, and a malformed-envelope structural-count failure
+would instead dead-letter-and-continue — so the two settings disagree about
+whether the run should stop. Rather than silently no-op a user-set
+`dlq_granularity: document`, clinker rejects the combination at
+config-validation time.
+
+```
+[E344] source 'claims': `dlq_granularity: document` cannot be combined with
+`error_handling.strategy: fail_fast` — document-level dead-lettering keeps the
+run going past a bad document, which contradicts fail-fast's
+abort-on-first-error. Use `strategy: continue` (or `best_effort`) with
+`dlq_granularity: document`, or set `dlq_granularity: record` to keep fail-fast
+```
+
+## Example
+
+```yaml
+# Rejected: document-level DLQ under fail_fast.
+pipeline:
+  name: claims
+error_handling:
+  strategy: fail_fast              # aborts on the first error
+nodes:
+  - type: source
+    name: claims
+    config:
+      name: claims
+      type: x12
+      glob: ./claims/*.edi
+      dlq_granularity: document    # but this asks to keep going past a bad document
+```
+
+```yaml
+# Corrected (option A): keep document-level dead-lettering; switch the run to
+# continue so a bad document is dead-lettered instead of aborting the run.
+pipeline:
+  name: claims
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: claims
+    config:
+      name: claims
+      type: x12
+      glob: ./claims/*.edi
+      dlq_granularity: document
+```
+
+```yaml
+# Corrected (option B): keep fail_fast; drop document-level dead-lettering so
+# the first error aborts the run as fail_fast intends.
+pipeline:
+  name: claims
+error_handling:
+  strategy: fail_fast
+nodes:
+  - type: source
+    name: claims
+    config:
+      name: claims
+      type: x12
+      glob: ./claims/*.edi
+      dlq_granularity: record      # the default
+```
+
+## How to fix
+
+1. **Set `strategy: continue`** (or `best_effort`) if you want document-level
+   dead-lettering — a bad document is then dead-lettered and the run proceeds.
+
+2. **Set `dlq_granularity: record`** (the default) on the source if you want
+   `fail_fast` — the first error aborts the run, and there is nothing to
+   dead-letter at the document grain.
+
+## Technical context
+
+`fail_fast` is the abort-on-first-error strategy: the dispatcher propagates the
+first record failure as a run error before any dead-letter routing. Document-
+level dead-lettering exists only to avoid aborting — it buffers each document
+and, at the document's boundary, flushes it clean or routes its records to the
+DLQ. A malformed-envelope structural-count failure (an X12 `SE`/`GE`/`IEA`,
+EDIFACT `UNT`/`UNZ`, or HL7 `BTS`/`FTS` count mismatch) is dead-lettered at the
+file grain under `dlq_granularity: document` — which under `fail_fast` would
+mean continuing past an error the strategy says should abort the run. Because
+the two dispositions cannot both hold, the validator rejects the pairing up
+front rather than silently ignoring the granularity field.
+
+## See also
+
+- "Document-level DLQ" in the error-handling reference
+- "Malformed envelopes (structural validation)" in the error-handling reference
+- Error E343, the per-source-file-output / document-DLQ conflict

--- a/docs/user/src/formats/edifact.md
+++ b/docs/user/src/formats/edifact.md
@@ -149,6 +149,19 @@ the correct reference.
 A missing `UNZ` at end of input is a truncation error; content after the
 `UNZ` trailer is rejected.
 
+### Routing a count mismatch to the DLQ
+
+By default a `UNT`/`UNZ` **count** mismatch aborts the run. A source declaring
+`dlq_granularity: document` instead dead-letters the whole interchange / file
+to the DLQ — the file's records become a `structural_validation` trigger plus
+`document_rejected` collaterals, and no record of the malformed file reaches
+the sink. The count is only known at the trailer, after the body has streamed,
+so the rejection lands at the sink boundary (no record is written out), not
+literally before the first record. The grain is the whole file. The
+control-reference *echo* mismatches and every other corruption (truncation,
+post-trailer content) always abort, even under the opt-in. See [Malformed
+envelopes](../pipelines/error-handling.md#malformed-envelopes-structural-validation).
+
 ## Writing EDIFACT
 
 An EDIFACT Output node reconstructs the envelope around emitted records.

--- a/docs/user/src/formats/hl7.md
+++ b/docs/user/src/formats/hl7.md
@@ -233,6 +233,19 @@ truncation or corruption signal):
 Content after the `FTS` file trailer is rejected. A bare `MSH`-led file
 needs no trailers and validates with no count checks.
 
+### Routing a count mismatch to the DLQ
+
+By default a `BTS`/`FTS` **count** mismatch aborts the run. A source declaring
+`dlq_granularity: document` instead dead-letters the whole file to the DLQ —
+the file's records become a `structural_validation` trigger plus
+`document_rejected` collaterals, and no record of the malformed file reaches
+the sink. The count is only known at the trailer, after the body has streamed,
+so the rejection lands at the sink boundary (no record is written out), not
+literally before the first record. The grain is the whole file. Other
+corruption (truncation, post-trailer content) always aborts, even under the
+opt-in. An empty `BTS-1`/`FTS-1` still disables the check entirely. See
+[Malformed envelopes](../pipelines/error-handling.md#malformed-envelopes-structural-validation).
+
 ## Writing HL7
 
 An HL7 Output node re-emits the `MSH` and body segments from the record

--- a/docs/user/src/formats/x12.md
+++ b/docs/user/src/formats/x12.md
@@ -221,6 +221,21 @@ corruption signal):
 A missing `IEA` at end of input is a truncation error; content after the
 `IEA` trailer is rejected.
 
+### Routing a count mismatch to the DLQ
+
+By default a `SE`/`GE`/`IEA` **count** mismatch aborts the run. A source
+declaring `dlq_granularity: document` instead dead-letters the whole
+interchange / file to the DLQ — the file's records become a
+`structural_validation` trigger plus `document_rejected` collaterals, and no
+record of the malformed file reaches the sink. The count is only known at the
+trailer, after the body has streamed, so the rejection lands at the sink
+boundary (no record is written out), not literally before the first record.
+The grain is the whole file: an `SE`-level mismatch rejects the entire
+interchange, not just that transaction set. The control-number *echo*
+mismatches (`SE02`/`GE02`/`IEA02`) and every other corruption (truncation,
+post-trailer content) always abort, even under the opt-in. See [Malformed
+envelopes](../pipelines/error-handling.md#malformed-envelopes-structural-validation).
+
 ## Writing X12
 
 An X12 Output node reconstructs the three-tier envelope around emitted

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -63,6 +63,15 @@ project:
   - running_fraction: row_index / $doc.Summary.record_count
 ```
 
+Note that an *extracted* trailer section you read via `$doc.*` is distinct
+from the **structural counts** an EDI reader validates internally (the X12
+`SE`/`GE`/`IEA`, EDIFACT `UNT`/`UNZ`, HL7 `BTS`/`FTS` segment counts). Those
+trailer counts are checked by the reader against the body it streamed, and a
+mismatch is a structural-integrity failure — see [Malformed
+envelopes](error-handling.md#malformed-envelopes-structural-validation) for
+how `dlq_granularity: document` dead-letters a malformed file instead of
+aborting the run.
+
 The pre-scan reads the envelope-bearing segments of the file before
 body streaming begins. Envelope payloads are small (a few hundred bytes
 per document is typical), and how much of the file the reader retains to
@@ -166,8 +175,12 @@ envelope:
 
 Only the `UNB` header is extractable. Trailer segments (`UNT`, `UNZ`)
 that arrive after the body are **not** envelope sections — their control
-counts are validated by the reader instead. A `segment` extract naming
-any tag other than `UNB` is rejected at startup. See
+counts are validated by the reader instead. A mismatch between a trailer's
+declared count and the body the reader streamed is a structural-integrity
+failure: by default it aborts the run, and under a source's
+`dlq_granularity: document` opt-in it dead-letters the whole file to the DLQ
+(see [Malformed envelopes](error-handling.md#malformed-envelopes-structural-validation)).
+A `segment` extract naming any tag other than `UNB` is rejected at startup. See
 [EDIFACT Format](../formats/edifact.md) for the full reference.
 
 A JSON example:

--- a/docs/user/src/pipelines/error-handling.md
+++ b/docs/user/src/pipelines/error-handling.md
@@ -94,6 +94,7 @@ The `_cxl_dlq_error_category` column contains one of these values:
 | `late_record` | A record arrived at a time-windowed aggregate after its event-time window had already closed |
 | `expansion_limit_exceeded` | A transform's `emit each` fan-out produced more output records than its `max_expansion` ceiling allows |
 | `combine_output_row` | A Combine output-stage eval failed for one driver row (probe-key, residual, or matched / `on_miss: null_fields` body); the entry carries the contributing-build lineage and rewinds both the driver and matched build source's rollback cursor. Routed to the DLQ under `continue` / `best_effort` across every Combine join mode; `fail_fast` propagates the eval error |
+| `structural_validation` | An envelope trailer's declared count did not match the body the reader streamed (X12 `SE`/`GE`/`IEA`, EDIFACT `UNT`/`UNZ`, HL7 `BTS`/`FTS`). The root-cause `trigger: true` entry for a malformed envelope rejected under a source's `dlq_granularity: document` policy; every already-streamed record of the same file is a `document_rejected` collateral |
 
 ## Advanced options
 
@@ -170,7 +171,41 @@ This is the document-shaped analogue of [correlation keys](#correlation-key): us
 
 **Output restriction.** Document-level DLQ flushes each whole document to a single output writer, so it cannot be combined with a [per-source-file output](../nodes/output.md) (a `{source_file}` / `{source_path}` path template over a multi-file source). The two are rejected together at compile time (E343); use a single output path, or set `dlq_granularity: record` if per-file output is the requirement.
 
+**Strategy requirement.** `dlq_granularity: document` requires `error_handling.strategy: continue` (or `best_effort`). It is incompatible with the default `fail_fast`: document-level dead-lettering keeps the run going past a bad document, which contradicts fail-fast's abort-on-first-error. The combination is rejected at compile time (E344) — set `strategy: continue` to dead-letter bad documents, or keep `fail_fast` with the default `dlq_granularity: record`.
+
 **Spilling stages.** Document identity survives memory pressure end to end. The per-document buffer identifies each document before buffering and spills under the memory budget, and a blocking stage (Sort, hash Aggregate, grace-hash Combine) between the source and the output preserves each record's document context — including the source file the grain keys on — across its own spill round-trip. A document whose records pass through a spilling stage is therefore still grouped and rejected as one document under memory pressure, exactly as it would be in memory.
+
+### Malformed envelopes (structural validation)
+
+Envelope formats carry their own structural-integrity claims: an X12 interchange declares a segment count in each `SE`/`GE`/`IEA` trailer, EDIFACT in each `UNT`/`UNZ`, HL7 batch/file in each `BTS`/`FTS`. When the declared count does not match the body the reader actually streamed, the file is structurally invalid.
+
+Under `dlq_granularity: document`, such a count mismatch dead-letters the **whole source file** to the DLQ rather than aborting the run:
+
+- the file's records dead-letter as one `structural_validation` root-cause entry (`_cxl_dlq_trigger = true`) plus a `document_rejected` collateral for every other already-streamed record of the file;
+- **no** record of the malformed file reaches the success sink.
+
+```yaml
+nodes:
+  - type: source
+    name: claims
+    config:
+      name: claims
+      type: x12
+      glob: ./claims/*.edi
+      dlq_granularity: document   # reuse the document opt-in — no separate config
+```
+
+The opt-in is the same `dlq_granularity: document` knob that governs per-record document rejection above; there is no separate `validation:` block. A malformed envelope is simply one more reason a source under the `document` policy condemns a whole document.
+
+**Honest timing — rejected at the sink boundary, not before the first record.** The trailer that carries the count arrives at the *end* of the file, after every body record it counts has already streamed through the DAG. Clinker is a bounded-memory streaming engine — it does not buffer the whole file up front to pre-validate it (that would defeat the streaming model). So the count mismatch is detected mid-stream, the file is marked failed, and the document-level DLQ buffer rejects every already-streamed record of the file at its close. The user-visible outcome is the same — **no record of a malformed envelope is ever written to the output** — but the rejection lands at the sink boundary, not literally before the file's first record streams.
+
+**Grain — the whole file.** An `SE`-level mismatch (one transaction set inside a larger interchange) rejects the **entire interchange / file**, not just that one transaction set, because the document grain is the outermost source file (see [Document grain](#document-level-dlq) above). Split the input so each interchange is its own file if you need finer rejection.
+
+**Multiple files keep flowing.** When a `glob` / `paths` source matches several files and one is malformed, only that file dead-letters — ingestion continues to the remaining files, so the clean files after a bad one still reach the sink. (This is unlike the default `record` granularity, where a count mismatch aborts the whole run and no file's records are written.) Dead-lettering one malformed file never silently drops the good files around it.
+
+**Default behavior unchanged.** Under the default `dlq_granularity: record`, a structural count mismatch still **aborts the run** exactly as before — the document-DLQ disposition is strictly opt-in. Genuine corruption that is *not* a count mismatch (a truncated stream, a bad delimiter, a control-number echo mismatch, a segment after the interchange trailer) **always aborts**, even under the `document` opt-in: only the trailer-count claims are reclassified to the DLQ; structural corruption that makes the stream un-parseable is never silently dead-lettered.
+
+> **Cryptographic integrity (checksums / signatures) is not yet validated.** Envelope formats can also carry a SHA-256 body hash, a JWS-signed JSON payload, or an XML Signature. Clinker extracts these envelope sections but does not yet verify them. Tracked for a future release.
 
 ## Exit codes
 


### PR DESCRIPTION
Under a per-source dlq_granularity: document opt-in, a malformed EDI envelope (an X12 SE/GE/IEA, EDIFACT UNT/UNZ, or HL7 BTS/FTS segment/group/message count mismatch) now dead-letters the whole document through the document-level dead-letter machinery rather than aborting the run: one structural_validation trigger plus document_rejected collaterals, with none of the document's records reaching the success sink. The existing readers already detect these count mismatches at the trailer; this reclassifies them (FormatError::StructuralCount) and routes them to the reject path. The count is only known at the trailer (mid-stream), so the reject is applied at the sink via the document buffer's mark-then-reject-on-flush — the user-visible outcome is that no record of a malformed document is output. Under the default record granularity, and for genuine corruption that is not a count mismatch, the run still aborts as before. Cryptographic envelope integrity is out of scope (tracked separately).

Closes #98.