### PR TITLE
plan: fix E347 relaxation holes and E355 over-rejections (follow-up to #630)

### DIFF
--- a/crates/clinker-exec/src/executor/structured_output_guard.rs
+++ b/crates/clinker-exec/src/executor/structured_output_guard.rs
@@ -44,7 +44,7 @@ impl StructuredOutputFormat {
 
 pub(crate) fn structured_output_format(format: &OutputFormat) -> Option<StructuredOutputFormat> {
     // Gate on the shared single-document predicate so this runtime allow-list
-    // and the plan-time E355 cardinality gate cannot drift apart (LD-011): the
+    // and the plan-time E355 cardinality gate cannot drift apart; the
     // discriminant map below just names which structured envelope to report.
     if !format.is_single_document() {
         return None;

--- a/crates/clinker-exec/tests/output_envelope_seam.rs
+++ b/crates/clinker-exec/tests/output_envelope_seam.rs
@@ -1230,3 +1230,180 @@ nodes:
     parse_config(yaml)
         .expect("an envelope node between the Combine and the Output relaxes the E347 ban");
 }
+
+#[test]
+fn reconstruct_envelope_downstream_of_combine_through_preserve_envelope_is_rejected_e347() {
+    // A `preserve` Envelope does NOT consolidate — it passes the Combine's
+    // synthetic `<merged>` grain through unchanged — so the reconstruct arm
+    // would still stream those records unframed. The relaxation must NOT fire
+    // for a preserve envelope; E347 still applies.
+    let yaml = r#"
+pipeline:
+  name: e347_preserve
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: json
+      glob: ./left/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: right
+    config:
+      name: right
+      type: json
+      glob: ./right/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: combine
+    name: joined
+    input:
+      a: left
+      b: right
+    config:
+      where: "a.id == b.id"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit id = a.id
+  - type: envelope
+    name: framed
+    body: joined
+    config:
+      strategy: preserve
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: json
+      path: out.json
+      reconstruct_envelope: true
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(
+        err.contains("E347"),
+        "preserve does not consolidate; expected E347, got: {err}"
+    );
+    assert!(
+        err.contains("joined"),
+        "message should name the lineage stripper: {err}"
+    );
+}
+
+#[test]
+fn reconstruct_envelope_with_concat_envelope_on_sibling_branch_is_rejected_e347() {
+    // A `concat` Envelope only consolidates ITS body branch. A stripper on a
+    // sibling merge branch is still unconsolidated, so its `<merged>` records
+    // reach the reconstruct-envelope Output unframed — E347 must still fire.
+    let yaml = r#"
+pipeline:
+  name: e347_sibling
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: json
+      glob: ./left/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: right
+    config:
+      name: right
+      type: json
+      glob: ./right/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: source
+    name: other
+    config:
+      name: other
+      type: json
+      glob: ./other/*.json
+      options:
+        record_path: records
+      schema:
+        - { name: id, type: int }
+  - type: combine
+    name: joined
+    input:
+      a: left
+      b: right
+    config:
+      where: "a.id == b.id"
+      match: first
+      on_miss: skip
+      propagate_ck: driver
+      cxl: |
+        emit id = a.id
+  - type: envelope
+    name: framed
+    body: other
+    config:
+      strategy: concat
+  - type: merge
+    name: both
+    inputs: [joined, framed]
+    config:
+      mode: concat
+  - type: output
+    name: out
+    input: both
+    config:
+      name: out
+      type: json
+      path: out.json
+      reconstruct_envelope: true
+"#;
+    let err = expect_validation_error(yaml);
+    assert!(
+        err.contains("E347"),
+        "a sibling-branch concat envelope must not shield the Combine branch; expected E347, got: {err}"
+    );
+    assert!(
+        err.contains("joined"),
+        "message should name the unconsolidated stripper: {err}"
+    );
+}
+
+#[test]
+fn single_document_output_with_per_source_file_fanout_is_allowed() {
+    // Per-file fan-out (`{source_file}` path template) routes each document to
+    // its own output file, so each lands in its own valid single-document
+    // envelope — E355 must not reject it.
+    let yaml = r#"
+pipeline:
+  name: e355_fanout_ok
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      paths: [a.csv, b.csv]
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: x12
+      path: "out_{source_file}.x12"
+"#;
+    parse_config(yaml)
+        .expect("per-file fan-out gives each document its own single-document envelope");
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2516,8 +2516,16 @@ fn stream_cardinality<'a>(
             use crate::config::pipeline_node::EnvelopeStrategy;
             match config.strategy {
                 EnvelopeStrategy::Concat => Cardinality::Single,
-                // `preserve` keeps per-document grains — pass-through, not a collapser.
-                EnvelopeStrategy::Preserve => join_input_cardinality(by_name, node, visited),
+                // `preserve` keeps per-document grains, so the output document
+                // cardinality follows the BODY only — `direct_input_names`
+                // returns the body first, then the optional header/trailer
+                // framing ports, which carry framing records, not body
+                // documents, and must not inflate the body's cardinality.
+                EnvelopeStrategy::Preserve => node
+                    .direct_input_names()
+                    .first()
+                    .map(|body| stream_cardinality(by_name, body, visited))
+                    .unwrap_or(Cardinality::Single),
             }
         }
         // A merge of >= 2 document-carrying inputs is itself multi-document:
@@ -2565,15 +2573,30 @@ fn source_cardinality(source: &SourceConfig) -> Cardinality {
     }
 }
 
-/// Whether an `Envelope` node sits between `output_name` and the nearest
-/// upstream lineage stripper on some path — i.e. the user has inserted explicit
-/// consolidation downstream of a `Combine` / `Aggregate` / `Composition`. Used
-/// to relax the E347 lineage ban: re-enveloping downstream of a stripper is
-/// legal THROUGH an Envelope node (the E355 cardinality gate then enforces that
-/// the Envelope actually consolidates a multi-document body). The walk stops
-/// descending at a stripper, so an Envelope found above a stripper — which would
-/// not consolidate the stripped stream — does not count.
-fn envelope_consolidates_stripped_lineage(config: &PipelineConfig, output_name: &str) -> bool {
+/// A node that strips document lineage — `Combine` / `Aggregate` / `Composition`
+/// emit records with a synthetic (`<merged>`) document context (see
+/// [`trace_output_lineage`]).
+fn is_lineage_stripper(node: &PipelineNode) -> bool {
+    matches!(
+        node,
+        PipelineNode::Combine { .. }
+            | PipelineNode::Aggregate { .. }
+            | PipelineNode::Composition { .. }
+    )
+}
+
+/// Find a lineage stripper whose synthetic `<merged>` records can reach
+/// `output_name` WITHOUT being re-consolidated by a `concat` `Envelope`, or
+/// `None` if every stripper on the way is shielded. A `concat` Envelope
+/// re-stamps its whole body onto one document grain, so it shields a
+/// `reconstruct_envelope` Output from synthetic grains; a `preserve` Envelope
+/// passes the synthetic grain through unchanged and so does NOT shield. This is
+/// the E347 relaxation predicate: re-enveloping downstream of a stripper is
+/// legal only through a *consolidating* Envelope, and only for the strippers it
+/// actually covers (a `concat` Envelope on a sibling merge branch does not
+/// shield a stripper on another branch).
+fn unconsolidated_stripper(config: &PipelineConfig, output_name: &str) -> Option<String> {
+    use crate::config::pipeline_node::EnvelopeStrategy;
     let by_name: HashMap<&str, &PipelineNode> = config
         .nodes
         .iter()
@@ -2588,19 +2611,21 @@ fn envelope_consolidates_stripped_lineage(config: &PipelineConfig, output_name: 
         let Some(node) = by_name.get(name) else {
             continue;
         };
-        match node {
-            PipelineNode::Envelope { .. } => return true,
-            PipelineNode::Combine { .. }
-            | PipelineNode::Aggregate { .. }
-            | PipelineNode::Composition { .. } => continue,
-            _ => {
-                for up in node.direct_input_names() {
-                    stack.push(up);
-                }
-            }
+        // A `concat` Envelope consolidates everything on its body path into one
+        // grain — stop descending, the strippers above it are shielded.
+        if let PipelineNode::Envelope { config, .. } = node
+            && config.strategy == EnvelopeStrategy::Concat
+        {
+            continue;
+        }
+        if is_lineage_stripper(node) {
+            return Some(name.to_string());
+        }
+        for up in node.direct_input_names() {
+            stack.push(up);
         }
     }
-    false
+    None
 }
 
 /// The synthesized `$doc` vocabulary of a segment/positional format: the
@@ -3971,6 +3996,17 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         if !output.format.is_single_document() {
             continue;
         }
+        // Per-file fan-out (`split:`, or a `{source_file}` / `{source_path}`
+        // path template) routes each document to its own output file, so every
+        // document lands in its own valid single-document envelope rather than
+        // being merged into one — exactly the remedy this gate's message names.
+        let per_file_fanout = output.split.is_some()
+            || crate::config::path_template::PathTemplate::parse(&output.path)
+                .map(|t| t.has_per_record_tokens())
+                .unwrap_or(false);
+        if per_file_fanout {
+            continue;
+        }
         if trace_output_lineage(config, &output.name).body_cardinality == Cardinality::Multi {
             return Err(ConfigError::Validation(format!(
                 "[E355] output '{name}': `{format}` output frames a single top-level \
@@ -4133,18 +4169,19 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
             // Reject only when no such consolidation is present; the E355
             // cardinality gate above then enforces that a single-document output
             // actually gets a consolidating (`concat`) Envelope.
-            if let Some(stripper) = lineage.lineage_stripper.as_deref()
-                && !envelope_consolidates_stripped_lineage(config, out)
+            if lineage.lineage_stripper.is_some()
+                && let Some(stripper) = unconsolidated_stripper(config, out)
             {
                 return Err(ConfigError::Validation(format!(
                     "[E347] output '{out}': `reconstruct_envelope` cannot be combined with an \
                      upstream node ('{stripper}') that strips document lineage unless an \
-                     `envelope` node consolidates the merged stream first — a Combine, \
-                     Aggregate, or Composition emits records with no originating document, so \
-                     the per-document envelope cannot be framed around them (the framing arm \
-                     would stream them unframed, e.g. producing malformed JSON). Insert an \
-                     `envelope` node between '{stripper}' and this output to consolidate the \
-                     merged stream into one document, or drop `reconstruct_envelope`"
+                     `envelope` node with `strategy: concat` consolidates the merged stream \
+                     first — a Combine, Aggregate, or Composition emits records with no \
+                     originating document, so the per-document envelope cannot be framed around \
+                     them (the framing arm would stream them unframed, e.g. producing malformed \
+                     JSON). Insert an `envelope` node with `strategy: concat` between '{stripper}' \
+                     and this output to consolidate the merged stream into one document, or drop \
+                     `reconstruct_envelope`"
                 )));
             }
 

--- a/docs/explain/E355.md
+++ b/docs/explain/E355.md
@@ -78,7 +78,7 @@ nodes:
     inputs: [book_a, book_b]
   - type: envelope
     name: one_doc
-    input: both
+    body: both
     config: { strategy: concat }  # collapse the body into one document
   - type: output
     name: out


### PR DESCRIPTION
Follow-up to #630. A review run after #630 merged surfaced real defects in the E347 relaxation and the E355 gate that are now on `main`; this fixes them forward.

## Correctness fixes — E347 relaxation (silent corruption)

The relaxation accepted *any* envelope reachable upstream of the output, which was too permissive in two ways:

- **`preserve` envelope:** a `preserve` envelope does not consolidate — it passes a lineage stripper's synthetic `<merged>` grain through unchanged — yet it suppressed E347. `Combine`/`Aggregate` → `Envelope{preserve}` → `reconstruct_envelope` JSON output would validate but stream records unframed at runtime (malformed JSON).
- **Sibling merge branch:** a `concat` envelope on one merge branch suppressed E347 even when a stripper on the *other* branch was left unconsolidated — again reaching the output unframed.

Fix: replace the "any envelope reachable" check with a walk that stops only at `concat` envelopes and reports any lineage stripper still reachable — so E347 relaxes **only** through a consolidating envelope that actually covers the stripper.

## Over-rejection fixes — E355 (false compile errors)

- **Per-file fan-out:** a single-document output that fans out per file (`split:` / a `{source_file}` path template) gives each document its own valid envelope, but E355 still rejected it — contradicting the diagnostic's own recommended remedy. E355 now skips per-file-fan-out outputs.
- **Preserve framing ports:** `preserve` envelope cardinality now follows the body port only; a multi-document header/trailer framing port no longer inflates it to multi-document.

## Nits

- Drop an internal process code from a source comment.
- Fix the envelope body port key (`body:`) in the E355 explain example so the remedy YAML parses.

Regression tests added for the preserve-envelope, sibling-branch, and per-file-fan-out cases. Validation: `cargo test -p clinker-plan -p clinker-exec`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --all --check` — all clean.