### PR TITLE
clinker: add --lineage flag to export OpenLineage column lineage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "clinker-core-types",
  "clinker-exec",
  "clinker-format",
+ "clinker-lineage",
  "clinker-net",
  "clinker-plan",
  "clinker-record",

--- a/crates/clinker-lineage/src/emit.rs
+++ b/crates/clinker-lineage/src/emit.rs
@@ -1,0 +1,172 @@
+//! Assemble a built column lineage into an OpenLineage run-event pair.
+//!
+//! [`column_lineage`](crate::column_lineage) computes dataset identities and the
+//! per-output column-lineage facet but stays free of run-lifecycle concerns — it
+//! has no run id and no clock. This module is the bridge to the wire model: it
+//! pairs a `START` and a `COMPLETE` [`RunEvent`] under one `run_id`, attaching the
+//! column-lineage facet to the `COMPLETE` event's output datasets, per the
+//! finite-batch convention documented on [`RunEvent`].
+//!
+//! `run_id` and `event_time` are caller-supplied; this crate has no UUID or clock
+//! dependency, so the CLI passes the run's `execution_id` and a UTC timestamp.
+
+use crate::builder::PlanColumnLineage;
+use crate::openlineage::{
+    Dataset, DatasetFacets, EventType, Job, OPENLINEAGE_SCHEMA_URL, PRODUCER, Run, RunEvent,
+};
+
+/// Build the `[START, COMPLETE]` OpenLineage event pair describing one run's
+/// column lineage.
+///
+/// Both events share `run_id`, `job`, `event_time`, and the [`PRODUCER`] /
+/// [`OPENLINEAGE_SCHEMA_URL`] stamps. The `START` event announces the run with no
+/// datasets; the `COMPLETE` event carries the input datasets (facet-less) and the
+/// output datasets, each bearing its `columnLineage` facet. This is a static,
+/// plan-derived export, so a single `event_time` is used for both events.
+pub fn run_events(
+    lineage: &PlanColumnLineage,
+    run_id: &str,
+    job: Job,
+    event_time: &str,
+) -> Vec<RunEvent> {
+    let run = Run {
+        run_id: run_id.to_string(),
+    };
+    let start = RunEvent {
+        event_time: event_time.to_string(),
+        producer: PRODUCER.to_string(),
+        schema_url: OPENLINEAGE_SCHEMA_URL.to_string(),
+        event_type: EventType::Start,
+        run: run.clone(),
+        job: job.clone(),
+        inputs: Vec::new(),
+        outputs: Vec::new(),
+    };
+
+    let inputs: Vec<Dataset> = lineage.inputs.iter().cloned().map(Dataset::from).collect();
+    let outputs: Vec<Dataset> = lineage
+        .outputs
+        .iter()
+        .map(|out| {
+            let mut dataset = Dataset::from(out.dataset.clone());
+            dataset.facets = Some(DatasetFacets {
+                column_lineage: Some(out.facet.clone()),
+            });
+            dataset
+        })
+        .collect();
+
+    let complete = RunEvent {
+        event_time: event_time.to_string(),
+        producer: PRODUCER.to_string(),
+        schema_url: OPENLINEAGE_SCHEMA_URL.to_string(),
+        event_type: EventType::Complete,
+        run,
+        job,
+        inputs,
+        outputs,
+    };
+
+    vec![start, complete]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::builder::OutputColumnLineage;
+    use crate::dataset::DatasetId;
+    use crate::openlineage::{
+        CLINKER_PIPELINE_FACET_SCHEMA_URL, COLUMN_LINEAGE_FACET_SCHEMA_URL,
+        ColumnLineageDatasetFacet, JobFacets, PipelineJobFacet,
+    };
+    use std::collections::BTreeMap;
+
+    fn sample_lineage() -> PlanColumnLineage {
+        PlanColumnLineage {
+            inputs: vec![DatasetId {
+                namespace: "file".to_string(),
+                name: "/w/data/in.csv".to_string(),
+            }],
+            outputs: vec![OutputColumnLineage {
+                dataset: DatasetId {
+                    namespace: "file".to_string(),
+                    name: "/w/out/out.csv".to_string(),
+                },
+                facet: ColumnLineageDatasetFacet {
+                    producer: PRODUCER.to_string(),
+                    schema_url: COLUMN_LINEAGE_FACET_SCHEMA_URL.to_string(),
+                    fields: BTreeMap::new(),
+                    dataset: Vec::new(),
+                },
+            }],
+        }
+    }
+
+    fn sample_job() -> Job {
+        Job {
+            namespace: "clinker".to_string(),
+            name: "demo".to_string(),
+            facets: Some(JobFacets {
+                clinker_pipeline: Some(PipelineJobFacet {
+                    producer: PRODUCER.to_string(),
+                    schema_url: CLINKER_PIPELINE_FACET_SCHEMA_URL.to_string(),
+                    source_hash: "abc123".to_string(),
+                }),
+            }),
+        }
+    }
+
+    #[test]
+    fn pairs_start_then_complete_sharing_run_id() {
+        let events = run_events(
+            &sample_lineage(),
+            "run-1",
+            sample_job(),
+            "2020-02-22T22:42:42Z",
+        );
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, EventType::Start);
+        assert_eq!(events[1].event_type, EventType::Complete);
+        assert_eq!(events[0].run.run_id, "run-1");
+        assert_eq!(events[1].run.run_id, "run-1");
+    }
+
+    #[test]
+    fn facet_attaches_to_complete_outputs_only() {
+        let events = run_events(
+            &sample_lineage(),
+            "run-1",
+            sample_job(),
+            "2020-02-22T22:42:42Z",
+        );
+        let (start, complete) = (&events[0], &events[1]);
+        // START announces the run with no datasets.
+        assert!(start.inputs.is_empty());
+        assert!(start.outputs.is_empty());
+        // COMPLETE carries inputs (facet-less) and facet-bearing outputs.
+        assert_eq!(complete.inputs.len(), 1);
+        assert!(complete.inputs[0].facets.is_none());
+        assert_eq!(complete.outputs.len(), 1);
+        let facets = complete.outputs[0].facets.as_ref().expect("output facets");
+        assert!(facets.column_lineage.is_some());
+    }
+
+    #[test]
+    fn job_facet_carried_on_both_events() {
+        let events = run_events(
+            &sample_lineage(),
+            "run-1",
+            sample_job(),
+            "2020-02-22T22:42:42Z",
+        );
+        for event in &events {
+            let facet = event
+                .job
+                .facets
+                .as_ref()
+                .and_then(|f| f.clinker_pipeline.as_ref())
+                .expect("clinker pipeline job facet");
+            assert_eq!(facet.source_hash, "abc123");
+        }
+    }
+}

--- a/crates/clinker-lineage/src/lib.rs
+++ b/crates/clinker-lineage/src/lib.rs
@@ -10,7 +10,9 @@
 //! [`builder::column_lineage`] populates both DIRECT (value-derivation) per-column
 //! lineage and whole-dataset INDIRECT influence (filter / join / group-by / sort /
 //! conditional). Precise composition and envelope (`$doc`) traversal remain out of
-//! scope; see that module's documented limitations.
+//! scope; see that module's documented limitations. The [`emit`] module assembles
+//! a built lineage into a `START`/`COMPLETE` run-event pair ready for
+//! [`openlineage::write_ndjson`].
 //!
 //! The model is pinned to OpenLineage core spec `2-0-2` and the
 //! `ColumnLineageDatasetFacet` `1-2-0`. No general-purpose Rust OpenLineage client
@@ -20,12 +22,15 @@
 
 pub mod builder;
 pub mod dataset;
+pub mod emit;
 pub mod openlineage;
 
 pub use builder::{OutputColumnLineage, PlanColumnLineage, column_lineage};
 pub use dataset::{DatasetId, FALLBACK_NAMESPACE, FILE_NAMESPACE, dataset_identity};
+pub use emit::run_events;
 pub use openlineage::{
-    COLUMN_LINEAGE_FACET_SCHEMA_URL, ColumnLineageDatasetFacet, Dataset, DatasetFacets, EventType,
-    FieldLineage, InputField, Job, OPENLINEAGE_SCHEMA_URL, PRODUCER, Run, RunEvent, Transformation,
+    CLINKER_PIPELINE_FACET_SCHEMA_URL, COLUMN_LINEAGE_FACET_SCHEMA_URL, ColumnLineageDatasetFacet,
+    Dataset, DatasetFacets, EventType, FieldLineage, InputField, Job, JobFacets,
+    OPENLINEAGE_SCHEMA_URL, PRODUCER, PipelineJobFacet, Run, RunEvent, Transformation,
     TransformationSubtype, TransformationType, write_ndjson,
 };

--- a/crates/clinker-lineage/src/lib.rs
+++ b/crates/clinker-lineage/src/lib.rs
@@ -30,7 +30,7 @@ pub use dataset::{DatasetId, FALLBACK_NAMESPACE, FILE_NAMESPACE, dataset_identit
 pub use emit::run_events;
 pub use openlineage::{
     CLINKER_PIPELINE_FACET_SCHEMA_URL, COLUMN_LINEAGE_FACET_SCHEMA_URL, ColumnLineageDatasetFacet,
-    Dataset, DatasetFacets, EventType, FieldLineage, InputField, Job, JobFacets,
+    Dataset, DatasetFacets, EventType, FieldLineage, InputField, JOB_NAMESPACE, Job, JobFacets,
     OPENLINEAGE_SCHEMA_URL, PRODUCER, PipelineJobFacet, Run, RunEvent, Transformation,
     TransformationSubtype, TransformationType, write_ndjson,
 };

--- a/crates/clinker-lineage/src/openlineage/event.rs
+++ b/crates/clinker-lineage/src/openlineage/event.rs
@@ -59,6 +59,24 @@ pub struct Job {
     pub facets: Option<JobFacets>,
 }
 
+impl Job {
+    /// A clinker pipeline job: the [`JOB_NAMESPACE`] namespace, the pipeline
+    /// `name`, and a [`PipelineJobFacet`] carrying the pipeline's content hash.
+    /// The hash rides in the facet, not the name, so the job name stays stable
+    /// across edits while runs of the same definition remain correlatable.
+    ///
+    /// [`JOB_NAMESPACE`]: super::JOB_NAMESPACE
+    pub fn for_pipeline(name: impl Into<String>, source_hash: String) -> Self {
+        Job {
+            namespace: super::JOB_NAMESPACE.to_string(),
+            name: name.into(),
+            facets: Some(JobFacets {
+                clinker_pipeline: Some(PipelineJobFacet::new(source_hash)),
+            }),
+        }
+    }
+}
+
 /// The facet bundle attached to a [`Job`].
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct JobFacets {
@@ -208,6 +226,22 @@ mod tests {
         assert!(v["inputs"][0].get("facets").is_none());
         // A job with no facets omits the key too.
         assert!(v["job"].get("facets").is_none());
+    }
+
+    #[test]
+    fn for_pipeline_stamps_namespace_and_hash_facet() {
+        use crate::openlineage::{CLINKER_PIPELINE_FACET_SCHEMA_URL, JOB_NAMESPACE, PRODUCER};
+        let job = Job::for_pipeline("orders", "deadbeef".to_string());
+        assert_eq!(job.namespace, JOB_NAMESPACE);
+        assert_eq!(job.name, "orders");
+        let facet = job
+            .facets
+            .as_ref()
+            .and_then(|f| f.clinker_pipeline.as_ref())
+            .expect("clinker pipeline facet");
+        assert_eq!(facet.source_hash, "deadbeef");
+        assert_eq!(facet.producer, PRODUCER);
+        assert_eq!(facet.schema_url, CLINKER_PIPELINE_FACET_SCHEMA_URL);
     }
 
     #[test]

--- a/crates/clinker-lineage/src/openlineage/event.rs
+++ b/crates/clinker-lineage/src/openlineage/event.rs
@@ -2,7 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::facet::ColumnLineageDatasetFacet;
+use super::facet::{ColumnLineageDatasetFacet, PipelineJobFacet};
 
 /// A single OpenLineage run-state event.
 ///
@@ -55,6 +55,16 @@ pub struct Run {
 pub struct Job {
     pub namespace: String,
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub facets: Option<JobFacets>,
+}
+
+/// The facet bundle attached to a [`Job`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct JobFacets {
+    /// Clinker pipeline-source fingerprint facet (producer-defined).
+    #[serde(rename = "clinker_pipeline", skip_serializing_if = "Option::is_none")]
+    pub clinker_pipeline: Option<PipelineJobFacet>,
 }
 
 /// An input or output dataset referenced by a run event.
@@ -127,6 +137,7 @@ mod tests {
             job: Job {
                 namespace: "clinker".to_string(),
                 name: "orders".to_string(),
+                facets: None,
             },
             inputs: vec![Dataset {
                 namespace: "file".to_string(),
@@ -195,5 +206,29 @@ mod tests {
         // A dataset with no facets omits the key rather than emitting null.
         let v = serde_json::to_value(sample_event()).unwrap();
         assert!(v["inputs"][0].get("facets").is_none());
+        // A job with no facets omits the key too.
+        assert!(v["job"].get("facets").is_none());
+    }
+
+    #[test]
+    fn job_facet_serializes_under_clinker_pipeline_key() {
+        use crate::openlineage::{CLINKER_PIPELINE_FACET_SCHEMA_URL, PipelineJobFacet};
+        let mut event = sample_event();
+        event.job.facets = Some(JobFacets {
+            clinker_pipeline: Some(PipelineJobFacet {
+                producer: PRODUCER.to_string(),
+                schema_url: CLINKER_PIPELINE_FACET_SCHEMA_URL.to_string(),
+                source_hash: "deadbeef".to_string(),
+            }),
+        });
+        let v = serde_json::to_value(&event).unwrap();
+        let facet = &v["job"]["facets"]["clinker_pipeline"];
+        assert_eq!(facet["sourceHash"], "deadbeef");
+        assert!(facet.get("_producer").is_some());
+        assert!(facet.get("_schemaURL").is_some());
+        // Round-trips through the wire form unchanged.
+        let json = serde_json::to_string(&event).unwrap();
+        let back: RunEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
     }
 }

--- a/crates/clinker-lineage/src/openlineage/facet.rs
+++ b/crates/clinker-lineage/src/openlineage/facet.rs
@@ -86,6 +86,26 @@ pub enum TransformationSubtype {
     Conditional,
 }
 
+/// A clinker-specific job facet carrying the pipeline's content fingerprint.
+///
+/// OpenLineage defines no standard facet for a pipeline-source hash, so this is a
+/// producer-defined facet: its `_schemaURL` points at the clinker producer rather
+/// than an `openlineage.io` schema. Carrying the hash here — instead of encoding
+/// it in the job name — lets consumers correlate runs of the exact same pipeline
+/// definition while keeping the job name stable across edits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PipelineJobFacet {
+    /// URI of the software that produced this facet.
+    #[serde(rename = "_producer")]
+    pub producer: String,
+    /// Schema URL of the facet spec this conforms to (clinker-owned).
+    #[serde(rename = "_schemaURL")]
+    pub schema_url: String,
+    /// Lowercase hex of the pipeline config's content hash.
+    #[serde(rename = "sourceHash")]
+    pub source_hash: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/clinker-lineage/src/openlineage/facet.rs
+++ b/crates/clinker-lineage/src/openlineage/facet.rs
@@ -106,6 +106,22 @@ pub struct PipelineJobFacet {
     pub source_hash: String,
 }
 
+impl PipelineJobFacet {
+    /// A pipeline-hash facet stamped with the clinker [`PRODUCER`] and
+    /// [`CLINKER_PIPELINE_FACET_SCHEMA_URL`], so the producer/schema-URL
+    /// convention lives in this crate rather than at each call site.
+    ///
+    /// [`PRODUCER`]: super::PRODUCER
+    /// [`CLINKER_PIPELINE_FACET_SCHEMA_URL`]: super::CLINKER_PIPELINE_FACET_SCHEMA_URL
+    pub fn new(source_hash: String) -> Self {
+        Self {
+            producer: super::PRODUCER.to_string(),
+            schema_url: super::CLINKER_PIPELINE_FACET_SCHEMA_URL.to_string(),
+            source_hash,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/clinker-lineage/src/openlineage/mod.rs
+++ b/crates/clinker-lineage/src/openlineage/mod.rs
@@ -7,10 +7,10 @@ mod event;
 mod facet;
 mod ndjson;
 
-pub use event::{Dataset, DatasetFacets, EventType, Job, Run, RunEvent};
+pub use event::{Dataset, DatasetFacets, EventType, Job, JobFacets, Run, RunEvent};
 pub use facet::{
-    ColumnLineageDatasetFacet, FieldLineage, InputField, Transformation, TransformationSubtype,
-    TransformationType,
+    ColumnLineageDatasetFacet, FieldLineage, InputField, PipelineJobFacet, Transformation,
+    TransformationSubtype, TransformationType,
 };
 pub use ndjson::write_ndjson;
 
@@ -23,3 +23,9 @@ pub const COLUMN_LINEAGE_FACET_SCHEMA_URL: &str =
 
 /// Producer URI stamped on emitted events and facets, identifying this emitter.
 pub const PRODUCER: &str = "https://github.com/rustpunk/clinker";
+
+/// Schema URL for the clinker-specific pipeline job facet (the facet-level
+/// `_schemaURL`). OpenLineage has no standard pipeline-hash facet, so this points
+/// at the clinker producer rather than `openlineage.io`.
+pub const CLINKER_PIPELINE_FACET_SCHEMA_URL: &str =
+    "https://github.com/rustpunk/clinker/spec/facets/PipelineJobFacet.json";

--- a/crates/clinker-lineage/src/openlineage/mod.rs
+++ b/crates/clinker-lineage/src/openlineage/mod.rs
@@ -24,6 +24,9 @@ pub const COLUMN_LINEAGE_FACET_SCHEMA_URL: &str =
 /// Producer URI stamped on emitted events and facets, identifying this emitter.
 pub const PRODUCER: &str = "https://github.com/rustpunk/clinker";
 
+/// OpenLineage namespace for clinker pipeline jobs (the `job.namespace`).
+pub const JOB_NAMESPACE: &str = "clinker";
+
 /// Schema URL for the clinker-specific pipeline job facet (the facet-level
 /// `_schemaURL`). OpenLineage has no standard pipeline-hash facet, so this points
 /// at the clinker producer rather than `openlineage.io`.

--- a/crates/clinker-lineage/src/openlineage/ndjson.rs
+++ b/crates/clinker-lineage/src/openlineage/ndjson.rs
@@ -46,6 +46,7 @@ mod tests {
             job: Job {
                 namespace: "clinker".to_string(),
                 name: "orders".to_string(),
+                facets: None,
             },
             inputs: vec![],
             outputs: vec![],

--- a/crates/clinker/Cargo.toml
+++ b/crates/clinker/Cargo.toml
@@ -13,6 +13,7 @@ clinker-net = { workspace = true }
 clinker-channel = { workspace = true }
 clinker-format = { workspace = true }
 clinker-record = { workspace = true }
+clinker-lineage = { workspace = true }
 clap = { workspace = true }
 indexmap = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -153,6 +153,11 @@ pub struct RunArgs {
     )]
     pub explain: Option<ExplainFormat>,
 
+    /// Build column lineage and write OpenLineage NDJSON, then exit (no data
+    /// read). Give a file path, or `-` for stdout.
+    #[arg(long, value_name = "PATH", help_heading = "Validation")]
+    pub lineage: Option<PathBuf>,
+
     /// Validate config and CXL without processing data
     #[arg(long, help_heading = "Validation")]
     pub dry_run: bool,
@@ -648,6 +653,10 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // re-copying it per run.
     let staging_policy = storage_config.staging.clone();
 
+    // Keep the workspace root for plan-derived lineage (--lineage): the same
+    // base_dir the compiler resolves source/output paths against, so dataset
+    // names line up. `workspace_root` is moved into `compile_ctx` below.
+    let lineage_base_dir = workspace_root.clone();
     let mut compile_ctx =
         clinker_plan::config::CompileContext::with_pipeline_dir(workspace_root, pipeline_dir);
     compile_ctx.allow_absolute_paths = args.allow_absolute_paths;
@@ -832,6 +841,54 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                 print!("{}", dag.explain_dot());
             }
         }
+        return Ok(0);
+    }
+
+    // Plan-derived OpenLineage column lineage. Like --explain, compile the plan
+    // and emit without reading any data, then exit. runId = the run's
+    // execution_id so a later live-run emission can correlate.
+    if let Some(path) = &args.lineage {
+        let mut compiled_plan =
+            pipeline_config
+                .compile(&compile_ctx)
+                .map_err(|diags| PipelineError::Compilation {
+                    transform_name: String::new(),
+                    messages: diags.iter().map(|d| d.message.clone()).collect(),
+                })?;
+        if let Some(binding) = &channel_binding {
+            let overlay = clinker_channel::apply_channel_overlay(
+                &mut compiled_plan,
+                binding,
+                &pipeline_config,
+            );
+            abort_on_overlay_errors(&overlay)?;
+        }
+
+        let lineage = clinker_lineage::column_lineage(&compiled_plan, &lineage_base_dir);
+        // The pipeline content hash rides in a job facet, not the job name, so
+        // the job name stays stable across edits while runs of the same pipeline
+        // definition remain correlatable.
+        let source_hash: String = pipeline_hash.iter().map(|b| format!("{b:02x}")).collect();
+        let job = clinker_lineage::Job {
+            namespace: clinker_lineage::FALLBACK_NAMESPACE.to_string(),
+            name: pipeline_config.pipeline.name.clone(),
+            facets: Some(clinker_lineage::JobFacets {
+                clinker_pipeline: Some(clinker_lineage::PipelineJobFacet {
+                    producer: clinker_lineage::PRODUCER.to_string(),
+                    schema_url: clinker_lineage::CLINKER_PIPELINE_FACET_SCHEMA_URL.to_string(),
+                    source_hash,
+                }),
+            }),
+        };
+        let event_time = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        let events = clinker_lineage::run_events(&lineage, &execution_id, job, &event_time);
+
+        let writer: Box<dyn std::io::Write> = if path.as_os_str() == std::ffi::OsStr::new("-") {
+            Box::new(std::io::stdout().lock())
+        } else {
+            Box::new(std::fs::File::create(path)?)
+        };
+        clinker_lineage::write_ndjson(&events, writer).map_err(PipelineError::Io)?;
         return Ok(0);
     }
 

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -154,8 +154,14 @@ pub struct RunArgs {
     pub explain: Option<ExplainFormat>,
 
     /// Build column lineage and write OpenLineage NDJSON, then exit (no data
-    /// read). Give a file path, or `-` for stdout.
-    #[arg(long, value_name = "PATH", help_heading = "Validation")]
+    /// read). Give a file path, or `-` for stdout. A plan-only export, so it
+    /// cannot be combined with --explain, --dry-run, or -n.
+    #[arg(
+        long,
+        value_name = "PATH",
+        help_heading = "Validation",
+        conflicts_with_all = ["explain", "dry_run", "dry_run_n"]
+    )]
     pub lineage: Option<PathBuf>,
 
     /// Validate config and CXL without processing data
@@ -653,10 +659,12 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // re-copying it per run.
     let staging_policy = storage_config.staging.clone();
 
-    // Keep the workspace root for plan-derived lineage (--lineage): the same
-    // base_dir the compiler resolves source/output paths against, so dataset
-    // names line up. `workspace_root` is moved into `compile_ctx` below.
-    let lineage_base_dir = workspace_root.clone();
+    // Anchor for plan-derived lineage (--lineage): the pipeline file's directory,
+    // i.e. the `workspace_root.join(pipeline_dir)` the compile context
+    // reconstructs and against which relative source/output `path:` strings
+    // resolve — so dataset names name the same bytes a run reads/writes. Both
+    // halves are moved into `compile_ctx` next, so capture the join now.
+    let lineage_base_dir = workspace_root.join(&pipeline_dir);
     let mut compile_ctx =
         clinker_plan::config::CompileContext::with_pipeline_dir(workspace_root, pipeline_dir);
     compile_ctx.allow_absolute_paths = args.allow_absolute_paths;
@@ -707,6 +715,11 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         n: None,
         unique_suffix_width: 0,
     };
+    // --lineage names output datasets from the pipeline's declared output paths,
+    // so snapshot the config before per-run tokens ({execution_id}/{timestamp}/…)
+    // are baked into them just below; the export compiles from this snapshot to
+    // keep dataset names reproducible across runs of the same pipeline.
+    let lineage_config = args.lineage.as_ref().map(|_| pipeline_config.clone());
     clinker_plan::config::path_template::resolve_output_path_templates_in_place(
         &mut pipeline_config,
         &template_ctx,
@@ -845,48 +858,41 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     }
 
     // Plan-derived OpenLineage column lineage. Like --explain, compile the plan
-    // and emit without reading any data, then exit. runId = the run's
-    // execution_id so a later live-run emission can correlate.
+    // and emit without reading any data, then exit. The export is static: its
+    // runId is this invocation's execution_id and does NOT identify a
+    // data-processing run (live run-lifecycle emission with real timing is a
+    // follow-up). Compiles from the pre-template snapshot so output dataset
+    // names are the declared paths, not this run's resolved ones.
     if let Some(path) = &args.lineage {
+        let cfg = lineage_config
+            .as_ref()
+            .expect("lineage_config is captured whenever --lineage is set");
         let mut compiled_plan =
-            pipeline_config
-                .compile(&compile_ctx)
+            cfg.compile(&compile_ctx)
                 .map_err(|diags| PipelineError::Compilation {
                     transform_name: String::new(),
                     messages: diags.iter().map(|d| d.message.clone()).collect(),
                 })?;
         if let Some(binding) = &channel_binding {
-            let overlay = clinker_channel::apply_channel_overlay(
-                &mut compiled_plan,
-                binding,
-                &pipeline_config,
-            );
+            let overlay = clinker_channel::apply_channel_overlay(&mut compiled_plan, binding, cfg);
             abort_on_overlay_errors(&overlay)?;
         }
 
         let lineage = clinker_lineage::column_lineage(&compiled_plan, &lineage_base_dir);
-        // The pipeline content hash rides in a job facet, not the job name, so
-        // the job name stays stable across edits while runs of the same pipeline
-        // definition remain correlatable.
-        let source_hash: String = pipeline_hash.iter().map(|b| format!("{b:02x}")).collect();
-        let job = clinker_lineage::Job {
-            namespace: clinker_lineage::FALLBACK_NAMESPACE.to_string(),
-            name: pipeline_config.pipeline.name.clone(),
-            facets: Some(clinker_lineage::JobFacets {
-                clinker_pipeline: Some(clinker_lineage::PipelineJobFacet {
-                    producer: clinker_lineage::PRODUCER.to_string(),
-                    schema_url: clinker_lineage::CLINKER_PIPELINE_FACET_SCHEMA_URL.to_string(),
-                    source_hash,
-                }),
-            }),
-        };
+        let source_hash = clinker_exec::output::sidecar::hash_to_hex(&pipeline_hash);
+        let job = clinker_lineage::Job::for_pipeline(cfg.pipeline.name.clone(), source_hash);
         let event_time = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
         let events = clinker_lineage::run_events(&lineage, &execution_id, job, &event_time);
 
         let writer: Box<dyn std::io::Write> = if path.as_os_str() == std::ffi::OsStr::new("-") {
             Box::new(std::io::stdout().lock())
         } else {
-            Box::new(std::fs::File::create(path)?)
+            Box::new(std::fs::File::create(path).map_err(|e| {
+                PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+                    "cannot open --lineage output {}: {e}",
+                    path.display()
+                )))
+            })?)
         };
         clinker_lineage::write_ndjson(&events, writer).map_err(PipelineError::Io)?;
         return Ok(0);

--- a/crates/clinker/tests/lineage_cli.rs
+++ b/crates/clinker/tests/lineage_cli.rs
@@ -1,0 +1,177 @@
+//! End-to-end coverage for `clinker run --lineage`: the built binary must emit a
+//! well-formed OpenLineage START/COMPLETE NDJSON pair carrying DIRECT and INDIRECT
+//! column lineage. The lineage *computation* is unit-tested in `clinker-lineage`;
+//! these tests pin the CLI wiring and the on-the-wire document shape.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+/// `examples/` lives at the workspace root, two levels above this crate.
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root two levels above the crate manifest")
+        .to_path_buf()
+}
+
+/// Run `clinker run <pipeline> --lineage -` and return the two parsed NDJSON
+/// events (START, COMPLETE).
+fn run_lineage(pipeline: &Path) -> (serde_json::Value, serde_json::Value) {
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg(pipeline)
+        .arg("--lineage")
+        .arg("-")
+        .output()
+        .expect("spawn clinker");
+    assert!(
+        output.status.success(),
+        "clinker run --lineage failed:\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("utf-8 stdout");
+    let lines: Vec<&str> = stdout.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        lines.len(),
+        2,
+        "expected exactly two NDJSON lines (START, COMPLETE), got:\n{stdout}"
+    );
+    let start: serde_json::Value = serde_json::from_str(lines[0]).expect("START line is JSON");
+    let complete: serde_json::Value =
+        serde_json::from_str(lines[1]).expect("COMPLETE line is JSON");
+    (start, complete)
+}
+
+#[test]
+fn lineage_emits_start_complete_pair_with_column_lineage() {
+    let pipeline = repo_root().join("examples/pipelines/audit_join.yaml");
+    let (start, complete) = run_lineage(&pipeline);
+
+    // --- Event envelope: a START then a COMPLETE sharing one runId. ---
+    assert_eq!(start["eventType"], "START");
+    assert_eq!(complete["eventType"], "COMPLETE");
+    assert_eq!(
+        start["schemaURL"],
+        "https://openlineage.io/spec/2-0-2/OpenLineage.json"
+    );
+    let run_id = start["run"]["runId"].as_str().expect("runId string");
+    assert_eq!(
+        complete["run"]["runId"].as_str(),
+        Some(run_id),
+        "START and COMPLETE must share one runId"
+    );
+    uuid::Uuid::parse_str(run_id).expect("runId is a UUID");
+    for event in [&start, &complete] {
+        let event_time = event["eventTime"].as_str().expect("eventTime string");
+        assert!(
+            event_time.ends_with('Z'),
+            "eventTime should be RFC-3339 UTC: {event_time}"
+        );
+    }
+
+    // --- Job identity + pipeline-hash job facet (not encoded in the name). ---
+    assert_eq!(complete["job"]["namespace"], "clinker");
+    assert_eq!(complete["job"]["name"], "audit_join");
+    let source_hash = complete["job"]["facets"]["clinker_pipeline"]["sourceHash"]
+        .as_str()
+        .expect("clinker_pipeline job facet sourceHash");
+    assert_eq!(source_hash.len(), 64, "sourceHash is full 64-char hex");
+    assert!(source_hash.chars().all(|c| c.is_ascii_hexdigit()));
+
+    // --- START announces the run with no datasets. ---
+    assert!(start.get("inputs").is_none(), "START carries no inputs");
+    assert!(start.get("outputs").is_none(), "START carries no outputs");
+
+    // --- COMPLETE carries the input datasets (facet-less) ... ---
+    let inputs = complete["inputs"].as_array().expect("inputs array");
+    assert_eq!(inputs.len(), 2, "two source datasets joined");
+    let input_names: Vec<&str> = inputs
+        .iter()
+        .map(|d| d["name"].as_str().expect("input dataset name"))
+        .collect();
+    assert!(
+        input_names
+            .iter()
+            .any(|n| n.ends_with("data/audit_orders.csv"))
+    );
+    assert!(
+        input_names
+            .iter()
+            .any(|n| n.ends_with("data/audit_events.csv"))
+    );
+    assert!(
+        inputs.iter().all(|d| d.get("facets").is_none()),
+        "input datasets carry no facets"
+    );
+
+    // --- ... and the output dataset with its columnLineage facet. ---
+    let outputs = complete["outputs"].as_array().expect("outputs array");
+    assert_eq!(outputs.len(), 1);
+    let facet = &outputs[0]["facets"]["columnLineage"];
+    assert_eq!(
+        facet["_schemaURL"],
+        "https://openlineage.io/spec/facets/1-2-0/ColumnLineageDatasetFacet.json"
+    );
+
+    // DIRECT: each output column resolves to its own source column.
+    let amount = &facet["fields"]["amount"]["inputFields"][0];
+    assert!(
+        amount["name"]
+            .as_str()
+            .unwrap()
+            .ends_with("data/audit_orders.csv")
+    );
+    assert_eq!(amount["field"], "amount");
+    assert_eq!(amount["transformations"][0]["type"], "DIRECT");
+    assert_eq!(amount["transformations"][0]["subtype"], "IDENTITY");
+    let actor = &facet["fields"]["actor"]["inputFields"][0];
+    assert!(
+        actor["name"]
+            .as_str()
+            .unwrap()
+            .ends_with("data/audit_events.csv")
+    );
+
+    // INDIRECT: the join key influences the dataset as a whole.
+    let influence = facet["dataset"].as_array().expect("INDIRECT dataset array");
+    assert!(
+        influence.iter().any(|f| {
+            f["field"] == "order_id"
+                && f["transformations"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|t| t["type"] == "INDIRECT" && t["subtype"] == "JOIN")
+        }),
+        "expected a JOIN influence on order_id, got: {influence:#?}"
+    );
+}
+
+#[test]
+fn lineage_writes_to_a_file_path() {
+    let pipeline = repo_root().join("examples/pipelines/audit_join.yaml");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out = dir.path().join("lineage.ndjson");
+
+    let status = Command::new(clinker_bin())
+        .arg("run")
+        .arg(&pipeline)
+        .arg("--lineage")
+        .arg(&out)
+        .status()
+        .expect("spawn clinker");
+    assert!(status.success(), "clinker run --lineage <file> failed");
+
+    let contents = std::fs::read_to_string(&out).expect("read lineage file");
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 2, "two NDJSON lines written to file");
+    let start: serde_json::Value = serde_json::from_str(lines[0]).unwrap();
+    let complete: serde_json::Value = serde_json::from_str(lines[1]).unwrap();
+    assert_eq!(start["eventType"], "START");
+    assert_eq!(complete["eventType"], "COMPLETE");
+}

--- a/crates/clinker/tests/lineage_cli.rs
+++ b/crates/clinker/tests/lineage_cli.rs
@@ -175,3 +175,87 @@ fn lineage_writes_to_a_file_path() {
     assert_eq!(start["eventType"], "START");
     assert_eq!(complete["eventType"], "COMPLETE");
 }
+
+#[test]
+fn lineage_conflicts_with_explain() {
+    // --lineage is a plan-only export; combining it with --explain would
+    // silently drop one, so clap must reject the combination.
+    let pipeline = repo_root().join("examples/pipelines/audit_join.yaml");
+    let output = Command::new(clinker_bin())
+        .args(["run"])
+        .arg(&pipeline)
+        .args(["--explain", "text", "--lineage", "-"])
+        .output()
+        .expect("spawn clinker");
+    assert!(
+        !output.status.success(),
+        "--explain + --lineage must be rejected, not silently accepted"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot be used with"),
+        "expected a clap conflict error, got:\n{stderr}"
+    );
+}
+
+/// Write a one-source → one-output pipeline (explicit schema, so compile needs
+/// no data file) into `dir` and return its path.
+fn write_pipeline(dir: &Path, output_path: &str) -> PathBuf {
+    let yaml = format!(
+        "pipeline:\n  name: lineage_fixture\nnodes:\n  - type: source\n    name: src\n    \
+         config:\n      name: src\n      type: csv\n      path: ./data/in.csv\n      \
+         options: {{ has_header: true }}\n      schema:\n        - {{ name: id, type: string }}\n  \
+         - type: output\n    name: out\n    input: src\n    config:\n      name: out\n      \
+         type: csv\n      path: \"{output_path}\"\n"
+    );
+    let path = dir.join("pipeline.yaml");
+    std::fs::write(&path, yaml).expect("write pipeline");
+    path
+}
+
+fn output_dataset_name(pipeline: &Path, base_dir: Option<&Path>) -> String {
+    let mut cmd = Command::new(clinker_bin());
+    cmd.arg("run").arg(pipeline).args(["--lineage", "-"]);
+    if let Some(base) = base_dir {
+        cmd.arg("--base-dir").arg(base);
+    }
+    let output = cmd.output().expect("spawn clinker");
+    assert!(
+        output.status.success(),
+        "lineage run failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let complete: serde_json::Value = serde_json::from_str(stdout.lines().nth(1).unwrap()).unwrap();
+    complete["outputs"][0]["name"].as_str().unwrap().to_string()
+}
+
+#[test]
+fn templated_output_dataset_name_is_the_declared_template() {
+    // A per-run {execution_id} token must NOT be baked into the dataset name,
+    // or two runs of the same pipeline name different (un-joinable) datasets.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let pipeline = write_pipeline(dir.path(), "./output/report-{execution_id}.csv");
+    let name1 = output_dataset_name(&pipeline, None);
+    let name2 = output_dataset_name(&pipeline, None);
+    assert!(
+        name1.ends_with("report-{execution_id}.csv"),
+        "dataset name must keep the literal template, got: {name1}"
+    );
+    assert_eq!(name1, name2, "templated output name must be reproducible");
+}
+
+#[test]
+fn base_dir_anchors_dataset_names_at_the_pipeline_directory() {
+    // With --base-dir an ancestor of the pipeline file, the pipeline_dir
+    // component must survive in the resolved dataset name.
+    let ws = tempfile::tempdir().expect("tempdir");
+    let subdir = ws.path().join("subdir");
+    std::fs::create_dir_all(&subdir).expect("mkdir subdir");
+    let pipeline = write_pipeline(&subdir, "./out.csv");
+    let name = output_dataset_name(&pipeline, Some(ws.path()));
+    assert!(
+        name.contains("/subdir/"),
+        "dataset name must include the pipeline subdir, got: {name}"
+    );
+}

--- a/docs/ai/20_CRATE_MAP.md
+++ b/docs/ai/20_CRATE_MAP.md
@@ -28,7 +28,7 @@ clinker-bench-support -> clinker-record
 clinker-benchmarks -> clinker-bench-support + clinker-exec + clinker-plan + cxl
 ```
 
-Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clinker-record`; `clinker-format -> clinker-record, cxl`; `clinker-plan -> clinker-core-types, clinker-format, clinker-record, cxl`; `clinker-exec -> clinker-core-types, clinker-format, clinker-plan, clinker-record, cxl`; `clinker-channel -> clinker-core-types, clinker-plan, clinker-record`; `clinker-net -> clinker-exec, clinker-format, clinker-plan, clinker-record`; `clinker -> clinker-channel, clinker-core-types, clinker-exec, clinker-format, clinker-net, clinker-plan, clinker-record`; `cxl-cli -> cxl, clinker-record`; `clinker-schema -> clinker-plan`; `clinker-lineage -> clinker-plan, clinker-record, cxl`.
+Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clinker-record`; `clinker-format -> clinker-record, cxl`; `clinker-plan -> clinker-core-types, clinker-format, clinker-record, cxl`; `clinker-exec -> clinker-core-types, clinker-format, clinker-plan, clinker-record, cxl`; `clinker-channel -> clinker-core-types, clinker-plan, clinker-record`; `clinker-net -> clinker-exec, clinker-format, clinker-plan, clinker-record`; `clinker -> clinker-channel, clinker-core-types, clinker-exec, clinker-format, clinker-lineage, clinker-net, clinker-plan, clinker-record`; `cxl-cli -> cxl, clinker-record`; `clinker-schema -> clinker-plan`; `clinker-lineage -> clinker-plan, clinker-record, cxl`.
 
 ## Current Layering Rules Inferred From Source
 
@@ -39,7 +39,7 @@ Important normal dependency edges from `cargo metadata --no-deps`: `cxl -> clink
 - `clinker-plan` is compile-time orchestration and DAG construction below the runtime executor; its crate docs explicitly say execution consumes its plan (`crates/clinker-plan/src/lib.rs`).
 - `clinker-exec` is runtime orchestration and operators; binaries and network transports depend on it rather than the reverse (`crates/clinker-exec/src/lib.rs`; `crates/clinker-exec/src/executor/mod.rs`).
 - `clinker-channel`, `clinker-net`, `clinker-schema`, `clinker`, and `cxl-cli` appear to be edge/application or integration crates around the plan/exec/language core.
-- `clinker-lineage` is a plan-time, read-only consumer of `clinker-plan`: it maps Source/Output nodes to OpenLineage dataset identities and walks the compiled DAG to emit DIRECT column-level lineage facets (OpenLineage `2-0-2` / `ColumnLineageDatasetFacet` `1-2-0`). It reads typed/compiled programs off plan nodes via `cxl`; it does not run pipelines (`crates/clinker-lineage/src/lib.rs`).
+- `clinker-lineage` is a plan-time, read-only consumer of `clinker-plan`: it maps Source/Output nodes to OpenLineage dataset identities and walks the compiled DAG to emit DIRECT (per-column) and INDIRECT (whole-dataset influence) column-level lineage facets (OpenLineage `2-0-2` / `ColumnLineageDatasetFacet` `1-2-0`). It reads typed/compiled programs off plan nodes via `cxl`; it does not run pipelines (`crates/clinker-lineage/src/lib.rs`). The `clinker` CLI consumes it via `run --lineage <path>`, which compiles the plan and writes a static START/COMPLETE OpenLineage NDJSON pair without reading data (mirroring `--explain`).
 - Benchmark crates appear intended to stay outside the runtime layer. `clinker-benchmarks/src/lib.rs` says it houses a runner needing both `clinker-exec` and `clinker-bench-support` to avoid a circular dependency.
 
 ## Cycles And Suspicious Coupling

--- a/docs/ai/50_TESTING_AND_COMMANDS.md
+++ b/docs/ai/50_TESTING_AND_COMMANDS.md
@@ -199,6 +199,7 @@ Common pipeline commands from `CLAUDE.md` and user docs:
 
 ```bash
 cargo run -p clinker -- run examples/pipelines/customer_etl.yaml --explain
+cargo run -p clinker -- run examples/pipelines/customer_etl.yaml --lineage -
 cargo run -p clinker -- run examples/pipelines/customer_etl.yaml --dry-run -n 10
 cargo run -p clinker -- run examples/pipelines/tumbling_clicks.yaml
 cargo run -p clinker -- run examples/pipelines/hopping_sliding_5m_1h.yaml

--- a/docs/user/src/SUMMARY.md
+++ b/docs/user/src/SUMMARY.md
@@ -77,6 +77,7 @@
 - [CLI Reference](ops/cli-reference.md)
 - [Validation & Dry Run](ops/validation.md)
 - [Explain Plans](ops/explain.md)
+- [Column Lineage](ops/lineage.md)
 - [Memory Tuning](ops/memory.md)
 - [Storage & Spill Location](ops/storage.md)
 - [Streaming vs. Blocking Stages](ops/streaming-vs-blocking.md)

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -25,6 +25,7 @@ clinker run [OPTIONS] <CONFIG>
 | `--error-threshold <N>` | `0` (unlimited) | Maximum number of records routed to the dead-letter queue before the pipeline aborts. `0` means no limit -- the pipeline will run to completion regardless of DLQ volume. |
 | `--batch-id <ID>` | UUID v7 | Custom execution identifier. Appears in metrics output and log lines. Use a meaningful value (e.g. `daily-2026-04-11`) for correlation across retries. |
 | `--explain [FORMAT]` | `text` | Print the execution plan and exit without processing data. Accepted formats: `text`, `json`, `dot`. See [Explain Plans](explain.md). |
+| `--lineage <PATH>` | -- | Build column lineage and write it as OpenLineage NDJSON, then exit without processing data. Give a file path, or `-` for stdout. See [Column Lineage](lineage.md). |
 | `--dry-run` | -- | Validate the configuration (YAML structure, CXL syntax, type checking, DAG wiring) without reading any data. |
 | `-n, --dry-run-n <N>` | -- | Process only the first `N` records through the full pipeline. Implies `--dry-run`. |
 | `--dry-run-output <FILE>` | stdout | Redirect dry-run output to a file instead of stdout. Only meaningful with `-n`. |

--- a/docs/user/src/ops/lineage.md
+++ b/docs/user/src/ops/lineage.md
@@ -1,0 +1,66 @@
+# Column Lineage
+
+The `--lineage` flag builds the pipeline's **column-level lineage** -- which source columns each output column is derived from, and which source columns influence the output as a whole -- and writes it as [OpenLineage](https://openlineage.io) events. Like `--explain`, it compiles the plan and exits **without reading any data**, so the lineage is derived statically from the pipeline definition.
+
+```bash
+# Write to a file
+clinker run pipeline.yaml --lineage lineage.ndjson
+
+# Write to stdout (pipe into other tooling)
+clinker run pipeline.yaml --lineage -
+```
+
+## Output format
+
+The output is [NDJSON](https://github.com/ndjson/ndjson-spec) (one JSON object per line) conforming to the OpenLineage `2-0-2` core spec. A run is described by a **`START`** event followed by a **`COMPLETE`** event that share one `runId`:
+
+```json
+{"eventType":"START","run":{"runId":"019f030d-0b3e-7ee1-86ec-1bb5b4a2776b"},"job":{"namespace":"clinker","name":"audit_join","facets":{"clinker_pipeline":{"sourceHash":"7fd096a9..."}}}, ...}
+{"eventType":"COMPLETE","run":{"runId":"019f030d-0b3e-7ee1-86ec-1bb5b4a2776b"}, "inputs":[...], "outputs":[{"namespace":"file","name":".../audit_report.csv","facets":{"columnLineage":{ ... }}}]}
+```
+
+- **`runId`** is the run's execution id (a UUID v7), shared by both events.
+- **`job.namespace`** is `clinker`; **`job.name`** is the pipeline name. The pipeline's content hash rides in the `clinker_pipeline` job facet (`sourceHash`), not the job name -- so the name stays stable across edits while runs of the same definition remain correlatable.
+- **`inputs`** are the source datasets; **`outputs`** are the sink datasets. Filesystem datasets use the `file` namespace with the resolved path as the name; a network source falls back to the `clinker` namespace plus the node name.
+- The `columnLineage` facet is attached to each **output** dataset on the `COMPLETE` event.
+
+## Reading the `columnLineage` facet
+
+The facet has two parts, mirroring the OpenLineage `ColumnLineageDatasetFacet`:
+
+```json
+"columnLineage": {
+  "fields": {
+    "amount": { "inputFields": [
+      { "namespace":"file", "name":".../audit_orders.csv", "field":"amount",
+        "transformations":[{"type":"DIRECT","subtype":"IDENTITY"}] }
+    ]}
+  },
+  "dataset": [
+    { "namespace":"file", "name":".../audit_orders.csv", "field":"order_id",
+      "transformations":[{"type":"INDIRECT","subtype":"JOIN"}] }
+  ]
+}
+```
+
+- **`fields`** -- **DIRECT** (value-derivation) lineage, keyed per output column: the source columns each output column's *value* is computed from. A rename (`emit full = name`) or a multi-hop chain collapses to the originating source column.
+- **`dataset`** -- **INDIRECT** (influence) lineage for the dataset as a whole: source columns that shaped *which rows* exist, via filtering, joining, grouping, or sorting -- collected once rather than duplicated across every column.
+
+Each transformation carries a `type` (`DIRECT` / `INDIRECT`) and a `subtype` (`IDENTITY`, `TRANSFORMATION`, `AGGREGATION`, `JOIN`, `GROUP_BY`, `FILTER`, `SORT`, `CONDITIONAL`).
+
+## When to use
+
+- **Impact analysis** -- before changing a source schema, see which outputs and columns depend on it.
+- **Auditing & governance** -- feed the OpenLineage events into a catalog (e.g. Marquez) to track data provenance.
+- **Review** -- attach the lineage of a new pipeline to a PR to confirm the intended derivations.
+
+Because `--lineage` reads no data, it runs instantly and works on a pipeline whose inputs do not yet exist.
+
+## Limitations
+
+Lineage is derived from the compiled plan, so a few constructs are approximated:
+
+- A **Composition** node is treated opaquely: every output column is taken to derive from every composition input column.
+- **Envelope** / `$doc` provenance is best-effort same-name passthrough.
+- INDIRECT influence covers route/cull predicates, join keys, aggregate grouping, and correlation sort. An aggregate's pre-aggregation row `filter`, a transform-inline `filter`, and Reshape `order_by` / `partition_by` are not (yet) attributed as influence.
+- Constant and `count(*)` columns (which have no source input) are omitted from `fields`; engine-stamped columns (`$ck.*`, `$meta.*`, `$source.*`) are skipped, mirroring the default writer.

--- a/docs/user/src/ops/lineage.md
+++ b/docs/user/src/ops/lineage.md
@@ -19,7 +19,7 @@ The output is [NDJSON](https://github.com/ndjson/ndjson-spec) (one JSON object p
 {"eventType":"COMPLETE","run":{"runId":"019f030d-0b3e-7ee1-86ec-1bb5b4a2776b"}, "inputs":[...], "outputs":[{"namespace":"file","name":".../audit_report.csv","facets":{"columnLineage":{ ... }}}]}
 ```
 
-- **`runId`** is the run's execution id (a UUID v7), shared by both events.
+- **`runId`** is a UUID v7 minted for this export and shared by both events. Because `--lineage` is a *static, plan-derived* export, the `START`/`COMPLETE` pair describes the pipeline's lineage, not an executed data run — no rows are processed and the two events share one timestamp. A separate `clinker run` mints its own `runId`. (Live run-lifecycle emission with real timing is a planned follow-up.)
 - **`job.namespace`** is `clinker`; **`job.name`** is the pipeline name. The pipeline's content hash rides in the `clinker_pipeline` job facet (`sourceHash`), not the job name -- so the name stays stable across edits while runs of the same definition remain correlatable.
 - **`inputs`** are the source datasets; **`outputs`** are the sink datasets. Filesystem datasets use the `file` namespace with the resolved path as the name; a network source falls back to the `clinker` namespace plus the node name.
 - The `columnLineage` facet is attached to each **output** dataset on the `COMPLETE` event.


### PR DESCRIPTION
Closes #663. The capstone of the column-lineage work: it makes the `clinker-lineage` crate consumable from the CLI.

## What it does

`clinker run <pipeline> --lineage <path>` compiles the pipeline and writes its column lineage as [OpenLineage](https://openlineage.io) NDJSON, then exits without reading any data — mirroring `--explain`. Use `-` for stdout.

The output is a `START` + `COMPLETE` run-event pair (OpenLineage `2-0-2`) sharing one run id. The `COMPLETE` event carries the input/output datasets, with the `columnLineage` facet on each output dataset:

- **DIRECT** per-column lineage — each output column resolved to the source columns its value derives from.
- **INDIRECT** influence — source columns that shaped which rows exist (filter / join / group-by / sort).

The pipeline's content hash rides in a job facet rather than the job name, so the name stays stable across edits.

## Notes

- A static, plan-derived export (no data read, no run executed), so it cannot be combined with `--explain`, `--dry-run`, or `-n`.
- Output dataset names use the pipeline's declared paths, resolved against the pipeline directory, so a templated sink path yields a stable, reproducible name across runs.

## Docs & tests

- User guide: new Column Lineage page, CLI-reference row, and summary entry; AI onboarding crate map/command list updated.
- End-to-end tests assert the emitted document shape, the flag conflicts, templated-output stability, and base-dir anchoring; unit tests cover the event assembly and job facet.