### PR TITLE
format,engine: de-buffer the XML document reader

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -27,11 +27,11 @@ use clinker_plan::error::PipelineError;
 /// Build a format-specific reader from input config and a re-openable source.
 ///
 /// Dispatches on `InputFormat` to construct the correct reader type. The JSON
-/// arm threads the [`ReopenableSource`] straight through so its envelope
-/// pre-scan and body stream each open a fresh `Read` without buffering the
-/// whole file; every other (one-pass) format opens the source once and streams
-/// that single `Read`. Returns `Box<dyn FormatReader>` — all downstream code
-/// uses trait methods (`schema()`, `next_record()`).
+/// and XML arms thread the [`ReopenableSource`] straight through so their
+/// envelope pre-scan and body stream each open a fresh `Read` without buffering
+/// the whole file; every other (one-pass) format opens the source once and
+/// streams that single `Read`. Returns `Box<dyn FormatReader>` — all downstream
+/// code uses trait methods (`schema()`, `next_record()`).
 fn build_format_reader(
     input: &clinker_plan::config::SourceConfig,
     source: ReopenableSource,
@@ -58,7 +58,7 @@ fn build_format_reader(
                 input.array_paths.as_deref(),
                 &input.declared_doc_paths,
             );
-            Ok(Box::new(XmlReader::new(open_one_shot(&source)?, config)?))
+            Ok(Box::new(XmlReader::from_source(source, config)?))
         }
         clinker_plan::config::InputFormat::FixedWidth(opts) => {
             let fields = extract_field_defs(input)?;

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -819,6 +819,100 @@ mod tests {
     }
 
     #[test]
+    fn open_buf_strips_the_bom_on_every_open() {
+        // The body and the envelope pre-scan each call `open_buf` on their own
+        // fresh `Read`, so a Windows-authored file (Excel / PowerShell utf8
+        // export) presents the leading BOM to *both* opens. The strip must
+        // therefore live in `open_buf` (the shared per-open path), not in one
+        // caller. quick-xml 0.37 tolerates a stray prolog BOM, so a strip
+        // regression would NOT surface at the record/section level — it would
+        // only show as raw BOM bytes leading the parser's input. Assert the
+        // contract at that byte level, independent of quick-xml: every
+        // `open_buf` hands back a reader whose first bytes are the document,
+        // not `\u{feff}`. Two opens prove the strip is per-open, not one-shot.
+        let mut bytes = UTF8_BOM.to_vec();
+        bytes.extend_from_slice(b"<doc><x>1</x></doc>");
+        let source = ReopenableSource::buffer(Cursor::new(bytes)).expect("buffer source");
+
+        for pass in ["body", "pre-scan"] {
+            let (mut buf, _identity) = XmlReader::open_buf(&source).expect("open_buf");
+            let head = buf.fill_buf().expect("fill");
+            assert!(
+                head.starts_with(b"<doc>"),
+                "{pass} open leaked a BOM: stream starts with {:?}",
+                &head[..head.len().min(UTF8_BOM.len() + 2)]
+            );
+            assert!(
+                !head.starts_with(&UTF8_BOM),
+                "{pass} open left the BOM in place"
+            );
+        }
+    }
+
+    #[test]
+    fn open_buf_passes_through_a_bomless_open_unchanged() {
+        // A file with no BOM (the common case) must not lose its first bytes:
+        // `strip_leading_bom` consumes only when the marker is present, so the
+        // document element survives the probe intact.
+        let source =
+            ReopenableSource::buffer(Cursor::new(b"<doc><x>1</x></doc>".to_vec())).expect("buffer");
+        let (mut buf, _identity) = XmlReader::open_buf(&source).expect("open_buf");
+        assert!(buf.fill_buf().expect("fill").starts_with(b"<doc>"));
+    }
+
+    #[test]
+    fn prepare_document_extracts_sections_from_a_bom_prefixed_source() {
+        // End-to-end companion to `open_buf_strips_the_bom_on_every_open`: a
+        // BOM-prefixed envelope-bearing document still yields clean section
+        // values and clean body records, exercising the pre-scan and body
+        // opens through the full `prepare_document` / `next_record` path.
+        let xml = r#"<doc>
+            <BatchInfo><batch_id>RUN-001</batch_id><count>42</count></BatchInfo>
+            <records><record><x>1</x></record><record><x>2</x></record></records>
+            <Summary><hash>abc</hash></Summary>
+        </doc>"#;
+        let mut bytes = UTF8_BOM.to_vec();
+        bytes.extend_from_slice(xml.as_bytes());
+
+        let specs: &[SectionSpec] = &[
+            (
+                "BatchInfo",
+                "/doc/BatchInfo",
+                &[
+                    ("batch_id", EnvelopeFieldType::String),
+                    ("count", EnvelopeFieldType::Int),
+                ],
+            ),
+            (
+                "Summary",
+                "/doc/Summary",
+                &[("hash", EnvelopeFieldType::String)],
+            ),
+        ];
+        let cfg = envelope_config(specs);
+
+        let mut reader = XmlReader::from_reader(
+            Cursor::new(bytes),
+            envelope_reader_config(specs, "doc/records/record"),
+        )
+        .expect("XML buffer read");
+        let sections = reader.prepare_document(&cfg).expect("envelope pre-scan");
+        assert_eq!(sections.len(), 2);
+
+        let head = unwrap_section_map(sections.get("BatchInfo").expect("BatchInfo extracted"));
+        assert_eq!(head.get("batch_id"), Some(&Value::String("RUN-001".into())));
+        assert_eq!(head.get("count"), Some(&Value::Integer(42)));
+        let foot = unwrap_section_map(sections.get("Summary").expect("Summary extracted"));
+        assert_eq!(foot.get("hash"), Some(&Value::String("abc".into())));
+
+        let r1 = reader.next_record().expect("body record").expect("first");
+        assert_eq!(r1.get("x"), Some(&Value::Integer(1)));
+        let r2 = reader.next_record().expect("body record").expect("second");
+        assert_eq!(r2.get("x"), Some(&Value::Integer(2)));
+        assert!(reader.next_record().expect("eof").is_none());
+    }
+
+    #[test]
     fn prepare_document_empty_config_returns_empty() {
         let xml = r#"<doc><a><x>1</x></a></doc>"#;
         let mut reader = reader_from_str(xml, default_config_with_path("doc/a"));

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -1,24 +1,26 @@
-//! Streaming XML reader using quick-xml pull parser.
+//! Streaming XML reader using quick-xml's pull parser.
 //!
 //! Navigates to `record_path`, extracts attributes with configurable prefix,
 //! flattens nested elements with `.` separator, handles namespaces.
 //!
-//! The reader buffers its entire input at construction time into an
-//! `Arc<[u8]>` so the envelope pre-scan (run before any body record emits)
-//! and the body iteration can each parse from a fresh cursor over the same
-//! byte slice. That raw byte buffer is retained for the reader's lifetime —
-//! it backs both the body parser and the transient pre-scan cursor, so
-//! there is one read from disk regardless of envelope declarations.
+//! **O(1 record) memory, no whole-document buffer:** the body walks the
+//! document element-at-a-time from a freshly re-opened `BufReader` —
+//! quick-xml's `read_event_into` pulls one event at a time, so only a single
+//! record's `element_stack` plus the event buffer is live at once, never the
+//! whole input.
 //!
-//! What the pre-scan removed is the full-tree *section materialization*, not
-//! the raw byte buffer: the envelope pre-scan no longer captures undeclared
-//! sections at all, and the retained payload of each declared section is
-//! bounded by `max_index_bytes`, charged incrementally so an oversized
-//! declared section aborts mid-parse before its subtree fully materializes.
-//! See [`crate::xml::streaming`] for the event-driven pruned-extraction
-//! pass.
+//! Envelope-aware sources run a streaming pre-scan before any body record
+//! emits: it walks the document once over its *own* freshly re-opened reader,
+//! flattening ONLY the subtrees the declared `$doc.*` paths name (every other
+//! element's body is event-walked and dropped, never allocated) into a
+//! path-pruned index capped by `max_index_bytes`, charged incrementally so an
+//! oversized declared section aborts mid-parse before its subtree fully
+//! materializes. The pre-scan and the body each open their own [`Read`] from
+//! the [`ReopenableSource`], so neither consumes the other and no shared
+//! whole-file byte buffer is retained for a file-backed input. See
+//! [`crate::xml::streaming`] for the event-driven pruned-extraction pass.
 
-use std::io::{self, Cursor, Read};
+use std::io::{BufRead, BufReader, Read};
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -29,9 +31,11 @@ use clinker_record::{Record, Schema, SchemaBuilder, Value};
 
 use cxl::analyzer::doc_paths::DocPath;
 
+use crate::bom::UTF8_BOM;
 use crate::doc_index::DocArenaIndex;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
+use crate::source::{ReopenableSource, SourceIdentity};
 use crate::traits::FormatReader;
 use crate::xml::streaming::{SectionTarget, extract_sections};
 
@@ -86,24 +90,37 @@ pub enum XmlArrayMode {
     Join,
 }
 
+/// A quick-xml pull parser over a re-opened, BOM-stripped `BufReader`.
+///
+/// Both the body parser and the envelope pre-scan parse over this same reader
+/// shape — a fresh `Read` from the [`ReopenableSource`], never a whole-document
+/// byte buffer.
+pub(crate) type BodyParser = XmlParser<BufReader<Box<dyn Read + Send>>>;
+
 /// Streaming XML reader.
 ///
-/// Buffers its entire input at construction time into an `Arc<[u8]>` so two
-/// parsers can walk the same bytes: one transient parser for the envelope
-/// pre-scan, and one stateful parser for body record iteration. Holding the
-/// raw bytes makes every declared section available to every body record,
-/// since a post-body section must be extracted before the first record
-/// emits.
+/// Walks the body element-at-a-time from a freshly re-opened `BufReader`, so
+/// only one record's `element_stack` plus the event buffer is live at once —
+/// never a whole-document byte buffer. The envelope pre-scan and the body
+/// iteration each open their own [`Read`] from `source`, so a post-body
+/// section (extracted before the first record emits) is available without
+/// retaining the input: a path-backed source is read twice, never buffered.
 ///
-/// The envelope pre-scan no longer materializes undeclared sections, and
-/// each retained section's payload is bounded by `max_index_bytes` (charged
-/// incrementally, aborting mid-parse on an oversized section). The raw byte
-/// buffer itself remains — only the full-tree section materialization was
-/// removed — so held memory is the source file's size plus the bounded
-/// section payloads while the reader exists.
+/// The envelope pre-scan retains only the declared sections' subtrees, each
+/// bounded by `max_index_bytes` (charged incrementally, aborting mid-parse on
+/// an oversized section), so held memory is O(declared sections) plus one
+/// live record while the reader exists.
 pub struct XmlReader {
-    bytes: Arc<[u8]>,
-    parser: XmlParser<Cursor<Arc<[u8]>>>,
+    /// The re-openable byte source. Body iteration and the envelope pre-scan
+    /// each open their own fresh [`Read`] from it, so no whole-document buffer
+    /// is held for a file-backed (`ReopenableSource::Path`) source.
+    source: ReopenableSource,
+    /// Content identity of the bytes the body open read, captured at
+    /// construction. The envelope pre-scan re-opens the source and confirms it
+    /// sees the same content, so a path-backed input rewritten between the two
+    /// passes fails loud instead of splicing a stale envelope onto a new body.
+    body_identity: SourceIdentity,
+    parser: BodyParser,
     config: XmlReaderConfig,
     schema: Option<Arc<Schema>>,
     buf: Vec<u8>,
@@ -120,28 +137,27 @@ pub struct XmlReader {
 }
 
 impl XmlReader {
-    /// Build a reader from any `Read` source. Drains the input into a
-    /// shared `Arc<[u8]>` buffer at construction; subsequent envelope
-    /// pre-scan and body iteration each parse from a fresh cursor over
-    /// the same bytes.
-    pub fn new<R: Read>(mut reader: R, config: XmlReaderConfig) -> io::Result<Self> {
-        let mut bytes_vec = Vec::new();
-        reader.read_to_end(&mut bytes_vec)?;
-        // Strip a leading UTF-8 BOM (Windows utf8 export) before the bytes
-        // reach the parser, so it does not precede the prolog/root element.
-        if bytes_vec.starts_with(&crate::bom::UTF8_BOM) {
-            bytes_vec.drain(..crate::bom::UTF8_BOM.len());
-        }
-        let bytes: Arc<[u8]> = Arc::from(bytes_vec);
-        Ok(Self::from_bytes(bytes, config))
-    }
-
-    /// Build a reader directly from a buffered byte slice. Used
-    /// internally by [`Self::new`] and by envelope pre-scan to reset
-    /// the body parser at start of stream.
-    fn from_bytes(bytes: Arc<[u8]>, config: XmlReaderConfig) -> Self {
-        let mut parser = XmlParser::from_reader(Cursor::new(Arc::clone(&bytes)));
-        parser.config_mut().trim_text(true);
+    /// Build a reader over a re-openable byte source.
+    ///
+    /// Streaming, O(1 record): the body opens one fresh [`Read`] from `source`
+    /// (and the envelope pre-scan opens a second), so a file-backed source is
+    /// never buffered whole.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError`] if the source cannot be opened or the leading
+    /// BOM probe fails. Construction reads no further: quick-xml pulls events
+    /// lazily, so a parse error surfaces later from `next_record`.
+    pub fn from_source(
+        source: ReopenableSource,
+        config: XmlReaderConfig,
+    ) -> Result<Self, FormatError> {
+        // XML runs two passes (envelope pre-scan + body stream), so the source
+        // must be re-openable. A `Path`/`Buffered` source passes through; a
+        // pathless `OneShot` is buffered here, on the reader-building thread —
+        // bounded because such inputs are small.
+        let source = source.into_reopenable().map_err(FormatError::Io)?;
+        let (parser, body_identity) = Self::open_body(&source)?;
 
         let path_segments: Vec<String> = config
             .record_path
@@ -149,8 +165,9 @@ impl XmlReader {
             .map(|p| p.split('/').map(String::from).collect())
             .unwrap_or_default();
 
-        XmlReader {
-            bytes,
+        Ok(XmlReader {
+            source,
+            body_identity,
             parser,
             config,
             schema: None,
@@ -160,7 +177,61 @@ impl XmlReader {
             xml_depth: 0,
             pending: None,
             done: false,
-        }
+        })
+    }
+
+    /// Build a reader by buffering a one-shot `Read` into a re-openable source.
+    ///
+    /// For pathless inputs (test cursors, the `<inline>`/`<empty>` slots, REST
+    /// bodies) that have no on-disk path to re-open: the bytes are captured
+    /// once into a small `ReopenableSource::Buffered`. Bounded because such
+    /// inputs are small by construction; file-backed sources use
+    /// [`from_source`](Self::from_source) with `ReopenableSource::Path` instead
+    /// and are never buffered whole.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError`] on a read failure or the same open errors as
+    /// [`from_source`](Self::from_source).
+    pub fn from_reader<R: Read + Send + 'static>(
+        reader: R,
+        config: XmlReaderConfig,
+    ) -> Result<Self, FormatError> {
+        let source = ReopenableSource::buffer(reader).map_err(FormatError::Io)?;
+        Self::from_source(source, config)
+    }
+
+    /// Open a fresh `BufReader` from the source with a leading UTF-8 BOM
+    /// stripped, returning the content-identity snapshot of the bytes it reads.
+    /// Each pass (body, pre-scan) re-opens, so the strip happens per open
+    /// rather than once over a shared buffer; the identity lets a later pass
+    /// detect the input changing between passes.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Io`] if the source cannot be opened or the BOM
+    /// probe read fails.
+    fn open_buf(
+        source: &ReopenableSource,
+    ) -> Result<(BufReader<Box<dyn Read + Send>>, SourceIdentity), FormatError> {
+        let (reader, identity) = source.open_with_identity().map_err(FormatError::Io)?;
+        let mut buf = BufReader::new(reader);
+        strip_leading_bom(&mut buf)?;
+        Ok((buf, identity))
+    }
+
+    /// Open the body parser over a fresh `BufReader` and snapshot the identity
+    /// of the bytes it read, so the envelope pre-scan can confirm it re-opens
+    /// the same content.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Io`] if the source cannot be opened.
+    fn open_body(source: &ReopenableSource) -> Result<(BodyParser, SourceIdentity), FormatError> {
+        let (buf, identity) = Self::open_buf(source)?;
+        let mut parser = XmlParser::from_reader(buf);
+        parser.config_mut().trim_text(true);
+        Ok((parser, identity))
     }
 
     /// Navigate to the record_path and read one complete record element.
@@ -468,15 +539,28 @@ impl FormatReader for XmlReader {
             }
         }
 
-        // Single streaming pass over a fresh cursor: only the matched
-        // subtrees are flattened; every unmatched element body is
-        // counted-and-dropped. The cap is charged *as each declared
-        // section's payload is built*, so an oversized declared section
-        // aborts the parse mid-subtree rather than after the whole subtree
-        // materializes. Body iteration keeps its own independent cursor over
-        // `self.bytes`.
+        // Single streaming pass over a freshly re-opened reader: only the
+        // matched subtrees are flattened; every unmatched element body is
+        // event-walked and dropped. The cap is charged *as each declared
+        // section's payload is built*, so an oversized declared section aborts
+        // the parse mid-subtree rather than after the whole subtree
+        // materializes. Body iteration opens its own independent reader, so
+        // this pass does not consume it and no shared whole-file buffer is
+        // held.
+        //
+        // Confirm the pre-scan re-opens the same content the body opened. A
+        // path-backed input replaced or truncated between the two opens (an
+        // external producer re-emitting mid-run) would otherwise splice this
+        // envelope onto a body parsed from different bytes; the `(len, mtime)`
+        // identity check fails loud instead. This is a cheap courtesy guard
+        // under the finite-batch input-stability contract, not a fingerprint —
+        // see `SourceIdentity`.
+        let (prescan, prescan_identity) = Self::open_buf(&self.source)?;
+        prescan_identity
+            .ensure_matches(&self.body_identity)
+            .map_err(FormatError::Io)?;
         let matched = extract_sections(
-            &self.bytes,
+            prescan,
             &targets,
             &self.config.namespace_handling,
             &self.config.attribute_prefix,
@@ -553,6 +637,25 @@ pub(crate) fn extract_attributes_static(
     Ok(attrs)
 }
 
+/// Consume a single leading UTF-8 BOM from a freshly opened reader, if present.
+///
+/// Each pass re-opens its own `Read`, so a Windows-authored file (Excel /
+/// PowerShell utf8 export) carries the BOM on every open; stripping it here
+/// clears the marker before it precedes the prolog/root element, for both body
+/// iteration and the envelope pre-scan. The `BufReader`'s default capacity
+/// exceeds the 3-byte BOM, so the marker is always wholly inside the first fill.
+///
+/// # Errors
+///
+/// Returns [`FormatError::Io`] if the probe read fails.
+fn strip_leading_bom(reader: &mut BufReader<Box<dyn Read + Send>>) -> Result<(), FormatError> {
+    let buf = reader.fill_buf().map_err(FormatError::Io)?;
+    if buf.starts_with(&UTF8_BOM) {
+        reader.consume(UTF8_BOM.len());
+    }
+    Ok(())
+}
+
 /// Simple type inference from string values (same rules as JSON).
 fn infer_value(s: &str) -> Value {
     if s.is_empty() {
@@ -580,7 +683,8 @@ mod tests {
     use std::io::Cursor;
 
     fn reader_from_str(xml: &str, config: XmlReaderConfig) -> XmlReader {
-        XmlReader::new(Cursor::new(xml.as_bytes().to_vec()), config).expect("XML buffer read")
+        XmlReader::from_reader(Cursor::new(xml.as_bytes().to_vec()), config)
+            .expect("XML buffer read")
     }
 
     fn default_config_with_path(path: &str) -> XmlReaderConfig {
@@ -851,7 +955,7 @@ mod tests {
         let xml = r#"<Root><Orders><Order><id>1</id><name>Alice</name></Order></Orders></Root>"#;
         let mut bytes = crate::bom::UTF8_BOM.to_vec();
         bytes.extend_from_slice(xml.as_bytes());
-        let mut r = XmlReader::new(
+        let mut r = XmlReader::from_reader(
             Cursor::new(bytes),
             default_config_with_path("Root/Orders/Order"),
         )

--- a/crates/clinker-format/src/xml/streaming.rs
+++ b/crates/clinker-format/src/xml/streaming.rs
@@ -21,14 +21,13 @@
 //! even a single oversized declared section fails loud at ~the cap, before
 //! the whole subtree materializes, not after.
 
-use std::io::Cursor;
-use std::sync::Arc;
+use std::io::{BufReader, Read};
 
 use quick_xml::Reader as XmlParser;
 use quick_xml::events::Event;
 
 use crate::error::FormatError;
-use crate::xml::reader::{NamespaceMode, elem_name_static, extract_attributes_static};
+use crate::xml::reader::{BodyParser, NamespaceMode, elem_name_static, extract_attributes_static};
 
 /// One matched section's name paired with its flat `(field, raw_string)`
 /// payload, as produced by [`extract_sections`].
@@ -78,13 +77,13 @@ impl SectionTarget {
 /// offending section and the cap when a declared section's retained bytes
 /// cross `max_index_bytes` mid-parse.
 pub(crate) fn extract_sections(
-    bytes: &Arc<[u8]>,
+    reader: BufReader<Box<dyn Read + Send>>,
     targets: &[SectionTarget],
     ns: &NamespaceMode,
     attr_prefix: &str,
     max_index_bytes: Option<usize>,
 ) -> Result<Vec<MatchedSection>, FormatError> {
-    let mut parser = XmlParser::from_reader(Cursor::new(Arc::clone(bytes)));
+    let mut parser = XmlParser::from_reader(reader);
     parser.config_mut().trim_text(true);
 
     let mut path_stack: Vec<String> = Vec::new();
@@ -201,7 +200,7 @@ fn path_matches(stack: &[String], segs: &[String]) -> bool {
 /// Returns [`FormatError::Xml`] on a parse failure, or naming `section` and
 /// the cap when the retained bytes cross `max_index_bytes` mid-subtree.
 fn read_section_payload(
-    parser: &mut XmlParser<Cursor<Arc<[u8]>>>,
+    parser: &mut BodyParser,
     buf: &mut Vec<u8>,
     ns: &NamespaceMode,
     attr_prefix: &str,

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -433,7 +433,7 @@ mod tests {
 
         // Read back
         let cursor = std::io::Cursor::new(output.as_bytes().to_vec());
-        let mut reader = XmlReader::new(
+        let mut reader = XmlReader::from_reader(
             cursor,
             XmlReaderConfig {
                 record_path: Some("Root/Record".into()),

--- a/crates/clinker-format/tests/streaming_doc_index_xml.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_xml.rs
@@ -1,11 +1,14 @@
-//! Bounded-retention behavior of the streaming XML envelope pre-scan.
+//! Bounded-retention and bounded-memory behavior of the streaming XML reader.
 //!
-//! Proves the pre-scan retains only the declared `$doc.*` section subtrees —
-//! a multi-MB body of undeclared records is event-walked and dropped, never
-//! flattened into the document index — and that an over-budget retention
-//! fails loud mid-build rather than after a full materialization.
+//! Proves the envelope pre-scan retains only the declared `$doc.*` section
+//! subtrees — a multi-MB body of undeclared records is event-walked and
+//! dropped, never flattened into the document index — that an over-budget
+//! retention fails loud mid-build rather than after a full materialization,
+//! and that the body itself streams element-at-a-time from a re-opened
+//! path-backed source with no whole-document buffer.
 
 use clinker_format::FormatError;
+use clinker_format::ReopenableSource;
 use clinker_format::envelope::{
     EnvelopeConfig, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection,
 };
@@ -14,6 +17,7 @@ use clinker_format::xml::reader::{XmlReader, XmlReaderConfig};
 use clinker_record::Value;
 use cxl::analyzer::doc_paths::DocPath;
 use indexmap::IndexMap;
+use std::io::Write;
 
 /// One envelope section: name, slash-path, typed fields.
 type SectionSpec<'a> = (&'a str, &'a str, &'a [(&'a str, EnvelopeFieldType)]);
@@ -51,7 +55,7 @@ fn declared_paths(specs: &[SectionSpec]) -> Vec<DocPath> {
 }
 
 fn reader(xml: String, specs: &[SectionSpec], record_path: &str, cap: usize) -> XmlReader {
-    XmlReader::new(
+    XmlReader::from_reader(
         std::io::Cursor::new(xml.into_bytes()),
         XmlReaderConfig {
             record_path: Some(record_path.into()),
@@ -61,6 +65,16 @@ fn reader(xml: String, specs: &[SectionSpec], record_path: &str, cap: usize) -> 
         },
     )
     .expect("XML buffer read")
+}
+
+/// A unique temp path under the OS temp dir, namespaced by pid + thread so
+/// concurrent test threads never collide on a fixed name.
+fn temp_path(tag: &str) -> std::path::PathBuf {
+    std::env::temp_dir().join(format!(
+        "clinker-{tag}-{}-{:?}.xml",
+        std::process::id(),
+        std::thread::current().id()
+    ))
 }
 
 /// A document with a large undeclared body and a small declared trailer:
@@ -230,7 +244,7 @@ fn prescan_skips_entirely_when_no_doc_path_declared() {
     )];
     let cfg = envelope_config(specs);
 
-    let mut reader = XmlReader::new(
+    let mut reader = XmlReader::from_reader(
         std::io::Cursor::new(xml.as_bytes().to_vec()),
         XmlReaderConfig {
             record_path: Some("doc/records/record".into()),
@@ -322,7 +336,7 @@ fn prescan_prunes_the_unread_section_in_a_mixed_envelope() {
     // ...but only `Foot` is referenced by a `$doc` path.
     let declared = declared_paths(&[foot_spec]);
 
-    let mut reader = XmlReader::new(
+    let mut reader = XmlReader::from_reader(
         std::io::Cursor::new(xml.into_bytes()),
         XmlReaderConfig {
             record_path: Some("doc/records/record".into()),
@@ -367,4 +381,191 @@ fn prescan_preserves_namespaces_attributes_and_cdata() {
     let meta = unwrap_map(sections.get("Meta").expect("Meta retained"));
     assert_eq!(meta.get("tag.@kind"), Some(&Value::String("run".into())));
     assert_eq!(meta.get("note"), Some(&Value::String("a & b".into())));
+}
+
+/// A multi-MB body streams element-at-a-time from a path-backed source: the
+/// body walks one `<record>` at a time and re-opening by path means no
+/// whole-document byte buffer is held either.
+#[test]
+fn large_record_body_streams_without_collecting_or_buffering() {
+    // ~1.5 MB document of ~50k small records, written to a real file so the
+    // reader re-opens by path (the production shape) rather than buffering
+    // bytes.
+    let rows = 50_000usize;
+    let mut xml = String::from("<doc><records>");
+    for i in 0..rows {
+        xml.push_str(&format!(
+            "<record><id>{i}</id><name>row-{i}</name></record>"
+        ));
+    }
+    xml.push_str("</records></doc>");
+    assert!(
+        xml.len() > 1_000_000,
+        "body should be > 1 MB: {}",
+        xml.len()
+    );
+
+    let path = temp_path("large-body");
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(xml.as_bytes())
+        .unwrap();
+
+    let mut reader = XmlReader::from_source(
+        ReopenableSource::path(&path),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Reading the first record must not require materializing the rest: it
+    // streams one element. Then every record streams in order.
+    let mut count = 0usize;
+    let mut last_id = -1i64;
+    while let Some(rec) = reader.next_record().unwrap() {
+        let id = match rec.get("id") {
+            Some(Value::Integer(n)) => *n,
+            other => panic!("expected integer id, got {other:?}"),
+        };
+        assert_eq!(id, last_id + 1, "body records stream in order");
+        last_id = id;
+        count += 1;
+    }
+    let _ = std::fs::remove_file(&path);
+    assert_eq!(count, rows, "every body record streamed exactly once");
+}
+
+/// A path-backed input rewritten between the body open (at construction) and
+/// the envelope pre-scan (at `prepare_document`) is caught: the pre-scan
+/// refuses to splice an envelope from new bytes onto a body parsed from old
+/// ones, and fails loud instead of silently mismatching.
+#[test]
+fn envelope_prescan_rejects_a_file_changed_between_passes() {
+    let path = temp_path("changed-between-passes");
+    let original = r#"<doc><Summary><record_count>2</record_count></Summary><records><record><x>1</x></record><record><x>2</x></record></records></doc>"#;
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(original.as_bytes())
+        .unwrap();
+
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/doc/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    // Construction opens the body and snapshots the file's identity.
+    let mut reader = XmlReader::from_source(
+        ReopenableSource::path(&path),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // An external producer rewrites the file to different content before the
+    // pre-scan re-opens it.
+    std::fs::File::create(&path)
+        .unwrap()
+        .write_all(br#"<doc><Summary><record_count>9999</record_count></Summary><records><record><x>7</x></record><record><x>8</x></record><record><x>9</x></record></records></doc>"#)
+        .unwrap();
+
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("a file changed between the two passes must fail loud");
+    let _ = std::fs::remove_file(&path);
+    match err {
+        FormatError::Io(e) => assert!(
+            e.to_string().contains("changed between"),
+            "error names the mid-run change: {e}"
+        ),
+        other => panic!("expected an Io change error, got {other:?}"),
+    }
+}
+
+/// A malformed document (an unclosed element) surfaces a hard
+/// [`FormatError::Xml`] from the streaming walk rather than silently
+/// truncating the record stream — the pull parser reports the parse failure,
+/// it is not swallowed.
+#[test]
+fn malformed_unclosed_element_surfaces_xml_error() {
+    // `<name>` is never closed before EOF.
+    let xml = r#"<doc><records><record><id>1</id><name>unterminated</record></records></doc>"#;
+    let mut reader = XmlReader::from_reader(
+        std::io::Cursor::new(xml.as_bytes().to_vec()),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            ..Default::default()
+        },
+    )
+    .expect("construction reads no bytes; a parse error surfaces while streaming");
+
+    // Drive the reader until it either errors or EOFs. A well-formedness
+    // violation must produce an `Xml` error, never a clean `None` that hides
+    // the truncation.
+    let mut saw_error = false;
+    loop {
+        match reader.next_record() {
+            Ok(Some(_)) => continue,
+            Ok(None) => break,
+            Err(FormatError::Xml(_)) => {
+                saw_error = true;
+                break;
+            }
+            Err(other) => panic!("expected FormatError::Xml, got {other:?}"),
+        }
+    }
+    assert!(
+        saw_error,
+        "an unclosed element must surface as FormatError::Xml, not silently truncate"
+    );
+}
+
+/// A deeply nested document (200+ levels) streams to completion without
+/// crashing: clinker's XML walk tracks depth with heap `Vec`s and `usize`
+/// counters, never native recursion, so a deep document cannot overflow the
+/// stack the way a recursive descent parser would.
+#[test]
+fn deeply_nested_document_streams_without_stack_overflow() {
+    const DEPTH: usize = 250;
+    // Build `<doc><records><record>` then DEPTH nested `<n>` wrappers around a
+    // leaf value, closing them all back out.
+    let mut xml = String::from("<doc><records><record>");
+    for _ in 0..DEPTH {
+        xml.push_str("<n>");
+    }
+    xml.push_str("<leaf>deep</leaf>");
+    for _ in 0..DEPTH {
+        xml.push_str("</n>");
+    }
+    xml.push_str("</record></records></doc>");
+
+    let mut reader = XmlReader::from_reader(
+        std::io::Cursor::new(xml.into_bytes()),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            ..Default::default()
+        },
+    )
+    .expect("construction reads no bytes");
+
+    // The single deeply-nested record streams cleanly — the flattened leaf is
+    // present under its `.`-joined nesting prefix, and the iterative walk never
+    // recurses, so no stack overflow.
+    let rec = reader
+        .next_record()
+        .expect("deep nesting streams, never crashes")
+        .expect("one record");
+    let leaf_key: String = std::iter::repeat_n("n", DEPTH)
+        .chain(std::iter::once("leaf"))
+        .collect::<Vec<_>>()
+        .join(".");
+    assert_eq!(rec.get(&leaf_key), Some(&Value::String("deep".into())));
+    assert!(reader.next_record().unwrap().is_none());
 }

--- a/crates/clinker-net/src/rest.rs
+++ b/crates/clinker-net/src/rest.rs
@@ -488,9 +488,9 @@ fn decode_body(
         }
         InputFormat::Xml(opts) => {
             let config = build_xml_config(opts.as_ref(), array_paths);
-            Ok(Box::new(clinker_format::xml::reader::XmlReader::new(
-                cursor, config,
-            )?))
+            Ok(Box::new(
+                clinker_format::xml::reader::XmlReader::from_reader(cursor, config)?,
+            ))
         }
         other => Err(schema_err(format!(
             "rest body decode requires json or xml format, got {}",

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -60,8 +60,10 @@ sections a program actually reads are retained, so envelope metadata sits
 far below this ceiling in practice — the cap exists to convert an unbounded
 mistake into a clear error.
 
-The reader still buffers the raw source bytes for the lifetime of the read
-(one disk read backs both the body parser and the pre-scan); the pre-scan
-no longer materializes the section subtrees themselves. See
+The reader holds no whole-document buffer: the body walks the document
+element-at-a-time, and the envelope pre-scan opens the source a second time
+to walk it independently — a file source is read twice, never buffered. Peak
+memory is the bounded section index plus a single live record, not the input
+size. See
 [Document Envelope Context](../pipelines/envelope-and-doc-context.md) for
 the full model.


### PR DESCRIPTION
## What

De-buffers the XML document reader so it streams under bounded memory instead of holding the whole document in RAM. Previously the reader did `read_to_end` into an `Arc<[u8]>` retained for its lifetime; now it streams the body element-at-a-time via quick-xml's iterative pull parser, mirroring the JSON reader's de-buffer.

## How

Reuses the re-openable-source plumbing already on `main`: a two-open model (envelope pre-scan + body stream) over `ReopenableSource`, with the `SourceIdentity` `(len, mtime)` cross-pass guard so a path-backed source that changes between the two opens fails loud (`FormatError::Io`) rather than splicing a stale envelope onto a new body. `XmlReader::new` is replaced by `from_source`/`from_reader`; `extract_sections`/`read_section_payload` are generalized from `&Arc<[u8]>` to a re-opened `BufReader<Box<dyn Read + Send>>` (event-loop bodies unchanged, so `$doc` path-pruning and the `max_index_bytes` cap-charge behave identically). No new dependency, no new diagnostic code, and no synthetic nesting-depth cap — quick-xml's parser and clinker's XML walks are iterative (heap stacks, never recursion), so deep nesting cannot overflow the stack.

Peak memory is now O(declared sections, capped by `max_index_bytes`) + O(1 record) + the `BufReader` fill block, with the whole-document `Arc<[u8]>` gone from the XML path.

## Tests

- `large_record_body_streams_without_collecting_or_buffering` — a >1 MB path-backed document streams without buffering.
- `envelope_prescan_rejects_a_file_changed_between_passes` — the cross-pass identity guard fails loud.
- `malformed_unclosed_element_surfaces_xml_error` — truncated input errors, never silently truncates.
- `deeply_nested_document_streams_without_stack_overflow` — 250 nested levels, no crash, no synthetic cap.
- The pre-existing section cap/pruning/namespace tests are preserved, proving byte-identical extraction.

Closes #512.