### PR TITLE
Move runtime program artifacts on-node; remove executor startup lookup tables

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -63,6 +63,8 @@ pub(crate) fn dispatch_aggregation(
     let PlanNode::Aggregation {
         ref name,
         ref compiled,
+        ref typed,
+        has_distinct,
         strategy: agg_strategy,
         ref output_schema,
         ref config,
@@ -132,6 +134,8 @@ pub(crate) fn dispatch_aggregation(
             node_idx,
             producer_idx,
             name,
+            typed,
+            has_distinct,
             agg_strategy,
             compiled,
             output_schema,
@@ -177,11 +181,10 @@ pub(crate) fn dispatch_aggregation(
     let out_rows: Vec<AggSortRow> = if is_time_windowed {
         // Time-windowed path: per-(window) AggregateStream instances
         // dispatched in `run_time_windowed_aggregate`, each building its own
-        // evaluator from `transform_idx` (the heavy `TypedProgram` lives
-        // behind an Arc, so a per-window evaluator clone is cheap). The
+        // evaluator from the node's typed program (the heavy `TypedProgram`
+        // lives behind an Arc, so a per-window evaluator clone is cheap). The
         // strict path below never reaches here, so the spill schema is built
         // only on this windowed branch — never built-then-dropped.
-        let transform_idx = ctx.transform_idx(name.as_str());
         let spill_schema = aggregate_spill_schema(compiled);
         let mem_limit = parse_memory_limit(ctx.config);
         let win_ctx = WindowedAggContext {
@@ -191,7 +194,8 @@ pub(crate) fn dispatch_aggregation(
             output_schema: Arc::clone(output_schema),
             spill_schema,
             mem_limit,
-            transform_idx,
+            typed: Arc::clone(typed),
+            has_distinct,
         };
         run_time_windowed_aggregate(
             ctx,
@@ -225,21 +229,11 @@ pub(crate) fn dispatch_aggregation(
         // Build the single retained-stream artifacts here, on the branch
         // that consumes them — the strict path below re-derives its own per
         // document, so nothing is built-then-dropped on the dominant arm.
-        let transform_idx = ctx.transform_idx(name.as_str());
-        let evaluator = match transform_idx {
-            Some(idx) => ProgramEvaluator::with_max_expansion(
-                Arc::clone(&ctx.compiled_transforms[idx].typed),
-                ctx.compiled_transforms[idx].has_distinct(),
-                ctx.compiled_transforms[idx].max_expansion,
-            ),
-            None => {
-                return Err(PipelineError::Internal {
-                    op: "aggregation",
-                    node: name.clone(),
-                    detail: "no compiled transform found for aggregate node".to_string(),
-                });
-            }
-        };
+        let evaluator = ProgramEvaluator::with_max_expansion(
+            Arc::clone(typed),
+            has_distinct,
+            cxl::eval::DEFAULT_MAX_EXPANSION,
+        );
         let spill_schema = aggregate_spill_schema(compiled);
         let mem_limit = parse_memory_limit(ctx.config);
         // Resolve the spill compression mode against this aggregate's
@@ -379,8 +373,15 @@ pub(crate) fn dispatch_aggregation(
         // Builds nothing in the prelude: each document's table derives its
         // own evaluator + spill schema through the `ctx`-free factory, so a
         // strict run allocates no throwaway evaluator or spill schema here.
-        let factory =
-            DocAggregatorFactory::from_ctx(ctx, name, agg_strategy, compiled, output_schema)?;
+        let factory = DocAggregatorFactory::from_ctx(
+            ctx,
+            name,
+            typed,
+            has_distinct,
+            agg_strategy,
+            compiled,
+            output_schema,
+        )?;
         run_strict_aggregate_per_document(ctx, factory, name, output_schema, &input, &input_puncts)?
     };
 
@@ -549,27 +550,18 @@ impl DocAggregatorFactory {
     /// Snapshot the build inputs out of `ctx` for an aggregate node.
     /// Resolves the spill schema, memory limit, and spill-compression mode
     /// from `ctx` itself — the same derivations the single-stream paths run
-    /// inline — so the caller passes only the node identity.
-    ///
-    /// Returns an error when no compiled transform backs the node — the
-    /// same hard-abort `PipelineError::Internal` the single-stream paths
-    /// raise, surfaced here once at construction so [`Self::make`] only
-    /// fails on the never-taken `for_node` arm.
+    /// inline. The typed `aggregate:` program and its distinct-ness are read
+    /// off the `PlanNode::Aggregation` by the caller and passed in here; an
+    /// aggregate's fan-out ceiling is always [`cxl::eval::DEFAULT_MAX_EXPANSION`].
     fn from_ctx(
         ctx: &ExecutorContext<'_>,
         node_name: &str,
+        typed: &Arc<cxl::typecheck::TypedProgram>,
+        has_distinct: bool,
         strategy: AggregateStrategy,
         compiled: &Arc<cxl::plan::CompiledAggregate>,
         output_schema: &Arc<Schema>,
     ) -> Result<Self, PipelineError> {
-        let transform_idx =
-            ctx.transform_idx(node_name)
-                .ok_or_else(|| PipelineError::Internal {
-                    op: "aggregation",
-                    node: node_name.to_string(),
-                    detail: "no compiled transform found for aggregate node".to_string(),
-                })?;
-        let compiled_transform = &ctx.compiled_transforms[transform_idx];
         // The compression mode resolves against the output-schema width and
         // batch size so a spilled table's on-disk format matches what
         // `--explain` reports.
@@ -580,9 +572,9 @@ impl DocAggregatorFactory {
         Ok(Self {
             strategy,
             compiled: Arc::clone(compiled),
-            typed: Arc::clone(&compiled_transform.typed),
-            has_distinct: compiled_transform.has_distinct(),
-            max_expansion: compiled_transform.max_expansion,
+            typed: Arc::clone(typed),
+            has_distinct,
+            max_expansion: cxl::eval::DEFAULT_MAX_EXPANSION,
             output_schema: Arc::clone(output_schema),
             spill_schema,
             mem_limit: parse_memory_limit(ctx.config),
@@ -1114,6 +1106,8 @@ fn run_streaming_aggregate_ingest(
     node_idx: NodeIndex,
     producer_idx: NodeIndex,
     name: &str,
+    typed: &Arc<cxl::typecheck::TypedProgram>,
+    has_distinct: bool,
     agg_strategy: AggregateStrategy,
     compiled: &Arc<cxl::plan::CompiledAggregate>,
     output_schema: &Arc<Schema>,
@@ -1134,7 +1128,15 @@ fn run_streaming_aggregate_ingest(
     // `sum_consumer_usage` while live, and is unregistered when that
     // document flushes (on its `DocumentClose`, or at disconnect for the
     // document left open).
-    let factory = DocAggregatorFactory::from_ctx(ctx, name, agg_strategy, compiled, output_schema)?;
+    let factory = DocAggregatorFactory::from_ctx(
+        ctx,
+        name,
+        typed,
+        has_distinct,
+        agg_strategy,
+        compiled,
+        output_schema,
+    )?;
 
     // Install the bounded streaming-ingest channel keyed by the producer's
     // index, so its dispatch arm streams into it with no producer-side
@@ -1400,7 +1402,11 @@ struct WindowedAggContext<'a> {
     output_schema: Arc<Schema>,
     spill_schema: Arc<Schema>,
     mem_limit: usize,
-    transform_idx: Option<usize>,
+    /// Typed `aggregate:` program read off the `PlanNode::Aggregation`. Each
+    /// per-window stream clones a fresh `ProgramEvaluator` from this Arc.
+    typed: Arc<cxl::typecheck::TypedProgram>,
+    /// Distinct-ness of `typed`, computed once at lowering.
+    has_distinct: bool,
 }
 
 impl WindowedAggContext<'_> {
@@ -1423,21 +1429,11 @@ impl WindowedAggContext<'_> {
         ),
         PipelineError,
     > {
-        let evaluator = match self.transform_idx {
-            Some(idx) => ProgramEvaluator::with_max_expansion(
-                Arc::clone(&ctx.compiled_transforms[idx].typed),
-                ctx.compiled_transforms[idx].has_distinct(),
-                ctx.compiled_transforms[idx].max_expansion,
-            ),
-            None => {
-                return Err(PipelineError::Internal {
-                    op: "time-windowed-aggregation",
-                    node: self.name.to_string(),
-                    detail: "no compiled transform found for time-windowed aggregate node"
-                        .to_string(),
-                });
-            }
-        };
+        let evaluator = ProgramEvaluator::with_max_expansion(
+            Arc::clone(&self.typed),
+            self.has_distinct,
+            cxl::eval::DEFAULT_MAX_EXPANSION,
+        );
         let agg_consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
         let agg_consumer_id = ctx.memory_budget.register_consumer(Arc::new(
             crate::aggregation::AggregateConsumer::new(agg_consumer_handle.clone()),

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -2349,8 +2349,10 @@ pub(crate) fn transform_fused_consume(
     // carries no program); the fused loop forwards records unevaluated.
     let transform_payload = match &current_dag.graph[node_idx] {
         PlanNode::Transform {
-            resolved: Some(p), ..
-        } => Some((Arc::clone(&p.typed), p.max_expansion)),
+            resolved: Some(p),
+            has_distinct,
+            ..
+        } => Some((Arc::clone(&p.typed), p.max_expansion, *has_distinct)),
         _ => None,
     };
     let expected_input = current_dag.graph[node_idx]
@@ -2388,12 +2390,7 @@ pub(crate) fn transform_fused_consume(
     });
 
     let mut evaluator_opt: Option<ProgramEvaluator> =
-        transform_payload.map(|(typed, max_expansion)| {
-            let has_distinct = typed
-                .program
-                .statements
-                .iter()
-                .any(|s| matches!(s, cxl::ast::Statement::Distinct { .. }));
+        transform_payload.map(|(typed, max_expansion, has_distinct)| {
             ProgramEvaluator::with_max_expansion(typed, has_distinct, max_expansion)
         });
 

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -440,9 +440,7 @@ pub(crate) fn push_write_error(
 
 use crate::executor::node_buffer::NodeBuffer;
 use crate::executor::schema_check::check_input_schema;
-use crate::executor::{
-    CompiledRoute, CompiledTransform, DlqEntry, evaluate_single_transform, stage_metrics,
-};
+use crate::executor::{CompiledRoute, DlqEntry, evaluate_single_transform, stage_metrics};
 use clinker_plan::BudgetCategory;
 use clinker_plan::plan::bind_schema::CompileArtifacts;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
@@ -459,10 +457,6 @@ use clinker_record::Schema;
 ///   mini-DAG without duplicating arm logic.
 /// * `output_configs` / `primary_output` — output sinks and the
 ///   declaration-order primary used as the fallback projection target.
-/// * `transform_by_name` — (scope → name) → index into
-///   `compiled_transforms`; resolve via [`ExecutorContext::transform_idx`].
-/// * `compiled_transforms` — precompiled CXL programs for Transform and
-///   Aggregation arms.
 /// * `stable` / `source_batch_arc` / `strategy` — pipeline-stable scalars
 ///   reused at every per-record dispatch site.
 ///
@@ -492,9 +486,6 @@ pub(crate) struct ExecutorContext<'a> {
     pub(crate) artifacts: &'a CompileArtifacts,
     pub(crate) output_configs: &'a [OutputConfig],
     pub(crate) primary_output: &'a OutputConfig,
-    pub(crate) compiled_transforms: &'a [CompiledTransform],
-    pub(crate) transform_by_name:
-        HashMap<clinker_plan::plan::bind_schema::NodeScope, HashMap<&'a str, usize>>,
     pub(crate) stable: &'a StableEvalContext,
     /// Backing storage for `$source.batch` — per-pipeline-run UUID v7
     /// (per-source attribution is sub-issue #54). Distinct from
@@ -1022,32 +1013,6 @@ pub(crate) struct RetainedAggregatorState {
 }
 
 impl<'a> ExecutorContext<'a> {
-    /// The scope the dispatcher is currently executing in: the innermost
-    /// composition body on `window_runtime.active_stack`, or `TopLevel` when
-    /// the stack is empty (the top-level DAG walk).
-    pub(crate) fn current_node_scope(&self) -> clinker_plan::plan::bind_schema::NodeScope {
-        use clinker_plan::plan::bind_schema::NodeScope;
-        self.window_runtime
-            .active_stack
-            .last()
-            .copied()
-            .map(NodeScope::Body)
-            .unwrap_or(NodeScope::TopLevel)
-    }
-
-    /// Resolve a node's `CompiledTransform` index by its scope-qualified
-    /// identity — the current execution scope plus the bare node name — so a
-    /// body transform named the same as a top-level (or sibling-body)
-    /// transform selects its own program instead of a colliding bare-name
-    /// entry. `None` when no compiled program is registered for that node
-    /// (e.g. a top-level aggregate, which carries its logic on the node).
-    pub(crate) fn transform_idx(&self, name: &str) -> Option<usize> {
-        self.transform_by_name
-            .get(&self.current_node_scope())?
-            .get(name)
-            .copied()
-    }
-
     /// Poll the run's shutdown flag at an operator chunk boundary. When
     /// the token has tripped (SIGINT/SIGTERM, or a programmatic
     /// request), record the interruption and return
@@ -2379,7 +2344,15 @@ pub(crate) fn transform_fused_consume(
         }
     };
 
-    let transform_idx_opt = ctx.transform_idx(name);
+    // The typed program + fan-out ceiling come off the `PlanNode::Transform`
+    // payload. `None` is the defensive pass-through (a node that did not lower
+    // carries no program); the fused loop forwards records unevaluated.
+    let transform_payload = match &current_dag.graph[node_idx] {
+        PlanNode::Transform {
+            resolved: Some(p), ..
+        } => Some((Arc::clone(&p.typed), p.max_expansion)),
+        _ => None,
+    };
     let expected_input = current_dag.graph[node_idx]
         .expected_input_schema_in(current_dag)
         .cloned();
@@ -2414,13 +2387,15 @@ pub(crate) fn transform_fused_consume(
         ctx.streaming_charge_handle(node_idx, name, spill_allowed)
     });
 
-    let mut evaluator_opt: Option<ProgramEvaluator> = transform_idx_opt.map(|idx| {
-        ProgramEvaluator::with_max_expansion(
-            Arc::clone(&ctx.compiled_transforms[idx].typed),
-            ctx.compiled_transforms[idx].has_distinct(),
-            ctx.compiled_transforms[idx].max_expansion,
-        )
-    });
+    let mut evaluator_opt: Option<ProgramEvaluator> =
+        transform_payload.map(|(typed, max_expansion)| {
+            let has_distinct = typed
+                .program
+                .statements
+                .iter()
+                .any(|s| matches!(s, cxl::ast::Statement::Distinct { .. }));
+            ProgramEvaluator::with_max_expansion(typed, has_distinct, max_expansion)
+        });
 
     let rx = ctx
         .source_records
@@ -2627,8 +2602,7 @@ pub(crate) fn transform_fused_consume(
                 }
             } else {
                 // Transform has no compiled CXL — passthrough behavior
-                // mirrors the buffered arm's `transform_by_name.get` miss
-                // at the top of the existing path.
+                // mirrors the buffered arm's absent-payload pass-through.
                 let advance_source = source_name_arc_of(&rec);
                 event_batcher.push_record(rec, rn)?;
                 advance_cursor(ctx, &advance_source, rn);

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -55,7 +55,6 @@ pub use storage_validate::{
 };
 pub(crate) use streaming::StreamingOutputTaskOutput;
 use streaming::{compute_streaming_output_specs, streaming_output};
-pub(crate) use transform::CompiledTransform;
 pub use transform::{TransformSpec, build_transform_specs};
 pub(crate) use transform::{
     WindowedEvalCtx, evaluate_single_transform, evaluate_single_transform_windowed,
@@ -172,9 +171,6 @@ struct DagExecInputs<'a> {
     /// Declared Source configs in declaration order. Borrowed for
     /// per-source seeding (watermark idle-timeouts, count slots).
     source_configs: &'a [clinker_plan::config::SourceConfig],
-    /// Compiled per-node CXL transform programs, looked up by name at
-    /// each Transform / Aggregation dispatch arm.
-    transforms: &'a [CompiledTransform],
     /// Topologically-sorted execution DAG walked by the dispatcher.
     plan: &'a ExecutionPlanDag,
     /// Compile artifacts (bound schemas, composition bodies) consulted
@@ -487,63 +483,6 @@ impl PipelineExecutor {
                 config.pipeline.vars.as_ref(),
                 &config.nodes,
             );
-        let mut compiled_transforms: Vec<CompiledTransform> = resolved_transforms
-            .iter()
-            .map(|t| {
-                // `resolved_transforms` are top-level transforms; resolve each
-                // by its TopLevel key in the scope-qualified `typed` table.
-                let typed = validated_plan
-                    .artifacts()
-                    .typed_get(
-                        clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                        &t.name,
-                    )
-                    .cloned()
-                    .ok_or_else(|| PipelineError::Compilation {
-                        transform_name: t.name.clone(),
-                        messages: vec![
-                            "internal: bind_schema produced no typed program for this node"
-                                .to_string(),
-                        ],
-                    })?;
-                Ok::<CompiledTransform, PipelineError>(CompiledTransform {
-                    name: t.name.clone(),
-                    scope: clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                    typed,
-                    max_expansion: t.max_expansion,
-                })
-            })
-            .collect::<Result<_, _>>()?;
-
-        // Extend with body transforms. Composition bodies' Transform
-        // / Aggregate nodes have their typed programs in `artifacts.typed`
-        // under their own `Body` scope. The body dispatcher looks them up in
-        // the same runtime table the top-level walker uses; that table is
-        // keyed by `(scope, name)`, so two bodies (or a body and the top
-        // level) with same-named nodes each keep their own program — no
-        // bare-name collapse.
-        for (body_id, body) in validated_plan.artifacts().composition_bodies.iter() {
-            for idx in body.graph.node_indices() {
-                let body_node = &body.graph[idx];
-                let n = body_node.name();
-                if matches!(
-                    body_node,
-                    clinker_plan::plan::execution::PlanNode::Transform { .. }
-                        | clinker_plan::plan::execution::PlanNode::Aggregation { .. }
-                ) && let Some(typed) = validated_plan.artifacts().typed_get(
-                    clinker_plan::plan::bind_schema::NodeScope::Body(*body_id),
-                    n,
-                ) {
-                    compiled_transforms.push(CompiledTransform {
-                        name: n.to_string(),
-                        scope: clinker_plan::plan::bind_schema::NodeScope::Body(*body_id),
-                        typed: typed.clone(),
-                        max_expansion: cxl::eval::DEFAULT_MAX_EXPANSION,
-                    });
-                }
-            }
-        }
-
         // Compile route conditions if any transform has a route config.
         // Collect all emitted field names for route condition resolution.
         let compiled_route = {
@@ -553,84 +492,42 @@ impl PipelineExecutor {
                 .find_map(|t| t.route.as_ref());
             match route_config {
                 Some(rc) => {
-                    // Union of user-declared fields across every Source's
-                    // bound output_row. Engine-stamped tail columns
-                    // ($ck.*, $widened, $source.file) are filtered: Route
-                    // conditions reference user-declared field names, not
-                    // engine sidecars. Previously this seeded only the
-                    // primary source's reader columns, which silently
-                    // dropped non-primary fields from Route resolution in
-                    // multi-source pipelines.
+                    // Route conditions reference the fields visible on the
+                    // records flowing into the Route. A top-level Route has one
+                    // incoming data edge, and its predecessor's widened
+                    // `output_schema` already unions every upstream field —
+                    // every Source column plus every Transform / Combine /
+                    // Aggregate emit on the path to the Route. Reading that
+                    // schema off the DAG is the complete field set without
+                    // re-walking the typed-program table. Engine-stamped tail
+                    // columns ($ck.*, $widened, $source.file) carry the
+                    // reserved `$` prefix and are filtered: Route conditions
+                    // reference user-declared field names, not engine sidecars.
+                    let dag = validated_plan.dag();
                     let mut emitted_fields: Vec<String> = Vec::new();
-                    for src_cfg in &source_configs {
-                        // Sources are top-level nodes; resolve by TopLevel key.
-                        if let Some(typed) = validated_plan.artifacts().typed_get(
-                            clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                            &src_cfg.name,
+                    for route_idx in dag.graph.node_indices() {
+                        if !matches!(
+                            &dag.graph[route_idx],
+                            clinker_plan::plan::execution::PlanNode::Route { .. }
                         ) {
-                            for (qf, _) in typed.output_row.fields() {
-                                let s = qf.name.to_string();
-                                if s.starts_with('$') {
-                                    continue;
-                                }
-                                if !emitted_fields.contains(&s) {
-                                    emitted_fields.push(s);
-                                }
-                            }
-                        }
-                    }
-                    for ct in &compiled_transforms {
-                        cxl::ast::for_each_field_emit(
-                            &ct.typed.program.statements,
-                            &mut |name, _| {
-                                if !emitted_fields.iter().any(|s| s == name) {
-                                    emitted_fields.push(name.to_string());
-                                }
-                            },
-                        );
-                    }
-                    // Combine nodes also emit fields via their `cxl:` body;
-                    // those typed programs live in `artifacts.typed` keyed
-                    // by the combine's scope-qualified id (not in
-                    // `compiled_transforms`, which is transform-only). A route
-                    // downstream of a combine sees the combine's emits, so
-                    // every emit in every typed program that's NOT a transform
-                    // must be surfaced to the route resolver. The table is now
-                    // `ScopedNodeId`-keyed; the transform-name filter and emit
-                    // collection both operate on the bare `name`.
-                    let transform_names: std::collections::HashSet<&str> = compiled_transforms
-                        .iter()
-                        .map(|ct| ct.name.as_str())
-                        .collect();
-                    for (scoped, typed) in &validated_plan.artifacts().typed {
-                        if transform_names.contains(scoped.name.as_str()) {
                             continue;
                         }
-                        cxl::ast::for_each_field_emit(&typed.program.statements, &mut |name, _| {
-                            if !emitted_fields.iter().any(|s| s == name) {
-                                emitted_fields.push(name.to_string());
+                        let Some(pred_idx) = dag
+                            .graph
+                            .neighbors_directed(route_idx, petgraph::Direction::Incoming)
+                            .next()
+                        else {
+                            continue;
+                        };
+                        let pred_schema = dag.graph[pred_idx].output_schema_in(dag);
+                        for col in pred_schema.columns() {
+                            let s = col.as_ref();
+                            if s.starts_with('$') {
+                                continue;
                             }
-                        });
-                    }
-                    // A decomposed N-ary combine's `cxl:` body lives only on its
-                    // `PlanNode::Combine.typed` — decomposition does not re-home
-                    // it into `artifacts.typed` — so collect those emits off the
-                    // node too, or a Route downstream of such a combine cannot
-                    // resolve the fields it emits.
-                    for node in validated_plan.dag().graph.node_weights() {
-                        if let clinker_plan::plan::execution::PlanNode::Combine {
-                            typed: Some(typed),
-                            ..
-                        } = node
-                        {
-                            cxl::ast::for_each_field_emit(
-                                &typed.program.statements,
-                                &mut |name, _| {
-                                    if !emitted_fields.iter().any(|s| s == name) {
-                                        emitted_fields.push(name.to_string());
-                                    }
-                                },
-                            );
+                            if !emitted_fields.iter().any(|f| f == s) {
+                                emitted_fields.push(s.to_string());
+                            }
                         }
                     }
                     Some(Self::compile_route(rc, &emitted_fields, &scoped_vars)?)
@@ -647,7 +544,7 @@ impl PipelineExecutor {
         // Routes carry their own conditions.
         let mut compiled_routes_by_name: std::collections::HashMap<String, CompiledRoute> =
             std::collections::HashMap::new();
-        for (body_id, body) in validated_plan.artifacts().composition_bodies.iter() {
+        for (_body_id, body) in validated_plan.artifacts().composition_bodies.iter() {
             for (route_name, route_body) in &body.route_bodies {
                 // Build the body Route's RouteConfig from its parsed
                 // RouteBody. The condition resolver needs the field
@@ -681,19 +578,23 @@ impl PipelineExecutor {
                         }
                     }
                 }
-                // Only this body's own nodes contribute emits. The `typed`
-                // table is `ScopedNodeId`-keyed, so filter by this body's
-                // scope — a top-level node sharing a name with a body node
-                // stays out of this body's route field set.
-                for (scoped, typed) in &validated_plan.artifacts().typed {
-                    if scoped.scope != clinker_plan::plan::bind_schema::NodeScope::Body(*body_id) {
-                        continue;
-                    }
-                    cxl::ast::for_each_field_emit(&typed.program.statements, &mut |name, _| {
-                        if !emitted_fields.iter().any(|s| s == name) {
-                            emitted_fields.push(name.to_string());
+                // Only this body's own nodes contribute emits. Walk the body
+                // mini-DAG and union each producing node's widened
+                // `output_schema` columns — every Transform / Combine /
+                // Aggregate emit shows up there once binding has widened the
+                // node's schema, so the body's own producers contribute their
+                // fields without reaching into the scope-keyed typed table.
+                // A top-level node sharing a name with a body node stays out
+                // because we only walk this body's graph.
+                for node in body.graph.node_weights() {
+                    if let Some(schema) = node.stored_output_schema() {
+                        for col in schema.columns() {
+                            let s = col.as_ref().to_string();
+                            if !emitted_fields.contains(&s) {
+                                emitted_fields.push(s);
+                            }
                         }
-                    });
+                    }
                 }
                 let cr = Self::compile_route(&route_config, &emitted_fields, &scoped_vars)?;
                 compiled_routes_by_name.insert(route_name.clone(), cr);
@@ -905,7 +806,6 @@ impl PipelineExecutor {
             &DagExecInputs {
                 config,
                 source_configs: &source_configs,
-                transforms: &compiled_transforms,
                 plan,
                 artifacts: validated_plan.artifacts(),
                 params,
@@ -1093,7 +993,6 @@ impl PipelineExecutor {
         let &DagExecInputs {
             config,
             source_configs,
-            transforms,
             plan,
             artifacts,
             params,
@@ -1171,23 +1070,6 @@ impl PipelineExecutor {
         let source_ingestion_timestamp = pipeline_start_time;
 
         let strategy = config.error_handling.strategy;
-
-        // (scope → name → index) map for looking up `CompiledTransform` by
-        // a node's scope-qualified identity. Keyed by `NodeScope` first so a
-        // body transform named the same as a top-level (or sibling-body)
-        // transform resolves its own program; the dispatcher reads the
-        // current scope off `window_runtime.active_stack`. Borrowed by the
-        // dispatcher's Transform / Aggregation arms.
-        let mut transform_by_name: HashMap<
-            clinker_plan::plan::bind_schema::NodeScope,
-            HashMap<&str, usize>,
-        > = HashMap::new();
-        for (i, t) in transforms.iter().enumerate() {
-            transform_by_name
-                .entry(t.scope)
-                .or_default()
-                .insert(t.name.as_str(), i);
-        }
 
         // Correlation grouping context. `Some(...)` iff at least one
         // source declares a `correlation_key:`; the planner's
@@ -1419,8 +1301,6 @@ impl PipelineExecutor {
             artifacts,
             output_configs: &output_configs,
             primary_output: &output_configs[0],
-            compiled_transforms: transforms,
-            transform_by_name,
             stable: &stable,
             source_batch_arc: &source_batch_arc,
             source_count_per_source,

--- a/crates/clinker-exec/src/executor/transform.rs
+++ b/crates/clinker-exec/src/executor/transform.rs
@@ -1,5 +1,5 @@
-//! Executor-internal transform spec + compiled transform, and the
-//! per-record transform evaluation helpers the dispatch arms drive.
+//! Executor-internal transform spec and the per-record transform
+//! evaluation helpers the dispatch arms drive.
 
 use std::sync::Arc;
 
@@ -10,9 +10,7 @@ use crate::pipeline::index::{GroupByKey, value_to_group_key};
 use crate::pipeline::window_context::PartitionWindowContext;
 use clinker_plan::config::PipelineConfig;
 use clinker_plan::plan::execution::ExecutionPlanDag;
-use cxl::ast::Statement;
 use cxl::eval::{EvalContext, EvalResult, ProgramEvaluator, SkipReason};
-use cxl::typecheck::TypedProgram;
 
 use super::{NullStorage, record_with_emitted_fields};
 
@@ -156,29 +154,6 @@ pub fn build_transform_specs(config: &PipelineConfig) -> Vec<TransformSpec> {
         }
     }
     out
-}
-
-/// Compiled transform: CXL source compiled once, evaluated per record.
-#[derive(Debug)]
-pub struct CompiledTransform {
-    pub(crate) name: String,
-    /// Scope the node lives in. Two composition bodies (or a top-level node
-    /// and a body) can hold same-named transforms with different programs;
-    /// the runtime dispatch table keys on `(scope, name)` so each resolves
-    /// its own program instead of collapsing to one bare-name entry.
-    pub(crate) scope: clinker_plan::plan::bind_schema::NodeScope,
-    pub(crate) typed: Arc<TypedProgram>,
-    pub(crate) max_expansion: u64,
-}
-
-impl CompiledTransform {
-    pub(crate) fn has_distinct(&self) -> bool {
-        self.typed
-            .program
-            .statements
-            .iter()
-            .any(|s| matches!(s, Statement::Distinct { .. }))
-    }
 }
 
 /// Single emitted (or skipped) output of a per-record transform

--- a/crates/clinker-exec/src/executor/transform_dispatch.rs
+++ b/crates/clinker-exec/src/executor/transform_dispatch.rs
@@ -41,6 +41,7 @@ pub(crate) fn dispatch_transform(
         ref name,
         window_index,
         ref resolved,
+        has_distinct,
         ..
     } = *node
     else {
@@ -108,14 +109,10 @@ pub(crate) fn dispatch_transform(
 
     // The compiled program is the per-record evaluator for the transform
     // hot loop: it lowers each statement to a closure once and skips the
-    // per-record AST re-match a recursive tree-walk would pay. `distinct`
-    // detection scans the node's typed program for a `distinct` statement.
-    let has_distinct = payload
-        .typed
-        .program
-        .statements
-        .iter()
-        .any(|s| matches!(s, cxl::ast::Statement::Distinct { .. }));
+    // per-record AST re-match a recursive tree-walk would pay. `has_distinct`
+    // is read off the node — computed once at lowering, the single source of
+    // truth `compute_node_properties` also reads — mirroring the aggregate
+    // dispatch path rather than re-scanning the program per dispatch.
     let mut evaluator = ProgramEvaluator::with_max_expansion(
         Arc::clone(&payload.typed),
         has_distinct,

--- a/crates/clinker-exec/src/executor/transform_dispatch.rs
+++ b/crates/clinker-exec/src/executor/transform_dispatch.rs
@@ -40,6 +40,7 @@ pub(crate) fn dispatch_transform(
     let PlanNode::Transform {
         ref name,
         window_index,
+        ref resolved,
         ..
     } = *node
     else {
@@ -84,12 +85,13 @@ pub(crate) fn dispatch_transform(
         }
     };
 
-    // Find the CompiledTransform for this node, scoped to the body (or top
-    // level) currently executing.
-    let transform_idx = match ctx.transform_idx(name.as_str()) {
-        Some(idx) => idx,
+    // Read the typed program off the `PlanNode::Transform` payload. Every
+    // lowered Transform carries a `Some(payload)` with a typechecked program;
+    // an absent payload is the defensive pass-through (a node that failed to
+    // lower has no program to run).
+    let payload = match resolved {
+        Some(p) => p,
         None => {
-            // No transform found — pass through
             tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &input_records)?;
             let nb = admit_node_buffer(
                 ctx,
@@ -106,11 +108,18 @@ pub(crate) fn dispatch_transform(
 
     // The compiled program is the per-record evaluator for the transform
     // hot loop: it lowers each statement to a closure once and skips the
-    // per-record AST re-match a recursive tree-walk would pay.
+    // per-record AST re-match a recursive tree-walk would pay. `distinct`
+    // detection scans the node's typed program for a `distinct` statement.
+    let has_distinct = payload
+        .typed
+        .program
+        .statements
+        .iter()
+        .any(|s| matches!(s, cxl::ast::Statement::Distinct { .. }));
     let mut evaluator = ProgramEvaluator::with_max_expansion(
-        Arc::clone(&ctx.compiled_transforms[transform_idx].typed),
-        ctx.compiled_transforms[transform_idx].has_distinct(),
-        ctx.compiled_transforms[transform_idx].max_expansion,
+        Arc::clone(&payload.typed),
+        has_distinct,
+        payload.max_expansion,
     );
 
     let expected_input = current_dag.graph[node_idx]

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3593,8 +3593,8 @@ pub(crate) fn lower_node_to_plan_node(
             let output_schema = schema_from_bound(name);
             // Carry the typed program and its distinct-ness on the node so the
             // executor builds its per-group evaluator off the node instead of a
-            // scope-keyed startup table; `has_distinct` is the same scan
-            // `CompiledTransform::has_distinct` performed.
+            // scope-keyed startup table; `has_distinct` records whether the
+            // typed program contains a `distinct` statement.
             let has_distinct = extract_has_distinct(&typed);
             Some(PlanNode::Aggregation {
                 name: name.to_string(),

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3462,6 +3462,7 @@ pub(crate) fn lower_node_to_plan_node(
                     typed,
                     declares: config.declares.clone(),
                     phase: config.phase,
+                    max_expansion: config.max_expansion,
                 })),
                 parallelism_class,
                 tier: 0,
@@ -3590,11 +3591,18 @@ pub(crate) fn lower_node_to_plan_node(
             // `finalize_group_inner` had no slot to populate from the
             // group key.
             let output_schema = schema_from_bound(name);
+            // Carry the typed program and its distinct-ness on the node so the
+            // executor builds its per-group evaluator off the node instead of a
+            // scope-keyed startup table; `has_distinct` is the same scan
+            // `CompiledTransform::has_distinct` performed.
+            let has_distinct = extract_has_distinct(&typed);
             Some(PlanNode::Aggregation {
                 name: name.to_string(),
                 span,
                 config: agg_cfg,
                 compiled: Arc::new(compiled_agg),
+                typed,
+                has_distinct,
                 strategy: AggregateStrategy::Hash,
                 output_schema,
                 fallback_reason: None,

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -304,6 +304,21 @@ pub enum PlanNode {
         config: AggregateConfig,
         #[serde(skip)]
         compiled: Arc<CompiledAggregate>,
+        /// Typechecked CXL `aggregate:` program the executor evaluates per
+        /// group. Carried on the node — mirroring `PlanTransformPayload.typed`
+        /// — so the runtime builds its `ProgramEvaluator` off the node it is
+        /// dispatching instead of from a scope-keyed startup table. Populated
+        /// at lowering from `artifacts.typed_get(scope, name)`; never `None`
+        /// (a CXL typecheck failure surfaces as a compile-time diagnostic and
+        /// the node is not lowered).
+        #[serde(skip)]
+        typed: Arc<TypedProgram>,
+        /// `true` iff the typed program contains a `distinct` statement —
+        /// the same scan `CompiledTransform::has_distinct` performed.
+        /// Threaded into the per-group `ProgramEvaluator`. Computed at
+        /// lowering from `typed`.
+        #[serde(skip)]
+        has_distinct: bool,
         strategy: AggregateStrategy,
         #[serde(skip)]
         output_schema: Arc<Schema>,
@@ -515,6 +530,11 @@ pub struct PlanTransformPayload {
     /// `phase: init` runs the transform (and its transitive ancestors)
     /// to completion before any runtime-phase node sees a record.
     pub phase: crate::config::pipeline_node::Phase,
+    /// `emit each` per-record fan-out ceiling, carried on the node so the
+    /// executor reads it off the `PlanNode::Transform` it is dispatching
+    /// rather than from a startup-built side table. Populated at lowering
+    /// from the authored `TransformBody::max_expansion`.
+    pub max_expansion: u64,
 }
 
 /// Fully-resolved Output payload.

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -313,10 +313,9 @@ pub enum PlanNode {
         /// the node is not lowered).
         #[serde(skip)]
         typed: Arc<TypedProgram>,
-        /// `true` iff the typed program contains a `distinct` statement —
-        /// the same scan `CompiledTransform::has_distinct` performed.
-        /// Threaded into the per-group `ProgramEvaluator`. Computed at
-        /// lowering from `typed`.
+        /// `true` iff the typed program contains a `distinct` statement.
+        /// Threaded into the per-group `ProgramEvaluator` so the executor
+        /// reads it off the node. Computed at lowering from `typed`.
         #[serde(skip)]
         has_distinct: bool,
         strategy: AggregateStrategy,


### PR DESCRIPTION
Part of #641 (node-identity milestone), phase 1. Closes #642.

## What this does

Runtime-defining program artifacts now live on the plan node, and the executor reads them directly off the node it is dispatching instead of from lookup tables built at executor startup:

- **Transform** dispatch reads the typed program and `max_expansion` off the node's transform payload.
- **Aggregate** dispatch reads the typed program and `has_distinct` off the aggregation node — the node now carries the typed program its per-group evaluator needs (previously it carried only its compiled-aggregate value, which omits the program).
- The **route** condition resolver collects its emitted-field set off the DAG — each route's predecessor's widened output schema, which already unions every upstream field — instead of walking the compile-time typed-program table.

The `compiled_transforms` vector, its `(scope, name)` index, the `CompiledTransform` struct, and the scope-resolution helpers used only by them are deleted. The executor no longer reads the compile-time typed-program table at all.

Scope-correctness across composition-body scopes is preserved structurally: body instances are lowered per instance, so a node and a same-named node inside a body each carry their own program on their own node copy — no `(scope, name)` runtime key needed.

## Route scope

This phase severs the route resolver from the compile-time typed table but keeps the two route lookup tables (`compiled_route` / `compiled_routes_by_name`). Deleting those requires carrying the typed branch programs on the route node — a plan-schema change with its own validation surface — tracked in #646. The load-bearing outcome here (the executor fully severed from the compile-time typed table) is complete.

## Behavior note

Body transforms now honor an authored `max_expansion:` that the previous startup-table path silently forced to the engine default. Behavior is unchanged for the common case — the config default equals the engine default — so this affects only a body transform that explicitly sets a non-default ceiling (a latent fix).

## Validation

- Full workspace build, `clippy --all-targets -D warnings`, `fmt --check`, `cargo test --workspace`, and the benchmark smoke suite all pass.
- A repository search confirms zero reads of the compile-time typed-program table or the deleted transform tables remain in the execution crate.
- Existing transform / aggregate / route behavior is unchanged.

Note: `test-macos` may fail on a pre-existing RSS-probe flake (`test_rss_bytes_increases_after_alloc`) unrelated to this change.