### PR TITLE
plan,exec: carry only runtime state in CompiledPlan; drop compile scratch

### DIFF
--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -56,14 +56,15 @@ pub(crate) fn dispatch_combine(
         ref resolved_column_map,
         ref propagate_ck,
         // Typed `cxl:` body program carried on the node (like
-        // `PlanTransformPayload.typed`). Read here instead of re-fetching
-        // from the name-keyed `ctx.artifacts.typed` map. A lowered combine
-        // with a body has `Some`; body-less steps (`match: collect`,
-        // synthetic non-final N-ary steps) have `None`.
+        // `PlanTransformPayload.typed`). The runtime context carries no
+        // typed-program table, so the program is read off this node
+        // instance. A lowered combine with a body has `Some`; body-less
+        // steps (`match: collect`, synthetic non-final N-ary steps) have
+        // `None`.
         typed: ref body_typed_on_node,
         // Per-input metadata and the decomposed `where:` predicate, carried
-        // on the node for the same reason as `typed`: a bare-name lookup into
-        // `ctx.artifacts` is last-writer-wins across same-named combines in
+        // on the node for the same reason as `typed`: a single name-keyed
+        // side-table would be last-writer-wins across same-named combines in
         // sibling composition bodies, so reading them off this node instance
         // is what makes the runtime join scope-correct.
         combine_inputs: ref combine_inputs_on_node,

--- a/crates/clinker-exec/src/executor/commit/detect.rs
+++ b/crates/clinker-exec/src/executor/commit/detect.rs
@@ -96,7 +96,7 @@ pub(crate) fn detect_retract_scope(
             _ => None,
         })
         .collect();
-    for body in ctx.artifacts.composition_bodies.values() {
+    for body in ctx.composition_bodies.values() {
         for idx in body.graph.node_indices() {
             if let PlanNode::Aggregation { name, .. } = &body.graph[idx] {
                 aggregate_idx_by_name.entry(name.clone()).or_insert(idx);

--- a/crates/clinker-exec/src/executor/commit/dispatch.rs
+++ b/crates/clinker-exec/src/executor/commit/dispatch.rs
@@ -163,9 +163,9 @@ fn dispatch_deferred_inner(
         // deferred region (the same predicate the plan-time
         // continuation walker uses to decide whether to record a
         // continuation in the first place).
-        let needs_recurse = ctx.artifacts.body_of(body_id).is_some_and(|b| {
+        let needs_recurse = ctx.composition_bodies.get(&body_id).is_some_and(|b| {
             clinker_plan::plan::composition_body::body_or_descendants_have_deferred_region(
-                ctx.artifacts,
+                ctx.composition_bodies,
                 b,
             )
         });
@@ -380,7 +380,7 @@ fn recurse_into_body(
     body_id: CompositionBodyId,
     events: &mut Vec<DlqEvent>,
 ) -> Result<(), PipelineError> {
-    let bound_body = match ctx.artifacts.body_of(body_id) {
+    let bound_body = match ctx.composition_bodies.get(&body_id) {
         Some(b) => b,
         None => return Ok(()),
     };

--- a/crates/clinker-exec/src/executor/commit/mod.rs
+++ b/crates/clinker-exec/src/executor/commit/mod.rs
@@ -156,7 +156,6 @@ pub(crate) fn orchestrate(
     // contract be exercised with a synthetic small cap; production
     // callers always see the structural value.
     let body_node_count: usize = ctx
-        .artifacts
         .composition_bodies
         .values()
         .map(|b| b.graph.node_count())
@@ -371,9 +370,9 @@ fn is_relaxed_pipeline(ctx: &ExecutorContext<'_>, current_dag: &ExecutionPlanDag
         else {
             return false;
         };
-        ctx.artifacts.body_of(*body).is_some_and(|b| {
+        ctx.composition_bodies.get(body).is_some_and(|b| {
             clinker_plan::plan::composition_body::body_or_descendants_have_deferred_region(
-                ctx.artifacts,
+                ctx.composition_bodies,
                 b,
             )
         })

--- a/crates/clinker-exec/src/executor/composition_dispatch.rs
+++ b/crates/clinker-exec/src/executor/composition_dispatch.rs
@@ -60,8 +60,8 @@ pub(crate) fn dispatch_composition(
     // graph directly and `collect_port_records` walks live
     // edges, so the body's lookup is deferred to
     // `execute_composition_body`.
-    ctx.artifacts
-        .body_of(body)
+    ctx.composition_bodies
+        .get(&body)
         .ok_or_else(|| PipelineError::compose_body_missing(name.clone()))?;
 
     // Schema-check parent records before stepping into the
@@ -253,10 +253,10 @@ fn execute_composition_body(
 
     // Resolve body and pre-compute everything that needs the
     // bound_body borrow before the swap so the body_dag clone is
-    // independent of the artifacts borrow.
+    // independent of the composition_bodies borrow.
     let bound_body = ctx
-        .artifacts
-        .body_of(body_id)
+        .composition_bodies
+        .get(&body_id)
         .ok_or_else(|| PipelineError::compose_body_missing(composition_name.to_string()))?;
 
     let body_dag = clinker_plan::plan::execution::ExecutionPlanDag::from_body(bound_body);

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -442,7 +442,7 @@ use crate::executor::node_buffer::NodeBuffer;
 use crate::executor::schema_check::check_input_schema;
 use crate::executor::{CompiledRoute, DlqEntry, evaluate_single_transform, stage_metrics};
 use clinker_plan::BudgetCategory;
-use clinker_plan::plan::bind_schema::CompileArtifacts;
+use clinker_plan::plan::composition_body::CompositionBodies;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 use clinker_record::Schema;
 
@@ -451,7 +451,8 @@ use clinker_record::Schema;
 ///
 /// Borrowed (immutable for the entire walk):
 /// * `config`      — the YAML pipeline config (e.g. error strategy).
-/// * `artifacts`   — compile-time CXL typed programs and combine metadata.
+/// * `composition_bodies` — the bound composition bodies the dispatcher
+///   re-enters; the only compile-artifact slice the runtime walk needs.
 /// * `current_dag` — the DAG being walked. Composition body recursion will
 ///   later swap this in place to re-enter the dispatcher on a body's
 ///   mini-DAG without duplicating arm logic.
@@ -483,7 +484,10 @@ use clinker_record::Schema;
 pub(crate) struct ExecutorContext<'a> {
     // Borrowed plan-time state.
     pub(crate) config: &'a PipelineConfig,
-    pub(crate) artifacts: &'a CompileArtifacts,
+    /// Bound composition bodies the dispatcher re-enters at runtime. The
+    /// runtime-retained slice of the former compile artifacts; resolved
+    /// by `CompositionBodyId` via `composition_bodies.get(&id)`.
+    pub(crate) composition_bodies: &'a CompositionBodies,
     pub(crate) output_configs: &'a [OutputConfig],
     pub(crate) primary_output: &'a OutputConfig,
     pub(crate) stable: &'a StableEvalContext,

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -173,9 +173,12 @@ struct DagExecInputs<'a> {
     source_configs: &'a [clinker_plan::config::SourceConfig],
     /// Topologically-sorted execution DAG walked by the dispatcher.
     plan: &'a ExecutionPlanDag,
-    /// Compile artifacts (bound schemas, composition bodies) consulted
-    /// by the dispatcher while walking the plan.
-    artifacts: &'a clinker_plan::plan::bind_schema::CompileArtifacts,
+    /// Bound composition bodies the dispatcher re-enters while walking
+    /// the plan — the runtime-retained slice of the compile artifacts.
+    composition_bodies: &'a clinker_plan::plan::composition_body::CompositionBodies,
+    /// Planner column-statistics catalog, seeded into the runtime
+    /// accumulator at context construction.
+    statistics: &'a clinker_plan::plan::statistics::StatisticsCatalog,
     /// Per-run parameters: execution / batch ids, channel variable
     /// overrides, shutdown token.
     params: &'a PipelineRunParams,
@@ -544,7 +547,7 @@ impl PipelineExecutor {
         // Routes carry their own conditions.
         let mut compiled_routes_by_name: std::collections::HashMap<String, CompiledRoute> =
             std::collections::HashMap::new();
-        for (_body_id, body) in validated_plan.artifacts().composition_bodies.iter() {
+        for (_body_id, body) in validated_plan.composition_bodies().iter() {
             for (route_name, route_body) in &body.route_bodies {
                 // Build the body Route's RouteConfig from its parsed
                 // RouteBody. The condition resolver needs the field
@@ -807,7 +810,8 @@ impl PipelineExecutor {
                 config,
                 source_configs: &source_configs,
                 plan,
-                artifacts: validated_plan.artifacts(),
+                composition_bodies: validated_plan.composition_bodies(),
+                statistics: validated_plan.statistics(),
                 params,
             },
             DagExecResources {
@@ -994,7 +998,8 @@ impl PipelineExecutor {
             config,
             source_configs,
             plan,
-            artifacts,
+            composition_bodies,
+            statistics,
             params,
         } = inputs;
         let DagExecResources {
@@ -1298,7 +1303,7 @@ impl PipelineExecutor {
 
         let mut ctx = dispatch::ExecutorContext {
             config,
-            artifacts,
+            composition_bodies,
             output_configs: &output_configs,
             primary_output: &output_configs[0],
             stable: &stable,
@@ -1369,7 +1374,7 @@ impl PipelineExecutor {
             // Plane A row counts so a downstream node reading it sees the
             // metadata-derived estimates until an operator finalize
             // supersedes one with an exec-measured figure.
-            runtime_statistics: Arc::new(std::sync::Mutex::new(artifacts.statistics.clone())),
+            runtime_statistics: Arc::new(std::sync::Mutex::new(statistics.clone())),
         };
 
         // Resolve dispatch order through the memory arbitrator rather

--- a/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
@@ -550,7 +550,7 @@ o6,ENG,300
     // its body-local deferred region was registered. Without this the
     // orchestrator's `is_relaxed_pipeline` check (which now inspects
     // bodies) returns false and the commit-time recurse never fires.
-    let bodies: Vec<_> = compiled.artifacts().composition_bodies.values().collect();
+    let bodies: Vec<_> = compiled.composition_bodies().values().collect();
     assert_eq!(
         bodies.len(),
         1,
@@ -794,7 +794,7 @@ o6,ENG,300
 
     // Sanity-pin: exactly two bodies are bound; the inner one carries
     // the deferred region rooted at its `dept_totals` Aggregate.
-    let bodies: Vec<_> = compiled.artifacts().composition_bodies.values().collect();
+    let bodies: Vec<_> = compiled.composition_bodies().values().collect();
     assert_eq!(bodies.len(), 2, "inner and outer bodies must both bind");
     assert!(
         bodies.iter().any(|b| !b.deferred_regions.is_empty()),

--- a/crates/clinker-exec/tests/auto_widen_integration.rs
+++ b/crates/clinker-exec/tests/auto_widen_integration.rs
@@ -376,16 +376,35 @@ nodes:
     include_unmapped: true
 "#;
     let config = parse_config(yaml).expect("parse pipeline yaml");
-    let plan = PipelineConfig::compile(&config, &CompileContext::default())
-        .expect("same-policy merge must compile cleanly");
-    let row = plan
-        .typed_output_row("merged")
+    // The merge node's cxl output Row comes off `bind_schema` artifacts (the
+    // `pub` compile-scratch entry point); the lowered `PlanNode::Merge.
+    // output_schema` assertion below reads the slim plan's DAG. This fixture
+    // is composition-free, so the symbol table is empty.
+    let ctx = CompileContext::default();
+    let symbol_table = indexmap::IndexMap::new();
+    let mut diags = Vec::new();
+    let artifacts = clinker_plan::plan::bind_schema::bind_schema(
+        &config.nodes,
+        &mut diags,
+        &ctx,
+        &symbol_table,
+        std::path::Path::new(""),
+        Default::default(),
+    );
+    let merged_id = artifacts
+        .top_level_id(&config.nodes, "merged")
+        .expect("merged node id");
+    let row = artifacts
+        .typed_get(merged_id)
+        .map(|tp| &tp.output_row)
         .expect("merge must publish a bound output row");
     assert!(
         row.has_field("$widened"),
         "merge's typed output row must carry the `$widened` sidecar inherited from \
          its (same-policy) inputs"
     );
+    let plan =
+        PipelineConfig::compile(&config, &ctx).expect("same-policy merge must compile cleanly");
     let merge_node = plan
         .dag()
         .graph

--- a/crates/clinker-exec/tests/bind_schema_test.rs
+++ b/crates/clinker-exec/tests/bind_schema_test.rs
@@ -27,6 +27,57 @@ fn compile_yaml(yaml: &str) -> clinker_plan::plan::CompiledPlan {
         .expect("fixture must compile")
 }
 
+/// Bind a FLAT (composition-free) fixture directly through the `pub`
+/// [`bind_schema`] entry point — the same compile-scratch source production
+/// `compile_with_diagnostics` consumes — returning the populated
+/// [`CompileArtifacts`] (`typed`, `top_level_node_ids`, …) alongside the
+/// parsed [`PipelineConfig`]. These fixtures declare no compositions, so the
+/// symbol table is empty and the pipeline dir is the empty path.
+fn bind_yaml(
+    yaml: &str,
+) -> (
+    clinker_plan::plan::bind_schema::CompileArtifacts,
+    PipelineConfig,
+) {
+    let config: PipelineConfig = clinker_plan::yaml::from_str(yaml).expect("fixture must parse");
+    // Guard the empty-symbol-table assumption: a composition node would bind
+    // against a missing signature and silently produce wrong rows. Fail loudly
+    // so a future composition fixture is routed through a scan-based bind path
+    // instead of mis-binding here.
+    assert!(
+        !config.nodes.iter().any(|n| matches!(
+            n.value,
+            clinker_plan::config::pipeline_node::PipelineNode::Composition { .. }
+        )),
+        "bind_yaml is for composition-free fixtures only; this fixture declares a composition",
+    );
+    let ctx = CompileContext::default();
+    let symbol_table = indexmap::IndexMap::new();
+    let mut diags = Vec::new();
+    let artifacts = clinker_plan::plan::bind_schema::bind_schema(
+        &config.nodes,
+        &mut diags,
+        &ctx,
+        &symbol_table,
+        std::path::Path::new(""),
+        Default::default(),
+    );
+    (artifacts, config)
+}
+
+/// Resolve a top-level node's bound output [`Row`] off the compile
+/// artifacts. Replaces the former `CompiledPlan::typed_output_row`:
+/// resolve the node's id by name, then read its typed program's
+/// `output_row` from the `typed` side-table.
+fn typed_output_row<'a>(
+    config: &PipelineConfig,
+    artifacts: &'a clinker_plan::plan::bind_schema::CompileArtifacts,
+    name: &str,
+) -> Option<&'a cxl::typecheck::Row> {
+    let id = artifacts.top_level_id(&config.nodes, name)?;
+    artifacts.typed_get(id).map(|tp| &tp.output_row)
+}
+
 /// Gate test: a pipeline with a source declaring `schema: [{name: a, type: string}]`
 /// produces `typed_output_row("source1") == Row::closed({a: String})`.
 #[test]
@@ -52,10 +103,9 @@ nodes:
       type: csv
       path: out.csv
 "#;
-    let plan = compile_yaml(yaml);
-    let row = plan
-        .typed_output_row("source1")
-        .expect("source1 must have a bound row");
+    let (artifacts, config) = bind_yaml(yaml);
+    let row =
+        typed_output_row(&config, &artifacts, "source1").expect("source1 must have a bound row");
     // Schema includes the user-declared `a` + `b`, the `$widened`
     // engine-stamped sidecar (auto_widen is the default `OnUnmapped`
     // policy), and the `$source.file` / `$source.name` /
@@ -114,10 +164,8 @@ nodes:
       type: csv
       path: out.csv
 "#;
-    let plan = compile_yaml(yaml);
-    let row = plan
-        .typed_output_row("tx")
-        .expect("transform must have a bound row");
+    let (artifacts, config) = bind_yaml(yaml);
+    let row = typed_output_row(&config, &artifacts, "tx").expect("transform must have a bound row");
     assert!(row.has_field("x"), "upstream column 'x' must propagate");
     assert!(row.has_field("y"), "emitted column 'y' must appear");
 }
@@ -151,21 +199,21 @@ nodes:
       type: csv
       path: out.csv
 "#;
-    let plan = compile_yaml(yaml);
+    let (artifacts, config) = bind_yaml(yaml);
     assert!(
-        plan.typed_output_row("s1").is_some(),
+        typed_output_row(&config, &artifacts, "s1").is_some(),
         "source must have bound row"
     );
     assert!(
-        plan.typed_output_row("t1").is_some(),
+        typed_output_row(&config, &artifacts, "t1").is_some(),
         "transform must have bound row"
     );
     assert!(
-        plan.typed_output_row("o1").is_some(),
+        typed_output_row(&config, &artifacts, "o1").is_some(),
         "output must have bound row"
     );
     assert!(
-        plan.typed_output_row("nonexistent").is_none(),
+        typed_output_row(&config, &artifacts, "nonexistent").is_none(),
         "nonexistent node must return None"
     );
 }
@@ -294,7 +342,10 @@ nodes:
       type: csv
       path: out.csv
 "#;
+    // The lowered Source `output_schema` comes off the slim plan's DAG; the
+    // `typed_output_row` cxl-Row check below reads `bind_schema` artifacts.
     let plan = compile_yaml(yaml);
+    let (artifacts, config) = bind_yaml(yaml);
     let schema = source_output_schema(&plan, "src");
 
     // User-declared columns stay at their declared positions, then
@@ -328,7 +379,7 @@ nodes:
 
     // The same widening lands on the typecheck Row produced by
     // `bind_schema` — confirms the source goes through `columns_from_decl`.
-    let row = plan.typed_output_row("src").expect("bound row");
+    let row = typed_output_row(&config, &artifacts, "src").expect("bound row");
     assert!(row.has_field("$ck.employee_id"));
 }
 
@@ -421,8 +472,12 @@ nodes:
       type: csv
       path: out.csv
 "#;
+    // `typed_output_row` reads the cxl Row off `bind_schema` artifacts; the
+    // lowered `PlanNode::Transform.output_schema` assertion below reads the
+    // slim plan's DAG. Both surfaces are checked independently.
     let plan = compile_yaml(yaml);
-    let row = plan.typed_output_row("tx").expect("tx row");
+    let (artifacts, config) = bind_yaml(yaml);
+    let row = typed_output_row(&config, &artifacts, "tx").expect("tx row");
     assert!(
         row.has_field("$ck.id"),
         "transform downstream of widened source must inherit shadow column"
@@ -549,10 +604,13 @@ nodes:
       type: csv
       path: out.csv
 "#;
+    // `typed_output_row` reads the cxl Row off `bind_schema` artifacts; the
+    // lowered `PlanNode::Aggregation.output_schema` assertion below reads the
+    // slim plan's DAG. Both surfaces are checked independently.
     let plan = compile_yaml(yaml);
-    let agg_row = plan
-        .typed_output_row("agg")
-        .expect("aggregate must have a bound row");
+    let (artifacts, config) = bind_yaml(yaml);
+    let agg_row =
+        typed_output_row(&config, &artifacts, "agg").expect("aggregate must have a bound row");
     assert!(
         agg_row.has_field("$widened"),
         "aggregate's bound row must include `$widened` when the upstream source's auto_widen \
@@ -685,23 +743,19 @@ nodes:
     assert!(parent_schema.contains("$ck.id"));
 
     // Body port-synthetic Source ("data" port): walks the composition
-    // body's mini-DAG and finds a PlanNode::Source named after the
-    // port. Its output_schema must mirror the parent's widening.
-    // `composition_body_assignments` keys by the call-site node's id;
-    // resolve `passthrough`'s id off the declaration-order id vector.
-    let passthrough_id = plan
-        .config()
-        .nodes
-        .iter()
-        .zip(plan.artifacts().top_level_node_ids.iter())
-        .find_map(|(spanned, id)| (spanned.value.name() == "passthrough").then_some(*id))
-        .expect("top-level `passthrough` id");
+    // body's mini-DAG and finds a PlanNode::Source named after the port.
+    // Its output_schema must mirror the parent's widening. The body id is
+    // stamped on the `passthrough` Composition node in the slim plan's
+    // lowered DAG — resolve it there.
     let body_id = plan
-        .artifacts()
-        .composition_body_assignments
-        .get(&passthrough_id)
-        .copied()
-        .expect("composition body assigned");
+        .dag()
+        .graph
+        .node_weights()
+        .find_map(|n| match n {
+            PlanNode::Composition { name, body, .. } if name == "passthrough" => Some(*body),
+            _ => None,
+        })
+        .expect("top-level `passthrough` composition must carry a body id");
     let body = plan.body_of(body_id).expect("body present");
     let port_node = body
         .graph

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -1376,7 +1376,7 @@ nodes:
     }
 
     /// Compile a fixture and return the full `CompiledPlan` so tests can
-    /// reach `.dag()`, `.config()`, and `.artifacts()` without re-running
+    /// reach `.dag()`, `.config()`, and `.statistics()` without re-running
     /// the lowering pipeline. Mirrors `compile_plan`'s scratch-path opt-in.
     fn compile_full_plan(config: &PipelineConfig) -> clinker_plan::plan::CompiledPlan {
         let ctx = clinker_plan::config::CompileContext {
@@ -1402,7 +1402,7 @@ nodes:
 
         let text = plan
             .dag()
-            .explain_text_with_artifacts(plan.config(), plan.artifacts());
+            .explain_text_with_statistics(plan.config(), plan.statistics());
 
         assert!(
             text.contains("Combine 'bracketed':"),
@@ -1447,7 +1447,7 @@ nodes:
 
         let text = plan
             .dag()
-            .explain_text_with_artifacts(plan.config(), plan.artifacts());
+            .explain_text_with_statistics(plan.config(), plan.statistics());
 
         assert!(
             text.contains("Combine 'fully_enriched' (3 inputs, binary decomposition):"),
@@ -1483,7 +1483,7 @@ nodes:
         let config = parse_fixture(&yaml);
         let plan = compile_full_plan(&config);
 
-        let view = clinker_plan::plan::execution::ExplainJson::new(plan.dag(), plan.artifacts());
+        let view = clinker_plan::plan::execution::ExplainJson::new(plan.dag(), plan.statistics());
         let json: serde_json::Value =
             serde_json::to_value(&view).expect("ExplainJson must serialize cleanly");
 
@@ -1576,46 +1576,34 @@ nodes:
         }
     }
 
-    /// Gate: a combine whose `combine_predicates` entry is missing (no
-    /// decomposed predicate stored — the kind of state a compile-time
-    /// E303 leaves the artifacts side-table in) must not panic during
-    /// explain rendering. Mirrors the existing `display_name()` defensive
-    /// rendering at execution.rs that falls back to `<unselected>` for an
-    /// empty driving input. We construct this state by compiling a
-    /// successful plan and then mutating the artifacts to drop the
-    /// predicate entry — closer to the real failure mode (artifacts
-    /// state inconsistent with PlanNode) than fabricating a synthetic
-    /// PlanNode from scratch.
+    /// Gate: the combine block's header and `Predicate: equalities=...`
+    /// count summary render off the node, not from a compile-time
+    /// side-table. Explain reads `predicate_summary` / `decomposed_predicate`
+    /// off the `PlanNode`; the statistics catalog only backs the row
+    /// estimates. So the header + summary render without panicking
+    /// regardless of predicate-detail availability.
     #[test]
-    fn test_explain_combine_with_e3xx_error() {
-        use std::collections::HashMap;
-
+    fn test_explain_combine_block_renders_off_node() {
         let yaml = load_fixture("two_input_equi.yaml");
         let config = parse_fixture(&yaml);
         let plan = compile_full_plan(&config);
 
-        // Build a CompileArtifacts mirror with an empty
-        // combine_predicates table. The rest of the side-tables stay
-        // intact (combine_inputs etc.) because the explain block falls
-        // back to summary-only when predicate detail is unavailable —
-        // it doesn't crash through downstream lookups.
-        let original = plan.artifacts();
-        let mut censored = original.clone();
-        censored.combine_predicates = HashMap::new();
-
+        // The combine block's header and `Predicate: equalities=...` count
+        // summary render off the node (`predicate_summary` /
+        // `decomposed_predicate` on `PlanNode::Combine`); the statistics
+        // catalog only backs the row estimates. No compile-time predicate
+        // side-table is consulted, so the block renders straight from the
+        // lowered plan.
         let text = plan
             .dag()
-            .explain_text_with_artifacts(plan.config(), &censored);
-        // The block still renders — header + summary line — without
-        // panic. The detail bucket headers (Equalities:/Ranges:/
-        // Residual:) are absent because the predicate is unreachable.
+            .explain_text_with_statistics(plan.config(), plan.statistics());
         assert!(
             text.contains("Combine 'enriched':"),
-            "explain must still render the block header on missing predicate; got:\n{text}",
+            "explain must render the combine block header; got:\n{text}",
         );
         assert!(
             text.contains("Predicate: equalities="),
-            "explain must still render the count summary on missing predicate; got:\n{text}",
+            "explain must render the count summary line; got:\n{text}",
         );
     }
 
@@ -1667,7 +1655,7 @@ nodes:
 
         let text = plan
             .dag()
-            .explain_text_with_artifacts(plan.config(), plan.artifacts());
+            .explain_text_with_statistics(plan.config(), plan.statistics());
         assert!(
             text.contains("(8 inputs, binary decomposition):"),
             "8-input combine must label the group header with `(8 inputs, binary decomposition):`; got:\n{text}",
@@ -1697,13 +1685,13 @@ nodes:
 
         let text = plan
             .dag()
-            .explain_text_with_artifacts(plan.config(), plan.artifacts());
+            .explain_text_with_statistics(plan.config(), plan.statistics());
         assert!(
             text.contains("Match: collect"),
             "match: collect must surface in the text explain block; got:\n{text}",
         );
 
-        let view = clinker_plan::plan::execution::ExplainJson::new(plan.dag(), plan.artifacts());
+        let view = clinker_plan::plan::execution::ExplainJson::new(plan.dag(), plan.statistics());
         let json: serde_json::Value =
             serde_json::to_value(&view).expect("ExplainJson must serialize cleanly");
         let nodes = json["nodes"]

--- a/crates/clinker-exec/tests/composition_body_window.rs
+++ b/crates/clinker-exec/tests/composition_body_window.rs
@@ -112,8 +112,7 @@ nodes:
 
     // The body's BoundBody must carry a single IndexSpec rooted at
     // the body's Aggregate node.
-    let artifacts = plan.artifacts();
-    let bodies: Vec<_> = artifacts.composition_bodies.values().collect();
+    let bodies: Vec<_> = plan.composition_bodies().values().collect();
     assert_eq!(bodies.len(), 1, "exactly one composition body");
     let body = bodies[0];
     assert_eq!(
@@ -183,8 +182,7 @@ nodes:
         .find(|i| dag.graph[*i].name() == "src")
         .expect("parent DAG carries src");
 
-    let artifacts = plan.artifacts();
-    let bodies: Vec<_> = artifacts.composition_bodies.values().collect();
+    let bodies: Vec<_> = plan.composition_bodies().values().collect();
     assert_eq!(bodies.len(), 1, "one body");
     let body = bodies[0];
     assert_eq!(body.body_indices_to_build.len(), 1, "one body IndexSpec");

--- a/crates/clinker-exec/tests/cull_explain_snapshot.rs
+++ b/crates/clinker-exec/tests/cull_explain_snapshot.rs
@@ -12,8 +12,8 @@ fn render_explain(yaml: &str) -> String {
     let config: PipelineConfig = parse_config(yaml).expect("parse_config");
     let plan = config.compile(&CompileContext::default()).expect("compile");
     let dag = plan.dag();
-    let artifacts = plan.artifacts();
-    dag.explain_text_with_artifacts(&config, artifacts)
+    let statistics = plan.statistics();
+    dag.explain_text_with_statistics(&config, statistics)
 }
 
 /// A source → cull → (main output + audit side output) pipeline. The Cull

--- a/crates/clinker-exec/tests/explain_arbitration.rs
+++ b/crates/clinker-exec/tests/explain_arbitration.rs
@@ -41,7 +41,7 @@ fn render_explain_with_artifacts_anchored(yaml: &str, anchor: &Path) -> String {
     let ctx = CompileContext::with_pipeline_dir(anchor, "");
     let plan = config.compile(&ctx).expect("compile");
     plan.dag()
-        .explain_text_with_artifacts(&config, plan.artifacts())
+        .explain_text_with_statistics(&config, plan.statistics())
 }
 
 /// Write `contents` to `<dir>/<name>` and assert its on-disk length so a
@@ -446,12 +446,13 @@ fn explain_renders_exec_sketches_in_statistics_block() {
     let ctx = CompileContext::with_pipeline_dir(tmp.path(), "");
     let plan = config.compile(&ctx).expect("compile");
 
-    // Clone the artifacts and fold in the build-side sketches the grace-hash
-    // join records at completion, keyed under the build upstream node.
-    let mut artifacts = plan.artifacts().clone();
+    // Clone the statistics catalog and fold in the build-side sketches the
+    // grace-hash join records at completion, keyed under the build upstream
+    // node.
+    let mut statistics = plan.statistics().clone();
     let key = StatKey::new("products", "product_id");
-    artifacts.statistics.record_distinct(key.clone(), 58);
-    artifacts.statistics.record_heavy_hitters(
+    statistics.record_distinct(key.clone(), 58);
+    statistics.record_heavy_hitters(
         key.clone(),
         vec![
             (Value::from("p0"), 12),
@@ -459,7 +460,7 @@ fn explain_renders_exec_sketches_in_statistics_block() {
             (Value::from("p2"), 4),
         ],
     );
-    artifacts.statistics.record_bloom(
+    statistics.record_bloom(
         key,
         BloomSummary {
             bit_count: 560,
@@ -468,7 +469,9 @@ fn explain_renders_exec_sketches_in_statistics_block() {
         },
     );
 
-    let text = plan.dag().explain_text_with_artifacts(&config, &artifacts);
+    let text = plan
+        .dag()
+        .explain_text_with_statistics(&config, &statistics);
 
     assert!(
         text.contains("58 distinct [exec sketch]"),

--- a/crates/clinker-exec/tests/retraction_explain_snapshot.rs
+++ b/crates/clinker-exec/tests/retraction_explain_snapshot.rs
@@ -12,8 +12,8 @@ fn render_explain(yaml: &str) -> String {
     let config: PipelineConfig = parse_config(yaml).expect("parse_config");
     let plan = config.compile(&CompileContext::default()).expect("compile");
     let dag = plan.dag();
-    let artifacts = plan.artifacts();
-    dag.explain_text_with_artifacts(&config, artifacts)
+    let statistics = plan.statistics();
+    dag.explain_text_with_statistics(&config, statistics)
 }
 
 /// Mixed Reversible + BufferRequired bindings in one relaxed Aggregate

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2214,7 +2214,7 @@ impl PipelineConfig {
             }
         }
 
-        let plan = CompiledPlan::new(dag, runtime_config, artifacts);
+        let plan = CompiledPlan::from_compile(dag, runtime_config, artifacts);
         Ok((plan, diags))
     }
 }

--- a/crates/clinker-plan/src/plan/compiled.rs
+++ b/crates/clinker-plan/src/plan/compiled.rs
@@ -3,14 +3,34 @@
 //! `CompiledPlan` is the typed-handle output of the
 //! [`crate::config::PipelineConfig::compile`] lowering path. It wraps
 //! a validated `PipelineConfig`, its lowered DAG, and the
-//! compile-time CXL typecheck artifacts produced by
-//! [`crate::plan::bind_schema::bind_schema`].
-
-use cxl::typecheck::Row;
+//! runtime-retained slice of the compile artifacts: the bound
+//! composition bodies, the statistics catalog, and the provenance
+//! side-table. The transient compile scratch (per-node typed CXL
+//! programs, combine metadata, the `PlanNodeId` mint counters) lives on
+//! [`CompileArtifacts`] only during compilation and is dropped when the
+//! plan is built — it never enters `CompiledPlan`. Tests that need to
+//! inspect that scratch call [`crate::plan::bind_schema::bind_schema`]
+//! directly (the same entry point `compile` consumes) and read the
+//! returned [`CompileArtifacts`]; post-lowering state (deferred regions,
+//! body assignments) is reachable off the slim plan via [`Self::dag`] and
+//! [`Self::body_of`].
+//!
+//! ## Deriving a node's scoped lineage (klinx export)
+//!
+//! `PlanNodeId` is the sole internal identity; it carries no scope. A
+//! human-readable scoped path (`Outer/Inner/name`) is *derived*, never
+//! keyed: a top-level node lives in [`Self::dag`]; a composition-body
+//! node lives in the graph of the [`BoundBody`] whose
+//! `CompositionBodyId` indexes [`Self::composition_bodies`]. Walk those
+//! graphs to find the node carrying a given `PlanNodeId`, read its
+//! `name`, and prefix the scope's body name(s). No materialized
+//! `PlanNodeId → (scope, name)` map exists because the only consumer is
+//! the out-of-tree klinx exporter; an in-tree map would be unused.
 
 use super::bind_schema::CompileArtifacts;
-use super::composition_body::{BoundBody, CompositionBodyId};
+use super::composition_body::{BoundBody, CompositionBodies, CompositionBodyId};
 use super::execution::ExecutionPlanDag;
+use super::statistics::StatisticsCatalog;
 use crate::config::PipelineConfig;
 use crate::config::composition::ProvenanceDb;
 
@@ -29,7 +49,15 @@ pub struct ChannelIdentity {
 pub struct CompiledPlan {
     dag: ExecutionPlanDag,
     config: PipelineConfig,
-    artifacts: CompileArtifacts,
+    /// Bound composition bodies the executor re-enters at runtime. The
+    /// top-level pipeline is NOT here — it lives on `dag` directly.
+    composition_bodies: CompositionBodies,
+    /// Planner-wide column-statistics catalog, seeded into the runtime
+    /// accumulator and consulted by `--explain` row estimates.
+    statistics: StatisticsCatalog,
+    /// Provenance-tracked config values, queried by the `--field`
+    /// provenance path and mutated by channel overlay application.
+    provenance: ProvenanceDb,
     channel_identity: Option<ChannelIdentity>,
     /// BLAKE3 of the post-env-var-interpolated source YAML, copied
     /// from `PipelineConfig.source_hash` at compile time. Zero array
@@ -38,16 +66,28 @@ pub struct CompiledPlan {
 }
 
 impl CompiledPlan {
-    pub(crate) fn new(
+    /// Build a slim plan from a finished compile, moving the
+    /// runtime-retained fields out of `artifacts` and dropping the
+    /// transient compile scratch. Called once, at the tail of
+    /// [`crate::config::PipelineConfig::compile_with_diagnostics`].
+    pub(crate) fn from_compile(
         dag: ExecutionPlanDag,
         config: PipelineConfig,
         artifacts: CompileArtifacts,
     ) -> Self {
         let pipeline_hash = config.source_hash;
+        let CompileArtifacts {
+            composition_bodies,
+            statistics,
+            provenance,
+            ..
+        } = artifacts;
         Self {
             dag,
             config,
-            artifacts,
+            composition_bodies,
+            statistics,
+            provenance,
             channel_identity: None,
             pipeline_hash,
         }
@@ -61,13 +101,18 @@ impl CompiledPlan {
         &self.config
     }
 
-    /// Compile-time CXL typecheck artifacts — one entry per CXL-bearing
-    /// node keyed by its `PlanNodeId` (so a top-level node and a
-    /// composition-body node sharing a name get distinct ids and stay
-    /// distinct). The runtime executor reads this map to pull each node's
-    /// `Arc<TypedProgram>` instead of re-typechecking.
-    pub fn artifacts(&self) -> &CompileArtifacts {
-        &self.artifacts
+    /// Bound composition bodies the executor re-enters. The executor
+    /// reads this to step into each `PipelineNode::Composition`'s
+    /// mini-DAG; tooling walks it for body drill-in.
+    pub fn composition_bodies(&self) -> &CompositionBodies {
+        &self.composition_bodies
+    }
+
+    /// Planner-wide column-statistics catalog. Cloned into the runtime
+    /// accumulator at executor entry and read by `--explain` row
+    /// estimates.
+    pub fn statistics(&self) -> &StatisticsCatalog {
+        &self.statistics
     }
 
     /// Look up a composition body by its ID.
@@ -75,35 +120,21 @@ impl CompiledPlan {
     /// Returns the `BoundBody` containing the composition's expanded nodes,
     /// bound schemas, and port rows. Used by tooling for drill-in rendering.
     pub fn body_of(&self, id: CompositionBodyId) -> Option<&BoundBody> {
-        self.artifacts.body_of(id)
-    }
-
-    /// Look up the bound output row type for a top-level node by name.
-    ///
-    /// Returns `None` for nodes that didn't participate in `bind_schema`
-    /// (e.g. compositions whose binding failed). Only top-level nodes are
-    /// visible here; composition-body programs are keyed by their own
-    /// `PlanNodeId` in the `typed` table and are reached via
-    /// [`Self::body_of`]. Resolves the name to its top-level `PlanNodeId`
-    /// through the declaration-order id vector (top-level names are
-    /// unique).
-    pub fn typed_output_row(&self, name: &str) -> Option<&Row> {
-        let id = self.artifacts.top_level_id(&self.config.nodes, name)?;
-        self.artifacts.typed_get(id).map(|tp| &tp.output_row)
+        self.composition_bodies.get(&id)
     }
 
     /// Side-table of provenance-tracked config values for composition nodes.
     /// Populated during `bind_schema`; consumed by tooling inspectors and
     /// channel overlay.
     pub fn provenance(&self) -> &ProvenanceDb {
-        &self.artifacts.provenance
+        &self.provenance
     }
 
     /// Mutable access to the provenance side-table for channel overlay
     /// application. The overlay applies `ChannelDefault`/`ChannelFixed`
     /// layers to existing `ResolvedValue` entries.
     pub fn provenance_mut(&mut self) -> &mut ProvenanceDb {
-        &mut self.artifacts.provenance
+        &mut self.provenance
     }
 
     /// The channel identity stamped by [`apply_channel_overlay`], if any.

--- a/crates/clinker-plan/src/plan/composition_body.rs
+++ b/crates/clinker-plan/src/plan/composition_body.rs
@@ -31,6 +31,13 @@ impl Default for CompositionBodyId {
     }
 }
 
+/// All bound composition bodies, keyed by `CompositionBodyId`. The
+/// runtime-retained slice of the former `CompileArtifacts` — the
+/// executor re-enters these mini-DAGs and nothing else from compile
+/// scratch survives into `CompiledPlan`. Declaration-order preserving
+/// (`IndexMap`) so body iteration is deterministic.
+pub type CompositionBodies = IndexMap<CompositionBodyId, BoundBody>;
+
 /// A bound composition body — one nested scope with its own NodeIndex
 /// space inside `graph`, its own per-node row map, and its own nested
 /// bodies (for composition-of-composition recursion).
@@ -79,9 +86,10 @@ pub struct BoundBody {
     pub port_name_to_node_idx: HashMap<String, NodeIndex>,
 
     /// Per-node output row inside this body scope. Keyed by node name.
-    /// Consumers that want a public accessor go through
-    /// `CompiledPlan::typed_output_row`, which only sees top-level
-    /// names; body-scope rows are drill-in state.
+    /// Body-scope rows are drill-in state reached through this `BoundBody`
+    /// (itself looked up via `CompiledPlan::body_of`); top-level node rows
+    /// live in the compile-time `CompileArtifacts.typed` table, keyed by
+    /// `PlanNodeId`.
     pub body_rows: HashMap<String, Row>,
 
     /// Per-body-node original `input:` references in declaration
@@ -234,7 +242,7 @@ impl BoundBody {
 /// stay synchronized; a divergent answer between plan and runtime
 /// would silently strand commit-time work.
 pub fn body_or_descendants_have_deferred_region(
-    artifacts: &crate::plan::bind_schema::CompileArtifacts,
+    composition_bodies: &CompositionBodies,
     body: &BoundBody,
 ) -> bool {
     if !body.deferred_regions.is_empty() {
@@ -244,8 +252,8 @@ pub fn body_or_descendants_have_deferred_region(
         let PlanNode::Composition { body: nested, .. } = &body.graph[idx] else {
             return false;
         };
-        artifacts
-            .body_of(*nested)
-            .is_some_and(|b| body_or_descendants_have_deferred_region(artifacts, b))
+        composition_bodies
+            .get(nested)
+            .is_some_and(|b| body_or_descendants_have_deferred_region(composition_bodies, b))
     })
 }

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -616,13 +616,14 @@ impl ExecutionPlanDag {
             }
         }
 
-        // Combine blocks render only when artifacts are threaded through
-        // (`explain_with_artifacts` / `explain_full_with_artifacts`).
-        // Without artifacts, `combine_predicates` is unreachable and the
-        // detail block degrades to the summary line embedded in
-        // `display_name()`'s header. The memory-limit argument is ignored
-        // when artifacts is `None`; pass `0` rather than re-reading the
-        // default to avoid a config-coupling cycle here.
+        // Combine blocks render only when the statistics catalog is
+        // threaded through (`explain_with_statistics` /
+        // `explain_full_with_statistics`). The per-node combine metadata
+        // is read off the node, but the row-estimate formatting needs the
+        // catalog; without it the detail block degrades to the summary
+        // line embedded in `display_name()`'s header. The memory-limit
+        // argument is ignored when the catalog is `None`; pass `0` rather
+        // than re-reading the default to avoid a config-coupling cycle here.
         self.render_combine_section(&mut out, None, 0);
 
         self.render_retraction_section(&mut out, None);
@@ -656,7 +657,7 @@ impl ExecutionPlanDag {
     /// and buffer-mode windows.
     ///
     /// `config` is `Some` when the caller went through one of the
-    /// artifacts-aware entry points and can read the pipeline-level
+    /// statistics-aware entry points and can read the pipeline-level
     /// `correlation_fanout_policy` default plus the `correlation_key`
     /// used to classify aggregates. Without it the block still emits
     /// per-window detail; aggregate detection requires the correlation
@@ -820,29 +821,29 @@ impl ExecutionPlanDag {
     }
 
     /// `--explain` text with combine multi-line blocks. Identical to
-    /// [`Self::explain`] except that combine nodes — when paired with
-    /// the `CompileArtifacts` that produced this DAG — render a full
-    /// per-node block (strategy, inputs + roles, predicate decomposition
-    /// detail, match/on-miss policy, planned-share memory budget). N-ary
-    /// chains (`decomposed_from = Some(_)`) group under their original
-    /// user-declared name with numbered step lines.
-    pub fn explain_with_artifacts(
+    /// [`Self::explain`] except that combine nodes — when paired with the
+    /// statistics catalog that backs this DAG's row estimates — render a
+    /// full per-node block (strategy, inputs + roles, predicate
+    /// decomposition detail, match/on-miss policy, planned-share memory
+    /// budget). N-ary chains (`decomposed_from = Some(_)`) group under
+    /// their original user-declared name with numbered step lines.
+    pub fn explain_with_statistics(
         &self,
         config: &PipelineConfig,
-        artifacts: &crate::plan::bind_schema::CompileArtifacts,
+        statistics: &crate::plan::statistics::StatisticsCatalog,
         total_memory_limit_bytes: u64,
     ) -> String {
         // Build the base block (everything except combines) by reusing
         // `explain()` and then overwriting the combine section with the
-        // artifacts-aware render. `explain()` calls
+        // statistics-aware render. `explain()` calls
         // `render_combine_section(.., None, ..)` which is a no-op for
-        // every combine node when artifacts are absent — so the output
+        // every combine node when the catalog is absent — so the output
         // of `explain()` already has no combine block to dedupe.
         let classes = self.classify_node_buffers(config);
         let policy_name = config.pipeline.memory.backpressure.policy_name();
         let mut out = self.explain(&classes, policy_name);
-        self.render_combine_section(&mut out, Some(artifacts), total_memory_limit_bytes);
-        render_statistics_section(&mut out, &artifacts.statistics);
+        self.render_combine_section(&mut out, Some(statistics), total_memory_limit_bytes);
+        render_statistics_section(&mut out, statistics);
         out
     }
 
@@ -853,16 +854,16 @@ impl ExecutionPlanDag {
     /// chain of binary combines that share the original user-declared
     /// name in `decomposed_from` — emits one group header followed by
     /// numbered `Step N:` lines. Singleton combines render their own
-    /// block. Without `artifacts`, the function returns immediately
-    /// (predicate detail is unreachable; the header line on
+    /// block. Without the statistics catalog, the function returns
+    /// immediately (row-estimate detail is unreachable; the header line on
     /// `display_name()` is the only signal).
     fn render_combine_section(
         &self,
         out: &mut String,
-        artifacts: Option<&crate::plan::bind_schema::CompileArtifacts>,
+        statistics: Option<&crate::plan::statistics::StatisticsCatalog>,
         total_memory_limit_bytes: u64,
     ) {
-        let Some(artifacts) = artifacts else {
+        let Some(statistics) = statistics else {
             return;
         };
 
@@ -893,7 +894,7 @@ impl ExecutionPlanDag {
             if indices.len() > 1 {
                 self.render_combine_group(out, group_name, indices, planned_share);
             } else {
-                self.render_combine_single(out, indices[0], artifacts, planned_share);
+                self.render_combine_single(out, indices[0], statistics, planned_share);
             }
         }
     }
@@ -903,15 +904,16 @@ impl ExecutionPlanDag {
     /// input + estimated rows, build inputs + roles, predicate
     /// summary + per-bucket detail (PostgreSQL 3-tier), match mode,
     /// on-miss policy, planned-share memory budget. Defensive paths
-    /// handle a combine whose `combine_predicates` entry is missing
-    /// (E303 fired at compile time) by rendering `<unselected>` /
-    /// summary-only — mirrors `display_name()`'s `<unselected>`
-    /// fallback for an unset driving input.
+    /// handle a combine whose on-node `decomposed_predicate` is `None`
+    /// (a body-less `match: collect` step, or E303 fired at compile
+    /// time) by rendering the count summary only and skipping the detail
+    /// buckets — mirrors `display_name()`'s `<unselected>` fallback for
+    /// an unset driving input.
     fn render_combine_single(
         &self,
         out: &mut String,
         idx: NodeIndex,
-        artifacts: &crate::plan::bind_schema::CompileArtifacts,
+        statistics: &crate::plan::statistics::StatisticsCatalog,
         planned_share: u64,
     ) {
         let PlanNode::Combine {
@@ -945,10 +947,8 @@ impl ExecutionPlanDag {
         } else {
             driving_input.as_str()
         };
-        let drive_rows = format_estimated_rows(
-            inputs_for_node.and_then(|m| m.get(drive_label)),
-            &artifacts.statistics,
-        );
+        let drive_rows =
+            format_estimated_rows(inputs_for_node.and_then(|m| m.get(drive_label)), statistics);
         out.push_str(&format!(
             "  Driving input: {drive_label} (probe, est. {drive_rows} rows)\n",
         ));
@@ -957,7 +957,7 @@ impl ExecutionPlanDag {
             let role = describe_build_role(strategy, build_name);
             let rows = format_estimated_rows(
                 inputs_for_node.and_then(|m| m.get(build_name.as_str())),
-                &artifacts.statistics,
+                statistics,
             );
             out.push_str(&format!(
                 "  Build input: {build_name} ({role}, est. {rows} rows)\n",
@@ -1062,22 +1062,22 @@ impl ExecutionPlanDag {
         out.push('\n');
     }
 
-    /// Like [`Self::explain_full`] but emits the artifacts-aware
+    /// Like [`Self::explain_full`] but emits the statistics-aware
     /// per-combine multi-line block alongside the existing transform /
     /// sort / route blocks. Intended for the CLI `--explain` path
     /// where the caller already holds the [`crate::plan::CompiledPlan`]
-    /// that produced this DAG.
-    pub fn explain_full_with_artifacts(
+    /// that produced this DAG and its statistics catalog.
+    pub fn explain_full_with_statistics(
         &self,
         config: &PipelineConfig,
-        artifacts: &crate::plan::bind_schema::CompileArtifacts,
+        statistics: &crate::plan::statistics::StatisticsCatalog,
     ) -> String {
         let total_limit =
             crate::config::utils::parse_memory_limit_bytes(config.pipeline.memory.limit.as_deref());
-        let mut out = self.explain_with_artifacts(config, artifacts, total_limit);
+        let mut out = self.explain_with_statistics(config, statistics, total_limit);
         // Re-render the retraction section with the pipeline config in
         // scope so the fanout-policy line resolves to the user-visible
-        // setting. `explain()` (called inside `explain_with_artifacts`)
+        // setting. `explain()` (called inside `explain_with_statistics`)
         // already emitted a config-less variant; strip it before
         // re-rendering to avoid duplicate blocks.
         if let Some(start) = out.find("=== Retraction ===\n") {
@@ -1088,15 +1088,15 @@ impl ExecutionPlanDag {
         out
     }
 
-    /// Like [`Self::explain_text`] but routes through the artifacts-
+    /// Like [`Self::explain_text`] but routes through the statistics-
     /// aware text formatter so combine blocks render with full per-
     /// node detail.
-    pub fn explain_text_with_artifacts(
+    pub fn explain_text_with_statistics(
         &self,
         config: &PipelineConfig,
-        artifacts: &crate::plan::bind_schema::CompileArtifacts,
+        statistics: &crate::plan::statistics::StatisticsCatalog,
     ) -> String {
-        let mut out = self.explain_full_with_artifacts(config, artifacts);
+        let mut out = self.explain_full_with_statistics(config, statistics);
         self.append_topology_section(&mut out);
         out
     }
@@ -1286,7 +1286,7 @@ impl ExecutionPlanDag {
 
     /// Append the `CXL Expressions`, `Type Annotations`, `Memory Budget`
     /// trailing sections that `explain_full` adds onto a base
-    /// `explain()` body. Factored so the artifacts-aware variant can
+    /// `explain()` body. Factored so the statistics-aware variant can
     /// reuse them.
     fn append_full_sections(&self, out: &mut String, config: &PipelineConfig) {
         // CXL AST (reformatted expressions from config)
@@ -1331,7 +1331,7 @@ impl ExecutionPlanDag {
     }
 
     /// Append the `DAG Topology` section that `explain_text` adds onto
-    /// a base `explain_full` body. Factored so the artifacts-aware
+    /// a base `explain_full` body. Factored so the statistics-aware
     /// variant can reuse it without duplicating the topology walk.
     fn append_topology_section(&self, out: &mut String) {
         out.push_str("=== DAG Topology ===\n\n");
@@ -1673,11 +1673,11 @@ struct NodeEntry<'a> {
 ///
 /// Keeping the wrapper out of `ExecutionPlanDag` itself preserves the
 /// existing `serde_json::to_value(&dag)` / `to_string_pretty(&dag)`
-/// callers (which neither receive nor want artifacts) without bumping
-/// the JSON `schema_version`.
+/// callers (which neither receive nor want the statistics catalog)
+/// without bumping the JSON `schema_version`.
 pub struct ExplainJson<'a> {
     dag: &'a ExecutionPlanDag,
-    artifacts: &'a crate::plan::bind_schema::CompileArtifacts,
+    statistics: &'a crate::plan::statistics::StatisticsCatalog,
     /// Storage observability at parity with the text `--explain` output:
     /// per-stage spill estimates, the resolved spill root / disk cap, the
     /// per-operator compression decision, cap headroom, and the staging
@@ -1689,14 +1689,14 @@ pub struct ExplainJson<'a> {
 }
 
 impl<'a> ExplainJson<'a> {
-    /// Build an artifacts-aware JSON view of an execution plan.
+    /// Build a statistics-aware JSON view of an execution plan.
     pub fn new(
         dag: &'a ExecutionPlanDag,
-        artifacts: &'a crate::plan::bind_schema::CompileArtifacts,
+        statistics: &'a crate::plan::statistics::StatisticsCatalog,
     ) -> Self {
         Self {
             dag,
-            artifacts,
+            statistics,
             storage_summary: None,
         }
     }
@@ -1863,12 +1863,12 @@ impl<'a> Serialize for ExplainJson<'a> {
         map.serialize_entry("schema_version", "1")?;
 
         // Combine-aware node list. Walks `topo_order` and emits a
-        // `CombineNodeEntry` for combine variants (carrying the
-        // artifacts-derived fields), falling back to the plain
+        // `CombineNodeEntry` for combine variants (whose row estimates
+        // read the statistics catalog), falling back to the plain
         // `NodeEntry` for everything else.
         struct EnrichedNodeList<'a> {
             dag: &'a ExecutionPlanDag,
-            artifacts: &'a crate::plan::bind_schema::CompileArtifacts,
+            statistics: &'a crate::plan::statistics::StatisticsCatalog,
             combine_count_total: usize,
             total_memory_limit: u64,
         }
@@ -1889,7 +1889,7 @@ impl<'a> Serialize for ExplainJson<'a> {
                         let entry = CombineNodeEntry {
                             node,
                             depends_on: &depends_on,
-                            artifacts: self.artifacts,
+                            statistics: self.statistics,
                             memory_budget_bytes: planned_share,
                         };
                         seq.serialize_element(&entry)?;
@@ -1922,7 +1922,7 @@ impl<'a> Serialize for ExplainJson<'a> {
             "nodes",
             &EnrichedNodeList {
                 dag: self.dag,
-                artifacts: self.artifacts,
+                statistics: self.statistics,
                 combine_count_total,
                 total_memory_limit,
             },
@@ -1956,8 +1956,8 @@ impl<'a> Serialize for ExplainJson<'a> {
     }
 }
 
-/// Per-Combine-node JSON entry carrying the artifacts-derived
-/// predicate detail (`equalities[].left/.right`, `ranges[]`,
+/// Per-Combine-node JSON entry carrying the node-derived predicate
+/// detail (`equalities[].left/.right`, `ranges[]`,
 /// `has_residual`), per-input role + cardinality, and the
 /// planned-share `memory_budget_bytes`. Flattens the underlying
 /// `PlanNode::Combine` shape to preserve every field the plain
@@ -1967,7 +1967,7 @@ impl<'a> Serialize for ExplainJson<'a> {
 struct CombineNodeEntry<'a> {
     node: &'a PlanNode,
     depends_on: &'a Vec<String>,
-    artifacts: &'a crate::plan::bind_schema::CompileArtifacts,
+    statistics: &'a crate::plan::statistics::StatisticsCatalog,
     memory_budget_bytes: u64,
 }
 
@@ -1996,8 +1996,8 @@ impl<'a> Serialize for CombineNodeEntry<'a> {
         );
 
         // Combine-specific extras. The per-input metadata and decomposed
-        // predicate come off the node (the runtime source); the statistics
-        // catalog stays in artifacts.
+        // predicate come off the node (the runtime source); only the
+        // row-estimate figures consult the statistics catalog.
         if let PlanNode::Combine {
             strategy,
             driving_input,
@@ -2014,7 +2014,7 @@ impl<'a> Serialize for CombineNodeEntry<'a> {
             // Per-input role + estimated rows.
             let inputs_value = build_inputs_json(
                 combine_inputs.as_ref(),
-                &self.artifacts.statistics,
+                self.statistics,
                 driving_input,
                 build_inputs,
                 strategy,

--- a/crates/clinker-plan/src/plan/tests/combine_body_typed_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/combine_body_typed_on_node.rs
@@ -11,7 +11,7 @@
 use crate::plan::execution::PlanNode;
 use petgraph::graph::DiGraph;
 
-use super::deferred_region::compile_with_dir_full;
+use super::deferred_region::{body_id_for, compile_with_dir_full};
 
 /// Read the typed `cxl:` body program off the named `PlanNode::Combine`
 /// in `graph`, panicking if the node is absent, is not a Combine, or
@@ -174,20 +174,9 @@ nodes:
     );
 
     // 2. BODY combine: program is reachable off the node in the
-    //    composition body's `graph`, with the same fidelity.
-    let artifacts = compiled.artifacts();
-    let body_comp_id = compiled
-        .config()
-        .nodes
-        .iter()
-        .zip(artifacts.top_level_node_ids.iter())
-        .find_map(|(spanned, id)| (spanned.value.name() == "body").then_some(*id))
-        .expect("top-level `body` composition id");
-    let body_id = artifacts
-        .composition_body_assignments
-        .get(&body_comp_id)
-        .copied()
-        .expect("composition body assignment for `body`");
+    //    composition body's `graph`, with the same fidelity. Resolve the
+    //    body id off the slim plan's stamped Composition node.
+    let body_id = body_id_for(&compiled, "body");
     let bound = compiled.body_of(body_id).expect("bound body");
     let body = combine_body_typed(&bound.graph, "body_combine");
     assert!(

--- a/crates/clinker-plan/src/plan/tests/combine_where_scoped_key.rs
+++ b/crates/clinker-plan/src/plan/tests/combine_where_scoped_key.rs
@@ -14,7 +14,7 @@
 //! predicates, and asserts the two combines get DISTINCT `PlanNodeId`s with
 //! their own independent `combine_where_typed` entry.
 
-use super::deferred_region::compile_with_dir_full;
+use super::deferred_region::bind_schema_with_dir;
 
 /// A top-level combine and a composition-body combine both named `join_x`,
 /// each with a distinct `where:` predicate, get distinct `PlanNodeId`s and
@@ -134,18 +134,13 @@ nodes:
       path: out_body.csv
       include_unmapped: true
 "#;
-    let compiled = compile_with_dir_full(yaml, workspace.path());
-    let artifacts = compiled.artifacts();
+    let (artifacts, config) = bind_schema_with_dir(yaml, workspace.path());
 
     // The body's scope id comes from the composition-body assignment,
     // keyed by the `body` composition call-site node's own id — resolved
-    // from the declaration-order id vector the way production does.
-    let body_comp_id = compiled
-        .config()
-        .nodes
-        .iter()
-        .zip(artifacts.top_level_node_ids.iter())
-        .find_map(|(spanned, id)| (spanned.value.name() == "body").then_some(*id))
+    // through the production `top_level_id` resolver.
+    let body_comp_id = artifacts
+        .top_level_id(&config.nodes, "body")
         .expect("top-level `body` composition id");
     let body_id = artifacts
         .composition_body_assignments
@@ -153,18 +148,14 @@ nodes:
         .copied()
         .expect("composition body assignment for `body`");
 
-    // Resolve each combine's id: the top-level `join_x` from the
-    // declaration-order id vector (top-level names are unique), the body
-    // `join_x` off the bound body's mini-DAG. The two same-named combines
-    // live in disjoint scopes and so must get DISTINCT ids.
-    let top_id = compiled
-        .config()
-        .nodes
-        .iter()
-        .zip(artifacts.top_level_node_ids.iter())
-        .find_map(|(spanned, id)| (spanned.value.name() == "join_x").then_some(*id))
+    // Resolve each combine's id: the top-level `join_x` (top-level names are
+    // unique), the body `join_x` off the bound body's mini-DAG. The two
+    // same-named combines live in disjoint scopes and so must get DISTINCT
+    // ids.
+    let top_id = artifacts
+        .top_level_id(&config.nodes, "join_x")
         .expect("top-level `join_x` id");
-    let body = compiled.body_of(body_id).expect("bound body for `body`");
+    let body = artifacts.body_of(body_id).expect("bound body for `body`");
     let body_idx = body
         .name_to_idx
         .get("join_x")

--- a/crates/clinker-plan/src/plan/tests/deferred_region.rs
+++ b/crates/clinker-plan/src/plan/tests/deferred_region.rs
@@ -15,6 +15,7 @@ use petgraph::graph::NodeIndex;
 
 use crate::config::{CompileContext, PipelineConfig, parse_config};
 use crate::plan::CompiledPlan;
+use crate::plan::bind_schema::CompileArtifacts;
 use crate::plan::execution::ExecutionPlanDag;
 
 fn compile(yaml: &str) -> ExecutionPlanDag {
@@ -30,6 +31,35 @@ pub(super) fn compile_with_dir_full(yaml: &str, workspace_root: &std::path::Path
     let config: PipelineConfig = parse_config(yaml).expect("parse");
     let ctx = CompileContext::with_pipeline_dir(workspace_root, PathBuf::from("pipelines"));
     config.compile(&ctx).expect("compile")
+}
+
+/// Bind a composition fixture directly through [`bind_schema`], returning
+/// the full [`CompileArtifacts`] (compile-scratch: `typed`,
+/// `combine_where_typed`, `composition_body_assignments`,
+/// `top_level_node_ids`, plus the bound `composition_bodies`) alongside the
+/// parsed [`PipelineConfig`]. `bind_schema` is `pub` and consumed by
+/// production `compile_with_diagnostics`, so the compile-scratch is reached
+/// through a non-test API. Deferred regions are NOT computed here (those run
+/// later, in `compile`); tests needing post-lowering regions use
+/// [`compile_with_dir_full`] + the slim plan.
+pub(super) fn bind_schema_with_dir(
+    yaml: &str,
+    workspace_root: &std::path::Path,
+) -> (CompileArtifacts, PipelineConfig) {
+    let config: PipelineConfig = parse_config(yaml).expect("parse");
+    let ctx = CompileContext::with_pipeline_dir(workspace_root, PathBuf::from("pipelines"));
+    let symbol_table = crate::config::composition::scan_workspace_signatures(ctx.workspace_root())
+        .expect("composition corpus must scan");
+    let mut diags = Vec::new();
+    let artifacts = crate::plan::bind_schema::bind_schema(
+        &config.nodes,
+        &mut diags,
+        &ctx,
+        &symbol_table,
+        &ctx.pipeline_dir,
+        Default::default(),
+    );
+    (artifacts, config)
 }
 
 fn node_idx_for(plan: &ExecutionPlanDag, node_name: &str) -> NodeIndex {
@@ -49,30 +79,48 @@ fn body_node_idx_for(
         .unwrap_or_else(|| panic!("body node {node_name:?} not found"))
 }
 
-/// Resolve a top-level composition call-site node's [`PlanNodeId`] by name,
-/// the way the production lowering does: from the declaration-order id
-/// vector (top-level names are unique). `composition_body_assignments` keys
-/// by this id, so reads must resolve it rather than indexing by name.
-fn top_level_id_for(compiled: &CompiledPlan, node_name: &str) -> crate::plan::PlanNodeId {
-    let artifacts = compiled.artifacts();
-    compiled
-        .config()
-        .nodes
-        .iter()
-        .zip(artifacts.top_level_node_ids.iter())
-        .find_map(|(spanned, id)| (spanned.value.name() == node_name).then_some(*id))
-        .unwrap_or_else(|| panic!("top-level composition node {node_name:?} not found"))
+/// Resolve a top-level composition's [`CompositionBodyId`] off the slim
+/// plan: find the `PlanNode::Composition` by name in the parent DAG and
+/// read the `body` id stamped on it post-lowering. This replaces the old
+/// `artifacts.composition_body_assignments` lookup — the body id now lives
+/// on the node itself.
+pub(super) fn body_id_for(
+    compiled: &CompiledPlan,
+    comp_name: &str,
+) -> crate::plan::CompositionBodyId {
+    let dag = compiled.dag();
+    dag.graph
+        .node_indices()
+        .find_map(|i| match &dag.graph[i] {
+            crate::plan::execution::PlanNode::Composition { name, body, .. }
+                if name == comp_name =>
+            {
+                Some(*body)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("top-level composition node {comp_name:?} not found"))
 }
 
-/// Resolve a body-internal composition call-site node's [`PlanNodeId`] by
-/// name from its parent body's mini-DAG. Body nodes carry their own stable
-/// id, which keys `composition_body_assignments` for nested compositions.
-fn body_composition_id_for(
+/// Resolve a nested composition's [`CompositionBodyId`] off its enclosing
+/// body's mini-DAG: find the `PlanNode::Composition` by name in `body.graph`
+/// and read the `body` id stamped on it. The body-graph analogue of
+/// [`body_id_for`].
+fn nested_body_id_for(
     body: &crate::plan::composition_body::BoundBody,
-    node_name: &str,
-) -> crate::plan::PlanNodeId {
-    let idx = body_node_idx_for(body, node_name);
-    body.graph[idx].id()
+    comp_name: &str,
+) -> crate::plan::CompositionBodyId {
+    body.graph
+        .node_indices()
+        .find_map(|i| match &body.graph[i] {
+            crate::plan::execution::PlanNode::Composition { name, body, .. }
+                if name == comp_name =>
+            {
+                Some(*body)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("nested composition node {comp_name:?} not found in body"))
 }
 
 /// Test 1: Simple region — Source(CK=order_id) → Aggregate(group_by=dept,
@@ -558,15 +606,10 @@ nodes:
     let out_idx = node_idx_for(plan, "out");
 
     // Body-local regions: look up the bound body via the composition's
-    // name → body-id assignment, then assert the body-internal
-    // Aggregate is the producer, the body's Transform is a member, and
-    // both NodeIndex slots are keyed for O(1) dispatcher lookup.
-    let artifacts = compiled.artifacts();
-    let body_id = artifacts
-        .composition_body_assignments
-        .get(&top_level_id_for(&compiled, "body"))
-        .copied()
-        .expect("composition 'body' must be assigned a CompositionBodyId");
+    // name → body-id stamped on the slim plan's node, then assert the
+    // body-internal Aggregate is the producer, the body's Transform is a
+    // member, and both NodeIndex slots are keyed for O(1) dispatcher lookup.
+    let body_id = body_id_for(&compiled, "body");
     let bound = compiled
         .body_of(body_id)
         .expect("body_id must resolve to a BoundBody");
@@ -722,15 +765,10 @@ nodes:
 
     // Body-local: the inner body owns the relaxed Aggregate; the outer
     // body owns no relaxed Aggregate of its own and thus has no body-
-    // local region keyed on its mini-DAG. Walk the assignments to
-    // locate both bodies and verify the load-bearing one carries the
-    // expected producer.
-    let artifacts = compiled.artifacts();
-    let outer_body_id = artifacts
-        .composition_body_assignments
-        .get(&top_level_id_for(&compiled, "outer"))
-        .copied()
-        .expect("outer composition assignment");
+    // local region keyed on its mini-DAG. Resolve both bodies off the
+    // slim plan and verify the load-bearing one carries the expected
+    // producer.
+    let outer_body_id = body_id_for(&compiled, "outer");
     let outer_body = compiled
         .body_of(outer_body_id)
         .expect("outer BoundBody resolves");
@@ -739,14 +777,10 @@ nodes:
         "outer body has no relaxed Aggregate of its own; its body-local map stays empty",
     );
 
-    // Inner body assignment lives under the body-internal Composition
-    // node `inner_call` inside `outer_wrap.comp.yaml` — resolve its id off
-    // the outer body's mini-DAG.
-    let inner_body_id = artifacts
-        .composition_body_assignments
-        .get(&body_composition_id_for(outer_body, "inner_call"))
-        .copied()
-        .expect("inner_call composition assignment");
+    // Inner body id lives on the body-internal Composition node
+    // `inner_call` inside `outer_wrap.comp.yaml` — resolve it off the
+    // outer body's mini-DAG.
+    let inner_body_id = nested_body_id_for(outer_body, "inner_call");
     let inner_body = compiled
         .body_of(inner_body_id)
         .expect("inner BoundBody resolves");
@@ -1066,14 +1100,9 @@ nodes:
     );
 
     // Outer body: continuation for the inner Composition with the
-    // outer body's own Transform downstream. Resolve the outer body
-    // and the inner Composition's body-local NodeIndex.
-    let artifacts = compiled.artifacts();
-    let outer_body_id = artifacts
-        .composition_body_assignments
-        .get(&top_level_id_for(&compiled, "outer"))
-        .copied()
-        .expect("outer composition assignment");
+    // outer body's own Transform downstream. Resolve the outer body off
+    // the slim plan, then the inner Composition's body-local NodeIndex.
+    let outer_body_id = body_id_for(&compiled, "outer");
     let outer_body = compiled
         .body_of(outer_body_id)
         .expect("outer BoundBody resolves");
@@ -1274,12 +1303,7 @@ nodes:
       include_unmapped: true
 "#;
     let compiled = compile_with_dir_full(yaml, workspace.path());
-    let artifacts = compiled.artifacts();
-    let body_id = artifacts
-        .composition_body_assignments
-        .get(&top_level_id_for(&compiled, "body"))
-        .copied()
-        .expect("composition 'body' must be assigned a CompositionBodyId");
+    let body_id = body_id_for(&compiled, "body");
     let bound = compiled
         .body_of(body_id)
         .expect("body_id must resolve to a BoundBody");
@@ -1390,12 +1414,7 @@ nodes:
       include_unmapped: true
 "#;
     let compiled = compile_with_dir_full(yaml, workspace.path());
-    let artifacts = compiled.artifacts();
-    let body_id = artifacts
-        .composition_body_assignments
-        .get(&top_level_id_for(&compiled, "body"))
-        .copied()
-        .expect("composition 'body' must be assigned a CompositionBodyId");
+    let body_id = body_id_for(&compiled, "body");
     let bound = compiled
         .body_of(body_id)
         .expect("body_id must resolve to a BoundBody");
@@ -1534,23 +1553,15 @@ nodes:
       include_unmapped: true
 "#;
     let compiled = compile_with_dir_full(yaml, workspace.path());
-    let artifacts = compiled.artifacts();
 
     // `inner_call` is body-internal to the top-level `outer` composition;
-    // resolve outer's body first, then key by inner_call's body-local id.
-    let outer_body_id = artifacts
-        .composition_body_assignments
-        .get(&top_level_id_for(&compiled, "outer"))
-        .copied()
-        .expect("outer composition must be assigned a CompositionBodyId");
+    // resolve outer's body off the slim plan, then key by inner_call's
+    // body-local id stamped on the outer body's node.
+    let outer_body_id = body_id_for(&compiled, "outer");
     let outer_body = compiled
         .body_of(outer_body_id)
         .expect("outer body resolves");
-    let inner_body_id = artifacts
-        .composition_body_assignments
-        .get(&body_composition_id_for(outer_body, "inner_call"))
-        .copied()
-        .expect("inner_call composition must be assigned a CompositionBodyId");
+    let inner_body_id = nested_body_id_for(outer_body, "inner_call");
     let inner_body = compiled
         .body_of(inner_body_id)
         .expect("inner body resolves");
@@ -1690,22 +1701,24 @@ nodes:
       path: out_b.csv
       include_unmapped: true
 "#;
+    // The slim plan supplies the post-compile parent continuations and the
+    // real parent graph; `bind_schema` supplies a `CompileArtifacts` for the
+    // `continuation_support` signature. The walk's members here are plain
+    // Transforms (`parent_a`/`parent_b`), never Compositions, so the walker
+    // never dereferences a body id through `artifacts.body_of` — the two id
+    // spaces are never crossed.
     let compiled = compile_with_dir_full(yaml, workspace.path());
+    let (artifacts, _config) = bind_schema_with_dir(yaml, workspace.path());
     let plan = compiled.dag();
-    let artifacts = compiled.artifacts();
 
     let body_a_idx = node_idx_for(plan, "body_a");
     let body_b_idx = node_idx_for(plan, "body_b");
 
     // The two call sites today bind to distinct body IDs (1:1
-    // allocator); pick `body_a`'s id as the canonical body and
-    // forge a second call site pointing at the same id but
-    // referencing `body_b`'s `composition_idx` and continuation.
-    let canonical_body_id: CompositionBodyId = artifacts
-        .composition_body_assignments
-        .get(&plan.graph[body_a_idx].id())
-        .copied()
-        .expect("body_a must be assigned");
+    // allocator); pick `body_a`'s id (stamped on the slim plan's node) as
+    // the canonical body and forge a second call site pointing at the same
+    // id but referencing `body_b`'s `composition_idx` and continuation.
+    let canonical_body_id: CompositionBodyId = body_id_for(&compiled, "body_a");
 
     // Pull the existing per-call-site continuation members from the
     // real plan-time analysis path: each Composition's
@@ -1766,7 +1779,7 @@ nodes:
         "out",
         &analysis,
         &plan.graph,
-        artifacts,
+        &artifacts,
         &mut memo,
         &mut active,
     );
@@ -1809,7 +1822,7 @@ nodes:
         "out",
         &single_analysis,
         &plan.graph,
-        artifacts,
+        &artifacts,
         &mut memo2,
         &mut active2,
     );
@@ -1907,12 +1920,7 @@ nodes:
       include_unmapped: true
 "#;
     let compiled = compile_with_dir_full(yaml, workspace.path());
-    let artifacts = compiled.artifacts();
-    let body_id = artifacts
-        .composition_body_assignments
-        .get(&top_level_id_for(&compiled, "body"))
-        .copied()
-        .expect("composition 'body' must be assigned a CompositionBodyId");
+    let body_id = body_id_for(&compiled, "body");
     let bound = compiled
         .body_of(body_id)
         .expect("body_id must resolve to a BoundBody");

--- a/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
+++ b/crates/clinker-plan/src/plan/tests/typed_scoped_key.rs
@@ -14,7 +14,7 @@
 //! and asserts the two nodes get DISTINCT `PlanNodeId`s with their own
 //! independent typed entry.
 
-use super::deferred_region::compile_with_dir_full;
+use super::deferred_region::bind_schema_with_dir;
 
 /// A top-level transform and a composition-body transform both named
 /// `shape`, each emitting a distinct field, get distinct `PlanNodeId`s and
@@ -102,18 +102,13 @@ nodes:
       path: out_body.csv
       include_unmapped: true
 "#;
-    let compiled = compile_with_dir_full(yaml, workspace.path());
-    let artifacts = compiled.artifacts();
+    let (artifacts, config) = bind_schema_with_dir(yaml, workspace.path());
 
     // The body's scope id comes from the composition-body assignment,
     // keyed by the `body` composition call-site node's own id — resolved
-    // from the declaration-order id vector the way production does.
-    let body_comp_id = compiled
-        .config()
-        .nodes
-        .iter()
-        .zip(artifacts.top_level_node_ids.iter())
-        .find_map(|(spanned, id)| (spanned.value.name() == "body").then_some(*id))
+    // through the production `top_level_id` resolver.
+    let body_comp_id = artifacts
+        .top_level_id(&config.nodes, "body")
         .expect("top-level `body` composition id");
     let body_id = artifacts
         .composition_body_assignments
@@ -121,18 +116,13 @@ nodes:
         .copied()
         .expect("composition body assignment for `body`");
 
-    // Resolve the top-level `shape` node's id from the declaration-order id
-    // vector (top-level names are unique), and the body `shape` node's id
-    // off the bound body's mini-DAG. The two same-named nodes live in
-    // disjoint scopes and so must get DISTINCT ids.
-    let top_id = compiled
-        .config()
-        .nodes
-        .iter()
-        .zip(artifacts.top_level_node_ids.iter())
-        .find_map(|(spanned, id)| (spanned.value.name() == "shape").then_some(*id))
+    // Resolve the top-level `shape` node's id (top-level names are unique),
+    // and the body `shape` node's id off the bound body's mini-DAG. The two
+    // same-named nodes live in disjoint scopes and so must get DISTINCT ids.
+    let top_id = artifacts
+        .top_level_id(&config.nodes, "shape")
         .expect("top-level `shape` id");
-    let body = compiled.body_of(body_id).expect("bound body for `body`");
+    let body = artifacts.body_of(body_id).expect("bound body for `body`");
     let body_idx = body
         .name_to_idx
         .get("shape")

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -736,12 +736,12 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
             abort_on_overlay_errors(&overlay)?;
         }
         let dag = compiled_plan.dag();
-        let artifacts = compiled_plan.artifacts();
+        let statistics = compiled_plan.statistics();
         match format {
             ExplainFormat::Text => {
                 print!(
                     "{}",
-                    dag.explain_text_with_artifacts(&pipeline_config, artifacts)
+                    dag.explain_text_with_statistics(&pipeline_config, statistics)
                 );
                 // Resolved spill root: the directory under which the per-run
                 // `clinker-spill-*` directory is created. Shows the configured
@@ -819,7 +819,7 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                     spill_root_dir.as_deref(),
                     &args.config,
                 );
-                let view = clinker_plan::plan::execution::ExplainJson::new(dag, artifacts)
+                let view = clinker_plan::plan::execution::ExplainJson::new(dag, statistics)
                     .with_storage_summary(storage_summary);
                 let json = serde_json::to_string_pretty(&view).map_err(|e| {
                     PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(


### PR DESCRIPTION
## Summary

`CompiledPlan` embedded the full `CompileArtifacts` — every node's typed CXL program, combine metadata, and the dense node-id mint counters — and the runtime executor carried that whole value through the run, even though at run time it only reads the bound composition bodies and the statistics catalog. This change makes `CompiledPlan` carry only the state the executor and tooling actually need at run time, and drops the transient compile scratch as soon as compilation finishes.

## Changes

- `CompiledPlan` now holds `dag`, `config`, `composition_bodies`, `statistics`, `provenance`, `channel_identity`, and `pipeline_hash` as direct fields. A new `from_compile` constructor moves the runtime-retained fields out of `CompileArtifacts` and drops the rest; `CompileArtifacts` never enters `CompiledPlan`.
- Removed `CompiledPlan::artifacts()` and `CompiledPlan::typed_output_row()`.
- The executor's plan-time context (`ExecutorContext` / `DagExecInputs`) now borrows the bound composition bodies (via a `CompositionBodies` type alias) plus the statistics catalog used to seed the runtime accumulator, rather than the whole `CompileArtifacts`.
- The `--explain` text and JSON renderers now take a `&StatisticsCatalog`. They only ever read the statistics catalog — combine predicate detail is read off the node — so `--explain` output is unchanged.
- A node's human-readable scoped path is derived on demand by walking the DAG and the bound bodies (each composition node carries its body id). No internal node-id → (scope, name) map is materialized.
- Tests that inspect compile-time artifacts now bind through the public `bind_schema` entry point (the same one compilation consumes); post-lowering state such as deferred regions and body ids is read off the slimmed plan.

## Validation

- `cargo fmt --check`; `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 3330 passed, 0 failed
- `cargo check --workspace --benches` plus the benchmark smoke suite
- `--explain` text and JSON verified unchanged on a join pipeline (the explain snapshot tests pass against committed baselines)

Closes #644.
