### PR TITLE
record: schema-described envelope-record replaces the loose $doc section map (#571)

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -2112,7 +2112,6 @@ fn emit_aggregate_finalize_dlq(
 mod tests {
     use super::*;
     use clinker_record::{DocumentContext, Value};
-    use indexmap::IndexMap;
 
     fn record_in_document(doc_id: DocumentId, tag: &str) -> Record {
         let schema = Arc::new(Schema::new(vec!["tag".into()]));
@@ -2120,7 +2119,7 @@ mod tests {
         record.set_doc_ctx(Arc::new(DocumentContext::new(
             doc_id,
             Arc::from("file.csv"),
-            IndexMap::new(),
+            clinker_record::EnvelopeRecord::empty(),
         )));
         record
     }

--- a/crates/clinker-exec/src/executor/batch_handoff.rs
+++ b/crates/clinker-exec/src/executor/batch_handoff.rs
@@ -411,7 +411,6 @@ mod tests {
     use clinker_record::{
         DocumentContext, DocumentId, Record, Schema, Value, synthetic_document_context,
     };
-    use indexmap::IndexMap;
 
     use crate::executor::stream_event::PunctuationKind;
 
@@ -429,7 +428,7 @@ mod tests {
         Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from(""),
-            IndexMap::new(),
+            clinker_record::EnvelopeRecord::empty(),
         ))
     }
 

--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -583,7 +583,7 @@ fn drive_record_source(
                             Arc::new(clinker_record::DocumentContext::new(
                                 clinker_record::DocumentId::next(),
                                 Arc::clone(&file_arc),
-                                indexmap::IndexMap::new(),
+                                clinker_record::EnvelopeRecord::empty(),
                             ))
                         });
                         let rep_record = build_representative_record(
@@ -812,7 +812,7 @@ fn open_file_level_doc(
     let new_ctx = Arc::new(clinker_record::DocumentContext::new(
         clinker_record::DocumentId::next(),
         Arc::clone(file_arc),
-        envelope_sections,
+        clinker_record::EnvelopeRecord::from_sections(envelope_sections),
     ));
     push_doc_punctuation(
         stream,
@@ -867,9 +867,10 @@ fn apply_envelope_events(
                 // output-envelope / document-DLQ frame via `child_frame`;
                 // `Inherit` (an X12 `GS`/`ST`) stays inside the enclosing
                 // interchange frame via `child`.
+                let envelope = clinker_record::EnvelopeRecord::from_sections(sections);
                 let child = Arc::new(match frame {
-                    clinker_format::FrameRole::NewFrame => parent.child_frame(id, sections),
-                    clinker_format::FrameRole::Inherit => parent.child(id, sections),
+                    clinker_format::FrameRole::NewFrame => parent.child_frame(id, envelope),
+                    clinker_format::FrameRole::Inherit => parent.child(id, envelope),
                 });
                 push_doc_punctuation(
                     stream,

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -881,7 +881,6 @@ mod tests {
     use clinker_format::FormatWriter;
     use clinker_format::error::FormatError;
     use clinker_record::{DocumentContext, DocumentId, FieldResolver, Schema, Value};
-    use indexmap::IndexMap;
     use std::sync::Mutex;
 
     /// A [`FormatWriter`] that records every hook invocation as an ordered
@@ -925,7 +924,7 @@ mod tests {
         Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from(file),
-            IndexMap::new(),
+            clinker_record::EnvelopeRecord::empty(),
         ))
     }
 
@@ -998,7 +997,8 @@ mod tests {
         // interchange document — begin/end fire exactly once for the whole
         // `ISA..IEA`, not once per transaction set.
         let outer = doc("multi.x12");
-        let inner = Arc::new(outer.child(DocumentId::next(), IndexMap::new()));
+        let inner =
+            Arc::new(outer.child(DocumentId::next(), clinker_record::EnvelopeRecord::empty()));
         let records = vec![record(1, &outer), record(2, &inner), record(3, &outer)];
         let (log, written) = run_log(&records);
         assert_eq!(
@@ -1028,10 +1028,14 @@ mod tests {
         let file_doc = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::clone(&file),
-            IndexMap::new(),
+            clinker_record::EnvelopeRecord::empty(),
         ));
-        let msg1 = Arc::new(file_doc.child_frame(DocumentId::next(), IndexMap::new()));
-        let msg2 = Arc::new(file_doc.child_frame(DocumentId::next(), IndexMap::new()));
+        let msg1 = Arc::new(
+            file_doc.child_frame(DocumentId::next(), clinker_record::EnvelopeRecord::empty()),
+        );
+        let msg2 = Arc::new(
+            file_doc.child_frame(DocumentId::next(), clinker_record::EnvelopeRecord::empty()),
+        );
         let records = vec![record(1, &msg1), record(2, &msg1), record(3, &msg2)];
         let (log, written) = run_log(&records);
         assert_eq!(

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -274,13 +274,12 @@ pub(crate) fn reconcile_document_boundaries(
 mod tests {
     use super::*;
     use clinker_record::{DocumentContext, Schema, Value, synthetic_document_context};
-    use indexmap::IndexMap;
 
     fn doc_ctx() -> Arc<DocumentContext> {
         Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("doc.x12"),
-            IndexMap::new(),
+            clinker_record::EnvelopeRecord::empty(),
         ))
     }
 

--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -702,7 +702,7 @@ mod tests {
         Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from(file),
-            sections,
+            clinker_record::EnvelopeRecord::from_sections(sections),
         ))
     }
 

--- a/crates/clinker-exec/src/pipeline/spill.rs
+++ b/crates/clinker-exec/src/pipeline/spill.rs
@@ -541,7 +541,7 @@ mod tests {
         Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from(file),
-            sections,
+            clinker_record::EnvelopeRecord::from_sections(sections),
         ))
     }
 

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -577,7 +577,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            clinker_record::EnvelopeRecord::from_sections(sections),
         ));
         input.set_doc_ctx(Arc::clone(&ctx));
 

--- a/crates/clinker-format/src/counting.rs
+++ b/crates/clinker-format/src/counting.rs
@@ -243,8 +243,7 @@ mod tests {
     fn counted_format_writer_forwards_document_hooks_to_inner() {
         use std::sync::{Arc, Mutex};
 
-        use clinker_record::DocumentId;
-        use indexmap::IndexMap;
+        use clinker_record::{DocumentId, EnvelopeRecord};
 
         let log = Arc::new(Mutex::new(Vec::new()));
         let probe = HookProbe {
@@ -252,7 +251,11 @@ mod tests {
         };
         let mut counted = CountedFormatWriter::new(Box::new(probe), SharedByteCounter::new());
 
-        let doc = DocumentContext::new(DocumentId::next(), Arc::from("file.x12"), IndexMap::new());
+        let doc = DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("file.x12"),
+            EnvelopeRecord::empty(),
+        );
         counted.begin_document(&doc).unwrap();
         counted.end_document(&doc).unwrap();
 

--- a/crates/clinker-format/src/doc_index.rs
+++ b/crates/clinker-format/src/doc_index.rs
@@ -33,18 +33,18 @@ use crate::error::FormatError;
 /// incrementally against `max_index_bytes`; the cap fires mid-build
 /// (before OOM), not post-hoc.
 pub struct DocArenaIndex {
-    /// Declared section names, in first-seen order. A reader's pre-scan
-    /// consults [`Self::wants_section`] before descending into a section,
-    /// so an undeclared section is skipped without materializing it.
-    wanted_sections: Vec<Box<str>>,
-    /// Field-level retention per section, consulted by [`Self::wants_field`]
-    /// so a reader coerces only the fields some program actually reads.
-    /// A section maps to `Some(set)` when every path into it names a concrete
-    /// field — only those fields are retained. It maps to `None` (retain all
-    /// fields) when any path references the whole section (empty field) or
-    /// reaches in by index, since an index selects an element of the
-    /// already-retained subtree and a whole-section reference needs every
-    /// field. Absent from the map ⇒ no path wants the section at all.
+    /// Field-level retention per section, in first-seen order. Its key set is
+    /// the declared section set: a reader's pre-scan consults
+    /// [`Self::wants_section`] (an O(1) key lookup here) before descending into
+    /// a section, so an undeclared section is skipped without materializing it,
+    /// and consults [`Self::wants_field`] so a reader coerces only the fields
+    /// some program actually reads. A section maps to `Some(set)` when every
+    /// path into it names a concrete field — only those fields are retained. It
+    /// maps to `None` (retain all fields) when any path references the whole
+    /// section (empty field) or reaches in by index, since an index selects an
+    /// element of the already-retained subtree and a whole-section reference
+    /// needs every field. Absent from the map ⇒ no path wants the section at
+    /// all.
     wanted_fields: IndexMap<Box<str>, Option<Vec<Box<str>>>>,
     /// Retained section subtrees, keyed by section name in insertion
     /// order. One entry per inserted section.
@@ -65,15 +65,8 @@ impl DocArenaIndex {
     /// sections. `max_index_bytes` caps total retained bytes; the cap is
     /// checked incrementally in [`Self::insert`].
     pub fn new(declared: &[DocPath], max_index_bytes: Option<usize>) -> Self {
-        let mut wanted_sections: Vec<Box<str>> = Vec::new();
         let mut wanted_fields: IndexMap<Box<str>, Option<Vec<Box<str>>>> = IndexMap::new();
         for path in declared {
-            if !wanted_sections
-                .iter()
-                .any(|s| s.as_ref() == path.section.as_ref())
-            {
-                wanted_sections.push(path.section.clone());
-            }
             // A whole-section reference (empty field) or any indexed reference
             // promotes the section to retain-all (`None`); a concrete field
             // adds to the section's set unless the section is already
@@ -90,7 +83,6 @@ impl DocArenaIndex {
             }
         }
         DocArenaIndex {
-            wanted_sections,
             wanted_fields,
             sections: IndexMap::new(),
             retained_bytes: 0,
@@ -101,14 +93,15 @@ impl DocArenaIndex {
     /// `true` when no path was declared — the reader's pre-scan can skip
     /// the document entirely.
     pub fn is_empty(&self) -> bool {
-        self.wanted_sections.is_empty()
+        self.wanted_fields.is_empty()
     }
 
     /// `true` when some declared path references `section` — the reader
     /// descends into the section; otherwise it skips the section without
-    /// materializing its subtree.
+    /// materializing its subtree. O(1): the declared section set is exactly
+    /// the `wanted_fields` key set.
     pub fn wants_section(&self, section: &str) -> bool {
-        self.wanted_sections.iter().any(|s| s.as_ref() == section)
+        self.wanted_fields.contains_key(section)
     }
 
     /// `true` when some declared path reads `field` of `section` — the reader

--- a/crates/clinker-format/src/doc_index.rs
+++ b/crates/clinker-format/src/doc_index.rs
@@ -37,6 +37,15 @@ pub struct DocArenaIndex {
     /// consults [`Self::wants_section`] before descending into a section,
     /// so an undeclared section is skipped without materializing it.
     wanted_sections: Vec<Box<str>>,
+    /// Field-level retention per section, consulted by [`Self::wants_field`]
+    /// so a reader coerces only the fields some program actually reads.
+    /// A section maps to `Some(set)` when every path into it names a concrete
+    /// field — only those fields are retained. It maps to `None` (retain all
+    /// fields) when any path references the whole section (empty field) or
+    /// reaches in by index, since an index selects an element of the
+    /// already-retained subtree and a whole-section reference needs every
+    /// field. Absent from the map ⇒ no path wants the section at all.
+    wanted_fields: IndexMap<Box<str>, Option<Vec<Box<str>>>>,
     /// Retained section subtrees, keyed by section name in insertion
     /// order. One entry per inserted section.
     sections: IndexMap<Box<str>, Value>,
@@ -57,6 +66,7 @@ impl DocArenaIndex {
     /// checked incrementally in [`Self::insert`].
     pub fn new(declared: &[DocPath], max_index_bytes: Option<usize>) -> Self {
         let mut wanted_sections: Vec<Box<str>> = Vec::new();
+        let mut wanted_fields: IndexMap<Box<str>, Option<Vec<Box<str>>>> = IndexMap::new();
         for path in declared {
             if !wanted_sections
                 .iter()
@@ -64,9 +74,24 @@ impl DocArenaIndex {
             {
                 wanted_sections.push(path.section.clone());
             }
+            // A whole-section reference (empty field) or any indexed reference
+            // promotes the section to retain-all (`None`); a concrete field
+            // adds to the section's set unless the section is already
+            // retain-all. `IndexMap`'s entry API keeps the first-seen order.
+            let entry = wanted_fields
+                .entry(path.section.clone())
+                .or_insert_with(|| Some(Vec::new()));
+            if path.field.is_empty() || !path.indices.is_empty() {
+                *entry = None;
+            } else if let Some(fields) = entry
+                && !fields.iter().any(|f| f.as_ref() == path.field.as_ref())
+            {
+                fields.push(path.field.clone());
+            }
         }
         DocArenaIndex {
             wanted_sections,
+            wanted_fields,
             sections: IndexMap::new(),
             retained_bytes: 0,
             max_index_bytes,
@@ -84,6 +109,27 @@ impl DocArenaIndex {
     /// materializing its subtree.
     pub fn wants_section(&self, section: &str) -> bool {
         self.wanted_sections.iter().any(|s| s.as_ref() == section)
+    }
+
+    /// `true` when some declared path reads `field` of `section` — the reader
+    /// coerces and retains the field; otherwise it skips coercing it.
+    ///
+    /// A section reached only by concrete `(section, field)` paths prunes to
+    /// exactly those fields. A section reached by a whole-section reference
+    /// (empty field) or any indexed path retains every field (an index selects
+    /// an element of the already-retained subtree), so this returns `true` for
+    /// any field of such a section. A section no path references at all wants
+    /// no fields — but a reader gates on [`Self::wants_section`] first, so this
+    /// is reached only for a wanted section.
+    pub fn wants_field(&self, section: &str, field: &str) -> bool {
+        match self.wanted_fields.get(section) {
+            // Retain-all: whole-section or indexed reference.
+            Some(None) => true,
+            // Concrete field set: retain only the named fields.
+            Some(Some(fields)) => fields.iter().any(|f| f.as_ref() == field),
+            // Section not referenced by any path.
+            None => false,
+        }
     }
 
     /// Charge an already-built `value`'s heap-size estimate against the cap,
@@ -214,6 +260,50 @@ mod tests {
             None,
         );
         assert!(idx.wants_section("summary"));
+    }
+
+    #[test]
+    fn wants_field_prunes_to_concrete_fields_only() {
+        // A section reached by two concrete fields retains exactly those; a
+        // sibling field the program never reads is pruned.
+        let idx = DocArenaIndex::new(
+            &[path("Summary", "record_count"), path("Summary", "checksum")],
+            None,
+        );
+        assert!(idx.wants_field("Summary", "record_count"));
+        assert!(idx.wants_field("Summary", "checksum"));
+        assert!(!idx.wants_field("Summary", "unread"));
+        // A section no path references wants nothing.
+        assert!(!idx.wants_field("Header", "anything"));
+    }
+
+    #[test]
+    fn wants_field_whole_section_reference_retains_all() {
+        // An empty-field (whole-section) reference promotes the section to
+        // retain-all, so an unnamed field is still wanted.
+        let idx = DocArenaIndex::new(&[path("Summary", "")], None);
+        assert!(idx.wants_section("Summary"));
+        assert!(idx.wants_field("Summary", "anything"));
+        assert!(idx.wants_field("Summary", "else_entirely"));
+    }
+
+    #[test]
+    fn wants_field_indexed_reference_retains_all_of_its_section() {
+        // An indexed path selects an element of the already-retained subtree,
+        // so the whole section is retained — every field is wanted, even a
+        // concrete sibling field declared alongside.
+        let idx = DocArenaIndex::new(
+            &[
+                indexed_path("summary", "items", vec![DocIndex::Int(0)]),
+                path("summary", "checksum"),
+            ],
+            None,
+        );
+        assert!(idx.wants_field("summary", "items"));
+        assert!(idx.wants_field("summary", "checksum"));
+        // Retain-all wins even though `checksum` is a concrete field — the
+        // indexed reference dominates the section's retention.
+        assert!(idx.wants_field("summary", "unread_sibling"));
     }
 
     #[test]

--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -897,7 +897,7 @@ mod tests {
         use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
         use crate::envelope::EnvelopeFieldType;
         use crate::traits::FormatWriter;
-        use clinker_record::{DocumentContext, DocumentId};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
 
         // UNB element 4 (index 3, the prep date/time) is empty, so the
         // control reference "REF9" stays at the standard 5th-element
@@ -923,7 +923,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let schema = r.schema().unwrap();
         let out = {
@@ -1036,7 +1036,7 @@ mod tests {
         use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
         use crate::envelope::EnvelopeFieldType;
         use crate::traits::FormatWriter;
-        use clinker_record::{DocumentContext, DocumentId};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
 
         // NAD body element "Caf鏃" carries 0xE9 (é); a second body element
         // carries 0xF1 (ñ). UNOC declares Latin-1.
@@ -1062,7 +1062,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let schema = r.schema().unwrap();
         let out_bytes = {
@@ -1109,7 +1109,7 @@ mod tests {
         use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
         use crate::envelope::EnvelopeFieldType;
         use crate::traits::FormatWriter;
-        use clinker_record::{DocumentContext, DocumentId};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
 
         // UNB sender element (e02) is "Café" with é = 0xE9 (a single Latin-1
         // byte). UNOC declares Latin-1.
@@ -1144,7 +1144,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let schema = r.schema().unwrap();
         let out_bytes = {
@@ -1181,7 +1181,7 @@ mod tests {
         use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
         use crate::envelope::EnvelopeFieldType;
         use crate::traits::FormatWriter;
-        use clinker_record::{DocumentContext, DocumentId};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
 
         // UNB sender element is "Café" with é = 0xC3 0xA9 (two UTF-8 bytes).
         // A byte-wise placeholder decode would surface "Ã©" (two codepoints).
@@ -1209,7 +1209,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let schema = r.schema().unwrap();
         let out_bytes = {

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -620,7 +620,7 @@ mod tests {
 
     #[test]
     fn unb_echoed_from_doc_section() {
-        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
         use indexmap::IndexMap;
 
         // Build a record carrying a `$doc.unb` section with positional
@@ -638,7 +638,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
 
         let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
@@ -658,7 +658,7 @@ mod tests {
 
     #[test]
     fn unb_from_doc_raw_preserves_empty_middle_element() {
-        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
         use indexmap::IndexMap;
 
         // A real UNB whose element 4 (index 3) is empty. The reader
@@ -682,7 +682,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
         record.set_doc_ctx(ctx);
@@ -707,7 +707,7 @@ mod tests {
 
     #[test]
     fn unz_echoes_control_ref_shifted_past_empty_padding() {
-        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
         use indexmap::IndexMap;
 
         // A UNB with all four mandatory leading composites populated plus
@@ -732,7 +732,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
         record.set_doc_ctx(ctx);
@@ -754,7 +754,7 @@ mod tests {
 
     #[test]
     fn unz_echoes_control_ref_past_split_date_time() {
-        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
         use indexmap::IndexMap;
 
         // A UNB whose S004 date/time is transmitted as two separate
@@ -780,7 +780,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.edi"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let mut record = body(&s, "BGM", "M1", "ORDERS", &["220"]);
         record.set_doc_ctx(ctx);

--- a/crates/clinker-format/src/envelope_writer.rs
+++ b/crates/clinker-format/src/envelope_writer.rs
@@ -163,14 +163,14 @@ pub(crate) fn test_doc_with_sections(
     std::sync::Arc::new(DocumentContext::new(
         clinker_record::DocumentId::next(),
         std::sync::Arc::from("test.doc"),
-        map,
+        clinker_record::EnvelopeRecord::from_sections(map),
     ))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use clinker_record::DocumentId;
+    use clinker_record::{DocumentId, EnvelopeRecord};
     use std::sync::Arc;
 
     fn section(fields: &[(&str, Value)]) -> Value {
@@ -184,7 +184,11 @@ mod tests {
     fn doc_with(section_name: &str, fields: &[(&str, Value)]) -> DocumentContext {
         let mut sections = IndexMap::new();
         sections.insert(Box::from(section_name), section(fields));
-        DocumentContext::new(DocumentId::next(), Arc::from("f.csv"), sections)
+        DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("f.csv"),
+            EnvelopeRecord::from_sections(sections),
+        )
     }
 
     #[test]

--- a/crates/clinker-format/src/hl7/reader.rs
+++ b/crates/clinker-format/src/hl7/reader.rs
@@ -1168,7 +1168,7 @@ mod tests {
     fn reader_doc_writer_round_trip_preserves_msh_and_escapes() {
         use crate::hl7::writer::{Hl7Writer, Hl7WriterConfig};
         use crate::traits::FormatWriter;
-        use clinker_record::{DocumentContext, DocumentId};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
 
         // PID-3 is a real composite CX field with four components and a
         // repetition (`~`); the OBX field carries a literal '|' that arrives
@@ -1193,7 +1193,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("adt.hl7"),
-            IndexMap::new(),
+            EnvelopeRecord::empty(),
         ));
         let schema = r.schema().unwrap();
         let out = {

--- a/crates/clinker-format/src/hl7/writer.rs
+++ b/crates/clinker-format/src/hl7/writer.rs
@@ -642,7 +642,7 @@ mod tests {
 
     #[test]
     fn file_header_echoed_from_doc_section() {
-        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
         use indexmap::IndexMap;
 
         let s = schema();
@@ -658,7 +658,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("a.hl7"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
 
         let mut msh = record(
@@ -685,7 +685,7 @@ mod tests {
         // at the first missing `fNN` key: with `f01` and `f03` declared but
         // `f02` absent, the FHS header must carry an empty field at position 2
         // rather than truncating at the gap.
-        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
         use indexmap::IndexMap;
 
         let s = schema();
@@ -698,7 +698,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("a.hl7"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
 
         let mut msh = record(&s, "MSH", &["^~\\&", "S"]);

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -468,7 +468,7 @@ impl FormatReader for JsonReader {
                     )));
                 }
             };
-            let typed = coerce_json_section_fields(name, payload_obj, &section.fields)?;
+            let typed = coerce_json_section_fields(name, payload_obj, &section.fields, &index)?;
             let path = doc_path_for_section(name);
             index.insert(&path, Value::Map(Box::new(typed)))?;
         }
@@ -597,13 +597,23 @@ fn json_value_kind(v: &serde_json::Value) -> &'static str {
 /// missing fields drop out (CXL eval maps to `Value::Null`); type
 /// mismatch raises a format error citing the section + field +
 /// observed JSON value.
+///
+/// A declared field no program reads is skipped before coercion: a
+/// wide-schema section referenced by a single field coerces only that field,
+/// so an unread (and possibly malformed) sibling field is never parsed or
+/// type-checked. `index` is the retention authority that knows the read set
+/// (see [`DocArenaIndex::wants_field`]).
 fn coerce_json_section_fields(
     section_name: &str,
     obj: &serde_json::Map<String, serde_json::Value>,
     schema: &IndexMap<String, EnvelopeFieldType>,
+    index: &DocArenaIndex,
 ) -> Result<IndexMap<Box<str>, Value>, FormatError> {
     let mut out: IndexMap<Box<str>, Value> = IndexMap::with_capacity(schema.len());
     for (field, ty) in schema {
+        if !index.wants_field(section_name, field) {
+            continue;
+        }
         let json_val = match obj.get(field.as_str()) {
             Some(v) if !v.is_null() => v,
             _ => continue,

--- a/crates/clinker-format/src/splitting/tests.rs
+++ b/crates/clinker-format/src/splitting/tests.rs
@@ -906,8 +906,7 @@ impl FormatWriter for HookProbe {
 
 #[test]
 fn splitting_writer_forwards_document_hooks_to_active_inner() {
-    use clinker_record::DocumentId;
-    use indexmap::IndexMap;
+    use clinker_record::{DocumentId, EnvelopeRecord};
 
     let schema = make_schema(&["id"]);
     let registry = FileRegistry::new();
@@ -927,7 +926,11 @@ fn splitting_writer_forwards_document_hooks_to_active_inner() {
     };
     let mut writer = SplittingWriter::new(registry.file_factory(), writer_factory, schema, policy);
 
-    let doc = DocumentContext::new(DocumentId::next(), Arc::from("file.x12"), IndexMap::new());
+    let doc = DocumentContext::new(
+        DocumentId::next(),
+        Arc::from("file.x12"),
+        EnvelopeRecord::empty(),
+    );
     // `begin_document` arrives before any record: the splitter must lazy-open
     // the first file so the framing reaches a real inner writer.
     writer.begin_document(&doc).unwrap();

--- a/crates/clinker-format/src/swift/writer.rs
+++ b/crates/clinker-format/src/swift/writer.rs
@@ -435,7 +435,7 @@ mod tests {
         DEFAULT_APP_HEADER_SECTION, DEFAULT_BASIC_HEADER_SECTION, DEFAULT_TRAILER_SECTION,
         DEFAULT_USER_HEADER_SECTION,
     };
-    use clinker_record::{DocumentContext, DocumentId};
+    use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
     use indexmap::IndexMap;
     use std::io::Cursor;
 
@@ -476,7 +476,7 @@ mod tests {
         Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("a.swift"),
-            out,
+            EnvelopeRecord::from_sections(out),
         ))
     }
 

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -1158,7 +1158,7 @@ mod tests {
     fn reader_doc_writer_round_trip_preserves_isa_and_structure() {
         use crate::traits::FormatWriter;
         use crate::x12::writer::{X12Writer, X12WriterConfig};
-        use clinker_record::{DocumentContext, DocumentId};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
 
         let input = interchange();
 
@@ -1173,7 +1173,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.x12"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
         let schema = r.schema().unwrap();
         let out = {

--- a/crates/clinker-format/src/x12/writer.rs
+++ b/crates/clinker-format/src/x12/writer.rs
@@ -752,7 +752,7 @@ mod tests {
 
     #[test]
     fn isa_echoed_from_doc_section() {
-        use clinker_record::{DocumentContext, DocumentId, Value as RecVal};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
         use indexmap::IndexMap;
 
         let s = schema();
@@ -769,7 +769,7 @@ mod tests {
         let ctx = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.x12"),
-            sections,
+            EnvelopeRecord::from_sections(sections),
         ));
 
         let mut record = body(&s, "BEG", "0001", "850", &["00"]);

--- a/crates/clinker-format/src/xml/streaming.rs
+++ b/crates/clinker-format/src/xml/streaming.rs
@@ -86,6 +86,7 @@ pub(crate) fn extract_sections(
     let mut parser = XmlParser::from_reader(reader);
     parser.config_mut().trim_text(true);
 
+    let parse_ctx = SectionParseCtx { ns, attr_prefix };
     let mut path_stack: Vec<String> = Vec::new();
     let mut captured: Vec<MatchedSection> = Vec::new();
     let mut charge = ByteCharge {
@@ -107,14 +108,25 @@ pub(crate) fn extract_sections(
                     .iter()
                     .find(|t| path_matches(&path_stack, &t.segments))
                 {
+                    // The matched section element's OWN attributes belong to
+                    // the section, addressable as bare `@attr` (no element
+                    // prefix) — exactly as the body reader seeds a record's
+                    // start-tag attributes. Seed them before the children so
+                    // `<Summary id="5">` exposes `$doc.Summary.@id`; the
+                    // children's nested fields follow.
+                    let mut seed: Vec<(String, String)> = Vec::new();
+                    for (key, val) in extract_attributes_static(attr_prefix, e)? {
+                        charge.charge(key.len() + val.len(), &target.name)?;
+                        seed.push((key, val));
+                    }
                     let payload = read_section_payload(
                         &mut parser,
                         &mut buf,
-                        ns,
-                        attr_prefix,
+                        &parse_ctx,
                         path_stack.len(),
                         &target.name,
                         &mut charge,
+                        seed,
                     )?;
                     captured.push((target.name.clone(), payload));
                     // `read_section_payload` consumed the matched subtree up
@@ -148,6 +160,14 @@ pub(crate) fn extract_sections(
     }
 
     Ok(captured)
+}
+
+/// The two static per-parse settings the section walk threads unchanged
+/// through every element: namespace handling and the attribute-key prefix.
+/// Grouped so the subtree reader carries them as one borrow.
+struct SectionParseCtx<'a> {
+    ns: &'a NamespaceMode,
+    attr_prefix: &'a str,
 }
 
 /// Running retained-byte total for the streaming pass, charged against the
@@ -189,6 +209,11 @@ fn path_matches(stack: &[String], segs: &[String]) -> bool {
 /// pairs, charging each retained pair against `charge` and aborting
 /// mid-subtree the instant the running total crosses the cap.
 ///
+/// `seed` carries the matched element's own start-tag attributes (already
+/// charged by the caller), which lead the payload as bare `@attr` keys before
+/// the children's nested fields — matching the body reader's start-attribute
+/// seeding.
+///
 /// Produces the same flat payload the body record extractor does — same
 /// `.`-joined nested-element prefixes, attribute prefixing, and CData /
 /// text handling — so a declared section's output is byte-identical to the
@@ -202,13 +227,13 @@ fn path_matches(stack: &[String], segs: &[String]) -> bool {
 fn read_section_payload(
     parser: &mut BodyParser,
     buf: &mut Vec<u8>,
-    ns: &NamespaceMode,
-    attr_prefix: &str,
+    ctx: &SectionParseCtx,
     section_depth: usize,
     section: &str,
     charge: &mut ByteCharge,
+    seed: Vec<(String, String)>,
 ) -> Result<Vec<(String, String)>, FormatError> {
-    let mut fields: Vec<(String, String)> = Vec::new();
+    let mut fields: Vec<(String, String)> = seed;
     let mut element_stack: Vec<String> = Vec::new();
     let mut depth_here = section_depth;
     loop {
@@ -219,9 +244,9 @@ fn read_section_payload(
         match event {
             Event::Start(ref e) => {
                 depth_here += 1;
-                let name = elem_name_static(ns, &e.name());
+                let name = elem_name_static(ctx.ns, &e.name());
                 element_stack.push(name);
-                let attrs = extract_attributes_static(attr_prefix, e)?;
+                let attrs = extract_attributes_static(ctx.attr_prefix, e)?;
                 let prefix = element_stack.join(".");
                 for (k, v) in attrs {
                     let key = format!("{prefix}.{k}");
@@ -237,7 +262,7 @@ fn read_section_payload(
                 element_stack.pop();
             }
             Event::Empty(ref e) => {
-                let name = elem_name_static(ns, &e.name());
+                let name = elem_name_static(ctx.ns, &e.name());
                 let prefix = if element_stack.is_empty() {
                     name.clone()
                 } else {
@@ -245,7 +270,7 @@ fn read_section_payload(
                 };
                 charge.charge(prefix.len(), section)?;
                 fields.push((prefix.clone(), String::new()));
-                let attrs = extract_attributes_static(attr_prefix, e)?;
+                let attrs = extract_attributes_static(ctx.attr_prefix, e)?;
                 for (k, v) in attrs {
                     let key = format!("{prefix}.{k}");
                     charge.charge(key.len() + v.len(), section)?;

--- a/crates/clinker-format/tests/streaming_doc_index_json.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_json.rs
@@ -407,6 +407,114 @@ fn prescan_prunes_the_unread_section_in_a_mixed_envelope() {
     );
 }
 
+#[test]
+fn prescan_coerces_only_the_read_fields_of_a_wide_section() {
+    // A wide-schema section whose program reads exactly ONE field must coerce
+    // only that field. The unread fields are not parsed or type-checked — so a
+    // declared-but-unread field carrying a value that would FAIL its declared
+    // coercion is skipped silently rather than aborting the run (the #496
+    // regression: eager coercion of every declared field).
+    let json = r#"{"Summary":{"record_count":7,"checksum":"not-an-int","ratio":"not-a-float"},"records":[{"x":1}]}"#;
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/Summary",
+        &[
+            ("record_count", EnvelopeFieldType::Int),
+            // Declared Int / Float, but the document carries non-numeric
+            // strings — these would error if eagerly coerced.
+            ("checksum", EnvelopeFieldType::Int),
+            ("ratio", EnvelopeFieldType::Float),
+        ],
+    )];
+    let cfg = envelope_config(specs);
+
+    // Only `record_count` is referenced by a `$doc` path.
+    let declared = vec![DocPath {
+        section: "Summary".into(),
+        field: "record_count".into(),
+        indices: Vec::new(),
+    }];
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared,
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader
+        .prepare_document(&cfg)
+        .expect("unread malformed fields must not abort the pre-scan");
+    let summary = match sections.get("Summary").expect("Summary retained") {
+        Value::Map(m) => m,
+        other => panic!("expected map, got {other:?}"),
+    };
+    // The read field coerced and survives.
+    assert_eq!(summary.get("record_count"), Some(&Value::Integer(7)));
+    // The unread fields were never coerced — absent from the retained payload.
+    assert!(
+        summary.get("checksum").is_none(),
+        "an unread declared field must not be coerced or retained"
+    );
+    assert!(summary.get("ratio").is_none());
+}
+
+#[test]
+fn prescan_retains_all_fields_when_section_referenced_whole_or_indexed() {
+    // A whole-section reference (empty field) or an indexed reference retains
+    // every declared field — the complement of the field-pruned case. Here a
+    // single indexed path into `Summary` promotes the whole section, so every
+    // declared field is coerced and retained.
+    let json =
+        r#"{"Summary":{"record_count":7,"checksum":42,"items":[10,20]},"records":[{"x":1}]}"#;
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/Summary",
+        &[
+            ("record_count", EnvelopeFieldType::Int),
+            ("checksum", EnvelopeFieldType::Int),
+            ("items", EnvelopeFieldType::String),
+        ],
+    )];
+    let cfg = envelope_config(specs);
+
+    // An indexed reference into `Summary.items[0]` promotes the section to
+    // retain-all — even fields no concrete path names.
+    let declared = vec![DocPath {
+        section: "Summary".into(),
+        field: "items".into(),
+        indices: vec![cxl::analyzer::doc_paths::DocIndex::Int(0)],
+    }];
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared,
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader.prepare_document(&cfg).expect("pre-scan");
+    let summary = match sections.get("Summary").expect("Summary retained") {
+        Value::Map(m) => m,
+        other => panic!("expected map, got {other:?}"),
+    };
+    // Every declared field retained — indexed reference promotes retain-all.
+    assert_eq!(summary.get("record_count"), Some(&Value::Integer(7)));
+    assert_eq!(summary.get("checksum"), Some(&Value::Integer(42)));
+    assert!(
+        summary.get("items").is_some(),
+        "the indexed field is retained alongside its section's other fields"
+    );
+}
+
 /// A multi-MB top-level array streams element-at-a-time: the whole array is
 /// never collected into a `Vec`, and re-opening by path means no whole-file
 /// byte buffer is held either. Body consumption tracks records yielded, not the

--- a/crates/clinker-format/tests/streaming_doc_index_xml.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_xml.rs
@@ -383,6 +383,37 @@ fn prescan_preserves_namespaces_attributes_and_cdata() {
     assert_eq!(meta.get("note"), Some(&Value::String("a & b".into())));
 }
 
+#[test]
+fn prescan_retains_the_matched_section_elements_own_attributes() {
+    // The matched section element carries its own attributes
+    // (`<Summary id="5" run="R-1">…`). The streaming pre-scan must seed those
+    // as bare `@attr` fields of the section — exactly as the body reader seeds
+    // a record's start-tag attributes — so `$doc.Summary.@id` resolves. Child
+    // element attributes are still captured under their `.`-joined prefix.
+    let xml = r#"<doc><Summary id="5" run="R-1"><line tag="net"></line><record_count>3</record_count></Summary><records><record><x>1</x></record></records></doc>"#.to_string();
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/doc/Summary",
+        &[
+            ("@id", EnvelopeFieldType::Int),
+            ("@run", EnvelopeFieldType::String),
+            ("line.@tag", EnvelopeFieldType::String),
+            ("record_count", EnvelopeFieldType::Int),
+        ],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = reader(xml, specs, "doc/records/record", 64 * 1_000_000);
+    let sections = reader.prepare_document(&cfg).expect("pre-scan");
+    let summary = unwrap_map(sections.get("Summary").expect("Summary retained"));
+    // The matched element's OWN attributes — the #505 regression.
+    assert_eq!(summary.get("@id"), Some(&Value::Integer(5)));
+    assert_eq!(summary.get("@run"), Some(&Value::String("R-1".into())));
+    // Child-element attributes and child text still captured alongside.
+    assert_eq!(summary.get("line.@tag"), Some(&Value::String("net".into())));
+    assert_eq!(summary.get("record_count"), Some(&Value::Integer(3)));
+}
+
 /// A multi-MB body streams element-at-a-time from a path-backed source: the
 /// body walks one `<record>` at a time and re-opening by path means no
 /// whole-document byte buffer is held either.

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -9,8 +9,7 @@
 //! body record: one column per declared section, each value the section's
 //! `Value::Map` payload. One [`Arc<Schema>`] backs the envelope, so the ambient
 //! `$doc` view (this module) and any node-input view a downstream consolidation
-//! node takes (via [`DocumentContext::envelope_record`]) borrow the SAME record
-//! rather than a re-encoding.
+//! node takes borrow the SAME record rather than a re-encoding.
 //!
 //! Section names are arbitrary user-chosen identifiers declared in the
 //! source's envelope config (no reserved names — `Head`, `Foot`,
@@ -116,8 +115,8 @@ impl DocumentGrain {
 ///
 /// The whole record is held behind ONE [`Arc<Schema>`]: the ambient `$doc`
 /// resolver reads it through [`DocumentContext::get_section_field`], and a
-/// downstream consolidation node borrows the same record via
-/// [`DocumentContext::envelope_record`] — neither re-encodes it.
+/// downstream consolidation node borrows the same record (via a crate-internal
+/// accessor that goes public with the Envelope node) — neither re-encodes it.
 #[derive(Debug, Clone)]
 pub struct EnvelopeRecord {
     schema: Arc<Schema>,
@@ -277,7 +276,10 @@ impl DocumentContext {
     /// The same single [`Arc<Schema>`] backs both this borrow and the ambient
     /// `$doc` resolution path ([`Self::get_section_field`] reads through it),
     /// so there is exactly one in-memory encoding of the envelope per document.
-    pub fn envelope_record(&self) -> &EnvelopeRecord {
+    ///
+    /// Crate-internal for now: the only cross-crate consumer is the Envelope
+    /// node, which lands separately; the public accessor lands with it.
+    fn envelope_record(&self) -> &EnvelopeRecord {
         &self.envelope
     }
 

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -3,7 +3,14 @@
 //! A [`DocumentContext`] is built once per file (per document) by the
 //! source reader's envelope pre-scan, then attached as `Arc<DocumentContext>`
 //! to every body record emitted from that document. CXL `$doc.<section>.<field>`
-//! expressions resolve against the sections map held on this struct.
+//! expressions resolve against the [`EnvelopeRecord`] held on this struct.
+//!
+//! The envelope is modeled with the same [`Schema`] + [`Value`] machinery as a
+//! body record: one column per declared section, each value the section's
+//! `Value::Map` payload. One [`Arc<Schema>`] backs the envelope, so the ambient
+//! `$doc` view (this module) and any node-input view a downstream consolidation
+//! node takes (via [`DocumentContext::envelope_record`]) borrow the SAME record
+//! rather than a re-encoding.
 //!
 //! Section names are arbitrary user-chosen identifiers declared in the
 //! source's envelope config (no reserved names — `Head`, `Foot`,
@@ -12,6 +19,7 @@
 //! streams, so all `$doc.*` values are available on every body record
 //! throughout the body stream.
 
+use crate::schema::Schema;
 use crate::value::Value;
 use indexmap::IndexMap;
 use serde::de::{self, SeqAccess, Visitor};
@@ -94,13 +102,115 @@ impl DocumentGrain {
     }
 }
 
+/// A document's envelope, modeled with the same [`Schema`] + [`Value`]
+/// machinery as a body record.
+///
+/// One column per declared section (insertion-ordered, ancestor-flattened);
+/// each section payload is an opaque [`Value::Map`], so any engine-internal
+/// keys a reader injects for lossless writer round-trip (X12 / EDIFACT / HL7
+/// `$raw`, the SWIFT synthetic `body`) ride along untouched. The schema column
+/// list is the section *name* list — a `Schema` column carries only a name and
+/// optional engine-stamp metadata, never a per-column value type, so the
+/// section payload's `Value::Map` shape is implicit in the value, not the
+/// schema.
+///
+/// The whole record is held behind ONE [`Arc<Schema>`]: the ambient `$doc`
+/// resolver reads it through [`DocumentContext::get_section_field`], and a
+/// downstream consolidation node borrows the same record via
+/// [`DocumentContext::envelope_record`] — neither re-encodes it.
+#[derive(Debug, Clone)]
+pub struct EnvelopeRecord {
+    schema: Arc<Schema>,
+    /// Section payloads, positional and parallel to `schema.columns()`. Each
+    /// is the section's `Value::Map` (or, for a malformed reader emission, some
+    /// other `Value`, which `$doc` field access treats as a miss).
+    sections: Vec<Value>,
+}
+
+impl EnvelopeRecord {
+    /// Build an envelope record from the reader/driver's ordered section map.
+    ///
+    /// The schema columns are the section names in insertion order; the values
+    /// are the section payloads positionally. Keeps reader/driver population a
+    /// one-line wrap over the `IndexMap` the pre-scan already produces.
+    pub fn from_sections(sections: IndexMap<Box<str>, Value>) -> Self {
+        let mut columns: Vec<Box<str>> = Vec::with_capacity(sections.len());
+        let mut values: Vec<Value> = Vec::with_capacity(sections.len());
+        for (name, payload) in sections {
+            columns.push(name);
+            values.push(payload);
+        }
+        Self {
+            schema: Arc::new(Schema::new(columns)),
+            sections: values,
+        }
+    }
+
+    /// The empty envelope: no sections, so every `$doc.*` resolves `None`.
+    /// Used for synthetic / zero-body contexts.
+    pub fn empty() -> Self {
+        Self {
+            schema: Arc::new(Schema::new(Vec::new())),
+            sections: Vec::new(),
+        }
+    }
+
+    /// The payload `Value` for a named section, or `None` when the section is
+    /// undeclared on this envelope.
+    fn section_value(&self, section: &str) -> Option<&Value> {
+        let idx = self.schema.index(section)?;
+        self.sections.get(idx)
+    }
+
+    /// Resolve a section's field by chained lookup: section payload `Value::Map`
+    /// then `field`. Returns `None` when the section is undeclared, the payload
+    /// is not a map, or the field is absent. The value is cloned owned.
+    fn get_field(&self, section: &str, field: &str) -> Option<Value> {
+        match self.section_value(section)? {
+            Value::Map(m) => m.get(field).cloned(),
+            _ => None,
+        }
+    }
+
+    /// Borrow a section's inner field map in declared order, or `None` when the
+    /// section is undeclared or its payload is not a [`Value::Map`].
+    fn field_map(&self, section: &str) -> Option<&IndexMap<Box<str>, Value>> {
+        match self.section_value(section)? {
+            Value::Map(m) => Some(m),
+            _ => None,
+        }
+    }
+
+    /// Build a child envelope: this record's columns unioned with `child`'s,
+    /// `child` shadowing on a same-name collision (innermost-wins). A colliding
+    /// section keeps the ancestor's column position but takes the child's
+    /// payload; a fresh child section appends after the ancestors — matching the
+    /// `IndexMap::insert` order the flattened side-table used.
+    fn merged_with(&self, child: EnvelopeRecord) -> EnvelopeRecord {
+        let mut merged: IndexMap<Box<str>, Value> =
+            IndexMap::with_capacity(self.sections.len() + child.sections.len());
+        for (name, payload) in self.schema.columns().iter().zip(self.sections.iter()) {
+            merged.insert(name.clone(), payload.clone());
+        }
+        for (name, payload) in child
+            .schema
+            .columns()
+            .iter()
+            .zip(child.sections.into_iter())
+        {
+            merged.insert(name.clone(), payload);
+        }
+        EnvelopeRecord::from_sections(merged)
+    }
+}
+
 /// Envelope context for one document.
 ///
-/// One per source file. The `sections` map holds every envelope section
+/// One per source file. The [`EnvelopeRecord`] holds every envelope section
 /// declared in the source's YAML envelope config, populated upfront by the
 /// reader's pre-scan pass; each section's payload is a [`Value::Map`] of
 /// field name → typed value. CXL `$doc.<section>.<field>` resolves by
-/// looking up `<section>` in this map, then `<field>` in the inner map.
+/// looking up `<section>` in the record, then `<field>` in the inner map.
 ///
 /// Cloned per record as `Arc<DocumentContext>` — refcount bump only,
 /// no data duplication.
@@ -113,23 +223,30 @@ pub struct DocumentContext {
     /// See [`DocumentGrain`] for the per-format mapping.
     grain: DocumentGrain,
     source_file: Arc<str>,
-    sections: IndexMap<Box<str>, Value>,
+    /// The envelope as a schema-described record: one column per declared
+    /// section (insertion-ordered, ancestor-flattened); each value is the
+    /// section's `Value::Map` payload, carrying any engine-internal keys
+    /// (`$raw`, `body`) the readers inject. ONE `Arc<Schema>` — the ambient
+    /// `$doc` view and any consolidation-input view borrow THIS, never a
+    /// re-encoding.
+    envelope: EnvelopeRecord,
 }
 
 impl DocumentContext {
     /// Build a populated document context for a single source file.
     /// Called once per file by the source ingest path after the reader's
-    /// envelope pre-scan returns the section map.
+    /// envelope pre-scan returns the section map (wrapped in an
+    /// [`EnvelopeRecord`] at the driver seam).
     ///
     /// The file-level document is its own frame: its [`grain`](Self::grain)
     /// is derived from `id`. Nested levels inherit or re-mint this grain via
     /// [`Self::child`] / [`Self::child_frame`].
-    pub fn new(id: DocumentId, source_file: Arc<str>, sections: IndexMap<Box<str>, Value>) -> Self {
+    pub fn new(id: DocumentId, source_file: Arc<str>, envelope: EnvelopeRecord) -> Self {
         Self {
             id,
             grain: DocumentGrain(id),
             source_file,
-            sections,
+            envelope,
         }
     }
 
@@ -154,14 +271,24 @@ impl DocumentContext {
         &self.source_file
     }
 
+    /// The document's envelope as a schema-described record — the node-input
+    /// view a downstream consolidation node reduces over.
+    ///
+    /// The same single [`Arc<Schema>`] backs both this borrow and the ambient
+    /// `$doc` resolution path ([`Self::get_section_field`] reads through it),
+    /// so there is exactly one in-memory encoding of the envelope per document.
+    pub fn envelope_record(&self) -> &EnvelopeRecord {
+        &self.envelope
+    }
+
     /// Open a nested envelope level beneath this one, flattening the
-    /// ancestry into a single sibling sections map.
+    /// ancestry into a single sibling envelope record.
     ///
     /// Multi-level envelope formats (EDI X12 ISA → GS → ST) nest
     /// envelopes inside a file. Rather than chain `DocumentContext`s,
     /// each inner level mints a fresh context that carries every section
     /// the enclosing levels declared *plus* its own — all siblings in one
-    /// map. A record streamed inside the ST level therefore resolves the
+    /// record. A record streamed inside the ST level therefore resolves the
     /// ISA's `$doc.interchange.*`, the GS's `$doc.group.*`, and its own
     /// `$doc.transaction.*` through the same two-level lookup, with no CXL
     /// syntax change. Per-level section *names* keep the levels distinct;
@@ -174,7 +301,7 @@ impl DocumentContext {
     /// file shares the file identity). Sections are cloned by `Arc`/`Value`
     /// — envelope payloads are small (a few fields per level), so the copy
     /// is O(declared sections), not O(body).
-    pub fn child(&self, id: DocumentId, sections: IndexMap<Box<str>, Value>) -> Self {
+    pub fn child(&self, id: DocumentId, sections: EnvelopeRecord) -> Self {
         self.child_inner(id, sections, self.grain)
     }
 
@@ -186,26 +313,17 @@ impl DocumentContext {
     /// whose framing document is a nested level repeated within one file:
     /// each HL7 `MSH` message opens a fresh frame, so a multi-message file
     /// reconstructs one output envelope per message, while still resolving the
-    /// enclosing `FHS`/`BHS` `$doc.*` sections through the flattened map.
-    pub fn child_frame(&self, id: DocumentId, sections: IndexMap<Box<str>, Value>) -> Self {
+    /// enclosing `FHS`/`BHS` `$doc.*` sections through the flattened record.
+    pub fn child_frame(&self, id: DocumentId, sections: EnvelopeRecord) -> Self {
         self.child_inner(id, sections, DocumentGrain(id))
     }
 
-    fn child_inner(
-        &self,
-        id: DocumentId,
-        sections: IndexMap<Box<str>, Value>,
-        grain: DocumentGrain,
-    ) -> Self {
-        let mut merged = self.sections.clone();
-        for (name, payload) in sections {
-            merged.insert(name, payload);
-        }
+    fn child_inner(&self, id: DocumentId, sections: EnvelopeRecord, grain: DocumentGrain) -> Self {
         Self {
             id,
             grain,
             source_file: Arc::clone(&self.source_file),
-            sections: merged,
+            envelope: self.envelope.merged_with(sections),
         }
     }
 
@@ -213,15 +331,11 @@ impl DocumentContext {
     /// `None` if either the section is undeclared on this document or
     /// the field is missing from the section's payload. CXL eval maps
     /// `None` to [`Value::Null`] per the streaming-resolver convention.
+    ///
+    /// Reads through [`Self::envelope_record`], so the ambient `$doc` view and
+    /// the node-input view share one encoding.
     pub fn get_section_field(&self, section: &str, field: &str) -> Option<Value> {
-        match self.sections.get(section)? {
-            Value::Map(m) => m.get(field).cloned(),
-            // A section declared but not a Map (e.g., scalar / array
-            // payload) is structurally invalid for field access; the
-            // envelope config schema is fields:-shaped, so reaching here
-            // means the reader emitted a non-Map payload.
-            _ => None,
-        }
+        self.envelope_record().get_field(section, field)
     }
 
     /// Borrow a whole section's ordered field map by name, for an output
@@ -232,12 +346,10 @@ impl DocumentContext {
     /// payload is not a [`Value::Map`] (the envelope config schema is always
     /// `fields:`-shaped, so a non-Map payload means the reader emitted an
     /// unexpected shape). The borrow is O(1) — no field is cloned; the writer
-    /// iterates the returned map in insertion order.
+    /// iterates the returned map in insertion order. Reads through
+    /// [`Self::envelope_record`].
     pub fn section_fields(&self, section: &str) -> Option<&IndexMap<Box<str>, Value>> {
-        match self.sections.get(section)? {
-            Value::Map(m) => Some(m),
-            _ => None,
-        }
+        self.envelope_record().field_map(section)
     }
 }
 
@@ -245,29 +357,37 @@ impl DocumentContext {
 //
 // A `DocumentContext` is interned once per spill file (one frame per distinct
 // `DocumentId`), so its codec is hand-written rather than derived for two
-// reasons: `IndexMap` has no insertion-order-preserving serde impl, and the
-// `Arc<str>` source file must collapse to its bytes on the wire and rebuild as
-// a fresh `Arc<str>` on read (the in-memory `Arc` identity does not — and need
-// not — survive the spill boundary; see the module-level note on per-document
-// re-hydration). The shape is a 4-tuple mirroring `Value::Map`'s pair-vec
-// encoding so section insertion order is preserved exactly:
+// reasons: the envelope's section order must be preserved on the wire (it has
+// no derive that guarantees ordering), and the `Arc<str>` source file must
+// collapse to its bytes on the wire and rebuild as a fresh `Arc<str>` on read
+// (the in-memory `Arc` identity does not — and need not — survive the spill
+// boundary; see the module-level note on per-document re-hydration). The shape
+// is a 4-tuple mirroring `Value::Map`'s pair-vec encoding so section insertion
+// order is preserved exactly:
 //   (DocumentId, DocumentGrain, source_file: &str, sections: Vec<(&str, &Value)>)
 // The `grain` rides the wire so a spilled record stays in the SAME envelope
-// frame it carried before spilling —
-// it is not re-derived from `id` on read, because a nested HL7 message frame's
-// grain differs from its own id. On read each `(String, Value)` pair re-inserts
-// in order into a fresh `IndexMap`, and the source file rebuilds via `Arc::from`.
+// frame it carried before spilling — it is not re-derived from `id` on read,
+// because a nested HL7 message frame's grain differs from its own id. On read
+// each `(String, Value)` pair re-inserts in order into a fresh `EnvelopeRecord`,
+// and the source file rebuilds via `Arc::from`.
 
 impl Serialize for DocumentContext {
     /// Serializes this context as `(id, grain, source_file, ordered section pairs)`.
     ///
     /// Used only by the spill interning path, which writes one context frame
     /// per distinct document per file (`O(distinct documents)`, never
-    /// `O(records)`). Section order is preserved by emitting the `IndexMap`
-    /// as an ordered pair vector, matching the `Value::Map` codec.
+    /// `O(records)`). Section order is preserved by emitting the envelope's
+    /// `(name, value)` columns as an ordered pair vector, matching the
+    /// `Value::Map` codec.
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let pairs: Vec<(&str, &Value)> =
-            self.sections.iter().map(|(k, v)| (k.as_ref(), v)).collect();
+        let pairs: Vec<(&str, &Value)> = self
+            .envelope
+            .schema
+            .columns()
+            .iter()
+            .map(|c| c.as_ref())
+            .zip(self.envelope.sections.iter())
+            .collect();
         let mut tup = serializer.serialize_tuple(4)?;
         tup.serialize_element(&self.id)?;
         tup.serialize_element(&self.grain)?;
@@ -281,11 +401,11 @@ impl<'de> Deserialize<'de> for DocumentContext {
     /// Reconstructs a context from `(id, grain, source_file, ordered section pairs)`.
     ///
     /// Rebuilds the `source_file` as a fresh `Arc<str>` and re-inserts the
-    /// section pairs into a new `IndexMap` in wire order, so a document's
-    /// section ordering survives a spill round-trip. The rebuilt `Arc<str>`
-    /// is a distinct allocation from the live ingest stream's — equality is
-    /// by content, not pointer identity. The `grain` round-trips verbatim so
-    /// the record stays governed by the frame it spilled with.
+    /// section pairs into a new [`EnvelopeRecord`] in wire order, so a
+    /// document's section ordering survives a spill round-trip. The rebuilt
+    /// `Arc<str>` is a distinct allocation from the live ingest stream's —
+    /// equality is by content, not pointer identity. The `grain` round-trips
+    /// verbatim so the record stays governed by the frame it spilled with.
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         struct ContextVisitor;
 
@@ -320,7 +440,7 @@ impl<'de> Deserialize<'de> for DocumentContext {
                     id,
                     grain,
                     source_file: Arc::from(source_file.as_str()),
-                    sections,
+                    envelope: EnvelopeRecord::from_sections(sections),
                 })
             }
         }
@@ -336,7 +456,7 @@ fn synthetic_storage() -> &'static Arc<DocumentContext> {
             id: DocumentId::SYNTHETIC,
             grain: DocumentGrain::SYNTHETIC,
             source_file: Arc::from(""),
-            sections: IndexMap::new(),
+            envelope: EnvelopeRecord::empty(),
         })
     })
 }
@@ -347,7 +467,7 @@ fn synthetic_storage() -> &'static Arc<DocumentContext> {
 /// Transform-synthesized records, test fixtures, and any internal-path
 /// record assembly that pre-dates the envelope system. Single
 /// allocation backing the singleton; this function bumps the refcount.
-/// The sections map is empty, so `$doc.<section>.<field>` against this
+/// The envelope is empty, so `$doc.<section>.<field>` against this
 /// context always returns `None` (callers map to `Value::Null`).
 pub fn synthetic_document_context() -> Arc<DocumentContext> {
     synthetic_storage().clone()
@@ -371,6 +491,10 @@ mod tests {
             m.insert(Box::from(*k), v.clone());
         }
         Value::Map(Box::new(m))
+    }
+
+    fn envelope(sections: IndexMap<Box<str>, Value>) -> EnvelopeRecord {
+        EnvelopeRecord::from_sections(sections)
     }
 
     #[test]
@@ -411,7 +535,11 @@ mod tests {
             Box::from("Foot"),
             make_section(&[("record_count", Value::Integer(42))]),
         );
-        let ctx = DocumentContext::new(DocumentId::next(), Arc::from("payments.xml"), sections);
+        let ctx = DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("payments.xml"),
+            envelope(sections),
+        );
 
         assert_eq!(
             ctx.get_section_field("Head", "batch_id"),
@@ -435,7 +563,7 @@ mod tests {
             make_section(&[("control_ref", Value::String("000000001".into()))]),
         );
         let file: Arc<str> = Arc::from("claim.x12");
-        let parent = DocumentContext::new(DocumentId::next(), Arc::clone(&file), isa);
+        let parent = DocumentContext::new(DocumentId::next(), Arc::clone(&file), envelope(isa));
 
         let mut gs = IndexMap::new();
         gs.insert(
@@ -443,7 +571,7 @@ mod tests {
             make_section(&[("functional_id", Value::String("HC".into()))]),
         );
         let group_id = DocumentId::next();
-        let child = parent.child(group_id, gs);
+        let child = parent.child(group_id, envelope(gs));
 
         // Distinct identity per level, shared file.
         assert_ne!(child.id(), parent.id());
@@ -476,7 +604,11 @@ mod tests {
     fn file_level_grain_is_its_own_id() {
         // A file-level document (CSV/JSON/XML/fixed-width/EDIFACT and the X12
         // ISA / HL7 FHS) is its own frame: grain == id.
-        let ctx = DocumentContext::new(DocumentId::next(), Arc::from("a.csv"), IndexMap::new());
+        let ctx = DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("a.csv"),
+            EnvelopeRecord::empty(),
+        );
         assert_eq!(ctx.grain().document_id(), ctx.id());
     }
 
@@ -492,10 +624,10 @@ mod tests {
             Box::from("file_header"),
             make_section(&[("sender", Value::String("LAB".into()))]),
         );
-        let file_doc = DocumentContext::new(DocumentId::next(), Arc::clone(&file), fhs);
+        let file_doc = DocumentContext::new(DocumentId::next(), Arc::clone(&file), envelope(fhs));
 
-        let msg1 = file_doc.child_frame(DocumentId::next(), IndexMap::new());
-        let msg2 = file_doc.child_frame(DocumentId::next(), IndexMap::new());
+        let msg1 = file_doc.child_frame(DocumentId::next(), EnvelopeRecord::empty());
+        let msg2 = file_doc.child_frame(DocumentId::next(), EnvelopeRecord::empty());
 
         // Each message is its own frame.
         assert_ne!(msg1.grain(), msg2.grain());
@@ -517,9 +649,13 @@ mod tests {
         // A `child_frame` (HL7 message) followed by an ordinary `child`
         // (a hypothetical sub-level) keeps the message's grain — `child`
         // always inherits its parent's grain, wherever that frame began.
-        let file = DocumentContext::new(DocumentId::next(), Arc::from("f.hl7"), IndexMap::new());
-        let message = file.child_frame(DocumentId::next(), IndexMap::new());
-        let sub = message.child(DocumentId::next(), IndexMap::new());
+        let file = DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("f.hl7"),
+            EnvelopeRecord::empty(),
+        );
+        let message = file.child_frame(DocumentId::next(), EnvelopeRecord::empty());
+        let sub = message.child(DocumentId::next(), EnvelopeRecord::empty());
         assert_eq!(sub.grain(), message.grain());
         assert_ne!(sub.grain(), file.grain());
     }
@@ -531,14 +667,14 @@ mod tests {
             Box::from("meta"),
             make_section(&[("level", Value::String("interchange".into()))]),
         );
-        let parent = DocumentContext::new(DocumentId::next(), Arc::from("f.x12"), outer);
+        let parent = DocumentContext::new(DocumentId::next(), Arc::from("f.x12"), envelope(outer));
 
         let mut inner = IndexMap::new();
         inner.insert(
             Box::from("meta"),
             make_section(&[("level", Value::String("transaction".into()))]),
         );
-        let child = parent.child(DocumentId::next(), inner);
+        let child = parent.child(DocumentId::next(), envelope(inner));
 
         // Innermost wins on a name collision — lexical-scope intuition.
         assert_eq!(
@@ -550,7 +686,11 @@ mod tests {
     #[test]
     fn source_file_is_borrowable_for_ptr_eq() {
         let file: Arc<str> = Arc::from("doc.xml");
-        let ctx = DocumentContext::new(DocumentId::next(), Arc::clone(&file), IndexMap::new());
+        let ctx = DocumentContext::new(
+            DocumentId::next(),
+            Arc::clone(&file),
+            EnvelopeRecord::empty(),
+        );
         assert!(Arc::ptr_eq(ctx.source_file(), &file));
     }
 
@@ -559,6 +699,51 @@ mod tests {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<DocumentContext>();
         assert_send_sync::<Arc<DocumentContext>>();
+    }
+
+    #[test]
+    fn envelope_record_is_single_arc_backing_both_views() {
+        // The same single `Arc<Schema>` backs the ambient `$doc` resolution
+        // path and the node-input borrow — proving one encoding, not two.
+        let mut sections = IndexMap::new();
+        sections.insert(
+            Box::from("Head"),
+            make_section(&[("batch_id", Value::String("RUN-001".into()))]),
+        );
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("payments.xml"),
+            envelope(sections),
+        ));
+
+        // Cloning the per-record `Arc<DocumentContext>` (as the executor does)
+        // shares the underlying envelope — the schema Arc is one allocation,
+        // pointer-identical across the clone.
+        let clone = Arc::clone(&ctx);
+        assert!(Arc::ptr_eq(&ctx, &clone));
+        assert!(Arc::ptr_eq(
+            &ctx.envelope_record().schema,
+            &clone.envelope_record().schema
+        ));
+
+        // The ambient `$doc` reader and the node-input view resolve the SAME
+        // record: `get_section_field` reads through `envelope_record`, so a
+        // value the ambient view resolves is the same value the node-input
+        // borrow exposes positionally — no parallel encoding.
+        assert_eq!(
+            ctx.get_section_field("Head", "batch_id"),
+            Some(Value::String("RUN-001".into()))
+        );
+        let node_view = ctx.envelope_record();
+        let head_idx = node_view.schema.index("Head").expect("Head column");
+        match &node_view.sections[head_idx] {
+            Value::Map(m) => assert_eq!(
+                m.get("batch_id"),
+                Some(&Value::String("RUN-001".into())),
+                "node-input view sees the same payload the ambient view resolves"
+            ),
+            other => panic!("expected Value::Map, got {other:?}"),
+        }
     }
 
     #[test]
@@ -608,8 +793,12 @@ mod tests {
         // Model an HL7 message frame: build a file-level context, then a
         // `child_frame` whose grain differs from its own id, so the round-trip
         // proves the grain is carried verbatim (not re-derived from id).
-        let file_doc = DocumentContext::new(id, Arc::from("payments/run-001.xml"), IndexMap::new());
-        let ctx = file_doc.child_frame(DocumentId::next(), sections);
+        let file_doc = DocumentContext::new(
+            id,
+            Arc::from("payments/run-001.xml"),
+            EnvelopeRecord::empty(),
+        );
+        let ctx = file_doc.child_frame(DocumentId::next(), envelope(sections));
         let expected_grain = ctx.grain();
         let expected_id = ctx.id();
         assert_ne!(
@@ -629,7 +818,13 @@ mod tests {
         );
         assert_eq!(back.source_file().as_ref(), "payments/run-001.xml");
         // Section names survive in insertion order, not sorted order.
-        let names: Vec<&str> = back.sections.keys().map(|k| k.as_ref()).collect();
+        let names: Vec<&str> = back
+            .envelope_record()
+            .schema
+            .columns()
+            .iter()
+            .map(|c| c.as_ref())
+            .collect();
         assert_eq!(names, vec!["z_section", "a_section", "m_section"]);
         // Field values, including a nested Value::Map, survive intact.
         assert_eq!(

--- a/crates/clinker-record/src/lib.rs
+++ b/crates/clinker-record/src/lib.rs
@@ -21,7 +21,7 @@ pub use coercion::{
 };
 pub use counters::{PipelineCounters, RetractionCounters};
 pub use document_context::{
-    DocumentContext, DocumentGrain, DocumentId, synthetic_document_context,
+    DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, synthetic_document_context,
     synthetic_document_context_ref,
 };
 pub use field_str::FieldStr;

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_record_set_doc_ctx_attaches_real_context() {
-        use crate::document_context::{DocumentContext, DocumentId};
+        use crate::document_context::{DocumentContext, DocumentId, EnvelopeRecord};
         let schema = test_schema();
         let mut record = Record::new(schema, vec![Value::Null; 5]);
         let id = DocumentId::next();
@@ -568,7 +568,11 @@ mod tests {
                 m
             })),
         );
-        let ctx = Arc::new(DocumentContext::new(id, Arc::from("doc.xml"), sections));
+        let ctx = Arc::new(DocumentContext::new(
+            id,
+            Arc::from("doc.xml"),
+            EnvelopeRecord::from_sections(sections),
+        ));
         record.set_doc_ctx(Arc::clone(&ctx));
         assert!(Arc::ptr_eq(record.doc_ctx(), &ctx));
         assert_eq!(record.doc_ctx().id(), id);

--- a/crates/cxl/src/eval/compiled/tests.rs
+++ b/crates/cxl/src/eval/compiled/tests.rs
@@ -305,7 +305,7 @@ fn eval_project_with_doc(
 /// `(field, Value)` payload as a `Value::Map`. Field values may themselves
 /// be `Value::Array` / `Value::Map` to exercise indexed `$doc` chains.
 fn doc_with_section(name: &str, fields: &[(&str, Value)]) -> Arc<clinker_record::DocumentContext> {
-    use clinker_record::{DocumentContext, DocumentId};
+    use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
     let mut payload = indexmap::IndexMap::new();
     for (k, v) in fields {
         payload.insert(Box::from(*k), v.clone());
@@ -315,7 +315,7 @@ fn doc_with_section(name: &str, fields: &[(&str, Value)]) -> Arc<clinker_record:
     Arc::new(DocumentContext::new(
         DocumentId::next(),
         Arc::from("proof.json"),
-        sections,
+        EnvelopeRecord::from_sections(sections),
     ))
 }
 

--- a/crates/cxl/src/eval/context.rs
+++ b/crates/cxl/src/eval/context.rs
@@ -515,7 +515,7 @@ mod tests {
         let doc = Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::clone(&file),
-            sections,
+            clinker_record::EnvelopeRecord::from_sections(sections),
         ));
         let mut ctx = make_ctx(&stable, &file, &batch, 1);
         ctx.doc_ctx = &doc;


### PR DESCRIPTION
## Summary

Replaces the document envelope's loosely-typed side-table
(`DocumentContext.sections: IndexMap<Box<str>, Value>`) with a
schema-described envelope-record (`EnvelopeRecord` = `Arc<Schema>` +
per-section `Value` payloads), modeled with the same `Schema`/`Value`
machinery as a body record. This is the foundation for the write-side
envelope work: downstream operators can reduce over a typed envelope record
backed by a single shared `Arc`, instead of an out-of-band map.

`$doc.<section>.<field>` runtime semantics are **byte-identical** — same
null-on-missing, nested and indexed access, ancestor flattening,
innermost-section-wins on name collision, and lossless round-trip of the
engine-internal section keys the structured writers depend on (X12 / EDIFACT /
HL7 raw-element echo, SWIFT block body).

Folds in two reader pre-scan fixes that live in the exact code this rip
rewrites (fixing them in the old path would have been wasted work):

- An XML envelope section's **own attributes** now survive the pre-scan
  (previously only child-element attributes were captured).
- A declared-but-unread **JSON** section field is no longer eagerly coerced —
  coercion is pruned to the fields a downstream program actually references,
  via a new field-level wanted-path predicate on the document index.

## Scope notes for reviewers

- The reader-to-driver wire still passes the section `IndexMap`; it is
  converted to `EnvelopeRecord` once at the ingest boundary. The wire shape
  was never the in-memory representation, so this is the smallest correct
  cascade — not a parallel encoding (the old field is fully deleted).
- The **promoted-output-port** view of the envelope-record lands with its
  consumer in #567; the plan-time `$doc` **schema propagation** lands with its
  consumer in #576. This change establishes the single-`Arc` representation
  both of those build on, and proves the single-encoding invariant with a
  dedicated test.

## Testing

Full workspace gauntlet green: `fmt`, `clippy` (with and without
`--all-targets`), `test` (3246 tests), bench checks, `deny`. New tests: the
single-`Arc` envelope invariant; the XML own-attribute regression; the JSON
lazy-coercion regression plus a unit test for the field-level wanted-path
predicate. All existing `$doc` integration tests and the EDIFACT / X12 / HL7 /
SWIFT round-trip tests pass unchanged.

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)
