### PR TITLE
chore: gitignore clinker-case-probe-*.tmp test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ examples/pipelines/per-source-ck/output/
 tests/e2e/
 .playwright-mcp/
 notes/
+
+# Filesystem case-sensitivity probe files clinker writes (and cleans up) during
+# test runs; they can linger if a run is interrupted.
+clinker-case-probe-*.tmp


### PR DESCRIPTION
clinker writes filesystem case-sensitivity probe files (`clinker-case-probe-<digits>.tmp`) during test runs and cleans them up on completion, but an interrupted run can leave them behind. Ignore the pattern so the leftovers never show as untracked or get committed.