### PR TITLE
docs: make AI onboarding wording definitive

### DIFF
--- a/crates/clinker-bench-support/AGENTS.md
+++ b/crates/clinker-bench-support/AGENTS.md
@@ -109,7 +109,7 @@ Update relevant docs when this crate changes public helpers, benchmark discovery
 - `docs/ai/90_CRATE_AGENT_PLAN.md`
 - Relevant YAML under `benches/pipelines/` when discovery assumptions or benchmark coverage change.
 
-## Unclear / ask human
+## Approval Gates
 
 Track unresolved questions only in `docs/ai/80_OPEN_QUESTIONS.md`. Relevant entries include benchmark helper runtime boundaries, benchmark identity/cache compatibility, and the long-term `bench-alloc` dependency edge.
 

--- a/crates/clinker-benchmarks/AGENTS.md
+++ b/crates/clinker-benchmarks/AGENTS.md
@@ -99,7 +99,7 @@ Update relevant docs when benchmark commands, benchmark coverage, report output,
 - `docs/ai/90_CRATE_AGENT_PLAN.md`
 - Relevant YAML under `benches/pipelines/`
 
-## Unclear / ask human
+## Approval Gates
 
 Track unresolved questions only in `docs/ai/80_OPEN_QUESTIONS.md`. Relevant entries include unsupported generated benchmark formats and benchmark report compatibility.
 

--- a/crates/clinker-channel/AGENTS.md
+++ b/crates/clinker-channel/AGENTS.md
@@ -61,7 +61,7 @@ Current normal dependencies are intentional: `clinker-plan`, `clinker-core-types
 - Per-source advisory locks protect copy/publish, readers, cleanup, overwrite, and crash purge.
 - Crash purge must be liveness-aware and grace-gated; do not reap live sibling artifacts.
 - `SourceStager` keeps shared read guards alive until cleanup so staged files cannot vanish before or during reads.
-- Hypothesis: resource overlay fields are parsed but not fully applied by `apply_channel_overlay`; ask before documenting resources as implemented overlay behavior.
+- Resource overlay fields are parsed but not fully applied by `apply_channel_overlay`; ask before documenting resources as implemented overlay behavior.
 
 ## Common mistakes for AI agents to avoid
 
@@ -73,7 +73,7 @@ Current normal dependencies are intentional: `clinker-plan`, `clinker-core-types
 - Turning staging into per-run temp-only paths and breaking reuse.
 - Removing the manifest commit-marker discipline.
 - Making cleanup or purge delete files without lock/liveness checks.
-- Assuming staging is a planner concern; policy parsing/validation is in `clinker-plan`, copy mechanics are here, and CLI orchestrates.
+- Treating staging as a planner concern; policy parsing/validation is in `clinker-plan`, copy mechanics are here, and CLI orchestrates.
 
 ## Local commands
 

--- a/crates/clinker-core-types/AGENTS.md
+++ b/crates/clinker-core-types/AGENTS.md
@@ -41,7 +41,7 @@ Current normal dependencies are intentionally small:
 
 - `serde-saphyr` for span/error interop.
 - `petgraph` for graph storage and algorithms.
-- `miette` is declared in `Cargo.toml`; Hypothesis: it is retained for diagnostic interoperability even though direct source use in this crate is currently weak.
+- `miette` is declared in `Cargo.toml`; retain or remove it only after checking diagnostic interoperability and recording any unresolved dependency question in `docs/ai/80_OPEN_QUESTIONS.md`.
 
 No internal workspace crate dependencies are currently allowed.
 
@@ -71,7 +71,7 @@ No internal workspace crate dependencies are currently allowed.
 - String-matching DLQ categories instead of using `DlqErrorCategory`.
 - Changing `DlqErrorCategory::as_str` values casually; they appear in DLQ output.
 - Making `FileId` zero-based or using raw integers where `FileId`/`Span` should carry meaning.
-- Assuming synthetic spans can render file/column context without a higher-layer source database.
+- Treating synthetic spans as able to render file/column context without a higher-layer source database.
 
 ## Local commands
 
@@ -90,7 +90,7 @@ planner/executor/channel tests that consume the changed API.
 - `docs/ai/80_OPEN_QUESTIONS.md` for unresolved architecture or dependency questions.
 - User explain docs when diagnostic codes become user-facing.
 
-## Unclear / ask human
+## Approval Gates
 
 - Keep this file short and boundary-focused because this crate is small leaf
   vocabulary.

--- a/crates/clinker-exec/AGENTS.md
+++ b/crates/clinker-exec/AGENTS.md
@@ -72,7 +72,7 @@ Existing normal dependencies are intentional evidence:
 - Runtime writes fields against schemas already widened/bound by planning.
 - Use `PipelineError::Internal` for violated plan/runtime invariants instead of panics.
 - Snapshot tests, fixture YAML, and proptests are design contracts.
-- Hypothesis: `bench-alloc` is acceptable only while strictly feature-gated and absent from default runtime paths.
+- `bench-alloc` must remain strictly feature-gated and absent from default runtime paths unless the central open-question registry records a different decision.
 
 ## Common mistakes for AI agents to avoid
 

--- a/crates/clinker-net/AGENTS.md
+++ b/crates/clinker-net/AGENTS.md
@@ -53,7 +53,7 @@ Current normal dependencies are intentional: `clinker-exec`, `clinker-plan`, `cl
 - HTTP/connect/body failures are hard source errors, not per-row DLQ records.
 - 5xx/transport failures retry only within configured retry limits; 4xx is fatal.
 - Page body reads are capped by `MAX_PAGE_BYTES`.
-- Hypothesis: SQL cursor wording in docs/manifests is roadmap language, not implemented behavior in this crate.
+- SQL cursor wording in docs/manifests is roadmap language, not implemented behavior in this crate; route changes to the central open-question registry before documenting it as current behavior.
 
 ## Common mistakes for AI agents to avoid
 
@@ -64,7 +64,7 @@ Current normal dependencies are intentional: `clinker-exec`, `clinker-plan`, `cl
 - Special-casing REST inside executor operator dispatch.
 - Turning hard HTTP/body errors into per-row DLQ records.
 - Bypassing `CoercingReader` and drifting from file-source row semantics.
-- Assuming local socket tests will pass inside restricted sandboxes.
+- Treating local socket tests as guaranteed to pass inside restricted sandboxes.
 
 ## Local commands
 

--- a/crates/clinker-plan/AGENTS.md
+++ b/crates/clinker-plan/AGENTS.md
@@ -72,8 +72,8 @@ type/device detection.
 - Use `ValidatedPath` for trusted paths; do not expose raw path bypasses.
 - `CompileContext::default()` is test convenience. Production callers should pass explicit workspace root / pipeline directory.
 - Retired `cxl_compile` module name and `E100` diagnostic code must stay absent.
-- Hypothesis: schema/CXL binding should remain ahead of DAG execution so runtime code consumes compiled artifacts rather than re-typechecking user programs.
-- Hypothesis: composition bodies should stay isolated from enclosing scope except through declared ports, config, resources, and scoped vars.
+- Schema/CXL binding should remain ahead of DAG execution so runtime code consumes compiled artifacts rather than re-typechecking user programs.
+- Composition bodies should stay isolated from enclosing scope except through declared ports, config, resources, and scoped vars.
 
 ## Common mistakes for AI agents to avoid
 

--- a/crates/clinker-record/AGENTS.md
+++ b/crates/clinker-record/AGENTS.md
@@ -70,7 +70,7 @@ Current dev/bench dependencies are expected only for tests and benches:
 - `FieldMetadata` marks engine-stamped columns; default user-field iteration skips stamped columns.
 - Group keys canonicalize default integers/floats together, reject NaN, and treat null as caller-controlled.
 - Accumulator finalize must surface overflow via `AccumulatorError`, not wrapping casts.
-- Hypothesis: crate-local guidance is mostly needed for broad changes to `Value`, `Record`, schema, provenance, document context, storage, accumulator, or counter semantics.
+- Crate-local guidance is most relevant for broad changes to `Value`, `Record`, schema, provenance, document context, storage, accumulator, or counter semantics.
 
 ## Common mistakes for AI agents to avoid
 
@@ -101,7 +101,7 @@ For Rust source changes, also run the relevant workspace gates from the root
 - `docs/user/src/cxl/builtins-map.md` and related `docs/user/src/cxl/*.md` for public value/map behavior changes.
 - Relevant user/engine envelope and document-context docs before copying older examples.
 
-## Unclear / ask human
+## Approval Gates
 
 - Keep this file narrowly scoped to record/value/schema risks and avoid
   duplicating the root onboarding docs.

--- a/crates/clinker-schema/AGENTS.md
+++ b/crates/clinker-schema/AGENTS.md
@@ -106,7 +106,7 @@ Update relevant docs/examples when this crate changes schema file shape, discove
 - `docs/engine/src/architecture.md`, after verifying against current source because older engine docs contain stale crate layout.
 - `examples/pipelines/retract-demo/*.schema.yaml`
 
-## Unclear / ask human
+## Approval Gates
 
 Track unresolved questions only in `docs/ai/80_OPEN_QUESTIONS.md`. Relevant entries include the `clinker-schema`/`clinker-plan` boundary and schema validation completeness.
 

--- a/crates/clinker/AGENTS.md
+++ b/crates/clinker/AGENTS.md
@@ -89,7 +89,7 @@ Current dependencies are intentional unless a change is approved: workspace crat
 - Weakening atomic output or DLQ promotion behavior.
 - Moving source staging into lower crates without architectural review.
 - Copying stale "inputs/outputs/transformations" wording from older help/docs without checking current unified `nodes:` config.
-- Assuming every parsed CLI flag is fully wired; verify use in `run` before documenting behavior.
+- Treating every parsed CLI flag as fully wired; verify use in `run` before documenting behavior.
 
 ## Local commands
 

--- a/crates/cxl-cli/AGENTS.md
+++ b/crates/cxl-cli/AGENTS.md
@@ -50,7 +50,7 @@ Existing normal dependencies are expected:
 
 - Workspace crates: `cxl` and `clinker-record`.
 - CLI/data support: `clap`, `serde_json`, `indexmap`, and `chrono`.
-- `miette` is declared in `Cargo.toml`; Hypothesis: keep it only if CLI diagnostics are intended to move toward richer miette rendering, because current source prints diagnostics manually.
+- `miette` is declared in `Cargo.toml`; keep it only if CLI diagnostics are intended to move toward richer miette rendering, because current source prints diagnostics manually.
 
 ### Forbidden or suspicious dependencies
 
@@ -76,7 +76,7 @@ Existing normal dependencies are expected:
 - Changing documented exit codes without updating user docs.
 - Breaking JSON stdout by mixing notes/errors into stdout.
 - Adding pipeline execution, YAML config parsing, REST/file format handling, or bounded-memory runtime concerns here.
-- Assuming user docs are current without checking source.
+- Treating user docs as current without checking source.
 
 ## Local commands
 
@@ -96,7 +96,7 @@ For language semantics changes, also run the relevant `crates/cxl` checks.
 - `docs/user/src/ops/cli-reference.md` if CLI reference wording changes.
 - `docs/ai/20_CRATE_MAP.md`, `docs/ai/50_TESTING_AND_COMMANDS.md`, `docs/ai/70_GLOSSARY.md`, `docs/ai/80_OPEN_QUESTIONS.md`, and possibly `docs/ai/90_CRATE_AGENT_PLAN.md`.
 
-## Unclear / ask human
+## Approval Gates
 
 - Keep this local guidance focused on CLI behavior. CXL language semantics
   belong primarily in `crates/cxl/AGENTS.md` and the `cxl` crate.

--- a/crates/cxl/AGENTS.md
+++ b/crates/cxl/AGENTS.md
@@ -74,7 +74,7 @@ Existing dev/bench dependencies are also expected: `criterion`,
 - Scoped variable types mirror config-side definitions locally so `cxl` does not depend on `clinker-plan`.
 - Aggregate mode is different from row-transform mode; keep `AggCall`, group-by field, `distinct`, and fan-out restrictions aligned across typecheck and extraction.
 - `ProgramEvaluator` is compile-once and stateful per evaluator instance; distinct state, partition reset, and `max_expansion` live outside immutable compiled programs.
-- Hypothesis: new AST variants should be reviewed across parser, resolver, typechecker, analyzer visitor, aggregate extractor, evaluator, docs, and tests in one change.
+- New AST variants should be reviewed across parser, resolver, typechecker, analyzer visitor, aggregate extractor, evaluator, docs, and tests in one change.
 
 ## Common mistakes for AI agents to avoid
 

--- a/docs/ai/00_READ_THIS_FIRST.md
+++ b/docs/ai/00_READ_THIS_FIRST.md
@@ -16,8 +16,8 @@ Use these evidence labels consistently:
   or a local command in this workspace.
 - **Strong inference:** Not directly stated as a rule, but strongly supported
   by current code structure, tests, manifests, and repeated local patterns.
-- **Hypothesis:** Plausible but not yet confirmed. Do not build architecture or
-  user-facing claims on it without more evidence.
+- **Needs grounding:** Plausible but not yet confirmed. Do not build architecture or
+  user-facing claims on it; move it to open questions or validate it against code.
 - **Open question:** Unresolved uncertainty that should be tracked in
   [docs/ai/80_OPEN_QUESTIONS.md](80_OPEN_QUESTIONS.md), not guessed around.
 

--- a/docs/ai/10_ARCHITECTURE.md
+++ b/docs/ai/10_ARCHITECTURE.md
@@ -13,7 +13,7 @@ Primary evidence used for this pass:
 - Edge surfaces: `crates/clinker/src/main.rs`, `crates/clinker-channel/src/lib.rs`, `crates/clinker-schema/src/lib.rs`, `examples/pipelines/customer_etl.yaml`.
 - Tests and CI: `crates/clinker-exec/tests/*`, `crates/clinker-plan/src/plan/tests/*`, `crates/clinker-format/tests/*`, `crates/clinker-net/tests/*`, `crates/clinker-channel/tests/*`, `.github/workflows/ci.yml`.
 
-## What Clinker Appears To Be
+## What Clinker Is
 
 Verified facts:
 
@@ -23,9 +23,9 @@ Verified facts:
 - CXL is the per-record expression language layer. The `cxl` crate exposes parser, resolver, typechecker, analyzer, aggregate extraction, and evaluator modules; plan and exec compile and evaluate CXL-bearing nodes.
 - Clinker is not currently an editor application in this repository. Tooling-facing surfaces appear to be data/API outputs such as `ExplainFormat::Json`, `CompiledPlan::provenance`, `CompiledPlan::typed_output_row`, and `clinker-schema`.
 
-Hypothesis:
+Current description:
 
-- The project is best described as a bounded-memory, single-process DAG executor for finite ETL jobs, with YAML configuration, CXL expression programs, streaming readers/writers, and an explicit plan/runtime boundary. This matches crate docs and runtime contracts, but maintainers should confirm whether "ETL engine" or "batch DAG executor" is the preferred public wording.
+- Clinker is a bounded-memory, single-process DAG executor for finite ETL jobs, with YAML configuration, CXL expression programs, streaming readers/writers, and an explicit plan/runtime boundary. Preferred public wording is tracked in `docs/ai/80_OPEN_QUESTIONS.md`.
 
 ## Major Subsystems
 
@@ -124,9 +124,9 @@ Verified facts:
 - Shutdown uses per-run `ShutdownToken` values backed by `Arc<AtomicBool>`. A process-wide `ctrlc` handler broadcasts to registered live tokens through a `Weak` registry.
 - Memory arbitration is concurrent but centralized. Registered consumers expose usage/pause/spill hooks; operators poll `should_spill` / `should_abort` at chunk boundaries.
 
-Hypothesis:
+Current guidance:
 
-- `tokio` exists in workspace dependencies, but current core pipeline execution should be treated as non-async. Adding async transport or a Tokio-driven executor would be an architectural change, not a local refactor.
+- `tokio` exists in workspace dependencies, but current core pipeline execution is non-async. Adding async transport or a Tokio-driven executor is an architectural change, not a local refactor.
 
 ## Serialization, Configuration, And Resource Loading
 
@@ -208,10 +208,6 @@ These are supported by current code structure or source comments:
 - Benchmark/test support should not leak into default runtime paths.
 - Public behavior changes need matching docs/examples/tests at the boundary they affect.
 
-## Areas Of Uncertainty
+## Open Question Routing
 
-- `clinker-format -> cxl` is a current dependency edge, apparently for CXL-aware envelope/extraction behavior, but `20_CRATE_MAP.md` flags whether this is intended as a permanent layering rule.
-- `clinker-net -> clinker-exec` is current and deliberate for `RecordSource`, but it means network transport is an executor integration crate rather than a low-level IO layer.
-- `PipelineExecutor::run_plan_with_readers_writers` requires `CompiledPlan`, yet the run body currently re-enters compilation through the embedded config. Future changes around plan reuse should inspect this carefully before assuming the stored DAG is the sole runtime input.
-- The repo has `tokio` in workspace dependencies, but core execution is synchronous. It is unclear whether `tokio` is reserved for external/editor tooling or stale dependency surface.
-- `reserve/` appears to be a crates.io name-reservation package, not runtime code, but this is inferred from local files.
+Current unresolved architecture questions are tracked in `docs/ai/80_OPEN_QUESTIONS.md`. In particular, check that registry before changing layering around `clinker-format`, `clinker-net`, plan reuse in `PipelineExecutor`, async/Tokio usage, or the non-workspace `reserve/` package.

--- a/docs/ai/20_CRATE_MAP.md
+++ b/docs/ai/20_CRATE_MAP.md
@@ -4,7 +4,7 @@ Purpose: Give future AI agents a factual map of the current Cargo workspace, wit
 
 ## Workspace Overview
 
-The root workspace has 13 members: `clinker-record`, `cxl`, `cxl-cli`, `clinker-format`, `clinker-core-types`, `clinker-plan`, `clinker-exec`, `clinker-net`, `clinker-channel`, `clinker`, `clinker-schema`, `clinker-bench-support`, and `clinker-benchmarks` (`Cargo.toml`). `reserve/` is a separate non-member Cargo package named `clinker` with its own `[workspace]` table; it appears to be a crates.io name-reservation placeholder, not runtime code.
+The root workspace has 13 members: `clinker-record`, `cxl`, `cxl-cli`, `clinker-format`, `clinker-core-types`, `clinker-plan`, `clinker-exec`, `clinker-net`, `clinker-channel`, `clinker`, `clinker-schema`, `clinker-bench-support`, and `clinker-benchmarks` (`Cargo.toml`). `reserve/` is a separate non-member Cargo package named `clinker` with its own `[workspace]` table; `reserve/src/lib.rs` identifies it as a crates.io name-reservation placeholder, not runtime code.
 
 No Cargo `examples` targets were found. The repository does contain YAML pipeline examples and fixtures under `examples/pipelines/` plus benchmark pipeline configs under `benches/pipelines/`.
 
@@ -30,14 +30,14 @@ clinker-benchmarks -> clinker-bench-support + clinker-exec + clinker-plan + cxl
 
 Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clinker-record`; `clinker-format -> clinker-record, cxl`; `clinker-plan -> clinker-core-types, clinker-format, clinker-record, cxl`; `clinker-exec -> clinker-core-types, clinker-format, clinker-plan, clinker-record, cxl`; `clinker-channel -> clinker-core-types, clinker-plan, clinker-record`; `clinker-net -> clinker-exec, clinker-format, clinker-plan, clinker-record`; `clinker -> clinker-channel, clinker-core-types, clinker-exec, clinker-format, clinker-net, clinker-plan, clinker-record`; `cxl-cli -> cxl, clinker-record`; `clinker-schema -> clinker-plan`.
 
-## Suspected Layering Rules
+## Current Layering Rules Inferred From Source
 
 - `clinker-core-types` appears intended as a leaf crate: its crate docs say it holds spans, diagnostics, graph, and DLQ vocabulary and "deliberately holds no executor, config, or schema types" (`crates/clinker-core-types/src/lib.rs`).
-- `clinker-record` appears to be the shared data model leaf for row values, schemas, storage traits, grouping keys, document context, and accumulators (`crates/clinker-record/src/lib.rs`).
-- `cxl` appears to sit above records but below planning/execution: it parses, resolves, type-checks, plans aggregates, and evaluates expressions against `clinker-record` values (`crates/cxl/src/lib.rs`).
-- `clinker-format` appears to own streaming readers/writers and document/envelope framing. It depends on `cxl`, so it is not a pure serialization leaf (`crates/clinker-format/Cargo.toml`; `crates/clinker-format/src/lib.rs`).
-- `clinker-plan` appears to be compile-time orchestration and DAG construction below the runtime executor; its crate docs explicitly say execution consumes its plan (`crates/clinker-plan/src/lib.rs`).
-- `clinker-exec` appears to be runtime orchestration and operators; binaries and network transports depend on it rather than the reverse (`crates/clinker-exec/src/lib.rs`; `crates/clinker-exec/src/executor/mod.rs`).
+- `clinker-record` is the shared data model leaf for row values, schemas, storage traits, grouping keys, document context, and accumulators (`crates/clinker-record/src/lib.rs`).
+- `cxl` sits above records but below planning/execution: it parses, resolves, type-checks, plans aggregates, and evaluates expressions against `clinker-record` values (`crates/cxl/src/lib.rs`).
+- `clinker-format` owns streaming readers/writers and document/envelope framing. It depends on `cxl`, so it is not a pure serialization leaf (`crates/clinker-format/Cargo.toml`; `crates/clinker-format/src/lib.rs`).
+- `clinker-plan` is compile-time orchestration and DAG construction below the runtime executor; its crate docs explicitly say execution consumes its plan (`crates/clinker-plan/src/lib.rs`).
+- `clinker-exec` is runtime orchestration and operators; binaries and network transports depend on it rather than the reverse (`crates/clinker-exec/src/lib.rs`; `crates/clinker-exec/src/executor/mod.rs`).
 - `clinker-channel`, `clinker-net`, `clinker-schema`, `clinker`, and `cxl-cli` appear to be edge/application or integration crates around the plan/exec/language core.
 - Benchmark crates appear intended to stay outside the runtime layer. `clinker-benchmarks/src/lib.rs` says it houses a runner needing both `clinker-exec` and `clinker-bench-support` to avoid a circular dependency.
 
@@ -54,7 +54,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-record`
 - Path: `crates/clinker-record`
 - Role: Library crate plus `record_ops` Criterion bench.
-- Purpose: Appears to define Clinker's core in-memory data model: `Value`, `Record`, `Schema`, field strings, coercion, grouping keys, provenance, document context, storage traits, pipeline counters, and aggregate accumulator state.
+- Purpose: Defines Clinker's core in-memory data model: `Value`, `Record`, `Schema`, field strings, coercion, grouping keys, provenance, document context, storage traits, pipeline counters, and aggregate accumulator state.
 - Important public modules: `accumulator`, `coercion`, `counters`, `document_context`, `field_str`, `group_key`, `minimal`, `provenance`, `record`, `record_view`, `resolver`, `schema`, `schema_def`, `storage`, `value`.
 - Internal dependencies: none for normal build; dev-depends on `clinker-bench-support`.
 - Architecturally important external dependencies: `serde`, `serde_json`, `chrono`, `ahash`, `indexmap`, `smol_str`; `postcard` and `criterion` for dev/bench.
@@ -67,7 +67,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-core-types`
 - Path: `crates/clinker-core-types`
 - Role: Library crate.
-- Purpose: Appears to provide leaf vocabulary shared by planning, execution, diagnostics, and channels: source spans, structured diagnostics, name-keyed graph utilities, and DLQ categories/stage helpers.
+- Purpose: Provides leaf vocabulary shared by planning, execution, diagnostics, and channels: source spans, structured diagnostics, name-keyed graph utilities, and DLQ categories/stage helpers.
 - Important public modules: `diagnostic`, `dlq`, `graph`, `span`.
 - Internal dependencies: none.
 - Architecturally important external dependencies: `miette`, `petgraph`, `serde-saphyr`.
@@ -80,7 +80,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `cxl`
 - Path: `crates/cxl`
 - Role: Library crate plus `eval` and `parse` benches.
-- Purpose: Appears to own the CXL expression language pipeline: AST, lexer/parser, module evaluation, name resolution, type checking, static analysis, aggregate extraction, and runtime evaluation.
+- Purpose: Owns the CXL expression language pipeline: AST, lexer/parser, module evaluation, name resolution, type checking, static analysis, aggregate extraction, and runtime evaluation.
 - Important public modules: `analyzer`, `ast`, `builtins`, `eval`, `lexer`, `module_eval`, `parser`, `plan`, `resolve`, `typecheck`.
 - Internal dependencies: `clinker-record`; dev-depends on `clinker-bench-support`.
 - Architecturally important external dependencies: `miette` for diagnostics, `regex`, `indexmap`, `ahash`, `tracing`, `static_assertions`, `serde`, `chrono`; `proptest`, `criterion`, and `tracing-subscriber` for dev/bench.
@@ -93,7 +93,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `cxl-cli`
 - Path: `crates/cxl-cli`
 - Role: Binary crate (`cxl-cli` package target; command name in Clap is `cxl`).
-- Purpose: Appears to be a standalone language tool for checking, evaluating, and formatting CXL files or inline expressions.
+- Purpose: Provides a standalone language tool for checking, evaluating, and formatting CXL files or inline expressions.
 - Important public modules: none; all code is in `src/main.rs`. Main command symbols include `Cli`, `Command`, `cmd_check`, `cmd_eval`, and `cmd_fmt`.
 - Internal dependencies: `cxl`, `clinker-record`.
 - Architecturally important external dependencies: `clap`, `miette`, `serde_json`, `indexmap`, `chrono`.
@@ -106,7 +106,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-format`
 - Path: `crates/clinker-format`
 - Role: Library crate plus integration tests and `io_throughput` bench.
-- Purpose: Appears to own streaming format IO, including CSV, JSON/NDJSON, XML, fixed-width, HL7, X12, EDIFACT, SWIFT, multi-record support, document indexes, source reopenability, output envelopes, counting writers, BOM handling, and output splitting.
+- Purpose: Owns streaming format IO, including CSV, JSON/NDJSON, XML, fixed-width, HL7, X12, EDIFACT, SWIFT, multi-record support, document indexes, source reopenability, output envelopes, counting writers, BOM handling, and output splitting.
 - Important public modules: `bom`, `counting`, `csv`, `doc_index`, `edifact`, `envelope`, `envelope_writer`, `error`, `fixed_width`, `hl7`, `json`, `multi_record`, `source`, `splitting`, `swift`, `traits`, `x12`, `xml`. `segment_tokenizer` is crate-private.
 - Internal dependencies: `clinker-record`, `cxl`; dev-depends on `clinker-bench-support`.
 - Architecturally important external dependencies: `csv`, `quick-xml`, `serde`, `serde_json`, `miette`, `tracing`, `indexmap`, `chrono`.
@@ -119,7 +119,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-plan`
 - Path: `crates/clinker-plan`
 - Role: Library crate with in-crate plan/config tests.
-- Purpose: Appears to parse YAML pipeline/composition configuration, resolve schemas and source discovery, validate configs, compile CXL against row types, and produce typed execution DAGs consumed by `clinker-exec`.
+- Purpose: Parses YAML pipeline/composition configuration, resolve schemas and source discovery, validate configs, compile CXL against row types, and produce typed execution DAGs consumed by `clinker-exec`.
 - Important public modules: `config`, `error`, `plan`, `runtime_error`, `schema`, `security`, `span`, `validation`, `yaml`. `config` exposes source/output/format/route/aggregate/storage/composition modules; `plan` exposes `compiled`, `execution`, `properties`, `statistics`, `streaming_eligibility`, `deferred_region`, and `envelope_synthesis`.
 - Internal dependencies: `clinker-core-types`, `clinker-format`, `clinker-record`, `cxl`.
 - Architecturally important external dependencies: `serde`, `serde_json`, `serde-saphyr`, `toml`, `indexmap`, `miette`, `petgraph`, `regex`, `tracing`, `walkdir`, `glob`, `blake3`, `postcard`, `lz4_flex`, `tempfile`, platform `nix`/`windows-sys`.
@@ -132,7 +132,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-exec`
 - Path: `crates/clinker-exec`
 - Role: Library crate with the largest integration-test and benchmark surface.
-- Purpose: Appears to execute compiled pipeline DAGs: source ingestion, dispatch for node kinds, transforms, aggregations, combines/joins, route/merge/reshape/cull/output dispatch, DLQ, metrics, memory arbitration, spill handling, record sources, progress, and runtime modules.
+- Purpose: Executes compiled pipeline DAGs: source ingestion, dispatch for node kinds, transforms, aggregations, combines/joins, route/merge/reshape/cull/output dispatch, DLQ, metrics, memory arbitration, spill handling, record sources, progress, and runtime modules.
 - Important public modules: `aggregation`, `dlq`, `executor`, `exit_codes`, `log_dispatch`, `log_rules`, `log_template`, `metrics`, `modules`, `output`, `partial`, `pipeline`, `progress`, `projection`, `sketch`, `source`. The `executor` module exposes `PipelineExecutor`, `PipelineRunParams`, `ExecutionReport`, `WriterRegistry`, `RecordSource`, `SourceInput`, and validation types. The `pipeline` module exposes sort, combine, grace hash, IEJoin, memory, spill, streaming merge, and window context helpers.
 - Internal dependencies: `clinker-core-types`, `clinker-format`, `clinker-plan`, `clinker-record`, `cxl`; optional normal dependency on `clinker-bench-support`; dev-depends on `clinker-bench-support` and `clinker-channel`.
 - Architecturally important external dependencies: `crossbeam-channel`, `rayon`, `arc-swap`, `hashbrown`, `lz4_flex`, `postcard`, `fs4`, `petgraph`, `miette`, `tracing`, `serde-saphyr`, `serde_json`, `csv`, `glob`, `uuid`, `ctrlc` on native targets, `windows-sys` on Windows, `criterion`, `insta`, `proptest`, `serial_test`.
@@ -145,7 +145,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-channel`
 - Path: `crates/clinker-channel`
 - Role: Library crate plus integration tests and `channel_merge` bench.
-- Purpose: Appears to manage channel files for multi-tenant pipeline/composition launches: binding channel targets, validating config override paths, applying overlays, and staging source copies with reuse/crash-safety logic.
+- Purpose: Manages channel files for multi-tenant pipeline/composition launches: binding channel targets, validating config override paths, applying overlays, and staging source copies with reuse/crash-safety logic.
 - Important public modules: `binding`, `error`, `overlay`, `staging_copy`.
 - Internal dependencies: `clinker-core-types`, `clinker-plan`, `clinker-record`.
 - Architecturally important external dependencies: `serde-saphyr`, `serde`, `serde_json`, `blake3`, `indexmap`, `tracing`, `thiserror`, `walkdir`, `uuid`, `tempfile`, `fs4`, Unix `nix`.
@@ -158,7 +158,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-net`
 - Path: `crates/clinker-net`
 - Role: Library crate plus REST integration tests.
-- Purpose: Appears to provide finite-pull network source readers, currently REST, that adapt paginated network data into executor `RecordSource` inputs.
+- Purpose: Provides finite-pull network source readers, currently REST, that adapt paginated network data into executor `RecordSource` inputs.
 - Important public modules: no public submodules; `rest` is private. Public API is `build_rest_source`.
 - Internal dependencies: `clinker-exec`, `clinker-format`, `clinker-plan`, `clinker-record`; dev-depends on `clinker-bench-support` and `clinker-exec` with `test-utils`.
 - Architecturally important external dependencies: `ureq` with rustls, `serde_json`, `indexmap`, `tracing`.
@@ -171,7 +171,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker`
 - Path: `crates/clinker`
 - Role: Binary crate for the main CLI.
-- Purpose: Appears to be the user-facing ETL CLI that runs pipelines, performs dry-run/explain flows, applies channels, resolves memory/threads/output behavior, collects metrics, and explains diagnostic codes.
+- Purpose: Provides the user-facing ETL CLI that runs pipelines, performs dry-run/explain flows, applies channels, resolves memory/threads/output behavior, collects metrics, and explains diagnostic codes.
 - Important public modules: none; all code is in `src/main.rs`. Main symbols include `Cli`, `Commands`, `RunArgs`, `MetricsCommands`, `CollectArgs`, and `ExplainArgs`.
 - Internal dependencies: `clinker-channel`, `clinker-core-types`, `clinker-exec`, `clinker-format`, `clinker-net`, `clinker-plan`, `clinker-record`.
 - Architecturally important external dependencies: `clap`, `miette`, `tracing`, `tracing-subscriber`, `serde-saphyr`, `serde_json`, `indexmap`, `chrono`, `num_cpus`, `uuid`, `tempfile`.
@@ -184,7 +184,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-schema`
 - Path: `crates/clinker-schema`
 - Role: Library crate.
-- Purpose: Appears to parse `.schema.yaml` files, discover schemas and pipelines in a workspace, build schema indexes, and validate pipeline source/schema references.
+- Purpose: Parses `.schema.yaml` files, discover schemas and pipelines in a workspace, build schema indexes, and validate pipeline source/schema references.
 - Important public modules: `discovery`, `model`, `parse`, `validate`.
 - Internal dependencies: `clinker-plan`.
 - Architecturally important external dependencies: `serde`, `serde_json`, `serde-saphyr`, `ahash`; `tempfile` for dev tests.
@@ -197,7 +197,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-bench-support`
 - Path: `crates/clinker-bench-support`
 - Role: Library support crate for tests/benchmarks, plus `bench_alloc` integration test gated by feature usage.
-- Purpose: Appears to provide deterministic test/benchmark data generation, workspace and benchmark pipeline discovery, IO capture helpers, synthetic readers, reusable cached benchmark data, combine data generation, and optional allocation accounting.
+- Purpose: Provides deterministic test/benchmark data generation, workspace and benchmark pipeline discovery, IO capture helpers, synthetic readers, reusable cached benchmark data, combine data generation, and optional allocation accounting.
 - Important public modules: `alloc` behind `bench-alloc`, `cache`, `combine`, `generators`, `io`.
 - Internal dependencies: `clinker-record`.
 - Architecturally important external dependencies: `fastrand`, `blake3`, `glob`, `serde`, `serde_json`, `chrono`; dev `quick-xml`, `tempfile`, `serial_test`.
@@ -210,7 +210,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker-benchmarks`
 - Path: `crates/clinker-benchmarks`
 - Role: Library benchmark harness plus `e2e_matrix` and feature-gated `e2e_xlarge` benches.
-- Purpose: Appears to run end-to-end pipeline benchmarks over YAML benchmark configs, map pipeline input formats to generated data formats, execute pipelines through `clinker-exec`, and report benchmark output including CI JSON.
+- Purpose: Runs end-to-end pipeline benchmarks over YAML benchmark configs, map pipeline input formats to generated data formats, execute pipelines through `clinker-exec`, and report benchmark output including CI JSON.
 - Important public modules: `format_mapping`, `report`, `runner`.
 - Internal dependencies: `clinker-bench-support`, `clinker-exec`, `clinker-plan`, `cxl`.
 - Architecturally important external dependencies: `criterion`, `indexmap`, `serde`, `serde_json`, `chrono`, `tempfile`.
@@ -223,7 +223,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - Crate name: `clinker`
 - Path: `reserve`
 - Role: Separate non-workspace library package.
-- Purpose: Appears to reserve the published crate name while implementation continues in the main workspace.
+- Purpose: Reserves the published crate name while implementation continues in the main workspace.
 - Important public modules: none.
 - Internal dependencies: none.
 - Architecturally important external dependencies: none.

--- a/docs/ai/40_COMMON_PATTERNS.md
+++ b/docs/ai/40_COMMON_PATTERNS.md
@@ -28,7 +28,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `ProgressReporter`, `MemoryConsumer`, `ArbitrationPolicy`,
    `AccumulatorOp`, `SchedulingHint`, `Clock`, `RecordStorage`,
    `FieldResolver`, and `WindowContext`.
-3. Why it seems to exist: traits mark real subsystem boundaries: byte-format
+3. Rationale: traits mark real subsystem boundaries: byte-format
    IO, transport-agnostic source ingestion, memory arbitration, progress
    reporting, expression evaluation, and storage lookup. Many are `Send` or
    `Send + Sync` because executor ownership crosses `std::thread`, Rayon, or
@@ -55,7 +55,7 @@ manifests, tests, examples, or safe local commands before being copied here.
 2. Where it appears: `SchemaBuilder` is defined in `clinker-record` and used
    across format readers, projection, planning, aggregation, combine, benches,
    and executor tests.
-3. Why it seems to exist: schema construction is common and must keep field
+3. Rationale: schema construction is common and must keep field
    metadata aligned with column order while materializing fresh schemas as
    `Arc<Schema>`.
 4. How to copy it correctly: use `SchemaBuilder::new()` or
@@ -79,7 +79,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `EvalErrorKind`, `ConfigError`, `SchemaError`, `ChannelError`,
    `StagingError`, `HashAggError`, `CombineError`, `ArenaError`, and many
    smaller parser/validation errors.
-3. Why it seems to exist: each subsystem owns its diagnostic vocabulary and the
+3. Rationale: each subsystem owns its diagnostic vocabulary and the
    top-level runtime error aggregates failures through variants or `From`
    conversions. Some errors manually implement `Display`/`Error`; `thiserror`
    is used where that is simpler and local.
@@ -107,7 +107,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `PipelineNode`, `NodeHeader`, `MergeHeader`, `CombineHeader`,
    composition raw config, sort specs, schema-source specs, transform inputs,
    aggregate correlation keys, and resources.
-3. Why it seems to exist: user-facing config errors need YAML source spans,
+3. Rationale: user-facing config errors need YAML source spans,
    strict unknown-field rejection, and bounded parser behavior. Manual
    visitors preserve spans and variant-specific `deny_unknown_fields` where a
    `serde_json::Value` intermediate would erase span data.
@@ -136,7 +136,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `NodeId`, `TailVarId`, `DottedPath`, `CxlSource`, `ValidatedPath`,
    `SourceIdentity`, `ConsumerId`, and local wrapper structs like
    `SharedByteCounter`.
-3. Why it seems to exist: wrappers prevent mixing unrelated integers or
+3. Rationale: wrappers prevent mixing unrelated integers or
    strings, encode validation state, preserve origin spans, and provide a
    narrow public API around internal representation.
 4. How to copy it correctly: use a newtype when the type carries a domain
@@ -165,7 +165,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `WindowRuntimeRegistry`, `SourceReaders`, `ScopedVarsRegistry`,
    `BuiltinRegistry`, `DocArenaIndex`, `SourceDb`, `ReopenableSource`,
    `SourceStager`, and staging lock/manifest helpers.
-3. Why it seems to exist: the executor coordinates many shared resources
+3. Rationale: the executor coordinates many shared resources
    without hidden globals: memory accounting, writer ownership, window arena
    lookup, source inputs, scoped variables, builtins, document indexes, loaded
    source text, and stable multi-pass input handles.
@@ -194,7 +194,7 @@ manifests, tests, examples, or safe local commands before being copied here.
 2. Where it appears: `StreamEvent`, `Punctuation`, `PunctuationKind`,
    `StructuralReject`, `EventBatch`, `EventBatcher`, `SourceStream`, and
    executor dispatch arms that preserve or reconcile punctuations.
-3. Why it seems to exist: document-boundary signals must preserve strict order
+3. Rationale: document-boundary signals must preserve strict order
    relative to records. The code explicitly rejects out-of-band signaling for
    these events.
 4. How to copy it correctly: carry new stream-control information as a typed
@@ -218,7 +218,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `Box<dyn FormatReader>`, `SourceInput::Files` / `SourceInput::Records`,
    `SourceReaders`, `ReopenableSource`, `RestRecordSource`, and
    `build_rest_source`.
-3. Why it seems to exist: source ingestion should be transport-agnostic after
+3. Rationale: source ingestion should be transport-agnostic after
    records are yielded. File inputs decode bytes through format readers;
    network sources implement the row-yielding trait directly and still flow
    into the same ingest channel.
@@ -243,7 +243,7 @@ manifests, tests, examples, or safe local commands before being copied here.
 1. Pattern name: Local pattern: typed composition resource declarations.
 2. Where it appears: `ResourceDecl`, `ResourceKind`, `Resource`,
    `resources_schema`, and composition call-site `resources`.
-3. Why it seems to exist: compositions declare resource slots separately from
+3. Rationale: compositions declare resource slots separately from
    config params, while resolved runtime resources carry typed payloads and
    YAML spans for diagnostics. Evidence currently shows only file resources,
    with validation still partly stubbed.
@@ -270,7 +270,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `source_dispatch`, `transform_dispatch`, `aggregate_dispatch`,
    `combine_dispatch`, `route_dispatch`, `merge_dispatch`, `output_dispatch`,
    `reshape_dispatch`, and `cull_dispatch`.
-3. Why it seems to exist: planning builds a typed execution DAG, and runtime
+3. Rationale: planning builds a typed execution DAG, and runtime
    walks it synchronously with node-kind-specific operators. There is no
    evidence of Bevy-style ECS resources/systems/components.
 4. How to copy it correctly: new runtime behavior should normally attach to a
@@ -290,7 +290,7 @@ manifests, tests, examples, or safe local commands before being copied here.
 1. Pattern name: Feature/domain modules with curated crate-root exports.
 2. Where it appears: `clinker-record`, `clinker-format`, `clinker-plan`,
    `clinker-exec`, `cxl`, and smaller crates.
-3. Why it seems to exist: public crates expose core vocabulary at the crate
+3. Rationale: public crates expose core vocabulary at the crate
    root while keeping implementation modules organized by domain or operator.
    The executor uses many `pub(crate)` dispatch modules and only exports the
    public entry points and support types needed by callers.
@@ -316,7 +316,7 @@ manifests, tests, examples, or safe local commands before being copied here.
 2. Where it appears: `bench-alloc`, `bench-xlarge`, `test-utils`, target
    dependencies for Unix/Windows/native signal handling, and platform-specific
    RSS/CPU/IO/filesystem probes.
-3. Why it seems to exist: default runtime builds should not depend on
+3. Rationale: default runtime builds should not depend on
    benchmark instrumentation or test-only surfaces. OS-specific APIs are kept
    behind `cfg` arms with fallback behavior where possible.
 4. How to copy it correctly: keep optional behavior behind explicit features
@@ -344,7 +344,7 @@ manifests, tests, examples, or safe local commands before being copied here.
 2. Where it appears: `serde` derives/attributes, `thiserror::Error`,
    `static_assertions::assert_impl_all!`, `proptest!`, `insta::assert_snapshot!`,
    and Clap derives in CLI crates.
-3. Why it seems to exist: macros reduce boilerplate for serialization, CLI
+3. Rationale: macros reduce boilerplate for serialization, CLI
    parsing, error displays, compile-time trait assertions, snapshots, and
    property tests. There is little evidence of local `macro_rules!` DSLs.
 4. How to copy it correctly: prefer the existing derive/test macros for their
@@ -368,7 +368,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    allocation accounting, process RSS/CPU/IO probes, Windows filesystem probes,
    UTF-8 generation in bench helpers, and test/env-var code required by Rust
    2024.
-3. Why it seems to exist: unsafe is used where Rust cannot express a compact
+3. Rationale: unsafe is used where Rust cannot express a compact
    in-memory representation, global allocator instrumentation, or OS FFI.
 4. How to copy it correctly: keep unsafe in the narrow module that owns the
    invariant. Add a `SAFETY:` comment explaining the contract at every unsafe
@@ -395,7 +395,7 @@ manifests, tests, examples, or safe local commands before being copied here.
    `crates/clinker-exec/tests/fixtures`; snapshots under
    `crates/clinker-exec/tests/snapshots`; `proptest` in CXL and IEJoin tests;
    Criterion benches under crate `benches/`.
-3. Why it seems to exist: narrow unit tests cover local parsing/formatting/data
+3. Rationale: narrow unit tests cover local parsing/formatting/data
    structures; integration tests pin pipeline behavior and public executor
    entry points; snapshots preserve user-visible explain/diagnostic output;
    property tests cover broad algorithm/evaluator invariants.
@@ -424,7 +424,7 @@ manifests, tests, examples, or safe local commands before being copied here.
 2. Where it appears: `examples/pipelines`, `examples/pipelines/data`,
    `examples/pipelines/channels`, `examples/pipelines/compositions`,
    `examples/pipelines/tests/baseline`, and `benches/pipelines`.
-3. Why it seems to exist: examples double as user-facing pipeline material and
+3. Rationale: examples double as user-facing pipeline material and
    integration/benchmark fixtures. Bench configs are grouped by feature area
    rather than by Rust crate.
 4. How to copy it correctly: add runnable pipeline examples under
@@ -450,7 +450,7 @@ project-wide conventions without more support.
 1. Pattern name: Local pattern: `ValidatedPath` proof token.
 2. Where it appears: `clinker-plan::security::ValidatedPath` and
    `SourceDb::load`.
-3. Why it seems to exist: callers that need trusted paths are forced through
+3. Rationale: callers that need trusted paths are forced through
    validation before file loading.
 4. How to copy it correctly: consume `ValidatedPath` by value at APIs that
    require the guarantee. Keep construction private.
@@ -460,7 +460,7 @@ project-wide conventions without more support.
 
 1. Pattern name: Local pattern: `FieldStr` compact string storage.
 2. Where it appears: `clinker-record::field_str`.
-3. Why it seems to exist: `Value::String` is common enough that its memory
+3. Rationale: `Value::String` is common enough that its memory
    width affects spill/RSS accounting.
 4. How to copy it correctly: use `FieldStr` through the public string API; do
    not duplicate its union layout elsewhere.
@@ -473,7 +473,7 @@ project-wide conventions without more support.
 1. Pattern name: Local pattern: `bench-alloc` global allocator accounting.
 2. Where it appears: `clinker-bench-support::alloc` and
    `clinker-exec::executor::stage_metrics`.
-3. Why it seems to exist: benchmarks need scoped allocation deltas without
+3. Rationale: benchmarks need scoped allocation deltas without
    enabling allocation accounting in normal runtime builds.
 4. How to copy it correctly: keep it behind the `bench-alloc` feature and use
    `Region` deltas for benchmark measurements.

--- a/docs/ai/50_TESTING_AND_COMMANDS.md
+++ b/docs/ai/50_TESTING_AND_COMMANDS.md
@@ -331,7 +331,7 @@ Status: **Inferred from CI for the exact online forms.** Locked/offline variants
 - `Too many open files (os error 24)` in spill tests: check `ulimit -n`. Retry with `ulimit -n 4096 && cargo test ...`.
 - `Operation not permitted` in `crates/clinker-net/tests/rest_executor_e2e.rs`: the test likely cannot bind a local socket in the sandbox. Rerun outside the sandbox or in normal CI.
 - `cargo deny check` cannot acquire `~/.cargo/advisory-dbs/db.lock`: the filesystem sandbox is read-only for that cargo advisory DB path. Rerun with permission to write/read the cargo advisory database.
-- `cargo test --workspace` appears to hang or run for a long time: the workspace has a large test suite with many integration tests. Use `cargo test -p <package>` or an exact test filter while iterating.
+- `cargo test --workspace` can run for a long time: the workspace has a large test suite with many integration tests. Use `cargo test -p <package>` or an exact test filter while iterating.
 - `cargo test --benches -p clinker-benchmarks` runs many `Testing e2e/...` cases: this is expected. It is CI's benchmark smoke gate, not a quick compile check.
 - Rustdoc warnings from `cargo doc --workspace --no-deps`: current docs build exits 0 with warnings for broken/private intra-doc links, invalid HTML tags, and bare URLs. Do not treat these warnings as a new failure unless your change introduced them or the command becomes warning-denied.
 - Missing `README.md`: there is no root README in this checkout. Use `CLAUDE.md`, `Cargo.toml`, CI, crate manifests, `docs/user`, `docs/engine`, examples, tests, and benches as primary command evidence.

--- a/docs/ai/AI_CHANGELOG.md
+++ b/docs/ai/AI_CHANGELOG.md
@@ -58,14 +58,24 @@ What this entry can say factually:
 - Agent-authored PRs are documented as evidence for one Agent Task.
 - Agents must not merge PRs by default; in this public-contribution repository,
   maintainers review and merge unless they explicitly instruct otherwise.
-- Sequence dependencies are tracked with `Blocked by:` / `Unblocks:` issue
-  blocks, project status, and project ordering. Blocked issues are excluded from
-  `Agent Ready`.
+- Sequence dependencies are tracked primarily with native GitHub `blocked by` /
+  `blocking` relationships, plus project status and project ordering. Body
+  blocks/comments are fallback mirrors for external blockers or tool permission
+  gaps. Blocked issues are excluded from `Agent Ready`.
 - GitHub Projects are documented as flow boards only; stale projects should be
   archived or rebuilt, and the active Project should expose focused queue,
   grounding, decision, review, milestone, and decision-register views.
 - Workflow-relevant issues and PRs are expected to be added to the active
   Project and default to `Status = Intake` until routed.
+- Closed issues tied to active umbrellas or dependency chains should remain in
+  the Project as `Status = Done`; only confirmed unrelated closed items should
+  be archived.
+- Rejected, superseded, or intentionally abandoned items that remain useful
+  board context should use `Status = Won't Do`.
+- GitHub Projects saved views are documented as a manual web UI setup step
+  because current `gh project` commands do not manage saved views and the
+  available GraphQL schema exposes Project v2 views for reading, not creating
+  or updating.
 - Implementation agents now have a post-implementation follow-up check to
   compare acceptance criteria against the diff, scan for shortcut/scope-creep
   signatures, and capture deferred findings as comments or follow-up issues.
@@ -140,30 +150,9 @@ changes.
   `RecordSource` inputs. This means network transport is integrated at the
   executor-source boundary, not isolated as a pure low-level IO crate.
 
-## Major Unresolved Questions
+## Open Question Routing
 
-For the full list, see [docs/ai/80_OPEN_QUESTIONS.md](80_OPEN_QUESTIONS.md).
-The highest-impact questions from the initial documentation pass are:
-
-- Should `PipelineExecutor::run_plan_with_readers_writers` consume the stored
-  `CompiledPlan` DAG directly, or is re-entering compilation through
-  `CompiledPlan::config()` intentional?
-- Should channel `resources.default` and `resources.fixed` be implemented,
-  rejected, or documented as reserved?
-- Should pipeline-target channel config keys be validated before overlay
-  application?
-- What is the intended long-term boundary between `clinker-schema` and
-  `clinker-plan`?
-- How complete should `clinker-schema` discovery and validation become?
-- Should user-facing docs be updated everywhere to the unified `nodes:` shape
-  and all current node types?
-- Should source-node and transport docs describe file and finite REST as
-  implemented, while treating SQL cursor language as roadmap or unsupported?
-- Is the `clinker-format -> cxl` dependency an intended permanent layering
-  rule?
-- Which public planner and CXL APIs are stable user-facing API versus exposed
-  internal surface?
-
+Current unresolved questions are tracked in `docs/ai/80_OPEN_QUESTIONS.md`. Keep this changelog focused on dated evidence, resolved uncertainty, and factual documentation maintenance history.
 ## Instructions For Future Agents
 
 - Update this file when making architectural changes, changing subsystem


### PR DESCRIPTION
## Summary
- replace speculative AI onboarding wording with direct factual phrasing
- route unresolved uncertainty to docs/ai/80_OPEN_QUESTIONS.md
- rename local uncertainty sections to approval/routing language

## Verification
- git diff --check