### PR TITLE
exec: standalone Envelope node with grain-keyed preserve framing (#585)

### DIFF
--- a/crates/clinker-exec/src/executor/context.rs
+++ b/crates/clinker-exec/src/executor/context.rs
@@ -155,6 +155,12 @@ fn arcs_reachable_from(
                     stack.push(upstream.value.name().to_string());
                 }
             }
+            PipelineNode::Envelope { header, .. } => {
+                stack.push(header.body.value.name().to_string());
+                for inp in [&header.header, &header.trailer].into_iter().flatten() {
+                    stack.push(inp.value.name().to_string());
+                }
+            }
             other => {
                 if let Some(input) = other.input_node_name() {
                     stack.push(input.to_string());
@@ -163,4 +169,59 @@ fn arcs_reachable_from(
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pipeline `src(in.csv) -> body(transform) -> framed(envelope) -> m(merge)`.
+    /// The Merge consumes the Envelope's output. The qualified-source arc map
+    /// keys the Merge input by the upstream node name (`framed`) and must
+    /// resolve it to the body source's path — which requires the arc walk to
+    /// descend *through* the Envelope to its body, then to the Source. With the
+    /// Envelope arm absent the walk stops at `framed` (its `input_node_name()`
+    /// is `None`, a multi-port node) and yields no arcs, leaving `framed`
+    /// absent from the map entirely.
+    #[test]
+    fn arc_walk_descends_through_envelope_to_body_source() {
+        let yaml = r#"
+pipeline:
+  name: envelope_arc_walk
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: body
+    input: src
+    config:
+      cxl: "emit id = id"
+  - type: envelope
+    name: framed
+    body: body
+    config: { strategy: preserve }
+  - type: merge
+    name: m
+    inputs: [framed]
+"#;
+        let config: PipelineConfig =
+            clinker_plan::yaml::from_str(yaml).expect("parse envelope arc-walk pipeline");
+
+        let arcs = compute_source_input_arcs(&config);
+        let merge_input = arcs
+            .get("framed")
+            .expect("Merge input `framed` must resolve through the Envelope to a source path");
+        let paths: Vec<&str> = merge_input.iter().map(|a| a.as_ref()).collect();
+        assert_eq!(
+            paths,
+            vec!["in.csv"],
+            "arc walk must descend through the Envelope to the body source `in.csv`"
+        );
+    }
 }

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -2749,6 +2749,15 @@ pub(crate) fn dispatch_plan_node(
             crate::executor::cull_dispatch::dispatch_cull(ctx, current_dag, node_idx, &node)?;
         }
 
+        PlanNode::Envelope { .. } => {
+            crate::executor::envelope_dispatch::dispatch_envelope(
+                ctx,
+                current_dag,
+                node_idx,
+                &node,
+            )?;
+        }
+
         PlanNode::Composition { .. } => {
             crate::executor::composition_dispatch::dispatch_composition(
                 ctx,

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -1,0 +1,85 @@
+//! `PlanNode::Envelope` dispatch arm.
+//!
+//! Frames a body stream into per-document documents. With the
+//! [`EnvelopeStrategy::Preserve`] strategy this is a transparent framing
+//! stage: it drains the body predecessor's full output and re-parks every
+//! record into its successors' slots **with the record's document context and
+//! grain unchanged**, forwarding the document-boundary punctuations verbatim.
+//! A downstream Output therefore frames on the same grains it would have seen
+//! without the node — the `preserve` Envelope is byte-identical to today's
+//! per-document framing, now declarable as an explicit composable stage.
+//!
+//! # Inputs
+//!
+//! The node has a single wired predecessor this release: the `body` input.
+//! The optional `header:` / `trailer:` ports are rejected when wired at plan
+//! validation, so [`single_predecessor`] resolves exactly the body stream.
+//!
+//! # Memory model
+//!
+//! Streaming pass-through: the drained body is re-parked into a `NodeBuffer`
+//! whose own arbitrator wrapper provides the memory bound, so the resident
+//! peak is the concurrently-open frames' records — identical to a Cull or
+//! Merge re-park, never the whole input at once. The node registers no
+//! spillable stage consumer of its own.
+
+use petgraph::graph::NodeIndex;
+
+use crate::executor::dispatch::{
+    ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
+};
+use clinker_plan::config::pipeline_node::EnvelopeStrategy;
+use clinker_plan::error::PipelineError;
+use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
+
+/// Execute the `Envelope` arm for `node_idx`. Drains the body predecessor and,
+/// for the `Preserve` strategy, re-parks every record into this node's own
+/// `node_buffers` slot with the document context and grain unchanged,
+/// forwarding the body's punctuations.
+pub(crate) fn dispatch_envelope(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    node: &PlanNode,
+) -> Result<(), PipelineError> {
+    let PlanNode::Envelope {
+        ref name, strategy, ..
+    } = *node
+    else {
+        unreachable!("dispatch_envelope called with non-Envelope node");
+    };
+
+    let pred = single_predecessor(current_dag, node_idx, "envelope", name)?;
+    let (records, puncts) = match drain_node_buffer_slot(ctx, pred) {
+        Some(nb) => nb.drain_split()?,
+        None => (Vec::new(), Vec::new()),
+    };
+
+    // Exhaustive over `EnvelopeStrategy`. `preserve` forwards the body
+    // unchanged; the consolidation and synthesizing strategies are additive
+    // variants that will add their own arms.
+    match strategy {
+        EnvelopeStrategy::Preserve => {
+            // Re-park the drained body into THIS node's own slot, leaving each
+            // record's document context and grain untouched and forwarding the
+            // body's punctuations verbatim. Every downstream consumer resolves
+            // its input from its predecessor's slot — a linear consumer
+            // (Transform / Aggregate / Output / Sort / Reshape / Cull) drains
+            // the predecessor it computes, and a fan-in consumer (Merge /
+            // Combine) reads each predecessor slot directly — so writing to
+            // `node_idx` is exactly where each successor looks. This mirrors the
+            // Transform/Sort linear-producer convention (own-slot write), not
+            // the Route/Cull fork convention (per-successor-slot write).
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                node_idx,
+                records,
+                puncts,
+                node_buffer_spill_allowed(current_dag, node_idx),
+            )?;
+            ctx.node_buffers.insert(node_idx, nb);
+            Ok(())
+        }
+    }
+}

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -17,11 +17,12 @@
 //!
 //! # Memory model
 //!
-//! Streaming pass-through: the drained body is re-parked into a `NodeBuffer`
-//! whose own arbitrator wrapper provides the memory bound, so the resident
-//! peak is the concurrently-open frames' records — identical to a Cull or
-//! Merge re-park, never the whole input at once. The node registers no
-//! spillable stage consumer of its own.
+//! The node drains the body predecessor's full `NodeBuffer` and materializes
+//! it into its own `NodeBuffer` slot — the same re-park model as Cull and
+//! Merge. The slot's arbitrator wrapper provides the memory bound (it spills
+//! the slot when the budget trips), so the resident set is the slot's records,
+//! not an incrementally-streamed subset. The node registers no spillable stage
+//! consumer of its own.
 
 use petgraph::graph::NodeIndex;
 

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod cull_dispatch;
 pub(crate) mod dispatch;
 mod dlq;
 pub(crate) mod document_dlq;
+pub(crate) mod envelope_dispatch;
 mod ingest;
 pub(crate) mod merge_dispatch;
 pub mod node_buffer;

--- a/crates/clinker-exec/tests/envelope_node.rs
+++ b/crates/clinker-exec/tests/envelope_node.rs
@@ -1,0 +1,684 @@
+//! End-to-end behavior of the standalone `Envelope` node with the `preserve`
+//! framing strategy.
+//!
+//! `preserve` is a transparent framing stage: it passes body records through
+//! with their document context and grain unchanged and forwards the
+//! document-boundary punctuations, so a downstream Output frames per grain
+//! exactly as it would without the node. These tests prove three claims:
+//!
+//! - **Differential oracle (the headline):** the SAME pipeline with a
+//!   `preserve` Envelope node between the body and a `reconstruct_envelope`
+//!   Output produces byte-identical output AND the same per-document framing
+//!   count as the pipeline without it. A `preserve` that altered grains, order,
+//!   or punctuations would diverge.
+//! - **Grain-keyed framing, not file-keyed:** a nested X12-style interchange
+//!   (whose `GS`/`ST` levels inherit the interchange grain) frames once per
+//!   interchange; an HL7-style multi-message file (each message a fresh grain)
+//!   frames once per message.
+//! - **Config parse / serde** for the node and its single-variant strategy.
+//!
+//! Framing is observed through the CSV writer's per-document envelope
+//! rendering: with `reconstruct_envelope: true` and an `envelope:` spec naming
+//! a `$doc` section, the writer emits one footer row per framed document
+//! carrying the streaming-computed body-record count. Counting footer rows
+//! yields the document count; the per-footer count validates the body→grain
+//! partitioning.
+
+use std::collections::HashMap;
+use std::io::{Cursor, Write};
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, SourceInput};
+use clinker_exec::source::RecordSource;
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_format::{EnvelopeEvent, FormatError, FrameRole};
+use clinker_record::{Record, Schema, SchemaBuilder, Value};
+use indexmap::IndexMap;
+
+// ─── Scripted multi-level envelope reader ───────────────────────────────
+//
+// Replays a fixed step script modeling a multi-level envelope reader (cf.
+// the nested-envelope ingest tests). Extended here with a per-`Open` frame
+// role so a script can model both an X12 interchange (`Inherit` — nested
+// levels share the file grain) and an HL7 multi-message file (`NewFrame` —
+// each message mints its own grain).
+
+/// One scripted step. `Open` carries one section (`name` → `tag`) and a frame
+/// role; `Record` emits a body row; `Close` pops the innermost level.
+enum Step {
+    Open {
+        file: &'static str,
+        name: &'static str,
+        tag_val: &'static str,
+        frame: FrameRole,
+    },
+    Close {
+        file: &'static str,
+    },
+    Record {
+        file: &'static str,
+        id: i64,
+    },
+}
+
+struct ScriptedReader {
+    schema: Arc<Schema>,
+    steps: std::collections::VecDeque<Step>,
+    pending_events: Vec<EnvelopeEvent>,
+    current_file: Option<Arc<str>>,
+    file_arcs: HashMap<&'static str, Arc<str>>,
+}
+
+impl ScriptedReader {
+    fn new(steps: Vec<Step>) -> Self {
+        let schema = SchemaBuilder::with_capacity(1).with_field("id").build();
+        Self {
+            schema,
+            steps: steps.into_iter().collect(),
+            pending_events: Vec::new(),
+            current_file: None,
+            file_arcs: HashMap::new(),
+        }
+    }
+
+    fn file_arc(&mut self, file: &'static str) -> Arc<str> {
+        Arc::clone(
+            self.file_arcs
+                .entry(file)
+                .or_insert_with(|| Arc::from(file)),
+        )
+    }
+
+    fn section(name: &str, tag_val: &str) -> IndexMap<Box<str>, Value> {
+        let mut field = IndexMap::new();
+        field.insert(Box::from("tag"), Value::String(tag_val.into()));
+        let mut sections = IndexMap::new();
+        sections.insert(Box::from(name), Value::Map(Box::new(field)));
+        sections
+    }
+}
+
+impl RecordSource for ScriptedReader {
+    fn schema(&mut self) -> Result<Arc<Schema>, FormatError> {
+        Ok(Arc::clone(&self.schema))
+    }
+
+    fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
+        while let Some(step) = self.steps.pop_front() {
+            match step {
+                Step::Open {
+                    file,
+                    name,
+                    tag_val,
+                    frame,
+                } => {
+                    self.current_file = Some(self.file_arc(file));
+                    self.pending_events.push(EnvelopeEvent::OpenLevel {
+                        sections: Self::section(name, tag_val),
+                        frame,
+                    });
+                }
+                Step::Close { file } => {
+                    self.current_file = Some(self.file_arc(file));
+                    self.pending_events.push(EnvelopeEvent::CloseLevel);
+                }
+                Step::Record { file, id } => {
+                    self.current_file = Some(self.file_arc(file));
+                    return Ok(Some(Record::new(
+                        Arc::clone(&self.schema),
+                        vec![Value::Integer(id)],
+                    )));
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    fn current_source_file(&self) -> Option<&Arc<str>> {
+        self.current_file.as_ref()
+    }
+
+    fn take_envelope_events(&mut self) -> Vec<EnvelopeEvent> {
+        std::mem::take(&mut self.pending_events)
+    }
+}
+
+// ─── Pipeline templates ─────────────────────────────────────────────────
+
+/// A pipeline that frames each document into a CSV with a per-document footer
+/// carrying the streaming body-record count. When `with_envelope` is set, a
+/// `preserve` Envelope node sits between the body Transform and the Output;
+/// otherwise the Transform feeds the Output directly. Both feed the SAME
+/// `reconstruct_envelope` Output, so the only difference is the presence of
+/// the framing stage — the differential-oracle control.
+fn scripted_pipeline(with_envelope: bool) -> String {
+    // When the Envelope node is present the Output reads from `framed` (the
+    // Envelope node); when absent the Output reads directly from the body
+    // Transform `tag`. The Transform keeps the same name in both arms, so the
+    // only structural difference is the inserted framing stage — the control
+    // for the differential oracle.
+    let (envelope_node, output_input) = if with_envelope {
+        (
+            "  - type: envelope\n    name: framed\n    body: tag\n    \
+             config: { strategy: preserve }\n",
+            "framed",
+        )
+    } else {
+        ("", "tag")
+    };
+    let transform_name = "tag";
+    format!(
+        r#"
+pipeline:
+  name: envelope_scripted
+nodes:
+  - type: source
+    name: edi
+    config:
+      name: edi
+      type: csv
+      path: placeholder.csv
+      # The `interchange` section is declared so the Output's
+      # `footer_from_doc: interchange` passes the feeding-source section-name
+      # check; the scripted reader supplies its runtime value per document.
+      envelope:
+        sections:
+          interchange:
+            extract: {{ record_type: H }}
+            fields:
+              tag: string
+      schema:
+        - {{ name: id, type: int }}
+  - type: transform
+    name: {transform_name}
+    input: edi
+    config:
+      cxl: |
+        emit id = id
+        emit tag = $doc.interchange.tag
+{envelope_node}  - type: output
+    name: out
+    input: {output_input}
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          footer_from_doc: interchange
+"#
+    )
+}
+
+/// Compile and run a scripted-reader pipeline, returning the written CSV bytes
+/// plus the run counters.
+fn run_scripted(
+    with_envelope: bool,
+    steps: Vec<Step>,
+) -> (String, clinker_record::PipelineCounters) {
+    let mut config = clinker_plan::config::parse_config(&scripted_pipeline(with_envelope))
+        .expect("parse scripted envelope pipeline");
+    // Pathless source: drive the registered `Records` transport, not fs.
+    for spanned in &mut config.nodes {
+        if let clinker_plan::config::PipelineNode::Source { config: body, .. } = &mut spanned.value
+        {
+            body.source.path = None;
+        }
+    }
+    let plan = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("compile scripted envelope pipeline");
+
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "edi".to_string(),
+        SourceInput::Records(Box::new(ScriptedReader::new(steps))),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let report = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams {
+            execution_id: "env-exec".to_string(),
+            batch_id: "env-batch".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("drive scripted envelope pipeline");
+    (buf.as_string(), report.counters)
+}
+
+/// Count the per-document footer rows the CSV envelope writer rendered. Each
+/// Parse the framed CSV into the per-document framing it reveals.
+///
+/// The CSV writer emits, per framed document, one footer **section row** at the
+/// document's close carrying the `interchange.tag` value as its single cell.
+/// Body rows are `id,tag` (two cells) and the column header is `id,tag`. So a
+/// document boundary is exactly a single-cell row; the body rows between two
+/// boundaries belong to the document that boundary closes.
+///
+/// Returns `(framed_document_count, per_document_body_counts)`. Asserting on
+/// both is what makes a grain merge/split visible: a `preserve` that collapsed
+/// two grains into one would drop a footer and merge two body counts.
+fn footer_stats(csv: &str) -> (usize, Vec<i64>) {
+    let mut footers: Vec<i64> = Vec::new();
+    let mut pending_body: i64 = 0;
+    for line in csv.lines() {
+        let cells: Vec<&str> = line.split(',').collect();
+        match cells.as_slice() {
+            // Column header `id,tag`: a body row's first cell is numeric, the
+            // header's is the literal column name `id`. Both are two-cell;
+            // the header is skipped by recognizing the literal column names.
+            [a, b] if *a == "id" && *b == "tag" => {}
+            // Body row `id,tag`: first cell is the numeric id.
+            [a, _] if a.parse::<i64>().is_ok() => pending_body += 1,
+            // Footer section row: a single cell carrying the document's tag.
+            [_single] => {
+                footers.push(pending_body);
+                pending_body = 0;
+            }
+            _ => {}
+        }
+    }
+    (footers.len(), footers)
+}
+
+// ─── Differential oracle (the headline acceptance) ──────────────────────
+
+#[test]
+fn preserve_envelope_is_byte_identical_to_no_envelope() {
+    // Two files, each a self-contained interchange (Inherit levels share the
+    // file grain), so the run frames exactly twice.
+    let steps = || {
+        vec![
+            Step::Open {
+                file: "a.x12",
+                name: "interchange",
+                tag_val: "ISA-A",
+                frame: FrameRole::Inherit,
+            },
+            Step::Record {
+                file: "a.x12",
+                id: 1,
+            },
+            Step::Record {
+                file: "a.x12",
+                id: 2,
+            },
+            Step::Close { file: "a.x12" },
+            Step::Open {
+                file: "b.x12",
+                name: "interchange",
+                tag_val: "ISA-B",
+                frame: FrameRole::Inherit,
+            },
+            Step::Record {
+                file: "b.x12",
+                id: 3,
+            },
+            Step::Close { file: "b.x12" },
+        ]
+    };
+
+    let (without, without_counters) = run_scripted(false, steps());
+    let (with, with_counters) = run_scripted(true, steps());
+
+    // Sanity: the body rows are present and tagged from their own interchange.
+    assert!(without.contains("ISA-A"), "missing doc A rows: {without}");
+    assert!(without.contains("ISA-B"), "missing doc B rows: {without}");
+
+    // Headline: inserting a `preserve` Envelope node changes nothing — same
+    // bytes, same record count. A grain-altering or reordering preserve fails.
+    assert_eq!(
+        with, without,
+        "preserve Envelope must be byte-identical to the no-envelope path"
+    );
+    assert_eq!(
+        with_counters.records_written, without_counters.records_written,
+        "records_written invariant under the preserve Envelope node",
+    );
+
+    // And the framing count is equal: exactly two framed documents either way,
+    // with the body counts (2 then 1) keyed on grain.
+    let (without_frames, without_counts) = footer_stats(&without);
+    let (with_frames, with_counts) = footer_stats(&with);
+    assert_eq!(
+        without_frames, 2,
+        "two interchanges → two framed documents (control): {without}"
+    );
+    assert_eq!(
+        with_frames, without_frames,
+        "preserve Envelope preserves the framing count"
+    );
+    assert_eq!(
+        without_counts,
+        vec![2, 1],
+        "per-document body counts keyed on grain (control): {without}"
+    );
+    assert_eq!(
+        with_counts, without_counts,
+        "preserve Envelope preserves per-document body counts"
+    );
+}
+
+// ─── Grain-keyed framing: nested X12 interchange ────────────────────────
+
+#[test]
+fn nested_x12_interchange_frames_once_per_interchange() {
+    // One interchange, three nested levels: ISA → GS → ST → records. Every
+    // nested level `Inherit`s the interchange grain, so the whole `ISA..IEA`
+    // is ONE framed document regardless of the GS/ST nesting — framing is
+    // keyed on grain, not on the (single) source file or the nested levels.
+    let steps = vec![
+        Step::Open {
+            file: "claim.x12",
+            name: "interchange",
+            tag_val: "ISA-1",
+            frame: FrameRole::Inherit,
+        },
+        Step::Open {
+            file: "claim.x12",
+            name: "group",
+            tag_val: "GS-1",
+            frame: FrameRole::Inherit,
+        },
+        Step::Open {
+            file: "claim.x12",
+            name: "transaction",
+            tag_val: "ST-1",
+            frame: FrameRole::Inherit,
+        },
+        Step::Record {
+            file: "claim.x12",
+            id: 10,
+        },
+        Step::Record {
+            file: "claim.x12",
+            id: 11,
+        },
+        Step::Close { file: "claim.x12" }, // ST
+        Step::Close { file: "claim.x12" }, // GS
+        Step::Close { file: "claim.x12" }, // ISA
+    ];
+
+    let (csv, _counters) = run_scripted(true, steps);
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(
+        frames, 1,
+        "nested ISA/GS/ST is ONE framed document (grain-keyed): {csv}"
+    );
+    assert_eq!(
+        counts,
+        vec![2],
+        "the one interchange frames both body records: {csv}"
+    );
+}
+
+#[test]
+fn two_x12_interchanges_frame_twice() {
+    // Two interchanges in two files → two grains → two framed documents. Guards
+    // against a framing keyed on something coarser than the interchange grain.
+    let steps = vec![
+        Step::Open {
+            file: "a.x12",
+            name: "interchange",
+            tag_val: "ISA-A",
+            frame: FrameRole::Inherit,
+        },
+        Step::Record {
+            file: "a.x12",
+            id: 1,
+        },
+        Step::Close { file: "a.x12" },
+        Step::Open {
+            file: "b.x12",
+            name: "interchange",
+            tag_val: "ISA-B",
+            frame: FrameRole::Inherit,
+        },
+        Step::Record {
+            file: "b.x12",
+            id: 2,
+        },
+        Step::Record {
+            file: "b.x12",
+            id: 3,
+        },
+        Step::Close { file: "b.x12" },
+    ];
+
+    let (csv, _counters) = run_scripted(true, steps);
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(frames, 2, "two interchanges → two framed documents: {csv}");
+    assert_eq!(counts, vec![1, 2], "per-interchange body counts: {csv}");
+}
+
+// ─── Grain-keyed framing: HL7 multi-message file ────────────────────────
+
+#[test]
+fn hl7_multi_message_file_frames_once_per_message() {
+    // One file, two HL7-style messages. Each message opens a `NewFrame` level
+    // (mints a fresh grain, the way each `MSH` does), so the single file frames
+    // TWICE — keyed on the per-message grain, NOT on the source file. A
+    // file-keyed framing would collapse this to one document and fail.
+    let steps = vec![
+        Step::Open {
+            file: "batch.hl7",
+            name: "interchange",
+            tag_val: "MSH-1",
+            frame: FrameRole::NewFrame,
+        },
+        Step::Record {
+            file: "batch.hl7",
+            id: 1,
+        },
+        Step::Record {
+            file: "batch.hl7",
+            id: 2,
+        },
+        Step::Close { file: "batch.hl7" }, // MSH-1
+        Step::Open {
+            file: "batch.hl7",
+            name: "interchange",
+            tag_val: "MSH-2",
+            frame: FrameRole::NewFrame,
+        },
+        Step::Record {
+            file: "batch.hl7",
+            id: 3,
+        },
+        Step::Close { file: "batch.hl7" }, // MSH-2
+    ];
+
+    let (csv, _counters) = run_scripted(true, steps);
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(
+        frames, 2,
+        "two HL7 messages in one file → two framed documents (grain-keyed, not file-keyed): {csv}"
+    );
+    assert_eq!(
+        counts,
+        vec![2, 1],
+        "per-message body counts keyed on the MSH grain: {csv}"
+    );
+}
+
+#[test]
+fn hl7_framing_matches_no_envelope_control() {
+    // The same HL7 multi-message file with and without the preserve Envelope
+    // node must produce identical framing — proving the node neither merges nor
+    // splits the per-message grains.
+    let steps = || {
+        vec![
+            Step::Open {
+                file: "batch.hl7",
+                name: "interchange",
+                tag_val: "MSH-1",
+                frame: FrameRole::NewFrame,
+            },
+            Step::Record {
+                file: "batch.hl7",
+                id: 1,
+            },
+            Step::Close { file: "batch.hl7" },
+            Step::Open {
+                file: "batch.hl7",
+                name: "interchange",
+                tag_val: "MSH-2",
+                frame: FrameRole::NewFrame,
+            },
+            Step::Record {
+                file: "batch.hl7",
+                id: 2,
+            },
+            Step::Close { file: "batch.hl7" },
+        ]
+    };
+    let (without, _) = run_scripted(false, steps());
+    let (with, _) = run_scripted(true, steps());
+    assert_eq!(
+        with, without,
+        "preserve Envelope preserves HL7 per-message framing byte-for-byte"
+    );
+    assert_eq!(footer_stats(&with).0, 2, "two MSH frames survive: {with}");
+}
+
+// ─── Punctuation forwarding: per-document Aggregate downstream ───────────
+
+/// A pipeline `source → preserve Envelope → per-document count Aggregate →
+/// output` over a multi-file CSV glob. The Aggregate flushes its groups on
+/// each document-close punctuation, so it produces one group set per document
+/// ONLY if the Envelope forwards those boundary punctuations. A `preserve`
+/// that swallowed them would collapse every file into one cross-document
+/// aggregate — the regression this test exists to catch. When
+/// `with_envelope` is false the Envelope node is omitted (the control).
+fn aggregate_pipeline(with_envelope: bool) -> String {
+    let (envelope_node, agg_input) = if with_envelope {
+        (
+            "  - type: envelope\n    name: framed\n    body: events\n    \
+             config: { strategy: preserve }\n",
+            "framed",
+        )
+    } else {
+        ("", "events")
+    };
+    format!(
+        r#"
+pipeline:
+  name: envelope_agg
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - {{ name: category, type: string }}
+{envelope_node}  - type: aggregate
+    name: by_category
+    input: {agg_input}
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: by_category
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#
+    )
+}
+
+/// Run the aggregate pipeline over in-memory CSV files (each file a document),
+/// returning the sorted `category,n` body lines.
+fn run_aggregate(with_envelope: bool, files: &[(&str, &str)]) -> Vec<String> {
+    let config =
+        clinker_plan::config::parse_config(&aggregate_pipeline(with_envelope)).expect("parse");
+    let plan = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("compile");
+
+    let slots: Vec<FileSlot> = files
+        .iter()
+        .map(|(name, body)| {
+            FileSlot::new(
+                PathBuf::from(*name),
+                Box::new(Cursor::new(body.as_bytes().to_vec())),
+            )
+        })
+        .collect();
+    let readers: clinker_exec::executor::SourceReaders =
+        HashMap::from([("events".to_string(), SourceInput::Files(slots))]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams {
+            execution_id: "agg".to_string(),
+            batch_id: "agg".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("run aggregate pipeline");
+
+    let mut body: Vec<String> = buf
+        .as_string()
+        .lines()
+        .skip(1)
+        .map(str::to_string)
+        .collect();
+    body.sort();
+    body
+}
+
+#[test]
+fn preserve_envelope_forwards_document_boundaries_to_downstream_aggregate() {
+    // Two files = two documents. Category `x` appears twice in A and three
+    // times in B. A per-document flush yields x=2 (doc A) and x=3 (doc B) plus
+    // y=1 (doc A) — three rows. If the Envelope swallowed the document-close
+    // punctuations the Aggregate would collapse to a single cross-document
+    // x=5, so this is the punctuation-forwarding regression guard.
+    let files = [
+        ("a.csv", "category\nx\nx\ny\n"),
+        ("b.csv", "category\nx\nx\nx\n"),
+    ];
+
+    let with = run_aggregate(true, &files);
+    assert_eq!(
+        with,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "preserve Envelope must forward per-document closes so the downstream \
+         Aggregate flushes per document (x=2 doc A, x=3 doc B), not a merged x=5",
+    );
+
+    // And it matches the no-Envelope control exactly — the node changes nothing
+    // about the document boundaries the Aggregate observes.
+    let without = run_aggregate(false, &files);
+    assert_eq!(
+        with, without,
+        "per-document aggregation is identical with and without the preserve Envelope",
+    );
+}

--- a/crates/clinker-plan/src/config/node_header.rs
+++ b/crates/clinker-plan/src/config/node_header.rs
@@ -231,6 +231,69 @@ impl Serialize for CombineHeader {
     }
 }
 
+/// Header for envelope nodes — a required `body:` input plus two optional
+/// `header:` / `trailer:` ports.
+///
+/// The `body:` stream is the records the node frames into documents; the
+/// `header:` and `trailer:` ports name streams whose records prepend / append
+/// to each framed document. This slice accepts both optional ports in the YAML
+/// shape but rejects a *wired* value at plan validation — the `preserve`
+/// strategy frames each body record with the body's own ambient envelope and
+/// reads no second stream. A later release wires them.
+///
+/// Each input reference carries a [`Spanned`] wrapper so a diagnostic on an
+/// undeclared upstream can point at the exact YAML line/column. The
+/// `Serialize` impl is hand-rolled to drop the spans and skip the two unset
+/// optional ports, so the YAML round-trip shape is unchanged.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EnvelopeHeader {
+    pub name: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// The records this node frames into documents. Required.
+    pub body: Spanned<NodeInput>,
+    /// Optional header-record stream. Accepted in config; a wired value is
+    /// rejected at plan validation this release (its draining lands later).
+    #[serde(default)]
+    pub header: Option<Spanned<NodeInput>>,
+    /// Optional trailer-record stream. Same not-yet-wired status as `header`.
+    #[serde(default)]
+    pub trailer: Option<Spanned<NodeInput>>,
+    #[serde(default, rename = "_notes")]
+    pub notes: Option<serde_json::Value>,
+}
+
+impl Serialize for EnvelopeHeader {
+    fn serialize<S: serde::Serializer>(&self, s: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut state = s.serialize_struct("EnvelopeHeader", 6)?;
+        state.serialize_field("name", &self.name)?;
+        if self.description.is_some() {
+            state.serialize_field("description", &self.description)?;
+        } else {
+            state.skip_field("description")?;
+        }
+        state.serialize_field("body", &self.body.value)?;
+        // Emit each optional port only when set, dropping its span. An unset
+        // port is skipped so the round-trip shape matches the authored YAML.
+        match &self.header {
+            Some(h) => state.serialize_field("header", &h.value)?,
+            None => state.skip_field("header")?,
+        }
+        match &self.trailer {
+            Some(t) => state.serialize_field("trailer", &t.value)?,
+            None => state.skip_field("trailer")?,
+        }
+        if self.notes.is_some() {
+            state.serialize_field("_notes", &self.notes)?;
+        } else {
+            state.skip_field("_notes")?;
+        }
+        state.end()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -765,6 +765,7 @@ impl PipelineConfig {
                 | PipelineNode::Merge { .. }
                 | PipelineNode::Reshape { .. }
                 | PipelineNode::Cull { .. }
+                | PipelineNode::Envelope { .. }
                 | PipelineNode::Composition { .. }
                 | PipelineNode::Combine { .. } => None,
             })
@@ -1257,6 +1258,16 @@ impl PipelineConfig {
                 PipelineNode::Combine { header, .. } => {
                     for node_input in header.input.values() {
                         wire(&input_full_reference(&node_input.value), None);
+                    }
+                }
+                PipelineNode::Envelope { header, .. } => {
+                    // Wire the body spine plus any wired header / trailer port
+                    // (a wired value is rejected at validation this release,
+                    // but the edge is built unconditionally so the rejection
+                    // diagnostic still resolves the reference).
+                    wire(&input_full_reference(&header.body.value), None);
+                    for inp in [&header.header, &header.trailer].into_iter().flatten() {
+                        wire(&input_full_reference(&inp.value), None);
                     }
                 }
             }
@@ -2272,6 +2283,12 @@ fn resolve_all_input_references(
             PipelineNode::Combine { header, .. } => {
                 for (qualifier, node_input) in &header.input {
                     emit(consumer_name, Some(qualifier.as_str()), node_input);
+                }
+            }
+            PipelineNode::Envelope { header, .. } => {
+                emit(consumer_name, None, &header.body);
+                for inp in [&header.header, &header.trailer].into_iter().flatten() {
+                    emit(consumer_name, None, inp);
                 }
             }
         }
@@ -3433,6 +3450,21 @@ pub(crate) fn lower_node_to_plan_node(
                 output_schema: schema_from_bound(name),
             })
         }
+        // Envelope lowers to a single-output pass-through carrying the framing
+        // strategy and the body's (unchanged) output schema. A missing typed
+        // entry means bind_schema could not resolve the body input — skip.
+        PipelineNode::Envelope { header, config } => {
+            artifacts.typed.get(name)?;
+            Some(crate::plan::execution::PlanNode::Envelope {
+                name: name.to_string(),
+                span,
+                strategy: config.strategy,
+                body_input: header.body.value.name().to_string(),
+                header_input: header.header.as_ref().map(|i| i.value.name().to_string()),
+                trailer_input: header.trailer.as_ref().map(|i| i.value.name().to_string()),
+                output_schema: schema_from_bound(name),
+            })
+        }
     }
 }
 
@@ -3962,6 +3994,30 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         for (name, decl) in vars {
             if let Some(default) = &decl.default {
                 check_scoped_var_default("vars", name, decl.var_type, default)?;
+            }
+        }
+    }
+
+    // Reject a wired `header:` / `trailer:` port on an Envelope node. The
+    // `preserve` strategy frames each body record with the body's own ambient
+    // envelope and reads no second stream, so an explicit header/trailer input
+    // would silently do nothing. A later release wires them; until then a wired
+    // value is a clear configuration error rather than a no-op.
+    for spanned in &config.nodes {
+        if let PipelineNode::Envelope { header, .. } = &spanned.value {
+            let wired = if header.header.is_some() {
+                Some("header")
+            } else if header.trailer.is_some() {
+                Some("trailer")
+            } else {
+                None
+            };
+            if let Some(port) = wired {
+                return Err(ConfigError::Validation(format!(
+                    "envelope node '{}': explicit `{port}` input wiring is not yet supported — \
+                     omit it to frame with the body's own envelope",
+                    header.name
+                )));
             }
         }
     }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3453,15 +3453,12 @@ pub(crate) fn lower_node_to_plan_node(
         // Envelope lowers to a single-output pass-through carrying the framing
         // strategy and the body's (unchanged) output schema. A missing typed
         // entry means bind_schema could not resolve the body input — skip.
-        PipelineNode::Envelope { header, config } => {
+        PipelineNode::Envelope { config, .. } => {
             artifacts.typed.get(name)?;
             Some(crate::plan::execution::PlanNode::Envelope {
                 name: name.to_string(),
                 span,
                 strategy: config.strategy,
-                body_input: header.body.value.name().to_string(),
-                header_input: header.header.as_ref().map(|i| i.value.name().to_string()),
-                trailer_input: header.trailer.as_ref().map(|i| i.value.name().to_string()),
                 output_schema: schema_from_bound(name),
             })
         }

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -41,7 +41,9 @@ use indexmap::IndexMap;
 use serde::de::{self, IntoDeserializer, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 
-use crate::config::node_header::{CombineHeader, MergeHeader, NodeHeader, SourceHeader};
+use crate::config::node_header::{
+    CombineHeader, EnvelopeHeader, MergeHeader, NodeHeader, SourceHeader,
+};
 use crate::plan::index::AnalyticWindowSpec;
 use crate::yaml::CxlSource;
 
@@ -145,6 +147,22 @@ pub enum PipelineNode {
         #[serde(flatten)]
         header: NodeHeader,
         config: CullBody,
+    },
+    /// Frames a body stream into per-document documents. A discrete,
+    /// composable stage placeable after any operator (Transform / Merge /
+    /// Combine / Aggregate), mirroring the message/EDI/XML envelope-wrapper
+    /// prior art.
+    ///
+    /// This slice ships the `preserve` strategy only — one framed document per
+    /// body grain, byte-identical to today's per-document framing. The body
+    /// records pass through with their document context and grain unchanged;
+    /// the optional `header:` / `trailer:` ports are accepted in config but a
+    /// wired value is rejected at plan validation until a later release wires
+    /// them.
+    Envelope {
+        #[serde(flatten)]
+        header: EnvelopeHeader,
+        config: EnvelopeBody,
     },
     /// Composition call-site node. Lowered to `PlanNode::Composition` in
     /// Stage 5; body nodes live in `CompileArtifacts.composition_bodies`
@@ -381,6 +399,13 @@ impl<'de> Deserialize<'de> for PipelineNode {
                         let (header, config) = payload.into_variant_parts();
                         Ok(PipelineNode::Cull { header, config })
                     }
+                    "envelope" => {
+                        let payload = EnvelopePayload::deserialize(
+                            de::value::MapAccessDeserializer::new(dispatch),
+                        )?;
+                        let (header, config) = payload.into_variant_parts();
+                        Ok(PipelineNode::Envelope { header, config })
+                    }
                     "composition" => {
                         let payload = CompositionPayload::deserialize(
                             de::value::MapAccessDeserializer::new(dispatch),
@@ -399,6 +424,7 @@ impl<'de> Deserialize<'de> for PipelineNode {
                             "output",
                             "reshape",
                             "cull",
+                            "envelope",
                             "composition",
                         ],
                     )),
@@ -613,6 +639,40 @@ impl CullPayload {
     }
 }
 
+// ---- Envelope --------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct EnvelopePayload {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    body: crate::yaml::Spanned<crate::config::node_header::NodeInput>,
+    #[serde(default)]
+    header: Option<crate::yaml::Spanned<crate::config::node_header::NodeInput>>,
+    #[serde(default)]
+    trailer: Option<crate::yaml::Spanned<crate::config::node_header::NodeInput>>,
+    #[serde(default, rename = "_notes")]
+    notes: Option<serde_json::Value>,
+    config: EnvelopeBody,
+}
+
+impl EnvelopePayload {
+    fn into_variant_parts(self) -> (EnvelopeHeader, EnvelopeBody) {
+        (
+            EnvelopeHeader {
+                name: self.name,
+                description: self.description,
+                body: self.body,
+                header: self.header,
+                trailer: self.trailer,
+                notes: self.notes,
+            },
+            self.config,
+        )
+    }
+}
+
 // ---- Merge -----------------------------------------------------------
 
 #[derive(Deserialize)]
@@ -730,6 +790,7 @@ impl PipelineNode {
             | PipelineNode::Composition { header, .. } => &header.name,
             PipelineNode::Merge { header, .. } => &header.name,
             PipelineNode::Combine { header, .. } => &header.name,
+            PipelineNode::Envelope { header, .. } => &header.name,
         }
     }
 
@@ -748,7 +809,8 @@ impl PipelineNode {
             | PipelineNode::Composition { header, .. } => Some(header.input.value.name()),
             PipelineNode::Source { .. }
             | PipelineNode::Merge { .. }
-            | PipelineNode::Combine { .. } => None,
+            | PipelineNode::Combine { .. }
+            | PipelineNode::Envelope { .. } => None,
         }
     }
 
@@ -784,6 +846,14 @@ impl PipelineNode {
             PipelineNode::Combine { header, .. } => {
                 header.input.values().map(|i| i.value.name()).collect()
             }
+            // Body first so a lineage walk picks the body spine; the optional
+            // header / trailer ports follow when wired (skipped when unset).
+            PipelineNode::Envelope { header, .. } => {
+                let mut inputs = vec![header.body.value.name()];
+                inputs.extend(header.header.iter().map(|i| i.value.name()));
+                inputs.extend(header.trailer.iter().map(|i| i.value.name()));
+                inputs
+            }
         }
     }
 
@@ -818,6 +888,7 @@ impl PipelineNode {
             PipelineNode::Output { .. } => "output",
             PipelineNode::Reshape { .. } => "reshape",
             PipelineNode::Cull { .. } => "cull",
+            PipelineNode::Envelope { .. } => "envelope",
             PipelineNode::Composition { .. } => "composition",
         }
     }
@@ -1250,6 +1321,27 @@ pub struct RouteBody {
     pub mode: crate::config::RouteMode,
     pub conditions: IndexMap<String, CxlSource>,
     pub default: String,
+}
+
+/// Envelope variant body. `body:` / `header:` / `trailer:` inputs live on
+/// [`EnvelopeHeader`], not here — this carries only the framing strategy.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields, default)]
+pub struct EnvelopeBody {
+    #[serde(default)]
+    pub strategy: EnvelopeStrategy,
+}
+
+/// Envelope framing strategy. This slice ships `preserve`; the consolidation
+/// (`concat`) and synthesizing strategies are additive variants in later slices.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeStrategy {
+    /// One framed document per body grain — today's per-document framing,
+    /// made an explicit, composable stage. Body records pass through with
+    /// their document context and grain unchanged.
+    #[default]
+    Preserve,
 }
 
 /// Merge variant body. `inputs:` lives on `MergeHeader`, not here.
@@ -2431,6 +2523,179 @@ nodes:
         assert!(
             json.contains("long_unique"),
             "a flagged column must emit the key, got: {json}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod envelope_tests {
+    use super::*;
+    use crate::config::PipelineConfig;
+
+    /// A minimal pipeline whose body Transform feeds an Envelope node. The
+    /// `{envelope_block}` placeholder carries the node's config under test.
+    fn pipeline_with_envelope(envelope_block: &str) -> String {
+        format!(
+            r#"
+pipeline:
+  name: envelope_cfg
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: id, type: int }}
+  - type: transform
+    name: body
+    input: src
+    config:
+      cxl: "emit id = id"
+{envelope_block}"#
+        )
+    }
+
+    /// Locate the single Envelope node in a parsed config.
+    fn envelope_of(config: &PipelineConfig) -> (&EnvelopeHeader, &EnvelopeBody) {
+        config
+            .nodes
+            .iter()
+            .find_map(|n| match &n.value {
+                PipelineNode::Envelope { header, config } => Some((header, config)),
+                _ => None,
+            })
+            .expect("config has an envelope node")
+    }
+
+    #[test]
+    fn envelope_preserve_parses_with_body_and_strategy() {
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    \
+             config: { strategy: preserve }\n",
+        );
+        let config: PipelineConfig = crate::yaml::from_str(&yaml).expect("parse envelope node");
+        let (header, body) = envelope_of(&config);
+        assert_eq!(header.name, "framed");
+        assert_eq!(header.body.value.name(), "body");
+        assert!(header.header.is_none(), "no header port wired");
+        assert!(header.trailer.is_none(), "no trailer port wired");
+        assert_eq!(body.strategy, EnvelopeStrategy::Preserve);
+    }
+
+    #[test]
+    fn envelope_strategy_defaults_to_preserve() {
+        // An empty `config: {}` selects the default strategy, which is the
+        // only variant this slice ships.
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    config: {}\n",
+        );
+        let config: PipelineConfig =
+            crate::yaml::from_str(&yaml).expect("parse default-strategy envelope");
+        let (_, body) = envelope_of(&config);
+        assert_eq!(
+            body.strategy,
+            EnvelopeStrategy::Preserve,
+            "the default envelope strategy is `preserve`"
+        );
+        // And the standalone enum default agrees.
+        assert_eq!(EnvelopeStrategy::default(), EnvelopeStrategy::Preserve);
+    }
+
+    #[test]
+    fn envelope_node_round_trips_through_serialize() {
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    \
+             config: { strategy: preserve }\n",
+        );
+        let config: PipelineConfig = crate::yaml::from_str(&yaml).expect("parse");
+        let envelope = config
+            .nodes
+            .iter()
+            .find(|n| matches!(n.value, PipelineNode::Envelope { .. }))
+            .expect("envelope node present");
+        // Serialize just the node and re-parse it — the hand-rolled
+        // `EnvelopeHeader::Serialize` drops spans and the unset ports, so the
+        // round-trip recovers an equal logical shape.
+        let json = serde_json::to_value(&envelope.value).expect("serialize envelope node");
+        let reparsed: PipelineNode =
+            serde_json::from_value(json).expect("re-parse serialized envelope node");
+        match reparsed {
+            PipelineNode::Envelope { header, config } => {
+                assert_eq!(header.name, "framed");
+                assert_eq!(header.body.value.name(), "body");
+                assert!(header.header.is_none());
+                assert!(header.trailer.is_none());
+                assert_eq!(config.strategy, EnvelopeStrategy::Preserve);
+            }
+            other => panic!("round-trip changed the variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn envelope_rejects_unknown_field_under_config() {
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    \
+             config: { strategy: preserve, bogus: 1 }\n",
+        );
+        let err = crate::yaml::from_str::<PipelineConfig>(&yaml)
+            .expect_err("unknown config field must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bogus"),
+            "error should name the field, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn envelope_requires_body_input() {
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    config: { strategy: preserve }\n",
+        );
+        let err = crate::yaml::from_str::<PipelineConfig>(&yaml)
+            .expect_err("missing body input must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("body"),
+            "error should name the missing `body`, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn envelope_rejects_wired_header_port() {
+        // A wired `header:` is accepted by the YAML shape but rejected at plan
+        // validation this release — `preserve` reads only the body's own
+        // ambient envelope. Pin the not-yet-supported message.
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    header: body\n    \
+             config: { strategy: preserve }\n",
+        );
+        let err = crate::config::parse_config(&yaml)
+            .expect_err("a wired header port must be rejected at validation");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("envelope node 'framed'")
+                && msg.contains("`header`")
+                && msg.contains("not yet supported"),
+            "error must explain the not-yet-supported header wiring, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn envelope_rejects_wired_trailer_port() {
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    trailer: body\n    \
+             config: { strategy: preserve }\n",
+        );
+        let err = crate::config::parse_config(&yaml)
+            .expect_err("a wired trailer port must be rejected at validation");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("envelope node 'framed'")
+                && msg.contains("`trailer`")
+                && msg.contains("not yet supported"),
+            "error must explain the not-yet-supported trailer wiring, got: {msg}"
         );
     }
 }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -2053,6 +2053,20 @@ fn bind_schema_inner(
                     );
                 }
             }
+            // Envelope adopts the body input's schema verbatim — it does not
+            // widen (the `preserve` strategy passes body records through
+            // unchanged). The optional `header:` / `trailer:` ports are
+            // rejected when wired at `validate_config`, so binding reads only
+            // the body input here.
+            PipelineNode::Envelope { header, .. } => {
+                if let Some(upstream) = upstream_schema(&header.body.value, schema_by_name) {
+                    let row = upstream.clone();
+                    schema_by_name.insert(name.clone(), row.clone());
+                    artifacts
+                        .typed
+                        .insert(name, Arc::new(synthetic_typed_program(row)));
+                }
+            }
             // Phase Combine C.1.1 + C.1.2 + C.1.3 (single-pass arm).
             //
             // Combine compile runs as a single pass in `bind_combine`.
@@ -2529,6 +2543,20 @@ fn bind_composition(
                     wire(&r, None);
                 }
             }
+            PipelineNode::Envelope { header, .. } => {
+                let refs = std::iter::once(&header.body)
+                    .chain(header.header.iter())
+                    .chain(header.trailer.iter());
+                for ni in refs {
+                    let r = match &ni.value {
+                        crate::config::node_header::NodeInput::Single(s) => s.clone(),
+                        crate::config::node_header::NodeInput::Port { node, port } => {
+                            format!("{node}.{port}")
+                        }
+                    };
+                    wire(&r, None);
+                }
+            }
         }
     }
 
@@ -2615,6 +2643,16 @@ fn bind_composition(
             PipelineNode::Combine { header, .. } => header
                 .input
                 .values()
+                .map(|ni| match &ni.value {
+                    crate::config::node_header::NodeInput::Single(s) => s.clone(),
+                    crate::config::node_header::NodeInput::Port { node, port } => {
+                        format!("{node}.{port}")
+                    }
+                })
+                .collect(),
+            PipelineNode::Envelope { header, .. } => std::iter::once(&header.body)
+                .chain(header.header.iter())
+                .chain(header.trailer.iter())
                 .map(|ni| match &ni.value {
                     crate::config::node_header::NodeInput::Single(s) => s.clone(),
                     crate::config::node_header::NodeInput::Port { node, port } => {

--- a/crates/clinker-plan/src/plan/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/deferred_region.rs
@@ -1016,8 +1016,11 @@ fn propagate_through_node_for_body(node: &PlanNode, set: &mut HashSet<String>) {
             // tighten this but only matters once a runtime consumer
             // exists.
         }
-        PlanNode::Merge { .. } | PlanNode::Sort { .. } | PlanNode::CorrelationCommit { .. } => {
-            // Passthrough.
+        PlanNode::Merge { .. }
+        | PlanNode::Sort { .. }
+        | PlanNode::Envelope { .. }
+        | PlanNode::CorrelationCommit { .. } => {
+            // Passthrough — body columns flow through unchanged.
         }
         PlanNode::Aggregation {
             config, compiled, ..

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -1382,6 +1382,7 @@ impl ExecutionPlanDag {
                 }
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }
+                | PlanNode::Envelope { .. }
                 | PlanNode::Output { .. }
                 | PlanNode::Sort { .. }
                 | PlanNode::Composition { .. }
@@ -1519,6 +1520,7 @@ impl ExecutionPlanDag {
                 }
                 PlanNode::Source { .. }
                 | PlanNode::Transform { .. }
+                | PlanNode::Envelope { .. }
                 | PlanNode::Output { .. }
                 | PlanNode::Sort { .. }
                 | PlanNode::Composition { .. }

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -226,23 +226,14 @@ pub enum PlanNode {
     /// unchanged, and the document-boundary punctuations are forwarded
     /// verbatim — so a downstream Output frames byte-identically to today's
     /// per-document framing. The node does not widen: its output schema is
-    /// the body input's schema. `header_input` / `trailer_input` are the
-    /// optional port references; a wired value is rejected at plan validation
-    /// this release, so the executor resolves only the single body predecessor.
+    /// the body input's schema. A wired header/trailer port is rejected at
+    /// plan validation this release, so the executor resolves the single body
+    /// predecessor topologically rather than carrying named port references.
     Envelope {
         name: String,
         #[serde(skip)]
         span: Span,
         strategy: crate::config::pipeline_node::EnvelopeStrategy,
-        /// Name of the body input node (the framed stream).
-        body_input: String,
-        /// Optional header-port input node name. `None` this release (a wired
-        /// value is rejected at validation); carried for the later wiring slice.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        header_input: Option<String>,
-        /// Optional trailer-port input node name. Same not-yet-wired status.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        trailer_input: Option<String>,
         /// Output schema, adopted verbatim from the body input (Envelope does
         /// not widen). Populated by `bind_schema`.
         #[serde(skip)]

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -219,6 +219,35 @@ pub enum PlanNode {
         #[serde(skip)]
         output_schema: Arc<Schema>,
     },
+    /// Frames a body stream into per-document documents.
+    ///
+    /// Streaming single-output pass-through. With the `Preserve` strategy
+    /// every body record flows through with its document context and grain
+    /// unchanged, and the document-boundary punctuations are forwarded
+    /// verbatim — so a downstream Output frames byte-identically to today's
+    /// per-document framing. The node does not widen: its output schema is
+    /// the body input's schema. `header_input` / `trailer_input` are the
+    /// optional port references; a wired value is rejected at plan validation
+    /// this release, so the executor resolves only the single body predecessor.
+    Envelope {
+        name: String,
+        #[serde(skip)]
+        span: Span,
+        strategy: crate::config::pipeline_node::EnvelopeStrategy,
+        /// Name of the body input node (the framed stream).
+        body_input: String,
+        /// Optional header-port input node name. `None` this release (a wired
+        /// value is rejected at validation); carried for the later wiring slice.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        header_input: Option<String>,
+        /// Optional trailer-port input node name. Same not-yet-wired status.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        trailer_input: Option<String>,
+        /// Output schema, adopted verbatim from the body input (Envelope does
+        /// not widen). Populated by `bind_schema`.
+        #[serde(skip)]
+        output_schema: Arc<Schema>,
+    },
     /// Planner-synthesized sort enforcer.
     ///
     /// Inserted by `ExecutionPlanDag::insert_enforcer_sorts` on edges feeding
@@ -455,6 +484,7 @@ impl PlanNode {
             | PlanNode::Output { name, .. }
             | PlanNode::Reshape { name, .. }
             | PlanNode::Cull { name, .. }
+            | PlanNode::Envelope { name, .. }
             | PlanNode::Sort { name, .. }
             | PlanNode::Aggregation { name, .. }
             | PlanNode::Composition { name, .. }
@@ -474,6 +504,7 @@ impl PlanNode {
             | PlanNode::Output { span, .. }
             | PlanNode::Reshape { span, .. }
             | PlanNode::Cull { span, .. }
+            | PlanNode::Envelope { span, .. }
             | PlanNode::Sort { span, .. }
             | PlanNode::Aggregation { span, .. }
             | PlanNode::Composition { span, .. }
@@ -520,6 +551,7 @@ impl PlanNode {
             | PlanNode::Composition { output_schema, .. }
             | PlanNode::Reshape { output_schema, .. }
             | PlanNode::Cull { output_schema, .. }
+            | PlanNode::Envelope { output_schema, .. }
             | PlanNode::Merge { output_schema, .. } => output_schema
                 .columns()
                 .iter()
@@ -556,6 +588,7 @@ impl PlanNode {
             | PlanNode::Composition { output_schema, .. }
             | PlanNode::Reshape { output_schema, .. }
             | PlanNode::Cull { output_schema, .. }
+            | PlanNode::Envelope { output_schema, .. }
             | PlanNode::Merge { output_schema, .. } => Some(output_schema),
             PlanNode::Route { .. }
             | PlanNode::Output { .. }
@@ -646,6 +679,7 @@ impl PlanNode {
             PlanNode::CorrelationCommit { .. } => "correlation_commit",
             PlanNode::Reshape { .. } => "reshape",
             PlanNode::Cull { .. } => "cull",
+            PlanNode::Envelope { .. } => "envelope",
         }
     }
 
@@ -717,6 +751,12 @@ impl PlanNode {
                 )
             }
             PlanNode::Sort { name, .. } => format!("[sort] {name}"),
+            PlanNode::Envelope { name, strategy, .. } => {
+                let s = match strategy {
+                    crate::config::pipeline_node::EnvelopeStrategy::Preserve => "preserve",
+                };
+                format!("[envelope:{s}] {name}")
+            }
             PlanNode::Aggregation { name, strategy, .. } => {
                 let s = match strategy {
                     AggregateStrategy::Hash => "hash",
@@ -959,13 +999,16 @@ pub(super) fn arbitration_class(node: &PlanNode) -> ArbitrationClass {
             can_back_pressure: false,
         },
         // Stateless or sink stages register no spillable consumer:
-        // Transform / Route / Merge stream record-at-a-time, Output is a
-        // sink, Composition is a structural wrapper whose body nodes
-        // carry their own classes, and CorrelationCommit's group buffer
-        // is bounded by `max_group_buffer` rather than the arbitrator.
+        // Transform / Route / Merge stream record-at-a-time, Envelope passes
+        // body records through unchanged (its NodeBuffer slot carries its own
+        // arbitrator wrapper, not a stage consumer), Output is a sink,
+        // Composition is a structural wrapper whose body nodes carry their own
+        // classes, and CorrelationCommit's group buffer is bounded by
+        // `max_group_buffer` rather than the arbitrator.
         PlanNode::Transform { .. }
         | PlanNode::Route { .. }
         | PlanNode::Merge { .. }
+        | PlanNode::Envelope { .. }
         | PlanNode::Output { .. }
         | PlanNode::Composition { .. }
         | PlanNode::CorrelationCommit { .. } => ArbitrationClass {
@@ -1031,10 +1074,13 @@ pub(super) fn writes_spill_files(node: &PlanNode) -> bool {
         // the budget and re-splits on reload, so it writes real spill files
         // and must appear in the disk-spill projection surfaces.
         PlanNode::Cull { .. } => true,
+        // Envelope passes body records through unchanged and registers no
+        // spillable consumer, so it never writes spill files.
         PlanNode::Source { .. }
         | PlanNode::Transform { .. }
         | PlanNode::Route { .. }
         | PlanNode::Merge { .. }
+        | PlanNode::Envelope { .. }
         | PlanNode::Output { .. }
         | PlanNode::Composition { .. }
         | PlanNode::CorrelationCommit { .. } => false,

--- a/crates/clinker-plan/src/plan/execution/scheduling.rs
+++ b/crates/clinker-plan/src/plan/execution/scheduling.rs
@@ -1056,6 +1056,34 @@ fn compute_one(
             }
         }
 
+        PlanNode::Envelope { name, .. } => {
+            // Envelope `preserve` re-parks body records in drained order with
+            // their grains unchanged — it neither reorders, repartitions, nor
+            // transforms CK visibility — so the parent's ordering, partitioning,
+            // and CK set all flow through. Provenance is rewritten to point at
+            // this node so explain can chain through, matching Route / Output.
+            let parent = match parents.first() {
+                Some(p) => p,
+                None => return NodeProperties::unordered_single(),
+            };
+            let provenance = if parent.ordering.sort_order.is_some() {
+                OrderingProvenance::Preserved {
+                    from_node: name.clone(),
+                }
+            } else {
+                parent.ordering.provenance.clone()
+            };
+            NodeProperties {
+                ordering: Ordering {
+                    sort_order: parent.ordering.sort_order.clone(),
+                    provenance,
+                },
+                partitioning: parent.partitioning.clone(),
+                ck_set: parent.ck_set.clone(),
+                ..NodeProperties::unordered_single()
+            }
+        }
+
         PlanNode::Combine {
             name, propagate_ck, ..
         } => {

--- a/crates/clinker-plan/src/plan/tests/ck_lattice.rs
+++ b/crates/clinker-plan/src/plan/tests/ck_lattice.rs
@@ -956,20 +956,7 @@ fn assert_every_node_has_properties(plan: &crate::plan::execution::ExecutionPlan
             plan.node_properties.contains_key(&idx),
             "node {} ({}) has no NodeProperties entry",
             plan.graph[idx].name(),
-            match &plan.graph[idx] {
-                PlanNode::Source { .. } => "source",
-                PlanNode::Transform { .. } => "transform",
-                PlanNode::Sort { .. } => "sort",
-                PlanNode::Aggregation { .. } => "aggregation",
-                PlanNode::Route { .. } => "route",
-                PlanNode::Merge { .. } => "merge",
-                PlanNode::Combine { .. } => "combine",
-                PlanNode::Output { .. } => "output",
-                PlanNode::Reshape { .. } => "reshape",
-                PlanNode::Cull { .. } => "cull",
-                PlanNode::Composition { .. } => "composition",
-                PlanNode::CorrelationCommit { .. } => "correlation_commit",
-            }
+            plan.graph[idx].type_tag(),
         );
     }
 }

--- a/docs/user/src/SUMMARY.md
+++ b/docs/user/src/SUMMARY.md
@@ -30,6 +30,7 @@
 - [Aggregate Nodes](nodes/aggregate.md)
 - [Reshape Nodes](nodes/reshape.md)
 - [Cull Nodes](nodes/cull.md)
+- [Envelope Nodes](nodes/envelope.md)
 - [Output Nodes](nodes/output.md)
 
 # Source Formats

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -1,0 +1,76 @@
+# Envelope Nodes
+
+Envelope nodes frame a body stream into per-document documents. An Envelope is a discrete, composable stage you can place after **any** operator — a Transform, a Merge, a Combine, or an Aggregate — to declare "from here on, treat the records as belonging to framed documents." It mirrors the message/EDI/XML envelope-wrapper pattern (the Enterprise Integration Patterns *Envelope Wrapper*, XProc's `p:wrap-sequence`): the body is the payload, and the envelope is the document boundary around it.
+
+This page documents the `preserve` strategy. Consolidation (`concat`) and synthesizing strategies arrive in later releases.
+
+## Basic structure
+
+```yaml
+- type: envelope
+  name: framed
+  body: merged
+  config:
+    strategy: preserve
+```
+
+The node reads its `body:` input and emits the same records, framed per document. A downstream [Output](output.md) with `reconstruct_envelope: true` then writes one framed document per body grain.
+
+## Inputs: `body`, and the not-yet-wired `header` / `trailer`
+
+| Input | Required | Status |
+|-------|----------|--------|
+| `body` | yes | The records to frame into documents. |
+| `header` | no | A stream whose records prepend to each framed document. **Accepted in config but not yet wired** — a wired value is rejected at plan validation this release. |
+| `trailer` | no | A stream whose records append to each framed document. Same not-yet-wired status. |
+
+Wiring an explicit `header:` or `trailer:` input is rejected with a clear "not yet supported" message:
+
+```
+envelope node 'framed': explicit `header` input wiring is not yet supported —
+omit it to frame with the body's own envelope
+```
+
+Until those ports are wired, an Envelope frames each body record using the body's own **ambient envelope** — the document context every record already carries from its source — rather than a second input stream.
+
+## `strategy: preserve`
+
+`preserve` emits **one framed document per body grain**. It is a transparent framing stage: body records pass through with their document context and grain unchanged, and the document-boundary signals are forwarded verbatim. Inserting a `preserve` Envelope between a body stage and an Output is byte-identical to today's per-document framing — its value is being the *explicit, composable* stage that later strategies extend, not a change in output.
+
+`preserve` is the default, so `config: { strategy: preserve }` and an empty `config: {}` are equivalent.
+
+### Framing is keyed on the document grain, never the source file
+
+The grain is the level at which one logical document is reconstructed — and it is not always one-per-file:
+
+- A **nested X12 interchange** frames **once per interchange**. The `GS` functional-group and `ST` transaction-set levels inherit the interchange grain, so an `ISA … IEA` interchange is one framed document regardless of how many groups or transaction sets it nests.
+- An **HL7 multi-message file** frames **once per message**. Each `MSH` message opens its own grain, so a single file containing several messages produces several framed documents.
+
+Because framing keys on the grain rather than the source file, splitting or combining files never silently changes the document count.
+
+## Placement
+
+An Envelope is a normal single-input, single-output node — put it anywhere a record stream flows:
+
+```yaml
+nodes:
+  # … sources, a Combine that joins two streams into `merged` …
+  - type: envelope
+    name: framed
+    body: merged
+    config: { strategy: preserve }
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+```
+
+Placing the Envelope **after** a Combine or Aggregate is the intended use: it declares the document framing for the combined or reduced result, which is exactly where the later consolidation and synthesizing strategies do their work.
+
+## Memory model
+
+`preserve` is a **streaming pass-through**. It does not buffer a whole document or the whole input — body records flow through one batch at a time, bounded the same way any intermediate stage is (the engine's memory arbitrator governs the node's buffer and spills to disk under pressure). The resident footprint is the records of the concurrently-open documents, not the total input size.

--- a/docs/user/src/nodes/index.md
+++ b/docs/user/src/nodes/index.md
@@ -5,7 +5,7 @@ A Clinker pipeline is a single flat `nodes:` list. Every entry carries a
 taxonomy**. There is no separate "join section" or "filter section":
 records flow through one homogeneous graph of typed nodes, wired together
 by [`input:` / `inputs:`](../pipelines/structure.md#wiring-input-and-inputs).
-This part documents the eight record-processing node kinds; a ninth,
+This part documents the nine record-processing node kinds; a tenth,
 [Composition](../pipelines/compositions.md), is a call-site that inlines a
 reusable sub-pipeline and is covered under Pipelines.
 
@@ -23,6 +23,7 @@ nodes, and leaves at an Output:
 | [Aggregate](aggregate.md) | Grouped or windowed reduction. | 1 → 1 | Blocking (or streaming when sorted) |
 | [Reshape](reshape.md) | Pivot / unpivot between wide and long record shapes. | 1 → 1 | Blocking |
 | [Cull](cull.md) | Per-correlation-group removal on a group-level predicate, with a `removed_to` side-output port. | 1 → 2 | Blocking |
+| [Envelope](envelope.md) | Frames a body stream into per-document documents; a composable framing stage. | 1 → 1 | Streaming |
 | [Output](output.md) | Writes records to a sink; the exit point. | 1 → 0 | Streaming |
 
 ## Streaming vs blocking


### PR DESCRIPTION
## Summary

Adds the **Envelope** pipeline node — a discrete, composable framing stage
placeable after any operator (Transform / Merge / Combine / Aggregate),
matching the message/EDI/XML prior art (EIP *Envelope Wrapper*, XProc
`p:wrap-sequence`). This is the first half of the standalone-envelope work
(#572): the node end-to-end (config taxonomy → plan node → schema binding →
executor dispatch) with the `preserve` strategy.

`preserve` = one framed document per body grain — **byte-identical to today's
per-document framing**, now declarable as an explicit stage rather than an
implicit sink behavior. Framing is keyed on the document grain, never the
source file: a nested X12 interchange frames once per interchange (group /
transaction-set levels inherit the interchange grain); an HL7 multi-message
file frames once per message.

## Scope notes for reviewers

- The `strategy` enum ships a single `preserve` variant; the `concat`
  consolidation strategy and the synthesizing strategies are additive
  follow-ups (the sibling issue and #573–575). Not a dead variant — a
  forward-compatible, defaulted enum.
- The `header` / `trailer` input ports are accepted in config but a wired value
  is **rejected at plan validation** until its handling lands; `preserve`
  frames with the body's own envelope (no second input stream this slice).
- A test panic-message helper that hand-enumerated every plan-node variant was
  replaced with the canonical `type_tag()` accessor (removes a parallel
  variant→label map).

## Testing

Full workspace gauntlet green: `fmt`, `clippy` (with and without
`--all-targets`), `test`, bench checks, `deny`. New tests:

- a **differential oracle** proving a `preserve` Envelope node produces
  byte-identical output to the same pipeline *without* it (with equal
  document-framing open/close counts);
- X12 per-interchange and HL7 per-message framing **counts** (grain-keyed, not
  file-keyed);
- config parse / serialize round-trip, unknown-field rejection, and a
  **pinned-error** rejection of a wired `header` / `trailer` port.

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)
