### PR TITLE
exec: Envelope node concat strategy + multi-header consolidation guard (#586)

### DIFF
--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -1,13 +1,28 @@
 //! `PlanNode::Envelope` dispatch arm.
 //!
-//! Frames a body stream into per-document documents. With the
-//! [`EnvelopeStrategy::Preserve`] strategy this is a transparent framing
-//! stage: it drains the body predecessor's full output and re-parks every
-//! record into its successors' slots **with the record's document context and
-//! grain unchanged**, forwarding the document-boundary punctuations verbatim.
-//! A downstream Output therefore frames on the same grains it would have seen
-//! without the node — the `preserve` Envelope is byte-identical to today's
-//! per-document framing, now declarable as an explicit composable stage.
+//! Frames a body stream into per-document documents.
+//!
+//! With the [`EnvelopeStrategy::Preserve`] strategy this is a transparent
+//! framing stage: it drains the body predecessor's full output and re-parks
+//! every record into its successors' slots **with the record's document context
+//! and grain unchanged**, forwarding the document-boundary punctuations
+//! verbatim. A downstream Output therefore frames on the same grains it would
+//! have seen without the node — the `preserve` Envelope is byte-identical to
+//! today's per-document framing, now declarable as an explicit composable stage.
+//!
+//! With the [`EnvelopeStrategy::Concat`] strategy the node consolidates: it
+//! mints ONE fresh document context for the whole body and re-stamps every
+//! drained record onto it, then re-frames the body with a single
+//! `DocumentOpen`/`DocumentClose` pair. A multi-document body therefore frames
+//! as one document (one open, one close). The consolidated header is the body's
+//! common envelope — every incoming document's `DocumentOpen` envelope folded to
+//! the distinct non-empty set; an empty set yields a headerless document and a
+//! single member yields that common header. Re-stamping touches only the grain
+//! (framing) and the ambient `$doc.*` view — each record's `$source.*` is a real
+//! tail column stamped at ingest, so it is untouched and concat is lossless on
+//! per-record provenance. Two or more distinct non-empty headers under the one
+//! document is rejected ([`PipelineError::EnvelopeMultiHeaderConflict`], E350)
+//! rather than silently shadowed.
 //!
 //! # Inputs
 //!
@@ -24,19 +39,33 @@
 //! not an incrementally-streamed subset. The node registers no spillable stage
 //! consumer of its own.
 
+use std::sync::Arc;
+
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
 };
+use crate::executor::node_buffer::DrainedEvents;
+use crate::executor::stream_event::{Punctuation, PunctuationKind};
 use clinker_plan::config::pipeline_node::EnvelopeStrategy;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
+use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Record};
 
-/// Execute the `Envelope` arm for `node_idx`. Drains the body predecessor and,
-/// for the `Preserve` strategy, re-parks every record into this node's own
-/// `node_buffers` slot with the document context and grain unchanged,
-/// forwarding the body's punctuations.
+/// Execute the `Envelope` arm for `node_idx`. Drains the body predecessor and
+/// re-parks the framed body into this node's own `node_buffers` slot.
+///
+/// `Preserve` re-parks every record with its document context and grain
+/// unchanged, forwarding the body's punctuations. `Concat` re-stamps every
+/// record onto one consolidated document context and re-frames with a single
+/// open/close pair.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::EnvelopeMultiHeaderConflict`] (E350) under `Concat`
+/// when the body carries two or more distinct non-empty envelope headers — one
+/// consolidated document cannot frame two headers without dropping one.
 pub(crate) fn dispatch_envelope(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
@@ -57,30 +86,129 @@ pub(crate) fn dispatch_envelope(
     };
 
     // Exhaustive over `EnvelopeStrategy`. `preserve` forwards the body
-    // unchanged; the consolidation and synthesizing strategies are additive
-    // variants that will add their own arms.
-    match strategy {
+    // unchanged; `concat` consolidates the whole body onto one document; the
+    // synthesizing strategies are additive variants that will add their own
+    // arms. Both arms re-park into THIS node's own slot — every downstream
+    // consumer resolves its input from its predecessor's slot, so writing to
+    // `node_idx` is exactly where each successor looks (the Transform/Sort
+    // linear-producer convention, not the Route/Cull per-successor fork).
+    let (records, puncts) = match strategy {
         EnvelopeStrategy::Preserve => {
-            // Re-park the drained body into THIS node's own slot, leaving each
-            // record's document context and grain untouched and forwarding the
-            // body's punctuations verbatim. Every downstream consumer resolves
-            // its input from its predecessor's slot — a linear consumer
-            // (Transform / Aggregate / Output / Sort / Reshape / Cull) drains
-            // the predecessor it computes, and a fan-in consumer (Merge /
-            // Combine) reads each predecessor slot directly — so writing to
-            // `node_idx` is exactly where each successor looks. This mirrors the
-            // Transform/Sort linear-producer convention (own-slot write), not
-            // the Route/Cull fork convention (per-successor-slot write).
-            let nb = admit_node_buffer(
-                ctx,
-                name,
-                node_idx,
-                records,
-                puncts,
-                node_buffer_spill_allowed(current_dag, node_idx),
-            )?;
-            ctx.node_buffers.insert(node_idx, nb);
-            Ok(())
+            // Leave each record's document context and grain untouched and
+            // forward the body's punctuations verbatim.
+            (records, puncts)
+        }
+        EnvelopeStrategy::Concat => consolidate(name, records, puncts)?,
+    };
+
+    let nb = admit_node_buffer(
+        ctx,
+        name,
+        node_idx,
+        records,
+        puncts,
+        node_buffer_spill_allowed(current_dag, node_idx),
+    )?;
+    ctx.node_buffers.insert(node_idx, nb);
+    Ok(())
+}
+
+/// Collapse a multi-document body onto ONE consolidated document context.
+///
+/// Re-stamps every record's document context to the consolidated one (its grain
+/// — the framing key — and its ambient `$doc.*` view become the consolidated
+/// document's; each record's `$source.*` is a real tail column from ingest and
+/// is untouched), and replaces the incoming punctuations with exactly one
+/// `DocumentOpen`/`DocumentClose` pair so the body frames as a single document.
+///
+/// The consolidated header is the body's common envelope, derived from the
+/// incoming `DocumentOpen` punctuations (authoritative — they cover an
+/// empty-body document a record scan would miss): the distinct non-empty
+/// envelopes, where zero yields a headerless document, one yields that common
+/// header, and a colliding empty document coexists with the single header.
+///
+/// An empty body (no records and no punctuations) emits nothing.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::EnvelopeMultiHeaderConflict`] (E350) when two or
+/// more distinct non-empty headers would land under the one document.
+fn consolidate(
+    name: &str,
+    records: Vec<(Record, u64)>,
+    puncts: Vec<Punctuation>,
+) -> Result<DrainedEvents, PipelineError> {
+    // An empty body frames nothing — no document to open or close.
+    if records.is_empty() && puncts.is_empty() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    // Fold every incoming document's open-envelope down to the distinct
+    // non-empty set. The count is O(documents), bounded; dedup is a linear
+    // scan against the kept set since `EnvelopeRecord` is `PartialEq` but not
+    // `Hash`.
+    let mut distinct_headers: Vec<&EnvelopeRecord> = Vec::new();
+    for p in puncts
+        .iter()
+        .filter(|p| p.kind() == PunctuationKind::DocumentOpen)
+    {
+        let env = p.doc_ctx().envelope_record();
+        if env.is_empty() {
+            continue;
+        }
+        if !distinct_headers.contains(&env) {
+            distinct_headers.push(env);
         }
     }
+
+    if distinct_headers.len() >= 2 {
+        return Err(PipelineError::EnvelopeMultiHeaderConflict {
+            envelope: name.to_string(),
+            header_count: distinct_headers.len(),
+        });
+    }
+
+    let consolidated_header = match distinct_headers.first() {
+        Some(env) => (*env).clone(),
+        None => EnvelopeRecord::empty(),
+    };
+
+    // The consolidated document inherits the first incoming document's source
+    // file as its representative identity, preferring the first `DocumentOpen`.
+    // That path only keys the document-DLQ and is otherwise informational here;
+    // per-record `$source.file` is a tail column stamped at ingest and is
+    // unaffected by the re-stamp.
+    let source_file = puncts
+        .iter()
+        .find(|p| p.kind() == PunctuationKind::DocumentOpen)
+        .map(|p| Arc::clone(p.source_file()))
+        .or_else(|| {
+            records
+                .first()
+                .map(|(r, _)| Arc::clone(r.doc_ctx().source_file()))
+        })
+        .unwrap_or_else(|| Arc::from(""));
+
+    let ctx = Arc::new(DocumentContext::new(
+        DocumentId::next(),
+        source_file,
+        consolidated_header,
+    ));
+
+    let restamped: Vec<(Record, u64)> = records
+        .into_iter()
+        .map(|(mut record, rn)| {
+            record.set_doc_ctx(Arc::clone(&ctx));
+            (record, rn)
+        })
+        .collect();
+
+    // Re-frame: discard the incoming per-document boundaries and emit exactly
+    // one open and one close on the consolidated context.
+    let framing = vec![
+        Punctuation::document_open(Arc::clone(&ctx)),
+        Punctuation::document_close(ctx),
+    ];
+
+    Ok((restamped, framing))
 }

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -14,15 +14,22 @@
 //! mints ONE fresh document context for the whole body and re-stamps every
 //! drained record onto it, then re-frames the body with a single
 //! `DocumentOpen`/`DocumentClose` pair. A multi-document body therefore frames
-//! as one document (one open, one close). The consolidated header is the body's
-//! common envelope — every incoming document's `DocumentOpen` envelope folded to
-//! the distinct non-empty set; an empty set yields a headerless document and a
-//! single member yields that common header. Re-stamping touches only the grain
-//! (framing) and the ambient `$doc.*` view — each record's `$source.*` is a real
-//! tail column stamped at ingest, so it is untouched and concat is lossless on
-//! per-record provenance. Two or more distinct non-empty headers under the one
-//! document is rejected ([`PipelineError::EnvelopeMultiHeaderConflict`], E350)
-//! rather than silently shadowed.
+//! as one document (one open, one close). The consolidated header is the body
+//! grains' common envelope — one grain is one output document, so the distinct
+//! non-empty headers are folded from the body RECORDS grouped by grain (each
+//! record carries the innermost fully-merged envelope, exactly what a
+//! reconstruct-envelope writer attaches per output document). An empty set
+//! yields a headerless document and a single member yields that common header.
+//! Per-level `DocumentOpen` punctuations and ancestor-frame / empty-body
+//! documents emit no body records, so they are framing artifacts that do NOT
+//! contribute a header — a nested X12 interchange (ISA/GS/ST) whose three levels
+//! each open a cumulative envelope is one body grain with one header, not three.
+//! Re-stamping touches only the grain (framing) and the ambient `$doc.*` view —
+//! each record's `$source.*` is a real tail column stamped at ingest, so it is
+//! untouched and concat is lossless on per-record provenance. Two or more
+//! distinct non-empty headers across the body grains is rejected
+//! ([`PipelineError::EnvelopeMultiHeaderConflict`], E350) rather than silently
+//! shadowed.
 //!
 //! # Inputs
 //!
@@ -51,7 +58,7 @@ use crate::executor::stream_event::{Punctuation, PunctuationKind};
 use clinker_plan::config::pipeline_node::EnvelopeStrategy;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
-use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Record};
+use clinker_record::{DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, Record};
 
 /// Execute the `Envelope` arm for `node_idx`. Drains the body predecessor and
 /// re-parks the framed body into this node's own `node_buffers` slot.
@@ -64,8 +71,8 @@ use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Record};
 /// # Errors
 ///
 /// Returns [`PipelineError::EnvelopeMultiHeaderConflict`] (E350) under `Concat`
-/// when the body carries two or more distinct non-empty envelope headers — one
-/// consolidated document cannot frame two headers without dropping one.
+/// when the body grains carry two or more distinct non-empty envelope headers —
+/// one consolidated document cannot frame two headers without dropping one.
 pub(crate) fn dispatch_envelope(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
@@ -121,11 +128,17 @@ pub(crate) fn dispatch_envelope(
 /// is untouched), and replaces the incoming punctuations with exactly one
 /// `DocumentOpen`/`DocumentClose` pair so the body frames as a single document.
 ///
-/// The consolidated header is the body's common envelope, derived from the
-/// incoming `DocumentOpen` punctuations (authoritative — they cover an
-/// empty-body document a record scan would miss): the distinct non-empty
-/// envelopes, where zero yields a headerless document, one yields that common
-/// header, and a colliding empty document coexists with the single header.
+/// The consolidated header is the body grains' common envelope: the body
+/// records grouped by [`DocumentGrain`] are the output documents (one grain is
+/// one document), and each record carries the innermost fully-merged envelope a
+/// reconstruct-envelope writer would attach. Folding the distinct non-empty
+/// envelopes across grains yields zero (a headerless document), one (that common
+/// header, with a colliding empty document coexisting), or — rejected — two or
+/// more. Headers are derived from records and NOT from the incoming
+/// `DocumentOpen` punctuations: ingest mints one open per envelope *level*, so a
+/// nested format (X12 ISA/GS/ST) opens several cumulative envelopes for one
+/// document, and ancestor-frame / empty-body documents open with no body records
+/// at all — neither is an output document, so neither contributes a header.
 ///
 /// An empty body (no records and no punctuations) emits nothing.
 ///
@@ -135,7 +148,7 @@ pub(crate) fn dispatch_envelope(
 /// more distinct non-empty headers would land under the one document.
 fn consolidate(
     name: &str,
-    records: Vec<(Record, u64)>,
+    mut records: Vec<(Record, u64)>,
     puncts: Vec<Punctuation>,
 ) -> Result<DrainedEvents, PipelineError> {
     // An empty body frames nothing — no document to open or close.
@@ -143,20 +156,21 @@ fn consolidate(
         return Ok((Vec::new(), Vec::new()));
     }
 
-    // Fold every incoming document's open-envelope down to the distinct
-    // non-empty set. The count is O(documents), bounded; dedup is a linear
-    // scan against the kept set since `EnvelopeRecord` is `PartialEq` but not
-    // `Hash`.
+    // Fold the body grains' headers down to the distinct non-empty set, in one
+    // pass over the records: the first record of each grain is that output
+    // document, and its envelope is the document's header. The grain set bounds
+    // the work — O(records) hashset probes plus an O(grains²) `PartialEq` dedup
+    // (`EnvelopeRecord` is not `Hash`), both bounded by the document count.
+    let mut seen_grains: std::collections::HashSet<DocumentGrain> =
+        std::collections::HashSet::new();
     let mut distinct_headers: Vec<&EnvelopeRecord> = Vec::new();
-    for p in puncts
-        .iter()
-        .filter(|p| p.kind() == PunctuationKind::DocumentOpen)
-    {
-        let env = p.doc_ctx().envelope_record();
-        if env.is_empty() {
+    for (record, _) in &records {
+        let doc = record.doc_ctx();
+        if !seen_grains.insert(doc.grain()) {
             continue;
         }
-        if !distinct_headers.contains(&env) {
+        let env = doc.envelope_record();
+        if !env.is_empty() && !distinct_headers.contains(&env) {
             distinct_headers.push(env);
         }
     }
@@ -175,9 +189,9 @@ fn consolidate(
 
     // The consolidated document inherits the first incoming document's source
     // file as its representative identity, preferring the first `DocumentOpen`.
-    // That path only keys the document-DLQ and is otherwise informational here;
-    // per-record `$source.file` is a tail column stamped at ingest and is
-    // unaffected by the re-stamp.
+    // That path only seeds the document-DLQ representative and is otherwise
+    // informational here; per-record `$source.file` is a tail column stamped at
+    // ingest and is unaffected by the re-stamp.
     let source_file = puncts
         .iter()
         .find(|p| p.kind() == PunctuationKind::DocumentOpen)
@@ -195,13 +209,12 @@ fn consolidate(
         consolidated_header,
     ));
 
-    let restamped: Vec<(Record, u64)> = records
-        .into_iter()
-        .map(|(mut record, rn)| {
-            record.set_doc_ctx(Arc::clone(&ctx));
-            (record, rn)
-        })
-        .collect();
+    // Re-stamp every record's document context to the consolidated one in place
+    // — only the grain/`$doc.*` view changes; the `$source.*` tail column is
+    // untouched, so concat stays lossless on per-record provenance.
+    for (record, _) in records.iter_mut() {
+        record.set_doc_ctx(Arc::clone(&ctx));
+    }
 
     // Re-frame: discard the incoming per-document boundaries and emit exactly
     // one open and one close on the consolidated context.
@@ -210,5 +223,5 @@ fn consolidate(
         Punctuation::document_close(ctx),
     ];
 
-    Ok((restamped, framing))
+    Ok((records, framing))
 }

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -138,6 +138,15 @@ impl Punctuation {
         self.doc_ctx.id()
     }
 
+    /// The full envelope context of the document this punctuation marks.
+    /// The Envelope node's `concat` strategy reads each `DocumentOpen`'s
+    /// context to fold a body's per-document headers into one consolidated
+    /// header — the punctuations are authoritative because they cover an
+    /// empty-body document a record scan would miss.
+    pub fn doc_ctx(&self) -> &Arc<DocumentContext> {
+        &self.doc_ctx
+    }
+
     /// Source file the marked document belongs to. Every envelope level of
     /// one file (the file-level document and each nested level) shares the
     /// same `source_file` Arc, so this identifies the OUTERMOST (file /

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -138,15 +138,6 @@ impl Punctuation {
         self.doc_ctx.id()
     }
 
-    /// The full envelope context of the document this punctuation marks.
-    /// The Envelope node's `concat` strategy reads each `DocumentOpen`'s
-    /// context to fold a body's per-document headers into one consolidated
-    /// header — the punctuations are authoritative because they cover an
-    /// empty-body document a record scan would miss.
-    pub fn doc_ctx(&self) -> &Arc<DocumentContext> {
-        &self.doc_ctx
-    }
-
     /// Source file the marked document belongs to. Every envelope level of
     /// one file (the file-level document and each nested level) shares the
     /// same `source_file` Arc, so this identifies the OUTERMOST (file /

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -71,7 +71,8 @@ mod tests {
                 | PipelineError::CompositionBodyError { .. }
                 | PipelineError::MemoryBudgetExceeded { .. }
                 | PipelineError::UnsatisfiableMemoryBudget { .. }
-                | PipelineError::CombineMissingMatch { .. },
+                | PipelineError::CombineMissingMatch { .. }
+                | PipelineError::EnvelopeMultiHeaderConflict { .. },
             ) => 1,
             Err(
                 PipelineError::Eval(_)

--- a/crates/clinker-exec/tests/envelope_node.rs
+++ b/crates/clinker-exec/tests/envelope_node.rs
@@ -46,12 +46,18 @@ use indexmap::IndexMap;
 // each message mints its own grain).
 
 /// One scripted step. `Open` carries one section (`name` → `tag`) and a frame
-/// role; `Record` emits a body row; `Close` pops the innermost level.
+/// role; `OpenHeaderless` opens a frame level carrying NO sections (a genuinely
+/// headerless document, e.g. an HL7 message whose header extracts no fields);
+/// `Record` emits a body row; `Close` pops the innermost level.
 enum Step {
     Open {
         file: &'static str,
         name: &'static str,
         tag_val: &'static str,
+        frame: FrameRole,
+    },
+    OpenHeaderless {
+        file: &'static str,
         frame: FrameRole,
     },
     Close {
@@ -117,6 +123,13 @@ impl RecordSource for ScriptedReader {
                     self.current_file = Some(self.file_arc(file));
                     self.pending_events.push(EnvelopeEvent::OpenLevel {
                         sections: Self::section(name, tag_val),
+                        frame,
+                    });
+                }
+                Step::OpenHeaderless { file, frame } => {
+                    self.current_file = Some(self.file_arc(file));
+                    self.pending_events.push(EnvelopeEvent::OpenLevel {
+                        sections: IndexMap::new(),
                         frame,
                     });
                 }
@@ -553,22 +566,26 @@ fn hl7_framing_matches_no_envelope_control() {
 
 // ─── Punctuation forwarding: per-document Aggregate downstream ───────────
 
-/// A pipeline `source → preserve Envelope → per-document count Aggregate →
-/// output` over a multi-file CSV glob. The Aggregate flushes its groups on
-/// each document-close punctuation, so it produces one group set per document
-/// ONLY if the Envelope forwards those boundary punctuations. A `preserve`
-/// that swallowed them would collapse every file into one cross-document
-/// aggregate — the regression this test exists to catch. When
-/// `with_envelope` is false the Envelope node is omitted (the control).
-fn aggregate_pipeline(with_envelope: bool) -> String {
-    let (envelope_node, agg_input) = if with_envelope {
-        (
-            "  - type: envelope\n    name: framed\n    body: events\n    \
-             config: { strategy: preserve }\n",
+/// A pipeline `source → Envelope → per-document count Aggregate → output` over
+/// a multi-file CSV glob. The Aggregate flushes its groups on each
+/// document-close punctuation. `strategy` selects the Envelope's framing — or,
+/// when `None`, omits the Envelope entirely (the control):
+///
+/// - `Some("preserve")` forwards each file's boundaries, so the Aggregate
+///   produces one group set per file. A `preserve` that swallowed the boundaries
+///   would collapse every file into one cross-document aggregate.
+/// - `Some("concat")` consolidates all files onto one document, so the Aggregate
+///   flushes ONCE — every file's groups merge into a single cross-file set.
+fn aggregate_pipeline(strategy: Option<&str>) -> String {
+    let (envelope_node, agg_input) = match strategy {
+        Some(s) => (
+            format!(
+                "  - type: envelope\n    name: framed\n    body: events\n    \
+                 config: {{ strategy: {s} }}\n"
+            ),
             "framed",
-        )
-    } else {
-        ("", "events")
+        ),
+        None => (String::new(), "events"),
     };
     format!(
         r#"
@@ -608,9 +625,8 @@ nodes:
 
 /// Run the aggregate pipeline over in-memory CSV files (each file a document),
 /// returning the sorted `category,n` body lines.
-fn run_aggregate(with_envelope: bool, files: &[(&str, &str)]) -> Vec<String> {
-    let config =
-        clinker_plan::config::parse_config(&aggregate_pipeline(with_envelope)).expect("parse");
+fn run_aggregate(strategy: Option<&str>, files: &[(&str, &str)]) -> Vec<String> {
+    let config = clinker_plan::config::parse_config(&aggregate_pipeline(strategy)).expect("parse");
     let plan = config
         .compile(&clinker_plan::config::CompileContext::default())
         .expect("compile");
@@ -654,6 +670,240 @@ fn run_aggregate(with_envelope: bool, files: &[(&str, &str)]) -> Vec<String> {
     body
 }
 
+// ─── Concat strategy: multi-document body → one framed document ──────────
+//
+// `concat` collapses every body grain onto ONE consolidated document context,
+// so a multi-document body frames as a single document (one open, one close).
+// These fixtures drive the SAME single-source `ScriptedReader`, using two
+// `NewFrame` opens to model two distinct documents feeding the Envelope's one
+// input port — grain-equivalent to a 2-input "Merge → Envelope" (a Merge would
+// hand the Envelope two grains exactly as two `NewFrame` levels do), without the
+// extra source-wiring the single-port harness would otherwise need.
+
+/// A concat pipeline: source → body Transform → `concat` Envelope → a SECOND
+/// Transform reading `$doc.interchange.tag` (the consolidated header, post-
+/// concat) → Output. The post-envelope Transform is what makes the consolidated
+/// header observable on a body record: it resolves `$doc` against the document
+/// context concat re-stamped, not the source's per-document context.
+fn concat_pipeline() -> String {
+    r#"
+pipeline:
+  name: envelope_concat
+nodes:
+  - type: source
+    name: edi
+    config:
+      name: edi
+      type: csv
+      path: placeholder.csv
+      envelope:
+        sections:
+          interchange:
+            extract: { record_type: H }
+            fields:
+              tag: string
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: tag
+    input: edi
+    config:
+      cxl: |
+        emit id = id
+  - type: envelope
+    name: framed
+    body: tag
+    config: { strategy: concat }
+  - type: transform
+    name: stamp
+    input: framed
+    config:
+      cxl: |
+        emit id = id
+        emit doc_tag = $doc.interchange.tag
+  - type: output
+    name: out
+    input: stamp
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          footer_from_doc: interchange
+"#
+    .to_string()
+}
+
+/// Run a concat pipeline over a scripted step list, returning the run result so
+/// the caller can assert either the written CSV or the error (the conflict
+/// test). The `Ok` payload is the written CSV bytes.
+fn run_concat(steps: Vec<Step>) -> Result<String, clinker_plan::error::PipelineError> {
+    let mut config =
+        clinker_plan::config::parse_config(&concat_pipeline()).expect("parse concat pipeline");
+    for spanned in &mut config.nodes {
+        if let clinker_plan::config::PipelineNode::Source { config: body, .. } = &mut spanned.value
+        {
+            body.source.path = None;
+        }
+    }
+    let plan = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("compile concat pipeline");
+
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "edi".to_string(),
+        SourceInput::Records(Box::new(ScriptedReader::new(steps))),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams {
+            execution_id: "concat-exec".to_string(),
+            batch_id: "concat-batch".to_string(),
+            ..Default::default()
+        },
+    )?;
+    Ok(buf.as_string())
+}
+
+/// One `NewFrame` document carrying `id` rows tagged with `tag_val`.
+fn concat_doc(file: &'static str, tag_val: &'static str, ids: &[i64]) -> Vec<Step> {
+    let mut steps = vec![Step::Open {
+        file,
+        name: "interchange",
+        tag_val,
+        frame: FrameRole::NewFrame,
+    }];
+    for &id in ids {
+        steps.push(Step::Record { file, id });
+    }
+    steps.push(Step::Close { file });
+    steps
+}
+
+/// One genuinely headerless `NewFrame` document carrying `id` rows.
+fn concat_headerless_doc(file: &'static str, ids: &[i64]) -> Vec<Step> {
+    let mut steps = vec![Step::OpenHeaderless {
+        file,
+        frame: FrameRole::NewFrame,
+    }];
+    for &id in ids {
+        steps.push(Step::Record { file, id });
+    }
+    steps.push(Step::Close { file });
+    steps
+}
+
+#[test]
+fn concat_carries_a_common_non_empty_header() {
+    // Two documents with IDENTICAL non-empty headers (`tag = COMMON`). Concat
+    // must NOT flag a conflict — two equal headers fold to one common header —
+    // and the consolidated document must carry it: the post-envelope Transform
+    // resolves `$doc.interchange.tag` to `COMMON` on every re-stamped body row.
+    let mut steps = concat_doc("a.x12", "COMMON", &[1, 2]);
+    steps.extend(concat_doc("b.x12", "COMMON", &[3]));
+
+    let csv = run_concat(steps).expect("identical headers fold without conflict");
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(
+        frames, 1,
+        "identical headers → one consolidated document: {csv}"
+    );
+    assert_eq!(
+        counts,
+        vec![3],
+        "all three body rows under the one document: {csv}"
+    );
+
+    // The common header is readable post-concat: every body row's `doc_tag`
+    // column (emitted from `$doc.interchange.tag` AFTER the Envelope) is the
+    // common value. A re-stamp that lost the header would yield empty cells.
+    let body_rows: Vec<&str> = csv
+        .lines()
+        .filter(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            c.len() == 2 && c[0].parse::<i64>().is_ok()
+        })
+        .collect();
+    assert_eq!(body_rows.len(), 3, "three body rows present: {csv}");
+    for row in &body_rows {
+        let cells: Vec<&str> = row.split(',').collect();
+        assert_eq!(
+            cells[1], "COMMON",
+            "$doc.interchange.tag resolves to the consolidated common header: {row}"
+        );
+    }
+}
+
+#[test]
+fn concat_headed_plus_headerless_carries_the_single_header() {
+    // One headed document (`tag = ONLY`) and one genuinely headerless document
+    // (a `NewFrame` carrying no sections). The single real header wins; the
+    // headerless document coexists without conflict, and the consolidated
+    // document carries `ONLY` — readable as `$doc.interchange.tag` on a body row.
+    let mut steps = concat_doc("a.x12", "ONLY", &[1]);
+    steps.extend(concat_headerless_doc("b.x12", &[2]));
+
+    let csv = run_concat(steps).expect("headed + headerless folds without conflict");
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(
+        frames, 1,
+        "headed + headerless → one consolidated document: {csv}"
+    );
+    assert_eq!(
+        counts,
+        vec![2],
+        "both body rows under the one consolidated document: {csv}"
+    );
+    // The headed document's value is the consolidated header, carried onto every
+    // re-stamped body row by the post-envelope `$doc.interchange.tag` read.
+    let doc_tags: Vec<&str> = csv
+        .lines()
+        .filter_map(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            (c.len() == 2 && c[0].parse::<i64>().is_ok()).then(|| c[1])
+        })
+        .collect();
+    assert_eq!(
+        doc_tags,
+        vec!["ONLY", "ONLY"],
+        "the single real header is carried onto the consolidated document: {csv}"
+    );
+}
+
+#[test]
+fn concat_two_distinct_headers_is_e350_conflict() {
+    // Two documents with DISTINCT non-empty headers (`ISA-A` vs `ISA-B`). One
+    // consolidated document cannot frame both, so concat aborts with E350 rather
+    // than silently dropping a header. Pin the code — accepting any error would
+    // mask a regression that fired the wrong diagnostic.
+    let mut steps = concat_doc("a.x12", "ISA-A", &[1]);
+    steps.extend(concat_doc("b.x12", "ISA-B", &[2]));
+
+    let err = run_concat(steps).expect_err("distinct headers must abort with E350");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("E350"),
+        "the multi-header conflict pins diagnostic code E350, got: {msg}"
+    );
+    assert!(
+        matches!(
+            err,
+            clinker_plan::error::PipelineError::EnvelopeMultiHeaderConflict { .. }
+        ),
+        "the error is the multi-header conflict variant, got: {err:?}"
+    );
+}
+
 #[test]
 fn preserve_envelope_forwards_document_boundaries_to_downstream_aggregate() {
     // Two files = two documents. Category `x` appears twice in A and three
@@ -666,7 +916,7 @@ fn preserve_envelope_forwards_document_boundaries_to_downstream_aggregate() {
         ("b.csv", "category\nx\nx\nx\n"),
     ];
 
-    let with = run_aggregate(true, &files);
+    let with = run_aggregate(Some("preserve"), &files);
     assert_eq!(
         with,
         vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
@@ -676,9 +926,45 @@ fn preserve_envelope_forwards_document_boundaries_to_downstream_aggregate() {
 
     // And it matches the no-Envelope control exactly — the node changes nothing
     // about the document boundaries the Aggregate observes.
-    let without = run_aggregate(false, &files);
+    let without = run_aggregate(None, &files);
     assert_eq!(
         with, without,
         "per-document aggregation is identical with and without the preserve Envelope",
+    );
+}
+
+#[test]
+fn concat_envelope_merges_all_files_into_one_aggregate_flush() {
+    // The headerless-document framing probe, observed through a downstream
+    // Aggregate. Each CSV file is a headerless document (the source declares no
+    // `envelope:`). `concat` collapses both files onto ONE consolidated
+    // document, so the Aggregate flushes ONCE and category `x` merges across
+    // files into a single x=5 (2 from A + 3 from B) — versus the per-file x=2 /
+    // x=3 the `preserve` control produces. This is the framing-collapse
+    // acceptance: two documents in, one framed document out.
+    let files = [
+        ("a.csv", "category\nx\nx\ny\n"),
+        ("b.csv", "category\nx\nx\nx\n"),
+    ];
+
+    let concat = run_aggregate(Some("concat"), &files);
+    assert_eq!(
+        concat,
+        vec!["x,5".to_string(), "y,1".to_string()],
+        "concat collapses both files into one document, so the Aggregate flushes \
+         once and category x merges cross-file to 5 (not per-file 2 and 3)",
+    );
+
+    // The preserve control keeps the files as separate documents — the
+    // differential that proves concat actually consolidated the framing.
+    let preserve = run_aggregate(Some("preserve"), &files);
+    assert_eq!(
+        preserve,
+        vec!["x,2".to_string(), "x,3".to_string(), "y,1".to_string()],
+        "preserve keeps per-file documents, so x stays split 2 / 3",
+    );
+    assert_ne!(
+        concat, preserve,
+        "concat and preserve must differ — concat merged the document framing",
     );
 }

--- a/crates/clinker-exec/tests/envelope_node.rs
+++ b/crates/clinker-exec/tests/envelope_node.rs
@@ -803,6 +803,45 @@ fn concat_headerless_doc(file: &'static str, ids: &[i64]) -> Vec<Step> {
     steps
 }
 
+/// One nested X12-style interchange: ISA → GS → ST, three `Inherit` levels each
+/// carrying a DISTINCT `interchange` section value, then `id` body rows, then
+/// three closes. Every level inherits the interchange grain, so the whole
+/// `ISA..IEA` is ONE body grain — one output document — whose body records carry
+/// the innermost fully-merged envelope (`tag` = the ST value, innermost wins).
+///
+/// Ingest mints one `DocumentOpen` per level, so this single interchange emits
+/// three cumulative non-empty open-envelopes — the shape that wrongly tripped
+/// the multi-header guard when it counted per-level opens instead of body grains.
+fn nested_x12_interchange_doc(file: &'static str, ids: &[i64]) -> Vec<Step> {
+    let mut steps = vec![
+        Step::Open {
+            file,
+            name: "interchange",
+            tag_val: "ISA-LEVEL",
+            frame: FrameRole::Inherit,
+        },
+        Step::Open {
+            file,
+            name: "interchange",
+            tag_val: "GS-LEVEL",
+            frame: FrameRole::Inherit,
+        },
+        Step::Open {
+            file,
+            name: "interchange",
+            tag_val: "ST-LEVEL",
+            frame: FrameRole::Inherit,
+        },
+    ];
+    for &id in ids {
+        steps.push(Step::Record { file, id });
+    }
+    steps.push(Step::Close { file }); // ST
+    steps.push(Step::Close { file }); // GS
+    steps.push(Step::Close { file }); // ISA
+    steps
+}
+
 #[test]
 fn concat_carries_a_common_non_empty_header() {
     // Two documents with IDENTICAL non-empty headers (`tag = COMMON`). Concat
@@ -895,12 +934,249 @@ fn concat_two_distinct_headers_is_e350_conflict() {
         msg.contains("E350"),
         "the multi-header conflict pins diagnostic code E350, got: {msg}"
     );
+    // Destructure rather than `matches!`: the reported `header_count` is the
+    // load-bearing payload (it names how many distinct headers clashed), so a
+    // bug that fired the variant with the wrong count must fail here.
+    match err {
+        clinker_plan::error::PipelineError::EnvelopeMultiHeaderConflict {
+            header_count, ..
+        } => {
+            assert_eq!(
+                header_count, 2,
+                "two distinct headers (ISA-A, ISA-B) → header_count == 2"
+            );
+        }
+        other => panic!("expected the multi-header conflict variant, got: {other:?}"),
+    }
+}
+
+#[test]
+fn concat_nested_x12_interchange_is_one_header_not_per_level_conflict() {
+    // A single nested X12-style interchange: ISA → GS → ST, three `Inherit`
+    // levels. Ingest mints one `DocumentOpen` per level, so this ONE interchange
+    // emits three distinct cumulative open-envelopes — but it is one body grain,
+    // one output document, with one header (the innermost, fully-merged
+    // envelope). Deriving the header set from per-level opens would count three
+    // and fire E350 on a perfectly valid single interchange; deriving it from
+    // the body grains counts one and succeeds. This is the regression guard.
+    let steps = nested_x12_interchange_doc("claim.x12", &[10, 11]);
+
+    let csv =
+        run_concat(steps).expect("a single nested interchange must not trip the header guard");
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(
+        frames, 1,
+        "nested ISA/GS/ST is ONE consolidated document, not a multi-header conflict: {csv}"
+    );
+    assert_eq!(
+        counts,
+        vec![2],
+        "both body rows under the one consolidated interchange: {csv}"
+    );
+
+    // The carried header resolves on every body row: `$doc.interchange.tag`
+    // (emitted AFTER the Envelope) is the innermost level's value — innermost
+    // shadows ancestor on the merged envelope.
+    let doc_tags: Vec<&str> = csv
+        .lines()
+        .filter_map(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            (c.len() == 2 && c[0].parse::<i64>().is_ok()).then(|| c[1])
+        })
+        .collect();
+    assert_eq!(
+        doc_tags,
+        vec!["ST-LEVEL", "ST-LEVEL"],
+        "the consolidated header is the innermost fully-merged envelope: {csv}"
+    );
+}
+
+#[test]
+fn concat_three_documents_same_header_is_one_document_no_conflict() {
+    // Three documents, all with the SAME non-empty header (`tag = SHARED`).
+    // Three equal headers fold to one common header — concat must NOT flag a
+    // conflict and must frame exactly one consolidated document. Guards the
+    // dedup against a false-positive (e.g. counting documents instead of
+    // distinct headers).
+    let mut steps = concat_doc("a.x12", "SHARED", &[1]);
+    steps.extend(concat_doc("b.x12", "SHARED", &[2, 3]));
+    steps.extend(concat_doc("c.x12", "SHARED", &[4]));
+
+    let csv = run_concat(steps).expect("three identical headers fold without conflict");
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(
+        frames, 1,
+        "three identical headers → one consolidated document: {csv}"
+    );
+    assert_eq!(
+        counts,
+        vec![4],
+        "all four body rows under the one document: {csv}"
+    );
+    let doc_tags: Vec<&str> = csv
+        .lines()
+        .filter_map(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            (c.len() == 2 && c[0].parse::<i64>().is_ok()).then(|| c[1])
+        })
+        .collect();
+    assert_eq!(
+        doc_tags,
+        vec!["SHARED", "SHARED", "SHARED", "SHARED"],
+        "the single common header is carried onto every re-stamped body row: {csv}"
+    );
+}
+
+#[test]
+fn concat_single_document_carries_its_header() {
+    // One document in → one consolidated document out, header carried. The
+    // degenerate case: concat over a single document is a no-op on framing
+    // (still one document) and must not lose the header.
+    let steps = concat_doc("solo.x12", "SOLO", &[7, 8, 9]);
+
+    let csv = run_concat(steps).expect("single-document concat succeeds");
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(frames, 1, "one document in → one document out: {csv}");
+    assert_eq!(counts, vec![3], "all three body rows framed once: {csv}");
+    let doc_tags: Vec<&str> = csv
+        .lines()
+        .filter_map(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            (c.len() == 2 && c[0].parse::<i64>().is_ok()).then(|| c[1])
+        })
+        .collect();
+    assert_eq!(
+        doc_tags,
+        vec!["SOLO", "SOLO", "SOLO"],
+        "the lone document's header is carried through concat: {csv}"
+    );
+}
+
+#[test]
+fn concat_empty_body_emits_no_document() {
+    // An empty body (no records, no envelope events) frames nothing — concat
+    // opens no document, so the writer renders only its column header and no
+    // body or footer rows.
+    let csv = run_concat(Vec::new()).expect("empty body succeeds");
+    let (frames, counts) = footer_stats(&csv);
+    assert_eq!(frames, 0, "an empty body emits no framed document: {csv:?}");
     assert!(
-        matches!(
-            err,
-            clinker_plan::error::PipelineError::EnvelopeMultiHeaderConflict { .. }
-        ),
-        "the error is the multi-header conflict variant, got: {err:?}"
+        counts.is_empty(),
+        "no per-document body counts for an empty body: {csv:?}"
+    );
+}
+
+// ─── Concat provenance: per-record `$source.file` survives consolidation ─────
+
+/// A concat pipeline that emits `$source.file` as an output column, to prove the
+/// re-stamp does not clobber it. The body Transform carries `$source.file`
+/// through; the Envelope consolidates; the post-envelope Output writes it. Unlike
+/// `concat_pipeline`, this does NOT reconstruct an envelope footer — the
+/// assertion is purely on the per-record tail column.
+fn concat_provenance_pipeline() -> String {
+    r#"
+pipeline:
+  name: envelope_concat_provenance
+nodes:
+  - type: source
+    name: edi
+    config:
+      name: edi
+      type: csv
+      path: placeholder.csv
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: tag
+    input: edi
+    config:
+      cxl: |
+        emit id = id
+        emit src_file = $source.file
+  - type: envelope
+    name: framed
+    body: tag
+    config: { strategy: concat }
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#
+    .to_string()
+}
+
+/// Run the provenance pipeline over a scripted step list, returning the written
+/// CSV bytes.
+fn run_concat_provenance(steps: Vec<Step>) -> String {
+    let mut config = clinker_plan::config::parse_config(&concat_provenance_pipeline())
+        .expect("parse concat provenance pipeline");
+    for spanned in &mut config.nodes {
+        if let clinker_plan::config::PipelineNode::Source { config: body, .. } = &mut spanned.value
+        {
+            body.source.path = None;
+        }
+    }
+    let plan = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("compile concat provenance pipeline");
+
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "edi".to_string(),
+        SourceInput::Records(Box::new(ScriptedReader::new(steps))),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams {
+            execution_id: "concat-prov-exec".to_string(),
+            batch_id: "concat-prov-batch".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("drive concat provenance pipeline");
+    buf.as_string()
+}
+
+#[test]
+fn concat_preserves_per_record_source_file() {
+    // Two documents from DIFFERENT source files but the SAME header (so no
+    // header conflict — the focus is provenance, not the guard). Concat re-stamps
+    // the document context onto one consolidated grain, but `$source.file` is a
+    // real tail column stamped at ingest — the re-stamp must not touch it. Each
+    // record must still carry its ORIGINAL source file after consolidation.
+    let mut steps = concat_doc("alpha.x12", "SHARED", &[1, 2]);
+    steps.extend(concat_doc("beta.x12", "SHARED", &[3]));
+
+    let csv = run_concat_provenance(steps);
+    let lines: Vec<&str> = csv.lines().collect();
+    // Header `id,src_file` then three body rows in ingest order.
+    let header = lines.first().expect("output has a header line");
+    assert!(
+        header.starts_with("id,src_file"),
+        "expected an id,src_file header, got: {csv}"
+    );
+    let body: Vec<(&str, &str)> = lines[1..]
+        .iter()
+        .filter_map(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            (c.len() == 2 && c[0].parse::<i64>().is_ok()).then(|| (c[0], c[1]))
+        })
+        .collect();
+    assert_eq!(
+        body,
+        vec![("1", "alpha.x12"), ("2", "alpha.x12"), ("3", "beta.x12")],
+        "each record keeps its original `$source.file` across consolidation: {csv}"
     );
 }
 

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -1332,8 +1332,8 @@ pub struct EnvelopeBody {
     pub strategy: EnvelopeStrategy,
 }
 
-/// Envelope framing strategy. This slice ships `preserve`; the consolidation
-/// (`concat`) and synthesizing strategies are additive variants in later slices.
+/// Envelope framing strategy. The synthesizing (header-folding) strategies
+/// are additive variants in later slices.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EnvelopeStrategy {
@@ -1342,6 +1342,13 @@ pub enum EnvelopeStrategy {
     /// their document context and grain unchanged.
     #[default]
     Preserve,
+    /// Collapse a multi-document body into ONE framed document: every body
+    /// record is re-stamped onto a single consolidated document context, so
+    /// the body opens and closes exactly once. The consolidated document
+    /// carries the body's common envelope header when every header agrees
+    /// (headerless documents coexist); two distinct non-empty headers under
+    /// the one document is rejected at runtime rather than silently shadowed.
+    Concat,
 }
 
 /// Merge variant body. `inputs:` lives on `MergeHeader`, not here.
@@ -2582,6 +2589,21 @@ nodes:
         assert!(header.header.is_none(), "no header port wired");
         assert!(header.trailer.is_none(), "no trailer port wired");
         assert_eq!(body.strategy, EnvelopeStrategy::Preserve);
+    }
+
+    #[test]
+    fn envelope_concat_parses_strategy() {
+        // `strategy: concat` selects the consolidation strategy — distinct
+        // from the `preserve` default — so a clash here would surface as the
+        // wrong framing arm at runtime.
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    \
+             config: { strategy: concat }\n",
+        );
+        let config: PipelineConfig =
+            crate::yaml::from_str(&yaml).expect("parse concat-strategy envelope");
+        let (_, body) = envelope_of(&config);
+        assert_eq!(body.strategy, EnvelopeStrategy::Concat);
     }
 
     #[test]

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -193,6 +193,18 @@ pub enum PipelineError {
         combine: String,
         driver_row: u64,
     },
+    /// E350 — an Envelope node with the `concat` strategy collapsed a
+    /// multi-document body into one framed document, but the body carried
+    /// two or more distinct non-empty envelope headers. One consolidated
+    /// document can frame only one header, so emitting it would silently
+    /// drop every header but one. Rather than shadow, concat rejects: the
+    /// run needs a header-folding strategy (e.g. choose one, regenerate, or
+    /// merge) to declare which header wins. `envelope` names the node.
+    /// Always aborts the run.
+    EnvelopeMultiHeaderConflict {
+        envelope: String,
+        header_count: usize,
+    },
     /// E320 — the cumulative on-disk size of the run's spill files crossed
     /// the configured `storage.spill.disk_cap_bytes` quota. Deliberately
     /// distinct from E310 (`MemoryBudgetExceeded`): a run can sit well
@@ -372,6 +384,19 @@ impl fmt::Display for PipelineError {
                 f,
                 "E319 combine '{combine}': on_miss: error — no matching build row \
                  for driver row {driver_row}"
+            ),
+            Self::EnvelopeMultiHeaderConflict {
+                envelope,
+                header_count,
+            } => write!(
+                f,
+                "E350 envelope '{envelope}': concat collapses the body into one \
+                 framed document, but the body carried {header_count} distinct \
+                 non-empty envelope headers — one document can frame only one \
+                 header, so concat will not silently drop the rest. Make the \
+                 headers identical upstream, or add a header-folding strategy \
+                 that declares which header the consolidated document keeps. \
+                 See: clinker explain --code E350"
             ),
             Self::SpillCapExceeded {
                 node,

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -2053,11 +2053,12 @@ fn bind_schema_inner(
                     );
                 }
             }
-            // Envelope adopts the body input's schema verbatim — it does not
-            // widen (the `preserve` strategy passes body records through
-            // unchanged). The optional `header:` / `trailer:` ports are
-            // rejected when wired at `validate_config`, so binding reads only
-            // the body input here.
+            // Envelope adopts the body input's schema verbatim — neither
+            // strategy widens it: `preserve` passes body records through
+            // unchanged, and `concat` changes only the framing grain and the
+            // ambient `$doc` view, not the record schema. The optional
+            // `header:` / `trailer:` ports are rejected when wired at
+            // `validate_config`, so binding reads only the body input here.
             PipelineNode::Envelope { header, .. } => {
                 if let Some(upstream) = upstream_schema(&header.body.value, schema_by_name) {
                     let row = upstream.clone();

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -219,16 +219,20 @@ pub enum PlanNode {
         #[serde(skip)]
         output_schema: Arc<Schema>,
     },
-    /// Frames a body stream into per-document documents.
+    /// Frames a body stream into documents. Single-input, single-output.
     ///
-    /// Streaming single-output pass-through. With the `Preserve` strategy
-    /// every body record flows through with its document context and grain
-    /// unchanged, and the document-boundary punctuations are forwarded
-    /// verbatim — so a downstream Output frames byte-identically to today's
-    /// per-document framing. The node does not widen: its output schema is
-    /// the body input's schema. A wired header/trailer port is rejected at
-    /// plan validation this release, so the executor resolves the single body
-    /// predecessor topologically rather than carrying named port references.
+    /// `Preserve` is a transparent framing stage: every body record flows
+    /// through with its document context and grain unchanged and the
+    /// document-boundary punctuations are forwarded verbatim, so a downstream
+    /// Output frames byte-identically to today's per-document framing.
+    /// `Concat` consolidates: it drains the whole body, folds the per-document
+    /// headers to one, re-stamps every record onto a single consolidated
+    /// document context, and re-frames with one open/close pair — so a
+    /// multi-document body writes as one document. Neither strategy widens:
+    /// the output schema is the body input's schema. A wired header/trailer
+    /// port is rejected at plan validation this release, so the executor
+    /// resolves the single body predecessor topologically rather than carrying
+    /// named port references.
     Envelope {
         name: String,
         #[serde(skip)]

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -745,6 +745,7 @@ impl PlanNode {
             PlanNode::Envelope { name, strategy, .. } => {
                 let s = match strategy {
                     crate::config::pipeline_node::EnvelopeStrategy::Preserve => "preserve",
+                    crate::config::pipeline_node::EnvelopeStrategy::Concat => "concat",
                 };
                 format!("[envelope:{s}] {name}")
             }

--- a/crates/clinker-plan/src/plan/execution/scheduling.rs
+++ b/crates/clinker-plan/src/plan/execution/scheduling.rs
@@ -1057,10 +1057,14 @@ fn compute_one(
         }
 
         PlanNode::Envelope { name, .. } => {
-            // Envelope `preserve` re-parks body records in drained order with
-            // their grains unchanged — it neither reorders, repartitions, nor
-            // transforms CK visibility — so the parent's ordering, partitioning,
-            // and CK set all flow through. Provenance is rewritten to point at
+            // Both Envelope strategies re-park body records in drained order and
+            // touch only the document grain / framing: `preserve` leaves each
+            // record's grain untouched, while `concat` re-stamps every record
+            // onto one consolidated grain. Neither reorders, repartitions, nor
+            // transforms CK visibility, and this model tracks sort-order,
+            // partitioning, and CK set — not the grain — so a grain/framing
+            // change is invisible to it and the parent's properties flow through
+            // unchanged for either strategy. Provenance is rewritten to point at
             // this node so explain can chain through, matching Route / Output.
             let parent = match parents.first() {
                 Some(p) => p,

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -241,6 +241,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E347" => Some(include_str!("../../../../docs/explain/E347.md")),
         "E348" => Some(include_str!("../../../../docs/explain/E348.md")),
         "E349" => Some(include_str!("../../../../docs/explain/E349.md")),
+        "E350" => Some(include_str!("../../../../docs/explain/E350.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -465,8 +466,8 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E15Y", "W101", "W302", "W305",
-            "W306",
+            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E15Y", "W101", "W302",
+            "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -154,6 +154,14 @@ impl EnvelopeRecord {
         }
     }
 
+    /// `true` when this envelope declares no sections — the headerless
+    /// envelope an empty-body document or a synthetic context carries.
+    /// Concat treats a headerless document as carrying no common header,
+    /// so empties coexist with a single real header without conflicting.
+    pub fn is_empty(&self) -> bool {
+        self.sections.is_empty()
+    }
+
     /// The payload `Value` for a named section, or `None` when the section is
     /// undeclared on this envelope.
     fn section_value(&self, section: &str) -> Option<&Value> {
@@ -200,6 +208,22 @@ impl EnvelopeRecord {
             merged.insert(name.clone(), payload);
         }
         EnvelopeRecord::from_sections(merged)
+    }
+}
+
+/// Two envelopes are equal when they declare the same section names in the
+/// same order AND carry the same positional payloads.
+///
+/// Hand-written rather than derived because [`Schema`] has no `PartialEq`:
+/// the comparison reaches into `schema.columns()` (a `[Box<str>]`) and the
+/// parallel `sections` (a `[Value]`), both of which compare. Concat's
+/// multi-header consolidation guard uses this to fold a body's per-document
+/// headers down to the distinct set: two documents whose headers compare
+/// equal share one common header; two distinct non-empty headers under one
+/// consolidated document are the conflict it rejects.
+impl PartialEq for EnvelopeRecord {
+    fn eq(&self, other: &Self) -> bool {
+        self.schema.columns() == other.schema.columns() && self.sections == other.sections
     }
 }
 
@@ -277,9 +301,10 @@ impl DocumentContext {
     /// `$doc` resolution path ([`Self::get_section_field`] reads through it),
     /// so there is exactly one in-memory encoding of the envelope per document.
     ///
-    /// Crate-internal for now: the only cross-crate consumer is the Envelope
-    /// node, which lands separately; the public accessor lands with it.
-    fn envelope_record(&self) -> &EnvelopeRecord {
+    /// The cross-crate consumer is the Envelope node's `concat` strategy: it
+    /// reads each incoming document's envelope to fold a body's per-document
+    /// headers down to one consolidated header (or reject a clash).
+    pub fn envelope_record(&self) -> &EnvelopeRecord {
         &self.envelope
     }
 

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -212,15 +212,21 @@ impl EnvelopeRecord {
 }
 
 /// Two envelopes are equal when they declare the same section names in the
-/// same order AND carry the same positional payloads.
+/// same order and each section's payload compares equal.
 ///
-/// Hand-written rather than derived because [`Schema`] has no `PartialEq`:
-/// the comparison reaches into `schema.columns()` (a `[Box<str>]`) and the
-/// parallel `sections` (a `[Value]`), both of which compare. Concat's
-/// multi-header consolidation guard uses this to fold a body's per-document
-/// headers down to the distinct set: two documents whose headers compare
-/// equal share one common header; two distinct non-empty headers under one
-/// consolidated document are the conflict it rejects.
+/// The section-name list (`schema.columns()`, a `[Box<str>]`) is compared
+/// positionally, so the same sections in a different declared order are
+/// *distinct* headers. Each section's payload is a [`Value::Map`], whose
+/// equality is by key — field order within a section does not matter — but the
+/// payload includes any engine-injected keys (`$raw`, the SWIFT synthetic
+/// `body`) the readers carry, so two headers that agree on every user-visible
+/// field but differ in preserved raw bytes compare distinct.
+///
+/// Hand-written rather than derived because [`Schema`] has no `PartialEq`.
+/// Concat's multi-header consolidation guard uses this to fold a body's
+/// per-document headers down to the distinct set: two documents whose headers
+/// compare equal share one common header; two distinct non-empty headers under
+/// one consolidated document are the conflict it rejects.
 impl PartialEq for EnvelopeRecord {
     fn eq(&self, other: &Self) -> bool {
         self.schema.columns() == other.schema.columns() && self.sections == other.sections

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -321,7 +321,8 @@ fn main() -> ExitCode {
                         | PipelineError::CompositionBodyError { .. }
                         | PipelineError::MemoryBudgetExceeded { .. }
                         | PipelineError::UnsatisfiableMemoryBudget { .. }
-                        | PipelineError::CombineMissingMatch { .. } => ExitCode::from(1),
+                        | PipelineError::CombineMissingMatch { .. }
+                        | PipelineError::EnvelopeMultiHeaderConflict { .. } => ExitCode::from(1),
                         // Disk-cap exceedance (E320) is a resource-exhaustion
                         // halt — the run filled its configured spill budget.
                         // Group it with the other infrastructure failures

--- a/docs/explain/E350.md
+++ b/docs/explain/E350.md
@@ -2,10 +2,11 @@
 
 ## What it means
 
-An [Envelope](../user/src/nodes/envelope.md) node with `strategy: concat` collapses
-a multi-document body into a **single** framed document — every body record is
-re-stamped onto one consolidated document context, so the body opens and closes
-exactly once. That consolidated document can carry only **one** envelope header.
+An Envelope node (see the "Envelope Nodes" pipeline reference) with
+`strategy: concat` collapses a multi-document body into a **single** framed
+document — every body record is re-stamped onto one consolidated document
+context, so the body opens and closes exactly once. That consolidated document
+can carry only **one** envelope header.
 
 This diagnostic fires when the collapsed body carried **two or more distinct
 non-empty headers** under that one document. Concat will not silently keep one
@@ -88,11 +89,15 @@ nodes:
 
 ## Technical context
 
-Concat reads the `DocumentOpen` punctuation of every incoming document — the
-punctuations are authoritative because they cover empty-body documents a record
-scan would miss — and folds their envelope headers down to the distinct
-non-empty set. Zero distinct non-empty headers yields a headerless consolidated
-document; exactly one yields that common header; two or more is this conflict.
+Concat groups the body records by document grain — one grain is one output
+document — and folds the grains' envelope headers down to the distinct non-empty
+set. Each body record carries the innermost fully-merged envelope a
+reconstruct-envelope writer would attach, so the header set comes from the
+records that actually frame a document, not from the per-level document opens
+(a nested format opens several cumulative envelopes for one document) or from
+ancestor-frame / empty-body documents (which frame no body records at all). Zero
+distinct non-empty headers yields a headerless consolidated document; exactly one
+yields that common header; two or more is this conflict.
 
 Header equality compares the section-name list and the positional section
 payloads, so two documents whose headers carry the same sections with the same

--- a/docs/explain/E350.md
+++ b/docs/explain/E350.md
@@ -1,0 +1,107 @@
+# Error E350: concat collapsed a body carrying two distinct headers into one document
+
+## What it means
+
+An [Envelope](../user/src/nodes/envelope.md) node with `strategy: concat` collapses
+a multi-document body into a **single** framed document — every body record is
+re-stamped onto one consolidated document context, so the body opens and closes
+exactly once. That consolidated document can carry only **one** envelope header.
+
+This diagnostic fires when the collapsed body carried **two or more distinct
+non-empty headers** under that one document. Concat will not silently keep one
+header and drop the rest, so it stops the run. A headerless document coexists
+with a single real header (the header is the common one); the conflict is
+strictly *two different non-empty headers, one document*.
+
+```
+envelope 'framed': concat collapses the body into one framed document, but the
+body carried 2 distinct non-empty envelope headers — one document can frame only
+one header, so concat will not silently drop the rest. Make the headers identical
+upstream, or add a header-folding strategy that declares which header the
+consolidated document keeps.
+```
+
+## Example
+
+```yaml
+# Rejected: a Merge feeds two documents with different headers into a concat
+# Envelope. The two ISA-A / ISA-B headers cannot both survive one document.
+nodes:
+  - type: source
+    name: file_a
+    config:
+      name: file_a
+      type: x12
+      path: a.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields: { e13: string }
+      schema:
+        - { name: seg, type: string }
+  - type: source
+    name: file_b
+    config:
+      name: file_b
+      type: x12
+      path: b.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields: { e13: string }
+      schema:
+        - { name: seg, type: string }
+  - type: merge
+    name: both
+    inputs: [file_a, file_b]
+  - type: envelope
+    name: framed
+    body: both
+    config: { strategy: concat }      # two distinct headers → E350
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+```
+
+## How to fix
+
+1. **Use `strategy: preserve`** if you want one framed document per source
+   document — `preserve` keeps each header on its own document and never
+   consolidates, so distinct headers never clash.
+
+2. **Make the headers identical upstream.** When the documents genuinely belong
+   to one consolidated document, project their headers to the same sections and
+   values (e.g. drop the per-source control number) so concat sees one common
+   header.
+
+3. **Declare a header-folding strategy** to state which header the consolidated
+   document keeps when the inputs differ — choosing one, regenerating a fresh
+   header from the consolidated body, or merging the headers field by field.
+   Concat itself never guesses; the fold makes the choice explicit.
+
+## Technical context
+
+Concat reads the `DocumentOpen` punctuation of every incoming document — the
+punctuations are authoritative because they cover empty-body documents a record
+scan would miss — and folds their envelope headers down to the distinct
+non-empty set. Zero distinct non-empty headers yields a headerless consolidated
+document; exactly one yields that common header; two or more is this conflict.
+
+Header equality compares the section-name list and the positional section
+payloads, so two documents whose headers carry the same sections with the same
+values fold to one (no conflict) while any difference in a section name or a
+field value splits them. The guard runs at framing time, before any record is
+re-stamped onto the consolidated context, so a conflicting body never produces
+a partial document.
+
+## See also
+
+- "Envelope Nodes" in the pipeline reference — the `concat` strategy
+- Error E319 — a combine with `on_miss: error` saw an unmatched driver row

--- a/docs/explain/E350.md
+++ b/docs/explain/E350.md
@@ -14,6 +14,11 @@ header and drop the rest, so it stops the run. A headerless document coexists
 with a single real header (the header is the common one); the conflict is
 strictly *two different non-empty headers, one document*.
 
+The headers compared are those of the documents that contribute body records —
+the records the consolidated document actually frames. A document that carries a
+header but no body records frames nothing once consolidated, so it does not enter
+the comparison.
+
 ```
 envelope 'framed': concat collapses the body into one framed document, but the
 body carried 2 distinct non-empty envelope headers — one document can frame only
@@ -99,10 +104,14 @@ ancestor-frame / empty-body documents (which frame no body records at all). Zero
 distinct non-empty headers yields a headerless consolidated document; exactly one
 yields that common header; two or more is this conflict.
 
-Header equality compares the section-name list and the positional section
-payloads, so two documents whose headers carry the same sections with the same
-values fold to one (no conflict) while any difference in a section name or a
-field value splits them. The guard runs at framing time, before any record is
+Header equality compares the section-name list in order and each section's
+payload. A section's payload compares by field (field order within a section
+does not matter), but it includes any raw content the reader preserves, so two
+headers that agree on every user-visible field yet differ in preserved raw bytes
+— an interchange control number embedded in the raw segment, say — are still
+distinct. Two documents whose headers carry the same sections with the same
+values fold to one (no conflict); any difference in a section name or a field
+value splits them. The guard runs at framing time, before any record is
 re-stamped onto the consolidated context, so a conflicting body never produces
 a partial document.
 

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -75,11 +75,13 @@ Re-stamping changes only the **framing** (the grain) and the ambient `$doc.*` vi
 
 ### The consolidated header, and the two-headers conflict
 
-One consolidated document can carry only **one** envelope header. `concat` derives it from the incoming documents' headers:
+One consolidated document can carry only **one** envelope header. `concat` derives it from the headers of the documents that contribute body records, taking one header per document:
 
 - **Every header agrees** (or there is only one) → the consolidated document carries that **common header**.
 - **No document carries a header** → the consolidated document is **headerless**.
 - **A headed document and a headerless document** → the single header wins; the headerless document coexists with it (no conflict).
+
+Only documents that contribute body records take part: a document that carries a header but no body records frames nothing once consolidated, so it never enters the comparison. Header identity is **structural** — two documents share a header when they declare the same sections, in the same order, with the same field values (including any raw content the reader preserves). Two files that differ only in an embedded control number therefore count as distinct headers.
 
 When the body carries **two or more distinct non-empty headers**, `concat` refuses to silently keep one and drop the rest. The run fails with **E350** (run `clinker explain --code E350` for the full write-up):
 

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -81,7 +81,7 @@ One consolidated document can carry only **one** envelope header. `concat` deriv
 - **No document carries a header** → the consolidated document is **headerless**.
 - **A headed document and a headerless document** → the single header wins; the headerless document coexists with it (no conflict).
 
-When the body carries **two or more distinct non-empty headers**, `concat` refuses to silently keep one and drop the rest. The run fails with [**E350**](../../../explain/E350.md):
+When the body carries **two or more distinct non-empty headers**, `concat` refuses to silently keep one and drop the rest. The run fails with **E350** (run `clinker explain --code E350` for the full write-up):
 
 ```
 envelope 'framed': concat collapses the body into one framed document, but the
@@ -120,4 +120,4 @@ Placing the Envelope **after** a Combine or Aggregate is the intended use: it de
 
 Both strategies re-park the body into the node's own buffer slot, which the engine's memory arbitrator governs and spills to disk under pressure — so neither strategy is bounded by total input size held in RAM.
 
-`preserve` is a transparent framing pass-through: it forwards records and their document boundaries unchanged. `concat` additionally re-stamps each record onto the one consolidated document context and replaces the per-document boundaries with a single open/close pair; the header consolidation it does first is `O(documents)`, not `O(records)`, because it inspects only each document's open boundary, not the body rows.
+`preserve` is a transparent framing pass-through: it forwards records and their document boundaries unchanged. `concat` additionally re-stamps each record onto the one consolidated document context and replaces the per-document boundaries with a single open/close pair; the header consolidation it does first groups the body records by document — one document's worth of body records shares one grain and one header — so it does one pass over the records to collect the distinct headers, comparing only one envelope per document (the work is bounded by the number of documents, not the number of body rows).

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -2,7 +2,7 @@
 
 Envelope nodes frame a body stream into per-document documents. An Envelope is a discrete, composable stage you can place after **any** operator — a Transform, a Merge, a Combine, or an Aggregate — to declare "from here on, treat the records as belonging to framed documents." It mirrors the message/EDI/XML envelope-wrapper pattern (the Enterprise Integration Patterns *Envelope Wrapper*, XProc's `p:wrap-sequence`): the body is the payload, and the envelope is the document boundary around it.
 
-This page documents the `preserve` strategy. Consolidation (`concat`) and synthesizing strategies arrive in later releases.
+This page documents the `preserve` and `concat` strategies. The synthesizing (header-folding) strategies arrive in later releases.
 
 ## Basic structure
 
@@ -48,6 +48,51 @@ The grain is the level at which one logical document is reconstructed — and it
 
 Because framing keys on the grain rather than the source file, splitting or combining files never silently changes the document count.
 
+## `strategy: concat`
+
+`concat` does the opposite of `preserve`: it collapses a **multi-document body into one framed document**. Every body record is re-stamped onto a single consolidated document context, so the body opens and closes **exactly once** regardless of how many documents fed in. This is the strategy to use when several source documents — say two files joined by a Merge — should write as one consolidated document with a single header and footer.
+
+```yaml
+nodes:
+  - type: merge
+    name: both
+    inputs: [file_a, file_b]
+  - type: envelope
+    name: framed
+    body: both
+    config: { strategy: concat }
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+```
+
+Re-stamping changes only the **framing** (the grain) and the ambient `$doc.*` view a record sees — it does **not** disturb per-record fields. In particular `$source.file` is a real column stamped when each record is read, so it still reports the record's own originating file after a concat. Concat is lossless on per-record provenance; it changes only which document the record is framed inside.
+
+### The consolidated header, and the two-headers conflict
+
+One consolidated document can carry only **one** envelope header. `concat` derives it from the incoming documents' headers:
+
+- **Every header agrees** (or there is only one) → the consolidated document carries that **common header**.
+- **No document carries a header** → the consolidated document is **headerless**.
+- **A headed document and a headerless document** → the single header wins; the headerless document coexists with it (no conflict).
+
+When the body carries **two or more distinct non-empty headers**, `concat` refuses to silently keep one and drop the rest. The run fails with [**E350**](../../../explain/E350.md):
+
+```
+envelope 'framed': concat collapses the body into one framed document, but the
+body carried 2 distinct non-empty envelope headers — one document can frame only
+one header, so concat will not silently drop the rest. Make the headers identical
+upstream, or add a header-folding strategy that declares which header the
+consolidated document keeps.
+```
+
+To resolve a conflict, either keep the documents separate with `preserve`, make the headers identical upstream (project them to the same sections and values), or — in a later release — declare a header-folding strategy that states which header the consolidated document keeps.
+
 ## Placement
 
 An Envelope is a normal single-input, single-output node — put it anywhere a record stream flows:
@@ -73,4 +118,6 @@ Placing the Envelope **after** a Combine or Aggregate is the intended use: it de
 
 ## Memory model
 
-`preserve` is a **streaming pass-through**. It does not buffer a whole document or the whole input — body records flow through one batch at a time, bounded the same way any intermediate stage is (the engine's memory arbitrator governs the node's buffer and spills to disk under pressure). The resident footprint is the records of the concurrently-open documents, not the total input size.
+Both strategies re-park the body into the node's own buffer slot, which the engine's memory arbitrator governs and spills to disk under pressure — so neither strategy is bounded by total input size held in RAM.
+
+`preserve` is a transparent framing pass-through: it forwards records and their document boundaries unchanged. `concat` additionally re-stamps each record onto the one consolidated document context and replaces the per-document boundaries with a single open/close pair; the header consolidation it does first is `O(documents)`, not `O(records)`, because it inspects only each document's open boundary, not the body rows.


### PR DESCRIPTION
## Summary

Adds the `concat` framing strategy to the Envelope node. Where `preserve` emits one framed document per body grain, `concat` collapses a multi-document body into a **single** framed document: it mints one fresh document context for the whole body, re-stamps every drained record onto it, and re-frames with exactly one document-open / document-close pair. A multi-document body therefore opens and closes once — the NDJSON / back-to-back-message analogue.

## Header consolidation

The consolidated document carries the body's **common** envelope header, derived from the incoming documents' open boundaries (authoritative because they cover an empty-body document a record scan would miss). The distinct non-empty headers are folded down:

- zero distinct non-empty → a headerless consolidated document,
- one → that common header,
- a headerless document coexists with a single real header (no conflict).

Re-stamping changes only the framing grain and the ambient `$doc.*` view. Each record's `$source.file` is a real column stamped at read time, so per-record provenance is untouched — `concat` is lossless on it.

## The two-headers-one-document guard (E350)

When the body carries **two or more distinct non-empty headers** under the one consolidated document, `concat` refuses to silently keep one and drop the rest. It aborts the run with a new diagnostic, **E350**, pointing the operator at making the headers identical upstream or declaring a header-folding strategy. The run exits 1 (a pipeline-validation failure), matching the other always-abort runtime guards.

Header equality is structural: same section-name list in order plus same positional payloads, implemented as a hand-written `PartialEq` for the envelope record (its schema has no derivable equality).

## Out of scope

The header-folding strategies that *resolve* the conflict (choose-one, regenerate, merge) and the grainless-header case are tracked separately.

## Tests

`concat` framing-collapse (two documents in → one document out, observed via downstream aggregate flush — the CSV writer renders no footer for a headerless document, so an aggregate differential is the correct probe), common-header carry with `$doc.*` resolution after consolidation, headed + headerless coexistence, and the E350 conflict pinned by both error code and variant. Existing `preserve` tests unchanged.

Full CI gauntlet green; new diagnostic doc at `docs/explain/E350.md` and user docs updated.

Closes #586
