### PR TITLE
engine: output-envelope config + per-document writers + frame grain (#546)

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -849,7 +849,7 @@ fn apply_envelope_events(
 ) -> Result<(), PipelineError> {
     for event in src_reader.take_envelope_events() {
         match event {
-            clinker_format::EnvelopeEvent::OpenLevel { sections } => {
+            clinker_format::EnvelopeEvent::OpenLevel { sections, frame } => {
                 // Open a fresh file-level document when none is open yet,
                 // or when the open stack belongs to a different file than
                 // this event — a trailing header-only interchange for a new
@@ -862,7 +862,15 @@ fn apply_envelope_events(
                     open_file_level_doc(src_cfg, stream, doc_stack, src_reader, file_arc)?;
                 }
                 let parent = doc_stack.last().expect("file-level document opened above");
-                let child = Arc::new(parent.child(clinker_record::DocumentId::next(), sections));
+                let id = clinker_record::DocumentId::next();
+                // `FrameRole::NewFrame` (an HL7 `MSH` message) begins its own
+                // output-envelope / document-DLQ frame via `child_frame`;
+                // `Inherit` (an X12 `GS`/`ST`) stays inside the enclosing
+                // interchange frame via `child`.
+                let child = Arc::new(match frame {
+                    clinker_format::FrameRole::NewFrame => parent.child_frame(id, sections),
+                    clinker_format::FrameRole::Inherit => parent.child(id, sections),
+                });
                 push_doc_punctuation(
                     stream,
                     crate::executor::stream_event::Punctuation::document_open(Arc::clone(&child)),
@@ -1345,7 +1353,10 @@ mod tests {
                         field.insert(Box::from("tag"), Value::String(name.into()));
                         let mut sections = IndexMap::new();
                         sections.insert(Box::from(name), Value::Map(Box::new(field)));
-                        self.pending.push(EnvelopeEvent::OpenLevel { sections });
+                        self.pending.push(EnvelopeEvent::OpenLevel {
+                            sections,
+                            frame: clinker_format::FrameRole::Inherit,
+                        });
                     }
                     Step::Close => self.pending.push(EnvelopeEvent::CloseLevel),
                     Step::Record(id) => {

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -109,10 +109,10 @@ pub(crate) fn dispatch_output(
     // `reconstruct_envelope: true`, its writer's `begin_document` /
     // `end_document` framing must fire around each document's records. This
     // arm detects document boundaries from each record's `doc_ctx`
-    // (a change in `source_file` between consecutive records) rather than the
-    // records-only path's boundary-blind write loop. It buffers nothing: each
-    // body record streams straight through `write_record` between the header
-    // and footer, so a 1 GiB document flows at O(1-record).
+    // (a change in the per-frame `grain()` between consecutive records) rather
+    // than the records-only path's boundary-blind write loop. It buffers
+    // nothing: each body record streams straight through `write_record`
+    // between the header and footer, so a 1 GiB document flows at O(1-record).
     if resolve_out_cfg(ctx, name).reconstruct_envelope {
         return dispatch_output_envelope(ctx, current_dag, node_idx, name);
     }
@@ -423,12 +423,19 @@ fn drain_output_input_events(
 /// `DocumentClose` events after all records, so an interleaved boundary stream
 /// never reaches a terminal Output.
 ///
-/// The grain is the per-document FRAME ([`clinker_record::DocumentGrain`]),
-/// the SAME grain the document-DLQ buckets at, so framing and dead-lettering
-/// agree. An X12 `GS`/`ST` inherits the interchange grain, so a whole
-/// `ISA..IEA` interchange frames as one envelope; an HL7 `MSH` opens a fresh
-/// grain, so a multi-message file frames once PER message; a flat file
+/// The grain is the per-document FRAME ([`clinker_record::DocumentGrain`]). An
+/// X12 `GS`/`ST` inherits the interchange grain, so a whole `ISA..IEA`
+/// interchange frames as one envelope; an HL7 `MSH` opens a fresh grain, so a
+/// multi-message file frames once PER message; a flat file
 /// (CSV/JSON/XML/fixed-width/EDIFACT) is one grain per file.
+///
+/// This per-frame grain is DELIBERATELY distinct from the document-DLQ's
+/// keying, which stays at the file grain (`source_file`): an HL7 `BTS`/`FTS`
+/// batch/file count mismatch is a whole-file structural failure, so the DLQ
+/// must condemn the whole file, not one message. Framing and dead-lettering
+/// therefore use different grains and never co-execute — `reconstruct_envelope`
+/// and `dlq_granularity: document` are mutually exclusive (rejected by E347),
+/// so no record is ever both DLQ-bucketed and envelope-framed.
 ///
 /// Bounded-memory: this path buffers no records. It holds only the current
 /// document's context, so a multi-gigabyte document streams at O(1-record).

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -418,19 +418,17 @@ fn drain_output_input_events(
 ///
 /// Boundary detection is RECORD-driven, not punctuation-driven: every
 /// `Record` carries its `Arc<DocumentContext>`, and a document boundary is a
-/// change in the record's `doc_ctx().source_file()` between consecutive
-/// records. Punctuations cannot drive this — the executor's buffers
-/// tail-clump all `DocumentClose` events after all records, so an
-/// interleaved boundary stream never reaches a terminal Output.
+/// change in the record's `doc_ctx().grain()` between consecutive records.
+/// Punctuations cannot drive this — the executor's buffers tail-clump all
+/// `DocumentClose` events after all records, so an interleaved boundary stream
+/// never reaches a terminal Output.
 ///
-/// The grain is FILE-LEVEL: boundaries key on `source_file`, so nested
-/// envelope levels (which mint fresh ids via `DocumentContext::child` but
-/// share the file's `source_file` Arc) frame as one document, and a file
-/// holding several messages (HL7 batch, EDIFACT/X12 interchange) frames as
-/// one document rather than one per message. With the writer hooks defaulting
-/// to no-ops this is byte-identical to today; per-message framing for
-/// multi-message formats is resolved when the format writers render the
-/// envelope (tracked at <https://github.com/rustpunk/clinker/issues/194>).
+/// The grain is the per-document FRAME ([`clinker_record::DocumentGrain`]),
+/// the SAME grain the document-DLQ buckets at, so framing and dead-lettering
+/// agree. An X12 `GS`/`ST` inherits the interchange grain, so a whole
+/// `ISA..IEA` interchange frames as one envelope; an HL7 `MSH` opens a fresh
+/// grain, so a multi-message file frames once PER message; a flat file
+/// (CSV/JSON/XML/fixed-width/EDIFACT) is one grain per file.
 ///
 /// Bounded-memory: this path buffers no records. It holds only the current
 /// document's context, so a multi-gigabyte document streams at O(1-record).
@@ -578,12 +576,11 @@ struct EnvelopeWriterDriver {
 
 impl EnvelopeWriterDriver {
     /// Write one already-projected body record, framing per document. The
-    /// record's own `doc_ctx` drives boundary detection: when its
-    /// `source_file` differs from the currently-open document's, the prior
-    /// document ends (`end_document`) and the new one begins
-    /// (`begin_document`) before the record is written. Records whose
-    /// `source_file` is non-concrete (an in-pipeline synthesis / fan-in row)
-    /// stream through unframed.
+    /// record's own `doc_ctx` drives boundary detection: when its frame
+    /// `grain` differs from the currently-open document's, the prior document
+    /// ends (`end_document`) and the new one begins (`begin_document`) before
+    /// the record is written. Records whose `source_file` is non-concrete (an
+    /// in-pipeline synthesis / fan-in row) stream through unframed.
     ///
     /// Opens the writer lazily on the first record (via `open_writer`,
     /// deriving the schema from it). A `None` from `open_writer` means no
@@ -623,23 +620,25 @@ impl EnvelopeWriterDriver {
     /// belongs to no document, so it neither closes the open document nor
     /// opens one — it streams through inside whatever framing is current.
     ///
-    /// The same-document test is `Arc::ptr_eq` first (every record of a
-    /// document shares the document's `source_file` Arc — the ingest stamps it
-    /// once and `DocumentContext::child` clones the same Arc — so pointer
-    /// identity settles the common case without an O(path-length) string
-    /// compare on this per-record hot path), with a string-equality fallback
-    /// for the one case ptr identity does not survive: a document whose
-    /// records span two spill chunks of the input buffer, where each chunk's
-    /// `SpillReader` rebuilds a fresh (equal-valued) `source_file` Arc. Without
-    /// the fallback that document would be spuriously split mid-stream.
+    /// The same-document test compares the record's
+    /// [`grain`](clinker_record::DocumentContext::grain) against the open
+    /// document's. The grain is a `Copy` value identity (not a pointer), so it
+    /// is correct across an input-buffer spill boundary for free: a frame whose
+    /// records span two spill chunks rebuilds a fresh `source_file` Arc per
+    /// chunk, but the grain round-trips verbatim, so the frame is not
+    /// spuriously split mid-stream. Keying on grain rather than `source_file`
+    /// is what makes a multi-message HL7 file frame once per message (each
+    /// `MSH` is its own grain) while a nested X12 interchange still frames once
+    /// (its `GS`/`ST` levels inherit the interchange grain).
     fn maybe_cross_boundary(&mut self, doc_ctx: &Arc<clinker_record::DocumentContext>) {
-        let file = doc_ctx.source_file();
-        if !crate::executor::document_dlq::is_concrete_file(file) {
+        if !crate::executor::document_dlq::is_concrete_file(doc_ctx.source_file()) {
             return;
         }
-        let same_doc = self.open_doc.as_ref().is_some_and(|open| {
-            Arc::ptr_eq(open.source_file(), file) || open.source_file().as_ref() == file.as_ref()
-        });
+        let grain = doc_ctx.grain();
+        let same_doc = self
+            .open_doc
+            .as_ref()
+            .is_some_and(|open| open.grain() == grain);
         if same_doc {
             return;
         }
@@ -984,13 +983,13 @@ mod tests {
     }
 
     #[test]
-    fn nested_envelope_fires_only_at_outermost_pair() {
-        // One file, two envelope levels: the inner level mints a fresh
-        // `DocumentId` via `child` but SHARES the file's `source_file` Arc.
-        // Keying boundary detection on `source_file` (not the id) frames at
-        // the outermost (file) grain, so a record carrying the inner-level
-        // context still belongs to the one file document — begin/end fire
-        // exactly once.
+    fn nested_x12_interchange_fires_only_at_the_interchange_pair() {
+        // One X12 interchange, two nested levels: the inner level mints a
+        // fresh `DocumentId` via `child` but INHERITS the interchange grain.
+        // Keying boundary detection on the grain frames at the interchange, so
+        // a record carrying the inner (GS/ST) context still belongs to the one
+        // interchange document — begin/end fire exactly once for the whole
+        // `ISA..IEA`, not once per transaction set.
         let outer = doc("multi.x12");
         let inner = Arc::new(outer.child(DocumentId::next(), IndexMap::new()));
         let records = vec![record(1, &outer), record(2, &inner), record(3, &outer)];
@@ -1005,7 +1004,42 @@ mod tests {
                 "end:multi.x12",
                 "flush",
             ],
-            "begin/end fire once for the file, not per nested level",
+            "begin/end fire once for the interchange, not per nested level",
+        );
+        assert_eq!(written, 3);
+    }
+
+    #[test]
+    fn multi_message_hl7_file_frames_once_per_message() {
+        // One HL7 file, two messages: each `MSH` opens a fresh frame via
+        // `child_frame`, so the two message contexts share the file's
+        // `source_file` Arc but carry DISTINCT grains. Keying on grain frames
+        // ONCE PER MESSAGE — begin/end fire around each message's records —
+        // even though both messages live in one file. (Keying on `source_file`
+        // would collapse them into a single frame, the bug this fixes.)
+        let file: Arc<str> = Arc::from("messages.hl7");
+        let file_doc = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::clone(&file),
+            IndexMap::new(),
+        ));
+        let msg1 = Arc::new(file_doc.child_frame(DocumentId::next(), IndexMap::new()));
+        let msg2 = Arc::new(file_doc.child_frame(DocumentId::next(), IndexMap::new()));
+        let records = vec![record(1, &msg1), record(2, &msg1), record(3, &msg2)];
+        let (log, written) = run_log(&records);
+        assert_eq!(
+            log,
+            vec![
+                "begin:messages.hl7",
+                "write:1",
+                "write:2",
+                "end:messages.hl7",
+                "begin:messages.hl7",
+                "write:3",
+                "end:messages.hl7",
+                "flush",
+            ],
+            "begin/end fire once per HL7 message, not once for the whole file",
         );
         assert_eq!(written, 3);
     }
@@ -1031,19 +1065,26 @@ mod tests {
     }
 
     #[test]
-    fn equal_but_distinct_source_file_arcs_do_not_split_a_document() {
-        // A document whose records span two input spill chunks carries a fresh
-        // (equal-valued) `source_file` Arc per chunk, because each chunk's
-        // `SpillReader` rebuilds the interning table. Pure `Arc::ptr_eq` would
-        // see two pointers and spuriously close + reopen the document
-        // mid-stream; the string-equality fallback keeps it framed as one.
-        // `doc()` mints a fresh Arc each call, so two `doc("split.csv")` model
-        // the cross-chunk rebuild.
+    fn spilled_chunk_rebuild_does_not_split_a_document() {
+        // A document whose records span two input spill chunks has its
+        // `DocumentContext` rebuilt per chunk by the spill codec, producing a
+        // fresh `source_file` Arc but the SAME grain (the codec carries the
+        // grain verbatim). Keying boundary detection on the grain therefore
+        // keeps the frame intact across the spill boundary — a pure
+        // `Arc::ptr_eq` on `source_file` would spuriously split it. The
+        // postcard round-trip is exactly what the spill path does.
         let chunk1 = doc("split.csv");
-        let chunk2 = doc("split.csv");
+        let bytes = postcard::to_stdvec(chunk1.as_ref()).unwrap();
+        let rebuilt: DocumentContext = postcard::from_bytes(&bytes).unwrap();
+        let chunk2 = Arc::new(rebuilt);
         assert!(
             !Arc::ptr_eq(chunk1.source_file(), chunk2.source_file()),
-            "the two contexts must hold distinct (equal-valued) Arcs to model the split",
+            "the rebuilt context must hold a distinct `source_file` Arc to model the spill",
+        );
+        assert_eq!(
+            chunk1.grain(),
+            chunk2.grain(),
+            "but the grain survives the spill round-trip verbatim",
         );
         let records = vec![record(1, &chunk1), record(2, &chunk2)];
         let (log, _written) = run_log(&records);

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -225,15 +225,8 @@ fn resolve_envelope_spec(
     if !reconstruct_envelope {
         return None;
     }
-    let cfg = cfg?;
-    if cfg.is_empty() {
-        return None;
-    }
-    Some(clinker_format::OutputEnvelopeSpec {
-        header_from_doc: cfg.header_from_doc.clone(),
-        footer_from_doc: cfg.footer_from_doc.clone(),
-        footer_record_count_field: cfg.footer_record_count_field.clone(),
-    })
+    let spec = clinker_format::OutputEnvelopeSpec::from(cfg?);
+    (!spec.is_empty()).then_some(spec)
 }
 
 fn build_writer_factory(

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -213,17 +213,45 @@ fn extract_output_field_defs(
 /// For CSV with `repeat_header`, the first call creates a `HeaderCapturingCsvWriter`
 /// and subsequent calls replay the captured header via `write_preset_header`.
 /// For fixed-width, the factory captures pre-resolved `FieldDef`s from the output schema.
+/// Map the plan's `OutputEnvelopeConfig` onto the format-local
+/// `OutputEnvelopeSpec` the writers consume, but only when the Output declares
+/// `reconstruct_envelope: true`. Returns `None` (no framing) when the flag is
+/// off, no envelope config is declared, or the declared config is empty — so
+/// the flag-off path stays byte-identical.
+fn resolve_envelope_spec(
+    reconstruct_envelope: bool,
+    cfg: Option<&clinker_plan::config::OutputEnvelopeConfig>,
+) -> Option<clinker_format::OutputEnvelopeSpec> {
+    if !reconstruct_envelope {
+        return None;
+    }
+    let cfg = cfg?;
+    if cfg.is_empty() {
+        return None;
+    }
+    Some(clinker_format::OutputEnvelopeSpec {
+        header_from_doc: cfg.header_from_doc.clone(),
+        footer_from_doc: cfg.footer_from_doc.clone(),
+        footer_record_count_field: cfg.footer_record_count_field.clone(),
+    })
+}
+
 fn build_writer_factory(
     format: &OutputFormat,
     include_header: Option<bool>,
     repeat_header: bool,
     field_defs: Option<Vec<clinker_record::schema_def::FieldDef>>,
     include_engine_stamped: bool,
+    reconstruct_envelope: bool,
 ) -> WriterFactory {
     match format {
         OutputFormat::Csv(opts) => {
             let mut csv_config = build_csv_writer_config(opts.as_ref(), include_header);
             csv_config.include_engine_stamped = include_engine_stamped;
+            csv_config.envelope = resolve_envelope_spec(
+                reconstruct_envelope,
+                opts.as_ref().and_then(|o| o.envelope.as_ref()),
+            );
             if repeat_header {
                 let shared_header: Arc<Mutex<Option<Vec<Box<str>>>>> = Arc::new(Mutex::new(None));
                 let call_count = Arc::new(AtomicU32::new(0));
@@ -260,6 +288,10 @@ fn build_writer_factory(
         OutputFormat::Json(opts) => {
             let mut json_config = build_json_writer_config(opts.as_ref());
             json_config.include_engine_stamped = include_engine_stamped;
+            json_config.envelope = resolve_envelope_spec(
+                reconstruct_envelope,
+                opts.as_ref().and_then(|o| o.envelope.as_ref()),
+            );
             Box::new(move |counting_writer, schema| {
                 Ok(Box::new(JsonWriter::new(
                     counting_writer,
@@ -271,6 +303,10 @@ fn build_writer_factory(
         OutputFormat::Xml(opts) => {
             let mut xml_config = build_xml_writer_config(opts.as_ref());
             xml_config.include_engine_stamped = include_engine_stamped;
+            xml_config.envelope = resolve_envelope_spec(
+                reconstruct_envelope,
+                opts.as_ref().and_then(|o| o.envelope.as_ref()),
+            );
             Box::new(move |counting_writer, schema| {
                 Ok(Box::new(XmlWriter::new(
                     counting_writer,
@@ -280,7 +316,11 @@ fn build_writer_factory(
             })
         }
         OutputFormat::FixedWidth(opts) => {
-            let fw_config = build_fw_writer_config(opts.as_ref());
+            let mut fw_config = build_fw_writer_config(opts.as_ref());
+            fw_config.envelope = resolve_envelope_spec(
+                reconstruct_envelope,
+                opts.as_ref().and_then(|o| o.envelope.as_ref()),
+            );
             let fields = field_defs.expect(
                 "fixed-width writer factory requires field_defs — \
                  build_format_writer must validate schema before calling",
@@ -370,6 +410,7 @@ pub(crate) fn build_format_writer(
         repeat_header,
         field_defs,
         output.include_correlation_keys,
+        output.reconstruct_envelope,
     );
 
     if let Some(ref split) = output.split {

--- a/crates/clinker-exec/tests/nested_envelope_test.rs
+++ b/crates/clinker-exec/tests/nested_envelope_test.rs
@@ -27,7 +27,7 @@ use std::collections::HashMap;
 use std::io::Write;
 use std::sync::Arc;
 
-use clinker_format::{EnvelopeEvent, FormatError};
+use clinker_format::{EnvelopeEvent, FormatError, FrameRole};
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
 use indexmap::IndexMap;
 
@@ -119,6 +119,7 @@ impl RecordSource for ScriptedReader {
                     self.current_file = Some(self.file_arc(file));
                     self.pending_events.push(EnvelopeEvent::OpenLevel {
                         sections: Self::section(name, tag_val),
+                        frame: FrameRole::Inherit,
                     });
                 }
                 Step::Close { file } => {

--- a/crates/clinker-exec/tests/output_envelope_seam.rs
+++ b/crates/clinker-exec/tests/output_envelope_seam.rs
@@ -653,3 +653,309 @@ nodes:
         "got:\n{out}"
     );
 }
+
+#[test]
+fn reconstruct_envelope_downstream_of_combine_is_rejected_e347() {
+    // A cross-document Combine emits `<merged>`-lineage rows with no
+    // originating document. Routing those into an enveloped (JSON) Output
+    // would produce body bytes outside any open document object — malformed
+    // JSON. The plan-time guard rejects the shape before it can run.
+    let yaml = r#"
+pipeline:
+  name: env_combine
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: json
+      glob: ./left/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: right
+    config:
+      name: right
+      type: json
+      glob: ./right/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: combine
+    name: joined
+    input:
+      a: left
+      b: right
+    config:
+      where: "a.id == b.id"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit id = a.id
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: json
+      path: out.json
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Head
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E347"), "expected E347, got: {err}");
+    assert!(
+        err.contains("strips document lineage") && err.contains("joined"),
+        "message should name the lineage-stripping Combine: {err}"
+    );
+}
+
+#[test]
+fn reconstruct_envelope_downstream_of_aggregate_is_rejected_e347() {
+    // An Aggregate finalizes group rows through the merged eval context, so
+    // every emitted row is synthetic-grained — same hazard as Combine.
+    let yaml = r#"
+pipeline:
+  name: env_agg
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      schema:
+        - { name: amount, type: int }
+  - type: aggregate
+    name: totals
+    input: payments
+    config:
+      group_by: []
+      cxl: |
+        emit total = sum(amount)
+  - type: output
+    name: out
+    input: totals
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Head
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E347"), "expected E347, got: {err}");
+    assert!(
+        err.contains("strips document lineage"),
+        "message should explain the lineage stripping: {err}"
+    );
+}
+
+#[test]
+fn envelope_section_on_non_feeding_source_is_rejected_e346() {
+    // Two sources, two independent Output legs. `out_a` is fed only by
+    // `src_a` (which declares `HeadA`), but its envelope names `HeadB` —
+    // declared only on the NON-feeding `src_b`. Scoping the check to the
+    // feeding source(s) catches this; a pipeline-wide union would not.
+    let yaml = r#"
+pipeline:
+  name: env_multi_source
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: json
+      glob: ./a/*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          HeadA:
+            extract: { json_pointer: "/HeadA" }
+            fields:
+              id: string
+      schema:
+        - { name: amount, type: int }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: json
+      glob: ./b/*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          HeadB:
+            extract: { json_pointer: "/HeadB" }
+            fields:
+              id: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out_a
+    input: src_a
+    config:
+      name: out_a
+      type: csv
+      path: out_a.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: HeadB
+  - type: output
+    name: out_b
+    input: src_b
+    config:
+      name: out_b
+      type: csv
+      path: out_b.csv
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E346"), "expected E346, got: {err}");
+    assert!(
+        err.contains("HeadB") && err.contains("out_a"),
+        "message should name the unreachable section and the output: {err}"
+    );
+    // And the feeding source's own section is listed as the valid choice.
+    assert!(
+        err.contains("HeadA"),
+        "should list the feeding source's sections: {err}"
+    );
+}
+
+#[test]
+fn footer_count_without_footer_section_is_rejected_e346() {
+    let yaml = r#"
+pipeline:
+  name: env_count_only
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Head:
+            extract: { json_pointer: "/Head" }
+            fields:
+              batch_id: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: payments
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Head
+          footer_record_count_field: record_count
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E346"), "expected E346, got: {err}");
+    assert!(
+        err.contains("footer_record_count_field") && err.contains("footer_from_doc"),
+        "message should explain the count requires a footer section: {err}"
+    );
+}
+
+#[test]
+fn csv_envelope_missing_section_in_a_document_writes_no_framing() {
+    // Two files: file A's document carries the `Head` section; file B's does
+    // not (its JSON has no `/Head`). The writer must emit a header row only
+    // for A — B's missing section writes NOTHING (not a blank row).
+    let yaml = r#"
+pipeline:
+  name: env_missing_section
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Head:
+            extract: { json_pointer: "/Head" }
+            fields:
+              batch_id: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: payments
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Head
+"#;
+    let config = parse_config(yaml).expect("parse missing-section pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile missing-section pipeline");
+
+    let file_a = FileSlot::new(
+        PathBuf::from("a.json"),
+        Box::new(Cursor::new(
+            br#"{ "Head": { "batch_id": "A" }, "records": [ { "amount": 1 } ] }"#.to_vec(),
+        )),
+    );
+    // File B has NO `Head` section — its document lacks the configured header.
+    let file_b = FileSlot::new(
+        PathBuf::from("b.json"),
+        Box::new(Cursor::new(
+            br#"{ "records": [ { "amount": 2 } ] }"#.to_vec(),
+        )),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "payments".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file_a, file_b]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run missing-section pipeline");
+    assert_eq!(report.counters.records_written, 2);
+
+    let out = buf.as_string();
+    let lines: Vec<&str> = out.lines().collect();
+    // A: header row "A" then body "1". B: NO header row, just body "2".
+    assert_eq!(lines, vec!["A", "1", "2"], "got:\n{out}");
+}

--- a/crates/clinker-exec/tests/output_envelope_seam.rs
+++ b/crates/clinker-exec/tests/output_envelope_seam.rs
@@ -388,3 +388,268 @@ nodes:
         "message should mention correlation_key: {err}"
     );
 }
+
+#[test]
+fn envelope_unknown_header_section_is_rejected_e346() {
+    // The source declares a `BatchInfo` envelope section, but the CSV output's
+    // `header_from_doc` names `Headr` (a typo) — E346 catches it at plan time.
+    let yaml = r#"
+pipeline:
+  name: env_unknown_section
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          BatchInfo:
+            extract: { json_pointer: "/BatchInfo" }
+            fields:
+              batch_id: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: payments
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Headr
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E346"), "expected E346, got: {err}");
+    assert!(
+        err.contains("Headr"),
+        "message should name the bad section: {err}"
+    );
+    assert!(
+        err.contains("BatchInfo"),
+        "message should list the declared sections: {err}"
+    );
+}
+
+#[test]
+fn envelope_computed_footer_on_fixed_width_is_rejected_e346() {
+    // A computed footer record count is unsupported on fixed-width output —
+    // its positional lines have no field to inject a count into. E346 rejects
+    // it even though the referenced section is otherwise declared.
+    let yaml = r#"
+pipeline:
+  name: env_fw_count
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Foot:
+            extract: { json_pointer: "/Foot" }
+            fields:
+              checksum: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: payments
+    config:
+      name: out
+      type: fixed_width
+      path: out.txt
+      reconstruct_envelope: true
+      schema:
+        fields:
+          - { name: amount, width: 10 }
+      options:
+        envelope:
+          footer_from_doc: Foot
+          footer_record_count_field: record_count
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E346"), "expected E346, got: {err}");
+    assert!(
+        err.contains("footer_record_count_field"),
+        "message should name the unsupported option: {err}"
+    );
+    assert!(
+        err.contains("fixed_width") || err.contains("fixed-width"),
+        "message should name the format: {err}"
+    );
+}
+
+#[test]
+fn envelope_known_sections_validate_clean() {
+    // The control: header + footer naming declared sections, and a computed
+    // footer count on CSV (a format that supports it), validate without E346.
+    let yaml = r#"
+pipeline:
+  name: env_ok
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Head:
+            extract: { json_pointer: "/Head" }
+            fields:
+              batch_id: string
+          Foot:
+            extract: { json_pointer: "/Foot" }
+            fields:
+              checksum: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: payments
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Head
+          footer_from_doc: Foot
+          footer_record_count_field: record_count
+"#;
+    parse_config(yaml).expect("a well-formed envelope config validates clean");
+}
+
+/// A document with a Head + Foot section and a configurable batch id, for the
+/// end-to-end CSV envelope framing test.
+fn doc_with_envelope(batch: &str, amounts: &[i64]) -> String {
+    let recs: Vec<String> = amounts
+        .iter()
+        .map(|a| format!("{{ \"amount\": {a} }}"))
+        .collect();
+    format!(
+        "{{ \"Head\": {{ \"batch_id\": \"{batch}\" }}, \
+            \"Foot\": {{ \"checksum\": \"SUM-{batch}\" }}, \
+            \"records\": [ {} ] }}",
+        recs.join(", ")
+    )
+}
+
+/// End-to-end CSV envelope reconstruction over two files (two documents),
+/// asserting per-document header + body + footer framing with a streaming
+/// record count. Proves the writer hooks render the envelope, the grain frames
+/// per file, and the count resets per document.
+#[test]
+fn csv_envelope_reconstructs_header_body_footer_per_document() {
+    let yaml = r#"
+pipeline:
+  name: csv_envelope_e2e
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Head:
+            extract: { json_pointer: "/Head" }
+            fields:
+              batch_id: string
+          Foot:
+            extract: { json_pointer: "/Foot" }
+            fields:
+              checksum: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: payments
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_header: false
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Head
+          footer_from_doc: Foot
+          footer_record_count_field: record_count
+"#;
+    let config = parse_config(yaml).expect("parse csv envelope pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile csv envelope pipeline");
+
+    let file_a = FileSlot::new(
+        PathBuf::from("batch_a.json"),
+        Box::new(Cursor::new(doc_with_envelope("A", &[10, 20]).into_bytes())),
+    );
+    let file_b = FileSlot::new(
+        PathBuf::from("batch_b.json"),
+        Box::new(Cursor::new(
+            doc_with_envelope("B", &[30, 40, 50]).into_bytes(),
+        )),
+    );
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "payments".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![file_a, file_b]),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("run csv envelope pipeline");
+    assert_eq!(report.counters.records_written, 5, "2 + 3 body records");
+
+    // Each file frames as its own document: header row (batch id), body rows,
+    // footer row (checksum + streaming record count for that document).
+    let out = buf.as_string();
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "A",       // doc A header (Head.batch_id)
+            "10",      // body
+            "20",      // body
+            "SUM-A,2", // doc A footer (Foot.checksum + record_count=2)
+            "B",       // doc B header
+            "30",      // body
+            "40",      // body
+            "50",      // body
+            "SUM-B,3", // doc B footer (record_count=3, reset per document)
+        ],
+        "got:\n{out}"
+    );
+}

--- a/crates/clinker-format/src/csv/writer.rs
+++ b/crates/clinker-format/src/csv/writer.rs
@@ -60,8 +60,7 @@ impl<W: Write> CsvWriter<W> {
         let framer = config
             .envelope
             .clone()
-            .filter(|s| !s.is_empty())
-            .map(EnvelopeFramer::new);
+            .and_then(OutputEnvelopeSpec::into_framer);
         // Envelope header/footer rows carry a different field count than the
         // body rows (a section's fields vs the record schema), so the writer
         // must accept ragged records when framing is active. The non-envelope
@@ -84,14 +83,12 @@ impl<W: Write> CsvWriter<W> {
     /// row, optionally appending a trailing computed-count cell.
     fn write_section_row(
         inner: &mut csv::Writer<W>,
-        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+        fields: &indexmap::IndexMap<Box<str>, Value>,
         count: Option<(&str, i64)>,
     ) -> Result<(), FormatError> {
         let mut cells: Vec<String> = Vec::new();
-        if let Some(fields) = fields {
-            for (name, value) in fields {
-                cells.push(value_to_csv_cell(name, value)?);
-            }
+        for (name, value) in fields {
+            cells.push(value_to_csv_cell(name, value)?);
         }
         if let Some((_field, n)) = count {
             cells.push(n.to_string());
@@ -122,7 +119,12 @@ impl<W: Write + Send> FormatWriter for CsvWriter<W> {
         // Header is built from the writer's pinned schema. Engine-stamped
         // columns (today: `$ck.<field>`) are stripped unless the Output
         // node opts in.
-        if self.config.include_header && !self.header_written {
+        //
+        // Under envelope framing the schema column-header row is SUPPRESSED:
+        // it would otherwise emit once, before the first document's envelope
+        // header row, giving documents inconsistent layouts (header row only
+        // on the first). The per-document envelope header section replaces it.
+        if self.config.include_header && !self.header_written && self.framer.is_none() {
             let header: Vec<&str> =
                 filtered_header_columns(&self.schema, self.config.include_engine_stamped);
             self.inner.write_record(&header)?;
@@ -157,9 +159,10 @@ impl<W: Write + Send> FormatWriter for CsvWriter<W> {
             return Ok(());
         };
         framer.begin();
-        if framer.has_header() {
-            let header = framer.header_fields(doc);
-            Self::write_section_row(&mut self.inner, header, None)?;
+        // Only emit a header row when the document actually carries the
+        // configured section — a missing section writes nothing.
+        if let Some(fields) = framer.header_fields(doc) {
+            Self::write_section_row(&mut self.inner, fields, None)?;
         }
         Ok(())
     }
@@ -168,10 +171,11 @@ impl<W: Write + Send> FormatWriter for CsvWriter<W> {
         let Some(framer) = self.framer.as_ref() else {
             return Ok(());
         };
-        if framer.has_footer() {
-            let footer = framer.footer_fields(doc);
+        // Likewise the footer: emit only when the configured section is
+        // present; the computed count rides the present footer section.
+        if let Some(fields) = framer.footer_fields(doc) {
             let count = framer.footer_count();
-            Self::write_section_row(&mut self.inner, footer, count)?;
+            Self::write_section_row(&mut self.inner, fields, count)?;
         }
         Ok(())
     }
@@ -514,24 +518,7 @@ mod tests {
         }
     }
 
-    fn doc_with_sections(
-        sections: &[(&str, &[(&str, Value)])],
-    ) -> std::sync::Arc<clinker_record::DocumentContext> {
-        use indexmap::IndexMap;
-        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
-        for (name, fields) in sections {
-            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
-            for (k, v) in *fields {
-                inner.insert(Box::from(*k), v.clone());
-            }
-            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
-        }
-        std::sync::Arc::new(clinker_record::DocumentContext::new(
-            clinker_record::DocumentId::next(),
-            Arc::from("f.csv"),
-            map,
-        ))
-    }
+    use crate::envelope_writer::test_doc_with_sections as doc_with_sections;
 
     #[test]
     fn csv_envelope_frames_header_body_footer() {

--- a/crates/clinker-format/src/csv/writer.rs
+++ b/crates/clinker-format/src/csv/writer.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
 use std::sync::{Arc, Mutex};
 
-use clinker_record::{Record, Schema, Value};
+use clinker_record::{DocumentContext, Record, Schema, Value};
 
+use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
 
@@ -17,6 +18,11 @@ pub struct CsvWriterConfig {
     /// default output unless the Output node opts in via
     /// `include_correlation_keys: true`.
     pub include_engine_stamped: bool,
+    /// Per-document envelope reconstruction. `None` (the default) renders no
+    /// framing and keeps the output byte-identical to the boundary-unaware
+    /// path. `Some` is set by the executor only when the Output declares
+    /// `reconstruct_envelope: true` with a non-empty envelope config.
+    pub envelope: Option<OutputEnvelopeSpec>,
 }
 
 impl Default for CsvWriterConfig {
@@ -25,6 +31,7 @@ impl Default for CsvWriterConfig {
             delimiter: b',',
             include_header: true,
             include_engine_stamped: false,
+            envelope: None,
         }
     }
 }
@@ -34,24 +41,63 @@ impl Default for CsvWriterConfig {
 /// Writes schema fields in schema order, then overflow fields in
 /// sorted key order (deterministic output). Header row is written
 /// on first `write_record()` call if `include_header` is true.
+///
+/// Under `reconstruct_envelope`, `begin_document` emits the header section's
+/// field values as one CSV row before the document's body, and `end_document`
+/// emits the footer section's values (plus the streaming record count) as one
+/// CSV row after it — no document is buffered, so framing stays O(1-record).
 pub struct CsvWriter<W: Write> {
     inner: csv::Writer<W>,
     schema: Arc<Schema>,
     config: CsvWriterConfig,
     header_written: bool,
+    /// Per-document envelope framer, present only when `config.envelope` is.
+    framer: Option<EnvelopeFramer>,
 }
 
 impl<W: Write> CsvWriter<W> {
     pub fn new(writer: W, schema: Arc<Schema>, config: CsvWriterConfig) -> Self {
+        let framer = config
+            .envelope
+            .clone()
+            .filter(|s| !s.is_empty())
+            .map(EnvelopeFramer::new);
+        // Envelope header/footer rows carry a different field count than the
+        // body rows (a section's fields vs the record schema), so the writer
+        // must accept ragged records when framing is active. The non-envelope
+        // path keeps the strict equal-length default, preserving today's
+        // behavior and its UnequalLengths guard against schema drift.
         let inner = csv::WriterBuilder::new()
             .delimiter(config.delimiter)
+            .flexible(framer.is_some())
             .from_writer(writer);
         Self {
             inner,
             schema,
             config,
             header_written: false,
+            framer,
         }
+    }
+
+    /// Emit one envelope section's field values (in declared order) as a CSV
+    /// row, optionally appending a trailing computed-count cell.
+    fn write_section_row(
+        inner: &mut csv::Writer<W>,
+        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+        count: Option<(&str, i64)>,
+    ) -> Result<(), FormatError> {
+        let mut cells: Vec<String> = Vec::new();
+        if let Some(fields) = fields {
+            for (name, value) in fields {
+                cells.push(value_to_csv_cell(name, value)?);
+            }
+        }
+        if let Some((_field, n)) = count {
+            cells.push(n.to_string());
+        }
+        inner.write_record(&cells)?;
+        Ok(())
     }
 
     /// Write a pre-captured header row, bypassing first-record discovery.
@@ -95,11 +141,38 @@ impl<W: Write + Send> FormatWriter for CsvWriter<W> {
         }
 
         self.inner.write_record(&fields)?;
+        if let Some(framer) = self.framer.as_mut() {
+            framer.count_record();
+        }
         Ok(())
     }
 
     fn flush(&mut self) -> Result<(), FormatError> {
         self.inner.flush()?;
+        Ok(())
+    }
+
+    fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        let Some(framer) = self.framer.as_mut() else {
+            return Ok(());
+        };
+        framer.begin();
+        if framer.has_header() {
+            let header = framer.header_fields(doc);
+            Self::write_section_row(&mut self.inner, header, None)?;
+        }
+        Ok(())
+    }
+
+    fn end_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        let Some(framer) = self.framer.as_ref() else {
+            return Ok(());
+        };
+        if framer.has_footer() {
+            let footer = framer.footer_fields(doc);
+            let count = framer.footer_count();
+            Self::write_section_row(&mut self.inner, footer, count)?;
+        }
         Ok(())
     }
 }
@@ -439,5 +512,83 @@ mod tests {
             }
             other => panic!("expected UnserializableMapValue, got {other:?}"),
         }
+    }
+
+    fn doc_with_sections(
+        sections: &[(&str, &[(&str, Value)])],
+    ) -> std::sync::Arc<clinker_record::DocumentContext> {
+        use indexmap::IndexMap;
+        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (name, fields) in sections {
+            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
+            for (k, v) in *fields {
+                inner.insert(Box::from(*k), v.clone());
+            }
+            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
+        }
+        std::sync::Arc::new(clinker_record::DocumentContext::new(
+            clinker_record::DocumentId::next(),
+            Arc::from("f.csv"),
+            map,
+        ))
+    }
+
+    #[test]
+    fn csv_envelope_frames_header_body_footer() {
+        let schema = make_schema(&["amount"]);
+        let config = CsvWriterConfig {
+            include_header: false,
+            envelope: Some(OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: Some("count".into()),
+            }),
+            ..Default::default()
+        };
+        let doc = doc_with_sections(&[
+            ("Head", &[("batch_id", Value::String("A".into()))]),
+            ("Foot", &[("checksum", Value::String("SUM".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let mut writer = CsvWriter::new(&mut buf, Arc::clone(&schema), config);
+            writer.begin_document(&doc).unwrap();
+            writer
+                .write_record(&make_record(&schema, vec![Value::Integer(10)]))
+                .unwrap();
+            writer
+                .write_record(&make_record(&schema, vec![Value::Integer(20)]))
+                .unwrap();
+            writer.end_document(&doc).unwrap();
+            writer.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out, "A\n10\n20\nSUM,2\n", "got: {out}");
+    }
+
+    #[test]
+    fn csv_envelope_off_is_byte_identical() {
+        // No envelope spec: begin/end_document are no-ops and the body is the
+        // plain CSV the boundary-unaware path produces.
+        let schema = make_schema(&["amount"]);
+        let doc = doc_with_sections(&[("Head", &[("batch_id", Value::String("A".into()))])]);
+        let mut buf = Vec::new();
+        {
+            let mut writer = CsvWriter::new(
+                &mut buf,
+                Arc::clone(&schema),
+                CsvWriterConfig {
+                    include_header: false,
+                    ..Default::default()
+                },
+            );
+            writer.begin_document(&doc).unwrap();
+            writer
+                .write_record(&make_record(&schema, vec![Value::Integer(10)]))
+                .unwrap();
+            writer.end_document(&doc).unwrap();
+            writer.flush().unwrap();
+        }
+        assert_eq!(String::from_utf8(buf).unwrap(), "10\n");
     }
 }

--- a/crates/clinker-format/src/envelope.rs
+++ b/crates/clinker-format/src/envelope.rs
@@ -47,10 +47,38 @@ pub enum EnvelopeEvent {
     /// extracted for it (already coerced to their declared field types,
     /// keyed by user-declared section name). The driver opens a child
     /// document context whose sections layer over the enclosing levels.
-    OpenLevel { sections: IndexMap<Box<str>, Value> },
+    ///
+    /// `frame` tells the driver whether this level begins a new
+    /// output-envelope / document-DLQ frame (see [`FrameRole`]). Most nested
+    /// levels are [`FrameRole::Inherit`] (an X12 `GS`/`ST` stays inside the
+    /// interchange frame); a level the format treats as a self-contained
+    /// document — each HL7 `MSH` message — is [`FrameRole::NewFrame`].
+    OpenLevel {
+        sections: IndexMap<Box<str>, Value>,
+        frame: FrameRole,
+    },
     /// Leave the innermost open nested envelope level. The driver closes
     /// the matching document context.
     CloseLevel,
+}
+
+/// Whether a nested envelope level begins a fresh per-document frame — the
+/// grain at which the engine reconstructs an output envelope and dead-letters
+/// a whole document.
+///
+/// The frame is whichever level the format treats as one logical document:
+/// the X12 interchange (so its nested `GS`/`ST` levels `Inherit`), or each HL7
+/// message (so each `MSH` is a `NewFrame`). The driver maps `Inherit` to
+/// [`clinker_record::DocumentContext::child`] and `NewFrame` to
+/// [`clinker_record::DocumentContext::child_frame`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameRole {
+    /// Stay inside the enclosing frame — this level's records share the
+    /// enclosing document's grain (X12 `GS`/`ST` under one `ISA`).
+    Inherit,
+    /// Begin a new frame — this level is itself a logical document (an HL7
+    /// `MSH` message), so its records get a distinct grain.
+    NewFrame,
 }
 
 /// Configuration for one source's envelope sections.

--- a/crates/clinker-format/src/envelope_writer.rs
+++ b/crates/clinker-format/src/envelope_writer.rs
@@ -43,6 +43,17 @@ impl OutputEnvelopeSpec {
             && self.footer_from_doc.is_none()
             && self.footer_record_count_field.is_none()
     }
+
+    /// Consume this spec into an [`EnvelopeFramer`], or `None` when the spec is
+    /// empty (no framing). The four generic writers call this on their
+    /// `config.envelope` to build their per-document framer in one step.
+    pub fn into_framer(self) -> Option<EnvelopeFramer> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(EnvelopeFramer::new(self))
+        }
+    }
 }
 
 /// Per-document envelope state held by a writer across the document's body.
@@ -80,8 +91,17 @@ impl EnvelopeFramer {
         self.record_count = self.record_count.saturating_add(1);
     }
 
+    /// Body records counted for the currently-open document so far. The JSON
+    /// writer uses this to decide the body-array comma (drive off the same
+    /// counter rather than a duplicate field).
+    pub fn record_count(&self) -> u64 {
+        self.record_count
+    }
+
     /// The header section's ordered fields for `doc`, or `None` when no header
-    /// is configured or the named section is absent from this document.
+    /// is configured OR the named section is absent from this document.
+    /// Writers render the header iff this is `Some`, so a document missing the
+    /// configured section emits NO header (rather than a blank one).
     pub fn header_fields<'a>(
         &self,
         doc: &'a DocumentContext,
@@ -93,10 +113,15 @@ impl EnvelopeFramer {
     }
 
     /// The footer section's ordered fields for `doc`, or `None` when no footer
-    /// is configured or the named section is absent. The streaming-computed
-    /// count (if `footer_record_count_field` is set) is appended SEPARATELY by
-    /// [`Self::footer_count`] so a writer renders both without cloning the
-    /// section map.
+    /// is configured OR the named section is absent from this document. As with
+    /// the header, writers render the footer iff this is `Some`. The
+    /// streaming-computed count (if `footer_record_count_field` is set) is
+    /// appended SEPARATELY by [`Self::footer_count`], so a writer renders both
+    /// without cloning the section map.
+    ///
+    /// `footer_record_count_field` requires `footer_from_doc` (enforced at plan
+    /// time by E346), so a configured count always rides a present footer
+    /// section — there is no count-only footer.
     pub fn footer_fields<'a>(
         &self,
         doc: &'a DocumentContext,
@@ -116,18 +141,30 @@ impl EnvelopeFramer {
             .as_deref()
             .map(|field| (field, self.record_count as i64))
     }
+}
 
-    /// Whether a footer should be emitted at all — either a named section is
-    /// configured, or a computed count is (a count with no section still
-    /// emits a footer carrying just the count).
-    pub fn has_footer(&self) -> bool {
-        self.spec.footer_from_doc.is_some() || self.spec.footer_record_count_field.is_some()
+/// Build a [`DocumentContext`] carrying the named sections (each a map of
+/// scalar fields), for the envelope-writer unit tests across the four generic
+/// writers. The `source_file` is a fixed placeholder — these tests exercise
+/// section rendering, not file grain. Shared here so the four writer test
+/// modules do not each re-define it.
+#[cfg(test)]
+pub(crate) fn test_doc_with_sections(
+    sections: &[(&str, &[(&str, Value)])],
+) -> std::sync::Arc<DocumentContext> {
+    let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
+    for (name, fields) in sections {
+        let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (k, v) in *fields {
+            inner.insert(Box::from(*k), v.clone());
+        }
+        map.insert(Box::from(*name), Value::Map(Box::new(inner)));
     }
-
-    /// Whether a header section is configured.
-    pub fn has_header(&self) -> bool {
-        self.spec.header_from_doc.is_some()
-    }
+    std::sync::Arc::new(DocumentContext::new(
+        clinker_record::DocumentId::next(),
+        std::sync::Arc::from("test.doc"),
+        map,
+    ))
 }
 
 #[cfg(test)]
@@ -166,8 +203,8 @@ mod tests {
         let fields = framer.header_fields(&doc).expect("header section present");
         let names: Vec<&str> = fields.keys().map(|k| k.as_ref()).collect();
         assert_eq!(names, vec!["batch_id", "run_date"]);
-        assert!(framer.has_header());
-        assert!(!framer.has_footer());
+        // No footer configured → footer_fields resolves None regardless of doc.
+        assert!(framer.footer_fields(&doc).is_none());
     }
 
     #[test]
@@ -191,12 +228,13 @@ mod tests {
         framer.count_record();
         framer.count_record();
         framer.count_record();
+        assert_eq!(framer.record_count(), 3);
         assert_eq!(framer.footer_count(), Some(("count", 3)));
         // A new document resets the counter.
         framer.begin();
         framer.count_record();
+        assert_eq!(framer.record_count(), 1);
         assert_eq!(framer.footer_count(), Some(("count", 1)));
-        assert!(framer.has_footer());
     }
 
     #[test]

--- a/crates/clinker-format/src/envelope_writer.rs
+++ b/crates/clinker-format/src/envelope_writer.rs
@@ -1,0 +1,213 @@
+//! Shared per-document output-envelope reconstruction for the generic
+//! formats (CSV / JSON / XML / fixed-width).
+//!
+//! Each generic [`crate::FormatWriter`] holds an optional [`OutputEnvelopeSpec`]
+//! and, when `reconstruct_envelope` is active, renders a per-document header on
+//! [`crate::FormatWriter::begin_document`] (echoing a named `$doc` section) and
+//! a footer on [`crate::FormatWriter::end_document`] (echoing a named section
+//! plus an optional streaming-computed record count). The body streams between
+//! them one record at a time — no document is ever buffered, so framing is
+//! O(1-record) regardless of document size.
+//!
+//! This module owns only the format-agnostic parts: the spec, the running
+//! record counter, and resolving a section's ordered fields off a
+//! [`DocumentContext`]. Each writer renders those fields in its own native
+//! shape (a CSV row, a JSON object, an XML element, a fixed-width line).
+
+use clinker_record::{DocumentContext, Value};
+use indexmap::IndexMap;
+
+/// Format-local mirror of the plan's `OutputEnvelopeConfig`, carried on each
+/// generic writer's config. clinker-format does not depend on clinker-plan, so
+/// the executor's writer registry maps the plan config onto this struct when
+/// it builds a writer.
+///
+/// All three fields are optional and independent: a header-only envelope sets
+/// only `header_from_doc`; a footer that just stamps a count sets
+/// `footer_from_doc` + `footer_record_count_field`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OutputEnvelopeSpec {
+    /// `$doc` section echoed as the per-document header (before the body).
+    pub header_from_doc: Option<String>,
+    /// `$doc` section echoed as the per-document footer (after the body).
+    pub footer_from_doc: Option<String>,
+    /// Field name under which the streaming-computed body record count is
+    /// injected into the footer. Requires `footer_from_doc`.
+    pub footer_record_count_field: Option<String>,
+}
+
+impl OutputEnvelopeSpec {
+    /// `true` when nothing is declared — the writer renders no framing.
+    pub fn is_empty(&self) -> bool {
+        self.header_from_doc.is_none()
+            && self.footer_from_doc.is_none()
+            && self.footer_record_count_field.is_none()
+    }
+}
+
+/// Per-document envelope state held by a writer across the document's body.
+///
+/// Holds the active spec and a single running record counter — never any body
+/// record — so the writer's footprint stays O(1). `begin` resets the count for
+/// the new document; each body record increments it; `end` reads it into the
+/// computed footer field.
+#[derive(Debug, Default)]
+pub struct EnvelopeFramer {
+    spec: OutputEnvelopeSpec,
+    /// Body records written for the currently-open document. Reset on each
+    /// `begin_document`, incremented per record, read by the footer.
+    record_count: u64,
+}
+
+impl EnvelopeFramer {
+    /// Build a framer for `spec`. A writer constructs one only when its config
+    /// carries a non-empty spec under an active `reconstruct_envelope`.
+    pub fn new(spec: OutputEnvelopeSpec) -> Self {
+        Self {
+            spec,
+            record_count: 0,
+        }
+    }
+
+    /// Reset the body record counter at the start of a new document. Call from
+    /// `begin_document` before rendering the header.
+    pub fn begin(&mut self) {
+        self.record_count = 0;
+    }
+
+    /// Count one body record for the open document. Call from `write_record`.
+    pub fn count_record(&mut self) {
+        self.record_count = self.record_count.saturating_add(1);
+    }
+
+    /// The header section's ordered fields for `doc`, or `None` when no header
+    /// is configured or the named section is absent from this document.
+    pub fn header_fields<'a>(
+        &self,
+        doc: &'a DocumentContext,
+    ) -> Option<&'a IndexMap<Box<str>, Value>> {
+        self.spec
+            .header_from_doc
+            .as_deref()
+            .and_then(|name| doc.section_fields(name))
+    }
+
+    /// The footer section's ordered fields for `doc`, or `None` when no footer
+    /// is configured or the named section is absent. The streaming-computed
+    /// count (if `footer_record_count_field` is set) is appended SEPARATELY by
+    /// [`Self::footer_count`] so a writer renders both without cloning the
+    /// section map.
+    pub fn footer_fields<'a>(
+        &self,
+        doc: &'a DocumentContext,
+    ) -> Option<&'a IndexMap<Box<str>, Value>> {
+        self.spec
+            .footer_from_doc
+            .as_deref()
+            .and_then(|name| doc.section_fields(name))
+    }
+
+    /// The `(field_name, count_value)` pair to append to the footer, or `None`
+    /// when no computed count is configured. The count is the number of body
+    /// records written for the document just closed.
+    pub fn footer_count(&self) -> Option<(&str, i64)> {
+        self.spec
+            .footer_record_count_field
+            .as_deref()
+            .map(|field| (field, self.record_count as i64))
+    }
+
+    /// Whether a footer should be emitted at all — either a named section is
+    /// configured, or a computed count is (a count with no section still
+    /// emits a footer carrying just the count).
+    pub fn has_footer(&self) -> bool {
+        self.spec.footer_from_doc.is_some() || self.spec.footer_record_count_field.is_some()
+    }
+
+    /// Whether a header section is configured.
+    pub fn has_header(&self) -> bool {
+        self.spec.header_from_doc.is_some()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::DocumentId;
+    use std::sync::Arc;
+
+    fn section(fields: &[(&str, Value)]) -> Value {
+        let mut m: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (k, v) in fields {
+            m.insert(Box::from(*k), v.clone());
+        }
+        Value::Map(Box::new(m))
+    }
+
+    fn doc_with(section_name: &str, fields: &[(&str, Value)]) -> DocumentContext {
+        let mut sections = IndexMap::new();
+        sections.insert(Box::from(section_name), section(fields));
+        DocumentContext::new(DocumentId::next(), Arc::from("f.csv"), sections)
+    }
+
+    #[test]
+    fn header_and_footer_fields_resolve_in_declared_order() {
+        let doc = doc_with(
+            "Head",
+            &[
+                ("batch_id", Value::String("B1".into())),
+                ("run_date", Value::String("2026-06-13".into())),
+            ],
+        );
+        let framer = EnvelopeFramer::new(OutputEnvelopeSpec {
+            header_from_doc: Some("Head".into()),
+            ..Default::default()
+        });
+        let fields = framer.header_fields(&doc).expect("header section present");
+        let names: Vec<&str> = fields.keys().map(|k| k.as_ref()).collect();
+        assert_eq!(names, vec!["batch_id", "run_date"]);
+        assert!(framer.has_header());
+        assert!(!framer.has_footer());
+    }
+
+    #[test]
+    fn missing_section_resolves_none() {
+        let doc = doc_with("Head", &[("x", Value::Integer(1))]);
+        let framer = EnvelopeFramer::new(OutputEnvelopeSpec {
+            header_from_doc: Some("Nope".into()),
+            ..Default::default()
+        });
+        assert!(framer.header_fields(&doc).is_none());
+    }
+
+    #[test]
+    fn footer_count_tracks_body_records_and_resets_per_document() {
+        let mut framer = EnvelopeFramer::new(OutputEnvelopeSpec {
+            footer_from_doc: Some("Foot".into()),
+            footer_record_count_field: Some("count".into()),
+            ..Default::default()
+        });
+        framer.begin();
+        framer.count_record();
+        framer.count_record();
+        framer.count_record();
+        assert_eq!(framer.footer_count(), Some(("count", 3)));
+        // A new document resets the counter.
+        framer.begin();
+        framer.count_record();
+        assert_eq!(framer.footer_count(), Some(("count", 1)));
+        assert!(framer.has_footer());
+    }
+
+    #[test]
+    fn empty_spec_is_empty() {
+        assert!(OutputEnvelopeSpec::default().is_empty());
+        assert!(
+            !OutputEnvelopeSpec {
+                header_from_doc: Some("H".into()),
+                ..Default::default()
+            }
+            .is_empty()
+        );
+    }
+}

--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -110,8 +110,7 @@ impl<W: Write> FixedWidthWriter<W> {
         let framer = config
             .envelope
             .clone()
-            .filter(|s| !s.is_empty())
-            .map(EnvelopeFramer::new);
+            .and_then(OutputEnvelopeSpec::into_framer);
         Ok(Self {
             writer,
             fields: resolved,
@@ -126,17 +125,16 @@ impl<W: Write> FixedWidthWriter<W> {
     /// separator. Envelope sections carry no width schema, so values are
     /// written unpadded — a header/trailer LINE round-trips, but not a
     /// column-positioned one (that would need a width declaration the envelope
-    /// config does not carry). A computed footer count is rejected at plan
-    /// time for fixed-width (E346), so `count` is always `None` here.
+    /// config does not carry). Called only for a section the document actually
+    /// carries (a missing section emits no line). A computed footer count is
+    /// rejected at plan time for fixed-width (E346).
     fn write_section_line(
         &mut self,
-        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+        fields: &indexmap::IndexMap<Box<str>, Value>,
     ) -> Result<(), FormatError> {
         let mut line = String::new();
-        if let Some(fields) = fields {
-            for value in fields.values() {
-                line.push_str(&value_to_envelope_cell(value));
-            }
+        for value in fields.values() {
+            line.push_str(&value_to_envelope_cell(value));
         }
         self.writer.write_all(line.as_bytes())?;
         match self.config.line_separator {
@@ -278,12 +276,12 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
             return Ok(());
         };
         framer.begin();
-        let has_header = framer.has_header();
         // Clone the header fields out so the immutable framer borrow ends
-        // before the `&mut self` write below.
+        // before the `&mut self` write below; `None` (document lacks the
+        // configured section) emits no header line.
         let header = framer.header_fields(doc).cloned();
-        if has_header {
-            self.write_section_line(header.as_ref())?;
+        if let Some(fields) = header.as_ref() {
+            self.write_section_line(fields)?;
         }
         Ok(())
     }
@@ -292,10 +290,9 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
         let Some(framer) = self.framer.as_ref() else {
             return Ok(());
         };
-        let has_footer = framer.has_footer();
         let footer = framer.footer_fields(doc).cloned();
-        if has_footer {
-            self.write_section_line(footer.as_ref())?;
+        if let Some(fields) = footer.as_ref() {
+            self.write_section_line(fields)?;
         }
         Ok(())
     }
@@ -595,24 +592,7 @@ mod tests {
         }
     }
 
-    fn doc_with_sections(
-        sections: &[(&str, &[(&str, Value)])],
-    ) -> std::sync::Arc<clinker_record::DocumentContext> {
-        use indexmap::IndexMap;
-        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
-        for (name, fields) in sections {
-            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
-            for (k, v) in *fields {
-                inner.insert(Box::from(*k), v.clone());
-            }
-            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
-        }
-        std::sync::Arc::new(clinker_record::DocumentContext::new(
-            clinker_record::DocumentId::next(),
-            std::sync::Arc::from("f.txt"),
-            map,
-        ))
-    }
+    use crate::envelope_writer::test_doc_with_sections as doc_with_sections;
 
     #[test]
     fn fixed_width_envelope_emits_header_and_footer_lines() {

--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
 
 use clinker_record::schema_def::{FieldDef, FieldType, Justify, LineSeparator, TruncationPolicy};
-use clinker_record::{Record, Value};
+use clinker_record::{DocumentContext, Record, Value};
 
+use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
 
@@ -10,12 +11,19 @@ use crate::traits::FormatWriter;
 #[derive(Clone)]
 pub struct FixedWidthWriterConfig {
     pub line_separator: LineSeparator,
+    /// Per-document envelope reconstruction. `None` (the default) renders no
+    /// framing. `Some` is set by the executor under `reconstruct_envelope:
+    /// true`. A computed footer record count is rejected at plan time (E346)
+    /// for fixed-width, so the spec the executor passes here never carries
+    /// `footer_record_count_field`.
+    pub envelope: Option<OutputEnvelopeSpec>,
 }
 
 impl Default for FixedWidthWriterConfig {
     fn default() -> Self {
         Self {
             line_separator: LineSeparator::Lf,
+            envelope: None,
         }
     }
 }
@@ -31,11 +39,19 @@ struct WriteField {
 
 /// Schema-driven fixed-width record writer.
 /// Type-aware truncation: numeric -> Error, string -> Warn (configurable per field).
+///
+/// Under `reconstruct_envelope`, `begin_document` emits the header section's
+/// field values as one leading line and `end_document` the footer's as one
+/// trailing line, each joined positionally in declared field order with the
+/// configured line separator. The body streams between them, so framing stays
+/// O(1-record).
 pub struct FixedWidthWriter<W: Write> {
     writer: W,
     fields: Vec<WriteField>,
     config: FixedWidthWriterConfig,
     truncation_warnings: Vec<String>,
+    /// Per-document envelope framer, present only when `config.envelope` is.
+    framer: Option<EnvelopeFramer>,
 }
 
 impl<W: Write> FixedWidthWriter<W> {
@@ -91,12 +107,44 @@ impl<W: Write> FixedWidthWriter<W> {
             })
             .collect::<Result<_, FormatError>>()?;
 
+        let framer = config
+            .envelope
+            .clone()
+            .filter(|s| !s.is_empty())
+            .map(EnvelopeFramer::new);
         Ok(Self {
             writer,
             fields: resolved,
             config,
             truncation_warnings: Vec::new(),
+            framer,
         })
+    }
+
+    /// Emit one envelope section as a single fixed-width line: the section's
+    /// field values (in declared order) concatenated, then the configured line
+    /// separator. Envelope sections carry no width schema, so values are
+    /// written unpadded — a header/trailer LINE round-trips, but not a
+    /// column-positioned one (that would need a width declaration the envelope
+    /// config does not carry). A computed footer count is rejected at plan
+    /// time for fixed-width (E346), so `count` is always `None` here.
+    fn write_section_line(
+        &mut self,
+        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+    ) -> Result<(), FormatError> {
+        let mut line = String::new();
+        if let Some(fields) = fields {
+            for value in fields.values() {
+                line.push_str(&value_to_envelope_cell(value));
+            }
+        }
+        self.writer.write_all(line.as_bytes())?;
+        match self.config.line_separator {
+            LineSeparator::Lf => self.writer.write_all(b"\n")?,
+            LineSeparator::CrLf => self.writer.write_all(b"\r\n")?,
+            LineSeparator::None => {}
+        }
+        Ok(())
     }
 
     /// Get any truncation warnings emitted during writing.
@@ -215,11 +263,57 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
             LineSeparator::None => {} // no separator
         }
 
+        if let Some(framer) = self.framer.as_mut() {
+            framer.count_record();
+        }
         Ok(())
     }
 
     fn flush(&mut self) -> Result<(), FormatError> {
         self.writer.flush().map_err(FormatError::Io)
+    }
+
+    fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        let Some(framer) = self.framer.as_mut() else {
+            return Ok(());
+        };
+        framer.begin();
+        let has_header = framer.has_header();
+        // Clone the header fields out so the immutable framer borrow ends
+        // before the `&mut self` write below.
+        let header = framer.header_fields(doc).cloned();
+        if has_header {
+            self.write_section_line(header.as_ref())?;
+        }
+        Ok(())
+    }
+
+    fn end_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        let Some(framer) = self.framer.as_ref() else {
+            return Ok(());
+        };
+        let has_footer = framer.has_footer();
+        let footer = framer.footer_fields(doc).cloned();
+        if has_footer {
+            self.write_section_line(footer.as_ref())?;
+        }
+        Ok(())
+    }
+}
+
+/// Stringify an envelope section value for a fixed-width header/trailer line.
+/// Envelope sections carry no width schema, so values are written as their
+/// natural string form (no padding); `Null` is the empty string.
+fn value_to_envelope_cell(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::String(s) => s.to_string(),
+        Value::Integer(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::Bool(b) => b.to_string(),
+        Value::Date(d) => d.format("%Y%m%d").to_string(),
+        Value::DateTime(dt) => dt.format("%Y%m%d%H%M%S").to_string(),
+        Value::Array(_) | Value::Map(_) => String::new(),
     }
 }
 
@@ -499,5 +593,60 @@ mod tests {
             }
             other => panic!("expected UnserializableMapValue, got {other:?}"),
         }
+    }
+
+    fn doc_with_sections(
+        sections: &[(&str, &[(&str, Value)])],
+    ) -> std::sync::Arc<clinker_record::DocumentContext> {
+        use indexmap::IndexMap;
+        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (name, fields) in sections {
+            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
+            for (k, v) in *fields {
+                inner.insert(Box::from(*k), v.clone());
+            }
+            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
+        }
+        std::sync::Arc::new(clinker_record::DocumentContext::new(
+            clinker_record::DocumentId::next(),
+            std::sync::Arc::from("f.txt"),
+            map,
+        ))
+    }
+
+    #[test]
+    fn fixed_width_envelope_emits_header_and_footer_lines() {
+        // A header line and a footer line bracket the body, each joining the
+        // section's field values (unpadded — envelope sections carry no width
+        // schema). A computed footer count is rejected at plan time for
+        // fixed-width (E346), so the spec here carries none.
+        let mut amount = field("amount");
+        amount.field_type = Some(FieldType::Integer);
+        amount.width = Some(5);
+        amount.justify = Some(Justify::Right);
+        amount.pad = Some("0".into());
+        let config = FixedWidthWriterConfig {
+            line_separator: LineSeparator::Lf,
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: None,
+            }),
+        };
+        let doc = doc_with_sections(&[
+            ("Head", &[("tag", Value::String("HDR".into()))]),
+            ("Foot", &[("tag", Value::String("TRL".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let mut w = FixedWidthWriter::new(&mut buf, vec![amount], config).unwrap();
+            w.begin_document(&doc).unwrap();
+            w.write_record(&make_record(&["amount"], vec![Value::Integer(7)]))
+                .unwrap();
+            w.end_document(&doc).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out, "HDR\n00007\nTRL\n", "got: {out}");
     }
 }

--- a/crates/clinker-format/src/hl7/reader.rs
+++ b/crates/clinker-format/src/hl7/reader.rs
@@ -39,7 +39,9 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
-use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, coerce_section_fields};
+use crate::envelope::{
+    EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, FrameRole, coerce_section_fields,
+};
 use crate::error::FormatError;
 use crate::hl7::RAW_FIELDS_KEY;
 use crate::hl7::field_split::Hl7FieldSplit;
@@ -361,8 +363,12 @@ impl<R: Read> Hl7Reader<R> {
         }
         self.open_batch = Some(OpenBatch { message_count: 0 });
         self.batch_count += 1;
+        // A batch wraps messages but is not itself the framing document — the
+        // message is. So the batch level stays inside whatever frame is
+        // current (in practice the file), inheriting its grain.
         self.pending_events.push(EnvelopeEvent::OpenLevel {
             sections: positional_section("batch", &bhs.fields),
+            frame: FrameRole::Inherit,
         });
         Ok(())
     }
@@ -408,8 +414,13 @@ impl<R: Read> Hl7Reader<R> {
         if let Some(batch) = self.open_batch.as_mut() {
             batch.message_count += 1;
         }
+        // Each HL7 message IS a logical document: it opens a fresh frame, so a
+        // multi-message file reconstructs one output envelope per message and
+        // dead-letters per message rather than collapsing the whole file into
+        // one frame.
         self.pending_events.push(EnvelopeEvent::OpenLevel {
             sections: message_section(msh),
+            frame: FrameRole::NewFrame,
         });
         self.open_message = Some(OpenMessage {
             control_id,
@@ -816,7 +827,7 @@ mod tests {
         let mut r = reader(&adt_message());
         let _ = r.next_record().unwrap().unwrap();
         let events = r.take_envelope_events();
-        let EnvelopeEvent::OpenLevel { sections } = &events[0] else {
+        let EnvelopeEvent::OpenLevel { sections, .. } = &events[0] else {
             panic!("expected message OpenLevel");
         };
         let set = match sections.get("transaction_set").unwrap() {

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -1,11 +1,21 @@
 //! JSON writer supporting array mode, NDJSON mode, pretty-printing,
 //! and null omission. Implements `FormatWriter`.
+//!
+//! Under `reconstruct_envelope` the whole-stream array framing is REPLACED by
+//! per-document object framing: each enveloped document becomes one JSON
+//! object `{ "<header>": {...}, "body": [ ... ], "<footer>": {...} }`, with the
+//! header/footer keys named by the source's `$doc` sections and the footer
+//! optionally carrying a streaming record count. Multiple documents in one
+//! stream are each individually framed — wrapped in an outer array in `array`
+//! mode, or one object per line in `ndjson` mode. The body array streams one
+//! record at a time, so no document is ever buffered.
 
 use std::io::Write;
 use std::sync::Arc;
 
-use clinker_record::{Record, Schema, Value};
+use clinker_record::{DocumentContext, Record, Schema, Value};
 
+use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
 
@@ -28,6 +38,11 @@ pub struct JsonWriterConfig {
     /// snapshots) appear as keys in the emitted JSON object. Defaults
     /// to `false` to keep engine-internal namespaces out of output.
     pub include_engine_stamped: bool,
+    /// Per-document envelope reconstruction. `None` (the default) keeps the
+    /// whole-stream array / NDJSON framing byte-identical to today. `Some` is
+    /// set by the executor only under `reconstruct_envelope: true` and
+    /// reframes the output to one object per document.
+    pub envelope: Option<OutputEnvelopeSpec>,
 }
 
 impl Default for JsonWriterConfig {
@@ -37,6 +52,7 @@ impl Default for JsonWriterConfig {
             pretty: false,
             preserve_nulls: false,
             include_engine_stamped: false,
+            envelope: None,
         }
     }
 }
@@ -50,15 +66,44 @@ pub struct JsonWriter<W: Write> {
     _schema: Arc<Schema>,
     config: JsonWriterConfig,
     records_written: u64,
+    /// Per-document envelope framer + state machine, present only when
+    /// `config.envelope` is. Drives the per-document-object reframe.
+    envelope: Option<EnvelopeState>,
+}
+
+/// Per-document-object framing state for the envelope reframe. Tracks the
+/// running framer (header/footer sections + record count), how many document
+/// objects have been emitted (for the outer-array comma in `array` mode), and
+/// whether the current document's body array has any record yet (for the
+/// body-array comma). Holds no body record — bounded memory.
+struct EnvelopeState {
+    framer: EnvelopeFramer,
+    /// Document objects emitted so far this stream.
+    docs_written: u64,
+    /// Records appended to the currently-open document's body array.
+    body_in_doc: u64,
+    /// Whether a document object is currently open (between begin/end).
+    doc_open: bool,
 }
 
 impl<W: Write> JsonWriter<W> {
     pub fn new(writer: W, schema: Arc<Schema>, config: JsonWriterConfig) -> Self {
+        let envelope = config
+            .envelope
+            .clone()
+            .filter(|s| !s.is_empty())
+            .map(|spec| EnvelopeState {
+                framer: EnvelopeFramer::new(spec),
+                docs_written: 0,
+                body_in_doc: 0,
+                doc_open: false,
+            });
         Self {
             writer,
             _schema: schema,
             config,
             records_written: 0,
+            envelope,
         }
     }
 
@@ -87,18 +132,72 @@ impl<W: Write> JsonWriter<W> {
         }
         Jv::Object(obj)
     }
+
+    /// Serialize a JSON value with the configured pretty/compact mode.
+    fn serialize_value(&self, value: &serde_json::Value) -> Result<String, FormatError> {
+        let s = if self.config.pretty {
+            serde_json::to_string_pretty(value)
+        } else {
+            serde_json::to_string(value)
+        }
+        .map_err(|e| FormatError::Json(e.to_string()))?;
+        Ok(s)
+    }
+
+    /// Build a JSON object from an envelope section's ordered fields, plus an
+    /// optional trailing computed-count entry. `null` is always emitted for a
+    /// section (envelope sections are small typed metadata, not body records),
+    /// so the round-trip stays faithful regardless of `preserve_nulls`.
+    fn section_object(
+        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+        count: Option<(&str, i64)>,
+    ) -> serde_json::Value {
+        use serde_json::{Map, Value as Jv};
+        let mut obj = Map::new();
+        if let Some(fields) = fields {
+            for (name, value) in fields {
+                obj.insert(name.to_string(), clinker_to_json(value));
+            }
+        }
+        if let Some((field, n)) = count {
+            obj.insert(field.to_string(), Jv::Number(n.into()));
+        }
+        Jv::Object(obj)
+    }
+
+    /// Append one body record to the currently-open document object's `body`
+    /// array, comma-separating from prior body records.
+    fn write_enveloped_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        let json_val = self.record_to_json(record);
+        let serialized = self.serialize_value(&json_val)?;
+        let env = self
+            .envelope
+            .as_mut()
+            .expect("write_enveloped_record only called with an envelope state");
+        if env.body_in_doc > 0 {
+            self.writer.write_all(b",").map_err(FormatError::Io)?;
+        }
+        self.writer
+            .write_all(serialized.as_bytes())
+            .map_err(FormatError::Io)?;
+        env.body_in_doc += 1;
+        env.framer.count_record();
+        Ok(())
+    }
 }
 
 impl<W: Write + Send> FormatWriter for JsonWriter<W> {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
-        let json_val = self.record_to_json(record);
-
-        let serialized = if self.config.pretty {
-            serde_json::to_string_pretty(&json_val)
-        } else {
-            serde_json::to_string(&json_val)
+        // Envelope mode: append to the open document object's `body` array.
+        // A document is always open here (the dispatch arm fires
+        // `begin_document` before the first record), so this never writes a
+        // stray top-level record.
+        if self.envelope.is_some() {
+            return self.write_enveloped_record(record);
         }
-        .map_err(|e| FormatError::Json(e.to_string()))?;
+
+        let json_val = self.record_to_json(record);
+        let serialized = self.serialize_value(&json_val)?;
 
         match self.config.format {
             JsonOutputMode::Array => {
@@ -126,14 +225,115 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
     }
 
     fn flush(&mut self) -> Result<(), FormatError> {
-        if let JsonOutputMode::Array = self.config.format {
-            if self.records_written > 0 {
-                self.writer.write_all(b"\n]\n").map_err(FormatError::Io)?;
-            } else {
-                self.writer.write_all(b"[]\n").map_err(FormatError::Io)?;
+        match self.envelope.as_ref() {
+            // Envelope mode: in `array` mode the per-document objects are
+            // wrapped in an outer array, closed here; `ndjson` mode needs no
+            // wrapper. An empty stream emits `[]` (array) / nothing (ndjson),
+            // matching the non-enveloped empty shape.
+            Some(env) => {
+                if let JsonOutputMode::Array = self.config.format {
+                    if env.docs_written > 0 {
+                        self.writer.write_all(b"\n]\n").map_err(FormatError::Io)?;
+                    } else {
+                        self.writer.write_all(b"[]\n").map_err(FormatError::Io)?;
+                    }
+                }
+            }
+            None => {
+                if let JsonOutputMode::Array = self.config.format {
+                    if self.records_written > 0 {
+                        self.writer.write_all(b"\n]\n").map_err(FormatError::Io)?;
+                    } else {
+                        self.writer.write_all(b"[]\n").map_err(FormatError::Io)?;
+                    }
+                }
             }
         }
         self.writer.flush().map_err(FormatError::Io)?;
+        Ok(())
+    }
+
+    fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        let Some(env) = self.envelope.as_mut() else {
+            return Ok(());
+        };
+        env.framer.begin();
+        let header = env
+            .framer
+            .has_header()
+            .then(|| Self::section_object(env.framer.header_fields(doc), None));
+        // Outer framing between document objects: `[\n` / `,\n` (array) or a
+        // newline separator (ndjson).
+        match self.config.format {
+            JsonOutputMode::Array => {
+                if env.docs_written == 0 {
+                    self.writer.write_all(b"[\n").map_err(FormatError::Io)?;
+                } else {
+                    self.writer.write_all(b",\n").map_err(FormatError::Io)?;
+                }
+            }
+            JsonOutputMode::Ndjson => {
+                if env.docs_written > 0 {
+                    self.writer.write_all(b"\n").map_err(FormatError::Io)?;
+                }
+            }
+        }
+        // Open the document object, emit the optional header, open the body
+        // array. The body's records stream in via `write_record`.
+        self.writer.write_all(b"{").map_err(FormatError::Io)?;
+        if let Some(header) = header {
+            let s = self.serialize_value(&header)?;
+            self.writer
+                .write_all(b"\"header\":")
+                .map_err(FormatError::Io)?;
+            self.writer
+                .write_all(s.as_bytes())
+                .map_err(FormatError::Io)?;
+            self.writer.write_all(b",").map_err(FormatError::Io)?;
+        }
+        self.writer
+            .write_all(b"\"body\":[")
+            .map_err(FormatError::Io)?;
+        // Re-borrow to reset the body counter (the `header` build dropped the
+        // earlier mutable borrow).
+        if let Some(env) = self.envelope.as_mut() {
+            env.body_in_doc = 0;
+            env.doc_open = true;
+        }
+        Ok(())
+    }
+
+    fn end_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        if self.envelope.as_ref().is_none_or(|e| !e.doc_open) {
+            return Ok(());
+        }
+        // Close the body array.
+        self.writer.write_all(b"]").map_err(FormatError::Io)?;
+        // Emit the optional footer (section fields + computed count).
+        let footer = {
+            let env = self
+                .envelope
+                .as_ref()
+                .expect("doc_open implies an envelope state");
+            env.framer.has_footer().then(|| {
+                Self::section_object(env.framer.footer_fields(doc), env.framer.footer_count())
+            })
+        };
+        if let Some(footer) = footer {
+            let s = self.serialize_value(&footer)?;
+            self.writer
+                .write_all(b",\"footer\":")
+                .map_err(FormatError::Io)?;
+            self.writer
+                .write_all(s.as_bytes())
+                .map_err(FormatError::Io)?;
+        }
+        // Close the document object.
+        self.writer.write_all(b"}").map_err(FormatError::Io)?;
+        if let Some(env) = self.envelope.as_mut() {
+            env.docs_written += 1;
+            env.doc_open = false;
+        }
         Ok(())
     }
 }
@@ -346,5 +546,122 @@ mod tests {
         assert_eq!(r1.get("active"), Some(&Value::Bool(true)));
         assert_eq!(r2.get("name"), Some(&Value::String("Bob".into())));
         assert_eq!(r2.get("age"), Some(&Value::Integer(25)));
+    }
+
+    use clinker_record::{DocumentContext, DocumentId};
+    use indexmap::IndexMap;
+
+    fn doc_with_sections(sections: &[(&str, &[(&str, Value)])]) -> Arc<DocumentContext> {
+        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (name, fields) in sections {
+            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
+            for (k, v) in *fields {
+                inner.insert(Box::from(*k), v.clone());
+            }
+            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
+        }
+        Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            std::sync::Arc::from("f.json"),
+            map,
+        ))
+    }
+
+    fn amount_record(schema: &Arc<Schema>, n: i64) -> Record {
+        Record::new(Arc::clone(schema), vec![Value::Integer(n)])
+    }
+
+    #[test]
+    fn json_envelope_array_mode_frames_each_document_as_an_object() {
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Array,
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: Some("count".into()),
+            }),
+            ..Default::default()
+        };
+        let doc_a = doc_with_sections(&[
+            ("Head", &[("batch_id", Value::String("A".into()))]),
+            ("Foot", &[("checksum", Value::String("SUM-A".into()))]),
+        ]);
+        let doc_b = doc_with_sections(&[
+            ("Head", &[("batch_id", Value::String("B".into()))]),
+            ("Foot", &[("checksum", Value::String("SUM-B".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let mut w = JsonWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc_a).unwrap();
+            w.write_record(&amount_record(&schema, 10)).unwrap();
+            w.write_record(&amount_record(&schema, 20)).unwrap();
+            w.end_document(&doc_a).unwrap();
+            w.begin_document(&doc_b).unwrap();
+            w.write_record(&amount_record(&schema, 30)).unwrap();
+            w.end_document(&doc_b).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        // Valid JSON: an outer array of two document objects.
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON array");
+        let arr = parsed.as_array().expect("outer array");
+        assert_eq!(arr.len(), 2, "one object per document: {out}");
+        assert_eq!(arr[0]["header"]["batch_id"], "A");
+        assert_eq!(
+            arr[0]["body"],
+            serde_json::json!([{"amount":10},{"amount":20}])
+        );
+        assert_eq!(arr[0]["footer"]["checksum"], "SUM-A");
+        assert_eq!(arr[0]["footer"]["count"], 2);
+        assert_eq!(arr[1]["header"]["batch_id"], "B");
+        assert_eq!(arr[1]["footer"]["count"], 1, "count resets per document");
+    }
+
+    #[test]
+    fn json_envelope_ndjson_mode_one_document_object_per_line() {
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let doc_a = doc_with_sections(&[("Head", &[("batch_id", Value::String("A".into()))])]);
+        let doc_b = doc_with_sections(&[("Head", &[("batch_id", Value::String("B".into()))])]);
+        let mut buf = Vec::new();
+        {
+            let mut w = JsonWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc_a).unwrap();
+            w.write_record(&amount_record(&schema, 10)).unwrap();
+            w.end_document(&doc_a).unwrap();
+            w.begin_document(&doc_b).unwrap();
+            w.write_record(&amount_record(&schema, 20)).unwrap();
+            w.end_document(&doc_b).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 2, "one document object per line: {out}");
+        let d0: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        assert_eq!(d0["header"]["batch_id"], "A");
+        assert_eq!(d0["body"], serde_json::json!([{"amount":10}]));
+    }
+
+    #[test]
+    fn json_envelope_off_is_byte_identical() {
+        // No envelope spec: array framing is the plain whole-stream array.
+        let schema = test_schema();
+        let records = vec![make_record(&schema, "Alice", 30, true)];
+        let baseline = write_records(JsonWriterConfig::default(), &records, &schema);
+        let parsed: serde_json::Value = serde_json::from_str(&baseline).unwrap();
+        assert!(
+            parsed.as_array().unwrap()[0]["body"].is_null(),
+            "no per-doc body key"
+        );
+        assert_eq!(parsed.as_array().unwrap()[0]["name"], "Alice");
     }
 }

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -72,16 +72,15 @@ pub struct JsonWriter<W: Write> {
 }
 
 /// Per-document-object framing state for the envelope reframe. Tracks the
-/// running framer (header/footer sections + record count), how many document
-/// objects have been emitted (for the outer-array comma in `array` mode), and
-/// whether the current document's body array has any record yet (for the
-/// body-array comma). Holds no body record — bounded memory.
+/// running framer (header/footer sections + the body record count, which also
+/// drives the body-array comma), whether ANY document object has been emitted
+/// (for the outer-array comma in `array` mode), and whether a document object
+/// is currently open. Holds no body record — bounded memory.
 struct EnvelopeState {
     framer: EnvelopeFramer,
-    /// Document objects emitted so far this stream.
-    docs_written: u64,
-    /// Records appended to the currently-open document's body array.
-    body_in_doc: u64,
+    /// Whether at least one document object has been emitted this stream —
+    /// drives the outer-array `[\n` vs `,\n` separator in `array` mode.
+    any_doc_written: bool,
     /// Whether a document object is currently open (between begin/end).
     doc_open: bool,
 }
@@ -91,11 +90,10 @@ impl<W: Write> JsonWriter<W> {
         let envelope = config
             .envelope
             .clone()
-            .filter(|s| !s.is_empty())
-            .map(|spec| EnvelopeState {
-                framer: EnvelopeFramer::new(spec),
-                docs_written: 0,
-                body_in_doc: 0,
+            .and_then(OutputEnvelopeSpec::into_framer)
+            .map(|framer| EnvelopeState {
+                framer,
+                any_doc_written: false,
                 doc_open: false,
             });
         Self {
@@ -149,15 +147,13 @@ impl<W: Write> JsonWriter<W> {
     /// section (envelope sections are small typed metadata, not body records),
     /// so the round-trip stays faithful regardless of `preserve_nulls`.
     fn section_object(
-        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+        fields: &indexmap::IndexMap<Box<str>, Value>,
         count: Option<(&str, i64)>,
     ) -> serde_json::Value {
         use serde_json::{Map, Value as Jv};
         let mut obj = Map::new();
-        if let Some(fields) = fields {
-            for (name, value) in fields {
-                obj.insert(name.to_string(), clinker_to_json(value));
-            }
+        for (name, value) in fields {
+            obj.insert(name.to_string(), clinker_to_json(value));
         }
         if let Some((field, n)) = count {
             obj.insert(field.to_string(), Jv::Number(n.into()));
@@ -166,7 +162,18 @@ impl<W: Write> JsonWriter<W> {
     }
 
     /// Append one body record to the currently-open document object's `body`
-    /// array, comma-separating from prior body records.
+    /// array, comma-separating from prior body records (off the framer's
+    /// running record count, so there is no duplicate counter).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FormatError::Json`] when NO document object is open — a record
+    /// reached an enveloped JSON writer without a `begin_document` (a record
+    /// with no originating document, e.g. a `<merged>` fan-in / aggregate row).
+    /// The plan-time guard (E347) rejects the pipeline shapes that produce
+    /// such records upstream of an enveloped Output, so this is a defense-in-
+    /// depth safety net: it raises a clean error rather than writing record
+    /// bytes outside any `{...,"body":[` object (which would be malformed JSON).
     fn write_enveloped_record(&mut self, record: &Record) -> Result<(), FormatError> {
         let json_val = self.record_to_json(record);
         let serialized = self.serialize_value(&json_val)?;
@@ -174,13 +181,19 @@ impl<W: Write> JsonWriter<W> {
             .envelope
             .as_mut()
             .expect("write_enveloped_record only called with an envelope state");
-        if env.body_in_doc > 0 {
+        if !env.doc_open {
+            return Err(FormatError::Json(
+                "enveloped JSON output received a record with no open document — a record \
+                 with no originating document (a fan-in / aggregate row) cannot be framed"
+                    .to_string(),
+            ));
+        }
+        if env.framer.record_count() > 0 {
             self.writer.write_all(b",").map_err(FormatError::Io)?;
         }
         self.writer
             .write_all(serialized.as_bytes())
             .map_err(FormatError::Io)?;
-        env.body_in_doc += 1;
         env.framer.count_record();
         Ok(())
     }
@@ -232,7 +245,7 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
             // matching the non-enveloped empty shape.
             Some(env) => {
                 if let JsonOutputMode::Array = self.config.format {
-                    if env.docs_written > 0 {
+                    if env.any_doc_written {
                         self.writer.write_all(b"\n]\n").map_err(FormatError::Io)?;
                     } else {
                         self.writer.write_all(b"[]\n").map_err(FormatError::Io)?;
@@ -258,22 +271,25 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
             return Ok(());
         };
         env.framer.begin();
+        // Build the optional header object only when the document carries the
+        // configured section (a missing section emits no `"header"` key).
         let header = env
             .framer
-            .has_header()
-            .then(|| Self::section_object(env.framer.header_fields(doc), None));
+            .header_fields(doc)
+            .map(|fields| Self::section_object(fields, None));
+        let any_doc_written = env.any_doc_written;
         // Outer framing between document objects: `[\n` / `,\n` (array) or a
         // newline separator (ndjson).
         match self.config.format {
             JsonOutputMode::Array => {
-                if env.docs_written == 0 {
-                    self.writer.write_all(b"[\n").map_err(FormatError::Io)?;
-                } else {
+                if any_doc_written {
                     self.writer.write_all(b",\n").map_err(FormatError::Io)?;
+                } else {
+                    self.writer.write_all(b"[\n").map_err(FormatError::Io)?;
                 }
             }
             JsonOutputMode::Ndjson => {
-                if env.docs_written > 0 {
+                if any_doc_written {
                     self.writer.write_all(b"\n").map_err(FormatError::Io)?;
                 }
             }
@@ -294,10 +310,7 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
         self.writer
             .write_all(b"\"body\":[")
             .map_err(FormatError::Io)?;
-        // Re-borrow to reset the body counter (the `header` build dropped the
-        // earlier mutable borrow).
         if let Some(env) = self.envelope.as_mut() {
-            env.body_in_doc = 0;
             env.doc_open = true;
         }
         Ok(())
@@ -309,15 +322,16 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
         }
         // Close the body array.
         self.writer.write_all(b"]").map_err(FormatError::Io)?;
-        // Emit the optional footer (section fields + computed count).
+        // Emit the optional footer only when the document carries the
+        // configured footer section (the computed count rides it).
         let footer = {
             let env = self
                 .envelope
                 .as_ref()
                 .expect("doc_open implies an envelope state");
-            env.framer.has_footer().then(|| {
-                Self::section_object(env.framer.footer_fields(doc), env.framer.footer_count())
-            })
+            env.framer
+                .footer_fields(doc)
+                .map(|fields| Self::section_object(fields, env.framer.footer_count()))
         };
         if let Some(footer) = footer {
             let s = self.serialize_value(&footer)?;
@@ -331,7 +345,7 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
         // Close the document object.
         self.writer.write_all(b"}").map_err(FormatError::Io)?;
         if let Some(env) = self.envelope.as_mut() {
-            env.docs_written += 1;
+            env.any_doc_written = true;
             env.doc_open = false;
         }
         Ok(())
@@ -548,27 +562,40 @@ mod tests {
         assert_eq!(r2.get("age"), Some(&Value::Integer(25)));
     }
 
-    use clinker_record::{DocumentContext, DocumentId};
-    use indexmap::IndexMap;
-
-    fn doc_with_sections(sections: &[(&str, &[(&str, Value)])]) -> Arc<DocumentContext> {
-        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
-        for (name, fields) in sections {
-            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
-            for (k, v) in *fields {
-                inner.insert(Box::from(*k), v.clone());
-            }
-            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
-        }
-        Arc::new(DocumentContext::new(
-            DocumentId::next(),
-            std::sync::Arc::from("f.json"),
-            map,
-        ))
-    }
+    use crate::envelope_writer::test_doc_with_sections as doc_with_sections;
 
     fn amount_record(schema: &Arc<Schema>, n: i64) -> Record {
         Record::new(Arc::clone(schema), vec![Value::Integer(n)])
+    }
+
+    #[test]
+    fn json_envelope_record_with_no_open_document_errors_cleanly() {
+        // Defense-in-depth: the plan-time E347 guard rejects pipelines that
+        // route lineage-stripped (`<merged>`) records into an enveloped JSON
+        // Output, so `begin_document` always fires first in production. If one
+        // ever reached here without an open document, the writer must raise a
+        // clean error rather than emit record bytes outside any `body` array
+        // (which would be malformed JSON).
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Array,
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut w = JsonWriter::new(&mut buf, Arc::clone(&schema), config);
+        // No begin_document — write straight into the envelope writer.
+        let err = w.write_record(&amount_record(&schema, 1)).unwrap_err();
+        match err {
+            FormatError::Json(msg) => assert!(
+                msg.contains("no open document"),
+                "expected the no-open-document message, got: {msg}"
+            ),
+            other => panic!("expected FormatError::Json, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -4,6 +4,7 @@ pub mod csv;
 pub mod doc_index;
 pub mod edifact;
 pub mod envelope;
+pub mod envelope_writer;
 pub mod error;
 pub mod fixed_width;
 pub mod hl7;
@@ -23,6 +24,7 @@ pub use envelope::{
     EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection, FrameRole,
     NestedEnvelopeSection,
 };
+pub use envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 pub use error::FormatError;
 pub use source::ReopenableSource;
 pub use traits::{FormatReader, FormatWriter};

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -20,7 +20,7 @@ pub mod xml;
 pub use counting::{CountedFormatWriter, CountingWriter, SharedByteCounter};
 pub use doc_index::DocArenaIndex;
 pub use envelope::{
-    EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection,
+    EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, EnvelopeFieldType, EnvelopeSection, FrameRole,
     NestedEnvelopeSection,
 };
 pub use error::FormatError;

--- a/crates/clinker-format/src/splitting/tests.rs
+++ b/crates/clinker-format/src/splitting/tests.rs
@@ -749,6 +749,7 @@ fn test_splitting_writer_json_produces_valid_files() {
         pretty: false,
         preserve_nulls: false,
         include_engine_stamped: false,
+        envelope: None,
     };
 
     let json_factory: WriterFactory = Box::new(
@@ -819,6 +820,7 @@ fn test_splitting_writer_xml_produces_valid_files() {
         record_element: "item".into(),
         preserve_nulls: false,
         include_engine_stamped: false,
+        envelope: None,
     };
 
     let xml_factory: WriterFactory = Box::new(

--- a/crates/clinker-format/src/swift/reader.rs
+++ b/crates/clinker-format/src/swift/reader.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
-use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract};
+use crate::envelope::{EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, FrameRole};
 use crate::error::FormatError;
 use crate::swift::tokenizer::{
     BlockTokenizer, ParsedBlock, ParsedBlock4Line, TEXT_BLOCK_ID, split_block4,
@@ -191,8 +191,13 @@ impl<R: Read> SwiftReader<R> {
             // records. Open it once, before the first record (or, for a
             // header-only message, immediately before the close) so the
             // driver's document stack always balances.
+            // A SWIFT MT message is itself the logical document, so its
+            // message level opens a fresh frame. One message per file today,
+            // so this matches the file grain; marking it `NewFrame` keeps the
+            // grain correct if a multi-message container is ever supported.
             self.pending_events.push(EnvelopeEvent::OpenLevel {
                 sections: IndexMap::new(),
+                frame: FrameRole::NewFrame,
             });
             self.level_open = true;
         }

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -32,7 +32,8 @@ use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
 use crate::envelope::{
-    EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, NestedEnvelopeSection, coerce_section_fields,
+    EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, FrameRole, NestedEnvelopeSection,
+    coerce_section_fields,
 };
 use crate::error::FormatError;
 use crate::traits::FormatReader;
@@ -285,8 +286,13 @@ impl<R: Read> X12Reader<R> {
         });
         self.group_count += 1;
         let sections = nested_sections(gs, self.group_section.as_ref(), DEFAULT_GROUP_SECTION)?;
-        self.pending_events
-            .push(EnvelopeEvent::OpenLevel { sections });
+        // A `GS` functional group stays inside the interchange frame — the
+        // X12 framing document is the `ISA` interchange, so its nested levels
+        // inherit the interchange grain.
+        self.pending_events.push(EnvelopeEvent::OpenLevel {
+            sections,
+            frame: FrameRole::Inherit,
+        });
         Ok(())
     }
 
@@ -351,8 +357,13 @@ impl<R: Read> X12Reader<R> {
             group.set_count += 1;
         }
         let sections = nested_sections(st, self.set_section.as_ref(), DEFAULT_SET_SECTION)?;
-        self.pending_events
-            .push(EnvelopeEvent::OpenLevel { sections });
+        // An `ST` transaction set also stays inside the interchange frame, so
+        // a whole `ISA..IEA` interchange reconstructs as one output envelope
+        // rather than one per transaction set.
+        self.pending_events.push(EnvelopeEvent::OpenLevel {
+            sections,
+            frame: FrameRole::Inherit,
+        });
         Ok(())
     }
 
@@ -746,7 +757,7 @@ mod tests {
         let mut r = reader(&data);
         let _ = r.next_record().unwrap().unwrap();
         let events = r.take_envelope_events();
-        let EnvelopeEvent::OpenLevel { sections } = &events[0] else {
+        let EnvelopeEvent::OpenLevel { sections, .. } = &events[0] else {
             panic!("expected group OpenLevel");
         };
         let group = match sections.get("functional_group").unwrap() {
@@ -763,7 +774,7 @@ mod tests {
         let mut r = reader(&data);
         let _ = r.next_record().unwrap().unwrap();
         let events = r.take_envelope_events();
-        let EnvelopeEvent::OpenLevel { sections } = &events[1] else {
+        let EnvelopeEvent::OpenLevel { sections, .. } = &events[1] else {
             panic!("expected set OpenLevel");
         };
         let set = match sections.get("transaction_set").unwrap() {
@@ -794,7 +805,7 @@ mod tests {
         r.take_envelope_events()
             .into_iter()
             .filter_map(|e| match e {
-                EnvelopeEvent::OpenLevel { sections } => Some(sections),
+                EnvelopeEvent::OpenLevel { sections, .. } => Some(sections),
                 EnvelopeEvent::CloseLevel => None,
             })
             .collect()

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -65,8 +65,7 @@ impl<W: Write> XmlWriter<W> {
         let framer = config
             .envelope
             .clone()
-            .filter(|s| !s.is_empty())
-            .map(EnvelopeFramer::new);
+            .and_then(OutputEnvelopeSpec::into_framer);
         Self {
             writer: XmlEmitter::new(writer),
             _schema: schema,
@@ -78,19 +77,18 @@ impl<W: Write> XmlWriter<W> {
 
     /// Emit a `<wrapper>…</wrapper>` element whose children are the section's
     /// fields rendered as nested elements (reusing the dotted-name expansion),
-    /// optionally appending a `<count_field>N</count_field>` child. A section
-    /// with no fields and no count emits an empty `<wrapper/>`.
+    /// optionally appending a `<count_field>N</count_field>` child. Called only
+    /// for a section the document actually carries (a missing section emits no
+    /// wrapper at all).
     fn write_section_element(
         &mut self,
         wrapper: &str,
-        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+        fields: &indexmap::IndexMap<Box<str>, Value>,
         count: Option<(&str, i64)>,
     ) -> Result<(), FormatError> {
         let mut pairs: Vec<(&str, &Value)> = Vec::new();
-        if let Some(fields) = fields {
-            for (name, value) in fields {
-                pairs.push((name.as_ref(), value));
-            }
+        for (name, value) in fields {
+            pairs.push((name.as_ref(), value));
         }
         // The computed count is held as an owned Value so it can be borrowed
         // into the same pair list the section fields use.
@@ -224,18 +222,17 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         self.writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
-        // Reset the per-document counter and emit the header element.
-        let (has_header, header_owned) = {
+        // Reset the per-document counter and clone the header section's fields
+        // out (so the immutable framer borrow ends before the `&mut self`
+        // write below). `None` when the document lacks the configured section
+        // — then no `<header>` is emitted.
+        let header_owned: Option<indexmap::IndexMap<Box<str>, Value>> = {
             let framer = self.framer.as_mut().expect("framer checked above");
             framer.begin();
-            // Clone the header section's fields out so the immutable borrow of
-            // `framer` ends before the `&mut self` write below.
-            let owned: Option<indexmap::IndexMap<Box<str>, Value>> =
-                framer.header_fields(doc).cloned();
-            (framer.has_header(), owned)
+            framer.header_fields(doc).cloned()
         };
-        if has_header {
-            self.write_section_element("header", header_owned.as_ref(), None)?;
+        if let Some(fields) = header_owned.as_ref() {
+            self.write_section_element("header", fields, None)?;
         }
         Ok(())
     }
@@ -244,15 +241,16 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         let Some(framer) = self.framer.as_ref() else {
             return Ok(());
         };
-        let has_footer = framer.has_footer();
+        // `None` when the document lacks the configured footer section — then
+        // no `<footer>` is emitted (the count rides the present section only).
         let footer_owned: Option<indexmap::IndexMap<Box<str>, Value>> =
             framer.footer_fields(doc).cloned();
         let count_owned: Option<(String, i64)> = framer
             .footer_count()
             .map(|(field, n)| (field.to_string(), n));
-        if has_footer {
+        if let Some(fields) = footer_owned.as_ref() {
             let count_ref = count_owned.as_ref().map(|(f, n)| (f.as_str(), *n));
-            self.write_section_element("footer", footer_owned.as_ref(), count_ref)?;
+            self.write_section_element("footer", fields, count_ref)?;
         }
         let end = BytesEnd::new("Document");
         self.writer
@@ -584,24 +582,7 @@ mod tests {
         }
     }
 
-    fn doc_with_sections(
-        sections: &[(&str, &[(&str, Value)])],
-    ) -> Arc<clinker_record::DocumentContext> {
-        use indexmap::IndexMap;
-        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
-        for (name, fields) in sections {
-            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
-            for (k, v) in *fields {
-                inner.insert(Box::from(*k), v.clone());
-            }
-            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
-        }
-        Arc::new(clinker_record::DocumentContext::new(
-            clinker_record::DocumentId::next(),
-            Arc::from("f.xml"),
-            map,
-        ))
-    }
+    use crate::envelope_writer::test_doc_with_sections as doc_with_sections;
 
     #[test]
     fn xml_envelope_wraps_each_document_with_header_and_footer() {

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -1,5 +1,11 @@
 //! XML writer with configurable root/record elements, dotted field expansion
 //! to nested elements, null handling, and proper escaping.
+//!
+//! Under `reconstruct_envelope`, each document is wrapped in a `<Document>`
+//! element inside the root: `begin_document` opens `<Document>` and emits the
+//! header section as a `<header>` element; the body `<Record>` elements stream
+//! between; `end_document` emits a `<footer>` element (section fields plus the
+//! streaming record count) and closes `</Document>`. No document is buffered.
 
 use std::io::Write;
 use std::sync::Arc;
@@ -7,8 +13,9 @@ use std::sync::Arc;
 use quick_xml::Writer as XmlEmitter;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 
-use clinker_record::{Record, Schema, Value};
+use clinker_record::{DocumentContext, Record, Schema, Value};
 
+use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
 
@@ -21,6 +28,11 @@ pub struct XmlWriterConfig {
     /// snapshots) emit as nested elements. Defaults to `false` so
     /// engine-internal namespaces stay out of the XML output.
     pub include_engine_stamped: bool,
+    /// Per-document envelope reconstruction. `None` (the default) keeps the
+    /// flat `<Root><Record/>…</Root>` output byte-identical. `Some` is set by
+    /// the executor under `reconstruct_envelope: true` and wraps each document
+    /// in a `<Document>` frame with header/footer elements.
+    pub envelope: Option<OutputEnvelopeSpec>,
 }
 
 impl Default for XmlWriterConfig {
@@ -30,6 +42,7 @@ impl Default for XmlWriterConfig {
             record_element: "Record".into(),
             preserve_nulls: false,
             include_engine_stamped: false,
+            envelope: None,
         }
     }
 }
@@ -43,16 +56,59 @@ pub struct XmlWriter<W: Write> {
     _schema: Arc<Schema>,
     config: XmlWriterConfig,
     header_written: bool,
+    /// Per-document envelope framer, present only when `config.envelope` is.
+    framer: Option<EnvelopeFramer>,
 }
 
 impl<W: Write> XmlWriter<W> {
     pub fn new(writer: W, schema: Arc<Schema>, config: XmlWriterConfig) -> Self {
+        let framer = config
+            .envelope
+            .clone()
+            .filter(|s| !s.is_empty())
+            .map(EnvelopeFramer::new);
         Self {
             writer: XmlEmitter::new(writer),
             _schema: schema,
             config,
             header_written: false,
+            framer,
         }
+    }
+
+    /// Emit a `<wrapper>…</wrapper>` element whose children are the section's
+    /// fields rendered as nested elements (reusing the dotted-name expansion),
+    /// optionally appending a `<count_field>N</count_field>` child. A section
+    /// with no fields and no count emits an empty `<wrapper/>`.
+    fn write_section_element(
+        &mut self,
+        wrapper: &str,
+        fields: Option<&indexmap::IndexMap<Box<str>, Value>>,
+        count: Option<(&str, i64)>,
+    ) -> Result<(), FormatError> {
+        let mut pairs: Vec<(&str, &Value)> = Vec::new();
+        if let Some(fields) = fields {
+            for (name, value) in fields {
+                pairs.push((name.as_ref(), value));
+            }
+        }
+        // The computed count is held as an owned Value so it can be borrowed
+        // into the same pair list the section fields use.
+        let count_value = count.map(|(field, n)| (field, Value::Integer(n)));
+        if let Some((field, ref v)) = count_value {
+            pairs.push((field, v));
+        }
+        let tree = build_field_tree(&pairs, self.config.preserve_nulls)?;
+        let start = BytesStart::new(wrapper);
+        self.writer
+            .write_event(Event::Start(start))
+            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        self.write_field_tree(&tree)?;
+        let end = BytesEnd::new(wrapper);
+        self.writer
+            .write_event(Event::End(end))
+            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        Ok(())
     }
 
     fn write_header(&mut self) -> Result<(), FormatError> {
@@ -141,6 +197,9 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
             .write_event(Event::End(end))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
 
+        if let Some(framer) = self.framer.as_mut() {
+            framer.count_record();
+        }
         Ok(())
     }
 
@@ -151,6 +210,54 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
             .write_event(Event::End(end))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
         self.writer.get_mut().flush().map_err(FormatError::Io)?;
+        Ok(())
+    }
+
+    fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        if self.framer.is_none() {
+            return Ok(());
+        }
+        // Ensure the root element is open before the first document.
+        self.write_header()?;
+        // Open the per-document wrapper.
+        let start = BytesStart::new("Document");
+        self.writer
+            .write_event(Event::Start(start))
+            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        // Reset the per-document counter and emit the header element.
+        let (has_header, header_owned) = {
+            let framer = self.framer.as_mut().expect("framer checked above");
+            framer.begin();
+            // Clone the header section's fields out so the immutable borrow of
+            // `framer` ends before the `&mut self` write below.
+            let owned: Option<indexmap::IndexMap<Box<str>, Value>> =
+                framer.header_fields(doc).cloned();
+            (framer.has_header(), owned)
+        };
+        if has_header {
+            self.write_section_element("header", header_owned.as_ref(), None)?;
+        }
+        Ok(())
+    }
+
+    fn end_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        let Some(framer) = self.framer.as_ref() else {
+            return Ok(());
+        };
+        let has_footer = framer.has_footer();
+        let footer_owned: Option<indexmap::IndexMap<Box<str>, Value>> =
+            framer.footer_fields(doc).cloned();
+        let count_owned: Option<(String, i64)> = framer
+            .footer_count()
+            .map(|(field, n)| (field.to_string(), n));
+        if has_footer {
+            let count_ref = count_owned.as_ref().map(|(f, n)| (f.as_str(), *n));
+            self.write_section_element("footer", footer_owned.as_ref(), count_ref)?;
+        }
+        let end = BytesEnd::new("Document");
+        self.writer
+            .write_event(Event::End(end))
+            .map_err(|e| FormatError::Xml(e.to_string()))?;
         Ok(())
     }
 }
@@ -475,5 +582,74 @@ mod tests {
             }
             other => panic!("expected UnserializableMapValue, got {other:?}"),
         }
+    }
+
+    fn doc_with_sections(
+        sections: &[(&str, &[(&str, Value)])],
+    ) -> Arc<clinker_record::DocumentContext> {
+        use indexmap::IndexMap;
+        let mut map: IndexMap<Box<str>, Value> = IndexMap::new();
+        for (name, fields) in sections {
+            let mut inner: IndexMap<Box<str>, Value> = IndexMap::new();
+            for (k, v) in *fields {
+                inner.insert(Box::from(*k), v.clone());
+            }
+            map.insert(Box::from(*name), Value::Map(Box::new(inner)));
+        }
+        Arc::new(clinker_record::DocumentContext::new(
+            clinker_record::DocumentId::next(),
+            Arc::from("f.xml"),
+            map,
+        ))
+    }
+
+    #[test]
+    fn xml_envelope_wraps_each_document_with_header_and_footer() {
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = XmlWriterConfig {
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: Some("count".into()),
+            }),
+            ..Default::default()
+        };
+        let doc = doc_with_sections(&[
+            ("Head", &[("batch_id", Value::String("A".into()))]),
+            ("Foot", &[("checksum", Value::String("SUM".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let mut w = XmlWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc).unwrap();
+            w.write_record(&Record::new(Arc::clone(&schema), vec![Value::Integer(10)]))
+                .unwrap();
+            w.write_record(&Record::new(Arc::clone(&schema), vec![Value::Integer(20)]))
+                .unwrap();
+            w.end_document(&doc).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        // Each document is a <Document> with a <header>, the body <Record>s,
+        // and a <footer> carrying the section field plus the computed count.
+        assert!(out.contains("<Document>"), "got: {out}");
+        assert!(
+            out.contains("<header><batch_id>A</batch_id></header>"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("<Record><amount>10</amount></Record>"),
+            "got: {out}"
+        );
+        assert!(
+            out.contains("<footer><checksum>SUM</checksum><count>2</count></footer>"),
+            "got: {out}"
+        );
+        assert!(out.contains("</Document>"), "got: {out}");
+        // The whole thing is valid XML wrapped in the root.
+        assert!(
+            out.contains("<Root>") && out.contains("</Root>"),
+            "got: {out}"
+        );
     }
 }

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -186,13 +186,17 @@ pub struct OutputEnvelopeConfig {
     pub footer_record_count_field: Option<String>,
 }
 
-impl OutputEnvelopeConfig {
-    /// `true` when no header, footer, or computed footer field is declared —
-    /// the writer renders no framing at all.
-    pub fn is_empty(&self) -> bool {
-        self.header_from_doc.is_none()
-            && self.footer_from_doc.is_none()
-            && self.footer_record_count_field.is_none()
+impl From<&OutputEnvelopeConfig> for clinker_format::OutputEnvelopeSpec {
+    /// Lower the plan config onto the format-local spec the writers consume.
+    /// The executor calls this only under `reconstruct_envelope: true`; the
+    /// resulting spec's `is_empty` / `into_framer` decide whether any framing
+    /// is rendered (so an empty config stays byte-identical to flag-off).
+    fn from(cfg: &OutputEnvelopeConfig) -> Self {
+        Self {
+            header_from_doc: cfg.header_from_doc.clone(),
+            footer_from_doc: cfg.footer_from_doc.clone(),
+            footer_record_count_field: cfg.footer_record_count_field.clone(),
+        }
     }
 }
 

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -150,12 +150,62 @@ pub enum SplitOversizeGroupPolicy {
     Allow,
 }
 
+/// Per-document output-envelope reconstruction for the generic formats
+/// (CSV / JSON / XML / fixed-width).
+///
+/// Mirrors the EDI `*_from_doc` vocabulary: a named `$doc` section is echoed
+/// as the per-document HEADER before the body and another as the FOOTER after
+/// it, so a header/trailer-shaped source round-trips through a generic output.
+/// The footer may additionally carry a streaming-computed record count under
+/// a named field. Section names are arbitrary user-chosen identifiers — the
+/// engine reserves none; an unknown name is rejected at plan-validation time
+/// with diagnostic **E346**.
+///
+/// Bounded memory: the header is emitted on the document's first record and
+/// the footer on its close, with the body streamed one record at a time
+/// between them — no document's records are ever buffered. Active only when
+/// the Output also sets `reconstruct_envelope: true`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields, default)]
+pub struct OutputEnvelopeConfig {
+    /// Name of the `$doc` section echoed as the per-document header, emitted
+    /// before the document's first body record. `None` writes no header.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub header_from_doc: Option<String>,
+    /// Name of the `$doc` section echoed as the per-document footer, emitted
+    /// after the document's last body record. `None` writes no footer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer_from_doc: Option<String>,
+    /// When set, the footer additionally carries the streaming-computed count
+    /// of body records written for the document, under this field name. The
+    /// count is maintained incrementally (one running integer), never by
+    /// buffering the body. Requires a `footer_from_doc` section to attach to.
+    /// Rejected with **E346** on a format that cannot inject a computed field
+    /// into its footer (fixed-width).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footer_record_count_field: Option<String>,
+}
+
+impl OutputEnvelopeConfig {
+    /// `true` when no header, footer, or computed footer field is declared —
+    /// the writer renders no framing at all.
+    pub fn is_empty(&self) -> bool {
+        self.header_from_doc.is_none()
+            && self.footer_from_doc.is_none()
+            && self.footer_record_count_field.is_none()
+    }
+}
+
 /// CSV-specific output options.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct CsvOutputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub delimiter: Option<String>,
+    /// Per-document envelope reconstruction (header/footer sections). Active
+    /// only with `reconstruct_envelope: true` on the Output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub envelope: Option<OutputEnvelopeConfig>,
 }
 
 /// JSON-specific output options.
@@ -166,6 +216,13 @@ pub struct JsonOutputOptions {
     pub format: Option<JsonOutputFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pretty: Option<bool>,
+    /// Per-document envelope reconstruction. With this set and
+    /// `reconstruct_envelope: true`, the whole-stream array framing is
+    /// replaced by one JSON object per document: `{ "<header>": {...},
+    /// "body": [ ... ], "<footer>": {...} }`. Active only with
+    /// `reconstruct_envelope: true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub envelope: Option<OutputEnvelopeConfig>,
 }
 
 /// JSON output format mode.
@@ -185,6 +242,13 @@ pub struct XmlOutputOptions {
     pub root_element: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_element: Option<String>,
+    /// Per-document envelope reconstruction. With this set and
+    /// `reconstruct_envelope: true`, each document is wrapped in its own
+    /// `<record_element-doc>`-style frame carrying the header section, the
+    /// body records, and the footer section. Active only with
+    /// `reconstruct_envelope: true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub envelope: Option<OutputEnvelopeConfig>,
 }
 
 /// Fixed-width output options.
@@ -193,6 +257,15 @@ pub struct XmlOutputOptions {
 pub struct FixedWidthOutputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub line_separator: Option<LineSeparator>,
+    /// Per-document envelope reconstruction (header/footer rows). The header
+    /// section's fields are emitted as one leading line and the footer's as
+    /// one trailing line, joined positionally in declared field order. A
+    /// computed footer record count (`footer_record_count_field`) is rejected
+    /// at plan time with **E346** — a fixed-width line has no field to inject
+    /// a count into without a width declaration. Active only with
+    /// `reconstruct_envelope: true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub envelope: Option<OutputEnvelopeConfig>,
 }
 
 /// EDIFACT output options.

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2244,6 +2244,83 @@ fn generic_output_envelope(
     }
 }
 
+/// The upstream lineage of an Output, as it bears on envelope reconstruction:
+/// the set of Source node names that feed it, and the name of the first
+/// document-lineage-stripping node found on any path to it (if any).
+///
+/// A node strips document lineage when it emits records with a synthetic /
+/// merged [`clinker_record::DocumentContext`] rather than carrying their
+/// originating document's context forward:
+///
+/// - `Aggregate` finalizes group rows through the merged eval context (even
+///   per-document aggregation finalizes through it), so every emitted row is
+///   synthetic-grained.
+/// - `Combine` fans several inputs into merged-lineage rows.
+/// - `Composition` is opaque at config-validation time (its body lives in a
+///   separate artifact, not in `config.nodes`), so its lineage cannot be
+///   proven preserved — treated conservatively as a stripper.
+///
+/// Such records reach an enveloped Output with a non-concrete `source_file`,
+/// which the envelope arm streams UNFRAMED. The plan-time guard (E347) uses
+/// `lineage_stripper` to reject the combination before it can emit malformed /
+/// misattributed framing; `feeding_sources` scopes the E346 section-name check
+/// to the sources whose documents this Output actually frames.
+struct OutputLineage {
+    feeding_sources: std::collections::BTreeSet<String>,
+    lineage_stripper: Option<String>,
+}
+
+/// Walk upstream from `output_name` over the config node graph, collecting the
+/// feeding sources and the first lineage-stripping node on any path. Cycle-safe
+/// via a visited set (cycles are rejected separately by the DAG-edge pass, so
+/// this only guards against re-traversal, never relies on acyclicity).
+fn trace_output_lineage(config: &PipelineConfig, output_name: &str) -> OutputLineage {
+    let by_name: HashMap<&str, &PipelineNode> = config
+        .nodes
+        .iter()
+        .map(|n| (n.value.name(), &n.value))
+        .collect();
+    let mut feeding_sources = std::collections::BTreeSet::new();
+    let mut lineage_stripper: Option<String> = None;
+    let mut visited: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut stack: Vec<&str> = vec![output_name];
+    while let Some(node_name) = stack.pop() {
+        if !visited.insert(node_name) {
+            continue;
+        }
+        let Some(node) = by_name.get(node_name) else {
+            continue;
+        };
+        match node {
+            PipelineNode::Source { .. } => {
+                feeding_sources.insert(node_name.to_string());
+            }
+            PipelineNode::Aggregate { .. }
+            | PipelineNode::Combine { .. }
+            | PipelineNode::Composition { .. } => {
+                // Record the first stripper found (deterministic by the
+                // declaration-order traversal seed), but keep walking so the
+                // feeding-source set stays complete for the E346 scoping.
+                if lineage_stripper.is_none() {
+                    lineage_stripper = Some(node_name.to_string());
+                }
+                for up in node.direct_input_names() {
+                    stack.push(up);
+                }
+            }
+            _ => {
+                for up in node.direct_input_names() {
+                    stack.push(up);
+                }
+            }
+        }
+    }
+    OutputLineage {
+        feeding_sources,
+        lineage_stripper,
+    }
+}
+
 /// A rejected `$doc` path against a closed envelope schema: the formatted
 /// diagnostic message plus its fix-it help text.
 struct UndeclaredDocPath {
@@ -3249,14 +3326,13 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         // below names the offending output directly — no re-derivation.
         let has_document_dlq = config.any_source_has_document_dlq();
         let has_correlation_key = config.any_source_has_correlation_key();
-        // Every `$doc` section name any source declares, for the E346
-        // unknown-section check. Section names are user-defined and shared
-        // across the pipeline, so an envelope header/footer may reference any
-        // section any source extracts.
-        let declared_envelope_sections: std::collections::HashSet<String> = config
+        // E346 scopes its section-name check to the sources that actually FEED
+        // each Output (not the pipeline-wide union), so a header/footer naming
+        // a section declared only on a non-feeding source is rejected — that
+        // would otherwise emit a silently-empty header/footer.
+        let source_envelope_by_name: HashMap<&str, &crate::config::SourceConfig> = config
             .source_configs()
-            .filter_map(|s| s.envelope.as_ref())
-            .flat_map(|e| e.sections.keys().cloned())
+            .map(|s| (s.name.as_str(), s))
             .collect();
         for output in config.output_configs() {
             if !output.reconstruct_envelope {
@@ -3298,45 +3374,91 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                 )));
             }
 
+            // Trace this Output's upstream lineage once: the sources feeding it
+            // (for the E346 section-name scoping) and any document-lineage
+            // stripper on the path (for the guard just below).
+            let lineage = trace_output_lineage(config, out);
+
+            // A cross-document `Combine` / global-or-per-document `Aggregate` /
+            // opaque `Composition` upstream emits records with a synthetic
+            // (`<merged>`) document context, which the envelope arm streams
+            // UNFRAMED. For JSON that means body bytes outside any open
+            // document object — malformed JSON — and for every format it means
+            // silently dropped framing / a miscounted footer. Reject the
+            // combination at plan time rather than emit broken output.
+            if let Some(stripper) = lineage.lineage_stripper.as_deref() {
+                return Err(ConfigError::Validation(format!(
+                    "[E347] output '{out}': `reconstruct_envelope` cannot be combined with an \
+                     upstream node ('{stripper}') that strips document lineage — a Combine, \
+                     Aggregate, or Composition emits records with no originating document, so \
+                     the per-document envelope cannot be framed around them (the framing arm \
+                     would stream them unframed, e.g. producing malformed JSON). Remove the \
+                     intervening node from this Output's path, or drop `reconstruct_envelope`"
+                )));
+            }
+
             // E346: the output-envelope config (header/footer sections + a
-            // possible computed footer) must reference sections the sources
-            // actually declare, and a computed footer count is unsupported on
-            // a format whose lines are positional (fixed-width). Only checked
-            // for an Output that reconstructs the envelope AND carries an
-            // envelope config; a flag-on Output with no envelope config frames
-            // nothing and is fine.
+            // possible computed footer) must reference sections the FEEDING
+            // sources actually declare, and a computed footer count is
+            // unsupported on a format whose lines are positional (fixed-width).
+            // Only checked for an Output that reconstructs the envelope AND
+            // carries an envelope config; a flag-on Output with no envelope
+            // config frames nothing and is fine.
             let Some((envelope_cfg, supports_computed_footer)) =
                 generic_output_envelope(&output.format)
             else {
                 continue;
             };
+            // Sections declared by THIS output's feeding sources only — a
+            // header/footer naming a section that exists solely on a
+            // non-feeding source would emit an empty header/footer silently,
+            // the exact failure E346 exists to catch.
+            let feeding_sections: std::collections::BTreeSet<&str> = lineage
+                .feeding_sources
+                .iter()
+                .filter_map(|s| source_envelope_by_name.get(s.as_str()))
+                .filter_map(|s| s.envelope.as_ref())
+                .flat_map(|e| e.sections.keys().map(|k| k.as_str()))
+                .collect();
             for (role, section) in [
                 ("header_from_doc", envelope_cfg.header_from_doc.as_deref()),
                 ("footer_from_doc", envelope_cfg.footer_from_doc.as_deref()),
             ] {
                 let Some(section) = section else { continue };
-                if !declared_envelope_sections.contains(section) {
-                    let mut declared: Vec<&str> = declared_envelope_sections
-                        .iter()
-                        .map(|s| s.as_str())
-                        .collect();
-                    declared.sort_unstable();
+                if !feeding_sections.contains(section) {
+                    let declared: Vec<&str> = feeding_sections.iter().copied().collect();
                     return Err(ConfigError::Validation(format!(
                         "[E346] output '{out}': envelope {role} references section \
-                         '{section}' which no source declares an `envelope:` section for. \
-                         Declared sections across all sources: {declared:?}. Name a declared \
-                         section, or add the section to a source's `envelope:` config"
+                         '{section}' which no source feeding this output declares an \
+                         `envelope:` section for. Sections declared by the feeding \
+                         source(s): {declared:?}. Name a declared section, or add the \
+                         section to a feeding source's `envelope:` config"
                     )));
                 }
             }
-            if envelope_cfg.footer_record_count_field.is_some() && !supports_computed_footer {
-                return Err(ConfigError::Validation(format!(
-                    "[E346] output '{out}': envelope `footer_record_count_field` is not \
-                     supported for {} output — a fixed-width line has no field to inject a \
-                     computed count into without a width declaration. Drop \
-                     `footer_record_count_field`, or use a CSV / JSON / XML output",
-                    output.format.format_name()
-                )));
+            if envelope_cfg.footer_record_count_field.is_some() {
+                // A computed count is injected INTO the footer section, so it
+                // requires a `footer_from_doc` to attach to — a count-only
+                // footer has no section to ride and would otherwise be silently
+                // dropped (the writer emits a footer only when its section is
+                // present on the document).
+                if envelope_cfg.footer_from_doc.is_none() {
+                    return Err(ConfigError::Validation(format!(
+                        "[E346] output '{out}': envelope `footer_record_count_field` requires \
+                         `footer_from_doc` — the computed record count is injected into the \
+                         footer section, so a footer section must be named for it to attach to. \
+                         Add `footer_from_doc`, or drop `footer_record_count_field`"
+                    )));
+                }
+                if !supports_computed_footer {
+                    return Err(ConfigError::Validation(format!(
+                        "[E346] output '{out}': envelope `footer_record_count_field` is not \
+                         supported for {} output — a fixed-width line has no field to inject a \
+                         computed count into without a width declaration. Drop \
+                         `footer_record_count_field`, or use a CSV / JSON / XML output",
+                        output.format.format_name()
+                    )));
+                }
             }
         }
     }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -876,11 +876,73 @@ impl PipelineConfig {
                 }
             }
         }
-        let declared_doc_paths: HashMap<String, Vec<cxl::analyzer::doc_paths::DocPath>> =
+        let mut declared_doc_paths: HashMap<String, Vec<cxl::analyzer::doc_paths::DocPath>> =
             doc_paths_by_source
                 .into_iter()
                 .map(|(source, paths)| (source, paths.into_iter().collect()))
                 .collect();
+        // Output-envelope reconstruction is a SECOND consumer of `$doc`
+        // sections, beyond CXL `$doc.*` references: an Output's
+        // `header_from_doc` / `footer_from_doc` echoes a whole section, but it
+        // appears in no program, so the readers' path-pruned pre-scan would
+        // not extract it. Register each enveloped section's declared fields as
+        // doc paths against the source(s) feeding that Output, so the reader
+        // retains the section. The reader extracts the whole declared section
+        // once any of its fields is wanted, so one path per declared field is
+        // sufficient (and passes the E341 closed-schema check, since each
+        // field is real). A header/footer naming an undeclared section is
+        // rejected separately by E346 below, so an absent section here is fine.
+        {
+            let source_by_name: HashMap<&str, &crate::config::SourceConfig> = source_configs
+                .iter()
+                .map(|s| (s.name.as_str(), s))
+                .collect();
+            for output in self.output_configs() {
+                if !output.reconstruct_envelope {
+                    continue;
+                }
+                let Some((env_cfg, _)) = generic_output_envelope(&output.format) else {
+                    continue;
+                };
+                let sections: Vec<&str> = [
+                    env_cfg.header_from_doc.as_deref(),
+                    env_cfg.footer_from_doc.as_deref(),
+                ]
+                .into_iter()
+                .flatten()
+                .collect();
+                if sections.is_empty() {
+                    continue;
+                }
+                let Some(feeding) = node_sources.get(&output.name) else {
+                    continue;
+                };
+                for source_name in feeding {
+                    let Some(source) = source_by_name.get(source_name.as_str()) else {
+                        continue;
+                    };
+                    let Some(envelope) = source.envelope.as_ref() else {
+                        continue;
+                    };
+                    let paths = declared_doc_paths.entry(source_name.clone()).or_default();
+                    for section_name in &sections {
+                        let Some(section) = envelope.sections.get(*section_name) else {
+                            continue;
+                        };
+                        for field in section.fields.keys() {
+                            let path = cxl::analyzer::doc_paths::DocPath {
+                                section: Box::from(*section_name),
+                                field: Box::from(field.as_str()),
+                                indices: Vec::new(),
+                            };
+                            if !paths.contains(&path) {
+                                paths.push(path);
+                            }
+                        }
+                    }
+                }
+            }
+        }
         // E341 — a `$doc.<section>.<field>` access must name a section and
         // field the feeding source's envelope actually declares. Without
         // this check a typo (`$doc.Summry.total` against a declared
@@ -2157,6 +2219,31 @@ fn envelope_schema_is_closed(format: &InputFormat) -> bool {
     matches!(format, InputFormat::Xml(_) | InputFormat::Json(_))
 }
 
+/// The output-envelope config of a generic-format Output (CSV / JSON / XML /
+/// fixed-width) paired with whether that format can carry a computed footer
+/// field, or `None` when the format declares no envelope config (or is an EDI
+/// format, which has its own per-format reconstruction vocabulary, not this
+/// generic one).
+///
+/// Used by the E346 check: a non-`None` result means the Output reconstructs a
+/// generic output envelope whose section names and computed footer must be
+/// validated. Fixed-width returns `false` for the computed-footer flag — its
+/// positional lines have no field to inject a count into.
+fn generic_output_envelope(
+    format: &OutputFormat,
+) -> Option<(&crate::config::OutputEnvelopeConfig, bool)> {
+    match format {
+        OutputFormat::Csv(opts) => opts.as_ref()?.envelope.as_ref().map(|e| (e, true)),
+        OutputFormat::Json(opts) => opts.as_ref()?.envelope.as_ref().map(|e| (e, true)),
+        OutputFormat::Xml(opts) => opts.as_ref()?.envelope.as_ref().map(|e| (e, true)),
+        OutputFormat::FixedWidth(opts) => opts.as_ref()?.envelope.as_ref().map(|e| (e, false)),
+        OutputFormat::Edifact(_)
+        | OutputFormat::X12(_)
+        | OutputFormat::Hl7(_)
+        | OutputFormat::Swift(_) => None,
+    }
+}
+
 /// A rejected `$doc` path against a closed envelope schema: the formatted
 /// diagnostic message plus its fix-it help text.
 struct UndeclaredDocPath {
@@ -3162,6 +3249,15 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         // below names the offending output directly — no re-derivation.
         let has_document_dlq = config.any_source_has_document_dlq();
         let has_correlation_key = config.any_source_has_correlation_key();
+        // Every `$doc` section name any source declares, for the E346
+        // unknown-section check. Section names are user-defined and shared
+        // across the pipeline, so an envelope header/footer may reference any
+        // section any source extracts.
+        let declared_envelope_sections: std::collections::HashSet<String> = config
+            .source_configs()
+            .filter_map(|s| s.envelope.as_ref())
+            .flat_map(|e| e.sections.keys().cloned())
+            .collect();
         for output in config.output_configs() {
             if !output.reconstruct_envelope {
                 continue;
@@ -3199,6 +3295,47 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                      writes through its own commit stage, which envelope framing bypasses, so \
                      dirty correlation groups would leak into the framed output and inflate \
                      the success counts. Drop `correlation_key`, or drop `reconstruct_envelope`"
+                )));
+            }
+
+            // E346: the output-envelope config (header/footer sections + a
+            // possible computed footer) must reference sections the sources
+            // actually declare, and a computed footer count is unsupported on
+            // a format whose lines are positional (fixed-width). Only checked
+            // for an Output that reconstructs the envelope AND carries an
+            // envelope config; a flag-on Output with no envelope config frames
+            // nothing and is fine.
+            let Some((envelope_cfg, supports_computed_footer)) =
+                generic_output_envelope(&output.format)
+            else {
+                continue;
+            };
+            for (role, section) in [
+                ("header_from_doc", envelope_cfg.header_from_doc.as_deref()),
+                ("footer_from_doc", envelope_cfg.footer_from_doc.as_deref()),
+            ] {
+                let Some(section) = section else { continue };
+                if !declared_envelope_sections.contains(section) {
+                    let mut declared: Vec<&str> = declared_envelope_sections
+                        .iter()
+                        .map(|s| s.as_str())
+                        .collect();
+                    declared.sort_unstable();
+                    return Err(ConfigError::Validation(format!(
+                        "[E346] output '{out}': envelope {role} references section \
+                         '{section}' which no source declares an `envelope:` section for. \
+                         Declared sections across all sources: {declared:?}. Name a declared \
+                         section, or add the section to a source's `envelope:` config"
+                    )));
+                }
+            }
+            if envelope_cfg.footer_record_count_field.is_some() && !supports_computed_footer {
+                return Err(ConfigError::Validation(format!(
+                    "[E346] output '{out}': envelope `footer_record_count_field` is not \
+                     supported for {} output — a fixed-width line has no field to inject a \
+                     computed count into without a width declaration. Drop \
+                     `footer_record_count_field`, or use a CSV / JSON / XML output",
+                    output.format.format_name()
                 )));
             }
         }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -237,6 +237,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E343" => Some(include_str!("../../../../docs/explain/E343.md")),
         "E344" => Some(include_str!("../../../../docs/explain/E344.md")),
         "E345" => Some(include_str!("../../../../docs/explain/E345.md")),
+        "E346" => Some(include_str!("../../../../docs/explain/E346.md")),
         "E347" => Some(include_str!("../../../../docs/explain/E347.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
@@ -462,7 +463,7 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E344", "E345", "E347", "E15Y", "W101", "W302", "W305", "W306",
+            "E343", "E344", "E345", "E346", "E347", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -220,6 +220,22 @@ impl DocumentContext {
             _ => None,
         }
     }
+
+    /// Borrow a whole section's ordered field map by name, for an output
+    /// writer reconstructing a per-document header/footer that echoes every
+    /// field of a `$doc` section in declared order.
+    ///
+    /// Returns `None` when the section is undeclared on this document or its
+    /// payload is not a [`Value::Map`] (the envelope config schema is always
+    /// `fields:`-shaped, so a non-Map payload means the reader emitted an
+    /// unexpected shape). The borrow is O(1) — no field is cloned; the writer
+    /// iterates the returned map in insertion order.
+    pub fn section_fields(&self, section: &str) -> Option<&IndexMap<Box<str>, Value>> {
+        match self.sections.get(section)? {
+            Value::Map(m) => Some(m),
+            _ => None,
+        }
+    }
 }
 
 // ── Spill codec ─────────────────────────────────────────────────────────────

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -53,8 +53,7 @@ impl DocumentId {
 }
 
 /// Identity of the per-outermost-logical-document **frame** a record belongs
-/// to — the grain at which the engine reconstructs an output envelope and
-/// dead-letters a whole document.
+/// to — the grain at which the engine reconstructs an output envelope.
 ///
 /// A frame is NOT always the innermost or the outermost envelope level: it is
 /// whichever level the source format treats as one logical document.
@@ -69,10 +68,14 @@ impl DocumentId {
 /// - EDIFACT, CSV, JSON, XML, fixed-width: the file is the only level, so the
 ///   frame is the file (one grain per file).
 ///
-/// `Copy`/`Eq`/`Hash` so both the envelope-writer boundary detector and the
-/// document-DLQ bucket map key on it directly. Two contexts of the same frame
-/// (e.g. the `GS` and `ST` of one X12 interchange) compare equal even though
-/// their own [`DocumentId`]s differ.
+/// `Copy`/`Eq`/`Hash` so the envelope-writer boundary detector can key on it
+/// directly. Two contexts of the same frame (e.g. the `GS` and `ST` of one X12
+/// interchange) compare equal even though their own [`DocumentId`]s differ.
+///
+/// This is distinct from the document-DLQ's keying: the DLQ keys on
+/// `source_file` (the file grain), because a structural-count failure condemns
+/// a whole file. The two never co-execute — `reconstruct_envelope` and
+/// `dlq_granularity: document` are mutually exclusive.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct DocumentGrain(DocumentId);
@@ -136,9 +139,10 @@ impl DocumentContext {
     }
 
     /// The frame this record belongs to — the grain at which output-envelope
-    /// reconstruction and document-level dead-lettering operate. Equal across
-    /// every level of one frame (e.g. an X12 interchange's `ISA`/`GS`/`ST`
-    /// contexts all report the interchange grain); distinct per HL7 message.
+    /// reconstruction operates (the document-DLQ keys on `source_file`
+    /// instead; see [`DocumentGrain`]). Equal across every level of one frame
+    /// (e.g. an X12 interchange's `ISA`/`GS`/`ST` contexts all report the
+    /// interchange grain); distinct per HL7 message.
     pub fn grain(&self) -> DocumentGrain {
         self.grain
     }
@@ -181,9 +185,8 @@ impl DocumentContext {
     /// its own `id` rather than inherited from the parent. Used for formats
     /// whose framing document is a nested level repeated within one file:
     /// each HL7 `MSH` message opens a fresh frame, so a multi-message file
-    /// frames once per message (its output envelope and document-DLQ verdict
-    /// are per message), while still resolving the enclosing `FHS`/`BHS`
-    /// `$doc.*` sections through the flattened map.
+    /// reconstructs one output envelope per message, while still resolving the
+    /// enclosing `FHS`/`BHS` `$doc.*` sections through the flattened map.
     pub fn child_frame(&self, id: DocumentId, sections: IndexMap<Box<str>, Value>) -> Self {
         self.child_inner(id, sections, DocumentGrain(id))
     }
@@ -249,8 +252,8 @@ impl DocumentContext {
 // re-hydration). The shape is a 4-tuple mirroring `Value::Map`'s pair-vec
 // encoding so section insertion order is preserved exactly:
 //   (DocumentId, DocumentGrain, source_file: &str, sections: Vec<(&str, &Value)>)
-// The `grain` rides the wire so a spilled record stays governed by the SAME
-// frame (envelope reconstruction / document-DLQ) it carried before spilling —
+// The `grain` rides the wire so a spilled record stays in the SAME envelope
+// frame it carried before spilling —
 // it is not re-derived from `id` on read, because a nested HL7 message frame's
 // grain differs from its own id. On read each `(String, Value)` pair re-inserts
 // in order into a fresh `IndexMap`, and the source file rebuilds via `Arc::from`.

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -52,6 +52,45 @@ impl DocumentId {
     pub const SYNTHETIC: Self = Self(0);
 }
 
+/// Identity of the per-outermost-logical-document **frame** a record belongs
+/// to — the grain at which the engine reconstructs an output envelope and
+/// dead-letters a whole document.
+///
+/// A frame is NOT always the innermost or the outermost envelope level: it is
+/// whichever level the source format treats as one logical document.
+///
+/// - X12 (ISA → GS → ST): the frame is the **interchange** (the file-level
+///   `ISA`). The `GS` functional group and `ST` transaction set
+///   [`DocumentContext::child`] levels INHERIT the interchange grain, so a
+///   whole interchange frames as one document.
+/// - HL7 (FHS → BHS → MSH): the frame is the **message**. Each `MSH` opens a
+///   fresh grain via [`DocumentContext::child_frame`], so a multi-message file
+///   frames once per message.
+/// - EDIFACT, CSV, JSON, XML, fixed-width: the file is the only level, so the
+///   frame is the file (one grain per file).
+///
+/// `Copy`/`Eq`/`Hash` so both the envelope-writer boundary detector and the
+/// document-DLQ bucket map key on it directly. Two contexts of the same frame
+/// (e.g. the `GS` and `ST` of one X12 interchange) compare equal even though
+/// their own [`DocumentId`]s differ.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DocumentGrain(DocumentId);
+
+impl DocumentGrain {
+    /// The grain shared by every record produced outside a real document
+    /// (Transform synthesis, fan-in merge rows, test fixtures) — the grain of
+    /// the [`DocumentId::SYNTHETIC`] context. Such records belong to no frame,
+    /// so callers treat this grain as "unframed".
+    pub const SYNTHETIC: Self = Self(DocumentId::SYNTHETIC);
+
+    /// The inner [`DocumentId`] this grain is identified by — the id of the
+    /// framing level (the X12 interchange, the HL7 message, or the file).
+    pub fn document_id(self) -> DocumentId {
+        self.0
+    }
+}
+
 /// Envelope context for one document.
 ///
 /// One per source file. The `sections` map holds every envelope section
@@ -65,6 +104,11 @@ impl DocumentId {
 #[derive(Debug)]
 pub struct DocumentContext {
     id: DocumentId,
+    /// The frame this context belongs to. A file-level context's grain is its
+    /// own [`DocumentId`]; a [`Self::child`] level inherits its parent's
+    /// grain; a [`Self::child_frame`] level mints a new grain from its own id.
+    /// See [`DocumentGrain`] for the per-format mapping.
+    grain: DocumentGrain,
     source_file: Arc<str>,
     sections: IndexMap<Box<str>, Value>,
 }
@@ -73,9 +117,14 @@ impl DocumentContext {
     /// Build a populated document context for a single source file.
     /// Called once per file by the source ingest path after the reader's
     /// envelope pre-scan returns the section map.
+    ///
+    /// The file-level document is its own frame: its [`grain`](Self::grain)
+    /// is derived from `id`. Nested levels inherit or re-mint this grain via
+    /// [`Self::child`] / [`Self::child_frame`].
     pub fn new(id: DocumentId, source_file: Arc<str>, sections: IndexMap<Box<str>, Value>) -> Self {
         Self {
             id,
+            grain: DocumentGrain(id),
             source_file,
             sections,
         }
@@ -84,6 +133,14 @@ impl DocumentContext {
     /// Opaque identity for dedup and per-document bucketing.
     pub fn id(&self) -> DocumentId {
         self.id
+    }
+
+    /// The frame this record belongs to — the grain at which output-envelope
+    /// reconstruction and document-level dead-lettering operate. Equal across
+    /// every level of one frame (e.g. an X12 interchange's `ISA`/`GS`/`ST`
+    /// contexts all report the interchange grain); distinct per HL7 message.
+    pub fn grain(&self) -> DocumentGrain {
+        self.grain
     }
 
     /// Originating source file path. Equal to `$source.file` for records
@@ -114,12 +171,36 @@ impl DocumentContext {
     /// — envelope payloads are small (a few fields per level), so the copy
     /// is O(declared sections), not O(body).
     pub fn child(&self, id: DocumentId, sections: IndexMap<Box<str>, Value>) -> Self {
+        self.child_inner(id, sections, self.grain)
+    }
+
+    /// Open a nested level that begins a NEW document frame.
+    ///
+    /// Identical to [`Self::child`] in section flattening and `source_file`
+    /// inheritance, but the new level's [`grain`](Self::grain) is minted from
+    /// its own `id` rather than inherited from the parent. Used for formats
+    /// whose framing document is a nested level repeated within one file:
+    /// each HL7 `MSH` message opens a fresh frame, so a multi-message file
+    /// frames once per message (its output envelope and document-DLQ verdict
+    /// are per message), while still resolving the enclosing `FHS`/`BHS`
+    /// `$doc.*` sections through the flattened map.
+    pub fn child_frame(&self, id: DocumentId, sections: IndexMap<Box<str>, Value>) -> Self {
+        self.child_inner(id, sections, DocumentGrain(id))
+    }
+
+    fn child_inner(
+        &self,
+        id: DocumentId,
+        sections: IndexMap<Box<str>, Value>,
+        grain: DocumentGrain,
+    ) -> Self {
         let mut merged = self.sections.clone();
         for (name, payload) in sections {
             merged.insert(name, payload);
         }
         Self {
             id,
+            grain,
             source_file: Arc::clone(&self.source_file),
             sections: merged,
         }
@@ -149,14 +230,17 @@ impl DocumentContext {
 // `Arc<str>` source file must collapse to its bytes on the wire and rebuild as
 // a fresh `Arc<str>` on read (the in-memory `Arc` identity does not — and need
 // not — survive the spill boundary; see the module-level note on per-document
-// re-hydration). The shape is a 3-tuple mirroring `Value::Map`'s pair-vec
+// re-hydration). The shape is a 4-tuple mirroring `Value::Map`'s pair-vec
 // encoding so section insertion order is preserved exactly:
-//   (DocumentId, source_file: &str, sections: Vec<(&str, &Value)>)
-// On read each `(String, Value)` pair re-inserts in order into a fresh
-// `IndexMap`, and the source file rebuilds via `Arc::from`.
+//   (DocumentId, DocumentGrain, source_file: &str, sections: Vec<(&str, &Value)>)
+// The `grain` rides the wire so a spilled record stays governed by the SAME
+// frame (envelope reconstruction / document-DLQ) it carried before spilling —
+// it is not re-derived from `id` on read, because a nested HL7 message frame's
+// grain differs from its own id. On read each `(String, Value)` pair re-inserts
+// in order into a fresh `IndexMap`, and the source file rebuilds via `Arc::from`.
 
 impl Serialize for DocumentContext {
-    /// Serializes this context as `(id, source_file, ordered section pairs)`.
+    /// Serializes this context as `(id, grain, source_file, ordered section pairs)`.
     ///
     /// Used only by the spill interning path, which writes one context frame
     /// per distinct document per file (`O(distinct documents)`, never
@@ -165,8 +249,9 @@ impl Serialize for DocumentContext {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let pairs: Vec<(&str, &Value)> =
             self.sections.iter().map(|(k, v)| (k.as_ref(), v)).collect();
-        let mut tup = serializer.serialize_tuple(3)?;
+        let mut tup = serializer.serialize_tuple(4)?;
         tup.serialize_element(&self.id)?;
+        tup.serialize_element(&self.grain)?;
         tup.serialize_element(self.source_file.as_ref())?;
         tup.serialize_element(&pairs)?;
         tup.end()
@@ -174,13 +259,14 @@ impl Serialize for DocumentContext {
 }
 
 impl<'de> Deserialize<'de> for DocumentContext {
-    /// Reconstructs a context from `(id, source_file, ordered section pairs)`.
+    /// Reconstructs a context from `(id, grain, source_file, ordered section pairs)`.
     ///
     /// Rebuilds the `source_file` as a fresh `Arc<str>` and re-inserts the
     /// section pairs into a new `IndexMap` in wire order, so a document's
     /// section ordering survives a spill round-trip. The rebuilt `Arc<str>`
     /// is a distinct allocation from the live ingest stream's — equality is
-    /// by content, not pointer identity.
+    /// by content, not pointer identity. The `grain` round-trips verbatim so
+    /// the record stays governed by the frame it spilled with.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct ContextVisitor;
 
@@ -188,32 +274,39 @@ impl<'de> Deserialize<'de> for DocumentContext {
             type Value = DocumentContext;
 
             fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-                write!(f, "a (DocumentId, source_file, sections) tuple")
+                write!(
+                    f,
+                    "a (DocumentId, DocumentGrain, source_file, sections) tuple"
+                )
             }
 
             fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<DocumentContext, A::Error> {
                 let id: DocumentId = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let source_file: std::string::String = seq
+                let grain: DocumentGrain = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                let pairs: Vec<(std::string::String, Value)> = seq
+                let source_file: std::string::String = seq
                     .next_element()?
                     .ok_or_else(|| de::Error::invalid_length(2, &self))?;
+                let pairs: Vec<(std::string::String, Value)> = seq
+                    .next_element()?
+                    .ok_or_else(|| de::Error::invalid_length(3, &self))?;
                 let mut sections = IndexMap::with_capacity(pairs.len());
                 for (k, v) in pairs {
                     sections.insert(k.into_boxed_str(), v);
                 }
                 Ok(DocumentContext {
                     id,
+                    grain,
                     source_file: Arc::from(source_file.as_str()),
                     sections,
                 })
             }
         }
 
-        deserializer.deserialize_tuple(3, ContextVisitor)
+        deserializer.deserialize_tuple(4, ContextVisitor)
     }
 }
 
@@ -222,6 +315,7 @@ fn synthetic_storage() -> &'static Arc<DocumentContext> {
     SYNTHETIC.get_or_init(|| {
         Arc::new(DocumentContext {
             id: DocumentId::SYNTHETIC,
+            grain: DocumentGrain::SYNTHETIC,
             source_file: Arc::from(""),
             sections: IndexMap::new(),
         })
@@ -351,6 +445,64 @@ mod tests {
         );
         // The parent never gained the child's section.
         assert!(parent.get_section_field("group", "functional_id").is_none());
+
+        // X12 grain: a `child` level INHERITS the parent's frame grain, so a
+        // GS/ST level reports the interchange (ISA file-level) grain — one
+        // frame per interchange, not per transaction set.
+        assert_eq!(child.grain(), parent.grain());
+        assert_eq!(parent.grain().document_id(), parent.id());
+    }
+
+    #[test]
+    fn file_level_grain_is_its_own_id() {
+        // A file-level document (CSV/JSON/XML/fixed-width/EDIFACT and the X12
+        // ISA / HL7 FHS) is its own frame: grain == id.
+        let ctx = DocumentContext::new(DocumentId::next(), Arc::from("a.csv"), IndexMap::new());
+        assert_eq!(ctx.grain().document_id(), ctx.id());
+    }
+
+    #[test]
+    fn child_frame_mints_a_fresh_grain_per_level() {
+        // HL7 grain: each `MSH` message opens a fresh frame via `child_frame`,
+        // so two messages of one file get DISTINCT grains (one envelope frame
+        // per message) while still inheriting the file's `source_file` and any
+        // enclosing `$doc.*` sections.
+        let file: Arc<str> = Arc::from("messages.hl7");
+        let mut fhs = IndexMap::new();
+        fhs.insert(
+            Box::from("file_header"),
+            make_section(&[("sender", Value::String("LAB".into()))]),
+        );
+        let file_doc = DocumentContext::new(DocumentId::next(), Arc::clone(&file), fhs);
+
+        let msg1 = file_doc.child_frame(DocumentId::next(), IndexMap::new());
+        let msg2 = file_doc.child_frame(DocumentId::next(), IndexMap::new());
+
+        // Each message is its own frame.
+        assert_ne!(msg1.grain(), msg2.grain());
+        assert_eq!(msg1.grain().document_id(), msg1.id());
+        assert_eq!(msg2.grain().document_id(), msg2.id());
+        // And neither shares the file-level frame.
+        assert_ne!(msg1.grain(), file_doc.grain());
+        // Both still resolve the enclosing FHS section and share the file.
+        assert_eq!(
+            msg1.get_section_field("file_header", "sender"),
+            Some(Value::String("LAB".into()))
+        );
+        assert!(Arc::ptr_eq(msg1.source_file(), &file));
+        assert!(Arc::ptr_eq(msg2.source_file(), &file));
+    }
+
+    #[test]
+    fn grandchild_inherits_the_nearest_frame_grain() {
+        // A `child_frame` (HL7 message) followed by an ordinary `child`
+        // (a hypothetical sub-level) keeps the message's grain — `child`
+        // always inherits its parent's grain, wherever that frame began.
+        let file = DocumentContext::new(DocumentId::next(), Arc::from("f.hl7"), IndexMap::new());
+        let message = file.child_frame(DocumentId::next(), IndexMap::new());
+        let sub = message.child(DocumentId::next(), IndexMap::new());
+        assert_eq!(sub.grain(), message.grain());
+        assert_ne!(sub.grain(), file.grain());
     }
 
     #[test]
@@ -434,12 +586,28 @@ mod tests {
         );
         sections.insert(Box::from("m_section"), make_section(&[]));
         let id = DocumentId::next();
-        let ctx = DocumentContext::new(id, Arc::from("payments/run-001.xml"), sections);
+        // Model an HL7 message frame: build a file-level context, then a
+        // `child_frame` whose grain differs from its own id, so the round-trip
+        // proves the grain is carried verbatim (not re-derived from id).
+        let file_doc = DocumentContext::new(id, Arc::from("payments/run-001.xml"), IndexMap::new());
+        let ctx = file_doc.child_frame(DocumentId::next(), sections);
+        let expected_grain = ctx.grain();
+        let expected_id = ctx.id();
+        assert_ne!(
+            expected_grain.document_id(),
+            file_doc.id(),
+            "a child_frame's grain is its own id, distinct from the parent's"
+        );
 
         let bytes = postcard::to_stdvec(&ctx).unwrap();
         let back: DocumentContext = postcard::from_bytes(&bytes).unwrap();
 
-        assert_eq!(back.id(), id);
+        assert_eq!(back.id(), expected_id);
+        assert_eq!(
+            back.grain(),
+            expected_grain,
+            "grain round-trips verbatim, not re-derived from id"
+        );
         assert_eq!(back.source_file().as_ref(), "payments/run-001.xml");
         // Section names survive in insertion order, not sorted order.
         let names: Vec<&str> = back.sections.keys().map(|k| k.as_ref()).collect();

--- a/crates/clinker-record/src/lib.rs
+++ b/crates/clinker-record/src/lib.rs
@@ -21,7 +21,8 @@ pub use coercion::{
 };
 pub use counters::{PipelineCounters, RetractionCounters};
 pub use document_context::{
-    DocumentContext, DocumentId, synthetic_document_context, synthetic_document_context_ref,
+    DocumentContext, DocumentGrain, DocumentId, synthetic_document_context,
+    synthetic_document_context_ref,
 };
 pub use field_str::FieldStr;
 pub use group_key::{GroupByKey, GroupKeyError, value_to_group_key};

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -1997,7 +1997,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E345/E347, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E347, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/docs/explain/E346.md
+++ b/docs/explain/E346.md
@@ -1,0 +1,91 @@
+# Error E346: output envelope references an unknown section or an unsupported computed footer
+
+## What it means
+
+A generic-format Output (CSV / JSON / XML / fixed-width) declares
+`reconstruct_envelope: true` with an `envelope:` block whose `header_from_doc`
+or `footer_from_doc` names a `$doc` section that no source in the pipeline
+declares, OR requests a computed footer (`footer_record_count_field`) on a
+format that cannot inject a computed field into its footer (fixed-width).
+
+The output envelope echoes a named document section before the body (the
+header) and another after it (the footer), mirroring the EDI per-document
+reconstruction vocabulary. The section names are matched against the
+`envelope:` sections declared on the sources, so a typo or a missing source
+declaration would otherwise produce an empty header/footer with no diagnostic.
+E346 catches the mismatch at plan-validation time instead.
+
+```
+[E346] output 'out': envelope header_from_doc references section 'Headr' which
+no source declares an `envelope:` section for. Declared sections across all
+sources: ["Head", "Foot"]. Name a declared section, or add the section to a
+source's `envelope:` config
+```
+
+```
+[E346] output 'out': envelope `footer_record_count_field` is not supported for
+fixed-width output — a fixed-width line has no field to inject a computed count
+into without a width declaration. Drop `footer_record_count_field`, or use a
+CSV / JSON / XML output
+```
+
+## Example
+
+```yaml
+# Rejected: header_from_doc names a section no source declares.
+pipeline:
+  name: payments
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: xml
+      path: ./run.xml
+      envelope:
+        sections:
+          Head:                       # declared section name is "Head"
+            extract: { xml_path: /Batch/Header }
+            fields: { batch_id: string }
+  - type: output
+    name: out
+    input: payments
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: Headr      # typo — no such section
+```
+
+```yaml
+# Corrected: the header names the declared section.
+      options:
+        envelope:
+          header_from_doc: Head
+```
+
+## How to fix
+
+1. **Match a declared section name.** Set `header_from_doc` / `footer_from_doc`
+   to a section name that appears under some source's `envelope: sections:`.
+   The diagnostic lists every section declared across the pipeline's sources.
+
+2. **Declare the section on a source.** If the section should exist but no
+   source extracts it, add it to a source's `envelope:` config.
+
+3. **Drop the computed footer on fixed-width.** Fixed-width output cannot carry
+   a `footer_record_count_field` — remove it, or switch the Output to CSV /
+   JSON / XML, which can.
+
+## Technical context
+
+Validation runs in `clinker-plan` after the `reconstruct_envelope`
+compatibility checks (E347). It collects every section name declared across all
+sources' `envelope:` configs, then verifies each generic Output's
+`header_from_doc` / `footer_from_doc` against that set and rejects a
+`footer_record_count_field` on a fixed-width Output. Section names are
+user-defined — the engine reserves none — so the only check is membership in
+the declared set.

--- a/docs/explain/E346.md
+++ b/docs/explain/E346.md
@@ -89,3 +89,9 @@ sources' `envelope:` configs, then verifies each generic Output's
 `footer_record_count_field` on a fixed-width Output. Section names are
 user-defined — the engine reserves none — so the only check is membership in
 the declared set.
+
+## See also
+
+- "Output envelope reconstruction" in the output reference
+- Error E347, the `reconstruct_envelope` pipeline-shape conflicts
+- Error E341, the closed-envelope-schema `$doc.<section>.<field>` check

--- a/docs/explain/E346.md
+++ b/docs/explain/E346.md
@@ -3,23 +3,37 @@
 ## What it means
 
 A generic-format Output (CSV / JSON / XML / fixed-width) declares
-`reconstruct_envelope: true` with an `envelope:` block whose `header_from_doc`
-or `footer_from_doc` names a `$doc` section that no source in the pipeline
-declares, OR requests a computed footer (`footer_record_count_field`) on a
-format that cannot inject a computed field into its footer (fixed-width).
+`reconstruct_envelope: true` with an `envelope:` block that is malformed in one
+of three ways:
+
+1. `header_from_doc` / `footer_from_doc` names a `$doc` section that none of
+   the sources FEEDING this output declares;
+2. `footer_record_count_field` is set without a `footer_from_doc` to attach
+   the computed count to;
+3. `footer_record_count_field` is set on a format whose lines are positional
+   (fixed-width), which has no field to inject a computed count into.
 
 The output envelope echoes a named document section before the body (the
 header) and another after it (the footer), mirroring the EDI per-document
 reconstruction vocabulary. The section names are matched against the
-`envelope:` sections declared on the sources, so a typo or a missing source
-declaration would otherwise produce an empty header/footer with no diagnostic.
+`envelope:` sections declared on the output's FEEDING sources (not the
+pipeline-wide union — a section declared only on a source that does not feed
+this output would silently produce an empty header/footer), so a typo or a
+missing declaration would otherwise emit empty framing with no diagnostic.
 E346 catches the mismatch at plan-validation time instead.
 
 ```
 [E346] output 'out': envelope header_from_doc references section 'Headr' which
-no source declares an `envelope:` section for. Declared sections across all
-sources: ["Head", "Foot"]. Name a declared section, or add the section to a
-source's `envelope:` config
+no source feeding this output declares an `envelope:` section for. Sections
+declared by the feeding source(s): ["Head", "Foot"]. Name a declared section,
+or add the section to a feeding source's `envelope:` config
+```
+
+```
+[E346] output 'out': envelope `footer_record_count_field` requires
+`footer_from_doc` — the computed record count is injected into the footer
+section, so a footer section must be named for it to attach to. Add
+`footer_from_doc`, or drop `footer_record_count_field`
 ```
 
 ```

--- a/docs/explain/E347.md
+++ b/docs/explain/E347.md
@@ -8,7 +8,7 @@ honor. Envelope reconstruction frames one document stream into a **single**
 writer — emitting a per-document header before each document's first record and
 a footer after its last — so it is incompatible with anything that routes the
 same records to a different writer or buffers them under a different commit
-model. Three combinations are rejected:
+model. Four combinations are rejected:
 
 - **Per-file output `split:` / a per-source-file path template**
   (`{source_file}` / `{source_path}`). These fan each record out to a writer
@@ -25,6 +25,14 @@ model. Three combinations are rejected:
   writes through its own commit stage, which the envelope arm bypasses. Dirty
   correlation groups would leak into the framed output and inflate the success
   counts.
+
+- **An upstream node that strips document lineage** — a cross-document
+  `Combine`, an `Aggregate` (whose group rows finalize through a merged eval
+  context, even under per-document aggregation), or a `Composition` (whose body
+  is opaque at validation time). These emit records with no originating
+  document (`<merged>` lineage), which the envelope arm streams UNFRAMED: for
+  JSON that is body bytes outside any open document object — malformed JSON —
+  and for every format it silently drops the framing or miscounts the footer.
 
 ```
 [E347] output 'out': `reconstruct_envelope` cannot be combined with per-file


### PR DESCRIPTION
## Summary

Implements **#546 / #194b** — output-envelope config + per-document header/footer for the four generic-format writers, on top of the #194a executor seam (#548). Closes #546.

### Grain fix (blocker #1, done first)
Introduces `DocumentGrain(DocumentId)` on `DocumentContext` — set in `new()` (file-level doc id), **inherited** through `child()`, **re-minted** in the new `child_frame()`. Readers signal which nested level starts a frame via `EnvelopeEvent::OpenLevel { frame: FrameRole }` (`Inherit` | `NewFrame`). The envelope-writer boundary detector now keys on `doc_ctx.grain()` instead of `source_file`, and the grain rides the spill codec verbatim (replacing the old `Arc::ptr_eq` + string-equality dance).

Per-format framing (verified against the readers):
- **X12** (ISA→GS→ST): GS/ST `Inherit` → one frame per **interchange**.
- **HL7** (FHS→BHS→MSH): each MSH `NewFrame` → one frame per **message**.
- **EDIFACT**: one frame per interchange/file (see Limitations).
- **CSV/JSON/XML/fixed-width**: one frame per file.

### Config + writers
`OutputEnvelopeConfig` (`header_from_doc` / `footer_from_doc` / `footer_record_count_field`) on the four generic options, mirroring the EDI `*_from_doc` vocabulary. `begin_document`/`end_document` implemented in csv/json/xml/fixed_width. **Bounded memory** preserved (header on open, body streamed, footer on close — never buffer a document's records). JSON's whole-stream-array framing is reframed to per-document objects. `reconstruct_envelope: false` path is byte-identical.

### Diagnostic
**E346** at plan-validation: (a) an envelope references a `$doc` section no source declares, or (b) a computed footer on fixed-width (positional lines can't inject a computed field). Explain doc added.

## ⚠️ Review focus — deliberate deviations (flagged for the gate)
1. **Document-DLQ kept at file grain, NOT unified to `DocumentGrain`.** The handoff's blocker wording said "shared grain for both drivers", but a message-grain DLQ broke HL7 BTS whole-document condemnation (`hl7_bts_count_mismatch_rejects_whole_document`). DLQ stays file-grain; framing is per-message; both use `DocumentGrain` as the type. **Please confirm this is the correct semantics.**
2. **EDIFACT frames per interchange, not per message** — the EDIFACT reader emits no per-message context (UNH is a body-record column), so per-message framing would need a reader rewrite. Out of scope here; deferred.

## Limitations / follow-ups (→ #547)
JSON envelope object uses fixed `header`/`body`/`footer` keys; XML `<Document>` wrapper name is hardcoded; fixed-width envelope lines are unpadded (sections carry no width schema). Golden round-trip fixtures (#547) are the place to lock these shapes.

## Verification
Full 8-step gauntlet green (run with an isolated `CARGO_TARGET_DIR` — the repo's `.cargo/config.toml` shares one target dir across worktrees). New tests: grain unit tests, per-writer envelope framing, multi-message HL7 framing, nested-X12 interchange framing, spill-rebuild stability, E346 arms, and an end-to-end two-document CSV envelope test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
