### PR TITLE
docs: document compile-time typechecking of route branch conditions

### DIFF
--- a/docs/user/src/nodes/route.md
+++ b/docs/user/src/nodes/route.md
@@ -32,6 +32,12 @@ The `conditions:` field is an ordered map of branch names to CXL boolean express
 
 Condition keys become the port names used in downstream `input:` wiring.
 
+### Compile-time checking
+
+Branch conditions are typechecked when the pipeline is compiled -- the same plan-building pass you trigger with `clinker run pipeline.yaml --dry-run` (see [Validation & Dry Run](../ops/validation.md)). Each condition is checked against the concrete column types of the route's input, so a condition that references an unknown column or compares incompatible types fails at compile time rather than partway through a run.
+
+Compile failures surface as an **E200** diagnostic (the shared CXL resolution/type-error code) and name the offending branch -- for example `split_by_value (branch high)` -- so in a multi-branch route the error points at the specific branch rather than just the route node.
+
 ## Default branch
 
 The `default:` field is **required**. Records that match no condition are routed to the default branch. The default branch name must not collide with any condition key.


### PR DESCRIPTION
## What

Documents a recently-landed behavior change for **Route** nodes: branch conditions are now typechecked at compile time against the route's concrete upstream schema.

A condition that references an unknown column or compares incompatible types now fails when the pipeline is compiled (for example via `clinker run pipeline.yaml --dry-run`) with an `E200` diagnostic, instead of slipping through to a runtime failure. The diagnostic names the offending branch — e.g. `split_by_value (branch high)` — so in a multi-branch route the error points at the specific branch rather than just the route node.

## Change

- `docs/user/src/nodes/route.md`: new **Compile-time checking** note under the *Conditions* section. It frames `E200` as the shared CXL resolution/type-error diagnostic (not a route-specific code) and cross-links the Validation & Dry Run page.

## Validation

- `mdbook build` of the user guide succeeds; the new note renders and the relative link to the validation page resolves.
- `git diff --check` clean.
