### PR TITLE
exec,plan,record: Envelope node declarative header/footer synthesis

### DIFF
--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -57,6 +57,7 @@ use std::sync::Arc;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
+use crate::aggregation::{AggregateEvalScope, eval_expr_in_agg_scope};
 use crate::executor::dispatch::{
     ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
 };
@@ -65,8 +66,12 @@ use crate::executor::node_buffer::DrainedEvents;
 use crate::executor::stream_event::{Punctuation, PunctuationKind};
 use clinker_plan::config::pipeline_node::EnvelopeStrategy;
 use clinker_plan::error::PipelineError;
+use clinker_plan::plan::envelope_synthesis::EnvelopeSynthesis;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
-use clinker_record::{DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, Record};
+use clinker_record::accumulator::AccumulatorEnum;
+use clinker_record::{DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, Record, Value};
+use cxl::plan::BindingArg;
+use indexmap::IndexMap;
 
 /// Execute the `Envelope` arm for `node_idx`. Drains the body predecessor and
 /// re-parks the framed body into this node's own `node_buffers` slot.
@@ -103,6 +108,7 @@ pub(crate) fn dispatch_envelope(
         strategy,
         ref header_input,
         header_upstream,
+        ref synthesis,
         ..
     } = *node
     else {
@@ -155,7 +161,7 @@ pub(crate) fn dispatch_envelope(
     // slot, so writing to `node_idx` is exactly where each successor looks (the
     // Transform/Sort linear-producer convention, not the Route/Cull
     // per-successor fork).
-    let (records, puncts) = match strategy {
+    let (mut records, mut puncts) = match strategy {
         EnvelopeStrategy::Preserve => {
             // Leave each record's grain untouched (header replacement, when
             // wired, preserved the grain) and forward the body's punctuations
@@ -164,6 +170,16 @@ pub(crate) fn dispatch_envelope(
         }
         EnvelopeStrategy::Concat => consolidate(name, records, puncts)?,
     };
+
+    // Declarative header/footer synthesis layers on top of either strategy: it
+    // groups the framed body by document grain (one grain per output document —
+    // exactly one after concat, one per body document after preserve) and per
+    // grain stamps the synthesized header/footer sections into the document's
+    // envelope, then re-stamps the grain's records and punctuations onto the
+    // rebuilt context. Skipped when the node declares no synthesis.
+    if let Some(synthesis) = synthesis {
+        synthesize_sections(ctx, name, synthesis, &mut records, &mut puncts)?;
+    }
 
     let nb = admit_node_buffer(
         ctx,
@@ -420,6 +436,253 @@ fn consolidate(
     ];
 
     Ok((records, framing))
+}
+
+/// Stamp the node's synthesized header/footer sections into each output
+/// document's envelope, then re-stamp the document's records and boundary
+/// punctuations onto the rebuilt context.
+///
+/// Groups the framed `records` by [`DocumentGrain`] in first-seen order — one
+/// grain is one output document (exactly one after `concat`, one per body
+/// document after `preserve`). Per grain it folds the footer aggregates over
+/// the grain's records, evaluates the header scalars against the grain's first
+/// record (so `$source.*` / `$doc.*` ground), merges the synthesized sections
+/// into the grain's current envelope (a synthesized section overrides an
+/// existing same-named section; untouched sections ride through), and rebuilds
+/// ONE shared `Arc<DocumentContext>` per grain on the SAME grain via
+/// [`DocumentContext::with_replaced_envelope`]. Every record of the grain is
+/// re-stamped to that shared context (a refcount bump, not a rebuild), and each
+/// boundary punctuation is re-stamped to the rebuilt context for its grain.
+///
+/// # Memory model
+///
+/// Bounded by the already-materialized body plus `O(grains × footer-fields)`
+/// accumulators held only for the duration of one grain's fold — every footer
+/// aggregate in the allow-list is an O(1) accumulator, so the footer state per
+/// document is independent of its body-row count. No new unbounded state.
+///
+/// # Errors
+///
+/// Returns [`PipelineError`] when a footer accumulator's finalize overflows or a
+/// header / footer residual fails to evaluate — both surface as an Internal
+/// engine error naming the node, since the expressions were typechecked and
+/// allow-list-validated at compile time.
+fn synthesize_sections(
+    ctx: &ExecutorContext<'_>,
+    name: &str,
+    synthesis: &EnvelopeSynthesis,
+    records: &mut [(Record, u64)],
+    puncts: &mut [Punctuation],
+) -> Result<(), PipelineError> {
+    // Group record indices by grain, preserving first-seen order so the rebuilt
+    // contexts (and any downstream observation order) follow body order.
+    let mut grain_order: Vec<DocumentGrain> = Vec::new();
+    let mut indices_by_grain: HashMap<DocumentGrain, Vec<usize>> = HashMap::new();
+    for (i, (record, _)) in records.iter().enumerate() {
+        let grain = record.doc_ctx().grain();
+        indices_by_grain
+            .entry(grain)
+            .or_insert_with(|| {
+                grain_order.push(grain);
+                Vec::new()
+            })
+            .push(i);
+    }
+
+    // One rebuilt context per grain, shared by every record/punct of the grain.
+    let mut rebuilt: HashMap<DocumentGrain, Arc<DocumentContext>> = HashMap::new();
+    for grain in &grain_order {
+        let indices = &indices_by_grain[grain];
+        // The grain's first record grounds the header eval context and seeds the
+        // base envelope the synthesized sections merge onto.
+        let first_idx = indices[0];
+        let base_envelope = records[first_idx].0.doc_ctx().envelope_record().clone();
+
+        let mut synthesized: IndexMap<Box<str>, Value> = IndexMap::new();
+        // Footer first, header second — declaration order within each is
+        // preserved by the spec's section vectors; a header section and a footer
+        // section never share a name in practice, and if they did the header
+        // (evaluated second) would win, matching the "header overrides" read.
+        for section in &synthesis.footer {
+            let payload = fold_footer_section(name, section, records, indices)?;
+            synthesized.insert(Box::from(section.section.as_str()), payload);
+        }
+        for section in &synthesis.header {
+            let payload = eval_header_section(
+                ctx,
+                name,
+                section,
+                &records[first_idx].0,
+                records[first_idx].1,
+            )?;
+            synthesized.insert(Box::from(section.section.as_str()), payload);
+        }
+
+        let merged = merge_envelope_sections(&base_envelope, synthesized);
+        let new_ctx = Arc::new(
+            records[first_idx]
+                .0
+                .doc_ctx()
+                .with_replaced_envelope(merged),
+        );
+        rebuilt.insert(*grain, Arc::clone(&new_ctx));
+
+        for &idx in indices {
+            records[idx].0.set_doc_ctx(Arc::clone(&new_ctx));
+        }
+    }
+
+    // Re-stamp boundary punctuations onto the rebuilt context for their grain.
+    // The Output writer frames off RECORD context, not punctuations, but a
+    // non-Output downstream consumer reads boundaries, so keep them consistent.
+    for punct in puncts.iter_mut() {
+        let grain = punct.doc_ctx().grain();
+        if let Some(new_ctx) = rebuilt.get(&grain) {
+            *punct = punct.clone().with_doc_ctx(Arc::clone(new_ctx));
+        }
+    }
+
+    Ok(())
+}
+
+/// Fold one footer section's streaming aggregates over a grain's records and
+/// emit the section payload (`Value::Map` of `field -> value`) in field order.
+///
+/// Builds one [`AccumulatorEnum`] per binding, adds each grain record's binding
+/// value (a bare field value, or `Null` for `count(*)`), finalizes the slots,
+/// and evaluates each compiled emit residual in an empty-key aggregate scope.
+fn fold_footer_section(
+    name: &str,
+    section: &clinker_plan::plan::envelope_synthesis::SynthesizedFooterSection,
+    records: &[(Record, u64)],
+    indices: &[usize],
+) -> Result<Value, PipelineError> {
+    let compiled = &section.compiled;
+    let mut accs: Vec<AccumulatorEnum> = compiled
+        .bindings
+        .iter()
+        .map(|b| AccumulatorEnum::for_type(&b.acc_type))
+        .collect();
+
+    for &idx in indices {
+        let record = &records[idx].0;
+        for (binding, acc) in compiled.bindings.iter().zip(accs.iter_mut()) {
+            // Footer args are bare-field or `*` only (enforced at compile via
+            // E354), so the value is a direct column read or `Null` for the
+            // wildcard count.
+            let value = match &binding.arg {
+                BindingArg::Field(field_idx) => record
+                    .values()
+                    .get(*field_idx as usize)
+                    .cloned()
+                    .unwrap_or(Value::Null),
+                BindingArg::Wildcard => Value::Null,
+                // Unreachable: the compile-time allow-list rejects composed args.
+                BindingArg::Expr(_) | BindingArg::Pair(_, _) => {
+                    return Err(PipelineError::Internal {
+                        op: "envelope",
+                        node: name.to_string(),
+                        detail: format!(
+                            "footer section {:?} carries a composed aggregate argument that the \
+                             allow-list should have rejected at compile",
+                            section.section
+                        ),
+                    });
+                }
+            };
+            acc.add(&value);
+        }
+    }
+
+    let slots: Vec<Value> = accs
+        .iter()
+        .enumerate()
+        .map(|(i, acc)| {
+            acc.finalize().map_err(|e| PipelineError::Internal {
+                op: "envelope",
+                node: name.to_string(),
+                detail: format!(
+                    "footer section {:?} aggregate {} finalize failed: {e}",
+                    section.section, compiled.bindings[i].output_name
+                ),
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let scope = AggregateEvalScope {
+        key: &[],
+        slots: &slots,
+    };
+    let mut fields: IndexMap<Box<str>, Value> = IndexMap::with_capacity(compiled.emits.len());
+    for emit in &compiled.emits {
+        let value = eval_expr_in_agg_scope(&emit.residual, &scope).map_err(|e| {
+            PipelineError::Internal {
+                op: "envelope",
+                node: name.to_string(),
+                detail: format!(
+                    "footer section {:?} field {} residual eval failed: {e}",
+                    section.section, emit.output_name
+                ),
+            }
+        })?;
+        fields.insert(Box::from(emit.output_name.as_ref()), value);
+    }
+    Ok(Value::Map(Box::new(fields)))
+}
+
+/// Evaluate one header section's scalar fields against the grain's first record
+/// and emit the section payload (`Value::Map` of `field -> value`) in field
+/// order.
+///
+/// The header evaluates against the first record only to ground `$source.*` /
+/// `$doc.*`; body-column references are rejected at compile (E353), so the
+/// record's columns are never read.
+fn eval_header_section(
+    ctx: &ExecutorContext<'_>,
+    name: &str,
+    section: &clinker_plan::plan::envelope_synthesis::SynthesizedHeaderSection,
+    record: &Record,
+    row_num: u64,
+) -> Result<Value, PipelineError> {
+    let source_file = crate::executor::dispatch::source_file_arc_of(record);
+    let source_name = crate::executor::dispatch::source_name_arc_of(record);
+    let eval_ctx = ctx.eval_ctx_for_record(&source_file, &source_name, row_num, record.doc_ctx());
+
+    let mut fields: IndexMap<Box<str>, Value> = IndexMap::with_capacity(section.fields.len());
+    for (field, expr) in &section.fields {
+        let scalar = cxl::eval::compile_scalar(&section.typed, expr);
+        let value = scalar
+            .eval(&eval_ctx, record)
+            .map_err(|e| PipelineError::Internal {
+                op: "envelope",
+                node: name.to_string(),
+                detail: format!(
+                    "header section {:?} field {field:?} eval failed: {e}",
+                    section.section
+                ),
+            })?;
+        fields.insert(field.clone(), value);
+    }
+    Ok(Value::Map(Box::new(fields)))
+}
+
+/// Merge synthesized sections onto a base envelope by name: every base section
+/// rides through in declared order, then each synthesized section overrides an
+/// existing same-named section in place (keeping the base position) or appends
+/// after the base sections — the regenerate semantics for header/footer
+/// synthesis.
+fn merge_envelope_sections(
+    base: &EnvelopeRecord,
+    synthesized: IndexMap<Box<str>, Value>,
+) -> EnvelopeRecord {
+    let mut merged: IndexMap<Box<str>, Value> = IndexMap::new();
+    for (section_name, payload) in base.sections() {
+        merged.insert(Box::from(section_name), payload.clone());
+    }
+    for (section_name, payload) in synthesized {
+        merged.insert(section_name, payload);
+    }
+    EnvelopeRecord::from_sections(merged)
 }
 
 #[cfg(test)]

--- a/crates/clinker-exec/src/executor/stream_event.rs
+++ b/crates/clinker-exec/src/executor/stream_event.rs
@@ -151,6 +151,22 @@ impl Punctuation {
     pub fn kind(&self) -> PunctuationKind {
         self.kind
     }
+
+    /// The document context this punctuation marks. The Envelope node's
+    /// header/footer synthesis reads it to match a boundary to the rebuilt
+    /// per-grain context after stamping synthesized sections.
+    pub(crate) fn doc_ctx(&self) -> &Arc<DocumentContext> {
+        &self.doc_ctx
+    }
+
+    /// Rebuild this punctuation on a different document context, preserving its
+    /// kind and any structural-reject payload. Used by the Envelope node's
+    /// synthesis step to re-stamp a boundary onto the context carrying the
+    /// freshly synthesized header/footer sections, keeping the stream
+    /// internally consistent for any non-Output downstream consumer.
+    pub(crate) fn with_doc_ctx(self, doc_ctx: Arc<DocumentContext>) -> Self {
+        Self { doc_ctx, ..self }
+    }
 }
 
 /// Inline channel/buffer payload — either a body record or a document

--- a/crates/clinker-exec/tests/envelope_node.rs
+++ b/crates/clinker-exec/tests/envelope_node.rs
@@ -1616,3 +1616,314 @@ nodes:
         "the rejection still names the trailer port specifically, got: {msg}"
     );
 }
+
+// ─── Declarative header/footer synthesis (orthogonal to the strategy) ────────
+//
+// An Envelope node may synthesize a fresh header (scalar CXL) and footer
+// (streaming aggregate CXL over the framed body) per output document. Synthesis
+// layers on top of EITHER strategy: under `concat` one document carries the
+// merged-body footer count; under `preserve` each document carries its own
+// grain's count. The synthesized sections render through the existing
+// `header_from_doc` / `footer_from_doc` writer path.
+
+/// A synthesis pipeline: source → body Transform → Envelope (with `header:` +
+/// `footer:` synthesis) → Output. `strategy` selects `concat` or `preserve`;
+/// `footer_field` is the single footer `field: <CXL aggregate>` line under the
+/// `interchange` section (e.g. `"record_count: count()"` or `"total: sum(id)"`).
+/// Keeping the footer to one field per pipeline keeps the rendered footer a
+/// single-cell row that [`synthesis_stats`] parses unambiguously.
+///
+/// The source declares two envelope sections so the writer's `header_from_doc:
+/// preamble` / `footer_from_doc: interchange` pass the feeding-source section-
+/// name check; the synthesized sections supply their runtime values.
+fn synthesis_pipeline(strategy: &str, footer_field: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: envelope_synth
+  vars:
+    sender_id: {{ type: string, default: "ACME" }}
+nodes:
+  - type: source
+    name: edi
+    config:
+      name: edi
+      type: csv
+      path: placeholder.csv
+      envelope:
+        sections:
+          preamble:
+            extract: {{ record_type: P }}
+            fields:
+              sender: string
+          interchange:
+            extract: {{ record_type: H }}
+            fields:
+              tag: string
+      schema:
+        - {{ name: id, type: int }}
+  - type: transform
+    name: body
+    input: edi
+    config:
+      cxl: |
+        emit id = id
+  - type: envelope
+    name: framed
+    body: body
+    config:
+      strategy: {strategy}
+      header:
+        preamble:
+          sender: $vars.sender_id
+      footer:
+        interchange:
+          {footer_field}
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: preamble
+          footer_from_doc: interchange
+"#
+    )
+}
+
+/// Run a synthesis pipeline over a scripted step list, returning the written
+/// CSV bytes. `footer_field` is the single `field: <aggregate>` footer line.
+fn run_synthesis(strategy: &str, footer_field: &str, steps: Vec<Step>) -> String {
+    let mut config =
+        clinker_plan::config::parse_config(&synthesis_pipeline(strategy, footer_field))
+            .expect("parse synthesis pipeline");
+    for spanned in &mut config.nodes {
+        if let clinker_plan::config::PipelineNode::Source { config: body, .. } = &mut spanned.value
+        {
+            body.source.path = None;
+        }
+    }
+    let plan = config
+        .compile(&clinker_plan::config::CompileContext::default())
+        .expect("compile synthesis pipeline");
+
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "edi".to_string(),
+        SourceInput::Records(Box::new(ScriptedReader::new(steps))),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+
+    PipelineExecutor::run_plan_with_readers_writers(
+        &plan,
+        readers,
+        writers,
+        &PipelineRunParams {
+            execution_id: "synth-exec".to_string(),
+            batch_id: "synth-batch".to_string(),
+            ..Default::default()
+        },
+    )
+    .expect("drive synthesis pipeline");
+    buf.as_string()
+}
+
+/// Parse a synthesized-envelope CSV into `(header_senders, footer_counts)`.
+///
+/// The writer emits, per framed document: a header section row (the synthesized
+/// `preamble.sender` — a single non-numeric cell), then the body `id` rows (each
+/// a single numeric cell, the `id` column header suppressed under framing), then
+/// a footer section row (the synthesized `interchange.record_count` — a single
+/// numeric cell). A header row therefore opens a document and closes the
+/// previous document's numeric run; the LAST numeric cell of that run is the
+/// footer count (it follows every body row), and the remaining numerics are body
+/// ids. This recovers both synthesized values per document by emission order
+/// alone — no value-collision assumption.
+fn synthesis_stats(csv: &str) -> (Vec<String>, Vec<i64>) {
+    let mut headers: Vec<String> = Vec::new();
+    let mut footers: Vec<i64> = Vec::new();
+    let mut numeric_run: Vec<i64> = Vec::new();
+    // The final numeric of a document's run is its footer count; flush it when
+    // the next header opens (or at EOF).
+    fn flush(run: &mut Vec<i64>, footers: &mut Vec<i64>) {
+        if let Some(footer) = run.pop() {
+            footers.push(footer);
+        }
+        run.clear();
+    }
+    for line in csv.lines() {
+        let cells: Vec<&str> = line.split(',').collect();
+        match cells.as_slice() {
+            // A header row's lone cell is the non-numeric sender id; it opens a
+            // new document and closes the prior document's numeric run.
+            [only] if only.parse::<i64>().is_err() && !only.is_empty() => {
+                flush(&mut numeric_run, &mut footers);
+                headers.push((*only).to_string());
+            }
+            // A body id or the footer count — both single numeric cells.
+            [only] => {
+                if let Ok(n) = only.parse::<i64>() {
+                    numeric_run.push(n);
+                }
+            }
+            _ => {}
+        }
+    }
+    flush(&mut numeric_run, &mut footers);
+    (headers, footers)
+}
+
+#[test]
+fn concat_synthesis_emits_one_footer_with_the_merged_body_count() {
+    // Two body documents (3 + 1 = 4 rows) sharing one header, so concat folds
+    // them without an E350 multi-header conflict. Under `concat` they collapse
+    // to ONE framed document, so the synthesized footer carries the SINGLE
+    // merged count (4) and the synthesized header renders `$vars.sender_id` once.
+    let mut steps = concat_doc("a.x12", "ISA", &[1, 2, 3]);
+    steps.extend(concat_doc("b.x12", "ISA", &[4]));
+
+    let csv = run_synthesis("concat", "record_count: count()", steps);
+    let (headers, footers) = synthesis_stats(&csv);
+    assert_eq!(
+        headers,
+        vec!["ACME".to_string()],
+        "concat synthesizes one header carrying the $vars-derived sender: {csv}"
+    );
+    assert_eq!(
+        footers,
+        vec![4],
+        "concat synthesizes one footer whose record_count is the merged body count: {csv}"
+    );
+}
+
+#[test]
+fn preserve_synthesis_emits_a_per_grain_footer_count() {
+    // The SAME two body documents under `preserve` stay separate, so each frames
+    // its own document with its OWN synthesized footer count (3, then 1) and its
+    // own synthesized header. This is the #574 acceptance differential: the same
+    // `footer: count()` yields one merged count under concat and per-grain counts
+    // under preserve.
+    let mut steps = concat_doc("a.x12", "ISA-A", &[1, 2, 3]);
+    steps.extend(concat_doc("b.x12", "ISA-B", &[4]));
+
+    let csv = run_synthesis("preserve", "record_count: count()", steps);
+    let (headers, footers) = synthesis_stats(&csv);
+    assert_eq!(
+        headers,
+        vec!["ACME".to_string(), "ACME".to_string()],
+        "preserve synthesizes one header per grain, each carrying the sender: {csv}"
+    );
+    assert_eq!(
+        footers,
+        vec![3, 1],
+        "preserve synthesizes a per-grain footer count (3 then 1), not a merged 4: {csv}"
+    );
+}
+
+#[test]
+fn synthesis_count_differs_between_concat_and_preserve() {
+    // The headline differential, asserted directly: one merged count vs two
+    // per-grain counts over the SAME body and the SAME `footer: count()`.
+    let steps = || {
+        let mut s = concat_doc("a.x12", "ISA", &[1, 2, 3]);
+        s.extend(concat_doc("b.x12", "ISA", &[4]));
+        s
+    };
+    let (_, concat_counts) =
+        synthesis_stats(&run_synthesis("concat", "record_count: count()", steps()));
+    let (_, preserve_counts) =
+        synthesis_stats(&run_synthesis("preserve", "record_count: count()", steps()));
+    assert_eq!(concat_counts, vec![4], "concat → one merged count");
+    assert_eq!(preserve_counts, vec![3, 1], "preserve → per-grain counts");
+    assert_ne!(
+        concat_counts, preserve_counts,
+        "synthesis is orthogonal to the strategy: the strategy decides the grain \
+         cardinality, so the same footer aggregate differs across the two"
+    );
+}
+
+// ─── Field-arg footer aggregates: the BindingArg::Field(idx) value path ──────
+//
+// `count()` folds through the `BindingArg::Wildcard` path (it ignores the row
+// value). A `sum(id)` / `min(id)` / `max(id)` footer instead folds through
+// `BindingArg::Field(idx)`, where `idx` is the compile-time field index
+// `extract_aggregates` resolves against the body input schema and the runtime
+// reads as `record.values()[idx]`. These tests fold a field aggregate over
+// KNOWN body ids and assert the EXACT rendered numeric value, so a compile-time
+// index misaligned with the runtime `record.values()` layout fails loudly here
+// — the gap a count-only suite would pass straight through.
+
+#[test]
+fn concat_synthesis_field_sum_renders_the_exact_merged_total() {
+    // ids [1,2,3] + [4] under concat → one document. `sum(id)` reads each
+    // record's `id` column through the Field path; the footer must render the
+    // exact merged total 10 (= 1+2+3+4), distinct from every body id so a
+    // wrong-column read could not coincidentally match.
+    let mut steps = concat_doc("a.x12", "ISA", &[1, 2, 3]);
+    steps.extend(concat_doc("b.x12", "ISA", &[4]));
+
+    let csv = run_synthesis("concat", "total: sum(id)", steps);
+    let (_, footers) = synthesis_stats(&csv);
+    assert_eq!(
+        footers,
+        vec![10],
+        "concat sum(id) folds the Field path over the merged body to 1+2+3+4=10: {csv}"
+    );
+}
+
+#[test]
+fn preserve_synthesis_field_sum_renders_the_per_grain_total() {
+    // The SAME body under preserve → two documents, each summing its OWN grain's
+    // ids through the Field path: grain A = 1+2+3 = 6, grain B = 4. A merged 10
+    // (or a swapped 4/6) would fail — proving the per-grain Field fold keys on
+    // the right records AND reads the right column.
+    let mut steps = concat_doc("a.x12", "ISA-A", &[1, 2, 3]);
+    steps.extend(concat_doc("b.x12", "ISA-B", &[4]));
+
+    let csv = run_synthesis("preserve", "total: sum(id)", steps);
+    let (_, footers) = synthesis_stats(&csv);
+    assert_eq!(
+        footers,
+        vec![6, 4],
+        "preserve sum(id) folds the Field path per grain to [6, 4], not a merged 10: {csv}"
+    );
+}
+
+#[test]
+fn concat_synthesis_field_min_and_max_render_the_exact_extremes() {
+    // min(id) and max(id) over [10,2,30,4] under concat must render 2 and 30 —
+    // the Field path feeds each `id` value into the Min / Max accumulator. Using
+    // unsorted ids whose extremes are interior values (not the first or last
+    // body row) makes a "reads the wrong slot" or "keeps the first/last seen"
+    // bug fail loudly.
+    let min_csv = run_synthesis("concat", "lowest: min(id)", {
+        let mut s = concat_doc("a.x12", "ISA", &[10, 2, 30]);
+        s.extend(concat_doc("b.x12", "ISA", &[4]));
+        s
+    });
+    let (_, min_footers) = synthesis_stats(&min_csv);
+    assert_eq!(
+        min_footers,
+        vec![2],
+        "concat min(id) folds the Field path to the true minimum 2: {min_csv}"
+    );
+
+    let max_csv = run_synthesis("concat", "highest: max(id)", {
+        let mut s = concat_doc("a.x12", "ISA", &[10, 2, 30]);
+        s.extend(concat_doc("b.x12", "ISA", &[4]));
+        s
+    });
+    let (_, max_footers) = synthesis_stats(&max_csv);
+    assert_eq!(
+        max_footers,
+        vec![30],
+        "concat max(id) folds the Field path to the true maximum 30: {max_csv}"
+    );
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3479,6 +3479,11 @@ pub(crate) fn lower_node_to_plan_node(
                     }
                 })
                 .unwrap_or_default();
+            // The compiled header/footer synthesis (when the node declared a
+            // `config.header:` / `config.footer:` map) was built during binding
+            // against the body input row and stashed in `CompileArtifacts`;
+            // attach it here. Absent → the node synthesizes nothing.
+            let synthesis = artifacts.envelope_synthesis.get(name).map(Arc::clone);
             Some(crate::plan::execution::PlanNode::Envelope {
                 name: name.to_string(),
                 span,
@@ -3486,6 +3491,7 @@ pub(crate) fn lower_node_to_plan_node(
                 header_input,
                 header_upstream: None,
                 output_schema: schema_from_bound(name),
+                synthesis,
             })
         }
     }

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -1323,17 +1323,47 @@ pub struct RouteBody {
     pub default: String,
 }
 
-/// Envelope variant body. `body:` / `header:` / `trailer:` inputs live on
-/// [`EnvelopeHeader`], not here — this carries only the framing strategy.
+/// Envelope variant body. The `body:` / `header:` / `trailer:` input *ports*
+/// live on [`EnvelopeHeader`], not here — this carries the framing strategy and
+/// the optional declarative header/footer synthesis maps.
+///
+/// `header` / `footer` are **orthogonal** to `strategy`: the strategy is the
+/// document-cardinality axis (`preserve` = one document per body grain,
+/// `concat` = one consolidated document), while synthesis layers on top of
+/// either. So `footer: { interchange: { record_count: count() } }` emits the
+/// per-grain count under `preserve` and the single merged count under `concat`.
+///
+/// Both maps are keyed `section -> field -> CXL expression`. The section name is
+/// user-defined (it is the `EnvelopeRecord` section a downstream writer renders
+/// via `header_from_doc` / `footer_from_doc`); the inner [`IndexMap`] preserves
+/// field declaration order, which is the rendered cell order. The inner `header`
+/// field map here is distinct from the wired `header:` input port on
+/// [`EnvelopeHeader`] — a different key at a different nesting level.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields, default)]
 pub struct EnvelopeBody {
     #[serde(default)]
     pub strategy: EnvelopeStrategy,
+    /// Declarative header synthesis: `section -> field -> scalar CXL`. Each
+    /// expression is evaluated once per output document at its open, over
+    /// document-open-knowable inputs (`$vars` / `$source` / `$pipeline` / the
+    /// ambient `$doc.*` envelope). Body-field references are rejected at compile
+    /// time — the header is emitted before the body streams.
+    #[serde(default)]
+    pub header: IndexMap<String, IndexMap<String, CxlSource>>,
+    /// Declarative footer synthesis: `section -> field -> aggregate CXL`. Each
+    /// expression folds the document's body records as a streaming
+    /// distributive/algebraic reduction (`count` / `sum` / `avg` / `min` /
+    /// `max`), maintained as an O(1) accumulator per open grain and emitted at
+    /// the grain's close. Holistic and non-O(1) reductions are rejected at
+    /// compile time.
+    #[serde(default)]
+    pub footer: IndexMap<String, IndexMap<String, CxlSource>>,
 }
 
-/// Envelope framing strategy. The synthesizing (header-folding) strategies
-/// are additive variants in later slices.
+/// Envelope framing strategy — the document-cardinality axis. Declarative
+/// header/footer synthesis ([`EnvelopeBody::header`] / [`EnvelopeBody::footer`])
+/// layers on top of either variant.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum EnvelopeStrategy {
@@ -2745,5 +2775,98 @@ nodes:
                 && msg.contains("not yet supported"),
             "error must explain the not-yet-supported trailer wiring, got: {msg}"
         );
+    }
+
+    #[test]
+    fn envelope_footer_synthesis_parses_section_keyed() {
+        // A `footer:` map is section-keyed (section -> field -> aggregate CXL).
+        // The inner IndexMap must preserve declaration order, which is the
+        // rendered cell order.
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    config:\n      \
+             strategy: concat\n      footer:\n        interchange:\n          \
+             record_count: count()\n          total: sum(amount)\n",
+        );
+        let config: PipelineConfig =
+            crate::yaml::from_str(&yaml).expect("parse footer-synthesis envelope");
+        let (_, body) = envelope_of(&config);
+        assert_eq!(body.strategy, EnvelopeStrategy::Concat);
+        assert!(body.header.is_empty(), "no header synthesis declared");
+        let interchange = body
+            .footer
+            .get("interchange")
+            .expect("footer carries the `interchange` section");
+        let fields: Vec<(&str, &str)> = interchange
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_ref()))
+            .collect();
+        assert_eq!(
+            fields,
+            vec![("record_count", "count()"), ("total", "sum(amount)")],
+            "footer fields preserve declaration order as rendered cell order"
+        );
+    }
+
+    #[test]
+    fn envelope_header_synthesis_parses_section_keyed() {
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    config:\n      \
+             strategy: preserve\n      header:\n        interchange:\n          \
+             sender: $vars.sender_id\n",
+        );
+        let config: PipelineConfig =
+            crate::yaml::from_str(&yaml).expect("parse header-synthesis envelope");
+        let (_, body) = envelope_of(&config);
+        assert!(body.footer.is_empty(), "no footer synthesis declared");
+        let interchange = body
+            .header
+            .get("interchange")
+            .expect("header carries the `interchange` section");
+        assert_eq!(
+            interchange.get("sender").map(|c| c.as_ref()),
+            Some("$vars.sender_id"),
+            "header field carries its scalar CXL source"
+        );
+    }
+
+    #[test]
+    fn envelope_synthesis_round_trips_through_serialize() {
+        // The header/footer maps survive a serialize → re-parse round trip.
+        let yaml = pipeline_with_envelope(
+            "  - type: envelope\n    name: framed\n    body: body\n    config:\n      \
+             strategy: concat\n      header:\n        head:\n          \
+             who: $vars.sender_id\n      footer:\n        foot:\n          n: count()\n",
+        );
+        let config: PipelineConfig = crate::yaml::from_str(&yaml).expect("parse");
+        let envelope = config
+            .nodes
+            .iter()
+            .find(|n| matches!(n.value, PipelineNode::Envelope { .. }))
+            .expect("envelope node present");
+        let json = serde_json::to_value(&envelope.value).expect("serialize envelope node");
+        let reparsed: PipelineNode =
+            serde_json::from_value(json).expect("re-parse serialized envelope node");
+        match reparsed {
+            PipelineNode::Envelope { config, .. } => {
+                assert_eq!(config.strategy, EnvelopeStrategy::Concat);
+                assert_eq!(
+                    config
+                        .header
+                        .get("head")
+                        .and_then(|s| s.get("who"))
+                        .map(|c| c.as_ref()),
+                    Some("$vars.sender_id")
+                );
+                assert_eq!(
+                    config
+                        .footer
+                        .get("foot")
+                        .and_then(|s| s.get("n"))
+                        .map(|c| c.as_ref()),
+                    Some("count()")
+                );
+            }
+            other => panic!("round-trip changed the variant: {other:?}"),
+        }
     }
 }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -131,6 +131,14 @@ pub struct CompileArtifacts {
     /// body typecheck (or the collect-mode path, which has no body)
     /// surface an empty map here.
     pub combine_resolved_columns: HashMap<String, crate::plan::execution::ResolvedColumnMap>,
+    /// Compiled declarative header/footer synthesis per Envelope node, keyed
+    /// by node name. Populated during binding (where the body input `Row` is
+    /// in scope) for every Envelope that declares a `config.header:` or
+    /// `config.footer:` map; consumed at lowering to attach the spec to
+    /// `PlanNode::Envelope.synthesis`. An Envelope declaring neither is absent
+    /// from this map and lowers with `synthesis: None`.
+    pub envelope_synthesis:
+        HashMap<String, Arc<crate::plan::envelope_synthesis::EnvelopeSynthesis>>,
     /// Monotonic counter for fresh tail-variable IDs allocated during
     /// row-polymorphic propagation (composition input-port binding).
     /// Threaded as `&mut u32` into `build_input_port_rows`; IDs are
@@ -2059,10 +2067,31 @@ fn bind_schema_inner(
             // ambient `$doc` view, not the record schema. A wired `header:` port
             // replaces the framing header (not the record schema), so binding
             // reads only the body input for the output row here.
-            PipelineNode::Envelope { header, .. } => {
+            PipelineNode::Envelope { header, config } => {
                 if let Some(upstream) = upstream_schema(&header.body.value, schema_by_name) {
                     let row = upstream.clone();
                     schema_by_name.insert(name.clone(), row.clone());
+                    // Compile declarative header/footer synthesis against the
+                    // body input `Row` (the Envelope's output row, since it does
+                    // not widen). Header scalars typecheck in `Row` mode and may
+                    // not reference a body column (E353); footer aggregates
+                    // typecheck in `GroupBy` mode with an empty group_by and must
+                    // be in the streaming allow-list (E354). Errors push onto
+                    // `diags` and the node lowers without a synthesis spec.
+                    if (!config.header.is_empty() || !config.footer.is_empty())
+                        && let Some(synthesis) = compile_envelope_synthesis(
+                            &name,
+                            config,
+                            &row,
+                            span,
+                            &bind_ctx.scoped_vars,
+                            diags,
+                        )
+                    {
+                        artifacts
+                            .envelope_synthesis
+                            .insert(name.clone(), Arc::new(synthesis));
+                    }
                     artifacts
                         .typed
                         .insert(name, Arc::new(synthetic_typed_program(row)));
@@ -3433,6 +3462,344 @@ fn typecheck_cxl(
                 LabeledSpan::primary(span, String::new()),
             )
         })
+}
+
+/// Compile an Envelope node's declarative header/footer synthesis against the
+/// body input `Row` (the Envelope's output row, since it does not widen).
+///
+/// Returns `Some(spec)` when at least one section compiled cleanly; `None` when
+/// every declared section failed compilation (all errors already pushed onto
+/// `diags`). A section that fails to compile is dropped and its diagnostic is
+/// emitted, so a present spec carries only the sections the executor can run.
+///
+/// # Header sections
+///
+/// Each field is typechecked in [`AggregateMode::Row`] as a synthetic
+/// `emit <field> = <expr>` program (all of a section's fields in one program,
+/// so they share the typed side-tables). The header is emitted before any body
+/// record streams, so a body-column reference is meaningless — any
+/// [`Expr::FieldRef`] / [`Expr::QualifiedFieldRef`] in a header expression is
+/// rejected with **E353**.
+///
+/// # Footer sections
+///
+/// Each field is typechecked in [`AggregateMode::GroupBy`] with an empty
+/// group_by (the per-document grouping is external) and extracted via
+/// [`cxl::plan::extract_aggregates`]. Every binding must be in the streaming
+/// allow-list — `count` / `sum` / `avg` / `min` / `max`, the O(1)
+/// distributive/algebraic set — with a bare-field or `*` argument; a holistic
+/// aggregate (`collect`, `any`, `weighted_avg`) or a composed/two-arg argument
+/// is rejected with **E354**. Holistic functions that are not CXL functions at
+/// all (`median`, `mode`) already fail typechecking as unknown functions.
+#[allow(clippy::result_large_err)]
+fn compile_envelope_synthesis(
+    name: &str,
+    config: &crate::config::pipeline_node::EnvelopeBody,
+    body_row: &Row,
+    span: Span,
+    scoped_vars: &cxl::resolve::ScopedVarsRegistry,
+    diags: &mut Vec<Diagnostic>,
+) -> Option<crate::plan::envelope_synthesis::EnvelopeSynthesis> {
+    use crate::plan::envelope_synthesis::{
+        EnvelopeSynthesis, SynthesizedFooterSection, SynthesizedHeaderSection,
+    };
+
+    let mut header_sections: Vec<SynthesizedHeaderSection> = Vec::new();
+    for (section, fields) in &config.header {
+        if let Some(compiled) =
+            compile_header_section(name, section, fields, body_row, span, scoped_vars, diags)
+        {
+            header_sections.push(compiled);
+        }
+    }
+
+    let mut footer_sections: Vec<SynthesizedFooterSection> = Vec::new();
+    for (section, fields) in &config.footer {
+        if let Some(compiled) =
+            compile_footer_section(name, section, fields, body_row, span, scoped_vars, diags)
+        {
+            footer_sections.push(compiled);
+        }
+    }
+
+    let synthesis = EnvelopeSynthesis {
+        header: header_sections,
+        footer: footer_sections,
+    };
+    if synthesis.is_empty() {
+        None
+    } else {
+        Some(synthesis)
+    }
+}
+
+/// Compile one header section: typecheck all its fields together as a `Row`-mode
+/// program, then reject any body-column reference with E353. Returns `None` (and
+/// pushes a diagnostic) on a typecheck failure or an E353 rejection.
+#[allow(clippy::result_large_err)]
+fn compile_header_section(
+    name: &str,
+    section: &str,
+    fields: &IndexMap<String, crate::yaml::CxlSource>,
+    body_row: &Row,
+    span: Span,
+    scoped_vars: &cxl::resolve::ScopedVarsRegistry,
+    diags: &mut Vec<Diagnostic>,
+) -> Option<crate::plan::envelope_synthesis::SynthesizedHeaderSection> {
+    use crate::plan::envelope_synthesis::SynthesizedHeaderSection;
+
+    // One synthetic program per section: `emit <field> = <expr>` per field, in
+    // declaration order, so they typecheck together and share side-tables.
+    let mut program = String::new();
+    for (field, expr) in fields {
+        program.push_str("emit ");
+        program.push_str(field);
+        program.push_str(" = ");
+        program.push_str(expr.as_ref());
+        program.push('\n');
+    }
+
+    let typed = match typecheck_cxl(
+        &format!("{name}:header.{section}"),
+        &program,
+        body_row,
+        AggregateMode::Row,
+        span,
+        scoped_vars,
+    ) {
+        Ok(t) => t,
+        Err(d) => {
+            diags.push(d);
+            return None;
+        }
+    };
+
+    // Pair each field's typed emit expression by output name. A header field
+    // expression that references a body column is rejected: the header is
+    // emitted before the body streams, so a body value is not yet knowable.
+    let mut field_exprs: Vec<(Box<str>, Expr)> = Vec::new();
+    let mut rejected = false;
+    cxl::ast::for_each_field_emit(&typed.program.statements, &mut |field, expr| {
+        if let Some(bad) = first_body_field_ref(expr) {
+            diags.push(
+                Diagnostic::error(
+                    "E353",
+                    format!(
+                        "envelope {name:?} header section {section:?} field {field:?} references \
+                         body column {bad:?} — the header is emitted before the body streams, so \
+                         it may read only $vars / $source / $pipeline / $doc, never a body field"
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                )
+                .with_help(
+                    "compute the value from a document-open-knowable input ($vars / $source / \
+                     $pipeline / $doc), or move a body-derived value into a footer aggregate",
+                ),
+            );
+            rejected = true;
+        }
+        field_exprs.push((Box::from(field), expr.clone()));
+    });
+
+    if rejected {
+        return None;
+    }
+
+    Some(SynthesizedHeaderSection {
+        section: section.to_string(),
+        typed: Arc::new(typed),
+        fields: field_exprs,
+    })
+}
+
+/// The name of the first body-column reference reachable from `expr`, or `None`
+/// when the expression reads only document-open-knowable inputs ($-namespaces).
+/// A bare [`Expr::FieldRef`] is a body column; a [`Expr::QualifiedFieldRef`]'s
+/// dotted path is reported joined. `$source` / `$doc` / `$vars` / `$pipeline`
+/// accesses are NOT field references and pass.
+fn first_body_field_ref(expr: &Expr) -> Option<String> {
+    match expr {
+        Expr::FieldRef { name, .. } => Some(name.to_string()),
+        Expr::QualifiedFieldRef { parts, .. } => Some(
+            parts
+                .iter()
+                .map(|p| p.as_ref())
+                .collect::<Vec<_>>()
+                .join("."),
+        ),
+        Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
+            first_body_field_ref(lhs).or_else(|| first_body_field_ref(rhs))
+        }
+        Expr::Unary { operand, .. } => first_body_field_ref(operand),
+        Expr::IfThenElse {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => first_body_field_ref(condition)
+            .or_else(|| first_body_field_ref(then_branch))
+            .or_else(|| else_branch.as_deref().and_then(first_body_field_ref)),
+        Expr::IndexAccess {
+            receiver, index, ..
+        } => first_body_field_ref(receiver).or_else(|| first_body_field_ref(index)),
+        Expr::MethodCall { receiver, args, .. } => {
+            first_body_field_ref(receiver).or_else(|| args.iter().find_map(first_body_field_ref))
+        }
+        Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
+            args.iter().find_map(first_body_field_ref)
+        }
+        Expr::Match { subject, arms, .. } => subject
+            .as_deref()
+            .and_then(first_body_field_ref)
+            .or_else(|| {
+                arms.iter().find_map(|arm| {
+                    first_body_field_ref(&arm.pattern).or_else(|| first_body_field_ref(&arm.body))
+                })
+            }),
+        Expr::Closure { body, .. } => first_body_field_ref(body),
+        Expr::Literal { .. }
+        | Expr::PipelineAccess { .. }
+        | Expr::VarsAccess { .. }
+        | Expr::SourceAccess { .. }
+        | Expr::QualifiedSourceAccess { .. }
+        | Expr::RecordAccess { .. }
+        | Expr::DocAccess { .. }
+        | Expr::Now { .. }
+        | Expr::Wildcard { .. }
+        | Expr::AggSlot { .. }
+        | Expr::GroupKey { .. } => None,
+    }
+}
+
+/// Compile one footer section: typecheck its fields as a `GroupBy`-mode program
+/// with an empty group_by, extract the aggregates, then reject any binding
+/// outside the streaming allow-list (or with a composed argument) with E354.
+/// Returns `None` (and pushes a diagnostic) on any failure.
+#[allow(clippy::result_large_err)]
+fn compile_footer_section(
+    name: &str,
+    section: &str,
+    fields: &IndexMap<String, crate::yaml::CxlSource>,
+    body_row: &Row,
+    span: Span,
+    scoped_vars: &cxl::resolve::ScopedVarsRegistry,
+    diags: &mut Vec<Diagnostic>,
+) -> Option<crate::plan::envelope_synthesis::SynthesizedFooterSection> {
+    use clinker_record::accumulator::AggregateType;
+    use cxl::plan::BindingArg;
+
+    use crate::plan::envelope_synthesis::SynthesizedFooterSection;
+
+    let mut program = String::new();
+    for (field, expr) in fields {
+        program.push_str("emit ");
+        program.push_str(field);
+        program.push_str(" = ");
+        program.push_str(expr.as_ref());
+        program.push('\n');
+    }
+
+    let typed = match typecheck_cxl(
+        &format!("{name}:footer.{section}"),
+        &program,
+        body_row,
+        AggregateMode::GroupBy {
+            group_by_fields: HashSet::new(),
+        },
+        span,
+        scoped_vars,
+    ) {
+        Ok(t) => t,
+        Err(d) => {
+            diags.push(d);
+            return None;
+        }
+    };
+
+    let input_schema: Vec<String> = body_row
+        .field_names()
+        .map(|qf| qf.name.to_string())
+        .collect();
+    let compiled = match cxl::plan::extract_aggregates(&typed, &[], &input_schema) {
+        Ok(c) => c,
+        Err(errs) => {
+            for e in errs {
+                diags.push(Diagnostic::error(
+                    "E354",
+                    format!(
+                        "envelope {name:?} footer section {section:?}: aggregate extraction \
+                         failed: {}",
+                        e.message
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                ));
+            }
+            return None;
+        }
+    };
+
+    // Every binding must be a streaming distributive/algebraic aggregate over a
+    // bare field or `*`. Holistic / non-O(1) aggregates and composed (multi-arg
+    // or expression) arguments are not supported by the streaming footer fold.
+    let mut rejected = false;
+    for binding in &compiled.bindings {
+        let allowed_type = matches!(
+            binding.acc_type,
+            AggregateType::Count { .. }
+                | AggregateType::Sum
+                | AggregateType::Avg
+                | AggregateType::Min
+                | AggregateType::Max
+        );
+        if !allowed_type {
+            diags.push(
+                Diagnostic::error(
+                    "E354",
+                    format!(
+                        "envelope {name:?} footer section {section:?} uses aggregate {} \
+                         ({:?}), which is not a streaming footer aggregate — a footer fold \
+                         supports only count / sum / avg / min / max",
+                        binding.output_name, binding.acc_type
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                )
+                .with_help(
+                    "rewrite the footer with a count / sum / avg / min / max aggregate, or \
+                     compute a holistic value in an upstream Aggregate node",
+                ),
+            );
+            rejected = true;
+            continue;
+        }
+        if !matches!(binding.arg, BindingArg::Field(_) | BindingArg::Wildcard) {
+            diags.push(
+                Diagnostic::error(
+                    "E354",
+                    format!(
+                        "envelope {name:?} footer section {section:?} aggregate {} takes a \
+                         composed or multi-argument expression — a footer fold supports only a \
+                         bare field or `*` argument (count() / count(*) / sum(amount) / min(x))",
+                        binding.output_name
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                )
+                .with_help(
+                    "project the composed value in an upstream Transform, then aggregate the \
+                     resulting bare column in the footer",
+                ),
+            );
+            rejected = true;
+        }
+    }
+
+    if rejected {
+        return None;
+    }
+
+    Some(SynthesizedFooterSection {
+        section: section.to_string(),
+        compiled: Arc::new(compiled),
+    })
 }
 
 /// Propagate an upstream row through a Transform node: start with all

--- a/crates/clinker-plan/src/plan/envelope_synthesis.rs
+++ b/crates/clinker-plan/src/plan/envelope_synthesis.rs
@@ -1,0 +1,91 @@
+//! Compiled header/footer synthesis spec for the `Envelope` node.
+//!
+//! An Envelope node may declare, orthogonally to its framing strategy, a set
+//! of synthesized header and footer sections (`config.header` / `config.footer`
+//! in the pipeline YAML). This module holds the plan-compile artifact that the
+//! executor evaluates per output document:
+//!
+//! - **Header** sections are scalar projections evaluated once per output
+//!   document at its open. Each field is a CXL expression over
+//!   document-open-knowable inputs only (`$vars` / `$source` / `$pipeline` /
+//!   the ambient `$doc.*` envelope); body-column references are rejected at
+//!   compile time, since the header is emitted before any body record streams.
+//! - **Footer** sections are streaming aggregate folds over the framed body
+//!   records of one document. Each field is a distributive/algebraic aggregate
+//!   (`count` / `sum` / `avg` / `min` / `max`) maintained as an O(1)
+//!   accumulator per open document and emitted at the document's close.
+//!
+//! Synthesis layers on top of either framing strategy: under `preserve` it
+//! produces a per-document header/footer; under `concat` it produces the single
+//! consolidated document's header/footer. Both reduce to "group the framed body
+//! by document grain, then per grain evaluate header scalars and fold footer
+//! aggregates" — the strategy only decides how many grains there are.
+//!
+//! **Not serde-derivable.** It holds [`cxl::ast::Expr`] /
+//! [`cxl::typecheck::TypedProgram`] / [`cxl::plan::CompiledAggregate`], none of
+//! which serialize (the same constraint that keeps `PlanNode::Aggregation`'s
+//! `compiled` field `#[serde(skip)]`). The spec lives behind `Arc` on
+//! `PlanNode::Envelope` with `#[serde(skip)]` and is reconstructed by the
+//! compiler, never shipped through the JSON `--explain` channel.
+
+use std::sync::Arc;
+
+use cxl::ast::Expr;
+use cxl::plan::CompiledAggregate;
+use cxl::typecheck::TypedProgram;
+
+/// One synthesized header section: a named `EnvelopeRecord` section whose
+/// fields are scalar CXL expressions evaluated against the grain's first
+/// record at document open.
+#[derive(Debug, Clone)]
+pub struct SynthesizedHeaderSection {
+    /// Target `EnvelopeRecord` section name (user-defined; the section a
+    /// downstream writer renders via `header_from_doc`).
+    pub section: String,
+    /// The section's typed program — one synthetic `emit <field> = <expr>`
+    /// statement per declared field, typechecked together against the body
+    /// input schema. Shared by every field's scalar compile so the typed
+    /// side-tables (regex cache, literal baking) are built once.
+    pub typed: Arc<TypedProgram>,
+    /// Fields in declaration order (= rendered cell order). Each carries the
+    /// output field name and the expression the executor lowers to a
+    /// `CompiledScalar` via [`cxl::eval::ProgramEvaluator::compile_scalar`].
+    pub fields: Vec<(Box<str>, Expr)>,
+}
+
+/// One synthesized footer section: a named `EnvelopeRecord` section whose
+/// fields are streaming aggregate folds over the document's framed body.
+#[derive(Debug, Clone)]
+pub struct SynthesizedFooterSection {
+    /// Target `EnvelopeRecord` section name (the section a downstream writer
+    /// renders via `footer_from_doc`).
+    pub section: String,
+    /// The compiled aggregate for this section — one `emit <field> = <agg>`
+    /// statement per declared field, extracted with an empty group_by (the
+    /// per-document grouping is external, done by the executor over grains).
+    /// Each emit's `output_name` is the rendered field name.
+    pub compiled: Arc<CompiledAggregate>,
+}
+
+/// Compiled declarative header/footer synthesis for one Envelope node.
+///
+/// Attached to `PlanNode::Envelope` as `Option<Arc<EnvelopeSynthesis>>`; `None`
+/// when the node declares neither a `header:` nor a `footer:` synthesis map.
+/// The executor, when present, groups the framed body by document grain and per
+/// grain stamps the synthesized sections into the document's `EnvelopeRecord`.
+#[derive(Debug, Clone)]
+pub struct EnvelopeSynthesis {
+    /// Header sections in declaration order.
+    pub header: Vec<SynthesizedHeaderSection>,
+    /// Footer sections in declaration order.
+    pub footer: Vec<SynthesizedFooterSection>,
+}
+
+impl EnvelopeSynthesis {
+    /// `true` when the node declares neither a header nor a footer section —
+    /// the lowering site stores `None` rather than an empty spec in that case,
+    /// so a present `EnvelopeSynthesis` always carries at least one section.
+    pub fn is_empty(&self) -> bool {
+        self.header.is_empty() && self.footer.is_empty()
+    }
+}

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -264,6 +264,14 @@ pub enum PlanNode {
         /// not widen). Populated by `bind_schema`.
         #[serde(skip)]
         output_schema: Arc<Schema>,
+        /// Compiled declarative header/footer synthesis. `Some` iff the node
+        /// declared a `config.header:` or `config.footer:` map; the executor
+        /// then stamps the synthesized sections into each output document's
+        /// `EnvelopeRecord`. `None` when neither is declared. Holds non-serde
+        /// CXL artifacts (`Expr` / `TypedProgram` / `CompiledAggregate`), so it
+        /// is reconstructed at compile and never shipped through `--explain`.
+        #[serde(skip)]
+        synthesis: Option<Arc<crate::plan::envelope_synthesis::EnvelopeSynthesis>>,
     },
     /// Planner-synthesized sort enforcer.
     ///

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -244,6 +244,8 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E350" => Some(include_str!("../../../../docs/explain/E350.md")),
         "E351" => Some(include_str!("../../../../docs/explain/E351.md")),
         "E352" => Some(include_str!("../../../../docs/explain/E352.md")),
+        "E353" => Some(include_str!("../../../../docs/explain/E353.md")),
+        "E354" => Some(include_str!("../../../../docs/explain/E354.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -468,8 +470,8 @@ mod tests {
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352", "E15Y",
-            "W101", "W302", "W305", "W306",
+            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352", "E353",
+            "E354", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/mod.rs
+++ b/crates/clinker-plan/src/plan/mod.rs
@@ -3,6 +3,7 @@ pub mod combine;
 pub mod compiled;
 pub mod composition_body;
 pub mod deferred_region;
+pub mod envelope_synthesis;
 pub mod execution;
 pub mod explain_provenance;
 pub mod extraction;

--- a/crates/clinker-plan/src/plan/tests/envelope_synthesis.rs
+++ b/crates/clinker-plan/src/plan/tests/envelope_synthesis.rs
@@ -1,0 +1,159 @@
+//! Compile-time validation of the Envelope node's declarative header/footer
+//! synthesis.
+//!
+//! Header expressions are evaluated at document open, before the body streams,
+//! so a body-column reference is rejected with E353. Footer aggregates fold the
+//! body as O(1) accumulators, so an aggregate outside the streaming allow-list —
+//! or one not a CXL function at all — is rejected (E354 for the former, an
+//! unknown-function typecheck error for the latter).
+
+use crate::config::{CompileContext, parse_config};
+
+/// Build a pipeline whose body Transform feeds an Envelope node, with the
+/// Envelope's `config:` block supplied verbatim by the caller. The body carries
+/// an `amount` column so footer aggregates have a real field to fold.
+fn pipeline_with_envelope_config(config_block: &str) -> String {
+    let mut yaml = String::from(
+        r#"
+pipeline:
+  name: envelope_synth
+  vars:
+    sender_id: { type: string, default: "ACME" }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: int }
+        - { name: amount, type: int }
+  - type: transform
+    name: body
+    input: src
+    config:
+      cxl: |
+        emit id = id
+        emit amount = amount
+  - type: envelope
+    name: framed
+    body: body
+    config:
+"#,
+    );
+    for line in config_block.lines() {
+        yaml.push_str(&format!("      {line}\n"));
+    }
+    yaml.push_str(
+        "  - type: output\n    name: out\n    input: framed\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+    );
+    yaml
+}
+
+#[test]
+fn footer_count_and_sum_compile_clean() {
+    // The streaming allow-list (count / sum) over bare-field / `*` arguments
+    // compiles without diagnostics — the happy path the rejections guard.
+    let yaml = pipeline_with_envelope_config(
+        "strategy: concat\nfooter:\n  interchange:\n    n: count()\n    total: sum(amount)",
+    );
+    let config = parse_config(&yaml).expect("parse footer pipeline");
+    config
+        .compile(&CompileContext::default())
+        .expect("count / sum footer aggregates compile clean");
+}
+
+#[test]
+fn header_referencing_a_body_field_is_e353() {
+    // A header field reads the body column `amount`. The header is emitted
+    // before the body streams, so this is rejected with E353 — pin the code.
+    let yaml = pipeline_with_envelope_config(
+        "strategy: concat\nheader:\n  interchange:\n    total: amount",
+    );
+    let config = parse_config(&yaml).expect("parse header pipeline");
+    let err = config
+        .compile(&CompileContext::default())
+        .expect_err("a body-field reference in a header must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E353")
+        .unwrap_or_else(|| panic!("expected an E353 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("amount"),
+        "E353 must name the offending body column: {}",
+        diag.message
+    );
+}
+
+#[test]
+fn header_reading_vars_compiles_clean() {
+    // A header reading only `$vars` (a document-open-knowable input) is the
+    // intended header shape and compiles without diagnostics — the control
+    // proving E353 fires on the body reference, not on header synthesis itself.
+    let yaml = pipeline_with_envelope_config(
+        "strategy: preserve\nheader:\n  interchange:\n    sender: $vars.sender_id",
+    );
+    let config = parse_config(&yaml).expect("parse header-vars pipeline");
+    config
+        .compile(&CompileContext::default())
+        .expect("a $vars-only header compiles clean");
+}
+
+#[test]
+fn footer_collect_is_e354() {
+    // `collect(amount)` is a holistic aggregate — it accumulates every value,
+    // not an O(1) fold — so it is rejected as a non-streaming footer aggregate.
+    let yaml = pipeline_with_envelope_config(
+        "strategy: concat\nfooter:\n  interchange:\n    items: collect(amount)",
+    );
+    let config = parse_config(&yaml).expect("parse collect-footer pipeline");
+    let err = config
+        .compile(&CompileContext::default())
+        .expect_err("a holistic footer aggregate must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E354")
+        .unwrap_or_else(|| panic!("expected an E354 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("count / sum / avg / min / max"),
+        "E354 must name the streaming allow-list: {}",
+        diag.message
+    );
+}
+
+#[test]
+fn footer_median_is_a_compile_error() {
+    // `median` is not a CXL aggregate function at all, so it fails typechecking
+    // as an unknown function (surfaced as E200) — a compile error either way,
+    // satisfying the "median(x) is a compile error" acceptance without a
+    // special case in the allow-list.
+    let yaml = pipeline_with_envelope_config(
+        "strategy: concat\nfooter:\n  interchange:\n    mid: median(amount)",
+    );
+    let config = parse_config(&yaml).expect("parse median-footer pipeline");
+    let err = config
+        .compile(&CompileContext::default())
+        .expect_err("median is not a CXL aggregate and must fail to compile");
+    assert!(
+        err.iter().any(|d| d.code == "E200" || d.code == "E354"),
+        "median must surface a compile diagnostic (unknown function), got: {err:?}"
+    );
+}
+
+#[test]
+fn footer_composed_argument_is_e354() {
+    // `sum(amount * 1.1)` is a composed argument — the footer fold supports only
+    // a bare field or `*`, so the composed argument is rejected with E354.
+    let yaml = pipeline_with_envelope_config(
+        "strategy: concat\nfooter:\n  interchange:\n    gross: sum(amount * 2)",
+    );
+    let config = parse_config(&yaml).expect("parse composed-arg footer pipeline");
+    let err = config
+        .compile(&CompileContext::default())
+        .expect_err("a composed aggregate argument must fail to compile");
+    assert!(
+        err.iter().any(|d| d.code == "E354"),
+        "a composed footer argument must surface E354, got: {err:?}"
+    );
+}

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -5,6 +5,7 @@ mod dag;
 mod dedup_node_rooted;
 mod deferred_region;
 mod doc_paths;
+mod envelope_synthesis;
 mod explain_buffer_class;
 mod explain_polish;
 mod plan_time_window_root;

--- a/crates/clinker-record/src/document_context.rs
+++ b/crates/clinker-record/src/document_context.rs
@@ -157,6 +157,20 @@ impl EnvelopeRecord {
         }
     }
 
+    /// Iterate the envelope's sections in declared order as `(name, payload)`
+    /// pairs — the section name list paired positionally with the payloads.
+    ///
+    /// Used by the Envelope node's header/footer synthesis to merge fresh
+    /// synthesized sections onto an existing envelope: the merge re-emits the
+    /// untouched sections in order, then overlays the synthesized ones by name.
+    pub fn sections(&self) -> impl Iterator<Item = (&str, &Value)> {
+        self.schema
+            .columns()
+            .iter()
+            .map(|c| c.as_ref())
+            .zip(self.sections.iter())
+    }
+
     /// The empty envelope: no sections, so every `$doc.*` resolves `None`.
     /// Used for synthetic / zero-body contexts.
     pub fn empty() -> Self {

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2000,7 +2000,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             None => {
                 return Err(format!(
                     "unknown diagnostic code '{code}'. Valid codes: E101-E108, E150b-E150e, \
-                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E347, \
+                     E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E354, \
                      W101/W302/W305/W306"
                 )
                 .into());

--- a/docs/explain/E353.md
+++ b/docs/explain/E353.md
@@ -1,0 +1,90 @@
+# Error E353: an envelope header expression references a body column
+
+## What it means
+
+An Envelope node's declarative `header:` synthesis (see the "Envelope Nodes"
+pipeline reference) computes a fresh header **once per output document at the
+document's open** — before any body record streams through. A header field may
+therefore read only inputs that are known at document open: pipeline
+configuration (`$vars`), per-document provenance (`$source`), pipeline-scope
+state (`$pipeline`), and the ambient envelope (`$doc.*`). It may **not** read a
+body column, because there is no "current body record" yet when the header is
+emitted.
+
+This diagnostic fires when a `header:` expression contains a body-column
+reference — a bare field name like `amount`, or a qualified path like
+`line.amount`. Per-row body values belong in a **footer** aggregate
+(`count(*)`, `sum(amount)`), which folds the body records of the document and
+emits at the document's close.
+
+```
+envelope 'framed' header section 'interchange' field 'total' references body
+column 'amount' — the header is emitted before the body streams, so it may read
+only $vars / $source / $pipeline / $doc, never a body field
+```
+
+## Example
+
+```yaml
+# Rejected: a header field reads the body column `amount`.
+nodes:
+  - type: envelope
+    name: framed
+    body: payments
+    config:
+      strategy: concat
+      header:
+        interchange:
+          sender: $vars.sender_id      # OK — a static config knob
+          total: sum(amount)           # rejected — body-derived value in a header
+```
+
+```yaml
+# Corrected: the body-derived total moves to a footer aggregate; the header
+# carries only document-open-knowable values.
+nodes:
+  - type: envelope
+    name: framed
+    body: payments
+    config:
+      strategy: concat
+      header:
+        interchange:
+          sender: $vars.sender_id
+      footer:
+        interchange:
+          total: sum(amount)
+```
+
+## How to fix
+
+1. **Move a body-derived value into a `footer:` aggregate.** A footer folds the
+   document's body records, so `sum(amount)` / `count(*)` belong there, not in
+   the header.
+
+2. **Compute the header value from a document-open-knowable input.** Read
+   `$vars.*` for static configuration, `$source.*` for the originating file,
+   `$pipeline.*` for run-scope state, or `$doc.<section>.<field>` for a value the
+   source's envelope already carries.
+
+3. **Project the value upstream and read it through `$doc`.** If a header value
+   genuinely derives from the document's content, compute it in an upstream stage
+   that promotes it into an envelope section, then read it in the header with
+   `$doc.<section>.<field>`.
+
+## Technical context
+
+Header synthesis is typechecked at compile time against the Envelope's body
+input schema in row mode, then its expression tree is walked for any
+`FieldRef` / `QualifiedFieldRef` leaf. Those leaves resolve against a body
+record's columns at evaluation time — but a header is evaluated once at document
+open against the document's first record only to ground `$source.*` / `$doc.*`,
+never to read a body value, so a body-column leaf would either read an arbitrary
+first row (a silent correctness trap) or fail to resolve. Rejecting it at compile
+time keeps the header's contract explicit: header inputs are document-open
+constants, footer inputs are body folds.
+
+## See also
+
+- "Envelope Nodes" in the pipeline reference — `header:` / `footer:` synthesis
+- Error E354 — a footer aggregate is not a streaming footer aggregate

--- a/docs/explain/E354.md
+++ b/docs/explain/E354.md
@@ -1,0 +1,93 @@
+# Error E354: an envelope footer uses a non-streaming aggregate
+
+## What it means
+
+An Envelope node's declarative `footer:` synthesis (see the "Envelope Nodes"
+pipeline reference) folds the body records of each output document into a footer
+section, then emits it at the document's close. The fold is maintained as an
+**O(1) accumulator per open document**, so it supports only the streaming
+distributive/algebraic aggregates — `count`, `sum`, `avg`, `min`, `max` — each
+over a **bare field or `*`** argument.
+
+This diagnostic fires when a footer field uses anything outside that set:
+
+- A **holistic or unbounded aggregate** — `collect` (accumulates every value),
+  `any` (an ill-defined footer total), or `weighted_avg` (a two-argument
+  aggregate). These cannot be maintained as an O(1) per-document accumulator.
+
+- A **composed or multi-argument aggregate argument** — `sum(amount * 1.1)`,
+  `weighted_avg(value, weight)`. A footer fold supports only a bare field or
+  `*`; project the composed value in an upstream Transform first, then aggregate
+  the resulting bare column.
+
+A footer call to a function that is not a CXL aggregate at all (`median(x)`,
+`mode(x)`) fails earlier as an unknown-function typecheck error, not as E354.
+
+```
+envelope 'framed' footer section 'interchange' uses aggregate items
+(Collect), which is not a streaming footer aggregate — a footer fold supports
+only count / sum / avg / min / max
+```
+
+## Example
+
+```yaml
+# Rejected: a footer collects every line id — a holistic, unbounded aggregate.
+nodes:
+  - type: envelope
+    name: framed
+    body: lines
+    config:
+      strategy: concat
+      footer:
+        interchange:
+          record_count: count()
+          items: collect(line_id)     # rejected — holistic aggregate
+```
+
+```yaml
+# Corrected: the footer carries only streaming aggregates.
+nodes:
+  - type: envelope
+    name: framed
+    body: lines
+    config:
+      strategy: concat
+      footer:
+        interchange:
+          record_count: count()
+          total: sum(amount)
+          largest: max(amount)
+```
+
+## How to fix
+
+1. **Use a streaming aggregate** — `count` / `sum` / `avg` / `min` / `max` — for
+   the footer field. These are the control-total shapes a document footer
+   typically needs (record count, sum, min/max).
+
+2. **Project a composed value upstream.** For `sum(amount * 1.1)`, emit the
+   product as a column in an upstream Transform (`emit gross = amount * 1.1`),
+   then write `sum(gross)` in the footer over the bare column.
+
+3. **Compute a holistic value in an upstream Aggregate node.** A `collect` or a
+   weighted average over the whole body belongs in an Aggregate before the
+   Envelope, whose result a header can then read through `$doc`.
+
+## Technical context
+
+Footer synthesis is typechecked at compile time in group-by mode with an empty
+group_by (the per-document grouping is external — the executor groups the framed
+body by document grain), then extracted into accumulator bindings. Each binding
+carries an accumulator type and an argument classification; the validator admits
+only the `Count` / `Sum` / `Avg` / `Min` / `Max` accumulator types with a
+`Field` or `Wildcard` argument. The admitted set is exactly the aggregates whose
+state is bounded independent of the document's row count, so a document's footer
+costs one accumulator slot per field regardless of how many body records it
+frames — the property that lets footer synthesis stay within the Envelope node's
+bounded-memory model.
+
+## See also
+
+- "Envelope Nodes" in the pipeline reference — `header:` / `footer:` synthesis
+- Error E353 — an envelope header expression references a body column

--- a/docs/user/src/nodes/envelope.md
+++ b/docs/user/src/nodes/envelope.md
@@ -2,7 +2,7 @@
 
 Envelope nodes frame a body stream into per-document documents. An Envelope is a discrete, composable stage you can place after **any** operator — a Transform, a Merge, a Combine, or an Aggregate — to declare "from here on, treat the records as belonging to framed documents." It mirrors the message/EDI/XML envelope-wrapper pattern (the Enterprise Integration Patterns *Envelope Wrapper*, XProc's `p:wrap-sequence`): the body is the payload, and the envelope is the document boundary around it.
 
-This page documents the `preserve` and `concat` strategies. The synthesizing (header-folding) strategies arrive in later releases.
+This page documents the `preserve` and `concat` framing strategies and the orthogonal `header:` / `footer:` synthesis that layers on top of either.
 
 ## Basic structure
 
@@ -127,7 +127,54 @@ upstream, or add a header-folding strategy that declares which header the
 consolidated document keeps.
 ```
 
-To resolve a conflict, either keep the documents separate with `preserve`, make the headers identical upstream (project them to the same sections and values), or — in a later release — declare a header-folding strategy that states which header the consolidated document keeps.
+To resolve a conflict, either keep the documents separate with `preserve`, make the headers identical upstream (project them to the same sections and values), or use `header:` synthesis (below) to regenerate a fresh consolidated header that does not depend on the source headers agreeing.
+
+## Synthesizing a header and footer
+
+`header:` and `footer:` are **orthogonal** to the framing strategy. The strategy decides *how many* output documents there are (`preserve` = one per body grain, `concat` = one consolidated); synthesis decides *what header and footer each of those documents carries*. The node computes a fresh header (declarative scalar expressions) and footer (streaming aggregates over the framed body) **per output document**, stamps them as named sections into the document's envelope, and the same `header_from_doc` / `footer_from_doc` writer path renders them.
+
+Both maps are keyed `section -> field -> CXL expression`. The section name is user-chosen — it is the envelope section a downstream [Output](output.md) renders via `header_from_doc` / `footer_from_doc`. The inner field map preserves declaration order, which is the rendered cell order. A synthesized section **overrides** an existing same-named section on the document (a regenerate); other sections ride through untouched.
+
+```yaml
+- type: envelope
+  name: framed
+  body: merged
+  config:
+    strategy: concat            # or preserve — synthesis works the same on either
+    header:                     # section -> field -> scalar CXL
+      interchange:
+        sender: $vars.sender_id
+        created: $pipeline.run_date
+    footer:                     # section -> field -> aggregate CXL
+      interchange:
+        record_count: count()
+        total: sum(amount)
+```
+
+### Header fields: evaluated once at document open
+
+A `header:` field is a scalar expression evaluated **once per output document, before the body streams**. It may read only inputs known at document open — pipeline configuration (`$vars`), per-document provenance (`$source`), pipeline-scope state (`$pipeline`), and the ambient envelope (`$doc.*`). It may **not** read a body column, because there is no "current body record" when the header is emitted; a body-column reference is rejected at compile time with **E353** (run `clinker explain --code E353`). Put body-derived values in a footer aggregate instead.
+
+### Footer fields: streaming aggregates over the body
+
+A `footer:` field folds the document's body records into a footer value at the document's close. The fold is an **O(1) accumulator per open document**, so it supports exactly the streaming distributive/algebraic aggregates over a **bare field or `*`**:
+
+| Aggregate | Example |
+|-----------|---------|
+| `count` | `count()`, `count(*)` |
+| `sum` | `sum(amount)` |
+| `avg` | `avg(amount)` |
+| `min` | `min(amount)` |
+| `max` | `max(amount)` |
+
+Anything else is rejected at compile time. A holistic or unbounded aggregate (`collect`, `any`, `weighted_avg`) or a composed/multi-argument aggregate (`sum(amount * 1.1)`, `weighted_avg(value, weight)`) raises **E354** (run `clinker explain --code E354`); a non-aggregate function (`median`, `mode`) fails earlier as an unknown function. Project a composed value in an upstream Transform, or compute a holistic value in an upstream Aggregate, then aggregate the bare column here.
+
+### Synthesis is orthogonal: the same footer differs across strategies
+
+Because the strategy sets the grain cardinality, the **same** `footer: { interchange: { record_count: count() } }` produces a different result on each strategy over the same body:
+
+- Under `strategy: preserve`, each body document frames its own output document, so each footer's `record_count` is **that document's** body count.
+- Under `strategy: concat`, the whole body collapses to one document, so the single footer's `record_count` is the **merged** body count.
 
 ## Placement
 
@@ -157,3 +204,5 @@ Placing the Envelope **after** a Combine or Aggregate is the intended use: it de
 Both strategies re-park the body into the node's own buffer slot, which the engine's memory arbitrator governs and spills to disk under pressure — so neither strategy is bounded by total input size held in RAM.
 
 `preserve` is a transparent framing pass-through: it forwards records and their document boundaries unchanged. `concat` additionally re-stamps each record onto the one consolidated document context and replaces the per-document boundaries with a single open/close pair; the header consolidation it does first groups the body records by document — one document's worth of body records shares one grain and one header — so it does one pass over the records to collect the distinct headers, comparing only one envelope per document (the work is bounded by the number of documents, not the number of body rows).
+
+`header:` / `footer:` synthesis adds, on top of the materialized body, one O(1) accumulator per footer field per open document — every allowed footer aggregate (`count` / `sum` / `avg` / `min` / `max`) holds a fixed-size state regardless of how many body rows it folds. So a document's footer state is independent of its body-row count, and synthesis stays within the node's bounded-memory model.


### PR DESCRIPTION
## Summary

Adds declarative header/footer synthesis to the `Envelope` node. A node can now compute a document's header (declarative scalar expressions) and footer (streaming aggregates over the framed body) and stamp them as named envelope sections, which the existing `header_from_doc` / `footer_from_doc` writer path renders.

Synthesis is orthogonal to the framing strategy: `strategy: {preserve, concat}` stays the document-cardinality axis, and `header:` / `footer:` layer on either. The same `footer: count()` therefore yields one merged count under `concat` and a per-grain count under `preserve`.

```yaml
- type: envelope
  name: framed
  body: merged
  config:
    strategy: concat            # or preserve
    header:
      interchange: { sender: $vars.sender_id }
    footer:
      interchange: { record_count: count(), total: sum(amount) }
```

## Behavior & guards

- **Header**: document-open-knowable inputs only (`$vars` / `$source` / `$pipeline` / the ambient `$doc.*` envelope); a body-field reference is a compile error (**E353**) — the header is emitted before the body streams. Evaluated once per output document.
- **Footer**: streaming `count` / `sum` / `avg` / `min` / `max` over a bare field or `*`, one O(1) accumulator per open document. Holistic reductions and composed arguments are compile errors (**E354**). Counts/totals are recomputed from the framed body, never copied.
- Synthesized sections merge into each document's envelope by name (a synthesized section overrides an existing same-named section); untouched sections ride through.

## Tests

- End-to-end differentials through the CSV writer: `count()` → one merged count under concat vs per-grain counts under preserve; `sum` / `min` / `max` over known field values assert the exact rendered totals (the field-index path, verified by a temporary index-offset mutation that makes the new tests fail loudly while the count-only tests stay green).
- Compile-rejection coverage for E353, E354, holistic (`median`/`collect`) and composed (`sum(x * 2)`) footer arguments.

## Docs

- `docs/user/src/nodes/envelope.md` documents the synthesis config, the allowed footer aggregates, and the header input restrictions.
- `docs/explain/E353.md` / `E354.md` + `clinker explain --code E353|E354`.

## Out of scope

Format-native control-total recomputation and writer-owned monotonic control numbers (#577); composed footer aggregate arguments (#577).

Closes #574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)