### PR TITLE
ci: add PR branch updater workflow

### DIFF
--- a/.github/workflows/pr-auto-update-branches.yml
+++ b/.github/workflows/pr-auto-update-branches.yml
@@ -1,0 +1,24 @@
+name: Auto-update PR branches
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "17 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: pr-auto-update-branches-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  update:
+    uses: rustpunk/github-workflows/.github/workflows/pr-auto-update-branches.yml@main
+    with:
+      base: main
+    secrets:
+      PR_BRANCH_UPDATE_TOKEN: ${{ secrets.PR_BRANCH_UPDATE_TOKEN }}


### PR DESCRIPTION
Adds the local trigger wrapper for the reusable PR branch updater workflow in rustpunk/github-workflows. The implementation stays centralized; this repo keeps only the push/schedule/manual triggers and base branch input.