### PR TITLE
config: reject overflowing memory.limit size suffixes (checked_mul + typed error)

### DIFF
--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -386,9 +386,16 @@ impl PipelineExecutor {
         // storage-config validation the CLI run path performs, instead of
         // letting the run park. Scoped to the pausing policies; `spill`
         // makes forward progress under a tiny budget and is left alone.
+        // The run boundary is where a bad `memory.limit` becomes a user-facing
+        // error: an unparseable value falls back to the default budget, but a
+        // value whose binary-suffix scaling overflows `u64` fails the run here
+        // with a config diagnostic instead of panicking or wrapping. Every
+        // downstream consumer (arbitrator, dispatch budgets) re-reads the same
+        // validated string, so this gate keeps them overflow-free.
         let configured_limit = clinker_plan::config::utils::parse_memory_limit_bytes(
             config.pipeline.memory.limit.as_deref(),
-        );
+        )
+        .map_err(PipelineError::Config)?;
         crate::pipeline::memory::reject_unsatisfiable_budget(
             configured_limit,
             config.pipeline.memory.backpressure,

--- a/crates/clinker-exec/src/executor/util.rs
+++ b/crates/clinker-exec/src/executor/util.rs
@@ -301,10 +301,15 @@ pub(crate) fn record_with_emitted_fields(
 /// on a 32-bit host a limit above `usize::MAX` saturates rather than
 /// wrapping.
 pub(crate) fn parse_memory_limit(config: &PipelineConfig) -> usize {
-    usize::try_from(clinker_plan::config::utils::parse_memory_limit_bytes(
+    // Reached only from inside a run, after the startup boundary
+    // (`run_with_readers_writers_in_context`) has already rejected an
+    // overflowing `memory.limit`. The default-on-error fallback is therefore
+    // unreachable on the run path; it only keeps this helper panic-free.
+    let bytes = clinker_plan::config::utils::parse_memory_limit_bytes(
         config.pipeline.memory.limit.as_deref(),
-    ))
-    .unwrap_or(usize::MAX)
+    )
+    .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES);
+    usize::try_from(bytes).unwrap_or(usize::MAX)
 }
 
 /// Build a `MemoryArbitrator` from the pipeline-level `memory:` block.
@@ -317,7 +322,11 @@ pub(crate) fn build_arbitrator_from_config(
     config: &PipelineConfig,
 ) -> crate::pipeline::memory::MemoryArbitrator {
     let mem = &config.pipeline.memory;
-    let limit = clinker_plan::config::utils::parse_memory_limit_bytes(mem.limit.as_deref());
+    // Called only after the run boundary validated `memory.limit`, so the
+    // default-on-error fallback never fires here on the run path; it keeps the
+    // builder total rather than re-surfacing an already-rejected error.
+    let limit = clinker_plan::config::utils::parse_memory_limit_bytes(mem.limit.as_deref())
+        .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES);
     crate::pipeline::memory::MemoryArbitrator::with_policy(
         limit,
         0.80,
@@ -381,7 +390,8 @@ nodes:
             let config = clinker_plan::config::parse_config(&yaml).expect("parses");
             let arbitrator_ceiling = clinker_plan::config::utils::parse_memory_limit_bytes(
                 config.pipeline.memory.limit.as_deref(),
-            );
+            )
+            .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES);
             assert_eq!(
                 parse_memory_limit(&config) as u64,
                 arbitrator_ceiling,

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1797,7 +1797,8 @@ mod tests {
 
     #[test]
     fn test_parse_memory_limit_default_512mb() {
-        let limit = clinker_plan::config::utils::parse_memory_limit_bytes(None);
+        let limit = clinker_plan::config::utils::parse_memory_limit_bytes(None)
+            .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES);
         let arbitrator = MemoryArbitrator::with_policy(limit, 0.80, Box::new(NoOpPolicy));
         assert_eq!(arbitrator.limit(), 512 * 1024 * 1024);
         assert!((arbitrator.spill_threshold_pct() - 0.80).abs() < f64::EPSILON);

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -1829,7 +1829,8 @@ mod tests {
         let mut budget = match rk.budget_bytes {
             Some(b) => MemoryArbitrator::with_policy(b, 0.80, Box::new(NoOpPolicy)),
             None => MemoryArbitrator::with_policy(
-                clinker_plan::config::utils::parse_memory_limit_bytes(None),
+                clinker_plan::config::utils::parse_memory_limit_bytes(None)
+                    .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES),
                 0.80,
                 Box::new(NoOpPolicy),
             ),

--- a/crates/clinker-plan/src/config/utils.rs
+++ b/crates/clinker-plan/src/config/utils.rs
@@ -112,26 +112,61 @@ impl<'de> Deserialize<'de> for TimeBound {
     }
 }
 
+/// Memory budget used when `memory.limit` is omitted, empty, or
+/// unparseable. The arbitrator ceiling, the planner's grace-hash
+/// heuristic, and the `--explain` renderers all fall back to this single
+/// value so every consumer agrees on the default budget.
+pub const DEFAULT_MEMORY_LIMIT_BYTES: u64 = 512 * 1024 * 1024;
+
 /// Parse the `memory.limit` knob into a byte count.
 ///
 /// Binary units: a trailing `G`/`g`, `M`/`m`, or `K`/`k` multiplies by
 /// 1024^3 / 1024^2 / 1024; a bare integer is bytes. `None`, an empty
-/// value, or any unparseable input falls back to the 512 MB default that
-/// the arbitrator and the `--explain` renderers share.
-pub fn parse_memory_limit_bytes(s: Option<&str>) -> u64 {
-    s.and_then(|s| {
-        let s = s.trim();
-        if let Some(num) = s.strip_suffix('G').or_else(|| s.strip_suffix('g')) {
-            num.parse::<u64>().ok().map(|n| n * 1024 * 1024 * 1024)
-        } else if let Some(num) = s.strip_suffix('M').or_else(|| s.strip_suffix('m')) {
-            num.parse::<u64>().ok().map(|n| n * 1024 * 1024)
-        } else if let Some(num) = s.strip_suffix('K').or_else(|| s.strip_suffix('k')) {
-            num.parse::<u64>().ok().map(|n| n * 1024)
-        } else {
-            s.parse::<u64>().ok()
-        }
+/// value, or any unparseable input falls back to
+/// [`DEFAULT_MEMORY_LIMIT_BYTES`] (512 MB).
+///
+/// A value whose numeric part parses but whose binary-suffix scaling
+/// exceeds `u64::MAX` is rejected with [`ConfigError::Validation`] rather
+/// than silently wrapping — the suffix multiplication is checked.
+///
+/// [`ConfigError::Validation`]: crate::config::ConfigError::Validation
+pub fn parse_memory_limit_bytes(s: Option<&str>) -> Result<u64, crate::config::ConfigError> {
+    let Some(raw) = s else {
+        return Ok(DEFAULT_MEMORY_LIMIT_BYTES);
+    };
+    let trimmed = raw.trim();
+    let (num_part, multiplier) = if let Some(num) = trimmed
+        .strip_suffix('G')
+        .or_else(|| trimmed.strip_suffix('g'))
+    {
+        (num, 1024 * 1024 * 1024)
+    } else if let Some(num) = trimmed
+        .strip_suffix('M')
+        .or_else(|| trimmed.strip_suffix('m'))
+    {
+        (num, 1024 * 1024)
+    } else if let Some(num) = trimmed
+        .strip_suffix('K')
+        .or_else(|| trimmed.strip_suffix('k'))
+    {
+        (num, 1024)
+    } else {
+        (trimmed, 1)
+    };
+    // An unparseable numeric part keeps the lenient fallback contract: the
+    // caller gets the default budget, matching the historical handling of
+    // `None`/empty/garbage input. Only a value that parses cleanly yet
+    // overflows the byte range when scaled by its binary suffix is an
+    // error — that is the case the previous unchecked multiply wrapped (or
+    // panicked on in debug builds).
+    let Ok(value) = num_part.parse::<u64>() else {
+        return Ok(DEFAULT_MEMORY_LIMIT_BYTES);
+    };
+    value.checked_mul(multiplier).ok_or_else(|| {
+        crate::config::ConfigError::Validation(format!(
+            "memory.limit {trimmed:?} overflows the maximum addressable byte count (u64::MAX)"
+        ))
     })
-    .unwrap_or(512 * 1024 * 1024) // 512MB default
 }
 
 /// Byte size for `min_size` / `max_size`. Decimal units (1KB = 1000 bytes,
@@ -212,17 +247,87 @@ pub(crate) fn default_include_unmapped() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_memory_limit_bytes;
+    use super::{DEFAULT_MEMORY_LIMIT_BYTES, parse_memory_limit_bytes};
+    use crate::config::ConfigError;
 
     #[test]
     fn memory_limit_parses_unit_suffixes() {
-        assert_eq!(parse_memory_limit_bytes(Some("512M")), 536_870_912);
-        assert_eq!(parse_memory_limit_bytes(Some("512m")), 536_870_912);
-        assert_eq!(parse_memory_limit_bytes(Some("2G")), 2_147_483_648);
-        assert_eq!(parse_memory_limit_bytes(Some("2g")), 2_147_483_648);
-        assert_eq!(parse_memory_limit_bytes(Some("512K")), 524_288);
-        assert_eq!(parse_memory_limit_bytes(Some("1024")), 1024);
-        assert_eq!(parse_memory_limit_bytes(None), 512 * 1024 * 1024);
-        assert_eq!(parse_memory_limit_bytes(Some("garbage")), 512 * 1024 * 1024);
+        // `.ok()` collapses the success arm to a comparable `Option<u64>`;
+        // `ConfigError` is not `PartialEq`, so the Result cannot be compared
+        // directly.
+        assert_eq!(
+            parse_memory_limit_bytes(Some("512M")).ok(),
+            Some(536_870_912)
+        );
+        assert_eq!(
+            parse_memory_limit_bytes(Some("512m")).ok(),
+            Some(536_870_912)
+        );
+        assert_eq!(
+            parse_memory_limit_bytes(Some("2G")).ok(),
+            Some(2_147_483_648)
+        );
+        assert_eq!(
+            parse_memory_limit_bytes(Some("2g")).ok(),
+            Some(2_147_483_648)
+        );
+        assert_eq!(parse_memory_limit_bytes(Some("512K")).ok(), Some(524_288));
+        assert_eq!(parse_memory_limit_bytes(Some("1024")).ok(), Some(1024));
+        assert_eq!(
+            parse_memory_limit_bytes(None).ok(),
+            Some(DEFAULT_MEMORY_LIMIT_BYTES)
+        );
+    }
+
+    #[test]
+    fn memory_limit_unparseable_falls_back_to_default() {
+        // The lenient contract: a value that does not parse (no recognized
+        // suffix, non-numeric body) yields the default budget, not an error.
+        assert_eq!(
+            parse_memory_limit_bytes(Some("garbage")).ok(),
+            Some(DEFAULT_MEMORY_LIMIT_BYTES)
+        );
+        assert_eq!(
+            parse_memory_limit_bytes(Some("")).ok(),
+            Some(DEFAULT_MEMORY_LIMIT_BYTES)
+        );
+        // Numeric body that itself exceeds `u64` (parse failure, never
+        // reaching the suffix multiply) also falls back rather than erroring.
+        assert_eq!(
+            parse_memory_limit_bytes(Some("99999999999999999999G")).ok(),
+            Some(DEFAULT_MEMORY_LIMIT_BYTES)
+        );
+    }
+
+    #[test]
+    fn memory_limit_max_safe_value_does_not_overflow() {
+        // `floor(u64::MAX / 1024^3) = 2^34 - 1` is the largest `G`-suffixed
+        // value whose scaling still fits in `u64`.
+        let max_safe_g = (1u64 << 34) - 1; // 17_179_869_183
+        assert_eq!(
+            parse_memory_limit_bytes(Some(&format!("{max_safe_g}G"))).ok(),
+            Some(max_safe_g * 1024 * 1024 * 1024),
+        );
+        // A bare byte count at the ceiling has multiplier 1 — also safe.
+        assert_eq!(
+            parse_memory_limit_bytes(Some(&u64::MAX.to_string())).ok(),
+            Some(u64::MAX),
+        );
+    }
+
+    #[test]
+    fn memory_limit_overflow_is_a_typed_error() {
+        // `2^34 * 1024^3 = 2^64`, one past `u64::MAX` — the numeric part
+        // parses, but the suffix multiply overflows and must be rejected.
+        let overflow_g = 1u64 << 34; // 17_179_869_184
+        match parse_memory_limit_bytes(Some(&format!("{overflow_g}G"))) {
+            Err(ConfigError::Validation(msg)) => {
+                assert!(
+                    msg.contains("memory.limit") && msg.contains("overflow"),
+                    "diagnostic must name the setting and the overflow; got: {msg}"
+                );
+            }
+            other => panic!("expected ConfigError::Validation for overflow, got: {other:?}"),
+        }
     }
 }

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -967,12 +967,16 @@ fn grace_hash_should_fire(
     statistics: &crate::plan::statistics::StatisticsCatalog,
     mem_limit_str: Option<&str>,
 ) -> bool {
-    use crate::config::utils::parse_memory_limit_bytes;
+    use crate::config::utils::{DEFAULT_MEMORY_LIMIT_BYTES, parse_memory_limit_bytes};
 
     let Some(build_estimate) = build_side_row_count(inputs, statistics) else {
         return false;
     };
-    let limit = parse_memory_limit_bytes(mem_limit_str);
+    // This is an advisory planning threshold, not a run gate: a `memory.limit`
+    // that overflows is rejected at the executor's startup boundary before any
+    // run reaches dispatch, so fall back to the default budget here rather than
+    // threading a config error through strategy selection.
+    let limit = parse_memory_limit_bytes(mem_limit_str).unwrap_or(DEFAULT_MEMORY_LIMIT_BYTES);
     let soft_limit = limit / 100 * 80;
     let estimated_bytes =
         build_estimate.saturating_mul(crate::plan::statistics::RECORD_BYTES_ESTIMATE);

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -1072,8 +1072,12 @@ impl ExecutionPlanDag {
         config: &PipelineConfig,
         statistics: &crate::plan::statistics::StatisticsCatalog,
     ) -> String {
+        // Rendering is advisory and infallible by contract; an overflowing
+        // `memory.limit` is rejected at the executor's run boundary, so the
+        // explain view falls back to the default budget instead of erroring.
         let total_limit =
-            crate::config::utils::parse_memory_limit_bytes(config.pipeline.memory.limit.as_deref());
+            crate::config::utils::parse_memory_limit_bytes(config.pipeline.memory.limit.as_deref())
+                .unwrap_or(crate::config::utils::DEFAULT_MEMORY_LIMIT_BYTES);
         let mut out = self.explain_with_statistics(config, statistics, total_limit);
         // Re-render the retraction section with the pipeline config in
         // scope so the fanout-policy line resolves to the user-visible
@@ -1916,7 +1920,8 @@ impl<'a> Serialize for ExplainJson<'a> {
         // share derived from the global default (512MB) divided by
         // the combine count. Callers that have already overridden
         // the limit see the correct share through the text path.
-        let total_memory_limit = crate::config::utils::parse_memory_limit_bytes(None);
+        // `None` always resolves to the default budget; surface it directly.
+        let total_memory_limit = crate::config::utils::DEFAULT_MEMORY_LIMIT_BYTES;
 
         map.serialize_entry(
             "nodes",

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -219,7 +219,11 @@ pub struct RunArgs {
 
 impl RunArgs {
     /// Resolve memory limit from CLI flag or default (512MB).
-    pub fn memory_limit_bytes(&self) -> u64 {
+    ///
+    /// Returns a config error when the flag value's binary-suffix scaling
+    /// overflows `u64`, so the caller surfaces a clear diagnostic to the
+    /// operator instead of panicking or silently wrapping to a tiny budget.
+    pub fn memory_limit_bytes(&self) -> Result<u64, clinker_plan::config::ConfigError> {
         parse_memory_limit_bytes(self.mem_limit.as_deref().or(Some("512M")))
     }
 
@@ -2213,7 +2217,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["clinker", "run", "--memory-limit", "512K", "p.yaml"]).unwrap();
         match cli.command {
-            Commands::Run(args) => assert_eq!(args.memory_limit_bytes(), 524288),
+            Commands::Run(args) => assert_eq!(args.memory_limit_bytes().ok(), Some(524288)),
             _ => panic!("expected Run command"),
         }
     }
@@ -2223,7 +2227,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["clinker", "run", "--memory-limit", "256M", "p.yaml"]).unwrap();
         match cli.command {
-            Commands::Run(args) => assert_eq!(args.memory_limit_bytes(), 268435456),
+            Commands::Run(args) => assert_eq!(args.memory_limit_bytes().ok(), Some(268435456)),
             _ => panic!("expected Run command"),
         }
     }
@@ -2233,7 +2237,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["clinker", "run", "--memory-limit", "2G", "p.yaml"]).unwrap();
         match cli.command {
-            Commands::Run(args) => assert_eq!(args.memory_limit_bytes(), 2147483648),
+            Commands::Run(args) => assert_eq!(args.memory_limit_bytes().ok(), Some(2147483648)),
             _ => panic!("expected Run command"),
         }
     }
@@ -2243,7 +2247,7 @@ mod tests {
         let cli =
             Cli::try_parse_from(["clinker", "run", "--memory-limit", "1000000", "p.yaml"]).unwrap();
         match cli.command {
-            Commands::Run(args) => assert_eq!(args.memory_limit_bytes(), 1000000),
+            Commands::Run(args) => assert_eq!(args.memory_limit_bytes().ok(), Some(1000000)),
             _ => panic!("expected Run command"),
         }
     }
@@ -2252,7 +2256,9 @@ mod tests {
     fn test_cli_run_default_memory_limit() {
         let cli = Cli::try_parse_from(["clinker", "run", "p.yaml"]).unwrap();
         match cli.command {
-            Commands::Run(args) => assert_eq!(args.memory_limit_bytes(), 512 * 1024 * 1024),
+            Commands::Run(args) => {
+                assert_eq!(args.memory_limit_bytes().ok(), Some(512 * 1024 * 1024))
+            }
             _ => panic!("expected Run command"),
         }
     }

--- a/crates/clinker/tests/memory_limit_cli.rs
+++ b/crates/clinker/tests/memory_limit_cli.rs
@@ -1,0 +1,100 @@
+//! CLI integration coverage for `memory.limit` overflow handling.
+//!
+//! A `memory.limit` whose binary-suffix scaling exceeds the addressable byte
+//! range (`u64`) must fail the run with a config diagnostic, not panic or
+//! silently wrap to a tiny budget. The check is the executor's startup gate,
+//! reached once the source file set has been discovered, so these tests
+//! provide a real input file and shell out to the compiled binary to exercise
+//! the path an operator would hit.
+
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+/// Minimal single-row pipeline whose `memory.limit` is templated in. Source
+/// and output use workspace-relative paths (absolute paths are rejected by the
+/// path-security check), so the run executes with its working directory set to
+/// the temp dir.
+const PIPELINE_TEMPLATE: &str = r#"pipeline:
+  name: mem_limit_overflow
+  memory:
+    limit: "__LIMIT__"
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+/// Write `pipeline.yaml` (with the limit templated in) plus a real one-row
+/// input CSV into a fresh temp dir. Returns the temp dir (kept alive for the
+/// run's duration).
+fn pipeline_with_limit(limit: &str) -> tempfile::TempDir {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    std::fs::write(tmp.path().join("in.csv"), "amount\n1\n").expect("write input csv");
+    let yaml = PIPELINE_TEMPLATE.replace("__LIMIT__", limit);
+    std::fs::write(tmp.path().join("pipeline.yaml"), yaml).expect("write pipeline yaml");
+    tmp
+}
+
+#[test]
+fn overflowing_memory_limit_fails_run_at_startup() {
+    // 2^34 G = 2^34 * 1024^3 = 2^64 bytes, one past u64::MAX — the numeric
+    // part parses cleanly but the suffix multiply overflows.
+    let tmp = pipeline_with_limit("17179869184G");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg("pipeline.yaml")
+        .current_dir(tmp.path())
+        .output()
+        .expect("spawn clinker");
+
+    assert!(
+        !output.status.success(),
+        "run with an overflowing memory.limit must fail; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("memory.limit"),
+        "diagnostic must name the failing setting; got:\n{stderr}"
+    );
+}
+
+#[test]
+fn valid_memory_limit_passes_the_startup_gate() {
+    // A well-formed `memory.limit` must clear the overflow gate and let the
+    // run complete successfully.
+    let tmp = pipeline_with_limit("256M");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg("pipeline.yaml")
+        .current_dir(tmp.path())
+        .output()
+        .expect("spawn clinker");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "a valid memory.limit run must succeed; stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("memory.limit"),
+        "a valid memory.limit must not trip the overflow gate; got:\n{stderr}"
+    );
+}

--- a/docs/user/src/ops/memory.md
+++ b/docs/user/src/ops/memory.md
@@ -52,6 +52,13 @@ The CLI flag overrides the YAML value. Suffixes are **binary (1024-based)**: `K`
 
 **Default:** 512 MB.
 
+**Invalid values:** an empty or unparseable limit (for example a stray
+non-numeric value) falls back to the 512 MB default. A value whose size is
+well-formed but too large to represent — its scaled byte count exceeds the
+maximum a 64-bit counter can hold — is rejected at startup with a config error
+that names `memory.limit`, rather than wrapping to a small budget. Pick a limit
+that fits your host's real memory.
+
 ## Choosing a backpressure policy
 
 When memory use approaches the limit (the soft threshold is 80 % of `limit`), something has to give up memory. The `backpressure` knob chooses what:


### PR DESCRIPTION
## Summary
`parse_memory_limit_bytes` scaled size suffixes (KB/MB/GB) with unchecked multiplication, so a large `memory.limit` value could silently wrap to a small budget. It now scales with `checked_mul` and surfaces overflow as a typed error.

## Changes
- `parse_memory_limit_bytes` returns `Result<u64, ConfigError>`; a value that parses but overflows when scaled yields `ConfigError::Validation` naming `memory.limit`.
- The result is threaded through callers; the executor startup gate maps it to a config error, so a run fails fast (exit 1) instead of wrapping (release) or panicking (debug).
- `None` / empty / unparseable still fall back to the 512 MB default — only parse-then-overflow is rejected.

## Tests
- Parser: max-safe boundary, just-overflow, invalid input.
- One CLI test: an overflowing `memory.limit` fails at startup with a clear config error.

Closes #672.
