### PR TITLE
exec,record: named same_header header-identity + shared grain→header derivation (#604)

### DIFF
--- a/crates/clinker-exec/src/executor/envelope.rs
+++ b/crates/clinker-exec/src/executor/envelope.rs
@@ -1,0 +1,68 @@
+//! Shared envelope-folding primitives for the `Envelope` node's strategies.
+//!
+//! The consolidation strategies (`concat`, and the upcoming choose-one /
+//! folding variants) all face the same first step: a materialized, multi-
+//! document body has to be reduced to the *set of headers* it carries, one
+//! header per output document. This module owns that reduction so every
+//! strategy shares one encoding of what "the body's headers" means rather than
+//! re-deriving it.
+
+use clinker_record::{DocumentGrain, EnvelopeRecord, Record};
+
+/// The distinct non-empty headers a materialized body carries, in body order.
+///
+/// One [`DocumentGrain`] is one output document, and the *first record of a
+/// grain* is that document's representative — its
+/// [`envelope_record`](clinker_record::DocumentContext::envelope_record) is the
+/// document's header. (Each record carries the innermost fully-merged envelope,
+/// exactly what a reconstruct-envelope writer attaches per output document, so
+/// any record of a grain would do; the first is simply the one reached first.)
+///
+/// The derivation:
+///
+/// - **Grain-keyed, not punctuation-keyed.** Headers come from the body
+///   *records* grouped by grain, never from `DocumentOpen` punctuations. Ingest
+///   mints one open per envelope *level*, so a nested format (X12 ISA → GS → ST)
+///   opens several cumulative envelopes for one logical document; counting opens
+///   would see three headers where there is one. A grain spanning all three
+///   levels is one document with one header (the innermost merged envelope).
+///
+/// - **Empty headers contribute nothing.** A grain whose representative
+///   envelope [`is_empty`](EnvelopeRecord::is_empty) (a headerless or synthetic
+///   document) adds no header, so a headless document coexists with a single
+///   real header without conflict. A grain with no body records never appears in
+///   the input slice at all, so an ancestor-frame / empty-body document — which
+///   emits no body records — likewise contributes no header.
+///
+/// - **Deduped by [`EnvelopeRecord::same_header`], not `PartialEq`.** Two
+///   documents whose headers agree on every user-visible field fold to one even
+///   when they differ in engine-injected `$`-prefixed keys (an X12 `ISA`
+///   control number, a timestamp in the preserved `$raw` bytes). The first
+///   occurrence's full [`EnvelopeRecord`] is the one retained, so a downstream
+///   writer reconstructs from the first document's raw bytes.
+///
+/// The result preserves first-seen order. Its length is the count a multi-header
+/// consolidation guard rejects on (`>= 2` distinct headers cannot share one
+/// consolidated document); its first element is the consolidated header when the
+/// body carries exactly one.
+///
+/// Cost: one pass over `records` (an `O(records)` grain-membership probe set)
+/// plus an `O(grains²)` `same_header` dedup — both bounded by the document
+/// count, not the record count, because the work per record after the first of
+/// its grain is a single hashset hit.
+pub(crate) fn distinct_body_headers(records: &[(Record, u64)]) -> Vec<EnvelopeRecord> {
+    let mut seen_grains: std::collections::HashSet<DocumentGrain> =
+        std::collections::HashSet::new();
+    let mut headers: Vec<EnvelopeRecord> = Vec::new();
+    for (record, _) in records {
+        let doc = record.doc_ctx();
+        if !seen_grains.insert(doc.grain()) {
+            continue;
+        }
+        let env = doc.envelope_record();
+        if !env.is_empty() && !headers.iter().any(|h| h.same_header(env)) {
+            headers.push(env.clone());
+        }
+    }
+    headers
+}

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -53,12 +53,13 @@ use petgraph::graph::NodeIndex;
 use crate::executor::dispatch::{
     ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
 };
+use crate::executor::envelope::distinct_body_headers;
 use crate::executor::node_buffer::DrainedEvents;
 use crate::executor::stream_event::{Punctuation, PunctuationKind};
 use clinker_plan::config::pipeline_node::EnvelopeStrategy;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
-use clinker_record::{DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, Record};
+use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Record};
 
 /// Execute the `Envelope` arm for `node_idx`. Drains the body predecessor and
 /// re-parks the framed body into this node's own `node_buffers` slot.
@@ -156,24 +157,12 @@ fn consolidate(
         return Ok((Vec::new(), Vec::new()));
     }
 
-    // Fold the body grains' headers down to the distinct non-empty set, in one
-    // pass over the records: the first record of each grain is that output
-    // document, and its envelope is the document's header. The grain set bounds
-    // the work — O(records) hashset probes plus an O(grains²) `PartialEq` dedup
-    // (`EnvelopeRecord` is not `Hash`), both bounded by the document count.
-    let mut seen_grains: std::collections::HashSet<DocumentGrain> =
-        std::collections::HashSet::new();
-    let mut distinct_headers: Vec<&EnvelopeRecord> = Vec::new();
-    for (record, _) in &records {
-        let doc = record.doc_ctx();
-        if !seen_grains.insert(doc.grain()) {
-            continue;
-        }
-        let env = doc.envelope_record();
-        if !env.is_empty() && !distinct_headers.contains(&env) {
-            distinct_headers.push(env);
-        }
-    }
+    // Fold the body grains' headers down to the distinct non-empty set. Headers
+    // are deduped by `same_header`, so two documents that agree on every
+    // user-visible field fold to one even when their engine-preserved `$raw`
+    // bytes differ (e.g. an X12 `ISA` control number) — a structural compare
+    // would split them and wrongly raise E350.
+    let distinct_headers = distinct_body_headers(&records);
 
     if distinct_headers.len() >= 2 {
         return Err(PipelineError::EnvelopeMultiHeaderConflict {
@@ -182,10 +171,13 @@ fn consolidate(
         });
     }
 
-    let consolidated_header = match distinct_headers.first() {
-        Some(env) => (*env).clone(),
-        None => EnvelopeRecord::empty(),
-    };
+    // The consolidated document keeps the FIRST header's full `EnvelopeRecord`
+    // (engine keys included), so a reconstruct-envelope writer rebuilds from the
+    // first document's raw bytes.
+    let consolidated_header = distinct_headers
+        .into_iter()
+        .next()
+        .unwrap_or_else(EnvelopeRecord::empty);
 
     // The consolidated document inherits the first incoming document's source
     // file as its representative identity, preferring the first `DocumentOpen`.

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod cull_dispatch;
 pub(crate) mod dispatch;
 mod dlq;
 pub(crate) mod document_dlq;
+pub(crate) mod envelope;
 pub(crate) mod envelope_dispatch;
 mod ingest;
 pub(crate) mod merge_dispatch;

--- a/crates/clinker-exec/tests/envelope_node.rs
+++ b/crates/clinker-exec/tests/envelope_node.rs
@@ -56,6 +56,17 @@ enum Step {
         tag_val: &'static str,
         frame: FrameRole,
     },
+    /// Open a frame whose section carries the same user `tag` field PLUS an
+    /// engine-injected `$raw` key (an X12-style raw element shadow). The `raw`
+    /// value distinguishes two otherwise-identical headers, modeling the
+    /// interchange-control-number drift `same_header` must ignore.
+    OpenWithRaw {
+        file: &'static str,
+        name: &'static str,
+        tag_val: &'static str,
+        raw: &'static str,
+        frame: FrameRole,
+    },
     OpenHeaderless {
         file: &'static str,
         frame: FrameRole,
@@ -104,6 +115,18 @@ impl ScriptedReader {
         sections.insert(Box::from(name), Value::Map(Box::new(field)));
         sections
     }
+
+    /// Like [`Self::section`], but the section payload also carries an engine-
+    /// injected `$raw` key (the `$`-sigil convention the X12/EDIFACT/HL7 readers
+    /// use to stash lossless raw bytes alongside the user fields).
+    fn section_with_raw(name: &str, tag_val: &str, raw: &str) -> IndexMap<Box<str>, Value> {
+        let mut field = IndexMap::new();
+        field.insert(Box::from("tag"), Value::String(tag_val.into()));
+        field.insert(Box::from("$raw"), Value::String(raw.into()));
+        let mut sections = IndexMap::new();
+        sections.insert(Box::from(name), Value::Map(Box::new(field)));
+        sections
+    }
 }
 
 impl RecordSource for ScriptedReader {
@@ -123,6 +146,19 @@ impl RecordSource for ScriptedReader {
                     self.current_file = Some(self.file_arc(file));
                     self.pending_events.push(EnvelopeEvent::OpenLevel {
                         sections: Self::section(name, tag_val),
+                        frame,
+                    });
+                }
+                Step::OpenWithRaw {
+                    file,
+                    name,
+                    tag_val,
+                    raw,
+                    frame,
+                } => {
+                    self.current_file = Some(self.file_arc(file));
+                    self.pending_events.push(EnvelopeEvent::OpenLevel {
+                        sections: Self::section_with_raw(name, tag_val, raw),
                         frame,
                     });
                 }
@@ -790,6 +826,30 @@ fn concat_doc(file: &'static str, tag_val: &'static str, ids: &[i64]) -> Vec<Ste
     steps
 }
 
+/// One `NewFrame` document whose header carries `tag_val` AND an engine-injected
+/// `$raw` value, plus `id` body rows. Two such documents with the same `tag_val`
+/// but different `raw` model two files from one trading partner that differ only
+/// in an interchange control number stashed in the preserved raw bytes.
+fn concat_doc_with_raw(
+    file: &'static str,
+    tag_val: &'static str,
+    raw: &'static str,
+    ids: &[i64],
+) -> Vec<Step> {
+    let mut steps = vec![Step::OpenWithRaw {
+        file,
+        name: "interchange",
+        tag_val,
+        raw,
+        frame: FrameRole::NewFrame,
+    }];
+    for &id in ids {
+        steps.push(Step::Record { file, id });
+    }
+    steps.push(Step::Close { file });
+    steps
+}
+
 /// One genuinely headerless `NewFrame` document carrying `id` rows.
 fn concat_headerless_doc(file: &'static str, ids: &[i64]) -> Vec<Step> {
     let mut steps = vec![Step::OpenHeaderless {
@@ -948,6 +1008,62 @@ fn concat_two_distinct_headers_is_e350_conflict() {
         }
         other => panic!("expected the multi-header conflict variant, got: {other:?}"),
     }
+}
+
+#[test]
+fn concat_headers_differing_only_in_engine_raw_fold_without_conflict() {
+    // Two documents whose `interchange` headers agree on every user field
+    // (`tag = PARTNER`) but differ in the engine-preserved `$raw` bytes — the
+    // X12 interchange-control-number footgun. A structural compare would split
+    // them and raise E350; folding by header identity (ignoring the `$`-prefixed
+    // engine key) consolidates them into ONE document with no conflict. This
+    // would have tripped E350 before headers were compared by identity.
+    let mut steps = concat_doc_with_raw("a.x12", "PARTNER", "ISA*...*000000001", &[1, 2]);
+    steps.extend(concat_doc_with_raw(
+        "b.x12",
+        "PARTNER",
+        "ISA*...*000000002",
+        &[3],
+    ));
+
+    let csv =
+        run_concat(steps).expect("headers differing only in engine $raw must fold, not conflict");
+
+    // The footer-from-doc renders BOTH the user `tag` field and the engine
+    // `$raw` field, so this section's footer is a two-cell row (`tag,$raw`) —
+    // unlike the single-field sections `footer_stats` is tuned for. Count the
+    // footer rows directly: the body rows are `id,PARTNER` (numeric first cell),
+    // the lone footer is `PARTNER,<raw>` (non-numeric first cell).
+    let body_rows: Vec<&str> = csv
+        .lines()
+        .filter(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            c.first().is_some_and(|first| first.parse::<i64>().is_ok())
+        })
+        .collect();
+    let footer_rows: Vec<&str> = csv
+        .lines()
+        .filter(|l| {
+            let c: Vec<&str> = l.split(',').collect();
+            c.len() == 2 && c[0] == "PARTNER"
+        })
+        .collect();
+    assert_eq!(
+        footer_rows.len(),
+        1,
+        "headers differing only in $raw fold to ONE consolidated document (one footer): {csv}"
+    );
+    assert_eq!(
+        body_rows.len(),
+        3,
+        "all three body rows land under the one consolidated document: {csv}"
+    );
+    // The consolidated document keeps the FIRST document's full header, so its
+    // footer carries the first document's `$raw` (000000001), never the second's.
+    assert_eq!(
+        footer_rows[0], "PARTNER,ISA*...*000000001",
+        "the consolidated header is the FIRST document's full EnvelopeRecord, $raw included: {csv}"
+    );
 }
 
 #[test]

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -79,6 +79,11 @@ impl DocumentId {
 /// directly. Two contexts of the same frame (e.g. the `GS` and `ST` of one X12
 /// interchange) compare equal even though their own [`DocumentId`]s differ.
 ///
+/// One grain is one output document: the Envelope node's consolidation
+/// strategies group a materialized body by grain to derive its set of headers
+/// (the first record of each grain carries that document's header), so the
+/// grain is the join key between "a record" and "the document it frames into".
+///
 /// This is distinct from the document-DLQ's keying: the DLQ keys on
 /// `source_file` (the file grain), because a structural-count failure condemns
 /// a whole file. The two never co-execute — `reconstruct_envelope` and
@@ -117,6 +122,13 @@ impl DocumentGrain {
 /// resolver reads it through [`DocumentContext::get_section_field`], and a
 /// downstream consolidation node borrows the same record (via a crate-internal
 /// accessor that goes public with the Envelope node) — neither re-encodes it.
+///
+/// Two equality relations apply, for two different questions. [`PartialEq`] is
+/// literal/structural — engine keys included — and backs the spill round-trip.
+/// [`Self::same_header`] is semantic header identity: it excludes the
+/// `$`-prefixed engine keys so two headers that agree on every user-visible
+/// field fold even when their preserved raw bytes differ (e.g. an X12 `ISA`
+/// control number).
 #[derive(Debug, Clone)]
 pub struct EnvelopeRecord {
     schema: Arc<Schema>,
@@ -188,6 +200,78 @@ impl EnvelopeRecord {
         }
     }
 
+    /// Two envelopes name the same sections (positionally) and every section's
+    /// payload agrees on all *user-visible* fields — the semantic
+    /// header-identity relation, as distinct from the literal structural
+    /// [`PartialEq`].
+    ///
+    /// Why this differs from `PartialEq`: readers stash engine-internal keys
+    /// alongside the user-declared fields inside a section payload so a writer
+    /// can reconstruct the original bytes losslessly. The X12 / EDIFACT / HL7
+    /// readers carry a `$raw` element list under each header section, and that
+    /// list embeds interchange control numbers and timestamps that legitimately
+    /// vary between two files from the same trading partner. Under `PartialEq`
+    /// those two headers compare distinct — the bytes differ — so concat's
+    /// consolidation guard would reject them as a multi-header conflict even
+    /// though every addressable header field matches. `same_header` excludes
+    /// those engine keys so the two fold to one header.
+    ///
+    /// Exclusion rule: a `$`-prefixed key in a section payload is engine-
+    /// injected (the `$`-sigil system-namespace convention, matching CXL's
+    /// `$pipeline.*` / `$doc.*` and the readers' `$raw`) and is ignored on both
+    /// sides. User-declared section fields never start with `$`, so the rule
+    /// excludes exactly the reader-internal shadow and nothing a user authored.
+    ///
+    /// Section names are still compared positionally (the same sections in a
+    /// different declared order are distinct headers) and section fields by key
+    /// (field order within a section does not matter), exactly as `PartialEq`
+    /// does — `same_header` differs from `PartialEq` only in dropping the
+    /// `$`-prefixed keys before comparing each section's payload.
+    ///
+    /// When two headers are `same_header`-equal but differ in an excluded key,
+    /// the caller keeps ONE of the two full [`EnvelopeRecord`]s (engine keys
+    /// included) as the consolidated document's representative — concat keeps
+    /// the first document's, so the consolidated output reconstructs from the
+    /// first document's `$raw`.
+    pub fn same_header(&self, other: &EnvelopeRecord) -> bool {
+        if self.schema.columns() != other.schema.columns() {
+            return false;
+        }
+        self.sections
+            .iter()
+            .zip(other.sections.iter())
+            .all(|(a, b)| Self::section_payload_eq(a, b))
+    }
+
+    /// Compare two section payloads ignoring engine-injected `$`-prefixed keys.
+    ///
+    /// Two `Value::Map` payloads agree when their non-`$` entries are equal as
+    /// a key→value set (order-independent, since [`Value`] map equality is by
+    /// key). A non-map payload (a malformed reader emission) is compared by
+    /// strict equality — there are no keys to filter, so the literal value must
+    /// match.
+    fn section_payload_eq(a: &Value, b: &Value) -> bool {
+        match (a, b) {
+            (Value::Map(am), Value::Map(bm)) => {
+                let user = |m: &IndexMap<Box<str>, Value>| -> Vec<(Box<str>, Value)> {
+                    m.iter()
+                        .filter(|(k, _)| !k.starts_with('$'))
+                        .map(|(k, v)| (k.clone(), v.clone()))
+                        .collect()
+                };
+                let mut left = user(am);
+                let mut right = user(bm);
+                if left.len() != right.len() {
+                    return false;
+                }
+                left.sort_by(|x, y| x.0.cmp(&y.0));
+                right.sort_by(|x, y| x.0.cmp(&y.0));
+                left == right
+            }
+            (a, b) => a == b,
+        }
+    }
+
     /// Build a child envelope: this record's columns unioned with `child`'s,
     /// `child` shadowing on a same-name collision (innermost-wins). A colliding
     /// section keeps the ancestor's column position but takes the child's
@@ -211,8 +295,9 @@ impl EnvelopeRecord {
     }
 }
 
-/// Two envelopes are equal when they declare the same section names in the
-/// same order and each section's payload compares equal.
+/// Literal, structural equality: two envelopes are equal when they declare the
+/// same section names in the same order and each section's payload compares
+/// byte-for-byte equal — engine-injected keys included.
 ///
 /// The section-name list (`schema.columns()`, a `[Box<str>]`) is compared
 /// positionally, so the same sections in a different declared order are
@@ -222,11 +307,14 @@ impl EnvelopeRecord {
 /// `body`) the readers carry, so two headers that agree on every user-visible
 /// field but differ in preserved raw bytes compare distinct.
 ///
+/// This is deliberately strict: the spill codec round-trips an envelope through
+/// postcard and the spill tests assert the rebuilt record equals the original
+/// down to its `$raw` bytes, which only holds under structural equality. For
+/// the *semantic* "do these name the same header" question — which must ignore
+/// the engine keys so two files differing only in a control number fold — use
+/// [`EnvelopeRecord::same_header`] instead.
+///
 /// Hand-written rather than derived because [`Schema`] has no `PartialEq`.
-/// Concat's multi-header consolidation guard uses this to fold a body's
-/// per-document headers down to the distinct set: two documents whose headers
-/// compare equal share one common header; two distinct non-empty headers under
-/// one consolidated document are the conflict it rejects.
 impl PartialEq for EnvelopeRecord {
     fn eq(&self, other: &Self) -> bool {
         self.schema.columns() == other.schema.columns() && self.sections == other.sections
@@ -777,6 +865,149 @@ mod tests {
             ),
             other => panic!("expected Value::Map, got {other:?}"),
         }
+    }
+
+    fn section_with(fields: &[(&str, Value)]) -> Value {
+        make_section(fields)
+    }
+
+    #[test]
+    fn same_header_ignores_dollar_prefixed_engine_keys() {
+        // Two X12-style headers identical in every user field but differing in
+        // the engine-preserved `$raw` element list (one carries an interchange
+        // control number, the other does not). `same_header` must fold them;
+        // `PartialEq` must still split them — the spill round-trip depends on
+        // the strict relation.
+        let mut a = IndexMap::new();
+        a.insert(
+            Box::from("interchange"),
+            section_with(&[
+                ("sender", Value::String("ACME".into())),
+                (
+                    "$raw",
+                    Value::Array(vec![Value::String("ISA*00*...*000000001".into())]),
+                ),
+            ]),
+        );
+        let mut b = IndexMap::new();
+        b.insert(
+            Box::from("interchange"),
+            section_with(&[
+                ("sender", Value::String("ACME".into())),
+                (
+                    "$raw",
+                    Value::Array(vec![Value::String("ISA*00*...*000000002".into())]),
+                ),
+            ]),
+        );
+        let ea = envelope(a);
+        let eb = envelope(b);
+
+        assert!(
+            ea.same_header(&eb),
+            "headers agreeing on every user field fold despite differing $raw"
+        );
+        assert!(
+            eb.same_header(&ea),
+            "same_header is symmetric over the $raw difference"
+        );
+        assert_ne!(
+            ea, eb,
+            "PartialEq stays strict: the differing $raw makes the records structurally distinct"
+        );
+    }
+
+    #[test]
+    fn same_header_distinguishes_sections_in_different_declared_order() {
+        // Same two sections, declared in a different order — positionally
+        // distinct headers, so `same_header` is FALSE.
+        let mut a = IndexMap::new();
+        a.insert(Box::from("head"), section_with(&[("k", Value::Integer(1))]));
+        a.insert(Box::from("foot"), section_with(&[("k", Value::Integer(2))]));
+        let mut b = IndexMap::new();
+        b.insert(Box::from("foot"), section_with(&[("k", Value::Integer(2))]));
+        b.insert(Box::from("head"), section_with(&[("k", Value::Integer(1))]));
+
+        assert!(
+            !envelope(a).same_header(&envelope(b)),
+            "the same sections in a different declared order are distinct headers"
+        );
+    }
+
+    #[test]
+    fn same_header_ignores_field_order_within_a_section() {
+        // Same section with the SAME user fields in a different order →
+        // `same_header` TRUE (field order within a section does not matter).
+        let mut a = IndexMap::new();
+        a.insert(
+            Box::from("head"),
+            section_with(&[("x", Value::Integer(1)), ("y", Value::String("v".into()))]),
+        );
+        let mut b = IndexMap::new();
+        b.insert(
+            Box::from("head"),
+            section_with(&[("y", Value::String("v".into())), ("x", Value::Integer(1))]),
+        );
+
+        assert!(
+            envelope(a).same_header(&envelope(b)),
+            "field order within a section is irrelevant to header identity"
+        );
+    }
+
+    #[test]
+    fn same_header_distinguishes_differing_user_fields() {
+        // A real user-field difference (not an engine key) must split headers,
+        // proving the exclusion rule does not over-fold.
+        let mut a = IndexMap::new();
+        a.insert(
+            Box::from("head"),
+            section_with(&[("sender", Value::String("ACME".into()))]),
+        );
+        let mut b = IndexMap::new();
+        b.insert(
+            Box::from("head"),
+            section_with(&[("sender", Value::String("OTHER".into()))]),
+        );
+
+        assert!(
+            !envelope(a).same_header(&envelope(b)),
+            "a differing user field makes two headers distinct"
+        );
+    }
+
+    #[test]
+    fn same_header_swift_body_field_is_compared_not_excluded() {
+        // The SWIFT `body` key is NOT `$`-prefixed: it is the sole, user-
+        // addressable field of a service-block section, so it is compared, not
+        // excluded. Two SWIFT-style headers with different `body` content are
+        // distinct — the exclusion rule covers only the `$raw` shadow.
+        let mut a = IndexMap::new();
+        a.insert(
+            Box::from("basic_header"),
+            section_with(&[("body", Value::String("F01BANKBEBB".into()))]),
+        );
+        let mut b = IndexMap::new();
+        b.insert(
+            Box::from("basic_header"),
+            section_with(&[("body", Value::String("F01OTHERBANK".into()))]),
+        );
+
+        assert!(
+            !envelope(a).same_header(&envelope(b)),
+            "the user-addressable SWIFT `body` field is compared, not excluded"
+        );
+    }
+
+    #[test]
+    fn same_header_empty_envelopes_are_equal() {
+        assert!(EnvelopeRecord::empty().same_header(&EnvelopeRecord::empty()));
+        let mut a = IndexMap::new();
+        a.insert(Box::from("head"), section_with(&[("k", Value::Integer(1))]));
+        assert!(
+            !envelope(a).same_header(&EnvelopeRecord::empty()),
+            "a non-empty header is not the same header as the empty envelope"
+        );
     }
 
     #[test]

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -245,28 +245,27 @@ impl EnvelopeRecord {
 
     /// Compare two section payloads ignoring engine-injected `$`-prefixed keys.
     ///
-    /// Two `Value::Map` payloads agree when their non-`$` entries are equal as
-    /// a key→value set (order-independent, since [`Value`] map equality is by
-    /// key). A non-map payload (a malformed reader emission) is compared by
-    /// strict equality — there are no keys to filter, so the literal value must
-    /// match.
+    /// Two `Value::Map` payloads agree when their non-`$` top-level entries are
+    /// equal as a key→value set: the same set of non-`$` keys, each mapping to
+    /// an equal [`Value`]. The comparison is by keyed lookup, so it is
+    /// order-independent and allocation-free — no clone or sort. Only top-level
+    /// keys are filtered; a `$`-prefixed key nested inside a field value is
+    /// compared structurally, which is sound because readers inject their
+    /// engine shadow (`$raw`) at the section-payload root, never nested. A
+    /// non-map payload (a malformed reader emission) is compared by strict
+    /// equality — there are no keys to filter.
     fn section_payload_eq(a: &Value, b: &Value) -> bool {
         match (a, b) {
             (Value::Map(am), Value::Map(bm)) => {
-                let user = |m: &IndexMap<Box<str>, Value>| -> Vec<(Box<str>, Value)> {
-                    m.iter()
-                        .filter(|(k, _)| !k.starts_with('$'))
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect()
+                let user_key_count = |m: &IndexMap<Box<str>, Value>| {
+                    m.keys().filter(|k| !k.starts_with('$')).count()
                 };
-                let mut left = user(am);
-                let mut right = user(bm);
-                if left.len() != right.len() {
+                if user_key_count(am) != user_key_count(bm) {
                     return false;
                 }
-                left.sort_by(|x, y| x.0.cmp(&y.0));
-                right.sort_by(|x, y| x.0.cmp(&y.0));
-                left == right
+                am.iter()
+                    .filter(|(k, _)| !k.starts_with('$'))
+                    .all(|(k, v)| bm.get(&**k) == Some(v))
             }
             (a, b) => a == b,
         }
@@ -307,12 +306,13 @@ impl EnvelopeRecord {
 /// `body`) the readers carry, so two headers that agree on every user-visible
 /// field but differ in preserved raw bytes compare distinct.
 ///
-/// This is deliberately strict: the spill codec round-trips an envelope through
-/// postcard and the spill tests assert the rebuilt record equals the original
-/// down to its `$raw` bytes, which only holds under structural equality. For
-/// the *semantic* "do these name the same header" question — which must ignore
-/// the engine keys so two files differing only in a control number fold — use
-/// [`EnvelopeRecord::same_header`] instead.
+/// This is deliberately strict — it includes the engine-injected keys, so a
+/// spill round-trip that altered the preserved `$raw` bytes would be observable
+/// under whole-record equality. The strict-vs-semantic distinction is pinned by
+/// the `same_header` unit tests, which assert a record pair that `same_header`
+/// folds is still `!=` here. For the *semantic* "do these name the same header"
+/// question — which must ignore the engine keys so two files differing only in
+/// a control number fold — use [`EnvelopeRecord::same_header`] instead.
 ///
 /// Hand-written rather than derived because [`Schema`] has no `PartialEq`.
 impl PartialEq for EnvelopeRecord {


### PR DESCRIPTION
## Summary

Structural prep for the Envelope-node header-folding strategies (#573/#574/#575), landing the two parts that have real consumers now.

**A named header-identity relation.** Adds `EnvelopeRecord::same_header(&self, &other)` — the *semantic* "are these two documents' headers the same" relation — distinct from `PartialEq`, which stays as literal structural equality (the spill round-trip depends on it). `concat`'s multi-header consolidation guard now compares headers via `same_header` instead of `PartialEq`.

**`same_header` excludes engine-injected raw content.** A section payload's `$`-prefixed keys (notably `$raw`, the reader-preserved raw segment bytes) are ignored. This fixes a real footgun: two X12 files from one trading partner whose `ISA` differs only in an interchange control number embedded in `$raw` previously tripped E350 ("two distinct headers"); they now fold to one consolidated document. Section names are still compared positionally; user fields within a section compare order-independently. The SWIFT `body` key is *not* excluded — it is the user-addressable content of a service block, not engine shadow data.

**Shared grain→header derivation.** Extracts the "group body records by document grain, take each grain's representative header, fold to the distinct non-empty set" rule out of `consolidate()` into a `pub(crate)` helper (`crates/clinker-exec/src/executor/envelope.rs`), so the upcoming folding strategies share one encoding.

## Scope notes

- The data-carrying `EnvelopeStrategy` reshape (the third part originally grouped here) is deferred to the strategy that first needs it (`choose_one`), since the enum's current serde shape already accepts a struct variant and the reshape has no consumer until then.
- No behavior change to `concat` beyond the `$raw`-exclusion fix; `preserve` untouched. The streaming output writer keys document boundaries on grain identity and does no header-content comparison, so it needs no change.

## Tests

`same_header` unit tests cover: `$raw`-only differences fold; section-name reordering stays distinct; intra-section field reordering folds; a real user-field difference splits; the SWIFT `body` field is compared; `PartialEq` stays strict where `same_header` folds. A concat integration test drives two headers differing only in `$raw` → one consolidated document, no E350. See-it-fail verified for both. Full CI gauntlet green.

Closes #604
Refs #605
