### PR TITLE
Fix schema glob filtering and CXL CLI mapping

### DIFF
--- a/crates/clinker-schema/AGENTS.md
+++ b/crates/clinker-schema/AGENTS.md
@@ -65,7 +65,7 @@ Existing direct dependencies are the baseline:
 - `FieldDescriptor::nullable` defaults to `true`.
 - Nested fields are recursive and flatten to dot notation.
 - Discovery is non-recursive by default: schemas under `schema_dir`, pipelines in the workspace root.
-- Include glob support is simple directory/extension scanning; `exclude_globs` is currently not applied.
+- Include/exclude glob support is simple directory/filename wildcard scanning, not full recursive glob handling.
 - `extract_schema_refs` is line-oriented and only strips simple scalar `schema:` values.
 - Validation warnings are advisory. They should not become planner errors from this crate.
 - CXL field extraction in `validate.rs` is heuristic, not parser/typechecker-backed.
@@ -75,7 +75,7 @@ Existing direct dependencies are the baseline:
 
 - Describing this as runtime schema binding; planner schema binding lives in `clinker-plan`.
 - Claiming discovery performs full YAML-aware pipeline parsing.
-- Claiming full glob/exclude support.
+- Claiming full recursive glob support.
 - Claiming compiler-grade CXL validation.
 - Copying old `inputs:` / `transformations:` pipeline shapes from tests or stale docs into current user guidance.
 - Copying stale editor-tooling wording into new docs without checking current source.

--- a/crates/clinker-schema/src/discovery.rs
+++ b/crates/clinker-schema/src/discovery.rs
@@ -5,6 +5,7 @@
 //! `referencing_pipelines`, and builds a `SchemaIndex`.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -124,14 +125,22 @@ pub fn discover_pipelines(
 fn discover_pipelines_with_globs(
     workspace_root: &Path,
     include_globs: &[String],
-    _exclude_globs: &[String],
+    exclude_globs: &[String],
 ) -> Vec<PathBuf> {
-    // Simple glob expansion — match files in workspace
+    // Simple glob expansion — match files in workspace.
+    let excluded: HashSet<PathBuf> = exclude_globs
+        .iter()
+        .flat_map(|pattern| {
+            let full_pattern = workspace_root.join(pattern).display().to_string();
+            glob_paths(&full_pattern).unwrap_or_default()
+        })
+        .collect();
+
     let mut results = Vec::new();
     for pattern in include_globs {
         let full_pattern = workspace_root.join(pattern).display().to_string();
         if let Ok(paths) = glob_paths(&full_pattern) {
-            results.extend(paths);
+            results.extend(paths.into_iter().filter(|p| !excluded.contains(p)));
         }
     }
     results.sort();
@@ -141,31 +150,65 @@ fn discover_pipelines_with_globs(
 
 /// Simple glob expansion using std::fs.
 fn glob_paths(pattern: &str) -> Result<Vec<PathBuf>, ()> {
-    // For now, just check if the pattern is a simple directory/*.yaml
-    // Full glob support can be added with the `glob` crate later.
+    // For now, support simple directory/name patterns with `*` and `?` in the
+    // filename component. Full recursive glob support can be added with the
+    // `glob` crate later if this crate takes that dependency deliberately.
     let path = Path::new(pattern);
     if let Some(parent) = path.parent()
         && parent.is_dir()
     {
-        let ext_match = path.extension().and_then(|e| e.to_str()).unwrap_or("yaml");
+        let Some(file_pattern) = path.file_name().and_then(|n| n.to_str()) else {
+            return Ok(Vec::new());
+        };
         let Ok(entries) = fs::read_dir(parent) else {
             return Ok(Vec::new());
         };
         return Ok(entries
             .filter_map(|e| e.ok())
             .filter(|e| {
-                // Case-insensitive: a case-preserving filesystem (macOS APFS,
-                // Windows NTFS) returns the on-disk casing, so `*.yaml` must
-                // still match a file stored as `flow.YAML`.
                 e.path()
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case(ext_match))
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| wildcard_match_ascii_case_insensitive(file_pattern, name))
             })
             .map(|e| e.path())
             .collect());
     }
     Ok(Vec::new())
+}
+
+fn wildcard_match_ascii_case_insensitive(pattern: &str, candidate: &str) -> bool {
+    let pattern = pattern.as_bytes();
+    let candidate = candidate.as_bytes();
+    let mut p = 0;
+    let mut c = 0;
+    let mut star = None;
+    let mut match_after_star = 0;
+
+    while c < candidate.len() {
+        if p < pattern.len()
+            && (pattern[p] == b'?' || pattern[p].eq_ignore_ascii_case(&candidate[c]))
+        {
+            p += 1;
+            c += 1;
+        } else if p < pattern.len() && pattern[p] == b'*' {
+            star = Some(p);
+            p += 1;
+            match_after_star = c;
+        } else if let Some(star_idx) = star {
+            p = star_idx + 1;
+            match_after_star += 1;
+            c = match_after_star;
+        } else {
+            return false;
+        }
+    }
+
+    while p < pattern.len() && pattern[p] == b'*' {
+        p += 1;
+    }
+
+    p == pattern.len()
 }
 
 /// Extract `schema:` references from a pipeline YAML file.
@@ -581,6 +624,48 @@ fields:
             names.contains(&"flow.YAML"),
             "glob discovery missed mixed-case extension: {names:?}"
         );
+    }
+
+    #[test]
+    fn test_glob_discovery_applies_exclude_globs() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join("schemas")).unwrap();
+
+        write_file(root, "keep.yaml", "pipeline: {name: keep}");
+        write_file(root, "skip.yaml", "pipeline: {name: skip}");
+        write_file(root, "skip-extra.yaml", "pipeline: {name: skip_extra}");
+
+        let pipelines = discover_pipelines(
+            root,
+            "schemas",
+            &["*.yaml".to_string()],
+            &["skip*.yaml".to_string()],
+        );
+        let names: Vec<_> = pipelines
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+
+        assert_eq!(names, vec!["keep.yaml"]);
+    }
+
+    #[test]
+    fn test_glob_discovery_exact_pattern_does_not_overmatch_by_extension() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        fs::create_dir(root.join("schemas")).unwrap();
+
+        write_file(root, "pipeline.yaml", "pipeline: {name: keep}");
+        write_file(root, "other.yaml", "pipeline: {name: other}");
+
+        let pipelines = discover_pipelines(root, "schemas", &["pipeline.yaml".to_string()], &[]);
+        let names: Vec<_> = pipelines
+            .iter()
+            .map(|p| p.file_name().unwrap().to_str().unwrap())
+            .collect();
+
+        assert_eq!(names, vec!["pipeline.yaml"]);
     }
 
     #[test]

--- a/crates/cxl-cli/AGENTS.md
+++ b/crates/cxl-cli/AGENTS.md
@@ -100,8 +100,8 @@ For language semantics changes, also run the relevant `crates/cxl` checks.
 
 - Keep this local guidance focused on CLI behavior. CXL language semantics
   belong primarily in `crates/cxl/AGENTS.md` and the `cxl` crate.
-- `docs/user/src/cxl/cxl-cli.md` shows multiple `-e` flags, but `Command::Eval.expr` is `Option<String>`. Decide whether docs are stale or CLI should support repeated `-e`.
-- `json_to_value` maps nested JSON objects to `Value::Null`, while the user docs do not clearly document object handling for `--record`.
+- `Command::Eval.expr` is a single `Option<String>`; examples with multiple statements should use one `-e` value containing the CXL source.
+- `json_to_value` preserves nested JSON objects as `Value::Map`; keep `docs/user/src/cxl/cxl-cli.md` aligned if that mapping changes.
 
 ## Evidence
 

--- a/crates/cxl-cli/Cargo.toml
+++ b/crates/cxl-cli/Cargo.toml
@@ -3,7 +3,7 @@ name = "cxl-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Standalone CXL language validator and REPL"
+description = "Standalone CXL language validator, evaluator, and formatter"
 
 [dependencies]
 cxl = { workspace = true }

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -806,7 +806,7 @@ mod tests {
         let Some(Value::Array(scores)) = profile.get("scores") else {
             panic!("expected nested array to stay Value::Array");
         };
-        assert_eq!(scores.get(0), Some(&Value::Integer(1)));
+        assert_eq!(scores.first(), Some(&Value::Integer(1)));
         let Some(Value::Map(score_obj)) = scores.get(1) else {
             panic!("expected object inside array to become Value::Map");
         };

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -287,12 +287,12 @@ fn cmd_eval(file: Option<&str>, expr: Option<&str>, record_json: Option<&str>, f
         static_vars: std::sync::Arc::new(indexmap::IndexMap::new()),
     };
     let source_file_arc: std::sync::Arc<str> = std::sync::Arc::from(source_name);
-    // REPL has no Source-node context, but `$source.name` is a stable
+    // CLI eval has no Source-node context, but `$source.name` is a stable
     // per-record namespace; surface the parameter as the originating
     // name so `emit n = $source.name` echoes back the same string the
     // caller passed in.
     let source_name_arc: std::sync::Arc<str> = std::sync::Arc::from(source_name);
-    // REPL has no real batch context — use the same placeholder as the
+    // CLI eval has no real batch context — use the same placeholder as the
     // stable execution_id so `$source.batch` is at least non-empty.
     let source_batch_arc: std::sync::Arc<str> = std::sync::Arc::clone(&stable.pipeline_batch_id);
     let ctx = EvalContext {
@@ -309,7 +309,7 @@ fn cmd_eval(file: Option<&str>, expr: Option<&str>, record_json: Option<&str>, f
 
     let resolver = HashMapResolver::new(record_map);
 
-    // The REPL drives the same statement-level evaluator the engine uses
+    // CLI eval drives the same statement-level evaluator the engine uses
     // per record, so `filter`, `distinct`, and `emit each` behave exactly
     // as they would inside a Transform node rather than being silently
     // ignored. `distinct` needs the dedup set allocated up front.
@@ -515,7 +515,13 @@ fn json_to_value(v: serde_json::Value) -> Value {
         }
         serde_json::Value::String(s) => Value::String(s.into()),
         serde_json::Value::Array(arr) => Value::Array(arr.into_iter().map(json_to_value).collect()),
-        serde_json::Value::Object(_) => Value::Null, // Nested objects not supported in v1
+        serde_json::Value::Object(map) => {
+            let mut out = indexmap::IndexMap::with_capacity(map.len());
+            for (key, value) in map {
+                out.insert(key.into_boxed_str(), json_to_value(value));
+            }
+            Value::Map(Box::new(out))
+        }
     }
 }
 
@@ -777,6 +783,34 @@ mod tests {
             parse_field_value("hello world"),
             Value::String("hello world".into())
         );
+    }
+
+    #[test]
+    fn test_json_to_value_preserves_nested_objects() {
+        let value = json_to_value(serde_json::json!({
+            "profile": {
+                "name": "Alice",
+                "active": true,
+                "scores": [1, {"kind": "bonus"}]
+            }
+        }));
+
+        let Value::Map(root) = value else {
+            panic!("expected root JSON object to become Value::Map");
+        };
+        let Some(Value::Map(profile)) = root.get("profile") else {
+            panic!("expected nested object to become Value::Map");
+        };
+        assert_eq!(profile.get("name"), Some(&Value::String("Alice".into())));
+        assert_eq!(profile.get("active"), Some(&Value::Bool(true)));
+        let Some(Value::Array(scores)) = profile.get("scores") else {
+            panic!("expected nested array to stay Value::Array");
+        };
+        assert_eq!(scores.get(0), Some(&Value::Integer(1)));
+        let Some(Value::Map(score_obj)) = scores.get(1) else {
+            panic!("expected object inside array to become Value::Map");
+        };
+        assert_eq!(score_obj.get("kind"), Some(&Value::String("bonus".into())));
     }
 
     // Note: cmd_check/cmd_eval/cmd_fmt call process::exit() and cannot be tested

--- a/docs/ai/00_READ_THIS_FIRST.md
+++ b/docs/ai/00_READ_THIS_FIRST.md
@@ -184,8 +184,6 @@ current uncertainties are:
   node count, or unclear envelope/document-context examples.
 - Transport docs need alignment around implemented file and finite REST support
   versus SQL cursor wording.
-- `cxl-cli` docs/manifest wording needs alignment around repeated `-e`
-  examples and whether a REPL is actually implemented.
 - The `clinker-format -> cxl` dependency edge is current, but whether it is a
   permanent layering rule remains open.
 - Some public planner/CXL symbols may be exposed without a clear stability

--- a/docs/ai/80_OPEN_QUESTIONS.md
+++ b/docs/ai/80_OPEN_QUESTIONS.md
@@ -105,10 +105,11 @@ evidence.
 - Question: Should `extract_schema_refs`, include/exclude glob behavior, format
   matching, and CXL field validation become YAML/parser-backed, or is the
   current heuristic authoring support enough?
-- Why it matters: Current guidance says `exclude_globs` is not applied,
-  `schema:` extraction is line-oriented, CXL field extraction is heuristic, and
-  some warning variants appear unused. Docs and tests should not imply full
-  workspace validation unless that is implemented.
+- Why it matters: Current guidance says include/exclude glob behavior is
+  simple filename wildcard matching, `schema:` extraction is line-oriented,
+  CXL field extraction is heuristic, and some warning variants appear unused.
+  Docs and tests should not imply full workspace validation unless that is
+  implemented.
 - Files/modules involved: `crates/clinker-schema/AGENTS.md`,
   `crates/clinker-schema/src/discovery.rs`,
   `crates/clinker-schema/src/validate.rs`,
@@ -228,36 +229,25 @@ evidence.
   if intentionally reserved.
 - Priority: Medium
 
-### 12. Should `cxl-cli` docs, manifest description, and CLI behavior be aligned?
+### 12. Should `cxl-cli` docs, manifest description, and CLI behavior be aligned? (RESOLVED)
 
-- Question: Are user docs showing multiple `-e` flags correct, or should the
-  docs be corrected to match `Command::Eval.expr: Option<String>`? Should the
-  `cxl-cli` manifest description continue saying "REPL" when source currently
-  exposes only `check`, `eval`, and `fmt` subcommands?
-- Why it matters: Repeated expression examples and REPL wording can mislead
-  users and future tests. If repeated `-e` or REPL behavior is intended, the CLI
-  type and evaluation/output semantics need to change deliberately.
+- Resolution: `Command::Eval.expr` remains a single `Option<String>`.
+  User docs now show multiple CXL statements inside one `-e` value, and the
+  `cxl-cli` package description says validator/evaluator/formatter.
 - Files/modules involved: `crates/cxl-cli/AGENTS.md`,
   `crates/cxl-cli/Cargo.toml`, `crates/cxl-cli/src/main.rs`,
   `docs/user/src/cxl/cxl-cli.md`, `docs/ai/20_CRATE_MAP.md`.
-- Suggested way to resolve it: Decide the intended CLI behavior. Either update
-  docs/manifest wording to one expression and no REPL, or change the Clap field
-  and CLI implementation to support the promised behavior with tests.
-- Priority: Medium
+- Priority: Resolved
 
-### 13. Should `cxl-cli --record` preserve nested JSON objects as `Value::Map`?
+### 13. Should `cxl-cli --record` preserve nested JSON objects as `Value::Map`? (RESOLVED)
 
-- Question: Is mapping nested JSON objects to `Value::Null` in `json_to_value`
-  intentional v1 scope, or should objects become `Value::Map`?
-- Why it matters: `clinker-record::Value` has a `Map` variant, and silently
-  nulling objects affects evaluation results. Docs need to state the behavior
-  if it remains intentional.
+- Resolution: `json_to_value` now recursively maps JSON objects to
+  `Value::Map`; the CXL CLI docs list `{object}` as `Map`, and unit coverage
+  pins nested objects inside maps and arrays.
 - Files/modules involved: `crates/cxl-cli/AGENTS.md`,
   `crates/cxl-cli/src/main.rs`, `crates/clinker-record/src/value.rs`,
   `docs/user/src/cxl/cxl-cli.md`.
-- Suggested way to resolve it: Confirm the intended object mapping. Add unit
-  tests for nested objects and update CXL CLI docs to match the chosen behavior.
-- Priority: Medium
+- Priority: Resolved
 
 ### 14. Should `PipelineCounters::ok_count` use a globally unique source-row identity?
 

--- a/docs/engine/src/architecture.md
+++ b/docs/engine/src/architecture.md
@@ -19,7 +19,7 @@ These pillars are why the memory arbitrator is a single in-process component rat
 ## Crate dependency layers (bottom → top)
 
 ```
-Applications:   clinker (CLI)  |  cxl-cli (REPL)
+Applications:   clinker (CLI)  |  cxl-cli (CXL tool)
                      ↓                ↓
 Orchestration:  clinker-core (DAG planner + executor)
                 clinker-channel (workspace/channel mgmt)

--- a/docs/user/src/cxl/cxl-cli.md
+++ b/docs/user/src/cxl/cxl-cli.md
@@ -60,11 +60,11 @@ $ cxl eval transform.cxl \
 $ cxl eval transform.cxl --record '{"price": 10.5, "qty": 3}'
 ```
 
-**Multiple inline expressions:**
+**Multiple inline statements:**
 
 ```bash
-$ cxl eval -e 'let tax = 0.21' -e 'emit net = price * (1 - tax)' \
-    --field price=100
+$ cxl eval -e 'let tax = 0.21
+emit net = price * (1 - tax)' --field price=100
 ```
 
 ```json
@@ -146,13 +146,16 @@ JSON types map directly:
 | decimal number | Float |
 | `"string"` | String |
 | `[array]` | Array |
+| `{object}` | Map |
 
 ## Output format
 
 Output is always JSON. Each `emit` statement produces a key-value pair:
 
 ```bash
-$ cxl eval -e 'emit a = 1' -e 'emit b = "two"' -e 'emit c = true'
+$ cxl eval -e 'emit a = 1
+emit b = "two"
+emit c = true'
 ```
 
 ```json
@@ -237,8 +240,9 @@ $ cxl eval -e 'emit tier = match {
 **Test date operations:**
 
 ```bash
-$ cxl eval -e 'emit year = d.year()' -e 'emit month = d.month()' \
-    -e 'emit next_week = d.add_days(7)' \
+$ cxl eval -e 'emit year = d.year()
+emit month = d.month()
+emit next_week = d.add_days(7)' \
     --record '{"d": "2024-03-15"}'
 ```
 

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Clinker ships two command-line tools: `clinker` (the pipeline runner) and `cxl` (the expression REPL, covered in the [CXL CLI chapter](../cxl/cxl-cli.md)). This page is the complete reference for `clinker`.
+Clinker ships two command-line tools: `clinker` (the pipeline runner) and `cxl` (the expression checker/evaluator/formatter, covered in the [CXL CLI chapter](../cxl/cxl-cli.md)). This page is the complete reference for `clinker`.
 
 ## clinker run
 


### PR DESCRIPTION
## Summary
- apply schema exclude globs during include-glob discovery and match filename patterns instead of extension-only patterns
- preserve nested JSON objects from `cxl eval --record` as CXL map values
- align CXL CLI docs and package metadata with the current checker/evaluator/formatter behavior

## Tests
- `cargo test -p clinker-schema -p cxl-cli --locked --offline`
- `cargo clippy -p cxl-cli --all-targets --locked --offline -- -D warnings`
- `cargo run --locked --offline -p cxl-cli -- eval -e 'let tax = 0.21\nemit net = price * (1 - tax)' --field price=100`
- `cargo run --locked --offline -p cxl-cli -- eval -e 'emit name = profile["name"]' --record '{"profile":{"name":"Alice"}}'`
- `git diff --check`