### PR TITLE
chore: repo-relative docs symlink + remove stray local path comment

### DIFF
--- a/crates/clinker-exec/src/pipeline/combine.rs
+++ b/crates/clinker-exec/src/pipeline/combine.rs
@@ -1714,9 +1714,7 @@ mod tests {
         // dominates and the ratio rises toward 1.25×. That is the
         // intentional time-memory tradeoff of caching build-side key
         // Values to avoid re-extraction on every chain scan (plan
-        // decision; see C.2.1 sub-task in
-        // /home/glitch/.claude/plans/thoroughly-plan-how-to-silly-fairy.md
-        // Section 4).
+        // decision; see the C.2.1 sub-task).
         let cols: Vec<String> = (0..10).map(|i| format!("c{i}")).collect();
         let col_refs: Vec<&str> = cols.iter().map(|s| s.as_str()).collect();
         let schema = test_schema(&col_refs);

--- a/docs/ai/github-workflow
+++ b/docs/ai/github-workflow
@@ -1,1 +1,1 @@
-/home/glitch/.agents/docs/github-workflow
+../../../../../.agents/docs/github-workflow


### PR DESCRIPTION
Two small hygiene fixes: (1) make the docs/ai/github-workflow symlink repo-relative instead of an absolute filesystem path; (2) remove a stray absolute local filesystem path left in a test comment in the combine pipeline. No behavior change.