### PR TITLE
Reject multi-document structured outputs

### DIFF
--- a/crates/clinker-exec/src/executor/correlation_dispatch.rs
+++ b/crates/clinker-exec/src/executor/correlation_dispatch.rs
@@ -20,6 +20,7 @@ use crate::executor::dispatch::{
     CorrelationGroupBuffer, CorrelationRecordSlot, ExecutorContext, MERGED_SOURCE_NAME, push_dlq,
     push_write_error, source_name_arc_of,
 };
+use crate::executor::structured_output_guard::StructuredOutputDocumentGuard;
 use crate::executor::{DlqEntry, build_format_writer};
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::ExecutionPlanDag;
@@ -346,7 +347,7 @@ fn flush_clean_records_to_writers(
     ctx: &mut ExecutorContext<'_>,
     per_output: std::collections::BTreeMap<String, Vec<CorrelationRecordSlot>>,
 ) -> Result<(), PipelineError> {
-    for (output_name, slots) in per_output {
+    'outputs: for (output_name, slots) in per_output {
         if slots.is_empty() {
             continue;
         }
@@ -355,6 +356,13 @@ fn flush_clean_records_to_writers(
             .iter()
             .find(|o| o.name == output_name)
             .unwrap_or(ctx.primary_output);
+        let mut structured_guard = StructuredOutputDocumentGuard::new(&out_cfg.format);
+        for slot in &slots {
+            if let Err(err) = structured_guard.observe(&output_name, slot.projected.doc_ctx()) {
+                ctx.output_errors.push(err);
+                continue 'outputs;
+            }
+        }
         let output_schema = Arc::clone(slots[0].projected.schema());
 
         let Some(raw_writer) = ctx.writers.remove(&output_name) else {

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -65,6 +65,7 @@ use crate::executor::dispatch::{
 };
 use crate::executor::node_buffer::NodeBuffer;
 use crate::executor::stream_event::StreamEvent;
+use crate::executor::structured_output_guard::StructuredOutputDocumentGuard;
 use crate::executor::{DlqEntry, build_format_writer};
 use crate::projection::project_output_from_record;
 use clinker_plan::config::OutputConfig;
@@ -327,6 +328,7 @@ pub(crate) struct DocumentDlqDriver<'cfg> {
     batch_size: usize,
     ok_count: u64,
     records_written: u64,
+    structured_guard: StructuredOutputDocumentGuard,
 }
 
 impl<'cfg> DocumentDlqDriver<'cfg> {
@@ -357,6 +359,7 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
             batch_size: ctx.batch_size,
             ok_count: 0,
             records_written: 0,
+            structured_guard: StructuredOutputDocumentGuard::new(&out_cfg.format),
         }
     }
 
@@ -475,6 +478,14 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
         // drains directly.)
         for item in drain_records_in_arrival_order(buffer) {
             let (record, row_num) = item?;
+            if let Err(err) = self
+                .structured_guard
+                .observe(&self.output_name, record.doc_ctx())
+            {
+                ctx.output_errors.push(err);
+                self.arbitrator.unregister_consumer(consumer_id);
+                return Ok(());
+            }
             projected.push(project_output_from_record(
                 &record,
                 self.out_cfg,
@@ -497,6 +508,13 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
     /// source (or in-pipeline synthesis) routes to a document-DLQ Output,
     /// and for a late record arriving after its file already flushed clean.
     fn write_through(&mut self, ctx: &mut ExecutorContext<'_>, record: Record, row_num: u64) {
+        if let Err(err) = self
+            .structured_guard
+            .observe(&self.output_name, record.doc_ctx())
+        {
+            ctx.output_errors.push(err);
+            return;
+        }
         let projected =
             project_output_from_record(&record, self.out_cfg, self.cxl_emit_names.as_deref());
         if ctx.ok_source_rows.insert(row_num) {

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -32,6 +32,7 @@ pub mod spill_purge;
 pub mod storage_validate;
 pub(crate) mod stream_event;
 mod streaming;
+pub(crate) mod structured_output_guard;
 pub(crate) mod time_window;
 pub(crate) mod transform;
 pub(crate) mod transform_dispatch;

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -20,6 +20,9 @@ use crate::executor::dispatch::{
     push_write_error, source_file_path_of,
 };
 use crate::executor::schema_check::check_input_schema;
+use crate::executor::structured_output_guard::{
+    StructuredOutputDocumentGuard, structured_output_format,
+};
 use crate::executor::{build_format_writer, stage_metrics};
 use crate::projection::project_output_from_record;
 use clinker_plan::error::PipelineError;
@@ -216,6 +219,53 @@ pub(crate) fn dispatch_output(
         buffered = Vec::new();
         unbuffered = input_records;
     }
+
+    // Inline field access (not `resolve_out_cfg`) so the borrow is scoped to
+    // `output_configs` / `primary_output`: this arm interleaves `out_cfg`'s
+    // borrow with `&mut ctx` on other fields (correlation buffers, writers,
+    // timers), which disjoint sub-field borrows permit but a whole-`ctx`
+    // helper borrow would not.
+    let out_cfg = ctx
+        .output_configs
+        .iter()
+        .find(|o| o.name == *name)
+        .unwrap_or(ctx.primary_output);
+    if !unbuffered.is_empty() && structured_output_format(&out_cfg.format).is_some() {
+        if ctx.fan_out_writers.contains_key(name) {
+            let mut guards: HashMap<Arc<str>, StructuredOutputDocumentGuard> = HashMap::new();
+            for (record, _) in &unbuffered {
+                let Some(file_path) = source_file_path_of(record) else {
+                    continue;
+                };
+                let file_arc: Arc<str> = Arc::from(file_path);
+                let guard = guards
+                    .entry(file_arc)
+                    .or_insert_with(|| StructuredOutputDocumentGuard::new(&out_cfg.format));
+                if let Err(err) = guard.observe(name, record.doc_ctx()) {
+                    ctx.output_errors.push(err);
+                    return Ok(());
+                }
+            }
+        } else {
+            let mut guard = StructuredOutputDocumentGuard::new(&out_cfg.format);
+            for (record, _) in &unbuffered {
+                if let Err(err) = guard.observe(name, record.doc_ctx()) {
+                    ctx.output_errors.push(err);
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    // `include_unmapped: false` consults the upstream CXL emit names (resolved
+    // in the preamble above) to drop upstream passthroughs the user did not
+    // explicitly emit.
+    let cxl_emit_names_opt: Option<&[String]> = if cxl_emit_names.is_empty() {
+        None
+    } else {
+        Some(&cxl_emit_names)
+    };
+
     // Counter semantics:
     //
     // * `records_written` increments per WRITE — under
@@ -256,26 +306,6 @@ pub(crate) fn dispatch_output(
     // reaching the writer, not every intermediate node
     // transition (Invariant 3).
     let scan_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::SchemaScan);
-    // Inline field access (not `resolve_out_cfg`) so the borrow is scoped to
-    // `output_configs` / `primary_output`: this arm interleaves `out_cfg`'s
-    // borrow with `&mut ctx` on other fields (correlation buffers, writers,
-    // timers), which disjoint sub-field borrows permit but a whole-`ctx`
-    // helper borrow would not.
-    let out_cfg = ctx
-        .output_configs
-        .iter()
-        .find(|o| o.name == *name)
-        .unwrap_or(ctx.primary_output);
-
-    // `include_unmapped: false` consults the upstream CXL emit names (resolved
-    // in the preamble above) to drop upstream passthroughs the user did not
-    // explicitly emit.
-    let cxl_emit_names_opt: Option<&[String]> = if cxl_emit_names.is_empty() {
-        None
-    } else {
-        Some(&cxl_emit_names)
-    };
-
     // Buffer non-null-key records. Project once, push slot.
     // Overflow check fires the moment a group's record count
     // exceeds the configured cap; subsequent records of the
@@ -484,6 +514,7 @@ fn dispatch_output_envelope(
 
     let events = drain_output_input_event_iter(ctx, current_dag, node_idx);
     let mut driver = EnvelopeWriterDriver::default();
+    let mut structured_guard = StructuredOutputDocumentGuard::new(&out_cfg.format);
 
     for event in events {
         // Boundaries come from records, so punctuations are irrelevant here —
@@ -505,6 +536,15 @@ fn dispatch_output_envelope(
             }
             ctx.output_errors.append(&mut driver.errors);
             return Err(e);
+        }
+        if let Err(err) = structured_guard.observe(name, record.doc_ctx()) {
+            {
+                let _guard = ctx.write_timer.guard();
+                driver.finish();
+            }
+            ctx.output_errors.append(&mut driver.errors);
+            ctx.output_errors.push(err);
+            return Ok(());
         }
         let projected = {
             let _guard = ctx.projection_timer.guard();

--- a/crates/clinker-exec/src/executor/streaming.rs
+++ b/crates/clinker-exec/src/executor/streaming.rs
@@ -23,6 +23,7 @@ use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::certify_streaming_edge;
 
 use super::stream_event::{Punctuation, StreamEvent};
+use super::structured_output_guard::StructuredOutputDocumentGuard;
 use super::{WriterRegistry, build_format_writer, dispatch, stage_metrics};
 
 /// Identify fused producer → single `Output` chains eligible for
@@ -320,10 +321,12 @@ struct OutputStreamConsumer {
     writer: Option<Box<dyn FormatWriter>>,
     /// Holds the raw sink until the first record triggers the lazy build.
     raw_writer_slot: Option<Box<dyn Write + Send>>,
+    structured_guard: StructuredOutputDocumentGuard,
 }
 
 impl OutputStreamConsumer {
     fn new(raw_writer: Box<dyn Write + Send>, spec: StreamingOutputSpec) -> Self {
+        let structured_guard = StructuredOutputDocumentGuard::new(&spec.out_cfg.format);
         Self {
             spec,
             out: StreamingOutputTaskOutput {
@@ -340,6 +343,7 @@ impl OutputStreamConsumer {
             )),
             writer: None,
             raw_writer_slot: Some(raw_writer),
+            structured_guard,
         }
     }
 }
@@ -365,6 +369,14 @@ impl StreamingConsumer for OutputStreamConsumer {
         {
             self.out.errors.push(err);
             return ControlFlow::Continue(());
+        }
+
+        if let Err(err) = self
+            .structured_guard
+            .observe(&self.spec.output_name, record.doc_ctx())
+        {
+            self.out.errors.push(err);
+            return ControlFlow::Break(());
         }
 
         let projected = {

--- a/crates/clinker-exec/src/executor/structured_output_guard.rs
+++ b/crates/clinker-exec/src/executor/structured_output_guard.rs
@@ -1,0 +1,150 @@
+//! Runtime guard for structured writers that can frame only one envelope.
+//!
+//! EDIFACT, X12, HL7, and SWIFT writers currently build one structured
+//! envelope for the record stream they receive. Until per-document structured
+//! framing lands, a single writer must not receive records from more than one
+//! concrete document grain: that would silently merge multiple documents into
+//! one interchange/message envelope.
+
+use std::sync::Arc;
+
+use clinker_format::error::FormatError;
+use clinker_plan::config::OutputFormat;
+use clinker_plan::error::PipelineError;
+use clinker_record::{DocumentContext, DocumentGrain};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StructuredOutputFormat {
+    Edifact,
+    X12,
+    Hl7,
+    Swift,
+}
+
+impl StructuredOutputFormat {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Edifact => "edifact",
+            Self::X12 => "x12",
+            Self::Hl7 => "hl7",
+            Self::Swift => "swift",
+        }
+    }
+
+    fn error(self, message: String) -> PipelineError {
+        let err = match self {
+            Self::Edifact => FormatError::Edifact(message),
+            Self::X12 => FormatError::X12(message),
+            Self::Hl7 => FormatError::Hl7(message),
+            Self::Swift => FormatError::Swift(message),
+        };
+        PipelineError::Format(err)
+    }
+}
+
+pub(crate) fn structured_output_format(format: &OutputFormat) -> Option<StructuredOutputFormat> {
+    match format {
+        OutputFormat::Edifact(_) => Some(StructuredOutputFormat::Edifact),
+        OutputFormat::X12(_) => Some(StructuredOutputFormat::X12),
+        OutputFormat::Hl7(_) => Some(StructuredOutputFormat::Hl7),
+        OutputFormat::Swift(_) => Some(StructuredOutputFormat::Swift),
+        OutputFormat::Csv(_)
+        | OutputFormat::Json(_)
+        | OutputFormat::Xml(_)
+        | OutputFormat::FixedWidth(_) => None,
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct StructuredOutputDocumentGuard {
+    format: Option<StructuredOutputFormat>,
+    first: Option<(DocumentGrain, Arc<str>)>,
+}
+
+impl StructuredOutputDocumentGuard {
+    pub(crate) fn new(format: &OutputFormat) -> Self {
+        Self {
+            format: structured_output_format(format),
+            first: None,
+        }
+    }
+
+    pub(crate) fn observe(
+        &mut self,
+        output_name: &str,
+        doc_ctx: &Arc<DocumentContext>,
+    ) -> Result<(), PipelineError> {
+        let Some(format) = self.format else {
+            return Ok(());
+        };
+        if !crate::executor::document_dlq::is_concrete_file(doc_ctx.source_file()) {
+            return Ok(());
+        }
+
+        let grain = doc_ctx.grain();
+        match &self.first {
+            Some((first_grain, _)) if *first_grain == grain => Ok(()),
+            Some((first_grain, first_file)) => Err(format.error(format!(
+                "output '{output_name}': {} structured output cannot write a multi-document body into one envelope; first document grain {:?} from {:?}, then grain {:?} from {:?}. consolidate intentionally with an envelope node or route each document to a separate output path",
+                format.name(),
+                first_grain,
+                first_file,
+                grain,
+                doc_ctx.source_file(),
+            ))),
+            None => {
+                self.first = Some((grain, Arc::clone(doc_ctx.source_file())));
+                Ok(())
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
+
+    fn doc(file: &str) -> Arc<DocumentContext> {
+        Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from(file),
+            EnvelopeRecord::empty(),
+        ))
+    }
+
+    #[test]
+    fn structured_formats_are_guarded() {
+        assert!(structured_output_format(&OutputFormat::Edifact(None)).is_some());
+        assert!(structured_output_format(&OutputFormat::X12(None)).is_some());
+        assert!(structured_output_format(&OutputFormat::Hl7(None)).is_some());
+        assert!(structured_output_format(&OutputFormat::Swift(None)).is_some());
+    }
+
+    #[test]
+    fn rejects_second_concrete_document_grain() {
+        let mut guard = StructuredOutputDocumentGuard::new(&OutputFormat::Swift(None));
+        let first = doc("a.swift");
+        let second = doc("b.swift");
+
+        guard
+            .observe("out", &first)
+            .expect("first document allowed");
+        let err = guard
+            .observe("out", &second)
+            .expect_err("second concrete document is rejected");
+        let message = format!("{err}");
+        assert!(message.contains("SWIFT error"), "{message}");
+        assert!(message.contains("multi-document body"), "{message}");
+        assert!(message.contains("out"), "{message}");
+    }
+
+    #[test]
+    fn non_structured_outputs_do_not_guard_document_grains() {
+        let mut guard = StructuredOutputDocumentGuard::new(&OutputFormat::Csv(None));
+        guard.observe("out", &doc("a.csv")).expect("first document");
+        guard
+            .observe("out", &doc("b.csv"))
+            .expect("csv can write record sequences from multiple files");
+    }
+}

--- a/crates/clinker-exec/tests/structured_output_multidoc.rs
+++ b/crates/clinker-exec/tests/structured_output_multidoc.rs
@@ -1,0 +1,152 @@
+//! Structured output writers must not silently merge multiple documents into
+//! one envelope.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn run_yaml(yaml: &str, readers: SourceReaders) -> Result<String, String> {
+    let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
+    let plan = config
+        .compile(&CompileContext::default())
+        .map_err(|e| format!("compile: {e:?}"))?;
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+        .map(|_| "ok".to_string())
+        .map_err(|e| format!("{e}"))
+}
+
+fn single_source_yaml(output_format: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: structured_output_multidoc
+nodes:
+  - type: source
+    name: body
+    config:
+      name: body
+      type: csv
+      glob: ./*.csv
+      schema:
+        - {{ name: id, type: int }}
+        - {{ name: tag, type: string }}
+  - type: output
+    name: out
+    input: body
+    config:
+      name: out
+      type: {output_format}
+      path: out.{output_format}
+"#
+    )
+}
+
+#[test]
+fn structured_single_writer_outputs_reject_multi_file_bodies() {
+    for output_format in ["swift", "x12", "edifact", "hl7"] {
+        let readers: SourceReaders = HashMap::from([(
+            "body".to_string(),
+            clinker_exec::executor::SourceInput::Files(vec![
+                slot("a", "id,tag\n1,A\n"),
+                slot("b", "id,tag\n2,B\n"),
+            ]),
+        )]);
+
+        let err = run_yaml(&single_source_yaml(output_format), readers)
+            .expect_err("structured output must reject multi-document body");
+        assert!(
+            err.contains("multi-document body"),
+            "{output_format} error should explain document-cardinality violation: {err}"
+        );
+        assert!(
+            err.contains("out"),
+            "{output_format} error should name the output: {err}"
+        );
+    }
+}
+
+fn streaming_merge_yaml() -> &'static str {
+    r#"
+pipeline:
+  name: structured_output_streaming_multidoc
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: csv
+      path: left.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: source
+    name: right
+    config:
+      name: right
+      type: csv
+      path: right.csv
+      schema:
+        - { name: id, type: int }
+        - { name: tag, type: string }
+  - type: merge
+    name: merged
+    inputs: [left, right]
+    config:
+      mode: interleave
+  - type: output
+    name: out
+    input: merged
+    config:
+      name: out
+      type: swift
+      path: out.swift
+"#
+}
+
+#[test]
+fn streaming_structured_output_rejects_multi_document_merge_body() {
+    let readers: SourceReaders = HashMap::from([
+        (
+            "left".to_string(),
+            clinker_exec::executor::SourceInput::Files(vec![slot("left", "id,tag\n1,L\n")]),
+        ),
+        (
+            "right".to_string(),
+            clinker_exec::executor::SourceInput::Files(vec![slot("right", "id,tag\n2,R\n")]),
+        ),
+    ]);
+
+    let err = run_yaml(streaming_merge_yaml(), readers)
+        .expect_err("streaming structured output must reject multi-document body");
+    assert!(err.contains("SWIFT error"), "{err}");
+    assert!(err.contains("multi-document body"), "{err}");
+}

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -14,7 +14,9 @@ Output nodes write processed records to files. They are the terminal nodes of a 
     path: "./output/result.csv"
 ```
 
-The `type:` field selects the output format: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`, or `hl7`. The `edifact` and `x12` writers reconstruct their EDI interchange envelopes around emitted records; the `hl7` writer re-emits HL7 v2 segments and optionally wraps them in batch/file envelopes. See [EDIFACT Format](../formats/edifact.md), [X12 Format](../formats/x12.md), and [HL7 v2 Format](../formats/hl7.md).
+The `type:` field selects the output format: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`, `hl7`, or `swift`. The `edifact`, `x12`, and `swift` writers reconstruct one interchange/message envelope around emitted records; the `hl7` writer re-emits HL7 v2 segments and optionally wraps them in batch/file envelopes. See [EDIFACT Format](../formats/edifact.md), [X12 Format](../formats/x12.md), [HL7 v2 Format](../formats/hl7.md), and [SWIFT MT Format](../formats/swift.md).
+
+Structured single-writer outputs (`edifact`, `x12`, `hl7`, and `swift`) accept one concrete document grain per output file. A multi-file source or multi-input merge feeding one of these outputs is rejected instead of being silently written as one merged envelope. To write multiple structured documents, consolidate them deliberately with an Envelope node first or route each document to a separate output path.
 
 ## Field control
 


### PR DESCRIPTION
Closes #584

## Summary
- reject multi-document bodies before EDIFACT, X12, HL7, or SWIFT single-writer outputs can frame them as one envelope
- apply the guard across buffered, streaming, correlation-commit, document-DLQ, and per-source-file fan-out writer paths
- document the one-document-grain structured output limit and add focused executor coverage

## Verification
- `CARGO_TARGET_DIR=~/.cargo/tmp/clinker-target-agent-584 cargo test -p clinker-exec --test structured_output_multidoc`
- `CARGO_TARGET_DIR=~/.cargo/tmp/clinker-target-agent-584 cargo test -p clinker-exec structured_output_guard`
- `CARGO_TARGET_DIR=~/.cargo/tmp/clinker-target-agent-584 cargo test -p clinker-exec --test swift_pipeline --test x12_pipeline --test edifact_pipeline --test hl7_pipeline`
- `git diff --cached --check`
