### PR TITLE
plan,exec: carry Cull and Reshape predicate programs on-node (closes #654)

### DIFF
--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -55,7 +55,6 @@ use std::sync::Arc;
 
 use clinker_record::{GroupByKey, Record, Schema, SchemaBuilder, Value};
 use cxl::eval::ProgramEvaluator;
-use cxl::typecheck::{QualifiedField, Row, Type};
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
@@ -86,12 +85,11 @@ const CULL_SPILL_PRIORITY: i32 = 15;
 /// cap: beyond it, per-file overhead outweighs further skew reduction.
 const MAX_SKEW_PARTITION_BITS: u32 = 12;
 
-/// Synthetic output column the predicate aggregate emits the per-group
-/// removal decision into. A reserved `__cull_…__` name: the CXL parser
-/// rejects an `emit` to a `$`-namespaced column, so the synthetic emit
-/// target must be a plain identifier; the double-underscore bracketing keeps
-/// it out of any realistic user column space.
-const DROP_DECISION_COLUMN: &str = "__cull_drop_decision__";
+// Synthetic output column the decision aggregate emits the per-group removal
+// decision into. Shared with the compile-time binder, which builds the
+// `emit <col> = (rule_1) or …` decision program with this target — both sides
+// reference the one constant in clinker-plan so they cannot drift.
+use clinker_plan::config::pipeline_node::CULL_DROP_DECISION_COLUMN as DROP_DECISION_COLUMN;
 
 /// Arbitrator-facing wrapper over the Cull group buffer.
 ///
@@ -152,6 +150,8 @@ pub(crate) fn dispatch_cull(
         ref name,
         ref config,
         ref output_schema,
+        ref compiled,
+        ref typed,
         ..
     } = *node
     else {
@@ -204,6 +204,8 @@ pub(crate) fn dispatch_cull(
         name,
         config,
         output_schema,
+        compiled,
+        typed,
         input,
         input_puncts,
         &handle,
@@ -228,21 +230,23 @@ fn run_cull_grouped(
     name: &str,
     config: &CullBody,
     output_schema: &Arc<Schema>,
+    compiled: &Arc<cxl::plan::CompiledAggregate>,
+    typed: &Arc<cxl::typecheck::TypedProgram>,
     input: Vec<(Record, u64)>,
     input_puncts: Vec<crate::executor::stream_event::Punctuation>,
     handle: &Arc<ConsumerHandle>,
 ) -> Result<(), PipelineError> {
     // The schema is uniform across a node_buffer slot, so the first record's
-    // schema drives both the predicate aggregate compile and the spill
-    // schema.
+    // schema drives the spill schema for the raw-record group buffer.
     let input_schema = input[0].0.schema().clone();
 
     // Compute the per-group removal decision by folding every record through
     // an in-memory aggregate over the OR of all rules' `drop_group_when`
-    // predicates (group-by = `partition_by`). The aggregate's per-group
-    // state is O(groups) and is not spilled — only the raw buffered records
-    // (which dominate the footprint) spill, below.
-    let drop_decisions = compute_drop_decisions(ctx, name, config, &input_schema, &input)?;
+    // predicates (group-by = `partition_by`), built once at lowering and
+    // carried on the node. The aggregate's per-group state is O(groups) and
+    // is not spilled — only the raw buffered records (which dominate the
+    // footprint) spill, below.
+    let drop_decisions = compute_drop_decisions(ctx, name, config, compiled, typed, &input)?;
 
     let spill_compress = ctx
         .spill_compress
@@ -332,14 +336,13 @@ fn compute_drop_decisions(
     ctx: &mut ExecutorContext<'_>,
     name: &str,
     config: &CullBody,
-    input_schema: &Arc<Schema>,
+    compiled: &Arc<cxl::plan::CompiledAggregate>,
+    typed: &Arc<cxl::typecheck::TypedProgram>,
     input: &[(Record, u64)],
 ) -> Result<HashMap<Vec<GroupByKey>, bool>, PipelineError> {
     use crate::aggregation::{AggregateStream, AggregatorConfig, SortRow};
 
-    let predicate_src = build_drop_predicate(config);
-    let compiled = compile_drop_aggregate(name, config, &predicate_src, input_schema)?;
-    let evaluator = ProgramEvaluator::new(Arc::clone(&compiled.typed), false);
+    let evaluator = ProgramEvaluator::new(Arc::clone(typed), false);
 
     // Output schema = partition-by columns ++ the boolean decision column.
     // Spill schema is unused (the predicate aggregate runs in-memory: budget
@@ -364,7 +367,7 @@ fn compute_drop_decisions(
     let mut stream = AggregateStream::for_node(
         clinker_plan::plan::types::AggregateStrategy::Hash,
         AggregatorConfig {
-            compiled: Arc::clone(&compiled.compiled),
+            compiled: Arc::clone(compiled),
             evaluator,
             output_schema: Arc::clone(&drop_output_schema),
             spill_schema,
@@ -406,100 +409,6 @@ fn compute_drop_decisions(
         decisions.insert(key, drop);
     }
     Ok(decisions)
-}
-
-/// Compiled predicate aggregate: the deduplicated aggregate plan plus the
-/// typed program the evaluator lowers expression bindings against.
-struct CompiledDropAggregate {
-    compiled: Arc<cxl::plan::CompiledAggregate>,
-    typed: Arc<cxl::typecheck::TypedProgram>,
-}
-
-/// Build the OR-combined removal predicate `emit <decision> = (r1) or (r2) …`.
-/// A group is removed when any rule's `drop_group_when` predicate holds, so
-/// the per-group decision is the disjunction of every rule's predicate.
-fn build_drop_predicate(config: &CullBody) -> String {
-    let disjuncts: Vec<String> = config
-        .rules
-        .iter()
-        .map(|r| format!("({})", r.drop_group_when.source))
-        .collect();
-    // `bind_cull` rejects an empty `rules:` list, so a valid plan always has
-    // at least one disjunct; the empty fallback is defensive only (the
-    // executor compiles the predicate independently of bind-time validation).
-    let body = if disjuncts.is_empty() {
-        "false".to_string()
-    } else {
-        disjuncts.join(" or ")
-    };
-    format!("emit {DROP_DECISION_COLUMN} = {body}")
-}
-
-/// Parse → resolve → typecheck the predicate aggregate program in aggregate
-/// context (group-by = `partition_by`) and extract its aggregate plan.
-///
-/// Type errors here are a planner-invariant violation (`bind_cull` already
-/// typechecked each rule fragment), so they surface as
-/// [`PipelineError::Compilation`].
-fn compile_drop_aggregate(
-    name: &str,
-    config: &CullBody,
-    source: &str,
-    schema: &Arc<Schema>,
-) -> Result<CompiledDropAggregate, PipelineError> {
-    let make_err = |messages: Vec<String>| PipelineError::Compilation {
-        transform_name: format!("cull:{name}:drop_group_when"),
-        messages,
-    };
-
-    let type_cols: indexmap::IndexMap<QualifiedField, Type> = schema
-        .columns()
-        .iter()
-        .map(|c| (QualifiedField::bare(c.as_ref()), Type::Any))
-        .collect();
-    let row = Row::closed(type_cols, cxl::lexer::Span::new(0, 0));
-    let field_refs: Vec<&str> = schema.columns().iter().map(|c| c.as_ref()).collect();
-    let schema_names: Vec<String> = schema.columns().iter().map(|c| c.to_string()).collect();
-    let scoped_vars = cxl::resolve::ScopedVarsRegistry::default();
-
-    let parse_result = cxl::parser::Parser::parse(source);
-    if !parse_result.errors.is_empty() {
-        return Err(make_err(
-            parse_result
-                .errors
-                .iter()
-                .map(|e| e.message.clone())
-                .collect(),
-        ));
-    }
-    let resolved = cxl::resolve::resolve_program_with_modules_and_vars(
-        parse_result.ast,
-        &field_refs,
-        parse_result.node_count,
-        &std::collections::HashMap::new(),
-        &scoped_vars,
-    )
-    .map_err(|diags| make_err(diags.into_iter().map(|d| d.message).collect()))?;
-    let agg_mode = cxl::typecheck::pass::AggregateMode::GroupBy {
-        group_by_fields: config.partition_by.iter().cloned().collect(),
-    };
-    let typed =
-        cxl::typecheck::pass::type_check_with_mode_and_vars(resolved, &row, agg_mode, &scoped_vars)
-            .map_err(|diags| {
-                make_err(
-                    diags
-                        .into_iter()
-                        .filter(|d| !d.is_warning)
-                        .map(|d| d.message)
-                        .collect(),
-                )
-            })?;
-    let compiled = cxl::plan::extract_aggregates(&typed, &config.partition_by, &schema_names)
-        .map_err(|diags| make_err(diags.into_iter().map(|d| d.message).collect()))?;
-    Ok(CompiledDropAggregate {
-        compiled: Arc::new(compiled),
-        typed: Arc::new(typed),
-    })
 }
 
 /// Deliver the kept and removed record sets to their producer-side output

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -73,8 +73,12 @@ use clinker_plan::plan::execution::{
 use crate::executor::NullStorage;
 
 /// A compiled rule: the trigger predicate plus the per-field mutation and
-/// synthesis assignment evaluators, all built against the live input
-/// schema at dispatch time (the same condition-compile seam Route uses).
+/// synthesis assignment evaluators. The evaluators are rebuilt here per
+/// dispatch (by [`build_rules`]) from the rule's on-node typed programs —
+/// the `ProgramEvaluator` holds per-thread state and is non-`Clone`, so it
+/// cannot live on the node; the typechecking itself happened once at
+/// lowering, mirroring how Route and Aggregation rebuild their evaluators
+/// off-node.
 struct CompiledRule {
     name: String,
     /// `filter <when>` — `Emit` iff the row is a trigger row.

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -48,7 +48,6 @@ use std::sync::Arc;
 
 use clinker_record::{GroupByKey, Record, Schema, Value};
 use cxl::eval::{EvalContext, EvalResult, ProgramEvaluator};
-use cxl::typecheck::{QualifiedField, Row, Type};
 use petgraph::graph::NodeIndex;
 
 use crate::executor::DlqEntry;
@@ -67,7 +66,9 @@ use clinker_plan::config::pipeline_node::{
 };
 use clinker_plan::config::{SortField, SortOrder};
 use clinker_plan::error::PipelineError;
-use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, single_predecessor};
+use clinker_plan::plan::execution::{
+    CompiledReshapeRule, ExecutionPlanDag, PlanNode, single_predecessor,
+};
 
 use crate::executor::NullStorage;
 
@@ -176,6 +177,7 @@ pub(crate) fn dispatch_reshape(
         ref name,
         ref config,
         ref output_schema,
+        ref compiled_rules,
         ..
     } = *node
     else {
@@ -228,6 +230,7 @@ pub(crate) fn dispatch_reshape(
         name,
         config,
         output_schema,
+        compiled_rules,
         input,
         input_puncts,
         &handle,
@@ -251,15 +254,19 @@ fn run_reshape_grouped(
     name: &str,
     config: &ReshapeBody,
     output_schema: &Arc<Schema>,
+    compiled_rules: &[CompiledReshapeRule],
     input: Vec<(Record, u64)>,
     input_puncts: Vec<crate::executor::stream_event::Punctuation>,
     handle: &Arc<ConsumerHandle>,
 ) -> Result<(), PipelineError> {
-    // Compile every rule's predicate / assignment program against the live
-    // input schema. The schema is uniform across a node_buffer slot, so the
-    // first record's schema drives the typecheck row.
+    // Rebuild the per-dispatch evaluators from the node's compiled rule
+    // programs (typechecked once at lowering). The `ProgramEvaluator` is
+    // non-`Clone` and holds per-thread state, so it is reconstructed here
+    // rather than carried on the node — the same seam Route/Aggregation use.
+    let mut rules = build_rules(compiled_rules);
+    // The schema is uniform across a node_buffer slot, so the first record's
+    // schema drives the spill schema for the raw-record group buffer.
     let input_schema = input[0].0.schema().clone();
-    let mut rules = compile_rules(name, config, &input_schema)?;
 
     // The spill file stores INPUT records, so the spill schema is the input
     // schema. The compression FLAG, however, is resolved against the
@@ -968,127 +975,42 @@ fn eval_scalar(
     }
 }
 
-/// Compile each rule's `when` / `set` / `overrides` CXL against `schema`.
-fn compile_rules(
-    node_name: &str,
-    config: &ReshapeBody,
-    schema: &Arc<clinker_record::Schema>,
-) -> Result<Vec<CompiledRule>, PipelineError> {
-    let type_cols: indexmap::IndexMap<QualifiedField, Type> = schema
-        .columns()
+/// Rebuild the per-dispatch executor rules from the node's compiled rule
+/// programs. Each [`CompiledReshapeRule`] carries the typechecked
+/// `Arc<TypedProgram>`s (built once at lowering); the `ProgramEvaluator`
+/// (non-`Clone`, holds per-thread state) is reconstructed here per dispatch,
+/// mirroring how Route and Aggregation rebuild their evaluators off-node.
+fn build_rules(compiled_rules: &[CompiledReshapeRule]) -> Vec<CompiledRule> {
+    compiled_rules
         .iter()
-        .map(|c| (QualifiedField::bare(c.as_ref()), Type::Any))
-        .collect();
-    let row = Row::closed(type_cols, cxl::lexer::Span::new(0, 0));
-    let field_refs: Vec<&str> = schema.columns().iter().map(|c| c.as_ref()).collect();
-
-    let mut compiled = Vec::with_capacity(config.rules.len());
-    for rule in &config.rules {
-        let when = compile_program(
-            node_name,
-            &rule.name,
-            "when",
-            &format!("filter {}", rule.when.source),
-            &row,
-            &field_refs,
-        )?;
-        let mut set = Vec::new();
-        if let Some(mutate) = &rule.mutate {
-            for (field, value) in &mutate.set {
-                let prog = compile_program(
-                    node_name,
-                    &rule.name,
-                    field,
-                    &format!("emit {field} = {}", value.source),
-                    &row,
-                    &field_refs,
-                )?;
-                set.push((field.clone(), prog));
-            }
-        }
-        let synth = match &rule.synthesize {
-            None => None,
-            Some(s) => {
-                let mut overrides = Vec::new();
-                for (field, value) in &s.overrides {
-                    let prog = compile_program(
-                        node_name,
-                        &rule.name,
-                        field,
-                        &format!("emit {field} = {}", value.source),
-                        &row,
-                        &field_refs,
-                    )?;
-                    overrides.push((field.clone(), prog));
-                }
-                Some(CompiledSynth {
-                    copy_from: s.copy_from,
-                    overrides,
-                })
-            }
-        };
-        compiled.push(CompiledRule {
-            name: rule.name.clone(),
-            when,
-            set,
-            synth,
-        });
-    }
-    Ok(compiled)
-}
-
-/// Parse → resolve → typecheck a single CXL fragment into a
-/// [`ProgramEvaluator`]. Type errors here are a planner invariant violation
-/// (bind_schema already typechecked the same fragment), so they surface as
-/// `PipelineError::Compilation`.
-fn compile_program(
-    node_name: &str,
-    rule_name: &str,
-    field: &str,
-    source: &str,
-    row: &Row,
-    field_refs: &[&str],
-) -> Result<ProgramEvaluator, PipelineError> {
-    let scoped_vars = cxl::resolve::ScopedVarsRegistry::default();
-    let make_err = |messages: Vec<String>| PipelineError::Compilation {
-        transform_name: format!("reshape:{node_name}:{rule_name}:{field}"),
-        messages,
-    };
-
-    let parse_result = cxl::parser::Parser::parse(source);
-    if !parse_result.errors.is_empty() {
-        return Err(make_err(
-            parse_result
-                .errors
+        .map(|r| CompiledRule {
+            name: r.name.clone(),
+            when: ProgramEvaluator::new(Arc::clone(&r.when), false),
+            set: r
+                .set
                 .iter()
-                .map(|e| e.message.clone())
+                .map(|(field, prog)| {
+                    (
+                        field.clone(),
+                        ProgramEvaluator::new(Arc::clone(prog), false),
+                    )
+                })
                 .collect(),
-        ));
-    }
-    let resolved = cxl::resolve::resolve_program_with_modules_and_vars(
-        parse_result.ast,
-        field_refs,
-        parse_result.node_count,
-        &std::collections::HashMap::new(),
-        &scoped_vars,
-    )
-    .map_err(|diags| make_err(diags.into_iter().map(|d| d.message).collect()))?;
-    let typed = cxl::typecheck::pass::type_check_with_mode_and_vars(
-        resolved,
-        row,
-        cxl::typecheck::pass::AggregateMode::Row,
-        &scoped_vars,
-    )
-    .map_err(|diags| {
-        make_err(
-            diags
-                .into_iter()
-                .filter(|d| !d.is_warning)
-                .map(|d| d.message)
-                .collect(),
-        )
-    })?;
-    Ok(ProgramEvaluator::new(Arc::new(typed), false))
+            synth: r.synth.as_ref().map(|s| CompiledSynth {
+                copy_from: s.copy_from,
+                overrides: s
+                    .overrides
+                    .iter()
+                    .map(|(field, prog)| {
+                        (
+                            field.clone(),
+                            ProgramEvaluator::new(Arc::clone(prog), false),
+                        )
+                    })
+                    .collect(),
+            }),
+        })
+        .collect()
 }
 
 /// Extract the `partition_by` key tuple from a record. Mirrors the

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3733,38 +3733,75 @@ pub(crate) fn lower_node_to_plan_node(
                 combine_driving,
             })
         }
-        // Reshape lowers to PlanNode::Reshape carrying the parsed config
-        // and the audit-widened output schema. The executor compiles each
-        // rule's `when` / `set` / `overrides` CXL against the live input
-        // schema at dispatch time, so no per-rule typed program is threaded
-        // through CompileArtifacts.
+        // Reshape lowers to PlanNode::Reshape carrying the parsed config, the
+        // audit-widened output schema, and the per-rule typechecked CXL
+        // programs (`compiled_rules`) bind_reshape produced. The executor
+        // rebuilds its per-rule evaluators off those at dispatch instead of
+        // recompiling the rule source — mirroring Aggregation / Route.
         PipelineNode::Reshape { config, .. } => {
-            // A missing typed entry means bind_schema rejected the node
-            // (E200 on a rule predicate / assignment) — skip lowering.
-            artifacts.typed_get(id)?;
+            // The per-rule typed programs bind_reshape stored. A missing entry
+            // means bind rejected the node (E200 on a rule predicate /
+            // assignment / `$doc` use) — skip lowering.
+            let compiled_rules = artifacts.reshape_compiled.get(&id)?.clone();
+            // bind_reshape inserts the entry only when every rule compiled, so
+            // the count matches; guard defensively against a short set the way
+            // the Route arm guards `branch_programs`.
+            if compiled_rules.len() != config.rules.len() {
+                return None;
+            }
             Some(crate::plan::execution::PlanNode::Reshape {
                 name: name.to_string(),
                 id,
                 span,
                 config: config.clone(),
                 output_schema: schema_from_bound(),
+                compiled_rules,
             })
         }
-        // Cull lowers to PlanNode::Cull carrying the parsed config and the
-        // (unchanged) upstream output schema. The executor recompiles each
-        // rule's `drop_group_when` predicate against the live input schema
-        // at dispatch time, so no per-rule typed program is threaded
-        // through CompileArtifacts.
+        // Cull lowers to PlanNode::Cull carrying the parsed config, the
+        // (unchanged) upstream output schema, and the OR-combined
+        // `drop_group_when` decision aggregate. The executor evaluates that
+        // decision aggregate per group off the node — mirroring Aggregation —
+        // instead of recompiling the predicate at dispatch.
         PipelineNode::Cull { config, .. } => {
-            // A missing typed entry means bind_schema rejected the node
-            // (E200 on a rule predicate / removed_to) — skip lowering.
-            artifacts.typed_get(id)?;
+            // The OR-combined decision program bind_cull stored. A missing
+            // entry means bind rejected the node (E200 on a rule predicate /
+            // removed_to) — skip lowering.
+            let typed = artifacts.cull_decision_typed.get(&id)?.clone();
+            // Extract the decision aggregate from the typed program (mirrors
+            // the Aggregate arm). `typed.field_types` is keyed and ordered by
+            // bind's upstream Row, so its keys are the live column layout the
+            // aggregate projects against — no runtime schema thread needed.
+            let input_schema: Vec<String> = typed
+                .field_types
+                .keys()
+                .map(|qf| qf.name.to_string())
+                .collect();
+            let compiled =
+                match cxl::plan::extract_aggregates(&typed, &config.partition_by, &input_schema) {
+                    Ok(c) => c,
+                    Err(errs) => {
+                        for e in errs {
+                            diags.push(Diagnostic::error(
+                                "E210",
+                                format!(
+                                    "cull decision-aggregate extraction failed for {name:?}: {}",
+                                    e.message
+                                ),
+                                LabeledSpan::primary(span, String::new()),
+                            ));
+                        }
+                        return None;
+                    }
+                };
             Some(crate::plan::execution::PlanNode::Cull {
                 name: name.to_string(),
                 id,
                 span,
                 config: config.clone(),
                 output_schema: schema_from_bound(),
+                compiled: Arc::new(compiled),
+                typed,
             })
         }
         // Envelope lowers carrying the framing strategy, the body's (unchanged)

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -1495,6 +1495,17 @@ pub const RESHAPE_SYNTHESIZED_BY_COLUMN: &str = "$meta.synthesized_by";
 /// on records no rule mutated.
 pub const RESHAPE_MUTATED_BY_COLUMN: &str = "$meta.mutated_by";
 
+/// Synthetic output column the Cull decision aggregate emits the per-group
+/// removal decision into. The compile-time binder builds the OR-combined
+/// `emit <CULL_DROP_DECISION_COLUMN> = (rule_1) or (rule_2) …` decision
+/// program with this emit target, and the executor reads the boolean back
+/// out of each finalized group row by this name — so the two must agree on
+/// one constant. A reserved `__cull_…__` identifier: the CXL parser rejects
+/// an `emit` to a `$`-namespaced column, so the synthetic emit target must
+/// be a plain identifier; the double-underscore bracketing keeps it out of
+/// any realistic user column space.
+pub const CULL_DROP_DECISION_COLUMN: &str = "__cull_drop_decision__";
+
 /// Reshape variant body. A blocking grouping operator: it buffers each
 /// correlation group (keyed by `partition_by`), observes the whole
 /// group, then applies each rule's mutation and synthesis actions.

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -92,6 +92,27 @@ pub struct CompileArtifacts {
     /// the Route's source(s). Compile-time-only. The per-node id keeps a
     /// route named the same in two composition scopes from colliding.
     pub route_branch_typed: HashMap<PlanNodeId, Vec<Arc<TypedProgram>>>,
+    /// Per-Cull typed OR-combined `drop_group_when` decision program, keyed
+    /// by the Cull node's [`PlanNodeId`]. `bind_cull` builds and typechecks
+    /// the `emit <decision> = (rule_1) or (rule_2) …` program (after the
+    /// per-rule diagnostic typechecks pass) and stores it here. This is the
+    /// bind→lowering handoff: lowering runs `extract_aggregates` over it and
+    /// stamps the result onto `PlanNode::Cull.compiled` / `.typed`; the
+    /// runtime builds its decision evaluator off that on-node copy and never
+    /// reads this side-table. The per-node id keeps a cull named the same in
+    /// two composition scopes from colliding.
+    pub cull_decision_typed: HashMap<PlanNodeId, Arc<TypedProgram>>,
+    /// Per-Reshape typechecked rule programs, keyed by the Reshape node's
+    /// [`PlanNodeId`] — one [`CompiledReshapeRule`](crate::plan::execution::CompiledReshapeRule)
+    /// per `config.rules` entry, in declaration order. `bind_reshape` builds
+    /// these from the per-fragment typechecks it already runs (previously
+    /// discarded after the `$doc` guard). Bind→lowering handoff: lowering
+    /// stamps them onto `PlanNode::Reshape.compiled_rules`; the runtime
+    /// rebuilds its per-rule evaluators off that on-node copy and never reads
+    /// this side-table. The per-node id keeps a reshape named the same in two
+    /// composition scopes from colliding.
+    pub reshape_compiled:
+        HashMap<PlanNodeId, Arc<Vec<crate::plan::execution::CompiledReshapeRule>>>,
     /// All bound composition bodies, keyed by `CompositionBodyId`. The
     /// top-level pipeline is NOT in this map — it lives on
     /// `CompiledPlan.dag()` directly. Only body scopes are here.
@@ -1388,17 +1409,23 @@ fn bind_reshape(
         }
     }
 
-    // Typed programs for every rule fragment, retained so the `$doc`
-    // envelope-reference guard below can walk them once the per-rule
-    // typechecks have all run. Each is `(label, typed)` where `label` names
-    // the rule fragment for the guard's diagnostic.
-    let mut typed_fragments: Vec<(String, TypedProgram)> = Vec::new();
+    // Per-rule typechecked CXL programs, assembled into the on-node
+    // `CompiledReshapeRule` set that lowering stamps onto the node. Built
+    // only when every fragment typechecks (a single failure sets `ok =
+    // false`); the partially-built vec is consumed only on the `ok` path
+    // below, so the node is never lowered with a short rule set.
+    let mut compiled_rules: Vec<crate::plan::execution::CompiledReshapeRule> =
+        Vec::with_capacity(config.rules.len());
+    // The same typed programs paired with a fragment label, retained so the
+    // `$doc` envelope-reference guard below can walk them once every per-rule
+    // typecheck has run. `label` names the rule fragment for the diagnostic.
+    let mut guard_fragments: Vec<(String, Arc<TypedProgram>)> = Vec::new();
 
     // Per-rule predicate + assignment typechecks and invariants.
     for rule in &config.rules {
         // `when` predicate compiles as a row filter.
         let when_src = format!("filter {}", rule.when.source);
-        match typecheck_cxl(
+        let when_prog = match typecheck_cxl(
             &format!("{name}:{}:when", rule.name),
             &when_src,
             upstream,
@@ -1406,13 +1433,19 @@ fn bind_reshape(
             span,
             scoped_vars,
         ) {
-            Ok(typed) => typed_fragments.push((format!("rule {:?} `when`", rule.name), typed)),
+            Ok(typed) => {
+                let prog = Arc::new(typed);
+                guard_fragments.push((format!("rule {:?} `when`", rule.name), Arc::clone(&prog)));
+                Some(prog)
+            }
             Err(d) => {
                 diags.push(d);
                 ok = false;
+                None
             }
-        }
+        };
 
+        let mut set: Vec<(String, Arc<TypedProgram>)> = Vec::new();
         if let Some(mutate) = &rule.mutate {
             for (field, value) in &mutate.set {
                 // Group identity must survive Reshape: a `set` cannot
@@ -1467,8 +1500,14 @@ fn bind_reshape(
                     span,
                     scoped_vars,
                 ) {
-                    Ok(typed) => typed_fragments
-                        .push((format!("rule {:?} `mutate.set.{field}`", rule.name), typed)),
+                    Ok(typed) => {
+                        let prog = Arc::new(typed);
+                        guard_fragments.push((
+                            format!("rule {:?} `mutate.set.{field}`", rule.name),
+                            Arc::clone(&prog),
+                        ));
+                        set.push((field.clone(), prog));
+                    }
                     Err(d) => {
                         diags.push(d);
                         ok = false;
@@ -1477,7 +1516,7 @@ fn bind_reshape(
             }
         }
 
-        if let Some(synth) = &rule.synthesize {
+        let compiled_synth = if let Some(synth) = &rule.synthesize {
             // `copy_from: none` requires every upstream user column to be
             // supplied by `overrides`, so a synthesized row is never
             // silently all-null.
@@ -1508,6 +1547,7 @@ fn bind_reshape(
                     }
                 }
             }
+            let mut overrides: Vec<(String, Arc<TypedProgram>)> = Vec::new();
             for (field, value) in &synth.overrides {
                 match typecheck_cxl(
                     &format!("{name}:{}:override.{field}", rule.name),
@@ -1517,16 +1557,38 @@ fn bind_reshape(
                     span,
                     scoped_vars,
                 ) {
-                    Ok(typed) => typed_fragments.push((
-                        format!("rule {:?} `synthesize.overrides.{field}`", rule.name),
-                        typed,
-                    )),
+                    Ok(typed) => {
+                        let prog = Arc::new(typed);
+                        guard_fragments.push((
+                            format!("rule {:?} `synthesize.overrides.{field}`", rule.name),
+                            Arc::clone(&prog),
+                        ));
+                        overrides.push((field.clone(), prog));
+                    }
                     Err(d) => {
                         diags.push(d);
                         ok = false;
                     }
                 }
             }
+            Some(crate::plan::execution::CompiledReshapeSynth {
+                copy_from: synth.copy_from,
+                overrides,
+            })
+        } else {
+            None
+        };
+
+        // Assemble the rule only when its `when` typechecked. On any fragment
+        // failure `ok` is already false, so a partial `compiled_rules` is
+        // never consumed — the node is not lowered.
+        if let Some(when) = when_prog {
+            compiled_rules.push(crate::plan::execution::CompiledReshapeRule {
+                name: rule.name.clone(),
+                when,
+                set,
+                synth: compiled_synth,
+            });
         }
     }
 
@@ -1541,9 +1603,9 @@ fn bind_reshape(
         // Reshape rule fragments carry no scope ambiguity (they are
         // labels within one node's rule set), so attribute by the bare
         // label `String`.
-        let programs: Vec<(String, &TypedProgram)> = typed_fragments
+        let programs: Vec<(String, &TypedProgram)> = guard_fragments
             .iter()
-            .map(|(label, typed)| (label.clone(), typed))
+            .map(|(label, typed)| (label.clone(), typed.as_ref()))
             .collect();
         let doc_paths = cxl::analyzer::doc_paths::collect_doc_paths(&programs);
         // Any `$doc` reference disqualifies the rule — both statically-resolved
@@ -1605,6 +1667,12 @@ fn bind_reshape(
     );
     let out = Row::from_parts(declared, upstream.declared_span, upstream.tail.clone());
     schema_by_name.insert(name.to_string(), out.clone());
+    // Bind→lowering handoff: lowering stamps these onto
+    // `PlanNode::Reshape.compiled_rules`. Every rule is present here (each
+    // rule's `when` typechecked, else `ok` was false and we returned above).
+    artifacts
+        .reshape_compiled
+        .insert(id, Arc::new(compiled_rules));
     artifacts.typed_insert(id, Arc::new(synthetic_typed_program(out)));
 }
 
@@ -1744,10 +1812,9 @@ fn bind_cull(
     // Each rule's `drop_group_when` typechecks in aggregate context over the
     // whole group (group-by = `partition_by`), so an aggregate predicate such
     // as `count(*) > 100` or `sum(if status == 'error' then 1 else 0) > 0` is
-    // well-formed. The predicate is wrapped in a single `emit` so it
-    // typechecks through the same aggregate-mode path the Aggregate node uses;
-    // the bound result is discarded here (the executor recompiles this node's
-    // predicate against the live input schema at dispatch time).
+    // well-formed. Each rule is typechecked on its own first so a diagnostic
+    // names the offending rule; the combined decision program built below is
+    // what the runtime actually evaluates.
     let agg_mode = AggregateMode::GroupBy {
         group_by_fields: config.partition_by.iter().cloned().collect(),
     };
@@ -1768,6 +1835,44 @@ fn bind_cull(
 
     if !ok {
         return;
+    }
+
+    // Build the OR-combined decision program the runtime evaluates per group:
+    // a group is removed when ANY rule's predicate holds, so the decision is
+    // the disjunction of every rule's `drop_group_when`. This single program —
+    // emit target `CULL_DROP_DECISION_COLUMN` — is the one carried to the
+    // runtime: lowering runs `extract_aggregates` over it and stamps it onto
+    // `PlanNode::Cull.compiled` / `.typed`. `rules` is non-empty (rejected
+    // above), so there is always at least one disjunct.
+    let decision_body = config
+        .rules
+        .iter()
+        .map(|r| format!("({})", r.drop_group_when.source))
+        .collect::<Vec<_>>()
+        .join(" or ");
+    let decision_src = format!(
+        "emit {} = {decision_body}",
+        crate::config::pipeline_node::CULL_DROP_DECISION_COLUMN
+    );
+    match typecheck_cxl(
+        &format!("{name}:drop_group_when"),
+        &decision_src,
+        upstream,
+        agg_mode,
+        span,
+        scoped_vars,
+    ) {
+        Ok(typed) => {
+            artifacts.cull_decision_typed.insert(id, Arc::new(typed));
+        }
+        // The combined program is the per-rule predicates OR'd together, each
+        // of which typechecked above, so a failure here is an internal
+        // invariant violation rather than a user error. Surface it and skip
+        // lowering (the node will be absent from `cull_decision_typed`).
+        Err(d) => {
+            diags.push(d);
+            return;
+        }
     }
 
     // Cull does not widen: both output ports carry the unchanged upstream

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1809,26 +1809,34 @@ fn bind_cull(
         ok = false;
     }
 
-    // Each rule's `drop_group_when` typechecks in aggregate context over the
-    // whole group (group-by = `partition_by`), so an aggregate predicate such
-    // as `count(*) > 100` or `sum(if status == 'error' then 1 else 0) > 0` is
-    // well-formed. Each rule is typechecked on its own first so a diagnostic
-    // names the offending rule; the combined decision program built below is
-    // what the runtime actually evaluates.
-    let agg_mode = AggregateMode::GroupBy {
-        group_by_fields: config.partition_by.iter().cloned().collect(),
-    };
+    // Reject a `#` line-comment in any rule predicate. The rules are
+    // OR-combined into ONE single-line decision expression (`(r1) or (r2)`),
+    // and a CXL `#` comment runs to end-of-line — on that single line it would
+    // swallow every following disjunct and the closing paren. The disjunction
+    // has nowhere else to go (CXL `or` cannot span a newline, and an aggregate
+    // predicate cannot move into a `let` — let RHSs must be row-pure), so the
+    // honest fix is to reject the comment with a rule-named diagnostic rather
+    // than surface a baffling parse error against the synthetic combined
+    // program. A `#…#` date literal lexes as a date token, not a comment, so
+    // it is unaffected.
     for rule in &config.rules {
-        let drop_src = format!("emit __drop = {}", rule.drop_group_when.source);
-        if let Err(d) = typecheck_cxl(
-            &format!("{name}:{}:drop_group_when", rule.name),
-            &drop_src,
-            upstream,
-            agg_mode.clone(),
-            span,
-            scoped_vars,
-        ) {
-            diags.push(d);
+        if cxl::lexer::Lexer::tokenize(&rule.drop_group_when.source)
+            .iter()
+            .any(|(t, _)| *t == cxl::lexer::Token::Comment)
+        {
+            diags.push(
+                Diagnostic::error(
+                    "E200",
+                    format!(
+                        "cull {name:?} rule {:?}: drop_group_when may not contain a `#` comment — \
+                         the rule predicates are combined into a single expression where a line \
+                         comment would swallow the other rules",
+                        rule.name
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                )
+                .with_help("remove the `#` comment from the predicate"),
+            );
             ok = false;
         }
     }
@@ -1837,40 +1845,78 @@ fn bind_cull(
         return;
     }
 
-    // Build the OR-combined decision program the runtime evaluates per group:
-    // a group is removed when ANY rule's predicate holds, so the decision is
-    // the disjunction of every rule's `drop_group_when`. This single program —
-    // emit target `CULL_DROP_DECISION_COLUMN` — is the one carried to the
-    // runtime: lowering runs `extract_aggregates` over it and stamps it onto
-    // `PlanNode::Cull.compiled` / `.typed`. `rules` is non-empty (rejected
-    // above), so there is always at least one disjunct.
-    let decision_body = config
+    // Unlike `bind_reshape`, Cull has no `$doc` envelope-reference guard, and
+    // that asymmetry is intentional: Cull folds the decision aggregate over
+    // the live drained input at the START of dispatch — before any group-buffer
+    // spill — with each record's intact document context, and never
+    // re-evaluates the predicate after a spill. So a `$doc` reference in
+    // `drop_group_when` resolves deterministically. (Reshape needs the guard
+    // because it re-runs its rules at finalize, after a spill that drops `$doc`
+    // context.) If Cull's decision aggregate is ever allowed to spill, mirror
+    // Reshape's guard here.
+
+    // Build the decision program the runtime evaluates per group: a group is
+    // removed when ANY rule's `drop_group_when` holds, so the decision is the
+    // OR of every rule's predicate in one `emit`. The aggregates (`count`,
+    // `sum`, …) sit directly in the emit body, where `extract_aggregates`
+    // folds them at lowering; they cannot move into a `let` (let RHSs must be
+    // row-pure) and `or` cannot span a newline, so the disjunction is a single
+    // line — which is why a `#` comment in any rule is rejected above. Emit
+    // target = `CULL_DROP_DECISION_COLUMN`; lowering runs `extract_aggregates`
+    // over this program and stamps it onto `PlanNode::Cull.compiled`/`.typed`.
+    // `rules` is non-empty (rejected above).
+    let agg_mode = AggregateMode::GroupBy {
+        group_by_fields: config.partition_by.iter().cloned().collect(),
+    };
+    let disjunction = config
         .rules
         .iter()
         .map(|r| format!("({})", r.drop_group_when.source))
         .collect::<Vec<_>>()
         .join(" or ");
     let decision_src = format!(
-        "emit {} = {decision_body}",
+        "emit {} = {disjunction}",
         crate::config::pipeline_node::CULL_DROP_DECISION_COLUMN
     );
+
+    // Typecheck the combined program first — the happy path needs only this
+    // one pass. On failure, re-typecheck each rule on its own (same aggregate
+    // mode, with `or false` forcing a boolean operand) purely to attribute the
+    // diagnostic to the offending rule; fall back to the combined diagnostic
+    // if no single rule reproduces it. Either way, skip lowering (the node is
+    // absent from `cull_decision_typed`).
     match typecheck_cxl(
         &format!("{name}:drop_group_when"),
         &decision_src,
         upstream,
-        agg_mode,
+        agg_mode.clone(),
         span,
         scoped_vars,
     ) {
         Ok(typed) => {
             artifacts.cull_decision_typed.insert(id, Arc::new(typed));
         }
-        // The combined program is the per-rule predicates OR'd together, each
-        // of which typechecked above, so a failure here is an internal
-        // invariant violation rather than a user error. Surface it and skip
-        // lowering (the node will be absent from `cull_decision_typed`).
-        Err(d) => {
-            diags.push(d);
+        Err(combined) => {
+            let mut attributed = false;
+            for rule in &config.rules {
+                if let Err(d) = typecheck_cxl(
+                    &format!("{name}:{}:drop_group_when", rule.name),
+                    &format!(
+                        "emit __cull_pred = ({}) or false",
+                        rule.drop_group_when.source
+                    ),
+                    upstream,
+                    agg_mode.clone(),
+                    span,
+                    scoped_vars,
+                ) {
+                    diags.push(d);
+                    attributed = true;
+                }
+            }
+            if !attributed {
+                diags.push(combined);
+            }
             return;
         }
     }
@@ -1878,6 +1924,14 @@ fn bind_cull(
     // Cull does not widen: both output ports carry the unchanged upstream
     // row. Publish it as the node's output so downstream binding sees the
     // identical schema on the main and `removed_to` ports.
+    //
+    // This synthetic upstream-row program is kept in `typed` (distinct from
+    // the decision program in `cull_decision_typed`) deliberately: lowering's
+    // `schema_from_bound()` reads it to build the node's port `output_schema`
+    // (the unchanged upstream row), whereas the decision program's own
+    // output_row is the narrow `[partition_by, __cull_drop_decision__]` shape
+    // — wrong for the ports. The two `id`-keyed entries serve different
+    // consumers and must stay separate.
     let out = upstream.clone();
     schema_by_name.insert(name.to_string(), out.clone());
     artifacts.typed_insert(id, Arc::new(synthetic_typed_program(out)));

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -577,7 +577,9 @@ pub type ResolvedColumnMap = Arc<HashMap<QualifiedField, (JoinSide, u32)>>;
 /// config on every dispatch.
 #[derive(Debug, Clone)]
 pub struct CompiledReshapeRule {
-    /// Rule name, used in dispatch diagnostics and the `$meta.*` audit columns.
+    /// The authored rule name; it is stamped into the `$meta.*` audit columns
+    /// of every row this rule mutates or synthesizes, so it is output data, not
+    /// just a label.
     pub name: String,
     /// `filter <when>` — the trigger predicate, typechecked in row context.
     pub when: Arc<TypedProgram>,

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -207,10 +207,11 @@ pub enum PlanNode {
     ///
     /// Blocking grouping operator: buffers each `partition_by` group,
     /// observes it, then applies each rule's trigger-row mutation and
-    /// row synthesis. Single output. The executor compiles each rule's
-    /// `when` / `set` / `overrides` CXL against the live input schema at
-    /// dispatch time, so the plan node carries only the parsed `config` and
-    /// the widened output schema.
+    /// row synthesis. Single output. Each rule's `when` / `set` /
+    /// `overrides` CXL is typechecked once at lowering and carried on the
+    /// node as `compiled_rules`; the executor rebuilds the per-run
+    /// `ProgramEvaluator`s off the node at dispatch (mirroring Aggregation
+    /// / Route) instead of recompiling the rule source every dispatch.
     Reshape {
         name: String,
         /// Stable node identity; see the `Source` variant's `id`.
@@ -218,13 +219,23 @@ pub enum PlanNode {
         #[serde(skip)]
         span: Span,
         /// Parsed Reshape configuration (`partition_by` / `order_by` /
-        /// `rules`). Consumed by the executor's reshape dispatch arm.
+        /// `rules`). Still consumed at dispatch for the grouping key and
+        /// group ordering; the rule CXL is carried separately as typed
+        /// programs in `compiled_rules`.
         config: crate::config::pipeline_node::ReshapeBody,
         /// Widened output schema: the upstream columns plus the three
         /// `$meta.*` audit columns Reshape stamps. Populated by
         /// `bind_schema`.
         #[serde(skip)]
         output_schema: Arc<Schema>,
+        /// Per-rule typechecked CXL programs (`when` / `set` / `overrides`),
+        /// one [`CompiledReshapeRule`] per entry in `config.rules` and in
+        /// the same declaration order. Built at lowering from
+        /// `artifacts.reshape_compiled[id]`; the executor reconstructs each
+        /// rule's `ProgramEvaluator`s from these at dispatch. Behind `Arc`
+        /// so the per-dispatch whole-node clone stays O(1).
+        #[serde(skip)]
+        compiled_rules: Arc<Vec<CompiledReshapeRule>>,
     },
     /// Per-correlation-group record removal with a side-output port.
     ///
@@ -233,9 +244,12 @@ pub enum PlanNode {
     /// the whole group, and routes every record of a dropped group to the
     /// `removed_to` producer-side output port while untriggered groups flow
     /// to the main output port. Cull does not widen — both ports carry the
-    /// unchanged upstream schema. The executor compiles each rule's
-    /// predicate against the live input schema at dispatch time, so the plan
-    /// node carries only the parsed `config` and the unchanged output schema.
+    /// unchanged upstream schema. The rules' `drop_group_when` predicates are
+    /// OR-combined into one decision aggregate, typechecked and extracted
+    /// once at lowering, and carried on the node as `compiled` + `typed`
+    /// (mirroring `Aggregation`); the executor builds its per-group
+    /// `ProgramEvaluator` off the node at dispatch instead of recompiling
+    /// the predicate every dispatch.
     Cull {
         name: String,
         /// Stable node identity; see the `Source` variant's `id`.
@@ -243,14 +257,29 @@ pub enum PlanNode {
         #[serde(skip)]
         span: Span,
         /// Parsed Cull configuration (`partition_by` / `order_by` /
-        /// `rules` / `removed_to`). Consumed by the executor's cull
-        /// dispatch arm.
+        /// `rules` / `removed_to`). Still consumed at dispatch for the
+        /// grouping key, group ordering, and `removed_to` port routing; the
+        /// predicate CXL is carried separately as `compiled` + `typed`.
         config: crate::config::pipeline_node::CullBody,
         /// Output schema, equal to the upstream schema (Cull does not
         /// widen). Both the main and `removed_to` ports carry it.
         /// Populated by `bind_schema`.
         #[serde(skip)]
         output_schema: Arc<Schema>,
+        /// Extracted aggregate plan for the OR-combined `drop_group_when`
+        /// decision program (emit target
+        /// [`CULL_DROP_DECISION_COLUMN`](crate::config::pipeline_node::CULL_DROP_DECISION_COLUMN)).
+        /// Built at lowering via `extract_aggregates`, run per group by the
+        /// executor's decision aggregate to produce each group's boolean
+        /// removal decision. Describes the synthetic decision aggregate, not
+        /// the node's port output (which carries the unchanged upstream row).
+        #[serde(skip)]
+        compiled: Arc<CompiledAggregate>,
+        /// Typed OR-combined decision program the executor lowers its
+        /// per-group `ProgramEvaluator` against. The companion of `compiled`;
+        /// populated at lowering from `artifacts.cull_decision_typed[id]`.
+        #[serde(skip)]
+        typed: Arc<TypedProgram>,
     },
     /// Frames a body stream into documents. Single-input, single-output.
     ///
@@ -538,6 +567,35 @@ pub enum PlanNode {
 /// consumed by the executor's combine resolver mapping at executor
 /// start-up. One entry per qualified field the body reads.
 pub type ResolvedColumnMap = Arc<HashMap<QualifiedField, (JoinSide, u32)>>;
+
+/// One Reshape rule's typechecked CXL programs, built once at lowering and
+/// carried on `PlanNode::Reshape` — mirroring `PlanTransformPayload.typed`
+/// / `Aggregation.typed` / `Route.branch_programs`. The executor rebuilds
+/// the per-run `ProgramEvaluator` for each program at dispatch (the
+/// evaluator is non-`Clone`/non-`Send` and so can never live on the node),
+/// instead of re-parsing and re-typechecking the rule source from raw
+/// config on every dispatch.
+#[derive(Debug, Clone)]
+pub struct CompiledReshapeRule {
+    /// Rule name, used in dispatch diagnostics and the `$meta.*` audit columns.
+    pub name: String,
+    /// `filter <when>` — the trigger predicate, typechecked in row context.
+    pub when: Arc<TypedProgram>,
+    /// `mutate.set` field → `emit <field> = <expr>` program, in declaration order.
+    pub set: Vec<(String, Arc<TypedProgram>)>,
+    /// Present iff the rule synthesizes rows.
+    pub synth: Option<CompiledReshapeSynth>,
+}
+
+/// A Reshape rule's typechecked synthesis programs (the on-node companion
+/// of [`CompiledReshapeRule`]).
+#[derive(Debug, Clone)]
+pub struct CompiledReshapeSynth {
+    /// Base-value source for the synthesized row (trigger copy vs. all-null).
+    pub copy_from: crate::config::pipeline_node::CopyFrom,
+    /// `overrides` field → `emit <field> = <expr>` program, in declaration order.
+    pub overrides: Vec<(String, Arc<TypedProgram>)>,
+}
 
 /// Fully-resolved Source payload, populated by the
 /// `PipelineConfig::compile()` lowering path. Wraps the parse-time

--- a/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
@@ -1,0 +1,202 @@
+//! Cull and Reshape predicate programs travel on the plan node.
+//!
+//! `bind_schema` + lowering compile each operator's CXL once and stamp it
+//! onto the runtime node — Cull's OR-combined `drop_group_when` decision
+//! aggregate onto `PlanNode::Cull.compiled` / `.typed`, and Reshape's
+//! per-rule `when` / `set` / `overrides` programs onto
+//! `PlanNode::Reshape.compiled_rules` — mirroring `Aggregation` / `Route`.
+//! The executor reads these off the node and only rebuilds the cheap
+//! per-run `ProgramEvaluator` at dispatch, instead of re-parsing and
+//! re-typechecking the rule source every dispatch. These tests pin that the
+//! on-node programs are populated after a successful compile.
+
+use crate::config::pipeline_node::CULL_DROP_DECISION_COLUMN;
+use crate::config::{CompileContext, parse_config};
+use crate::plan::execution::PlanNode;
+
+/// Compile `yaml` to a `CompiledPlan`, panicking on any diagnostic.
+fn compile_ok(yaml: &str) -> crate::plan::CompiledPlan {
+    parse_config(yaml)
+        .expect("parse_config")
+        .compile(&CompileContext::default())
+        .expect("compile should succeed")
+}
+
+/// A multi-rule Cull carries its OR-combined `drop_group_when` decision
+/// aggregate on the node: the typed program emits the reserved decision
+/// column and the extracted aggregate groups by the cull's `partition_by`.
+#[test]
+fn cull_decision_program_travels_on_node() {
+    let yaml = r#"
+pipeline:
+  name: cull_on_node
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: int }
+        - { name: status, type: string }
+  - type: cull
+    name: cd
+    input: src
+    config:
+      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+        - name: drop_big
+          drop_group_when: "sum(amount) > 100"
+  - type: output
+    name: out
+    input: cd
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: cd.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
+    let compiled = compile_ok(yaml);
+    let g = &compiled.dag().graph;
+    let idx = g
+        .node_indices()
+        .find(|&i| g[i].name() == "cd")
+        .expect("cull node `cd` present");
+    let PlanNode::Cull {
+        typed,
+        compiled: agg,
+        ..
+    } = &g[idx]
+    else {
+        panic!("node `cd` is not a Cull");
+    };
+    // The on-node typed program is the OR-combined decision program: it
+    // carries statements, and the extracted aggregate emits the reserved
+    // decision column the executor reads back per group.
+    assert!(
+        !typed.program.statements.is_empty(),
+        "cull decision program should carry statements"
+    );
+    let emit_names: Vec<&str> = agg.emits.iter().map(|e| e.output_name.as_ref()).collect();
+    assert!(
+        emit_names.contains(&CULL_DROP_DECISION_COLUMN),
+        "cull decision aggregate should emit {CULL_DROP_DECISION_COLUMN:?}, got {emit_names:?}"
+    );
+    // The extracted aggregate groups by the cull's partition key and folds
+    // the predicate's aggregate functions (both rules use `sum`).
+    assert_eq!(
+        agg.group_by_fields,
+        vec!["id".to_string()],
+        "cull decision aggregate should group by partition_by"
+    );
+    assert!(
+        !agg.bindings.is_empty(),
+        "cull decision aggregate should carry the predicate's aggregate bindings"
+    );
+}
+
+/// A Reshape carries one `CompiledReshapeRule` per config rule, each with
+/// its `when` / `set` / `overrides` typed programs populated.
+#[test]
+fn reshape_rule_programs_travel_on_node() {
+    let yaml = r#"
+pipeline:
+  name: reshape_on_node
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: int }
+        - { name: label, type: string }
+  - type: reshape
+    name: rs
+    input: src
+    config:
+      partition_by: [id]
+      rules:
+        - name: bump
+          when: "amount > 0"
+          mutate:
+            set:
+              amount: "amount + 1"
+        - name: synth
+          when: "label == 'seed'"
+          synthesize:
+            copy_from: trigger
+            overrides:
+              label: "'synthesized'"
+  - type: output
+    name: out
+    input: rs
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let compiled = compile_ok(yaml);
+    let g = &compiled.dag().graph;
+    let idx = g
+        .node_indices()
+        .find(|&i| g[i].name() == "rs")
+        .expect("reshape node `rs` present");
+    let PlanNode::Reshape {
+        compiled_rules,
+        config,
+        ..
+    } = &g[idx]
+    else {
+        panic!("node `rs` is not a Reshape");
+    };
+    // One compiled rule per config rule, in declaration order.
+    assert_eq!(
+        compiled_rules.len(),
+        config.rules.len(),
+        "one CompiledReshapeRule per config rule"
+    );
+    assert_eq!(compiled_rules.len(), 2);
+
+    // Rule 0 mutates `amount`: a `when` program plus one `set` entry, no synth.
+    let bump = &compiled_rules[0];
+    assert_eq!(bump.name, "bump");
+    assert!(
+        !bump.when.program.statements.is_empty(),
+        "`when` program should carry statements"
+    );
+    assert_eq!(bump.set.len(), 1);
+    assert_eq!(bump.set[0].0, "amount");
+    assert!(bump.synth.is_none(), "mutate-only rule has no synth");
+
+    // Rule 1 synthesizes: a `synth` block with one override on `label`.
+    let synth_rule = &compiled_rules[1];
+    assert_eq!(synth_rule.name, "synth");
+    assert!(
+        synth_rule.set.is_empty(),
+        "synth-only rule has no mutate set"
+    );
+    let synth = synth_rule
+        .synth
+        .as_ref()
+        .expect("synthesize rule carries a synth block");
+    assert_eq!(synth.overrides.len(), 1);
+    assert_eq!(synth.overrides[0].0, "label");
+    assert!(
+        !synth.overrides[0].1.program.statements.is_empty(),
+        "override program should carry statements"
+    );
+}

--- a/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
@@ -106,6 +106,73 @@ nodes:
     );
 }
 
+/// A `#` line-comment in a Cull rule predicate is rejected at compile time
+/// with a clear, rule-named diagnostic. The rules are OR-combined into a
+/// single-line decision expression (aggregate predicates cannot move into
+/// `let`s and CXL `or` cannot span a newline), where a `#` comment would
+/// otherwise swallow the following disjuncts and the closing paren — so the
+/// binder rejects the comment up front instead of emitting a baffling parse
+/// error against the synthetic combined program.
+#[test]
+fn cull_rule_with_line_comment_rejected() {
+    let yaml = r#"
+pipeline:
+  name: cull_comment
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: int }
+        - { name: status, type: string }
+  - type: cull
+    name: cd
+    input: src
+    config:
+      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: drop_errors
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error in group"
+        - name: drop_big
+          drop_group_when: "sum(amount) > 100"
+  - type: output
+    name: out
+    input: cd
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: cd.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
+    let diags = parse_config(yaml)
+        .expect("parse_config")
+        .compile(&CompileContext::default())
+        .expect_err("compile should reject the `#` comment");
+    // A precise, rule-attributed diagnostic — not a parse error citing the
+    // synthetic combined program.
+    assert!(
+        diags.iter().any(|d| d.code == "E200"
+            && d.message.contains("drop_errors")
+            && d.message.contains("`#` comment")),
+        "expected an E200 naming rule `drop_errors` and the `#` comment, got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code.clone(), d.message.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// A Reshape carries one `CompiledReshapeRule` per config rule, each with
 /// its `when` / `set` / `overrides` typed programs populated.
 #[test]

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -2,6 +2,7 @@ mod ck_aligned_partition;
 mod ck_lattice;
 mod combine_body_typed_on_node;
 mod combine_where_scoped_key;
+mod cull_reshape_compiled_on_node;
 mod cull_validation;
 mod dag;
 mod dedup_node_rooted;


### PR DESCRIPTION
Closes #654.

## What

Cull and Reshape were the two predicate-bearing operators still compiling their CXL **at dispatch** on every run. Transform/Aggregation (#647) and Route (#651) already carry their compiled programs on the plan node and rebuild only the cheap per-run evaluator at dispatch. This finishes that migration so every predicate-bearing operator follows one principle: **compile once at lowering, carry the typed program on the node, rebuild the evaluator at dispatch.**

## How

- **bind_schema** now stores the typed programs instead of discarding them:
  - Cull: the OR-combined `drop_group_when` decision program (new `cull_decision_typed` side-table). Per-rule typechecks are retained for rule-named diagnostics.
  - Reshape: each rule's `when` / `set` / `overrides` programs, structured as `CompiledReshapeRule` (new `reshape_compiled` side-table).
- **Lowering** stamps them onto the node: `PlanNode::Cull.compiled` / `.typed` (via `extract_aggregates`, mirroring Aggregation) and `PlanNode::Reshape.compiled_rules`.
- **The executor** reads the programs off the node and rebuilds only the per-run `ProgramEvaluator` at dispatch. The dispatch-time compile paths — `compile_drop_aggregate`, `build_drop_predicate`, `CompiledDropAggregate`, `compile_rules`, `compile_program` — are deleted. No parallel old/new path remains.
- The Cull decision-column name moves to a shared `CULL_DROP_DECISION_COLUMN` constant so the binder's emit target and the executor's read cannot drift.

## Why this is safe

The dispatch-time predicate compile was fed `input[0].schema()`, which the input-schema contract (E314) guarantees is the same column layout as the upstream node's compile-time `output_schema` — so the predicate compile never needed a runtime-only schema. The genuinely dispatch-time value, the live `Arc<Schema>` used for spill round-trip, is untouched. The `ProgramEvaluator` (non-`Clone`, holds per-thread state) continues to be reconstructed at dispatch, exactly as Route and Aggregation already do.

## Validation

- `cargo test` across `clinker-plan`, `clinker-exec`, `cxl` and the full workspace — all green, including the existing Cull/Reshape executor tests (grouping, spill, side-output port) and explain snapshots.
- New tests assert the on-node programs are populated after compile: the Cull decision aggregate emits the decision column and groups by `partition_by`; each Reshape rule carries its `when` / `set` / `overrides` programs.
- `cargo clippy --all-targets -D warnings` and `cargo fmt` clean; `git diff --check` clean.

No user-facing surface (CXL grammar, YAML, CLI, output) changes — this is an internal plan/runtime representation change.