### PR TITLE
clinker-lineage: precise column lineage across composition boundaries

### DIFF
--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -90,15 +90,24 @@ pub struct OutputColumnLineage {
     pub facet: ColumnLineageDatasetFacet,
 }
 
+/// The result accumulators a scope walk fills: deduplicated input datasets and
+/// per-sink output lineage. Shared by reference across the top-level walk and
+/// every recursive composition-body walk, so a body's internal Sources and sinks
+/// land in the same result as the parent scope.
+#[derive(Default)]
+struct ScopeSink {
+    inputs: Vec<DatasetId>,
+    seen_inputs: HashSet<DatasetId>,
+    output_acc: Vec<OutputAcc>,
+}
+
 /// Build the DIRECT column lineage of `compiled`.
 ///
 /// `base_dir` is the workspace root (the directory containing the pipeline YAML),
 /// threaded in by the caller exactly as [`dataset_identity`] requires — it is not
 /// retained on [`CompiledPlan`].
 pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLineage {
-    let mut inputs: Vec<DatasetId> = Vec::new();
-    let mut seen_inputs: HashSet<DatasetId> = HashSet::new();
-    let mut output_acc: Vec<OutputAcc> = Vec::new();
+    let mut sink = ScopeSink::default();
 
     // Top-level scope: nothing pre-seeded.
     walk_scope(
@@ -107,13 +116,18 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
         compiled.dag(),
         &HashMap::new(),
         &HashMap::new(),
-        &mut inputs,
-        &mut seen_inputs,
-        &mut output_acc,
+        &mut sink,
     );
 
-    let outputs = output_acc.into_iter().map(OutputAcc::into_output).collect();
-    PlanColumnLineage { inputs, outputs }
+    let outputs = sink
+        .output_acc
+        .into_iter()
+        .map(OutputAcc::into_output)
+        .collect();
+    PlanColumnLineage {
+        inputs: sink.inputs,
+        outputs,
+    }
 }
 
 /// Walk one DAG scope — the top-level pipeline or a composition body — in
@@ -129,16 +143,13 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
 /// placeholder Source identity is never resolved (which would inject a phantom
 /// input). At the top level both seeds are empty, so this is a
 /// behavior-preserving extraction of the original single-scope walk.
-#[allow(clippy::too_many_arguments)]
 fn walk_scope(
     compiled: &CompiledPlan,
     base_dir: &Path,
     dag: &ExecutionPlanDag,
     seed_lineage: &HashMap<PlanNodeId, ColumnTerminals>,
     seed_influence: &HashMap<PlanNodeId, InfluenceMap>,
-    inputs: &mut Vec<DatasetId>,
-    seen_inputs: &mut HashSet<DatasetId>,
-    output_acc: &mut Vec<OutputAcc>,
+    sink: &mut ScopeSink,
 ) -> (
     HashMap<PlanNodeId, ColumnTerminals>,
     HashMap<PlanNodeId, InfluenceMap>,
@@ -182,8 +193,8 @@ fn walk_scope(
                         );
                         cols.insert(col.to_string(), terms);
                     }
-                    if seen_inputs.insert(ds.clone()) {
-                        inputs.push(ds);
+                    if sink.seen_inputs.insert(ds.clone()) {
+                        sink.inputs.push(ds);
                     }
                 }
                 cols
@@ -421,9 +432,7 @@ fn walk_scope(
                         &body_dag,
                         &seed_lineage,
                         &seed_influence,
-                        inputs,
-                        seen_inputs,
-                        output_acc,
+                        sink,
                     );
                     // Harvest the first declared output port — the records the
                     // composition surfaces, against the single `output_schema` the
@@ -502,7 +511,7 @@ fn walk_scope(
         if let PlanNode::Output { .. } = node
             && let Some(ds) = dataset_identity(node, base_dir)
         {
-            record_output(output_acc, ds, &cols, &node_influence);
+            record_output(&mut sink.output_acc, ds, &cols, &node_influence);
         }
 
         lineage.insert(node_id, cols);

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -114,8 +114,8 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
         compiled,
         base_dir,
         compiled.dag(),
-        &HashMap::new(),
-        &HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
         &mut sink,
     );
 
@@ -147,25 +147,25 @@ fn walk_scope(
     compiled: &CompiledPlan,
     base_dir: &Path,
     dag: &ExecutionPlanDag,
-    seed_lineage: &HashMap<PlanNodeId, ColumnTerminals>,
-    seed_influence: &HashMap<PlanNodeId, InfluenceMap>,
+    seed_lineage: HashMap<PlanNodeId, ColumnTerminals>,
+    seed_influence: HashMap<PlanNodeId, InfluenceMap>,
     sink: &mut ScopeSink,
 ) -> (
     HashMap<PlanNodeId, ColumnTerminals>,
     HashMap<PlanNodeId, InfluenceMap>,
 ) {
-    // Per node, per output column, the resolved Source terminals it derives from.
-    let mut lineage: HashMap<PlanNodeId, ColumnTerminals> = seed_lineage.clone();
-    // Per node, the whole-dataset INDIRECT influences accumulated from this node
-    // and every upstream — flushed into each Output's facet `dataset[]`.
-    let mut influence: HashMap<PlanNodeId, InfluenceMap> = seed_influence.clone();
     // Pre-seeded nodes keep their injected terminals/influence and are not
-    // recomputed by the walk.
+    // recomputed by the walk. Derived before the seeds move into the working maps.
     let seeded: HashSet<PlanNodeId> = seed_lineage
         .keys()
         .chain(seed_influence.keys())
         .copied()
         .collect();
+    // Per node, per output column, the resolved Source terminals it derives from.
+    let mut lineage: HashMap<PlanNodeId, ColumnTerminals> = seed_lineage;
+    // Per node, the whole-dataset INDIRECT influences accumulated from this node
+    // and every upstream — flushed into each Output's facet `dataset[]`.
+    let mut influence: HashMap<PlanNodeId, InfluenceMap> = seed_influence;
 
     for &idx in &dag.topo_order {
         let node = &dag.graph[idx];
@@ -426,12 +426,12 @@ fn walk_scope(
                             seed_influence.insert(body_src_id, inf.clone());
                         }
                     }
-                    let (body_lineage, body_influence) = walk_scope(
+                    let (body_lineage, mut body_influence) = walk_scope(
                         compiled,
                         base_dir,
                         &body_dag,
-                        &seed_lineage,
-                        &seed_influence,
+                        seed_lineage,
+                        seed_influence,
                         sink,
                     );
                     // Harvest the first declared output port — the records the
@@ -447,7 +447,7 @@ fn walk_scope(
                                 );
                             });
                         }
-                        comp_body_influence = body_influence.get(&out_id).cloned();
+                        comp_body_influence = body_influence.remove(&out_id);
                     }
                 }
                 cols

--- a/crates/clinker-lineage/src/builder.rs
+++ b/crates/clinker-lineage/src/builder.rs
@@ -21,6 +21,13 @@
 //! collapses naturally, and an upstream filter/join influence flows through every
 //! downstream node to the sink.
 //!
+//! A **Composition** node is traversed precisely: the walk recurses into the bound
+//! body, seeds each input-port Source from the parent producer feeding that port,
+//! and harvests the body's first output port — so each composition output column
+//! resolves to its true source columns, and a filter / join / group-by inside the
+//! body surfaces as INDIRECT influence on the sink. Nested compositions recurse
+//! the same way.
+//!
 //! ## Subtype model
 //!
 //! Each DIRECT input→output link carries one [`TransformationSubtype`]; along a
@@ -31,8 +38,6 @@
 //!
 //! ## Documented limitations
 //!
-//! - **Composition** nodes are treated opaquely: every output column derives from
-//!   every composition input column. Precise traversal is a #653 follow-up.
 //! - **Envelope** / `$doc` provenance is best-effort same-name passthrough only;
 //!   precise envelope lineage is a #653 follow-up.
 //! - A `match: collect` combine (no projection body) is resolved coarsely.
@@ -49,6 +54,7 @@ use std::sync::Arc;
 
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
+use petgraph::visit::EdgeRef;
 
 use clinker_plan::config::pipeline_node::MatchMode;
 use clinker_plan::plan::combine::encode_chain_column;
@@ -90,20 +96,77 @@ pub struct OutputColumnLineage {
 /// threaded in by the caller exactly as [`dataset_identity`] requires — it is not
 /// retained on [`CompiledPlan`].
 pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLineage {
-    let dag = compiled.dag();
-    // Per node, per output column, the resolved Source terminals it derives from.
-    let mut lineage: HashMap<PlanNodeId, ColumnTerminals> = HashMap::new();
-    // Per node, the whole-dataset INDIRECT influences accumulated from this node
-    // and every upstream — flushed into each Output's facet `dataset[]`.
-    let mut influence: HashMap<PlanNodeId, InfluenceMap> = HashMap::new();
     let mut inputs: Vec<DatasetId> = Vec::new();
     let mut seen_inputs: HashSet<DatasetId> = HashSet::new();
     let mut output_acc: Vec<OutputAcc> = Vec::new();
+
+    // Top-level scope: nothing pre-seeded.
+    walk_scope(
+        compiled,
+        base_dir,
+        compiled.dag(),
+        &HashMap::new(),
+        &HashMap::new(),
+        &mut inputs,
+        &mut seen_inputs,
+        &mut output_acc,
+    );
+
+    let outputs = output_acc.into_iter().map(OutputAcc::into_output).collect();
+    PlanColumnLineage { inputs, outputs }
+}
+
+/// Walk one DAG scope — the top-level pipeline or a composition body — in
+/// topological order, accumulating each node's DIRECT terminals and INDIRECT
+/// influence, and recording every Output sink into `output_acc`. Source datasets
+/// are deduplicated into `inputs`/`seen_inputs`. Returns the per-node terminal and
+/// influence maps so a caller (the Composition arm) can harvest a body's output
+/// ports.
+///
+/// `seed_lineage`/`seed_influence` pre-populate nodes whose lineage the caller
+/// already resolved — a composition body's input-port Source nodes, seeded from
+/// the parent producers feeding the call site. Those nodes are skipped so their
+/// placeholder Source identity is never resolved (which would inject a phantom
+/// input). At the top level both seeds are empty, so this is a
+/// behavior-preserving extraction of the original single-scope walk.
+#[allow(clippy::too_many_arguments)]
+fn walk_scope(
+    compiled: &CompiledPlan,
+    base_dir: &Path,
+    dag: &ExecutionPlanDag,
+    seed_lineage: &HashMap<PlanNodeId, ColumnTerminals>,
+    seed_influence: &HashMap<PlanNodeId, InfluenceMap>,
+    inputs: &mut Vec<DatasetId>,
+    seen_inputs: &mut HashSet<DatasetId>,
+    output_acc: &mut Vec<OutputAcc>,
+) -> (
+    HashMap<PlanNodeId, ColumnTerminals>,
+    HashMap<PlanNodeId, InfluenceMap>,
+) {
+    // Per node, per output column, the resolved Source terminals it derives from.
+    let mut lineage: HashMap<PlanNodeId, ColumnTerminals> = seed_lineage.clone();
+    // Per node, the whole-dataset INDIRECT influences accumulated from this node
+    // and every upstream — flushed into each Output's facet `dataset[]`.
+    let mut influence: HashMap<PlanNodeId, InfluenceMap> = seed_influence.clone();
+    // Pre-seeded nodes keep their injected terminals/influence and are not
+    // recomputed by the walk.
+    let seeded: HashSet<PlanNodeId> = seed_lineage
+        .keys()
+        .chain(seed_influence.keys())
+        .copied()
+        .collect();
 
     for &idx in &dag.topo_order {
         let node = &dag.graph[idx];
         let node_id = node.id();
 
+        if seeded.contains(&node_id) {
+            continue;
+        }
+
+        // Set by the Composition arm to the body's output-port INDIRECT influence,
+        // merged into this node's influence below.
+        let mut comp_body_influence: Option<InfluenceMap> = None;
         let cols: ColumnTerminals = match node {
             PlanNode::Source { .. } => {
                 let mut cols = ColumnTerminals::new();
@@ -317,20 +380,67 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
                 cols
             }
 
-            PlanNode::Composition { .. } => {
-                // Coarse: every output column derives from every input column.
-                let mut all = TermMap::new();
-                for up in upstream_ids(dag, idx) {
-                    if let Some(m) = lineage.get(&up) {
-                        for up_terms in m.0.values() {
-                            merge_terminals(&mut all, Some(up_terms), Subtype::Transformation);
+            PlanNode::Composition { body, .. } => {
+                // Recurse into the bound body and stitch named ports. Each input
+                // port is a real `Source` node in the body DAG (synthesized at bind
+                // time), so seeding those Sources from the parent producers and
+                // walking the body with the standard per-node rules resolves every
+                // output column to its true upstream source columns — no coarse
+                // all-to-all. `from_body` clones the body graph (O(body size),
+                // negligible vs. record volume); nested compositions recurse
+                // through this same arm.
+                let mut cols = ColumnTerminals::new();
+                if let Some(b) = compiled.body_of(*body) {
+                    let body_dag = ExecutionPlanDag::from_body(b);
+                    // Seed each bound input port's body Source from the parent
+                    // producer feeding it (the composition's incoming port-tagged
+                    // edge). Keyed by the port Source's globally-unique id, so the
+                    // body walk skips it rather than resolving its placeholder
+                    // identity into a phantom `clinker:<port>` input.
+                    let mut seed_lineage: HashMap<PlanNodeId, ColumnTerminals> = HashMap::new();
+                    let mut seed_influence: HashMap<PlanNodeId, InfluenceMap> = HashMap::new();
+                    for edge in dag.graph.edges_directed(idx, Direction::Incoming) {
+                        let Some(port) = edge.weight().port.as_deref() else {
+                            continue;
+                        };
+                        let Some(&body_src_idx) = b.port_name_to_node_idx.get(port) else {
+                            continue;
+                        };
+                        let body_src_id = b.graph[body_src_idx].id();
+                        let parent_id = dag.graph[edge.source()].id();
+                        if let Some(terms) = lineage.get(&parent_id) {
+                            seed_lineage.insert(body_src_id, terms.clone());
+                        }
+                        if let Some(inf) = influence.get(&parent_id) {
+                            seed_influence.insert(body_src_id, inf.clone());
                         }
                     }
+                    let (body_lineage, body_influence) = walk_scope(
+                        compiled,
+                        base_dir,
+                        &body_dag,
+                        &seed_lineage,
+                        &seed_influence,
+                        inputs,
+                        seen_inputs,
+                        output_acc,
+                    );
+                    // Harvest the first declared output port — the records the
+                    // composition surfaces, against the single `output_schema` the
+                    // node carries — matching the runtime harvest.
+                    if let Some((_, &out_idx)) = b.output_port_to_node_idx.iter().next() {
+                        let out_id = b.graph[out_idx].id();
+                        if let Some(body_out) = body_lineage.get(&out_id) {
+                            for_each_output_col(node, dag, |col| {
+                                cols.insert_nonempty(
+                                    col,
+                                    body_out.0.get(col).cloned().unwrap_or_default(),
+                                );
+                            });
+                        }
+                        comp_body_influence = body_influence.get(&out_id).cloned();
+                    }
                 }
-                let mut cols = ColumnTerminals::new();
-                for_each_output_col(node, dag, |col| {
-                    cols.insert_nonempty(col, all.clone());
-                });
                 cols
             }
 
@@ -378,20 +488,28 @@ pub fn column_lineage(compiled: &CompiledPlan, base_dir: &Path) -> PlanColumnLin
             }
         };
 
-        let node_influence = node_indirect_influence(node, dag, idx, &lineage, &influence);
+        let mut node_influence = node_indirect_influence(node, dag, idx, &lineage, &influence);
+        // A composition's in-body INDIRECT influence (filters / joins / group-bys
+        // inside the body), harvested at its output port, joins the inherited
+        // upstream influence. Set-union, so the parent influence carried through
+        // both paths is not double-counted.
+        if let Some(body_inf) = comp_body_influence {
+            for (terminal, subs) in body_inf {
+                node_influence.entry(terminal).or_default().extend(subs);
+            }
+        }
 
         if let PlanNode::Output { .. } = node
             && let Some(ds) = dataset_identity(node, base_dir)
         {
-            record_output(&mut output_acc, ds, &cols, &node_influence);
+            record_output(output_acc, ds, &cols, &node_influence);
         }
 
         lineage.insert(node_id, cols);
         influence.insert(node_id, node_influence);
     }
 
-    let outputs = output_acc.into_iter().map(OutputAcc::into_output).collect();
-    PlanColumnLineage { inputs, outputs }
+    (lineage, influence)
 }
 
 // ---------------------------------------------------------------------------
@@ -468,7 +586,7 @@ impl Terminal {
 type TermMap = BTreeMap<Terminal, Subtype>;
 
 /// All of one node's output columns mapped to their resolved terminals.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct ColumnTerminals(HashMap<String, TermMap>);
 
 impl ColumnTerminals {

--- a/crates/clinker-lineage/src/lib.rs
+++ b/crates/clinker-lineage/src/lib.rs
@@ -9,10 +9,10 @@
 //!
 //! [`builder::column_lineage`] populates both DIRECT (value-derivation) per-column
 //! lineage and whole-dataset INDIRECT influence (filter / join / group-by / sort /
-//! conditional). Precise composition and envelope (`$doc`) traversal remain out of
-//! scope; see that module's documented limitations. The [`emit`] module assembles
-//! a built lineage into a `START`/`COMPLETE` run-event pair ready for
-//! [`openlineage::write_ndjson`].
+//! conditional), tracing through composition bodies to true source columns.
+//! Envelope (`$doc`) traversal remains out of scope; see that module's documented
+//! limitations. The [`emit`] module assembles a built lineage into a
+//! `START`/`COMPLETE` run-event pair ready for [`openlineage::write_ndjson`].
 //!
 //! The model is pinned to OpenLineage core spec `2-0-2` and the
 //! `ColumnLineageDatasetFacet` `1-2-0`. No general-purpose Rust OpenLineage client

--- a/crates/clinker-lineage/tests/composition_lineage.rs
+++ b/crates/clinker-lineage/tests/composition_lineage.rs
@@ -1,4 +1,4 @@
-//! Column lineage traces precisely through composition boundaries (#664).
+//! Column lineage traces precisely through composition boundaries.
 //!
 //! Compositions are referenced by an on-disk `use:` path, so these tests compile
 //! inline parent pipelines against fixture `.comp.yaml` bodies under
@@ -40,15 +40,19 @@ fn lineage_of(yaml: &str) -> PlanColumnLineage {
     column_lineage(&compile_fixture(yaml), &fixtures_root())
 }
 
-/// The deterministic `file:` terminal name a source `path: data/src.csv` resolves
-/// to under `fixtures_root()`, mirroring `dataset::absolutize`.
-fn src_name() -> String {
+/// The deterministic `file:` terminal name a source `path: <rel>` resolves to
+/// under `fixtures_root()`, mirroring `dataset::absolutize`.
+fn file_dataset(rel: &str) -> String {
     fixtures_root()
-        .join("data/src.csv")
+        .join(rel)
         .to_string_lossy()
         .replace('\\', "/")
         .trim_end_matches('/')
         .to_string()
+}
+
+fn src_name() -> String {
+    file_dataset("data/src.csv")
 }
 
 fn direct(name: &str, field: &str, subtype: TransformationSubtype) -> InputField {
@@ -195,12 +199,38 @@ nodes:
 "#;
     let lineage = lineage_of(yaml);
     let src = src_name();
-    let fields = &only_output(&lineage).facet.fields;
+    let out = only_output(&lineage);
+    let fields = &out.facet.fields;
 
     use TransformationSubtype::Identity;
     // `y` (outer) = `z` (inner) = `customer_id` (source), through two boundaries.
     assert_field(fields, "y", &[direct(&src, "customer_id", Identity)]);
     assert_field(fields, "z", &[direct(&src, "customer_id", Identity)]);
+    // Open-row passthrough carries the source column across both boundaries.
+    assert_field(
+        fields,
+        "customer_id",
+        &[direct(&src, "customer_id", Identity)],
+    );
+    assert_eq!(
+        fields.len(),
+        3,
+        "no extra/dropped columns across two boundaries"
+    );
+    // The novel double-recursion seed loop must not leak a phantom
+    // `clinker:o_in`/`clinker:i_in` input at either boundary.
+    assert_eq!(
+        lineage.inputs,
+        vec![DatasetId {
+            namespace: "file".to_string(),
+            name: src.clone(),
+        }],
+        "only the real source should be an input across nested boundaries"
+    );
+    assert!(
+        out.facet.dataset.is_empty(),
+        "no INDIRECT influence expected"
+    );
 }
 
 /// An aggregate inside a composition body: the DIRECT subtypes cross the boundary
@@ -249,6 +279,105 @@ nodes:
             .dataset
             .contains(&indirect(&src, "department", &[GroupBy])),
         "expected in-body group-by to surface as INDIRECT influence, got {:?}",
+        out.facet.dataset
+    );
+}
+
+/// A body with TWO input ports fed by TWO different parents, joined inside the
+/// body. Exercises the multi-port seeding loop: each port's synthetic Source must
+/// be seeded from its OWN parent (no cross-wiring), each output column must
+/// resolve to the correct side, both real sources must appear as inputs (no
+/// phantom port inputs), and the in-body join keys must surface as INDIRECT.
+#[test]
+fn lineage_traces_each_input_port_to_its_own_parent() {
+    let yaml = r#"
+pipeline: { name: join_ports_test }
+nodes:
+  - type: source
+    name: orders_src
+    config:
+      name: orders_src
+      type: csv
+      path: data/orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+        - { name: quantity, type: int }
+  - type: source
+    name: products_src
+    config:
+      name: products_src
+      type: csv
+      path: data/products.csv
+      schema:
+        - { name: product_id, type: string }
+        - { name: name, type: string }
+        - { name: price, type: float }
+  - type: composition
+    name: comp
+    input: orders_src
+    use: ../compositions/join_ports.comp.yaml
+    inputs:
+      orders: orders_src
+      products: products_src
+  - type: output
+    name: out
+    input: comp
+    config: { name: out, type: csv, path: out/join.csv }
+"#;
+    let lineage = lineage_of(yaml);
+    let orders = file_dataset("data/orders.csv");
+    let products = file_dataset("data/products.csv");
+    let out = only_output(&lineage);
+    let fields = &out.facet.fields;
+
+    use TransformationSubtype::{Identity, Transformation};
+    // Each output column resolves to the column on its OWN side of the join.
+    assert_field(fields, "order_id", &[direct(&orders, "order_id", Identity)]);
+    assert_field(
+        fields,
+        "product_name",
+        &[direct(&products, "name", Identity)],
+    );
+    // A cross-side computed column draws from both parents (terminals ordered by
+    // namespace/name/field: orders.csv < products.csv).
+    assert_field(
+        fields,
+        "total",
+        &[
+            direct(&orders, "quantity", Transformation),
+            direct(&products, "price", Transformation),
+        ],
+    );
+
+    // Both real sources are inputs and nothing else — no phantom
+    // `clinker:orders`/`clinker:products` port inputs. Order-independent: the
+    // topological order of two independent roots is not contractually fixed.
+    assert_eq!(lineage.inputs.len(), 2, "exactly two real source inputs");
+    for name in [&orders, &products] {
+        assert!(
+            lineage.inputs.contains(&DatasetId {
+                namespace: "file".to_string(),
+                name: name.clone(),
+            }),
+            "missing real source input {name:?}; got {:?}",
+            lineage.inputs
+        );
+    }
+    // The in-body join key on each side surfaces as INDIRECT (JOIN) influence.
+    use TransformationSubtype::Join;
+    assert!(
+        out.facet
+            .dataset
+            .contains(&indirect(&orders, "product_id", &[Join])),
+        "expected orders join-key as INDIRECT JOIN, got {:?}",
+        out.facet.dataset
+    );
+    assert!(
+        out.facet
+            .dataset
+            .contains(&indirect(&products, "product_id", &[Join])),
+        "expected products join-key as INDIRECT JOIN, got {:?}",
         out.facet.dataset
     );
 }

--- a/crates/clinker-lineage/tests/composition_lineage.rs
+++ b/crates/clinker-lineage/tests/composition_lineage.rs
@@ -1,0 +1,254 @@
+//! Column lineage traces precisely through composition boundaries (#664).
+//!
+//! Compositions are referenced by an on-disk `use:` path, so these tests compile
+//! inline parent pipelines against fixture `.comp.yaml` bodies under
+//! `tests/fixtures/compositions/`. Like the unit tests in `builder.rs`, no source
+//! data is read — lineage is derived statically from the compiled plan — so the
+//! `data/src.csv` paths need not exist.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use clinker_lineage::{
+    DatasetId, FieldLineage, InputField, OutputColumnLineage, PlanColumnLineage, Transformation,
+    TransformationSubtype, TransformationType, column_lineage,
+};
+use clinker_plan::CompileContext;
+use clinker_plan::config::parse_config;
+use clinker_plan::plan::CompiledPlan;
+
+fn fixtures_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+}
+
+/// Compile an inline parent pipeline, resolving composition `use:` paths against
+/// `tests/fixtures/pipelines/` (so `../compositions/x.comp.yaml` lands in
+/// `tests/fixtures/compositions/`).
+fn compile_fixture(yaml: &str) -> CompiledPlan {
+    parse_config(yaml)
+        .expect("parse_config")
+        .compile(&CompileContext::with_pipeline_dir(
+            fixtures_root(),
+            "pipelines",
+        ))
+        .expect("compile should succeed")
+}
+
+fn lineage_of(yaml: &str) -> PlanColumnLineage {
+    column_lineage(&compile_fixture(yaml), &fixtures_root())
+}
+
+/// The deterministic `file:` terminal name a source `path: data/src.csv` resolves
+/// to under `fixtures_root()`, mirroring `dataset::absolutize`.
+fn src_name() -> String {
+    fixtures_root()
+        .join("data/src.csv")
+        .to_string_lossy()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+fn direct(name: &str, field: &str, subtype: TransformationSubtype) -> InputField {
+    InputField {
+        namespace: "file".to_string(),
+        name: name.to_string(),
+        field: field.to_string(),
+        transformations: vec![Transformation {
+            transformation_type: TransformationType::Direct,
+            subtype: Some(subtype),
+            description: None,
+            masking: None,
+        }],
+    }
+}
+
+fn indirect(name: &str, field: &str, subtypes: &[TransformationSubtype]) -> InputField {
+    InputField {
+        namespace: "file".to_string(),
+        name: name.to_string(),
+        field: field.to_string(),
+        transformations: subtypes
+            .iter()
+            .map(|s| Transformation {
+                transformation_type: TransformationType::Indirect,
+                subtype: Some(*s),
+                description: None,
+                masking: None,
+            })
+            .collect(),
+    }
+}
+
+fn only_output(lineage: &PlanColumnLineage) -> &OutputColumnLineage {
+    assert_eq!(
+        lineage.outputs.len(),
+        1,
+        "expected exactly one output dataset"
+    );
+    &lineage.outputs[0]
+}
+
+fn assert_field(fields: &BTreeMap<String, FieldLineage>, col: &str, expected: &[InputField]) {
+    let actual = fields
+        .get(col)
+        .unwrap_or_else(|| panic!("column {col:?} missing from lineage"));
+    assert_eq!(actual.input_fields, expected, "lineage for column {col:?}");
+}
+
+/// A single-boundary composition whose body renames a port column. The renamed
+/// output column must resolve to the TRUE source column (not the coarse
+/// all-to-all fan-out the opaque approximation produced), and the placeholder
+/// input-port Source must not leak as a phantom input.
+#[test]
+fn lineage_traces_through_a_composition_to_the_true_source_column() {
+    let yaml = r#"
+pipeline: { name: rename_test }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: data/src.csv
+      schema:
+        - { name: customer_id, type: string }
+        - { name: name, type: string }
+  - type: composition
+    name: comp
+    input: src
+    use: ../compositions/rename_id.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out
+    input: comp
+    config: { name: out, type: csv, path: out/rename.csv }
+"#;
+    let lineage = lineage_of(yaml);
+    let src = src_name();
+    let out = only_output(&lineage);
+    let fields = &out.facet.fields;
+
+    use TransformationSubtype::Identity;
+    // The rename resolves to its true source column — exact match rejects any
+    // fan-out to the sibling `name` column.
+    assert_field(fields, "x", &[direct(&src, "customer_id", Identity)]);
+    // Open-row passthrough through the port keeps each column's own source.
+    assert_field(
+        fields,
+        "customer_id",
+        &[direct(&src, "customer_id", Identity)],
+    );
+    assert_field(fields, "name", &[direct(&src, "name", Identity)]);
+    assert_eq!(
+        fields.len(),
+        3,
+        "no extra/omitted columns across the boundary"
+    );
+
+    // No filter/join/group inside the body → no INDIRECT influence.
+    assert!(
+        out.facet.dataset.is_empty(),
+        "no INDIRECT influence expected, got {:?}",
+        out.facet.dataset
+    );
+    // The bound input-port Source is seeded and skipped, so it never becomes a
+    // phantom `clinker:<port>` input — only the real source is reported.
+    assert_eq!(
+        lineage.inputs,
+        vec![DatasetId {
+            namespace: "file".to_string(),
+            name: src.clone(),
+        }],
+        "only the real source should be an input"
+    );
+}
+
+/// A composition that calls another composition: lineage must resolve across
+/// both stitched boundaries back to the real source column.
+#[test]
+fn lineage_traces_through_nested_compositions() {
+    let yaml = r#"
+pipeline: { name: nested_test }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: data/src.csv
+      schema:
+        - { name: customer_id, type: string }
+  - type: composition
+    name: top
+    input: src
+    use: ../compositions/outer.comp.yaml
+    inputs:
+      o_in: src
+  - type: output
+    name: out
+    input: top
+    config: { name: out, type: csv, path: out/nested.csv }
+"#;
+    let lineage = lineage_of(yaml);
+    let src = src_name();
+    let fields = &only_output(&lineage).facet.fields;
+
+    use TransformationSubtype::Identity;
+    // `y` (outer) = `z` (inner) = `customer_id` (source), through two boundaries.
+    assert_field(fields, "y", &[direct(&src, "customer_id", Identity)]);
+    assert_field(fields, "z", &[direct(&src, "customer_id", Identity)]);
+}
+
+/// An aggregate inside a composition body: the DIRECT subtypes cross the boundary
+/// (sum -> AGGREGATION, group key -> IDENTITY) and the in-body GROUP BY surfaces
+/// as INDIRECT (GROUP_BY) influence on the composition output.
+#[test]
+fn in_body_group_by_surfaces_as_indirect_influence() {
+    let yaml = r#"
+pipeline: { name: agg_test }
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: data/src.csv
+      schema:
+        - { name: department, type: string }
+        - { name: amount, type: int }
+  - type: composition
+    name: comp
+    input: src
+    use: ../compositions/agg_in_body.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out
+    input: comp
+    config: { name: out, type: csv, path: out/agg.csv }
+"#;
+    let lineage = lineage_of(yaml);
+    let src = src_name();
+    let out = only_output(&lineage);
+    let fields = &out.facet.fields;
+
+    use TransformationSubtype::{Aggregation, GroupBy, Identity};
+    assert_field(
+        fields,
+        "department",
+        &[direct(&src, "department", Identity)],
+    );
+    assert_field(fields, "total", &[direct(&src, "amount", Aggregation)]);
+
+    assert!(
+        out.facet
+            .dataset
+            .contains(&indirect(&src, "department", &[GroupBy])),
+        "expected in-body group-by to surface as INDIRECT influence, got {:?}",
+        out.facet.dataset
+    );
+}

--- a/crates/clinker-lineage/tests/fixtures/compositions/agg_in_body.comp.yaml
+++ b/crates/clinker-lineage/tests/fixtures/compositions/agg_in_body.comp.yaml
@@ -1,0 +1,23 @@
+# A body that aggregates with a GROUP BY. Proves both DIRECT subtypes across
+# the boundary (sum -> AGGREGATION, group key -> IDENTITY) and that an in-body
+# group-by surfaces as INDIRECT (GROUP_BY) influence on the composition output.
+_compose:
+  name: agg_in_body
+  inputs:
+    inp:
+      schema:
+        - { name: department, type: string }
+        - { name: amount, type: int }
+  outputs:
+    out: dept_totals
+  config_schema: {}
+
+nodes:
+  - type: aggregate
+    name: dept_totals
+    input: inp
+    config:
+      group_by: [department]
+      cxl: |
+        emit department = department
+        emit total = sum(amount)

--- a/crates/clinker-lineage/tests/fixtures/compositions/inner.comp.yaml
+++ b/crates/clinker-lineage/tests/fixtures/compositions/inner.comp.yaml
@@ -1,0 +1,18 @@
+# Inner composition of the nested pair: renames the port column into `z`.
+_compose:
+  name: inner
+  inputs:
+    i_in:
+      schema:
+        - { name: customer_id, type: string }
+  outputs:
+    i_out: inner_proj
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: inner_proj
+    input: i_in
+    config:
+      cxl: |
+        emit z = customer_id

--- a/crates/clinker-lineage/tests/fixtures/compositions/join_ports.comp.yaml
+++ b/crates/clinker-lineage/tests/fixtures/compositions/join_ports.comp.yaml
@@ -1,0 +1,36 @@
+# Two input ports joined inside the body. Exercises the multi-port seeding
+# path: each port's synthetic Source must be seeded from its OWN parent
+# producer (no cross-wiring), and the combine must resolve each output column
+# to the correct side.
+_compose:
+  name: join_ports
+  inputs:
+    orders:
+      schema:
+        - { name: order_id, type: string }
+        - { name: product_id, type: string }
+        - { name: quantity, type: int }
+    products:
+      schema:
+        - { name: product_id, type: string }
+        - { name: name, type: string }
+        - { name: price, type: float }
+  outputs:
+    out: enrich_combine
+  config_schema: {}
+
+nodes:
+  - type: combine
+    name: enrich_combine
+    input:
+      orders: orders
+      products: products
+    config:
+      where: "orders.product_id == products.product_id"
+      match: first
+      on_miss: null_fields
+      cxl: |
+        emit order_id = orders.order_id
+        emit product_name = products.name
+        emit total = products.price * orders.quantity
+      propagate_ck: driver

--- a/crates/clinker-lineage/tests/fixtures/compositions/outer.comp.yaml
+++ b/crates/clinker-lineage/tests/fixtures/compositions/outer.comp.yaml
@@ -1,0 +1,26 @@
+# Outer composition of the nested pair: calls `inner` and renames its `z`
+# output into `y`. Proves lineage resolves across two stitched composition
+# boundaries back to the real source column.
+_compose:
+  name: outer
+  inputs:
+    o_in:
+      schema:
+        - { name: customer_id, type: string }
+  outputs:
+    o_out: outer_tag
+  config_schema: {}
+
+nodes:
+  - type: composition
+    name: inner_call
+    input: o_in
+    use: ./inner.comp.yaml
+    inputs:
+      i_in: o_in
+  - type: transform
+    name: outer_tag
+    input: inner_call
+    config:
+      cxl: |
+        emit y = z

--- a/crates/clinker-lineage/tests/fixtures/compositions/rename_id.comp.yaml
+++ b/crates/clinker-lineage/tests/fixtures/compositions/rename_id.comp.yaml
@@ -1,0 +1,22 @@
+# Single input port; the body emits an output column derived from a port
+# column (a rename), plus open-row passthrough of the port columns. Used to
+# prove lineage traces through the body to the true source column rather than
+# fanning out to every input column.
+_compose:
+  name: rename_id
+  inputs:
+    inp:
+      schema:
+        - { name: customer_id, type: string }
+        - { name: name, type: string }
+  outputs:
+    out: body_proj
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: body_proj
+    input: inp
+    config:
+      cxl: |
+        emit x = customer_id

--- a/docs/user/src/ops/lineage.md
+++ b/docs/user/src/ops/lineage.md
@@ -43,7 +43,7 @@ The facet has two parts, mirroring the OpenLineage `ColumnLineageDatasetFacet`:
 }
 ```
 
-- **`fields`** -- **DIRECT** (value-derivation) lineage, keyed per output column: the source columns each output column's *value* is computed from. A rename (`emit full = name`) or a multi-hop chain collapses to the originating source column.
+- **`fields`** -- **DIRECT** (value-derivation) lineage, keyed per output column: the source columns each output column's *value* is computed from. A rename (`emit full = name`), a multi-hop chain, or a path through a **composition** body (including nested compositions) collapses to the originating source column.
 - **`dataset`** -- **INDIRECT** (influence) lineage for the dataset as a whole: source columns that shaped *which rows* exist, via filtering, joining, grouping, or sorting -- collected once rather than duplicated across every column.
 
 Each transformation carries a `type` (`DIRECT` / `INDIRECT`) and a `subtype` (`IDENTITY`, `TRANSFORMATION`, `AGGREGATION`, `JOIN`, `GROUP_BY`, `FILTER`, `SORT`, `CONDITIONAL`).
@@ -60,7 +60,6 @@ Because `--lineage` reads no data, it runs instantly and works on a pipeline who
 
 Lineage is derived from the compiled plan, so a few constructs are approximated:
 
-- A **Composition** node is treated opaquely: every output column is taken to derive from every composition input column.
 - **Envelope** / `$doc` provenance is best-effort same-name passthrough.
 - INDIRECT influence covers route/cull predicates, join keys, aggregate grouping, and correlation sort. An aggregate's pre-aggregation row `filter`, a transform-inline `filter`, and Reshape `order_by` / `partition_by` are not (yet) attributed as influence.
 - Constant and `count(*)` columns (which have no source input) are omitted from `fields`; engine-stamped columns (`$ck.*`, `$meta.*`, `$source.*`) are skipped, mirroring the default writer.


### PR DESCRIPTION
## Summary

Makes column-level data lineage precise across composition boundaries. Previously, `clinker-lineage` treated a `composition` node opaquely — every output column was reported as deriving from *every* composition input column (a coarse all-to-all approximation). This change walks into the composition body and stitches named input/output ports, so each composition output column traces to its true source column(s).

Closes #664.

## How it works

A composition's input ports are already represented as real `Source` nodes wired into the body's sub-DAG, so the lineage builder can reuse its existing per-node resolution on the body:

- At each `composition` node, seed every bound input-port `Source` with the already-resolved terminals of the parent producer feeding that port (read from the call site's incoming port-tagged edges).
- Recurse the body sub-DAG with the same per-node rules; the seeded port `Source` is skipped so it never leaks as a phantom input dataset.
- Harvest the body's first declared output port back onto the composition node's output columns, matching the runtime's single-output-port composition semantics.

A filter / join / group-by inside the body now surfaces as INDIRECT influence on the sink, and nested compositions recurse the same way. The per-node walk was extracted into a reusable `walk_scope`, so the top-level pipeline and a composition body are traversed identically; the top-level path is behavior-preserving.

## Tests

New integration tests in `crates/clinker-lineage/tests/composition_lineage.rs`, over on-disk composition fixtures:

- **single boundary** — a renamed output column resolves to the true source column (no fan-out), and no phantom port input leaks into the input list;
- **nested compositions** — resolution across two stitched boundaries;
- **aggregate inside a body** — DIRECT subtypes cross the boundary (`sum` → AGGREGATION, group key → IDENTITY) and the in-body `GROUP BY` surfaces as INDIRECT influence;
- **two-input-port body joined inside the composition** — each output column resolves to the correct side, both real sources appear as inputs, and both join keys surface as INDIRECT.

The existing builder unit tests pass unchanged (the refactor is behavior-preserving for non-composition pipelines).

## Docs

Updated the user-facing lineage doc and the crate docs to drop the now-obsolete "composition is treated opaquely" limitation.

## Out of scope

Envelope / `$doc` provenance remains coarse (tracked separately). A body that declares more than one output port is harvested at its first port, matching current runtime behavior.
