### PR TITLE
plan: document-cardinality gate (E355) + relax the E347 lineage ban

### DIFF
--- a/crates/clinker-exec/src/executor/structured_output_guard.rs
+++ b/crates/clinker-exec/src/executor/structured_output_guard.rs
@@ -43,6 +43,12 @@ impl StructuredOutputFormat {
 }
 
 pub(crate) fn structured_output_format(format: &OutputFormat) -> Option<StructuredOutputFormat> {
+    // Gate on the shared single-document predicate so this runtime allow-list
+    // and the plan-time E355 cardinality gate cannot drift apart (LD-011): the
+    // discriminant map below just names which structured envelope to report.
+    if !format.is_single_document() {
+        return None;
+    }
     match format {
         OutputFormat::Edifact(_) => Some(StructuredOutputFormat::Edifact),
         OutputFormat::X12(_) => Some(StructuredOutputFormat::X12),

--- a/crates/clinker-exec/tests/output_envelope_seam.rs
+++ b/crates/clinker-exec/tests/output_envelope_seam.rs
@@ -959,3 +959,274 @@ nodes:
     // A: header row "A" then body "1". B: NO header row, just body "2".
     assert_eq!(lines, vec!["A", "1", "2"], "got:\n{out}");
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// #570: plan-time document-cardinality gate (E355) + E347 lineage relaxation
+// ─────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn single_document_output_from_two_input_merge_is_rejected_e355() {
+    // A >=2-input Merge is a shape-provable multi-document body; a SWIFT output
+    // frames one message, so it is rejected at plan time with a remedy rather
+    // than silently merging the two documents into one envelope.
+    let yaml = r#"
+pipeline:
+  name: e355_merge
+nodes:
+  - type: source
+    name: a
+    config:
+      name: a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: b
+    config:
+      name: b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+  - type: merge
+    name: both
+    inputs: [a, b]
+    config:
+      mode: concat
+  - type: output
+    name: out
+    input: both
+    config:
+      name: out
+      type: swift
+      path: out.swift
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E355"), "expected E355, got: {err}");
+    assert!(
+        err.contains("out") && err.contains("envelope"),
+        "message should name the output and the envelope remedy: {err}"
+    );
+}
+
+#[test]
+fn single_document_output_from_explicit_paths_list_is_rejected_e355() {
+    // An explicit `paths:` list of >= 2 files is shape-provably multi-document.
+    let yaml = r#"
+pipeline:
+  name: e355_paths
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      paths: [a.csv, b.csv]
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: x12
+      path: out.x12
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(err.contains("E355"), "expected E355, got: {err}");
+}
+
+#[test]
+fn multi_document_output_from_two_input_merge_is_allowed() {
+    // A JSON output frames a valid document sequence, so a multi-document body
+    // is fine — the gate only applies to single-document formats.
+    let yaml = r#"
+pipeline:
+  name: e355_json_ok
+nodes:
+  - type: source
+    name: a
+    config:
+      name: a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: b
+    config:
+      name: b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+  - type: merge
+    name: both
+    inputs: [a, b]
+    config:
+      mode: concat
+  - type: output
+    name: out
+    input: both
+    config:
+      name: out
+      type: json
+      path: out.json
+"#;
+    parse_config(yaml).expect("multi-document JSON output accepts a multi-document body");
+}
+
+#[test]
+fn single_document_output_through_envelope_concat_is_allowed() {
+    // An `envelope` node with `strategy: concat` consolidates the multi-document
+    // body into one document, satisfying the single-document SWIFT output.
+    let yaml = r#"
+pipeline:
+  name: e355_concat_ok
+nodes:
+  - type: source
+    name: a
+    config:
+      name: a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: b
+    config:
+      name: b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+  - type: merge
+    name: both
+    inputs: [a, b]
+    config:
+      mode: concat
+  - type: envelope
+    name: one_doc
+    body: both
+    config:
+      strategy: concat
+  - type: output
+    name: out
+    input: one_doc
+    config:
+      name: out
+      type: swift
+      path: out.swift
+"#;
+    parse_config(yaml).expect("envelope concat consolidates the body for a single-document output");
+}
+
+#[test]
+fn single_document_output_through_envelope_preserve_is_rejected_e355() {
+    // `strategy: preserve` keeps per-document grains — it does NOT consolidate —
+    // so the multi-document body still reaches the single-document output.
+    let yaml = r#"
+pipeline:
+  name: e355_preserve
+nodes:
+  - type: source
+    name: a
+    config:
+      name: a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: b
+    config:
+      name: b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+  - type: merge
+    name: both
+    inputs: [a, b]
+    config:
+      mode: concat
+  - type: envelope
+    name: passthrough
+    body: both
+    config:
+      strategy: preserve
+  - type: output
+    name: out
+    input: passthrough
+    config:
+      name: out
+      type: swift
+      path: out.swift
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(
+        err.contains("E355"),
+        "preserve does not consolidate; expected E355, got: {err}"
+    );
+}
+
+#[test]
+fn combine_then_envelope_concat_allows_reconstruct_envelope_e347_relaxed() {
+    // The E347 lineage ban is relaxed: re-enveloping downstream of a Combine is
+    // legal THROUGH an Envelope node that consolidates the merged stream. Same
+    // shape as `reconstruct_envelope_downstream_of_combine_is_rejected_e347`
+    // (which has no Envelope node) — inserting the Envelope node clears E347.
+    let yaml = r#"
+pipeline:
+  name: e347_relaxed
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: json
+      glob: ./left/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: right
+    config:
+      name: right
+      type: json
+      glob: ./right/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: combine
+    name: joined
+    input:
+      a: left
+      b: right
+    config:
+      where: "a.id == b.id"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit id = a.id
+  - type: envelope
+    name: framed
+    body: joined
+    config:
+      strategy: concat
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: json
+      path: out.json
+      reconstruct_envelope: true
+"#;
+    parse_config(yaml)
+        .expect("an envelope node between the Combine and the Output relaxes the E347 ban");
+}

--- a/crates/clinker-exec/tests/structured_output_multidoc.rs
+++ b/crates/clinker-exec/tests/structured_output_multidoc.rs
@@ -145,8 +145,14 @@ fn streaming_structured_output_rejects_multi_document_merge_body() {
         ),
     ]);
 
+    // A >=2-input Merge is a shape-provable multi-document body, so the E355
+    // plan-time cardinality gate (#570) now rejects this at `parse_config`,
+    // ahead of the runtime guard. (The glob/multi-file body in the test above
+    // is content-dependent and still reaches the runtime guard.)
     let err = run_yaml(streaming_merge_yaml(), readers)
-        .expect_err("streaming structured output must reject multi-document body");
-    assert!(err.contains("SWIFT error"), "{err}");
-    assert!(err.contains("multi-document body"), "{err}");
+        .expect_err("merge into a single-document output must be rejected");
+    assert!(
+        err.contains("E355"),
+        "expected the E355 plan-time cardinality gate: {err}"
+    );
 }

--- a/crates/clinker-plan/src/config/format.rs
+++ b/crates/clinker-plan/src/config/format.rs
@@ -59,6 +59,28 @@ impl OutputFormat {
             OutputFormat::Swift(_) => "swift",
         }
     }
+
+    /// Whether this output frames a SINGLE top-level document envelope for the
+    /// entire record stream it receives — EDIFACT (`UNB..UNZ`), X12
+    /// (`ISA..IEA`), HL7 v2 (`FHS..FTS`), SWIFT MT (`{1:}..{5:}`). Feeding such
+    /// a format a body that carries more than one document collapses every
+    /// input document's records into one envelope, silently merging distinct
+    /// messages/interchanges (the E355 plan-time gate and the runtime guard in
+    /// `clinker-exec` both key off this). The generic formats (CSV / JSON /
+    /// XML / fixed-width) emit a valid document sequence and return `false`.
+    ///
+    /// Single source of truth for the single-document format set: the
+    /// `clinker-plan` cardinality gate and the `clinker-exec` runtime guard
+    /// both consult this so the two cannot diverge.
+    pub fn is_single_document(&self) -> bool {
+        matches!(
+            self,
+            OutputFormat::Edifact(_)
+                | OutputFormat::X12(_)
+                | OutputFormat::Hl7(_)
+                | OutputFormat::Swift(_)
+        )
+    }
 }
 
 /// Adjacently tagged format enum for outputs.
@@ -150,4 +172,37 @@ pub enum MergeMode {
     Concat,
     /// Drain predecessors concurrently; first-ready-wins.
     Interleave,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_document_predicate_matches_the_structured_formats() {
+        for f in [
+            OutputFormat::Edifact(None),
+            OutputFormat::X12(None),
+            OutputFormat::Hl7(None),
+            OutputFormat::Swift(None),
+        ] {
+            assert!(
+                f.is_single_document(),
+                "{} frames one envelope and is single-document",
+                f.format_name()
+            );
+        }
+        for f in [
+            OutputFormat::Csv(None),
+            OutputFormat::Json(None),
+            OutputFormat::Xml(None),
+            OutputFormat::FixedWidth(None),
+        ] {
+            assert!(
+                !f.is_single_document(),
+                "{} emits a document sequence, not a single envelope",
+                f.format_name()
+            );
+        }
+    }
 }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2399,6 +2399,12 @@ fn generic_output_envelope(
 struct OutputLineage {
     feeding_sources: std::collections::BTreeSet<String>,
     lineage_stripper: Option<String>,
+    /// Whether the body feeding this Output can statically carry >= 2 document
+    /// grains with no consolidating node on the path — the signal the E355
+    /// cardinality gate keys off. MULTI is the conservative default: a false
+    /// MULTI is a fixable compile error, a false SINGLE would let a
+    /// multi-document body silently merge into one single-document envelope.
+    body_cardinality: Cardinality,
 }
 
 /// Walk upstream from `output_name` over the config node graph, collecting the
@@ -2446,10 +2452,155 @@ fn trace_output_lineage(config: &PipelineConfig, output_name: &str) -> OutputLin
             }
         }
     }
+    // Document cardinality is a separate, path-sensitive fold (a consolidating
+    // node collapses only its own upstream subtree), so compute it with a fresh
+    // recursion over the same node map rather than contorting the flat walk above.
+    let body_cardinality =
+        stream_cardinality(&by_name, output_name, &mut std::collections::HashSet::new());
     OutputLineage {
         feeding_sources,
         lineage_stripper,
+        body_cardinality,
     }
+}
+
+/// Whether a node's output stream can statically carry more than one document.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Cardinality {
+    /// Provably collapses to at most one document grain at this point.
+    Single,
+    /// Can statically carry two or more document grains.
+    Multi,
+}
+
+impl Cardinality {
+    fn join(self, other: Cardinality) -> Cardinality {
+        if self == Cardinality::Multi || other == Cardinality::Multi {
+            Cardinality::Multi
+        } else {
+            Cardinality::Single
+        }
+    }
+}
+
+/// Conservatively decide whether the stream produced by `node_name` can carry
+/// two or more document grains. Consolidating nodes (`Combine` / `Aggregate` /
+/// `Composition`, or an `Envelope` with `strategy: concat`) collapse everything
+/// upstream of them to a single grain; an `Envelope` `preserve` and the
+/// per-record operators pass cardinality through; a `Merge` of >= 2 inputs is
+/// itself a multiplier; a `Source` is MULTI when it discovers multiple files or
+/// its reader yields multiple documents per file. Unknowns bias to MULTI (a
+/// false MULTI is a loud, fixable compile error; a false SINGLE would let silent
+/// document-merging through). Cycle-safe via the shared `visited` set.
+fn stream_cardinality<'a>(
+    by_name: &HashMap<&'a str, &'a PipelineNode>,
+    node_name: &'a str,
+    visited: &mut std::collections::HashSet<&'a str>,
+) -> Cardinality {
+    if !visited.insert(node_name) {
+        // Already folded on another path; the first visit returned its true
+        // value and `join` is monotonic toward MULTI, so re-counting it as
+        // SINGLE here cannot lower an already-MULTI result.
+        return Cardinality::Single;
+    }
+    let Some(node) = by_name.get(node_name) else {
+        return Cardinality::Single;
+    };
+    match node {
+        PipelineNode::Source { config, .. } => source_cardinality(&config.source),
+        // Consolidators: collapse the whole upstream subtree to one document.
+        PipelineNode::Combine { .. }
+        | PipelineNode::Aggregate { .. }
+        | PipelineNode::Composition { .. } => Cardinality::Single,
+        PipelineNode::Envelope { config, .. } => {
+            use crate::config::pipeline_node::EnvelopeStrategy;
+            match config.strategy {
+                EnvelopeStrategy::Concat => Cardinality::Single,
+                // `preserve` keeps per-document grains — pass-through, not a collapser.
+                EnvelopeStrategy::Preserve => join_input_cardinality(by_name, node, visited),
+            }
+        }
+        // A merge of >= 2 document-carrying inputs is itself multi-document:
+        // each predecessor contributes its own grains.
+        PipelineNode::Merge { .. } => {
+            if node.direct_input_names().len() >= 2 {
+                Cardinality::Multi
+            } else {
+                join_input_cardinality(by_name, node, visited)
+            }
+        }
+        // Per-record / pass-through operators: cardinality of their inputs.
+        PipelineNode::Transform { .. }
+        | PipelineNode::Route { .. }
+        | PipelineNode::Cull { .. }
+        | PipelineNode::Reshape { .. }
+        | PipelineNode::Output { .. } => join_input_cardinality(by_name, node, visited),
+    }
+}
+
+fn join_input_cardinality<'a>(
+    by_name: &HashMap<&'a str, &'a PipelineNode>,
+    node: &'a PipelineNode,
+    visited: &mut std::collections::HashSet<&'a str>,
+) -> Cardinality {
+    node.direct_input_names()
+        .into_iter()
+        .map(|up| stream_cardinality(by_name, up, visited))
+        .fold(Cardinality::Single, Cardinality::join)
+}
+
+/// A `Source` is statically MULTI only when its multiplicity is provable from
+/// the pipeline shape alone: an explicit `paths:` list of length >= 2 is
+/// definitely >= 2 documents. A `glob:`/`regex:` may match a single file, and a
+/// structured single file (X12/EDIFACT/HL7/SWIFT) may hold a single
+/// interchange/message — both are content-dependent, not shape-provable, so
+/// they are left to the runtime guard (which rejects precisely when a second
+/// concrete document grain materializes). This keeps single-document
+/// round-trips such as `x12 -> x12` legal at plan time.
+fn source_cardinality(source: &SourceConfig) -> Cardinality {
+    if source.paths.as_ref().is_some_and(|p| p.len() >= 2) {
+        Cardinality::Multi
+    } else {
+        Cardinality::Single
+    }
+}
+
+/// Whether an `Envelope` node sits between `output_name` and the nearest
+/// upstream lineage stripper on some path — i.e. the user has inserted explicit
+/// consolidation downstream of a `Combine` / `Aggregate` / `Composition`. Used
+/// to relax the E347 lineage ban: re-enveloping downstream of a stripper is
+/// legal THROUGH an Envelope node (the E355 cardinality gate then enforces that
+/// the Envelope actually consolidates a multi-document body). The walk stops
+/// descending at a stripper, so an Envelope found above a stripper — which would
+/// not consolidate the stripped stream — does not count.
+fn envelope_consolidates_stripped_lineage(config: &PipelineConfig, output_name: &str) -> bool {
+    let by_name: HashMap<&str, &PipelineNode> = config
+        .nodes
+        .iter()
+        .map(|n| (n.value.name(), &n.value))
+        .collect();
+    let mut visited: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut stack: Vec<&str> = vec![output_name];
+    while let Some(name) = stack.pop() {
+        if !visited.insert(name) {
+            continue;
+        }
+        let Some(node) = by_name.get(name) else {
+            continue;
+        };
+        match node {
+            PipelineNode::Envelope { .. } => return true,
+            PipelineNode::Combine { .. }
+            | PipelineNode::Aggregate { .. }
+            | PipelineNode::Composition { .. } => continue,
+            _ => {
+                for up in node.direct_input_names() {
+                    stack.push(up);
+                }
+            }
+        }
+    }
+    false
 }
 
 /// The synthesized `$doc` vocabulary of a segment/positional format: the
@@ -3800,6 +3951,42 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         }
     }
 
+    // [E355] A single-document output format frames ONE top-level envelope for
+    // its entire record stream. If the body feeding it is SHAPE-PROVABLY
+    // multi-document — a >=2-input Merge, or an explicit `paths:` list of >= 2
+    // files — with no consolidating node on the path (a
+    // Combine/Aggregate/Composition, or an Envelope with `strategy: concat`),
+    // every input document's records collapse into that one envelope, silently
+    // merging distinct interchanges/messages. This plan-time gate rejects the
+    // shape-provable case at `compile()` so the failure is a `clinker explain`
+    // diagnostic, not a mid-run abort. Content-dependent multiplicity (a
+    // `glob:`/`regex:` source that may match one file, a structured single file
+    // that may hold one interchange) is left to the runtime guard (#584), which
+    // rejects precisely when a second concrete grain materializes — so a
+    // single-document round-trip like `x12 -> x12` stays legal here.
+    // Multi-document formats (CSV/JSON/XML/fixed-width) frame a valid document
+    // sequence and are unaffected. Independent of `reconstruct_envelope` so it
+    // survives the later removal of that flag.
+    for output in config.output_configs() {
+        if !output.format.is_single_document() {
+            continue;
+        }
+        if trace_output_lineage(config, &output.name).body_cardinality == Cardinality::Multi {
+            return Err(ConfigError::Validation(format!(
+                "[E355] output '{name}': `{format}` output frames a single top-level \
+                 document envelope, but its body can carry more than one document with no \
+                 consolidating node on the path — every input document's records would \
+                 collapse into one envelope, silently merging distinct messages/interchanges. \
+                 Insert an `envelope` node with `strategy: concat` to consolidate the body \
+                 into one document, route each document to its own output via a per-document \
+                 `split:` / `{{source_file}}` path template, or choose a document-sequence \
+                 format (csv / json / xml / fixed_width)",
+                name = output.name,
+                format = output.format.format_name(),
+            )));
+        }
+    }
+
     // Document-level DLQ cannot coexist with per-source-file fan-out output.
     // Under `dlq_granularity: document` the engine buffers each document and
     // decides flush-vs-reject at its boundary, opening ONE writer for the
@@ -3939,16 +4126,25 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
             // (`<merged>`) document context, which the envelope arm streams
             // UNFRAMED. For JSON that means body bytes outside any open
             // document object — malformed JSON — and for every format it means
-            // silently dropped framing / a miscounted footer. Reject the
-            // combination at plan time rather than emit broken output.
-            if let Some(stripper) = lineage.lineage_stripper.as_deref() {
+            // silently dropped framing / a miscounted footer. This is legal,
+            // though, when an `Envelope` node sits between the stripper and the
+            // Output: it re-frames the merged stream into a consolidated
+            // document, so the per-document framing has a grain to attach to.
+            // Reject only when no such consolidation is present; the E355
+            // cardinality gate above then enforces that a single-document output
+            // actually gets a consolidating (`concat`) Envelope.
+            if let Some(stripper) = lineage.lineage_stripper.as_deref()
+                && !envelope_consolidates_stripped_lineage(config, out)
+            {
                 return Err(ConfigError::Validation(format!(
                     "[E347] output '{out}': `reconstruct_envelope` cannot be combined with an \
-                     upstream node ('{stripper}') that strips document lineage — a Combine, \
+                     upstream node ('{stripper}') that strips document lineage unless an \
+                     `envelope` node consolidates the merged stream first — a Combine, \
                      Aggregate, or Composition emits records with no originating document, so \
                      the per-document envelope cannot be framed around them (the framing arm \
-                     would stream them unframed, e.g. producing malformed JSON). Remove the \
-                     intervening node from this Output's path, or drop `reconstruct_envelope`"
+                     would stream them unframed, e.g. producing malformed JSON). Insert an \
+                     `envelope` node between '{stripper}' and this output to consolidate the \
+                     merged stream into one document, or drop `reconstruct_envelope`"
                 )));
             }
 

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -246,6 +246,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E352" => Some(include_str!("../../../../docs/explain/E352.md")),
         "E353" => Some(include_str!("../../../../docs/explain/E353.md")),
         "E354" => Some(include_str!("../../../../docs/explain/E354.md")),
+        "E355" => Some(include_str!("../../../../docs/explain/E355.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -471,7 +472,7 @@ mod tests {
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
             "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
             "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352", "E353",
-            "E354", "E15Y", "W101", "W302", "W305", "W306",
+            "E354", "E355", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/docs/explain/E347.md
+++ b/docs/explain/E347.md
@@ -29,10 +29,16 @@ model. Four combinations are rejected:
 - **An upstream node that strips document lineage** — a cross-document
   `Combine`, an `Aggregate` (whose group rows finalize through a merged eval
   context, even under per-document aggregation), or a `Composition` (whose body
-  is opaque at validation time). These emit records with no originating
-  document (`<merged>` lineage), which the envelope arm streams UNFRAMED: for
-  JSON that is body bytes outside any open document object — malformed JSON —
-  and for every format it silently drops the framing or miscounts the footer.
+  is opaque at validation time) — **with no `envelope` node between it and the
+  Output**. These emit records with no originating document (`<merged>`
+  lineage), which the envelope arm streams UNFRAMED: for JSON that is body bytes
+  outside any open document object — malformed JSON — and for every format it
+  silently drops the framing or miscounts the footer. This is **legal when an
+  `envelope` node sits between the stripper and the Output**: the Envelope node
+  re-frames the merged stream into a consolidated document, giving the
+  per-document framing a grain to attach to. (When the Output format is itself
+  single-document, error E355 then enforces that the Envelope actually
+  consolidates with `strategy: concat`.)
 
 ```
 [E347] output 'out': `reconstruct_envelope` cannot be combined with per-file
@@ -103,6 +109,11 @@ nodes:
    `reconstruct_envelope` — correlation buffering and envelope framing are
    different write-ownership models.
 
+4. **Insert an `envelope` node** between a lineage-stripping `Combine` /
+   `Aggregate` / `Composition` and the Output to re-frame the merged stream into
+   a consolidated document — re-enveloping downstream of a stripper is allowed
+   through an Envelope node. (Otherwise, drop `reconstruct_envelope`.)
+
 ## Technical context
 
 Envelope reconstruction is handled by a dedicated Output dispatch arm that
@@ -120,5 +131,6 @@ config-validation time.
 ## See also
 
 - "Output envelope reconstruction" in the output reference
+- Error E355, the single-document-output / multi-document-body cardinality gate
 - Error E343, the per-source-file-output / document-DLQ conflict
 - Error E344, the document-DLQ / fail-fast conflict

--- a/docs/explain/E355.md
+++ b/docs/explain/E355.md
@@ -1,0 +1,126 @@
+# Error E355: single-document output fed by a multi-document body
+
+## What it means
+
+A single-document output format frames **one** top-level envelope for the entire
+record stream it receives — an EDIFACT `UNB..UNZ` interchange, an X12 `ISA..IEA`
+interchange, an HL7 v2 `FHS..FTS` batch, or a SWIFT MT `{1:}..{5:}` message. The
+pipeline feeding this Output, however, can carry **more than one document**, and
+no node on the path consolidates them into one. Every input document's records
+would collapse into that single envelope, silently merging distinct
+messages/interchanges and losing their boundaries.
+
+This gate fires only when the body is **shape-provably** multi-document — i.e.
+provable from the pipeline graph alone, independent of file contents:
+
+- a **`merge` of two or more inputs**, each contributing its own documents;
+- a source with an explicit **`paths:` list of length ≥ 2** (two or more files).
+
+A node that consolidates the body to one document — a `combine`, `aggregate`, or
+`composition`, or an `envelope` node with `strategy: concat` — clears the gate.
+The generic formats (`csv` / `json` / `xml` / `fixed_width`) emit a valid
+document *sequence* and are never rejected by this gate.
+
+Content-dependent multiplicity is **not** caught here: a `glob:` / `regex:`
+source may match a single file, and a structured single file may hold a single
+interchange — so a single-document round-trip like `x12 → x12` stays legal at
+compile time. Those cases are caught by the runtime guard instead, which rejects
+the moment a second concrete document grain reaches a single-document writer.
+
+```
+[E355] output 'out': `swift` output frames a single top-level document envelope,
+but its body can carry more than one document with no consolidating node on the
+path — every input document's records would collapse into one envelope, silently
+merging distinct messages/interchanges. Insert an `envelope` node with
+`strategy: concat` to consolidate the body into one document, route each document
+to its own output via a per-document `split:` / `{source_file}` path template, or
+choose a document-sequence format (csv / json / xml / fixed_width)
+```
+
+## Example
+
+```yaml
+# Rejected: two sources merged into one single-document SWIFT output.
+pipeline:
+  name: payments
+nodes:
+  - type: source
+    name: book_a
+    config: { name: book_a, type: csv, path: ./a.csv }
+  - type: source
+    name: book_b
+    config: { name: book_b, type: csv, path: ./b.csv }
+  - type: merge
+    name: both
+    inputs: [book_a, book_b]      # two documents in the body
+  - type: output
+    name: out
+    input: both
+    config:
+      name: out
+      type: swift                 # frames ONE message — multi-doc body is ambiguous
+      path: out.mt
+```
+
+```yaml
+# Corrected: an envelope node consolidates the two documents into one.
+pipeline:
+  name: payments
+nodes:
+  - type: source
+    name: book_a
+    config: { name: book_a, type: csv, path: ./a.csv }
+  - type: source
+    name: book_b
+    config: { name: book_b, type: csv, path: ./b.csv }
+  - type: merge
+    name: both
+    inputs: [book_a, book_b]
+  - type: envelope
+    name: one_doc
+    input: both
+    config: { strategy: concat }  # collapse the body into one document
+  - type: output
+    name: out
+    input: one_doc
+    config: { name: out, type: swift, path: out.mt }
+```
+
+## How to fix
+
+1. **Consolidate the body into one document.** Insert an `envelope` node with
+   `strategy: concat` upstream of the Output. (An `envelope` with the default
+   `strategy: preserve` does *not* consolidate — it keeps per-document grains —
+   so it does not clear the gate.)
+
+2. **Route each document to its own output.** Use a per-document `split:` block
+   or a `{source_file}` / `{source_path}` path template so each input document
+   lands in its own file, each a valid single-document envelope.
+
+3. **Choose a document-sequence format.** If a sequence of documents in one
+   output is what you want, use `csv` / `json` / `xml` / `fixed_width`, which
+   frame each document in turn rather than a single top-level envelope.
+
+## Technical context
+
+Document cardinality is computed at config-validation time by a conservative
+upstream walk from each Output (`trace_output_lineage`): a source is
+multi-document when it matches multiple files or uses a multi-document reader; a
+`merge` of ≥ 2 inputs is itself a multiplier; `combine` / `aggregate` /
+`composition` and an `envelope` `concat` collapse their upstream subtree to one
+grain; every other operator passes cardinality through. Unknowns bias toward
+multi-document so the gate fails *toward* a clear, fixable compile error rather
+than toward silent corruption.
+
+This plan-time gate complements the runtime guard, which rejects the same
+condition when a second concrete document grain actually reaches one of these
+writers. The gate fires earlier — at `compile()`, before any I/O — for the cases
+provable from the pipeline shape alone, and keys off the same single-document
+format set so the two cannot diverge.
+
+## See also
+
+- "Output envelope reconstruction" and the Envelope node in the output reference
+- Error E347, the relaxed lineage rule (re-enveloping downstream of a Combine is
+  legal through an Envelope node)
+- Errors E323 / E338 / E339 / E342, the single-envelope-format / `split` conflict


### PR DESCRIPTION
Closes #570.

## Summary

A single-document output format — EDIFACT (`UNB..UNZ`), X12 (`ISA..IEA`), HL7 v2 (`FHS..FTS`), SWIFT MT (`{1:}..{5:}`) — frames one top-level envelope for its entire record stream. Feeding it a body that carries more than one document collapses every input document's records into that one envelope, silently merging distinct messages/interchanges. A runtime guard already rejects this when a second document grain actually reaches the writer; this PR adds the **plan-time** complement so the failure is a compile-time diagnostic rather than a mid-run abort.

## What changed

**E355 — plan-time cardinality gate.** At config validation, a single-document output fed by a *shape-provably* multi-document body — a merge of ≥2 inputs, or an explicit `paths:` list of ≥2 files — with no consolidating node on the path is rejected at `compile()` with a `clinker explain E355` diagnostic and a concrete remedy (insert an `envelope` node with `strategy: concat`, route each document to its own output, or pick a document-sequence format). Content-dependent multiplicity (a `glob:`/`regex:` source that may match a single file, or a structured file that may hold a single interchange) is left to the runtime guard, which rejects precisely when a second grain materializes — so single-document round-trips like `x12 → x12` stay legal at compile time.

**E347 relaxation.** Re-enveloping downstream of a `Combine`/`Aggregate` was previously banned outright. It is now legal *through an `Envelope` node* that consolidates the merged stream; the new cardinality gate enforces that a single-document output actually gets a consolidating (`concat`) envelope. E347's other conflicts (per-file split/fan-out, document-level DLQ, `correlation_key`) are unchanged.

## Implementation notes

- `OutputFormat::is_single_document()` is the single source of truth for the single-document format set, shared by the plan-time gate and the runtime guard so the two cannot diverge.
- The cardinality analysis extends the existing upstream lineage walk: consolidating nodes (`combine`/`aggregate`/`composition`, or an `envelope` with `strategy: concat`) collapse their subtree to one document; a `preserve` envelope and the per-record operators pass cardinality through; a `merge` of ≥2 inputs is a multiplier.
- New `docs/explain/E355.md`; `docs/explain/E347.md` updated for the relaxation.

## Tests

- **E355:** ≥2-input merge → single-document output (rejected); explicit ≥2-file `paths:` → rejected; multi-document (JSON) output → allowed; `envelope concat` consolidation → allowed; `envelope preserve` → still rejected.
- **E347:** `combine → envelope concat → reconstruct-envelope output` is now allowed; the no-envelope control still trips E347; the split / document-DLQ / `correlation_key` conflicts are unchanged.
- Existing structured-format round-trip tests (x12/swift/hl7/edifact) stay green, confirming single-document round-trips are not over-rejected.

Validation: `cargo test -p clinker-plan -p clinker-exec -p clinker`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check`, and `git diff --check` — all clean.

## Forward notes

- The single-document classification reflects today's single-envelope structured writers. When per-document structured framing lands (e.g. X12 back-to-back interchanges as a sequence), `OutputFormat::is_single_document()` is the single switch to revise.
- The E347 relaxation is a localized edit; when the `reconstruct_envelope` flag is later retired, the E347 block is removed wholesale and E355 (independent of that flag) remains as the sole document-cardinality gate.