### PR TITLE
plan,exec: carry combine inputs/predicate/driving on the node

### DIFF
--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -61,6 +61,13 @@ pub(crate) fn dispatch_combine(
         // with a body has `Some`; body-less steps (`match: collect`,
         // synthetic non-final N-ary steps) have `None`.
         typed: ref body_typed_on_node,
+        // Per-input metadata and the decomposed `where:` predicate, carried
+        // on the node for the same reason as `typed`: a bare-name lookup into
+        // `ctx.artifacts` is last-writer-wins across same-named combines in
+        // sibling composition bodies, so reading them off this node instance
+        // is what makes the runtime join scope-correct.
+        combine_inputs: ref combine_inputs_on_node,
+        decomposed_predicate: ref predicate_on_node,
         ..
     } = *node
     else {
@@ -113,23 +120,20 @@ pub(crate) fn dispatch_combine(
     let combine_output_schema = current_dag.graph[node_idx].stored_output_schema().cloned();
 
     let combine_inputs =
-        ctx.artifacts
-            .combine_inputs
-            .get(name)
+        combine_inputs_on_node
+            .as_ref()
             .ok_or_else(|| PipelineError::Internal {
                 op: "combine",
                 node: name.clone(),
                 detail: "no combine_inputs entry for combine node".to_string(),
             })?;
-    let decomposed =
-        ctx.artifacts
-            .combine_predicates
-            .get(name)
-            .ok_or_else(|| PipelineError::Internal {
-                op: "combine",
-                node: name.clone(),
-                detail: "no combine_predicates entry for combine node".to_string(),
-            })?;
+    let decomposed = predicate_on_node
+        .as_ref()
+        .ok_or_else(|| PipelineError::Internal {
+            op: "combine",
+            node: name.clone(),
+            detail: "no combine_predicates entry for combine node".to_string(),
+        })?;
 
     // E312 confines the executor to binary combines.
     // An escaped N>2 combine reaches the executor only

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -4634,6 +4634,10 @@ nodes:
             output_schema: clinker_record::SchemaBuilder::new().build(),
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
+            // Strategy selection reads these off the node; mirror lowering.
+            combine_inputs: artifacts.combine_inputs.get("test_combine").cloned(),
+            decomposed_predicate: artifacts.combine_predicates.get("test_combine").cloned(),
+            combine_driving: artifacts.combine_driving.get("test_combine").cloned(),
         });
 
         let mut plan = ExecutionPlanDag::from_parts(

--- a/crates/clinker-exec/tests/composition_combine_test.rs
+++ b/crates/clinker-exec/tests/composition_combine_test.rs
@@ -528,3 +528,131 @@ nodes:
         e303[0].message
     );
 }
+
+/// Run a multi-source pipeline through the executor, wiring one in-memory
+/// writer per declared output, and return each output's CSV text keyed by
+/// output name. Mirrors [`run_pipeline_multi_source`] but captures every
+/// output rather than only the first.
+fn run_pipeline_collect_outputs(yaml: &str, inputs: &[(&str, &str)]) -> HashMap<String, String> {
+    let config = parse_config(yaml).expect("parse pipeline yaml");
+    let root = fixture_workspace_root();
+    let ctx = CompileContext::with_pipeline_dir(&root, PathBuf::from("pipelines"));
+    let plan = config.compile(&ctx).expect("compile pipeline");
+
+    let mut readers: clinker_exec::executor::SourceReaders = HashMap::new();
+    for (name, data) in inputs {
+        readers.insert(
+            (*name).to_string(),
+            clinker_exec::executor::single_file_reader(
+                "test.csv",
+                Box::new(Cursor::new(data.as_bytes().to_vec())),
+            ),
+        );
+    }
+
+    let mut buffers: HashMap<String, SharedBuffer> = HashMap::new();
+    let mut writers: HashMap<String, Box<dyn Write + Send>> = HashMap::new();
+    for out in config.output_configs() {
+        let buf = SharedBuffer::new();
+        buffers.insert(out.name.clone(), buf.clone());
+        writers.insert(out.name.clone(), Box::new(buf) as Box<dyn Write + Send>);
+    }
+
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &test_params())
+        .expect("pipeline run");
+
+    buffers
+        .into_iter()
+        .map(|(name, buf)| (name, buf.as_string()))
+        .collect()
+}
+
+#[test]
+fn test_combine_same_name_across_sibling_bodies_executes_each_predicate() {
+    // Two sibling compositions each contain a combine named `shared_join`,
+    // but body A joins on `products.product_id` while body B joins on
+    // `products.alt_id`. These are distinct node instances in distinct body
+    // graphs. With the combine's decomposed predicate stored in a bare-name
+    // side-table, binding body B second overwrote the `shared_join` entry, so
+    // body A's combine executed body B's `alt_id` predicate at runtime and
+    // matched nothing. Carrying the predicate (and inputs / driving) on each
+    // node makes the two scope-correct: A matches on product_id, B does not
+    // match on alt_id.
+    let yaml = r#"
+pipeline:
+  name: combine_scope_collision
+nodes:
+  - type: source
+    name: orders_src
+    config:
+      name: orders_src
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+  - type: source
+    name: products_src
+    config:
+      name: products_src
+      type: csv
+      path: products.csv
+      schema:
+        - { name: product_id, type: string }
+        - { name: alt_id, type: string }
+        - { name: name, type: string }
+  - type: composition
+    name: join_a
+    input: orders_src
+    use: ../compositions/scope_collision_join_a.comp.yaml
+    inputs:
+      orders: orders_src
+      products: products_src
+  - type: composition
+    name: join_b
+    input: orders_src
+    use: ../compositions/scope_collision_join_b.comp.yaml
+    inputs:
+      orders: orders_src
+      products: products_src
+  - type: output
+    name: out_a
+    input: join_a
+    config:
+      name: out_a
+      type: csv
+      path: out_a.csv
+      include_unmapped: true
+  - type: output
+    name: out_b
+    input: join_b
+    config:
+      name: out_b
+      type: csv
+      path: out_b.csv
+      include_unmapped: true
+"#;
+    let orders_csv = "order_id,product_id\no1,A\n";
+    let products_csv = "product_id,alt_id,name\nA,Z,Widget\n";
+    let outputs = run_pipeline_collect_outputs(
+        yaml,
+        &[("orders_src", orders_csv), ("products_src", products_csv)],
+    );
+
+    let out_a = outputs.get("out_a").expect("out_a output present");
+    let out_b = outputs.get("out_b").expect("out_b output present");
+
+    // Body A joins on product_id (A == A): the order matches and the
+    // enriched row carries the product name.
+    assert!(
+        out_a.contains("o1") && out_a.contains("Widget"),
+        "body A (join on product_id) must emit the matched order; got out_a:\n{out_a}\nout_b:\n{out_b}"
+    );
+    // Body B joins on alt_id (A == Z): no match, `on_miss: skip` drops the
+    // driver row. A predicate collision on the shared name would have leaked
+    // body B's `alt_id` join into body A, emptying out_a as well.
+    assert!(
+        !out_b.contains("o1"),
+        "body B (join on alt_id) must not match the order; got out_b:\n{out_b}"
+    );
+}

--- a/crates/clinker-exec/tests/fixtures/compositions/scope_collision_join_a.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/scope_collision_join_a.comp.yaml
@@ -1,0 +1,36 @@
+# Sibling composition A for the runtime-combine scope-collision test.
+# Its combine is named `shared_join` — the SAME name used by the
+# sibling composition B (scope_collision_join_b) — but joins on
+# `products.product_id`. The two bodies are distinct node instances; the
+# runtime must read each combine's predicate off its own node, not from a
+# shared name-keyed table where the last-bound `shared_join` would win.
+_compose:
+  name: scope_collision_join_a
+  inputs:
+    orders:
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+    products:
+      schema:
+        - { name: product_id, type: string }
+        - { name: alt_id, type: string }
+        - { name: name, type: string }
+  outputs:
+    enriched: shared_join
+  config_schema: {}
+
+nodes:
+  - type: combine
+    name: shared_join
+    input:
+      orders: orders
+      products: products
+    config:
+      where: "orders.product_id == products.product_id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit order_id = orders.order_id
+        emit product_name = products.name
+      propagate_ck: driver

--- a/crates/clinker-exec/tests/fixtures/compositions/scope_collision_join_b.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/scope_collision_join_b.comp.yaml
@@ -1,0 +1,36 @@
+# Sibling composition B for the runtime-combine scope-collision test.
+# Its combine is also named `shared_join` but joins on `products.alt_id`
+# instead of `products.product_id`. With a bare-name combine-predicate
+# table, binding this body second overwrote the entry for `shared_join`,
+# so BOTH bodies' combines executed this `alt_id` predicate at runtime.
+# Reading the predicate off each node makes the two scope-correct.
+_compose:
+  name: scope_collision_join_b
+  inputs:
+    orders:
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+    products:
+      schema:
+        - { name: product_id, type: string }
+        - { name: alt_id, type: string }
+        - { name: name, type: string }
+  outputs:
+    enriched: shared_join
+  config_schema: {}
+
+nodes:
+  - type: combine
+    name: shared_join
+    input:
+      orders: orders
+      products: products
+    config:
+      where: "orders.product_id == products.alt_id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit order_id = orders.order_id
+        emit product_name = products.name
+      propagate_ck: driver

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3608,6 +3608,17 @@ pub(crate) fn lower_node_to_plan_node(
             // here — a body-less combine (e.g. `match: collect`) carries no
             // program.
             let typed = artifacts.typed.get(name).cloned();
+            // Carry the per-input metadata, decomposed `where:` predicate, and
+            // bind-time driving qualifier on the node so combine strategy
+            // selection and the executor read them by node instance instead of
+            // a bare-name lookup into `CompileArtifacts` (last-writer-wins
+            // across same-named combines in sibling composition bodies). Like
+            // `typed` / `resolved_column_map`, the read here is transiently
+            // scope-correct because each body is bound then lowered before the
+            // next body overwrites the shared map entry.
+            let combine_inputs = artifacts.combine_inputs.get(name).cloned();
+            let decomposed_predicate = artifacts.combine_predicates.get(name).cloned();
+            let combine_driving = artifacts.combine_driving.get(name).cloned();
             Some(crate::plan::execution::PlanNode::Combine {
                 name: name.to_string(),
                 span,
@@ -3623,6 +3634,9 @@ pub(crate) fn lower_node_to_plan_node(
                 output_schema: schema_from_bound(name),
                 resolved_column_map,
                 typed,
+                combine_inputs,
+                decomposed_predicate,
+                combine_driving,
             })
         }
         // Reshape lowers to PlanNode::Reshape carrying the parsed config

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -688,19 +688,14 @@ pub(crate) const SMALL_INPUT_THRESHOLD: u64 = 10_000;
 /// Threaded into [`select_combine_strategies_in_graph`] so the same
 /// work runs uniformly over the top-level
 /// [`crate::plan::execution::ExecutionPlanDag`] and over each
-/// composition body's mini-DAG. Carrying the subsets as a struct
-/// (rather than half a dozen positional arguments) lets the wrapper
+/// composition body's mini-DAG. The per-combine inputs / predicate /
+/// driving are read off each combine node; only the statistics catalog
+/// and the strategy hints stay in this struct, letting the wrapper
 /// `select_combine_strategies_in_bodies` borrow-split
 /// [`crate::plan::bind_schema::CompileArtifacts`] across
-/// `composition_bodies` (mutable) and the four lookup tables
-/// (immutable) without falling back to a clippy allow.
+/// `composition_bodies` (mutable) and those two tables (immutable)
+/// without falling back to a clippy allow.
 pub(crate) struct CombineSelectionTables<'a> {
-    /// Per-combine input qualifier metadata, keyed by combine node name.
-    pub combine_inputs: &'a std::collections::HashMap<String, IndexMap<String, CombineInput>>,
-    /// Per-combine decomposed `where:` predicate, keyed by combine node name.
-    pub combine_predicates: &'a std::collections::HashMap<String, DecomposedPredicate>,
-    /// Per-combine driving qualifier, keyed by combine node name.
-    pub combine_driving: &'a std::collections::HashMap<String, String>,
     /// Statistics catalog. Combine strategy selection reads each input's
     /// row count from here, keyed by the input's upstream node name, in
     /// place of a per-input cardinality field.
@@ -722,9 +717,6 @@ pub fn select_combine_strategies(
     // graph's mutable borrow without aliasing through `plan`.
     let node_properties_snapshot = plan.node_properties.clone();
     let tables = CombineSelectionTables {
-        combine_inputs: &artifacts.combine_inputs,
-        combine_predicates: &artifacts.combine_predicates,
-        combine_driving: &artifacts.combine_driving,
         statistics: &artifacts.statistics,
         combine_strategy_hints: &artifacts.combine_strategy_hints,
     };
@@ -751,23 +743,18 @@ pub fn select_combine_strategies_in_bodies(
     mem_limit_str: Option<&str>,
 ) {
     // Split the artifacts borrow: the bodies map mutates via
-    // `values_mut()`, while the lookup tables (combine_inputs,
-    // combine_predicates, combine_driving, combine_strategy_hints)
-    // remain immutable references for the inner per-graph call.
+    // `values_mut()`, while the strategy-selection lookup tables
+    // (statistics, combine_strategy_hints) remain immutable references for
+    // the inner per-graph call. The per-combine inputs / predicate / driving
+    // are read off each body node instead, so they are not borrowed here.
     let crate::plan::bind_schema::CompileArtifacts {
         composition_bodies,
-        combine_inputs,
-        combine_predicates,
-        combine_driving,
         statistics,
         combine_strategy_hints,
         ..
     } = artifacts;
 
     let tables = CombineSelectionTables {
-        combine_inputs,
-        combine_predicates,
-        combine_driving,
         statistics,
         combine_strategy_hints,
     };
@@ -816,13 +803,19 @@ pub(crate) fn select_combine_strategies_in_graph(
         .collect();
 
     for (idx, name, span) in combine_nodes {
-        let inputs = match tables.combine_inputs.get(&name) {
-            Some(i) => i,
-            None => continue,
-        };
-        let decomposed = match tables.combine_predicates.get(&name) {
-            Some(d) => d,
-            None => continue,
+        // Read the combine's inputs + decomposed predicate off the node
+        // (stamped at lowering / N-ary decomposition), cloning them out so the
+        // borrow is released before this pass mutates the node's strategy
+        // fields below. Both are present together for a successfully bound
+        // combine; a node missing either is skipped exactly as the absent
+        // map entries were.
+        let (inputs, decomposed) = match &graph[idx] {
+            PlanNode::Combine {
+                combine_inputs: Some(i),
+                decomposed_predicate: Some(d),
+                ..
+            } => (i.clone(), d.clone()),
+            _ => continue,
         };
 
         // Pre-classify the predicate shape. Three branches:
@@ -848,9 +841,12 @@ pub(crate) fn select_combine_strategies_in_graph(
             diags.push(combine_w302_small_both(&name, span));
         }
 
-        let driving = match tables.combine_driving.get(&name) {
-            Some(d) => d.clone(),
-            None => continue,
+        let driving = match &graph[idx] {
+            PlanNode::Combine {
+                combine_driving: Some(d),
+                ..
+            } => d.clone(),
+            _ => continue,
         };
 
         // All non-driver input qualifiers, in declaration (IndexMap)
@@ -864,7 +860,7 @@ pub(crate) fn select_combine_strategies_in_graph(
 
         let chosen_strategy: CombineStrategy = if has_equi && has_range {
             CombineStrategy::HashPartitionIEJoin {
-                partition_bits: compute_partition_bits(inputs, tables.statistics),
+                partition_bits: compute_partition_bits(&inputs, tables.statistics),
             }
         } else if !has_equi && has_range {
             // Pure-range predicate. SortMerge is preferred when both
@@ -888,7 +884,7 @@ pub(crate) fn select_combine_strategies_in_graph(
             } else {
                 CombineStrategy::IEJoin
             }
-        } else if grace_hash_should_fire(inputs, tables.statistics, mem_limit_str)
+        } else if grace_hash_should_fire(&inputs, tables.statistics, mem_limit_str)
             || matches!(
                 tables.combine_strategy_hints.get(&name),
                 Some(crate::config::CombineStrategyHint::GraceHash)
@@ -904,7 +900,7 @@ pub(crate) fn select_combine_strategies_in_graph(
             // its `MIN_BITS` floor — the executor still partitions the
             // build correctly, it just splits into fewer buckets.
             CombineStrategy::GraceHash {
-                partition_bits: compute_grace_partition_bits(inputs, tables.statistics),
+                partition_bits: compute_grace_partition_bits(&inputs, tables.statistics),
             }
         } else {
             CombineStrategy::HashBuildProbe
@@ -1725,12 +1721,16 @@ pub(crate) fn decompose_nary_combines(
         .graph
         .node_indices()
         .filter_map(|idx| match &plan.graph[idx] {
-            PlanNode::Combine { name, span, .. } => {
-                let count = artifacts
-                    .combine_inputs
-                    .get(name)
-                    .map(IndexMap::len)
-                    .unwrap_or(0);
+            PlanNode::Combine {
+                name,
+                span,
+                combine_inputs,
+                ..
+            } => {
+                // Input count comes off the node (stamped at lowering) — the
+                // same source the rewrite below reads, so the snapshot and the
+                // decomposition agree without a bare-name map lookup.
+                let count = combine_inputs.as_ref().map(IndexMap::len).unwrap_or(0);
                 if count > 2 {
                     Some((idx, name.clone(), *span))
                 } else {
@@ -1742,9 +1742,16 @@ pub(crate) fn decompose_nary_combines(
         .collect();
 
     for (original_idx, original_name, span) in nary {
-        let inputs = match artifacts.combine_inputs.get(&original_name) {
-            Some(i) => i.clone(),
-            None => continue,
+        // Read the original N-ary combine's runtime state off the node
+        // (stamped at lowering). Each binary step the decomposition produces
+        // carries its own slice on its own node below, so same-named combines
+        // in sibling composition bodies never collide through a shared map.
+        let inputs = match &plan.graph[original_idx] {
+            PlanNode::Combine {
+                combine_inputs: Some(i),
+                ..
+            } => i.clone(),
+            _ => continue,
         };
         if inputs.len() > MAX_COMBINE_INPUTS {
             diags.push(combine_e300_too_many_inputs(
@@ -1754,18 +1761,24 @@ pub(crate) fn decompose_nary_combines(
             ));
             continue;
         }
-        let predicate = match artifacts.combine_predicates.get(&original_name) {
-            Some(p) => p.clone(),
-            None => continue,
+        let predicate = match &plan.graph[original_idx] {
+            PlanNode::Combine {
+                decomposed_predicate: Some(p),
+                ..
+            } => p.clone(),
+            _ => continue,
         };
         if let Err(d) = validate_join_graph_connectivity(&inputs, &predicate, &original_name, span)
         {
             diags.push(*d);
             continue;
         }
-        let driving = match artifacts.combine_driving.get(&original_name) {
-            Some(d) => d.clone(),
-            None => continue,
+        let driving = match &plan.graph[original_idx] {
+            PlanNode::Combine {
+                combine_driving: Some(d),
+                ..
+            } => d.clone(),
+            _ => continue,
         };
 
         // Reconstruct the merged row from the per-input rows. This is
@@ -1970,6 +1983,12 @@ pub(crate) fn decompose_nary_combines(
                         // step. The executor reads `None` and emits the
                         // matched record directly, no body evaluation.
                         typed: None,
+                        // The per-step runtime state (inputs / predicate /
+                        // driving) is stamped onto the node in the loop below,
+                        // once the per-step input maps are materialized.
+                        combine_inputs: None,
+                        decomposed_predicate: None,
+                        combine_driving: None,
                     }),
                 )
             };
@@ -2079,7 +2098,8 @@ pub(crate) fn decompose_nary_combines(
             }
         }
 
-        // Populate CompileArtifacts for each step.
+        // Stamp each step's runtime state onto its own node, and keep the
+        // resolved-column side-table entry the lowering path expects.
         for (i, step) in steps.iter().enumerate() {
             // Per-step inputs map: driver row + build row. The driver
             // entry for step ≥ 1 carries the previous step's
@@ -2122,15 +2142,21 @@ pub(crate) fn decompose_nary_combines(
                 },
             );
 
-            artifacts
-                .combine_inputs
-                .insert(step.name.clone(), step_inputs);
-            artifacts
-                .combine_predicates
-                .insert(step.name.clone(), step.predicate_slice.clone());
-            artifacts
-                .combine_driving
-                .insert(step.name.clone(), step.driving_input.clone());
+            // Stamp the per-step runtime state onto the step's node (created
+            // above; the final step reuses the original combine's index) so
+            // strategy selection and the executor read it by node instance,
+            // not via a bare-name lookup that collides across sibling scopes.
+            if let PlanNode::Combine {
+                combine_inputs: step_node_inputs,
+                decomposed_predicate: step_node_predicate,
+                combine_driving: step_node_driving,
+                ..
+            } = &mut plan.graph[step_indices[i]]
+            {
+                *step_node_inputs = Some(step_inputs);
+                *step_node_predicate = Some(step.predicate_slice.clone());
+                *step_node_driving = Some(step.driving_input.clone());
+            }
             artifacts
                 .combine_resolved_columns
                 .insert(step.name.clone(), Arc::new(step_resolved_maps[i].clone()));
@@ -2433,6 +2459,10 @@ mod tests {
             output_schema: clinker_record::SchemaBuilder::new().build(),
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
+            // Mirror lowering: the strategy pass reads these off the node.
+            combine_inputs: artifacts.combine_inputs.get(combine_name).cloned(),
+            decomposed_predicate: artifacts.combine_predicates.get(combine_name).cloned(),
+            combine_driving: artifacts.combine_driving.get(combine_name).cloned(),
         });
         let plan = ExecutionPlanDag {
             graph,
@@ -2615,6 +2645,9 @@ mod tests {
             output_schema: clinker_record::SchemaBuilder::new().build(),
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
+            combine_inputs: None,
+            decomposed_predicate: None,
+            combine_driving: None,
         };
         assert_eq!(node.name(), "test_combine");
         assert_eq!(node.type_tag(), "combine");
@@ -2754,6 +2787,10 @@ mod tests {
             output_schema: clinker_record::SchemaBuilder::new().build(),
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
+            // Mirror lowering: N-ary decomposition reads these off the node.
+            combine_inputs: artifacts.combine_inputs.get(combine_name).cloned(),
+            decomposed_predicate: artifacts.combine_predicates.get(combine_name).cloned(),
+            combine_driving: artifacts.combine_driving.get(combine_name).cloned(),
         });
 
         let plan = ExecutionPlanDag {
@@ -2869,12 +2906,20 @@ mod tests {
         let mut diags = Vec::new();
         decompose_nary_combines(&mut plan, &mut artifacts, &mut diags);
         // Step 0 joined `a` with the smallest connected partner — `d`.
-        // The synthetic step name carries its build qualifier in
-        // `combine_inputs[step.name]`, so we look that up here.
-        let step0 = artifacts
-            .combine_inputs
-            .get("__combine_c_step_0")
-            .expect("step 0 inserted into combine_inputs");
+        // The synthetic step carries its build qualifier in its own node's
+        // `combine_inputs`, so we look that up here.
+        let step0 = plan
+            .graph
+            .node_weights()
+            .find_map(|n| match n {
+                crate::plan::execution::PlanNode::Combine {
+                    name,
+                    combine_inputs: Some(ci),
+                    ..
+                } if name == "__combine_c_step_0" => Some(ci),
+                _ => None,
+            })
+            .expect("step 0 node carries combine_inputs");
         assert!(
             step0.contains_key("d"),
             "greedy ordering picks d (smallest cardinality, connected via a—d shortcut); \

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -891,7 +891,7 @@ impl ExecutionPlanDag {
 
         for (group_name, indices) in &combine_groups {
             if indices.len() > 1 {
-                self.render_combine_group(out, group_name, indices, artifacts, planned_share);
+                self.render_combine_group(out, group_name, indices, planned_share);
             } else {
                 self.render_combine_single(out, indices[0], artifacts, planned_share);
             }
@@ -922,13 +922,17 @@ impl ExecutionPlanDag {
             predicate_summary,
             match_mode,
             on_miss,
+            combine_inputs,
+            decomposed_predicate,
             ..
         } = &self.graph[idx]
         else {
             return;
         };
 
-        let inputs_for_node = artifacts.combine_inputs.get(name);
+        // Per-input metadata + decomposed predicate are read off the node
+        // (the runtime source), not the bare-name `CompileArtifacts` maps.
+        let inputs_for_node = combine_inputs.as_ref();
 
         out.push_str(&format!("Combine '{name}':\n"));
         out.push_str(&format!(
@@ -970,7 +974,7 @@ impl ExecutionPlanDag {
                 "no"
             }
         ));
-        if let Some(decomposed) = artifacts.combine_predicates.get(name) {
+        if let Some(decomposed) = decomposed_predicate {
             out.push_str(&decomposed.format_text());
         }
 
@@ -995,7 +999,6 @@ impl ExecutionPlanDag {
         out: &mut String,
         group_name: &str,
         indices: &[NodeIndex],
-        artifacts: &crate::plan::bind_schema::CompileArtifacts,
         planned_share: u64,
     ) {
         let nary_inputs = indices.len() + 1;
@@ -1010,6 +1013,7 @@ impl ExecutionPlanDag {
                 driving_input,
                 build_inputs,
                 predicate_summary,
+                decomposed_predicate,
                 ..
             } = &self.graph[idx]
             else {
@@ -1036,11 +1040,11 @@ impl ExecutionPlanDag {
                 step_name,
             ));
 
-            // Per-step predicate detail under the step line. The
-            // detail is indented one more level than a singleton
-            // block because each step is already nested under the
+            // Per-step predicate detail under the step line, read off the
+            // step node. The detail is indented one more level than a
+            // singleton block because each step is already nested under the
             // group header.
-            if let Some(decomposed) = artifacts.combine_predicates.get(step_name) {
+            if let Some(decomposed) = decomposed_predicate {
                 let detail = decomposed.format_text();
                 for line in detail.lines() {
                     out.push_str("  ");
@@ -1991,23 +1995,25 @@ impl<'a> Serialize for CombineNodeEntry<'a> {
             ),
         );
 
-        // Combine-specific extras. Pull from the variant fields plus
-        // the artifacts side-table.
+        // Combine-specific extras. The per-input metadata and decomposed
+        // predicate come off the node (the runtime source); the statistics
+        // catalog stays in artifacts.
         if let PlanNode::Combine {
-            name,
             strategy,
             driving_input,
             build_inputs,
+            combine_inputs,
+            decomposed_predicate,
             ..
         } = self.node
         {
             // Rich predicate detail.
-            let predicate_value = build_predicate_json(self.artifacts.combine_predicates.get(name));
+            let predicate_value = build_predicate_json(decomposed_predicate.as_ref());
             obj.insert("predicate".to_string(), predicate_value);
 
             // Per-input role + estimated rows.
             let inputs_value = build_inputs_json(
-                self.artifacts.combine_inputs.get(name),
+                combine_inputs.as_ref(),
                 &self.artifacts.statistics,
                 driving_input,
                 build_inputs,
@@ -2194,6 +2200,9 @@ mod spill_projection_tests {
             output_schema: Arc::new(clinker_record::Schema::new(Vec::new())),
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
+            combine_inputs: None,
+            decomposed_predicate: None,
+            combine_driving: None,
         }
     }
 

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -31,6 +31,7 @@ pub use streaming_class::{
 
 use std::collections::{BTreeSet, HashMap};
 
+use indexmap::IndexMap;
 use petgraph::graph::{DiGraph, NodeIndex};
 use serde::Serialize;
 
@@ -448,6 +449,31 @@ pub enum PlanNode {
         /// optional, not `unwrap` it.
         #[serde(skip)]
         typed: Option<Arc<TypedProgram>>,
+        /// Per-input qualifier metadata in declaration order. Carried on the
+        /// node so combine strategy selection and the executor resolve a
+        /// combine's inputs by node instance rather than a bare-name lookup
+        /// into `CompileArtifacts.combine_inputs`, which is last-writer-wins
+        /// across same-named combines in sibling composition bodies. Stamped
+        /// at lowering, and per-step by N-ary decomposition. `None` for a
+        /// combine that failed binding.
+        #[serde(skip)]
+        combine_inputs: Option<IndexMap<String, crate::plan::combine::CombineInput>>,
+        /// Decomposed `where:` predicate (equalities / ranges / residual) the
+        /// strategy pass and the executor consume. The on-node companion of
+        /// the shape-only `predicate_summary`, carried for the same
+        /// node-instance scope-correctness reason as `combine_inputs`. `None`
+        /// for a combine that failed binding (then `predicate_summary` is
+        /// zero-valued).
+        #[serde(skip)]
+        decomposed_predicate: Option<crate::plan::combine::DecomposedPredicate>,
+        /// Driving (probe-side) input qualifier chosen at bind time by
+        /// `select_driving_input`. The strategy post-pass reads it off the
+        /// node to stamp the runtime `driving_input` / `build_inputs`. Distinct
+        /// from `driving_input`, which stays empty until that pass runs. `None`
+        /// when driver selection failed (E306) — the post-pass then skips the
+        /// combine, exactly as an absent `combine_driving` map entry did.
+        #[serde(skip)]
+        combine_driving: Option<String>,
     },
 }
 


### PR DESCRIPTION
## Summary

The runtime state a combine needs at execution — its per-input qualifier
metadata, the decomposed `where:` predicate, and the bind-time driving
qualifier — lived in node-name-keyed side-tables on `CompileArtifacts`. When
two combines share a node name across composition scopes (two sibling
compositions, or one composition instantiated twice), those tables collided
last-writer-wins, so combine strategy selection and the executor could resolve
a body combine against another scope's join — driving the wrong join at
runtime.

This finishes making the combine surface self-contained on the node. The three
fields now travel on `PlanNode::Combine` next to the already-on-node body
program and resolved-column map:

- Lowering and N-ary combine decomposition stamp each node (decomposition
  stamps per-step values onto its rewritten and synthetic step nodes).
- Combine strategy selection (top-level and composition-body variants), the
  executor, and `--explain` read these off the node, so a combine is
  scope-correct by node instance — no shared name-keyed lookup at runtime.

The name-keyed maps remain only as the bind→lowering handoff and the
pre-lowering document-path source attribution; no post-lowering path reads
them, so there is no surviving parallel old/new resting place.

`combine_strategy_hints` and the combine resolved-column side-table are left as
they are — out of scope for this change.

## Test plan

- New execution regression: two sibling compositions whose combines share a
  name but carry different join predicates now each run their own predicate
  (verified to fail before the fix and pass after).
- `cargo test --workspace` (full suite), the benchmark correctness gauntlet,
  `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`,
  and `cargo deny check` all pass.

Closes #633
