### PR TITLE
plan,exec,cxl: scope-key the per-node typed-program table and its consumers

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -181,7 +181,7 @@ pub(crate) fn dispatch_aggregation(
         // behind an Arc, so a per-window evaluator clone is cheap). The
         // strict path below never reaches here, so the spill schema is built
         // only on this windowed branch — never built-then-dropped.
-        let transform_idx = ctx.transform_by_name.get(name.as_str()).copied();
+        let transform_idx = ctx.transform_idx(name.as_str());
         let spill_schema = aggregate_spill_schema(compiled);
         let mem_limit = parse_memory_limit(ctx.config);
         let win_ctx = WindowedAggContext {
@@ -225,7 +225,7 @@ pub(crate) fn dispatch_aggregation(
         // Build the single retained-stream artifacts here, on the branch
         // that consumes them — the strict path below re-derives its own per
         // document, so nothing is built-then-dropped on the dominant arm.
-        let transform_idx = ctx.transform_by_name.get(name.as_str()).copied();
+        let transform_idx = ctx.transform_idx(name.as_str());
         let evaluator = match transform_idx {
             Some(idx) => ProgramEvaluator::with_max_expansion(
                 Arc::clone(&ctx.compiled_transforms[idx].typed),
@@ -562,15 +562,13 @@ impl DocAggregatorFactory {
         compiled: &Arc<cxl::plan::CompiledAggregate>,
         output_schema: &Arc<Schema>,
     ) -> Result<Self, PipelineError> {
-        let transform_idx = ctx
-            .transform_by_name
-            .get(node_name)
-            .copied()
-            .ok_or_else(|| PipelineError::Internal {
-                op: "aggregation",
-                node: node_name.to_string(),
-                detail: "no compiled transform found for aggregate node".to_string(),
-            })?;
+        let transform_idx =
+            ctx.transform_idx(node_name)
+                .ok_or_else(|| PipelineError::Internal {
+                    op: "aggregation",
+                    node: node_name.to_string(),
+                    detail: "no compiled transform found for aggregate node".to_string(),
+                })?;
         let compiled_transform = &ctx.compiled_transforms[transform_idx];
         // The compression mode resolves against the output-schema width and
         // batch size so a spilled table's on-disk format matches what

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -459,7 +459,8 @@ use clinker_record::Schema;
 ///   mini-DAG without duplicating arm logic.
 /// * `output_configs` / `primary_output` — output sinks and the
 ///   declaration-order primary used as the fallback projection target.
-/// * `transform_by_name` — name → index into `compiled_transforms`.
+/// * `transform_by_name` — (scope → name) → index into
+///   `compiled_transforms`; resolve via [`ExecutorContext::transform_idx`].
 /// * `compiled_transforms` — precompiled CXL programs for Transform and
 ///   Aggregation arms.
 /// * `stable` / `source_batch_arc` / `strategy` — pipeline-stable scalars
@@ -492,7 +493,8 @@ pub(crate) struct ExecutorContext<'a> {
     pub(crate) output_configs: &'a [OutputConfig],
     pub(crate) primary_output: &'a OutputConfig,
     pub(crate) compiled_transforms: &'a [CompiledTransform],
-    pub(crate) transform_by_name: HashMap<&'a str, usize>,
+    pub(crate) transform_by_name:
+        HashMap<clinker_plan::plan::bind_schema::NodeScope, HashMap<&'a str, usize>>,
     pub(crate) stable: &'a StableEvalContext,
     /// Backing storage for `$source.batch` — per-pipeline-run UUID v7
     /// (per-source attribution is sub-issue #54). Distinct from
@@ -1020,6 +1022,32 @@ pub(crate) struct RetainedAggregatorState {
 }
 
 impl<'a> ExecutorContext<'a> {
+    /// The scope the dispatcher is currently executing in: the innermost
+    /// composition body on `window_runtime.active_stack`, or `TopLevel` when
+    /// the stack is empty (the top-level DAG walk).
+    pub(crate) fn current_node_scope(&self) -> clinker_plan::plan::bind_schema::NodeScope {
+        use clinker_plan::plan::bind_schema::NodeScope;
+        self.window_runtime
+            .active_stack
+            .last()
+            .copied()
+            .map(NodeScope::Body)
+            .unwrap_or(NodeScope::TopLevel)
+    }
+
+    /// Resolve a node's `CompiledTransform` index by its scope-qualified
+    /// identity — the current execution scope plus the bare node name — so a
+    /// body transform named the same as a top-level (or sibling-body)
+    /// transform selects its own program instead of a colliding bare-name
+    /// entry. `None` when no compiled program is registered for that node
+    /// (e.g. a top-level aggregate, which carries its logic on the node).
+    pub(crate) fn transform_idx(&self, name: &str) -> Option<usize> {
+        self.transform_by_name
+            .get(&self.current_node_scope())?
+            .get(name)
+            .copied()
+    }
+
     /// Poll the run's shutdown flag at an operator chunk boundary. When
     /// the token has tripped (SIGINT/SIGTERM, or a programmatic
     /// request), record the interruption and return
@@ -2351,7 +2379,7 @@ pub(crate) fn transform_fused_consume(
         }
     };
 
-    let transform_idx_opt = ctx.transform_by_name.get(name).copied();
+    let transform_idx_opt = ctx.transform_idx(name);
     let expected_input = current_dag.graph[node_idx]
         .expected_input_schema_in(current_dag)
         .cloned();

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -508,6 +508,7 @@ impl PipelineExecutor {
                     })?;
                 Ok::<CompiledTransform, PipelineError>(CompiledTransform {
                     name: t.name.clone(),
+                    scope: clinker_plan::plan::bind_schema::NodeScope::TopLevel,
                     typed,
                     max_expansion: t.max_expansion,
                 })
@@ -515,14 +516,12 @@ impl PipelineExecutor {
             .collect::<Result<_, _>>()?;
 
         // Extend with body transforms. Composition bodies' Transform
-        // / Aggregate nodes have their typed programs sitting in
-        // `artifacts.typed` under their own `Body` scope. The body
-        // dispatcher arm looks up `transform_by_name` in the same
-        // (bare-name-keyed) runtime table the top-level walker uses, so
-        // every executable body node has to be present here too. Skip
-        // names already present so the top-level entry wins on collision.
-        let mut existing_names: std::collections::HashSet<String> =
-            compiled_transforms.iter().map(|c| c.name.clone()).collect();
+        // / Aggregate nodes have their typed programs in `artifacts.typed`
+        // under their own `Body` scope. The body dispatcher looks them up in
+        // the same runtime table the top-level walker uses; that table is
+        // keyed by `(scope, name)`, so two bodies (or a body and the top
+        // level) with same-named nodes each keep their own program — no
+        // bare-name collapse.
         for (body_id, body) in validated_plan.artifacts().composition_bodies.iter() {
             for idx in body.graph.node_indices() {
                 let body_node = &body.graph[idx];
@@ -531,18 +530,16 @@ impl PipelineExecutor {
                     body_node,
                     clinker_plan::plan::execution::PlanNode::Transform { .. }
                         | clinker_plan::plan::execution::PlanNode::Aggregation { .. }
-                ) && !existing_names.contains(n)
-                    && let Some(typed) = validated_plan.artifacts().typed_get(
-                        clinker_plan::plan::bind_schema::NodeScope::Body(*body_id),
-                        n,
-                    )
-                {
+                ) && let Some(typed) = validated_plan.artifacts().typed_get(
+                    clinker_plan::plan::bind_schema::NodeScope::Body(*body_id),
+                    n,
+                ) {
                     compiled_transforms.push(CompiledTransform {
                         name: n.to_string(),
+                        scope: clinker_plan::plan::bind_schema::NodeScope::Body(*body_id),
                         typed: typed.clone(),
                         max_expansion: cxl::eval::DEFAULT_MAX_EXPANSION,
                     });
-                    existing_names.insert(n.to_string());
                 }
             }
         }
@@ -685,9 +682,9 @@ impl PipelineExecutor {
                     }
                 }
                 // Only this body's own nodes contribute emits. The `typed`
-                // table is `ScopedNodeId`-keyed, so filter by `Body(body_id)` —
-                // this also fixes the prior bare-name match that would have
-                // pulled in a top-level node sharing a name with a body node.
+                // table is `ScopedNodeId`-keyed, so filter by this body's
+                // scope — a top-level node sharing a name with a body node
+                // stays out of this body's route field set.
                 for (scoped, typed) in &validated_plan.artifacts().typed {
                     if scoped.scope != clinker_plan::plan::bind_schema::NodeScope::Body(*body_id) {
                         continue;
@@ -1175,14 +1172,22 @@ impl PipelineExecutor {
 
         let strategy = config.error_handling.strategy;
 
-        // Name → index map for looking up `CompiledTransform` by node
-        // name. Borrowed by the dispatcher's Transform / Aggregation
-        // arms.
-        let transform_by_name: HashMap<&str, usize> = transforms
-            .iter()
-            .enumerate()
-            .map(|(i, t)| (t.name.as_str(), i))
-            .collect();
+        // (scope → name → index) map for looking up `CompiledTransform` by
+        // a node's scope-qualified identity. Keyed by `NodeScope` first so a
+        // body transform named the same as a top-level (or sibling-body)
+        // transform resolves its own program; the dispatcher reads the
+        // current scope off `window_runtime.active_stack`. Borrowed by the
+        // dispatcher's Transform / Aggregation arms.
+        let mut transform_by_name: HashMap<
+            clinker_plan::plan::bind_schema::NodeScope,
+            HashMap<&str, usize>,
+        > = HashMap::new();
+        for (i, t) in transforms.iter().enumerate() {
+            transform_by_name
+                .entry(t.scope)
+                .or_default()
+                .insert(t.name.as_str(), i);
+        }
 
         // Correlation grouping context. `Some(...)` iff at least one
         // source declares a `correlation_key:`; the planner's

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -490,10 +490,14 @@ impl PipelineExecutor {
         let mut compiled_transforms: Vec<CompiledTransform> = resolved_transforms
             .iter()
             .map(|t| {
+                // `resolved_transforms` are top-level transforms; resolve each
+                // by its TopLevel key in the scope-qualified `typed` table.
                 let typed = validated_plan
                     .artifacts()
-                    .typed
-                    .get(&t.name)
+                    .typed_get(
+                        clinker_plan::plan::bind_schema::NodeScope::TopLevel,
+                        &t.name,
+                    )
                     .cloned()
                     .ok_or_else(|| PipelineError::Compilation {
                         transform_name: t.name.clone(),
@@ -512,14 +516,14 @@ impl PipelineExecutor {
 
         // Extend with body transforms. Composition bodies' Transform
         // / Aggregate nodes have their typed programs sitting in
-        // `artifacts.typed` under the body's node name. The body
+        // `artifacts.typed` under their own `Body` scope. The body
         // dispatcher arm looks up `transform_by_name` in the same
-        // table the top-level walker uses, so every executable body
-        // node has to be present here too. Skip names already
-        // present so the top-level entry wins on collision.
+        // (bare-name-keyed) runtime table the top-level walker uses, so
+        // every executable body node has to be present here too. Skip
+        // names already present so the top-level entry wins on collision.
         let mut existing_names: std::collections::HashSet<String> =
             compiled_transforms.iter().map(|c| c.name.clone()).collect();
-        for body in validated_plan.artifacts().composition_bodies.values() {
+        for (body_id, body) in validated_plan.artifacts().composition_bodies.iter() {
             for idx in body.graph.node_indices() {
                 let body_node = &body.graph[idx];
                 let n = body_node.name();
@@ -528,7 +532,10 @@ impl PipelineExecutor {
                     clinker_plan::plan::execution::PlanNode::Transform { .. }
                         | clinker_plan::plan::execution::PlanNode::Aggregation { .. }
                 ) && !existing_names.contains(n)
-                    && let Some(typed) = validated_plan.artifacts().typed.get(n)
+                    && let Some(typed) = validated_plan.artifacts().typed_get(
+                        clinker_plan::plan::bind_schema::NodeScope::Body(*body_id),
+                        n,
+                    )
                 {
                     compiled_transforms.push(CompiledTransform {
                         name: n.to_string(),
@@ -559,7 +566,11 @@ impl PipelineExecutor {
                     // multi-source pipelines.
                     let mut emitted_fields: Vec<String> = Vec::new();
                     for src_cfg in &source_configs {
-                        if let Some(typed) = validated_plan.artifacts().typed.get(&src_cfg.name) {
+                        // Sources are top-level nodes; resolve by TopLevel key.
+                        if let Some(typed) = validated_plan.artifacts().typed_get(
+                            clinker_plan::plan::bind_schema::NodeScope::TopLevel,
+                            &src_cfg.name,
+                        ) {
                             for (qf, _) in typed.output_row.fields() {
                                 let s = qf.name.to_string();
                                 if s.starts_with('$') {
@@ -583,17 +594,19 @@ impl PipelineExecutor {
                     }
                     // Combine nodes also emit fields via their `cxl:` body;
                     // those typed programs live in `artifacts.typed` keyed
-                    // by combine node name (not in `compiled_transforms`,
-                    // which is transform-only). A route downstream of a
-                    // combine sees the combine's emits, so every emit in
-                    // every typed program that's NOT a transform must be
-                    // surfaced to the route resolver.
+                    // by the combine's scope-qualified id (not in
+                    // `compiled_transforms`, which is transform-only). A route
+                    // downstream of a combine sees the combine's emits, so
+                    // every emit in every typed program that's NOT a transform
+                    // must be surfaced to the route resolver. The table is now
+                    // `ScopedNodeId`-keyed; the transform-name filter and emit
+                    // collection both operate on the bare `name`.
                     let transform_names: std::collections::HashSet<&str> = compiled_transforms
                         .iter()
                         .map(|ct| ct.name.as_str())
                         .collect();
-                    for (node_name, typed) in &validated_plan.artifacts().typed {
-                        if transform_names.contains(node_name.as_str()) {
+                    for (scoped, typed) in &validated_plan.artifacts().typed {
+                        if transform_names.contains(scoped.name.as_str()) {
                             continue;
                         }
                         cxl::ast::for_each_field_emit(&typed.program.statements, &mut |name, _| {
@@ -637,7 +650,7 @@ impl PipelineExecutor {
         // Routes carry their own conditions.
         let mut compiled_routes_by_name: std::collections::HashMap<String, CompiledRoute> =
             std::collections::HashMap::new();
-        for body in validated_plan.artifacts().composition_bodies.values() {
+        for (body_id, body) in validated_plan.artifacts().composition_bodies.iter() {
             for (route_name, route_body) in &body.route_bodies {
                 // Build the body Route's RouteConfig from its parsed
                 // RouteBody. The condition resolver needs the field
@@ -671,8 +684,12 @@ impl PipelineExecutor {
                         }
                     }
                 }
-                for (n, typed) in &validated_plan.artifacts().typed {
-                    if !body.name_to_idx.contains_key(n.as_str()) {
+                // Only this body's own nodes contribute emits. The `typed`
+                // table is `ScopedNodeId`-keyed, so filter by `Body(body_id)` —
+                // this also fixes the prior bare-name match that would have
+                // pulled in a top-level node sharing a name with a body node.
+                for (scoped, typed) in &validated_plan.artifacts().typed {
+                    if scoped.scope != clinker_plan::plan::bind_schema::NodeScope::Body(*body_id) {
                         continue;
                     }
                     cxl::ast::for_each_field_emit(&typed.program.statements, &mut |name, _| {

--- a/crates/clinker-exec/src/executor/transform.rs
+++ b/crates/clinker-exec/src/executor/transform.rs
@@ -162,6 +162,11 @@ pub fn build_transform_specs(config: &PipelineConfig) -> Vec<TransformSpec> {
 #[derive(Debug)]
 pub struct CompiledTransform {
     pub(crate) name: String,
+    /// Scope the node lives in. Two composition bodies (or a top-level node
+    /// and a body) can hold same-named transforms with different programs;
+    /// the runtime dispatch table keys on `(scope, name)` so each resolves
+    /// its own program instead of collapsing to one bare-name entry.
+    pub(crate) scope: clinker_plan::plan::bind_schema::NodeScope,
     pub(crate) typed: Arc<TypedProgram>,
     pub(crate) max_expansion: u64,
 }

--- a/crates/clinker-exec/src/executor/transform_dispatch.rs
+++ b/crates/clinker-exec/src/executor/transform_dispatch.rs
@@ -84,9 +84,10 @@ pub(crate) fn dispatch_transform(
         }
     };
 
-    // Find the CompiledTransform for this node
-    let transform_idx = match ctx.transform_by_name.get(name.as_str()) {
-        Some(&idx) => idx,
+    // Find the CompiledTransform for this node, scoped to the body (or top
+    // level) currently executing.
+    let transform_idx = match ctx.transform_idx(name.as_str()) {
+        Some(idx) => idx,
         None => {
             // No transform found — pass through
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &input_records)?;

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -185,8 +185,10 @@ mod tests {
         expected_fields: &[&str],
     ) {
         let row = artifacts
-            .typed
-            .get(node_name)
+            .typed_get(
+                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
+                node_name,
+            )
             .map(|tp| &tp.output_row)
             .unwrap_or_else(|| panic!("no bound output row for node {node_name:?}"));
         let actual: Vec<String> = row.field_names().map(|qf| qf.to_string()).collect();
@@ -494,7 +496,10 @@ mod tests {
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
         assert!(
-            !artifacts.typed.contains_key("bad_collect"),
+            !artifacts.typed_contains(
+                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
+                "bad_collect"
+            ),
             "no output row published when E311 fires"
         );
     }
@@ -575,8 +580,10 @@ mod tests {
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
         let row = artifacts
-            .typed
-            .get("collected")
+            .typed_get(
+                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
+                "collected",
+            )
             .map(|tp| &tp.output_row)
             .expect("collected publishes a bound output row");
 
@@ -787,8 +794,10 @@ mod tests {
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
         let row = artifacts
-            .typed
-            .get("enriched")
+            .typed_get(
+                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
+                "enriched",
+            )
             .map(|tp| &tp.output_row)
             .expect("enriched publishes a bound output row");
         let names: Vec<String> = row.field_names().map(|qf| qf.to_string()).collect();
@@ -829,7 +838,10 @@ mod tests {
             ],
         );
         assert!(
-            artifacts.typed.contains_key("enriched"),
+            artifacts.typed_contains(
+                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
+                "enriched"
+            ),
             "artifacts.typed['enriched'] must be populated with body TypedProgram"
         );
     }

--- a/crates/clinker-exec/tests/cross_scope_doc_attribution_test.rs
+++ b/crates/clinker-exec/tests/cross_scope_doc_attribution_test.rs
@@ -1,0 +1,166 @@
+//! `$doc` path attribution is scope-correct across composition boundaries.
+//!
+//! A `$doc` access carries no source qualifier, so the planner attributes
+//! each referenced envelope path back to the source(s) feeding the
+//! referencing node, then validates it against that source's declared
+//! envelope schema. Before the attribution was scope-keyed, a body node
+//! sharing a name with a top-level node collided in the bare-name
+//! attribution tables, so the body's `$doc` paths were validated against the
+//! top-level node's source — a source that need not declare the body's
+//! section — spuriously failing compile with E341.
+//!
+//! This pipeline has a top-level transform `shape` reading `$doc.Head.xval`
+//! (its source declares only `Head`) and a composition-body transform ALSO
+//! named `shape` reading `$doc.Foot.yval` (its call-site source declares
+//! only `Foot`). With scope-correct attribution the pipeline compiles and each
+//! source carries exactly its own scope's path; with the old bare-name
+//! attribution the body's `Foot` access leaked onto the top-level source and
+//! tripped E341.
+
+use std::path::PathBuf;
+
+use clinker_plan::config::pipeline_node::PipelineNode;
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// Section names of the `$doc` paths the runtime source body named
+/// `source_name` carries after compile (by node identity / `header.name`).
+fn source_doc_sections(plan: &clinker_plan::plan::CompiledPlan, source_name: &str) -> Vec<String> {
+    plan.config()
+        .nodes
+        .iter()
+        .find_map(|spanned| match &spanned.value {
+            PipelineNode::Source { header, config } if header.name == source_name => Some(
+                config
+                    .source
+                    .declared_doc_paths
+                    .iter()
+                    .map(|p| p.section.to_string())
+                    .collect::<Vec<_>>(),
+            ),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn body_doc_paths_attribute_to_their_own_scope_source() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    // Body transform `shape` reads `$doc.Foot.yval`; its call-site source
+    // (`s_body`) declares only the `Foot` section.
+    std::fs::write(
+        comp_dir.join("scoped_doc.comp.yaml"),
+        r#"_compose:
+  name: scoped_doc
+  inputs:
+    inp:
+      schema:
+        - { name: amount, type: int }
+  outputs:
+    out: shape.out
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: shape
+    input: inp
+    config:
+      cxl: |
+        emit fy = $doc.Foot.yval
+"#,
+    )
+    .expect("write comp");
+
+    std::fs::create_dir_all(workspace.path().join("pipelines")).expect("mkdir pipelines");
+
+    // Top-level `shape` reads `$doc.Head.x`; its source (`s_top`) declares
+    // only the `Head` section. Both sources have a Closed envelope schema, so
+    // a path validated against the wrong source's schema fires E341.
+    let yaml = r#"
+pipeline:
+  name: cross_scope_doc
+nodes:
+  - type: source
+    name: s_top
+    config:
+      name: s_top
+      type: xml
+      glob: ./top/*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Head:
+            extract: { xml_path: "/doc/Head" }
+            fields:
+              xval: string
+      schema:
+        - { name: amount, type: int }
+  - type: source
+    name: s_body
+    config:
+      name: s_body
+      type: xml
+      glob: ./body/*.xml
+      options:
+        record_path: doc/records/record
+      envelope:
+        sections:
+          Foot:
+            extract: { xml_path: "/doc/Foot" }
+            fields:
+              yval: string
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: shape
+    input: s_top
+    config:
+      cxl: |
+        emit hx = $doc.Head.xval
+  - type: composition
+    name: body
+    input: s_body
+    use: ../compositions/scoped_doc.comp.yaml
+    inputs:
+      inp: s_body
+  - type: output
+    name: out_top
+    input: shape
+    config:
+      name: out_top
+      type: csv
+      path: out_top.csv
+      include_unmapped: true
+  - type: output
+    name: out_body
+    input: body
+    config:
+      name: out_body
+      type: csv
+      path: out_body.csv
+      include_unmapped: true
+"#;
+
+    let config = parse_config(yaml).expect("parse pipeline yaml");
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    // Compiling at all is the headline assertion: with bare-name attribution
+    // the body `shape`'s `$doc.Foot.yval` was validated against `s_top` (Closed,
+    // no `Foot`) and the compile failed with E341.
+    let plan = config
+        .compile(&ctx)
+        .expect("pipeline must compile: body $doc paths must not leak onto the top-level source");
+
+    let top_sections = source_doc_sections(&plan, "s_top");
+    let body_sections = source_doc_sections(&plan, "s_body");
+
+    assert!(
+        top_sections == vec!["Head".to_string()],
+        "s_top must carry ONLY its own `Head` path, not the body's `Foot`; got {top_sections:?}"
+    );
+    assert!(
+        body_sections == vec!["Foot".to_string()],
+        "s_body must carry ONLY the body `shape`'s `Foot` path, not the top-level `Head`; got {body_sections:?}"
+    );
+}

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -798,48 +798,39 @@ impl PipelineConfig {
         // conditions are typed into separate side-tables and chained in
         // below. Missing any of them would drop a referenced path from the
         // declared set.
-        let doc_refs: Vec<(&str, &cxl::typecheck::pass::TypedProgram)> = artifacts
+        // Attribute `$doc` paths by each program's scope-qualified
+        // `ScopedNodeId`, not its bare name, so a node named the same at top
+        // level and inside a composition body keeps its own `$doc` paths
+        // attributed to its own scope's source(s). The key is borrowed from
+        // the artifact tables (all three are `ScopedNodeId`-keyed), so no
+        // allocation; `&ScopedNodeId` is `Ord + Clone` as the collector needs.
+        let doc_refs: Vec<(
+            &crate::plan::bind_schema::ScopedNodeId,
+            &cxl::typecheck::pass::TypedProgram,
+        )> = artifacts
             .typed
             .iter()
-            // The `typed` table is keyed by `ScopedNodeId`; the downstream
-            // source attribution keys by the bare node name, so project the
-            // scoped key to its `name`. A node named the same in two scopes now
-            // contributes BOTH programs (the scope key no longer overwrites one
-            // with the other), which is strictly more correct for `$doc`
-            // detection.
-            .map(|(scoped, tp)| (scoped.name.as_str(), tp.as_ref()))
-            // A Combine's node-keyed `typed` entry holds only its `cxl:`
-            // body; its `where:` predicate program lives in a separate
-            // side-table, so include those too — a `$doc` access used only
-            // in a predicate would otherwise be dropped. The side-table is
-            // keyed by `ScopedNodeId`; the downstream source attribution
-            // keys by the bare node name, so project the scoped key to its
-            // `name`. A combine named the same in two scopes now contributes
-            // BOTH predicate programs (the scope key no longer overwrites
-            // one with the other), which is strictly more correct for `$doc`
-            // detection.
+            .map(|(scoped, tp)| (scoped, tp.as_ref()))
+            // A Combine's node-keyed `typed` entry holds only its `cxl:` body;
+            // its `where:` predicate program lives in a separate side-table, so
+            // include those too — a `$doc` access used only in a predicate
+            // would otherwise be dropped.
             .chain(
                 artifacts
                     .combine_where_typed
                     .iter()
-                    .map(|(scoped, tp)| (scoped.name.as_str(), tp.as_ref())),
+                    .map(|(scoped, tp)| (scoped, tp.as_ref())),
             )
             // A Route's node-keyed `typed` entry is an empty body; its
-            // branch-condition programs live in a separate side-table, one
-            // per branch. Include each, keyed by the Route node name so the
-            // per-node source attribution stamps the path onto the Route's
-            // source(s) — a `$doc` access used only in a route condition
-            // would otherwise be dropped. As with the combine side-table,
-            // project the `ScopedNodeId` to its bare `name` for the
-            // attribution key.
+            // branch-condition programs live in a separate side-table, one per
+            // branch. Include each so a `$doc` access used only in a route
+            // condition is still reachable.
             .chain(
                 artifacts
                     .route_branch_typed
                     .iter()
                     .flat_map(|(scoped, programs)| {
-                        programs
-                            .iter()
-                            .map(move |tp| (scoped.name.as_str(), tp.as_ref()))
+                        programs.iter().map(move |tp| (scoped, tp.as_ref()))
                     }),
             )
             .collect();
@@ -858,8 +849,10 @@ impl PipelineConfig {
             })
             .collect();
         if !doc_path_set.unresolvable.is_empty() {
-            for (node_name, d) in &doc_path_set.unresolvable {
-                let primary = match doc_node_line.get(node_name.as_str()) {
+            for (scoped, d) in &doc_path_set.unresolvable {
+                // doc_node_line is top-level-only; a body node falls back to
+                // SYNTHETIC, so look it up by the scoped key's bare name.
+                let primary = match doc_node_line.get(scoped.name.as_str()) {
                     Some(&line) => Span::line_only(line),
                     None => Span::SYNTHETIC,
                 };
@@ -886,8 +879,8 @@ impl PipelineConfig {
         let mut doc_paths_by_source: HashMap<String, std::collections::BTreeSet<_>> =
             HashMap::new();
         for (doc_path, nodes) in &doc_path_set.by_node {
-            for node_name in nodes {
-                let Some(sources) = node_sources.get(node_name) else {
+            for scoped in nodes {
+                let Some(sources) = node_sources.get(*scoped) else {
                     continue;
                 };
                 for source in sources {
@@ -945,7 +938,10 @@ impl PipelineConfig {
             if sections.is_empty() {
                 continue;
             }
-            let Some(feeding) = node_sources.get(&output.name) else {
+            let Some(feeding) = node_sources.get(&crate::plan::bind_schema::ScopedNodeId {
+                scope: crate::plan::bind_schema::NodeScope::TopLevel,
+                name: output.name.clone(),
+            }) else {
                 continue;
             };
             for source_name in feeding {
@@ -1041,15 +1037,15 @@ impl PipelineConfig {
             }
         }
         for (doc_path, ref_nodes) in &doc_path_set.by_node {
-            for node_name in ref_nodes {
-                let Some(sources) = node_sources.get(node_name) else {
+            for scoped in ref_nodes {
+                let Some(sources) = node_sources.get(*scoped) else {
                     continue;
                 };
                 for source_name in sources {
                     let Some(source) = source_by_name.get(source_name.as_str()) else {
                         continue;
                     };
-                    let primary = match doc_node_line.get(node_name.as_str()) {
+                    let primary = match doc_node_line.get(scoped.name.as_str()) {
                         Some(&line) => Span::line_only(line),
                         None => Span::SYNTHETIC,
                     };
@@ -3144,25 +3140,42 @@ fn rest_doc_access_diagnostic(
 fn build_node_source_sets(
     nodes: &[Spanned<PipelineNode>],
     artifacts: &crate::plan::bind_schema::CompileArtifacts,
-) -> HashMap<String, std::collections::BTreeSet<String>> {
+) -> HashMap<crate::plan::bind_schema::ScopedNodeId, std::collections::BTreeSet<String>> {
+    use crate::plan::bind_schema::{NodeScope, ScopedNodeId};
     use crate::plan::composition_body::CompositionBodyId;
 
-    let mut node_sources: HashMap<String, std::collections::BTreeSet<String>> = HashMap::new();
+    let mut node_sources: HashMap<ScopedNodeId, std::collections::BTreeSet<String>> =
+        HashMap::new();
+
+    // Key for a top-level node. The main loop walks only `self.nodes`
+    // (top-level) and the cross-node lookups resolve top-level upstreams, so
+    // every key built here is TopLevel; body nodes are keyed `Body(id)` by
+    // `attribute_body`.
+    fn top_key(name: &str) -> ScopedNodeId {
+        ScopedNodeId {
+            scope: NodeScope::TopLevel,
+            name: name.to_string(),
+        }
+    }
 
     // Attribute every node in a composition body (recursively through
-    // nested bodies) to the call-site's source set.
+    // nested bodies) to the call-site's source set, keyed by the body's
+    // scope so a body node named the same as a top-level node stays distinct.
     fn attribute_body(
         body_id: CompositionBodyId,
         call_site_sources: &std::collections::BTreeSet<String>,
         artifacts: &crate::plan::bind_schema::CompileArtifacts,
-        node_sources: &mut HashMap<String, std::collections::BTreeSet<String>>,
+        node_sources: &mut HashMap<ScopedNodeId, std::collections::BTreeSet<String>>,
     ) {
         let Some(body) = artifacts.body_of(body_id) else {
             return;
         };
         for body_node_name in body.name_to_idx.keys() {
             node_sources
-                .entry(body_node_name.clone())
+                .entry(ScopedNodeId {
+                    scope: NodeScope::Body(body_id),
+                    name: body_node_name.clone(),
+                })
                 .or_default()
                 .extend(call_site_sources.iter().cloned());
         }
@@ -3181,14 +3194,14 @@ fn build_node_source_sets(
             .map(|ci| ci.upstream_name.as_ref().to_string())
     };
 
-    // Union of the source sets feeding the named producers, resolved
-    // against the sets recorded for already-walked nodes.
+    // Union of the source sets feeding the named (top-level) producers,
+    // resolved against the sets recorded for already-walked nodes.
     let union_of = |producers: &[&str],
-                    sources: &HashMap<String, std::collections::BTreeSet<String>>|
+                    sources: &HashMap<ScopedNodeId, std::collections::BTreeSet<String>>|
      -> std::collections::BTreeSet<String> {
         producers
             .iter()
-            .filter_map(|inp| sources.get(*inp))
+            .filter_map(|inp| sources.get(&top_key(inp)))
             .flat_map(|s| s.iter().cloned())
             .collect()
     };
@@ -3201,7 +3214,7 @@ fn build_node_source_sets(
     // a body `$doc` access, can resolve against any bound port's source.
     let composition_call_site_sources =
         |inputs: &IndexMap<String, String>,
-         sources: &HashMap<String, std::collections::BTreeSet<String>>|
+         sources: &HashMap<ScopedNodeId, std::collections::BTreeSet<String>>|
          -> std::collections::BTreeSet<String> {
             let producers: Vec<&str> = inputs
                 .values()
@@ -3220,7 +3233,7 @@ fn build_node_source_sets(
             // when the planner could not pick a driver (the combine is then
             // omitted from the DAG, so the set is unused either way).
             PipelineNode::Combine { .. } => combine_driver_upstream(&name)
-                .and_then(|driver| node_sources.get(&driver).cloned())
+                .and_then(|driver| node_sources.get(&top_key(&driver)).cloned())
                 .unwrap_or_else(|| union_of(&spanned.value.direct_input_names(), &node_sources)),
             // A composition forwards the union of EVERY bound input port's
             // source set, not just its primary port — a downstream node
@@ -3246,7 +3259,7 @@ fn build_node_source_sets(
             attribute_body(body_id, &sources, artifacts, &mut node_sources);
         }
 
-        node_sources.insert(name, sources);
+        node_sources.insert(top_key(&name), sources);
     }
 
     node_sources

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -777,9 +777,10 @@ impl PipelineConfig {
         let compiled_refs: Vec<(&str, &cxl::typecheck::pass::TypedProgram)> = entries
             .iter()
             .filter_map(|e| {
+                // `entries` is the top-level analytic node list; analysis is
+                // top-level-only, so resolve each program by its TopLevel key.
                 artifacts
-                    .typed
-                    .get(&e.name)
+                    .typed_get(crate::plan::bind_schema::NodeScope::TopLevel, &e.name)
                     .map(|tp| (e.name.as_str(), tp.as_ref()))
             })
             .collect();
@@ -800,7 +801,13 @@ impl PipelineConfig {
         let doc_refs: Vec<(&str, &cxl::typecheck::pass::TypedProgram)> = artifacts
             .typed
             .iter()
-            .map(|(name, tp)| (name.as_str(), tp.as_ref()))
+            // The `typed` table is keyed by `ScopedNodeId`; the downstream
+            // source attribution keys by the bare node name, so project the
+            // scoped key to its `name`. A node named the same in two scopes now
+            // contributes BOTH programs (the scope key no longer overwrites one
+            // with the other), which is strictly more correct for `$doc`
+            // detection.
+            .map(|(scoped, tp)| (scoped.name.as_str(), tp.as_ref()))
             // A Combine's node-keyed `typed` entry holds only its `cxl:`
             // body; its `where:` predicate program lives in a separate
             // side-table, so include those too — a `$doc` access used only
@@ -1186,8 +1193,15 @@ impl PipelineConfig {
                 window_config: entry_idx.and_then(|i| window_configs[i].as_ref()),
                 primary_source: primary_source.as_str(),
             };
-            let plan_node =
-                lower_node_to_plan_node(node, &name, span, &artifacts, &lowering_ctx, &mut diags);
+            let plan_node = lower_node_to_plan_node(
+                node,
+                &name,
+                crate::plan::bind_schema::NodeScope::TopLevel,
+                span,
+                &artifacts,
+                &lowering_ctx,
+                &mut diags,
+            );
             if let Some(pn) = plan_node {
                 let idx = graph.add_node(pn);
                 name_to_idx.insert(name, idx);
@@ -1483,16 +1497,21 @@ impl PipelineConfig {
                         // E150e — windows over Combine emit columns
                         // cannot reference an array-typed field. The
                         // typed `output_row` lives in `artifacts.typed`
-                        // keyed by the combine's name and carries the
-                        // CXL `Type` per emitted column; a
+                        // keyed by the combine's scope-qualified id and
+                        // carries the CXL `Type` per emitted column; a
                         // `match: collect` body emits `Type::Array` for
                         // every collected build-row column. Window
                         // builtins (sum/avg/min/max/lag/lead/...) do
                         // not handle `Value::Array`, so they would
-                        // silently see Null at runtime.
+                        // silently see Null at runtime. This pass walks
+                        // the top-level analysis report, so the combine
+                        // is resolved by its TopLevel key.
                         if let crate::plan::execution::PlanNode::Combine { .. } = other {
                             let combine_name = other.name();
-                            if let Some(typed) = artifacts.typed.get(combine_name) {
+                            if let Some(typed) = artifacts.typed_get(
+                                crate::plan::bind_schema::NodeScope::TopLevel,
+                                combine_name,
+                            ) {
                                 for f in &report.transforms[i].accessed_fields {
                                     let is_array = typed
                                         .output_row
@@ -3267,6 +3286,7 @@ pub(crate) struct LoweringCtx<'a> {
 pub(crate) fn lower_node_to_plan_node(
     node: &PipelineNode,
     name: &str,
+    scope: crate::plan::bind_schema::NodeScope,
     span: clinker_core_types::span::Span,
     artifacts: &crate::plan::bind_schema::CompileArtifacts,
     ctx: &LoweringCtx<'_>,
@@ -3304,7 +3324,7 @@ pub(crate) fn lower_node_to_plan_node(
     // own `Arc<Schema>` recovers the same metadata here. The reserved
     // `$` prefix guarantees no user-declared column collides.
     let schema_from_bound = |node_name: &str| -> Arc<clinker_record::Schema> {
-        match artifacts.typed.get(node_name) {
+        match artifacts.typed_get(scope, node_name) {
             Some(tp) => {
                 let mut builder = SchemaBuilder::with_capacity(tp.output_row.field_count());
                 for (qf, _) in tp.output_row.fields() {
@@ -3359,7 +3379,7 @@ pub(crate) fn lower_node_to_plan_node(
         PipelineNode::Transform { config, .. } => {
             // Missing typed program means bind_schema hit a CXL error
             // (E108, E200, etc.) on this node — skip lowering.
-            let typed = match artifacts.typed.get(name) {
+            let typed = match artifacts.typed_get(scope, name) {
                 Some(t) => t.clone(),
                 None => return None,
             };
@@ -3501,7 +3521,7 @@ pub(crate) fn lower_node_to_plan_node(
             config: agg_body, ..
         } => {
             // Skip if bind_schema produced no typed program (CXL error).
-            let typed = match artifacts.typed.get(name) {
+            let typed = match artifacts.typed_get(scope, name) {
                 Some(t) => t.clone(),
                 None => return None,
             };
@@ -3599,23 +3619,22 @@ pub(crate) fn lower_node_to_plan_node(
                 .cloned()
                 .unwrap_or_else(|| Arc::new(std::collections::HashMap::new()));
             // Carry the typed `cxl:` body program on the node, mirroring the
-            // Transform arm's `artifacts.typed.get(name)` read into
-            // `PlanTransformPayload.typed`. Body and top-level combines both
-            // flow through this arm; the bare-name lookup into the
-            // `artifacts.typed` body-program table is collision-exposed exactly
-            // like the Transform arm's — cross-scope node-name reuse is
-            // last-writer-wins in that bare-keyed table. `None` is legitimate
-            // here — a body-less combine (e.g. `match: collect`) carries no
-            // program.
-            let typed = artifacts.typed.get(name).cloned();
+            // Transform arm's read into `PlanTransformPayload.typed`. Body and
+            // top-level combines both flow through this arm; the `typed` table
+            // is keyed by `ScopedNodeId`, so the read resolves this node
+            // instance's own program even when a top-level and a body combine
+            // share a name. `None` is legitimate here — a body-less combine
+            // (e.g. `match: collect`) carries no program.
+            let typed = artifacts.typed_get(scope, name).cloned();
             // Carry the per-input metadata, decomposed `where:` predicate, and
             // bind-time driving qualifier on the node so combine strategy
             // selection and the executor read them by node instance instead of
             // a bare-name lookup into `CompileArtifacts` (last-writer-wins
             // across same-named combines in sibling composition bodies). Like
-            // `typed` / `resolved_column_map`, the read here is transiently
-            // scope-correct because each body is bound then lowered before the
-            // next body overwrites the shared map entry.
+            // `resolved_column_map`, these maps are still bare-name keyed, so
+            // the read here is transiently scope-correct because each body is
+            // bound then lowered before the next body overwrites the shared map
+            // entry.
             let combine_inputs = artifacts.combine_inputs.get(name).cloned();
             let decomposed_predicate = artifacts.combine_predicates.get(name).cloned();
             let combine_driving = artifacts.combine_driving.get(name).cloned();
@@ -3647,7 +3666,7 @@ pub(crate) fn lower_node_to_plan_node(
         PipelineNode::Reshape { config, .. } => {
             // A missing typed entry means bind_schema rejected the node
             // (E200 on a rule predicate / assignment) — skip lowering.
-            artifacts.typed.get(name)?;
+            artifacts.typed_get(scope, name)?;
             Some(crate::plan::execution::PlanNode::Reshape {
                 name: name.to_string(),
                 span,
@@ -3663,7 +3682,7 @@ pub(crate) fn lower_node_to_plan_node(
         PipelineNode::Cull { config, .. } => {
             // A missing typed entry means bind_schema rejected the node
             // (E200 on a rule predicate / removed_to) — skip lowering.
-            artifacts.typed.get(name)?;
+            artifacts.typed_get(scope, name)?;
             Some(crate::plan::execution::PlanNode::Cull {
                 name: name.to_string(),
                 span,
@@ -3679,7 +3698,7 @@ pub(crate) fn lower_node_to_plan_node(
         // `resolve_envelope_header_upstreams` post-pass fills it. A missing
         // typed entry means bind_schema could not resolve the body input — skip.
         PipelineNode::Envelope { header, config } => {
-            artifacts.typed.get(name)?;
+            artifacts.typed_get(scope, name)?;
             let header_input = header
                 .header
                 .as_ref()

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -4,8 +4,8 @@
 //! source's schema from its author-declared `schema:` block, typechecks
 //! every Transform/Aggregate/Route body against the upstream Row, and
 //! propagates the output Row downstream. Result: a `CompileArtifacts`
-//! map keyed by node name holding one `Arc<TypedProgram>` per CXL-bearing
-//! node.
+//! map keyed by each node's `ScopedNodeId` holding one `Arc<TypedProgram>`
+//! per CXL-bearing node.
 //!
 //! For `PipelineNode::Composition` nodes, `bind_composition` recursively
 //! binds the composition body at the call-site boundary using
@@ -54,7 +54,7 @@ use clinker_core_types::{Diagnostic, LabeledSpan};
 pub const MAX_COMPOSITION_DEPTH: u32 = 50;
 
 /// Scope a plan node lives in. Top-level pipeline, or a specific composition body.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeScope {
     TopLevel,
     Body(crate::plan::composition_body::CompositionBodyId),
@@ -64,7 +64,7 @@ pub enum NodeScope {
 /// can hold same-named nodes; this pair disambiguates them where a bare node
 /// name would collide. Mirrors dbt's `<package>.<name>` and Beam's hierarchical
 /// node name.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ScopedNodeId {
     pub scope: NodeScope,
     pub name: String,
@@ -1484,9 +1484,12 @@ fn bind_reshape(
     // spilled (i.e. on the memory budget). Rather than silently differ, fail
     // loud here until envelope context survives the spill round-trip.
     if ok {
-        let programs: Vec<(&str, &TypedProgram)> = typed_fragments
+        // Reshape rule fragments carry no scope ambiguity (they are
+        // labels within one node's rule set), so attribute by the bare
+        // label `String`.
+        let programs: Vec<(String, &TypedProgram)> = typed_fragments
             .iter()
-            .map(|(label, typed)| (label.as_str(), typed))
+            .map(|(label, typed)| (label.clone(), typed))
             .collect();
         let doc_paths = cxl::analyzer::doc_paths::collect_doc_paths(&programs);
         // Any `$doc` reference disqualifies the rule — both statically-resolved

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -70,11 +70,20 @@ pub struct ScopedNodeId {
     pub name: String,
 }
 
-/// Compile artifacts produced by `bind_schema` — one entry per node name
+/// Compile artifacts produced by `bind_schema` — one entry per node
 /// whose CXL body successfully type-checked, plus per-node row types.
 #[derive(Debug, Default, Clone)]
 pub struct CompileArtifacts {
-    pub typed: HashMap<String, Arc<TypedProgram>>,
+    /// Per-node typed CXL program (transform/aggregate/combine-body plus
+    /// the synthetic pass-through programs for Source/Merge/Output/etc.),
+    /// keyed by the node's [`ScopedNodeId`]. The scope qualifier keeps a
+    /// node named the same in two composition scopes — or a top-level node
+    /// sharing a name with a composition-body node — from colliding in this
+    /// shared table; before scope-keying the last writer silently won.
+    /// Acts as the bind → lowering handoff (lowering reads each node's
+    /// program off the scope-correct key to stamp the node) and as the
+    /// compile-time `$doc` path-walk source.
+    pub typed: HashMap<ScopedNodeId, Arc<TypedProgram>>,
     /// Per-Combine `where:` predicate typed programs, keyed by the
     /// combine node's [`ScopedNodeId`]. The node-keyed `typed` map stores
     /// only a Combine's `cxl:` body; the `where:` predicate is decomposed
@@ -169,6 +178,47 @@ pub struct CompileArtifacts {
 }
 
 impl CompileArtifacts {
+    /// Look up a node's typed CXL program by its scope-qualified identity.
+    /// The lookup allocates the key's `String`; the table is per-node and
+    /// only read at compile time and executor startup, so this is not hot.
+    pub fn typed_get(&self, scope: NodeScope, name: &str) -> Option<&Arc<TypedProgram>> {
+        self.typed.get(&ScopedNodeId {
+            scope,
+            name: name.to_string(),
+        })
+    }
+
+    /// Whether a typed program is recorded for `(scope, name)`.
+    pub fn typed_contains(&self, scope: NodeScope, name: &str) -> bool {
+        self.typed_get(scope, name).is_some()
+    }
+
+    /// Record a node's typed CXL program under its scope-qualified identity.
+    pub fn typed_insert(
+        &mut self,
+        scope: NodeScope,
+        name: impl Into<String>,
+        prog: Arc<TypedProgram>,
+    ) {
+        self.typed.insert(
+            ScopedNodeId {
+                scope,
+                name: name.into(),
+            },
+            prog,
+        );
+    }
+
+    /// Drop a node's typed CXL program by its scope-qualified identity.
+    /// Used by N-ary combine decomposition when the original combine's
+    /// name leaves the graph.
+    pub fn typed_remove(&mut self, scope: NodeScope, name: &str) -> Option<Arc<TypedProgram>> {
+        self.typed.remove(&ScopedNodeId {
+            scope,
+            name: name.to_string(),
+        })
+    }
+
     /// Allocate a fresh, unique `CompositionBodyId`.
     pub fn fresh_body_id(&mut self) -> CompositionBodyId {
         let id = CompositionBodyId(self.next_body_id);
@@ -368,7 +418,7 @@ fn validate_init_phase_isolation(
 
     for (reader_name, read_span, typed_keys) in readers {
         for typed_key in &typed_keys {
-            let Some(typed) = artifacts.typed.get(typed_key) else {
+            let Some(typed) = artifacts.typed_get(NodeScope::TopLevel, typed_key) else {
                 continue;
             };
             let mut reads: Vec<(VarScope, String)> = Vec::new();
@@ -481,12 +531,14 @@ fn validate_post_merge_source_reads(
             continue;
         };
         let mut typed_keys: Vec<String> = Vec::new();
-        if spanned.value.reads_scope_vars_in_cxl() && artifacts.typed.contains_key(&reader_name) {
+        if spanned.value.reads_scope_vars_in_cxl()
+            && artifacts.typed_contains(NodeScope::TopLevel, &reader_name)
+        {
             typed_keys.push(reader_name.clone());
         }
         let span = span_for_node(spanned);
         for key in typed_keys {
-            let Some(typed) = artifacts.typed.get(&key) else {
+            let Some(typed) = artifacts.typed_get(NodeScope::TopLevel, &key) else {
                 continue;
             };
             let mut reads: Vec<(crate::config::VarScope, String)> = Vec::new();
@@ -603,12 +655,14 @@ fn validate_read_after_write(
     for spanned in nodes {
         let reader_name = spanned.value.name().to_string();
         let mut typed_keys: Vec<String> = Vec::new();
-        if spanned.value.reads_scope_vars_in_cxl() && artifacts.typed.contains_key(&reader_name) {
+        if spanned.value.reads_scope_vars_in_cxl()
+            && artifacts.typed_contains(NodeScope::TopLevel, &reader_name)
+        {
             typed_keys.push(reader_name.clone());
         }
         let span = span_for_node(spanned);
         for key in typed_keys {
-            let Some(typed) = artifacts.typed.get(&key) else {
+            let Some(typed) = artifacts.typed_get(NodeScope::TopLevel, &key) else {
                 continue;
             };
             let mut reads: Vec<(VarScope, String)> = Vec::new();
@@ -1207,6 +1261,10 @@ struct ReshapeNodeBinding<'a> {
     upstream: &'a Row,
     span: Span,
     scoped_vars: &'a cxl::resolve::ScopedVarsRegistry,
+    /// Scope this reshape is bound in, copied from `BindContext.current_scope`
+    /// at the call site. Stamps the `typed` table key so a reshape named the
+    /// same in two composition scopes does not collide.
+    scope: NodeScope,
 }
 
 /// Bind a `PipelineNode::Reshape`: validate `partition_by` against the
@@ -1236,6 +1294,7 @@ fn bind_reshape(
         upstream,
         span,
         scoped_vars,
+        scope,
     } = node;
     let mut ok = true;
 
@@ -1489,9 +1548,11 @@ fn bind_reshape(
     );
     let out = Row::from_parts(declared, upstream.declared_span, upstream.tail.clone());
     schema_by_name.insert(name.to_string(), out.clone());
-    artifacts
-        .typed
-        .insert(name.to_string(), Arc::new(synthetic_typed_program(out)));
+    artifacts.typed_insert(
+        scope,
+        name.to_string(),
+        Arc::new(synthetic_typed_program(out)),
+    );
 }
 
 /// Borrowed inputs for binding one `PipelineNode::Cull`.
@@ -1505,6 +1566,10 @@ struct CullNodeBinding<'a> {
     upstream: &'a Row,
     span: Span,
     scoped_vars: &'a cxl::resolve::ScopedVarsRegistry,
+    /// Scope this cull is bound in, copied from `BindContext.current_scope`
+    /// at the call site. Stamps the `typed` table key so a cull named the
+    /// same in two composition scopes does not collide.
+    scope: NodeScope,
 }
 
 /// Bind a `PipelineNode::Cull`: validate `partition_by` / `order_by`
@@ -1535,6 +1600,7 @@ fn bind_cull(
         upstream,
         span,
         scoped_vars,
+        scope,
     } = node;
     let mut ok = true;
 
@@ -1656,9 +1722,11 @@ fn bind_cull(
     // identical schema on the main and `removed_to` ports.
     let out = upstream.clone();
     schema_by_name.insert(name.to_string(), out.clone());
-    artifacts
-        .typed
-        .insert(name.to_string(), Arc::new(synthetic_typed_program(out)));
+    artifacts.typed_insert(
+        scope,
+        name.to_string(),
+        Arc::new(synthetic_typed_program(out)),
+    );
 }
 
 // ─── Internal recursive bind_schema ─────────────────────────────────
@@ -1802,9 +1870,11 @@ fn bind_schema_inner(
                 let cxl_span = cxl::lexer::Span::new(span.start as usize, span.start as usize);
                 let row = Row::closed(columns, cxl_span);
                 schema_by_name.insert(name.clone(), row.clone());
-                artifacts
-                    .typed
-                    .insert(name, Arc::new(synthetic_typed_program(row)));
+                artifacts.typed_insert(
+                    bind_ctx.current_scope,
+                    name,
+                    Arc::new(synthetic_typed_program(row)),
+                );
             }
             PipelineNode::Transform { header, config } => {
                 // E108: check for enclosing-scope reference BEFORE upstream lookup.
@@ -1838,7 +1908,7 @@ fn bind_schema_inner(
                         let out = propagate_row(&upstream, &typed);
                         schema_by_name.insert(name.clone(), out.clone());
                         typed.output_row = out;
-                        artifacts.typed.insert(name, Arc::new(typed));
+                        artifacts.typed_insert(bind_ctx.current_scope, name, Arc::new(typed));
                     }
                     Err(d) => diags.push(d),
                 }
@@ -1928,7 +1998,7 @@ fn bind_schema_inner(
                         let out = propagate_aggregate(&name, &config.group_by, &upstream, &typed);
                         schema_by_name.insert(name.clone(), out.clone());
                         typed.output_row = out;
-                        artifacts.typed.insert(name, Arc::new(typed));
+                        artifacts.typed_insert(bind_ctx.current_scope, name, Arc::new(typed));
                     }
                     Err(d) => diags.push(d),
                 }
@@ -1945,7 +2015,11 @@ fn bind_schema_inner(
                         &bind_ctx.scoped_vars,
                     ) {
                         empty.output_row = cloned.clone();
-                        artifacts.typed.insert(name.clone(), Arc::new(empty));
+                        artifacts.typed_insert(
+                            bind_ctx.current_scope,
+                            name.clone(),
+                            Arc::new(empty),
+                        );
                     }
                     // Type-check each branch condition into its own program
                     // so the compile-time `$doc` walk can reach an envelope
@@ -2047,18 +2121,22 @@ fn bind_schema_inner(
                 {
                     let row = upstream.clone();
                     schema_by_name.insert(name.clone(), row.clone());
-                    artifacts
-                        .typed
-                        .insert(name, Arc::new(synthetic_typed_program(row)));
+                    artifacts.typed_insert(
+                        bind_ctx.current_scope,
+                        name,
+                        Arc::new(synthetic_typed_program(row)),
+                    );
                 }
             }
             PipelineNode::Output { header, .. } => {
                 if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
                     let row = upstream.clone();
                     schema_by_name.insert(name.clone(), row.clone());
-                    artifacts
-                        .typed
-                        .insert(name, Arc::new(synthetic_typed_program(row)));
+                    artifacts.typed_insert(
+                        bind_ctx.current_scope,
+                        name,
+                        Arc::new(synthetic_typed_program(row)),
+                    );
                 }
             }
             PipelineNode::Reshape { header, config } => {
@@ -2071,6 +2149,7 @@ fn bind_schema_inner(
                             upstream: &upstream,
                             span,
                             scoped_vars: &bind_ctx.scoped_vars,
+                            scope: bind_ctx.current_scope,
                         },
                         diags,
                         artifacts,
@@ -2088,6 +2167,7 @@ fn bind_schema_inner(
                             upstream: &upstream,
                             span,
                             scoped_vars: &bind_ctx.scoped_vars,
+                            scope: bind_ctx.current_scope,
                         },
                         diags,
                         artifacts,
@@ -2126,9 +2206,11 @@ fn bind_schema_inner(
                             .envelope_synthesis
                             .insert(name.clone(), Arc::new(synthesis));
                     }
-                    artifacts
-                        .typed
-                        .insert(name, Arc::new(synthetic_typed_program(row)));
+                    artifacts.typed_insert(
+                        bind_ctx.current_scope,
+                        name,
+                        Arc::new(synthetic_typed_program(row)),
+                    );
                 }
             }
             // Phase Combine C.1.1 + C.1.2 + C.1.3 (single-pass arm).
@@ -2506,7 +2588,13 @@ fn bind_composition(
         // the strict default; `apply_retraction_flags` rewrites it.
         let lower_ctx = crate::config::LoweringCtx::default();
         if let Some(plan_node) = crate::config::lower_node_to_plan_node(
-            n, &n_name, body_span, artifacts, &lower_ctx, diags,
+            n,
+            &n_name,
+            NodeScope::Body(body_id),
+            body_span,
+            artifacts,
+            &lower_ctx,
+            diags,
         ) {
             let idx = body_graph.add_node(plan_node);
             body_name_to_idx.insert(n_name, idx);
@@ -4269,7 +4357,8 @@ fn bind_combine(
         }
         let output_row = Row::closed(output_decl, cxl_span);
         schema_by_name.insert(name.to_string(), output_row.clone());
-        artifacts.typed.insert(
+        artifacts.typed_insert(
+            scope,
             name.to_string(),
             Arc::new(synthetic_typed_program(output_row)),
         );
@@ -4366,9 +4455,7 @@ fn bind_combine(
         .combine_resolved_columns
         .insert(name.to_string(), Arc::new(resolved_map));
 
-    artifacts
-        .typed
-        .insert(name.to_string(), Arc::new(body_typed));
+    artifacts.typed_insert(scope, name.to_string(), Arc::new(body_typed));
 }
 
 /// Walk every `Expr::QualifiedFieldRef { parts: [qualifier, name] }` in

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -9,8 +9,8 @@
 //! The late-populated compile artifacts that these types describe do NOT
 //! live inline on `PlanNode::Combine`. Instead, they live in
 //! `CompileArtifacts` side-tables:
-//!   - `CompileArtifacts.typed["{name}"]`     — typed cxl-body program
-//!     (same key convention as Transform)
+//!   - `CompileArtifacts.typed` (keyed by the combine's `ScopedNodeId`)
+//!     — typed cxl-body program (same key convention as Transform)
 //!   - `CompileArtifacts.combine_predicates`  — `DecomposedPredicate`
 //!     (the residual re-typechecked program lives inside this, not in
 //!     `typed` — the where-clause TypedProgram is a local intermediate

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -2180,9 +2180,13 @@ pub(crate) fn decompose_nary_combines(
         // Drop the original combine's artifacts — its name is gone from
         // the graph (the index now hosts the final step under a
         // synthetic name). The body program already migrated onto the
-        // final step node above, so its flat `typed` entry is dropped
-        // here too rather than re-homed under the synthetic name.
-        artifacts.typed.remove(&original_name);
+        // final step node above, so its `typed` entry is dropped here too
+        // rather than re-homed under the synthetic name. This pass runs
+        // over the top-level DAG, so the `typed` key is TopLevel-scoped.
+        artifacts.typed_remove(
+            crate::plan::bind_schema::NodeScope::TopLevel,
+            &original_name,
+        );
         artifacts.combine_inputs.remove(&original_name);
         artifacts.combine_predicates.remove(&original_name);
         artifacts.combine_driving.remove(&original_name);

--- a/crates/clinker-plan/src/plan/compiled.rs
+++ b/crates/clinker-plan/src/plan/compiled.rs
@@ -61,10 +61,11 @@ impl CompiledPlan {
         &self.config
     }
 
-    /// Compile-time CXL typecheck artifacts — one entry per
-    /// CXL-bearing node (Transform/Aggregate/Route) keyed by node name.
-    /// The runtime executor reads this map directly to pull each
-    /// transform's `Arc<TypedProgram>` instead of re-typechecking.
+    /// Compile-time CXL typecheck artifacts — one entry per CXL-bearing
+    /// node keyed by its `ScopedNodeId` (so a top-level node and a
+    /// composition-body node sharing a name stay distinct). The runtime
+    /// executor reads this map to pull each node's `Arc<TypedProgram>`
+    /// instead of re-typechecking.
     pub fn artifacts(&self) -> &CompileArtifacts {
         &self.artifacts
     }

--- a/crates/clinker-plan/src/plan/compiled.rs
+++ b/crates/clinker-plan/src/plan/compiled.rs
@@ -77,12 +77,16 @@ impl CompiledPlan {
         self.artifacts.body_of(id)
     }
 
-    /// Look up the bound output row type for a node by name.
+    /// Look up the bound output row type for a top-level node by name.
     ///
     /// Returns `None` for nodes that didn't participate in `bind_schema`
-    /// (e.g. compositions whose binding failed).
+    /// (e.g. compositions whose binding failed). Only top-level nodes are
+    /// visible here; composition-body programs live under their `Body`
+    /// scope in the `typed` table and are reached via [`Self::body_of`].
     pub fn typed_output_row(&self, name: &str) -> Option<&Row> {
-        self.artifacts.typed.get(name).map(|tp| &tp.output_row)
+        self.artifacts
+            .typed_get(crate::plan::bind_schema::NodeScope::TopLevel, name)
+            .map(|tp| &tp.output_row)
     }
 
     /// Side-table of provenance-tracked config values for composition nodes.

--- a/crates/clinker-plan/src/plan/composition_body.rs
+++ b/crates/clinker-plan/src/plan/composition_body.rs
@@ -14,7 +14,7 @@ use super::execution::{PlanEdge, PlanNode};
 /// Opaque handle into `CompileArtifacts.composition_bodies`. Each
 /// `PipelineNode::Composition` in `CompiledPlan` carries one of these
 /// pointing at its bound body.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize)]
 pub struct CompositionBodyId(pub u32);
 
 impl CompositionBodyId {

--- a/crates/clinker-plan/src/plan/execution/composition.rs
+++ b/crates/clinker-plan/src/plan/execution/composition.rs
@@ -141,10 +141,12 @@ pub(crate) fn resolve_composition_body_windows(
             // `$window.sum(amount)` adds `amount`, and `emit x = y` adds
             // `y`. The analyzer is the same one consumed at top-level
             // lowering (`config/mod.rs`); body Transforms register their
-            // typed programs in `artifacts.typed` keyed by the body
-            // node's name, so the analyzer call here mirrors the
-            // top-level shape exactly.
-            if let Some(typed) = artifacts.typed.get(*transform_name) {
+            // typed programs in `artifacts.typed` under their own `Body`
+            // scope, so resolve by `(Body(body_id), name)` here.
+            if let Some(typed) = artifacts.typed_get(
+                crate::plan::bind_schema::NodeScope::Body(body_id),
+                transform_name,
+            ) {
                 let analysis = cxl::analyzer::analyze_transform(transform_name, typed);
                 for f in &analysis.accessed_fields {
                     arena_fields.insert(f.clone());

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -13,4 +13,5 @@ mod explain_polish;
 mod plan_time_window_root;
 mod reshape_validation;
 mod route_ports;
+mod typed_scoped_key;
 mod watermark_validation;

--- a/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
+++ b/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
@@ -1,0 +1,148 @@
+//! Scope-qualified keying of the shared `CompileArtifacts.typed`
+//! typed-program table (the transform / aggregate / combine-body surface).
+//!
+//! Every CXL-bearing node's typed program lands in `artifacts.typed` keyed
+//! by [`ScopedNodeId`]. Before scope-qualified keying it was keyed by the
+//! bare node name, so a node named the same at top level and inside a
+//! composition body overwrote one entry with the other — the surviving
+//! program was whichever the bind pass visited last. That fed the executor
+//! transform startup table, the `$doc`-attribution walk, and lowering's
+//! per-node program stamp from the wrong scope.
+//!
+//! This test compiles a pipeline where a TOP-LEVEL transform and a BODY
+//! transform share the SAME node name (`shape`) but emit DIFFERENT fields,
+//! and asserts both scope-keyed entries survive with their own distinct
+//! program.
+
+use crate::NodeScope;
+
+use super::deferred_region::compile_with_dir_full;
+
+/// A top-level transform and a composition-body transform both named
+/// `shape`, each emitting a distinct field, keep separate `typed` entries
+/// under their scope-qualified keys.
+#[test]
+fn typed_table_scoped_key_does_not_collide_across_scopes() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    // Body composition: a transform named `shape` that emits `body_marker`
+    // — distinct from the top-level `shape` below, which emits `top_marker`.
+    std::fs::write(
+        comp_dir.join("scoped_transform.comp.yaml"),
+        r#"_compose:
+  name: scoped_transform
+  inputs:
+    inp:
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: int }
+  outputs:
+    out: shape
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: shape
+    input: inp
+    config:
+      cxl: |
+        emit id = id
+        emit body_marker = val
+"#,
+    )
+    .expect("write comp");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    // Top-level pipeline: a transform ALSO named `shape`, emitting
+    // `top_marker`, plus a composition whose body holds the body `shape`.
+    let yaml = r#"
+pipeline:
+  name: typed_scoped
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: int }
+  - type: transform
+    name: shape
+    input: src
+    config:
+      cxl: |
+        emit id = id
+        emit top_marker = val
+  - type: composition
+    name: body
+    input: src
+    use: ../compositions/scoped_transform.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out_top
+    input: shape
+    config:
+      name: out_top
+      type: csv
+      path: out_top.csv
+      include_unmapped: true
+  - type: output
+    name: out_body
+    input: body
+    config:
+      name: out_body
+      type: csv
+      path: out_body.csv
+      include_unmapped: true
+"#;
+    let compiled = compile_with_dir_full(yaml, workspace.path());
+    let artifacts = compiled.artifacts();
+
+    // The body's scope id comes from the composition-body assignment.
+    let body_id = artifacts
+        .composition_body_assignments
+        .get("body")
+        .copied()
+        .expect("composition body assignment for `body`");
+
+    // Both scope-qualified keys resolve — with bare-name keying only one of
+    // these would have been populated (last writer wins).
+    let top = artifacts
+        .typed_get(NodeScope::TopLevel, "shape")
+        .expect("top-level `shape` program present under TopLevel scope key");
+    let body = artifacts
+        .typed_get(NodeScope::Body(body_id), "shape")
+        .expect("body `shape` program present under Body scope key");
+
+    let emits = |tp: &cxl::typecheck::TypedProgram, field: &str| -> bool {
+        tp.output_row
+            .fields()
+            .any(|(qf, _)| qf.name.as_ref() == field)
+    };
+
+    // Each scope's program carries its OWN emit and not the other's. With
+    // bare-name keying the two `shape` nodes shared one table slot, so the
+    // last writer's marker would appear under both keys (or one key would be
+    // absent entirely, already caught by the `expect`s above).
+    assert!(
+        emits(top, "top_marker") && !emits(top, "body_marker"),
+        "top-level `shape` must carry `top_marker` and not `body_marker`; \
+         got output row {:?}",
+        top.output_row
+    );
+    assert!(
+        emits(body, "body_marker") && !emits(body, "top_marker"),
+        "body `shape` must carry `body_marker` and not `top_marker`; \
+         got output row {:?}",
+        body.output_row
+    );
+}

--- a/crates/cxl/src/analyzer/doc_paths.rs
+++ b/crates/cxl/src/analyzer/doc_paths.rs
@@ -73,22 +73,26 @@ pub struct DocPath {
 /// path. Stamping every source with the pipeline-wide union would tell a
 /// multi-source run to extract envelope sections a given source's own
 /// document never declares.
-#[derive(Debug, Clone, Default)]
-pub struct DocPathSet {
-    /// Each statically-resolved path mapped to the set of node names whose
+/// `K` is the node-identity key the caller attributes paths by — a bare
+/// `&str`/`String` when scope cannot collide (e.g. reshape rule labels), or
+/// a scope-qualified identity (the planner's `ScopedNodeId`) when a node
+/// named the same in two scopes must stay distinct.
+#[derive(Debug, Clone)]
+pub struct DocPathSet<K> {
+    /// Each statically-resolved path mapped to the set of node keys whose
     /// program references it. The outer `BTreeMap` keys (paths) and inner
-    /// `BTreeSet` values (node names) are both ordered, so iteration is
+    /// `BTreeSet` values (node keys) are both ordered, so iteration is
     /// deterministic independent of program walk order.
-    pub by_node: BTreeMap<DocPath, BTreeSet<String>>,
-    /// One entry per `$doc` access whose index is not a literal. The
-    /// `String` is the name of the program's node so the caller can anchor
-    /// a plan-level diagnostic at that node; the [`TypeDiagnostic`] carries
-    /// the precise offending-index span and help.
-    pub unresolvable: Vec<(String, TypeDiagnostic)>,
+    pub by_node: BTreeMap<DocPath, BTreeSet<K>>,
+    /// One entry per `$doc` access whose index is not a literal. The `K` is
+    /// the program's node key so the caller can anchor a plan-level
+    /// diagnostic at that node; the [`TypeDiagnostic`] carries the precise
+    /// offending-index span and help.
+    pub unresolvable: Vec<(K, TypeDiagnostic)>,
 }
 
 #[cfg(test)]
-impl DocPathSet {
+impl<K> DocPathSet<K> {
     /// The deduplicated, sorted set of every resolved path across all
     /// nodes, discarding per-node attribution — a test convenience for
     /// asserting against the flat path list. Production callers consume
@@ -107,10 +111,14 @@ impl DocPathSet {
 /// multiple nodes is attributed to each of them, so the planner can union
 /// the source sets of every referencing node when stamping a source.
 /// Unresolvable-index diagnostics are accumulated in walk order.
-pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
-    let mut collector = DocPathCollector::default();
-    for (name, typed) in programs {
-        collector.node_name = name;
+pub fn collect_doc_paths<K: Ord + Clone>(programs: &[(K, &TypedProgram)]) -> DocPathSet<K> {
+    let mut collector: DocPathCollector<'_, K> = DocPathCollector {
+        node_key: None,
+        by_node: BTreeMap::new(),
+        unresolvable: Vec::new(),
+    };
+    for (key, typed) in programs {
+        collector.node_key = Some(key);
         for stmt in &typed.program.statements {
             collector.visit_statement(stmt);
         }
@@ -132,27 +140,32 @@ pub fn collect_doc_paths(programs: &[(&str, &TypedProgram)]) -> DocPathSet {
 /// not root at a `$doc` access, falls through to the default descent, so a
 /// `$doc` access nested in any control-flow branch or index expression is
 /// still collected.
-#[derive(Default)]
-struct DocPathCollector<'a> {
-    /// Name of the program currently being walked, so each collected path
-    /// — and each unresolvable-index diagnostic — is attributed to its
-    /// node.
-    node_name: &'a str,
-    by_node: BTreeMap<DocPath, BTreeSet<String>>,
-    unresolvable: Vec<(String, TypeDiagnostic)>,
+struct DocPathCollector<'a, K> {
+    /// Key of the program currently being walked, so each collected path —
+    /// and each unresolvable-index diagnostic — is attributed to its node.
+    /// `Some` for the duration of every program walk; never read while
+    /// `None`.
+    node_key: Option<&'a K>,
+    by_node: BTreeMap<DocPath, BTreeSet<K>>,
+    unresolvable: Vec<(K, TypeDiagnostic)>,
 }
 
-impl DocPathCollector<'_> {
+impl<K: Ord + Clone> DocPathCollector<'_, K> {
+    /// The key of the program currently being walked.
+    fn key(&self) -> K {
+        self.node_key
+            .expect("node_key is set before every program walk")
+            .clone()
+    }
+
     /// Record a resolved path against the node currently being walked.
     fn record(&mut self, path: DocPath) {
-        self.by_node
-            .entry(path)
-            .or_default()
-            .insert(self.node_name.to_string());
+        let key = self.key();
+        self.by_node.entry(path).or_default().insert(key);
     }
 }
 
-impl Visitor for DocPathCollector<'_> {
+impl<K: Ord + Clone> Visitor for DocPathCollector<'_, K> {
     fn visit_expr(&mut self, expr: &Expr) {
         // An IndexAccess whose receiver chain bottoms out at a DocAccess is
         // a `$doc` path with trailing indices — classify it as a unit
@@ -164,7 +177,10 @@ impl Visitor for DocPathCollector<'_> {
         {
             match classified {
                 Ok(path) => self.record(path),
-                Err(diag) => self.unresolvable.push((self.node_name.to_string(), diag)),
+                Err(diag) => {
+                    let key = self.key();
+                    self.unresolvable.push((key, diag));
+                }
             }
             return;
         }
@@ -310,13 +326,13 @@ mod tests {
         type_check(resolved, &schema).unwrap()
     }
 
-    fn collect(source: &str) -> DocPathSet {
+    fn collect(source: &str) -> DocPathSet<String> {
         let typed = compile(source);
-        collect_doc_paths(&[("t", &typed)])
+        collect_doc_paths(&[("t".to_string(), &typed)])
     }
 
     /// Sorted node names a path was attributed to.
-    fn attributed_to(set: &DocPathSet, p: &DocPath) -> Vec<String> {
+    fn attributed_to(set: &DocPathSet<String>, p: &DocPath) -> Vec<String> {
         set.by_node
             .get(p)
             .map(|nodes| nodes.iter().cloned().collect())
@@ -516,7 +532,7 @@ mod tests {
         // pipeline-wide union.
         let a = compile("emit x = $doc.Head.batch_id");
         let b = compile("emit y = $doc.Foot.record_count");
-        let set = collect_doc_paths(&[("node_a", &a), ("node_b", &b)]);
+        let set = collect_doc_paths(&[("node_a".to_string(), &a), ("node_b".to_string(), &b)]);
 
         let head = path("Head", "batch_id", vec![]);
         let foot = path("Foot", "record_count", vec![]);
@@ -531,7 +547,7 @@ mod tests {
         // planner unions their source sets when stamping.
         let a = compile("emit x = $doc.Head.batch_id");
         let b = compile("emit y = $doc.Head.batch_id + 1");
-        let set = collect_doc_paths(&[("node_a", &a), ("node_b", &b)]);
+        let set = collect_doc_paths(&[("node_a".to_string(), &a), ("node_b".to_string(), &b)]);
 
         let head = path("Head", "batch_id", vec![]);
         assert_eq!(set.all_paths(), vec![head.clone()]);


### PR DESCRIPTION
Closes #635.

## Summary

The compiled CXL program for each node lived in a single process-wide table keyed by **bare node name** (`CompileArtifacts.typed`). A composition body and the top-level pipeline — or two instances of the same composition — can hold same-named nodes, so the table (and the consumers that read it) collided last-writer-wins, and a node whose name was reused across scopes could pick up another scope's program. This PR makes the per-node typed-program surface scope-correct end to end, keyed by the existing `ScopedNodeId = (scope, name)` where `scope` is the top level or a specific composition body.

## What changed

**Typed-program table.** `CompileArtifacts.typed` is re-keyed from `HashMap<String, _>` to `HashMap<ScopedNodeId, _>`. Binding stamps each producer's scope; lowering threads a scope parameter (`TopLevel` for the top-level pass, `Body(id)` for composition-body lowering) and resolves every per-node program by it. The bare-name table does not survive as a parallel resting place — the scope-qualified table replaces it.

**`$doc` source attribution.** `collect_doc_paths` / `DocPathSet` are now generic over the node-identity key; the planner attributes each `$doc` path by the referencing program's `ScopedNodeId`, and the per-node source sets are keyed by `ScopedNodeId` (top-level nodes under `TopLevel`, body nodes under `Body(id)`). A body node's `$doc` paths are validated only against its own scope's source(s); previously they could leak onto a same-named top-level node's source and spuriously fail compile with E341.

**Runtime transform dispatch.** The runtime transform table is keyed `(scope, name)`: each compiled transform carries its `NodeScope`, the body-extension build drops the bare-name dedup, and the dispatcher resolves each node through the scope it is currently executing in. Two same-named transforms in different bodies run their own programs.

**Combine body program.** As a consequence, the combine body program stamped onto `PlanNode::Combine` at lowering is correct for the top-level-vs-body same-name case too, not just across sibling bodies.

## Tests

- A regression that a top-level transform and a composition-body transform sharing a name keep distinct typed entries under their scope keys.
- A regression that a body node reading a `$doc` section only its call-site source declares compiles cleanly (no cross-scope E341) and that each source carries exactly its own scope's path. Verified to fail with the exact E341 when the attribution is reverted to bare-name keying.

## Validation

`cargo test` across `cxl`, `clinker-plan`, `clinker-exec`, `clinker`, and the integration crates is green; `cargo fmt --check` and `cargo clippy --workspace -- -D warnings` are clean; `cargo check --workspace --benches` compiles.

## Follow-ups

Two items found while completing and validating this work, filed separately:

- #636 — the combine side-tables (`combine_inputs` / `combine_predicates` / `combine_driving`) are still bare-name keyed; scope-key them so combine lowering is scope-correct for the top-level-vs-body name-collision case too.
- #637 — a pre-existing, independent bug: a composition body whose chain starts with a `transform` emits no output (a combine body emits fine under the same wiring). Reproduces identically with or without the scope-keying here, so it is not a regression from this change.