### PR TITLE
plan: validate $doc paths for segment/positional + REST sources (#481, #507)

### DIFF
--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -82,9 +82,11 @@
 //! | `E338`      | error    | `x12` output combined with byte-limit `split` (an interchange is one indivisible ISA..IEA envelope) |
 //! | `E339`      | error    | `hl7` output combined with byte-limit `split` (a batch/file envelope is one indivisible FHS..FTS structure) |
 //! | `E340`      | error    | A `$doc.<section>.<field>` access is indexed by a non-literal expression, so its declared document path cannot be resolved at compile time |
-//! | `E341`      | error    | A `$doc.<section>.<field>` access names an envelope section or field a feeding XML/JSON source does not declare |
+//! | `E341`      | error    | A `$doc.<section>.<field>` access names an envelope section or field a feeding closed-schema source (XML / JSON) does not declare |
 //! | `E342`      | error    | `swift` output combined with byte-limit `split` (a SWIFT MT message is one indivisible brace-balanced `{1:..}..{5:..}` envelope) |
 //! | `E343`      | error    | A per-source-file output template (`{source_file}` / `{source_path}`) combined with a source declaring `dlq_granularity: document` (a buffered-and-flushed document is incompatible with per-record file fan-out) |
+//! | `E348`      | error    | A `$doc.<section>.<field>` access against a segment/positional source (X12 / EDIFACT / HL7) names a section the format does not synthesize, or a positional element outside the `e`/`f`-prefix pattern or beyond the configured `max_elements` / `max_fields` |
+//! | `E349`      | error    | A `$doc.<section>.<field>` access is attributed to a `rest` source (or a `rest` source declares an `envelope:` block) — a REST pull buffers no document, so the access can never resolve |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -31,7 +31,11 @@ use crate::traits::FormatReader;
 /// Default ceiling on the number of positional element columns the
 /// record schema exposes. A segment carrying more data elements than
 /// this errors with guidance rather than silently truncating.
-const DEFAULT_MAX_ELEMENTS: usize = 32;
+///
+/// Public so the planner's `$doc` positional-element validation can bound
+/// against the same ceiling the reader enforces, rather than duplicating
+/// the literal (which would silently drift if either changed).
+pub const DEFAULT_MAX_ELEMENTS: usize = 32;
 
 /// Configuration for the EDIFACT reader.
 pub struct EdifactReaderConfig {

--- a/crates/clinker-format/src/hl7/reader.rs
+++ b/crates/clinker-format/src/hl7/reader.rs
@@ -53,7 +53,11 @@ use crate::traits::FormatReader;
 /// Default ceiling on the number of positional field columns the record
 /// schema exposes. A segment carrying more data fields than this errors
 /// with guidance rather than silently truncating.
-const DEFAULT_MAX_FIELDS: usize = 64;
+///
+/// Public so the planner's `$doc` positional-field validation can bound
+/// against the same ceiling the reader enforces, rather than duplicating
+/// the literal (which would silently drift if either changed).
+pub const DEFAULT_MAX_FIELDS: usize = 64;
 
 /// The envelope segment tag `prepare_document` can extract as a `$doc`
 /// section. Only the file header `FHS` is resolvable from the bounded

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -28,3 +28,11 @@ pub use envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 pub use error::FormatError;
 pub use source::ReopenableSource;
 pub use traits::{FormatReader, FormatWriter};
+
+// Default positional-element/field ceilings each reader enforces on a
+// body segment, re-exported under format-disambiguated names so the
+// planner's `$doc` positional bound references the reader's own constant
+// instead of a duplicated literal that could silently drift.
+pub use edifact::reader::DEFAULT_MAX_ELEMENTS as EDIFACT_DEFAULT_MAX_ELEMENTS;
+pub use hl7::reader::DEFAULT_MAX_FIELDS as HL7_DEFAULT_MAX_FIELDS;
+pub use x12::reader::DEFAULT_MAX_ELEMENTS as X12_DEFAULT_MAX_ELEMENTS;

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -44,7 +44,11 @@ use crate::x12::tokenizer::{ParsedSegment, SegmentTokenizer, split_isa, split_se
 /// Default ceiling on the number of positional element columns the record
 /// schema exposes. A segment carrying more data elements than this errors
 /// with guidance rather than silently truncating.
-const DEFAULT_MAX_ELEMENTS: usize = 32;
+///
+/// Public so the planner's `$doc` positional-element validation can bound
+/// against the same ceiling the reader enforces, rather than duplicating
+/// the literal (which would silently drift if either changed).
+pub const DEFAULT_MAX_ELEMENTS: usize = 32;
 
 /// The envelope segment tags `prepare_document` can extract as `$doc`
 /// sections. Only the interchange header `ISA` is resolvable from the

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2,6 +2,10 @@
 
 use super::*;
 use crate::yaml::Spanned;
+// Default `fNN`/`eNN` ceilings each reader enforces, referenced by the HL7
+// split-field reachability check and the `$doc` positional-bound validation
+// so the planner's bounds cannot drift from the reader's own constants.
+use clinker_format::HL7_DEFAULT_MAX_FIELDS;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -889,55 +893,63 @@ impl PipelineConfig {
         // doc paths against the source(s) feeding that Output, so the reader
         // retains the section. The reader extracts the whole declared section
         // once any of its fields is wanted, so one path per declared field is
-        // sufficient (and passes the E341 closed-schema check, since each
-        // field is real). A header/footer naming an undeclared section is
-        // rejected separately by E346 below, so an absent section here is fine.
-        {
-            let source_by_name: HashMap<&str, &crate::config::SourceConfig> = source_configs
-                .iter()
-                .map(|s| (s.name.as_str(), s))
-                .collect();
-            for output in self.output_configs() {
-                if !output.reconstruct_envelope {
-                    continue;
-                }
-                let Some((env_cfg, _)) = generic_output_envelope(&output.format) else {
+        // sufficient.
+        //
+        // These registered paths drive the reader's path-pruned extraction
+        // (consumed at the `declared_doc_paths` stamp below); they do NOT
+        // flow through the `doc_schema_for` / E341/E348 validation pass,
+        // which iterates `doc_path_set.by_node` (the CXL `$doc.*` refs) and
+        // never sees this register map. A header/footer naming an undeclared
+        // section is rejected separately by E346 below, so an absent section
+        // here is fine.
+        //
+        // `source_by_name` is shared by this register block and the
+        // E341/E348/E349 validation pass below — one index over the source
+        // configs serves both.
+        let source_by_name: HashMap<&str, &crate::config::SourceConfig> = source_configs
+            .iter()
+            .map(|s| (s.name.as_str(), s))
+            .collect();
+        for output in self.output_configs() {
+            if !output.reconstruct_envelope {
+                continue;
+            }
+            let Some((env_cfg, _)) = generic_output_envelope(&output.format) else {
+                continue;
+            };
+            let sections: Vec<&str> = [
+                env_cfg.header_from_doc.as_deref(),
+                env_cfg.footer_from_doc.as_deref(),
+            ]
+            .into_iter()
+            .flatten()
+            .collect();
+            if sections.is_empty() {
+                continue;
+            }
+            let Some(feeding) = node_sources.get(&output.name) else {
+                continue;
+            };
+            for source_name in feeding {
+                let Some(source) = source_by_name.get(source_name.as_str()) else {
                     continue;
                 };
-                let sections: Vec<&str> = [
-                    env_cfg.header_from_doc.as_deref(),
-                    env_cfg.footer_from_doc.as_deref(),
-                ]
-                .into_iter()
-                .flatten()
-                .collect();
-                if sections.is_empty() {
-                    continue;
-                }
-                let Some(feeding) = node_sources.get(&output.name) else {
+                let Some(envelope) = source.envelope.as_ref() else {
                     continue;
                 };
-                for source_name in feeding {
-                    let Some(source) = source_by_name.get(source_name.as_str()) else {
+                let paths = declared_doc_paths.entry(source_name.clone()).or_default();
+                for section_name in &sections {
+                    let Some(section) = envelope.sections.get(*section_name) else {
                         continue;
                     };
-                    let Some(envelope) = source.envelope.as_ref() else {
-                        continue;
-                    };
-                    let paths = declared_doc_paths.entry(source_name.clone()).or_default();
-                    for section_name in &sections {
-                        let Some(section) = envelope.sections.get(*section_name) else {
-                            continue;
+                    for field in section.fields.keys() {
+                        let path = cxl::analyzer::doc_paths::DocPath {
+                            section: Box::from(*section_name),
+                            field: Box::from(field.as_str()),
+                            indices: Vec::new(),
                         };
-                        for field in section.fields.keys() {
-                            let path = cxl::analyzer::doc_paths::DocPath {
-                                section: Box::from(*section_name),
-                                field: Box::from(field.as_str()),
-                                indices: Vec::new(),
-                            };
-                            if !paths.contains(&path) {
-                                paths.push(path);
-                            }
+                        if !paths.contains(&path) {
+                            paths.push(path);
                         }
                     }
                 }
@@ -965,9 +977,14 @@ impl PipelineConfig {
         //   positional element is caught without false-positiving on a
         //   legitimate wire path.
         // - Unvalidated: CSV, fixed-width, SWIFT (see `doc_schema_for`).
-        let source_by_name: HashMap<&str, &crate::config::SourceConfig> = source_configs
+        //
+        // `doc_schema_for` is keyed once per source here, not rebuilt on
+        // every (path × node × source) iteration of the loop below — a
+        // `SegmentPositional` schema allocates its synthesized-section
+        // vector, so recomputing it per reference would be wasteful.
+        let doc_schema_by_source: HashMap<&str, DocSchema> = source_configs
             .iter()
-            .map(|s| (s.name.as_str(), s))
+            .map(|s| (s.name.as_str(), doc_schema_for(s)))
             .collect();
         // E349 — a `rest` source that declares an `envelope:` block. The
         // declaration is always inert (a REST pull buffers no document), so
@@ -1026,12 +1043,12 @@ impl PipelineConfig {
                         diags.push(rest_doc_access_diagnostic(&source.name, doc_path, primary));
                         continue;
                     }
-                    let problem = match doc_schema_for(source) {
-                        DocSchema::Closed => closed_doc_path_problem(source, doc_path),
-                        DocSchema::SegmentPositional(schema) => {
-                            segment_positional_doc_path_problem(source, &schema, doc_path)
+                    let problem = match doc_schema_by_source.get(source_name.as_str()) {
+                        Some(DocSchema::Closed) => closed_doc_path_problem(source, doc_path),
+                        Some(DocSchema::SegmentPositional(schema)) => {
+                            segment_positional_doc_path_problem(source, schema, doc_path)
                         }
-                        DocSchema::Unvalidated => None,
+                        Some(DocSchema::Unvalidated) | None => None,
                     };
                     let Some(problem) = problem else {
                         continue;
@@ -2423,10 +2440,21 @@ struct SegmentPositionalSchema {
     /// Positional field-name prefix: `e` for X12/EDIFACT element columns
     /// (`e01`…), `f` for HL7 field columns (`f01`…).
     positional_prefix: char,
-    /// 1-based upper bound on a positional element/field, mirroring the
-    /// reader's `max_elements` / `max_fields` (a segment carrying more is
-    /// rejected at read time, so a `$doc` reference past it can never
-    /// resolve).
+    /// 1-based upper bound on a positional element/field, set to the
+    /// reader's body-segment ceiling (`max_elements` / `max_fields`).
+    ///
+    /// This is a LOOSE bound, not a tight per-segment guarantee. The
+    /// synthesized nested levels are keyed by the *header* segment's actual
+    /// arity (an X12 `ST` carries ~3 elements, a `GS` ~8; an HL7 `MSH`/`BHS`
+    /// likewise has a fixed-ish field count), but that precise per-segment
+    /// arity is not known at plan time — and the readers themselves do not
+    /// enforce it (they cap only the body-segment element/field count). So
+    /// positional validation catches an unknown section name and a
+    /// grossly-out-of-range element (past the body max), but a mid-range
+    /// positional typo on a short header segment — e.g. `$doc.transaction_set.e20`
+    /// on a 3-element `ST` — passes here and still resolves null at run
+    /// time. Tightening to per-segment arity is tracked as a follow-up
+    /// (see `doc_schema_for`).
     max_positional: usize,
 }
 
@@ -2449,12 +2477,14 @@ enum SynthesizedFields {
     /// `set_section.fields`). The reader coerces and serves ONLY these
     /// fields, so the section is closed to them — an undeclared name (even
     /// an in-range positional one) resolves null.
+    ///
+    /// Owned `Vec<String>` rather than a borrow of the source's `IndexMap`:
+    /// the `DocSchema` is cached once per source and a borrow would thread a
+    /// lifetime through the cache and every helper signature, for a linear
+    /// scan over a handful of declared field names. Membership is checked
+    /// with `.iter().any(..)` — O(declared fields), trivially small.
     Declared(Vec<String>),
 }
-
-/// Default `eNN` element count for X12 and EDIFACT when `max_elements` is
-/// unset, matching each reader's `DEFAULT_MAX_ELEMENTS`.
-const EDI_DEFAULT_MAX_ELEMENTS: usize = 32;
 
 /// Build a synthesized nested section from an optional user-declared nested
 /// schema: a declared schema closes the section to its declared field
@@ -2478,6 +2508,12 @@ fn synthesized_section(
 /// Classify how a source's `$doc` references are validated, from its
 /// format. The REST transport is checked by the caller before this is
 /// consulted, so this maps purely on `InputFormat`.
+///
+/// The positional bound is the reader's body-segment ceiling, not the
+/// header segment's precise arity (see [`SegmentPositionalSchema`]). A
+/// tighter per-segment-arity bound — to catch a mid-range positional typo
+/// on a short header segment — is tracked at
+/// <https://github.com/rustpunk/clinker/issues/558>.
 fn doc_schema_for(source: &crate::config::SourceConfig) -> DocSchema {
     match &source.format {
         InputFormat::Xml(_) | InputFormat::Json(_) => DocSchema::Closed,
@@ -2497,7 +2533,7 @@ fn doc_schema_for(source: &crate::config::SourceConfig) -> DocSchema {
                 positional_prefix: 'e',
                 max_positional: opts
                     .and_then(|o| o.max_elements)
-                    .unwrap_or(EDI_DEFAULT_MAX_ELEMENTS),
+                    .unwrap_or(clinker_format::X12_DEFAULT_MAX_ELEMENTS),
             })
         }
         InputFormat::Edifact(opts) => DocSchema::SegmentPositional(SegmentPositionalSchema {
@@ -2509,7 +2545,7 @@ fn doc_schema_for(source: &crate::config::SourceConfig) -> DocSchema {
             max_positional: opts
                 .as_ref()
                 .and_then(|o| o.max_elements)
-                .unwrap_or(EDI_DEFAULT_MAX_ELEMENTS),
+                .unwrap_or(clinker_format::EDIFACT_DEFAULT_MAX_ELEMENTS),
         }),
         InputFormat::Hl7(opts) => DocSchema::SegmentPositional(SegmentPositionalSchema {
             // HL7's `batch` (BHS) and `transaction_set` (MSH) levels always
@@ -4020,11 +4056,6 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
 
     Ok(())
 }
-
-/// Default `fNN` column count for an HL7 source when `max_fields` is unset,
-/// matching the reader's documented default. A split field must name a
-/// position within this range to be reachable.
-const HL7_DEFAULT_MAX_FIELDS: usize = 64;
 
 /// Validate an HL7 source's `split_fields` declarations: each names a
 /// reachable positional field (`fNN`, `1 <= N <= max_fields`) with at least

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -943,26 +943,68 @@ impl PipelineConfig {
                 }
             }
         }
-        // E341 — a `$doc.<section>.<field>` access must name a section and
-        // field the feeding source's envelope actually declares. Without
-        // this check a typo (`$doc.Summry.total` against a declared
-        // `Summary`) compiles silently and resolves to `Value::Null` at
-        // run time; the cxl typechecker cannot catch it because `$doc.*`
-        // types as `Any` with no envelope context in scope.
+        // Cross-check every referenced `$doc.<section>.<field>` against the
+        // schema the feeding source's reader will actually serve. Without
+        // this a typo (`$doc.Summry.total` against a declared `Summary`)
+        // compiles silently and resolves to `Value::Null` at run time; the
+        // cxl typechecker cannot catch it because `$doc.*` types as `Any`
+        // with no envelope context in scope. The schema differs by source:
         //
-        // Only XML and JSON sources are validated: their reader extracts
-        // exactly the declared sections, each with exactly the declared
-        // fields, so the `EnvelopeConfig` is the authoritative closed
-        // schema. Segment- and positional-based formats (X12, EDIFACT,
-        // HL7, fixed-width) synthesize multi-level sections and positional
-        // fields beyond the declared config — e.g. an X12 reader exposes
-        // `$doc.functional_group.*` and `$doc.transaction_set.*` the config
-        // never names — so a closed-schema check would false-positive on
-        // them and is skipped.
+        // - REST transport (E349): a `rest` source buffers no document, so
+        //   any `$doc` access against it can never resolve — rejected
+        //   outright regardless of declared format.
+        // - Closed (E341): XML/JSON readers serve exactly the declared
+        //   `envelope:` sections/fields. The declaration is the
+        //   authoritative closed schema, so an omitted path is a genuine
+        //   typo.
+        // - Segment/positional (E348): X12/EDIFACT/HL7 synthesize nested
+        //   levels (`functional_group`/`transaction_set`/`batch`) keyed by
+        //   positional `eNN`/`fNN` elements beyond the declared header. A
+        //   path is checked against that known synthesized vocabulary plus
+        //   any user-declared section/field, so a typo or out-of-range
+        //   positional element is caught without false-positiving on a
+        //   legitimate wire path.
+        // - Unvalidated: CSV, fixed-width, SWIFT (see `doc_schema_for`).
         let source_by_name: HashMap<&str, &crate::config::SourceConfig> = source_configs
             .iter()
             .map(|s| (s.name.as_str(), s))
             .collect();
+        // E349 — a `rest` source that declares an `envelope:` block. The
+        // declaration is always inert (a REST pull buffers no document), so
+        // reject it even when no downstream node reads `$doc` from the
+        // source. The per-`$doc`-access E349 below covers the complementary
+        // case: a `$doc` read against a REST source that declared no
+        // envelope.
+        for source in &source_configs {
+            if let SourceTransport::Rest(_) = source.transport
+                && source.envelope.is_some()
+            {
+                let primary = doc_node_line
+                    .get(source.name.as_str())
+                    .map(|&line| Span::line_only(line))
+                    .unwrap_or(Span::SYNTHETIC);
+                diags.push(
+                    Diagnostic::error(
+                        "E349",
+                        format!(
+                            "the rest source '{}' declares an `envelope:` block, but a rest \
+                             source pulls records page by page over HTTP and buffers no \
+                             document — the declared sections are inert and every \
+                             `$doc.<section>.<field>` against this source resolves to null",
+                            source.name
+                        ),
+                        LabeledSpan::primary(primary, String::new()),
+                    )
+                    .with_help(
+                        "remove the `envelope:` block from this rest source; envelope \
+                         sections are a file-document concept. Pull document-level metadata \
+                         into record fields through the API's response shape (`record_path`, \
+                         `array_paths`) instead"
+                            .to_string(),
+                    ),
+                );
+            }
+        }
         for (doc_path, ref_nodes) in &doc_path_set.by_node {
             for node_name in ref_nodes {
                 let Some(sources) = node_sources.get(node_name) else {
@@ -972,19 +1014,31 @@ impl PipelineConfig {
                     let Some(source) = source_by_name.get(source_name.as_str()) else {
                         continue;
                     };
-                    if !envelope_schema_is_closed(&source.format) {
-                        continue;
-                    }
-                    let Some(problem) = undeclared_doc_path_problem(source, doc_path) else {
-                        continue;
-                    };
                     let primary = match doc_node_line.get(node_name.as_str()) {
                         Some(&line) => Span::line_only(line),
                         None => Span::SYNTHETIC,
                     };
+                    // A REST source has no buffered document; a `$doc`
+                    // access against it can never resolve. Reject before
+                    // the format-shaped schema check, which does not model
+                    // the transport.
+                    if let SourceTransport::Rest(_) = source.transport {
+                        diags.push(rest_doc_access_diagnostic(&source.name, doc_path, primary));
+                        continue;
+                    }
+                    let problem = match doc_schema_for(source) {
+                        DocSchema::Closed => closed_doc_path_problem(source, doc_path),
+                        DocSchema::SegmentPositional(schema) => {
+                            segment_positional_doc_path_problem(source, &schema, doc_path)
+                        }
+                        DocSchema::Unvalidated => None,
+                    };
+                    let Some(problem) = problem else {
+                        continue;
+                    };
                     diags.push(
                         Diagnostic::error(
-                            "E341",
+                            problem.code,
                             problem.message,
                             LabeledSpan::primary(primary, String::new()),
                         )
@@ -993,7 +1047,10 @@ impl PipelineConfig {
                 }
             }
         }
-        if diags.iter().any(|d| d.code == "E341") {
+        if diags
+            .iter()
+            .any(|d| d.code == "E341" || d.code == "E348" || d.code == "E349")
+        {
             return Err(diags);
         }
         // Keep an analysis-by-name index so we can surface the analysis
@@ -2204,19 +2261,49 @@ fn resolve_all_input_references(
     }
 }
 
-/// Whether a source format's `EnvelopeConfig` is the complete, closed set
-/// of `$doc` sections and fields the reader can supply.
+/// How a source's `$doc.<section>.<field>` references are validated at
+/// compile time, derived from the source's transport and format.
 ///
-/// XML and JSON readers extract exactly the declared sections, each with
-/// exactly the declared fields, so a used `$doc` path naming anything the
-/// config omits is a genuine typo. Segment- and positional-based formats
-/// (X12, EDIFACT, HL7, fixed-width) synthesize multi-level envelope
-/// sections and positional fields beyond the declared config — an X12
-/// reader exposes `$doc.functional_group.*` / `$doc.transaction_set.*`
-/// the config never names — so their envelope is open and the closed-set
-/// `$doc` validation is skipped for them.
-fn envelope_schema_is_closed(format: &InputFormat) -> bool {
-    matches!(format, InputFormat::Xml(_) | InputFormat::Json(_))
+/// A `$doc` access carries no envelope context the cxl typechecker can see,
+/// so the planner cross-checks each referenced path against the schema the
+/// feeding source's reader will actually serve. That schema differs by
+/// format family:
+///
+/// - **Closed** (XML, JSON): the reader serves exactly the sections and
+///   fields the `envelope:` block declares — the declaration is the
+///   complete schema, so a path naming anything it omits is a genuine typo
+///   (`E341`).
+/// - **Segment/positional** (X12, EDIFACT, HL7): the file-level header
+///   (`ISA`/`UNB`/`FHS`) is declared through `envelope:` and is closed, but
+///   the reader *also* synthesizes nested envelope levels the config never
+///   names — X12's `functional_group`/`transaction_set`, HL7's
+///   `batch`/`transaction_set` — keyed by positional `eNN`/`fNN` elements
+///   bounded by the format's `max_elements`/`max_fields`. A `$doc` path is
+///   validated against that known synthesized vocabulary plus any
+///   user-declared section/field, so a typo (`$doc.functonal_group.e06`)
+///   or an out-of-range positional element (`$doc.transaction_set.e99`) is
+///   caught (`E348`) without false-positiving on a legitimate wire path.
+/// - **Unvalidated** (CSV, fixed-width, SWIFT): not statically checked. A
+///   plain flat file synthesizes no `$doc` sections (a `$doc` read against
+///   one is inert but harmless), a multi-record flat file's `record_type`
+///   sections are author-declared but the section vocabulary the reader
+///   serves is not statically reconstructible here without resolving the
+///   `format_schema`, and SWIFT serves declared sections under user-chosen
+///   *or* stable default block labels — none fits the closed or positional
+///   model cleanly, so each is left unchecked rather than risk a false
+///   positive.
+///
+/// REST sources are handled before this classification: a `rest` transport
+/// buffers no document, so any `$doc` access against one can never resolve
+/// and is rejected outright (`E349`), regardless of the declared format.
+enum DocSchema {
+    /// Validate against the declared `envelope:` block alone.
+    Closed,
+    /// Validate against the format's synthesized section/positional-element
+    /// vocabulary plus any user-declared section/field.
+    SegmentPositional(SegmentPositionalSchema),
+    /// Not statically validated (CSV, fixed-width, SWIFT).
+    Unvalidated,
 }
 
 /// The output-envelope config of a generic-format Output (CSV / JSON / XML /
@@ -2321,24 +2408,155 @@ fn trace_output_lineage(config: &PipelineConfig, output_name: &str) -> OutputLin
     }
 }
 
-/// A rejected `$doc` path against a closed envelope schema: the formatted
-/// diagnostic message plus its fix-it help text.
-struct UndeclaredDocPath {
+/// The synthesized `$doc` vocabulary of a segment/positional format: the
+/// nested sections its reader produces beyond the declared `envelope:`
+/// block, the positional-element prefix, and the per-element bound.
+struct SegmentPositionalSchema {
+    /// Nested sections the reader synthesizes for this source, in addition
+    /// to any the user declares under `envelope.sections`. For X12 these are
+    /// the (possibly user-renamed) functional-group / transaction-set
+    /// levels; for HL7 the fixed `batch` / `transaction_set`; EDIFACT
+    /// synthesizes none beyond the declared `UNB` interchange. Each carries
+    /// how its fields are keyed (positional `eNN`/`fNN`, or a user-declared
+    /// typed nested schema).
+    synthesized_sections: Vec<SynthesizedSection>,
+    /// Positional field-name prefix: `e` for X12/EDIFACT element columns
+    /// (`e01`…), `f` for HL7 field columns (`f01`…).
+    positional_prefix: char,
+    /// 1-based upper bound on a positional element/field, mirroring the
+    /// reader's `max_elements` / `max_fields` (a segment carrying more is
+    /// rejected at read time, so a `$doc` reference past it can never
+    /// resolve).
+    max_positional: usize,
+}
+
+/// One synthesized nested section and the set of fields its reader serves.
+struct SynthesizedSection {
+    /// Section name `$doc.<name>.<field>` resolves under.
+    name: String,
+    /// How the section's fields are keyed. A default-keyed level exposes
+    /// every positional element up to the bound; a level given a typed
+    /// nested schema (X12 `group_section` / `set_section`) exposes ONLY its
+    /// declared fields, exactly as a declared file-level section does.
+    fields: SynthesizedFields,
+}
+
+/// How a synthesized nested section's fields are keyed.
+enum SynthesizedFields {
+    /// Default positional keying: every `<prefix>NN`, `1 <= N <= bound`.
+    Positional,
+    /// A user-declared typed schema (X12 `group_section.fields` /
+    /// `set_section.fields`). The reader coerces and serves ONLY these
+    /// fields, so the section is closed to them — an undeclared name (even
+    /// an in-range positional one) resolves null.
+    Declared(Vec<String>),
+}
+
+/// Default `eNN` element count for X12 and EDIFACT when `max_elements` is
+/// unset, matching each reader's `DEFAULT_MAX_ELEMENTS`.
+const EDI_DEFAULT_MAX_ELEMENTS: usize = 32;
+
+/// Build a synthesized nested section from an optional user-declared nested
+/// schema: a declared schema closes the section to its declared field
+/// names, an absent one keeps the default positional keying.
+fn synthesized_section(
+    default_name: &str,
+    declared: Option<&clinker_format::NestedEnvelopeSection>,
+) -> SynthesizedSection {
+    match declared {
+        Some(s) => SynthesizedSection {
+            name: s.name.clone(),
+            fields: SynthesizedFields::Declared(s.fields.keys().cloned().collect()),
+        },
+        None => SynthesizedSection {
+            name: default_name.to_string(),
+            fields: SynthesizedFields::Positional,
+        },
+    }
+}
+
+/// Classify how a source's `$doc` references are validated, from its
+/// format. The REST transport is checked by the caller before this is
+/// consulted, so this maps purely on `InputFormat`.
+fn doc_schema_for(source: &crate::config::SourceConfig) -> DocSchema {
+    match &source.format {
+        InputFormat::Xml(_) | InputFormat::Json(_) => DocSchema::Closed,
+        InputFormat::X12(opts) => {
+            let opts = opts.as_ref();
+            DocSchema::SegmentPositional(SegmentPositionalSchema {
+                synthesized_sections: vec![
+                    synthesized_section(
+                        "functional_group",
+                        opts.and_then(|o| o.group_section.as_ref()),
+                    ),
+                    synthesized_section(
+                        "transaction_set",
+                        opts.and_then(|o| o.set_section.as_ref()),
+                    ),
+                ],
+                positional_prefix: 'e',
+                max_positional: opts
+                    .and_then(|o| o.max_elements)
+                    .unwrap_or(EDI_DEFAULT_MAX_ELEMENTS),
+            })
+        }
+        InputFormat::Edifact(opts) => DocSchema::SegmentPositional(SegmentPositionalSchema {
+            // A single UNB..UNZ interchange synthesizes no nested level; the
+            // declared `UNB` section is the only one, so the synthesized set
+            // is empty and a non-`UNB`-declared section name is a typo.
+            synthesized_sections: Vec::new(),
+            positional_prefix: 'e',
+            max_positional: opts
+                .as_ref()
+                .and_then(|o| o.max_elements)
+                .unwrap_or(EDI_DEFAULT_MAX_ELEMENTS),
+        }),
+        InputFormat::Hl7(opts) => DocSchema::SegmentPositional(SegmentPositionalSchema {
+            // HL7's `batch` (BHS) and `transaction_set` (MSH) levels always
+            // surface their whole header verbatim as positional `fNN`
+            // columns — they carry no user-declared typed schema.
+            synthesized_sections: vec![
+                SynthesizedSection {
+                    name: "batch".to_string(),
+                    fields: SynthesizedFields::Positional,
+                },
+                SynthesizedSection {
+                    name: "transaction_set".to_string(),
+                    fields: SynthesizedFields::Positional,
+                },
+            ],
+            positional_prefix: 'f',
+            max_positional: opts
+                .as_ref()
+                .and_then(|o| o.max_fields)
+                .unwrap_or(HL7_DEFAULT_MAX_FIELDS),
+        }),
+        InputFormat::Csv(_) | InputFormat::FixedWidth(_) | InputFormat::Swift(_) => {
+            DocSchema::Unvalidated
+        }
+    }
+}
+
+/// A rejected `$doc` path: the diagnostic code, formatted message, and
+/// fix-it help text. The code distinguishes a closed-schema rejection
+/// (`E341`) from a segment/positional one (`E348`).
+struct DocPathProblem {
+    code: &'static str,
     message: String,
     help: String,
 }
 
 /// Check one `$doc.<section>.<field>` path against a source's declared
-/// envelope, returning the diagnostic content when the path names an
+/// closed envelope, returning the diagnostic content when the path names an
 /// undeclared section or an undeclared field within a declared section.
 ///
 /// Returns `None` when the path is fully declared. The caller has already
 /// confirmed the source's format carries a closed envelope schema, so an
 /// absent `envelope:` block means every `$doc` path is undeclared.
-fn undeclared_doc_path_problem(
+fn closed_doc_path_problem(
     source: &crate::config::SourceConfig,
     doc_path: &cxl::analyzer::doc_paths::DocPath,
-) -> Option<UndeclaredDocPath> {
+) -> Option<DocPathProblem> {
     let section_name = &*doc_path.section;
     let field_name = &*doc_path.field;
     let source_name = &source.name;
@@ -2347,7 +2565,8 @@ fn undeclared_doc_path_problem(
         .as_ref()
         .and_then(|env| env.sections.get(section_name));
     match section {
-        None => Some(UndeclaredDocPath {
+        None => Some(DocPathProblem {
+            code: "E341",
             message: format!(
                 "`$doc.{section_name}.{field_name}` references envelope section \
                  '{section_name}', but source '{source_name}' declares no such section"
@@ -2359,7 +2578,8 @@ fn undeclared_doc_path_problem(
                  `envelope.sections` exactly"
             ),
         }),
-        Some(section) if !section.fields.contains_key(field_name) => Some(UndeclaredDocPath {
+        Some(section) if !section.fields.contains_key(field_name) => Some(DocPathProblem {
+            code: "E341",
             message: format!(
                 "`$doc.{section_name}.{field_name}` references field '{field_name}' in \
                  envelope section '{section_name}', but source '{source_name}' declares no \
@@ -2372,6 +2592,244 @@ fn undeclared_doc_path_problem(
         }),
         Some(_) => None,
     }
+}
+
+/// Check one `$doc.<section>.<field>` path against a segment/positional
+/// format's synthesized vocabulary plus any user-declared section/field.
+///
+/// A path's section must be either a user-declared `envelope.sections` key
+/// (the closed file-level header — `ISA`/`UNB`/`FHS`) or one the reader
+/// synthesizes for this format (X12/HL7 nested levels). The field check
+/// then depends on the section kind:
+///
+/// - a **declared file-level section** is closed to its declared fields
+///   (the reader serves only those);
+/// - a **synthesized positional level** serves every `<prefix>NN`,
+///   `1 <= N <= bound`;
+/// - a **synthesized level given a typed nested schema** (X12
+///   `group_section` / `set_section`) is closed to its declared fields.
+///
+/// Returns the `E348` diagnostic content for a section outside the known
+/// set, or a field that section's reader will not serve.
+fn segment_positional_doc_path_problem(
+    source: &crate::config::SourceConfig,
+    schema: &SegmentPositionalSchema,
+    doc_path: &cxl::analyzer::doc_paths::DocPath,
+) -> Option<DocPathProblem> {
+    let section_name = &*doc_path.section;
+    let field_name = &*doc_path.field;
+    let source_name = &source.name;
+    let format = source.format.format_name();
+
+    let declared_section = source
+        .envelope
+        .as_ref()
+        .and_then(|env| env.sections.get(section_name));
+    let synthesized = schema
+        .synthesized_sections
+        .iter()
+        .find(|s| s.name == section_name);
+
+    // Unknown section — neither a declared file-level section nor one the
+    // reader synthesizes.
+    if declared_section.is_none() && synthesized.is_none() {
+        let mut known: Vec<String> = source
+            .envelope
+            .as_ref()
+            .map(|env| env.sections.keys().cloned().collect())
+            .unwrap_or_default();
+        known.extend(schema.synthesized_sections.iter().map(|s| s.name.clone()));
+        let known_list = if known.is_empty() {
+            String::from("(none)")
+        } else {
+            known.join(", ")
+        };
+        return Some(DocPathProblem {
+            code: "E348",
+            message: format!(
+                "`$doc.{section_name}.{field_name}` references envelope section \
+                 '{section_name}', but the {format} source '{source_name}' synthesizes no \
+                 such section"
+            ),
+            help: format!(
+                "name a section this {format} source exposes ({known_list}), declare \
+                 '{section_name}' under the source's `envelope.sections`, or correct the \
+                 spelling. Section names are case-sensitive"
+            ),
+        });
+    }
+
+    // A declared file-level section (`ISA`/`UNB`/`FHS`) is closed: the
+    // reader serves only its declared fields.
+    if let Some(section) = declared_section {
+        if section.fields.contains_key(field_name) {
+            return None;
+        }
+        return Some(undeclared_field_in_closed_section(
+            source_name,
+            format,
+            section_name,
+            field_name,
+            "`envelope.sections`",
+        ));
+    }
+
+    // A synthesized nested level: closed to its declared schema if it has
+    // one, else keyed by positional elements up to the bound. `synthesized`
+    // is `Some` here — the both-`None` case returned above, and the
+    // `declared_section` case returned just above — but match it rather than
+    // unwrap so the exhaustive path is explicit.
+    match synthesized.map(|s| &s.fields) {
+        Some(SynthesizedFields::Declared(fields)) => {
+            if fields.iter().any(|f| f == field_name) {
+                return None;
+            }
+            Some(undeclared_field_in_closed_section(
+                source_name,
+                format,
+                section_name,
+                field_name,
+                "the level's `fields` schema",
+            ))
+        }
+        Some(SynthesizedFields::Positional) => positional_field_problem(
+            source_name,
+            format,
+            section_name,
+            field_name,
+            schema.positional_prefix,
+            schema.max_positional,
+        ),
+        None => None,
+    }
+}
+
+/// `E348` for a field a closed section (a declared file-level section, or a
+/// synthesized level given a typed schema) does not declare.
+fn undeclared_field_in_closed_section(
+    source_name: &str,
+    format: &str,
+    section_name: &str,
+    field_name: &str,
+    declared_under: &str,
+) -> DocPathProblem {
+    DocPathProblem {
+        code: "E348",
+        message: format!(
+            "`$doc.{section_name}.{field_name}` references field '{field_name}' in section \
+             '{section_name}', but the {format} source '{source_name}' declares no such field \
+             in that section"
+        ),
+        help: format!(
+            "add '{field_name}' to that section's field schema ({declared_under}), or correct \
+             the name to a declared field. Field names are case-sensitive"
+        ),
+    }
+}
+
+/// Validate a field against a positionally-keyed synthesized level: it must
+/// be `<prefix>NN` with `1 <= N <= max_positional`. Returns `None` when in
+/// range, else the `E348` content for an out-of-range or non-positional
+/// field.
+fn positional_field_problem(
+    source_name: &str,
+    format: &str,
+    section_name: &str,
+    field_name: &str,
+    prefix: char,
+    max_positional: usize,
+) -> Option<DocPathProblem> {
+    match positional_element_index(field_name, prefix) {
+        Some(n) if n >= 1 && n <= max_positional => None,
+        Some(_) => Some(DocPathProblem {
+            code: "E348",
+            message: format!(
+                "`$doc.{section_name}.{field_name}` references positional element \
+                 '{field_name}', but the {format} source '{source_name}' exposes only \
+                 '{prefix}01'..'{prefix}{max:02}' on section '{section_name}' (its \
+                 configured {bound_opt} is {max})",
+                max = max_positional,
+                bound_opt = positional_bound_option(prefix),
+            ),
+            help: format!(
+                "reference a positional element within range, or raise the source's \
+                 `{bound_opt}` if the wire segment genuinely carries that many",
+                bound_opt = positional_bound_option(prefix),
+            ),
+        }),
+        None => Some(DocPathProblem {
+            code: "E348",
+            message: format!(
+                "`$doc.{section_name}.{field_name}` references field '{field_name}' on section \
+                 '{section_name}', but the {format} source '{source_name}' exposes that \
+                 section's wire data only as positional elements \
+                 ('{prefix}01'..'{prefix}{max:02}')",
+                max = max_positional,
+            ),
+            help: format!(
+                "reference a positional element ('{prefix}NN'), or declare '{field_name}' under \
+                 a typed nested-section schema for this level. Field names are case-sensitive"
+            ),
+        }),
+    }
+}
+
+/// Parse a positional element/field name into its 1-based index, or `None`
+/// when it does not match the EXACT column name the reader emits.
+///
+/// The readers key positional columns as `format!("{prefix}{:02}", i + 1)`
+/// — zero-padded to a minimum of two digits (`e01`, `f09`, `e32`, `e100`).
+/// A `$doc` access resolves by the literal field identifier, so only that
+/// canonical spelling resolves at run time: `$doc.s.e7` looks up a `e7`
+/// column that does not exist (the reader emits `e07`) and would silently
+/// yield null. We therefore accept a name only when it round-trips to the
+/// canonical key — rejecting `e7` (→ `e07`) and `e007` (→ `e07`) so the
+/// near-miss is caught rather than passing compile and resolving null.
+fn positional_element_index(field: &str, prefix: char) -> Option<usize> {
+    let rest = field.strip_prefix(prefix)?;
+    if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let n: usize = rest.parse().ok()?;
+    (field == format!("{prefix}{n:02}")).then_some(n)
+}
+
+/// The source-option name that bounds the positional element/field count
+/// for a given prefix, used in `E348` help text.
+fn positional_bound_option(prefix: char) -> &'static str {
+    match prefix {
+        'f' => "max_fields",
+        _ => "max_elements",
+    }
+}
+
+/// Build the `E349` diagnostic for a `$doc` access attributed to a REST
+/// source. A `rest` transport pulls records page by page over HTTP and
+/// buffers no single document, so it carries no envelope context — the
+/// access would resolve to `Value::Null` at run time with no signal.
+fn rest_doc_access_diagnostic(
+    source_name: &str,
+    doc_path: &cxl::analyzer::doc_paths::DocPath,
+    primary: clinker_core_types::span::Span,
+) -> clinker_core_types::Diagnostic {
+    use clinker_core_types::{Diagnostic, LabeledSpan};
+    let section = &*doc_path.section;
+    let field = &*doc_path.field;
+    Diagnostic::error(
+        "E349",
+        format!(
+            "`$doc.{section}.{field}` reads document-envelope context from the rest source \
+             '{source_name}', but a rest source pulls records page by page over HTTP and \
+             buffers no document — the access can never resolve and would silently yield null"
+        ),
+        LabeledSpan::primary(primary, String::new()),
+    )
+    .with_help(
+        "remove the `$doc` access; a rest source has no document envelope. Pull \
+         document-level metadata into record fields through the API's response shape \
+         (`record_path`, `array_paths`) instead"
+            .to_string(),
+    )
 }
 
 /// Map every CXL-bearing node name — top-level and composition-body — to

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -239,6 +239,8 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E345" => Some(include_str!("../../../../docs/explain/E345.md")),
         "E346" => Some(include_str!("../../../../docs/explain/E346.md")),
         "E347" => Some(include_str!("../../../../docs/explain/E347.md")),
+        "E348" => Some(include_str!("../../../../docs/explain/E348.md")),
+        "E349" => Some(include_str!("../../../../docs/explain/E349.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -463,7 +465,8 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E344", "E345", "E346", "E347", "E15Y", "W101", "W302", "W305", "W306",
+            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E15Y", "W101", "W302", "W305",
+            "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -444,8 +444,16 @@ fn test_segment_format_out_of_range_positional_element_aborts_with_e348() {
 
 #[test]
 fn test_segment_format_in_range_positional_element_compiles() {
-    // `e32` is exactly at the X12 default `max_elements` of 32 — the
-    // last reachable element, so it must compile (boundary check).
+    // `e32` is exactly at the X12 default `max_elements` of 32 — the body
+    // segment's element ceiling, so it must compile (boundary check).
+    //
+    // NOTE: this exercises the LOOSE body-segment bound, not a tight
+    // per-segment guarantee. A real `ST` transaction-set header carries
+    // only ~3 elements, so `$doc.transaction_set.e32` would resolve null at
+    // run time — yet it compiles, because the precise per-segment header
+    // arity is not known at plan time (and the reader itself caps only the
+    // body element count). Tightening to per-segment arity is tracked at
+    // https://github.com/rustpunk/clinker/issues/558.
     compile_x12("emit seg = seg_id\nemit st = $doc.transaction_set.e32")
         .expect("the boundary positional element must compile");
 }

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -8,6 +8,7 @@
 //! feeding it (never the pipeline-wide union), and a `$doc` access
 //! indexed by a non-literal aborts the compile with E340.
 
+use clinker_core_types::Diagnostic;
 use cxl::analyzer::doc_paths::{DocIndex, DocPath};
 
 use crate::config::{CompileContext, parse_config};
@@ -339,16 +340,16 @@ fn test_declared_doc_path_does_not_trip_e341() {
     assert!(source_doc_paths(&plan, "payments").contains(&path("Summary", "total", vec![])));
 }
 
-#[test]
-fn test_undeclared_doc_path_against_segment_format_is_not_validated() {
-    // X12 (and the other segment/positional formats) synthesize envelope
-    // levels beyond the declared config — `$doc.functional_group.*` and
-    // `$doc.transaction_set.*` are reader-derived, not config-declared. The
-    // closed-schema E341 check must NOT fire for these, or every multi-level
-    // EDI pipeline would be rejected.
-    let yaml = r#"
+/// Compile an X12 pipeline whose source declares an `ISA` interchange
+/// envelope section (`e13: string`) and a transform body supplied by the
+/// caller. Returns the compile result so a test can assert success or
+/// inspect diagnostics. The X12 reader synthesizes `functional_group` and
+/// `transaction_set` levels keyed positionally beyond the declared header.
+fn compile_x12(transform_cxl: &str) -> Result<crate::plan::CompiledPlan, Vec<Diagnostic>> {
+    let mut yaml = String::from(
+        r#"
 pipeline:
-  name: x12_doc_open
+  name: x12_doc_validate
 nodes:
   - type: source
     name: interchange
@@ -369,25 +370,336 @@ nodes:
     input: interchange
     config:
       cxl: |
-        emit seg = seg_id
-        emit gs06 = $doc.functional_group.e06
-        emit st02 = $doc.transaction_set.e02
-  - type: output
-    name: out
-    input: t0
-    config:
-      name: out
-      type: csv
-      path: out.csv
-"#;
-    let config = parse_config(yaml).expect("parse x12 pipeline");
-    let result = config.compile(&CompileContext::default());
-    if let Err(err) = &result {
+"#,
+    );
+    for line in transform_cxl.lines() {
+        yaml.push_str(&format!("        {line}\n"));
+    }
+    yaml.push_str(
+        "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+    );
+    let config = parse_config(&yaml).expect("parse x12 pipeline");
+    config.compile(&CompileContext::default())
+}
+
+#[test]
+fn test_segment_format_legitimate_wire_paths_compile() {
+    // X12 synthesizes `functional_group` / `transaction_set` levels keyed
+    // by positional `eNN` elements beyond the declared `ISA` header. A
+    // reference to a synthesized section with an in-range positional
+    // element is a legitimate wire path and must NOT trip any `$doc`
+    // diagnostic — a false positive here would reject every multi-level
+    // EDI pipeline.
+    let plan = compile_x12(
+        "emit seg = seg_id\n\
+         emit isa13 = $doc.interchange.e13\n\
+         emit gs06 = $doc.functional_group.e06\n\
+         emit st02 = $doc.transaction_set.e02",
+    )
+    .expect("legitimate X12 wire paths must compile");
+    // Sanity: the declared-header path still surfaces onto the source set.
+    assert!(source_doc_paths(&plan, "interchange").contains(&path("interchange", "e13", vec![])));
+}
+
+#[test]
+fn test_segment_format_misspelled_section_aborts_with_e348() {
+    // `functonal_group` misspells the synthesized `functional_group`
+    // section. A segment-format `$doc` typo must now be caught with E348
+    // (the contract changed from "not validated" — this is #481).
+    let err = compile_x12("emit seg = seg_id\nemit gs06 = $doc.functonal_group.e06")
+        .expect_err("a misspelled synthesized section must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E348")
+        .unwrap_or_else(|| panic!("expected an E348 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("functonal_group"),
+        "E348 message must name the undeclared section: {}",
+        diag.message
+    );
+    assert!(
+        diag.primary.span.synthetic_line_number().is_some(),
+        "E348 primary span must carry the referencing node's source line"
+    );
+    assert!(diag.help.is_some(), "E348 must carry help text");
+}
+
+#[test]
+fn test_segment_format_out_of_range_positional_element_aborts_with_e348() {
+    // `e99` is past the X12 default `max_elements` of 32, so the reader can
+    // never serve it — a typo that resolves null at run time. E348 catches
+    // the positional-bound case.
+    let err = compile_x12("emit seg = seg_id\nemit st = $doc.transaction_set.e99")
+        .expect_err("an out-of-range positional element must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E348")
+        .unwrap_or_else(|| panic!("expected an E348 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("e99") && diag.message.contains("32"),
+        "E348 message must name the offending element and the bound: {}",
+        diag.message
+    );
+}
+
+#[test]
+fn test_segment_format_in_range_positional_element_compiles() {
+    // `e32` is exactly at the X12 default `max_elements` of 32 — the
+    // last reachable element, so it must compile (boundary check).
+    compile_x12("emit seg = seg_id\nemit st = $doc.transaction_set.e32")
+        .expect("the boundary positional element must compile");
+}
+
+#[test]
+fn test_segment_format_unpadded_positional_element_aborts_with_e348() {
+    // The reader keys columns zero-padded (`e07`), and a `$doc` access
+    // resolves by the literal identifier. `$doc.transaction_set.e7` would
+    // look up a non-existent `e7` column and resolve null — a near-miss
+    // that must be caught, not accepted as in-range. The canonical `e07`
+    // compiles; the unpadded `e7` trips E348.
+    compile_x12("emit seg = seg_id\nemit st = $doc.transaction_set.e07")
+        .expect("the canonical zero-padded element must compile");
+    let err = compile_x12("emit seg = seg_id\nemit st = $doc.transaction_set.e7")
+        .expect_err("an unpadded positional element must fail to compile");
+    assert!(
+        err.iter().any(|d| d.code == "E348"),
+        "expected an E348 diagnostic for the unpadded element, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_segment_format_non_positional_field_aborts_with_e348() {
+    // A non-`eNN` field name on a synthesized positional section names no
+    // declared field and no positional element — a typo. E348 catches it.
+    let err = compile_x12("emit seg = seg_id\nemit st = $doc.transaction_set.amount")
+        .expect_err("a non-positional field on a positional section must fail");
+    assert!(
+        err.iter().any(|d| d.code == "E348"),
+        "expected an E348 diagnostic, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_segment_format_declared_header_section_is_closed() {
+    // The declared file-level `ISA` interchange section is CLOSED — the
+    // reader serves only its declared fields (`e13: string`), coercing
+    // nothing else. So an undeclared field is a typo even when it LOOKS
+    // like an in-range positional element (`e14`): the reader never serves
+    // it, and it would resolve null. Both `e14` (in-range positional but
+    // undeclared) and `zzz` (neither) must trip E348 — a false negative
+    // here would let a null-resolving path compile.
+    for field in ["e14", "zzz"] {
+        let cxl = format!("emit seg = seg_id\nemit isa = $doc.interchange.{field}");
+        let err = compile_x12(&cxl)
+            .err()
+            .unwrap_or_else(|| panic!("`$doc.interchange.{field}` should fail to compile"));
         assert!(
-            err.iter().all(|d| d.code != "E341"),
-            "segment-format `$doc` paths must not trip E341, got: {err:?}"
+            err.iter().any(|d| d.code == "E348"),
+            "an undeclared field on the closed ISA section must trip E348 ({field}): {err:?}"
         );
     }
+}
+
+#[test]
+fn test_hl7_synthesized_sections_and_positional_bound() {
+    // HL7 synthesizes `batch` / `transaction_set` keyed by `fNN` fields
+    // bounded by `max_fields` (default 64). A legitimate `fNN` compiles; a
+    // misspelled section trips E348.
+    fn compile_hl7(transform_cxl: &str) -> Result<crate::plan::CompiledPlan, Vec<Diagnostic>> {
+        let mut yaml = String::from(
+            r#"
+pipeline:
+  name: hl7_doc_validate
+nodes:
+  - type: source
+    name: msgs
+    config:
+      name: msgs
+      type: hl7
+      path: msgs.hl7
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: t0
+    input: msgs
+    config:
+      cxl: |
+"#,
+        );
+        for line in transform_cxl.lines() {
+            yaml.push_str(&format!("        {line}\n"));
+        }
+        yaml.push_str(
+            "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        );
+        let config = parse_config(&yaml).expect("parse hl7 pipeline");
+        config.compile(&CompileContext::default())
+    }
+
+    compile_hl7("emit seg = seg_id\nemit msh = $doc.transaction_set.f09")
+        .expect("a legitimate HL7 fNN path must compile");
+
+    let err = compile_hl7("emit seg = seg_id\nemit b = $doc.batchh.f01")
+        .expect_err("a misspelled HL7 section must fail");
+    assert!(
+        err.iter().any(|d| d.code == "E348"),
+        "expected an E348 diagnostic, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_x12_typed_nested_group_section_is_closed_to_declared_fields() {
+    // When the source gives the `GS` level a typed nested schema
+    // (`group_section`), the reader renames the level and serves ONLY its
+    // declared fields — the default positional `eNN` keying no longer
+    // applies. So the level is closed: a declared field compiles, a field
+    // it does not declare (even an in-range positional one) trips E348, and
+    // the OLD default name `functional_group` no longer exists.
+    fn compile(transform_cxl: &str) -> Result<crate::plan::CompiledPlan, Vec<Diagnostic>> {
+        let mut yaml = String::from(
+            r#"
+pipeline:
+  name: x12_group_section
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      path: po.x12
+      options:
+        group_section:
+          name: grp
+          fields:
+            e06: string
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: t0
+    input: interchange
+    config:
+      cxl: |
+"#,
+        );
+        for line in transform_cxl.lines() {
+            yaml.push_str(&format!("        {line}\n"));
+        }
+        yaml.push_str(
+            "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        );
+        let config = parse_config(&yaml).expect("parse x12 group_section pipeline");
+        config.compile(&CompileContext::default())
+    }
+
+    // The declared nested field resolves under the renamed section.
+    compile("emit seg = seg_id\nemit g = $doc.grp.e06")
+        .expect("a declared nested field on the renamed group section must compile");
+
+    // An undeclared in-range positional element on the now-closed level is
+    // a typo — the reader serves only `e06`.
+    let err = compile("emit seg = seg_id\nemit g = $doc.grp.e07")
+        .expect_err("an undeclared field on the typed nested section must fail");
+    assert!(
+        err.iter().any(|d| d.code == "E348"),
+        "expected an E348 diagnostic for the undeclared nested field, got: {err:?}"
+    );
+
+    // The default name no longer exists once the level is renamed.
+    let err = compile("emit seg = seg_id\nemit g = $doc.functional_group.e06")
+        .expect_err("the default section name must not exist after a rename");
+    assert!(
+        err.iter().any(|d| d.code == "E348"),
+        "expected an E348 diagnostic for the stale default name, got: {err:?}"
+    );
+}
+
+/// Compile a JSON pipeline whose source uses the `rest` transport, with an
+/// optional `envelope:` block and a transform body supplied by the caller.
+fn compile_rest(
+    with_envelope: bool,
+    transform_cxl: &str,
+) -> Result<crate::plan::CompiledPlan, Vec<Diagnostic>> {
+    let envelope_block = if with_envelope {
+        "      envelope:\n        sections:\n          Head:\n            extract: { json_pointer: \"/Head\" }\n            fields:\n              batch_id: string\n"
+    } else {
+        ""
+    };
+    let mut yaml = format!(
+        r#"
+pipeline:
+  name: rest_doc_validate
+nodes:
+  - type: source
+    name: api
+    config:
+      name: api
+      type: json
+      transport:
+        kind: rest
+        url: https://api.example.com/v1/records
+        max_pages: 25
+      options:
+        record_path: records
+{envelope_block}      schema:
+        - {{ name: amount, type: int }}
+  - type: transform
+    name: t0
+    input: api
+    config:
+      cxl: |
+"#,
+    );
+    for line in transform_cxl.lines() {
+        yaml.push_str(&format!("        {line}\n"));
+    }
+    yaml.push_str(
+        "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+    );
+    let config = parse_config(&yaml).expect("parse rest pipeline");
+    config.compile(&CompileContext::default())
+}
+
+#[test]
+fn test_rest_doc_access_aborts_with_e349() {
+    // A `$doc` read against a REST source (no envelope declared) can never
+    // resolve — a REST pull buffers no document. E349 rejects it (#507).
+    let err = compile_rest(false, "emit amount = amount\nemit b = $doc.Head.batch_id")
+        .expect_err("a `$doc` read against a rest source must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E349")
+        .unwrap_or_else(|| panic!("expected an E349 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("rest source") && diag.message.contains("batch_id"),
+        "E349 message must name the rest source and the access: {}",
+        diag.message
+    );
+    assert!(diag.help.is_some(), "E349 must carry help text");
+}
+
+#[test]
+fn test_rest_envelope_declaration_aborts_with_e349() {
+    // Declaring an `envelope:` block on a REST source is inert and rejected
+    // even when no downstream node reads `$doc` from it (#507).
+    let err = compile_rest(true, "emit amount = amount")
+        .expect_err("an `envelope:` block on a rest source must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E349")
+        .unwrap_or_else(|| panic!("expected an E349 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("envelope") && diag.message.contains("inert"),
+        "E349 message must explain the inert envelope: {}",
+        diag.message
+    );
+}
+
+#[test]
+fn test_rest_without_doc_or_envelope_compiles() {
+    // A REST source that neither declares an envelope nor is read via `$doc`
+    // is unaffected — the guard fires only on an actual `$doc`/envelope use.
+    compile_rest(false, "emit amount = amount + 1")
+        .expect("a plain rest source with no `$doc` use must compile");
 }
 
 #[test]

--- a/docs/explain/E348.md
+++ b/docs/explain/E348.md
@@ -1,0 +1,103 @@
+# Error E348: $doc path against a segment/positional format names an unknown section or out-of-range element
+
+## What it means
+
+A program reads `$doc.<section>.<field>` from a segment- or positional-based EDI
+source — **X12**, **EDIFACT**, or **HL7** — but the reference does not match the
+envelope vocabulary that format synthesizes. There are two causes:
+
+1. **Unknown section** — the section name is neither one the user declared under
+   `envelope.sections` nor one the reader synthesizes for the format. For X12 the
+   synthesized sections are `functional_group` and `transaction_set` (or the names
+   given via `group_section` / `set_section`); for HL7 they are `batch` and
+   `transaction_set`. EDIFACT synthesizes none beyond the declared `UNB`
+   interchange. A misspelling like `$doc.functonal_group.e06` lands here.
+
+2. **Out-of-range positional element** — the section is valid, but the field names
+   a positional element outside the format's element/field range. The synthesized
+   levels are keyed positionally: X12/EDIFACT use `e01`, `e02`, …, bounded by the
+   source's `max_elements` (default 32); HL7 uses `f01`, `f02`, …, bounded by
+   `max_fields` (default 64). A reference such as `$doc.transaction_set.e99` against
+   a source whose `max_elements` is 32 can never resolve, because the reader rejects
+   any wire segment carrying more elements than the bound.
+
+Without this check an undeclared section or out-of-range element compiles silently
+and resolves to `Value::Null` at run time, so the typo surfaces only as missing
+output data.
+
+```
+`$doc.functonal_group.e06` references envelope section 'functonal_group', but the
+x12 source 'interchange' synthesizes no such section
+```
+
+## Example
+
+```yaml
+# Rejected: `functonal_group` is misspelled — X12 synthesizes `functional_group`.
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      path: po.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields:
+              e13: string
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit gs06 = $doc.functonal_group.e06
+```
+
+```yaml
+# Corrected: the section name matches the synthesized `functional_group`.
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit gs06 = $doc.functional_group.e06
+```
+
+## How to fix
+
+1. **Correct the section name** to one the format exposes — a declared
+   `envelope.sections` key, or a synthesized level (`functional_group` /
+   `transaction_set` for X12, `batch` / `transaction_set` for HL7), including case.
+
+2. **Reference a positional element within range** (`eNN` / `fNN`, `1 <= N <=`
+   the configured bound), or raise the source's `max_elements` / `max_fields` if
+   the wire segment genuinely carries that many elements.
+
+3. **Declare a typed nested-section schema** (`group_section` / `set_section` on
+   X12) if you want a named field rather than a positional `eNN` element.
+
+## Technical context
+
+The cxl typechecker types every `$doc.<section>.<field>` access as `Any` — it has
+no envelope schema in scope. The planner closes that gap with two validation arms.
+The closed-schema arm (`E341`) checks XML / JSON sources, whose
+readers serve exactly the declared `envelope:` block. This segment/positional arm
+(`E348`) checks X12 / EDIFACT / HL7, whose readers synthesize nested envelope
+levels beyond the declared header: the file-level header (`ISA`/`UNB`/`FHS`) is the
+declared closed section, while the nested levels expose their wire data as
+positional `eNN`/`fNN` elements bounded by the configured element/field count. A
+path is validated against that known synthesized vocabulary plus any user-declared
+section/field, so a legitimate wire-derived path is accepted while a typo or an
+out-of-range element is rejected.
+
+## See also
+
+- "Envelopes & Document Context" in the pipeline reference
+- Error E341 — a `$doc` path against a closed-schema (XML/JSON) source
+- Error E340 — a `$doc` path indexed by a non-literal expression

--- a/docs/explain/E349.md
+++ b/docs/explain/E349.md
@@ -1,0 +1,87 @@
+# Error E349: $doc context read from a REST source, which buffers no document
+
+## What it means
+
+A `rest` source pulls its records page by page over paginated HTTP. It has no
+single buffered document with head and tail sections, so it carries no envelope
+context. This diagnostic fires in two cases:
+
+1. **A `$doc.<section>.<field>` access is attributed to a REST source** — a program
+   downstream of a `rest` source reads `$doc.*`. The access can never resolve and
+   would silently yield `null` at run time.
+
+2. **A `rest` source declares an `envelope:` block** — the declaration is inert. A
+   REST pull has no document to extract sections from, so the sections are never
+   populated and every `$doc` read against the source resolves to `null`.
+
+This is the same silent-empty failure mode the closed-schema check (`E341`) prevents
+for file sources, surfaced for the network transport. Rejecting it at compile keeps
+the fail-fast posture for a document read that can never resolve.
+
+```
+`$doc.Head.batch_id` reads document-envelope context from the rest source 'api',
+but a rest source pulls records page by page over HTTP and buffers no document —
+the access can never resolve and would silently yield null
+```
+
+## Example
+
+```yaml
+# Rejected: a $doc read against a rest source.
+nodes:
+  - type: source
+    name: api
+    config:
+      name: api
+      type: json
+      transport:
+        kind: rest
+        url: https://api.example.com/v1/records
+      options:
+        record_path: records
+  - type: transform
+    name: tag
+    input: api
+    config:
+      cxl: |
+        emit amount = amount
+        emit batch = $doc.Head.batch_id
+```
+
+```yaml
+# Corrected: pull the metadata into a record field through the response shape
+# instead of reading it as document-envelope context.
+  - type: transform
+    name: tag
+    input: api
+    config:
+      cxl: |
+        emit amount = amount
+        emit batch = batch_id          # a field on the record, not $doc
+```
+
+## How to fix
+
+1. **Remove the `$doc` access** (and any `envelope:` block) from the REST source.
+   Envelope sections are a file-document concept.
+
+2. **Pull document-level metadata into record fields** through the API's own
+   response shape — `record_path` to point at the record array, and `array_paths`
+   to hoist surrounding object fields onto each record — so the value travels as a
+   normal field rather than as document-envelope context.
+
+## Technical context
+
+`RestRecordSource::prepare_document` returns an empty section map unconditionally —
+there is no buffered document to pre-scan. Before this check, declaring `envelope:`
+on a REST source, or reading `$doc.*` from it, compiled and resolved to `null` at run
+time with no signal. The planner now rejects both shapes: it scans every source for
+a `rest` transport carrying an `envelope:` block, and it checks the transport of each
+source a referenced `$doc` path is attributed to. The check is on the transport, not
+the format, so it fires regardless of whether the REST source decodes JSON or XML.
+
+## See also
+
+- "Network (REST) sources carry no $doc context" in the Envelopes & Document Context reference
+- Error E341 — a `$doc` path against a closed-schema (XML/JSON) source
+- Error E348 — a `$doc` path against a segment/positional (X12/EDIFACT/HL7) source

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -158,11 +158,18 @@ source, one declaring a `discriminator:` + `records:` block.
 
 A `rest` source pulls its records page by page over paginated HTTP — it
 has no single buffered document with head and tail sections, so it
-carries no envelope context. Any `$doc.<section>.<field>` read against a
-REST source resolves to `null`, even when the source declares an
-`envelope:` block. Envelope sections are a file-document concept; pull
-the document-level metadata into record fields through the API's own
-response shape (`record_path`, `array_paths`) instead.
+carries no envelope context. Envelope sections are a file-document
+concept, so the compiler **rejects** them on a REST source rather than
+letting them silently resolve to `null`:
+
+- Declaring an `envelope:` block on a `rest` source is an error (`E349`) —
+  the declaration would be inert.
+- Reading `$doc.<section>.<field>` from a node fed by a `rest` source is an
+  error (`E349`) — the access can never resolve.
+
+Pull the document-level metadata into record fields through the API's own
+response shape (`record_path`, `array_paths`) instead, so the value travels
+as a normal field rather than as document-envelope context.
 
 ### EDIFACT `segment` extract
 
@@ -271,22 +278,43 @@ follows the same missing-value convention as `$source.*` and
 simply absent from the context; any `$doc.<missing_section>.<field>`
 resolves to `null`.
 
-## Declared-path validation (XML and JSON)
+## Declared-path validation
 
-For XML and JSON sources, the `envelope:` block is the complete schema:
-the reader extracts exactly the sections and fields it declares. So a
-`$doc.<section>.<field>` reference that names a section the source does
-not declare — or a field the declared section does not declare — is
-almost always a typo (`$doc.Summry.total` against a declared `Summary`),
-and would otherwise resolve silently to `null`. clinker rejects it at
-compile time with error `E341`, pointing at the node that made the
-reference. Run `clinker explain --code E341` for the full write-up.
+Every `$doc.<section>.<field>` reference is cross-checked at compile time
+against the schema the feeding source's reader will actually serve. A
+reference that can never resolve — almost always a typo — is rejected at
+compile time, pointing at the node that made it, rather than resolving
+silently to `null`. How the path is checked depends on the source:
 
-Segment- and positional-based formats (X12, EDIFACT, HL7, fixed-width)
-synthesize extra envelope levels and positional fields beyond what the
-config declares — an X12 reader exposes `$doc.functional_group.*` and
-`$doc.transaction_set.*` the config never names — so their `$doc` paths
-are not checked this way.
+**Closed-schema sources (XML, JSON)** — the `envelope:` block is the
+complete schema: the reader extracts exactly the sections and fields it
+declares. A reference naming a section the source does not declare, or a
+field the declared section does not declare, is rejected with error `E341`
+(`$doc.Summry.total` against a declared `Summary`). Run
+`clinker explain --code E341` for the full write-up.
+
+**Segment/positional sources (X12, EDIFACT, HL7)** — the file-level header
+(`ISA`/`UNB`/`FHS`) is declared through `envelope:` and is closed, but the
+reader *also* synthesizes nested envelope levels the config never names —
+X12's `functional_group` / `transaction_set`, HL7's `batch` /
+`transaction_set` — keyed by positional `eNN` / `fNN` elements bounded by
+the source's `max_elements` / `max_fields`. A `$doc` path is checked
+against that synthesized vocabulary plus any section/field you declared, so
+a legitimate wire-derived path (`$doc.functional_group.e06`) is accepted
+while a misspelled section (`$doc.functonal_group.e06`) or an out-of-range
+positional element (`$doc.transaction_set.e99`) is rejected with error
+`E348`. Run `clinker explain --code E348` for the full write-up.
+
+**REST sources** carry no document and reject `$doc` outright — see
+[Network (REST) sources carry no `$doc` context](#network-rest-sources-carry-no-doc-context)
+above (`E349`).
+
+CSV, fixed-width, and SWIFT MT sources are not statically checked. A plain
+flat file synthesizes no `$doc` sections; a multi-record flat file's
+`record_type` sections are author-declared but their served vocabulary is
+not reconstructed at this layer; and SWIFT serves declared sections under
+user-chosen *or* default block labels — none fits the closed or positional
+model cleanly.
 
 ## Indexed `$doc` access
 


### PR DESCRIPTION
## Summary

Extends the compile-time `$doc`-path validation seam to the source types it currently skips. Closes **#481** and **#507**.

Replaces the boolean `envelope_schema_is_closed` gate with a per-source `DocSchema` classification (`doc_schema_for`), keyed on transport first, then format:

- **REST transport → E349 (new).** A `$doc` path attributed to a `rest` source, or a `rest` source declaring an `envelope:` block, is rejected at compile (a REST pull buffers no document, so it can never carry `$doc` context — previously resolved silently to null).
- **Closed schema (E341, unchanged) → XML/JSON.** Validate against declared `envelope.sections`.
- **Segment/positional → E348 (new) → X12/EDIFACT/HL7.** Three section kinds matching what each reader serves: declared file-level header (ISA/UNB/FHS) closed to its declared fields; synthesized nested level with default keying → positional `eNN`/`fNN` within `1..=max_elements`; synthesized level given a typed nested schema (X12 `group_section`/`set_section`) closed to those declared fields.
- **Unvalidated:** CSV, fixed-width, SWIFT (CSV/FW multi-record `record_type` validation deferred → **#552**).

Legitimate wire paths (`$doc.functional_group.e06`) still compile; the positional check requires the reader's exact zero-padded spelling (`e07`, not `e7`).

## Diagnostic-code choice
New **E348**/**E349** rather than reusing E341 (its contract is the XML/JSON closed-schema arm). E346 avoided (reserved by #546). Explain docs added for both; user-doc REST-limitation note rewritten to reflect reject-at-compile.

## Superseded WIP
Did **not** port the salvaged `fd29caf5` WIP — its `cxl/analyzer/doc_paths.rs` core already landed on main via #431/#463/#470/#478/#482. Built entirely on current main's machinery.

## Limitations / follow-ups
- **CSV/fixed-width left unvalidated** (deliberate): the positional model only exists for X12/EDIFACT/HL7, and `nested_envelope_test.rs` exercises a scripted CSV reader with `$doc` paths that closed-schema CSV validation would false-positive. Multi-record `record_type` validation filed as **#552**.

## Verification
Full 8-step gauntlet green (run with an isolated `CARGO_TARGET_DIR`). Rewrote the segment-format E341 test (contract flipped to assert E348 fires) and added X12/HL7/REST/typed-nested/unpadded-element coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
