### PR TITLE
exec,record,plan: Envelope header input becomes a wired port (transform-in-place header replacement) (#579)

### DIFF
--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -183,16 +183,7 @@ pub(crate) fn dispatch_combine(
         .neighbors_directed(node_idx, Direction::Incoming)
         .collect();
     let predecessor_matches = |p: NodeIndex, target: &str| -> bool {
-        let pname = current_dag.graph[p].name();
-        if pname == target {
-            return true;
-        }
-        if let Some(stripped) =
-            pname.strip_prefix(clinker_plan::plan::execution::CORRELATION_SORT_PREFIX)
-        {
-            return stripped == target;
-        }
-        false
+        clinker_plan::plan::execution::matches_upstream_name(current_dag.graph[p].name(), target)
     };
     let driver_pred = predecessors
         .iter()

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -33,21 +33,28 @@
 //!
 //! # Inputs
 //!
-//! The node has a single wired predecessor this release: the `body` input.
-//! The optional `header:` / `trailer:` ports are rejected when wired at plan
-//! validation, so [`single_predecessor`] resolves exactly the body stream.
+//! The node always wires a `body` input. When a `header:` port is also wired,
+//! the node consumes a second predecessor — a 1-row-per-grain header stream —
+//! and **replaces** each body grain's ambient envelope with the matching header
+//! record (transform-in-place header replacement, attach-by-grain). The plan's
+//! `header_upstream` index identifies which predecessor is the header; the body
+//! is the other one. A wired `trailer:` port stays rejected at plan validation.
 //!
 //! # Memory model
 //!
 //! The node drains the body predecessor's full `NodeBuffer` and materializes
 //! it into its own `NodeBuffer` slot — the same re-park model as Cull and
-//! Merge. The slot's arbitrator wrapper provides the memory bound (it spills
-//! the slot when the budget trips), so the resident set is the slot's records,
-//! not an incrementally-streamed subset. The node registers no spillable stage
+//! Merge. A wired header stream is drained into a per-grain map (one entry per
+//! header document, bounded by the document count, not the record count). The
+//! slot's arbitrator wrapper provides the memory bound (it spills the slot when
+//! the budget trips), so the resident set is the slot's records, not an
+//! incrementally-streamed subset. The node registers no spillable stage
 //! consumer of its own.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
@@ -59,7 +66,7 @@ use crate::executor::stream_event::{Punctuation, PunctuationKind};
 use clinker_plan::config::pipeline_node::EnvelopeStrategy;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
-use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Record};
+use clinker_record::{DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, Record};
 
 /// Execute the `Envelope` arm for `node_idx`. Drains the body predecessor and
 /// re-parks the framed body into this node's own `node_buffers` slot.
@@ -67,13 +74,20 @@ use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Record};
 /// `Preserve` re-parks every record with its document context and grain
 /// unchanged, forwarding the body's punctuations. `Concat` re-stamps every
 /// record onto one consolidated document context and re-frames with a single
-/// open/close pair.
+/// open/close pair. When a `header:` port is wired, both strategies first
+/// replace each body grain's ambient envelope with the grain-matched wired
+/// header record, so `preserve` frames each document with its replacement
+/// header and `concat` folds the now-replaced headers.
 ///
 /// # Errors
 ///
 /// Returns [`PipelineError::EnvelopeMultiHeaderConflict`] (E350) under `Concat`
 /// when the body grains carry two or more distinct non-empty envelope headers —
 /// one consolidated document cannot frame two headers without dropping one.
+///
+/// Returns [`PipelineError::EnvelopeHeaderGrainUnmatched`] (E351) when a wired
+/// header record carries a grain that grounds to no in-flight body grain (or is
+/// the synthetic / ungrounded grain), so the node cannot place it by grain.
 pub(crate) fn dispatch_envelope(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
@@ -81,29 +95,63 @@ pub(crate) fn dispatch_envelope(
     node: &PlanNode,
 ) -> Result<(), PipelineError> {
     let PlanNode::Envelope {
-        ref name, strategy, ..
+        ref name,
+        strategy,
+        ref header_input,
+        header_upstream,
+        ..
     } = *node
     else {
         unreachable!("dispatch_envelope called with non-Envelope node");
     };
 
-    let pred = single_predecessor(current_dag, node_idx, "envelope", name)?;
-    let (records, puncts) = match drain_node_buffer_slot(ctx, pred) {
+    // Resolve the body predecessor. With no wired header the Envelope has a
+    // single incoming neighbor (the body). With a wired header it has two — the
+    // body and the header — distinguished by `header_upstream`; the body is the
+    // other one. Draining the body slot returns its records and punctuations.
+    let header_pred = if header_input.is_empty() {
+        None
+    } else {
+        Some(resolved_header_predecessor(
+            name,
+            header_input,
+            header_upstream,
+        )?)
+    };
+    let body_pred = match header_pred {
+        Some(header_pred) => body_predecessor_excluding(current_dag, node_idx, name, header_pred)?,
+        None => single_predecessor(current_dag, node_idx, "envelope", name)?,
+    };
+    let (mut records, puncts) = match drain_node_buffer_slot(ctx, body_pred) {
         Some(nb) => nb.drain_split()?,
         None => (Vec::new(), Vec::new()),
     };
 
+    // Drain the wired header stream and replace each body grain's ambient
+    // envelope with its grain-matched header record. This runs BEFORE the
+    // per-strategy step, so `preserve` forwards the replaced headers verbatim
+    // and `concat` folds them — the replacement is strategy-independent.
+    if let Some(header_pred) = header_pred {
+        let (header_records, _header_puncts) = match drain_node_buffer_slot(ctx, header_pred) {
+            Some(nb) => nb.drain_split()?,
+            None => (Vec::new(), Vec::new()),
+        };
+        replace_headers_by_grain(name, &mut records, &header_records)?;
+    }
+
     // Exhaustive over `EnvelopeStrategy`. `preserve` forwards the body
-    // unchanged; `concat` consolidates the whole body onto one document; the
-    // synthesizing strategies are additive variants that will add their own
-    // arms. Both arms re-park into THIS node's own slot — every downstream
-    // consumer resolves its input from its predecessor's slot, so writing to
-    // `node_idx` is exactly where each successor looks (the Transform/Sort
-    // linear-producer convention, not the Route/Cull per-successor fork).
+    // (with any replaced headers) unchanged; `concat` consolidates the whole
+    // body onto one document; the synthesizing strategies are additive variants
+    // that will add their own arms. Both arms re-park into THIS node's own slot
+    // — every downstream consumer resolves its input from its predecessor's
+    // slot, so writing to `node_idx` is exactly where each successor looks (the
+    // Transform/Sort linear-producer convention, not the Route/Cull
+    // per-successor fork).
     let (records, puncts) = match strategy {
         EnvelopeStrategy::Preserve => {
-            // Leave each record's document context and grain untouched and
-            // forward the body's punctuations verbatim.
+            // Leave each record's grain untouched (header replacement, when
+            // wired, preserved the grain) and forward the body's punctuations
+            // verbatim.
             (records, puncts)
         }
         EnvelopeStrategy::Concat => consolidate(name, records, puncts)?,
@@ -118,6 +166,137 @@ pub(crate) fn dispatch_envelope(
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
     ctx.node_buffers.insert(node_idx, nb);
+    Ok(())
+}
+
+/// Unwrap the resolved header predecessor index for a node whose `header:` port
+/// is wired (non-empty `header_input`).
+///
+/// # Errors
+///
+/// Returns [`PipelineError::Internal`] when `header_upstream` is `None` despite
+/// a wired header — the resolution post-pass guarantees a wired header that
+/// passed E004 validation resolves to a predecessor, so a `None` here is an
+/// engine bug, not user error.
+fn resolved_header_predecessor(
+    name: &str,
+    header_input: &str,
+    header_upstream: Option<NodeIndex>,
+) -> Result<NodeIndex, PipelineError> {
+    header_upstream.ok_or_else(|| PipelineError::Internal {
+        op: "envelope",
+        node: name.to_string(),
+        detail: format!(
+            "wired header input {header_input:?} did not resolve to a predecessor NodeIndex"
+        ),
+    })
+}
+
+/// Resolve the body predecessor as the node's single incoming neighbor that is
+/// NOT the header predecessor. The node has two incoming neighbors when a
+/// header is wired — the body and the header.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::Internal`] when the node does not have exactly two
+/// incoming neighbors, or when neither is the header predecessor — both
+/// planner-shape invariants the resolution post-pass guarantees.
+fn body_predecessor_excluding(
+    current_dag: &ExecutionPlanDag,
+    node_idx: NodeIndex,
+    name: &str,
+    header_pred: NodeIndex,
+) -> Result<NodeIndex, PipelineError> {
+    let preds: Vec<NodeIndex> = current_dag
+        .graph
+        .neighbors_directed(node_idx, Direction::Incoming)
+        .collect();
+    match preds.as_slice() {
+        [a, b] if *a == header_pred => Ok(*b),
+        [a, b] if *b == header_pred => Ok(*a),
+        [_, _] => Err(PipelineError::Internal {
+            op: "envelope",
+            node: name.to_string(),
+            detail: "resolved header predecessor is not an incoming neighbor".to_string(),
+        }),
+        _ => Err(PipelineError::Internal {
+            op: "envelope",
+            node: name.to_string(),
+            detail: format!(
+                "envelope with a wired header expects exactly 2 predecessors, got {}",
+                preds.len()
+            ),
+        }),
+    }
+}
+
+/// Replace each body record's ambient envelope with the wired header record
+/// carried on the SAME document grain — transform-in-place header replacement.
+///
+/// The grain is the join key: a header record's
+/// [`grain`](clinker_record::DocumentContext::grain) names the body document it
+/// frames, and its
+/// [`envelope_record`](clinker_record::DocumentContext::envelope_record) is the
+/// replacement header. Each matched body record's document context is rebuilt
+/// via [`with_replaced_envelope`](clinker_record::DocumentContext::with_replaced_envelope),
+/// which keeps the grain (and the rest of the framing identity) while swapping
+/// the header — so framing boundaries, which key on grain, are unchanged and
+/// only the rendered header differs. A body grain with no wired header keeps its
+/// ambient envelope.
+///
+/// Records re-stamped onto the same grain share one `Arc<DocumentContext>`, so
+/// the replacement allocates one context per replaced grain, not per record.
+///
+/// # Errors
+///
+/// Returns [`PipelineError::EnvelopeHeaderGrainUnmatched`] (E351) when a header
+/// record carries the synthetic grain (an ungrounded, in-pipeline-synthesized
+/// record) or a grain that matches no in-flight body document — the node cannot
+/// place a header that grounds to no body.
+fn replace_headers_by_grain(
+    name: &str,
+    body: &mut [(Record, u64)],
+    header_records: &[(Record, u64)],
+) -> Result<(), PipelineError> {
+    if header_records.is_empty() {
+        return Ok(());
+    }
+
+    // The set of grains the body actually carries. A header must ground to one
+    // of these; the synthetic grain (an ungrounded record) is never among them.
+    let body_grains: std::collections::HashSet<DocumentGrain> =
+        body.iter().map(|(r, _)| r.doc_ctx().grain()).collect();
+
+    // Map each body grain to its replacement header record. Reject a header
+    // whose grain grounds to no body document (E351). A header carrying the
+    // synthetic grain is rejected by the same membership test — the synthetic
+    // grain identifies no source document, so it is never a body grain.
+    let mut header_by_grain: HashMap<DocumentGrain, EnvelopeRecord> = HashMap::new();
+    for (header, _) in header_records {
+        let grain = header.doc_ctx().grain();
+        if !body_grains.contains(&grain) {
+            return Err(PipelineError::EnvelopeHeaderGrainUnmatched {
+                envelope: name.to_string(),
+                grain: format!("{:?}", grain.document_id()),
+            });
+        }
+        header_by_grain.insert(grain, header.doc_ctx().envelope_record().clone());
+    }
+
+    // Re-stamp each matched body record with a context carrying the replacement
+    // header on the same grain. Cache one rebuilt `Arc<DocumentContext>` per
+    // grain so records of a grain share it (a refcount bump, not a re-build).
+    let mut rebuilt: HashMap<DocumentGrain, Arc<DocumentContext>> = HashMap::new();
+    for (record, _) in body.iter_mut() {
+        let grain = record.doc_ctx().grain();
+        let Some(replacement) = header_by_grain.get(&grain) else {
+            continue;
+        };
+        let ctx = rebuilt.entry(grain).or_insert_with(|| {
+            Arc::new(record.doc_ctx().with_replaced_envelope(replacement.clone()))
+        });
+        record.set_doc_ctx(Arc::clone(ctx));
+    }
     Ok(())
 }
 
@@ -216,4 +395,228 @@ fn consolidate(
     ];
 
     Ok((records, framing))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::{Schema, SchemaBuilder, Value};
+    use indexmap::IndexMap;
+
+    fn body_schema() -> Arc<Schema> {
+        SchemaBuilder::with_capacity(1).with_field("id").build()
+    }
+
+    /// An `EnvelopeRecord` with one `interchange` section carrying `batch_id`.
+    fn header_envelope(batch_id: &str) -> EnvelopeRecord {
+        let mut field = IndexMap::new();
+        field.insert(Box::from("batch_id"), Value::String(batch_id.into()));
+        let mut sections = IndexMap::new();
+        sections.insert(Box::from("interchange"), Value::Map(Box::new(field)));
+        EnvelopeRecord::from_sections(sections)
+    }
+
+    /// A document context for one file, carrying `header_batch_id` as its
+    /// ambient `interchange.batch_id`. Its grain is minted from a fresh id.
+    fn doc_ctx(file: &str, header_batch_id: &str) -> Arc<DocumentContext> {
+        Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from(file),
+            header_envelope(header_batch_id),
+        ))
+    }
+
+    fn body_record(ctx: &Arc<DocumentContext>, id: i64) -> Record {
+        let mut r = Record::new(body_schema(), vec![Value::Integer(id)]);
+        r.set_doc_ctx(Arc::clone(ctx));
+        r
+    }
+
+    /// A header record carrying `ctx`'s grain but a REPLACEMENT envelope
+    /// (`with_replaced_envelope` preserves the grain, swaps the header). This is
+    /// the shape a grain-preserving header rewrite produces: same body grain,
+    /// different header values.
+    fn header_record(ctx: &Arc<DocumentContext>, replacement: EnvelopeRecord) -> Record {
+        let mut r = Record::new(body_schema(), vec![Value::Integer(0)]);
+        r.set_doc_ctx(Arc::new(ctx.with_replaced_envelope(replacement)));
+        r
+    }
+
+    fn batch_id_of(record: &Record) -> Option<Value> {
+        record
+            .doc_ctx()
+            .get_section_field("interchange", "batch_id")
+    }
+
+    #[test]
+    fn replace_attaches_rewritten_header_to_the_matching_grain() {
+        // Two body documents (grain A carries two records, grain B one). The
+        // wired header stream carries one rewritten header per grain, on the
+        // body's grain. After replacement, each body record's ambient header is
+        // the REWRITTEN value, not the body's original ambient header — the
+        // headline transform-in-place replacement.
+        let ctx_a = doc_ctx("a.x12", "ORIG-A");
+        let ctx_b = doc_ctx("b.x12", "ORIG-B");
+        let mut body = vec![
+            (body_record(&ctx_a, 1), 0),
+            (body_record(&ctx_a, 2), 1),
+            (body_record(&ctx_b, 3), 2),
+        ];
+        let headers = vec![
+            (header_record(&ctx_a, header_envelope("REWRITTEN-A")), 0),
+            (header_record(&ctx_b, header_envelope("REWRITTEN-B")), 1),
+        ];
+
+        replace_headers_by_grain("framed", &mut body, &headers)
+            .expect("matched headers attach without error");
+
+        // The two grain-A records carry REWRITTEN-A; the grain-B record carries
+        // REWRITTEN-B. A no-op (failing to replace) would leave ORIG-* here.
+        assert_eq!(
+            batch_id_of(&body[0].0),
+            Some(Value::String("REWRITTEN-A".into())),
+            "grain-A record 1 frames with the rewritten header"
+        );
+        assert_eq!(
+            batch_id_of(&body[1].0),
+            Some(Value::String("REWRITTEN-A".into())),
+            "grain-A record 2 frames with the rewritten header"
+        );
+        assert_eq!(
+            batch_id_of(&body[2].0),
+            Some(Value::String("REWRITTEN-B".into())),
+            "grain-B record frames with its own rewritten header, not grain-A's"
+        );
+
+        // The grain (the framing key) is preserved exactly — replacement swaps
+        // only the header, so a downstream Output frames on the same grains.
+        assert_eq!(
+            body[0].0.doc_ctx().grain(),
+            ctx_a.grain(),
+            "replacement preserves the body grain (framing key) for grain A"
+        );
+        assert_eq!(
+            body[2].0.doc_ctx().grain(),
+            ctx_b.grain(),
+            "replacement preserves the body grain (framing key) for grain B"
+        );
+
+        // Records of one grain share a single rebuilt context (one allocation
+        // per replaced grain, not per record).
+        assert!(
+            Arc::ptr_eq(body[0].0.doc_ctx(), body[1].0.doc_ctx()),
+            "the two grain-A records share one rebuilt document context"
+        );
+    }
+
+    #[test]
+    fn body_grain_without_a_wired_header_keeps_its_ambient_envelope() {
+        // Grain A has a wired replacement header; grain B has none. Grain B must
+        // keep its ambient header untouched — replacement is per-matched-grain,
+        // not all-or-nothing.
+        let ctx_a = doc_ctx("a.x12", "ORIG-A");
+        let ctx_b = doc_ctx("b.x12", "ORIG-B");
+        let mut body = vec![(body_record(&ctx_a, 1), 0), (body_record(&ctx_b, 2), 1)];
+        let headers = vec![(header_record(&ctx_a, header_envelope("REWRITTEN-A")), 0)];
+
+        replace_headers_by_grain("framed", &mut body, &headers)
+            .expect("a partial header stream is valid");
+
+        assert_eq!(
+            batch_id_of(&body[0].0),
+            Some(Value::String("REWRITTEN-A".into())),
+            "grain A frames with its replacement header"
+        );
+        assert_eq!(
+            batch_id_of(&body[1].0),
+            Some(Value::String("ORIG-B".into())),
+            "grain B, having no wired header, keeps its ambient header"
+        );
+        assert!(
+            Arc::ptr_eq(body[1].0.doc_ctx(), &ctx_b),
+            "an unreplaced grain keeps its original context Arc untouched"
+        );
+    }
+
+    #[test]
+    fn header_grain_matching_no_body_grain_is_e351() {
+        // The wired header carries a grain (file c.x12) absent from the body
+        // (files a/b). The node cannot place a header that grounds to no body
+        // document, so it aborts with E351 — pin the code AND the variant.
+        let ctx_a = doc_ctx("a.x12", "ORIG-A");
+        let ctx_orphan = doc_ctx("c.x12", "ORPHAN");
+        let mut body = vec![(body_record(&ctx_a, 1), 0)];
+        let headers = vec![(
+            header_record(&ctx_orphan, header_envelope("REWRITTEN-C")),
+            0,
+        )];
+
+        let err = replace_headers_by_grain("framed", &mut body, &headers)
+            .expect_err("an unmatched header grain must abort");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("E351"),
+            "the unmatched-grain abort pins diagnostic code E351, got: {msg}"
+        );
+        match err {
+            PipelineError::EnvelopeHeaderGrainUnmatched { envelope, grain } => {
+                assert_eq!(envelope, "framed", "the diagnostic names the node");
+                let expected = format!("{:?}", ctx_orphan.grain().document_id());
+                assert_eq!(
+                    grain, expected,
+                    "the payload carries the offending header's grain"
+                );
+            }
+            other => panic!("expected EnvelopeHeaderGrainUnmatched, got: {other:?}"),
+        }
+
+        // The body is left untouched on the error path (no partial replacement).
+        assert_eq!(
+            batch_id_of(&body[0].0),
+            Some(Value::String("ORIG-A".into())),
+            "a rejected header stream leaves the body's ambient headers intact"
+        );
+    }
+
+    #[test]
+    fn header_with_synthetic_grain_is_e351() {
+        // A header record carrying the synthetic (ungrounded) grain — the grain
+        // a Transform stamps onto an in-pipeline-synthesized record — grounds to
+        // no body document and is rejected, even though the body is non-empty.
+        let ctx_a = doc_ctx("a.x12", "ORIG-A");
+        let mut body = vec![(body_record(&ctx_a, 1), 0)];
+        // A record left on the synthetic context (Record::new default).
+        let synthetic_header = Record::new(body_schema(), vec![Value::Integer(0)]);
+        assert_eq!(
+            synthetic_header.doc_ctx().grain(),
+            DocumentGrain::SYNTHETIC,
+            "the default-constructed record carries the synthetic grain"
+        );
+        let headers = vec![(synthetic_header, 0)];
+
+        let err = replace_headers_by_grain("framed", &mut body, &headers)
+            .expect_err("a synthetic-grain header must abort");
+        assert!(
+            matches!(err, PipelineError::EnvelopeHeaderGrainUnmatched { .. }),
+            "a synthetic grain is rejected as ungrounded: {err}"
+        );
+    }
+
+    #[test]
+    fn an_empty_header_stream_is_a_no_op() {
+        // No wired header records → the body passes through unchanged (the
+        // strategy then frames with each grain's ambient header).
+        let ctx_a = doc_ctx("a.x12", "ORIG-A");
+        let mut body = vec![(body_record(&ctx_a, 1), 0)];
+        replace_headers_by_grain("framed", &mut body, &[]).expect("empty header stream is valid");
+        assert_eq!(
+            batch_id_of(&body[0].0),
+            Some(Value::String("ORIG-A".into())),
+            "an empty header stream leaves the ambient header in place"
+        );
+        assert!(
+            Arc::ptr_eq(body[0].0.doc_ctx(), &ctx_a),
+            "an empty header stream leaves the context Arc untouched"
+        );
+    }
 }

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -88,6 +88,10 @@ use clinker_record::{DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord,
 /// Returns [`PipelineError::EnvelopeHeaderGrainUnmatched`] (E351) when a wired
 /// header record carries a grain that grounds to no in-flight body grain (or is
 /// the synthetic / ungrounded grain), so the node cannot place it by grain.
+///
+/// Returns [`PipelineError::EnvelopeHeaderMultipleForGrain`] (E352) when the
+/// wired header stream carries two or more records for one body grain — exactly
+/// one header record per document grain is required.
 pub(crate) fn dispatch_envelope(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
@@ -132,6 +136,10 @@ pub(crate) fn dispatch_envelope(
     // per-strategy step, so `preserve` forwards the replaced headers verbatim
     // and `concat` folds them — the replacement is strategy-independent.
     if let Some(header_pred) = header_pred {
+        // The header stream's own punctuations are intentionally dropped: the
+        // body's punctuations drive output framing, and the header is a
+        // 1-row-per-grain metadata stream whose document boundaries are not part
+        // of the framed body.
         let (header_records, _header_puncts) = match drain_node_buffer_slot(ctx, header_pred) {
             Some(nb) => nb.drain_split()?,
             None => (Vec::new(), Vec::new()),
@@ -245,7 +253,9 @@ fn body_predecessor_excluding(
 /// ambient envelope.
 ///
 /// Records re-stamped onto the same grain share one `Arc<DocumentContext>`, so
-/// the replacement allocates one context per replaced grain, not per record.
+/// the replacement allocates one context per replaced grain, not per record. The
+/// header `EnvelopeRecord` is cloned exactly once per grain — when that single
+/// shared context is built — never copied into an intermediate map.
 ///
 /// # Errors
 ///
@@ -253,6 +263,10 @@ fn body_predecessor_excluding(
 /// record carries the synthetic grain (an ungrounded, in-pipeline-synthesized
 /// record) or a grain that matches no in-flight body document — the node cannot
 /// place a header that grounds to no body.
+///
+/// Returns [`PipelineError::EnvelopeHeaderMultipleForGrain`] (E352) when two or
+/// more header records carry the SAME body grain — exactly one header record per
+/// document grain is required, so a second is silent data loss, not a fold.
 fn replace_headers_by_grain(
     name: &str,
     body: &mut [(Record, u64)],
@@ -267,12 +281,16 @@ fn replace_headers_by_grain(
     let body_grains: std::collections::HashSet<DocumentGrain> =
         body.iter().map(|(r, _)| r.doc_ctx().grain()).collect();
 
-    // Map each body grain to its replacement header record. Reject a header
-    // whose grain grounds to no body document (E351). A header carrying the
-    // synthetic grain is rejected by the same membership test — the synthetic
-    // grain identifies no source document, so it is never a body grain.
-    let mut header_by_grain: HashMap<DocumentGrain, EnvelopeRecord> = HashMap::new();
-    for (header, _) in header_records {
+    // Index each body grain to its replacement header record (by position in
+    // `header_records`, so the envelope is not cloned here — it is cloned once,
+    // later, into the single shared context per grain). Reject a header whose
+    // grain grounds to no body document (E351); the synthetic grain fails the
+    // same membership test, as it names no source document. Reject a SECOND
+    // header on a grain already mapped (E352): one header per grain is the
+    // node's locked invariant, and last-write-wins would silently drop the
+    // first header.
+    let mut header_idx_by_grain: HashMap<DocumentGrain, usize> = HashMap::new();
+    for (pos, (header, _)) in header_records.iter().enumerate() {
         let grain = header.doc_ctx().grain();
         if !body_grains.contains(&grain) {
             return Err(PipelineError::EnvelopeHeaderGrainUnmatched {
@@ -280,19 +298,26 @@ fn replace_headers_by_grain(
                 grain: format!("{:?}", grain.document_id()),
             });
         }
-        header_by_grain.insert(grain, header.doc_ctx().envelope_record().clone());
+        if header_idx_by_grain.insert(grain, pos).is_some() {
+            return Err(PipelineError::EnvelopeHeaderMultipleForGrain {
+                envelope: name.to_string(),
+                grain: format!("{:?}", grain.document_id()),
+            });
+        }
     }
 
     // Re-stamp each matched body record with a context carrying the replacement
     // header on the same grain. Cache one rebuilt `Arc<DocumentContext>` per
-    // grain so records of a grain share it (a refcount bump, not a re-build).
+    // grain so records of a grain share it (a refcount bump, not a re-build);
+    // the header envelope is cloned exactly once, into that shared context.
     let mut rebuilt: HashMap<DocumentGrain, Arc<DocumentContext>> = HashMap::new();
     for (record, _) in body.iter_mut() {
         let grain = record.doc_ctx().grain();
-        let Some(replacement) = header_by_grain.get(&grain) else {
+        let Some(&header_pos) = header_idx_by_grain.get(&grain) else {
             continue;
         };
         let ctx = rebuilt.entry(grain).or_insert_with(|| {
+            let replacement = header_records[header_pos].0.doc_ctx().envelope_record();
             Arc::new(record.doc_ctx().with_replaced_envelope(replacement.clone()))
         });
         record.set_doc_ctx(Arc::clone(ctx));
@@ -599,6 +624,44 @@ mod tests {
         assert!(
             matches!(err, PipelineError::EnvelopeHeaderGrainUnmatched { .. }),
             "a synthetic grain is rejected as ungrounded: {err}"
+        );
+    }
+
+    #[test]
+    fn two_headers_on_one_grain_is_e352() {
+        // The wired header stream carries TWO records on grain A — a duplicate
+        // header for one body document. The node attaches exactly one header per
+        // grain and has no fold rule for a second, so it aborts with E352 rather
+        // than silently last-write-wins (which would drop the first header). Pin
+        // the code AND the variant payload.
+        let ctx_a = doc_ctx("a.x12", "ORIG-A");
+        let mut body = vec![(body_record(&ctx_a, 1), 0)];
+        let headers = vec![
+            (header_record(&ctx_a, header_envelope("REWRITE-1")), 0),
+            (header_record(&ctx_a, header_envelope("REWRITE-2")), 1),
+        ];
+
+        let err = replace_headers_by_grain("framed", &mut body, &headers)
+            .expect_err("two headers on one grain must abort");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("E352"),
+            "the duplicate-header abort pins diagnostic code E352, got: {msg}"
+        );
+        match err {
+            PipelineError::EnvelopeHeaderMultipleForGrain { envelope, grain } => {
+                assert_eq!(envelope, "framed", "the diagnostic names the node");
+                let expected = format!("{:?}", ctx_a.grain().document_id());
+                assert_eq!(grain, expected, "the payload carries the duplicated grain");
+            }
+            other => panic!("expected EnvelopeHeaderMultipleForGrain, got: {other:?}"),
+        }
+
+        // The body is left untouched on the error path (no partial replacement).
+        assert_eq!(
+            batch_id_of(&body[0].0),
+            Some(Value::String("ORIG-A".into())),
+            "a rejected header stream leaves the body's ambient header intact"
         );
     }
 

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -73,7 +73,8 @@ mod tests {
                 | PipelineError::UnsatisfiableMemoryBudget { .. }
                 | PipelineError::CombineMissingMatch { .. }
                 | PipelineError::EnvelopeMultiHeaderConflict { .. }
-                | PipelineError::EnvelopeHeaderGrainUnmatched { .. },
+                | PipelineError::EnvelopeHeaderGrainUnmatched { .. }
+                | PipelineError::EnvelopeHeaderMultipleForGrain { .. },
             ) => 1,
             Err(
                 PipelineError::Eval(_)

--- a/crates/clinker-exec/src/integration_tests.rs
+++ b/crates/clinker-exec/src/integration_tests.rs
@@ -72,7 +72,8 @@ mod tests {
                 | PipelineError::MemoryBudgetExceeded { .. }
                 | PipelineError::UnsatisfiableMemoryBudget { .. }
                 | PipelineError::CombineMissingMatch { .. }
-                | PipelineError::EnvelopeMultiHeaderConflict { .. },
+                | PipelineError::EnvelopeMultiHeaderConflict { .. }
+                | PipelineError::EnvelopeHeaderGrainUnmatched { .. },
             ) => 1,
             Err(
                 PipelineError::Eval(_)

--- a/crates/clinker-exec/tests/envelope_node.rs
+++ b/crates/clinker-exec/tests/envelope_node.rs
@@ -1360,3 +1360,259 @@ fn concat_envelope_merges_all_files_into_one_aggregate_flush() {
         "concat and preserve must differ — concat merged the document framing",
     );
 }
+
+// ─── Wired `header:` port (transform-in-place header replacement) ────────
+//
+// A wired `header:` port replaces each body grain's ambient envelope with the
+// matching header record, attached by grain. These tests cover the plan-level
+// wiring (the header input resolves to its predecessor), the end-to-end error
+// path (a header grounded to no body grain aborts the whole run with E351), and
+// the still-rejected `trailer:` port. The grain-matched replacement itself is
+// proved by the `replace_headers_by_grain` unit tests in `envelope_dispatch`,
+// which control grains directly — two independent sources cannot share a grain.
+
+/// A two-source pipeline: a body source and a separate header source, each
+/// transformed and wired into an Envelope node as `body:` / `header:`.
+fn header_port_pipeline() -> String {
+    r#"
+pipeline:
+  name: envelope_header_port
+nodes:
+  - type: source
+    name: body_src
+    config:
+      name: body_src
+      type: csv
+      path: body.csv
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: hdr_src
+    config:
+      name: hdr_src
+      type: csv
+      path: hdr.csv
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: body
+    input: body_src
+    config:
+      cxl: "emit id = id"
+  - type: transform
+    name: hdr
+    input: hdr_src
+    config:
+      cxl: "emit id = id"
+  - type: envelope
+    name: framed
+    body: body
+    header: hdr
+    config: { strategy: preserve }
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    .to_string()
+}
+
+#[test]
+fn wired_header_resolves_to_its_predecessor() {
+    // The Envelope's `header_input` lowers to the producer name `hdr`, and the
+    // resolution post-pass stamps `header_upstream` with that producer's
+    // NodeIndex — distinct from the body predecessor. Without resolution the
+    // executor cannot tell the two predecessors apart.
+    use clinker_plan::plan::execution::PlanNode;
+
+    let config = clinker_plan::config::parse_config(&header_port_pipeline())
+        .expect("a wired header port parses and validates");
+    let compiled = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("a wired header port compiles");
+    let graph = &compiled.dag().graph;
+
+    let envelope_idx = graph
+        .node_indices()
+        .find(|&i| matches!(&graph[i], PlanNode::Envelope { .. }))
+        .expect("the plan has an Envelope node");
+
+    let PlanNode::Envelope {
+        header_input,
+        header_upstream,
+        ..
+    } = &graph[envelope_idx]
+    else {
+        unreachable!("located by the Envelope match above");
+    };
+    assert_eq!(
+        header_input, "hdr",
+        "the wired header producer name lowers onto the plan node"
+    );
+    let resolved = header_upstream.expect("the wired header resolves to a predecessor NodeIndex");
+    assert_eq!(
+        graph[resolved].name(),
+        "hdr",
+        "header_upstream points at the header producer, not the body"
+    );
+
+    // The header predecessor is genuinely one of the two incoming neighbors,
+    // and the OTHER one is the body — the discriminator the executor relies on.
+    let preds: Vec<_> = graph
+        .neighbors_directed(envelope_idx, petgraph::Direction::Incoming)
+        .collect();
+    assert_eq!(preds.len(), 2, "a wired header gives the Envelope 2 inputs");
+    assert!(
+        preds.contains(&resolved),
+        "the resolved header predecessor is an incoming neighbor"
+    );
+    let body_pred = preds
+        .iter()
+        .find(|&&p| p != resolved)
+        .expect("a distinct body predecessor remains");
+    assert_eq!(
+        graph[*body_pred].name(),
+        "body",
+        "the non-header predecessor is the body producer"
+    );
+}
+
+#[test]
+fn wired_header_grain_unmatched_to_body_is_e351_end_to_end() {
+    // Two independent sources mint independent document grains, so the header
+    // records ground to grains the body never carries. Driven through the full
+    // executor, the run aborts with E351 — proving the wired header is drained
+    // and attach-by-grain runs end to end, not just in isolation.
+    let mut config =
+        clinker_plan::config::parse_config(&header_port_pipeline()).expect("parse header pipeline");
+    for spanned in &mut config.nodes {
+        if let clinker_plan::config::PipelineNode::Source { config: body, .. } = &mut spanned.value
+        {
+            body.source.path = None;
+        }
+    }
+    let plan = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("compile header pipeline");
+
+    // One body document (file b.csv) and one header document (file h.csv).
+    let body_steps = vec![
+        Step::Open {
+            file: "b.csv",
+            name: "interchange",
+            tag_val: "BODY",
+            frame: FrameRole::NewFrame,
+        },
+        Step::Record {
+            file: "b.csv",
+            id: 1,
+        },
+        Step::Close { file: "b.csv" },
+    ];
+    let hdr_steps = vec![
+        Step::Open {
+            file: "h.csv",
+            name: "interchange",
+            tag_val: "HEADER",
+            frame: FrameRole::NewFrame,
+        },
+        Step::Record {
+            file: "h.csv",
+            id: 9,
+        },
+        Step::Close { file: "h.csv" },
+    ];
+
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([
+        (
+            "body_src".to_string(),
+            SourceInput::Records(Box::new(ScriptedReader::new(body_steps))),
+        ),
+        (
+            "hdr_src".to_string(),
+            SourceInput::Records(Box::new(ScriptedReader::new(hdr_steps))),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    let err = PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams {
+            execution_id: "hdr-exec".to_string(),
+            batch_id: "hdr-batch".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect_err("a header grounded to no body grain must abort the run");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("E351"),
+        "the unmatched-grain abort pins E351 end to end, got: {msg}"
+    );
+    match err {
+        clinker_plan::error::PipelineError::EnvelopeHeaderGrainUnmatched { envelope, .. } => {
+            assert_eq!(envelope, "framed", "the diagnostic names the Envelope node");
+        }
+        other => panic!("expected EnvelopeHeaderGrainUnmatched, got: {other:?}"),
+    }
+}
+
+#[test]
+fn wired_trailer_is_rejected_at_validation() {
+    // `trailer:` has no draining path yet, so a wired value is still a config
+    // error — narrowed from the prior header+trailer rejection to trailer only.
+    let yaml = r#"
+pipeline:
+  name: envelope_trailer
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: body
+    input: src
+    config:
+      cxl: "emit id = id"
+  - type: transform
+    name: tail
+    input: src
+    config:
+      cxl: "emit id = id"
+  - type: envelope
+    name: framed
+    body: body
+    trailer: tail
+    config: { strategy: preserve }
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = clinker_plan::config::parse_config(yaml)
+        .expect_err("a wired trailer port is still rejected at validation");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("envelope node 'framed'")
+            && msg.contains("`trailer`")
+            && msg.contains("not yet supported"),
+        "the rejection still names the trailer port specifically, got: {msg}"
+    );
+}

--- a/crates/clinker-plan/src/config/node_header.rs
+++ b/crates/clinker-plan/src/config/node_header.rs
@@ -234,17 +234,18 @@ impl Serialize for CombineHeader {
 /// Header for envelope nodes — a required `body:` input plus two optional
 /// `header:` / `trailer:` ports.
 ///
-/// The `body:` stream is the records the node frames into documents; the
-/// `header:` and `trailer:` ports name streams whose records prepend / append
-/// to each framed document. This slice accepts both optional ports in the YAML
-/// shape but rejects a *wired* value at plan validation — the `preserve`
-/// strategy frames each body record with the body's own ambient envelope and
-/// reads no second stream. A later release wires them.
+/// The `body:` stream is the records the node frames into documents. A wired
+/// `header:` port is a 1-row-per-grain header stream whose records **replace**
+/// each body document's ambient envelope, matched by [`DocumentGrain`]
+/// (transform-in-place header replacement). The `trailer:` port has no draining
+/// path yet — a wired value is rejected at plan validation this release.
 ///
 /// Each input reference carries a [`Spanned`] wrapper so a diagnostic on an
 /// undeclared upstream can point at the exact YAML line/column. The
 /// `Serialize` impl is hand-rolled to drop the spans and skip the two unset
 /// optional ports, so the YAML round-trip shape is unchanged.
+///
+/// [`DocumentGrain`]: clinker_record::DocumentGrain
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct EnvelopeHeader {
@@ -253,11 +254,12 @@ pub struct EnvelopeHeader {
     pub description: Option<String>,
     /// The records this node frames into documents. Required.
     pub body: Spanned<NodeInput>,
-    /// Optional header-record stream. Accepted in config; a wired value is
-    /// rejected at plan validation this release (its draining lands later).
+    /// Optional header-record stream. A wired value replaces each body grain's
+    /// ambient envelope with the matching header record, attached by grain.
     #[serde(default)]
     pub header: Option<Spanned<NodeInput>>,
-    /// Optional trailer-record stream. Same not-yet-wired status as `header`.
+    /// Optional trailer-record stream. Rejected when wired this release — its
+    /// draining path lands later.
     #[serde(default)]
     pub trailer: Option<Spanned<NodeInput>>,
     #[serde(default, rename = "_notes")]

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -1972,6 +1972,16 @@ impl PipelineConfig {
             self.pipeline.memory.limit.as_deref(),
         );
 
+        // Envelope header-port resolution post-pass. Runs after every DAG edge
+        // is built and correlation Sorts are spliced, so a wired `header:` port
+        // resolves to its predecessor `NodeIndex` (the executor reads it to
+        // drain the header stream separately from the body). Composition body
+        // mini-DAGs hold their own Envelope nodes, so sweep them too.
+        crate::plan::execution::resolve_envelope_header_upstreams(&mut dag);
+        for body in artifacts.composition_bodies.values_mut() {
+            crate::plan::execution::resolve_envelope_header_upstreams_in_graph(&mut body.graph);
+        }
+
         // Per-node input-volume byte estimates. Runs last among the
         // property passes so the resolved aggregation/combine strategies
         // are visible (blocking-ness is read from the same arbitration
@@ -3450,15 +3460,31 @@ pub(crate) fn lower_node_to_plan_node(
                 output_schema: schema_from_bound(name),
             })
         }
-        // Envelope lowers to a single-output pass-through carrying the framing
-        // strategy and the body's (unchanged) output schema. A missing typed
-        // entry means bind_schema could not resolve the body input — skip.
-        PipelineNode::Envelope { config, .. } => {
+        // Envelope lowers carrying the framing strategy, the body's (unchanged)
+        // output schema, and — when a `header:` port is wired — the producer
+        // name of that header stream. The resolved `header_upstream` NodeIndex
+        // stays `None` here because the DAG edges (and any spliced correlation
+        // Sort) do not exist until after lowering; the
+        // `resolve_envelope_header_upstreams` post-pass fills it. A missing
+        // typed entry means bind_schema could not resolve the body input — skip.
+        PipelineNode::Envelope { header, config } => {
             artifacts.typed.get(name)?;
+            let header_input = header
+                .header
+                .as_ref()
+                .map(|h| match &h.value {
+                    crate::config::node_header::NodeInput::Single(s) => s.clone(),
+                    crate::config::node_header::NodeInput::Port { node, port } => {
+                        format!("{node}.{port}")
+                    }
+                })
+                .unwrap_or_default();
             Some(crate::plan::execution::PlanNode::Envelope {
                 name: name.to_string(),
                 span,
                 strategy: config.strategy,
+                header_input,
+                header_upstream: None,
                 output_schema: schema_from_bound(name),
             })
         }
@@ -3995,27 +4021,21 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         }
     }
 
-    // Reject a wired `header:` / `trailer:` port on an Envelope node. The
-    // `preserve` strategy frames each body record with the body's own ambient
-    // envelope and reads no second stream, so an explicit header/trailer input
-    // would silently do nothing. A later release wires them; until then a wired
-    // value is a clear configuration error rather than a no-op.
+    // Reject a wired `trailer:` port on an Envelope node. A wired `header:` is
+    // now a real port (it replaces each body grain's ambient envelope with a
+    // grain-matched header record), but `trailer:` has no draining path yet, so
+    // a wired value would silently do nothing. The undeclared-producer case for
+    // a wired `header:` is caught earlier by the unified input-reference pass
+    // (E004), exactly as for any other consumer input.
     for spanned in &config.nodes {
-        if let PipelineNode::Envelope { header, .. } = &spanned.value {
-            let wired = if header.header.is_some() {
-                Some("header")
-            } else if header.trailer.is_some() {
-                Some("trailer")
-            } else {
-                None
-            };
-            if let Some(port) = wired {
-                return Err(ConfigError::Validation(format!(
-                    "envelope node '{}': explicit `{port}` input wiring is not yet supported — \
-                     omit it to frame with the body's own envelope",
-                    header.name
-                )));
-            }
+        if let PipelineNode::Envelope { header, .. } = &spanned.value
+            && header.trailer.is_some()
+        {
+            return Err(ConfigError::Validation(format!(
+                "envelope node '{}': explicit `trailer` input wiring is not yet supported — \
+                 omit it to frame with the body's own envelope",
+                header.name
+            )));
         }
     }
 

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -153,12 +153,12 @@ pub enum PipelineNode {
     /// Combine / Aggregate), mirroring the message/EDI/XML envelope-wrapper
     /// prior art.
     ///
-    /// This slice ships the `preserve` strategy only — one framed document per
-    /// body grain, byte-identical to today's per-document framing. The body
-    /// records pass through with their document context and grain unchanged;
-    /// the optional `header:` / `trailer:` ports are accepted in config but a
-    /// wired value is rejected at plan validation until a later release wires
-    /// them.
+    /// The `preserve` strategy frames one document per body grain (byte-
+    /// identical to per-document framing); `concat` collapses a multi-document
+    /// body into one. A wired `header:` port replaces each body grain's ambient
+    /// envelope with a grain-matched header record (transform-in-place header
+    /// replacement); the `trailer:` port is accepted in config but rejected when
+    /// wired at plan validation until a later release wires it.
     Envelope {
         #[serde(flatten)]
         header: EnvelopeHeader,
@@ -2685,22 +2685,48 @@ nodes:
     }
 
     #[test]
-    fn envelope_rejects_wired_header_port() {
-        // A wired `header:` is accepted by the YAML shape but rejected at plan
-        // validation this release — `preserve` reads only the body's own
-        // ambient envelope. Pin the not-yet-supported message.
-        let yaml = pipeline_with_envelope(
-            "  - type: envelope\n    name: framed\n    body: body\n    header: body\n    \
-             config: { strategy: preserve }\n",
+    fn envelope_accepts_wired_header_port() {
+        // A wired `header:` is now a real port — it replaces each body grain's
+        // ambient envelope with a grain-matched header record — so validation
+        // must accept it and the parsed `EnvelopeHeader` must carry the wired
+        // reference. The header producer is a distinct transform off the source.
+        let yaml = format!(
+            r#"
+pipeline:
+  name: envelope_cfg
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: id, type: int }}
+  - type: transform
+    name: body
+    input: src
+    config:
+      cxl: "emit id = id"
+  - type: transform
+    name: hdr
+    input: src
+    config:
+      cxl: "emit id = id"
+{}"#,
+            "  - type: envelope\n    name: framed\n    body: body\n    header: hdr\n    \
+             config: { strategy: preserve }\n"
         );
-        let err = crate::config::parse_config(&yaml)
-            .expect_err("a wired header port must be rejected at validation");
-        let msg = err.to_string();
+        let config = crate::config::parse_config(&yaml)
+            .expect("a wired header port must pass validation now that it is a real port");
+        let (header, _) = envelope_of(&config);
         assert!(
-            msg.contains("envelope node 'framed'")
-                && msg.contains("`header`")
-                && msg.contains("not yet supported"),
-            "error must explain the not-yet-supported header wiring, got: {msg}"
+            matches!(&header.header, Some(h) if h.value.name() == "hdr"),
+            "the wired header reference must survive parse as `hdr`"
+        );
+        assert!(
+            header.trailer.is_none(),
+            "no trailer was wired in this fixture"
         );
     }
 

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -205,6 +205,22 @@ pub enum PipelineError {
         envelope: String,
         header_count: usize,
     },
+    /// E351 — an Envelope node with a wired `header:` port received a header
+    /// record whose document grain matches no in-flight body grain (or is the
+    /// synthetic / ungrounded grain a Transform stamps onto an in-pipeline-
+    /// synthesized record). The node attaches a header to a body strictly by
+    /// grain, so it cannot place a header that grounds to no body document —
+    /// doing so would either drop the header or mis-frame an unrelated document.
+    /// The fix is to carry the body's grain forward onto the header record: a
+    /// grain-preserving Transform of the source's promoted header keeps it, and
+    /// a replacement from a different source establishes it via a business-key
+    /// join against the body. `envelope` names the node; `grain` is the
+    /// offending header record's grain rendered for the diagnostic. Always
+    /// aborts the run.
+    EnvelopeHeaderGrainUnmatched {
+        envelope: String,
+        grain: String,
+    },
     /// E320 — the cumulative on-disk size of the run's spill files crossed
     /// the configured `storage.spill.disk_cap_bytes` quota. Deliberately
     /// distinct from E310 (`MemoryBudgetExceeded`): a run can sit well
@@ -397,6 +413,17 @@ impl fmt::Display for PipelineError {
                  headers identical upstream, or add a header-folding strategy \
                  that declares which header the consolidated document keeps. \
                  See: clinker explain --code E350"
+            ),
+            Self::EnvelopeHeaderGrainUnmatched { envelope, grain } => write!(
+                f,
+                "E351 envelope '{envelope}': a wired header record carries document \
+                 grain {grain}, which matches no in-flight body grain (or is a \
+                 synthetic / ungrounded grain). The node attaches a header to a body \
+                 strictly by grain, so it cannot place a header that grounds to no \
+                 body document. Carry the body's grain onto the header record — a \
+                 grain-preserving transform of the source's promoted header keeps it, \
+                 or a business-key join against the body establishes it. \
+                 See: clinker explain --code E351"
             ),
             Self::SpillCapExceeded {
                 node,

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -221,6 +221,20 @@ pub enum PipelineError {
         envelope: String,
         grain: String,
     },
+    /// E352 — an Envelope node with a wired `header:` port received two or more
+    /// header records carrying the SAME body document grain. The node attaches
+    /// exactly one header per document grain, so a second header on a grain is
+    /// ambiguous: keeping last-write-wins would silently drop the earlier header
+    /// (data loss), and the node has no fold rule to reconcile them. The fix is
+    /// to deduplicate the header stream to one record per grain upstream — an
+    /// Aggregate or distinct keyed on the grain's business key, or a Transform
+    /// that emits a single rewritten header per source document. `envelope`
+    /// names the node; `grain` is the offending duplicated grain rendered for
+    /// the diagnostic. Always aborts the run.
+    EnvelopeHeaderMultipleForGrain {
+        envelope: String,
+        grain: String,
+    },
     /// E320 — the cumulative on-disk size of the run's spill files crossed
     /// the configured `storage.spill.disk_cap_bytes` quota. Deliberately
     /// distinct from E310 (`MemoryBudgetExceeded`): a run can sit well
@@ -424,6 +438,17 @@ impl fmt::Display for PipelineError {
                  grain-preserving transform of the source's promoted header keeps it, \
                  or a business-key join against the body establishes it. \
                  See: clinker explain --code E351"
+            ),
+            Self::EnvelopeHeaderMultipleForGrain { envelope, grain } => write!(
+                f,
+                "E352 envelope '{envelope}': the wired header input carries two or \
+                 more records for document grain {grain} — exactly one header \
+                 record per document grain is required. The node attaches one \
+                 header per grain and has no rule to fold a second, so it will not \
+                 silently drop one. Deduplicate the header stream to one record \
+                 per grain upstream (an aggregate or distinct on the grain's \
+                 business key, or a transform that emits a single rewritten header \
+                 per source document). See: clinker explain --code E352"
             ),
             Self::SpillCapExceeded {
                 node,

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -2056,9 +2056,9 @@ fn bind_schema_inner(
             // Envelope adopts the body input's schema verbatim — neither
             // strategy widens it: `preserve` passes body records through
             // unchanged, and `concat` changes only the framing grain and the
-            // ambient `$doc` view, not the record schema. The optional
-            // `header:` / `trailer:` ports are rejected when wired at
-            // `validate_config`, so binding reads only the body input here.
+            // ambient `$doc` view, not the record schema. A wired `header:` port
+            // replaces the framing header (not the record schema), so binding
+            // reads only the body input for the output row here.
             PipelineNode::Envelope { header, .. } => {
                 if let Some(upstream) = upstream_schema(&header.body.value, schema_by_name) {
                     let row = upstream.clone();

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -928,11 +928,10 @@ pub(crate) fn select_combine_strategies_in_graph(
                 graph
                     .neighbors_directed(idx, petgraph::Direction::Incoming)
                     .find(|&p| {
-                        let pname = graph[p].name();
-                        pname == driver_name.as_ref()
-                            || pname
-                                .strip_prefix(crate::plan::execution::CORRELATION_SORT_PREFIX)
-                                .is_some_and(|stripped| stripped == driver_name.as_ref())
+                        crate::plan::execution::matches_upstream_name(
+                            graph[p].name(),
+                            driver_name.as_ref(),
+                        )
                     })
             });
 

--- a/crates/clinker-plan/src/plan/execution/enforcer.rs
+++ b/crates/clinker-plan/src/plan/execution/enforcer.rs
@@ -28,6 +28,23 @@ pub const CORRELATION_SORT_PREFIX: &str = "__correlation_sort_";
 /// User node names matching this prefix are rejected at compile time.
 pub const CORRELATION_COMMIT_PREFIX: &str = "__correlation_commit_";
 
+/// Match a predecessor node's name against a producer `target` name, treating a
+/// [`CORRELATION_SORT_PREFIX`]-prefixed Sort as an alias for the source it was
+/// spliced behind.
+///
+/// `inject_correlation_sort` splices a synthetic `__correlation_sort_<source>`
+/// Sort between a source and its consumers; the suffix is the original source
+/// name. An input named for that source therefore matches either the source
+/// directly or the splice alias. Shared by Combine driver resolution and Envelope
+/// header-port resolution, which both find a wired input among incoming neighbors
+/// by name.
+pub fn matches_upstream_name(node_name: &str, target: &str) -> bool {
+    node_name == target
+        || node_name
+            .strip_prefix(CORRELATION_SORT_PREFIX)
+            .is_some_and(|stripped| stripped == target)
+}
+
 impl ExecutionPlanDag {
     /// Enforcer-sort insertion.
     ///

--- a/crates/clinker-plan/src/plan/execution/graph_util.rs
+++ b/crates/clinker-plan/src/plan/execution/graph_util.rs
@@ -1,7 +1,7 @@
 //! Plan-graph lookups over a compiled [`ExecutionPlanDag`] shared by the
 //! planner's strategy-selection passes and the runtime dispatch.
 
-use super::{ExecutionPlanDag, PlanNode};
+use super::{CORRELATION_SORT_PREFIX, ExecutionPlanDag, PlanNode};
 use crate::error::PipelineError;
 use petgraph::Direction;
 
@@ -70,5 +70,78 @@ pub fn single_predecessor(
             node: node_name.to_string(),
             detail: format!("expected exactly 1 predecessor, got {}", preds.len()),
         }),
+    }
+}
+
+/// Resolve every top-level `PlanNode::Envelope`'s wired `header:` port to its
+/// predecessor `NodeIndex`, stamping `header_upstream` in place.
+///
+/// An Envelope with a wired header has TWO incoming neighbors (body + header),
+/// so the executor cannot use [`single_predecessor`] to find the body — it must
+/// know which predecessor carries the header. This post-pass matches the
+/// lowered `header_input` producer name against the node's incoming neighbors,
+/// mirroring the Combine driver resolution. The match strips the
+/// [`CORRELATION_SORT_PREFIX`] so a header stream spliced behind an injected
+/// correlation Sort still resolves to that Sort's index.
+///
+/// Runs after the DAG is fully enriched (all edges built, correlation Sorts
+/// spliced). Envelope nodes with no wired header (`header_input` empty) are
+/// skipped — `header_upstream` stays `None` and the executor frames with each
+/// body grain's ambient envelope. A non-empty `header_input` that matches no
+/// incoming neighbor also leaves `header_upstream` `None`; the executor then
+/// fails fast with an `Internal` error, because a header named at lowering must
+/// have produced an edge (the undeclared-producer case was already rejected at
+/// E004 validation).
+pub fn resolve_envelope_header_upstreams(plan: &mut ExecutionPlanDag) {
+    resolve_envelope_header_upstreams_in_graph(&mut plan.graph);
+}
+
+/// Per-graph core of [`resolve_envelope_header_upstreams`].
+///
+/// Split out so the same resolution runs over the top-level
+/// [`ExecutionPlanDag`] graph AND over each composition body's mini-DAG —
+/// body graphs hold their own `PlanNode::Envelope` nodes the top-level pass
+/// cannot reach, exactly like the Combine strategy-selection body sweep.
+pub(crate) fn resolve_envelope_header_upstreams_in_graph(
+    graph: &mut petgraph::graph::DiGraph<PlanNode, super::PlanEdge>,
+) {
+    let envelope_indices: Vec<petgraph::graph::NodeIndex> = graph
+        .node_indices()
+        .filter(|&idx| {
+            matches!(
+                &graph[idx],
+                PlanNode::Envelope { header_input, .. } if !header_input.is_empty()
+            )
+        })
+        .collect();
+
+    for idx in envelope_indices {
+        let PlanNode::Envelope { header_input, .. } = &graph[idx] else {
+            continue;
+        };
+        // The lowered `header_input` retains any `.port` suffix, but DAG edges
+        // connect to the producer node, so match against the bare producer name.
+        let target = header_input
+            .split('.')
+            .next()
+            .unwrap_or(header_input)
+            .to_string();
+
+        let resolved = graph
+            .neighbors_directed(idx, Direction::Incoming)
+            .find(|&p| {
+                let pname = graph[p].name();
+                pname == target
+                    || pname
+                        .strip_prefix(CORRELATION_SORT_PREFIX)
+                        .is_some_and(|stripped| stripped == target)
+            });
+
+        if let PlanNode::Envelope {
+            header_upstream, ..
+        } = &mut graph[idx]
+        {
+            *header_upstream = resolved;
+        }
     }
 }

--- a/crates/clinker-plan/src/plan/execution/graph_util.rs
+++ b/crates/clinker-plan/src/plan/execution/graph_util.rs
@@ -1,7 +1,7 @@
 //! Plan-graph lookups over a compiled [`ExecutionPlanDag`] shared by the
 //! planner's strategy-selection passes and the runtime dispatch.
 
-use super::{CORRELATION_SORT_PREFIX, ExecutionPlanDag, PlanNode};
+use super::{ExecutionPlanDag, PlanNode, matches_upstream_name};
 use crate::error::PipelineError;
 use petgraph::Direction;
 
@@ -129,13 +129,7 @@ pub(crate) fn resolve_envelope_header_upstreams_in_graph(
 
         let resolved = graph
             .neighbors_directed(idx, Direction::Incoming)
-            .find(|&p| {
-                let pname = graph[p].name();
-                pname == target
-                    || pname
-                        .strip_prefix(CORRELATION_SORT_PREFIX)
-                        .is_some_and(|stripped| stripped == target)
-            });
+            .find(|&p| matches_upstream_name(graph[p].name(), &target));
 
         if let PlanNode::Envelope {
             header_upstream, ..

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -19,7 +19,10 @@ pub use composition::*;
 pub use dag::*;
 pub use enforcer::*;
 pub use explain::*;
-pub use graph_util::{compute_init_phase_node_set, single_predecessor};
+pub(crate) use graph_util::resolve_envelope_header_upstreams_in_graph;
+pub use graph_util::{
+    compute_init_phase_node_set, resolve_envelope_header_upstreams, single_predecessor,
+};
 pub use streaming_class::{
     StreamClass, certify_streaming_edge, classify_stream_nodes,
     compute_merge_interleave_fused_sources, compute_streaming_aggregate_ingest_edges,
@@ -229,15 +232,34 @@ pub enum PlanNode {
     /// headers to one, re-stamps every record onto a single consolidated
     /// document context, and re-frames with one open/close pair — so a
     /// multi-document body writes as one document. Neither strategy widens:
-    /// the output schema is the body input's schema. A wired header/trailer
-    /// port is rejected at plan validation this release, so the executor
-    /// resolves the single body predecessor topologically rather than carrying
-    /// named port references.
+    /// the output schema is the body input's schema.
+    ///
+    /// A wired `header:` port replaces each body grain's ambient envelope with a
+    /// matched header record carried on the same grain (transform-in-place header
+    /// replacement). `header_input` names that port's producer (empty when no
+    /// header is wired); `header_upstream` is its resolved predecessor
+    /// `NodeIndex`, so the executor distinguishes the header predecessor from the
+    /// body predecessor without re-deriving from input names. A wired `trailer:`
+    /// port stays rejected at plan validation this release.
     Envelope {
         name: String,
         #[serde(skip)]
         span: Span,
         strategy: crate::config::pipeline_node::EnvelopeStrategy,
+        /// Producer name of the wired `header:` port (with any `.port` suffix
+        /// retained as authored). Empty string when no header is wired, in which
+        /// case the node frames with each body grain's own ambient envelope.
+        /// Populated at lowering from the node's `header:` reference.
+        header_input: String,
+        /// `NodeIndex` of the wired header predecessor, resolved from
+        /// `header_input` against the Envelope's incoming neighbors during the
+        /// `resolve_envelope_header_upstreams` post-pass (mirroring Combine's
+        /// `driving_upstream` resolution, including the correlation-sort-prefix
+        /// alias). `None` when no header is wired or before the post-pass runs;
+        /// the executor reads it to drain the header stream separately from the
+        /// body stream.
+        #[serde(skip)]
+        header_upstream: Option<petgraph::graph::NodeIndex>,
         /// Output schema, adopted verbatim from the body input (Envelope does
         /// not widen). Populated by `bind_schema`.
         #[serde(skip)]

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -242,6 +242,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E348" => Some(include_str!("../../../../docs/explain/E348.md")),
         "E349" => Some(include_str!("../../../../docs/explain/E349.md")),
         "E350" => Some(include_str!("../../../../docs/explain/E350.md")),
+        "E351" => Some(include_str!("../../../../docs/explain/E351.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -466,8 +467,8 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E15Y", "W101", "W302",
-            "W305", "W306",
+            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E15Y", "W101",
+            "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -243,6 +243,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E349" => Some(include_str!("../../../../docs/explain/E349.md")),
         "E350" => Some(include_str!("../../../../docs/explain/E350.md")),
         "E351" => Some(include_str!("../../../../docs/explain/E351.md")),
+        "E352" => Some(include_str!("../../../../docs/explain/E352.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -467,8 +468,8 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E15Y", "W101",
-            "W302", "W305", "W306",
+            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352", "E15Y",
+            "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -448,6 +448,27 @@ impl DocumentContext {
         }
     }
 
+    /// Build a context that keeps this document's framing identity — its
+    /// [`id`](Self::id), [`grain`](Self::grain), and [`source_file`](Self::source_file) —
+    /// but replaces its envelope wholesale with `envelope`.
+    ///
+    /// This is the transform-in-place header-replacement primitive: the
+    /// Envelope node's wired `header:` port frames each body grain with a
+    /// grain-matched replacement header, swapping the ambient header without
+    /// re-framing the document (the grain, the output-envelope reconstruction
+    /// key, is preserved exactly). Distinct from [`Self::child`] /
+    /// [`Self::child_frame`], which open a NESTED level and MERGE sections onto
+    /// the ancestry under a fresh id; this neither nests nor merges — it
+    /// overwrites the header on the same frame.
+    pub fn with_replaced_envelope(&self, envelope: EnvelopeRecord) -> Self {
+        Self {
+            id: self.id,
+            grain: self.grain,
+            source_file: Arc::clone(&self.source_file),
+            envelope,
+        }
+    }
+
     /// Resolve `$doc.<section>.<field>` by chained lookup. Returns
     /// `None` if either the section is undeclared on this document or
     /// the field is missing from the section's payload. CXL eval maps

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -322,7 +322,8 @@ fn main() -> ExitCode {
                         | PipelineError::MemoryBudgetExceeded { .. }
                         | PipelineError::UnsatisfiableMemoryBudget { .. }
                         | PipelineError::CombineMissingMatch { .. }
-                        | PipelineError::EnvelopeMultiHeaderConflict { .. } => ExitCode::from(1),
+                        | PipelineError::EnvelopeMultiHeaderConflict { .. }
+                        | PipelineError::EnvelopeHeaderGrainUnmatched { .. } => ExitCode::from(1),
                         // Disk-cap exceedance (E320) is a resource-exhaustion
                         // halt — the run filled its configured spill budget.
                         // Group it with the other infrastructure failures

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -323,7 +323,8 @@ fn main() -> ExitCode {
                         | PipelineError::UnsatisfiableMemoryBudget { .. }
                         | PipelineError::CombineMissingMatch { .. }
                         | PipelineError::EnvelopeMultiHeaderConflict { .. }
-                        | PipelineError::EnvelopeHeaderGrainUnmatched { .. } => ExitCode::from(1),
+                        | PipelineError::EnvelopeHeaderGrainUnmatched { .. }
+                        | PipelineError::EnvelopeHeaderMultipleForGrain { .. } => ExitCode::from(1),
                         // Disk-cap exceedance (E320) is a resource-exhaustion
                         // halt — the run filled its configured spill budget.
                         // Group it with the other infrastructure failures

--- a/docs/explain/E351.md
+++ b/docs/explain/E351.md
@@ -1,0 +1,100 @@
+# Error E351: a wired envelope header record carries a grain that matches no body document
+
+## What it means
+
+An Envelope node with a wired `header:` port replaces each body document's
+ambient header with a header record carried on the **same document grain** — the
+node attaches a header to a body strictly by grain. The grain is the correlation
+key: one header record per body document, matched by the framing identity the
+body record carries.
+
+This diagnostic fires when a header record reaching the node carries a grain that
+matches **no in-flight body grain** — including the synthetic / ungrounded grain
+a Transform stamps onto a record it synthesizes in-pipeline rather than reads
+from a real source document. The node cannot place a header that grounds to no
+body document: silently dropping it would lose the replacement, and attaching it
+to an unrelated document would mis-frame that document. So it stops the run.
+
+```
+envelope 'framed': a wired header record carries document grain <grain>, which
+matches no in-flight body grain (or is a synthetic / ungrounded grain). The node
+attaches a header to a body strictly by grain, so it cannot place a header that
+grounds to no body document.
+```
+
+## Example
+
+```yaml
+# Rejected: the rewrite Transform DROPS the body grain by synthesizing a fresh
+# record instead of carrying the source header's grain forward, so the header
+# arrives at the Envelope node grounded to no body document.
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: x12
+      path: payments.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields: { batch_id: string }
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: rewrite_header
+    input: payments.header     # the source's promoted header port
+    config:
+      # A grain-preserving rewrite keeps the input record's grain. A Transform
+      # that instead builds a record from scratch stamps the synthetic grain,
+      # which is what trips E351.
+      cxl: |
+        emit batch_id = "RUN-" + $run_id
+  - type: envelope
+    name: framed
+    body: payments
+    header: rewrite_header
+    config: { strategy: preserve }
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+```
+
+## How to fix
+
+1. **Carry the body's grain onto the header record.** A grain-preserving
+   `Transform` of the source's promoted header keeps the input record's grain,
+   so the rewritten header still grounds to the body document it framed. Rewrite
+   the header values in place rather than synthesizing a fresh record.
+
+2. **Establish the grain via a business-key join** when the replacement header
+   comes from a different source (a control table) that has no native grain.
+   Joining the body (driving side) against the replacement header on a business
+   key stamps the body's grain onto the joined header record, so it then
+   attaches by grain as usual.
+
+3. **Omit the `header:` port** to frame each body document with its own ambient
+   envelope — the default when no replacement header is wired.
+
+## Technical context
+
+The Envelope node materializes the body and the wired header stream, groups the
+header records by document grain, and frames each body grain with its matched
+header record (replacing the body grain's ambient envelope while preserving the
+grain — the output-envelope reconstruction key — exactly). A header record whose
+grain is not among the body grains has no document to frame, so the node rejects
+it rather than guess. The synthetic grain (the grain a Transform stamps onto an
+in-pipeline-synthesized record) is treated as a non-match for the same reason: it
+identifies no source document.
+
+## See also
+
+- "Envelope Nodes" in the pipeline reference — the wired `header:` port
+- Error E350 — concat collapsed a body carrying two distinct headers into one
+  document

--- a/docs/explain/E352.md
+++ b/docs/explain/E352.md
@@ -1,0 +1,98 @@
+# Error E352: a wired envelope header stream carries two headers for one body document
+
+## What it means
+
+An Envelope node with a wired `header:` port replaces each body document's
+ambient header with a header record carried on the **same document grain** — the
+node attaches exactly **one** header record per body document, matched by the
+framing identity (the grain) the body record carries.
+
+This diagnostic fires when two or more header records reaching the node carry the
+**same body grain**. The node has no fold rule to reconcile a second header onto
+a grain that is already framed: keeping the last would silently drop the earlier
+header (data loss), and there is no defined merge. So it stops the run rather than
+discard a header.
+
+```
+envelope 'framed': the wired header input carries two or more records for
+document grain <grain> — exactly one header record per document grain is
+required.
+```
+
+## Example
+
+```yaml
+# Rejected: the header source emits TWO header rows that ground to the same body
+# document grain (e.g. a control table with a duplicate key, or a rewrite that
+# fans one source document into two header records). The Envelope node cannot
+# choose which header frames the document.
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: x12
+      path: payments.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields: { batch_id: string }
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: rewrite_header
+    input: payments.header     # the source's promoted header port
+    config:
+      # If this stage fans one source header into more than one record while
+      # preserving the source grain, two headers land on one body grain — E352.
+      cxl: |
+        emit batch_id = $doc.interchange.batch_id
+  - type: envelope
+    name: framed
+    body: payments
+    header: rewrite_header
+    config: { strategy: preserve }
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+```
+
+## How to fix
+
+1. **Deduplicate the header stream to one record per grain.** Place an
+   `Aggregate` or a distinct keyed on the grain's business key (or directly on
+   the source document) ahead of the `header:` port, so exactly one header record
+   reaches the node per body document.
+
+2. **Emit a single rewritten header per source document.** A grain-preserving
+   `Transform` of the source's promoted header should produce exactly one output
+   record per input document; a stage that fans one header into several records
+   while keeping the grain is what trips E352.
+
+3. **Establish a one-to-one business-key join.** When the replacement header
+   comes from a control table, join the body (driving side) against the
+   replacement on a key that is unique per body document, so the join yields one
+   header record per grain rather than a fan-out.
+
+## Technical context
+
+The Envelope node materializes the body and the wired header stream, then groups
+the header records by document grain to build one replacement envelope per body
+document. The grouping enforces a one-header-per-grain cardinality invariant: a
+second header record on a grain already mapped is a hard error, not a
+last-write-wins overwrite, because overwriting would silently lose a header the
+author wired in. This mirrors the one-row-per-grain contract the wired header
+port is defined to carry.
+
+## See also
+
+- "Envelope Nodes" in the pipeline reference — the wired `header:` port
+- Error E351 — a wired header record grounds to no in-flight body document
+- Error E350 — concat collapsed a body carrying two distinct headers into one
+  document

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -50,6 +50,16 @@ attaches a header to a body strictly by grain, so it cannot place a header that
 grounds to no body document.
 ```
 
+Exactly **one** header record may carry each body document's grain. When the wired header stream carries **two or more** records on the same grain, the node has no rule to fold a second header onto an already-framed document, so it refuses to silently keep one and drop the rest. The run fails with **E352** (run `clinker explain --code E352` for the full write-up):
+
+```
+envelope 'framed': the wired header input carries two or more records for
+document grain <grain> — exactly one header record per document grain is
+required.
+```
+
+Deduplicate the header stream to one record per grain upstream — an aggregate or distinct on the grain's business key, or a Transform that emits a single rewritten header per source document.
+
 A wired `trailer:` input is still rejected this release with a clear "not yet supported" message:
 
 ```

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -16,22 +16,46 @@ This page documents the `preserve` and `concat` strategies. The synthesizing (he
 
 The node reads its `body:` input and emits the same records, framed per document. A downstream [Output](output.md) with `reconstruct_envelope: true` then writes one framed document per body grain.
 
-## Inputs: `body`, and the not-yet-wired `header` / `trailer`
+## Inputs: `body`, the wired `header`, and the not-yet-wired `trailer`
 
 | Input | Required | Status |
 |-------|----------|--------|
 | `body` | yes | The records to frame into documents. |
-| `header` | no | A stream whose records prepend to each framed document. **Accepted in config but not yet wired** — a wired value is rejected at plan validation this release. |
-| `trailer` | no | A stream whose records append to each framed document. Same not-yet-wired status. |
+| `header` | no | A 1-row-per-grain header stream. A wired value **replaces** each body document's header with the matching header record, attached by document grain. |
+| `trailer` | no | A stream whose records append to each framed document. **Accepted in config but not yet wired** — a wired value is rejected at plan validation this release. |
 
-Wiring an explicit `header:` or `trailer:` input is rejected with a clear "not yet supported" message:
+When you omit `header:`, an Envelope frames each body record using the body's own **ambient envelope** — the document context every record already carries from its source.
+
+### Wiring a `header:` port replaces the document's header
+
+A wired `header:` input is a second stream carrying one header record per document, each on the **same document grain** as the body it frames. The node attaches a header to a body strictly **by grain**, so the header record reaching it must carry the body's grain — and the node then **replaces** that document's ambient header with the wired header record (the framing grain is preserved; only the header changes). This is *transform-in-place* header replacement: rewrite a header's values upstream — for example, override a batch id or stamp a run date — and frame the body with the rewritten header instead of the source's original.
+
+```yaml
+nodes:
+  # `rewrite_header` rewrites the source header's values while keeping each
+  # record's grain, so the rewritten header still grounds to its body document.
+  - type: envelope
+    name: framed
+    body: payments
+    header: rewrite_header
+    config: { strategy: preserve }
+```
+
+The header record must carry a body document's grain. A grain-preserving Transform of the source's promoted header keeps it; a replacement from a different source establishes it via a business-key join against the body. A header record whose grain matches **no** in-flight body document (or carries the synthetic, ungrounded grain a Transform stamps onto a record it builds from scratch) cannot be placed, so the run fails with **E351** (run `clinker explain --code E351` for the full write-up):
 
 ```
-envelope node 'framed': explicit `header` input wiring is not yet supported —
+envelope 'framed': a wired header record carries document grain <grain>, which
+matches no in-flight body grain (or is a synthetic / ungrounded grain). The node
+attaches a header to a body strictly by grain, so it cannot place a header that
+grounds to no body document.
+```
+
+A wired `trailer:` input is still rejected this release with a clear "not yet supported" message:
+
+```
+envelope node 'framed': explicit `trailer` input wiring is not yet supported —
 omit it to frame with the body's own envelope
 ```
-
-Until those ports are wired, an Envelope frames each body record using the body's own **ambient envelope** — the document context every record already carries from its source — rather than a second input stream.
 
 ## `strategy: preserve`
 


### PR DESCRIPTION
## Summary

The Envelope node's `header:` input is now a real wired port. Previously it was accepted in config but a wired value was rejected at plan validation. A wired header is a one-row-per-document-grain stream whose records **replace** each body document's envelope header, matched by document grain — the framing/reconstruction key is preserved; only the header swaps. Replacement runs before the per-strategy step, so it composes with both `preserve` and `concat`.

This is the capability that the read-only ambient `$doc` context cannot provide: replacing a source header with new values from business logic (rewrite a batch id, override a run date, stamp a run id), supplied as a separate stream attached by grain.

## Behavior

- `header:` accepts any upstream producer that emits one header record per body document grain — a source's promoted header, a grain-preserving transform of it, or any one-row-per-grain stream.
- Each header attaches to the body document carrying the same grain. The grain is preserved; only the envelope header is replaced (1:N per document).
- Validation:
  - A header record whose grain matches no body document, or carries no grounded grain, aborts the run with **E351**.
  - Two or more header records on the same document grain aborts with **E352** — exactly one header per document grain is required; the node refuses to silently drop one.
  - A wired `trailer:` input remains rejected (not yet supported).

## Scope

- Exactly one header input. Wiring multiple named header inputs — and the header-selection strategies that consume them — is tracked in a separate issue.
- The Envelope output schema is unchanged: the header replaces framing metadata, it is not widened into body records.

## Docs

- New diagnostic write-ups: `clinker explain --code E351` and `--code E352`.
- Envelope node reference updated for the wired header input and the two new diagnostics.

Closes #579.
