### PR TITLE
Add agent workflow automation

### DIFF
--- a/.github/workflows/agent-issue-close-label-cleanup.yml
+++ b/.github/workflows/agent-issue-close-label-cleanup.yml
@@ -1,0 +1,62 @@
+name: Agent Issue Close Label Cleanup
+
+on:
+  issues:
+    types: [closed]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: agent-issue-labels-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove live agent routing labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const removeExact = new Set([
+              "agent-ready",
+              "agent-investigate",
+              "blocked",
+              "needs-context",
+              "needs-decision",
+              "needs-maintainer-review",
+              "needs-splitting",
+              "not-agent-ready",
+            ]);
+            const removePrefixes = ["agent-mode:"];
+
+            const labels = context.payload.issue.labels ?? [];
+            const names = labels
+              .map((label) => (typeof label === "string" ? label : label.name))
+              .filter(Boolean);
+
+            const toRemove = names.filter((name) => {
+              return (
+                removeExact.has(name) ||
+                removePrefixes.some((prefix) => name.startsWith(prefix))
+              );
+            });
+
+            for (const name of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name,
+                });
+                core.info(`Removed label: ${name}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Label already absent: ${name}`);
+                  continue;
+                }
+                throw error;
+              }
+            }

--- a/.github/workflows/agent-issue-reopened-routing.yml
+++ b/.github/workflows/agent-issue-reopened-routing.yml
@@ -1,0 +1,81 @@
+name: Agent Issue Reopened Routing
+
+on:
+  issues:
+    types: [reopened]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: agent-issue-labels-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  reset-routing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark reopened issue for grounding
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const removeExact = new Set(["agent-ready", "agent-investigate"]);
+            const removePrefixes = ["agent-mode:"];
+            const addNames = ["not-agent-ready", "needs-context"];
+
+            const issueLabels = context.payload.issue.labels ?? [];
+            const current = new Set(
+              issueLabels
+                .map((label) => (typeof label === "string" ? label : label.name))
+                .filter(Boolean),
+            );
+
+            const toRemove = [...current].filter((name) => {
+              return (
+                removeExact.has(name) ||
+                removePrefixes.some((prefix) => name.startsWith(prefix))
+              );
+            });
+
+            for (const name of toRemove) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name,
+                });
+                current.delete(name);
+                core.info(`Removed label: ${name}`);
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`Label already absent: ${name}`);
+                  current.delete(name);
+                  continue;
+                }
+                throw error;
+              }
+            }
+
+            const repoLabels = await github.paginate(
+              github.rest.issues.listLabelsForRepo,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100,
+              },
+            );
+            const available = new Set(repoLabels.map((label) => label.name));
+            const toAdd = addNames.filter(
+              (name) => available.has(name) && !current.has(name),
+            );
+
+            if (toAdd.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: toAdd,
+              });
+              core.info(`Added labels: ${toAdd.join(", ")}`);
+            }

--- a/.github/workflows/agent-label-sync.yml
+++ b/.github/workflows/agent-label-sync.yml
@@ -1,0 +1,106 @@
+name: Agent Label Sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Preview label changes without writing"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  issues: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sync agent workflow labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const dryRun = core.getInput("dry_run") !== "false";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const desired = [
+              { name: "agent-ready", color: "0e8a16", description: "Agent task is ready for autonomous implementation" },
+              { name: "agent-plan-first", color: "fbca04", description: "Agent must write a short plan before editing" },
+              { name: "agent-investigate", color: "5319e7", description: "Agent should investigate and ground the issue" },
+              { name: "needs-context", color: "d93f0b", description: "Needs grounding, reproduction, or missing context" },
+              { name: "needs-decision", color: "d93f0b", description: "Needs a bounded product, architecture, API, or policy decision" },
+              { name: "needs-splitting", color: "d93f0b", description: "Too broad; split before implementation" },
+              { name: "not-agent-ready", color: "b60205", description: "Not ready for autonomous agent pickup" },
+              { name: "blocked", color: "b60205", description: "Blocked by dependency, decision, PR, or external condition" },
+              { name: "needs-maintainer-review", color: "5319e7", description: "Needs maintainer attention before agent work proceeds" },
+              { name: "agent-size:S", color: "c5def5", description: "Small agent task" },
+              { name: "agent-size:M", color: "bfdadc", description: "Medium agent task" },
+              { name: "agent-size:L", color: "fbca04", description: "Large agent task; plan first" },
+              { name: "agent-size:XL", color: "d93f0b", description: "Too large for one autonomous task; split first" },
+              { name: "agent-mode:investigate", color: "1d76db", description: "Agent mode: investigate" },
+              { name: "agent-mode:implement", color: "1d76db", description: "Agent mode: implement" },
+              { name: "agent-mode:fix-ci", color: "1d76db", description: "Agent mode: fix CI" },
+              { name: "agent-mode:review", color: "1d76db", description: "Agent mode: review" },
+              { name: "agent-mode:docs-tests", color: "1d76db", description: "Agent mode: docs/tests" },
+              { name: "agent-mode:split", color: "1d76db", description: "Agent mode: split issue" },
+              { name: "agent-mode:decision", color: "1d76db", description: "Agent mode: decision gate" },
+              { name: "risk:low", color: "0e8a16", description: "Low implementation or review risk" },
+              { name: "risk:medium", color: "fbca04", description: "Medium implementation or review risk" },
+              { name: "risk:high", color: "d93f0b", description: "High implementation or review risk" },
+            ];
+
+            const existing = await github.paginate(github.rest.issues.listLabelsForRepo, {
+              owner,
+              repo,
+              per_page: 100,
+            });
+            const byName = new Map(existing.map((label) => [label.name, label]));
+            const changes = [];
+
+            for (const label of desired) {
+              const current = byName.get(label.name);
+              if (!current) {
+                changes.push(`create ${label.name}`);
+                if (!dryRun) {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                }
+                continue;
+              }
+
+              const needsUpdate =
+                current.color?.toLowerCase() !== label.color.toLowerCase() ||
+                (current.description ?? "") !== label.description;
+              if (needsUpdate) {
+                changes.push(`update ${label.name}`);
+                if (!dryRun) {
+                  await github.rest.issues.updateLabel({
+                    owner,
+                    repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                }
+              }
+            }
+
+            let summary = `# Agent Label Sync\n\n`;
+            summary += `Mode: ${dryRun ? "dry run" : "write"}\n\n`;
+            if (changes.length === 0) {
+              summary += "No label changes needed.\n";
+            } else {
+              summary += "Changes:\n";
+              for (const change of changes) {
+                summary += `- ${change}\n`;
+              }
+            }
+            await core.summary.addRaw(summary).write();

--- a/.github/workflows/agent-pr-merged-closeout-audit.yml
+++ b/.github/workflows/agent-pr-merged-closeout-audit.yml
@@ -1,0 +1,170 @@
+name: Agent PR Merged Closeout Audit
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: "Pull request number to audit"
+        required: true
+
+permissions:
+  issues: read
+  pull-requests: read
+
+jobs:
+  audit:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit closeout state
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.eventName === "workflow_dispatch"
+              ? Number(core.getInput("pull_request"))
+              : context.payload.pull_request.number;
+            const liveRoutingLabels = new Set([
+              "agent-ready",
+              "agent-investigate",
+              "blocked",
+              "needs-context",
+              "needs-decision",
+              "needs-maintainer-review",
+              "needs-splitting",
+              "not-agent-ready",
+            ]);
+
+            const query = `
+              query($owner:String!, $repo:String!, $number:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  pullRequest(number:$number) {
+                    number
+                    title
+                    url
+                    state
+                    merged
+                    closingIssuesReferences(first:20) {
+                      nodes {
+                        number
+                        title
+                        url
+                        state
+                        labels(first:50) {
+                          nodes { name }
+                        }
+                        projectItems(first:20) {
+                          nodes {
+                            fieldValues(first:30) {
+                              nodes {
+                                ... on ProjectV2ItemFieldSingleSelectValue {
+                                  name
+                                  field {
+                                    ... on ProjectV2FieldCommon { name }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            let data;
+            try {
+              data = await github.graphql(query, { owner, repo, number: prNumber });
+            } catch (error) {
+              core.warning(`Project-aware closeout query failed: ${error.message}`);
+              const fallback = await github.graphql(`
+                query($owner:String!, $repo:String!, $number:Int!) {
+                  repository(owner:$owner, name:$repo) {
+                    pullRequest(number:$number) {
+                      number
+                      title
+                      url
+                      state
+                      merged
+                      closingIssuesReferences(first:20) {
+                        nodes {
+                          number
+                          title
+                          url
+                          state
+                          labels(first:50) { nodes { name } }
+                        }
+                      }
+                    }
+                  }
+                }`,
+                { owner, repo, number: prNumber },
+              );
+              data = fallback;
+            }
+
+            const pr = data.repository.pullRequest;
+            const issues = pr.closingIssuesReferences.nodes;
+            const findings = [];
+
+            if (issues.length === 0) {
+              findings.push("no closing issue reference found");
+            }
+
+            for (const issue of issues) {
+              const issueFindings = [];
+              if (issue.state !== "CLOSED") {
+                issueFindings.push("issue is not closed");
+              }
+
+              const labels = issue.labels.nodes.map((label) => label.name);
+              const staleLabels = labels.filter(
+                (label) => liveRoutingLabels.has(label) || label.startsWith("agent-mode:"),
+              );
+              if (staleLabels.length > 0) {
+                issueFindings.push(`live routing labels still present: ${staleLabels.join(", ")}`);
+              }
+
+              const projectItems = issue.projectItems?.nodes ?? [];
+              if (projectItems.length === 0) {
+                issueFindings.push("project item/status not visible to this token");
+              } else {
+                const statuses = [];
+                for (const item of projectItems) {
+                  for (const value of item.fieldValues.nodes) {
+                    if (value.field?.name === "Status") {
+                      statuses.push(value.name);
+                    }
+                  }
+                }
+                if (!statuses.includes("Done")) {
+                  issueFindings.push(
+                    statuses.length > 0
+                      ? `project status is ${statuses.join(", ")}, expected Done`
+                      : "project status field not visible to this token",
+                  );
+                }
+              }
+
+              if (issueFindings.length > 0) {
+                findings.push(`[#${issue.number} ${issue.title}](${issue.url}): ${issueFindings.join("; ")}`);
+              }
+            }
+
+            let summary = `# Agent PR Merged Closeout Audit\n\n`;
+            summary += `PR: [#${pr.number} ${pr.title}](${pr.url})\n\n`;
+            if (findings.length === 0) {
+              summary += "No findings.\n";
+            } else {
+              summary += "Findings:\n";
+              for (const finding of findings) {
+                summary += `- ${finding}\n`;
+                core.warning(finding);
+              }
+            }
+            await core.summary.addRaw(summary).write();

--- a/.github/workflows/agent-queue-audit.yml
+++ b/.github/workflows/agent-queue-audit.yml
@@ -1,0 +1,145 @@
+name: Agent Queue Audit
+
+on:
+  schedule:
+    - cron: "17 13 * * 1"
+  workflow_dispatch:
+    inputs:
+      fail_on_findings:
+        description: "Fail the run when queue audit findings are present"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  issues: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Audit agent-ready issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const failOnFindings =
+              context.eventName === "workflow_dispatch" &&
+              core.getInput("fail_on_findings") === "true";
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const query = `repo:${owner}/${repo} is:issue is:open label:agent-ready`;
+            const ready = await github.paginate(github.rest.search.issuesAndPullRequests, {
+              q: query,
+              per_page: 100,
+            });
+
+            const findings = [];
+            const conflictingLabels = new Set([
+              "blocked",
+              "needs-context",
+              "needs-decision",
+              "needs-maintainer-review",
+              "needs-splitting",
+              "not-agent-ready",
+            ]);
+
+            function bodyHasAcceptance(body) {
+              return /acceptance criteria/i.test(body) || /done when/i.test(body);
+            }
+
+            function bodyHasVerification(body) {
+              return /verification|test command|cargo test|git diff --check/i.test(body);
+            }
+
+            function blockedByRefs(body) {
+              const lines = body.split(/\r?\n/);
+              const collected = [];
+              let inBlock = false;
+              for (const line of lines) {
+                if (/^\s*Blocked by:\s*/i.test(line)) {
+                  inBlock = true;
+                  collected.push(line);
+                  continue;
+                }
+                if (!inBlock) {
+                  continue;
+                }
+                if (/^\s*$/.test(line)) {
+                  break;
+                }
+                if (/^\s*[-*]\s+/.test(line) || /^\s*#\d+/.test(line)) {
+                  collected.push(line);
+                  continue;
+                }
+                break;
+              }
+              const block = collected.join("\n");
+              const refs = new Set();
+              for (const match of block.matchAll(/#(\d+)/g)) {
+                refs.add(Number(match[1]));
+              }
+              return [...refs];
+            }
+
+            async function openIssueRefs(numbers) {
+              const open = [];
+              for (const number of numbers) {
+                const issue = await github.rest.issues.get({
+                  owner,
+                  repo,
+                  issue_number: number,
+                });
+                if (issue.data.state === "open") {
+                  open.push(number);
+                }
+              }
+              return open;
+            }
+
+            for (const item of ready) {
+              const labels = item.labels.map((label) =>
+                typeof label === "string" ? label : label.name,
+              );
+              const itemFindings = [];
+              const conflicts = labels.filter((label) => conflictingLabels.has(label));
+              if (conflicts.length > 0) {
+                itemFindings.push(`conflicting labels: ${conflicts.join(", ")}`);
+              }
+              if (!bodyHasAcceptance(item.body ?? "")) {
+                itemFindings.push("missing visible acceptance criteria");
+              }
+              if (!bodyHasVerification(item.body ?? "")) {
+                itemFindings.push("missing visible verification command/evidence");
+              }
+              const blockedBy = blockedByRefs(item.body ?? "");
+              const openBlockers = await openIssueRefs(blockedBy);
+              if (openBlockers.length > 0) {
+                itemFindings.push(`open Blocked by refs: ${openBlockers.map((n) => `#${n}`).join(", ")}`);
+              }
+              if (itemFindings.length > 0) {
+                findings.push({ number: item.number, title: item.title, url: item.html_url, itemFindings });
+              }
+            }
+
+            let summary = `# Agent Queue Audit\n\n`;
+            summary += `Query: \`${query}\`\n\n`;
+            summary += `Open agent-ready issues checked: ${ready.length}\n\n`;
+            if (findings.length === 0) {
+              summary += `No findings.\n`;
+            } else {
+              summary += `Findings: ${findings.length}\n\n`;
+              for (const finding of findings) {
+                summary += `- [#${finding.number} ${finding.title}](${finding.url})\n`;
+                for (const detail of finding.itemFindings) {
+                  summary += `  - ${detail}\n`;
+                }
+              }
+            }
+            await core.summary.addRaw(summary).write();
+
+            if (findings.length > 0 && failOnFindings) {
+              core.setFailed(`Agent Queue Audit found ${findings.length} issue(s) needing attention.`);
+            }

--- a/.github/workflows/agent-stale-status-reminders.yml
+++ b/.github/workflows/agent-stale-status-reminders.yml
@@ -1,0 +1,224 @@
+name: Agent Stale Status Reminders
+
+on:
+  schedule:
+    - cron: "41 14 * * 1"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Report stale items without commenting"
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+      stale_days:
+        description: "Days without issue/PR or Project item updates before reminder"
+        required: true
+        default: "7"
+      cooldown_days:
+        description: "Minimum days between bot reminders on the same item"
+        required: true
+        default: "7"
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment on stale Agent Running / PR Open items
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN || github.token }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const projectNumber = 2;
+            const dryRun = context.eventName === "workflow_dispatch"
+              ? core.getInput("dry_run") !== "false"
+              : false;
+            const staleDays = Number(core.getInput("stale_days") || 7);
+            const cooldownDays = Number(core.getInput("cooldown_days") || 7);
+            const marker = "<!-- agent-stale-status-reminder -->";
+            const now = Date.now();
+            const staleMs = staleDays * 24 * 60 * 60 * 1000;
+            const cooldownMs = cooldownDays * 24 * 60 * 60 * 1000;
+
+            const query = `
+              query($owner:String!, $number:Int!, $after:String) {
+                user(login:$owner) {
+                  projectV2(number:$number) {
+                    title
+                    items(first:100, after:$after) {
+                      pageInfo { hasNextPage endCursor }
+                      nodes {
+                        id
+                        updatedAt
+                        content {
+                          __typename
+                          ... on Issue {
+                            number
+                            title
+                            url
+                            state
+                            updatedAt
+                          }
+                          ... on PullRequest {
+                            number
+                            title
+                            url
+                            state
+                            merged
+                            updatedAt
+                          }
+                        }
+                        fieldValues(first:30) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              name
+                              field {
+                                ... on ProjectV2FieldCommon { name }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            const items = [];
+            let after = null;
+            let projectTitle = "";
+            try {
+              do {
+                const data = await github.graphql(query, { owner, number: projectNumber, after });
+                const project = data.user?.projectV2;
+                if (!project) {
+                  core.warning(`Project ${owner}/${projectNumber} was not visible to this token.`);
+                  await core.summary
+                    .addRaw(`# Agent Stale Status Reminders\n\nProject was not visible to this token.\n`)
+                    .write();
+                  return;
+                }
+                projectTitle = project.title;
+                items.push(...project.items.nodes);
+                after = project.items.pageInfo.hasNextPage
+                  ? project.items.pageInfo.endCursor
+                  : null;
+              } while (after);
+            } catch (error) {
+              core.warning(`Project query failed: ${error.message}`);
+              await core.summary
+                .addRaw(`# Agent Stale Status Reminders\n\nProject query failed: ${error.message}\n`)
+                .write();
+              return;
+            }
+
+            function statusOf(item) {
+              for (const value of item.fieldValues.nodes) {
+                if (value.field?.name === "Status") {
+                  return value.name;
+                }
+              }
+              return "";
+            }
+
+            function latestUpdate(item) {
+              const times = [Date.parse(item.updatedAt)];
+              if (item.content?.updatedAt) {
+                times.push(Date.parse(item.content.updatedAt));
+              }
+              return Math.max(...times.filter((time) => Number.isFinite(time)));
+            }
+
+            async function recentlyReminded(number) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: number,
+                per_page: 100,
+              });
+              return comments.some((comment) => {
+                return (
+                  comment.body?.includes(marker) &&
+                  now - Date.parse(comment.created_at) < cooldownMs
+                );
+              });
+            }
+
+            const stale = [];
+            for (const item of items) {
+              const status = statusOf(item);
+              if (!["Agent Running", "PR Open"].includes(status)) {
+                continue;
+              }
+              const content = item.content;
+              if (!content || !["Issue", "PullRequest"].includes(content.__typename)) {
+                continue;
+              }
+              if (content.__typename === "Issue" && content.state !== "OPEN") {
+                continue;
+              }
+              if (content.__typename === "PullRequest" && content.state !== "OPEN") {
+                continue;
+              }
+              const updatedAt = latestUpdate(item);
+              if (now - updatedAt < staleMs) {
+                continue;
+              }
+              stale.push({
+                number: content.number,
+                title: content.title,
+                url: content.url,
+                status,
+                typename: content.__typename,
+                updatedAt,
+              });
+            }
+
+            const commented = [];
+            const skippedCooldown = [];
+            for (const item of stale) {
+              if (await recentlyReminded(item.number)) {
+                skippedCooldown.push(item);
+                continue;
+              }
+              if (!dryRun) {
+                const days = Math.floor((now - item.updatedAt) / (24 * 60 * 60 * 1000));
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: item.number,
+                  body: `${marker}\nThis item has been in Project status \`${item.status}\` without visible updates for about ${days} day(s). Please post a status update, move it to the next workflow state, or clear any blocker. This reminder does not change labels or Project fields.`,
+                });
+              }
+              commented.push(item);
+            }
+
+            let summary = `# Agent Stale Status Reminders\n\n`;
+            summary += `Project: ${projectTitle || `${owner}/${projectNumber}`}\n\n`;
+            summary += `Mode: ${dryRun ? "dry run" : "comment"}\n\n`;
+            summary += `Stale items found: ${stale.length}\n\n`;
+            if (commented.length > 0) {
+              summary += `Commented / would comment:\n`;
+              for (const item of commented) {
+                summary += `- [#${item.number} ${item.title}](${item.url}) (${item.status})\n`;
+              }
+              summary += `\n`;
+            }
+            if (skippedCooldown.length > 0) {
+              summary += `Skipped due to reminder cooldown:\n`;
+              for (const item of skippedCooldown) {
+                summary += `- [#${item.number} ${item.title}](${item.url}) (${item.status})\n`;
+              }
+            }
+            if (stale.length === 0) {
+              summary += "No stale Agent Running or PR Open items.\n";
+            }
+            await core.summary.addRaw(summary).write();

--- a/docs/ai/github-workflow/OPERATIONS.md
+++ b/docs/ai/github-workflow/OPERATIONS.md
@@ -71,6 +71,19 @@ The repository also carries issue-label cleanup workflows:
 These workflows intentionally do not restore `Agent Ready`; a reopened issue
 must go back through grounding before it can re-enter the Agent Queue.
 
+Additional operational workflows provide lightweight checks without replacing
+human routing:
+
+- Agent Queue Audit reports `agent-ready` issues that still show conflicting
+  labels, missing acceptance/verification text, or open `Blocked by:` refs.
+- Agent PR Merged Closeout Audit checks that merged PRs close their linked
+  issue, that live routing labels are gone, and that Project status is `Done`
+  when Project data is visible to the workflow token.
+- Agent Label Sync is manual and dry-run by default; it creates or updates the
+  workflow label set.
+- Agent Stale Status Reminders comments on stale `Agent Running` / `PR Open`
+  Project items after a cooldown. It does not change labels or Project fields.
+
 ## What Goes In The Project
 
 Add every open issue and PR that participates in delivery flow to the active

--- a/docs/ai/github-workflow/OPERATIONS.md
+++ b/docs/ai/github-workflow/OPERATIONS.md
@@ -61,6 +61,16 @@ Use built-in automations lightly:
 Do not automate `Agent Ready`. Readiness depends on scope, blockers,
 acceptance criteria, verification, and decision gates.
 
+The repository also carries issue-label cleanup workflows:
+
+- Closed issues remove live agent-routing labels such as `agent-ready`,
+  `needs-*`, `blocked`, and `agent-mode:*`.
+- Reopened issues remove stale ready/mode labels and, when those labels exist,
+  add `not-agent-ready` and `needs-context`.
+
+These workflows intentionally do not restore `Agent Ready`; a reopened issue
+must go back through grounding before it can re-enter the Agent Queue.
+
 ## What Goes In The Project
 
 Add every open issue and PR that participates in delivery flow to the active


### PR DESCRIPTION
## Summary
- add issue close/reopen workflows to clean or reset live agent-routing labels
- add operational workflows for Agent Queue audits, merged-PR closeout audits, manual label sync, and stale status reminders
- document the automation behavior and boundaries in the agent operations guide

## Verification
- `git diff --check`
- `git diff --cached --check`
- Ruby YAML parse check for all `.github/workflows/agent-*.yml`
- Node syntax check for embedded `github-script` blocks

`actionlint` was not installed locally, so it was not run.
