### PR TITLE
format: apply the declared CSV source encoding (utf-8 / iso-8859-1)

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -5,6 +5,7 @@
 use std::io::Read;
 use std::sync::Arc;
 
+use clinker_format::Charset;
 use clinker_format::ReopenableSource;
 use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
 use clinker_format::edifact::reader::{EdifactReader, EdifactReaderConfig};
@@ -16,7 +17,6 @@ use clinker_format::json::reader::{
 };
 use clinker_format::swift::reader::{SwiftReader, SwiftReaderConfig};
 use clinker_format::traits::FormatReader;
-use clinker_format::x12::Charset;
 use clinker_format::x12::reader::{X12Reader, X12ReaderConfig};
 use clinker_format::xml::reader::{
     NamespaceMode, XmlArrayMode, XmlArrayPath, XmlReader, XmlReaderConfig,
@@ -50,7 +50,7 @@ fn build_format_reader(
                     open_one_shot(&source)?,
                 ),
                 None => {
-                    let config = build_csv_reader_config(opts.as_ref());
+                    let config = build_csv_reader_config(opts.as_ref())?;
                     Ok(Box::new(CsvReader::from_reader(
                         open_one_shot(&source)?,
                         config,
@@ -1020,7 +1020,21 @@ fn build_multi_record_reader(
             )
         }
         MultiRecordKind::Csv(opts) => {
-            let cfg = build_csv_reader_config(opts);
+            let cfg = build_csv_reader_config(opts)?;
+            // The multi-record CSV backend decodes through the csv crate's
+            // UTF-8 string path, so it cannot honor a declared non-UTF-8
+            // `encoding`. Reject it at startup rather than silently dropping
+            // the option (a single-schema CSV source supports it end-to-end).
+            if cfg.charset != Charset::Utf8 {
+                return Err(PipelineError::Config(
+                    clinker_plan::config::ConfigError::Validation(format!(
+                        "source {:?}: multi-record CSV (a `records:` schema) does not support a \
+                         non-UTF-8 `encoding`; declare `encoding: utf-8` or read it as a \
+                         single-schema CSV source",
+                        input.name
+                    )),
+                ));
+            }
             Box::new(
                 clinker_format::multi_record::MultiRecordReader::new_csv(
                     reader,
@@ -1072,9 +1086,13 @@ enum MultiRecordKind<'a> {
 }
 
 /// Build CSV reader config from optional CSV input options.
+///
+/// A declared `encoding` is resolved to a [`Charset`] here so an unsupported
+/// value fails at startup with the name the user must fix, rather than being
+/// silently dropped (the reader otherwise always decoded as UTF-8).
 fn build_csv_reader_config(
     opts: Option<&clinker_plan::config::CsvInputOptions>,
-) -> CsvReaderConfig {
+) -> Result<CsvReaderConfig, PipelineError> {
     let mut config = CsvReaderConfig::default();
     if let Some(opts) = opts {
         if let Some(ref d) = opts.delimiter
@@ -1090,8 +1108,22 @@ fn build_csv_reader_config(
         if let Some(h) = opts.has_header {
             config.has_header = h;
         }
+        if let Some(encoding) = opts.encoding.as_deref() {
+            config.charset = parse_csv_charset(encoding)?;
+        }
     }
-    config
+    Ok(config)
+}
+
+/// Resolve a source-declared CSV `encoding` name to a [`Charset`], mapping an
+/// unsupported value to a config-validation error so the run fails at startup
+/// with the name the user must fix.
+fn parse_csv_charset(encoding: &str) -> Result<Charset, PipelineError> {
+    Charset::from_name(encoding).map_err(|e| {
+        PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+            "CSV source: {e}"
+        )))
+    })
 }
 
 /// Default cap on the JSON envelope pre-scan's path-pruned document index
@@ -1643,6 +1675,42 @@ nodes:
         assert!(
             last_record < first_close,
             "every body record must precede the message close; got {observed:?}"
+        );
+    }
+
+    fn csv_opts(encoding: Option<&str>) -> clinker_plan::config::CsvInputOptions {
+        clinker_plan::config::CsvInputOptions {
+            encoding: encoding.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn build_csv_reader_config_defaults_to_utf8() {
+        let cfg = build_csv_reader_config(None).expect("no options resolves");
+        assert_eq!(cfg.charset, Charset::Utf8);
+        let cfg = build_csv_reader_config(Some(&csv_opts(Some("utf-8")))).expect("utf-8 resolves");
+        assert_eq!(cfg.charset, Charset::Utf8);
+    }
+
+    #[test]
+    fn build_csv_reader_config_resolves_latin1() {
+        let cfg = build_csv_reader_config(Some(&csv_opts(Some("iso-8859-1"))))
+            .expect("iso-8859-1 resolves");
+        assert_eq!(cfg.charset, Charset::Latin1);
+    }
+
+    #[test]
+    fn build_csv_reader_config_rejects_unsupported_encoding_at_startup() {
+        // `CsvReaderConfig` is not `Debug`, so destructure rather than
+        // `expect_err` to reach the error.
+        let Err(err) = build_csv_reader_config(Some(&csv_opts(Some("shift_jis")))) else {
+            panic!("an unsupported CSV encoding must fail config build");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("shift_jis") && msg.contains("iso-8859-1"),
+            "error must name the unsupported value and the supported set: {msg}"
         );
     }
 }

--- a/crates/clinker-exec/src/pipeline/arena.rs
+++ b/crates/clinker-exec/src/pipeline/arena.rs
@@ -448,6 +448,7 @@ mod tests {
                 delimiter: b',',
                 quote_char: b'"',
                 has_header: true,
+                ..Default::default()
             },
         )
     }

--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -268,6 +268,7 @@ mod tests {
                 delimiter: b',',
                 quote_char: b'"',
                 has_header: true,
+                ..Default::default()
             },
         ))
     }

--- a/crates/clinker-exec/src/pipeline/window_context.rs
+++ b/crates/clinker-exec/src/pipeline/window_context.rs
@@ -332,6 +332,7 @@ mod tests {
                 delimiter: b',',
                 quote_char: b'"',
                 has_header: true,
+                ..Default::default()
             },
         );
         let budget = crate::pipeline::memory::MemoryArbitrator::with_policy(

--- a/crates/clinker-exec/tests/csv_charset.rs
+++ b/crates/clinker-exec/tests/csv_charset.rs
@@ -1,0 +1,161 @@
+//! End-to-end CSV `encoding` handling.
+//!
+//! Covers the observable behaviors of a declared CSV source `encoding`:
+//! (1) a single-schema source declaring `iso-8859-1` decodes high bytes
+//! correctly through to output; (2) an unsupported encoding fails the run at
+//! startup with a precise error naming it and the supported set; (3) a
+//! multi-record CSV source (a `records:` schema) rejects a non-UTF-8 encoding
+//! at startup rather than silently dropping it (the multi-record backend is
+//! UTF-8-only).
+
+use std::collections::HashMap;
+use std::io::Cursor;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams};
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// Drive a CSV pipeline over raw input bytes, returning the output bytes (so a
+/// non-UTF-8 input is fed faithfully) or a stringified run/compile error.
+fn run_csv(yaml: &str, source_name: &str, out_name: &str, input: &[u8]) -> Result<Vec<u8>, String> {
+    let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
+    let plan = config
+        .compile(&CompileContext::default())
+        .map_err(|e| format!("compile: {e:?}"))?;
+
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        source_name.to_string(),
+        clinker_exec::executor::single_file_reader("in.csv", Box::new(Cursor::new(input.to_vec()))),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        out_name.to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        ..Default::default()
+    };
+
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .map_err(|e| format!("run: {e:?}"))?;
+    Ok(buf.contents())
+}
+
+/// A single-schema CSV whose one body field carries the Latin-1 high byte for
+/// `é`. The bytes are not valid UTF-8, so the run only succeeds when the
+/// declared `iso-8859-1` charset is actually applied.
+fn latin1_input() -> Vec<u8> {
+    let mut bytes = b"name\nCaf".to_vec();
+    bytes.push(0xE9);
+    bytes.push(b'\n');
+    bytes
+}
+
+#[test]
+fn csv_latin1_source_decodes_high_bytes_end_to_end() {
+    let yaml = r#"
+pipeline:
+  name: csv_latin1
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      options:
+        encoding: iso-8859-1
+      schema:
+        - { name: name, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let out = run_csv(yaml, "src", "out", &latin1_input()).expect("latin1 CSV run");
+    let text = String::from_utf8(out).expect("CSV output is UTF-8 after decode");
+    assert!(
+        text.contains("Café"),
+        "declared iso-8859-1 high byte must decode to 'é': {text}"
+    );
+}
+
+#[test]
+fn csv_unsupported_encoding_fails_at_startup() {
+    let yaml = r#"
+pipeline:
+  name: csv_bad_encoding
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      options:
+        encoding: shift_jis
+      schema:
+        - { name: name, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = run_csv(yaml, "src", "out", b"name\nAlice\n")
+        .expect_err("an unsupported CSV encoding must fail the run");
+    assert!(
+        err.contains("shift_jis") && err.contains("iso-8859-1"),
+        "error should name the unsupported charset and the supported set: {err}"
+    );
+}
+
+#[test]
+fn csv_multi_record_rejects_non_utf8_encoding_at_startup() {
+    // A multi-record CSV source (a `records:` schema) is decoded by the
+    // UTF-8-only multi-record backend, so a declared non-UTF-8 `encoding` is
+    // rejected at startup instead of being silently dropped.
+    let yaml = r#"
+pipeline:
+  name: csv_mr_latin1
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      options:
+        encoding: iso-8859-1
+      schema:
+        - { name: record_type, type: string }
+        - { name: batch_id, type: string }
+      format_schema:
+        discriminator: { field: record_type }
+        records:
+          - { id: header, tag: H, fields: [ { name: record_type }, { name: batch_id } ] }
+          - { id: detail, tag: D, fields: [ { name: record_type }, { name: batch_id } ] }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = run_csv(yaml, "src", "out", b"H,x\nD,y\n")
+        .expect_err("multi-record CSV must reject a non-UTF-8 encoding");
+    assert!(
+        err.contains("multi-record") && err.contains("utf-8"),
+        "error should explain the multi-record CSV limitation: {err}"
+    );
+}

--- a/crates/clinker-format/src/charset.rs
+++ b/crates/clinker-format/src/charset.rs
@@ -1,24 +1,26 @@
-//! Character-set decoding for X12 element text.
+//! Pure-Rust single-byte character-set decoding for flat text formats.
 //!
-//! X12 interchanges carry a declared character repertoire (the "basic" and
-//! "extended" sets are ASCII subsets; real-world trading-partner agreements
-//! also push Latin-1 high bytes through free-text name/address fields).
-//! Unlike EDIFACT's `UNB` syntax identifier, X12 has no in-band element that
-//! names the body repertoire, so the encoding is declared on the source and
-//! defaults to UTF-8.
+//! Some text interchange and tabular formats carry a declared character
+//! repertoire rather than UTF-8 (X12 free-text name/address fields, CSV
+//! exports from legacy systems). These formats have no reliable in-band
+//! marker naming the body encoding, so the repertoire is declared on the
+//! source and defaults to UTF-8.
 //!
 //! Only single-byte repertoires whose byte↔codepoint mapping is total and
 //! round-trippable in pure Rust are supported, so a read→write→read cycle is
 //! byte-faithful for the configured charset. An unsupported or unconfigured
 //! non-UTF-8 repertoire fails explicitly rather than guessing or silently
 //! substituting replacement characters.
+//!
+//! No decoding dependency is pulled in: UTF-8 validates through the standard
+//! library and Latin-1 is a direct byte→codepoint map.
 
 use crate::error::FormatError;
 
-/// The character repertoire used to decode and encode X12 element text.
+/// The character repertoire used to decode and encode field/element text.
 ///
-/// Decoding happens per element (no whole-interchange buffering), so the
-/// charset is consulted once per segment split rather than over the stream.
+/// Decoding happens per field (no whole-input buffering), so the charset is
+/// consulted once per value rather than over the stream.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Charset {
     /// UTF-8 (the default). Strict: invalid UTF-8 is an error, not a
@@ -39,10 +41,10 @@ impl Charset {
     ///
     /// # Errors
     ///
-    /// Returns [`FormatError::X12`] naming the unsupported value and the
+    /// Returns [`FormatError::Charset`] naming the unsupported value and the
     /// supported set when the name matches no known repertoire, so a
-    /// mis-configured source fails at decode time with actionable guidance
-    /// rather than guessing.
+    /// mis-configured source fails with actionable guidance rather than
+    /// guessing.
     pub fn from_name(name: &str) -> Result<Self, FormatError> {
         // Match on a normalized form so `UTF-8`, `utf8`, `ISO-8859-1`,
         // `iso8859-1`, `Latin-1`, and `latin1` all resolve.
@@ -54,29 +56,29 @@ impl Charset {
         match normalized.as_str() {
             "utf8" => Ok(Charset::Utf8),
             "iso88591" | "latin1" | "l1" => Ok(Charset::Latin1),
-            _ => Err(FormatError::X12(format!(
-                "unsupported X12 character set {name:?}. Supported encodings are \
+            _ => Err(FormatError::Charset(format!(
+                "unsupported character set {name:?}. Supported encodings are \
                  \"utf-8\" (the default) and \"iso-8859-1\" (Latin-1)"
             ))),
         }
     }
 
-    /// Decode raw element bytes to a `String` through this repertoire,
+    /// Decode raw field bytes to a `String` through this repertoire,
     /// consuming the buffer so the UTF-8 path validates in place without a
-    /// copy (this runs once per segment on the hot path).
+    /// copy (this runs once per value on the hot path).
     ///
     /// # Errors
     ///
-    /// Returns [`FormatError::X12`] when the bytes are not valid in the
+    /// Returns [`FormatError::Charset`] when the bytes are not valid in the
     /// repertoire — only possible for [`Charset::Utf8`], since Latin-1 maps
     /// every byte. The message names the configured charset so a
     /// mis-declared encoding is diagnosable.
     pub fn decode(&self, bytes: Vec<u8>) -> Result<String, FormatError> {
         match self {
             Charset::Utf8 => String::from_utf8(bytes).map_err(|e| {
-                FormatError::X12(format!(
-                    "segment is not valid UTF-8: {e}. Declare the source's character \
-                     set (e.g. `encoding: iso-8859-1`) if the interchange uses a \
+                FormatError::Charset(format!(
+                    "input is not valid UTF-8: {e}. Declare the source's character \
+                     set (e.g. `encoding: iso-8859-1`) if the input uses a \
                      non-UTF-8 repertoire"
                 ))
             }),
@@ -85,11 +87,11 @@ impl Charset {
         }
     }
 
-    /// Encode element text to raw bytes through this repertoire.
+    /// Encode field text to raw bytes through this repertoire.
     ///
     /// # Errors
     ///
-    /// Returns [`FormatError::X12`] for [`Charset::Latin1`] when the text
+    /// Returns [`FormatError::Charset`] for [`Charset::Latin1`] when the text
     /// carries a character above `U+00FF` that Latin-1 cannot represent, so
     /// the writer fails explicitly rather than emitting a structurally
     /// truncated value. UTF-8 encoding never fails.
@@ -100,8 +102,8 @@ impl Charset {
                 .chars()
                 .map(|c| {
                     u32::from(c).try_into().map_err(|_| {
-                        FormatError::X12(format!(
-                            "element text {text:?} contains character {c:?} (U+{:04X}), which \
+                        FormatError::Charset(format!(
+                            "text {text:?} contains character {c:?} (U+{:04X}), which \
                              is outside ISO-8859-1 (Latin-1) and cannot be encoded; the \
                              configured charset cannot represent it",
                             u32::from(c)
@@ -136,7 +138,7 @@ mod tests {
     fn from_name_rejects_unsupported_with_precise_error() {
         let err = Charset::from_name("shift_jis").unwrap_err();
         assert!(
-            matches!(&err, FormatError::X12(m) if m.contains("shift_jis") && m.contains("iso-8859-1")),
+            matches!(&err, FormatError::Charset(m) if m.contains("shift_jis") && m.contains("iso-8859-1")),
             "expected precise unsupported-charset error, got {err:?}"
         );
     }
@@ -167,7 +169,7 @@ mod tests {
             .decode(vec![b'C', b'a', b'f', 0xE9])
             .unwrap_err();
         assert!(
-            matches!(&err, FormatError::X12(m) if m.contains("not valid UTF-8")),
+            matches!(&err, FormatError::Charset(m) if m.contains("not valid UTF-8")),
             "expected UTF-8 decode error, got {err:?}"
         );
     }
@@ -177,7 +179,7 @@ mod tests {
         // U+20AC (euro sign) is above U+00FF and cannot be Latin-1 encoded.
         let err = Charset::Latin1.encode("price €5").unwrap_err();
         assert!(
-            matches!(&err, FormatError::X12(m) if m.contains("Latin-1") && m.contains("U+20AC")),
+            matches!(&err, FormatError::Charset(m) if m.contains("Latin-1") && m.contains("U+20AC")),
             "expected out-of-range encode error, got {err:?}"
         );
     }

--- a/crates/clinker-format/src/csv/reader.rs
+++ b/crates/clinker-format/src/csv/reader.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
 
 use crate::bom::SkipBom;
+use crate::charset::Charset;
 use crate::error::FormatError;
 use crate::traits::FormatReader;
 
@@ -12,6 +13,11 @@ pub struct CsvReaderConfig {
     pub delimiter: u8,
     pub quote_char: u8,
     pub has_header: bool,
+    /// Character set the field bytes are decoded through. Defaults to UTF-8;
+    /// set from the source's declared `encoding` so a non-UTF-8 export (e.g.
+    /// `iso-8859-1`) decodes high bytes correctly instead of failing UTF-8
+    /// validation or silently corrupting them.
+    pub charset: Charset,
 }
 
 impl Default for CsvReaderConfig {
@@ -20,6 +26,7 @@ impl Default for CsvReaderConfig {
             delimiter: b',',
             quote_char: b'"',
             has_header: true,
+            charset: Charset::default(),
         }
     }
 }
@@ -30,6 +37,12 @@ impl Default for CsvReaderConfig {
 /// responsibility. Schema is inferred from the header row (or generated
 /// synthetically as `col_0`, `col_1`, ...).
 ///
+/// Rows are read as raw bytes (`csv::ByteRecord`) and each field — including
+/// header cells — is decoded through the configured [`Charset`]. UTF-8 (the
+/// default) validates strictly; a declared `iso-8859-1` source decodes high
+/// bytes faithfully. This per-field decode replaces the csv crate's implicit
+/// UTF-8-only string path so the source's declared `encoding` is honored.
+///
 /// A leading UTF-8 BOM (prepended by Excel "CSV UTF-8" and PowerShell
 /// `Out-File -Encoding utf8`) is stripped before parsing via [`SkipBom`],
 /// so the first header cell — or first data field under
@@ -39,7 +52,7 @@ pub struct CsvReader<R: Read> {
     schema: Option<Arc<Schema>>,
     config: CsvReaderConfig,
     row_count: u64,
-    record_buf: csv::StringRecord,
+    record_buf: csv::ByteRecord,
 }
 
 impl<R: Read> CsvReader<R> {
@@ -54,7 +67,7 @@ impl<R: Read> CsvReader<R> {
             schema: None,
             config,
             row_count: 0,
-            record_buf: csv::StringRecord::new(),
+            record_buf: csv::ByteRecord::new(),
         }
     }
 
@@ -64,16 +77,19 @@ impl<R: Read> CsvReader<R> {
         }
 
         let schema = if self.config.has_header {
-            let headers = self.inner.headers()?;
+            let charset = self.config.charset;
+            let headers = self.inner.byte_headers()?;
             if headers.is_empty() {
                 return Err(FormatError::SchemaInference("header row is empty".into()));
             }
-            headers
+            // Decode each header cell through the configured charset so a
+            // non-UTF-8 column name resolves identically to its body fields.
+            let columns: Vec<Box<str>> = headers
                 .iter()
-                .map(Box::<str>::from)
-                .collect::<SchemaBuilder>()
-                .build()
-        } else if !self.inner.read_record(&mut self.record_buf)? {
+                .map(|f| charset.decode(f.to_vec()).map(Box::<str>::from))
+                .collect::<Result<_, _>>()?;
+            columns.into_iter().collect::<SchemaBuilder>().build()
+        } else if !self.inner.read_byte_record(&mut self.record_buf)? {
             // Peek at the first record to determine column count. No
             // record at all ⇒ empty file ⇒ empty schema.
             SchemaBuilder::new().build()
@@ -97,30 +113,33 @@ impl<R: Read + Send> FormatReader for CsvReader<R> {
 
     fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
         let schema = self.ensure_schema()?;
+        let charset = self.config.charset;
 
         // If we peeked a record during no-header schema inference, consume it first
         if !self.config.has_header && self.row_count == 0 && !self.record_buf.is_empty() {
             self.row_count += 1;
-            let values: Vec<Value> = self
-                .record_buf
-                .iter()
-                .map(|f| Value::String(f.into()))
-                .collect();
+            let values = decode_record(&self.record_buf, charset)?;
             return Ok(Some(Record::new(schema, values)));
         }
 
-        if !self.inner.read_record(&mut self.record_buf)? {
+        if !self.inner.read_byte_record(&mut self.record_buf)? {
             return Ok(None);
         }
 
         self.row_count += 1;
-        let values: Vec<Value> = self
-            .record_buf
-            .iter()
-            .map(|f| Value::String(f.into()))
-            .collect();
+        let values = decode_record(&self.record_buf, charset)?;
         Ok(Some(Record::new(schema, values)))
     }
+}
+
+/// Decode every field of a raw [`csv::ByteRecord`] through `charset` into a
+/// `Value::String` column vector. A field that is not valid in the configured
+/// charset (only possible under [`Charset::Utf8`]) fails the record loudly
+/// rather than substituting replacement bytes.
+fn decode_record(rec: &csv::ByteRecord, charset: Charset) -> Result<Vec<Value>, FormatError> {
+    rec.iter()
+        .map(|f| charset.decode(f.to_vec()).map(|s| Value::String(s.into())))
+        .collect()
 }
 
 #[cfg(test)]
@@ -315,5 +334,77 @@ mod tests {
         assert_eq!(record.resolve("name"), Some(&Value::String("Ada".into())));
         assert_eq!(record.resolve("age"), Some(&Value::String("30".into())));
         assert_eq!(record.resolve("missing"), None);
+    }
+
+    /// Build CSV bytes whose body field carries the Latin-1 high byte for `é`.
+    /// `name\nCaf\xE9\n` is not valid UTF-8, so it exercises the non-UTF-8
+    /// decode path rather than incidental ASCII.
+    fn latin1_bytes() -> Vec<u8> {
+        let mut bytes = b"name\nCaf".to_vec();
+        bytes.push(0xE9); // 'é' in ISO-8859-1
+        bytes.push(b'\n');
+        bytes
+    }
+
+    #[test]
+    fn test_csv_reader_latin1_decodes_high_bytes() {
+        // Under the declared Latin-1 charset the high byte decodes to `é`.
+        let config = CsvReaderConfig {
+            charset: Charset::Latin1,
+            ..Default::default()
+        };
+        let bytes = latin1_bytes();
+        let mut reader = CsvReader::from_reader(&bytes[..], config);
+        let _schema = reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(record.get("name"), Some(&Value::String("Café".into())));
+        assert!(reader.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_csv_reader_latin1_decodes_high_byte_in_header() {
+        // A high byte in the header row decodes through the same charset, so
+        // the column name resolves to its decoded form.
+        let mut bytes = b"caf".to_vec();
+        bytes.push(0xE9); // header `café`
+        bytes.extend_from_slice(b"\n1\n");
+        let config = CsvReaderConfig {
+            charset: Charset::Latin1,
+            ..Default::default()
+        };
+        let mut reader = CsvReader::from_reader(&bytes[..], config);
+        let schema = reader.schema().unwrap();
+        assert_eq!(
+            schema.columns().iter().map(|c| &**c).collect::<Vec<_>>(),
+            vec!["café"]
+        );
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(record.get("café"), Some(&Value::String("1".into())));
+    }
+
+    #[test]
+    fn test_csv_reader_utf8_default_rejects_high_byte() {
+        // The same Latin-1 bytes under the default UTF-8 charset fail loudly
+        // rather than substituting replacement characters.
+        let bytes = latin1_bytes();
+        let mut reader = CsvReader::from_reader(&bytes[..], CsvReaderConfig::default());
+        let _schema = reader.schema().unwrap();
+        let err = reader.next_record().unwrap_err();
+        assert!(
+            matches!(&err, FormatError::Charset(m) if m.contains("not valid UTF-8")),
+            "expected a UTF-8 decode error naming the encoding, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_csv_reader_utf8_default_decodes_multibyte() {
+        // Valid multi-byte UTF-8 is unchanged under the default charset.
+        let csv = "name\nCafé\nAño";
+        let mut reader = CsvReader::from_reader(csv.as_bytes(), CsvReaderConfig::default());
+        let _schema = reader.schema().unwrap();
+        let r1 = reader.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("name"), Some(&Value::String("Café".into())));
+        let r2 = reader.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("name"), Some(&Value::String("Año".into())));
     }
 }

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -12,6 +12,12 @@ pub enum FormatError {
     Json(String),
     Xml(String),
     FixedWidth(String),
+    /// A character-set failure shared across formats that decode declared
+    /// non-UTF-8 text (CSV, X12): an unsupported `encoding` name, bytes that
+    /// are not valid in the configured repertoire, or text a single-byte
+    /// repertoire cannot encode. Carries a precise message naming the
+    /// offending value and the supported set.
+    Charset(String),
     /// An EDIFACT parse, envelope-count, or malformed-segment failure.
     /// Carries a precise message naming the offending control segment or
     /// constraint (bad UNA, UNT/UNZ count mismatch, control-ref echo
@@ -89,6 +95,7 @@ impl fmt::Display for FormatError {
             Self::Json(msg) => write!(f, "JSON error: {msg}"),
             Self::Xml(msg) => write!(f, "XML error: {msg}"),
             Self::FixedWidth(msg) => write!(f, "fixed-width error: {msg}"),
+            Self::Charset(msg) => write!(f, "charset error: {msg}"),
             Self::Edifact(msg) => write!(f, "EDIFACT error: {msg}"),
             Self::X12(msg) => write!(f, "X12 error: {msg}"),
             Self::Hl7(msg) => write!(f, "HL7 error: {msg}"),

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bom;
+pub mod charset;
 pub mod counting;
 pub mod csv;
 pub mod doc_index;
@@ -18,6 +19,7 @@ pub mod traits;
 pub mod x12;
 pub mod xml;
 
+pub use charset::Charset;
 pub use counting::{CountedFormatWriter, CountingWriter, SharedByteCounter};
 pub use doc_index::DocArenaIndex;
 pub use envelope::{

--- a/crates/clinker-format/src/x12/mod.rs
+++ b/crates/clinker-format/src/x12/mod.rs
@@ -28,12 +28,11 @@
 //! (so `$doc` envelope sections over `ISA` cost O(ISA)); the body streams
 //! one segment at a time. The whole interchange is never buffered.
 
-mod charset;
 pub mod reader;
 mod tokenizer;
 pub mod writer;
 
-pub use charset::Charset;
+pub use crate::charset::Charset;
 pub use reader::{X12Reader, X12ReaderConfig};
 pub use writer::{X12Writer, X12WriterConfig};
 

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -31,6 +31,7 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use indexmap::IndexMap;
 
+use crate::charset::Charset;
 use crate::envelope::{
     EnvelopeConfig, EnvelopeEvent, EnvelopeExtract, FrameRole, NestedEnvelopeSection,
     coerce_section_fields,
@@ -38,7 +39,6 @@ use crate::envelope::{
 use crate::error::FormatError;
 use crate::traits::FormatReader;
 use crate::x12::RAW_ELEMENTS_KEY;
-use crate::x12::charset::Charset;
 use crate::x12::tokenizer::{ParsedSegment, SegmentTokenizer, split_isa, split_segment};
 
 /// Default ceiling on the number of positional element columns the record
@@ -1273,7 +1273,7 @@ mod tests {
                 Err(e) => break e,
             }
         };
-        assert!(matches!(err, FormatError::X12(m) if m.contains("not valid UTF-8")));
+        assert!(matches!(err, FormatError::Charset(m) if m.contains("not valid UTF-8")));
     }
 
     /// The headline acceptance: a Latin-1 interchange read with the matching

--- a/crates/clinker-format/src/x12/tokenizer.rs
+++ b/crates/clinker-format/src/x12/tokenizer.rs
@@ -27,11 +27,11 @@
 
 use std::io::{BufRead, Read};
 
+use crate::charset::Charset;
 use crate::error::FormatError;
 use crate::segment_tokenizer::{
     SegmentFraming, TrailingSegment, read_raw_segment, skip_inter_segment_whitespace,
 };
-use crate::x12::charset::Charset;
 
 /// Hard ceiling on a single segment's raw byte length. A real X12 segment
 /// is well under a kilobyte; this cap exists only so a stream with no
@@ -199,8 +199,8 @@ impl<R: BufRead> SegmentTokenizer<R> {
     ///
     /// # Errors
     ///
-    /// Returns [`FormatError::X12`] when the segment bytes are not valid in
-    /// the configured charset (only possible under [`Charset::Utf8`]).
+    /// Returns [`FormatError::Charset`] when the segment bytes are not valid
+    /// in the configured charset (only possible under [`Charset::Utf8`]).
     pub(crate) fn next_segment(&mut self) -> Result<Option<String>, FormatError> {
         debug_assert!(
             self.initialized,
@@ -289,7 +289,7 @@ pub(crate) fn split_segment(raw: &str, delims: &Delimiters) -> ParsedSegment {
 ///
 /// # Errors
 ///
-/// Returns [`FormatError::X12`] when the header bytes are not valid in
+/// Returns [`FormatError::Charset`] when the header bytes are not valid in
 /// `charset` (only possible under [`Charset::Utf8`]).
 pub(crate) fn split_isa(
     header: &[u8],
@@ -434,7 +434,7 @@ mod tests {
         let mut t = SegmentTokenizer::new(Cursor::new(data), Charset::Utf8);
         let _ = t.read_isa_header().unwrap();
         let err = t.next_segment().unwrap_err();
-        assert!(matches!(err, FormatError::X12(m) if m.contains("not valid UTF-8")));
+        assert!(matches!(err, FormatError::Charset(m) if m.contains("not valid UTF-8")));
     }
 
     #[test]

--- a/crates/clinker-format/src/x12/writer.rs
+++ b/crates/clinker-format/src/x12/writer.rs
@@ -36,10 +36,10 @@ use std::sync::Arc;
 
 use clinker_record::{Record, Schema, Value};
 
+use crate::charset::Charset;
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
 use crate::x12::RAW_ELEMENTS_KEY;
-use crate::x12::charset::Charset;
 use crate::x12::tokenizer::Delimiters;
 
 /// Default X12 service delimiters used when no `ISA` header dictates

--- a/docs/user/src/formats/csv.md
+++ b/docs/user/src/formats/csv.md
@@ -36,7 +36,27 @@ standard [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180) defaults.
 | `delimiter` | `,` | Field separator. Set to `\t` for TSV, `;` for semicolon-delimited exports. |
 | `quote_char` | `"` | Quote character that escapes delimiters and newlines inside a field. |
 | `has_header` | `true` | When `true`, the first line names the columns and is consumed, not emitted. When `false`, fields bind to `schema:` positionally. |
-| `encoding` | `utf-8` | Text encoding used to decode the bytes before field splitting. |
+| `encoding` | `utf-8` | Character set each field — including the header row — is decoded through. Supported values are `utf-8` (the default) and `iso-8859-1` (aliases `latin-1`, `latin1`). See [Encoding](#encoding). |
+
+## Encoding
+
+The reader decodes every field through the source's declared `encoding`:
+
+- **`utf-8`** (the default) is strict — a byte sequence that is not valid
+  UTF-8 fails the run loudly rather than substituting replacement
+  characters, so a mis-declared encoding is caught instead of silently
+  corrupting data.
+- **`iso-8859-1`** (Latin-1; also spelled `latin-1` or `latin1`) maps each
+  byte `0xNN` to codepoint `U+00NN`, so high bytes such as `0xE9` (`é`)
+  from legacy exports decode correctly.
+
+An **unsupported** encoding is rejected at startup with a precise error
+naming the value and the supported set — it is never silently ignored.
+
+> Multi-record CSV sources (those declaring a `format_schema:` with a
+> `records:` list, described below) are decoded as UTF-8 only. Declaring a
+> non-UTF-8 `encoding` on such a source is rejected at startup; split the
+> file into a single-schema CSV source if it needs a non-UTF-8 charset.
 
 ## Header handling
 


### PR DESCRIPTION
## Summary
A CSV source could declare an `encoding:` option (documented in the user guide), but it was parsed and never applied — the reader always decoded as UTF-8. This applies it end to end.

## Changes
- Generalized the existing pure-Rust `Charset` facility (UTF-8 / ISO-8859-1) into a shared module and wired it into the plain CSV reader.
- `encoding` is resolved at config-build time; an unsupported value fails at startup with a precise error naming it and the supported set.
- The multi-record CSV path shares the option: a supported non-UTF-8 encoding there is rejected at startup (documented) rather than silently dropped.
- User docs updated.

## Tests
- Reader: high-byte ISO-8859-1 decode (body and header); UTF-8 default unchanged.
- Config: default UTF-8; iso-8859-1 resolves; unsupported encoding rejected at startup.
- End-to-end: a Latin-1 source decodes through to output; an unsupported encoding fails the run.

No new dependency. Closes #471.
