### PR TITLE
plan,exec,cxl: mint a dense PlanNodeId identity and key per-node compile artifacts by it

### DIFF
--- a/crates/clinker-exec/tests/bind_schema_test.rs
+++ b/crates/clinker-exec/tests/bind_schema_test.rs
@@ -687,10 +687,19 @@ nodes:
     // Body port-synthetic Source ("data" port): walks the composition
     // body's mini-DAG and finds a PlanNode::Source named after the
     // port. Its output_schema must mirror the parent's widening.
+    // `composition_body_assignments` keys by the call-site node's id;
+    // resolve `passthrough`'s id off the declaration-order id vector.
+    let passthrough_id = plan
+        .config()
+        .nodes
+        .iter()
+        .zip(plan.artifacts().top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == "passthrough").then_some(*id))
+        .expect("top-level `passthrough` id");
     let body_id = plan
         .artifacts()
         .composition_body_assignments
-        .get("passthrough")
+        .get(&passthrough_id)
         .copied()
         .expect("composition body assigned");
     let body = plan.body_of(body_id).expect("body present");

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -151,12 +151,27 @@ mod tests {
     ///
     /// Fixture name is passed without the `.yaml` extension —
     /// `compile_combine_fixture("two_input_equi")`.
+    /// Top-level node-name → `PlanNodeId`, built from the ids `bind_schema`
+    /// minted in declaration order zipped with each node's name. Top-level
+    /// names are unique, so this is collision-free; tests resolve a
+    /// user-facing node name to its id through it before reading the
+    /// id-keyed `typed` table.
+    type TopLevelIds = std::collections::HashMap<String, clinker_plan::plan::PlanNodeId>;
+
+    /// Resolve a top-level node's id by name, panicking if absent (the
+    /// fixtures here are all top-level and uniquely named).
+    fn top_id(ids: &TopLevelIds, name: &str) -> clinker_plan::plan::PlanNodeId {
+        *ids.get(name)
+            .unwrap_or_else(|| panic!("no top-level id for node {name:?}"))
+    }
+
     #[allow(dead_code)] // Used by C.1.1+ tests; referenced here as a gate.
     fn compile_combine_fixture(
         name: &str,
     ) -> (
         clinker_plan::plan::bind_schema::CompileArtifacts,
         Vec<clinker_core_types::Diagnostic>,
+        TopLevelIds,
     ) {
         let yaml = load_fixture(&format!("{name}.yaml"));
         let config = parse_fixture(&yaml);
@@ -171,7 +186,13 @@ mod tests {
             std::path::Path::new(""),
             Default::default(),
         );
-        (artifacts, diags)
+        let ids: TopLevelIds = config
+            .nodes
+            .iter()
+            .zip(artifacts.top_level_node_ids.iter())
+            .map(|(spanned, id)| (spanned.value.name().to_string(), *id))
+            .collect();
+        (artifacts, diags, ids)
     }
 
     /// Assert that the node's output row (as published on
@@ -181,14 +202,12 @@ mod tests {
     #[allow(dead_code)] // Pre-existing helper retained for combine gate tests.
     fn assert_output_row(
         artifacts: &clinker_plan::plan::bind_schema::CompileArtifacts,
+        ids: &TopLevelIds,
         node_name: &str,
         expected_fields: &[&str],
     ) {
         let row = artifacts
-            .typed_get(
-                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                node_name,
-            )
+            .typed_get(top_id(ids, node_name))
             .map(|tp| &tp.output_row)
             .unwrap_or_else(|| panic!("no bound output row for node {node_name:?}"));
         let actual: Vec<String> = row.field_names().map(|qf| qf.to_string()).collect();
@@ -207,6 +226,7 @@ mod tests {
     #[allow(dead_code)] // Exercised by C.1.2+ tests.
     fn assert_predicate_decomposition(
         artifacts: &clinker_plan::plan::bind_schema::CompileArtifacts,
+        ids: &TopLevelIds,
         node_name: &str,
         expected_equalities: usize,
         expected_ranges: usize,
@@ -214,7 +234,7 @@ mod tests {
     ) {
         let pred = artifacts
             .combine_predicates
-            .get(node_name)
+            .get(&top_id(ids, node_name))
             .unwrap_or_else(|| panic!("no decomposed predicate for combine {node_name:?}"));
         assert_eq!(
             pred.equalities.len(),
@@ -244,7 +264,7 @@ mod tests {
     /// both upstreams are declared sources.
     #[test]
     fn test_combine_schema_scaffold_compiles() {
-        let (_artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("two_input_equi");
         assert!(
             diags.is_empty(),
             "two_input_equi must bind cleanly; got codes: {:?}",
@@ -304,7 +324,7 @@ mod tests {
     /// construction path runs end-to-end for the canonical shape.
     #[test]
     fn test_combine_merged_row_two_inputs() {
-        let (_artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("two_input_equi");
         assert!(
             diags.is_empty(),
             "two_input_equi must bind cleanly at C.1.1; got codes: {:?}",
@@ -323,7 +343,7 @@ mod tests {
     /// warnings are out of scope for this gate.
     #[test]
     fn test_combine_merged_row_three_inputs() {
-        let (_artifacts, diags) = compile_combine_fixture("three_input_shared_key");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("three_input_shared_key");
         let errors: Vec<&str> = diags
             .iter()
             .filter(|d| matches!(d.severity, clinker_core_types::Severity::Error))
@@ -338,7 +358,7 @@ mod tests {
     /// C.1.1 gate: fewer than 2 declared inputs → E300.
     #[test]
     fn test_combine_e300_one_input() {
-        let (_artifacts, diags) = compile_combine_fixture("error_one_input");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_one_input");
         assert!(
             diags.iter().any(|d| d.code == "E300"),
             "error_one_input must produce E300; got codes: {:?}",
@@ -350,7 +370,7 @@ mod tests {
     /// namespaces (`$pipeline`, `$window`, `$meta`) → E301.
     #[test]
     fn test_combine_e301_reserved_namespace() {
-        let (_artifacts, diags) = compile_combine_fixture("error_reserved_namespace");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_reserved_namespace");
         assert!(
             diags.iter().any(|d| d.code == "E301"),
             "error_reserved_namespace must produce E301; got codes: {:?}",
@@ -362,7 +382,7 @@ mod tests {
     /// alias a genuine 3-part CXL reference → E301.
     #[test]
     fn test_combine_e301_dotted_qualifier() {
-        let (_artifacts, diags) = compile_combine_fixture("error_dotted_qualifier");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_dotted_qualifier");
         assert!(
             diags.iter().any(|d| d.code == "E301"),
             "error_dotted_qualifier must produce E301; got codes: {:?}",
@@ -382,7 +402,7 @@ mod tests {
     /// and populates `artifacts.combine_predicates`.
     #[test]
     fn test_combine_where_typecheck_bool() {
-        let (artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (artifacts, diags, ids) = compile_combine_fixture("two_input_equi");
         assert!(
             diags.is_empty(),
             "two_input_equi must bind cleanly; got codes: {:?}",
@@ -390,7 +410,7 @@ mod tests {
         );
         let pred = artifacts
             .combine_predicates
-            .get("enriched")
+            .get(&top_id(&ids, "enriched"))
             .expect("combine_predicates['enriched'] must exist");
         assert!(
             !pred.equalities.is_empty(),
@@ -401,7 +421,7 @@ mod tests {
     /// C.1.2 gate: a where-clause whose predicate is a non-Bool type → E303.
     #[test]
     fn test_combine_e303_where_not_bool() {
-        let (_artifacts, diags) = compile_combine_fixture("error_where_not_bool");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_where_not_bool");
         assert!(
             diags.iter().any(|d| d.code == "E303"),
             "error_where_not_bool must produce E303; got codes: {:?}",
@@ -413,7 +433,7 @@ mod tests {
     /// field → E304.
     #[test]
     fn test_combine_e304_unknown_field() {
-        let (_artifacts, diags) = compile_combine_fixture("error_unknown_field");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_unknown_field");
         assert!(
             diags.iter().any(|d| d.code == "E304"),
             "error_unknown_field must produce E304; got codes: {:?}",
@@ -425,7 +445,7 @@ mod tests {
     /// no cross-input extractables → E305.
     #[test]
     fn test_combine_e305_no_cross_input() {
-        let (_artifacts, diags) = compile_combine_fixture("error_no_cross_input");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_no_cross_input");
         assert!(
             diags.iter().any(|d| d.code == "E305"),
             "error_no_cross_input must produce E305; got codes: {:?}",
@@ -438,7 +458,7 @@ mod tests {
     /// cross joins; users must add a real predicate or use a Merge node.
     #[test]
     fn test_combine_e305_literal_true() {
-        let (_artifacts, diags) = compile_combine_fixture("error_literal_true");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_literal_true");
         assert!(
             diags.iter().any(|d| d.code == "E305"),
             "error_literal_true must produce E305; got codes: {:?}",
@@ -450,9 +470,9 @@ mod tests {
     /// no residual.
     #[test]
     fn test_combine_decompose_pure_equi() {
-        let (artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (artifacts, diags, ids) = compile_combine_fixture("two_input_equi");
         assert!(diags.is_empty(), "expected clean compile");
-        let pred = &artifacts.combine_predicates["enriched"];
+        let pred = &artifacts.combine_predicates[&top_id(&ids, "enriched")];
         assert_eq!(pred.equalities.len(), 1, "1 equality expected");
         assert_eq!(pred.ranges.len(), 0, "0 ranges expected");
         assert!(
@@ -470,13 +490,13 @@ mod tests {
     fn test_combine_decompose_mixed() {
         use clinker_plan::plan::combine::RangeOp;
 
-        let (artifacts, diags) = compile_combine_fixture("two_input_mixed");
+        let (artifacts, diags, ids) = compile_combine_fixture("two_input_mixed");
         assert!(
             diags.is_empty(),
             "two_input_mixed must bind cleanly; got codes: {:?}",
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
-        let pred = &artifacts.combine_predicates["qualified"];
+        let pred = &artifacts.combine_predicates[&top_id(&ids, "qualified")];
         assert_eq!(pred.equalities.len(), 1, "1 equality expected");
         assert_eq!(pred.ranges.len(), 2, "2 ranges expected");
         assert!(matches!(pred.ranges[0].op, RangeOp::Ge));
@@ -489,17 +509,14 @@ mod tests {
     /// processing the combine.
     #[test]
     fn test_combine_e311_collect_with_body() {
-        let (artifacts, diags) = compile_combine_fixture("error_collect_with_body");
+        let (artifacts, diags, ids) = compile_combine_fixture("error_collect_with_body");
         assert!(
             diags.iter().any(|d| d.code == "E311"),
             "error_collect_with_body must emit E311; got codes: {:?}",
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
         assert!(
-            !artifacts.typed_contains(
-                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                "bad_collect"
-            ),
+            !artifacts.typed_contains(top_id(&ids, "bad_collect")),
             "no output row published when E311 fires"
         );
     }
@@ -518,7 +535,7 @@ mod tests {
         use clinker_plan::plan::types::JoinSide;
         use cxl::typecheck::QualifiedField;
 
-        let (artifacts, diags) = compile_combine_fixture("match_all");
+        let (artifacts, diags, ids) = compile_combine_fixture("match_all");
         assert!(
             diags.is_empty(),
             "match_all must bind cleanly; got codes: {:?}",
@@ -526,7 +543,7 @@ mod tests {
         );
         let resolved = artifacts
             .combine_resolved_columns
-            .get("fanned")
+            .get(&top_id(&ids, "fanned"))
             .expect("bind_combine must publish a resolved_column_map");
 
         // Per `match_all.yaml`, driver = orders (declared first).
@@ -573,17 +590,14 @@ mod tests {
     fn test_combine_collect_output_row_auto_derived() {
         use cxl::typecheck::{QualifiedField, Type};
 
-        let (artifacts, diags) = compile_combine_fixture("match_collect");
+        let (artifacts, diags, ids) = compile_combine_fixture("match_collect");
         assert!(
             diags.is_empty(),
             "match_collect must bind cleanly under R1; got codes: {:?}",
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
         let row = artifacts
-            .typed_get(
-                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                "collected",
-            )
+            .typed_get(top_id(&ids, "collected"))
             .map(|tp| &tp.output_row)
             .expect("collected publishes a bound output row");
 
@@ -621,7 +635,7 @@ mod tests {
     /// `select_driving_input` and threads the explicit hint through.
     #[test]
     fn test_combine_driving_input_explicit_drive() {
-        let (artifacts, diags) = compile_combine_fixture("drive_hint");
+        let (artifacts, diags, ids) = compile_combine_fixture("drive_hint");
         assert!(
             diags.is_empty(),
             "drive_hint must bind cleanly; got codes: {:?}",
@@ -629,7 +643,7 @@ mod tests {
         );
         let driver = artifacts
             .combine_driving
-            .get("product_driven")
+            .get(&top_id(&ids, "product_driven"))
             .expect("combine_driving entry for product_driven");
         assert_eq!(driver, "products", "explicit drive wins over default");
     }
@@ -639,14 +653,16 @@ mod tests {
     /// `combine_driving` for that node.
     #[test]
     fn test_combine_e306_invalid_drive() {
-        let (artifacts, diags) = compile_combine_fixture("error_invalid_drive");
+        let (artifacts, diags, ids) = compile_combine_fixture("error_invalid_drive");
         assert!(
             diags.iter().any(|d| d.code == "E306"),
             "error_invalid_drive must emit E306; got codes: {:?}",
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
         assert!(
-            !artifacts.combine_driving.contains_key("bad_drive"),
+            !artifacts
+                .combine_driving
+                .contains_key(&top_id(&ids, "bad_drive")),
             "no combine_driving entry written when drive selection fails"
         );
     }
@@ -656,7 +672,7 @@ mod tests {
     /// `two_input_equi.yaml` the input map declares `orders` first.
     #[test]
     fn test_combine_driving_input_default_first_in_indexmap() {
-        let (artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (artifacts, diags, ids) = compile_combine_fixture("two_input_equi");
         assert!(
             diags.is_empty(),
             "two_input_equi must bind cleanly; got codes: {:?}",
@@ -664,7 +680,7 @@ mod tests {
         );
         let driver = artifacts
             .combine_driving
-            .get("enriched")
+            .get(&top_id(&ids, "enriched"))
             .expect("combine_driving entry for enriched");
         assert_eq!(driver, "orders", "first declared input drives by default");
     }
@@ -678,13 +694,13 @@ mod tests {
     /// compiled scalar reuses the where-clause's regex cache.
     #[test]
     fn test_combine_equality_program_compiled() {
-        let (artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (artifacts, diags, ids) = compile_combine_fixture("two_input_equi");
         assert!(
             diags.is_empty(),
             "two_input_equi must bind cleanly; got codes: {:?}",
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
-        let pred = &artifacts.combine_predicates["enriched"];
+        let pred = &artifacts.combine_predicates[&top_id(&ids, "enriched")];
         assert!(!pred.equalities.is_empty(), "expected at least 1 equality");
         for eq in &pred.equalities {
             assert!(
@@ -707,8 +723,8 @@ mod tests {
     /// residual holds the whole OR.
     #[test]
     fn test_combine_decompose_or_is_residual() {
-        let (artifacts, _diags) = compile_combine_fixture("error_or_predicate");
-        let pred = &artifacts.combine_predicates["combine_or"];
+        let (artifacts, _diags, ids) = compile_combine_fixture("error_or_predicate");
+        let pred = &artifacts.combine_predicates[&top_id(&ids, "combine_or")];
         assert_eq!(pred.equalities.len(), 0);
         assert_eq!(pred.ranges.len(), 0);
         assert!(pred.residual.is_some(), "residual must hold the OR whole");
@@ -720,13 +736,13 @@ mod tests {
     /// expressions per drill D5.
     #[test]
     fn test_combine_decompose_expression_equality() {
-        let (artifacts, diags) = compile_combine_fixture("expression_equi");
+        let (artifacts, diags, ids) = compile_combine_fixture("expression_equi");
         assert!(
             diags.is_empty(),
             "expression_equi must bind cleanly; got codes: {:?}",
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
-        let pred = &artifacts.combine_predicates["expr_combine"];
+        let pred = &artifacts.combine_predicates[&top_id(&ids, "expr_combine")];
         assert_eq!(pred.equalities.len(), 1, "1 equality expected");
         assert_eq!(pred.equalities[0].left_input.as_ref(), "orders");
         assert_eq!(pred.equalities[0].right_input.as_ref(), "products");
@@ -738,8 +754,8 @@ mod tests {
     /// `canEvaluate` semantics.
     #[test]
     fn test_combine_decompose_mixed_qualifier_residual() {
-        let (artifacts, _diags) = compile_combine_fixture("mixed_qualifier_expr");
-        let pred = &artifacts.combine_predicates["mixed_combine"];
+        let (artifacts, _diags, ids) = compile_combine_fixture("mixed_qualifier_expr");
+        let pred = &artifacts.combine_predicates[&top_id(&ids, "mixed_combine")];
         assert_eq!(pred.equalities.len(), 0);
         assert_eq!(pred.ranges.len(), 0);
         assert!(pred.residual.is_some());
@@ -750,7 +766,7 @@ mod tests {
     /// "only 2-part references are supported" message.
     #[test]
     fn test_combine_3part_ref_residual() {
-        let (_artifacts, diags) = compile_combine_fixture("error_3part_ref");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_3part_ref");
         assert!(
             diags.iter().any(|d| d.code == "E304"),
             "error_3part_ref must produce E304; got codes: {:?}",
@@ -787,17 +803,14 @@ mod tests {
     /// occurrence of `$widened` and asserting the count is exactly 1.
     #[test]
     fn test_combine_drops_build_side_widened_sidecar() {
-        let (artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (artifacts, diags, ids) = compile_combine_fixture("two_input_equi");
         assert!(
             diags.is_empty(),
             "two_input_equi must bind cleanly; got codes: {:?}",
             diags.iter().map(|d| &d.code).collect::<Vec<_>>()
         );
         let row = artifacts
-            .typed_get(
-                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                "enriched",
-            )
+            .typed_get(top_id(&ids, "enriched"))
             .map(|tp| &tp.output_row)
             .expect("enriched publishes a bound output row");
         let names: Vec<String> = row.field_names().map(|qf| qf.to_string()).collect();
@@ -814,7 +827,7 @@ mod tests {
     /// body TypedProgram.
     #[test]
     fn test_combine_output_row_from_emit() {
-        let (artifacts, diags) = compile_combine_fixture("two_input_equi");
+        let (artifacts, diags, ids) = compile_combine_fixture("two_input_equi");
         assert!(
             diags.is_empty(),
             "two_input_equi must bind cleanly; got codes: {:?}",
@@ -827,6 +840,7 @@ mod tests {
         // `combine_output_row` in `bind_schema.rs`.
         assert_output_row(
             &artifacts,
+            &ids,
             "enriched",
             &[
                 "order_id",
@@ -838,10 +852,7 @@ mod tests {
             ],
         );
         assert!(
-            artifacts.typed_contains(
-                clinker_plan::plan::bind_schema::NodeScope::TopLevel,
-                "enriched"
-            ),
+            artifacts.typed_contains(top_id(&ids, "enriched")),
             "artifacts.typed['enriched'] must be populated with body TypedProgram"
         );
     }
@@ -851,7 +862,7 @@ mod tests {
     /// output row, not the internal merged qualified row.
     #[test]
     fn test_combine_downstream_sees_output() {
-        let (_artifacts, diags) = compile_combine_fixture("combine_then_transform");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("combine_then_transform");
         assert!(
             diags.is_empty(),
             "combine_then_transform must bind cleanly; got codes: {:?}",
@@ -863,7 +874,7 @@ mod tests {
     /// → E308.
     #[test]
     fn test_combine_e308_unknown_merged_field() {
-        let (_artifacts, diags) = compile_combine_fixture("error_body_unknown_field");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_body_unknown_field");
         assert!(
             diags.iter().any(|d| d.code == "E308"),
             "error_body_unknown_field must produce E308; got codes: {:?}",
@@ -875,7 +886,7 @@ mod tests {
     /// has no pass-through semantics; every output field must be emitted.
     #[test]
     fn test_combine_e309_no_emit() {
-        let (_artifacts, diags) = compile_combine_fixture("error_no_emit");
+        let (_artifacts, diags, _ids) = compile_combine_fixture("error_no_emit");
         assert!(
             diags.iter().any(|d| d.code == "E309"),
             "error_no_emit must produce E309; got codes: {:?}",
@@ -4554,6 +4565,7 @@ nodes:
         };
         use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
         use clinker_plan::plan::row_type::{QualifiedField, Row};
+        use clinker_plan::plan::{EntityRef, PlanNodeId};
         use cxl::ast::{Expr, LiteralValue, NodeId, Program};
         use cxl::lexer::Span as CxlSpan;
         use cxl::typecheck::Type;
@@ -4563,9 +4575,12 @@ nodes:
         let mut artifacts = CompileArtifacts::default();
         let mut graph = petgraph::graph::DiGraph::new();
 
-        for q in ["orders", "products"] {
+        // Distinct ids per node so the from_parts id→index bridge keeps
+        // them separate; the combine below takes the next id.
+        for (i, q) in ["orders", "products"].into_iter().enumerate() {
             graph.add_node(PlanNode::Source {
                 name: q.to_string(),
+                id: PlanNodeId::new(i),
                 span: Span::SYNTHETIC,
                 resolved: None,
                 output_schema: clinker_record::SchemaBuilder::new().build(),
@@ -4590,12 +4605,15 @@ nodes:
                 },
             );
         }
+        // The combine node below is built with this id; key its side-table
+        // entries by the same id so the lowering-mirror reads resolve.
+        let combine_id = clinker_plan::plan::PlanNodeId::new(2);
         artifacts
             .combine_inputs
-            .insert("test_combine".to_string(), inputs_map.clone());
+            .insert(combine_id, inputs_map.clone());
         artifacts
             .combine_driving
-            .insert("test_combine".to_string(), "orders".to_string());
+            .insert(combine_id, "orders".to_string());
 
         let dummy_lit = || Expr::Literal {
             node_id: NodeId(0),
@@ -4627,12 +4645,11 @@ nodes:
             ranges: Vec::new(),
             residual: None,
         };
-        artifacts
-            .combine_predicates
-            .insert("test_combine".to_string(), predicate);
+        artifacts.combine_predicates.insert(combine_id, predicate);
 
         let combine_idx = graph.add_node(PlanNode::Combine {
             name: "test_combine".to_string(),
+            id: combine_id,
             span: Span::SYNTHETIC,
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
@@ -4647,9 +4664,9 @@ nodes:
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
             // Strategy selection reads these off the node; mirror lowering.
-            combine_inputs: artifacts.combine_inputs.get("test_combine").cloned(),
-            decomposed_predicate: artifacts.combine_predicates.get("test_combine").cloned(),
-            combine_driving: artifacts.combine_driving.get("test_combine").cloned(),
+            combine_inputs: artifacts.combine_inputs.get(&combine_id).cloned(),
+            decomposed_predicate: artifacts.combine_predicates.get(&combine_id).cloned(),
+            combine_driving: artifacts.combine_driving.get(&combine_id).cloned(),
         });
 
         let mut plan = ExecutionPlanDag::from_parts(

--- a/crates/clinker-exec/tests/composition_binding_test.rs
+++ b/crates/clinker-exec/tests/composition_binding_test.rs
@@ -18,6 +18,22 @@ fn parse_pipeline(yaml: &str) -> clinker_plan::config::PipelineConfig {
     clinker_plan::yaml::from_str(yaml).expect("parse PipelineConfig")
 }
 
+/// Resolve a top-level composition call-site node's `PlanNodeId` by name —
+/// `composition_body_assignments` keys by that id, so reads pair the
+/// declaration-order node list with the minted id vector the same way
+/// production lowering does.
+fn top_level_id(
+    cfg: &clinker_plan::config::PipelineConfig,
+    artifacts: &CompileArtifacts,
+    node_name: &str,
+) -> clinker_plan::plan::PlanNodeId {
+    cfg.nodes
+        .iter()
+        .zip(artifacts.top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == node_name).then_some(*id))
+        .unwrap_or_else(|| panic!("top-level node {node_name:?} not found"))
+}
+
 // ─────────────────────────────────────────────────────────────────────
 // Scaffold tests for composition binding.
 // ─────────────────────────────────────────────────────────────────────
@@ -141,10 +157,11 @@ nodes:
     );
 
     // Verify: composition_body_assignments has an entry for "enrich".
+    let enrich_id = top_level_id(&cfg, &artifacts, "enrich");
     assert!(
         artifacts
             .composition_body_assignments
-            .contains_key("enrich"),
+            .contains_key(&enrich_id),
         "expected 'enrich' in body assignments, got: {:?}",
         artifacts
             .composition_body_assignments
@@ -153,7 +170,7 @@ nodes:
     );
 
     // Verify: the assigned body_id points to a real BoundBody.
-    let body_id = artifacts.composition_body_assignments["enrich"];
+    let body_id = artifacts.composition_body_assignments[&enrich_id];
     assert_ne!(body_id, CompositionBodyId::SENTINEL);
     let body = artifacts
         .body_of(body_id)
@@ -222,7 +239,7 @@ nodes:
         Default::default(),
     );
 
-    let body_id = artifacts.composition_body_assignments["enrich"];
+    let body_id = artifacts.composition_body_assignments[&top_level_id(&cfg, &artifacts, "enrich")];
     let body = artifacts.body_of(body_id).unwrap();
 
     // The "customers" input port should have an Open row with declared
@@ -311,7 +328,7 @@ nodes:
     assert!(
         artifacts
             .composition_body_assignments
-            .contains_key("enrich"),
+            .contains_key(&top_level_id(&cfg, &artifacts, "enrich")),
         "enrich should have a body assignment"
     );
 }
@@ -381,7 +398,8 @@ nodes:
     );
 
     // The outer body should reference the inner body.
-    let outer_id = artifacts.composition_body_assignments["nested_process"];
+    let outer_id =
+        artifacts.composition_body_assignments[&top_level_id(&cfg, &artifacts, "nested_process")];
     let outer_body = artifacts.body_of(outer_id).unwrap();
     assert!(
         !outer_body.nested_body_ids.is_empty(),

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -774,13 +774,20 @@ impl PipelineConfig {
         for (i, e) in entries.iter().enumerate() {
             entries_by_name.insert(e.name.clone(), i);
         }
+        // Top-level node-name → `PlanNodeId`. Consumers below that hold a
+        // user-facing top-level name (the analyzer feed, the `$doc`
+        // source-attribution walk, the E150e array-window guard) resolve
+        // name → id → side-table through it.
+        let top_level_ids: HashMap<&str, crate::plan::PlanNodeId> =
+            artifacts.top_level_name_ids(&self.nodes);
         let compiled_refs: Vec<(&str, &cxl::typecheck::pass::TypedProgram)> = entries
             .iter()
             .filter_map(|e| {
                 // `entries` is the top-level analytic node list; analysis is
-                // top-level-only, so resolve each program by its TopLevel key.
-                artifacts
-                    .typed_get(crate::plan::bind_schema::NodeScope::TopLevel, &e.name)
+                // top-level-only, so resolve each program by its id.
+                top_level_ids
+                    .get(e.name.as_str())
+                    .and_then(|id| artifacts.typed_get(*id))
                     .map(|tp| (e.name.as_str(), tp.as_ref()))
             })
             .collect();
@@ -798,49 +805,60 @@ impl PipelineConfig {
         // conditions are typed into separate side-tables and chained in
         // below. Missing any of them would drop a referenced path from the
         // declared set.
-        // Attribute `$doc` paths by each program's scope-qualified
-        // `ScopedNodeId`, not its bare name, so a node named the same at top
-        // level and inside a composition body keeps its own `$doc` paths
-        // attributed to its own scope's source(s). The key is borrowed from
-        // the artifact tables (all three are `ScopedNodeId`-keyed), so no
-        // allocation; `&ScopedNodeId` is `Ord + Clone` as the collector needs.
-        let doc_refs: Vec<(
-            &crate::plan::bind_schema::ScopedNodeId,
-            &cxl::typecheck::pass::TypedProgram,
-        )> = artifacts
-            .typed
-            .iter()
-            .map(|(scoped, tp)| (scoped, tp.as_ref()))
-            // A Combine's node-keyed `typed` entry holds only its `cxl:` body;
-            // its `where:` predicate program lives in a separate side-table, so
-            // include those too — a `$doc` access used only in a predicate
-            // would otherwise be dropped.
-            .chain(
-                artifacts
-                    .combine_where_typed
-                    .iter()
-                    .map(|(scoped, tp)| (scoped, tp.as_ref())),
-            )
-            // A Route's node-keyed `typed` entry is an empty body; its
-            // branch-condition programs live in a separate side-table, one per
-            // branch. Include each so a `$doc` access used only in a route
-            // condition is still reachable.
-            .chain(
-                artifacts
-                    .route_branch_typed
-                    .iter()
-                    .flat_map(|(scoped, programs)| {
-                        programs.iter().map(move |tp| (scoped, tp.as_ref()))
-                    }),
-            )
-            .collect();
+        // Attribute `$doc` paths by each program's `PlanNodeId`, not its
+        // bare name, so a node named the same at top level and inside a
+        // composition body keeps its own `$doc` paths attributed to its own
+        // scope's source(s). The id is `Copy` (`Ord + Clone` as the
+        // collector needs), so the pairs carry it by value.
+        let doc_refs: Vec<(crate::plan::PlanNodeId, &cxl::typecheck::pass::TypedProgram)> =
+            artifacts
+                .typed
+                .iter()
+                .map(|(id, tp)| (*id, tp.as_ref()))
+                // A Combine's node-keyed `typed` entry holds only its `cxl:` body;
+                // its `where:` predicate program lives in a separate side-table, so
+                // include those too — a `$doc` access used only in a predicate
+                // would otherwise be dropped.
+                .chain(
+                    artifacts
+                        .combine_where_typed
+                        .iter()
+                        .map(|(id, tp)| (*id, tp.as_ref())),
+                )
+                // A Route's node-keyed `typed` entry is an empty body; its
+                // branch-condition programs live in a separate side-table, one per
+                // branch. Include each so a `$doc` access used only in a route
+                // condition is still reachable.
+                .chain(
+                    artifacts
+                        .route_branch_typed
+                        .iter()
+                        .flat_map(|(id, programs)| {
+                            programs.iter().map(move |tp| (*id, tp.as_ref()))
+                        }),
+                )
+                .collect();
         let doc_path_set = cxl::analyzer::doc_paths::collect_doc_paths(&doc_refs);
-        // Anchor each `$doc` diagnostic at the offending node's source line.
-        // Top-level node lines come from the saphyr-captured YAML position;
-        // a composition-body node (not present in `self.nodes`) falls back
-        // to a synthetic span. Shared by the E340 unresolvable-index pass
-        // and the E341 undeclared-path pass below.
-        let doc_node_line: HashMap<&str, u32> = self
+        // Anchor each `$doc` diagnostic at the offending node's source line,
+        // keyed by `PlanNodeId`. Top-level node lines come from the
+        // saphyr-captured YAML position (zip the minted ids with each
+        // node's line); a composition-body node (not present in
+        // `self.nodes`) has no entry and falls back to a synthetic span.
+        // Shared by the E340 unresolvable-index pass and the E341
+        // undeclared-path pass below.
+        let doc_node_line: HashMap<crate::plan::PlanNodeId, u32> = self
+            .nodes
+            .iter()
+            .zip(artifacts.top_level_node_ids.iter())
+            .filter_map(|(sp, id)| {
+                let line = sp.referenced.line();
+                (line > 0).then_some((*id, line as u32))
+            })
+            .collect();
+        // Top-level node-name → source line, for diagnostics keyed by a
+        // user-facing source name rather than a node id (the REST-envelope
+        // E349 pass below).
+        let doc_node_line_by_name: HashMap<&str, u32> = self
             .nodes
             .iter()
             .filter_map(|sp| {
@@ -849,10 +867,10 @@ impl PipelineConfig {
             })
             .collect();
         if !doc_path_set.unresolvable.is_empty() {
-            for (scoped, d) in &doc_path_set.unresolvable {
-                // doc_node_line is top-level-only; a body node falls back to
-                // SYNTHETIC, so look it up by the scoped key's bare name.
-                let primary = match doc_node_line.get(scoped.name.as_str()) {
+            for (node_id, d) in &doc_path_set.unresolvable {
+                // doc_node_line is top-level-only; a body node has no entry
+                // and falls back to SYNTHETIC.
+                let primary = match doc_node_line.get(node_id) {
                     Some(&line) => Span::line_only(line),
                     None => Span::SYNTHETIC,
                 };
@@ -875,12 +893,12 @@ impl PipelineConfig {
         // run must not stamp the pipeline-wide union onto every source —
         // a source would otherwise be told to extract envelope sections
         // its own document never declares.
-        let node_sources = build_node_source_sets(&self.nodes, &artifacts);
+        let node_sources = build_node_source_sets(&self.nodes, &top_level_ids, &artifacts);
         let mut doc_paths_by_source: HashMap<String, std::collections::BTreeSet<_>> =
             HashMap::new();
         for (doc_path, nodes) in &doc_path_set.by_node {
-            for scoped in nodes {
-                let Some(sources) = node_sources.get(*scoped) else {
+            for node_id in nodes {
+                let Some(sources) = node_sources.get(node_id) else {
                     continue;
                 };
                 for source in sources {
@@ -938,10 +956,10 @@ impl PipelineConfig {
             if sections.is_empty() {
                 continue;
             }
-            let Some(feeding) = node_sources.get(&crate::plan::bind_schema::ScopedNodeId {
-                scope: crate::plan::bind_schema::NodeScope::TopLevel,
-                name: output.name.clone(),
-            }) else {
+            let Some(feeding) = top_level_ids
+                .get(output.name.as_str())
+                .and_then(|id| node_sources.get(id))
+            else {
                 continue;
             };
             for source_name in feeding {
@@ -1010,7 +1028,7 @@ impl PipelineConfig {
             if let SourceTransport::Rest(_) = source.transport
                 && source.envelope.is_some()
             {
-                let primary = doc_node_line
+                let primary = doc_node_line_by_name
                     .get(source.name.as_str())
                     .map(|&line| Span::line_only(line))
                     .unwrap_or(Span::SYNTHETIC);
@@ -1037,15 +1055,15 @@ impl PipelineConfig {
             }
         }
         for (doc_path, ref_nodes) in &doc_path_set.by_node {
-            for scoped in ref_nodes {
-                let Some(sources) = node_sources.get(*scoped) else {
+            for node_id in ref_nodes {
+                let Some(sources) = node_sources.get(node_id) else {
                     continue;
                 };
                 for source_name in sources {
                     let Some(source) = source_by_name.get(source_name.as_str()) else {
                         continue;
                     };
-                    let primary = match doc_node_line.get(scoped.name.as_str()) {
+                    let primary = match doc_node_line.get(node_id) {
                         Some(&line) => Span::line_only(line),
                         None => Span::SYNTHETIC,
                     };
@@ -1169,7 +1187,7 @@ impl PipelineConfig {
         // emitted with `window_index = None`; a post-edge-wiring pass
         // populates the deduplicated index list and backfills the
         // field once the upstream `NodeIndex` is known.
-        for spanned in &self.nodes {
+        for (position, spanned) in self.nodes.iter().enumerate() {
             // Thread the real source line number off the saphyr
             // `Spanned<PipelineNode>::referenced` Location.
             // (c) If saphyr did not capture a line (the documented
@@ -1189,15 +1207,13 @@ impl PipelineConfig {
                 window_config: entry_idx.and_then(|i| window_configs[i].as_ref()),
                 primary_source: primary_source.as_str(),
             };
-            let plan_node = lower_node_to_plan_node(
-                node,
-                &name,
-                crate::plan::bind_schema::NodeScope::TopLevel,
-                span,
-                &artifacts,
-                &lowering_ctx,
-                &mut diags,
-            );
+            // Stamp the id minted by `bind_schema` for this declaration
+            // position. Indexing by ORIGINAL position (not lowered-node
+            // count) keeps the pairing correct even when an earlier node
+            // bound but did not lower (e.g. a failed-binding composition).
+            let id = artifacts.top_level_node_ids[position];
+            let plan_node =
+                lower_node_to_plan_node(node, id, span, &artifacts, &lowering_ctx, &mut diags);
             if let Some(pn) = plan_node {
                 let idx = graph.add_node(pn);
                 name_to_idx.insert(name, idx);
@@ -1493,21 +1509,17 @@ impl PipelineConfig {
                         // E150e — windows over Combine emit columns
                         // cannot reference an array-typed field. The
                         // typed `output_row` lives in `artifacts.typed`
-                        // keyed by the combine's scope-qualified id and
-                        // carries the CXL `Type` per emitted column; a
+                        // keyed by the combine's `PlanNodeId` and carries
+                        // the CXL `Type` per emitted column; a
                         // `match: collect` body emits `Type::Array` for
                         // every collected build-row column. Window
                         // builtins (sum/avg/min/max/lag/lead/...) do
                         // not handle `Value::Array`, so they would
-                        // silently see Null at runtime. This pass walks
-                        // the top-level analysis report, so the combine
-                        // is resolved by its TopLevel key.
+                        // silently see Null at runtime. The live combine
+                        // node is in hand, so resolve by its own id.
                         if let crate::plan::execution::PlanNode::Combine { .. } = other {
                             let combine_name = other.name();
-                            if let Some(typed) = artifacts.typed_get(
-                                crate::plan::bind_schema::NodeScope::TopLevel,
-                                combine_name,
-                            ) {
+                            if let Some(typed) = artifacts.typed_get(other.id()) {
                                 for f in &report.transforms[i].accessed_fields {
                                     let is_array = typed
                                         .output_row
@@ -1713,7 +1725,7 @@ impl PipelineConfig {
         // operator-level enforcer pass so the latter sees every
         // CK-driven sort already in place. No-op for sources that
         // declared no `correlation_key:`.
-        if let Err(e) = dag.inject_correlation_sort(&source_bodies) {
+        if let Err(e) = dag.inject_correlation_sort(&source_bodies, &mut artifacts) {
             diags.push(Diagnostic::error(
                 "E003",
                 format!("correlation-sort injection failed: {e}"),
@@ -1721,7 +1733,7 @@ impl PipelineConfig {
             ));
             return Err(diags);
         }
-        if let Err(e) = dag.insert_enforcer_sorts(&format_inputs_map) {
+        if let Err(e) = dag.insert_enforcer_sorts(&format_inputs_map, &mut artifacts) {
             diags.push(Diagnostic::error(
                 "E003",
                 format!("enforcer-sort insertion failed: {e}"),
@@ -1744,6 +1756,9 @@ impl PipelineConfig {
                 return Err(diags);
             }
         };
+        // Correlation-sort + enforcer-sort passes grew the graph; refresh
+        // the id→index bridge against the new node set.
+        dag.rebuild_id_index();
         crate::plan::execution::assign_tiers(&mut dag.graph, &dag.topo_order);
         if let Err(e) = dag.compute_node_properties(&inputs_map) {
             diags.push(Diagnostic::error(
@@ -1963,6 +1978,10 @@ impl PipelineConfig {
                 return Err(diags);
             }
         };
+        // N-ary decomposition added the (N-2) synthetic chain steps;
+        // refresh the bridge so their ids resolve and any reused-node
+        // index shift is reflected.
+        dag.rebuild_id_index();
 
         // Seed the statistics catalog's Plane A row counts from source
         // file metadata before the combine post-pass reads them. Uses the
@@ -2116,7 +2135,9 @@ impl PipelineConfig {
         // commit node and its incoming edges change the order. No-op
         // when no source declares a correlation key.
         let max_group_buffer = self.error_handling.max_group_buffer.unwrap_or(100_000);
-        if let Err(e) = dag.inject_correlation_commit(&source_bodies, max_group_buffer) {
+        if let Err(e) =
+            dag.inject_correlation_commit(&source_bodies, max_group_buffer, &mut artifacts)
+        {
             diags.push(Diagnostic::error(
                 "E003",
                 format!("correlation-commit injection failed: {e}"),
@@ -2143,6 +2164,10 @@ impl PipelineConfig {
                     return Err(diags);
                 }
             };
+            // The terminal commit node and its edges changed the graph;
+            // this is the last structural mutation, so refresh the bridge
+            // to its final state.
+            dag.rebuild_id_index();
         }
 
         // E152 — every PlanNode::Composition's incoming edges must carry
@@ -3123,7 +3148,7 @@ fn rest_doc_access_diagnostic(
 /// input's source set alone — using the union would tell the probe-side
 /// source to extract envelope sections only the driver's document
 /// declares. Both the Combine's `cxl:` body and its `where:` predicate
-/// program are keyed by the combine node's own name, so they share this
+/// program are keyed by the combine node's `PlanNodeId`, so they share this
 /// driving-input source set with no extra handling.
 ///
 /// A `Composition` forwards the union of EVERY bound `inputs:` port's
@@ -3139,43 +3164,37 @@ fn rest_doc_access_diagnostic(
 /// union is the correct attribution.
 fn build_node_source_sets(
     nodes: &[Spanned<PipelineNode>],
+    top_level_ids: &HashMap<&str, crate::plan::PlanNodeId>,
     artifacts: &crate::plan::bind_schema::CompileArtifacts,
-) -> HashMap<crate::plan::bind_schema::ScopedNodeId, std::collections::BTreeSet<String>> {
-    use crate::plan::bind_schema::{NodeScope, ScopedNodeId};
+) -> HashMap<crate::plan::PlanNodeId, std::collections::BTreeSet<String>> {
+    use crate::plan::PlanNodeId;
     use crate::plan::composition_body::CompositionBodyId;
 
-    let mut node_sources: HashMap<ScopedNodeId, std::collections::BTreeSet<String>> =
-        HashMap::new();
+    let mut node_sources: HashMap<PlanNodeId, std::collections::BTreeSet<String>> = HashMap::new();
 
-    // Key for a top-level node. The main loop walks only `self.nodes`
-    // (top-level) and the cross-node lookups resolve top-level upstreams, so
-    // every key built here is TopLevel; body nodes are keyed `Body(id)` by
-    // `attribute_body`.
-    fn top_key(name: &str) -> ScopedNodeId {
-        ScopedNodeId {
-            scope: NodeScope::TopLevel,
-            name: name.to_string(),
-        }
-    }
+    // The id of a top-level node by name. The main loop walks only
+    // `self.nodes` (top-level) and the cross-node lookups resolve top-level
+    // upstreams, so every key built here is a top-level id; body nodes are
+    // keyed by their own id in `attribute_body`. Returns `None` for an
+    // unknown name (an undeclared upstream already diagnosed elsewhere).
+    let top_id = |name: &str| -> Option<PlanNodeId> { top_level_ids.get(name).copied() };
 
     // Attribute every node in a composition body (recursively through
-    // nested bodies) to the call-site's source set, keyed by the body's
-    // scope so a body node named the same as a top-level node stays distinct.
+    // nested bodies) to the call-site's source set, keyed by each body
+    // node's own `PlanNodeId` (read off the body's mini-DAG) so a body node
+    // named the same as a top-level node stays distinct.
     fn attribute_body(
         body_id: CompositionBodyId,
         call_site_sources: &std::collections::BTreeSet<String>,
         artifacts: &crate::plan::bind_schema::CompileArtifacts,
-        node_sources: &mut HashMap<ScopedNodeId, std::collections::BTreeSet<String>>,
+        node_sources: &mut HashMap<PlanNodeId, std::collections::BTreeSet<String>>,
     ) {
         let Some(body) = artifacts.body_of(body_id) else {
             return;
         };
-        for body_node_name in body.name_to_idx.keys() {
+        for &idx in body.name_to_idx.values() {
             node_sources
-                .entry(ScopedNodeId {
-                    scope: NodeScope::Body(body_id),
-                    name: body_node_name.clone(),
-                })
+                .entry(body.graph[idx].id())
                 .or_default()
                 .extend(call_site_sources.iter().cloned());
         }
@@ -3184,11 +3203,12 @@ fn build_node_source_sets(
         }
     }
 
-    // The driving input's upstream node name for a combine, if the
-    // planner picked one (combines that fail driver selection are absent).
-    let combine_driver_upstream = |combine_name: &str| -> Option<String> {
-        let qualifier = artifacts.combine_driving.get(combine_name)?;
-        let inputs = artifacts.combine_inputs.get(combine_name)?;
+    // The driving input's upstream node name for a combine (resolved by the
+    // combine's id), if the planner picked one (combines that fail driver
+    // selection are absent).
+    let combine_driver_upstream = |combine_id: PlanNodeId| -> Option<String> {
+        let qualifier = artifacts.combine_driving.get(&combine_id)?;
+        let inputs = artifacts.combine_inputs.get(&combine_id)?;
         inputs
             .get(qualifier)
             .map(|ci| ci.upstream_name.as_ref().to_string())
@@ -3197,11 +3217,11 @@ fn build_node_source_sets(
     // Union of the source sets feeding the named (top-level) producers,
     // resolved against the sets recorded for already-walked nodes.
     let union_of = |producers: &[&str],
-                    sources: &HashMap<ScopedNodeId, std::collections::BTreeSet<String>>|
+                    sources: &HashMap<PlanNodeId, std::collections::BTreeSet<String>>|
      -> std::collections::BTreeSet<String> {
         producers
             .iter()
-            .filter_map(|inp| sources.get(&top_key(inp)))
+            .filter_map(|inp| top_id(inp).and_then(|id| sources.get(&id)))
             .flat_map(|s| s.iter().cloned())
             .collect()
     };
@@ -3214,7 +3234,7 @@ fn build_node_source_sets(
     // a body `$doc` access, can resolve against any bound port's source.
     let composition_call_site_sources =
         |inputs: &IndexMap<String, String>,
-         sources: &HashMap<ScopedNodeId, std::collections::BTreeSet<String>>|
+         sources: &HashMap<PlanNodeId, std::collections::BTreeSet<String>>|
          -> std::collections::BTreeSet<String> {
             let producers: Vec<&str> = inputs
                 .values()
@@ -3232,8 +3252,13 @@ fn build_node_source_sets(
             // not the union of every input. Falls back to the input union
             // when the planner could not pick a driver (the combine is then
             // omitted from the DAG, so the set is unused either way).
-            PipelineNode::Combine { .. } => combine_driver_upstream(&name)
-                .and_then(|driver| node_sources.get(&top_key(&driver)).cloned())
+            PipelineNode::Combine { .. } => top_id(&name)
+                .and_then(combine_driver_upstream)
+                .and_then(|driver| {
+                    top_id(&driver)
+                        .and_then(|id| node_sources.get(&id))
+                        .cloned()
+                })
                 .unwrap_or_else(|| union_of(&spanned.value.direct_input_names(), &node_sources)),
             // A composition forwards the union of EVERY bound input port's
             // source set, not just its primary port — a downstream node
@@ -3254,12 +3279,15 @@ fn build_node_source_sets(
         // envelope. That union is exactly the source set the Composition
         // arm above computed into `sources`, so reuse it.
         if let PipelineNode::Composition { .. } = &spanned.value
-            && let Some(&body_id) = artifacts.composition_body_assignments.get(&name)
+            && let Some(comp_id) = top_id(&name)
+            && let Some(&body_id) = artifacts.composition_body_assignments.get(&comp_id)
         {
             attribute_body(body_id, &sources, artifacts, &mut node_sources);
         }
 
-        node_sources.insert(top_key(&name), sources);
+        if let Some(id) = top_id(&name) {
+            node_sources.insert(id, sources);
+        }
     }
 
     node_sources
@@ -3298,13 +3326,13 @@ pub(crate) struct LoweringCtx<'a> {
 /// `LoweringCtx::default()` for body nodes.
 pub(crate) fn lower_node_to_plan_node(
     node: &PipelineNode,
-    name: &str,
-    scope: crate::plan::bind_schema::NodeScope,
+    id: crate::plan::PlanNodeId,
     span: clinker_core_types::span::Span,
     artifacts: &crate::plan::bind_schema::CompileArtifacts,
     ctx: &LoweringCtx<'_>,
     diags: &mut Vec<clinker_core_types::Diagnostic>,
 ) -> Option<crate::plan::execution::PlanNode> {
+    let name = node.name();
     use crate::plan::composition_body::CompositionBodyId;
     use crate::plan::execution::{
         NodeExecutionReqs, ParallelismClass, PartitionLookupKind, PlanNode, PlanOutputPayload,
@@ -3336,8 +3364,8 @@ pub(crate) fn lower_node_to_plan_node(
     // Aggregate / Combine output row inherits a `$ck.*` column, its
     // own `Arc<Schema>` recovers the same metadata here. The reserved
     // `$` prefix guarantees no user-declared column collides.
-    let schema_from_bound = |node_name: &str| -> Arc<clinker_record::Schema> {
-        match artifacts.typed_get(scope, node_name) {
+    let schema_from_bound = || -> Arc<clinker_record::Schema> {
+        match artifacts.typed_get(id) {
             Some(tp) => {
                 let mut builder = SchemaBuilder::with_capacity(tp.output_row.field_count());
                 for (qf, _) in tp.output_row.fields() {
@@ -3381,18 +3409,19 @@ pub(crate) fn lower_node_to_plan_node(
             let source = config.source.clone();
             Some(PlanNode::Source {
                 name: name.to_string(),
+                id,
                 span,
                 resolved: Some(Box::new(PlanSourcePayload {
                     source,
                     validated_path: None,
                 })),
-                output_schema: schema_from_bound(name),
+                output_schema: schema_from_bound(),
             })
         }
         PipelineNode::Transform { config, .. } => {
             // Missing typed program means bind_schema hit a CXL error
             // (E108, E200, etc.) on this node — skip lowering.
-            let typed = match artifacts.typed_get(scope, name) {
+            let typed = match artifacts.typed_get(id) {
                 Some(t) => t.clone(),
                 None => return None,
             };
@@ -3453,6 +3482,7 @@ pub(crate) fn lower_node_to_plan_node(
             let has_distinct = extract_has_distinct(&typed);
             Some(PlanNode::Transform {
                 name: name.to_string(),
+                id,
                 span,
                 resolved: Some(Box::new(PlanTransformPayload {
                     analytic_window: config.analytic_window.clone(),
@@ -3471,11 +3501,12 @@ pub(crate) fn lower_node_to_plan_node(
                 partition_lookup,
                 write_set,
                 has_distinct,
-                output_schema: schema_from_bound(name),
+                output_schema: schema_from_bound(),
             })
         }
         PipelineNode::Output { config, .. } => Some(PlanNode::Output {
             name: name.to_string(),
+            id,
             span,
             resolved: Some(Box::new(PlanOutputPayload {
                 output: config.output.clone(),
@@ -3485,6 +3516,7 @@ pub(crate) fn lower_node_to_plan_node(
         }),
         PipelineNode::Route { config, .. } => Some(PlanNode::Route {
             name: name.to_string(),
+            id,
             span,
             mode: config.mode,
             branches: config.conditions.keys().cloned().collect(),
@@ -3492,8 +3524,9 @@ pub(crate) fn lower_node_to_plan_node(
         }),
         PipelineNode::Merge { .. } => Some(PlanNode::Merge {
             name: name.to_string(),
+            id,
             span,
-            output_schema: schema_from_bound(name),
+            output_schema: schema_from_bound(),
         }),
         PipelineNode::Composition { .. } => {
             // Look up the body assigned by bind_composition. If binding
@@ -3501,7 +3534,7 @@ pub(crate) fn lower_node_to_plan_node(
             // node (the binding errors already surfaced in Stage 4.5).
             let body_id = artifacts
                 .composition_body_assignments
-                .get(name)
+                .get(&id)
                 .copied()
                 .unwrap_or(CompositionBodyId::SENTINEL);
             if body_id == CompositionBodyId::SENTINEL {
@@ -3526,6 +3559,7 @@ pub(crate) fn lower_node_to_plan_node(
                 .unwrap_or_else(|| SchemaBuilder::new().build());
             Some(PlanNode::Composition {
                 name: name.to_string(),
+                id,
                 span,
                 body: body_id,
                 output_schema: comp_output_schema,
@@ -3535,7 +3569,7 @@ pub(crate) fn lower_node_to_plan_node(
             config: agg_body, ..
         } => {
             // Skip if bind_schema produced no typed program (CXL error).
-            let typed = match artifacts.typed_get(scope, name) {
+            let typed = match artifacts.typed_get(id) {
                 Some(t) => t.clone(),
                 None => return None,
             };
@@ -3590,14 +3624,15 @@ pub(crate) fn lower_node_to_plan_node(
             // aggregate's `output_schema` and the runtime
             // `finalize_group_inner` had no slot to populate from the
             // group key.
-            let output_schema = schema_from_bound(name);
+            let output_schema = schema_from_bound();
             // Carry the typed program and its distinct-ness on the node so the
             // executor builds its per-group evaluator off the node instead of a
-            // scope-keyed startup table; `has_distinct` records whether the
+            // separate startup table; `has_distinct` records whether the
             // typed program contains a `distinct` statement.
             let has_distinct = extract_has_distinct(&typed);
             Some(PlanNode::Aggregation {
                 name: name.to_string(),
+                id,
                 span,
                 config: agg_cfg,
                 compiled: Arc::new(compiled_agg),
@@ -3631,36 +3666,34 @@ pub(crate) fn lower_node_to_plan_node(
             use crate::plan::combine::{CombinePredicateSummary, CombineStrategy};
             let predicate_summary = artifacts
                 .combine_predicates
-                .get(name)
+                .get(&id)
                 .map(CombinePredicateSummary::from_decomposed)
                 .unwrap_or_default();
             let resolved_column_map = artifacts
                 .combine_resolved_columns
-                .get(name)
+                .get(&id)
                 .cloned()
                 .unwrap_or_else(|| Arc::new(std::collections::HashMap::new()));
             // Carry the typed `cxl:` body program on the node, mirroring the
             // Transform arm's read into `PlanTransformPayload.typed`. Body and
             // top-level combines both flow through this arm; the `typed` table
-            // is keyed by `ScopedNodeId`, so the read resolves this node
+            // is keyed by `PlanNodeId`, so the read resolves this node
             // instance's own program even when a top-level and a body combine
             // share a name. `None` is legitimate here — a body-less combine
             // (e.g. `match: collect`) carries no program.
-            let typed = artifacts.typed_get(scope, name).cloned();
+            let typed = artifacts.typed_get(id).cloned();
             // Carry the per-input metadata, decomposed `where:` predicate, and
             // bind-time driving qualifier on the node so combine strategy
-            // selection and the executor read them by node instance instead of
-            // a bare-name lookup into `CompileArtifacts` (last-writer-wins
-            // across same-named combines in sibling composition bodies). Like
-            // `resolved_column_map`, these maps are still bare-name keyed, so
-            // the read here is transiently scope-correct because each body is
-            // bound then lowered before the next body overwrites the shared map
-            // entry.
-            let combine_inputs = artifacts.combine_inputs.get(name).cloned();
-            let decomposed_predicate = artifacts.combine_predicates.get(name).cloned();
-            let combine_driving = artifacts.combine_driving.get(name).cloned();
+            // selection and the executor read them by node instance. All three
+            // side-tables are keyed by `PlanNodeId`, so the read resolves this
+            // node's own entry even when a top-level and a body combine share a
+            // name.
+            let combine_inputs = artifacts.combine_inputs.get(&id).cloned();
+            let decomposed_predicate = artifacts.combine_predicates.get(&id).cloned();
+            let combine_driving = artifacts.combine_driving.get(&id).cloned();
             Some(crate::plan::execution::PlanNode::Combine {
                 name: name.to_string(),
+                id,
                 span,
                 strategy: CombineStrategy::HashBuildProbe,
                 driving_input: String::new(),
@@ -3671,7 +3704,7 @@ pub(crate) fn lower_node_to_plan_node(
                 on_miss: config.on_miss,
                 propagate_ck: config.propagate_ck.clone(),
                 decomposed_from: None,
-                output_schema: schema_from_bound(name),
+                output_schema: schema_from_bound(),
                 resolved_column_map,
                 typed,
                 combine_inputs,
@@ -3687,12 +3720,13 @@ pub(crate) fn lower_node_to_plan_node(
         PipelineNode::Reshape { config, .. } => {
             // A missing typed entry means bind_schema rejected the node
             // (E200 on a rule predicate / assignment) — skip lowering.
-            artifacts.typed_get(scope, name)?;
+            artifacts.typed_get(id)?;
             Some(crate::plan::execution::PlanNode::Reshape {
                 name: name.to_string(),
+                id,
                 span,
                 config: config.clone(),
-                output_schema: schema_from_bound(name),
+                output_schema: schema_from_bound(),
             })
         }
         // Cull lowers to PlanNode::Cull carrying the parsed config and the
@@ -3703,12 +3737,13 @@ pub(crate) fn lower_node_to_plan_node(
         PipelineNode::Cull { config, .. } => {
             // A missing typed entry means bind_schema rejected the node
             // (E200 on a rule predicate / removed_to) — skip lowering.
-            artifacts.typed_get(scope, name)?;
+            artifacts.typed_get(id)?;
             Some(crate::plan::execution::PlanNode::Cull {
                 name: name.to_string(),
+                id,
                 span,
                 config: config.clone(),
-                output_schema: schema_from_bound(name),
+                output_schema: schema_from_bound(),
             })
         }
         // Envelope lowers carrying the framing strategy, the body's (unchanged)
@@ -3719,7 +3754,7 @@ pub(crate) fn lower_node_to_plan_node(
         // `resolve_envelope_header_upstreams` post-pass fills it. A missing
         // typed entry means bind_schema could not resolve the body input — skip.
         PipelineNode::Envelope { header, config } => {
-            artifacts.typed_get(scope, name)?;
+            artifacts.typed_get(id)?;
             let header_input = header
                 .header
                 .as_ref()
@@ -3734,14 +3769,15 @@ pub(crate) fn lower_node_to_plan_node(
             // `config.header:` / `config.footer:` map) was built during binding
             // against the body input row and stashed in `CompileArtifacts`;
             // attach it here. Absent → the node synthesizes nothing.
-            let synthesis = artifacts.envelope_synthesis.get(name).map(Arc::clone);
+            let synthesis = artifacts.envelope_synthesis.get(&id).map(Arc::clone);
             Some(crate::plan::execution::PlanNode::Envelope {
                 name: name.to_string(),
+                id,
                 span,
                 strategy: config.strategy,
                 header_input,
                 header_upstream: None,
-                output_schema: schema_from_bound(name),
+                output_schema: schema_from_bound(),
                 synthesis,
             })
         }

--- a/crates/clinker-plan/src/lib.rs
+++ b/crates/clinker-plan/src/lib.rs
@@ -23,8 +23,7 @@ pub use config::{
 };
 pub use error::PipelineError;
 pub use plan::{
-    BoundBody, ColumnLookup, CompositionBodyId, NodeScope, QualifiedField, Row, RowTail,
-    ScopedNodeId, TailVarId,
+    BoundBody, ColumnLookup, CompositionBodyId, QualifiedField, Row, RowTail, TailVarId,
 };
 pub use runtime_error::{BudgetCategory, SpillError};
 

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -4,7 +4,7 @@
 //! source's schema from its author-declared `schema:` block, typechecks
 //! every Transform/Aggregate/Route body against the upstream Row, and
 //! propagates the output Row downstream. Result: a `CompileArtifacts`
-//! map keyed by each node's `ScopedNodeId` holding one `Arc<TypedProgram>`
+//! map keyed by each node's `PlanNodeId` holding one `Arc<TypedProgram>`
 //! per CXL-bearing node.
 //!
 //! For `PipelineNode::Composition` nodes, `bind_composition` recursively
@@ -41,6 +41,7 @@ use crate::plan::combine::{
 };
 use crate::plan::composition_body::{BoundBody, CompositionBodyId};
 use crate::plan::types::JoinSide;
+use crate::plan::{EntityRef, PlanNodeId};
 use crate::yaml::Spanned;
 use clinker_core_types::span::{FileId, Span};
 use clinker_core_types::{Diagnostic, LabeledSpan};
@@ -53,50 +54,33 @@ use clinker_core_types::{Diagnostic, LabeledSpan};
 /// so log-grep on either code finds exactly one emission site.
 pub const MAX_COMPOSITION_DEPTH: u32 = 50;
 
-/// Scope a plan node lives in. Top-level pipeline, or a specific composition body.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum NodeScope {
-    TopLevel,
-    Body(crate::plan::composition_body::CompositionBodyId),
-}
-
-/// Scope-qualified node identity. Two composition bodies (or top-level + a body)
-/// can hold same-named nodes; this pair disambiguates them where a bare node
-/// name would collide. Mirrors dbt's `<package>.<name>` and Beam's hierarchical
-/// node name.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ScopedNodeId {
-    pub scope: NodeScope,
-    pub name: String,
-}
-
 /// Compile artifacts produced by `bind_schema` — one entry per node
 /// whose CXL body successfully type-checked, plus per-node row types.
 #[derive(Debug, Default, Clone)]
 pub struct CompileArtifacts {
     /// Per-node typed CXL program (transform/aggregate/combine-body plus
     /// the synthetic pass-through programs for Source/Merge/Output/etc.),
-    /// keyed by the node's [`ScopedNodeId`]. The scope qualifier keeps a
-    /// node named the same in two composition scopes — or a top-level node
-    /// sharing a name with a composition-body node — from colliding in this
-    /// shared table; before scope-keying the last writer silently won.
-    /// Acts as the bind → lowering handoff (lowering reads each node's
-    /// program off the scope-correct key to stamp the node) and as the
+    /// keyed by the node's [`PlanNodeId`]. The id is the node's stable
+    /// identity, distinct for every node in the compiled plan — so a node
+    /// named the same in two composition scopes (or a top-level node
+    /// sharing a name with a composition-body node) gets distinct ids and
+    /// cannot collide in this shared table; bare-name keying let the last
+    /// writer silently win. Acts as the bind → lowering handoff (lowering
+    /// reads each node's program off its id to stamp the node) and as the
     /// compile-time `$doc` path-walk source.
-    pub typed: HashMap<ScopedNodeId, Arc<TypedProgram>>,
+    pub typed: HashMap<PlanNodeId, Arc<TypedProgram>>,
     /// Per-Combine `where:` predicate typed programs, keyed by the
-    /// combine node's [`ScopedNodeId`]. The node-keyed `typed` map stores
+    /// combine node's [`PlanNodeId`]. The node-keyed `typed` map stores
     /// only a Combine's `cxl:` body; the `where:` predicate is decomposed
     /// into `combine_predicates` and otherwise discarded as a standalone
     /// program. This side-table retains it so a `$doc` access used ONLY
     /// in a predicate (e.g. `l.amount > $doc.Head.cutoff`) is still
     /// reachable by the compile-time `$doc` path walk. Compile-time-only:
-    /// the runtime executor never reads it. The scope qualifier keeps a
-    /// combine named the same in two composition scopes from colliding;
-    /// klinx reads the `where` program back by `(scope, name)`.
-    pub combine_where_typed: HashMap<ScopedNodeId, Arc<TypedProgram>>,
+    /// the runtime executor never reads it. The per-node id keeps a
+    /// combine named the same in two composition scopes from colliding.
+    pub combine_where_typed: HashMap<PlanNodeId, Arc<TypedProgram>>,
     /// Per-Route branch-condition typed programs, keyed by the Route
-    /// node's [`ScopedNodeId`] — one program per branch, in declaration
+    /// node's [`PlanNodeId`] — one program per branch, in declaration
     /// order. A Route's node-keyed `typed` entry is an empty body (the
     /// node carries no `cxl:` projection); the branch conditions are
     /// otherwise compiled straight to runtime evaluators and never land
@@ -104,34 +88,38 @@ pub struct CompileArtifacts {
     /// ONLY in a route condition (e.g. `amount > $doc.Head.cutoff`) is
     /// still reachable by the compile-time `$doc` path walk and attributed
     /// to the Route's source(s). Compile-time-only: the runtime executor
-    /// never reads it. The scope qualifier keeps a route named the same in
+    /// never reads it. The per-node id keeps a route named the same in
     /// two composition scopes from colliding.
-    pub route_branch_typed: HashMap<ScopedNodeId, Vec<Arc<TypedProgram>>>,
+    pub route_branch_typed: HashMap<PlanNodeId, Vec<Arc<TypedProgram>>>,
     /// All bound composition bodies, keyed by `CompositionBodyId`. The
     /// top-level pipeline is NOT in this map — it lives on
     /// `CompiledPlan.dag()` directly. Only body scopes are here.
     pub composition_bodies: IndexMap<CompositionBodyId, BoundBody>,
     /// Monotonic counter for allocating fresh `CompositionBodyId`s.
     next_body_id: u32,
-    /// Mapping from composition node name to its assigned body ID.
-    /// Populated by `bind_composition`; consumed by `compile()` Stage 5
-    /// to write the body ID back onto the `PipelineNode::Composition`
-    /// variant (which was borrowed immutably during bind_schema).
-    pub composition_body_assignments: HashMap<String, CompositionBodyId>,
+    /// Mapping from a composition call-site node's [`PlanNodeId`] to its
+    /// assigned body ID. Populated by `bind_composition`; consumed by
+    /// `compile()` Stage 5 to write the body ID back onto the
+    /// `PipelineNode::Composition` variant (which was borrowed immutably
+    /// during bind_schema). The per-node id keeps a composition node named
+    /// the same in two composition scopes from colliding — bare-name keying
+    /// let the last writer silently win.
+    pub composition_body_assignments: HashMap<PlanNodeId, CompositionBodyId>,
     /// Monotonic counter for allocating fresh `FileId`s for body re-parses.
     next_file_id: u32,
     /// Side-table of provenance-tracked config values. Populated by
     /// `bind_composition` for each composition node's config params.
     pub provenance: ProvenanceDb,
-    /// Decomposed `where:` predicates per combine node, keyed by combine
-    /// node name. Populated by the predicate-decomposition pass; consumed
-    /// by combine strategy selection.
-    pub combine_predicates: HashMap<String, DecomposedPredicate>,
-    /// Per-input metadata per combine node, keyed by combine node name.
-    /// The inner `IndexMap` preserves declaration order of the inputs
-    /// (matches `CombineHeader.input` iteration order). Populated during
-    /// schema propagation.
-    pub combine_inputs: HashMap<String, IndexMap<String, CombineInput>>,
+    /// Decomposed `where:` predicates per combine node, keyed by the
+    /// combine node's [`PlanNodeId`]. Populated by the
+    /// predicate-decomposition pass; consumed by combine strategy
+    /// selection.
+    pub combine_predicates: HashMap<PlanNodeId, DecomposedPredicate>,
+    /// Per-input metadata per combine node, keyed by the combine node's
+    /// [`PlanNodeId`]. The inner `IndexMap` preserves declaration order of
+    /// the inputs (matches `CombineHeader.input` iteration order).
+    /// Populated during schema propagation.
+    pub combine_inputs: HashMap<PlanNodeId, IndexMap<String, CombineInput>>,
     /// Planner-wide column-statistics catalog. The single facility every
     /// node consults for row counts, distinct counts, heavy hitters, and
     /// membership. Plane A row counts are seeded from source file metadata
@@ -139,90 +127,96 @@ pub struct CompileArtifacts {
     /// in after a run. Combine strategy selection reads its row counts
     /// instead of a per-input cardinality field.
     pub statistics: crate::plan::statistics::StatisticsCatalog,
-    /// Driving-input qualifier per combine node, chosen at `bind_combine`
-    /// time by [`select_driving_input`] (explicit `drive:` → cardinality
-    /// → first-in-IndexMap default). The `select_combine_strategies`
+    /// Driving-input qualifier per combine node, keyed by the combine
+    /// node's [`PlanNodeId`]; the value is the chosen driving input's
+    /// qualifier string. Chosen at `bind_combine` time by
+    /// [`select_driving_input`] (explicit `drive:` → cardinality →
+    /// first-in-IndexMap default). The `select_combine_strategies`
     /// post-pass reads this to stamp the runtime
     /// `PlanNode::Combine.driving_input` field. Combines that fail driver
     /// selection (E306) are absent from this map and their post-pass
     /// entry is skipped.
-    pub combine_driving: HashMap<String, String>,
+    pub combine_driving: HashMap<PlanNodeId, String>,
     /// User-supplied [`CombineStrategyHint`] per combine node, keyed by
-    /// node name. Populated from `CombineBody.strategy` during
-    /// `bind_combine`. The `select_combine_strategies` post-pass reads
-    /// this to override the planner's predicate-shape default — today
-    /// only `GraceHash` on pure-equi predicates produces a non-default
-    /// outcome. Combines absent from this map default to
-    /// [`CombineStrategyHint::Auto`].
-    pub combine_strategy_hints: HashMap<String, crate::config::CombineStrategyHint>,
+    /// the combine node's [`PlanNodeId`]. Populated from
+    /// `CombineBody.strategy` during `bind_combine`. The
+    /// `select_combine_strategies` post-pass reads this to override the
+    /// planner's predicate-shape default — today only `GraceHash` on
+    /// pure-equi predicates produces a non-default outcome. Combines
+    /// absent from this map default to [`CombineStrategyHint::Auto`].
+    pub combine_strategy_hints: HashMap<PlanNodeId, crate::config::CombineStrategyHint>,
     /// Per-combine pre-resolved column map produced by the CXL
-    /// typechecker's combine-body walk. Key is the combine node's
-    /// name; value is the `ResolvedColumnMap` shape expected by
+    /// typechecker's combine-body walk. Keyed by the combine node's
+    /// [`PlanNodeId`]; value is the `ResolvedColumnMap` shape expected by
     /// `CombineResolverMapping::from_pre_resolved`. Combines that fail
     /// body typecheck (or the collect-mode path, which has no body)
     /// surface an empty map here.
-    pub combine_resolved_columns: HashMap<String, crate::plan::execution::ResolvedColumnMap>,
+    pub combine_resolved_columns: HashMap<PlanNodeId, crate::plan::execution::ResolvedColumnMap>,
     /// Compiled declarative header/footer synthesis per Envelope node, keyed
-    /// by node name. Populated during binding (where the body input `Row` is
-    /// in scope) for every Envelope that declares a `config.header:` or
-    /// `config.footer:` map; consumed at lowering to attach the spec to
-    /// `PlanNode::Envelope.synthesis`. An Envelope declaring neither is absent
-    /// from this map and lowers with `synthesis: None`.
+    /// by the node's [`PlanNodeId`]. Populated during binding (where the body
+    /// input `Row` is in scope) for every Envelope that declares a
+    /// `config.header:` or `config.footer:` map; consumed at lowering to
+    /// attach the spec to `PlanNode::Envelope.synthesis`. An Envelope
+    /// declaring neither is absent from this map and lowers with
+    /// `synthesis: None`. The per-node id keeps a top-level Envelope and a
+    /// composition-body Envelope sharing a name (both declaring header/footer)
+    /// from colliding — bare-name keying let the last writer silently win.
     pub envelope_synthesis:
-        HashMap<String, Arc<crate::plan::envelope_synthesis::EnvelopeSynthesis>>,
+        HashMap<PlanNodeId, Arc<crate::plan::envelope_synthesis::EnvelopeSynthesis>>,
     /// Monotonic counter for fresh tail-variable IDs allocated during
     /// row-polymorphic propagation (composition input-port binding).
     /// Threaded as `&mut u32` into `build_input_port_rows`; IDs are
     /// only comparable within a single `compile()` run.
     pub next_tail_var: u32,
+    /// Monotonic counter minting fresh [`PlanNodeId`]s. ONE counter feeds
+    /// top-level nodes, every composition body, and every planner-
+    /// synthesized node, so two instantiations of one composition body
+    /// get disjoint id sets by construction. Only comparable within a
+    /// single `compile()` run.
+    next_node_id: u32,
+    /// Minted `PlanNodeId`s for the top-level pipeline nodes, in
+    /// declaration order: index `i` is the id for `nodes[i]` as passed to
+    /// [`bind_schema`]. Minted before any body recursion so the top-level
+    /// ids occupy the low, stable range. Stage-5 lowering stamps each
+    /// lowered top-level `PlanNode.id` from this vector by the node's
+    /// original declaration position, which stays correct even when
+    /// lowering omits a node `bind_schema` visited (e.g. a
+    /// failed-binding composition).
+    pub top_level_node_ids: Vec<PlanNodeId>,
 }
 
 impl CompileArtifacts {
-    /// Look up a node's typed CXL program by its scope-qualified identity.
-    /// The lookup allocates the key's `String`; the table is per-node and
-    /// only read at compile time and executor startup, so this is not hot.
-    pub fn typed_get(&self, scope: NodeScope, name: &str) -> Option<&Arc<TypedProgram>> {
-        self.typed.get(&ScopedNodeId {
-            scope,
-            name: name.to_string(),
-        })
+    /// Look up a node's typed CXL program by its stable [`PlanNodeId`].
+    /// The table is per-node and only read at compile time and executor
+    /// startup, so this is not hot.
+    pub fn typed_get(&self, id: PlanNodeId) -> Option<&Arc<TypedProgram>> {
+        self.typed.get(&id)
     }
 
-    /// Whether a typed program is recorded for `(scope, name)`.
-    pub fn typed_contains(&self, scope: NodeScope, name: &str) -> bool {
-        self.typed_get(scope, name).is_some()
+    /// Whether a typed program is recorded for `id`.
+    pub fn typed_contains(&self, id: PlanNodeId) -> bool {
+        self.typed.contains_key(&id)
     }
 
-    /// Record a node's typed CXL program under its scope-qualified identity.
-    pub fn typed_insert(
-        &mut self,
-        scope: NodeScope,
-        name: impl Into<String>,
-        prog: Arc<TypedProgram>,
-    ) {
-        self.typed.insert(
-            ScopedNodeId {
-                scope,
-                name: name.into(),
-            },
-            prog,
-        );
-    }
-
-    /// Drop a node's typed CXL program by its scope-qualified identity.
-    /// Used by N-ary combine decomposition when the original combine's
-    /// name leaves the graph.
-    pub fn typed_remove(&mut self, scope: NodeScope, name: &str) -> Option<Arc<TypedProgram>> {
-        self.typed.remove(&ScopedNodeId {
-            scope,
-            name: name.to_string(),
-        })
+    /// Record a node's typed CXL program under its [`PlanNodeId`].
+    pub fn typed_insert(&mut self, id: PlanNodeId, prog: Arc<TypedProgram>) {
+        self.typed.insert(id, prog);
     }
 
     /// Allocate a fresh, unique `CompositionBodyId`.
     pub fn fresh_body_id(&mut self) -> CompositionBodyId {
         let id = CompositionBodyId(self.next_body_id);
         self.next_body_id += 1;
+        id
+    }
+
+    /// Mint the next fresh [`PlanNodeId`] from the single per-`compile()`
+    /// counter. Every node identity in a compiled plan — top-level, body,
+    /// and planner-synthesized — flows through here, so ids never collide
+    /// across scopes.
+    pub fn fresh_node_id(&mut self) -> PlanNodeId {
+        let id = PlanNodeId::new(self.next_node_id as usize);
+        self.next_node_id += 1;
         id
     }
 
@@ -239,6 +233,35 @@ impl CompileArtifacts {
     /// Look up a bound body by id.
     pub fn body_of(&self, id: CompositionBodyId) -> Option<&BoundBody> {
         self.composition_bodies.get(&id)
+    }
+
+    /// Correlate each top-level node's declared name with the
+    /// [`PlanNodeId`] minted for it, by zipping `nodes` against
+    /// `top_level_node_ids` (index `i` of the latter is the id for
+    /// `nodes[i]`). Top-level node names are unique (config validation
+    /// rejects duplicates), so the map is collision-free. The map covers
+    /// only top-level nodes, never body scopes, so it cannot reintroduce
+    /// the cross-scope name collision the per-node id keying removed.
+    pub fn top_level_name_ids<'a>(
+        &self,
+        nodes: &'a [Spanned<PipelineNode>],
+    ) -> HashMap<&'a str, PlanNodeId> {
+        nodes
+            .iter()
+            .zip(self.top_level_node_ids.iter())
+            .map(|(spanned, id)| (spanned.value.name(), *id))
+            .collect()
+    }
+
+    /// Resolve a single top-level node's [`PlanNodeId`] by its declared
+    /// name, scanning the `nodes` ↔ `top_level_node_ids` correlation. For
+    /// repeated lookups prefer [`Self::top_level_name_ids`] and reuse the
+    /// map; this convenience is for one-off resolutions.
+    pub fn top_level_id(&self, nodes: &[Spanned<PipelineNode>], name: &str) -> Option<PlanNodeId> {
+        nodes
+            .iter()
+            .zip(self.top_level_node_ids.iter())
+            .find_map(|(spanned, id)| (spanned.value.name() == name).then_some(*id))
     }
 
     /// Allocate a fresh `FileId` for body re-parses.
@@ -272,13 +295,6 @@ pub(crate) struct BindContext<'a> {
     /// call site. Empty for compositions that don't propagate scoped vars
     ///.
     pub scoped_vars: cxl::resolve::ScopedVarsRegistry,
-    /// Scope the nodes currently being bound live in. `TopLevel` at the
-    /// pipeline root; `bind_composition` saves and restores it around the
-    /// body recursion, setting it to `Body(body_id)` for the duration.
-    /// The scope-keyed compile-time side-tables (`combine_where_typed`,
-    /// `route_branch_typed`) stamp their producer keys from this so a
-    /// node named the same across two scopes does not collide.
-    pub current_scope: NodeScope,
 }
 
 // ─── Public entry point ─────────────────────────────────────────────
@@ -307,6 +323,17 @@ pub fn bind_schema(
     scoped_vars: cxl::resolve::ScopedVarsRegistry,
 ) -> CompileArtifacts {
     let mut artifacts = CompileArtifacts::default();
+    // Mint one id per top-level node in declaration order BEFORE any body
+    // recursion, so top-level ids occupy the low, stable id range and
+    // `top_level_node_ids[i]` pairs with `nodes[i]`. Lowering stamps the
+    // lowered node from this vector by original declaration position.
+    artifacts.top_level_node_ids = nodes.iter().map(|_| artifacts.fresh_node_id()).collect();
+    // Top-level name → id resolver, built from the just-minted ids zipped
+    // with each node's declared name. Top-level node names are unique
+    // (config validation rejects duplicates), so this is collision-free.
+    // Threaded into the bind walk so every per-node producer keys its
+    // side-table entry by the node's own id.
+    let top_level_ids = top_level_name_ids(nodes, &artifacts);
     let mut schema_by_name: HashMap<String, Row> = HashMap::new();
     let mut bind_ctx = BindContext {
         ctx,
@@ -316,10 +343,10 @@ pub fn bind_schema(
         enclosing_scope_names: HashSet::new(),
         origin_dir: pipeline_dir.to_path_buf(),
         scoped_vars,
-        current_scope: NodeScope::TopLevel,
     };
     bind_schema_inner(
         nodes,
+        &top_level_ids,
         diags,
         &mut bind_ctx,
         &mut artifacts,
@@ -331,11 +358,27 @@ pub fn bind_schema(
     // config-validation time by `validate_unique_scoped_declarations`,
     // so the previous compile-time E170 multi-writer check is dead.
     validate_init_phase_terminals(nodes, diags);
-    validate_read_after_write(nodes, &artifacts, diags);
-    validate_post_merge_source_reads(nodes, &artifacts, diags);
-    validate_init_phase_isolation(nodes, &artifacts, diags);
+    validate_read_after_write(nodes, &top_level_ids, &artifacts, diags);
+    validate_post_merge_source_reads(nodes, &top_level_ids, &artifacts, diags);
+    validate_init_phase_isolation(nodes, &top_level_ids, &artifacts, diags);
 
     artifacts
+}
+
+/// Owned-key view of [`CompileArtifacts::top_level_name_ids`] for the
+/// consumers that key by `String` — the read-after-write / post-merge /
+/// init validators and `bind_schema_inner`, all of which look up by an
+/// owned node name. The correlation itself lives once on the artifacts
+/// method; this only re-keys the borrowed names into owned `String`s.
+fn top_level_name_ids(
+    nodes: &[Spanned<PipelineNode>],
+    artifacts: &CompileArtifacts,
+) -> HashMap<String, PlanNodeId> {
+    artifacts
+        .top_level_name_ids(nodes)
+        .into_iter()
+        .map(|(name, id)| (name.to_string(), id))
+        .collect()
 }
 
 /// Compile-time check: a `phase: init` Transform may not read
@@ -380,6 +423,7 @@ fn iter_writers<'a>(nodes: &'a [Spanned<PipelineNode>]) -> Vec<WriterInfo<'a>> {
 
 fn validate_init_phase_isolation(
     nodes: &[Spanned<PipelineNode>],
+    top_level_ids: &HashMap<String, PlanNodeId>,
     artifacts: &CompileArtifacts,
     diags: &mut Vec<Diagnostic>,
 ) {
@@ -418,7 +462,10 @@ fn validate_init_phase_isolation(
 
     for (reader_name, read_span, typed_keys) in readers {
         for typed_key in &typed_keys {
-            let Some(typed) = artifacts.typed_get(NodeScope::TopLevel, typed_key) else {
+            let Some(typed) = top_level_ids
+                .get(typed_key)
+                .and_then(|id| artifacts.typed_get(*id))
+            else {
                 continue;
             };
             let mut reads: Vec<(VarScope, String)> = Vec::new();
@@ -487,6 +534,7 @@ fn validate_init_phase_isolation(
 /// secondary span on the closest Merge/Combine ancestor.
 fn validate_post_merge_source_reads(
     nodes: &[Spanned<PipelineNode>],
+    top_level_ids: &HashMap<String, PlanNodeId>,
     artifacts: &CompileArtifacts,
     diags: &mut Vec<Diagnostic>,
 ) {
@@ -530,15 +578,17 @@ fn validate_post_merge_source_reads(
         let Some(Some((merge_name, merge_span))) = post_merge.get(&reader_name).cloned() else {
             continue;
         };
-        let mut typed_keys: Vec<String> = Vec::new();
+        let reader_id = top_level_ids.get(&reader_name).copied();
+        let mut typed_keys: Vec<PlanNodeId> = Vec::new();
         if spanned.value.reads_scope_vars_in_cxl()
-            && artifacts.typed_contains(NodeScope::TopLevel, &reader_name)
+            && let Some(id) = reader_id
+            && artifacts.typed_contains(id)
         {
-            typed_keys.push(reader_name.clone());
+            typed_keys.push(id);
         }
         let span = span_for_node(spanned);
         for key in typed_keys {
-            let Some(typed) = artifacts.typed_get(NodeScope::TopLevel, &key) else {
+            let Some(typed) = artifacts.typed_get(key) else {
                 continue;
             };
             let mut reads: Vec<(crate::config::VarScope, String)> = Vec::new();
@@ -604,6 +654,7 @@ fn is_builtin_source_member(field: &str) -> bool {
 /// secondary span on the writer Transform.
 fn validate_read_after_write(
     nodes: &[Spanned<PipelineNode>],
+    top_level_ids: &HashMap<String, PlanNodeId>,
     artifacts: &CompileArtifacts,
     diags: &mut Vec<Diagnostic>,
 ) {
@@ -654,15 +705,17 @@ fn validate_read_after_write(
     // reader's ancestor set.
     for spanned in nodes {
         let reader_name = spanned.value.name().to_string();
-        let mut typed_keys: Vec<String> = Vec::new();
+        let reader_id = top_level_ids.get(&reader_name).copied();
+        let mut typed_keys: Vec<PlanNodeId> = Vec::new();
         if spanned.value.reads_scope_vars_in_cxl()
-            && artifacts.typed_contains(NodeScope::TopLevel, &reader_name)
+            && let Some(id) = reader_id
+            && artifacts.typed_contains(id)
         {
-            typed_keys.push(reader_name.clone());
+            typed_keys.push(id);
         }
         let span = span_for_node(spanned);
         for key in typed_keys {
-            let Some(typed) = artifacts.typed_get(NodeScope::TopLevel, &key) else {
+            let Some(typed) = artifacts.typed_get(key) else {
                 continue;
             };
             let mut reads: Vec<(VarScope, String)> = Vec::new();
@@ -1261,10 +1314,10 @@ struct ReshapeNodeBinding<'a> {
     upstream: &'a Row,
     span: Span,
     scoped_vars: &'a cxl::resolve::ScopedVarsRegistry,
-    /// Scope this reshape is bound in, copied from `BindContext.current_scope`
-    /// at the call site. Stamps the `typed` table key so a reshape named the
-    /// same in two composition scopes does not collide.
-    scope: NodeScope,
+    /// This reshape's stable [`PlanNodeId`], resolved from the bind walk's
+    /// scope name→id map. Keys the `typed` table entry so a reshape named
+    /// the same in two composition scopes does not collide.
+    id: PlanNodeId,
 }
 
 /// Bind a `PipelineNode::Reshape`: validate `partition_by` against the
@@ -1294,7 +1347,7 @@ fn bind_reshape(
         upstream,
         span,
         scoped_vars,
-        scope,
+        id,
     } = node;
     let mut ok = true;
 
@@ -1551,11 +1604,7 @@ fn bind_reshape(
     );
     let out = Row::from_parts(declared, upstream.declared_span, upstream.tail.clone());
     schema_by_name.insert(name.to_string(), out.clone());
-    artifacts.typed_insert(
-        scope,
-        name.to_string(),
-        Arc::new(synthetic_typed_program(out)),
-    );
+    artifacts.typed_insert(id, Arc::new(synthetic_typed_program(out)));
 }
 
 /// Borrowed inputs for binding one `PipelineNode::Cull`.
@@ -1569,10 +1618,10 @@ struct CullNodeBinding<'a> {
     upstream: &'a Row,
     span: Span,
     scoped_vars: &'a cxl::resolve::ScopedVarsRegistry,
-    /// Scope this cull is bound in, copied from `BindContext.current_scope`
-    /// at the call site. Stamps the `typed` table key so a cull named the
+    /// This cull's stable [`PlanNodeId`], resolved from the bind walk's
+    /// scope name→id map. Keys the `typed` table entry so a cull named the
     /// same in two composition scopes does not collide.
-    scope: NodeScope,
+    id: PlanNodeId,
 }
 
 /// Bind a `PipelineNode::Cull`: validate `partition_by` / `order_by`
@@ -1603,7 +1652,7 @@ fn bind_cull(
         upstream,
         span,
         scoped_vars,
-        scope,
+        id,
     } = node;
     let mut ok = true;
 
@@ -1725,11 +1774,7 @@ fn bind_cull(
     // identical schema on the main and `removed_to` ports.
     let out = upstream.clone();
     schema_by_name.insert(name.to_string(), out.clone());
-    artifacts.typed_insert(
-        scope,
-        name.to_string(),
-        Arc::new(synthetic_typed_program(out)),
-    );
+    artifacts.typed_insert(id, Arc::new(synthetic_typed_program(out)));
 }
 
 // ─── Internal recursive bind_schema ─────────────────────────────────
@@ -1737,8 +1782,18 @@ fn bind_cull(
 /// Internal recursive bind_schema. Walks nodes in topological order,
 /// seeds source schemas, typechecks CXL-bearing nodes, and recurses
 /// into composition bodies via `bind_composition`.
+///
+/// `node_ids` maps each node name in THIS scope to its [`PlanNodeId`] —
+/// for the top-level walk it is built from `top_level_node_ids`; for a
+/// composition body it is the per-body map pre-minted by
+/// `bind_composition` before this recursion. Names are unique within one
+/// scope (config validation rejects duplicates), so the resolution is
+/// unambiguous. Every per-node producer keys its side-table entry by the
+/// id resolved here, so a node named the same across two scopes gets
+/// distinct ids and cannot collide.
 fn bind_schema_inner(
     nodes: &[Spanned<PipelineNode>],
+    node_ids: &HashMap<String, PlanNodeId>,
     diags: &mut Vec<Diagnostic>,
     bind_ctx: &mut BindContext<'_>,
     artifacts: &mut CompileArtifacts,
@@ -1774,6 +1829,30 @@ fn bind_schema_inner(
         let node = &spanned.value;
         let name = node.name().to_string();
         let span = span_for(spanned);
+        // The node's stable id for this scope. Pre-minted before the walk
+        // (top-level vector zip, or body pre-mint), so every visited node
+        // is present. A missing entry can only mean an internal pre-mint /
+        // walk desync — fail loudly with an internal-error diagnostic
+        // rather than mint a colliding fresh id or silently drop the node.
+        let node_id = match node_ids.get(&name) {
+            Some(&id) => id,
+            None => {
+                debug_assert!(
+                    false,
+                    "bind_schema_inner: node {name:?} has no pre-minted PlanNodeId \
+                     (pre-mint/walk desync)"
+                );
+                diags.push(Diagnostic::error(
+                    "E000",
+                    format!(
+                        "internal error: node {name:?} has no pre-minted PlanNodeId \
+                         during schema binding"
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                ));
+                continue;
+            }
+        };
 
         // Compute the upstream-source set for this node BEFORE the
         // typecheck match — Aggregate's E156 guard reads it inside the
@@ -1873,11 +1952,7 @@ fn bind_schema_inner(
                 let cxl_span = cxl::lexer::Span::new(span.start as usize, span.start as usize);
                 let row = Row::closed(columns, cxl_span);
                 schema_by_name.insert(name.clone(), row.clone());
-                artifacts.typed_insert(
-                    bind_ctx.current_scope,
-                    name,
-                    Arc::new(synthetic_typed_program(row)),
-                );
+                artifacts.typed_insert(node_id, Arc::new(synthetic_typed_program(row)));
             }
             PipelineNode::Transform { header, config } => {
                 // E108: check for enclosing-scope reference BEFORE upstream lookup.
@@ -1911,7 +1986,7 @@ fn bind_schema_inner(
                         let out = propagate_row(&upstream, &typed);
                         schema_by_name.insert(name.clone(), out.clone());
                         typed.output_row = out;
-                        artifacts.typed_insert(bind_ctx.current_scope, name, Arc::new(typed));
+                        artifacts.typed_insert(node_id, Arc::new(typed));
                     }
                     Err(d) => diags.push(d),
                 }
@@ -2001,7 +2076,7 @@ fn bind_schema_inner(
                         let out = propagate_aggregate(&name, &config.group_by, &upstream, &typed);
                         schema_by_name.insert(name.clone(), out.clone());
                         typed.output_row = out;
-                        artifacts.typed_insert(bind_ctx.current_scope, name, Arc::new(typed));
+                        artifacts.typed_insert(node_id, Arc::new(typed));
                     }
                     Err(d) => diags.push(d),
                 }
@@ -2018,11 +2093,7 @@ fn bind_schema_inner(
                         &bind_ctx.scoped_vars,
                     ) {
                         empty.output_row = cloned.clone();
-                        artifacts.typed_insert(
-                            bind_ctx.current_scope,
-                            name.clone(),
-                            Arc::new(empty),
-                        );
+                        artifacts.typed_insert(node_id, Arc::new(empty));
                     }
                     // Type-check each branch condition into its own program
                     // so the compile-time `$doc` walk can reach an envelope
@@ -2051,13 +2122,9 @@ fn bind_schema_inner(
                         })
                         .collect();
                     if !branch_programs.is_empty() {
-                        artifacts.route_branch_typed.insert(
-                            ScopedNodeId {
-                                scope: bind_ctx.current_scope,
-                                name: name.clone(),
-                            },
-                            branch_programs,
-                        );
+                        artifacts
+                            .route_branch_typed
+                            .insert(node_id, branch_programs);
                     }
                     schema_by_name.insert(name, cloned);
                 }
@@ -2124,22 +2191,14 @@ fn bind_schema_inner(
                 {
                     let row = upstream.clone();
                     schema_by_name.insert(name.clone(), row.clone());
-                    artifacts.typed_insert(
-                        bind_ctx.current_scope,
-                        name,
-                        Arc::new(synthetic_typed_program(row)),
-                    );
+                    artifacts.typed_insert(node_id, Arc::new(synthetic_typed_program(row)));
                 }
             }
             PipelineNode::Output { header, .. } => {
                 if let Some(upstream) = upstream_schema(&header.input.value, schema_by_name) {
                     let row = upstream.clone();
                     schema_by_name.insert(name.clone(), row.clone());
-                    artifacts.typed_insert(
-                        bind_ctx.current_scope,
-                        name,
-                        Arc::new(synthetic_typed_program(row)),
-                    );
+                    artifacts.typed_insert(node_id, Arc::new(synthetic_typed_program(row)));
                 }
             }
             PipelineNode::Reshape { header, config } => {
@@ -2152,7 +2211,7 @@ fn bind_schema_inner(
                             upstream: &upstream,
                             span,
                             scoped_vars: &bind_ctx.scoped_vars,
-                            scope: bind_ctx.current_scope,
+                            id: node_id,
                         },
                         diags,
                         artifacts,
@@ -2170,7 +2229,7 @@ fn bind_schema_inner(
                             upstream: &upstream,
                             span,
                             scoped_vars: &bind_ctx.scoped_vars,
-                            scope: bind_ctx.current_scope,
+                            id: node_id,
                         },
                         diags,
                         artifacts,
@@ -2207,13 +2266,9 @@ fn bind_schema_inner(
                     {
                         artifacts
                             .envelope_synthesis
-                            .insert(name.clone(), Arc::new(synthesis));
+                            .insert(node_id, Arc::new(synthesis));
                     }
-                    artifacts.typed_insert(
-                        bind_ctx.current_scope,
-                        name,
-                        Arc::new(synthetic_typed_program(row)),
-                    );
+                    artifacts.typed_insert(node_id, Arc::new(synthetic_typed_program(row)));
                 }
             }
             // Phase Combine C.1.1 + C.1.2 + C.1.3 (single-pass arm).
@@ -2232,7 +2287,7 @@ fn bind_schema_inner(
                         config,
                         span,
                         scoped_vars: &bind_ctx.scoped_vars,
-                        scope: bind_ctx.current_scope,
+                        id: node_id,
                     },
                     diags,
                     artifacts,
@@ -2250,6 +2305,7 @@ fn bind_schema_inner(
                 bind_composition(
                     &CompositionBindParams {
                         node_name: &name,
+                        node_id,
                         use_path: r#use,
                         call_inputs: inputs,
                         call_outputs: outputs,
@@ -2278,6 +2334,10 @@ fn bind_schema_inner(
 /// validates against the resolved signature.
 struct CompositionBindParams<'a> {
     node_name: &'a str,
+    /// The call-site composition node's stable identity. Keys the body
+    /// assignment so two compositions named the same in disjoint scopes
+    /// (or sharing a name with a top-level node) get distinct entries.
+    node_id: PlanNodeId,
     use_path: &'a Path,
     call_inputs: &'a IndexMap<String, String>,
     call_outputs: &'a IndexMap<String, String>,
@@ -2300,6 +2360,7 @@ fn bind_composition(
 ) {
     let &CompositionBindParams {
         node_name,
+        node_id,
         use_path,
         call_inputs,
         call_outputs,
@@ -2434,9 +2495,6 @@ fn bind_composition(
     // declaration with the same type, the body's registry includes it.
     // Mismatches (parent missing the var, or type doesn't match) emit
     // E174.
-    // Bind this body's nodes under its own scope so the scope-keyed
-    // compile-time side-tables disambiguate same-named nodes across bodies.
-    let saved_scope = std::mem::replace(&mut bind_ctx.current_scope, NodeScope::Body(body_id));
     let saved_scoped_vars = std::mem::take(&mut bind_ctx.scoped_vars);
     bind_ctx.scoped_vars = build_body_scoped_vars(
         &signature.scoped_vars_schema,
@@ -2462,9 +2520,67 @@ fn bind_composition(
         body_schema_by_name.insert(port_name.clone(), row.clone());
     }
 
+    // Reject duplicate body node names (E001) before minting. The
+    // top-level E001 pass in `validate_acyclic` never sees body files, so a
+    // body with two same-named nodes would otherwise collapse to ONE
+    // `PlanNodeId` at the pre-mint below (`entry().or_insert_with`), which
+    // both trips the `rebuild_id_index` coverage assert in debug and
+    // silently aliases the two nodes' compiled programs in release. Emit
+    // one diagnostic per offending node and abandon this body — leaving it
+    // unbound mirrors the other `bind_composition` early-outs.
+    {
+        let mut seen: HashSet<&str> = HashSet::new();
+        let mut has_duplicate = false;
+        for spanned in &body_file.nodes {
+            let n_name = spanned.value.name();
+            if !seen.insert(n_name) {
+                has_duplicate = true;
+                diags.push(Diagnostic::error(
+                    "E001",
+                    format!(
+                        "composition node {node_name:?}: body file {} declares \
+                         duplicate node name: {n_name:?}",
+                        resolved_path.display()
+                    ),
+                    LabeledSpan::primary(span_for_node(spanned), String::new()),
+                ));
+            }
+        }
+        if has_duplicate {
+            return;
+        }
+    }
+
+    // Pre-mint a stable id per body node and per synthetic input-port
+    // source BEFORE binding, so the bind walk can key this body's typed /
+    // combine side-table entries by id — body node ids are not available
+    // at lowering time, which runs after binding. Step-14 lowering CARRIES
+    // these ids onto the body `PlanNode`s rather than minting fresh, so an
+    // id is minted exactly once per node and two instantiations of one
+    // composition body still get disjoint id sets (the shared counter
+    // advances on each pre-mint). Body names are unique here (the E001 pass
+    // above rejected duplicates), so each `or_insert_with` mints exactly
+    // once. Port-source ids are minted into a separate map because a port
+    // name and a body-internal node name can legally collide; each is
+    // consumed in its own lowering context.
+    let mut body_node_ids: HashMap<String, PlanNodeId> = HashMap::new();
+    for spanned in &body_file.nodes {
+        let n_name = spanned.value.name().to_string();
+        body_node_ids
+            .entry(n_name)
+            .or_insert_with(|| artifacts.fresh_node_id());
+    }
+    let mut body_port_source_ids: HashMap<String, PlanNodeId> = HashMap::new();
+    for (port_name, _row) in &input_port_rows {
+        body_port_source_ids
+            .entry(port_name.clone())
+            .or_insert_with(|| artifacts.fresh_node_id());
+    }
+
     // Recursive bind_schema on body nodes.
     bind_schema_inner(
         &body_file.nodes,
+        &body_node_ids,
         diags,
         bind_ctx,
         artifacts,
@@ -2474,7 +2590,6 @@ fn bind_composition(
     // Restore parent state.
     bind_ctx.depth -= 1;
     bind_ctx.use_path_stack.pop();
-    bind_ctx.current_scope = saved_scope;
     bind_ctx.enclosing_scope_names = saved_enclosing;
     bind_ctx.scoped_vars = saved_scoped_vars;
     bind_ctx.origin_dir = saved_origin_dir;
@@ -2564,8 +2679,11 @@ fn bind_composition(
         };
         let port_schema =
             schema_from_field_names(parent_row.field_names().map(|qf| qf.name.as_ref()));
+        // Carry the port-source id pre-minted before binding (never
+        // re-mint), so it never collides with a top-level or body node id.
         let port_source = crate::plan::execution::PlanNode::Source {
             name: port_name.clone(),
+            id: body_port_source_ids[port_name],
             span,
             resolved: None,
             output_schema: port_schema,
@@ -2590,14 +2708,12 @@ fn bind_composition(
         // top-level pass that walks the lattice. Lowering only stamps
         // the strict default; `apply_retraction_flags` rewrites it.
         let lower_ctx = crate::config::LoweringCtx::default();
+        // Carry the body node's id pre-minted before binding (never
+        // re-mint), so the typed/combine entries the bind walk keyed by
+        // this id resolve to the node lowered here.
+        let node_id = body_node_ids[&n_name];
         if let Some(plan_node) = crate::config::lower_node_to_plan_node(
-            n,
-            &n_name,
-            NodeScope::Body(body_id),
-            body_span,
-            artifacts,
-            &lower_ctx,
-            diags,
+            n, node_id, body_span, artifacts, &lower_ctx, diags,
         ) {
             let idx = body_graph.add_node(plan_node);
             body_name_to_idx.insert(n_name, idx);
@@ -2863,10 +2979,14 @@ fn bind_composition(
     bound_body.input_port_rows = input_port_rows;
     bound_body.nested_body_ids = nested_body_ids;
     bound_body.body_window_configs = body_window_configs;
+    // The body mini-DAG is structurally final here (its graph is built
+    // once and toposorted above; later body passes only stamp fields).
+    // Build the id→index bridge so every body node id resolves.
+    bound_body.rebuild_id_index();
     artifacts.insert_body(body_id, bound_body);
     artifacts
         .composition_body_assignments
-        .insert(node_name.to_string(), body_id);
+        .insert(node_id, body_id);
 
     // 16. Write composition's output row to parent scope.
     // Use the first output port's row as the composition node's output.
@@ -4049,10 +4169,13 @@ struct CombineNodeBinding<'a> {
     config: &'a CombineBody,
     span: Span,
     scoped_vars: &'a cxl::resolve::ScopedVarsRegistry,
-    /// Scope this combine is bound in, copied from `BindContext.current_scope`
-    /// at the call site. Stamps the `combine_where_typed` side-table key so a
-    /// combine named the same in two composition scopes does not collide.
-    scope: NodeScope,
+    /// This combine's stable [`PlanNodeId`], resolved from the bind walk's
+    /// scope name→id map. Keys every per-combine side-table entry
+    /// (`combine_where_typed`, `combine_inputs`, `combine_driving`,
+    /// `combine_strategy_hints`, `combine_predicates`,
+    /// `combine_resolved_columns`, `typed`) so a combine named the same in
+    /// two composition scopes does not collide.
+    id: PlanNodeId,
 }
 
 /// Bind a `PipelineNode::Combine` node in one bottom-up traversal.
@@ -4091,7 +4214,7 @@ fn bind_combine(
         config,
         span,
         scoped_vars,
-        scope,
+        id,
     } = node;
     // E300: combine requires at least 2 inputs.
     if header.input.len() < 2 {
@@ -4162,15 +4285,11 @@ fn bind_combine(
         span,
         diags,
     ) {
-        artifacts.combine_driving.insert(name.to_string(), driver);
+        artifacts.combine_driving.insert(id, driver);
     }
 
-    artifacts
-        .combine_inputs
-        .insert(name.to_string(), combine_inputs_entries);
-    artifacts
-        .combine_strategy_hints
-        .insert(name.to_string(), config.strategy);
+    artifacts.combine_inputs.insert(id, combine_inputs_entries);
+    artifacts.combine_strategy_hints.insert(id, config.strategy);
 
     let cxl_span = cxl::lexer::Span::new(span.start as usize, span.start as usize);
     let merged_row = Row::closed(merged_declared, cxl_span);
@@ -4190,13 +4309,9 @@ fn bind_combine(
         }
     };
 
-    artifacts.combine_where_typed.insert(
-        ScopedNodeId {
-            scope,
-            name: name.to_string(),
-        },
-        Arc::clone(&typed_where),
-    );
+    artifacts
+        .combine_where_typed
+        .insert(id, Arc::clone(&typed_where));
 
     // Post-walk for E304 (unknown / 3-part qualified refs in where).
     let e304_before = diags.iter().filter(|d| d.code == "E304").count();
@@ -4243,9 +4358,7 @@ fn bind_combine(
         diags.push(combine_e305(name, span));
     }
 
-    artifacts
-        .combine_predicates
-        .insert(name.to_string(), decomposed);
+    artifacts.combine_predicates.insert(id, decomposed);
 
     // If the where-clause was structurally broken (E304), short-circuit
     // to avoid cascading body errors. The body may be fine, but without
@@ -4273,13 +4386,13 @@ fn bind_combine(
             diags.push(combine_e311_collect_with_body(name, span));
             return;
         }
-        let driving = match artifacts.combine_driving.get(name).cloned() {
+        let driving = match artifacts.combine_driving.get(&id).cloned() {
             Some(d) => d,
             None => return,
         };
         let inputs = artifacts
             .combine_inputs
-            .get(name)
+            .get(&id)
             .expect("combine_inputs populated above");
         if inputs.len() != 2 {
             return;
@@ -4304,7 +4417,7 @@ fn bind_combine(
         }
         artifacts
             .combine_resolved_columns
-            .insert(name.to_string(), Arc::new(resolved_map));
+            .insert(id, Arc::new(resolved_map));
 
         let mut output_decl: IndexMap<QualifiedField, Type> = IndexMap::new();
         for (qf, ty) in driver_input.row.fields() {
@@ -4360,11 +4473,7 @@ fn bind_combine(
         }
         let output_row = Row::closed(output_decl, cxl_span);
         schema_by_name.insert(name.to_string(), output_row.clone());
-        artifacts.typed_insert(
-            scope,
-            name.to_string(),
-            Arc::new(synthetic_typed_program(output_row)),
-        );
+        artifacts.typed_insert(id, Arc::new(synthetic_typed_program(output_row)));
         return;
     }
 
@@ -4410,11 +4519,11 @@ fn bind_combine(
 
     let driver_row = artifacts
         .combine_driving
-        .get(name)
-        .and_then(|q| artifacts.combine_inputs.get(name).and_then(|m| m.get(q)))
+        .get(&id)
+        .and_then(|q| artifacts.combine_inputs.get(&id).and_then(|m| m.get(q)))
         .map(|input| input.row.clone());
-    let driver_qualifier_for_row = artifacts.combine_driving.get(name).cloned();
-    let inputs_for_row = artifacts.combine_inputs.get(name);
+    let driver_qualifier_for_row = artifacts.combine_driving.get(&id).cloned();
+    let inputs_for_row = artifacts.combine_inputs.get(&id);
     let output_row = combine_output_row(
         &body_typed,
         driver_row.as_ref(),
@@ -4437,10 +4546,10 @@ fn bind_combine(
     // that case every qualifier lands on `JoinSide::Build`, which is
     // harmless because the post-pass skips stamping the combine's
     // runtime fields and the executor never reaches it.
-    let driver_qualifier = artifacts.combine_driving.get(name).cloned();
+    let driver_qualifier = artifacts.combine_driving.get(&id).cloned();
     let inputs_for_resolve = artifacts
         .combine_inputs
-        .get(name)
+        .get(&id)
         .expect("combine_inputs populated above");
     let mut resolved_map =
         resolve_combine_body_columns(&body_typed, inputs_for_resolve, driver_qualifier.as_deref());
@@ -4456,9 +4565,9 @@ fn bind_combine(
     }
     artifacts
         .combine_resolved_columns
-        .insert(name.to_string(), Arc::new(resolved_map));
+        .insert(id, Arc::new(resolved_map));
 
-    artifacts.typed_insert(scope, name.to_string(), Arc::new(body_typed));
+    artifacts.typed_insert(id, Arc::new(body_typed));
 }
 
 /// Walk every `Expr::QualifiedFieldRef { parts: [qualifier, name] }` in

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -9,14 +9,16 @@
 //! The late-populated compile artifacts that these types describe do NOT
 //! live inline on `PlanNode::Combine`. Instead, they live in
 //! `CompileArtifacts` side-tables:
-//!   - `CompileArtifacts.typed` (keyed by the combine's `ScopedNodeId`)
+//!   - `CompileArtifacts.typed` (keyed by the combine's `PlanNodeId`)
 //!     — typed cxl-body program (same key convention as Transform)
 //!   - `CompileArtifacts.combine_predicates`  — `DecomposedPredicate`
 //!     (the residual re-typechecked program lives inside this, not in
 //!     `typed` — the where-clause TypedProgram is a local intermediate
 //!     that doesn't survive bind_schema)
 //!   - `CompileArtifacts.combine_inputs`      — per-input metadata
-//!     (name-keyed; see `CombineInput` for the no-`NodeIndex` rationale)
+//!     (keyed by the combine's `PlanNodeId`; the inner `IndexMap` is
+//!     keyed by input-port name. See `CombineInput` for why each input
+//!     still refers to its upstream node by name rather than `NodeIndex`.)
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -76,8 +78,8 @@ pub enum CombineStrategy {
 /// equality conjuncts, range conjuncts, and a residual program.
 ///
 /// Populated by C.1 and stored in `CompileArtifacts.combine_predicates`
-/// keyed by combine node name. The planner reads this in C.2 to pick a
-/// `CombineStrategy` and build hash keys / range indices.
+/// keyed by the combine node's `PlanNodeId`. The planner reads this in C.2
+/// to pick a `CombineStrategy` and build hash keys / range indices.
 #[derive(Debug, Clone)]
 pub struct DecomposedPredicate {
     pub equalities: Vec<EqualityConjunct>,
@@ -700,9 +702,10 @@ pub(crate) struct CombineSelectionTables<'a> {
     /// row count from here, keyed by the input's upstream node name, in
     /// place of a per-input cardinality field.
     pub statistics: &'a crate::plan::statistics::StatisticsCatalog,
-    /// Per-combine user-supplied strategy hint, keyed by combine node name.
+    /// Per-combine user-supplied strategy hint, keyed by the combine
+    /// node's [`crate::plan::PlanNodeId`].
     pub combine_strategy_hints:
-        &'a std::collections::HashMap<String, crate::config::CombineStrategyHint>,
+        &'a std::collections::HashMap<crate::plan::PlanNodeId, crate::config::CombineStrategyHint>,
 }
 
 pub fn select_combine_strategies(
@@ -794,15 +797,15 @@ pub(crate) fn select_combine_strategies_in_graph(
     use crate::plan::execution::PlanNode;
     use petgraph::graph::NodeIndex;
 
-    let combine_nodes: Vec<(NodeIndex, String, Span)> = graph
+    let combine_nodes: Vec<(NodeIndex, String, crate::plan::PlanNodeId, Span)> = graph
         .node_indices()
         .filter_map(|idx| match &graph[idx] {
-            PlanNode::Combine { name, span, .. } => Some((idx, name.clone(), *span)),
+            PlanNode::Combine { name, id, span, .. } => Some((idx, name.clone(), *id, *span)),
             _ => None,
         })
         .collect();
 
-    for (idx, name, span) in combine_nodes {
+    for (idx, name, id, span) in combine_nodes {
         // Read the combine's inputs + decomposed predicate off the node
         // (stamped at lowering / N-ary decomposition), cloning them out so the
         // borrow is released before this pass mutates the node's strategy
@@ -886,7 +889,7 @@ pub(crate) fn select_combine_strategies_in_graph(
             }
         } else if grace_hash_should_fire(&inputs, tables.statistics, mem_limit_str)
             || matches!(
-                tables.combine_strategy_hints.get(&name),
+                tables.combine_strategy_hints.get(&id),
                 Some(crate::config::CombineStrategyHint::GraceHash)
             )
         {
@@ -1818,6 +1821,7 @@ pub(crate) fn decompose_nary_combines(
         // index away from `Combine` would invalidate the snapshot's
         // assumption — skip and continue rather than panic.
         let PlanNode::Combine {
+            id: original_id,
             match_mode: original_match_mode,
             on_miss: original_on_miss,
             output_schema: original_output_schema,
@@ -1838,7 +1842,7 @@ pub(crate) fn decompose_nary_combines(
         // per-step maps below, and the final step's map differs from
         // the original because chain qualifiers route through Probe at
         // encoded indices rather than directly to the original sources.
-        artifacts.combine_resolved_columns.remove(&original_name);
+        artifacts.combine_resolved_columns.remove(&original_id);
 
         // Build a name → NodeIndex lookup over the current graph for
         // wiring source-edges. Snapshot here so it captures the
@@ -1966,6 +1970,11 @@ pub(crate) fn decompose_nary_combines(
                     step_output_schema.clone(),
                     plan.graph.add_node(PlanNode::Combine {
                         name: step.name.clone(),
+                        // Each newly-added (N-2) synthetic chain step mints
+                        // fresh. The reused final step (the `i == last_step_idx`
+                        // arm) keeps the original combine's id — only these
+                        // earlier steps are new nodes.
+                        id: artifacts.fresh_node_id(),
                         span,
                         strategy: CombineStrategy::HashBuildProbe,
                         driving_input: String::new(),
@@ -2142,10 +2151,15 @@ pub(crate) fn decompose_nary_combines(
                 },
             );
 
+            // The step's stable id: the final step reuses the original
+            // combine's index (and thus its id); earlier steps were minted
+            // fresh at node creation. Read it off the node so per-step
+            // side-table entries are keyed by the step's own id.
+            let step_id = plan.graph[step_indices[i]].id();
+
             // Stamp the per-step runtime state onto the step's node (created
             // above; the final step reuses the original combine's index) so
-            // strategy selection and the executor read it by node instance,
-            // not via a bare-name lookup that collides across sibling scopes.
+            // strategy selection and the executor read it by node instance.
             if let PlanNode::Combine {
                 combine_inputs: step_node_inputs,
                 decomposed_predicate: step_node_predicate,
@@ -2159,44 +2173,36 @@ pub(crate) fn decompose_nary_combines(
             }
             artifacts
                 .combine_resolved_columns
-                .insert(step.name.clone(), Arc::new(step_resolved_maps[i].clone()));
+                .insert(step_id, Arc::new(step_resolved_maps[i].clone()));
 
             // Propagate the user's strategy hint to every chain step.
             // The hint applies to the join semantics (pure-equi grace
             // hash), and a left-deep chain of pure-equi joins routes
             // every step through the same strategy when the user asked
             // for it.
-            if let Some(hint) = artifacts
-                .combine_strategy_hints
-                .get(&original_name)
-                .copied()
-            {
-                artifacts
-                    .combine_strategy_hints
-                    .insert(step.name.clone(), hint);
+            if let Some(hint) = artifacts.combine_strategy_hints.get(&original_id).copied() {
+                artifacts.combine_strategy_hints.insert(step_id, hint);
             }
         }
 
-        // Drop the original combine's artifacts — its name is gone from
-        // the graph (the index now hosts the final step under a
-        // synthetic name). The body program already migrated onto the
-        // final step node above, so its `typed` entry is dropped here too
-        // rather than re-homed under the synthetic name. This pass runs
-        // over the top-level DAG, so the `typed` key is TopLevel-scoped.
-        artifacts.typed_remove(
-            crate::plan::bind_schema::NodeScope::TopLevel,
-            &original_name,
-        );
-        artifacts.combine_inputs.remove(&original_name);
-        artifacts.combine_predicates.remove(&original_name);
-        artifacts.combine_driving.remove(&original_name);
-        artifacts.combine_strategy_hints.remove(&original_name);
+        // No per-original side-table cleanup: the final step reuses the
+        // original combine's node (and thus its `PlanNodeId`), so the
+        // entries keyed by `original_id` are the final step's own slots.
+        // `combine_strategy_hints` / `combine_resolved_columns` were just
+        // re-set to the final step's values in the per-step loop, and
+        // `combine_strategy_hints` is still read by
+        // `select_combine_strategies`; dropping `original_id` would delete
+        // those live entries. The original N-ary's other entries under
+        // `original_id` (`combine_inputs` / `combine_predicates` /
+        // `combine_driving` / `typed`) are read only at lowering, already
+        // past, so leaving them is inert.
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plan::{EntityRef, PlanNodeId};
 
     #[test]
     fn test_combine_strategy_serde_round_trip() {
@@ -2374,6 +2380,10 @@ mod tests {
         use indexmap::IndexMap;
 
         let combine_name = "test_combine";
+        // The single combine node below is built with this id; key its
+        // side-table entries by the same id so the lowering-mirror reads
+        // resolve.
+        let combine_id = PlanNodeId::new(0);
         let mut artifacts = CompileArtifacts::default();
 
         let mut inputs_map: IndexMap<String, CombineInput> = IndexMap::new();
@@ -2389,14 +2399,12 @@ mod tests {
                 },
             );
         }
-        artifacts
-            .combine_inputs
-            .insert(combine_name.to_string(), inputs_map);
+        artifacts.combine_inputs.insert(combine_id, inputs_map);
 
         if with_driver {
             artifacts
                 .combine_driving
-                .insert(combine_name.to_string(), inputs[0].0.to_string());
+                .insert(combine_id, inputs[0].0.to_string());
         }
 
         let dummy_lit = || Expr::Literal {
@@ -2437,19 +2445,18 @@ mod tests {
             ranges: (0..ranges).map(|_| mk_range()).collect(),
             residual: None,
         };
-        artifacts
-            .combine_predicates
-            .insert(combine_name.to_string(), decomposed);
+        artifacts.combine_predicates.insert(combine_id, decomposed);
 
         let predicate_summary = CombinePredicateSummary::from_decomposed(
             artifacts
                 .combine_predicates
-                .get(combine_name)
+                .get(&combine_id)
                 .expect("synthetic_combine_plan just inserted a DecomposedPredicate"),
         );
         let mut graph = petgraph::graph::DiGraph::new();
         graph.add_node(PlanNode::Combine {
             name: combine_name.to_string(),
+            id: combine_id,
             span: Span::SYNTHETIC,
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
@@ -2464,11 +2471,11 @@ mod tests {
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
             // Mirror lowering: the strategy pass reads these off the node.
-            combine_inputs: artifacts.combine_inputs.get(combine_name).cloned(),
-            decomposed_predicate: artifacts.combine_predicates.get(combine_name).cloned(),
-            combine_driving: artifacts.combine_driving.get(combine_name).cloned(),
+            combine_inputs: artifacts.combine_inputs.get(&combine_id).cloned(),
+            decomposed_predicate: artifacts.combine_predicates.get(&combine_id).cloned(),
+            combine_driving: artifacts.combine_driving.get(&combine_id).cloned(),
         });
-        let plan = ExecutionPlanDag {
+        let mut plan = ExecutionPlanDag {
             graph,
             topo_order: Vec::new(),
             source_dag: Vec::new(),
@@ -2481,7 +2488,9 @@ mod tests {
             node_properties: std::collections::HashMap::new(),
             deferred_regions: std::collections::HashMap::new(),
             parent_continuations: std::collections::HashMap::new(),
+            id_to_index: crate::plan::SecondaryMap::with_default(None),
         };
+        plan.rebuild_id_index();
         (plan, artifacts)
     }
 
@@ -2636,6 +2645,7 @@ mod tests {
 
         let node = PlanNode::Combine {
             name: "test_combine".into(),
+            id: PlanNodeId::new(0),
             span: Span::SYNTHETIC,
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
@@ -2685,13 +2695,19 @@ mod tests {
 
         let mut artifacts = CompileArtifacts::default();
         let mut graph = petgraph::graph::DiGraph::new();
+        // The combine node below takes the id after the per-input sources;
+        // key its side-table entries by the same id.
+        let combine_id = PlanNodeId::new(inputs.len());
 
         // Add a Source node per input qualifier so name lookups resolve
         // when the decomposition pass wires edges. The Source's
         // `output_schema` is empty; tests don't run records through it.
-        for (qual, _card) in &inputs {
+        // Distinct ids per node keep the id→index bridge from collapsing
+        // them; the combine below takes the next id after the sources.
+        for (i, (qual, _card)) in inputs.iter().enumerate() {
             graph.add_node(PlanNode::Source {
                 name: (*qual).to_string(),
+                id: PlanNodeId::new(i),
                 span: Span::SYNTHETIC,
                 resolved: None,
                 output_schema: clinker_record::SchemaBuilder::new().build(),
@@ -2717,10 +2733,10 @@ mod tests {
         }
         artifacts
             .combine_inputs
-            .insert(combine_name.to_string(), inputs_map.clone());
+            .insert(combine_id, inputs_map.clone());
         artifacts
             .combine_driving
-            .insert(combine_name.to_string(), driver.to_string());
+            .insert(combine_id, driver.to_string());
 
         // Construct EqualityConjuncts whose left/right inputs match the
         // edges argument. The expressions themselves are dummy literals;
@@ -2759,9 +2775,7 @@ mod tests {
             ranges: Vec::new(),
             residual: None,
         };
-        artifacts
-            .combine_predicates
-            .insert(combine_name.to_string(), predicate);
+        artifacts.combine_predicates.insert(combine_id, predicate);
 
         // Build the merged row mirror of bind_combine's logic so the
         // intermediate-row pruning has something to filter against.
@@ -2776,13 +2790,14 @@ mod tests {
 
         graph.add_node(PlanNode::Combine {
             name: combine_name.to_string(),
+            id: combine_id,
             span: Span::SYNTHETIC,
             strategy: CombineStrategy::HashBuildProbe,
             driving_input: String::new(),
             build_inputs: Vec::new(),
             driving_upstream: None,
             predicate_summary: CombinePredicateSummary::from_decomposed(
-                artifacts.combine_predicates.get(combine_name).unwrap(),
+                artifacts.combine_predicates.get(&combine_id).unwrap(),
             ),
             match_mode: MatchMode::First,
             on_miss: OnMiss::NullFields,
@@ -2792,12 +2807,19 @@ mod tests {
             resolved_column_map: Arc::new(std::collections::HashMap::new()),
             typed: None,
             // Mirror lowering: N-ary decomposition reads these off the node.
-            combine_inputs: artifacts.combine_inputs.get(combine_name).cloned(),
-            decomposed_predicate: artifacts.combine_predicates.get(combine_name).cloned(),
-            combine_driving: artifacts.combine_driving.get(combine_name).cloned(),
+            combine_inputs: artifacts.combine_inputs.get(&combine_id).cloned(),
+            decomposed_predicate: artifacts.combine_predicates.get(&combine_id).cloned(),
+            combine_driving: artifacts.combine_driving.get(&combine_id).cloned(),
         });
 
-        let plan = ExecutionPlanDag {
+        // Seed the artifacts node-id counter past the ids hand-assigned
+        // above so decomposition's `fresh_node_id()` mints non-colliding
+        // ids for the synthetic chain steps.
+        for _ in 0..=inputs.len() {
+            artifacts.fresh_node_id();
+        }
+
+        let mut plan = ExecutionPlanDag {
             graph,
             topo_order: Vec::new(),
             source_dag: Vec::new(),
@@ -2810,7 +2832,9 @@ mod tests {
             node_properties: std::collections::HashMap::new(),
             deferred_regions: std::collections::HashMap::new(),
             parent_continuations: std::collections::HashMap::new(),
+            id_to_index: crate::plan::SecondaryMap::with_default(None),
         };
+        plan.rebuild_id_index();
         (plan, artifacts, merged_row)
     }
 
@@ -2886,6 +2910,132 @@ mod tests {
             combines.len(),
             3,
             "4-input decomposition produces N-1 = 3 binary combines"
+        );
+    }
+
+    #[test]
+    fn decomposition_reused_final_step_keeps_plan_node_id() {
+        // Decomposition rewrites the N-ary combine into a left-deep chain
+        // and reuses the original node's `NodeIndex` (and thus its
+        // `PlanNodeId`) as the final step. If the reused node were ever
+        // re-minted, every side-table entry the bind walk keyed by the
+        // original id (typed body program, strategy hint, resolved-column
+        // map) would desync from the node and the executor would read the
+        // wrong program. This guards that contract directly.
+        use crate::plan::execution::PlanNode;
+
+        let (mut plan, mut artifacts, _row) = nary_plan(
+            "c",
+            vec![("a", None), ("b", None), ("d", None)],
+            vec![("a", "b"), ("b", "d")],
+            "a",
+        );
+
+        // Locate the user-authored combine and snapshot its identity BEFORE
+        // decomposition. The final step reuses this exact `NodeIndex`, so
+        // the post-pass node at this index must still carry `original_id`.
+        let original_idx = plan
+            .graph
+            .node_indices()
+            .find(|&i| matches!(&plan.graph[i], PlanNode::Combine { name, .. } if name == "c"))
+            .expect("nary_plan builds a combine named 'c'");
+        let original_id = plan.graph[original_idx].id();
+
+        // Seed body-program state under the original id so its migration to
+        // the retained-id final step is observable. The body's typed
+        // program lives on the node; decomposition `take()`s it onto the
+        // final step. The strategy hint lives in a `PlanNodeId`-keyed
+        // side-table; decomposition propagates it to every step id.
+        let body_program = Arc::new(cxl::typecheck::pass::TypedProgram {
+            program: cxl::ast::Program {
+                statements: Vec::new(),
+                span: cxl::lexer::Span::new(0, 0),
+            },
+            types: Vec::new(),
+            bindings: Vec::new(),
+            field_types: IndexMap::new(),
+            regexes: Vec::new(),
+            node_count: 0,
+            output_row: Row::closed(IndexMap::new(), cxl::lexer::Span::new(0, 0)),
+            source: None,
+        });
+        if let PlanNode::Combine { typed, .. } = &mut plan.graph[original_idx] {
+            *typed = Some(Arc::clone(&body_program));
+        }
+        artifacts
+            .combine_strategy_hints
+            .insert(original_id, crate::config::CombineStrategyHint::GraceHash);
+
+        let mut diags = Vec::new();
+        decompose_nary_combines(&mut plan, &mut artifacts, &mut diags);
+        let errors: Vec<&Diagnostic> = diags
+            .iter()
+            .filter(|d| matches!(d.severity, clinker_core_types::Severity::Error))
+            .collect();
+        assert!(errors.is_empty(), "no errors expected; got {errors:?}");
+
+        // (a) The reused final step — the node still at `original_idx` —
+        // keeps the original id; it was NOT re-minted.
+        assert_eq!(
+            plan.graph[original_idx].id(),
+            original_id,
+            "the reused final step must retain the original combine's PlanNodeId"
+        );
+
+        // 3 inputs → N-1 = 2 binary combines (one synthetic step + the
+        // reused final step).
+        let combines = collect_combines(&plan);
+        assert_eq!(combines.len(), 2, "3-input decomposition yields 2 combines");
+
+        // (b) Every combine has a DISTINCT id, and each synthetic step's id
+        // differs from the retained original.
+        let ids: Vec<PlanNodeId> = combines.iter().map(|n| n.id()).collect();
+        let unique: std::collections::HashSet<PlanNodeId> = ids.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            ids.len(),
+            "no two chain nodes may share a PlanNodeId; got {ids:?}"
+        );
+        // Every chain node records its origin combine. Exactly one keeps
+        // `original_id` (the reused final step); all others are freshly
+        // minted synthetic steps, none of which may reuse the original id.
+        for n in &combines {
+            assert!(
+                matches!(
+                    n,
+                    PlanNode::Combine { decomposed_from: Some(from), .. }
+                        if from.as_str() == "c"
+                ),
+                "every chain combine records its origin combine 'c'"
+            );
+        }
+        let retained = combines.iter().filter(|n| n.id() == original_id).count();
+        assert_eq!(
+            retained, 1,
+            "exactly one chain node — the reused final step — keeps the original id; \
+             a synthetic step must not reuse it"
+        );
+
+        // (c) The body program migrated to the retained-id final step, and
+        // the `PlanNodeId`-keyed side-tables still hold the final step's
+        // state under the retained id (no desync).
+        if let PlanNode::Combine { typed, .. } = &plan.graph[original_idx] {
+            assert!(
+                typed.is_some(),
+                "the body typed program must survive on the reused final step"
+            );
+        } else {
+            panic!("node at the original index must still be a Combine");
+        }
+        assert!(
+            artifacts.combine_strategy_hints.contains_key(&original_id),
+            "the strategy hint must remain keyed by the retained id"
+        );
+        assert!(
+            artifacts
+                .combine_resolved_columns
+                .contains_key(&original_id),
+            "the final step's resolved-column map must be keyed by the retained id"
         );
     }
 

--- a/crates/clinker-plan/src/plan/compiled.rs
+++ b/crates/clinker-plan/src/plan/compiled.rs
@@ -62,10 +62,10 @@ impl CompiledPlan {
     }
 
     /// Compile-time CXL typecheck artifacts — one entry per CXL-bearing
-    /// node keyed by its `ScopedNodeId` (so a top-level node and a
-    /// composition-body node sharing a name stay distinct). The runtime
-    /// executor reads this map to pull each node's `Arc<TypedProgram>`
-    /// instead of re-typechecking.
+    /// node keyed by its `PlanNodeId` (so a top-level node and a
+    /// composition-body node sharing a name get distinct ids and stay
+    /// distinct). The runtime executor reads this map to pull each node's
+    /// `Arc<TypedProgram>` instead of re-typechecking.
     pub fn artifacts(&self) -> &CompileArtifacts {
         &self.artifacts
     }
@@ -82,12 +82,14 @@ impl CompiledPlan {
     ///
     /// Returns `None` for nodes that didn't participate in `bind_schema`
     /// (e.g. compositions whose binding failed). Only top-level nodes are
-    /// visible here; composition-body programs live under their `Body`
-    /// scope in the `typed` table and are reached via [`Self::body_of`].
+    /// visible here; composition-body programs are keyed by their own
+    /// `PlanNodeId` in the `typed` table and are reached via
+    /// [`Self::body_of`]. Resolves the name to its top-level `PlanNodeId`
+    /// through the declaration-order id vector (top-level names are
+    /// unique).
     pub fn typed_output_row(&self, name: &str) -> Option<&Row> {
-        self.artifacts
-            .typed_get(crate::plan::bind_schema::NodeScope::TopLevel, name)
-            .map(|tp| &tp.output_row)
+        let id = self.artifacts.top_level_id(&self.config.nodes, name)?;
+        self.artifacts.typed_get(id).map(|tp| &tp.output_row)
     }
 
     /// Side-table of provenance-tracked config values for composition nodes.

--- a/crates/clinker-plan/src/plan/composition_body.rs
+++ b/crates/clinker-plan/src/plan/composition_body.rs
@@ -175,6 +175,14 @@ pub struct BoundBody {
     /// bodies that contain no nested Composition with a deferred
     /// region somewhere below.
     pub parent_continuations: HashMap<NodeIndex, ParentContinuation>,
+
+    /// Bridge from stable [`crate::plan::PlanNodeId`] identity to the body
+    /// node's storage position in `graph`. Identity survives re-indexing;
+    /// the `NodeIndex` is a position in this body's own NodeIndex space.
+    /// Rebuilt via [`BoundBody::rebuild_id_index`] once the body graph is
+    /// structurally final. The default is `None`, so an id naming no live
+    /// body node reads `None` rather than aliasing `NodeIndex(0)`.
+    pub id_to_index: crate::plan::SecondaryMap<crate::plan::PlanNodeId, Option<NodeIndex>>,
 }
 
 impl BoundBody {
@@ -200,7 +208,17 @@ impl BoundBody {
             body_window_configs: HashMap::new(),
             deferred_regions: HashMap::new(),
             parent_continuations: HashMap::new(),
+            id_to_index: crate::plan::SecondaryMap::with_default(None),
         }
+    }
+
+    /// Rebuild the [`crate::plan::PlanNodeId`] → [`NodeIndex`] bridge from
+    /// this body's `graph`. Call once the body mini-DAG is structurally
+    /// final (after toposort), so every live body node id resolves to its
+    /// current storage position. Replaces the prior map wholesale; see
+    /// [`super::execution::build_id_index`] for the coverage invariant.
+    pub fn rebuild_id_index(&mut self) {
+        self.id_to_index = super::execution::build_id_index(&self.graph);
     }
 }
 

--- a/crates/clinker-plan/src/plan/entity.rs
+++ b/crates/clinker-plan/src/plan/entity.rs
@@ -1,0 +1,225 @@
+#![forbid(unsafe_code)]
+//! Dense entity-id storage: typed `u32` newtype keys plus the two map
+//! shapes that key off them.
+//!
+//! This mirrors the `cranelift-entity` / rustc `IndexVec` model — a
+//! newtype index plus a dense `SecondaryMap` that attaches per-entity
+//! side data — while taking no external dependency. Everything here is
+//! pure `std`.
+//!
+//! The whole point is to replace `HashMap<NodeName, T>`-style side tables
+//! with `O(1)`-indexed vectors keyed by a stable, dense id. An
+//! [`EntityRef`] is just a position; identity is conferred by *where the
+//! id was minted*, not by anything stored in the value.
+
+use std::marker::PhantomData;
+use std::ops::Index;
+
+/// A typed, dense, `u32`-backed entity index.
+///
+/// Implementors are the newtype keys minted by [`entity_id!`]. The
+/// contract is a bijection with `usize` over the representable range:
+/// `EntityRef::new(i).index() == i`. Keys are positions into a backing
+/// `Vec`, so they must be `Copy`, totally comparable, and hashable to
+/// serve as map keys and set members.
+pub trait EntityRef: Copy + Eq + std::hash::Hash {
+    /// Build the key for slot `index`.
+    fn new(index: usize) -> Self;
+
+    /// The slot this key addresses.
+    fn index(self) -> usize;
+}
+
+/// Define a dense `u32` entity-id newtype implementing [`EntityRef`].
+///
+/// Accepts pass-through doc comments and attributes ahead of the struct,
+/// so callers document the id at the definition site. The generated type
+/// derives the full ordering/hashing/serde stack and renders as
+/// `Name(3)` in both `Debug` and `Display`.
+macro_rules! entity_id {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident;) => {
+        $(#[$meta])*
+        #[derive(
+            Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize,
+        )]
+        $vis struct $name(u32);
+
+        impl $crate::plan::entity::EntityRef for $name {
+            #[inline]
+            fn new(index: usize) -> Self {
+                debug_assert!(
+                    index <= u32::MAX as usize,
+                    concat!(stringify!($name), " index out of u32 range"),
+                );
+                $name(index as u32)
+            }
+
+            #[inline]
+            fn index(self) -> usize {
+                self.0 as usize
+            }
+        }
+
+        impl ::std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                // `Name(3)` reads the same in logs and in `{:?}` dumps,
+                // and stays terse inside the larger plan structures that
+                // embed these ids by the hundreds.
+                write!(f, concat!(stringify!($name), "({})"), self.0)
+            }
+        }
+
+        impl ::std::fmt::Display for $name {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                write!(f, concat!(stringify!($name), "({})"), self.0)
+            }
+        }
+    };
+}
+
+/// Dense side-table from an [`EntityRef`] key to a value, with a stored
+/// default for absent keys.
+///
+/// This never mints keys — it attaches data to keys minted elsewhere.
+/// Reads of an absent key (one past the end of the materialized backing
+/// vec) return the stored default rather than panicking; writes grow the
+/// vec with clones of that default. This is the Cranelift / rustc
+/// "dense + default-on-absent" shape.
+///
+/// The default determines what "absent" reads as: a
+/// `SecondaryMap<K, Option<T>>` reads `None` for never-written keys, a
+/// `SecondaryMap<K, u32>` reads `0`. Choose `V` (and, via
+/// [`with_default`](SecondaryMap::with_default), the default itself) so
+/// the absent reading is the one you want.
+#[derive(Debug, Clone)]
+pub struct SecondaryMap<K: EntityRef, V: Clone> {
+    values: Vec<V>,
+    default: V,
+    _key: PhantomData<fn(K) -> K>,
+}
+
+impl<K: EntityRef, V: Clone> SecondaryMap<K, V> {
+    /// An empty map whose absent-key default is `default`. Use this when
+    /// `V` has no `Default`, or when the wanted absent reading differs
+    /// from `V::default()`.
+    pub fn with_default(default: V) -> Self {
+        Self {
+            values: Vec::new(),
+            default,
+            _key: PhantomData,
+        }
+    }
+
+    /// Borrow the value at `k`, returning the stored default for any key
+    /// not yet materialized. Never panics.
+    pub fn get(&self, k: K) -> &V {
+        self.values.get(k.index()).unwrap_or(&self.default)
+    }
+
+    /// Set the value at `k`, growing the backing vec with clones of the
+    /// default so every intermediate slot stays readable as the default.
+    pub fn insert(&mut self, k: K, v: V) {
+        let i = k.index();
+        if i >= self.values.len() {
+            self.values.resize(i + 1, self.default.clone());
+        }
+        self.values[i] = v;
+    }
+
+    /// Drop all materialized slots. The default is retained.
+    pub fn clear(&mut self) {
+        self.values.clear();
+    }
+}
+
+impl<K: EntityRef, V: Clone> Index<K> for SecondaryMap<K, V> {
+    type Output = V;
+
+    /// Returns the stored default for absent keys; never panics.
+    fn index(&self, k: K) -> &V {
+        self.get(k)
+    }
+}
+
+entity_id! {
+    /// Dense, globally-unique identity for a node in a compiled plan.
+    ///
+    /// Minted once at graph-construction time and carried unchanged
+    /// through every plan and exec pass, a `PlanNodeId` is *the* key for
+    /// per-node side tables ([`SecondaryMap`] keyed by it). It is
+    /// deliberately distinct from a graph `NodeIndex`: a `NodeIndex` is a
+    /// storage position within one graph and can shift as the graph is
+    /// rebuilt, whereas a `PlanNodeId` is stable identity that survives
+    /// lowering, re-indexing, and cross-pass handoff.
+    pub struct PlanNodeId;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A standalone test key so the map tests do not lean on PlanNodeId's
+    // semantics, only on the EntityRef contract.
+    entity_id! {
+        /// Test-only entity key.
+        pub struct TestId;
+    }
+
+    #[test]
+    fn entity_ref_round_trips() {
+        for i in [0usize, 1, 2, 7, 1000, u32::MAX as usize] {
+            assert_eq!(TestId::new(i).index(), i);
+        }
+    }
+
+    #[test]
+    fn entity_ref_equality_and_ordering_follow_u32() {
+        let a = TestId::new(3);
+        let b = TestId::new(3);
+        let c = TestId::new(9);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert!(a < c);
+        assert!(c > b);
+    }
+
+    #[test]
+    fn entity_id_renders_as_documented() {
+        let id = PlanNodeId::new(3);
+        assert_eq!(format!("{id}"), "PlanNodeId(3)");
+        assert_eq!(format!("{id:?}"), "PlanNodeId(3)");
+    }
+
+    #[test]
+    fn secondary_map_with_default_for_non_default_value() {
+        // &str has no Default; with_default supplies the absent reading.
+        let mut m: SecondaryMap<TestId, &str> = SecondaryMap::with_default("missing");
+        assert_eq!(*m.get(TestId::new(0)), "missing");
+        m.insert(TestId::new(1), "present");
+        assert_eq!(*m.get(TestId::new(0)), "missing");
+        assert_eq!(*m.get(TestId::new(1)), "present");
+    }
+
+    #[test]
+    fn secondary_map_insert_past_end_grows_with_default() {
+        let mut m: SecondaryMap<TestId, u32> = SecondaryMap::with_default(0);
+        m.insert(TestId::new(3), 77);
+        // Intermediate slots materialized to the default; reads go through
+        // both `get` and the `Index` impl.
+        assert_eq!(*m.get(TestId::new(0)), 0);
+        assert_eq!(m[TestId::new(1)], 0);
+        assert_eq!(m[TestId::new(2)], 0);
+        assert_eq!(m[TestId::new(3)], 77);
+        // Beyond the materialized range still reads the default.
+        assert_eq!(*m.get(TestId::new(4)), 0);
+    }
+
+    #[test]
+    fn secondary_map_clear_retains_default() {
+        let mut m: SecondaryMap<TestId, u32> = SecondaryMap::with_default(9);
+        m.insert(TestId::new(0), 1);
+        m.clear();
+        // Cleared slots read the retained default again.
+        assert_eq!(*m.get(TestId::new(0)), 9);
+    }
+}

--- a/crates/clinker-plan/src/plan/execution/composition.rs
+++ b/crates/clinker-plan/src/plan/execution/composition.rs
@@ -55,34 +55,18 @@ pub(crate) fn resolve_composition_body_windows(
             continue;
         };
 
-        // Build a parent-DAG name → NodeIndex map once per body so
-        // later port resolutions don't re-walk the parent graph for
-        // every window. Top-level lookups walk parent_dag; nested-
-        // body lookups would need the enclosing body's mini-DAG, but
-        // for this pass the parent context is always the top-level
-        // DAG — nested ParentNode rooting through multiple body
-        // layers is an extension that the dispatcher's
-        // `current_body_node_input_refs` plumbing already handles via
-        // active_stack walks; the spec list emitted here points at the
-        // most-immediate parent-DAG operator. Top-level pipelines
-        // dominate the production geometry so this is the load-
-        // bearing case.
-        let mut parent_name_to_idx: std::collections::HashMap<&str, NodeIndex> =
-            std::collections::HashMap::new();
-        for idx in parent_dag.graph.node_indices() {
-            parent_name_to_idx.insert(parent_dag.graph[idx].name(), idx);
-        }
-
         // Find this body's call-site composition node in the parent
         // DAG. Multi-call-site signatures (the same .comp.yaml
         // referenced by N composition nodes) bind to N distinct
         // `CompositionBodyId`s — `composition_body_assignments` keys
-        // by composition node name, not body file path, so each
-        // body has exactly one composition node.
+        // by composition node id, not body file path, so each body has
+        // exactly one composition node. The call-site id resolves to its
+        // current `NodeIndex` through the parent DAG's `id_to_index`
+        // bridge.
         let mut composition_idx: Option<NodeIndex> = None;
-        for (comp_name, &assigned_id) in &artifacts.composition_body_assignments {
+        for (&comp_id, &assigned_id) in &artifacts.composition_body_assignments {
             if assigned_id == body_id
-                && let Some(&idx) = parent_name_to_idx.get(comp_name.as_str())
+                && let Some(idx) = *parent_dag.id_to_index.get(comp_id)
             {
                 composition_idx = Some(idx);
                 break;
@@ -141,12 +125,10 @@ pub(crate) fn resolve_composition_body_windows(
             // `$window.sum(amount)` adds `amount`, and `emit x = y` adds
             // `y`. The analyzer is the same one consumed at top-level
             // lowering (`config/mod.rs`); body Transforms register their
-            // typed programs in `artifacts.typed` under their own `Body`
-            // scope, so resolve by `(Body(body_id), name)` here.
-            if let Some(typed) = artifacts.typed_get(
-                crate::plan::bind_schema::NodeScope::Body(body_id),
-                transform_name,
-            ) {
+            // typed programs in `artifacts.typed` under their own
+            // `PlanNodeId`, so resolve by the body node's id here (read off
+            // the body mini-DAG at `transform_idx`).
+            if let Some(typed) = artifacts.typed_get(body.graph[transform_idx].id()) {
                 let analysis = cxl::analyzer::analyze_transform(transform_name, typed);
                 for f in &analysis.accessed_fields {
                     arena_fields.insert(f.clone());

--- a/crates/clinker-plan/src/plan/execution/dag.rs
+++ b/crates/clinker-plan/src/plan/execution/dag.rs
@@ -52,7 +52,7 @@ impl ExecutionPlanDag {
         output_projections: Vec<OutputSpec>,
         parallelism: ParallelismProfile,
     ) -> Self {
-        Self {
+        let mut dag = Self {
             graph,
             topo_order,
             source_dag,
@@ -62,7 +62,10 @@ impl ExecutionPlanDag {
             node_properties: HashMap::new(),
             deferred_regions: HashMap::new(),
             parent_continuations: HashMap::new(),
-        }
+            id_to_index: SecondaryMap::with_default(None),
+        };
+        dag.rebuild_id_index();
+        dag
     }
 
     /// Build a transient `ExecutionPlanDag` whose graph + topo_order
@@ -101,7 +104,28 @@ impl ExecutionPlanDag {
             // nested Composition, it reads continuations from the same
             // surface as the parent dispatcher uses.
             parent_continuations: body.parent_continuations.clone(),
+            // Runtime body DAGs never resolve id→index; the bridge is a
+            // compile-time concern (composition window resolution runs
+            // against the parent DAG at compile, not here), so leave it
+            // empty rather than clone the body's.
+            id_to_index: SecondaryMap::with_default(None),
         }
+    }
+
+    /// Rebuild the [`PlanNodeId`] → [`NodeIndex`] bridge from the current
+    /// graph. Call after every toposort or structural mutation that
+    /// finalizes the graph: the bridge must name every live node so a
+    /// later id lookup resolves to the node's current storage position.
+    /// Replaces the prior map wholesale so an id whose node was removed no
+    /// longer resolves. See [`build_id_index`] for the coverage invariant.
+    pub fn rebuild_id_index(&mut self) {
+        self.id_to_index = build_id_index(&self.graph);
+    }
+
+    /// Current storage position of the node with stable identity `id`, or
+    /// `None` when no live node carries that id.
+    pub fn index_of(&self, id: PlanNodeId) -> Option<NodeIndex> {
+        self.id_to_index[id]
     }
 
     /// `Some(region)` iff `idx` participates in any deferred region on
@@ -667,6 +691,7 @@ mod port_tag_guard_tests {
     use super::*;
     use crate::plan::bind_schema::CompileArtifacts;
     use crate::plan::composition_body::CompositionBodyId;
+    use crate::plan::{EntityRef, PlanNodeId, SecondaryMap};
     use clinker_record::SchemaBuilder;
     use std::sync::Arc;
 
@@ -684,21 +709,24 @@ mod port_tag_guard_tests {
             node_properties: HashMap::new(),
             deferred_regions: HashMap::new(),
             parent_continuations: HashMap::new(),
+            id_to_index: SecondaryMap::with_default(None),
         }
     }
 
-    fn source_node(name: &str) -> PlanNode {
+    fn source_node(name: &str, id: usize) -> PlanNode {
         PlanNode::Source {
             name: name.to_string(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             resolved: None,
             output_schema: SchemaBuilder::new().build(),
         }
     }
 
-    fn composition_node(name: &str) -> PlanNode {
+    fn composition_node(name: &str, id: usize) -> PlanNode {
         PlanNode::Composition {
             name: name.to_string(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             body: CompositionBodyId::SENTINEL,
             output_schema: Arc::new(clinker_record::Schema::new(Vec::new())),
@@ -708,8 +736,8 @@ mod port_tag_guard_tests {
     #[test]
     fn diagnose_silent_when_every_composition_edge_is_port_tagged() {
         let mut dag = empty_dag();
-        let src = dag.graph.add_node(source_node("src"));
-        let comp = dag.graph.add_node(composition_node("comp"));
+        let src = dag.graph.add_node(source_node("src", 0));
+        let comp = dag.graph.add_node(composition_node("comp", 1));
         dag.graph.add_edge(
             src,
             comp,
@@ -731,8 +759,8 @@ mod port_tag_guard_tests {
     #[test]
     fn diagnose_emits_e152_for_untagged_top_level_composition_edge() {
         let mut dag = empty_dag();
-        let src = dag.graph.add_node(source_node("src"));
-        let comp = dag.graph.add_node(composition_node("comp"));
+        let src = dag.graph.add_node(source_node("src", 0));
+        let comp = dag.graph.add_node(composition_node("comp", 1));
         dag.graph.add_edge(
             src,
             comp,
@@ -769,8 +797,8 @@ mod port_tag_guard_tests {
         let mut artifacts = CompileArtifacts::default();
         let body_id = artifacts.fresh_body_id();
         let mut body_graph = DiGraph::<PlanNode, PlanEdge>::new();
-        let body_src = body_graph.add_node(source_node("body_src"));
-        let body_comp = body_graph.add_node(composition_node("nested_comp"));
+        let body_src = body_graph.add_node(source_node("body_src", 0));
+        let body_comp = body_graph.add_node(composition_node("nested_comp", 1));
         body_graph.add_edge(
             body_src,
             body_comp,
@@ -797,6 +825,7 @@ mod port_tag_guard_tests {
             body_window_configs: HashMap::new(),
             deferred_regions: HashMap::new(),
             parent_continuations: HashMap::new(),
+            id_to_index: SecondaryMap::with_default(None),
         };
         artifacts.insert_body(body_id, body);
         let diags = diagnose_untagged_composition_edges(&dag, &artifacts);

--- a/crates/clinker-plan/src/plan/execution/enforcer.rs
+++ b/crates/clinker-plan/src/plan/execution/enforcer.rs
@@ -64,6 +64,7 @@ impl ExecutionPlanDag {
     pub fn insert_enforcer_sorts(
         &mut self,
         inputs: &HashMap<String, SourceConfig>,
+        artifacts: &mut crate::plan::bind_schema::CompileArtifacts,
     ) -> Result<(), PipelineError> {
         // Reserved-prefix guard: validate up-front so insertions cannot
         // collide with a user-declared name. Covers every reserved
@@ -155,6 +156,7 @@ impl ExecutionPlanDag {
             let consumer_name = self.graph[consumer_idx].name().to_string();
             let sort_node = PlanNode::Sort {
                 name: format!("{ENFORCER_SORT_PREFIX}{consumer_name}"),
+                id: artifacts.fresh_node_id(),
                 span: Span::SYNTHETIC,
                 sort_fields: required,
             };
@@ -195,6 +197,7 @@ impl ExecutionPlanDag {
     pub fn inject_correlation_sort(
         &mut self,
         sources: &[&crate::config::pipeline_node::SourceBody],
+        artifacts: &mut crate::plan::bind_schema::CompileArtifacts,
     ) -> Result<(), PipelineError> {
         for body in sources {
             let Some(correlation_key) = body.correlation_key.as_ref() else {
@@ -281,6 +284,7 @@ impl ExecutionPlanDag {
 
             let sort_node = PlanNode::Sort {
                 name: format!("{CORRELATION_SORT_PREFIX}{source_name}"),
+                id: artifacts.fresh_node_id(),
                 span: Span::SYNTHETIC,
                 sort_fields,
             };
@@ -335,6 +339,7 @@ impl ExecutionPlanDag {
         &mut self,
         sources: &[&crate::config::pipeline_node::SourceBody],
         max_group_buffer: u64,
+        artifacts: &mut crate::plan::bind_schema::CompileArtifacts,
     ) -> Result<(), PipelineError> {
         if sources.iter().all(|b| b.correlation_key.is_none()) {
             return Ok(());
@@ -372,6 +377,7 @@ impl ExecutionPlanDag {
 
         let commit_node = PlanNode::CorrelationCommit {
             name: format!("{CORRELATION_COMMIT_PREFIX}terminal"),
+            id: artifacts.fresh_node_id(),
             span: Span::SYNTHETIC,
             commit_group_by,
             max_group_buffer,

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -2167,6 +2167,7 @@ mod spill_projection_tests {
     use super::*;
     use crate::plan::combine::{CombinePredicateSummary, CombineStrategy};
     use crate::plan::properties::NodeProperties;
+    use crate::plan::{EntityRef, PlanNodeId};
     use petgraph::graph::DiGraph;
     use std::sync::Arc;
 
@@ -2184,9 +2185,10 @@ mod spill_projection_tests {
         )
     }
 
-    fn combine_node(name: &str, strategy: CombineStrategy) -> PlanNode {
+    fn combine_node(name: &str, id: usize, strategy: CombineStrategy) -> PlanNode {
         PlanNode::Combine {
             name: name.to_string(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             strategy,
             driving_input: "a".to_string(),
@@ -2206,9 +2208,10 @@ mod spill_projection_tests {
         }
     }
 
-    fn sort_node(name: &str) -> PlanNode {
+    fn sort_node(name: &str, id: usize) -> PlanNode {
         PlanNode::Sort {
             name: name.to_string(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             sort_fields: Vec::new(),
         }
@@ -2217,12 +2220,13 @@ mod spill_projection_tests {
     /// A Source carrying an explicit output schema of `column_names`. The
     /// schema is the exact `Arc` every record this Source emits carries, so a
     /// downstream node's runtime input-record width equals this column count.
-    fn source_node(name: &str, column_names: &[&str]) -> PlanNode {
+    fn source_node(name: &str, id: usize, column_names: &[&str]) -> PlanNode {
         let schema = clinker_record::Schema::new(
             column_names.iter().map(|c| Box::<str>::from(*c)).collect(),
         );
         PlanNode::Source {
             name: name.to_string(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             resolved: None,
             output_schema: Arc::new(schema),
@@ -2251,18 +2255,19 @@ mod spill_projection_tests {
         let mut dag = empty_dag();
         add_node(
             &mut dag,
-            combine_node("inline_join", CombineStrategy::HashBuildProbe),
+            combine_node("inline_join", 0, CombineStrategy::HashBuildProbe),
             1_000,
         );
         add_node(
             &mut dag,
-            combine_node("range_join", CombineStrategy::IEJoin),
+            combine_node("range_join", 1, CombineStrategy::IEJoin),
             1_000,
         );
         add_node(
             &mut dag,
             combine_node(
                 "hashpart_join",
+                2,
                 CombineStrategy::HashPartitionIEJoin { partition_bits: 4 },
             ),
             1_000,
@@ -2271,16 +2276,17 @@ mod spill_projection_tests {
             &mut dag,
             combine_node(
                 "grace_join",
+                3,
                 CombineStrategy::GraceHash { partition_bits: 4 },
             ),
             1_000,
         );
         add_node(
             &mut dag,
-            combine_node("merge_join", CombineStrategy::SortMerge),
+            combine_node("merge_join", 4, CombineStrategy::SortMerge),
             1_000,
         );
-        add_node(&mut dag, sort_node("external_sort"), 1_000);
+        add_node(&mut dag, sort_node("external_sort", 5), 1_000);
 
         let out = dag.spill_compression_explain(crate::config::CompressMode::Auto, 1_024);
 
@@ -2321,13 +2327,14 @@ mod spill_projection_tests {
         let mut dag = empty_dag();
         add_node(
             &mut dag,
-            combine_node("inline_join", CombineStrategy::HashBuildProbe),
+            combine_node("inline_join", 0, CombineStrategy::HashBuildProbe),
             5_000,
         );
         add_node(
             &mut dag,
             combine_node(
                 "grace_join",
+                1,
                 CombineStrategy::GraceHash { partition_bits: 4 },
             ),
             7_000,
@@ -2362,8 +2369,10 @@ mod spill_projection_tests {
         // Five-wide upstream: three declared columns plus two engine-stamped
         // tail columns, the shape ingest hands every record at runtime.
         let upstream_columns = ["sku", "price", "qty", "$source.file", "$source.name"];
-        let src_idx = dag.graph.add_node(source_node("orders", &upstream_columns));
-        let sort_idx = dag.graph.add_node(sort_node("__sort__orders"));
+        let src_idx = dag
+            .graph
+            .add_node(source_node("orders", 0, &upstream_columns));
+        let sort_idx = dag.graph.add_node(sort_node("__sort__orders", 1));
         dag.graph.add_edge(
             src_idx,
             sort_idx,

--- a/crates/clinker-plan/src/plan/execution/graph_util.rs
+++ b/crates/clinker-plan/src/plan/execution/graph_util.rs
@@ -1,9 +1,38 @@
 //! Plan-graph lookups over a compiled [`ExecutionPlanDag`] shared by the
 //! planner's strategy-selection passes and the runtime dispatch.
 
-use super::{ExecutionPlanDag, PlanNode, matches_upstream_name};
+use super::{ExecutionPlanDag, PlanEdge, PlanNode, matches_upstream_name};
 use crate::error::PipelineError;
+use crate::plan::{PlanNodeId, SecondaryMap};
 use petgraph::Direction;
+use petgraph::graph::DiGraph;
+
+/// Build the [`PlanNodeId`] → [`NodeIndex`] bridge for a finalized plan
+/// graph: every live node's id maps to `Some(its current index)`.
+///
+/// Call after every toposort or structural mutation that finalizes the
+/// graph — the bridge must name every live node so a later id lookup
+/// resolves to the node's current storage position. In debug builds this
+/// asserts the bridge covers every live node id; a missing entry signals a
+/// node minted with a stale/duplicate id, which would silently collapse two
+/// nodes in any id-keyed side table. Shared verbatim by the top-level
+/// [`ExecutionPlanDag`] and each composition `BoundBody`.
+pub(crate) fn build_id_index(
+    graph: &DiGraph<PlanNode, PlanEdge>,
+) -> SecondaryMap<PlanNodeId, Option<petgraph::graph::NodeIndex>> {
+    let mut id_to_index = SecondaryMap::with_default(None);
+    for idx in graph.node_indices() {
+        let id = graph[idx].id();
+        id_to_index.insert(id, Some(idx));
+    }
+    debug_assert!(
+        graph
+            .node_indices()
+            .all(|idx| id_to_index[graph[idx].id()] == Some(idx)),
+        "id_to_index bridge does not cover every live node id",
+    );
+    id_to_index
+}
 
 /// Compute the init-phase ancestor closure for a compiled plan.
 ///

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -19,7 +19,7 @@ pub use composition::*;
 pub use dag::*;
 pub use enforcer::*;
 pub use explain::*;
-pub(crate) use graph_util::resolve_envelope_header_upstreams_in_graph;
+pub(crate) use graph_util::{build_id_index, resolve_envelope_header_upstreams_in_graph};
 pub use graph_util::{
     compute_init_phase_node_set, resolve_envelope_header_upstreams, single_predecessor,
 };
@@ -42,6 +42,7 @@ use crate::plan::composition_body::CompositionBodyId;
 use crate::plan::index::{AnalyticWindowSpec, IndexSpec};
 use crate::plan::row_type::QualifiedField;
 use crate::plan::types::{AggregateStrategy, JoinSide};
+use crate::plan::{PlanNodeId, SecondaryMap};
 use clinker_core_types::span::Span;
 use clinker_record::Schema;
 use cxl::plan::CompiledAggregate;
@@ -93,6 +94,12 @@ pub enum NodeExecutionReqs {
 pub enum PlanNode {
     Source {
         name: String,
+        /// Dense, stable identity minted once at graph construction and
+        /// carried unchanged through every plan/exec pass. Distinct from
+        /// the petgraph `NodeIndex` storage position, which shifts as the
+        /// graph is rebuilt. Serialized so it round-trips through
+        /// `--explain`.
+        id: PlanNodeId,
         /// Source-span of this node in the originating YAML document.
         /// `Span::SYNTHETIC` for planner-synthesized nodes and for nodes
         /// produced by the legacy `transformations:` planner path that
@@ -113,6 +120,8 @@ pub enum PlanNode {
     },
     Transform {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Full resolved Transform payload.
@@ -149,6 +158,8 @@ pub enum PlanNode {
     },
     Route {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         mode: RouteMode,
@@ -157,6 +168,8 @@ pub enum PlanNode {
     },
     Merge {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Canonical output schema adopted from `input[0]`. All Merge inputs
@@ -170,6 +183,8 @@ pub enum PlanNode {
     },
     Output {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Full resolved Output payload.
@@ -187,6 +202,8 @@ pub enum PlanNode {
     /// schema.
     Reshape {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Parsed Reshape configuration (`partition_by` / `order_by` /
@@ -211,6 +228,8 @@ pub enum PlanNode {
     /// `config` and the unchanged output schema.
     Cull {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Parsed Cull configuration (`partition_by` / `order_by` /
@@ -244,6 +263,8 @@ pub enum PlanNode {
     /// port stays rejected at plan validation this release.
     Envelope {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         strategy: crate::config::pipeline_node::EnvelopeStrategy,
@@ -286,6 +307,8 @@ pub enum PlanNode {
     /// names starting with `__sort_for_` are rejected at compile time.
     Sort {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         sort_fields: Vec<SortField>,
@@ -299,6 +322,8 @@ pub enum PlanNode {
     /// shipped through the JSON `--explain` channel.
     Aggregation {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         config: AggregateConfig,
@@ -342,6 +367,8 @@ pub enum PlanNode {
     /// keyed by the `body` handle.
     Composition {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Handle into `CompileArtifacts.composition_bodies`. Populated by
@@ -368,6 +395,8 @@ pub enum PlanNode {
     /// [`CORRELATION_COMMIT_PREFIX`].
     CorrelationCommit {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Correlation key fields. The union of every source's
@@ -392,6 +421,8 @@ pub enum PlanNode {
     /// duplicated here.
     Combine {
         name: String,
+        /// Stable node identity; see the `Source` variant's `id`.
+        id: PlanNodeId,
         #[serde(skip)]
         span: Span,
         /// Planner-selected strategy. Defaults to `HashBuildProbe`;
@@ -553,6 +584,32 @@ pub struct PlanOutputPayload {
 }
 
 impl PlanNode {
+    /// Dense, stable identity of this node, minted once at graph
+    /// construction and carried unchanged through every plan/exec pass.
+    ///
+    /// This is the node's identity, as opposed to its petgraph
+    /// `NodeIndex`, which is a storage position that can shift when the
+    /// graph is rebuilt. Use the id (via a `SecondaryMap` keyed by it or
+    /// the DAG's `id_to_index` bridge) to attach per-node side data that
+    /// must survive lowering, re-indexing, and cross-pass handoff.
+    pub fn id(&self) -> PlanNodeId {
+        match self {
+            PlanNode::Source { id, .. }
+            | PlanNode::Transform { id, .. }
+            | PlanNode::Route { id, .. }
+            | PlanNode::Merge { id, .. }
+            | PlanNode::Output { id, .. }
+            | PlanNode::Reshape { id, .. }
+            | PlanNode::Cull { id, .. }
+            | PlanNode::Envelope { id, .. }
+            | PlanNode::Sort { id, .. }
+            | PlanNode::Aggregation { id, .. }
+            | PlanNode::Composition { id, .. }
+            | PlanNode::Combine { id, .. }
+            | PlanNode::CorrelationCommit { id, .. } => *id,
+        }
+    }
+
     /// Get the name of this node regardless of variant.
     pub fn name(&self) -> &str {
         match self {
@@ -1205,6 +1262,14 @@ pub struct ExecutionPlanDag {
     /// records to drive the parent's downstream chain on
     /// post-recompute data.
     pub parent_continuations: HashMap<NodeIndex, crate::plan::deferred_region::ParentContinuation>,
+    /// Bridge from stable [`PlanNodeId`] identity to the node's current
+    /// petgraph storage position. The id is identity; the `NodeIndex` is
+    /// where the node currently sits, which shifts as the graph is
+    /// rebuilt. Rebuilt via [`ExecutionPlanDag::rebuild_id_index`] after
+    /// every structural mutation that finalizes the graph. The default is
+    /// `None`, so reading an id that names no live node yields `None`
+    /// rather than silently aliasing `NodeIndex(0)`.
+    pub id_to_index: SecondaryMap<PlanNodeId, Option<NodeIndex>>,
 }
 
 /// Errors from execution plan compilation.

--- a/crates/clinker-plan/src/plan/extraction.rs
+++ b/crates/clinker-plan/src/plan/extraction.rs
@@ -405,22 +405,25 @@ mod tests {
         DependencyType, ExecutionPlanDag, NodeExecutionReqs, ParallelismClass, PlanEdge, PlanNode,
         SourceTier,
     };
+    use crate::plan::{EntityRef, PlanNodeId};
     use clinker_core_types::span::Span;
     use petgraph::graph::DiGraph;
     use std::collections::BTreeSet;
 
-    fn source(name: &str) -> PlanNode {
+    fn source(name: &str, id: usize) -> PlanNode {
         PlanNode::Source {
             name: name.to_owned(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             resolved: None,
             output_schema: clinker_record::SchemaBuilder::new().build(),
         }
     }
 
-    fn transform(name: &str) -> PlanNode {
+    fn transform(name: &str, id: usize) -> PlanNode {
         PlanNode::Transform {
             name: name.to_owned(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             resolved: None,
             parallelism_class: ParallelismClass::Stateless,
@@ -434,17 +437,19 @@ mod tests {
         }
     }
 
-    fn output(name: &str) -> PlanNode {
+    fn output(name: &str, id: usize) -> PlanNode {
         PlanNode::Output {
             name: name.to_owned(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             resolved: None,
         }
     }
 
-    fn route(name: &str) -> PlanNode {
+    fn route(name: &str, id: usize) -> PlanNode {
         PlanNode::Route {
             name: name.to_owned(),
+            id: PlanNodeId::new(id),
             span: Span::SYNTHETIC,
             mode: RouteMode::Exclusive,
             branches: vec![],
@@ -467,7 +472,7 @@ mod tests {
             .filter(|&&idx| matches!(graph[idx], PlanNode::Source { .. }))
             .map(|&idx| graph[idx].name().to_owned())
             .collect();
-        ExecutionPlanDag {
+        let mut dag = ExecutionPlanDag {
             graph,
             topo_order: topo,
             source_dag: vec![SourceTier { sources }],
@@ -480,16 +485,19 @@ mod tests {
             node_properties: Default::default(),
             deferred_regions: Default::default(),
             parent_continuations: Default::default(),
-        }
+            id_to_index: crate::plan::SecondaryMap::with_default(None),
+        };
+        dag.rebuild_id_index();
+        dag
     }
 
     /// Build a simple 4-node linear pipeline: src → t1 → t2 → out
     fn build_4_node_dag() -> ExecutionPlanDag {
         let mut graph = DiGraph::new();
-        let src = graph.add_node(source("src"));
-        let t1 = graph.add_node(transform("t1"));
-        let t2 = graph.add_node(transform("t2"));
-        let out_idx = graph.add_node(output("out"));
+        let src = graph.add_node(source("src", 0));
+        let t1 = graph.add_node(transform("t1", 1));
+        let t2 = graph.add_node(transform("t2", 2));
+        let out_idx = graph.add_node(output("out", 3));
         graph.add_edge(src, t1, data_edge());
         graph.add_edge(t1, t2, data_edge());
         graph.add_edge(t2, out_idx, data_edge());
@@ -499,10 +507,10 @@ mod tests {
     /// Build a DAG with a Route node: src → route → [branch_a, branch_b]
     fn build_route_dag() -> ExecutionPlanDag {
         let mut graph = DiGraph::new();
-        let src = graph.add_node(source("src"));
-        let router = graph.add_node(route("router"));
-        let a = graph.add_node(output("branch_a"));
-        let b = graph.add_node(output("branch_b"));
+        let src = graph.add_node(source("src", 0));
+        let router = graph.add_node(route("router", 1));
+        let a = graph.add_node(output("branch_a", 2));
+        let b = graph.add_node(output("branch_b", 3));
         graph.add_edge(src, router, data_edge());
         graph.add_edge(router, a, data_edge());
         graph.add_edge(router, b, data_edge());

--- a/crates/clinker-plan/src/plan/mod.rs
+++ b/crates/clinker-plan/src/plan/mod.rs
@@ -3,6 +3,7 @@ pub mod combine;
 pub mod compiled;
 pub mod composition_body;
 pub mod deferred_region;
+pub mod entity;
 pub mod envelope_synthesis;
 pub mod execution;
 pub mod explain_provenance;
@@ -15,9 +16,9 @@ pub mod statistics;
 pub mod streaming_eligibility;
 pub mod types;
 
-pub use bind_schema::{NodeScope, ScopedNodeId};
 pub use compiled::{ChannelIdentity, CompiledPlan};
 pub use composition_body::{BoundBody, CompositionBodyId};
+pub use entity::{EntityRef, PlanNodeId, SecondaryMap};
 pub use row_type::{ColumnLookup, QualifiedField, Row, RowTail, TailVarId};
 pub use streaming_eligibility::{StreamingEligibility, qualifies_for_streaming};
 pub use types::{AggregateStrategy, JoinSide};

--- a/crates/clinker-plan/src/plan/tests/combine_body_typed_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/combine_body_typed_on_node.rs
@@ -175,10 +175,17 @@ nodes:
 
     // 2. BODY combine: program is reachable off the node in the
     //    composition body's `graph`, with the same fidelity.
-    let body_id = compiled
-        .artifacts()
+    let artifacts = compiled.artifacts();
+    let body_comp_id = compiled
+        .config()
+        .nodes
+        .iter()
+        .zip(artifacts.top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == "body").then_some(*id))
+        .expect("top-level `body` composition id");
+    let body_id = artifacts
         .composition_body_assignments
-        .get("body")
+        .get(&body_comp_id)
         .copied()
         .expect("composition body assignment for `body`");
     let bound = compiled.body_of(body_id).expect("bound body");

--- a/crates/clinker-plan/src/plan/tests/combine_where_scoped_key.rs
+++ b/crates/clinker-plan/src/plan/tests/combine_where_scoped_key.rs
@@ -1,28 +1,26 @@
-//! Scope-qualified keying of the compile-time `combine_where_typed`
+//! Per-node-id keying of the compile-time `combine_where_typed`
 //! side-table.
 //!
 //! The `where:` predicate program of a Combine lands in the
-//! `CompileArtifacts.combine_where_typed` side-table keyed by
-//! [`ScopedNodeId`]. Before scope-qualified keying it was keyed by the
-//! bare node name, so a combine named the same at top level and inside a
-//! composition body overwrote one entry with the other — the surviving
-//! program was whichever the bind pass visited last, and klinx could not
-//! read the body combine's `where` program scope-correctly.
+//! `CompileArtifacts.combine_where_typed` side-table keyed by its
+//! [`PlanNodeId`]. Before id keying it was keyed by the bare node name, so
+//! a combine named the same at top level and inside a composition body
+//! overwrote one entry with the other — the surviving program was whichever
+//! the bind pass visited last, and klinx could not read the body combine's
+//! `where` program scope-correctly.
 //!
 //! This test compiles a pipeline where a TOP-LEVEL combine and a BODY
 //! combine share the SAME node name (`join_x`) but carry DIFFERENT `where:`
-//! predicates, and asserts both scope-keyed entries survive with their own
-//! distinct program.
-
-use crate::{NodeScope, ScopedNodeId};
+//! predicates, and asserts the two combines get DISTINCT `PlanNodeId`s with
+//! their own independent `combine_where_typed` entry.
 
 use super::deferred_region::compile_with_dir_full;
 
 /// A top-level combine and a composition-body combine both named `join_x`,
-/// each with a distinct `where:` predicate, keep separate
-/// `combine_where_typed` entries under their scope-qualified keys.
+/// each with a distinct `where:` predicate, get distinct `PlanNodeId`s and
+/// keep separate `combine_where_typed` entries under those ids.
 #[test]
-fn combine_where_typed_scoped_key_does_not_collide_across_scopes() {
+fn combine_where_typed_node_id_does_not_collide_across_scopes() {
     let workspace = tempfile::tempdir().expect("tempdir");
     let comp_dir = workspace.path().join("compositions");
     std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
@@ -139,33 +137,57 @@ nodes:
     let compiled = compile_with_dir_full(yaml, workspace.path());
     let artifacts = compiled.artifacts();
 
-    // The body's scope id comes from the composition-body assignment, the
-    // same handle klinx would use to build the read key.
+    // The body's scope id comes from the composition-body assignment,
+    // keyed by the `body` composition call-site node's own id — resolved
+    // from the declaration-order id vector the way production does.
+    let body_comp_id = compiled
+        .config()
+        .nodes
+        .iter()
+        .zip(artifacts.top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == "body").then_some(*id))
+        .expect("top-level `body` composition id");
     let body_id = artifacts
         .composition_body_assignments
-        .get("body")
+        .get(&body_comp_id)
         .copied()
         .expect("composition body assignment for `body`");
 
-    // Both scope-qualified keys resolve — with bare-name keying only one of
-    // these would have been populated (last writer wins).
-    let top_key = ScopedNodeId {
-        scope: NodeScope::TopLevel,
-        name: "join_x".to_string(),
-    };
-    let body_key = ScopedNodeId {
-        scope: NodeScope::Body(body_id),
-        name: "join_x".to_string(),
-    };
+    // Resolve each combine's id: the top-level `join_x` from the
+    // declaration-order id vector (top-level names are unique), the body
+    // `join_x` off the bound body's mini-DAG. The two same-named combines
+    // live in disjoint scopes and so must get DISTINCT ids.
+    let top_id = compiled
+        .config()
+        .nodes
+        .iter()
+        .zip(artifacts.top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == "join_x").then_some(*id))
+        .expect("top-level `join_x` id");
+    let body = compiled.body_of(body_id).expect("bound body for `body`");
+    let body_idx = body
+        .name_to_idx
+        .get("join_x")
+        .copied()
+        .expect("body `join_x` node index");
+    let body_id_for_join = body.graph[body_idx].id();
 
+    assert_ne!(
+        top_id, body_id_for_join,
+        "a top-level combine and a body combine sharing the name `join_x` must \
+         mint distinct PlanNodeIds; got top {top_id} and body {body_id_for_join}"
+    );
+
+    // Both id-keyed entries resolve — with bare-name keying only one of
+    // these would have been populated (last writer wins).
     let top_where = artifacts
         .combine_where_typed
-        .get(&top_key)
-        .expect("top-level join_x where program present under TopLevel scope key");
+        .get(&top_id)
+        .expect("top-level join_x where program present under its id");
     let body_where = artifacts
         .combine_where_typed
-        .get(&body_key)
-        .expect("body join_x where program present under Body scope key");
+        .get(&body_id_for_join)
+        .expect("body join_x where program present under its id");
 
     // The two programs are distinct — distinct `where:` predicates produce
     // distinct typed `Statement::Filter` bodies. The collision-regression:

--- a/crates/clinker-plan/src/plan/tests/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/tests/deferred_region.rs
@@ -49,6 +49,32 @@ fn body_node_idx_for(
         .unwrap_or_else(|| panic!("body node {node_name:?} not found"))
 }
 
+/// Resolve a top-level composition call-site node's [`PlanNodeId`] by name,
+/// the way the production lowering does: from the declaration-order id
+/// vector (top-level names are unique). `composition_body_assignments` keys
+/// by this id, so reads must resolve it rather than indexing by name.
+fn top_level_id_for(compiled: &CompiledPlan, node_name: &str) -> crate::plan::PlanNodeId {
+    let artifacts = compiled.artifacts();
+    compiled
+        .config()
+        .nodes
+        .iter()
+        .zip(artifacts.top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == node_name).then_some(*id))
+        .unwrap_or_else(|| panic!("top-level composition node {node_name:?} not found"))
+}
+
+/// Resolve a body-internal composition call-site node's [`PlanNodeId`] by
+/// name from its parent body's mini-DAG. Body nodes carry their own stable
+/// id, which keys `composition_body_assignments` for nested compositions.
+fn body_composition_id_for(
+    body: &crate::plan::composition_body::BoundBody,
+    node_name: &str,
+) -> crate::plan::PlanNodeId {
+    let idx = body_node_idx_for(body, node_name);
+    body.graph[idx].id()
+}
+
 /// Test 1: Simple region — Source(CK=order_id) → Aggregate(group_by=dept,
 /// total=sum(amount)) → Transform → Output. Exactly one region; producer
 /// is the aggregate; members carry the Transform; outputs carry the
@@ -538,7 +564,7 @@ nodes:
     let artifacts = compiled.artifacts();
     let body_id = artifacts
         .composition_body_assignments
-        .get("body")
+        .get(&top_level_id_for(&compiled, "body"))
         .copied()
         .expect("composition 'body' must be assigned a CompositionBodyId");
     let bound = compiled
@@ -702,7 +728,7 @@ nodes:
     let artifacts = compiled.artifacts();
     let outer_body_id = artifacts
         .composition_body_assignments
-        .get("outer")
+        .get(&top_level_id_for(&compiled, "outer"))
         .copied()
         .expect("outer composition assignment");
     let outer_body = compiled
@@ -714,10 +740,11 @@ nodes:
     );
 
     // Inner body assignment lives under the body-internal Composition
-    // node `inner_call` inside `outer_wrap.comp.yaml`.
+    // node `inner_call` inside `outer_wrap.comp.yaml` — resolve its id off
+    // the outer body's mini-DAG.
     let inner_body_id = artifacts
         .composition_body_assignments
-        .get("inner_call")
+        .get(&body_composition_id_for(outer_body, "inner_call"))
         .copied()
         .expect("inner_call composition assignment");
     let inner_body = compiled
@@ -1044,7 +1071,7 @@ nodes:
     let artifacts = compiled.artifacts();
     let outer_body_id = artifacts
         .composition_body_assignments
-        .get("outer")
+        .get(&top_level_id_for(&compiled, "outer"))
         .copied()
         .expect("outer composition assignment");
     let outer_body = compiled
@@ -1250,7 +1277,7 @@ nodes:
     let artifacts = compiled.artifacts();
     let body_id = artifacts
         .composition_body_assignments
-        .get("body")
+        .get(&top_level_id_for(&compiled, "body"))
         .copied()
         .expect("composition 'body' must be assigned a CompositionBodyId");
     let bound = compiled
@@ -1366,7 +1393,7 @@ nodes:
     let artifacts = compiled.artifacts();
     let body_id = artifacts
         .composition_body_assignments
-        .get("body")
+        .get(&top_level_id_for(&compiled, "body"))
         .copied()
         .expect("composition 'body' must be assigned a CompositionBodyId");
     let bound = compiled
@@ -1509,9 +1536,19 @@ nodes:
     let compiled = compile_with_dir_full(yaml, workspace.path());
     let artifacts = compiled.artifacts();
 
+    // `inner_call` is body-internal to the top-level `outer` composition;
+    // resolve outer's body first, then key by inner_call's body-local id.
+    let outer_body_id = artifacts
+        .composition_body_assignments
+        .get(&top_level_id_for(&compiled, "outer"))
+        .copied()
+        .expect("outer composition must be assigned a CompositionBodyId");
+    let outer_body = compiled
+        .body_of(outer_body_id)
+        .expect("outer body resolves");
     let inner_body_id = artifacts
         .composition_body_assignments
-        .get("inner_call")
+        .get(&body_composition_id_for(outer_body, "inner_call"))
         .copied()
         .expect("inner_call composition must be assigned a CompositionBodyId");
     let inner_body = compiled
@@ -1666,7 +1703,7 @@ nodes:
     // referencing `body_b`'s `composition_idx` and continuation.
     let canonical_body_id: CompositionBodyId = artifacts
         .composition_body_assignments
-        .get("body_a")
+        .get(&plan.graph[body_a_idx].id())
         .copied()
         .expect("body_a must be assigned");
 
@@ -1873,7 +1910,7 @@ nodes:
     let artifacts = compiled.artifacts();
     let body_id = artifacts
         .composition_body_assignments
-        .get("body")
+        .get(&top_level_id_for(&compiled, "body"))
         .copied()
         .expect("composition 'body' must be assigned a CompositionBodyId");
     let bound = compiled

--- a/crates/clinker-plan/src/plan/tests/dup_body_node_name.rs
+++ b/crates/clinker-plan/src/plan/tests/dup_body_node_name.rs
@@ -1,0 +1,108 @@
+//! Duplicate node names inside a composition body must be rejected (E001).
+//!
+//! The top-level E001 duplicate-name pass never sees composition body
+//! files, so without a body-local check two body nodes sharing a name would
+//! collapse to ONE `PlanNodeId` at the `bind_composition` pre-mint
+//! (`HashMap::entry().or_insert_with`) — tripping the `rebuild_id_index`
+//! coverage assert in debug builds and silently aliasing the two nodes'
+//! compiled programs in release. `bind_composition` detects the duplicate
+//! before minting and emits a clear bind-time diagnostic instead.
+
+use std::path::PathBuf;
+
+use crate::config::{CompileContext, PipelineConfig, parse_config};
+
+/// A composition body that declares two transforms both named `dup`
+/// fails to compile with an E001 diagnostic — and does not panic on the
+/// `rebuild_id_index` coverage assert.
+#[test]
+fn duplicate_body_node_name_aborts_with_e001() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    // Body composition with TWO transforms named `dup`. Under the old
+    // bare-name pre-mint these two would share a single `PlanNodeId`.
+    std::fs::write(
+        comp_dir.join("dup_body.comp.yaml"),
+        r#"_compose:
+  name: dup_body
+  inputs:
+    inp:
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: int }
+  outputs:
+    out: dup
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: dup
+    input: inp
+    config:
+      cxl: |
+        emit id = id
+        emit a = val
+  - type: transform
+    name: dup
+    input: dup
+    config:
+      cxl: |
+        emit id = id
+        emit b = a
+"#,
+    )
+    .expect("write comp");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    let yaml = r#"
+pipeline:
+  name: dup_body_demo
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      correlation_key: id
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: int }
+  - type: composition
+    name: body
+    input: src
+    use: ../compositions/dup_body.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out_body
+    input: body
+    config:
+      name: out_body
+      type: csv
+      path: out_body.csv
+      include_unmapped: true
+"#;
+
+    let config: PipelineConfig = parse_config(yaml).expect("parse");
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    // The compile must fail loudly with E001 rather than panic on the
+    // `rebuild_id_index` coverage assert or silently alias the two nodes.
+    let err = config
+        .compile(&ctx)
+        .expect_err("a composition body with duplicate node names must fail to compile");
+
+    let dup_diag = err.iter().find(|d| d.code == "E001").unwrap_or_else(|| {
+        panic!("expected an E001 diagnostic for the duplicate body node; got: {err:?}")
+    });
+    assert!(
+        dup_diag.message.contains("body") && dup_diag.message.contains("dup"),
+        "the E001 message must name the composition body and the duplicated name: {:?}",
+        dup_diag.message
+    );
+}

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -7,6 +7,7 @@ mod dag;
 mod dedup_node_rooted;
 mod deferred_region;
 mod doc_paths;
+mod dup_body_node_name;
 mod envelope_synthesis;
 mod explain_buffer_class;
 mod explain_polish;

--- a/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
+++ b/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
@@ -1,28 +1,26 @@
-//! Scope-qualified keying of the shared `CompileArtifacts.typed`
+//! Per-node-id keying of the shared `CompileArtifacts.typed`
 //! typed-program table (the transform / aggregate / combine-body surface).
 //!
 //! Every CXL-bearing node's typed program lands in `artifacts.typed` keyed
-//! by [`ScopedNodeId`]. Before scope-qualified keying it was keyed by the
-//! bare node name, so a node named the same at top level and inside a
-//! composition body overwrote one entry with the other — the surviving
-//! program was whichever the bind pass visited last. That fed the executor
-//! transform startup table, the `$doc`-attribution walk, and lowering's
-//! per-node program stamp from the wrong scope.
+//! by its [`PlanNodeId`]. Before id keying it was keyed by the bare node
+//! name, so a node named the same at top level and inside a composition
+//! body overwrote one entry with the other — the surviving program was
+//! whichever the bind pass visited last. That fed the executor transform
+//! startup table, the `$doc`-attribution walk, and lowering's per-node
+//! program stamp from the wrong scope.
 //!
 //! This test compiles a pipeline where a TOP-LEVEL transform and a BODY
 //! transform share the SAME node name (`shape`) but emit DIFFERENT fields,
-//! and asserts both scope-keyed entries survive with their own distinct
-//! program.
-
-use crate::NodeScope;
+//! and asserts the two nodes get DISTINCT `PlanNodeId`s with their own
+//! independent typed entry.
 
 use super::deferred_region::compile_with_dir_full;
 
 /// A top-level transform and a composition-body transform both named
-/// `shape`, each emitting a distinct field, keep separate `typed` entries
-/// under their scope-qualified keys.
+/// `shape`, each emitting a distinct field, get distinct `PlanNodeId`s and
+/// keep separate `typed` entries under those ids.
 #[test]
-fn typed_table_scoped_key_does_not_collide_across_scopes() {
+fn typed_table_node_id_does_not_collide_across_scopes() {
     let workspace = tempfile::tempdir().expect("tempdir");
     let comp_dir = workspace.path().join("compositions");
     std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
@@ -107,21 +105,55 @@ nodes:
     let compiled = compile_with_dir_full(yaml, workspace.path());
     let artifacts = compiled.artifacts();
 
-    // The body's scope id comes from the composition-body assignment.
+    // The body's scope id comes from the composition-body assignment,
+    // keyed by the `body` composition call-site node's own id — resolved
+    // from the declaration-order id vector the way production does.
+    let body_comp_id = compiled
+        .config()
+        .nodes
+        .iter()
+        .zip(artifacts.top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == "body").then_some(*id))
+        .expect("top-level `body` composition id");
     let body_id = artifacts
         .composition_body_assignments
-        .get("body")
+        .get(&body_comp_id)
         .copied()
         .expect("composition body assignment for `body`");
 
-    // Both scope-qualified keys resolve — with bare-name keying only one of
+    // Resolve the top-level `shape` node's id from the declaration-order id
+    // vector (top-level names are unique), and the body `shape` node's id
+    // off the bound body's mini-DAG. The two same-named nodes live in
+    // disjoint scopes and so must get DISTINCT ids.
+    let top_id = compiled
+        .config()
+        .nodes
+        .iter()
+        .zip(artifacts.top_level_node_ids.iter())
+        .find_map(|(spanned, id)| (spanned.value.name() == "shape").then_some(*id))
+        .expect("top-level `shape` id");
+    let body = compiled.body_of(body_id).expect("bound body for `body`");
+    let body_idx = body
+        .name_to_idx
+        .get("shape")
+        .copied()
+        .expect("body `shape` node index");
+    let body_id_for_shape = body.graph[body_idx].id();
+
+    assert_ne!(
+        top_id, body_id_for_shape,
+        "a top-level node and a body node sharing the name `shape` must mint \
+         distinct PlanNodeIds; got top {top_id} and body {body_id_for_shape}"
+    );
+
+    // Both id-keyed entries resolve — with bare-name keying only one of
     // these would have been populated (last writer wins).
     let top = artifacts
-        .typed_get(NodeScope::TopLevel, "shape")
-        .expect("top-level `shape` program present under TopLevel scope key");
-    let body = artifacts
-        .typed_get(NodeScope::Body(body_id), "shape")
-        .expect("body `shape` program present under Body scope key");
+        .typed_get(top_id)
+        .expect("top-level `shape` program present under its id");
+    let body_prog = artifacts
+        .typed_get(body_id_for_shape)
+        .expect("body `shape` program present under its id");
 
     let emits = |tp: &cxl::typecheck::TypedProgram, field: &str| -> bool {
         tp.output_row
@@ -129,7 +161,7 @@ nodes:
             .any(|(qf, _)| qf.name.as_ref() == field)
     };
 
-    // Each scope's program carries its OWN emit and not the other's. With
+    // Each id's program carries its OWN emit and not the other's. With
     // bare-name keying the two `shape` nodes shared one table slot, so the
     // last writer's marker would appear under both keys (or one key would be
     // absent entirely, already caught by the `expect`s above).
@@ -140,9 +172,9 @@ nodes:
         top.output_row
     );
     assert!(
-        emits(body, "body_marker") && !emits(body, "top_marker"),
+        emits(body_prog, "body_marker") && !emits(body_prog, "top_marker"),
         "body `shape` must carry `body_marker` and not `top_marker`; \
          got output row {:?}",
-        body.output_row
+        body_prog.output_row
     );
 }

--- a/crates/cxl/src/analyzer/doc_paths.rs
+++ b/crates/cxl/src/analyzer/doc_paths.rs
@@ -75,7 +75,7 @@ pub struct DocPath {
 /// document never declares.
 /// `K` is the node-identity key the caller attributes paths by — a bare
 /// `&str`/`String` when scope cannot collide (e.g. reshape rule labels), or
-/// a scope-qualified identity (the planner's `ScopedNodeId`) when a node
+/// a scope-distinct identity (the planner's `PlanNodeId`) when a node
 /// named the same in two scopes must stay distinct.
 #[derive(Debug, Clone)]
 pub struct DocPathSet<K> {

--- a/docs/ai/80_OPEN_QUESTIONS.md
+++ b/docs/ai/80_OPEN_QUESTIONS.md
@@ -496,7 +496,16 @@ evidence.
   renderer or link checker becomes required.
 - Priority: Low
 
-### 28. Should compiled per-node CXL artifacts be keyed by scope, not bare node name?
+### 28. Should compiled per-node CXL artifacts be keyed by scope, not bare node name? (RESOLVED)
+
+- Resolution: Every per-node-identity side-table in `CompileArtifacts`
+  (`typed`, `combine_where_typed`, `route_branch_typed`, the `combine_*` maps,
+  `envelope_synthesis`, `composition_body_assignments`) is now keyed by a dense
+  `PlanNodeId` minted once at graph construction — a stronger guarantee than
+  `(scope, name)`, since two instantiations of one composition body get
+  disjoint id sets by construction. `ScopedNodeId`/`NodeScope` were deleted, and
+  the cross-scope last-writer-wins collision can no longer occur for these
+  tables. One name-keyed facility remains by design — see open question 29.
 
 - Question: `CompileArtifacts.typed` and `CompileArtifacts.combine_where_typed`
   are flat maps keyed by the bare node name, shared across the top-level
@@ -524,4 +533,58 @@ evidence.
   the flat-map source so the program lowered onto each node is unambiguous;
   add a regression test with a nested composition that reuses a combine name.
   If not, add a bind-time diagnostic rejecting the collision.
+- Priority: Low
+
+### 29. Should `ProvenanceDb` be keyed by `PlanNodeId` despite its name-addressed query contract?
+
+- Question: After the `PlanNodeId` identity rip, `CompileArtifacts.provenance`
+  (`ProvenanceDb`) is the one per-node compile facility still keyed by the bare
+  `(node_name, param_name)`. A top-level node and a composition-body node that
+  share a name and both carry provenance-tracked config params collide in the
+  flat map. It was left name-keyed because its query surface is user-facing.
+- Why it matters: `explain --provenance` resolves a dotted `node_name.param_name`
+  path, and `ProvenanceDb`'s public API (`get`, `params_for_node`,
+  `node_names`) is name-addressed by contract — so re-keying the internal store
+  to `PlanNodeId` would require a `PlanNodeId → name` reverse map at every query
+  site and changes the externally-observable lookup model. The residual
+  collision is narrow (same name across scopes, both with tracked params) but
+  real.
+- Files/modules involved:
+  `crates/clinker-plan/src/plan/explain_provenance.rs` (`ProvenanceDb`),
+  `crates/clinker-plan/src/plan/bind_schema.rs` (`bind_composition` provenance
+  population), the `explain --provenance` CLI path.
+- Suggested way to resolve it: Decide whether cross-scope node-name reuse is
+  supported for provenance-tracked compositions. If so, key the internal store
+  by `PlanNodeId` and resolve the user-facing dotted path to an id at query
+  time (preserving the external contract); add a nested-composition regression
+  test. If not, add a bind-time diagnostic rejecting the same-name collision, or
+  document that provenance is attributed by scoped path.
+- Priority: Low
+
+### 30. Analytic windows inside a nested composition body are never resolved
+
+- Question: `resolve_composition_body_windows`
+  (`crates/clinker-plan/src/plan/execution/composition.rs`) resolves each
+  composition call site only against the TOP-LEVEL DAG's `id_to_index` bridge.
+  A composition node whose call site lives inside an enclosing body (a
+  composition-of-composition) has no entry in the top-level bridge, so its
+  `composition_idx` stays `None` and the inner body's analytic-window
+  `IndexSpec`s are never built/backfilled. Should body-window resolution walk
+  nested scopes?
+- Why it matters: A window builtin over a nested composition body sees an
+  unpopulated `window_index` and silently emits `Null`/incorrect window results
+  at runtime instead of a diagnostic. This is a pre-existing limitation — the
+  prior name-map scheme had the same top-level-only reach — surfaced (but not
+  changed) by the move to the `PlanNodeId -> NodeIndex` bridge.
+- Files/modules involved:
+  `crates/clinker-plan/src/plan/execution/composition.rs`
+  (`resolve_composition_body_windows`),
+  `crates/clinker-plan/src/plan/composition_body.rs`
+  (`body_indices_to_build`).
+- Suggested way to resolve it: Decide whether analytic windows are supported in
+  nested composition bodies. If so, resolve each body's call site against the
+  enclosing scope's bridge (recurse through `composition_bodies`), not only the
+  top-level DAG; add a nested-composition window regression test. If not, emit a
+  bind-time diagnostic rejecting `analytic_window:` in a body reachable only
+  through a nested composition.
 - Priority: Low


### PR DESCRIPTION
## Summary

Replaces bare node-name identity (scope-qualified after the fact via `ScopedNodeId`) with a dense `PlanNodeId(u32)` minted once at graph construction and carried — never re-minted — through every plan and exec pass. `PlanNodeId` is now the sole key for every per-node compile-time side-table, structurally eliminating the cross-scope name-collision class: a node named the same at top level and inside a composition body previously shared one side-table entry (last-writer-wins).

## What changed

- **New dense-entity toolkit** (`crates/clinker-plan/src/plan/entity.rs`): an `EntityRef` trait, an `entity_id!` newtype macro, and a `SecondaryMap` — dependency-free and `#![forbid(unsafe_code)]`. Defines `PlanNodeId`.
- **Minting + carry:** one monotonic counter in `bind_schema` mints top-level ids in declaration order and composition-body ids per call-site, so two instantiations of one body get disjoint id sets by construction. The id is carried onto every `PlanNode` at lowering and never re-minted; synthetic nodes (enforcer sorts, combine decomposition steps, correlation commit) mint fresh.
- **`PlanNodeId → NodeIndex` bridge** on the execution DAG and each bound body keeps petgraph as the storage layer while `PlanNodeId` is identity; rebuilt after each structural pass.
- **Re-keyed every per-node side-table** — `typed`, `combine_where_typed`, `route_branch_typed`, the combine input/predicate/driving/strategy/resolved-column maps, `envelope_synthesis`, `composition_body_assignments` — plus the `$doc`-path collector, from name/`ScopedNodeId` to `PlanNodeId`.
- **Deleted `ScopedNodeId` and `NodeScope`** entirely.
- **N-ary combine decomposition** keeps the reused final step's id while synthetic chain steps mint fresh (regression test added).
- **Node-name uniqueness within a composition body is now enforced** (E001) — previously a duplicate body name silently aliased one side-table slot.

## Not re-keyed (by design)

`provenance` and `statistics` stay name-keyed: provenance is queried by a user-facing `node_name.param_name` path, and the statistics catalog is seeded only from uniquely-named top-level sources. Residual considerations (provenance cross-scope keying; nested-composition analytic windows) are recorded in `docs/ai/80_OPEN_QUESTIONS.md`.

## Testing

Full workspace tests, `clippy --workspace -D warnings`, `fmt --check`, and the benchmark pre-flights all pass. New tests cover cross-scope id distinctness, decomposition id-retention, and duplicate-body-name rejection.

Closes #643. Closes #636.
