### PR TITLE
clinker-lineage: crate skeleton and OpenLineage event/facet model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,11 +85,11 @@ jobs:
       - run: >-
           cargo check --all-targets --target x86_64-pc-windows-msvc
           -p clinker-exec -p clinker-plan -p clinker-schema
-          -p clinker-channel -p cxl-cli
+          -p clinker-channel -p cxl-cli -p clinker-lineage
       - run: >-
           cargo check --all-targets --target aarch64-apple-darwin
           -p clinker-exec -p clinker-plan -p clinker-schema
-          -p clinker-channel -p cxl-cli
+          -p clinker-channel -p cxl-cli -p clinker-lineage
 
   deny:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "clinker-lineage"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "clinker-net"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/clinker-channel",
     "crates/clinker",
     "crates/clinker-schema",
+    "crates/clinker-lineage",
     "crates/clinker-bench-support",
     "crates/clinker-benchmarks",
 ]
@@ -31,6 +32,7 @@ clinker-exec = { path = "crates/clinker-exec" }
 clinker-net = { path = "crates/clinker-net" }
 clinker-channel = { path = "crates/clinker-channel" }
 clinker-schema = { path = "crates/clinker-schema" }
+clinker-lineage = { path = "crates/clinker-lineage" }
 
 toml = "0.8"
 serde = { version = "1", features = ["derive", "rc"] }

--- a/crates/clinker-lineage/Cargo.toml
+++ b/crates/clinker-lineage/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "clinker-lineage"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "OpenLineage column-level lineage emission from compiled Clinker plans"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/clinker-lineage/src/lib.rs
+++ b/crates/clinker-lineage/src/lib.rs
@@ -1,0 +1,21 @@
+//! OpenLineage lineage emission for Clinker.
+//!
+//! This crate serializes Clinker pipeline lineage as [OpenLineage] events — the
+//! vendor-neutral open standard for dataset and column-level lineage. This tier
+//! owns only the wire data model (the [`openlineage`] module) and an NDJSON
+//! writer; the builder that walks a compiled plan to populate these structures is
+//! layered on in sibling modules.
+//!
+//! The model is pinned to OpenLineage core spec `2-0-2` and the
+//! `ColumnLineageDatasetFacet` `1-2-0`. No general-purpose Rust OpenLineage client
+//! exists, so the structs are hand-rolled against the published JSON Schema.
+//!
+//! [OpenLineage]: https://openlineage.io
+
+pub mod openlineage;
+
+pub use openlineage::{
+    COLUMN_LINEAGE_FACET_SCHEMA_URL, ColumnLineageDatasetFacet, Dataset, DatasetFacets, EventType,
+    FieldLineage, InputField, Job, OPENLINEAGE_SCHEMA_URL, PRODUCER, Run, RunEvent, Transformation,
+    TransformationSubtype, TransformationType, write_ndjson,
+};

--- a/crates/clinker-lineage/src/openlineage/event.rs
+++ b/crates/clinker-lineage/src/openlineage/event.rs
@@ -1,0 +1,199 @@
+//! OpenLineage run-event model: the envelope that carries dataset lineage.
+
+use serde::{Deserialize, Serialize};
+
+use super::facet::ColumnLineageDatasetFacet;
+
+/// A single OpenLineage run-state event.
+///
+/// A finite batch run is conventionally described by a `START` then a `COMPLETE`
+/// event sharing one [`Run::run_id`]; dataset lineage (including the column-lineage
+/// facet) is attached to the [`outputs`](RunEvent::outputs) of the `COMPLETE` event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunEvent {
+    /// Event production time, RFC-3339 in UTC (e.g. `2020-02-22T22:42:42Z`).
+    #[serde(rename = "eventTime")]
+    pub event_time: String,
+    /// URI identifying the software that produced this event.
+    pub producer: String,
+    /// Schema URL of the core event spec this event conforms to.
+    #[serde(rename = "schemaURL")]
+    pub schema_url: String,
+    #[serde(rename = "eventType")]
+    pub event_type: EventType,
+    pub run: Run,
+    pub job: Job,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub inputs: Vec<Dataset>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub outputs: Vec<Dataset>,
+}
+
+/// Run lifecycle state. A batch run issues `START` then one terminal state
+/// (`COMPLETE`, `ABORT`, or `FAIL`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum EventType {
+    Start,
+    Running,
+    Complete,
+    Abort,
+    Fail,
+    Other,
+}
+
+/// Identity of one run of a [`Job`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Run {
+    /// Run identity as a UUID string (the spec constrains this to `format: uuid`).
+    #[serde(rename = "runId")]
+    pub run_id: String,
+}
+
+/// The job (pipeline) a [`Run`] is an execution of.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Job {
+    pub namespace: String,
+    pub name: String,
+}
+
+/// An input or output dataset referenced by a run event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Dataset {
+    pub namespace: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub facets: Option<DatasetFacets>,
+}
+
+/// The facet bundle attached to a [`Dataset`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatasetFacets {
+    #[serde(rename = "columnLineage", skip_serializing_if = "Option::is_none")]
+    pub column_lineage: Option<ColumnLineageDatasetFacet>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openlineage::{
+        COLUMN_LINEAGE_FACET_SCHEMA_URL, FieldLineage, InputField, OPENLINEAGE_SCHEMA_URL,
+        PRODUCER, Transformation, TransformationSubtype, TransformationType,
+    };
+    use std::collections::BTreeMap;
+
+    fn sample_event() -> RunEvent {
+        let mut fields = BTreeMap::new();
+        fields.insert(
+            "total".to_string(),
+            FieldLineage {
+                input_fields: vec![InputField {
+                    namespace: "file".to_string(),
+                    name: "/data/orders.csv".to_string(),
+                    field: "amount".to_string(),
+                    transformations: vec![Transformation {
+                        transformation_type: TransformationType::Direct,
+                        subtype: Some(TransformationSubtype::Aggregation),
+                        description: None,
+                        masking: None,
+                    }],
+                }],
+            },
+        );
+        let facet = ColumnLineageDatasetFacet {
+            producer: PRODUCER.to_string(),
+            schema_url: COLUMN_LINEAGE_FACET_SCHEMA_URL.to_string(),
+            fields,
+            dataset: vec![InputField {
+                namespace: "file".to_string(),
+                name: "/data/orders.csv".to_string(),
+                field: "region".to_string(),
+                transformations: vec![Transformation {
+                    transformation_type: TransformationType::Indirect,
+                    subtype: Some(TransformationSubtype::GroupBy),
+                    description: None,
+                    masking: None,
+                }],
+            }],
+        };
+        RunEvent {
+            event_time: "2020-02-22T22:42:42Z".to_string(),
+            producer: PRODUCER.to_string(),
+            schema_url: OPENLINEAGE_SCHEMA_URL.to_string(),
+            event_type: EventType::Complete,
+            run: Run {
+                run_id: "0190b7e0-0000-7000-8000-000000000000".to_string(),
+            },
+            job: Job {
+                namespace: "clinker".to_string(),
+                name: "orders".to_string(),
+            },
+            inputs: vec![Dataset {
+                namespace: "file".to_string(),
+                name: "/data/orders.csv".to_string(),
+                facets: None,
+            }],
+            outputs: vec![Dataset {
+                namespace: "file".to_string(),
+                name: "/out/summary.csv".to_string(),
+                facets: Some(DatasetFacets {
+                    column_lineage: Some(facet),
+                }),
+            }],
+        }
+    }
+
+    #[test]
+    fn serializes_to_openlineage_shape() {
+        let v = serde_json::to_value(sample_event()).unwrap();
+        // Required event keys.
+        assert!(v.get("eventTime").is_some());
+        assert!(v.get("producer").is_some());
+        assert!(v.get("schemaURL").is_some());
+        assert_eq!(v["eventType"], "COMPLETE");
+        assert!(v["run"].get("runId").is_some());
+        assert!(v["job"].get("namespace").is_some());
+        assert!(v["job"].get("name").is_some());
+        // The column-lineage facet carries the underscored base-facet fields.
+        let facet = &v["outputs"][0]["facets"]["columnLineage"];
+        assert!(facet.get("_producer").is_some());
+        assert!(facet.get("_schemaURL").is_some());
+        // DIRECT lineage keyed per output column.
+        let direct = &facet["fields"]["total"]["inputFields"][0]["transformations"][0];
+        assert_eq!(direct["type"], "DIRECT");
+        assert_eq!(direct["subtype"], "AGGREGATION");
+        // INDIRECT lineage in the whole-dataset array, not duplicated per column.
+        let indirect = &facet["dataset"][0]["transformations"][0];
+        assert_eq!(indirect["type"], "INDIRECT");
+        assert_eq!(indirect["subtype"], "GROUP_BY");
+    }
+
+    #[test]
+    fn round_trips() {
+        let event = sample_event();
+        let json = serde_json::to_string(&event).unwrap();
+        let back: RunEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn round_trips_with_empty_input_output_lists() {
+        // Empty inputs/outputs are omitted on the wire (skip_serializing_if) and must
+        // deserialize back to empty via `default`, not fail on a missing key.
+        let mut event = sample_event();
+        event.inputs = Vec::new();
+        event.outputs = Vec::new();
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("\"inputs\""));
+        assert!(!json.contains("\"outputs\""));
+        let back: RunEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[test]
+    fn omits_empty_optionals() {
+        // A dataset with no facets omits the key rather than emitting null.
+        let v = serde_json::to_value(sample_event()).unwrap();
+        assert!(v["inputs"][0].get("facets").is_none());
+    }
+}

--- a/crates/clinker-lineage/src/openlineage/facet.rs
+++ b/crates/clinker-lineage/src/openlineage/facet.rs
@@ -1,0 +1,118 @@
+//! OpenLineage `ColumnLineageDatasetFacet`: per-column field lineage.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Column-level lineage for one dataset.
+///
+/// DIRECT (value-derivation) lineage is keyed per output column in
+/// [`fields`](ColumnLineageDatasetFacet::fields); whole-dataset INDIRECT
+/// (influence via filter / join / group / sort) lineage is collected once in
+/// [`dataset`](ColumnLineageDatasetFacet::dataset) rather than duplicated across
+/// every column.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ColumnLineageDatasetFacet {
+    /// URI of the software that produced this facet.
+    #[serde(rename = "_producer")]
+    pub producer: String,
+    /// Schema URL of the facet spec this conforms to.
+    #[serde(rename = "_schemaURL")]
+    pub schema_url: String,
+    /// Output column name -> the input fields its value derives from. A
+    /// `BTreeMap` keeps the serialized key order deterministic.
+    pub fields: BTreeMap<String, FieldLineage>,
+    /// Input fields that influence the dataset as a whole (INDIRECT lineage).
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub dataset: Vec<InputField>,
+}
+
+/// The input fields one output column derives from.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FieldLineage {
+    #[serde(rename = "inputFields")]
+    pub input_fields: Vec<InputField>,
+}
+
+/// A reference to one input dataset column plus how it reaches the output.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InputField {
+    pub namespace: String,
+    pub name: String,
+    pub field: String,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub transformations: Vec<Transformation>,
+}
+
+/// How an input field reaches an output: its derivation/influence class.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Transformation {
+    #[serde(rename = "type")]
+    pub transformation_type: TransformationType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subtype: Option<TransformationSubtype>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Set when the transformation obfuscates the value (e.g. a hash).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub masking: Option<bool>,
+}
+
+/// Whether an output value is derived from the input (`DIRECT`) or merely
+/// influenced by it (`INDIRECT`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TransformationType {
+    Direct,
+    Indirect,
+}
+
+/// The specific derivation/influence kind under a [`TransformationType`].
+///
+/// The OpenLineage spec leaves `subtype` free-form; this crate is a producer and
+/// emits only the documented vocabulary below. Parsing foreign lineage carrying
+/// an out-of-set subtype is intentionally not supported here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TransformationSubtype {
+    Identity,
+    Transformation,
+    Aggregation,
+    Join,
+    GroupBy,
+    Filter,
+    Sort,
+    Window,
+    Conditional,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subtype_casing_matches_spec() {
+        let cases = [
+            (TransformationSubtype::Identity, "IDENTITY"),
+            (TransformationSubtype::Transformation, "TRANSFORMATION"),
+            (TransformationSubtype::Aggregation, "AGGREGATION"),
+            (TransformationSubtype::Join, "JOIN"),
+            (TransformationSubtype::GroupBy, "GROUP_BY"),
+            (TransformationSubtype::Filter, "FILTER"),
+            (TransformationSubtype::Sort, "SORT"),
+            (TransformationSubtype::Window, "WINDOW"),
+            (TransformationSubtype::Conditional, "CONDITIONAL"),
+        ];
+        for (variant, wire) in cases {
+            assert_eq!(serde_json::to_value(variant).unwrap(), wire);
+        }
+        assert_eq!(
+            serde_json::to_value(TransformationType::Direct).unwrap(),
+            "DIRECT"
+        );
+        assert_eq!(
+            serde_json::to_value(TransformationType::Indirect).unwrap(),
+            "INDIRECT"
+        );
+    }
+}

--- a/crates/clinker-lineage/src/openlineage/mod.rs
+++ b/crates/clinker-lineage/src/openlineage/mod.rs
@@ -1,0 +1,25 @@
+//! The OpenLineage wire data model and NDJSON serializer.
+//!
+//! Pinned to OpenLineage core spec `2-0-2` and `ColumnLineageDatasetFacet`
+//! `1-2-0`; the pinned versions are carried in the schema-URL constants below.
+
+mod event;
+mod facet;
+mod ndjson;
+
+pub use event::{Dataset, DatasetFacets, EventType, Job, Run, RunEvent};
+pub use facet::{
+    ColumnLineageDatasetFacet, FieldLineage, InputField, Transformation, TransformationSubtype,
+    TransformationType,
+};
+pub use ndjson::write_ndjson;
+
+/// Schema URL for an OpenLineage core run event (the event-level `schemaURL`).
+pub const OPENLINEAGE_SCHEMA_URL: &str = "https://openlineage.io/spec/2-0-2/OpenLineage.json";
+
+/// Schema URL for the column-lineage dataset facet (the facet-level `_schemaURL`).
+pub const COLUMN_LINEAGE_FACET_SCHEMA_URL: &str =
+    "https://openlineage.io/spec/facets/1-2-0/ColumnLineageDatasetFacet.json";
+
+/// Producer URI stamped on emitted events and facets, identifying this emitter.
+pub const PRODUCER: &str = "https://github.com/rustpunk/clinker";

--- a/crates/clinker-lineage/src/openlineage/ndjson.rs
+++ b/crates/clinker-lineage/src/openlineage/ndjson.rs
@@ -1,0 +1,78 @@
+//! Newline-delimited JSON serialization of OpenLineage run events.
+
+use std::io::{self, Write};
+
+use super::RunEvent;
+
+/// Writes `events` as newline-delimited JSON: one compact event per line, each
+/// terminated by `\n`. This is the conventional OpenLineage file/console
+/// transport for a finite batch run.
+///
+/// Each event is serialized fully in memory before any byte reaches `writer`, so
+/// a serialization failure cannot leave a partial line on the sink. The writer is
+/// flushed before returning, so a buffered sink's truncated tail surfaces as an
+/// error rather than being lost when the writer is dropped.
+///
+/// # Errors
+///
+/// Returns any I/O error from writing to or flushing `writer`, or an
+/// [`io::ErrorKind::Other`] error if an event cannot be serialized.
+pub fn write_ndjson<W: Write>(events: &[RunEvent], mut writer: W) -> io::Result<()> {
+    for event in events {
+        // `to_vec` is compact (no pretty-printing), so each event is one line; serializing
+        // to an owned buffer first keeps a serde failure from emitting a partial line.
+        let mut line = serde_json::to_vec(event).map_err(io::Error::other)?;
+        line.push(b'\n');
+        writer.write_all(&line)?;
+    }
+    writer.flush()?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::openlineage::{EventType, Job, Run};
+
+    fn minimal(event_type: EventType) -> RunEvent {
+        RunEvent {
+            event_time: "2020-02-22T22:42:42Z".to_string(),
+            producer: "https://example/producer".to_string(),
+            schema_url: "https://example/schema".to_string(),
+            event_type,
+            run: Run {
+                run_id: "0190b7e0-0000-7000-8000-000000000000".to_string(),
+            },
+            job: Job {
+                namespace: "clinker".to_string(),
+                name: "orders".to_string(),
+            },
+            inputs: vec![],
+            outputs: vec![],
+        }
+    }
+
+    #[test]
+    fn writes_each_event_in_order_one_per_line() {
+        let events = vec![minimal(EventType::Start), minimal(EventType::Complete)];
+        let mut buf = Vec::new();
+        write_ndjson(&events, &mut buf).unwrap();
+        let text = String::from_utf8(buf).unwrap();
+
+        let lines: Vec<&str> = text.lines().collect();
+        assert_eq!(lines.len(), 2);
+        // Each line is a standalone compact JSON object, emitted in input order.
+        let first: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+        let second: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(first["eventType"], "START");
+        assert_eq!(second["eventType"], "COMPLETE");
+        assert!(text.ends_with('\n'));
+    }
+
+    #[test]
+    fn emits_nothing_for_empty_slice() {
+        let mut buf = Vec::new();
+        write_ndjson(&[], &mut buf).unwrap();
+        assert!(buf.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Adds `clinker-lineage`, a new edge crate, and the OpenLineage wire data model it serializes to. This is the serialization foundation for emitting column-level field lineage from a compiled Clinker plan as [OpenLineage](https://openlineage.io) — the vendor-neutral open standard that data catalogs and lineage tools ingest.

## What's included

- **Event model** — `RunEvent` / `Run` / `Job` / `Dataset`, plus an `EventType` enum (START/RUNNING/COMPLETE/ABORT/FAIL/OTHER).
- **Column-lineage facet** — `ColumnLineageDatasetFacet` with per-output-column DIRECT lineage (`fields`) and a whole-dataset INDIRECT array (`dataset`), `InputField`, and typed `Transformation` `type`/`subtype` enums (DIRECT/INDIRECT; IDENTITY/TRANSFORMATION/AGGREGATION/JOIN/GROUP_BY/FILTER/SORT/WINDOW/CONDITIONAL).
- **NDJSON writer** — `write_ndjson` emits one compact event per line; each event is serialized whole before any byte is written (so a serialization error can't leave a partial line), and the writer is flushed before returning (so a buffered sink's truncated tail is reported rather than lost on drop).
- Pinned to OpenLineage core spec `2-0-2` and `ColumnLineageDatasetFacet` `1-2-0` via the schema-URL constants.

The structs are hand-rolled against the published JSON Schema — there is no general-purpose Rust OpenLineage client. UUIDs and timestamps are carried as strings (matching the existing wire models in the workspace), and the per-column map uses a `BTreeMap` for deterministic output.

## Scope

This crate is **producer-only and serialization-only**: it does not walk a compiled plan yet. Building the column-provenance graph (dataset identity, DIRECT/INDIRECT lineage from the DAG) and the CLI export flag land in follow-up work. `TransformationSubtype` is intentionally a closed enum of the spec's documented subtypes, since this crate emits rather than parses foreign lineage.

## Dependencies

No new dependency — `serde` + `serde_json`, both already in the workspace. The crate is registered in the workspace members and the cross-platform CI check.

## Tests

7 unit tests: OpenLineage `2-0-2`/`1-2-0` wire-shape assertions (underscored facet fields, `DIRECT`/`INDIRECT`, screaming-snake subtypes), full round-trip, empty-list round-trip (omit-on-empty then default-on-missing), NDJSON ordering/compactness, and empty-slice output.

## Verification

`cargo fmt --all --check`, `cargo clippy -p clinker-lineage --all-targets -- -D warnings` (both clippy passes), `cargo test -p clinker-lineage`, and `cargo check --workspace` all pass locally.

Closes #659. Part of the column-lineage umbrella #653.
