### PR TITLE
clinker-lineage: INDIRECT influence lineage + DIRECT correctness fixes

### DIFF
--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -34,15 +34,18 @@
 //! - Engine-stamped columns (`$ck.*` / `$meta.*` / `$source.*` / `$widened`) are
 //!   skipped, mirroring the default-writer strip.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::Path;
+use std::sync::Arc;
 
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use clinker_plan::plan::combine::encode_chain_column;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
-use clinker_plan::plan::{CompiledPlan, JoinSide, PlanNodeId, QualifiedField};
+use clinker_plan::plan::{
+    CompiledPlan, JoinSide, PlanNodeId, PredicateSupport, QualifiedField, predicate_support,
+};
 use clinker_record::Schema;
 use cxl::ast::{EmitTarget, Expr, Program, Statement, for_each_field_emit, program_support_into};
 use cxl::plan::BindingArg;
@@ -62,12 +65,12 @@ pub struct PlanColumnLineage {
     pub outputs: Vec<OutputColumnLineage>,
 }
 
-/// One sink dataset and the DIRECT column lineage of its columns.
+/// One sink dataset and the column lineage of its columns.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OutputColumnLineage {
     pub dataset: DatasetId,
-    /// `fields` populated with per-column DIRECT lineage; `dataset` (INDIRECT)
-    /// left empty for #662.
+    /// `facet.fields` carries per-column DIRECT (value-derivation) lineage;
+    /// `facet.dataset` carries the whole-dataset INDIRECT influence lineage.
     pub facet: ColumnLineageDatasetFacet,
 }
 
@@ -80,9 +83,12 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
     let dag = compiled.dag();
     // Per node, per output column, the resolved Source terminals it derives from.
     let mut lineage: HashMap<PlanNodeId, ColumnTerminals> = HashMap::new();
+    // Per node, the whole-dataset INDIRECT influences accumulated from this node
+    // and every upstream — flushed into each Output's facet `dataset[]`.
+    let mut influence: HashMap<PlanNodeId, InfluenceMap> = HashMap::new();
     let mut inputs: Vec<DatasetId> = Vec::new();
     let mut seen_inputs: HashSet<DatasetId> = HashSet::new();
-    let mut outputs: Vec<OutputColumnLineage> = Vec::new();
+    let mut output_acc: Vec<OutputAcc> = Vec::new();
 
     for &idx in &dag.topo_order {
         let node = &dag.graph[idx];
@@ -202,23 +208,11 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                 decomposed_from,
                 ..
             } => {
-                let map: &HashMap<QualifiedField, (JoinSide, u32)> = resolved_column_map;
-                let bare = bare_side_index(map);
-                let probe_idx = *driving_upstream;
-                // The build side is the incoming neighbor that is not the probe.
-                // For a self-join (`input: {a: src, b: src}`) both sides are the same
-                // physical predecessor, so fall back to the probe node — the side
-                // distinction is logical (via `resolved_column_map`'s `JoinSide`), not
-                // a distinct node.
-                let build_idx = dag
-                    .graph
-                    .neighbors_directed(idx, Direction::Incoming)
-                    .find(|n| Some(*n) != probe_idx)
-                    .or(probe_idx);
-                let probe =
-                    probe_idx.map(|n| (dag.graph[n].id(), dag.graph[n].output_schema_in(dag)));
-                let build =
-                    build_idx.map(|n| (dag.graph[n].id(), dag.graph[n].output_schema_in(dag)));
+                let sides = combine_sides(dag, idx, resolved_column_map, *driving_upstream);
+                let map = sides.map;
+                let probe = sides.probe;
+                let build = sides.build;
+                let bare = sides.bare;
 
                 let mut cols = ColumnTerminals::new();
                 match typed {
@@ -356,9 +350,6 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                 for_each_output_col(node, dag, |col| {
                     cols.insert_nonempty(col, passthrough(&lineage, up, col));
                 });
-                if let Some(ds) = dataset_identity(node, base_dir) {
-                    record_output(&mut outputs, ds, &cols);
-                }
                 cols
             }
 
@@ -378,9 +369,19 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
             }
         };
 
+        let node_influence = node_indirect_influence(node, dag, idx, &lineage, &influence);
+
+        if let PlanNode::Output { .. } = node
+            && let Some(ds) = dataset_identity(node, base_dir)
+        {
+            record_output(&mut output_acc, ds, &cols, &node_influence);
+        }
+
         lineage.insert(node_id, cols);
+        influence.insert(node_id, node_influence);
     }
 
+    let outputs = output_acc.into_iter().map(OutputAcc::into_output).collect();
     PlanColumnLineage { inputs, outputs }
 }
 
@@ -405,6 +406,35 @@ impl Subtype {
         }
     }
 }
+
+/// INDIRECT influence subtype: how a column influences the dataset as a whole
+/// (filtering, joining, grouping, sorting, conditionally reshaping) without its
+/// value flowing into a specific output column.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum IndirectSub {
+    Filter,
+    Join,
+    GroupBy,
+    Sort,
+    Conditional,
+}
+
+impl IndirectSub {
+    fn to_openlineage(self) -> TransformationSubtype {
+        match self {
+            IndirectSub::Filter => TransformationSubtype::Filter,
+            IndirectSub::Join => TransformationSubtype::Join,
+            IndirectSub::GroupBy => TransformationSubtype::GroupBy,
+            IndirectSub::Sort => TransformationSubtype::Sort,
+            IndirectSub::Conditional => TransformationSubtype::Conditional,
+        }
+    }
+}
+
+/// The INDIRECT influences accumulated for a node: each Source terminal mapped
+/// to the set of influence subtypes through which it reaches the dataset. The
+/// `BTreeMap`/`BTreeSet` keep the emitted `dataset[]` order deterministic.
+type InfluenceMap = BTreeMap<Terminal, BTreeSet<IndirectSub>>;
 
 /// One Source dataset column: the terminal of a DIRECT lineage path.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -907,46 +937,284 @@ fn resolve_side(
     }
 }
 
+/// The probe / build side resolution context of a Combine node: the pre-resolved
+/// `(side, index)` map, the unambiguous-bare-name index, and each side's upstream
+/// `(id, schema)`. Shared by the DIRECT body resolution and the INDIRECT
+/// JOIN-influence resolution.
+struct CombineSides<'a> {
+    map: &'a HashMap<QualifiedField, (JoinSide, u32)>,
+    bare: HashMap<String, (JoinSide, u32)>,
+    probe: Option<(PlanNodeId, &'a Arc<Schema>)>,
+    build: Option<(PlanNodeId, &'a Arc<Schema>)>,
+}
+
+/// Resolve a Combine's probe / build sides. The build side is the incoming
+/// neighbor that is not the probe; for a self-join (`input: {a: src, b: src}`)
+/// both sides are the same physical predecessor, so it falls back to the probe
+/// node — the side distinction is logical (`resolved_column_map`'s `JoinSide`),
+/// not a distinct node.
+fn combine_sides<'a>(
+    dag: &'a ExecutionPlanDag,
+    idx: NodeIndex,
+    resolved_column_map: &'a HashMap<QualifiedField, (JoinSide, u32)>,
+    driving_upstream: Option<NodeIndex>,
+) -> CombineSides<'a> {
+    let probe_idx = driving_upstream;
+    let build_idx = dag
+        .graph
+        .neighbors_directed(idx, Direction::Incoming)
+        .find(|n| Some(*n) != probe_idx)
+        .or(probe_idx);
+    CombineSides {
+        map: resolved_column_map,
+        bare: bare_side_index(resolved_column_map),
+        probe: probe_idx.map(|n| (dag.graph[n].id(), dag.graph[n].output_schema_in(dag))),
+        build: build_idx.map(|n| (dag.graph[n].id(), dag.graph[n].output_schema_in(dag))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// INDIRECT influence
+// ---------------------------------------------------------------------------
+
+/// The whole-dataset INDIRECT influences of `node`: every upstream node's
+/// accumulated influence (flowed through unchanged) plus the columns this node
+/// filters / joins / groups / sorts / conditionally reshapes on, each resolved
+/// to its Source terminals via the upstream DIRECT `lineage`.
+fn node_indirect_influence(
+    node: &PlanNode,
+    dag: &ExecutionPlanDag,
+    idx: NodeIndex,
+    lineage: &HashMap<PlanNodeId, ColumnTerminals>,
+    influence: &HashMap<PlanNodeId, InfluenceMap>,
+) -> InfluenceMap {
+    let mut inf = InfluenceMap::new();
+
+    // Inherited: a filter / join / group anywhere upstream taints every
+    // downstream dataset, so each upstream's influence flows through unchanged.
+    for up in upstream_ids(dag, idx) {
+        if let Some(up_inf) = influence.get(&up) {
+            for (terminal, subs) in up_inf {
+                inf.entry(terminal.clone())
+                    .or_default()
+                    .extend(subs.iter().copied());
+            }
+        }
+    }
+
+    // Local: this node's own influence predicate columns.
+    match node {
+        PlanNode::Route { .. } => {
+            if let Some(PredicateSupport::RouteBranches(branches)) = predicate_support(node) {
+                let up = single_upstream(dag, idx);
+                for cols in &branches {
+                    for col in cols {
+                        add_upstream_influence(
+                            &mut inf,
+                            upstream_col(lineage, up, col),
+                            IndirectSub::Filter,
+                        );
+                    }
+                }
+            }
+        }
+        PlanNode::Cull { .. } => {
+            if let Some(PredicateSupport::CullDrop(cols)) = predicate_support(node) {
+                let up = single_upstream(dag, idx);
+                for col in &cols {
+                    add_upstream_influence(
+                        &mut inf,
+                        upstream_col(lineage, up, col),
+                        IndirectSub::Filter,
+                    );
+                }
+            }
+        }
+        PlanNode::Aggregation { compiled, .. } => {
+            let up = single_upstream(dag, idx);
+            for col in &compiled.group_by_fields {
+                add_upstream_influence(
+                    &mut inf,
+                    upstream_col(lineage, up, col),
+                    IndirectSub::GroupBy,
+                );
+            }
+        }
+        PlanNode::Sort { sort_fields, .. } => {
+            let up = single_upstream(dag, idx);
+            for sf in sort_fields {
+                add_upstream_influence(
+                    &mut inf,
+                    upstream_col(lineage, up, &sf.field),
+                    IndirectSub::Sort,
+                );
+            }
+        }
+        PlanNode::Reshape { compiled_rules, .. } => {
+            let up = single_upstream(dag, idx);
+            for rule in compiled_rules.iter() {
+                let mut reads = HashSet::new();
+                program_support_into(&rule.when.program, &mut reads);
+                for col in &reads {
+                    add_upstream_influence(
+                        &mut inf,
+                        upstream_col(lineage, up, col),
+                        IndirectSub::Conditional,
+                    );
+                }
+            }
+        }
+        PlanNode::Combine {
+            resolved_column_map,
+            driving_upstream,
+            decomposed_predicate: Some(dp),
+            ..
+        } => {
+            let sides = combine_sides(dag, idx, resolved_column_map, *driving_upstream);
+            let mut refs = Vec::new();
+            for eq in &dp.equalities {
+                collect_field_refs(&eq.left_expr, &mut refs);
+                collect_field_refs(&eq.right_expr, &mut refs);
+            }
+            for range in &dp.ranges {
+                collect_field_refs(&range.left_expr, &mut refs);
+                collect_field_refs(&range.right_expr, &mut refs);
+            }
+            for qf in &refs {
+                let Some((side, cidx)) = resolve_side(qf, sides.map, &sides.bare) else {
+                    continue;
+                };
+                let resolved = match side {
+                    JoinSide::Probe => sides.probe.as_ref(),
+                    JoinSide::Build => sides.build.as_ref(),
+                };
+                if let Some((up_id, schema)) = resolved
+                    && let Some(col) = schema.column_name(cidx as usize)
+                {
+                    add_upstream_influence(
+                        &mut inf,
+                        lineage.get(up_id).and_then(|m| m.0.get(col)),
+                        IndirectSub::Join,
+                    );
+                }
+            }
+        }
+        _ => {}
+    }
+
+    inf
+}
+
+/// Add every Source terminal in `up_terms` to `inf` as an INDIRECT influence of
+/// subtype `sub` (the DIRECT subtype of the upstream path is irrelevant — only
+/// the source column identity matters for whole-dataset influence).
+fn add_upstream_influence(inf: &mut InfluenceMap, up_terms: Option<&TermMap>, sub: IndirectSub) {
+    if let Some(terms) = up_terms {
+        for terminal in terms.keys() {
+            inf.entry(terminal.clone()).or_default().insert(sub);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Output facet assembly
 // ---------------------------------------------------------------------------
 
-/// Append (or merge into) the output dataset's column-lineage facet.
+/// Accumulator for one sink dataset: its per-column DIRECT terminals and
+/// whole-dataset INDIRECT influences, merged across every Output node that
+/// resolves to the same dataset.
+struct OutputAcc {
+    dataset: DatasetId,
+    fields: BTreeMap<String, TermMap>,
+    influence: InfluenceMap,
+}
+
+impl OutputAcc {
+    fn into_output(self) -> OutputColumnLineage {
+        let fields = self
+            .fields
+            .iter()
+            .filter(|(_, terms)| !terms.is_empty())
+            .map(|(col, terms)| {
+                (
+                    col.clone(),
+                    FieldLineage {
+                        input_fields: input_fields(terms),
+                    },
+                )
+            })
+            .collect();
+        OutputColumnLineage {
+            dataset: self.dataset,
+            facet: ColumnLineageDatasetFacet {
+                producer: PRODUCER.to_string(),
+                schema_url: COLUMN_LINEAGE_FACET_SCHEMA_URL.to_string(),
+                fields,
+                dataset: indirect_input_fields(&self.influence),
+            },
+        }
+    }
+}
+
+/// Accumulate one Output node's DIRECT columns and INDIRECT influences into the
+/// sink dataset's entry, unioning with any prior Output node naming it.
 fn record_output(
-    outputs: &mut Vec<OutputColumnLineage>,
+    acc: &mut Vec<OutputAcc>,
     dataset: DatasetId,
     cols: &ColumnTerminals,
+    influence: &InfluenceMap,
 ) {
-    let fields: BTreeMap<String, FieldLineage> = cols
-        .0
-        .iter()
-        .filter(|(_, terms)| !terms.is_empty())
-        .map(|(col, terms)| {
-            (
-                col.clone(),
-                FieldLineage {
-                    input_fields: input_fields(terms),
-                },
-            )
-        })
-        .collect();
-
-    if let Some(existing) = outputs.iter_mut().find(|o| o.dataset == dataset) {
-        // Two Output nodes naming one dataset: merge their column maps.
-        for (col, fl) in fields {
-            existing.facet.fields.entry(col).or_insert(fl);
+    if let Some(existing) = acc.iter_mut().find(|o| o.dataset == dataset) {
+        for (col, terms) in &cols.0 {
+            if terms.is_empty() {
+                continue;
+            }
+            let slot = existing.fields.entry(col.clone()).or_default();
+            merge_terminals(slot, Some(terms), Subtype::Identity);
+        }
+        for (terminal, subs) in influence {
+            existing
+                .influence
+                .entry(terminal.clone())
+                .or_default()
+                .extend(subs.iter().copied());
         }
         return;
     }
-    outputs.push(OutputColumnLineage {
+    let fields = cols
+        .0
+        .iter()
+        .filter(|(_, terms)| !terms.is_empty())
+        .map(|(col, terms)| (col.clone(), terms.clone()))
+        .collect();
+    acc.push(OutputAcc {
         dataset,
-        facet: ColumnLineageDatasetFacet {
-            producer: PRODUCER.to_string(),
-            schema_url: COLUMN_LINEAGE_FACET_SCHEMA_URL.to_string(),
-            fields,
-            dataset: Vec::new(),
-        },
+        fields,
+        influence: influence.clone(),
     });
+}
+
+/// An [`InfluenceMap`] → the facet's whole-dataset INDIRECT `dataset[]`: one
+/// `InputField` per Source terminal, carrying one INDIRECT transformation per
+/// influence subtype.
+fn indirect_input_fields(influence: &InfluenceMap) -> Vec<InputField> {
+    influence
+        .iter()
+        .map(|(terminal, subs)| InputField {
+            namespace: terminal.namespace.clone(),
+            name: terminal.name.clone(),
+            field: terminal.field.clone(),
+            transformations: subs
+                .iter()
+                .map(|sub| Transformation {
+                    transformation_type: TransformationType::Indirect,
+                    subtype: Some(sub.to_openlineage()),
+                    description: None,
+                    masking: None,
+                })
+                .collect(),
+        })
+        .collect()
 }
 
 /// One terminal set → its OpenLineage `inputFields`, in `BTreeMap` (namespace,
@@ -1019,6 +1287,36 @@ mod tests {
             .get(col)
             .unwrap_or_else(|| panic!("column {col:?} missing from lineage"));
         assert_eq!(actual.input_fields, expected, "lineage for column {col:?}");
+    }
+
+    /// One INDIRECT `file:`-namespaced input field carrying the given subtypes.
+    fn indirect(name: &str, field: &str, subtypes: &[TransformationSubtype]) -> InputField {
+        InputField {
+            namespace: "file".to_string(),
+            name: name.to_string(),
+            field: field.to_string(),
+            transformations: subtypes
+                .iter()
+                .map(|s| Transformation {
+                    transformation_type: TransformationType::Indirect,
+                    subtype: Some(*s),
+                    description: None,
+                    masking: None,
+                })
+                .collect(),
+        }
+    }
+
+    /// The output dataset whose name contains `substr` (for multi-output plans).
+    fn output_named<'a>(
+        lineage: &'a PlanColumnLineage,
+        substr: &str,
+    ) -> &'a OutputColumnLineage {
+        lineage
+            .outputs
+            .iter()
+            .find(|o| o.dataset.name.contains(substr))
+            .unwrap_or_else(|| panic!("no output dataset containing {substr:?}"))
     }
 
     // -- subtype composition --------------------------------------------------
@@ -1167,6 +1465,360 @@ nodes:
                 "raw",
                 TransformationSubtype::Identity,
             )],
+        );
+    }
+
+    // -- INDIRECT influence (#662) --------------------------------------------
+
+    #[test]
+    fn route_predicate_columns_are_filter_influence_not_per_column() {
+        // A Route condition column influences every output port as FILTER, landing
+        // in the top-level `dataset[]` — not duplicated into per-column lineage.
+        let yaml = r#"
+pipeline: { name: r }
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: csv
+      path: data/s.csv
+      options: { has_header: true }
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: int }
+  - type: route
+    name: split
+    input: s
+    config:
+      mode: exclusive
+      conditions: { high: "amount > 100" }
+      default: low
+  - type: output
+    name: hi
+    input: split.high
+    config: { name: hi, type: csv, path: out/hi.csv }
+  - type: output
+    name: lo
+    input: split.low
+    config: { name: lo, type: csv, path: out/lo.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let src = "/w/data/s.csv";
+        let hi = output_named(&lineage, "hi.csv");
+        use TransformationSubtype::{Filter, Identity};
+        assert_eq!(
+            hi.facet.dataset,
+            vec![indirect(src, "amount", &[Filter])],
+            "route condition column is FILTER influence"
+        );
+        // The influence is NOT duplicated into the per-column DIRECT lineage:
+        // `amount` still passes through as a plain DIRECT identity column.
+        assert_field(&hi.facet.fields, "amount", &[direct(src, "amount", Identity)]);
+        for fl in hi.facet.fields.values() {
+            assert!(
+                fl.input_fields
+                    .iter()
+                    .flat_map(|f| &f.transformations)
+                    .all(|t| t.transformation_type == TransformationType::Direct),
+                "per-column lineage must stay DIRECT-only"
+            );
+        }
+    }
+
+    #[test]
+    fn cull_drop_predicate_columns_are_filter_influence() {
+        let yaml = r#"
+pipeline: { name: c }
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: csv
+      path: data/s.csv
+      options: { has_header: true }
+      schema:
+        - { name: employee_id, type: string }
+        - { name: amount, type: int }
+  - type: cull
+    name: trim
+    input: s
+    config:
+      partition_by: [employee_id]
+      removed_to: removed
+      rules:
+        - name: drop_big
+          drop_group_when: "sum(amount) > 100"
+  - type: output
+    name: out
+    input: trim
+    config: { name: out, type: csv, path: out/c.csv }
+  - type: output
+    name: audit
+    input: trim.removed
+    config: { name: audit, type: csv, path: out/audit.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let src = "/w/data/s.csv";
+        let out = output_named(&lineage, "c.csv");
+        assert_eq!(
+            out.facet.dataset,
+            vec![indirect(src, "amount", &[TransformationSubtype::Filter])],
+        );
+    }
+
+    #[test]
+    fn aggregation_group_by_columns_are_group_by_influence() {
+        let yaml = r#"
+pipeline: { name: a }
+nodes:
+  - type: source
+    name: sales
+    config:
+      name: sales
+      type: csv
+      path: data/sales.csv
+      options: { has_header: true }
+      schema:
+        - { name: region, type: string }
+        - { name: amount, type: int }
+  - type: aggregate
+    name: agg
+    input: sales
+    config:
+      group_by: [region]
+      cxl: |
+        emit region = region
+        emit total = sum(amount)
+  - type: output
+    name: out
+    input: agg
+    config: { name: out, type: csv, path: out/a.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        assert_eq!(
+            only_output(&lineage).facet.dataset,
+            vec![indirect(
+                "/w/data/sales.csv",
+                "region",
+                &[TransformationSubtype::GroupBy]
+            )],
+        );
+    }
+
+    #[test]
+    fn combine_join_keys_are_join_influence() {
+        let yaml = r#"
+pipeline: { name: c }
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: data/orders.csv
+      options: { has_header: true }
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: float }
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: data/events.csv
+      options: { has_header: true }
+      schema:
+        - { name: order_id, type: string }
+        - { name: actor, type: string }
+  - type: combine
+    name: joined
+    input:
+      orders: orders
+      events: events
+    config:
+      where: "orders.order_id == events.order_id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit order_id = orders.order_id
+        emit actor = events.actor
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config: { name: out, type: csv, path: out/c.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        use TransformationSubtype::Join;
+        assert_eq!(
+            only_output(&lineage).facet.dataset,
+            vec![
+                indirect("/w/data/events.csv", "order_id", &[Join]),
+                indirect("/w/data/orders.csv", "order_id", &[Join]),
+            ],
+        );
+    }
+
+    #[test]
+    fn reshape_when_guard_columns_are_conditional_influence() {
+        let yaml = r#"
+pipeline: { name: r }
+nodes:
+  - type: source
+    name: plans
+    config:
+      name: plans
+      type: csv
+      path: data/plans.csv
+      options: { has_header: true }
+      schema:
+        - { name: employee_id, type: string }
+        - { name: plan_start, type: int }
+        - { name: plan_end, type: int }
+  - type: reshape
+    name: backfill
+    input: plans
+    config:
+      partition_by: [employee_id]
+      order_by:
+        - { field: plan_start, order: asc }
+      rules:
+        - name: split
+          when: "plan_start - plan_end > 365"
+          mutate:
+            set:
+              plan_end: "plan_start"
+  - type: output
+    name: out
+    input: backfill
+    config: { name: out, type: csv, path: out/r.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let src = "/w/data/plans.csv";
+        use TransformationSubtype::Conditional;
+        // Sorted by (namespace, name, field): plan_end before plan_start.
+        assert_eq!(
+            only_output(&lineage).facet.dataset,
+            vec![
+                indirect(src, "plan_end", &[Conditional]),
+                indirect(src, "plan_start", &[Conditional]),
+            ],
+        );
+    }
+
+    #[test]
+    fn correlation_sort_key_is_sort_influence() {
+        // `PlanNode::Sort` is engine-synthesized only: a source `correlation_key`
+        // makes the enforcer inject a `__correlation_sort_<src>` Sort whose sort
+        // keys are the (real) correlation columns.
+        let yaml = r#"
+pipeline: { name: cs }
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: data/orders.csv
+      options: { has_header: true }
+      correlation_key: [region]
+      schema:
+        - { name: region, type: string }
+        - { name: order_id, type: string }
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: data/events.csv
+      options: { has_header: true }
+      correlation_key: [region]
+      schema:
+        - { name: region, type: string }
+        - { name: order_id, type: string }
+  - type: combine
+    name: joined
+    input: { orders: orders, events: events }
+    config:
+      where: "orders.order_id == events.order_id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit oid = orders.order_id
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config: { name: out, type: csv, path: out/cs.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        use TransformationSubtype::{Join, Sort};
+        assert_eq!(
+            only_output(&lineage).facet.dataset,
+            vec![
+                indirect("/w/data/events.csv", "order_id", &[Join]),
+                indirect("/w/data/events.csv", "region", &[Sort]),
+                indirect("/w/data/orders.csv", "order_id", &[Join]),
+                indirect("/w/data/orders.csv", "region", &[Sort]),
+            ],
+        );
+    }
+
+    #[test]
+    fn indirect_influence_accumulates_downstream() {
+        // A filter (Cull) upstream of a group-by (Aggregation) — both influences
+        // reach the final output's `dataset[]`.
+        let yaml = r#"
+pipeline: { name: acc }
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: csv
+      path: data/s.csv
+      options: { has_header: true }
+      schema:
+        - { name: region, type: string }
+        - { name: amount, type: int }
+  - type: cull
+    name: trim
+    input: s
+    config:
+      partition_by: [region]
+      removed_to: removed
+      rules:
+        - name: drop_big
+          drop_group_when: "sum(amount) > 1000"
+  - type: aggregate
+    name: agg
+    input: trim
+    config:
+      group_by: [region]
+      cxl: |
+        emit region = region
+        emit total = sum(amount)
+  - type: output
+    name: out
+    input: agg
+    config: { name: out, type: csv, path: out/acc.csv }
+  - type: output
+    name: audit
+    input: trim.removed
+    config: { name: audit, type: csv, path: out/audit.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let src = "/w/data/s.csv";
+        use TransformationSubtype::{Filter, GroupBy};
+        // amount (cull filter) and region (group-by) both accumulate at the sink.
+        assert_eq!(
+            output_named(&lineage, "acc.csv").facet.dataset,
+            vec![
+                indirect(src, "amount", &[Filter]),
+                indirect(src, "region", &[GroupBy]),
+            ],
         );
     }
 
@@ -1571,6 +2223,19 @@ nodes:
             fields,
             "category_name",
             &[direct("/w/data/categories.csv", "category_name", Identity)],
+        );
+
+        // JOIN influence accumulates across both decomposed steps, each join key
+        // resolved to its true source (not the intermediate encoded column).
+        use TransformationSubtype::Join;
+        assert_eq!(
+            only_output(&lineage).facet.dataset,
+            vec![
+                indirect("/w/data/categories.csv", "category_id", &[Join]),
+                indirect("/w/data/orders.csv", "product_id", &[Join]),
+                indirect("/w/data/products.csv", "category_id", &[Join]),
+                indirect("/w/data/products.csv", "product_id", &[Join]),
+            ],
         );
     }
 

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -40,6 +40,7 @@ use std::path::Path;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
+use clinker_plan::plan::combine::encode_chain_column;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 use clinker_plan::plan::{CompiledPlan, JoinSide, PlanNodeId, QualifiedField};
 use clinker_record::Schema;
@@ -192,15 +193,22 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                 typed,
                 resolved_column_map,
                 driving_upstream,
+                decomposed_from,
                 ..
             } => {
                 let map: &HashMap<QualifiedField, (JoinSide, u32)> = resolved_column_map;
                 let bare = bare_side_index(map);
                 let probe_idx = *driving_upstream;
+                // The build side is the incoming neighbor that is not the probe.
+                // For a self-join (`input: {a: src, b: src}`) both sides are the same
+                // physical predecessor, so fall back to the probe node — the side
+                // distinction is logical (via `resolved_column_map`'s `JoinSide`), not
+                // a distinct node.
                 let build_idx = dag
                     .graph
                     .neighbors_directed(idx, Direction::Incoming)
-                    .find(|n| Some(*n) != probe_idx);
+                    .find(|n| Some(*n) != probe_idx)
+                    .or(probe_idx);
                 let probe =
                     probe_idx.map(|n| (dag.graph[n].id(), dag.graph[n].output_schema_in(dag)));
                 let build =
@@ -237,6 +245,35 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                             }
                             cols.insert_nonempty(name, terms);
                         });
+                    }
+                    // Intermediate step of an N-ary decomposition: a body-less inner
+                    // join that carries every input column forward by IDENTITY. Its
+                    // output columns are the flat-encoded `__{qualifier}__{field}`
+                    // names, and `resolved_column_map` is a 1:1 cover of them keyed by
+                    // the original `(qualifier, field)`. Keying the lineage entry by
+                    // those encoded names lets the *final* decomposed step resolve its
+                    // probe references straight through this map.
+                    None if decomposed_from.is_some() => {
+                        for (qf, (side, cidx)) in map.iter() {
+                            let resolved = match side {
+                                JoinSide::Probe => probe.as_ref(),
+                                JoinSide::Build => build.as_ref(),
+                            };
+                            if let Some((up_id, schema)) = resolved
+                                && let Some(up_col) = schema.column_name(*cidx as usize)
+                            {
+                                let qualifier =
+                                    qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
+                                let out_name = encode_chain_column(qualifier, qf.name.as_ref());
+                                let mut terms = TermMap::new();
+                                merge_terminals(
+                                    &mut terms,
+                                    lineage.get(up_id).and_then(|m| m.0.get(up_col)),
+                                    Subtype::Identity,
+                                );
+                                cols.insert_nonempty(&out_name, terms);
+                            }
+                        }
                     }
                     None => {
                         // `match: collect`: probe columns pass through by name; any
@@ -1193,5 +1230,132 @@ nodes:
             input_names,
             vec!["/w/data/events.csv", "/w/data/orders.csv"]
         );
+    }
+
+    // -- N-ary / self-join combine --------------------------------------------
+
+    #[test]
+    fn nary_combine_resolves_each_column_through_decomposed_steps() {
+        // A 3-input combine decomposes into two binary steps; columns sourced from
+        // the all-but-last inputs (`order_id`, `product_name`) flow through the
+        // body-less intermediate step. They must resolve by IDENTITY to their true
+        // source, not get smeared as TRANSFORMATION against the last build input.
+        let yaml = r#"
+pipeline: { name: nary }
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: data/orders.csv
+      options: { has_header: true }
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+  - type: source
+    name: products
+    config:
+      name: products
+      type: csv
+      path: data/products.csv
+      options: { has_header: true }
+      schema:
+        - { name: product_id, type: string }
+        - { name: product_name, type: string }
+        - { name: category_id, type: string }
+  - type: source
+    name: categories
+    config:
+      name: categories
+      type: csv
+      path: data/categories.csv
+      options: { has_header: true }
+      schema:
+        - { name: category_id, type: string }
+        - { name: category_name, type: string }
+  - type: combine
+    name: enriched
+    input:
+      orders: orders
+      products: products
+      categories: categories
+    config:
+      where: "orders.product_id == products.product_id and products.category_id == categories.category_id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit order_id = orders.order_id
+        emit product_name = products.product_name
+        emit category_name = categories.category_name
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: enriched
+    config: { name: out, type: csv, path: out/nary.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        use TransformationSubtype::Identity;
+        assert_field(
+            fields,
+            "order_id",
+            &[direct("/w/data/orders.csv", "order_id", Identity)],
+        );
+        assert_field(
+            fields,
+            "product_name",
+            &[direct("/w/data/products.csv", "product_name", Identity)],
+        );
+        assert_field(
+            fields,
+            "category_name",
+            &[direct("/w/data/categories.csv", "category_name", Identity)],
+        );
+    }
+
+    #[test]
+    fn self_join_resolves_both_sides_to_the_same_source() {
+        // `input: {e: emp, m: emp}` — both sides are the same physical predecessor.
+        // The build side must still resolve (it previously dropped to no lineage
+        // because the build neighbor lookup excluded the only incoming node).
+        let yaml = r#"
+pipeline: { name: selfjoin }
+nodes:
+  - type: source
+    name: emp
+    config:
+      name: emp
+      type: csv
+      path: data/emp.csv
+      options: { has_header: true }
+      schema:
+        - { name: id, type: string }
+        - { name: name, type: string }
+        - { name: manager_id, type: string }
+  - type: combine
+    name: pairs
+    input:
+      e: emp
+      m: emp
+    config:
+      where: "e.manager_id == m.id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit emp_name = e.name
+        emit mgr_name = m.name
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: pairs
+    config: { name: out, type: csv, path: out/selfjoin.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        use TransformationSubtype::Identity;
+        assert_field(fields, "emp_name", &[direct("/w/data/emp.csv", "name", Identity)]);
+        // The build side resolves to the same source dataset/column.
+        assert_field(fields, "mgr_name", &[direct("/w/data/emp.csv", "name", Identity)]);
     }
 }

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -50,6 +50,7 @@ use std::sync::Arc;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
+use clinker_plan::config::pipeline_node::MatchMode;
 use clinker_plan::plan::combine::encode_chain_column;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 use clinker_plan::plan::{
@@ -130,21 +131,18 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                 // Explicit field emits, threading `let` and `emit each` scopes.
                 let mut emitted: HashMap<String, TermMap> = HashMap::new();
                 if let Some(payload) = resolved {
-                    // A single-input operator reads bare upstream columns; a
-                    // qualified leaf that is not a loop binding is a struct / system
-                    // access with no single source column to attribute.
+                    // A single-input operator reads upstream columns by name; a
+                    // qualified leaf that is not an in-scope binding is a nested /
+                    // struct access whose source is its base column (`address.city`
+                    // → `address`), mirroring the aggregate and combine paths.
                     let resolve_unbound = |qf: &QualifiedField| -> Option<TermMap> {
-                        qf.qualifier
-                            .is_none()
-                            .then(|| upstream_col(&lineage, up, qf.name.as_ref()).cloned())
-                            .flatten()
+                        let col = qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
+                        upstream_col(&lineage, up, col).cloned()
                     };
-                    let mut let_env = HashMap::new();
-                    let mut each_bindings = HashMap::new();
+                    let mut env = HashMap::new();
                     collect_field_emits(
                         &payload.typed.program.statements,
-                        &mut let_env,
-                        &mut each_bindings,
+                        &mut env,
                         &mut emitted,
                         &resolve_unbound,
                     );
@@ -215,6 +213,7 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                 resolved_column_map,
                 driving_upstream,
                 decomposed_from,
+                match_mode,
                 ..
             } => {
                 let sides = combine_sides(dag, idx, resolved_column_map, *driving_upstream);
@@ -238,13 +237,11 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                             let col = schema.column_name(cidx as usize)?;
                             lineage.get(up_id).and_then(|m| m.0.get(col)).cloned()
                         };
-                        let mut let_env = HashMap::new();
-                        let mut each_bindings = HashMap::new();
+                        let mut env = HashMap::new();
                         let mut emitted: HashMap<String, TermMap> = HashMap::new();
                         collect_field_emits(
                             &tp.program.statements,
-                            &mut let_env,
-                            &mut each_bindings,
+                            &mut env,
                             &mut emitted,
                             &resolve_unbound,
                         );
@@ -258,8 +255,12 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                     // names, and `resolved_column_map` is a 1:1 cover of them keyed by
                     // the original `(qualifier, field)`. Keying the lineage entry by
                     // those encoded names lets the *final* decomposed step resolve its
-                    // probe references straight through this map.
-                    None if decomposed_from.is_some() => {
+                    // probe references straight through this map. A `match: collect`
+                    // step (even when decomposed) has a real collected-array column,
+                    // so it routes to the collect arm, not here.
+                    None if decomposed_from.is_some()
+                        && !matches!(match_mode, MatchMode::Collect) =>
+                    {
                         for (qf, (side, cidx)) in map.iter() {
                             let resolved = match side {
                                 JoinSide::Probe => probe.as_ref(),
@@ -590,7 +591,8 @@ fn program_field_ref_subtype(program: &Program) -> Subtype {
 /// Walk a CXL program's statements collecting, per field-emit target, the
 /// resolved source terminals its value derives from.
 ///
-/// Threads two lexical scopes that a per-emit read-set walk misses:
+/// `env` is one lexical binding scope holding both kinds of in-program name
+/// that a per-emit read-set walk misses:
 ///
 /// - **`let` bindings:** `let x = a + b; emit y = x` — `y` derives from `a`/`b`.
 ///   On each `Let`, the RHS is resolved (against the upstream and earlier
@@ -601,22 +603,26 @@ fn program_field_ref_subtype(program: &Program) -> Subtype {
 ///   array's terminals (as a TRANSFORMATION — element extraction), so a body
 ///   reference to `it` / `it.field` resolves to the array column.
 ///
-/// `resolve_unbound` resolves a leaf that names neither a binding nor a loop
-/// variable — an operator-input column — and differs per node kind (bare
-/// upstream column for Transform; `input.field` via the combine resolver for
-/// Combine). Duplicate field emits are last-wins, matching the runtime.
+/// Both live in one map so the innermost binding of a name wins (a `let` may
+/// shadow a loop variable). `emit each` / `explode` bodies are a lexical block:
+/// the whole `env` is saved on entry and restored on exit, so a body-local
+/// binding never leaks into the enclosing or a sibling scope.
+///
+/// `resolve_unbound` resolves a leaf that names no in-scope binding — an
+/// operator-input column — and differs per node kind (upstream column for
+/// Transform; `input.field` via the combine resolver for Combine). Duplicate
+/// field emits are last-wins, matching the runtime.
 fn collect_field_emits(
     statements: &[Statement],
-    let_env: &mut HashMap<String, TermMap>,
-    each_bindings: &mut HashMap<String, TermMap>,
+    env: &mut HashMap<String, TermMap>,
     emitted: &mut HashMap<String, TermMap>,
     resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
 ) {
     for stmt in statements {
         match stmt {
             Statement::Let { name, expr, .. } => {
-                let terms = resolve_expr_terms(expr, let_env, each_bindings, resolve_unbound);
-                let_env.insert(name.to_string(), terms);
+                let terms = resolve_expr_terms(expr, env, resolve_unbound);
+                env.insert(name.to_string(), terms);
             }
             Statement::Emit {
                 name,
@@ -627,7 +633,7 @@ fn collect_field_emits(
                 if name.starts_with('$') {
                     continue;
                 }
-                let terms = resolve_expr_terms(expr, let_env, each_bindings, resolve_unbound);
+                let terms = resolve_expr_terms(expr, env, resolve_unbound);
                 emitted.insert(name.to_string(), terms);
             }
             Statement::EmitEach {
@@ -642,19 +648,16 @@ fn collect_field_emits(
                 body,
                 ..
             } => {
-                let src = resolve_expr_terms(source, let_env, each_bindings, resolve_unbound);
+                let src = resolve_expr_terms(source, env, resolve_unbound);
                 let mut tagged = TermMap::new();
                 merge_terminals(&mut tagged, Some(&src), Subtype::Transformation);
-                let prev = each_bindings.insert(binding.to_string(), tagged);
-                collect_field_emits(body, let_env, each_bindings, emitted, resolve_unbound);
-                match prev {
-                    Some(p) => {
-                        each_bindings.insert(binding.to_string(), p);
-                    }
-                    None => {
-                        each_bindings.remove(binding.as_ref());
-                    }
-                }
+                // The body is a lexical block: save the scope, bind the loop
+                // variable, recurse, then restore — body-local `let`s and the
+                // loop binding both fall out of scope here.
+                let saved = env.clone();
+                env.insert(binding.to_string(), tagged);
+                collect_field_emits(body, env, emitted, resolve_unbound);
+                *env = saved;
             }
             _ => {}
         }
@@ -666,8 +669,7 @@ fn collect_field_emits(
 /// else TRANSFORMATION) is composed onto every leaf it reads.
 fn resolve_expr_terms(
     expr: &Expr,
-    let_env: &HashMap<String, TermMap>,
-    each_bindings: &HashMap<String, TermMap>,
+    env: &HashMap<String, TermMap>,
     resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
 ) -> TermMap {
     let local = field_ref_subtype(expr);
@@ -675,28 +677,22 @@ fn resolve_expr_terms(
     collect_field_refs(expr, &mut refs);
     let mut out = TermMap::new();
     for qf in &refs {
-        let base = resolve_leaf_terms(qf, let_env, each_bindings, resolve_unbound);
+        let base = resolve_leaf_terms(qf, env, resolve_unbound);
         merge_terminals(&mut out, base.as_ref(), local);
     }
     out
 }
 
-/// Resolve one leaf field reference to its source terminals: an in-scope
-/// `emit each` loop binding (matched by the reference's first segment) wins,
-/// then a bare `let` binding, then `resolve_unbound` (the operator input).
+/// Resolve one leaf field reference to its source terminals: an in-scope binding
+/// (`let` or `emit each` loop variable, matched by the reference's first segment)
+/// wins, then `resolve_unbound` (the operator input).
 fn resolve_leaf_terms(
     qf: &QualifiedField,
-    let_env: &HashMap<String, TermMap>,
-    each_bindings: &HashMap<String, TermMap>,
+    env: &HashMap<String, TermMap>,
     resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
 ) -> Option<TermMap> {
     let first = qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
-    if let Some(terms) = each_bindings.get(first) {
-        return Some(terms.clone());
-    }
-    if qf.qualifier.is_none()
-        && let Some(terms) = let_env.get(qf.name.as_ref())
-    {
+    if let Some(terms) = env.get(first) {
         return Some(terms.clone());
     }
     resolve_unbound(qf)
@@ -925,6 +921,35 @@ fn collect_field_refs(expr: &Expr, out: &mut Vec<QualifiedField>) {
     }
 }
 
+/// Collect every field reference read by a program's statements (`emit` / `let` /
+/// `filter` predicates, and `emit each` source arrays + bodies). Used for the
+/// combine `where:` residual program, whose conjunct columns still influence the
+/// join even though they are neither an equality nor a range.
+fn collect_stmt_field_refs(statements: &[Statement], out: &mut Vec<QualifiedField>) {
+    for stmt in statements {
+        match stmt {
+            Statement::Emit { expr, .. }
+            | Statement::Let { expr, .. }
+            | Statement::ExprStmt { expr, .. } => collect_field_refs(expr, out),
+            Statement::Filter { predicate, .. } => collect_field_refs(predicate, out),
+            Statement::EmitEach { source, body, .. }
+            | Statement::ExplodeOuter { source, body, .. } => {
+                collect_field_refs(source, out);
+                collect_stmt_field_refs(body, out);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// The base (first dotted segment) of an input-column reference: a nested /
+/// struct access (`address.city`) influences via its source column `address`.
+/// Predicate read-sets keep qualified refs as the dotted path, but the upstream
+/// lineage map is keyed by bare column name.
+fn base_col(col: &str) -> &str {
+    col.split('.').next().unwrap_or(col)
+}
+
 /// Map a bare field name to its `(side, index)` when it is unambiguous across the
 /// combine's inputs — mirroring the executor's `bare_to_side` derivation.
 fn bare_side_index(
@@ -1028,23 +1053,33 @@ fn node_indirect_influence(
                     for col in cols {
                         add_upstream_influence(
                             &mut inf,
-                            upstream_col(lineage, up, col),
+                            upstream_col(lineage, up, base_col(col)),
                             IndirectSub::Filter,
                         );
                     }
                 }
             }
         }
-        PlanNode::Cull { .. } => {
+        PlanNode::Cull { config, .. } => {
+            let up = single_upstream(dag, idx);
             if let Some(PredicateSupport::CullDrop(cols)) = predicate_support(node) {
-                let up = single_upstream(dag, idx);
                 for col in &cols {
                     add_upstream_influence(
                         &mut inf,
-                        upstream_col(lineage, up, col),
+                        upstream_col(lineage, up, base_col(col)),
                         IndirectSub::Filter,
                     );
                 }
+            }
+            // `partition_by` groups rows for the per-group drop decision, so the
+            // partition columns influence which rows survive — GROUP_BY, mirroring
+            // Aggregation's group keys.
+            for col in &config.partition_by {
+                add_upstream_influence(
+                    &mut inf,
+                    upstream_col(lineage, up, base_col(col)),
+                    IndirectSub::GroupBy,
+                );
             }
         }
         PlanNode::Aggregation { compiled, .. } => {
@@ -1075,7 +1110,7 @@ fn node_indirect_influence(
                 for col in &reads {
                     add_upstream_influence(
                         &mut inf,
-                        upstream_col(lineage, up, col),
+                        upstream_col(lineage, up, base_col(col)),
                         IndirectSub::Conditional,
                     );
                 }
@@ -1096,6 +1131,11 @@ fn node_indirect_influence(
             for range in &dp.ranges {
                 collect_field_refs(&range.left_expr, &mut refs);
                 collect_field_refs(&range.right_expr, &mut refs);
+            }
+            // Non-equi / non-range conjuncts (`!=`, `or`, function predicates)
+            // live in the residual program; their columns still influence the join.
+            if let Some(residual) = &dp.residual {
+                collect_stmt_field_refs(&residual.program.statements, &mut refs);
             }
             for qf in &refs {
                 let Some((side, cidx)) = resolve_side(qf, sides.map, &sides.bare) else {
@@ -1482,7 +1522,159 @@ nodes:
         );
     }
 
-    // -- INDIRECT influence (#662) --------------------------------------------
+    // -- code-review regressions ----------------------------------------------
+
+    #[test]
+    fn transform_nested_ref_resolves_to_base_column() {
+        // `emit city = addr.city` (struct/nested access) attributes to the base
+        // source column `addr` instead of dropping the output column entirely.
+        let yaml = r#"
+pipeline: { name: tq }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: json
+      options: { format: ndjson }
+      path: data/rows.ndjson
+      schema:
+        - { name: addr, type: any }
+  - type: transform
+    name: t
+    input: rows
+    config: { cxl: "emit city = addr.city" }
+  - type: output
+    name: out
+    input: t
+    config:
+      name: out
+      type: json
+      options: { format: ndjson }
+      path: out/tq.ndjson
+      include_unmapped: false
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        assert_field(
+            fields,
+            "city",
+            &[direct(
+                "/w/data/rows.ndjson",
+                "addr",
+                TransformationSubtype::Identity,
+            )],
+        );
+    }
+
+    #[test]
+    fn combine_residual_conjunct_columns_are_join_influence() {
+        // A non-equi (`!=`) conjunct lands in the decomposed predicate's residual;
+        // its columns still influence the join and must appear in `dataset[]`.
+        let yaml = r#"
+pipeline: { name: cr }
+nodes:
+  - type: source
+    name: a
+    config:
+      name: a
+      type: csv
+      path: data/a.csv
+      options: { has_header: true }
+      schema:
+        - { name: k, type: string }
+        - { name: region, type: string }
+  - type: source
+    name: b
+    config:
+      name: b
+      type: csv
+      path: data/b.csv
+      options: { has_header: true }
+      schema:
+        - { name: k, type: string }
+        - { name: region, type: string }
+  - type: combine
+    name: j
+    input: { a: a, b: b }
+    config:
+      where: "a.k == b.k and a.region != b.region"
+      match: first
+      on_miss: skip
+      cxl: "emit out = a.k"
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: j
+    config: { name: out, type: csv, path: out/cr.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        use TransformationSubtype::Join;
+        assert_eq!(
+            only_output(&lineage).facet.dataset,
+            vec![
+                indirect("/w/data/a.csv", "k", &[Join]),
+                indirect("/w/data/a.csv", "region", &[Join]),
+                indirect("/w/data/b.csv", "k", &[Join]),
+                indirect("/w/data/b.csv", "region", &[Join]),
+            ],
+        );
+    }
+
+    #[test]
+    fn let_in_emit_each_body_does_not_leak() {
+        // A `let` inside an `emit each` body is block-scoped: it must not shadow
+        // a same-named outer binding seen by a later statement. Here the body's
+        // `let total = it` must not survive, so `emit out = total` resolves to the
+        // outer `let total = base`, not the loop array.
+        let yaml = r#"
+pipeline: { name: ll }
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: json
+      options: { format: ndjson }
+      path: data/s.ndjson
+      schema:
+        - { name: base, type: string }
+        - { name: items, type: any }
+  - type: transform
+    name: t
+    input: s
+    config:
+      cxl: |
+        let total = base
+        emit each it in items {
+          let total = it
+        }
+        emit out = total
+  - type: output
+    name: out
+    input: t
+    config:
+      name: out
+      type: json
+      options: { format: ndjson }
+      path: out/ll.ndjson
+      include_unmapped: false
+      exclude: [items]
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        assert_field(
+            fields,
+            "out",
+            &[direct(
+                "/w/data/s.ndjson",
+                "base",
+                TransformationSubtype::Identity,
+            )],
+        );
+    }
+
+    // -- INDIRECT influence --------------------------------------------
 
     #[test]
     fn route_predicate_columns_are_filter_influence_not_per_column() {
@@ -1580,9 +1772,15 @@ nodes:
         let lineage = lineage_of(yaml);
         let src = "/w/data/s.csv";
         let out = output_named(&lineage, "c.csv");
+        use TransformationSubtype::{Filter, GroupBy};
+        // The drop predicate column is FILTER; the partition key is GROUP_BY
+        // (it determines the per-group drop decision). Sorted by field name.
         assert_eq!(
             out.facet.dataset,
-            vec![indirect(src, "amount", &[TransformationSubtype::Filter])],
+            vec![
+                indirect(src, "amount", &[Filter]),
+                indirect(src, "employee_id", &[GroupBy]),
+            ],
         );
     }
 
@@ -2274,6 +2472,69 @@ nodes:
                 indirect("/w/data/products.csv", "category_id", &[Join]),
                 indirect("/w/data/products.csv", "product_id", &[Join]),
             ],
+        );
+    }
+
+    #[test]
+    fn four_input_combine_resolves_every_column_through_all_steps() {
+        // A 4-input join decomposes into three binary steps; columns from the
+        // earliest-joined inputs flow through two intermediate steps and must
+        // still resolve to their true source by IDENTITY.
+        let yaml = r#"
+pipeline: { name: four }
+nodes:
+  - type: source
+    name: a
+    config: { name: a, type: csv, path: data/a.csv, options: { has_header: true }, schema: [ { name: id, type: string }, { name: a_val, type: string } ] }
+  - type: source
+    name: b
+    config: { name: b, type: csv, path: data/b.csv, options: { has_header: true }, schema: [ { name: id, type: string }, { name: b_val, type: string } ] }
+  - type: source
+    name: c
+    config: { name: c, type: csv, path: data/c.csv, options: { has_header: true }, schema: [ { name: id, type: string }, { name: c_val, type: string } ] }
+  - type: source
+    name: d
+    config: { name: d, type: csv, path: data/d.csv, options: { has_header: true }, schema: [ { name: id, type: string }, { name: d_val, type: string } ] }
+  - type: combine
+    name: j
+    input: { a: a, b: b, c: c, d: d }
+    config:
+      where: "a.id == b.id and b.id == c.id and c.id == d.id"
+      match: first
+      on_miss: skip
+      cxl: |
+        emit a_val = a.a_val
+        emit b_val = b.b_val
+        emit c_val = c.c_val
+        emit d_val = d.d_val
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: j
+    config: { name: out, type: csv, path: out/four.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        use TransformationSubtype::Identity;
+        assert_field(
+            fields,
+            "a_val",
+            &[direct("/w/data/a.csv", "a_val", Identity)],
+        );
+        assert_field(
+            fields,
+            "b_val",
+            &[direct("/w/data/b.csv", "b_val", Identity)],
+        );
+        assert_field(
+            fields,
+            "c_val",
+            &[direct("/w/data/c.csv", "c_val", Identity)],
+        );
+        assert_field(
+            fields,
+            "d_val",
+            &[direct("/w/data/d.csv", "d_val", Identity)],
         );
     }
 

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -44,7 +44,7 @@ use clinker_plan::plan::combine::encode_chain_column;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 use clinker_plan::plan::{CompiledPlan, JoinSide, PlanNodeId, QualifiedField};
 use clinker_record::Schema;
-use cxl::ast::{Expr, Program, for_each_field_emit, program_support_into};
+use cxl::ast::{EmitTarget, Expr, Program, Statement, for_each_field_emit, program_support_into};
 use cxl::plan::BindingArg;
 
 use crate::dataset::{DatasetId, dataset_identity};
@@ -112,21 +112,27 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
 
             PlanNode::Transform { resolved, .. } => {
                 let up = single_upstream(dag, idx);
-                // Explicit field emits (recursing through `emit each` fan-out).
+                // Explicit field emits, threading `let` and `emit each` scopes.
                 let mut emitted: HashMap<String, TermMap> = HashMap::new();
                 if let Some(payload) = resolved {
-                    for_each_field_emit(&payload.typed.program.statements, &mut |name, expr| {
-                        if name.starts_with('$') {
-                            return;
-                        }
-                        let local = field_ref_subtype(expr);
-                        let mut reads = HashSet::new();
-                        expr.support_into(&mut reads);
-                        let slot = emitted.entry(name.to_string()).or_default();
-                        for r in &reads {
-                            merge_terminals(slot, upstream_col(&lineage, up, r), local);
-                        }
-                    });
+                    // A single-input operator reads bare upstream columns; a
+                    // qualified leaf that is not a loop binding is a struct / system
+                    // access with no single source column to attribute.
+                    let resolve_unbound = |qf: &QualifiedField| -> Option<TermMap> {
+                        qf.qualifier
+                            .is_none()
+                            .then(|| upstream_col(&lineage, up, qf.name.as_ref()).cloned())
+                            .flatten()
+                    };
+                    let mut let_env = HashMap::new();
+                    let mut each_bindings = HashMap::new();
+                    collect_field_emits(
+                        &payload.typed.program.statements,
+                        &mut let_env,
+                        &mut each_bindings,
+                        &mut emitted,
+                        &resolve_unbound,
+                    );
                 }
                 // Output schema = explicit emits + open-row passthrough of the rest.
                 let mut cols = ColumnTerminals::new();
@@ -217,34 +223,31 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                 let mut cols = ColumnTerminals::new();
                 match typed {
                     Some(tp) => {
-                        for_each_field_emit(&tp.program.statements, &mut |name, expr| {
-                            if name.starts_with('$') {
-                                return;
-                            }
-                            let local = field_ref_subtype(expr);
-                            let mut refs = Vec::new();
-                            collect_combine_refs(expr, &mut refs);
-                            let mut terms = TermMap::new();
-                            for qf in &refs {
-                                let Some((side, cidx)) = resolve_side(qf, map, &bare) else {
-                                    continue;
-                                };
-                                let resolved = match side {
-                                    JoinSide::Probe => probe.as_ref(),
-                                    JoinSide::Build => build.as_ref(),
-                                };
-                                if let Some((up_id, schema)) = resolved
-                                    && let Some(col) = schema.column_name(cidx as usize)
-                                {
-                                    merge_terminals(
-                                        &mut terms,
-                                        lineage.get(up_id).and_then(|m| m.0.get(col)),
-                                        local,
-                                    );
-                                }
-                            }
-                            cols.insert_nonempty(name, terms);
-                        });
+                        // A combine body reads `input.field` references resolved
+                        // through the side map; `let` / `emit each` scopes thread the
+                        // same way as a Transform.
+                        let resolve_unbound = |qf: &QualifiedField| -> Option<TermMap> {
+                            let (side, cidx) = resolve_side(qf, map, &bare)?;
+                            let (up_id, schema) = match side {
+                                JoinSide::Probe => probe.as_ref()?,
+                                JoinSide::Build => build.as_ref()?,
+                            };
+                            let col = schema.column_name(cidx as usize)?;
+                            lineage.get(up_id).and_then(|m| m.0.get(col)).cloned()
+                        };
+                        let mut let_env = HashMap::new();
+                        let mut each_bindings = HashMap::new();
+                        let mut emitted: HashMap<String, TermMap> = HashMap::new();
+                        collect_field_emits(
+                            &tp.program.statements,
+                            &mut let_env,
+                            &mut each_bindings,
+                            &mut emitted,
+                            &resolve_unbound,
+                        );
+                        for (name, terms) in emitted {
+                            cols.insert_nonempty(&name, terms);
+                        }
                     }
                     // Intermediate step of an N-ary decomposition: a body-less inner
                     // join that carries every input column forward by IDENTITY. Its
@@ -542,6 +545,125 @@ fn program_field_ref_subtype(program: &Program) -> Subtype {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Program-aware emit walker
+// ---------------------------------------------------------------------------
+
+/// Walk a CXL program's statements collecting, per field-emit target, the
+/// resolved source terminals its value derives from.
+///
+/// Threads two lexical scopes that a per-emit read-set walk misses:
+///
+/// - **`let` bindings:** `let x = a + b; emit y = x` — `y` derives from `a`/`b`.
+///   On each `Let`, the RHS is resolved (against the upstream and earlier
+///   bindings) and stored, so a later reference to the binding name expands to
+///   its terminals rather than resolving to nothing.
+/// - **`emit each` loop bindings:** `emit each it in items { emit sku = it.sku }`
+///   — `sku` derives from `items`. The loop binding is bound to the source
+///   array's terminals (as a TRANSFORMATION — element extraction), so a body
+///   reference to `it` / `it.field` resolves to the array column.
+///
+/// `resolve_unbound` resolves a leaf that names neither a binding nor a loop
+/// variable — an operator-input column — and differs per node kind (bare
+/// upstream column for Transform; `input.field` via the combine resolver for
+/// Combine). Duplicate field emits are last-wins, matching the runtime.
+fn collect_field_emits(
+    statements: &[Statement],
+    let_env: &mut HashMap<String, TermMap>,
+    each_bindings: &mut HashMap<String, TermMap>,
+    emitted: &mut HashMap<String, TermMap>,
+    resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
+) {
+    for stmt in statements {
+        match stmt {
+            Statement::Let { name, expr, .. } => {
+                let terms = resolve_expr_terms(expr, let_env, each_bindings, resolve_unbound);
+                let_env.insert(name.to_string(), terms);
+            }
+            Statement::Emit {
+                name,
+                expr,
+                target: EmitTarget::Field,
+                ..
+            } => {
+                if name.starts_with('$') {
+                    continue;
+                }
+                let terms = resolve_expr_terms(expr, let_env, each_bindings, resolve_unbound);
+                emitted.insert(name.to_string(), terms);
+            }
+            Statement::EmitEach {
+                binding,
+                source,
+                body,
+                ..
+            }
+            | Statement::ExplodeOuter {
+                binding,
+                source,
+                body,
+                ..
+            } => {
+                let src = resolve_expr_terms(source, let_env, each_bindings, resolve_unbound);
+                let mut tagged = TermMap::new();
+                merge_terminals(&mut tagged, Some(&src), Subtype::Transformation);
+                let prev = each_bindings.insert(binding.to_string(), tagged);
+                collect_field_emits(body, let_env, each_bindings, emitted, resolve_unbound);
+                match prev {
+                    Some(p) => {
+                        each_bindings.insert(binding.to_string(), p);
+                    }
+                    None => {
+                        each_bindings.remove(binding.as_ref());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Resolve the source terminals an emit/let RHS expression derives from. The
+/// whole expression's [`field_ref_subtype`] (IDENTITY for a bare copy/rename,
+/// else TRANSFORMATION) is composed onto every leaf it reads.
+fn resolve_expr_terms(
+    expr: &Expr,
+    let_env: &HashMap<String, TermMap>,
+    each_bindings: &HashMap<String, TermMap>,
+    resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
+) -> TermMap {
+    let local = field_ref_subtype(expr);
+    let mut refs = Vec::new();
+    collect_field_refs(expr, &mut refs);
+    let mut out = TermMap::new();
+    for qf in &refs {
+        let base = resolve_leaf_terms(qf, let_env, each_bindings, resolve_unbound);
+        merge_terminals(&mut out, base.as_ref(), local);
+    }
+    out
+}
+
+/// Resolve one leaf field reference to its source terminals: an in-scope
+/// `emit each` loop binding (matched by the reference's first segment) wins,
+/// then a bare `let` binding, then `resolve_unbound` (the operator input).
+fn resolve_leaf_terms(
+    qf: &QualifiedField,
+    let_env: &HashMap<String, TermMap>,
+    each_bindings: &HashMap<String, TermMap>,
+    resolve_unbound: &impl Fn(&QualifiedField) -> Option<TermMap>,
+) -> Option<TermMap> {
+    let first = qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
+    if let Some(terms) = each_bindings.get(first) {
+        return Some(terms.clone());
+    }
+    if qf.qualifier.is_none()
+        && let Some(terms) = let_env.get(qf.name.as_ref())
+    {
+        return Some(terms.clone());
+    }
+    resolve_unbound(qf)
+}
+
 /// The input column(s) and DIRECT subtype each contributing to one aggregate
 /// output column, read off the post-extraction `residual`.
 fn aggregate_emit_sources(
@@ -678,12 +800,15 @@ fn binding_arg_input_names(arg: &BindingArg, schema: Option<&Schema>) -> Vec<Str
 }
 
 // ---------------------------------------------------------------------------
-// Combine reference resolution
+// Field-reference collection and resolution
 // ---------------------------------------------------------------------------
 
-/// Collect every field reference (as a [`QualifiedField`]) read by a combine
-/// body expression, skipping system (`$`) namespaces.
-fn collect_combine_refs(expr: &Expr, out: &mut Vec<QualifiedField>) {
+/// Collect every field reference (as a [`QualifiedField`]) read by an
+/// expression, skipping system (`$`) namespaces. A bare `FieldRef` yields a
+/// bare `QualifiedField`; a `QualifiedFieldRef` yields the (qualifier, field)
+/// pair — used both for combine `input.field` resolution and for detecting an
+/// `emit each` loop-binding reference by its first segment.
+fn collect_field_refs(expr: &Expr, out: &mut Vec<QualifiedField>) {
     match expr {
         Expr::FieldRef { name, .. } => {
             if !name.starts_with('$') {
@@ -706,49 +831,49 @@ fn collect_combine_refs(expr: &Expr, out: &mut Vec<QualifiedField>) {
             }
         }
         Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
-            collect_combine_refs(lhs, out);
-            collect_combine_refs(rhs, out);
+            collect_field_refs(lhs, out);
+            collect_field_refs(rhs, out);
         }
-        Expr::Unary { operand, .. } => collect_combine_refs(operand, out),
+        Expr::Unary { operand, .. } => collect_field_refs(operand, out),
         Expr::IfThenElse {
             condition,
             then_branch,
             else_branch,
             ..
         } => {
-            collect_combine_refs(condition, out);
-            collect_combine_refs(then_branch, out);
+            collect_field_refs(condition, out);
+            collect_field_refs(then_branch, out);
             if let Some(eb) = else_branch {
-                collect_combine_refs(eb, out);
+                collect_field_refs(eb, out);
             }
         }
         Expr::Match { subject, arms, .. } => {
             if let Some(s) = subject {
-                collect_combine_refs(s, out);
+                collect_field_refs(s, out);
             }
             for arm in arms {
-                collect_combine_refs(&arm.pattern, out);
-                collect_combine_refs(&arm.body, out);
+                collect_field_refs(&arm.pattern, out);
+                collect_field_refs(&arm.body, out);
             }
         }
         Expr::MethodCall { receiver, args, .. } => {
-            collect_combine_refs(receiver, out);
+            collect_field_refs(receiver, out);
             for a in args {
-                collect_combine_refs(a, out);
+                collect_field_refs(a, out);
             }
         }
         Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
             for a in args {
-                collect_combine_refs(a, out);
+                collect_field_refs(a, out);
             }
         }
         Expr::IndexAccess {
             receiver, index, ..
         } => {
-            collect_combine_refs(receiver, out);
-            collect_combine_refs(index, out);
+            collect_field_refs(receiver, out);
+            collect_field_refs(index, out);
         }
-        Expr::Closure { body, .. } => collect_combine_refs(body, out),
+        Expr::Closure { body, .. } => collect_field_refs(body, out),
         _ => {}
     }
 }
@@ -1040,6 +1165,141 @@ nodes:
             &[direct(
                 "/w/data/s.csv",
                 "raw",
+                TransformationSubtype::Identity,
+            )],
+        );
+    }
+
+    // -- let / emit each / duplicate emit -------------------------------------
+
+    #[test]
+    fn let_bound_intermediate_resolves_to_its_source_reads() {
+        // `let x = a + b; emit y = x` — `y` derives from `a` and `b` even though
+        // the emit RHS names only the let binding.
+        let yaml = r#"
+pipeline: { name: letbind }
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: csv
+      path: data/s.csv
+      options: { has_header: true }
+      schema:
+        - { name: a, type: int }
+        - { name: b, type: int }
+  - type: transform
+    name: t
+    input: s
+    config:
+      cxl: |
+        let x = a + b
+        emit y = x
+  - type: output
+    name: out
+    input: t
+    config: { name: out, type: csv, path: out/letbind.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        let src = "/w/data/s.csv";
+        use TransformationSubtype::Transformation;
+        assert_field(
+            fields,
+            "y",
+            &[
+                direct(src, "a", Transformation),
+                direct(src, "b", Transformation),
+            ],
+        );
+    }
+
+    #[test]
+    fn emit_each_resolves_body_to_the_source_array_column() {
+        // `emit each it in items { emit sku = it["sku"] }` — `sku` derives from the
+        // `items` source array column, not from nothing.
+        let yaml = r#"
+pipeline: { name: explode }
+nodes:
+  - type: source
+    name: rows
+    config:
+      name: rows
+      type: json
+      options: { format: ndjson }
+      path: data/rows.ndjson
+      schema:
+        - { name: items, type: any }
+  - type: transform
+    name: explode
+    input: rows
+    config:
+      cxl: |
+        emit each it in items {
+          emit sku = it["sku"]
+        }
+  - type: output
+    name: out
+    input: explode
+    config:
+      name: out
+      type: json
+      options: { format: ndjson }
+      path: out/explode.ndjson
+      include_unmapped: false
+      exclude: [items]
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        assert_field(
+            fields,
+            "sku",
+            &[direct(
+                "/w/data/rows.ndjson",
+                "items",
+                TransformationSubtype::Transformation,
+            )],
+        );
+    }
+
+    #[test]
+    fn duplicate_emit_is_last_wins() {
+        // Two top-level emits to one column: only the last reaches the sink, so the
+        // lineage lists only the last source (matching the runtime).
+        let yaml = r#"
+pipeline: { name: dup }
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: csv
+      path: data/s.csv
+      options: { has_header: true }
+      schema:
+        - { name: list_price, type: float }
+        - { name: sale_price, type: float }
+  - type: transform
+    name: t
+    input: s
+    config:
+      cxl: |
+        emit price = list_price
+        emit price = sale_price
+  - type: output
+    name: out
+    input: t
+    config: { name: out, type: csv, path: out/dup.csv }
+"#;
+        let lineage = lineage_of(yaml);
+        let fields = &only_output(&lineage).facet.fields;
+        assert_field(
+            fields,
+            "price",
+            &[direct(
+                "/w/data/s.csv",
+                "sale_price",
                 TransformationSubtype::Identity,
             )],
         );

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -1,35 +1,44 @@
-//! DIRECT column-level lineage: walk a compiled plan back to its sources.
+//! Column-level lineage: walk a compiled plan back to its sources.
 //!
 //! [`column_lineage`] walks `compiled.dag()` in topological order and, for every
-//! output (sink) dataset column, resolves the **Source** dataset columns its
-//! *value* is derived from — DIRECT lineage in OpenLineage terms — populating the
-//! [`ColumnLineageDatasetFacet::fields`] map. Dataset identity comes from
-//! [`crate::dataset::dataset_identity`] (#660); value derivation is read off each
-//! operator's retained typed/compiled program.
+//! output (sink) dataset, computes two kinds of OpenLineage column lineage:
 //!
-//! Because topo order processes every upstream node first, the working map always
-//! stores terminals already resolved back to a Source dataset column — never an
+//! - **DIRECT** (value-derivation): for each output column, the **Source**
+//!   dataset columns its *value* is derived from, in
+//!   [`ColumnLineageDatasetFacet::fields`].
+//! - **INDIRECT** (influence): the Source columns that influence the dataset as a
+//!   whole — filtering (Route / Cull), joining (Combine), grouping (Aggregation),
+//!   sorting (Sort), conditional reshaping (Reshape `when:`) — collected once in
+//!   [`ColumnLineageDatasetFacet::dataset`].
+//!
+//! Dataset identity comes from [`crate::dataset::dataset_identity`] (#660); value
+//! derivation and influence are read off each operator's retained typed/compiled
+//! program.
+//!
+//! Because topo order processes every upstream node first, the working maps store
+//! terminals already resolved back to a Source dataset column — never an
 //! intermediate reference — so a rename (`emit full = name`) or a multi-hop chain
-//! collapses naturally: the stored `field` is the *source* column, the map key is
-//! the *local* output column.
+//! collapses naturally, and an upstream filter/join influence flows through every
+//! downstream node to the sink.
 //!
 //! ## Subtype model
 //!
-//! Each input→output link carries one DIRECT [`TransformationSubtype`]. Along a
+//! Each DIRECT input→output link carries one [`TransformationSubtype`]; along a
 //! path the dominant subtype wins, ranked `IDENTITY < TRANSFORMATION <
 //! AGGREGATION` (identity is transparent; an aggregate anywhere on the path
-//! dominates). The OpenLineage per-hop transformation *chain* is collapsed to this
-//! single dominant subtype.
+//! dominates). INDIRECT influences carry the per-node subtype (`FILTER` / `JOIN` /
+//! `GROUP_BY` / `SORT` / `CONDITIONAL`) and accumulate downstream unchanged.
 //!
 //! ## Documented limitations
 //!
-//! - **INDIRECT** influence lineage (filter / join / group-by / sort) is not
-//!   populated here — [`ColumnLineageDatasetFacet::dataset`] is left empty (#662).
 //! - **Composition** nodes are treated opaquely: every output column derives from
 //!   every composition input column. Precise traversal is a #653 follow-up.
 //! - **Envelope** / `$doc` provenance is best-effort same-name passthrough only;
 //!   precise envelope lineage is a #653 follow-up.
 //! - A `match: collect` combine (no projection body) is resolved coarsely.
+//! - INDIRECT influence covers the predicate / grouping / sort surfaces above; an
+//!   aggregate's pre-aggregation row `filter`, a Transform-inline `filter`, and
+//!   Reshape `order_by` / `partition_by` are not (yet) attributed as influence.
 //! - Constant and `count(*)` columns (no source input) are omitted from `fields`.
 //! - Engine-stamped columns (`$ck.*` / `$meta.*` / `$source.*` / `$widened`) are
 //!   skipped, mirroring the default-writer strip.
@@ -259,8 +268,7 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                             if let Some((up_id, schema)) = resolved
                                 && let Some(up_col) = schema.column_name(*cidx as usize)
                             {
-                                let qualifier =
-                                    qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
+                                let qualifier = qf.qualifier.as_deref().unwrap_or(qf.name.as_ref());
                                 let out_name = encode_chain_column(qualifier, qf.name.as_ref());
                                 let mut terms = TermMap::new();
                                 merge_terminals(
@@ -758,6 +766,15 @@ fn collect_agg_leaves<'a>(expr: &'a Expr, out: &mut Vec<AggLeaf<'a>>) {
         Expr::FieldRef { name, .. } => {
             if !name.starts_with('$') {
                 out.push(AggLeaf::Field(name));
+            }
+        }
+        Expr::QualifiedFieldRef { parts, .. } => {
+            // Aggregates are single-input; a qualified ref in a residual carries
+            // its base column in the first segment.
+            if let Some(first) = parts.first()
+                && !first.starts_with('$')
+            {
+                out.push(AggLeaf::Field(first.as_ref()));
             }
         }
         Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
@@ -1308,10 +1325,7 @@ mod tests {
     }
 
     /// The output dataset whose name contains `substr` (for multi-output plans).
-    fn output_named<'a>(
-        lineage: &'a PlanColumnLineage,
-        substr: &str,
-    ) -> &'a OutputColumnLineage {
+    fn output_named<'a>(lineage: &'a PlanColumnLineage, substr: &str) -> &'a OutputColumnLineage {
         lineage
             .outputs
             .iter()
@@ -1514,7 +1528,11 @@ nodes:
         );
         // The influence is NOT duplicated into the per-column DIRECT lineage:
         // `amount` still passes through as a plain DIRECT identity column.
-        assert_field(&hi.facet.fields, "amount", &[direct(src, "amount", Identity)]);
+        assert_field(
+            &hi.facet.fields,
+            "amount",
+            &[direct(src, "amount", Identity)],
+        );
         for fl in hi.facet.fields.values() {
             assert!(
                 fl.input_fields
@@ -2007,6 +2025,26 @@ nodes:
         );
     }
 
+    #[test]
+    fn agg_residual_qualified_ref_contributes_a_leaf() {
+        // A qualified field ref in an aggregate residual (low-likelihood — an
+        // aggregate is single-input) is no longer silently dropped: its base
+        // column contributes a leaf instead of falling through the catch-all.
+        use cxl::ast::NodeId;
+        use cxl::lexer::Span;
+        let expr = Expr::QualifiedFieldRef {
+            node_id: NodeId(0),
+            parts: vec!["amount".into(), "cents".into()].into(),
+            span: Span::default(),
+        };
+        let mut leaves = Vec::new();
+        collect_agg_leaves(&expr, &mut leaves);
+        assert!(
+            matches!(leaves.as_slice(), [AggLeaf::Field("amount")]),
+            "qualified ref base column must contribute a leaf"
+        );
+    }
+
     // -- Reshape --------------------------------------------------------------
 
     #[test]
@@ -2279,8 +2317,16 @@ nodes:
         let lineage = lineage_of(yaml);
         let fields = &only_output(&lineage).facet.fields;
         use TransformationSubtype::Identity;
-        assert_field(fields, "emp_name", &[direct("/w/data/emp.csv", "name", Identity)]);
+        assert_field(
+            fields,
+            "emp_name",
+            &[direct("/w/data/emp.csv", "name", Identity)],
+        );
         // The build side resolves to the same source dataset/column.
-        assert_field(fields, "mgr_name", &[direct("/w/data/emp.csv", "name", Identity)]);
+        assert_field(
+            fields,
+            "mgr_name",
+            &[direct("/w/data/emp.csv", "name", Identity)],
+        );
     }
 }

--- a/crates/clinker-lineage/src/lib.rs
+++ b/crates/clinker-lineage/src/lib.rs
@@ -4,13 +4,13 @@
 //! vendor-neutral open standard for dataset and column-level lineage. The
 //! [`openlineage`] module owns the wire data model and an NDJSON writer; the
 //! [`dataset`] module maps each Source/Output node to its OpenLineage dataset
-//! identity; and the [`builder`] module walks a compiled plan to compute DIRECT
+//! identity; and the [`builder`] module walks a compiled plan to compute
 //! column-level lineage from those identities.
 //!
-//! [`builder::column_lineage`] populates only DIRECT (value-derivation) lineage.
-//! INDIRECT influence (filter / join / group-by / sort), precise composition and
-//! envelope (`$doc`) traversal are deliberately out of scope here; see that
-//! module's documented limitations.
+//! [`builder::column_lineage`] populates both DIRECT (value-derivation) per-column
+//! lineage and whole-dataset INDIRECT influence (filter / join / group-by / sort /
+//! conditional). Precise composition and envelope (`$doc`) traversal remain out of
+//! scope; see that module's documented limitations.
 //!
 //! The model is pinned to OpenLineage core spec `2-0-2` and the
 //! `ColumnLineageDatasetFacet` `1-2-0`. No general-purpose Rust OpenLineage client

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -1362,7 +1362,7 @@ pub(crate) const MAX_COMBINE_INPUTS: usize = 8;
 /// from author-declared field names which never legally start with
 /// `__` (CXL identifiers begin with `[A-Za-z_]` but pipeline-author
 /// fields by convention do not lead with double-underscore).
-pub(crate) fn encode_chain_column(qualifier: &str, name: &str) -> String {
+pub fn encode_chain_column(qualifier: &str, name: &str) -> String {
     format!("__{qualifier}__{name}")
 }
 

--- a/docs/ai/30_DESIGN_RULES.md
+++ b/docs/ai/30_DESIGN_RULES.md
@@ -178,7 +178,7 @@ Existing files under `docs/*` may be stale. Treat them as secondary context only
   functions, variants, tests, and commands that support a rule.
 - Separate verified facts from hypotheses and stale references. Current example:
   older docs mention `clinker-core` and "11 workspace crates", while the current
-  root workspace has 13 members and separate `clinker-plan` / `clinker-exec` /
+  root workspace has 14 members and separate `clinker-plan` / `clinker-exec` /
   `clinker-core-types` crates.
 - Do not write marketing copy in AI-facing docs. Keep rules actionable for a
   future engineer or coding agent deciding whether a change crosses an


### PR DESCRIPTION
## Summary

Adds whole-dataset **INDIRECT** influence lineage to `clinker-lineage` (#662) and fixes several **DIRECT** column-lineage correctness gaps found after the builder first landed (#690). Column lineage is computed at plan time and is not yet wired to a user-facing surface (that lands in #663), so there is no runtime or pipeline-output behavior change.

## INDIRECT influence lineage (#662)

`column_lineage` now populates the OpenLineage `ColumnLineageDatasetFacet.dataset[]` array — the source columns that influence a dataset as a whole without their value flowing into a specific output column. Influence accumulates downstream: a filter, join, group-by, or sort anywhere upstream of an output appears in that output's `dataset[]`.

| Operator | Influencing columns | Subtype |
|----------|---------------------|---------|
| Route / Cull | branch / drop-group predicate columns | `FILTER` |
| Combine | `where:` join keys | `JOIN` |
| Aggregation | `group_by` columns | `GROUP_BY` |
| Sort | sort keys | `SORT` |
| Reshape | rule `when:` guard columns | `CONDITIONAL` |

Each influencing column is resolved back to its source dataset column and emitted once in the top-level `dataset[]` array — not duplicated into per-column `inputFields`.

Standalone `Sort` nodes are engine-synthesized (a source `correlation_key:` injects a correlation sort); they are not authored directly in YAML, so the `SORT` path is exercised through a `correlation_key` pipeline.

Out of scope for this change (documented as limitations in the module): an aggregate's pre-aggregation row filter, a Transform-inline `filter`, and Reshape `order_by` / `partition_by` are not yet attributed as influence.

## DIRECT lineage correctness fixes (#690)

- **let-bindings** — `let x = a + b; emit y = x` now attributes `y` to `a`/`b` instead of dropping the column.
- **emit-each sources** — `emit each it in items { emit sku = it.sku }` now attributes `sku` to the `items` source array.
- **N-ary (3+ input) joins** — columns carried through the intermediate join-decomposition steps now resolve to their true source by identity instead of being smeared against the last joined input. This shares the executor's chain-column encoder, now exposed as `pub`.
- **self-joins** (`input: {a: src, b: src}`) — the build side now resolves instead of dropping its lineage.
- **duplicate emits** to one column are last-wins, matching runtime behavior.
- **two outputs naming one dataset** now union their per-column lineage and their influences.
- a **qualified field reference in an aggregate residual** now contributes lineage.

The Transform and Combine read-collection is unified into one program-aware walker that threads `let` and `emit each` scopes; the combine side resolution (including the self-join fallback) is factored into a shared helper used by both the value-derivation and the join-influence paths.

## Tests

48 `clinker-lineage` unit tests (13 new), covering each INDIRECT subtype, downstream accumulation, N-ary join-key influence, and a regression test per #690 correctness fix.

## Validation

- `cargo test -p clinker-lineage` — 48 passed
- `cargo test -p clinker-plan` — 451 passed (`encode_chain_column` widened to `pub`)
- `cargo build -p clinker`, `cargo fmt --all --check`, `cargo clippy --all-targets` — clean

Closes #662
Closes #690
