### PR TITLE
engine: prove bounded-memory $doc over a 1 GiB document + OS peak-RSS helper

### DIFF
--- a/crates/clinker-bench-support/src/generators/mod.rs
+++ b/crates/clinker-bench-support/src/generators/mod.rs
@@ -3,4 +3,5 @@
 pub mod csv;
 pub mod fixed_width;
 pub mod json;
+pub mod nested_envelope;
 pub mod xml;

--- a/crates/clinker-bench-support/src/generators/nested_envelope.rs
+++ b/crates/clinker-bench-support/src/generators/nested_envelope.rs
@@ -1,0 +1,278 @@
+//! Streamed nested-envelope document generators for the bounded-memory
+//! `$doc` proof.
+//!
+//! Shape (JSON / XML twins):
+//! - a small **head** section at a declared pointer (`"Head"` / `<Head>`),
+//! - a huge **undeclared body** array (`"records"` / `<records>`),
+//! - a small **trailing** section after the body (`"Summary"` / `<Summary>`).
+//!
+//! The trailing section after a multi-GB body forces the envelope pre-scan
+//! to stream *past* the whole body to reach it — the exact path the proof
+//! guards: a reader that buffered the body to find the trailer would blow
+//! the memory budget the proof asserts.
+//!
+//! **Streaming guarantee.** Each generator takes `&mut impl Write` and emits
+//! the head, then loops emitting one body record at a time into a small
+//! reused scratch `Vec` that is flushed to the writer and cleared per record,
+//! then emits the trailer. No accumulator ever grows with `body_records`, so
+//! generating a 1 GiB document costs `O(one record)` of memory, not `O(1
+//! GiB)`. Determinism comes from `fastrand::Rng::with_seed`, so a fixed
+//! `(body_records, layout, string_len, blob_len, seed)` reproduces
+//! byte-for-byte.
+
+use std::io::{self, Write};
+
+use crate::FieldKind;
+
+/// Stream a nested-envelope JSON document to `w`.
+///
+/// Emits `{ "Head": {...}, "records": [ ...body_records... ], "Summary":
+/// {...} }`. The `Head` section carries a deterministic `batch_id`; the
+/// `Summary` trailer carries the body record count. Body records are
+/// `{ "id": <n>, "fN": <value>, ..., "blob": "<blob_len chars>" }` per
+/// `layout`.
+///
+/// `blob_len` is an undeclared per-record text field that scales the body's
+/// *byte* size independently of `body_records`. It lets a memory proof
+/// inflate the body to GB scale with only a few thousand records, so the
+/// body byte-size — not the record count — is the variable under test.
+///
+/// # Errors
+///
+/// Propagates any [`io::Error`] from `w` (a full disk, a closed pipe).
+pub fn write_nested_envelope_json(
+    w: &mut impl Write,
+    body_records: usize,
+    layout: &[FieldKind],
+    string_len: usize,
+    blob_len: usize,
+    seed: u64,
+) -> io::Result<()> {
+    let mut rng = fastrand::Rng::with_seed(seed);
+    // One reused scratch buffer for the whole body — never grows with
+    // `body_records`. Sized for a single record's worst case up front so the
+    // per-record `clear()`/refill never reallocates.
+    let mut scratch: Vec<u8> = Vec::with_capacity(64 + layout.len() * (string_len + 16) + blob_len);
+
+    // Head section at the declared `/Head` pointer.
+    write!(
+        w,
+        "{{\"Head\":{{\"batch_id\":\"RUN-{seed:08}\"}},\"records\":["
+    )?;
+
+    for i in 0..body_records {
+        scratch.clear();
+        if i > 0 {
+            scratch.push(b',');
+        }
+        scratch.extend_from_slice(format!("{{\"id\":{i}").as_bytes());
+        for (f, &kind) in layout.iter().enumerate() {
+            scratch.extend_from_slice(format!(",\"f{f}\":").as_bytes());
+            write_json_field(&mut scratch, kind, &mut rng, string_len);
+        }
+        if blob_len > 0 {
+            scratch.extend_from_slice(b",\"blob\":\"");
+            push_blob(&mut scratch, &mut rng, blob_len);
+            scratch.push(b'"');
+        }
+        scratch.push(b'}');
+        w.write_all(&scratch)?;
+    }
+
+    // Trailing section after the body — reached only by streaming past it.
+    write!(w, "],\"Summary\":{{\"record_count\":{body_records}}}}}")?;
+    Ok(())
+}
+
+/// Stream a nested-envelope XML document to `w`.
+///
+/// Emits `<doc><Head>...</Head><records>...</records><Summary>...</Summary></doc>`
+/// with a prolog. The `Head` element carries a deterministic `batch_id`; the
+/// `Summary` trailer carries the body record count. Body records are
+/// `<record><id>n</id><fN>value</fN>...<blob>...</blob></record>` per
+/// `layout`.
+///
+/// `blob_len` is an undeclared per-record text element that scales the
+/// body's *byte* size independently of `body_records` — see
+/// [`write_nested_envelope_json`].
+///
+/// # Errors
+///
+/// Propagates any [`io::Error`] from `w`.
+pub fn write_nested_envelope_xml(
+    w: &mut impl Write,
+    body_records: usize,
+    layout: &[FieldKind],
+    string_len: usize,
+    blob_len: usize,
+    seed: u64,
+) -> io::Result<()> {
+    let mut rng = fastrand::Rng::with_seed(seed);
+    let mut scratch: Vec<u8> = Vec::with_capacity(64 + layout.len() * (string_len + 24) + blob_len);
+
+    w.write_all(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<doc>")?;
+    write!(
+        w,
+        "<Head><batch_id>RUN-{seed:08}</batch_id></Head><records>"
+    )?;
+
+    for i in 0..body_records {
+        scratch.clear();
+        scratch.extend_from_slice(format!("<record><id>{i}</id>").as_bytes());
+        for (f, &kind) in layout.iter().enumerate() {
+            scratch.extend_from_slice(format!("<f{f}>").as_bytes());
+            // Body values are alphanumeric/date/numeric — none contain XML
+            // metacharacters, so no escaping is needed for the proof corpus.
+            crate::write_field_value(&mut scratch, kind, &mut rng, string_len);
+            scratch.extend_from_slice(format!("</f{f}>").as_bytes());
+        }
+        if blob_len > 0 {
+            scratch.extend_from_slice(b"<blob>");
+            // The blob is lowercase ASCII — no XML metacharacters.
+            push_blob(&mut scratch, &mut rng, blob_len);
+            scratch.extend_from_slice(b"</blob>");
+        }
+        scratch.extend_from_slice(b"</record>");
+        w.write_all(&scratch)?;
+    }
+
+    write!(
+        w,
+        "</records><Summary><record_count>{body_records}</record_count></Summary></doc>"
+    )?;
+    Ok(())
+}
+
+/// Append `blob_len` deterministic lowercase-ASCII bytes to `buf`. Carries
+/// no JSON/XML metacharacters, so it needs no escaping in either format.
+fn push_blob(buf: &mut Vec<u8>, rng: &mut fastrand::Rng, blob_len: usize) {
+    for _ in 0..blob_len {
+        buf.push(rng.u8(b'a'..=b'z'));
+    }
+}
+
+/// Write one JSON field value, quoting string-like kinds. Mirrors the
+/// per-field quoting in [`crate::generators::json`].
+fn write_json_field(
+    buf: &mut Vec<u8>,
+    kind: FieldKind,
+    rng: &mut fastrand::Rng,
+    string_len: usize,
+) {
+    match kind {
+        FieldKind::Int | FieldKind::Float | FieldKind::Bool => {
+            crate::write_field_value(buf, kind, rng, string_len);
+        }
+        FieldKind::String | FieldKind::Date => {
+            buf.push(b'"');
+            crate::write_field_value(buf, kind, rng, string_len);
+            buf.push(b'"');
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A small JSON instance parses as valid JSON, exposes the declared
+    /// head/trailer sections, carries exactly `body_records` body rows, and
+    /// includes the undeclared per-record `blob` when `blob_len > 0`.
+    #[test]
+    fn json_generator_produces_valid_document() {
+        let layout = FieldKind::default_layout(3);
+        let mut out = Vec::new();
+        write_nested_envelope_json(&mut out, 10, &layout, 8, 32, 42).unwrap();
+
+        let doc: serde_json::Value = serde_json::from_slice(&out).expect("valid JSON document");
+        assert_eq!(doc["Head"]["batch_id"], serde_json::json!("RUN-00000042"));
+        assert_eq!(doc["Summary"]["record_count"], serde_json::json!(10));
+        let records = doc["records"].as_array().expect("records is an array");
+        assert_eq!(records.len(), 10, "every body record is present");
+        // Body ids stream in order 0..10, each carrying the sized blob.
+        for (i, rec) in records.iter().enumerate() {
+            assert_eq!(rec["id"], serde_json::json!(i));
+            assert_eq!(
+                rec["blob"].as_str().expect("blob is a string").len(),
+                32,
+                "per-record blob is blob_len chars"
+            );
+        }
+    }
+
+    /// `blob_len = 0` omits the blob field entirely.
+    #[test]
+    fn json_generator_omits_blob_when_zero() {
+        let layout = FieldKind::default_layout(2);
+        let mut out = Vec::new();
+        write_nested_envelope_json(&mut out, 3, &layout, 6, 0, 1).unwrap();
+        let doc: serde_json::Value = serde_json::from_slice(&out).expect("valid JSON");
+        assert!(
+            doc["records"][0].get("blob").is_none(),
+            "no blob field when blob_len is 0"
+        );
+    }
+
+    /// Same parameters always produce identical bytes — the seed drives a
+    /// reproducible body, blob included.
+    #[test]
+    fn json_generator_deterministic() {
+        let layout = FieldKind::default_layout(4);
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        write_nested_envelope_json(&mut a, 50, &layout, 6, 16, 7).unwrap();
+        write_nested_envelope_json(&mut b, 50, &layout, 6, 16, 7).unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// A small XML instance is well-formed, and the `record` count matches.
+    #[test]
+    fn xml_generator_produces_valid_document() {
+        use quick_xml::Reader;
+        use quick_xml::events::Event;
+
+        let layout = FieldKind::default_layout(3);
+        let mut out = Vec::new();
+        write_nested_envelope_xml(&mut out, 10, &layout, 8, 32, 42).unwrap();
+
+        let mut reader = Reader::from_reader(out.as_slice());
+        let mut record_count = 0u64;
+        let mut saw_head = false;
+        let mut saw_summary = false;
+        let mut saw_blob = false;
+        let mut buf = Vec::new();
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(e)) => match e.name().as_ref() {
+                    b"record" => record_count += 1,
+                    b"Head" => saw_head = true,
+                    b"Summary" => saw_summary = true,
+                    b"blob" => saw_blob = true,
+                    _ => {}
+                },
+                Ok(Event::Eof) => break,
+                Err(e) => panic!("XML parse error: {e}"),
+                _ => {}
+            }
+            buf.clear();
+        }
+        assert_eq!(record_count, 10, "every body record is present");
+        assert!(saw_head, "declared head section emitted");
+        assert!(saw_summary, "trailing summary section emitted");
+        assert!(
+            saw_blob,
+            "per-record blob element emitted when blob_len > 0"
+        );
+    }
+
+    /// Same parameters always produce identical XML bytes.
+    #[test]
+    fn xml_generator_deterministic() {
+        let layout = FieldKind::default_layout(4);
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        write_nested_envelope_xml(&mut a, 50, &layout, 6, 16, 7).unwrap();
+        write_nested_envelope_xml(&mut b, 50, &layout, 6, 16, 7).unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/crates/clinker-bench-support/src/lib.rs
+++ b/crates/clinker-bench-support/src/lib.rs
@@ -97,6 +97,7 @@ pub use generators::fixed_width::{
     BenchFieldSpec, BenchFieldType, BenchJustify, field_specs_for, generate_fixed_width,
 };
 pub use generators::json::{generate_json_array, generate_ndjson};
+pub use generators::nested_envelope::{write_nested_envelope_json, write_nested_envelope_xml};
 pub use generators::xml::generate_xml;
 
 // ── Scale constants ────────────────────────────────────────────────

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -111,6 +111,93 @@ fn rss_bytes_impl() -> Option<u64> {
     None
 }
 
+/// Peak resident memory the process has ever held — the lifetime
+/// high-water mark of [`rss_bytes`], not the live figure. Returns `None`
+/// on unsupported platforms.
+///
+/// Unlike [`rss_bytes`] (a *current* reading that a `free()` can lower),
+/// this is a monotonic non-decreasing watermark the OS maintains: it only
+/// rises. That makes a `peak_after >= peak_before` comparison immune to a
+/// sibling thread's churn between the two samples — the property a
+/// bounded-memory proof needs.
+///
+/// **Unit invariant — every arm returns BYTES.** Linux `VmHWM` from
+/// `/proc/self/status` is reported in **kB**, so this multiplies by 1024;
+/// macOS `ri_lifetime_max_phys_footprint` and Windows `PeakWorkingSetSize`
+/// are already in bytes and pass through unconverted. A future editor must
+/// not "normalize" the Linux ×1024 away — the kB→bytes conversion is the
+/// one place the three arms differ.
+pub fn peak_rss_bytes() -> Option<u64> {
+    peak_rss_bytes_impl()
+}
+
+#[cfg(target_os = "linux")]
+fn peak_rss_bytes_impl() -> Option<u64> {
+    // `VmHWM:` is the peak resident set size — the high-water mark of the
+    // `VmRSS` figure `rss_bytes` reads. It is reported in kB, so multiply
+    // by 1024 to return BYTES (the unit invariant the other arms already
+    // satisfy without conversion).
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix("VmHWM:") {
+            let kb: u64 = rest.split_whitespace().next()?.parse().ok()?;
+            return Some(kb * 1024);
+        }
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn peak_rss_bytes_impl() -> Option<u64> {
+    // `ri_lifetime_max_phys_footprint` is the peak of the same
+    // `phys_footprint` figure `rss_bytes` samples live — already in BYTES,
+    // no conversion. Mirrors `rss_bytes_impl`'s delegation to
+    // `phys_footprint_bytes`.
+    super::sysstats::lifetime_max_phys_footprint_bytes()
+}
+
+#[cfg(target_os = "windows")]
+fn peak_rss_bytes_impl() -> Option<u64> {
+    use std::mem;
+    use windows_sys::Win32::System::ProcessStatus::{
+        K32GetProcessMemoryInfo, PROCESS_MEMORY_COUNTERS, PROCESS_MEMORY_COUNTERS_EX,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+    // `PeakWorkingSetSize` is the high-water mark of the process's working
+    // set — already in BYTES, no conversion. It lives in the leading base
+    // `PROCESS_MEMORY_COUNTERS` fields, so the same EX-struct-cast-to-base
+    // idiom `rss_bytes_impl` uses to read `PrivateUsage` reads it here with
+    // no extra `windows-sys` feature.
+    //
+    // SAFETY: identical to `rss_bytes_impl`. `GetCurrentProcess()` returns
+    // the always-valid pseudo-handle (-1) needing no `CloseHandle`; the
+    // pointer cast is sound because `PROCESS_MEMORY_COUNTERS_EX` is
+    // `#[repr(C)]` and layout-compatible with `PROCESS_MEMORY_COUNTERS` for
+    // the leading fields, and `cb` is the EX size so the kernel writes the
+    // full struct.
+    unsafe {
+        let handle = GetCurrentProcess();
+        let mut pmc: PROCESS_MEMORY_COUNTERS_EX = mem::zeroed();
+        pmc.cb = mem::size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32;
+        let ok = K32GetProcessMemoryInfo(
+            handle,
+            &mut pmc as *mut PROCESS_MEMORY_COUNTERS_EX as *mut PROCESS_MEMORY_COUNTERS,
+            mem::size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32,
+        );
+        if ok != 0 {
+            Some(pmc.PeakWorkingSetSize as u64)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn peak_rss_bytes_impl() -> Option<u64> {
+    None
+}
+
 /// Reject an unsatisfiable memory budget at startup, before any
 /// source-ingest thread spawns.
 ///
@@ -1294,10 +1381,57 @@ mod tests {
         );
     }
 
+    /// `peak_rss_bytes()` reports a monotonic high-water mark that never
+    /// decreases, so a touched 64 MiB allocation can only raise it.
+    ///
+    /// Unlike the `phys_footprint` / `PrivateUsage` probes — which read a
+    /// *current* figure a sibling thread's `free()` can lower between two
+    /// samples, forcing the `run_isolated` subprocess harness (issue #394) —
+    /// `VmHWM` / `PeakWorkingSetSize` / `ri_lifetime_max_phys_footprint` are
+    /// lifetime watermarks: they only rise. A `peak_after >= peak_before`
+    /// assertion is therefore inherently immune to sibling churn and needs
+    /// no process isolation. Gated to the first-class targets where
+    /// `peak_rss_bytes()` is defined.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn peak_rss_bytes_is_a_monotonic_high_water_mark() {
+        let before =
+            peak_rss_bytes().expect("peak_rss_bytes() must be readable on a first-class target");
+        assert!(before > 0, "peak RSS must be positive for a live process");
+
+        // On Linux the high-water mark must be on the same order as the
+        // current RSS — a cheap catch for a dropped `* 1024`, which would
+        // make `peak_rss_bytes` ~1024x smaller than `rss_bytes`. The exact
+        // `>= current` relation does NOT hold instant-to-instant: `VmHWM`
+        // here comes from `/proc/self/status` while `rss_bytes` reads
+        // `/proc/self/statm` (resident pages x page size), and the two
+        // kernel sources can disagree by a few pages at a sample boundary.
+        // Asserting `peak >= current / 2` tolerates that skew while still
+        // failing a 1024x unit error by a wide margin.
+        #[cfg(target_os = "linux")]
+        {
+            let current = rss_bytes().expect("rss_bytes() must be readable on Linux");
+            assert!(
+                before >= current / 2,
+                "peak RSS ({before}) must be on the order of current RSS ({current}); \
+                 a peak ~1024x smaller signals a missing kB->bytes conversion"
+            );
+        }
+
+        let buf = touch_pages(64 * 1024 * 1024);
+        let after =
+            peak_rss_bytes().expect("peak_rss_bytes() must be readable on a first-class target");
+        assert!(
+            after >= before,
+            "a high-water mark can only rise; before={before} after={after}"
+        );
+        drop(buf);
+    }
+
     /// Touch every page of a heap buffer so the pages are committed and
     /// resident, then keep the buffer alive across the read. Returns the
     /// buffer so the caller controls its drop point.
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn touch_pages(bytes: usize) -> Vec<u8> {
         let mut v: Vec<u8> = vec![0u8; bytes];
         let page = 4096;
@@ -1314,7 +1448,7 @@ mod tests {
     /// parent: absent in the parent (which re-execs), set in the child
     /// (which runs the probe body). Its presence also breaks the otherwise
     /// infinite re-exec loop.
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     const MEMPROBE_ISOLATED_ENV: &str = "CLINKER_MEMPROBE_ISOLATED";
 
     /// Marker the child prints to stdout after the probe's assertions pass.
@@ -1325,20 +1459,23 @@ mod tests {
     /// a filter quirk) and the probe never executed. A dedicated sentinel is
     /// robust to libtest output-format drift in a way that scraping for
     /// "1 passed" is not.
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     const MEMPROBE_RAN_SENTINEL: &str = "__clinker_memprobe_ran__";
 
     /// Runs `probe` in a child process where it is the sole test, so its
-    /// before/after memory samples bracket only its own allocation.
+    /// memory samples bracket only its own allocation and the process-global
+    /// RSS readings cannot be moved by a sibling test thread.
     ///
-    /// The probes read a process-global counter (Windows `PrivateUsage`,
-    /// macOS `phys_footprint`) and assert a direction of change. Under
-    /// `cargo test`'s default multi-threaded harness, sibling test threads
-    /// in the same binary commit and free large buffers between the two
-    /// samples, moving the global figure independently of this probe's own
-    /// allocation and tripping the assertion at random (issue #394).
-    /// `#[serial]` is insufficient: it only orders `#[serial]`-tagged tests,
-    /// leaving every other test in the binary concurrent.
+    /// The probes read a process-global counter (Linux `/proc/self/statm`
+    /// RSS, Windows `PrivateUsage`, macOS `phys_footprint`) and assert a
+    /// relation between two or more samples. Under `cargo test`'s default
+    /// multi-threaded harness, sibling test threads in the same binary
+    /// commit and free large buffers between the samples, moving the global
+    /// figure independently of this probe's own allocation and tripping the
+    /// assertion at random (issue #394). `#[serial]` is insufficient: it
+    /// only orders `#[serial]`-tagged tests, leaving every other test in the
+    /// binary concurrent. The mechanism is platform-agnostic, so it runs on
+    /// every first-class target rather than only macOS/Windows.
     ///
     /// On first entry (parent, env flag absent) this re-execs the test
     /// binary filtered to `test_path` alone, with the flag set, then
@@ -1348,7 +1485,7 @@ mod tests {
     /// failure surfaces the child's stderr (the real assertion text). On the
     /// recursive entry (child, env flag present) it runs `probe`, prints the
     /// sentinel, and returns, letting libtest report the result.
-    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     fn run_isolated(test_path: &str, probe: impl FnOnce()) {
         if std::env::var_os(MEMPROBE_ISOLATED_ENV).is_some() {
             probe();
@@ -1459,52 +1596,72 @@ mod tests {
         );
     }
 
+    /// This test samples `rss_bytes()` as `baseline`, then
+    /// `reject_unsatisfiable_budget` internally samples current RSS again as
+    /// `baseline_rss` and the test asserts `baseline_rss >= baseline`. Both
+    /// reads are of the process-global *current* RSS, so a sibling test
+    /// thread freeing memory between them lowers RSS and trips the
+    /// assertion under the multi-threaded harness — the same churn that
+    /// flakes the `phys_footprint` / `PrivateUsage` probes (issue #394).
+    /// Running it as the sole test in a child process via [`run_isolated`]
+    /// removes the sibling churn, so the two reads are stable and the
+    /// assertion holds without weakening it.
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn reject_unsatisfiable_budget_pins_both_policies() {
-        use clinker_plan::config::BackpressureKnob;
-        use clinker_plan::error::PipelineError;
+        run_isolated(
+            "pipeline::memory::tests::reject_unsatisfiable_budget_pins_both_policies",
+            || {
+                use clinker_plan::config::BackpressureKnob;
+                use clinker_plan::error::PipelineError;
 
-        // No baseline to compare against → cannot judge; never rejects.
-        let Some(baseline) = rss_bytes() else {
-            assert!(reject_unsatisfiable_budget(1, BackpressureKnob::Pause).is_ok());
-            return;
-        };
+                // No baseline to compare against → cannot judge; never rejects.
+                let Some(baseline) = rss_bytes() else {
+                    assert!(reject_unsatisfiable_budget(1, BackpressureKnob::Pause).is_ok());
+                    return;
+                };
 
-        // A 1-byte budget is below baseline RSS. Under the producer-pausing
-        // policies (pause/both) it would deadlock, so it is rejected at
-        // startup with the configured limit and the measured baseline.
-        for knob in [BackpressureKnob::Pause, BackpressureKnob::Both] {
-            match reject_unsatisfiable_budget(1, knob) {
-                Err(PipelineError::UnsatisfiableMemoryBudget {
-                    limit,
-                    baseline_rss,
-                }) => {
-                    assert_eq!(limit, 1);
-                    assert!(baseline_rss >= baseline, "baseline must be the live RSS");
+                // A 1-byte budget is below baseline RSS. Under the producer-pausing
+                // policies (pause/both) it would deadlock, so it is rejected at
+                // startup with the configured limit and the measured baseline.
+                for knob in [BackpressureKnob::Pause, BackpressureKnob::Both] {
+                    match reject_unsatisfiable_budget(1, knob) {
+                        Err(PipelineError::UnsatisfiableMemoryBudget {
+                            limit,
+                            baseline_rss,
+                        }) => {
+                            assert_eq!(limit, 1);
+                            assert!(baseline_rss >= baseline, "baseline must be the live RSS");
+                        }
+                        other => {
+                            panic!(
+                                "pausing policy must reject a sub-baseline budget; got {other:?}"
+                            )
+                        }
+                    }
                 }
-                other => panic!("pausing policy must reject a sub-baseline budget; got {other:?}"),
-            }
-        }
 
-        // Under spill the same sub-baseline budget never pauses, so it is
-        // NOT rejected — it spills/aborts via the runtime admission path.
-        assert!(
-            reject_unsatisfiable_budget(1, BackpressureKnob::Spill).is_ok(),
-            "spill policy must not reject a sub-baseline budget at startup"
+                // Under spill the same sub-baseline budget never pauses, so it is
+                // NOT rejected — it spills/aborts via the runtime admission path.
+                assert!(
+                    reject_unsatisfiable_budget(1, BackpressureKnob::Spill).is_ok(),
+                    "spill policy must not reject a sub-baseline budget at startup"
+                );
+
+                // A budget well above baseline is satisfiable under every policy.
+                let generous = baseline.saturating_mul(4).max(512 * 1024 * 1024);
+                for knob in [
+                    BackpressureKnob::Pause,
+                    BackpressureKnob::Both,
+                    BackpressureKnob::Spill,
+                ] {
+                    assert!(
+                        reject_unsatisfiable_budget(generous, knob).is_ok(),
+                        "a budget above baseline must be satisfiable under {knob:?}"
+                    );
+                }
+            },
         );
-
-        // A budget well above baseline is satisfiable under every policy.
-        let generous = baseline.saturating_mul(4).max(512 * 1024 * 1024);
-        for knob in [
-            BackpressureKnob::Pause,
-            BackpressureKnob::Both,
-            BackpressureKnob::Spill,
-        ] {
-            assert!(
-                reject_unsatisfiable_budget(generous, knob).is_ok(),
-                "a budget above baseline must be satisfiable under {knob:?}"
-            );
-        }
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/sysstats.rs
+++ b/crates/clinker-exec/src/pipeline/sysstats.rs
@@ -205,6 +205,17 @@ pub(crate) fn phys_footprint_bytes() -> Option<u64> {
     rusage_info_v4().map(|info| info.ri_phys_footprint)
 }
 
+/// Returns the lifetime high-water mark of the process's physical memory
+/// footprint in bytes (`ri_lifetime_max_phys_footprint`), the peak of the
+/// same `phys_footprint` figure [`phys_footprint_bytes`] samples live, or
+/// `None` when `proc_pid_rusage` fails. macOS-only; the peak-RSS gate reads
+/// this so a transient spike is captured even after the footprint falls back.
+/// Monotonic non-decreasing for the life of the process.
+#[cfg(target_os = "macos")]
+pub(crate) fn lifetime_max_phys_footprint_bytes() -> Option<u64> {
+    rusage_info_v4().map(|info| info.ri_lifetime_max_phys_footprint)
+}
+
 #[cfg(target_os = "macos")]
 fn io_counters_impl() -> Option<IoCounters> {
     rusage_info_v4().map(|info| IoCounters {

--- a/crates/clinker-exec/tests/doc_index_rss_proof.rs
+++ b/crates/clinker-exec/tests/doc_index_rss_proof.rs
@@ -1,0 +1,538 @@
+//! Bounded-memory end-to-end proof: a `Source -> Transform -> Output`
+//! pipeline over a nested-envelope document with a multi-hundred-MB (up to
+//! 1 GiB) undeclared body must finish with a peak resident-memory delta in
+//! the low tens of MiB — never proportional to the body's byte size.
+//!
+//! Why this proves the pillar. The transform reads only a declared `$doc`
+//! head path (`$doc.Head.batch_id`) and emits a single scalar. With no
+//! Aggregate / sort / Combine / window, the only thing that could spike RSS
+//! proportionally to the body is a reader that buffers the body to reach the
+//! trailing `Summary` section that sits *after* it. Both the JSON (#511) and
+//! XML (#512) readers stream their bodies, so the pre-scan parses-and-skips
+//! the body to reach the trailer and the body never lands in memory. The
+//! document is fed through the de-buffered file-slot path
+//! (`FileSlot::from_path` over a real temp file), NOT an in-memory `Cursor`,
+//! so a whole-file buffer is never created anywhere in the harness — a
+//! `Cursor` would defeat the proof by buffering the payload before the
+//! reader ever runs.
+//!
+//! Isolating body bytes from record count. The body grows by per-record
+//! *blob* size, not record count: a modest number of records each carry a
+//! large undeclared blob. A body-buffer regression scales with the body's
+//! BYTES (the blob), so the blob is the variable under test; the record
+//! count stays low so the executor's per-output-row `ok_count` accounting
+//! (one `u64` per row, held for the run) contributes a negligible, body-byte-
+//! independent term. Output is discarded through [`FirstLineSink`] so the
+//! harness never accumulates the emitted NDJSON either.
+//!
+//! The peak is measured with the monotonic high-water-mark
+//! [`peak_rss_bytes`] sampled after fixture generation (which streams to
+//! disk and adds nothing lasting) and again after the run; the delta is
+//! asserted below a hard threshold. The assertion fails LOUDLY on a
+//! body-buffer regression — there is no soft `eprintln`-and-continue.
+//!
+//! Gating. One shared body, sized by parameter. The default CI variants run
+//! a ~150 MiB body (well over the 64 MB `max_index_bytes` default and
+//! dwarfing the retained index, so bounded-vs-buffered is a real
+//! distinction) and finish in seconds. A second `#[ignore]`'d pair runs the
+//! full 1 GiB body — a documented heavy-data gate, run with
+//! `cargo test -p clinker-exec --test doc_index_rss_proof -- --ignored`.
+
+use std::collections::HashMap;
+use std::io::{BufWriter, Write};
+use std::sync::{Arc, Mutex};
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_bench_support::{FieldKind, write_nested_envelope_json, write_nested_envelope_xml};
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, SourceInput, SourceReaders};
+use clinker_exec::pipeline::memory::peak_rss_bytes;
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+use tempfile::NamedTempFile;
+
+/// Output sink that retains only the first emitted line and discards every
+/// byte after it.
+///
+/// The proof asserts the declared `$doc.Head` section resolves on body
+/// records (needs the first output line) but must NOT itself accumulate the
+/// whole output stream: at 1 GiB of body that is ~130 MiB of NDJSON, which
+/// would dominate the RSS delta and mask what the *engine* retains. A real
+/// `clinker run` streams output to a file descriptor and holds nothing, so
+/// discarding here measures the engine's true footprint, not the harness's.
+#[derive(Clone, Default)]
+struct FirstLineSink(Arc<Mutex<FirstLineState>>);
+
+#[derive(Default)]
+struct FirstLineState {
+    first_line: Vec<u8>,
+    done: bool,
+}
+
+impl FirstLineSink {
+    fn first_line(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().unwrap().first_line).into_owned()
+    }
+}
+
+impl Write for FirstLineSink {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut st = self.0.lock().unwrap();
+        if !st.done {
+            if let Some(nl) = buf.iter().position(|&b| b == b'\n') {
+                st.first_line.extend_from_slice(&buf[..nl]);
+                st.done = true;
+            } else {
+                st.first_line.extend_from_slice(buf);
+            }
+        }
+        // Report the whole slice consumed — the bytes after the first line
+        // are intentionally dropped on the floor.
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Peak-RSS-delta ceiling for the bounded path, in bytes.
+///
+/// The fused `source -> output` path holds at most a few in-flight records
+/// (the bounded ingest channel) plus the tiny retained `$doc` index, so its
+/// footprint is in the low tens of MiB regardless of body byte-size. A
+/// regression that buffered the body would scale with the body's bytes:
+/// ~150 MiB (CI variant) or ~1 GiB (heavy variant), overshooting this
+/// ceiling many times over. Started at 100 MiB. If CI noise proves flaky,
+/// loosen toward 150 MiB — but the bounded path sits far below either, so a
+/// body-buffer regression is caught anywhere in that band.
+const RSS_DELTA_THRESHOLD: u64 = 100 * 1024 * 1024;
+
+/// Body shape: a record *count* paired with a per-record *blob* size.
+///
+/// Body bytes = `records * blob_len` (plus framing). Two competing bounds
+/// shape the choice:
+///
+/// - **In-flight channel.** The bounded ingest channel holds up to its
+///   capacity (1024) records, so peak in-flight memory is roughly
+///   `min(records, 1024) * blob_len`. `blob_len` must stay small enough that
+///   this product sits well under [`RSS_DELTA_THRESHOLD`] even though the
+///   *total* body is GB-scale — the bound is O(capacity), not O(body).
+/// - **`ok_count` accounting.** The executor holds one `u64` per output row
+///   for the whole run, an O(records) term. At the record counts below this
+///   is a few MiB at most — negligible and, crucially, independent of the
+///   body's *byte* size, the variable a body-buffer regression scales with.
+///
+/// A 16 KB blob keeps the channel floor near 16 MiB while letting a large
+/// `records` count push the on-disk body to GB scale.
+#[derive(Clone, Copy)]
+struct BodySize {
+    records: usize,
+    blob_len: usize,
+}
+
+/// Per-record blob width, shared by both variants. 16 KB × the 1024-deep
+/// channel is a ~16 MiB in-flight floor — comfortably under the threshold —
+/// while a large record count scales the body to whatever size is wanted.
+const BLOB_LEN: usize = 16 * 1024;
+
+/// CI variant: ~128 MiB of body from 8,000 records × 16 KB blobs. Well over
+/// the 64 MB `max_index_bytes` default and orders of magnitude larger than
+/// the retained head/trailer index.
+const CI_BODY: BodySize = BodySize {
+    records: 8_000,
+    blob_len: BLOB_LEN,
+};
+
+/// Heavy `#[ignore]`'d variant: ~1 GiB of body from 65,536 records × 16 KB
+/// blobs. The 65,536-row `ok_count` term is under 2 MiB — negligible against
+/// the GB-scale body a buffer regression would resident.
+const XLARGE_BODY: BodySize = BodySize {
+    records: 65_536,
+    blob_len: BLOB_LEN,
+};
+
+/// Per-body-record typed-field string width — small; the body's bulk is the
+/// `blob`, not these typed fields.
+const STRING_LEN: usize = 24;
+
+/// JSON envelope pipeline: a declared `Head` section read by the transform,
+/// an undeclared `records` body, a `Summary` trailer that forces the
+/// pre-scan to stream past the body. The transform reads only the head path
+/// and emits one scalar — no body field is touched.
+const JSON_YAML: &str = r#"
+pipeline:
+  name: doc_rss_proof_json
+nodes:
+  - type: source
+    name: docs
+    config:
+      name: docs
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Head:
+            extract: { json_pointer: "/Head" }
+            fields:
+              batch_id: string
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: tag
+    input: docs
+    config:
+      cxl: |
+        emit x = $doc.Head.batch_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: json
+      options:
+        format: ndjson
+      path: out.json
+      include_unmapped: false
+      exclude: [id]
+"#;
+
+/// XML twin of [`JSON_YAML`]. Same shape: declared `Head`, undeclared
+/// `records` body, `Summary` trailer after the body.
+const XML_YAML: &str = r#"
+pipeline:
+  name: doc_rss_proof_xml
+nodes:
+  - type: source
+    name: docs
+    config:
+      name: docs
+      type: xml
+      glob: ./*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Head:
+            extract: { xml_path: "/doc/Head" }
+            fields:
+              batch_id: string
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: tag
+    input: docs
+    config:
+      cxl: |
+        emit x = $doc.Head.batch_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: json
+      options:
+        format: ndjson
+      path: out.json
+      include_unmapped: false
+      exclude: [id]
+"#;
+
+/// Which document format the proof body targets.
+#[derive(Clone, Copy)]
+enum DocFormat {
+    Json,
+    Xml,
+}
+
+/// Stream a nested-envelope fixture of `size.records` rows (each carrying a
+/// `size.blob_len`-byte undeclared blob) to a fresh temp file — extension
+/// matching the format so the glob/source type line up — and return the
+/// handle. The fixture is written through a `BufWriter` straight to disk: at
+/// no point is the multi-hundred-MB body held in memory by the generator.
+fn write_fixture(format: DocFormat, size: BodySize) -> NamedTempFile {
+    let suffix = match format {
+        DocFormat::Json => ".json",
+        DocFormat::Xml => ".xml",
+    };
+    let tmp = tempfile::Builder::new()
+        .suffix(suffix)
+        .tempfile()
+        .expect("create temp fixture file");
+    let layout = FieldKind::default_layout(3);
+    {
+        let mut w = BufWriter::new(tmp.as_file());
+        match format {
+            DocFormat::Json => {
+                write_nested_envelope_json(
+                    &mut w,
+                    size.records,
+                    &layout,
+                    STRING_LEN,
+                    size.blob_len,
+                    42,
+                )
+                .expect("stream JSON fixture to disk");
+            }
+            DocFormat::Xml => {
+                write_nested_envelope_xml(
+                    &mut w,
+                    size.records,
+                    &layout,
+                    STRING_LEN,
+                    size.blob_len,
+                    42,
+                )
+                .expect("stream XML fixture to disk");
+            }
+        }
+        w.flush().expect("flush fixture writer");
+    }
+    tmp
+}
+
+/// Run the bounded-memory proof for one format and body size: generate the
+/// on-disk fixture, sample the peak-RSS watermark, run the fused pipeline
+/// off the de-buffered file slot, sample the watermark again, and assert the
+/// delta stays under [`RSS_DELTA_THRESHOLD`].
+fn run_proof(format: DocFormat, size: BodySize) {
+    let yaml = match format {
+        DocFormat::Json => JSON_YAML,
+        DocFormat::Xml => XML_YAML,
+    };
+    let config = parse_config(yaml).expect("parse proof pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile proof pipeline");
+
+    let fixture = write_fixture(format, size);
+    let read_path = fixture.path().to_path_buf();
+
+    // De-buffered feed: the reader re-opens the file by path per pass and
+    // streams off disk. A `Cursor`/`single_file_reader` would buffer the
+    // whole payload and defeat the proof.
+    let file = FileSlot::from_path(read_path.clone(), read_path);
+    let readers: SourceReaders =
+        HashMap::from([("docs".to_string(), SourceInput::Files(vec![file]))]);
+
+    let sink = FirstLineSink::default();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(sink.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "doc-rss-proof".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    // Sample the high-water mark AFTER fixture generation (which streamed to
+    // disk and left nothing resident) and before the run.
+    let peak_before = peak_rss_bytes().expect("peak_rss_bytes() on a first-class target");
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run proof pipeline");
+
+    let peak_after = peak_rss_bytes().expect("peak_rss_bytes() on a first-class target");
+
+    // Every body record streamed end-to-end (proves the body was processed,
+    // not silently dropped) and the declared head section resolved on each.
+    assert_eq!(
+        report.counters.total_count as usize, size.records,
+        "every body record must stream through the fused pipeline"
+    );
+    assert_eq!(report.counters.dlq_count, 0, "no record dead-lettered");
+    let first_line = sink.first_line();
+    assert!(
+        first_line.contains("RUN-00000042"),
+        "the declared $doc.Head.batch_id must resolve on body records: {first_line}"
+    );
+
+    let delta = peak_after.saturating_sub(peak_before);
+    if std::env::var_os("CLINKER_RSS_PROOF_REPORT").is_some() {
+        eprintln!(
+            "RSS-PROOF-DELTA fmt={} records={} blob_len={} before={peak_before} after={peak_after} delta={delta}",
+            match format {
+                DocFormat::Json => "json",
+                DocFormat::Xml => "xml",
+            },
+            size.records,
+            size.blob_len,
+        );
+    }
+    assert!(
+        delta < RSS_DELTA_THRESHOLD,
+        "bounded-memory proof FAILED ({}): peak RSS rose by {delta} bytes \
+         (before={peak_before}, after={peak_after}) over a body of {} records x {} blob bytes, \
+         exceeding the {RSS_DELTA_THRESHOLD}-byte ceiling. A delta that scales with the body's \
+         byte size means the reader buffered the undeclared body instead of streaming past it.",
+        match format {
+            DocFormat::Json => "JSON",
+            DocFormat::Xml => "XML",
+        },
+        size.records,
+        size.blob_len,
+    );
+}
+
+#[test]
+fn json_doc_body_is_streamed_not_buffered_ci() {
+    run_proof(DocFormat::Json, CI_BODY);
+}
+
+#[test]
+fn xml_doc_body_is_streamed_not_buffered_ci() {
+    run_proof(DocFormat::Xml, CI_BODY);
+}
+
+#[test]
+#[ignore = "heavy — generates ~1 GiB at test time; run with cargo test -- --ignored"]
+fn json_doc_body_is_streamed_not_buffered_1gib() {
+    run_proof(DocFormat::Json, XLARGE_BODY);
+}
+
+#[test]
+#[ignore = "heavy — generates ~1 GiB at test time; run with cargo test -- --ignored"]
+fn xml_doc_body_is_streamed_not_buffered_1gib() {
+    run_proof(DocFormat::Xml, XLARGE_BODY);
+}
+
+// ── max_index_bytes cap propagation (YAML → reader, end-to-end) ──────────
+
+/// A JSON pipeline whose declared `Head.blob` section is intentionally large
+/// (~80 KB), parameterized on the `options.max_index_bytes` cap. Proves the
+/// YAML cap reaches the reader's streaming pre-scan: a tiny cap aborts
+/// mid-parse with the section-named cap error; a generous cap streams clean.
+fn cap_pipeline_yaml(max_index_bytes: usize) -> String {
+    format!(
+        r#"
+pipeline:
+  name: doc_cap_propagation
+nodes:
+  - type: source
+    name: docs
+    config:
+      name: docs
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+        max_index_bytes: {max_index_bytes}
+      envelope:
+        sections:
+          Head:
+            extract: {{ json_pointer: "/Head" }}
+            fields:
+              blob: string
+      schema:
+        - {{ name: id, type: int }}
+  - type: transform
+    name: tag
+    input: docs
+    config:
+      cxl: |
+        emit x = $doc.Head.blob
+  - type: output
+    name: out
+    input: docs
+    config:
+      name: out
+      type: json
+      options:
+        format: ndjson
+      path: out.json
+      include_unmapped: false
+      exclude: [id]
+"#
+    )
+}
+
+/// Write a JSON document with a large declared `Head.blob` (so the section's
+/// own retained bytes can exceed a tiny cap) plus a tiny two-record body, to
+/// a temp file. Returns the handle.
+fn write_large_head_fixture() -> NamedTempFile {
+    let tmp = tempfile::Builder::new()
+        .suffix(".json")
+        .tempfile()
+        .expect("create temp fixture file");
+    {
+        let mut w = BufWriter::new(tmp.as_file());
+        // ~80 KB declared blob — far above the 4 KB cap below, comfortably
+        // under any generous cap.
+        let blob = "z".repeat(80_000);
+        write!(w, "{{\"Head\":{{\"blob\":\"{blob}\"}},\"records\":[").unwrap();
+        write!(w, "{{\"id\":1}},{{\"id\":2}}").unwrap();
+        write!(w, "]}}").unwrap();
+        w.flush().expect("flush fixture");
+    }
+    tmp
+}
+
+/// Build the readers/writers and run the cap pipeline over the large-head
+/// fixture, returning the run `Result`.
+fn run_cap_pipeline(
+    max_index_bytes: usize,
+) -> Result<clinker_exec::executor::ExecutionReport, clinker_plan::error::PipelineError> {
+    let yaml = cap_pipeline_yaml(max_index_bytes);
+    let config = parse_config(&yaml).expect("parse cap pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile cap pipeline");
+
+    let fixture = write_large_head_fixture();
+    let read_path = fixture.path().to_path_buf();
+    let file = FileSlot::from_path(read_path.clone(), read_path);
+    let readers: SourceReaders =
+        HashMap::from([("docs".to_string(), SourceInput::Files(vec![file]))]);
+
+    let sink = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> =
+        HashMap::from([("out".to_string(), Box::new(sink) as Box<dyn Write + Send>)]);
+
+    let params = PipelineRunParams {
+        execution_id: "doc-cap".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    // Keep `fixture` alive until the run finishes (the reader re-opens it by
+    // path); `run_plan_with_readers_writers` drains synchronously, so the
+    // temp file outlives every read here.
+    let result = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params);
+    drop(fixture);
+    result
+}
+
+/// A tiny `max_index_bytes` declared in YAML reaches the reader and aborts
+/// the run mid-parse, naming the over-cap section and the cap value.
+#[test]
+fn tiny_max_index_bytes_cap_aborts_mid_parse() {
+    let err = run_cap_pipeline(4096).expect_err("a 4 KB cap must reject the ~80 KB Head section");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("max_index_bytes"),
+        "cap error must name the knob: {msg}"
+    );
+    assert!(
+        msg.contains("Head"),
+        "cap error must name the section: {msg}"
+    );
+    assert!(
+        msg.contains("mid-parse"),
+        "cap error must state the abort is mid-parse: {msg}"
+    );
+}
+
+/// The same pipeline with a generous `max_index_bytes` streams to
+/// completion — proving the tiny-cap failure was the cap firing, not a
+/// structural fault in the fixture.
+#[test]
+fn generous_max_index_bytes_cap_streams_clean() {
+    let report = run_cap_pipeline(1_000_000).expect("a 1 MB cap easily fits the ~80 KB Head");
+    assert_eq!(report.counters.total_count, 2, "both body records stream");
+    assert_eq!(report.counters.dlq_count, 0);
+}

--- a/crates/cxl/src/eval/compiled/tests.rs
+++ b/crates/cxl/src/eval/compiled/tests.rs
@@ -274,6 +274,51 @@ fn eval_project_capturing(
     (project(&result), snapshot_side_effects(&stable))
 }
 
+/// Evaluate `src` through the compiled evaluator with an explicit
+/// `Arc<DocumentContext>` bound as the per-record envelope context, so the
+/// compiled `Expr::DocAccess` lowering resolves `$doc.*` against real
+/// sections rather than the empty synthetic context.
+///
+/// Runs through the live `ProgramEvaluator::eval_record` entry, so the
+/// `DocAccess` (and any wrapping `IndexAccess`) closure under test is the
+/// exact one production lowers — not a test-local re-implementation.
+fn eval_project_with_doc(
+    src: &str,
+    fields: &[&str],
+    record: HashMap<String, Value>,
+    doc_ctx: &Arc<clinker_record::DocumentContext>,
+) -> ResultProjection {
+    let typed = type_program(src, fields);
+    let has_distinct = program_has_distinct(&typed);
+
+    let stable = StableEvalContext::test_default();
+    let resolver = HashMapResolver::new(record);
+
+    let mut ctx = EvalContext::test_default_borrowed(&stable);
+    ctx.doc_ctx = doc_ctx;
+    let mut eval = ProgramEvaluator::new(Arc::new(typed), has_distinct);
+    let result = eval.eval_record::<NullStorage>(&ctx, &resolver, None);
+    project(&result)
+}
+
+/// Build a `DocumentContext` whose single section `name` holds the given
+/// `(field, Value)` payload as a `Value::Map`. Field values may themselves
+/// be `Value::Array` / `Value::Map` to exercise indexed `$doc` chains.
+fn doc_with_section(name: &str, fields: &[(&str, Value)]) -> Arc<clinker_record::DocumentContext> {
+    use clinker_record::{DocumentContext, DocumentId};
+    let mut payload = indexmap::IndexMap::new();
+    for (k, v) in fields {
+        payload.insert(Box::from(*k), v.clone());
+    }
+    let mut sections = indexmap::IndexMap::new();
+    sections.insert(Box::from(name), Value::Map(Box::new(payload)));
+    Arc::new(DocumentContext::new(
+        DocumentId::next(),
+        Arc::from("proof.json"),
+        sections,
+    ))
+}
+
 // ── Corpus: the scalar core ───────────────────────────────
 
 /// The full three-valued Kleene truth table for `and` / `or`, every cell
@@ -887,6 +932,167 @@ fn index_access() {
             "emit out = nums[0 - 1]",
             &["nums"],
             HashMap::from([("nums".to_string(), nums())]),
+        ),
+        emit(Value::Null),
+    );
+}
+
+/// `$doc.<section>.<field>` through the compiled `Expr::DocAccess`
+/// lowering: a present field resolves to its value; an undeclared section
+/// or a missing field resolves to `Null` (never an error).
+#[test]
+fn doc_access_scalar_present_and_missing() {
+    let doc = doc_with_section(
+        "Head",
+        &[
+            ("batch_id", Value::String("RUN-001".into())),
+            ("count", Value::Integer(7)),
+        ],
+    );
+    let emit = |v: Value| ResultProjection::Emit {
+        fields: vec![("out".to_string(), v)],
+        record_vars: vec![],
+    };
+
+    // Present field → its value.
+    assert_eq!(
+        eval_project_with_doc("emit out = $doc.Head.batch_id", &[], HashMap::new(), &doc),
+        emit(Value::String("RUN-001".into())),
+    );
+    // Undeclared section → Null.
+    assert_eq!(
+        eval_project_with_doc("emit out = $doc.Foot.batch_id", &[], HashMap::new(), &doc),
+        emit(Value::Null),
+    );
+    // Declared section, missing field → Null.
+    assert_eq!(
+        eval_project_with_doc("emit out = $doc.Head.missing", &[], HashMap::new(), &doc),
+        emit(Value::Null),
+    );
+}
+
+/// `$doc` against a synthetic/empty document context resolves every path to
+/// `Null` — the record-free / undeclared-source default.
+#[test]
+fn doc_access_against_empty_context_is_null() {
+    use clinker_record::synthetic_document_context;
+    let doc = synthetic_document_context();
+    let emit = |v: Value| ResultProjection::Emit {
+        fields: vec![("out".to_string(), v)],
+        record_vars: vec![],
+    };
+    assert_eq!(
+        eval_project_with_doc("emit out = $doc.any.field", &[], HashMap::new(), &doc),
+        emit(Value::Null),
+    );
+}
+
+/// Indexed `$doc` access: a `$doc.<section>.<field>` whose field is a
+/// `Value::Array` indexes by integer — in-range yields the element,
+/// out-of-range yields `Null` with no panic. This is the compiled
+/// `IndexAccess` lowering wrapping the `DocAccess` leaf.
+#[test]
+fn doc_access_array_index_in_and_out_of_range() {
+    let doc = doc_with_section(
+        "Head",
+        &[(
+            "items",
+            Value::Array(vec![
+                Value::Integer(10),
+                Value::Integer(20),
+                Value::Integer(30),
+            ]),
+        )],
+    );
+    let emit = |v: Value| ResultProjection::Emit {
+        fields: vec![("out".to_string(), v)],
+        record_vars: vec![],
+    };
+    // In-range: items[0] → 10.
+    assert_eq!(
+        eval_project_with_doc("emit out = $doc.Head.items[0]", &[], HashMap::new(), &doc),
+        emit(Value::Integer(10)),
+    );
+    // Out-of-range → Null (no panic).
+    assert_eq!(
+        eval_project_with_doc("emit out = $doc.Head.items[9]", &[], HashMap::new(), &doc),
+        emit(Value::Null),
+    );
+}
+
+/// Keyed `$doc` access: a `$doc.<section>.<field>` whose field is a
+/// `Value::Map` indexes by string key — present yields the value, missing
+/// yields `Null`.
+#[test]
+fn doc_access_map_key_present_and_missing() {
+    let mut meta = indexmap::IndexMap::new();
+    meta.insert(Box::from("region"), Value::String("us-east".into()));
+    let doc = doc_with_section("Head", &[("meta", Value::Map(Box::new(meta)))]);
+    let emit = |v: Value| ResultProjection::Emit {
+        fields: vec![("out".to_string(), v)],
+        record_vars: vec![],
+    };
+    // Present key.
+    assert_eq!(
+        eval_project_with_doc(
+            "emit out = $doc.Head.meta[\"region\"]",
+            &[],
+            HashMap::new(),
+            &doc
+        ),
+        emit(Value::String("us-east".into())),
+    );
+    // Missing key → Null.
+    assert_eq!(
+        eval_project_with_doc(
+            "emit out = $doc.Head.meta[\"absent\"]",
+            &[],
+            HashMap::new(),
+            &doc
+        ),
+        emit(Value::Null),
+    );
+}
+
+/// Nested `$doc` chain: `$doc.<section>.<field>[i]["k"]` resolves through an
+/// array-of-maps. An out-of-range link short-circuits the whole chain to
+/// `Null` — the `IndexAccess` null-receiver gate means the trailing key
+/// access never runs against a non-map.
+#[test]
+fn doc_access_nested_chain_short_circuits_on_out_of_range() {
+    let mut row0 = indexmap::IndexMap::new();
+    row0.insert(Box::from("k"), Value::String("v0".into()));
+    let mut row1 = indexmap::IndexMap::new();
+    row1.insert(Box::from("k"), Value::String("v1".into()));
+    let doc = doc_with_section(
+        "Head",
+        &[(
+            "items",
+            Value::Array(vec![Value::Map(Box::new(row0)), Value::Map(Box::new(row1))]),
+        )],
+    );
+    let emit = |v: Value| ResultProjection::Emit {
+        fields: vec![("out".to_string(), v)],
+        record_vars: vec![],
+    };
+    // In-range chain: items[1]["k"] → "v1".
+    assert_eq!(
+        eval_project_with_doc(
+            "emit out = $doc.Head.items[1][\"k\"]",
+            &[],
+            HashMap::new(),
+            &doc
+        ),
+        emit(Value::String("v1".into())),
+    );
+    // Out-of-range first link short-circuits: items[9] is Null, so the
+    // trailing ["k"] resolves to Null instead of panicking.
+    assert_eq!(
+        eval_project_with_doc(
+            "emit out = $doc.Head.items[9][\"k\"]",
+            &[],
+            HashMap::new(),
+            &doc
         ),
         emit(Value::Null),
     );

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -245,6 +245,48 @@ config declares — an X12 reader exposes `$doc.functional_group.*` and
 `$doc.transaction_set.*` the config never names — so their `$doc` paths
 are not checked this way.
 
+## Indexed `$doc` access
+
+A section field that holds an array or a map can be indexed inline, the
+same way any record value is — see [Nested paths](../cxl/nested-paths.md)
+for the full bracket-index reference. Integer indices select array
+elements; string keys select map entries; the two compose into a chain:
+
+```yaml
+project:
+  - first_line:   $doc.Header.line_items[0]      # array element
+  - run_date:     $doc.Header.meta["run_date"]   # map entry
+  - first_sku:    $doc.Header.line_items[0]["sku"]  # array-of-maps chain
+```
+
+An out-of-range array index or a missing map key resolves to `null` — it
+never errors or panics, and a `null` mid-chain short-circuits the rest of
+the chain to `null` rather than failing. This is the same missing-value
+convention `$doc.<missing_field>` and `$source.*` follow.
+
+### Only literal paths are readable
+
+Every index segment must be a **literal** — a constant integer or string
+written in the program text. The section and field are always literal
+identifiers (the grammar requires it), so a literal index is the last
+piece a reader needs to know, before reading any input, exactly which
+envelope paths a run will consume. The pre-scan extracts precisely those
+statically-resolvable paths and nothing else.
+
+A **computed** index — one derived from runtime data, such as
+`$doc.Header.line_items[row_index]` — is not statically resolvable: the
+reader cannot pre-scan a row-dependent element. clinker rejects it at
+compile time with a diagnostic pointing at the offending index, rather
+than reading it at run time. Use a literal index, or pull the value into
+a record field upstream and index that instead.
+
+This compiles together with the declared-path rule above: a `$doc` read
+of a section or field the source does not declare is a **compile-time
+error** (`E341`), and a `$doc` read with a computed index is a
+**compile-time diagnostic** — neither reaches run time as a silent
+`null`. Only a literal path over a *declared* section is pre-scanned and
+readable.
+
 ## One document per file
 
 Each source file is its own document with its own envelope context.


### PR DESCRIPTION
## What

The final step of the document-shape nested-reader chain: proves the bounded-memory bound end-to-end now that the JSON and XML readers stream their bodies, and locks in `$doc` resolution + safety-cap behavior with tests.

## Changes

- **`peak_rss_bytes()` — OS high-water-mark reader.** A new reader in `clinker-exec` alongside `rss_bytes()`, reading the true kernel peak (Linux `/proc/self/status` `VmHWM`, macOS `ri_lifetime_max_phys_footprint`, Windows `PeakWorkingSetSize`), all normalized to bytes. The existing run-end RSS sample is event-sampled and a fused source→output pipeline polls nothing during ingest, so it would miss the transient buffer peak this work removes; a monotonic OS watermark cannot. No new dependency.
- **Streamed 1 GiB fixture generator** in the bench-support crate — writes a head section + large body + trailing section directly to a writer one record at a time (never buffers the document), generated at test time to a temp file, never committed.
- **RSS-gated proof test** — a `$doc`-only fused `source → output` pipeline over the fixture (fed via a path-backed re-openable source so it exercises the de-buffered reader), asserting peak resident delta stays under 100 MiB. A CI-sized variant runs by default; the full 1 GiB variant is gated behind `#[ignore]` (heavy data) and run locally. Measured peak: JSON 43 MiB, XML 2.5 MiB over a full 1 GiB document.
- **`$doc` eval + cap coverage** — compiled-eval tests for `$doc.section.field`, indexed/keyed access, nested chains, out-of-range → null (no panic), and empty-context resolution; plus end-to-end `max_index_bytes` cap-propagation (tiny cap aborts mid-parse, generous cap streams clean).
- **Docs** — indexed `$doc` access + declared-path/runtime-readability semantics added to the envelope/document-context page.
- **Test-infra de-flake** — `reject_unsatisfiable_budget_pins_both_policies` now runs through the existing subprocess-isolation harness (same process-global-RSS-sample root cause as the already-isolated probe tests), eliminating a known off-platform flake.

## Notes

While building the proof, a pre-existing O(output-rows) retention was found in the fan-out `ok_count` dedup accounting (unrelated to the readers); it is tracked separately as #543 and the proof is sized by per-record bytes to isolate the body-streaming signal from it.

Closes #107. Completes the final sub-issue of #385.