### PR TITLE
ci: reclaim runner disk and disable incremental compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,25 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Incremental compilation only speeds iterative local rebuilds; in CI every
+  # build is effectively from-scratch, so it just bloats target/ — a disk-
+  # pressure source on the multi-build check job below.
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      # Reclaim ~25-30 GB of preinstalled SDKs the Rust build never touches.
+      # This job compiles the whole workspace several times over (two clippy
+      # passes, the test build, and three bench-compile steps) into one shared
+      # target/, which can exhaust the hosted runner's root volume mid-link.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc /opt/hostedtoolcache/CodeQL
+          df -h /
 
       - uses: dtolnay/rust-toolchain@master
         with:


### PR DESCRIPTION
## Summary

The `check` job has intermittently failed with `rustc-LLVM ERROR: IO failure on output stream: No space left on device`. It is not a test failure — the job compiles the whole workspace several times in one run (two `clippy --workspace` passes, `cargo test --workspace`, and three bench-compile steps), and the cumulative `target/` can exhaust the hosted ubuntu runner's root volume mid-link.

## Changes

- **Free disk before building** (the `check` job only): remove ~25–30 GB of preinstalled SDKs the Rust build never uses (`/usr/local/lib/android`, `/usr/share/dotnet`, `/opt/ghc`, `/opt/hostedtoolcache/CodeQL`) and print `df -h /` for visibility. Implemented as a plain `rm` step rather than a third-party action, to avoid adding to the CI supply chain.
- **`CARGO_INCREMENTAL=0`** workspace-wide: incremental artifacts only help iterative local rebuilds; in CI they are never reused and just inflate `target/`. Has the side benefit of slightly faster builds.

No change to what is compiled or tested — purely runner-capacity hygiene. The other jobs (`test-windows`, `test-macos`) build the workspace only once, so the disk-reclaim step is scoped to `check`, but they still benefit from `CARGO_INCREMENTAL=0`.

## Follow-up option

If disk pressure on `check` ever returns, the structural fix is to split the three bench-compile steps into their own job so each runner gets a fresh disk (and CI parallelizes). Deferred since it would change the required-checks set.