### PR TITLE
channel-driven source-schema override: partial per-source config patches (all formats)

### DIFF
--- a/crates/clinker-channel/src/binding.rs
+++ b/crates/clinker-channel/src/binding.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 use clinker_core_types::Span;
 use clinker_core_types::{Diagnostic, LabeledSpan};
 use clinker_plan::config::ScopedVarDecl;
+use clinker_plan::config::SourceConfigPatch;
 use clinker_plan::config::composition::CompositionSymbolTable;
 
 use crate::error::ChannelError;
@@ -133,6 +134,12 @@ pub struct ChannelBinding {
     /// on Transforms via `declares: { scope: record }`. Channel-wide
     /// (every record sees the same channel-supplied default).
     pub vars_record: IndexMap<String, ScopedVarDecl>,
+    /// Per-source config patches keyed by source-node name. Applied to the
+    /// parsed pipeline config before validation/compile, so the run behaves
+    /// as if the source YAML had been hand-edited (schema column ops,
+    /// `array_paths` ops, and scalar per-format `options`). Source names are
+    /// resolved against the loaded pipeline at apply time, not here.
+    pub source_patches: IndexMap<String, SourceConfigPatch>,
     pub source_path: PathBuf,
     /// BLAKE3 hash of the raw file bytes, used as cache-invalidation identity.
     pub channel_hash: [u8; 32],
@@ -180,6 +187,7 @@ impl ChannelBinding {
             vars_pipeline: raw.vars.pipeline,
             vars_source: raw.vars.source,
             vars_record: raw.vars.record,
+            source_patches: raw.sources,
             source_path,
             channel_hash,
         })
@@ -203,6 +211,10 @@ struct RawChannelFile {
     resources: RawChannelConfig,
     #[serde(default)]
     vars: RawChannelVars,
+    /// Per-source config patches, keyed by source-node name. Parsed here;
+    /// validated against the pipeline's sources at apply time.
+    #[serde(default)]
+    sources: IndexMap<String, SourceConfigPatch>,
 }
 
 #[derive(Deserialize)]

--- a/crates/clinker-channel/tests/source_patch_parse_test.rs
+++ b/crates/clinker-channel/tests/source_patch_parse_test.rs
@@ -1,0 +1,143 @@
+//! Parse coverage for the channel `sources:` config-patch block (issue #550).
+//!
+//! These tests pin the on-the-wire YAML surface for the per-source patch: the
+//! schema column ops (`add` / `rename` / `retype` / `remove`), the
+//! `array_paths` ops (set-by-path / `remove`), and the scalar `options` map.
+//! Applying the parsed patch to a pipeline is covered in `clinker-plan`; here
+//! we only assert that every documented form deserializes into the typed
+//! [`SourceConfigPatch`] carried on the binding.
+
+use std::path::PathBuf;
+
+use clinker_channel::binding::ChannelBinding;
+use clinker_plan::config::{ArrayPathOp, SchemaColumnOp};
+
+fn binding(yaml: &[u8]) -> ChannelBinding {
+    ChannelBinding::from_yaml_bytes(yaml, PathBuf::from("test.channel.yaml"))
+        .expect("channel YAML parses")
+}
+
+#[test]
+fn parses_full_sources_patch_block() {
+    let b = binding(
+        br#"
+channel:
+  name: acme
+  target: ./pipeline.yaml
+sources:
+  transactions:
+    schema:
+      amount:      { retype: float }
+      cust_id:     { rename: customer_id }
+      order_notes: remove
+      region:      { add: { type: string } }
+    array_paths:
+      items:      { mode: join, separator: ";" }
+      line_items: remove
+    options:
+      record_path: batch_records
+"#,
+    );
+
+    let patch = b
+        .source_patches
+        .get("transactions")
+        .expect("transactions patch present");
+
+    // Schema ops: one of each form, in declared order.
+    let schema: Vec<(&String, &SchemaColumnOp)> = patch.schema.iter().collect();
+    assert_eq!(schema.len(), 4);
+    assert!(matches!(schema[0].1, SchemaColumnOp::Retype(_)));
+    assert!(matches!(schema[1].1, SchemaColumnOp::Rename(to) if to == "customer_id"));
+    assert!(matches!(schema[2].1, SchemaColumnOp::Remove));
+    assert!(matches!(schema[3].1, SchemaColumnOp::Add(_)));
+
+    // array_paths ops: a set-by-path and a remove.
+    assert!(matches!(
+        patch.array_paths.get("items"),
+        Some(ArrayPathOp::Set { separator: Some(s), .. }) if s == ";"
+    ));
+    assert!(matches!(
+        patch.array_paths.get("line_items"),
+        Some(ArrayPathOp::Remove)
+    ));
+
+    // options: one scalar key.
+    assert_eq!(
+        patch.options.get("record_path").and_then(|v| v.as_str()),
+        Some("batch_records")
+    );
+}
+
+#[test]
+fn absent_sources_block_is_empty() {
+    let b = binding(
+        br#"
+channel:
+  name: plain
+  target: ./pipeline.yaml
+"#,
+    );
+    assert!(b.source_patches.is_empty());
+}
+
+#[test]
+fn multiple_sources_each_carry_their_patch() {
+    let b = binding(
+        br#"
+channel:
+  name: multi
+  target: ./pipeline.yaml
+sources:
+  orders:
+    schema:
+      id: { retype: int }
+  customers:
+    options:
+      delimiter: "|"
+"#,
+    );
+    assert_eq!(b.source_patches.len(), 2);
+    assert!(b.source_patches.contains_key("orders"));
+    assert!(b.source_patches.contains_key("customers"));
+}
+
+#[test]
+fn schema_add_carries_long_unique_flag() {
+    let b = binding(
+        br#"
+channel:
+  name: lu
+  target: ./pipeline.yaml
+sources:
+  src:
+    schema:
+      uuid: { add: { type: string, long_unique: true } }
+"#,
+    );
+    match b.source_patches["src"].schema.get("uuid") {
+        Some(SchemaColumnOp::Add(add)) => assert!(add.long_unique),
+        other => panic!("expected add op, got {other:?}"),
+    }
+}
+
+#[test]
+fn unknown_op_key_is_a_parse_error() {
+    // A schema op map with an unrecognized key is rejected by the binding
+    // parser (deny_unknown_fields on the op payload).
+    let err = ChannelBinding::from_yaml_bytes(
+        br#"
+channel:
+  name: bad
+  target: ./pipeline.yaml
+sources:
+  src:
+    schema:
+      amount: { bogus: 1 }
+"#,
+        PathBuf::from("bad.channel.yaml"),
+    )
+    .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("YAML parse error"), "{msg}");
+}

--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -26,7 +26,7 @@
 //! `Type::Any` skip coercion. The `to_*` / `try_*` CXL builtins remain
 //! available for derived fields computed during the pipeline.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use clinker_format::error::FormatError;
@@ -48,11 +48,17 @@ pub struct CoercingReader {
     /// column's PHYSICAL name (`source_name` when aliased, else `name`) so an
     /// aliased source field is recognized as declared rather than widened.
     declared_names: HashSet<Box<str>>,
-    /// Physical input-field name to read each declared column FROM, indexed
-    /// by position across the declared columns (the `$widened` sidecar slot,
-    /// when present, has no entry — it is synthesized). Equals the exposed
-    /// column name unless the column declared a `source_name` alias.
-    physical_names: Vec<Box<str>>,
+    /// Physical input-field name to read each declared column FROM, indexed by
+    /// position across the declared columns. `None` in the common no-alias case
+    /// — the physical name then equals the exposed output-schema column name, so
+    /// reproject reads by that name and no per-column Vec is allocated. `Some`
+    /// only when at least one column declares a differing `source_name`.
+    physical_names: Option<Vec<Box<str>>>,
+    /// Exposed-name → physical-name for columns that alias a differently-named
+    /// physical field. Empty (unallocated) when no column aliases. Used to
+    /// detect an input field whose name clashes with an alias's exposed name,
+    /// which would otherwise silently mislocate that field.
+    aliased_exposed: HashMap<Box<str>, Box<str>>,
     /// Output schema — declared columns (keyed by exposed name) followed
     /// (under `AutoWiden`) by the `$widened` engine-stamped sidecar column.
     output_schema: Arc<Schema>,
@@ -89,14 +95,38 @@ impl CoercingReader {
         // record isn't gated behind an on-demand schema call.
         inner.schema()?;
 
-        // Physical name each column reads from: the `source_name` alias when
-        // set, else the exposed name. The declared-key set is built from these
-        // physical names so an aliased source field counts as declared.
-        let physical_names: Vec<Box<str>> = schema_decl
+        // A column "aliases" only when its `source_name` names a DIFFERENT
+        // physical field; `source_name == name` is a no-op treated as no alias.
+        let has_alias = schema_decl
+            .iter()
+            .any(|c| c.source_name.as_deref().is_some_and(|s| s != c.name));
+
+        // The declared-key set uses each column's PHYSICAL name (the alias when
+        // set, else the exposed name) so an aliased source field counts as
+        // declared rather than widened.
+        let declared_names: HashSet<Box<str>> = schema_decl
             .iter()
             .map(|c| c.source_name.as_deref().unwrap_or(c.name.as_str()).into())
             .collect();
-        let declared_names: HashSet<Box<str>> = physical_names.iter().cloned().collect();
+
+        // Per-column physical name is only materialized when some column
+        // aliases; otherwise reproject reads by the exposed output-schema name.
+        let physical_names: Option<Vec<Box<str>>> = has_alias.then(|| {
+            schema_decl
+                .iter()
+                .map(|c| c.source_name.as_deref().unwrap_or(c.name.as_str()).into())
+                .collect()
+        });
+
+        // Exposed-name → physical-name for real aliases, to detect an input
+        // field colliding with an alias's exposed name. Empty when no aliases.
+        let aliased_exposed: HashMap<Box<str>, Box<str>> = schema_decl
+            .iter()
+            .filter_map(|c| {
+                let physical = c.source_name.as_deref()?;
+                (physical != c.name).then(|| (c.name.as_str().into(), physical.into()))
+            })
+            .collect();
         let mut targets: Vec<Option<Type>> = schema_decl
             .iter()
             .map(|c| {
@@ -133,6 +163,7 @@ impl CoercingReader {
             inner,
             declared_names,
             physical_names,
+            aliased_exposed,
             output_schema,
             targets,
             long_unique,
@@ -149,6 +180,17 @@ impl CoercingReader {
         let mut sidecar: Option<IndexMap<Box<str>, Value>> = None;
         for (k, v) in record.iter_all_fields() {
             if !self.declared_names.contains(k) {
+                // Guard the alias collision before any policy branch: an input
+                // field named the same as an alias's exposed name would be
+                // silently widened/dropped while the aliased column exposes a
+                // different physical field's value under that name.
+                if let Some(physical) = self.aliased_exposed.get(k) {
+                    return Err(FormatError::AliasNameCollision {
+                        source: self.source_name.to_string(),
+                        exposed: k.to_string(),
+                        physical: physical.to_string(),
+                    });
+                }
                 match self.policy {
                     OnUnmapped::Reject => {
                         return Err(FormatError::UndeclaredField {
@@ -166,7 +208,8 @@ impl CoercingReader {
             }
         }
 
-        let col_count = self.output_schema.columns().len();
+        let cols = self.output_schema.columns();
+        let col_count = cols.len();
         let mut values: Vec<Value> = Vec::with_capacity(col_count);
         for i in 0..col_count {
             // The widened slot is filled from the sidecar map (if any
@@ -178,14 +221,15 @@ impl CoercingReader {
                 });
                 continue;
             }
-            // Read from the PHYSICAL input field (the `source_name` alias when
-            // set), then expose the value under the declared column at this
-            // position. For an un-aliased column the physical name equals the
-            // exposed name, so this reads exactly the same field as before.
-            let raw = record
-                .get(self.physical_names[i].as_ref())
-                .cloned()
-                .unwrap_or(Value::Null);
+            // Read from the PHYSICAL input field, exposing the value under the
+            // declared column at this position. Without aliases the physical
+            // name equals the exposed output-schema name, so this reads exactly
+            // the same field as before with no per-column Vec.
+            let physical: &str = match &self.physical_names {
+                Some(names) => names[i].as_ref(),
+                None => cols[i].as_ref(),
+            };
+            let raw = record.get(physical).cloned().unwrap_or(Value::Null);
             let coerced = match &self.targets[i] {
                 Some(target) => coerce_value(&raw, target).unwrap_or(raw),
                 None => raw,
@@ -425,6 +469,46 @@ mod tests {
         assert!(rec.get("cust_id").is_none());
         // ...and it did NOT fall into `$widened` (recognized as declared).
         assert_eq!(rec.get(WIDENED_SIDECAR_COLUMN), Some(&Value::Null));
+    }
+
+    /// If an aliased column's exposed name also exists as a real input field,
+    /// reading the alias would mislocate that field — the reader fails loudly
+    /// instead of silently widening/dropping it.
+    #[test]
+    fn test_source_name_alias_exposed_name_collision_errors() {
+        // Column exposes `customer_id` reading physical `cust_id`, but the CSV
+        // ALSO has a real `customer_id` column.
+        let schema = vec![col_from("customer_id", "cust_id", Type::String)];
+        let reader = csv_reader("cust_id,customer_id\nalice,bob\n");
+        let mut coercing =
+            CoercingReader::new(reader, &schema, auto_widen_policy(), "src").unwrap();
+
+        let err = coercing.next_record().unwrap_err();
+        match err {
+            FormatError::AliasNameCollision {
+                source,
+                exposed,
+                physical,
+            } => {
+                assert_eq!(source, "src");
+                assert_eq!(exposed, "customer_id");
+                assert_eq!(physical, "cust_id");
+            }
+            other => panic!("expected AliasNameCollision, got {other:?}"),
+        }
+    }
+
+    /// The collision fires under every policy, not just auto_widen — a `drop`
+    /// source would otherwise silently discard the real field.
+    #[test]
+    fn test_source_name_alias_collision_errors_under_drop() {
+        let schema = vec![col_from("customer_id", "cust_id", Type::String)];
+        let reader = csv_reader("cust_id,customer_id\nalice,bob\n");
+        let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
+        assert!(matches!(
+            coercing.next_record().unwrap_err(),
+            FormatError::AliasNameCollision { .. }
+        ));
     }
 
     /// An aliased column is coerced to its declared type just like a

--- a/crates/clinker-exec/src/pipeline/schema_coerce.rs
+++ b/crates/clinker-exec/src/pipeline/schema_coerce.rs
@@ -43,11 +43,18 @@ use clinker_plan::config::pipeline_node::{ColumnDecl, OnUnmapped, WIDENED_SIDECA
 /// `OnUnmapped` policy to undeclared input fields.
 pub struct CoercingReader {
     inner: Box<dyn FormatReader>,
-    /// Declared column names — lookup set for the policy's "is this
-    /// key in the declaration?" check.
+    /// Physical input-field names the declaration consumes — lookup set
+    /// for the policy's "is this key in the declaration?" check. Uses each
+    /// column's PHYSICAL name (`source_name` when aliased, else `name`) so an
+    /// aliased source field is recognized as declared rather than widened.
     declared_names: HashSet<Box<str>>,
-    /// Output schema — declared columns followed (under `AutoWiden`)
-    /// by the `$widened` engine-stamped sidecar column.
+    /// Physical input-field name to read each declared column FROM, indexed
+    /// by position across the declared columns (the `$widened` sidecar slot,
+    /// when present, has no entry — it is synthesized). Equals the exposed
+    /// column name unless the column declared a `source_name` alias.
+    physical_names: Vec<Box<str>>,
+    /// Output schema — declared columns (keyed by exposed name) followed
+    /// (under `AutoWiden`) by the `$widened` engine-stamped sidecar column.
     output_schema: Arc<Schema>,
     /// Per-output-column coercion target (`None` for pass-through).
     /// Indexed by position in `output_schema`. The `$widened` sidecar
@@ -82,8 +89,14 @@ impl CoercingReader {
         // record isn't gated behind an on-demand schema call.
         inner.schema()?;
 
-        let declared_names: HashSet<Box<str>> =
-            schema_decl.iter().map(|c| c.name.as_str().into()).collect();
+        // Physical name each column reads from: the `source_name` alias when
+        // set, else the exposed name. The declared-key set is built from these
+        // physical names so an aliased source field counts as declared.
+        let physical_names: Vec<Box<str>> = schema_decl
+            .iter()
+            .map(|c| c.source_name.as_deref().unwrap_or(c.name.as_str()).into())
+            .collect();
+        let declared_names: HashSet<Box<str>> = physical_names.iter().cloned().collect();
         let mut targets: Vec<Option<Type>> = schema_decl
             .iter()
             .map(|c| {
@@ -119,6 +132,7 @@ impl CoercingReader {
         Ok(CoercingReader {
             inner,
             declared_names,
+            physical_names,
             output_schema,
             targets,
             long_unique,
@@ -152,9 +166,9 @@ impl CoercingReader {
             }
         }
 
-        let cols = self.output_schema.columns();
-        let mut values: Vec<Value> = Vec::with_capacity(cols.len());
-        for (i, col) in cols.iter().enumerate() {
+        let col_count = self.output_schema.columns().len();
+        let mut values: Vec<Value> = Vec::with_capacity(col_count);
+        for i in 0..col_count {
             // The widened slot is filled from the sidecar map (if any
             // non-declared keys were observed); otherwise Null.
             if Some(i) == self.widened_idx {
@@ -164,7 +178,14 @@ impl CoercingReader {
                 });
                 continue;
             }
-            let raw = record.get(col).cloned().unwrap_or(Value::Null);
+            // Read from the PHYSICAL input field (the `source_name` alias when
+            // set), then expose the value under the declared column at this
+            // position. For an un-aliased column the physical name equals the
+            // exposed name, so this reads exactly the same field as before.
+            let raw = record
+                .get(self.physical_names[i].as_ref())
+                .cloned()
+                .unwrap_or(Value::Null);
             let coerced = match &self.targets[i] {
                 Some(target) => coerce_value(&raw, target).unwrap_or(raw),
                 None => raw,
@@ -278,6 +299,7 @@ mod tests {
             name: name.to_string(),
             ty,
             long_unique: false,
+            source_name: None,
         }
     }
 
@@ -286,6 +308,17 @@ mod tests {
             name: name.to_string(),
             ty,
             long_unique: true,
+            source_name: None,
+        }
+    }
+
+    /// A declared column aliasing a differently-named physical source column.
+    fn col_from(name: &str, source_name: &str, ty: Type) -> ColumnDecl {
+        ColumnDecl {
+            name: name.to_string(),
+            ty,
+            long_unique: false,
+            source_name: Some(source_name.to_string()),
         }
     }
 
@@ -362,6 +395,62 @@ mod tests {
         let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
 
         let rec = coercing.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("name"), Some(&Value::String("Alice".into())));
+    }
+
+    /// A `source_name` alias reads the physical CSV column and exposes the
+    /// value under the declared name — the physical column is recognized as
+    /// declared (never widened), and the exposed name carries the real data.
+    #[test]
+    fn test_source_name_alias_maps_physical_to_exposed() {
+        // Physical header is `cust_id`; the declaration exposes it as
+        // `customer_id`.
+        let schema = vec![
+            col("id", Type::String),
+            col_from("customer_id", "cust_id", Type::String),
+        ];
+        let reader = csv_reader("id,cust_id\n1,alice\n2,bob\n");
+        let mut coercing =
+            CoercingReader::new(reader, &schema, auto_widen_policy(), "src").unwrap();
+
+        // Output schema exposes the logical name.
+        let schema_arc = coercing.schema().unwrap();
+        let cols: Vec<&str> = schema_arc.columns().iter().map(|c| &**c).collect();
+        assert_eq!(cols, vec!["id", "customer_id", WIDENED_SIDECAR_COLUMN]);
+
+        let rec = coercing.next_record().unwrap().unwrap();
+        // The exposed column carries the physical column's value...
+        assert_eq!(rec.get("customer_id"), Some(&Value::String("alice".into())));
+        // ...the physical name is not a top-level output column...
+        assert!(rec.get("cust_id").is_none());
+        // ...and it did NOT fall into `$widened` (recognized as declared).
+        assert_eq!(rec.get(WIDENED_SIDECAR_COLUMN), Some(&Value::Null));
+    }
+
+    /// An aliased column is coerced to its declared type just like a
+    /// same-named column — the alias only changes which field it reads from.
+    #[test]
+    fn test_source_name_alias_still_coerces() {
+        let schema = vec![col_from("total", "raw_amount", Type::Int)];
+        let reader = csv_reader("raw_amount\n100\n250\n");
+        let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
+
+        let rec = coercing.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("total"), Some(&Value::Integer(100)));
+        let rec2 = coercing.next_record().unwrap().unwrap();
+        assert_eq!(rec2.get("total"), Some(&Value::Integer(250)));
+    }
+
+    /// Backward-compat: a column with `source_name == None` reads the field
+    /// whose key equals its `name`, exactly as before the alias field existed.
+    #[test]
+    fn test_no_alias_reads_by_name_unchanged() {
+        let schema = vec![col("id", Type::String), col("name", Type::String)];
+        let reader = csv_reader("id,name\n1,Alice\n");
+        let mut coercing = CoercingReader::new(reader, &schema, drop_policy(), "src").unwrap();
+
+        let rec = coercing.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("id"), Some(&Value::String("1".into())));
         assert_eq!(rec.get("name"), Some(&Value::String("Alice".into())));
     }
 

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -64,6 +64,18 @@ pub enum FormatError {
         source: String,
         field: String,
     },
+    /// A declared column aliases a physical source field (its `source_name`
+    /// differs from its exposed name), but the input ALSO carries a real field
+    /// named the same as the exposed name. Reading the alias would expose the
+    /// physical field's value under the exposed name while the real field of
+    /// that name is silently relocated (widened or dropped) — a data
+    /// mislocation. Raised so the collision fails loudly instead. Resolve it by
+    /// choosing an exposed name that does not clash with a real input field.
+    AliasNameCollision {
+        source: String,
+        exposed: String,
+        physical: String,
+    },
     /// A non-JSON writer (CSV / XML / fixed-width) was handed a record
     /// carrying a `Value::Map` payload at a regular column slot.
     /// JSON writers serialize maps natively; the other formats have
@@ -111,6 +123,17 @@ impl fmt::Display for FormatError {
                 f,
                 "source {source:?}: input record carries undeclared field {field:?} \
                  (set `on_unmapped: drop` to silently strip, or declare the field)"
+            ),
+            Self::AliasNameCollision {
+                source,
+                exposed,
+                physical,
+            } => write!(
+                f,
+                "[E236] source {source:?}: column exposed as {exposed:?} aliases physical field \
+                 {physical:?}, but the input also carries a real field named {exposed:?} — \
+                 reading the alias would mislocate that field. Rename the exposed column to a \
+                 name that does not clash with an input field."
             ),
             Self::UnserializableMapValue { format, column } => write!(
                 f,

--- a/crates/clinker-plan/src/config/error.rs
+++ b/crates/clinker-plan/src/config/error.rs
@@ -140,13 +140,18 @@ pub fn parse_config(yaml: &str) -> Result<PipelineConfig, ConfigError> {
     Ok(config)
 }
 
-/// Load and parse a pipeline config from a YAML file path with extra variables.
-/// `extra_vars` are checked before system env vars during interpolation.
+/// Read, interpolate, and parse a pipeline config from a YAML file path
+/// **without** running `validate_config`.
 ///
 /// Stamps `config.source_hash` with the BLAKE3 of the post-env-var
 /// interpolated YAML so the executor can resolve `{pipeline_hash}` tokens
 /// and write provenance sidecars without retaining the source bytes.
-pub fn load_config_with_vars(
+///
+/// Callers that need a fully-validated config use [`load_config_with_vars`].
+/// This split exists so channel source-config patches can mutate the parsed
+/// typed config before validation — the patched config is then the one
+/// `validate_config` and `compile()` see (see [`load_config_with_vars_and_patches`]).
+pub fn parse_config_with_vars(
     path: &std::path::Path,
     extra_vars: &[(&str, &str)],
 ) -> Result<PipelineConfig, ConfigError> {
@@ -154,6 +159,36 @@ pub fn load_config_with_vars(
     let interpolated = interpolate_env_vars(&yaml, extra_vars)?;
     let mut config: PipelineConfig = crate::yaml::from_str(&interpolated)?;
     config.source_hash = *blake3::hash(interpolated.as_bytes()).as_bytes();
+    Ok(config)
+}
+
+/// Load, parse, and validate a pipeline config from a YAML file path with
+/// extra variables. `extra_vars` are checked before system env vars during
+/// interpolation.
+pub fn load_config_with_vars(
+    path: &std::path::Path,
+    extra_vars: &[(&str, &str)],
+) -> Result<PipelineConfig, ConfigError> {
+    let config = parse_config_with_vars(path, extra_vars)?;
+    validate_config(&config)?;
+    Ok(config)
+}
+
+/// Load and parse a pipeline config, apply channel source-config patches to
+/// the parsed typed config, then validate.
+///
+/// The patches are applied after parse and before `validate_config`, so the
+/// patched config is exactly what validation and `compile()` consume on every
+/// run path. An empty patch map is a no-op equivalent to
+/// [`load_config_with_vars`]. Unknown source names or ill-formed patch ops
+/// surface as [`ConfigError::Validation`] before the pipeline compiles.
+pub fn load_config_with_vars_and_patches(
+    path: &std::path::Path,
+    extra_vars: &[(&str, &str)],
+    patches: &indexmap::IndexMap<String, crate::config::patch::SourceConfigPatch>,
+) -> Result<PipelineConfig, ConfigError> {
+    let mut config = parse_config_with_vars(path, extra_vars)?;
+    crate::config::patch::apply_source_patches(&mut config, patches)?;
     validate_config(&config)?;
     Ok(config)
 }

--- a/crates/clinker-plan/src/config/error.rs
+++ b/crates/clinker-plan/src/config/error.rs
@@ -189,6 +189,23 @@ pub fn load_config_with_vars_and_patches(
 ) -> Result<PipelineConfig, ConfigError> {
     let mut config = parse_config_with_vars(path, extra_vars)?;
     crate::config::patch::apply_source_patches(&mut config, patches)?;
+    // Fold the applied patches into the pipeline identity. `parse_config_with_vars`
+    // stamped `source_hash` from the pre-patch source bytes, so without this a
+    // channel-patched run would share the base pipeline's identity — colliding
+    // `{pipeline_hash}` output paths and conflating lineage across the base and
+    // its patched variants. An empty patch map contributes nothing, leaving the
+    // hash byte-identical to a plain load; a non-empty map mixes a canonical
+    // serialization of the patches in, so base-vs-patched and two-different-patch
+    // runs get distinct hashes.
+    if !patches.is_empty() {
+        let serialized = serde_json::to_vec(patches).map_err(|e| {
+            ConfigError::Validation(format!("internal: channel patch identity hashing: {e}"))
+        })?;
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(&config.source_hash);
+        hasher.update(&serialized);
+        config.source_hash = *hasher.finalize().as_bytes();
+    }
     validate_config(&config)?;
     Ok(config)
 }

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -7,6 +7,7 @@ pub mod format;
 pub mod fs_type;
 pub mod node_header;
 pub mod output;
+pub mod patch;
 pub mod path_template;
 pub mod pipeline;
 pub mod pipeline_node;
@@ -33,6 +34,9 @@ pub use format::*;
 pub use fs_type::{FsKind, case_sensitive_dir, classify, collision_key, same_device};
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use output::*;
+pub use patch::{
+    AddColumnPatch, ArrayPathOp, SchemaColumnOp, SourceConfigPatch, apply_source_patches,
+};
 pub use pipeline::*;
 pub use pipeline_node::{
     AggregateBody, MergeBody, OutputBody, Phase, PipelineNode, RouteBody, SourceBody,

--- a/crates/clinker-plan/src/config/patch.rs
+++ b/crates/clinker-plan/src/config/patch.rs
@@ -20,15 +20,17 @@ use super::*;
 use crate::config::pipeline_node::{ColumnDecl, PipelineNode, SchemaDecl, SourceBody};
 use cxl::typecheck::Type;
 use indexmap::IndexMap;
-use serde::Deserialize;
 use serde::de;
+use serde::{Deserialize, Serialize};
 
 /// Per-source config patch carried by a channel.
 ///
-/// Keyed forms only — leaf-replace, never deep-merge. `schema` ops are keyed
-/// by column name, `array_paths` ops by array path, and `options` sets a
-/// scalar per-format input option by its key.
-#[derive(Debug, Clone, Default, Deserialize)]
+/// Keyed forms only. `schema` ops are keyed by column name, `array_paths` ops
+/// by array path, and `options` sets a scalar per-format input option by its
+/// key. `Serialize` is derived for config-identity hashing only (folding the
+/// applied patches into the pipeline `source_hash`); the wire deserialize form
+/// is the channel YAML.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct SourceConfigPatch {
     /// Column-name-keyed schema ops (`add` / `rename` / `retype` / `remove`).
@@ -58,7 +60,10 @@ impl SourceConfigPatch {
 /// order_notes: remove                   # drop an existing column
 /// region:      { add: { type: string } }# add a new column (key = new name)
 /// ```
-#[derive(Debug, Clone)]
+///
+/// `Serialize` is derived for config-identity hashing only; the deserialize
+/// form is the channel YAML above.
+#[derive(Debug, Clone, Serialize)]
 pub enum SchemaColumnOp {
     /// Drop the keyed column.
     Remove,
@@ -71,7 +76,7 @@ pub enum SchemaColumnOp {
 }
 
 /// Payload for a schema `add` op: the new column's declared shape.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct AddColumnPatch {
     /// CXL type of the new column.
@@ -147,16 +152,20 @@ impl<'de> Deserialize<'de> for SchemaColumnOp {
 /// items:      { mode: join, separator: ";" }  # add-or-modify the entry
 /// line_items: remove                          # drop the entry
 /// ```
-#[derive(Debug, Clone)]
+///
+/// `Serialize` is derived for config-identity hashing only.
+#[derive(Debug, Clone, Serialize)]
 pub enum ArrayPathOp {
     /// Drop the keyed array-path entry.
     Remove,
-    /// Add-or-modify the keyed array-path entry (leaf-replace of the whole
-    /// entry — omitted fields take their defaults).
+    /// Add-or-modify the keyed array-path entry. A field is optional so a
+    /// partial modify keeps the omitted field: on an **existing** entry an
+    /// omitted `mode`/`separator` retains the current value; on a **new** entry
+    /// an omitted `mode` defaults to explode and an omitted `separator` is none.
     Set {
-        /// Explode (default) or join.
-        mode: ArrayMode,
-        /// Join separator; ignored for explode mode.
+        /// Explode or join; `None` = keep current (existing) / explode (new).
+        mode: Option<ArrayMode>,
+        /// Join separator; `None` = keep current (existing) / none (new).
         separator: Option<String>,
     },
 }
@@ -170,7 +179,7 @@ impl<'de> Deserialize<'de> for ArrayPathOp {
         #[serde(deny_unknown_fields)]
         struct SetMap {
             #[serde(default)]
-            mode: ArrayMode,
+            mode: Option<ArrayMode>,
             #[serde(default)]
             separator: Option<String>,
         }
@@ -206,14 +215,27 @@ pub fn apply_source_patches(
     config: &mut PipelineConfig,
     patches: &IndexMap<String, SourceConfigPatch>,
 ) -> Result<(), ConfigError> {
+    // Whether the pipeline calls any composition. Sources declared inside a
+    // composition body are not present in `config.nodes` at patch time (the
+    // body is expanded only during compile), so a patch targeting one cannot be
+    // resolved here — the unknown-source error explains that rather than
+    // implying a typo. Computed once so the per-source lookup can stay a plain
+    // borrow.
+    let has_composition = config
+        .nodes
+        .iter()
+        .any(|n| matches!(n.value, PipelineNode::Composition { .. }));
+
     for (src_name, patch) in patches {
         if patch.is_empty() {
             // Still resolve the source so an empty patch on a typo'd name
             // fails rather than passing silently.
-            source_body_mut(config, src_name).ok_or_else(|| unknown_source(src_name))?;
+            source_body_mut(config, src_name)
+                .ok_or_else(|| unknown_source(src_name, has_composition))?;
             continue;
         }
-        let body = source_body_mut(config, src_name).ok_or_else(|| unknown_source(src_name))?;
+        let body = source_body_mut(config, src_name)
+            .ok_or_else(|| unknown_source(src_name, has_composition))?;
         apply_schema_ops(&mut body.schema, &patch.schema, src_name)?;
         apply_array_path_ops(&mut body.source, &patch.array_paths, src_name)?;
         apply_option_ops(&mut body.source, &patch.options, src_name)?;
@@ -221,21 +243,36 @@ pub fn apply_source_patches(
     Ok(())
 }
 
-/// Locate a source node's body by its declared name.
+/// Locate a source node's body by its node identity (`header.name`).
+///
+/// The channel system keys sources by node identity — the `name:` on the node
+/// header — which can differ from the nested `config.name:`. Every other
+/// channel block (`vars.source`, E111) resolves the same way, so the patch
+/// target resolves by `header.name` for consistency.
 fn source_body_mut<'a>(config: &'a mut PipelineConfig, name: &str) -> Option<&'a mut SourceBody> {
     config
         .nodes
         .iter_mut()
         .find_map(|spanned| match &mut spanned.value {
-            PipelineNode::Source { config: body, .. } if body.source.name == name => Some(body),
+            PipelineNode::Source {
+                header,
+                config: body,
+            } if header.name == name => Some(body),
             _ => None,
         })
 }
 
-fn unknown_source(src_name: &str) -> ConfigError {
+fn unknown_source(src_name: &str, has_composition: bool) -> ConfigError {
+    let hint = if has_composition {
+        " (a source declared inside a composition body is not yet patchable by a \
+         channel `sources:` block — patch the composition's own source, or lift it \
+         to the top-level pipeline)"
+    } else {
+        ""
+    };
     ConfigError::Validation(format!(
         "[E230] channel source patch targets unknown source '{src_name}': \
-         no source node by that name in the pipeline"
+         no source node by that name in the pipeline{hint}"
     ))
 }
 
@@ -334,12 +371,20 @@ fn apply_array_path_ops(
             ArrayPathOp::Set { mode, separator } => {
                 let entries = source.array_paths.get_or_insert_with(Vec::new);
                 if let Some(existing) = entries.iter_mut().find(|a| a.path == *path) {
-                    existing.mode = mode.clone();
-                    existing.separator = separator.clone();
+                    // Partial modify: an omitted field keeps the current value,
+                    // so setting only `separator` on a `join` entry does not
+                    // silently revert its mode to explode.
+                    if let Some(m) = mode {
+                        existing.mode = m.clone();
+                    }
+                    if let Some(s) = separator {
+                        existing.separator = Some(s.clone());
+                    }
                 } else {
+                    // New entry: an omitted `mode` defaults to explode.
                     entries.push(ArrayPathConfig {
                         path: path.clone(),
-                        mode: mode.clone(),
+                        mode: mode.clone().unwrap_or_default(),
                         separator: separator.clone(),
                     });
                 }
@@ -687,6 +732,102 @@ nodes:
         assert!(err.to_string().contains("E230"), "{err}");
     }
 
+    /// A pipeline whose source NODE identity (`header.name`) differs from the
+    /// nested `config.name` — the two come from different YAML keys.
+    fn distinct_name_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: node_ident
+    config:
+      name: cfg_name
+      type: csv
+      path: /tmp/in.csv
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: node_ident
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse distinct-name pipeline")
+    }
+
+    #[test]
+    fn patch_resolves_by_node_header_name() {
+        let mut config = distinct_name_pipeline();
+        // Keyed by node identity (header.name), the same key every channel
+        // block uses.
+        apply(
+            &mut config,
+            "node_ident",
+            patch_from_yaml("schema:\n  amount: { retype: float }\n"),
+        )
+        .unwrap();
+        assert_eq!(columns(&config)[0], ("amount".to_string(), Type::Float));
+    }
+
+    #[test]
+    fn patch_by_config_name_does_not_resolve() {
+        let mut config = distinct_name_pipeline();
+        // The nested `config.name` is NOT the channel identity → unknown source.
+        let err = apply(
+            &mut config,
+            "cfg_name",
+            patch_from_yaml("schema:\n  amount: { retype: float }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E230"), "{err}");
+    }
+
+    #[test]
+    fn unknown_source_with_composition_gives_hint() {
+        // A pipeline that calls a composition: an unresolved source name gets a
+        // hint about composition-body sources rather than a bare typo error.
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: /tmp/in.csv
+      schema:
+        - { name: id, type: string }
+  - type: composition
+    name: comp
+    input: src
+    use: ./thing.comp.yaml
+  - type: output
+    name: out
+    input: comp
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        let mut config = crate::yaml::from_str(yaml).expect("parse composition pipeline");
+        let err = apply(
+            &mut config,
+            "inner_src",
+            patch_from_yaml("schema:\n  id: remove\n"),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("E230"), "{msg}");
+        assert!(
+            msg.contains("composition"),
+            "expected a composition-body hint: {msg}"
+        );
+    }
+
     /// A JSON source declaring a `record_path` option and one array-path entry.
     fn json_pipeline() -> PipelineConfig {
         let yaml = "\
@@ -756,6 +897,50 @@ nodes:
         let entries = array_paths(&config);
         assert_eq!(entries.len(), 2);
         assert!(entries.iter().any(|(p, _, _)| p == "tags"));
+    }
+
+    #[test]
+    fn array_paths_partial_modify_keeps_omitted_mode() {
+        let mut config = json_pipeline();
+        // Make `items` a join entry...
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("array_paths:\n  items: { mode: join, separator: \";\" }\n"),
+        )
+        .unwrap();
+        // ...then patch only the separator: the mode must stay join, not
+        // silently revert to explode.
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("array_paths:\n  items: { separator: \"|\" }\n"),
+        )
+        .unwrap();
+        let entries = array_paths(&config);
+        assert_eq!(entries.len(), 1);
+        assert!(
+            matches!(entries[0].1, ArrayMode::Join),
+            "mode must remain join, got {:?}",
+            entries[0].1
+        );
+        assert_eq!(entries[0].2.as_deref(), Some("|"));
+    }
+
+    #[test]
+    fn array_paths_new_entry_defaults_mode_explode() {
+        let mut config = json_pipeline();
+        // A new entry with no `mode` defaults to explode.
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("array_paths:\n  tags: { separator: \",\" }\n"),
+        )
+        .unwrap();
+        let entries = array_paths(&config);
+        let tags = entries.iter().find(|(p, _, _)| p == "tags").unwrap();
+        assert!(matches!(tags.1, ArrayMode::Explode));
+        assert_eq!(tags.2.as_deref(), Some(","));
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/patch.rs
+++ b/crates/clinker-plan/src/config/patch.rs
@@ -283,6 +283,17 @@ fn apply_schema_ops(
                     .iter_mut()
                     .find(|c| c.name == *col)
                     .expect("existence checked above");
+                // Rename is a physical→logical alias, not a bare relabel: the
+                // reader binds columns to input fields by name, so preserve the
+                // physical source column (defaulting to the current name on the
+                // first rename) while exposing the new name downstream. A second
+                // rename keeps the original physical binding.
+                column.source_name = Some(
+                    column
+                        .source_name
+                        .take()
+                        .unwrap_or_else(|| column.name.clone()),
+                );
                 column.name = to.clone();
             }
             SchemaColumnOp::Add(add) => {
@@ -296,6 +307,7 @@ fn apply_schema_ops(
                     name: col.clone(),
                     ty: add.ty.clone(),
                     long_unique: add.long_unique,
+                    source_name: None,
                 });
             }
         }
@@ -478,8 +490,21 @@ nodes:
         assert_eq!(columns(&config)[0], ("amount".to_string(), Type::Float));
     }
 
+    /// Fetch a column by exposed name from the single source.
+    fn column_named<'a>(config: &'a PipelineConfig, name: &str) -> &'a ColumnDecl {
+        config
+            .source_bodies()
+            .next()
+            .expect("one source")
+            .schema
+            .columns
+            .iter()
+            .find(|c| c.name == name)
+            .expect("column present")
+    }
+
     #[test]
-    fn schema_rename_renames_column() {
+    fn schema_rename_renames_column_and_sets_physical_alias() {
         let mut config = csv_pipeline();
         apply(
             &mut config,
@@ -487,7 +512,29 @@ nodes:
             patch_from_yaml("schema:\n  cust_id: { rename: customer_id }\n"),
         )
         .unwrap();
+        // Exposed name changes...
         assert_eq!(columns(&config)[1].0, "customer_id");
+        // ...but the physical binding is preserved: rename is an alias, not a
+        // bare relabel, so the reader still reads the `cust_id` source field.
+        let column = column_named(&config, "customer_id");
+        assert_eq!(column.source_name.as_deref(), Some("cust_id"));
+    }
+
+    #[test]
+    fn schema_double_rename_keeps_original_physical() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "schema:\n  cust_id: { rename: mid }\n  mid: { rename: customer_id }\n",
+            ),
+        )
+        .unwrap();
+        let column = column_named(&config, "customer_id");
+        // Both renames applied in order; the physical binding is still the
+        // original source column, not the intermediate name.
+        assert_eq!(column.source_name.as_deref(), Some("cust_id"));
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/patch.rs
+++ b/crates/clinker-plan/src/config/patch.rs
@@ -1,0 +1,827 @@
+//! Channel-driven source-config patches.
+//!
+//! A channel can override any part of a source node's parsed config through
+//! partial, path-addressed patches applied to the typed [`PipelineConfig`]
+//! *before* validation and compile. The patched config is exactly what
+//! `validate_config` sees and what `compile()` consumes, so a run behaves as
+//! if the operator had hand-edited the source YAML.
+//!
+//! The patch is applied by mutating the already-parsed typed config in place —
+//! the span-aware `Spanned<PipelineNode>` structure is preserved, never
+//! round-tripped through a span-losing intermediate value.
+//!
+//! v1 handles the format-agnostic schema-shaping surfaces: the CXL-typed
+//! column list (`schema`), nested-array explosion/join (`array_paths`), and
+//! scalar per-format input options (`options`). Deeper format-layer layouts
+//! (fixed-width/positional field schemas, X12/HL7 nested sections, multi-record
+//! discrimination) reuse this same framework as additional handlers.
+
+use super::*;
+use crate::config::pipeline_node::{ColumnDecl, PipelineNode, SchemaDecl, SourceBody};
+use cxl::typecheck::Type;
+use indexmap::IndexMap;
+use serde::Deserialize;
+use serde::de;
+
+/// Per-source config patch carried by a channel.
+///
+/// Keyed forms only — leaf-replace, never deep-merge. `schema` ops are keyed
+/// by column name, `array_paths` ops by array path, and `options` sets a
+/// scalar per-format input option by its key.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct SourceConfigPatch {
+    /// Column-name-keyed schema ops (`add` / `rename` / `retype` / `remove`).
+    pub schema: IndexMap<String, SchemaColumnOp>,
+    /// Array-path-keyed ops: set-by-path (add-or-modify) or `remove`.
+    pub array_paths: IndexMap<String, ArrayPathOp>,
+    /// Scalar per-format input options, keyed by option name. Merged onto the
+    /// source's current options and re-validated through the format's option
+    /// struct, so an unknown key is rejected exactly as in hand-written config.
+    pub options: IndexMap<String, serde_json::Value>,
+}
+
+impl SourceConfigPatch {
+    /// Whether this patch carries no ops — a no-op the apply pass can skip.
+    pub fn is_empty(&self) -> bool {
+        self.schema.is_empty() && self.array_paths.is_empty() && self.options.is_empty()
+    }
+}
+
+/// One column-keyed schema op.
+///
+/// YAML forms (the map key is the target column name):
+///
+/// ```yaml
+/// amount:      { retype: float }        # change an existing column's type
+/// cust_id:     { rename: customer_id }  # rename an existing column
+/// order_notes: remove                   # drop an existing column
+/// region:      { add: { type: string } }# add a new column (key = new name)
+/// ```
+#[derive(Debug, Clone)]
+pub enum SchemaColumnOp {
+    /// Drop the keyed column.
+    Remove,
+    /// Rename the keyed column to the given name.
+    Rename(String),
+    /// Change the keyed column's CXL type.
+    Retype(Type),
+    /// Add a new column named by the map key.
+    Add(AddColumnPatch),
+}
+
+/// Payload for a schema `add` op: the new column's declared shape.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AddColumnPatch {
+    /// CXL type of the new column.
+    #[serde(rename = "type")]
+    pub ty: Type,
+    /// Mirrors [`ColumnDecl::long_unique`] — advisory storage hint.
+    #[serde(default)]
+    pub long_unique: bool,
+}
+
+impl<'de> Deserialize<'de> for SchemaColumnOp {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Two accepted YAML shapes:
+        //   remove                         (bare scalar)
+        //   { rename | retype | add: ... } (single-key map)
+        // The bare scalar is handled explicitly; the map form accepts exactly
+        // one of the three op keys.
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct OpMap {
+            #[serde(default)]
+            rename: Option<String>,
+            #[serde(default)]
+            retype: Option<Type>,
+            #[serde(default)]
+            add: Option<AddColumnPatch>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Either {
+            Scalar(String),
+            Map(OpMap),
+        }
+
+        match Either::deserialize(d)? {
+            Either::Scalar(s) if s == "remove" => Ok(SchemaColumnOp::Remove),
+            Either::Scalar(other) => Err(de::Error::custom(format!(
+                "unknown schema op {other:?}; the bare scalar form only accepts `remove` — \
+                 use `{{ rename: <name> }}`, `{{ retype: <type> }}`, or `{{ add: {{ type: <type> }} }}`"
+            ))),
+            Either::Map(m) => {
+                let count =
+                    m.rename.is_some() as u8 + m.retype.is_some() as u8 + m.add.is_some() as u8;
+                match count {
+                    0 => Err(de::Error::custom(
+                        "empty schema op; provide exactly one of `rename`, `retype`, `add`, \
+                         or the bare scalar `remove`",
+                    )),
+                    1 => {
+                        if let Some(to) = m.rename {
+                            Ok(SchemaColumnOp::Rename(to))
+                        } else if let Some(t) = m.retype {
+                            Ok(SchemaColumnOp::Retype(t))
+                        } else {
+                            Ok(SchemaColumnOp::Add(m.add.expect("count==1 with add set")))
+                        }
+                    }
+                    _ => Err(de::Error::custom(
+                        "ambiguous schema op; provide exactly one of `rename`, `retype`, `add`",
+                    )),
+                }
+            }
+        }
+    }
+}
+
+/// One array-path-keyed op.
+///
+/// YAML forms (the map key is the array path):
+///
+/// ```yaml
+/// items:      { mode: join, separator: ";" }  # add-or-modify the entry
+/// line_items: remove                          # drop the entry
+/// ```
+#[derive(Debug, Clone)]
+pub enum ArrayPathOp {
+    /// Drop the keyed array-path entry.
+    Remove,
+    /// Add-or-modify the keyed array-path entry (leaf-replace of the whole
+    /// entry — omitted fields take their defaults).
+    Set {
+        /// Explode (default) or join.
+        mode: ArrayMode,
+        /// Join separator; ignored for explode mode.
+        separator: Option<String>,
+    },
+}
+
+impl<'de> Deserialize<'de> for ArrayPathOp {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Two accepted YAML shapes:
+        //   remove                       (bare scalar)
+        //   { mode?, separator? }        (entry map)
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct SetMap {
+            #[serde(default)]
+            mode: ArrayMode,
+            #[serde(default)]
+            separator: Option<String>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Either {
+            Scalar(String),
+            Map(SetMap),
+        }
+
+        match Either::deserialize(d)? {
+            Either::Scalar(s) if s == "remove" => Ok(ArrayPathOp::Remove),
+            Either::Scalar(other) => Err(de::Error::custom(format!(
+                "unknown array_paths op {other:?}; the bare scalar form only accepts `remove` — \
+                 use `{{ mode: explode|join, separator: <str> }}` to add or modify an entry"
+            ))),
+            Either::Map(m) => Ok(ArrayPathOp::Set {
+                mode: m.mode,
+                separator: m.separator,
+            }),
+        }
+    }
+}
+
+/// Apply channel source-config patches to the parsed config in place.
+///
+/// Runs after parse and before `validate_config`, so the patched config is
+/// the one validated and compiled. Each entry names a source node; an unknown
+/// source name or an ill-formed op is a config error (E230–E235) reported
+/// before the pipeline compiles.
+pub fn apply_source_patches(
+    config: &mut PipelineConfig,
+    patches: &IndexMap<String, SourceConfigPatch>,
+) -> Result<(), ConfigError> {
+    for (src_name, patch) in patches {
+        if patch.is_empty() {
+            // Still resolve the source so an empty patch on a typo'd name
+            // fails rather than passing silently.
+            source_body_mut(config, src_name).ok_or_else(|| unknown_source(src_name))?;
+            continue;
+        }
+        let body = source_body_mut(config, src_name).ok_or_else(|| unknown_source(src_name))?;
+        apply_schema_ops(&mut body.schema, &patch.schema, src_name)?;
+        apply_array_path_ops(&mut body.source, &patch.array_paths, src_name)?;
+        apply_option_ops(&mut body.source, &patch.options, src_name)?;
+    }
+    Ok(())
+}
+
+/// Locate a source node's body by its declared name.
+fn source_body_mut<'a>(config: &'a mut PipelineConfig, name: &str) -> Option<&'a mut SourceBody> {
+    config
+        .nodes
+        .iter_mut()
+        .find_map(|spanned| match &mut spanned.value {
+            PipelineNode::Source { config: body, .. } if body.source.name == name => Some(body),
+            _ => None,
+        })
+}
+
+fn unknown_source(src_name: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E230] channel source patch targets unknown source '{src_name}': \
+         no source node by that name in the pipeline"
+    ))
+}
+
+fn unknown_column(src: &str, col: &str, op: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E231] channel schema patch on source '{src}': {op} of unknown column '{col}'"
+    ))
+}
+
+fn apply_schema_ops(
+    schema: &mut SchemaDecl,
+    ops: &IndexMap<String, SchemaColumnOp>,
+    src: &str,
+) -> Result<(), ConfigError> {
+    for (col, op) in ops {
+        match op {
+            SchemaColumnOp::Remove => {
+                let idx = schema
+                    .columns
+                    .iter()
+                    .position(|c| c.name == *col)
+                    .ok_or_else(|| unknown_column(src, col, "remove"))?;
+                schema.columns.remove(idx);
+            }
+            SchemaColumnOp::Retype(ty) => {
+                let column = schema
+                    .columns
+                    .iter_mut()
+                    .find(|c| c.name == *col)
+                    .ok_or_else(|| unknown_column(src, col, "retype"))?;
+                column.ty = ty.clone();
+            }
+            SchemaColumnOp::Rename(to) => {
+                if !schema.columns.iter().any(|c| c.name == *col) {
+                    return Err(unknown_column(src, col, "rename"));
+                }
+                if to != col && schema.columns.iter().any(|c| c.name == *to) {
+                    return Err(ConfigError::Validation(format!(
+                        "[E233] channel schema patch on source '{src}': rename of '{col}' to \
+                         '{to}' collides with an existing column"
+                    )));
+                }
+                let column = schema
+                    .columns
+                    .iter_mut()
+                    .find(|c| c.name == *col)
+                    .expect("existence checked above");
+                column.name = to.clone();
+            }
+            SchemaColumnOp::Add(add) => {
+                if schema.columns.iter().any(|c| c.name == *col) {
+                    return Err(ConfigError::Validation(format!(
+                        "[E232] channel schema patch on source '{src}': add of column '{col}' \
+                         that already exists"
+                    )));
+                }
+                schema.columns.push(ColumnDecl {
+                    name: col.clone(),
+                    ty: add.ty.clone(),
+                    long_unique: add.long_unique,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_array_path_ops(
+    source: &mut SourceConfig,
+    ops: &IndexMap<String, ArrayPathOp>,
+    src: &str,
+) -> Result<(), ConfigError> {
+    for (path, op) in ops {
+        match op {
+            ArrayPathOp::Remove => {
+                let Some(entries) = source.array_paths.as_mut() else {
+                    return Err(unknown_array_path(src, path));
+                };
+                let Some(idx) = entries.iter().position(|a| a.path == *path) else {
+                    return Err(unknown_array_path(src, path));
+                };
+                entries.remove(idx);
+            }
+            ArrayPathOp::Set { mode, separator } => {
+                let entries = source.array_paths.get_or_insert_with(Vec::new);
+                if let Some(existing) = entries.iter_mut().find(|a| a.path == *path) {
+                    existing.mode = mode.clone();
+                    existing.separator = separator.clone();
+                } else {
+                    entries.push(ArrayPathConfig {
+                        path: path.clone(),
+                        mode: mode.clone(),
+                        separator: separator.clone(),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn unknown_array_path(src: &str, path: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E234] channel array_paths patch on source '{src}': remove of unknown path '{path}'"
+    ))
+}
+
+/// Merge scalar option overrides onto the source's current per-format options.
+///
+/// Serializes the current options to a JSON object, sets each override key,
+/// then re-deserializes through the format's option struct — reusing its
+/// `deny_unknown_fields` so an unknown or mistyped option is rejected (E235)
+/// exactly as it would be in hand-written config. The round-trip touches only
+/// the leaf option struct, never the span-aware pipeline-node structure.
+fn apply_option_ops(
+    source: &mut SourceConfig,
+    overrides: &IndexMap<String, serde_json::Value>,
+    src: &str,
+) -> Result<(), ConfigError> {
+    if overrides.is_empty() {
+        return Ok(());
+    }
+    let fmt = source.format.format_name();
+
+    macro_rules! patch_options {
+        ($cur:expr, $ty:ty, $wrap:path) => {{
+            let mut value = match $cur {
+                Some(existing) => {
+                    serde_json::to_value(existing).map_err(|e| options_internal(src, &e))?
+                }
+                None => serde_json::Value::Object(serde_json::Map::new()),
+            };
+            let obj = value
+                .as_object_mut()
+                .expect("format input options serialize to a JSON object");
+            for (key, val) in overrides {
+                obj.insert(key.clone(), val.clone());
+            }
+            let parsed: $ty =
+                serde_json::from_value(value).map_err(|e| options_rejected(src, fmt, &e))?;
+            $wrap(Some(parsed))
+        }};
+    }
+
+    let new_format = match &source.format {
+        InputFormat::Csv(o) => patch_options!(o, CsvInputOptions, InputFormat::Csv),
+        InputFormat::Json(o) => patch_options!(o, JsonInputOptions, InputFormat::Json),
+        InputFormat::Xml(o) => patch_options!(o, XmlInputOptions, InputFormat::Xml),
+        InputFormat::FixedWidth(o) => {
+            patch_options!(o, FixedWidthInputOptions, InputFormat::FixedWidth)
+        }
+        InputFormat::Edifact(o) => patch_options!(o, EdifactInputOptions, InputFormat::Edifact),
+        InputFormat::X12(o) => patch_options!(o, X12InputOptions, InputFormat::X12),
+        InputFormat::Hl7(o) => patch_options!(o, Hl7InputOptions, InputFormat::Hl7),
+        InputFormat::Swift(o) => patch_options!(o, SwiftInputOptions, InputFormat::Swift),
+    };
+    source.format = new_format;
+    Ok(())
+}
+
+fn options_rejected(src: &str, fmt: &str, err: &serde_json::Error) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E235] channel options patch on source '{src}' ({fmt} format): {err}"
+    ))
+}
+
+fn options_internal(src: &str, err: &serde_json::Error) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E235] channel options patch on source '{src}': could not read current options: {err}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A CSV source named `src` with three declared columns, feeding one
+    /// output. Parsed (not validated), which is all the patch handlers need.
+    fn csv_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: /tmp/in.csv
+      schema:
+        - { name: amount, type: int }
+        - { name: cust_id, type: string }
+        - { name: order_notes, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse csv pipeline")
+    }
+
+    fn patch_from_yaml(yaml: &str) -> SourceConfigPatch {
+        crate::yaml::from_str(yaml).expect("parse patch")
+    }
+
+    fn columns(config: &PipelineConfig) -> Vec<(String, Type)> {
+        config
+            .source_bodies()
+            .next()
+            .expect("one source")
+            .schema
+            .columns
+            .iter()
+            .map(|c| (c.name.clone(), c.ty.clone()))
+            .collect()
+    }
+
+    fn apply(
+        config: &mut PipelineConfig,
+        source: &str,
+        patch: SourceConfigPatch,
+    ) -> Result<(), ConfigError> {
+        let mut patches = IndexMap::new();
+        patches.insert(source.to_string(), patch);
+        apply_source_patches(config, &patches)
+    }
+
+    #[test]
+    fn schema_retype_changes_type() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  amount: { retype: float }\n"),
+        )
+        .unwrap();
+        assert_eq!(columns(&config)[0], ("amount".to_string(), Type::Float));
+    }
+
+    #[test]
+    fn schema_rename_renames_column() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  cust_id: { rename: customer_id }\n"),
+        )
+        .unwrap();
+        assert_eq!(columns(&config)[1].0, "customer_id");
+    }
+
+    #[test]
+    fn schema_remove_drops_column() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  order_notes: remove\n"),
+        )
+        .unwrap();
+        let names: Vec<String> = columns(&config).into_iter().map(|(n, _)| n).collect();
+        assert_eq!(names, vec!["amount".to_string(), "cust_id".to_string()]);
+    }
+
+    #[test]
+    fn schema_add_appends_column() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  region: { add: { type: string } }\n"),
+        )
+        .unwrap();
+        let cols = columns(&config);
+        assert_eq!(cols.last().unwrap(), &("region".to_string(), Type::String));
+    }
+
+    #[test]
+    fn schema_add_long_unique_flag_flows_through() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  uuid: { add: { type: string, long_unique: true } }\n"),
+        )
+        .unwrap();
+        let body = config.source_bodies().next().unwrap();
+        let col = body
+            .schema
+            .columns
+            .iter()
+            .find(|c| c.name == "uuid")
+            .unwrap();
+        assert!(col.long_unique);
+    }
+
+    #[test]
+    fn schema_combined_ops_apply_in_order() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "schema:\n  amount: { retype: float }\n  cust_id: { rename: customer_id }\n  order_notes: remove\n  region: { add: { type: string } }\n",
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            columns(&config),
+            vec![
+                ("amount".to_string(), Type::Float),
+                ("customer_id".to_string(), Type::String),
+                ("region".to_string(), Type::String),
+            ]
+        );
+    }
+
+    #[test]
+    fn schema_retype_unknown_column_errors() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  nope: { retype: float }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E231"), "{err}");
+    }
+
+    #[test]
+    fn schema_rename_unknown_column_errors() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  nope: { rename: x }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E231"), "{err}");
+    }
+
+    #[test]
+    fn schema_remove_unknown_column_errors() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  nope: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E231"), "{err}");
+    }
+
+    #[test]
+    fn schema_add_existing_column_errors() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  amount: { add: { type: float } }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E232"), "{err}");
+    }
+
+    #[test]
+    fn schema_rename_collision_errors() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  amount: { rename: cust_id }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E233"), "{err}");
+    }
+
+    #[test]
+    fn schema_rename_to_same_name_is_allowed() {
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("schema:\n  amount: { rename: amount }\n"),
+        )
+        .unwrap();
+        assert_eq!(columns(&config)[0].0, "amount");
+    }
+
+    #[test]
+    fn unknown_source_name_errors() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "ghost",
+            patch_from_yaml("schema:\n  amount: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E230"), "{err}");
+    }
+
+    /// A JSON source declaring a `record_path` option and one array-path entry.
+    fn json_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: json
+      path: /tmp/in.json
+      options:
+        record_path: data.rows
+      array_paths:
+        - { path: items, mode: explode }
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse json pipeline")
+    }
+
+    fn array_paths(config: &PipelineConfig) -> Vec<(String, ArrayMode, Option<String>)> {
+        config
+            .source_configs()
+            .next()
+            .unwrap()
+            .array_paths
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|a| (a.path, a.mode, a.separator))
+            .collect()
+    }
+
+    #[test]
+    fn array_paths_modify_existing_entry() {
+        let mut config = json_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("array_paths:\n  items: { mode: join, separator: \";\" }\n"),
+        )
+        .unwrap();
+        let entries = array_paths(&config);
+        assert_eq!(entries.len(), 1);
+        assert!(matches!(entries[0].1, ArrayMode::Join));
+        assert_eq!(entries[0].2.as_deref(), Some(";"));
+    }
+
+    #[test]
+    fn array_paths_add_new_entry() {
+        let mut config = json_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("array_paths:\n  tags: { mode: explode }\n"),
+        )
+        .unwrap();
+        let entries = array_paths(&config);
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|(p, _, _)| p == "tags"));
+    }
+
+    #[test]
+    fn array_paths_remove_entry() {
+        let mut config = json_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("array_paths:\n  items: remove\n"),
+        )
+        .unwrap();
+        assert!(array_paths(&config).is_empty());
+    }
+
+    #[test]
+    fn array_paths_remove_unknown_errors() {
+        let mut config = json_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("array_paths:\n  ghost: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E234"), "{err}");
+    }
+
+    #[test]
+    fn options_set_scalar_record_path() {
+        let mut config = json_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("options:\n  record_path: batch_records\n"),
+        )
+        .unwrap();
+        let source = config.source_configs().next().unwrap();
+        match &source.format {
+            InputFormat::Json(Some(opts)) => {
+                assert_eq!(opts.record_path.as_deref(), Some("batch_records"));
+            }
+            other => panic!("expected json options, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn options_unknown_key_errors() {
+        let mut config = json_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("options:\n  not_a_key: 5\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E235"), "{err}");
+    }
+
+    #[test]
+    fn options_set_preserves_existing_keys() {
+        // record_path was `data.rows`; overriding an unrelated csv-ish key is
+        // rejected, but setting `format` should keep record_path intact.
+        let mut config = json_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("options:\n  format: ndjson\n"),
+        )
+        .unwrap();
+        let source = config.source_configs().next().unwrap();
+        match &source.format {
+            InputFormat::Json(Some(opts)) => {
+                assert_eq!(opts.record_path.as_deref(), Some("data.rows"));
+                assert!(matches!(opts.format, Some(JsonFormat::Ndjson)));
+            }
+            other => panic!("expected json options, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn options_on_source_without_options_block() {
+        // A CSV source with no `options:` starts from an empty option struct;
+        // the override materializes it.
+        let mut config = csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("options:\n  delimiter: \"|\"\n"),
+        )
+        .unwrap();
+        let source = config.source_configs().next().unwrap();
+        match &source.format {
+            InputFormat::Csv(Some(opts)) => assert_eq!(opts.delimiter.as_deref(), Some("|")),
+            other => panic!("expected csv options, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_patch_on_unknown_source_still_errors() {
+        let mut config = csv_pipeline();
+        let err = apply(&mut config, "ghost", SourceConfigPatch::default()).unwrap_err();
+        assert!(err.to_string().contains("E230"), "{err}");
+    }
+
+    #[test]
+    fn schema_op_ambiguous_map_rejected_at_parse() {
+        let err = crate::yaml::from_str::<SourceConfigPatch>(
+            "schema:\n  amount: { rename: x, retype: float }\n",
+        )
+        .unwrap_err();
+        assert!(
+            format!("{}", err.0).contains("exactly one")
+                || format!("{}", err.0).contains("ambiguous"),
+            "{}",
+            err.0
+        );
+    }
+}

--- a/crates/clinker-plan/src/config/pipeline_node.rs
+++ b/crates/clinker-plan/src/config/pipeline_node.rs
@@ -968,6 +968,17 @@ pub struct ColumnDecl {
     /// leaves the default policy and serializes to byte-identical YAML.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub long_unique: bool,
+    /// Physical source column this declared column reads FROM, when it differs
+    /// from the exposed [`name`](Self::name). The reader matches input records
+    /// by physical name and re-labels the value under `name`, so downstream CXL
+    /// and the output see `name` while the value is drawn from `source_name`.
+    /// `None` (the common case) means physical == exposed: the column reads the
+    /// input field whose key equals `name`, identical to omitting this field.
+    /// Hand-writable in a base `schema:` block as a source-column alias, and set
+    /// by a channel `schema` patch's `rename` op (which relabels a source column
+    /// without severing its physical binding).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_name: Option<String>,
 }
 
 /// Policy for fields a reader discovers in an input record that the
@@ -2555,17 +2566,23 @@ nodes:
             name: "uuid".to_string(),
             ty: cxl::typecheck::Type::String,
             long_unique: false,
+            source_name: None,
         };
         let json = serde_json::to_string(&plain).expect("serialize");
         assert!(
             !json.contains("long_unique"),
             "an unflagged column must not emit the long_unique key, got: {json}"
         );
+        assert!(
+            !json.contains("source_name"),
+            "a column without an alias must not emit the source_name key, got: {json}"
+        );
 
         let flagged = ColumnDecl {
             name: "uuid".to_string(),
             ty: cxl::typecheck::Type::String,
             long_unique: true,
+            source_name: None,
         };
         let json = serde_json::to_string(&flagged).expect("serialize");
         assert!(

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2101,9 +2101,21 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
     let yaml = std::fs::read_to_string(config_path)?;
     let interpolated = clinker_plan::config::interpolate_env_vars(&yaml, &[])
         .map_err(|e| format!("environment variable interpolation failed: {e}"))?;
-    let pipeline_config: clinker_plan::config::PipelineConfig =
+    let mut pipeline_config: clinker_plan::config::PipelineConfig =
         clinker_plan::yaml::from_str(&interpolated)
             .map_err(|e| format!("YAML parse error: {e}"))?;
+
+    // Apply the channel's source-config patches before compile, so provenance
+    // is computed against the same patched plan a `run` would execute — no
+    // explain path compiles an unpatched config. Uses the shared
+    // `apply_source_patches` primitive that the run/`--explain`/`--lineage`
+    // paths reach through `load_config_with_vars_and_patches`.
+    if let Some(channel_path) = &args.channel {
+        let binding = clinker_channel::ChannelBinding::load(channel_path)
+            .map_err(|e| format!("channel '{}': {e}", channel_path.display()))?;
+        clinker_plan::config::apply_source_patches(&mut pipeline_config, &binding.source_patches)
+            .map_err(|e| format!("{e}"))?;
+    }
 
     // Resolve workspace root and pipeline_dir so composition `use:` paths
     // resolve correctly. The workspace root is the base_dir (default: CWD),

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -582,12 +582,12 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         unsafe { std::env::set_var("CLINKER_ENV", env_name) };
     }
 
-    let mut pipeline_config = clinker_plan::config::load_config_with_vars(&args.config, &[])
-        .map_err(PipelineError::Config)?;
-
-    // Load the channel binding once if `--channel` was supplied. The
-    // overlay itself runs against each `compile()` result below; the
-    // binding is borrowed by the `--explain` arm and the main run.
+    // Load the channel binding once if `--channel` was supplied. It is loaded
+    // BEFORE the pipeline config because its per-source config patches must be
+    // applied to the parsed config before validation/compile (below). The
+    // overlay for composition config/vars still runs against each `compile()`
+    // result later; the binding is borrowed by the `--explain` arm and the
+    // main run.
     let channel_binding = match args.channel.as_deref() {
         Some(path) => Some(clinker_channel::ChannelBinding::load(path).map_err(|e| {
             PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
@@ -615,6 +615,20 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
             );
         }
     }
+
+    // Apply the channel's source-config patches (schema / array_paths /
+    // options) to the parsed config before it is validated and compiled, so
+    // every run path — normal run, `--explain`, and `--lineage` — observes the
+    // patched shape. An absent channel (or one with no `sources:` block) is an
+    // empty map, making this equivalent to a plain validated load.
+    let empty_patches = indexmap::IndexMap::new();
+    let source_patches = channel_binding
+        .as_ref()
+        .map(|b| &b.source_patches)
+        .unwrap_or(&empty_patches);
+    let mut pipeline_config =
+        clinker_plan::config::load_config_with_vars_and_patches(&args.config, &[], source_patches)
+            .map_err(PipelineError::Config)?;
 
     // Resolve workspace_root and pipeline_dir ONCE at the entry point so
     // `compile()` never touches the process CWD. The invariant the compile

--- a/crates/clinker/tests/channel_source_patch.rs
+++ b/crates/clinker/tests/channel_source_patch.rs
@@ -1,0 +1,260 @@
+//! End-to-end coverage for the channel `sources:` config-patch block (#550).
+//!
+//! A channel patches a source's parsed config (schema column ops, `array_paths`
+//! ops, scalar `options`) before the pipeline is validated and compiled, so a
+//! run behaves as if the source YAML had been hand-edited. These tests shell
+//! out to the built `clinker` binary and assert the patch takes effect on the
+//! normal run path, is reflected by `--explain`, and that a bad patch fails at
+//! compile time with the documented diagnostic.
+
+use std::path::Path;
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+/// Write `contents` to `dir/name`.
+fn write(dir: &Path, name: &str, contents: &str) {
+    std::fs::write(dir.join(name), contents).expect("write fixture file");
+}
+
+/// Run `clinker run <pipeline>` (plus any extra args) inside `dir`.
+fn run_in(dir: &Path, extra: &[&str]) -> std::process::Output {
+    Command::new(clinker_bin())
+        .arg("run")
+        .arg("pipe.yaml")
+        .args(extra)
+        .current_dir(dir)
+        .output()
+        .expect("spawn clinker")
+}
+
+/// A CSV pipeline whose transform reads a numeric `amount` and a `region`
+/// column that the *base* schema does not provide — so the base pipeline
+/// fails to compile, and only the channel patch (rename `amnt`→`amount`,
+/// retype to int, add `region`) makes it valid.
+const CSV_PIPELINE: &str = "\
+pipeline:
+  name: csv_patch
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amnt, type: string }
+  - type: transform
+    name: calc
+    input: src
+    config:
+      cxl: |
+        emit doubled = amount * 2
+        emit zone = region
+  - type: output
+    name: out
+    input: calc
+    config:
+      name: out
+      type: csv
+      path: out.csv
+";
+
+const CSV_CHANNEL: &str = "\
+channel:
+  name: fix
+  target: ./pipe.yaml
+sources:
+  src:
+    schema:
+      amnt:   { rename: amount }
+      amount: { retype: int }
+      region: { add: { type: string } }
+";
+
+#[test]
+fn csv_schema_patch_enables_run_and_is_visible_downstream() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "in.csv", "id,amount,region\n1,100,west\n2,250,east\n");
+    write(p, "pipe.yaml", CSV_PIPELINE);
+    write(p, "fix.channel.yaml", CSV_CHANNEL);
+
+    // Base pipeline: `amount` (numeric) and `region` are not declared, so it
+    // fails to compile.
+    let base = run_in(p, &[]);
+    assert!(
+        !base.status.success(),
+        "base pipeline should fail without the channel patch"
+    );
+
+    // Channel patch makes it valid; output reflects retype (doubled), add
+    // (region readable by CXL → zone), and rename (amount bound to the CSV
+    // column).
+    let patched = run_in(p, &["--channel", "fix.channel.yaml"]);
+    assert!(
+        patched.status.success(),
+        "patched run failed:\n{}",
+        String::from_utf8_lossy(&patched.stderr)
+    );
+    let out = std::fs::read_to_string(p.join("out.csv")).expect("read out.csv");
+    let header = out.lines().next().unwrap_or_default();
+    assert!(header.contains("doubled"), "header: {header}");
+    assert!(header.contains("zone"), "header: {header}");
+    // amount retyped to int and doubled; region added and echoed as zone.
+    assert!(out.contains("1,100,west,200,west"), "output:\n{out}");
+    assert!(out.contains("2,250,east,500,east"), "output:\n{out}");
+}
+
+#[test]
+fn csv_schema_patch_is_reflected_by_explain() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "in.csv", "id,amount,region\n1,100,west\n");
+    write(p, "pipe.yaml", CSV_PIPELINE);
+    write(p, "fix.channel.yaml", CSV_CHANNEL);
+
+    // --explain compiles the same patched config: base fails, channel succeeds.
+    let base = run_in(p, &["--explain"]);
+    assert!(
+        !base.status.success(),
+        "base --explain should fail without the channel patch"
+    );
+    let patched = run_in(p, &["--channel", "fix.channel.yaml", "--explain"]);
+    assert!(
+        patched.status.success(),
+        "patched --explain failed:\n{}",
+        String::from_utf8_lossy(&patched.stderr)
+    );
+}
+
+#[test]
+fn json_options_and_array_paths_patch_changes_run_output() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(
+        p,
+        "in.json",
+        "{ \"small\": { \"rows\": [ {\"id\":\"1\",\"tags\":[\"x\",\"y\"]} ] }, \
+           \"big\": { \"rows\": [ {\"id\":\"1\",\"tags\":[\"x\",\"y\"]}, \
+                                   {\"id\":\"2\",\"tags\":[\"z\"]}, \
+                                   {\"id\":\"3\",\"tags\":[\"w\"]} ] } }\n",
+    );
+    write(
+        p,
+        "pipe.yaml",
+        "\
+pipeline:
+  name: json_patch
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: json
+      path: in.json
+      options:
+        record_path: small.rows
+      schema:
+        - { name: id, type: string }
+        - { name: tags, type: array }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+",
+    );
+    write(
+        p,
+        "jfix.channel.yaml",
+        "\
+channel:
+  name: jfix
+  target: ./pipe.yaml
+sources:
+  src:
+    options:
+      record_path: big.rows
+    array_paths:
+      tags: { mode: explode }
+",
+    );
+
+    // Base: record_path points at the single-row array; no explosion.
+    let base = run_in(p, &[]);
+    assert!(base.status.success(), "base json run failed");
+    let base_out = std::fs::read_to_string(p.join("out.csv")).expect("read out.csv");
+    let base_rows = base_out.lines().skip(1).filter(|l| !l.is_empty()).count();
+    assert_eq!(base_rows, 1, "base output:\n{base_out}");
+
+    // Channel: record_path override selects the three-row array, and the
+    // array_paths explode fans each record out per tag → 4 rows.
+    let patched = run_in(p, &["--channel", "jfix.channel.yaml"]);
+    assert!(
+        patched.status.success(),
+        "patched json run failed:\n{}",
+        String::from_utf8_lossy(&patched.stderr)
+    );
+    let out = std::fs::read_to_string(p.join("out.csv")).expect("read out.csv");
+    let rows = out.lines().skip(1).filter(|l| !l.is_empty()).count();
+    assert_eq!(rows, 4, "expected 4 exploded rows, got:\n{out}");
+    for tag in ["x", "y", "z", "w"] {
+        assert!(out.contains(tag), "missing exploded tag {tag}:\n{out}");
+    }
+}
+
+#[test]
+fn unknown_source_name_fails_at_compile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "in.csv", "id,amount,region\n1,100,west\n");
+    write(p, "pipe.yaml", CSV_PIPELINE);
+    write(
+        p,
+        "bad.channel.yaml",
+        "\
+channel:
+  name: bad
+  target: ./pipe.yaml
+sources:
+  ghost:
+    schema:
+      id: remove
+",
+    );
+    let out = run_in(p, &["--channel", "bad.channel.yaml"]);
+    assert!(!out.status.success(), "run with unknown source should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("E230"), "stderr:\n{stderr}");
+}
+
+#[test]
+fn unknown_column_op_fails_at_compile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "in.csv", "id,amount,region\n1,100,west\n");
+    write(p, "pipe.yaml", CSV_PIPELINE);
+    write(
+        p,
+        "bad.channel.yaml",
+        "\
+channel:
+  name: bad
+  target: ./pipe.yaml
+sources:
+  src:
+    schema:
+      not_a_column: { retype: int }
+",
+    );
+    let out = run_in(p, &["--channel", "bad.channel.yaml"]);
+    assert!(!out.status.success(), "run with unknown column should fail");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("E231"), "stderr:\n{stderr}");
+}

--- a/crates/clinker/tests/channel_source_patch.rs
+++ b/crates/clinker/tests/channel_source_patch.rs
@@ -30,10 +30,11 @@ fn run_in(dir: &Path, extra: &[&str]) -> std::process::Output {
         .expect("spawn clinker")
 }
 
-/// A CSV pipeline whose transform reads a numeric `amount` and a `region`
-/// column that the *base* schema does not provide — so the base pipeline
-/// fails to compile, and only the channel patch (rename `amnt`→`amount`,
-/// retype to int, add `region`) makes it valid.
+/// A CSV pipeline whose transform reads the POST-patch names (`customer_id`
+/// aliased from the physical `cust_id`, added `region`) and a numeric `amount`,
+/// so the base pipeline fails to compile and only the channel patch — rename
+/// `cust_id`→`customer_id`, retype `amount` to int, add `region` — makes it
+/// valid.
 const CSV_PIPELINE: &str = "\
 pipeline:
   name: csv_patch
@@ -46,13 +47,15 @@ nodes:
       path: in.csv
       schema:
         - { name: id, type: string }
-        - { name: amnt, type: string }
+        - { name: cust_id, type: string }
+        - { name: amount, type: string }
   - type: transform
     name: calc
     input: src
     config:
       cxl: |
         emit doubled = amount * 2
+        emit customer = customer_id
         emit zone = region
   - type: output
     name: out
@@ -70,30 +73,32 @@ channel:
 sources:
   src:
     schema:
-      amnt:   { rename: amount }
-      amount: { retype: int }
-      region: { add: { type: string } }
+      cust_id: { rename: customer_id }
+      amount:  { retype: int }
+      region:  { add: { type: string } }
 ";
 
 #[test]
 fn csv_schema_patch_enables_run_and_is_visible_downstream() {
     let dir = tempfile::tempdir().expect("tempdir");
     let p = dir.path();
-    write(p, "in.csv", "id,amount,region\n1,100,west\n2,250,east\n");
+    write(
+        p,
+        "in.csv",
+        "id,cust_id,amount,region\n1,alice,100,west\n2,bob,250,east\n",
+    );
     write(p, "pipe.yaml", CSV_PIPELINE);
     write(p, "fix.channel.yaml", CSV_CHANNEL);
 
-    // Base pipeline: `amount` (numeric) and `region` are not declared, so it
-    // fails to compile.
+    // Base pipeline: `customer_id` / `region` are not declared and `amount` is
+    // a string, so it fails to compile.
     let base = run_in(p, &[]);
     assert!(
         !base.status.success(),
         "base pipeline should fail without the channel patch"
     );
 
-    // Channel patch makes it valid; output reflects retype (doubled), add
-    // (region readable by CXL → zone), and rename (amount bound to the CSV
-    // column).
+    // Channel patch makes it valid; output proves the physical→logical mapping.
     let patched = run_in(p, &["--channel", "fix.channel.yaml"]);
     assert!(
         patched.status.success(),
@@ -102,18 +107,90 @@ fn csv_schema_patch_enables_run_and_is_visible_downstream() {
     );
     let out = std::fs::read_to_string(p.join("out.csv")).expect("read out.csv");
     let header = out.lines().next().unwrap_or_default();
+    assert!(header.contains("customer_id"), "header: {header}");
     assert!(header.contains("doubled"), "header: {header}");
     assert!(header.contains("zone"), "header: {header}");
-    // amount retyped to int and doubled; region added and echoed as zone.
-    assert!(out.contains("1,100,west,200,west"), "output:\n{out}");
-    assert!(out.contains("2,250,east,500,east"), "output:\n{out}");
+    // The renamed column is a real alias: the physical `cust_id` field's data
+    // lands under the exposed `customer_id` name, NOT in `$widened`. If rename
+    // were a bare relabel, `customer_id` would be empty and `cust_id` would be
+    // re-emitted as a widened column.
+    assert!(
+        !header.contains("cust_id"),
+        "physical `cust_id` must be consumed as declared, not re-emitted: {header}"
+    );
+    // amount retyped to int and doubled; region added and echoed as zone;
+    // customer_id carries the real cust_id data.
+    assert!(
+        out.contains("1,alice,100,west,200,alice,west"),
+        "output:\n{out}"
+    );
+    assert!(
+        out.contains("2,bob,250,east,500,bob,east"),
+        "output:\n{out}"
+    );
+}
+
+#[test]
+fn base_schema_source_name_alias_maps_physical_to_logical() {
+    // A hand-written base schema (no channel) can declare `source_name` to read
+    // a differently-named physical column — the same alias the channel rename
+    // op produces.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "in.csv", "id,cust_id\n1,alice\n2,bob\n");
+    write(
+        p,
+        "pipe.yaml",
+        "\
+pipeline:
+  name: alias_base
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: customer_id, type: string, source_name: cust_id }
+  - type: transform
+    name: calc
+    input: src
+    config:
+      cxl: |
+        emit customer = customer_id
+  - type: output
+    name: out
+    input: calc
+    config:
+      name: out
+      type: csv
+      path: out.csv
+",
+    );
+    let run = run_in(p, &[]);
+    assert!(
+        run.status.success(),
+        "base-schema alias run failed:\n{}",
+        String::from_utf8_lossy(&run.stderr)
+    );
+    let out = std::fs::read_to_string(p.join("out.csv")).expect("read out.csv");
+    let header = out.lines().next().unwrap_or_default();
+    assert!(header.contains("customer_id"), "header: {header}");
+    assert!(
+        !header.contains("cust_id"),
+        "physical name must not leak: {header}"
+    );
+    assert!(out.contains("1,alice"), "output:\n{out}");
+    assert!(out.contains("2,bob"), "output:\n{out}");
 }
 
 #[test]
 fn csv_schema_patch_is_reflected_by_explain() {
     let dir = tempfile::tempdir().expect("tempdir");
     let p = dir.path();
-    write(p, "in.csv", "id,amount,region\n1,100,west\n");
+    write(p, "in.csv", "id,cust_id,amount,region\n1,alice,100,west\n");
     write(p, "pipe.yaml", CSV_PIPELINE);
     write(p, "fix.channel.yaml", CSV_CHANNEL);
 

--- a/crates/clinker/tests/channel_source_patch.rs
+++ b/crates/clinker/tests/channel_source_patch.rs
@@ -335,3 +335,144 @@ sources:
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("E231"), "stderr:\n{stderr}");
 }
+
+/// Pipeline whose output path carries the `{pipeline_hash}` token, so the
+/// effective pipeline identity is observable as the output filename.
+const HASH_PIPELINE: &str = "\
+pipeline:
+  name: hash_demo
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: \"out_{pipeline_hash}.csv\"
+";
+
+#[test]
+fn channel_patch_changes_pipeline_hash_and_empty_patch_does_not() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "in.csv", "id,amount\n1,100\n");
+    write(p, "pipe.yaml", HASH_PIPELINE);
+    write(
+        p,
+        "a.channel.yaml",
+        "channel:\n  name: a\n  target: ./pipe.yaml\nsources:\n  src:\n    schema:\n      amount: { retype: int }\n",
+    );
+    write(
+        p,
+        "b.channel.yaml",
+        "channel:\n  name: b\n  target: ./pipe.yaml\nsources:\n  src:\n    schema:\n      amount: { retype: float }\n",
+    );
+    write(
+        p,
+        "empty.channel.yaml",
+        "channel:\n  name: e\n  target: ./pipe.yaml\n",
+    );
+
+    // Extract the `{pipeline_hash}` token from the single out_*.csv the run
+    // wrote, then clear it before the next run.
+    let hash_after = |args: &[&str]| -> String {
+        let out = run_in(p, args);
+        assert!(
+            out.status.success(),
+            "run failed:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let mut found = None;
+        for entry in std::fs::read_dir(p).unwrap() {
+            let name = entry.unwrap().file_name().into_string().unwrap();
+            if let Some(hash) = name
+                .strip_prefix("out_")
+                .and_then(|rest| rest.strip_suffix(".csv"))
+            {
+                found = Some(hash.to_string());
+                std::fs::remove_file(p.join(&name)).unwrap();
+            }
+        }
+        found.expect("an out_<hash>.csv file")
+    };
+
+    let base = hash_after(&[]);
+    let empty = hash_after(&["--channel", "empty.channel.yaml"]);
+    let patch_a = hash_after(&["--channel", "a.channel.yaml"]);
+    let patch_b = hash_after(&["--channel", "b.channel.yaml"]);
+
+    // An empty patch map leaves the pipeline hash byte-identical to the base.
+    assert_eq!(
+        empty, base,
+        "empty channel must not change the pipeline hash"
+    );
+    // A patched run has a distinct identity from the base...
+    assert_ne!(patch_a, base, "patched run must differ from base");
+    // ...and two different patches produce different identities.
+    assert_ne!(patch_a, patch_b, "two different patches must differ");
+}
+
+/// The `clinker explain` subcommand applies channel source-patches before
+/// compile: an unknown-source patch surfaces E230, proving the channel is
+/// loaded and applied on that path too (not silently ignored).
+#[test]
+fn explain_subcommand_applies_channel_source_patch() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "in.csv", "id,amount\n1,100\n");
+    write(
+        p,
+        "pipe.yaml",
+        "\
+pipeline:
+  name: explain_patch
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+",
+    );
+    write(
+        p,
+        "bad.channel.yaml",
+        "channel:\n  name: bad\n  target: ./pipe.yaml\nsources:\n  ghost:\n    schema:\n      id: remove\n",
+    );
+    let out = Command::new(clinker_bin())
+        .arg("explain")
+        .arg("pipe.yaml")
+        .arg("--field")
+        .arg("out.name")
+        .arg("--channel")
+        .arg("bad.channel.yaml")
+        .current_dir(p)
+        .output()
+        .expect("spawn clinker explain");
+    assert!(
+        !out.status.success(),
+        "explain with an unknown-source patch should fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("E230"), "stderr:\n{stderr}");
+}

--- a/docs/user/src/nodes/source.md
+++ b/docs/user/src/nodes/source.md
@@ -71,6 +71,23 @@ Omitting the flag (the common case) leaves the default behavior untouched. Set
 it only when you know a column is genuinely high-cardinality free text; on a
 column whose values repeat, leave it off.
 
+### `source_name` — read a differently-named physical column
+
+A column may carry an optional `source_name` naming the **physical** input
+column it reads from, when that differs from the exposed `name`. The reader
+matches input fields by physical name and re-labels the value under `name`, so
+downstream CXL and the output see `name` carrying the physical column's data.
+
+```yaml
+schema:
+  # read the physical `cust_id` column, expose it downstream as `customer_id`
+  - { name: customer_id, type: string, source_name: cust_id }
+```
+
+Omitting `source_name` (the common case) reads the input field whose key equals
+`name`, unchanged from before. A channel `schema` patch's `rename` op sets this
+alias automatically (see [Channels](../pipelines/channels.md)).
+
 ## Transport vs format
 
 A source declaration has two independent layers:

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -99,12 +99,90 @@ Channels that target a `.comp.yaml` may not carry a `vars:` block (composition v
 | **E109** | Var overrides not supported on composition channels. |
 | **E110** | Channel var shadows reserved system field for that scope. |
 | **E111** | `vars.source.<src>` references a source-node name not declared in the pipeline. |
+| **E230** | `sources.<src>` patch targets a source-node name not declared in the pipeline. |
+| **E231** | `schema` patch `rename` / `retype` / `remove` of a column that does not exist. |
+| **E232** | `schema` patch `add` of a column name that already exists. |
+| **E233** | `schema` patch `rename` target collides with an existing column. |
+| **E234** | `array_paths` patch `remove` of a path with no matching entry. |
+| **E235** | `options` patch sets an unknown or mistyped option key for the source's format. |
 | **W103** | Channel `config.*` key did not match any composition parameter in the compiled plan. |
 | **W104** | `channel.target` does not match the `<config>` argument passed to `clinker run`. |
 
 ### Cross-Transform declaration uniqueness
 
 `$pipeline`, `$source`, and `$record` are flat shared namespaces. The same name declared on more than one Transform's `declares:` is a config-validation error — clinker mirrors the fail-fast posture of Beam, Flink, Kafka Streams, Dagster, and post-fix dbt for shared-namespace key collisions. Authors who want shared state declare it once and reference everywhere.
+
+## Source config patches
+
+A channel can override any part of a **source** node's config through a
+`sources:` block. Each patch is applied to the parsed pipeline config **before**
+validation and compile, so the run behaves exactly as if the source YAML had
+been hand-edited — every per-column, per-array, and per-option rule that applies
+to hand-written config applies to the patched result.
+
+```yaml
+# channels/acme.channel.yaml
+channel:
+  name: acme
+  target: ./pipelines/orders.yaml
+
+sources:
+  transactions:                            # source-node name
+    options:
+      record_path: batch_records           # set a scalar per-format option
+    array_paths:                           # keyed by array path
+      items:      { mode: join, separator: ";" }  # add-or-modify an entry
+      line_items: remove                   # drop an entry
+    schema:                                # keyed by column name
+      amount:      { retype: float }       # change a column's CXL type
+      cust_id:     { rename: customer_id }  # rename a column
+      order_notes: remove                  # drop a column
+      region:      { add: { type: string } }  # add a new column
+```
+
+The top-level key under `sources:` is a **source-node name**; an unknown name is
+a compile error (**E230**). All ops are keyed and leaf-replace — there is no
+deep-merge.
+
+### `schema` ops
+
+Keyed by column name. Exactly one op per column:
+
+| Form | Effect | Errors |
+|------|--------|--------|
+| `<col>: { retype: <type> }` | Change the column's CXL type. | Unknown column → **E231** |
+| `<col>: { rename: <new> }` | Rename the column. | Unknown column → **E231**; `<new>` collides with an existing column → **E233** |
+| `<col>: remove` | Drop the column. | Unknown column → **E231** |
+| `<new>: { add: { type: <type>, long_unique?: <bool> } }` | Add a new column (the map key is its name). | Name already exists → **E232** |
+
+`<type>` is any CXL type (`string`, `int`, `float`, `bool`, `date`, `date_time`,
+`array`, `map`). Because the patch produces the same schema you could have
+written by hand, renaming a column also renames the on-disk field it binds to —
+for a CSV source, the new name must match the file's column header just as a
+hand-written schema would.
+
+### `array_paths` ops
+
+Keyed by array path (the `path:` of an [array-path entry](../formats/json.md)):
+
+| Form | Effect | Errors |
+|------|--------|--------|
+| `<path>: { mode: explode\|join, separator?: <str> }` | Add the entry, or replace an existing one at that path. | — |
+| `<path>: remove` | Drop the entry. | Unknown path → **E234** |
+
+### `options` ops
+
+A map of scalar per-format input options merged onto the source's current
+`options:`. The merged options are re-validated through the format's option
+struct, so an unknown or mistyped option key is rejected (**E235**) exactly as in
+hand-written config. Which keys are valid depends on the source's `type:` (e.g.
+`record_path` for `json`/`xml`, `delimiter` for `csv`).
+
+### Applies on every run path
+
+The patch is applied on the normal run path, on `clinker run --explain`, and on
+`clinker run --lineage` — all three compile the patched config. A channel with no
+`sources:` block leaves the pipeline config untouched.
 
 ## Workspace discovery
 

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -105,6 +105,7 @@ Channels that target a `.comp.yaml` may not carry a `vars:` block (composition v
 | **E233** | `schema` patch `rename` target collides with an existing column. |
 | **E234** | `array_paths` patch `remove` of a path with no matching entry. |
 | **E235** | `options` patch sets an unknown or mistyped option key for the source's format. |
+| **E236** | A renamed/aliased column's exposed name collides with a real input field, which would mislocate that field. Raised at read time. |
 | **W103** | Channel `config.*` key did not match any composition parameter in the compiled plan. |
 | **W104** | `channel.target` does not match the `<config>` argument passed to `clinker run`. |
 
@@ -180,8 +181,12 @@ Keyed by array path (the `path:` of an [array-path entry](../formats/json.md)):
 
 | Form | Effect | Errors |
 |------|--------|--------|
-| `<path>: { mode: explode\|join, separator?: <str> }` | Add the entry, or replace an existing one at that path. | — |
+| `<path>: { mode: explode\|join, separator?: <str> }` | Add or modify the entry at that path. | — |
 | `<path>: remove` | Drop the entry. | Unknown path → **E234** |
+
+On an **existing** entry a `Set` is a partial modify — an omitted field keeps its
+current value, so `{ separator: ";" }` on a `mode: join` entry leaves the mode
+unchanged. On a **new** entry an omitted `mode` defaults to explode.
 
 ### `options` ops
 
@@ -193,9 +198,21 @@ hand-written config. Which keys are valid depends on the source's `type:` (e.g.
 
 ### Applies on every run path
 
-The patch is applied on the normal run path, on `clinker run --explain`, and on
-`clinker run --lineage` — all three compile the patched config. A channel with no
-`sources:` block leaves the pipeline config untouched.
+The patch is applied on the normal run path, on `clinker run --explain`, on
+`clinker run --lineage`, and by the `clinker explain` provenance subcommand — no
+`--channel` path compiles an unpatched config. A channel with no `sources:` block
+leaves the pipeline config untouched. When patches change the effective source
+config, the run's pipeline identity (`{pipeline_hash}` in output paths, lineage)
+differs from the base and from other patched variants, so their outputs and
+lineage do not collide.
+
+### Scope
+
+`sources:` patches target **top-level** source nodes. A source declared inside a
+composition body is not reachable this way (patching it fails with **E230**,
+naming the composition-body limitation); patch the composition's own source, or
+lift the source to the top-level pipeline. Extending patches into composition
+bodies is tracked as a follow-up.
 
 ## Workspace discovery
 

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -151,15 +151,28 @@ Keyed by column name. Exactly one op per column:
 | Form | Effect | Errors |
 |------|--------|--------|
 | `<col>: { retype: <type> }` | Change the column's CXL type. | Unknown column → **E231** |
-| `<col>: { rename: <new> }` | Rename the column. | Unknown column → **E231**; `<new>` collides with an existing column → **E233** |
+| `<col>: { rename: <new> }` | Expose the column under `<new>` while still reading the original physical column (a source-column alias). | Unknown column → **E231**; `<new>` collides with an existing column → **E233** |
 | `<col>: remove` | Drop the column. | Unknown column → **E231** |
 | `<new>: { add: { type: <type>, long_unique?: <bool> } }` | Add a new column (the map key is its name). | Name already exists → **E232** |
 
 `<type>` is any CXL type (`string`, `int`, `float`, `bool`, `date`, `date_time`,
-`array`, `map`). Because the patch produces the same schema you could have
-written by hand, renaming a column also renames the on-disk field it binds to —
-for a CSV source, the new name must match the file's column header just as a
-hand-written schema would.
+`array`, `map`).
+
+`rename` is a **source-column alias**, not a bare relabel: the reader binds
+declared columns to input fields by name, so a rename keeps reading the original
+physical column and re-labels its value under the new name. Downstream CXL and
+the output see the new name, carrying the original column's data. (A second
+rename keeps the original physical binding.) This is the same alias a base
+`schema:` column can declare directly with the `source_name` field:
+
+```yaml
+schema:
+  # read the physical `cust_id` column, expose it downstream as `customer_id`
+  - { name: customer_id, type: string, source_name: cust_id }
+```
+
+Omitting `source_name` (the common case) reads the input field whose key equals
+`name`, unchanged from before.
 
 ### `array_paths` ops
 


### PR DESCRIPTION
## Summary

Adds channel-driven source-schema override: a channel can partially patch any source's config — schema columns, `array_paths`, and per-format `options` — *before* compile, so a run behaves as if the operator had hand-edited the source YAML. Uniform across every format.

## Channel surface

```yaml
# channel.yaml
sources:
  <source-node>:
    options: { record_path: batch_records }        # set a scalar per-format option
    array_paths:                                    # keyed by array path (partial modify)
      items:      { mode: join, separator: ";" }
      line_items: remove
    schema:                                         # keyed by column name
      amount:      { retype: decimal }              # change a column's type
      cust_id:     { rename: customer_id }          # rename a column
      order_notes: remove                           # drop a column
      region:      { add: { type: string } }        # add a column
```

Partial, keyed ops (leaf-replace, never deep-merge): `schema` by column name (add / rename / retype / remove), `array_paths` by path (partial modify / remove), `options` by key. Applied to the parsed typed config after parse and before validate/compile, so the patched config is what validation, typecheck, lineage, and execution all see — on every entry point (`run`, `--explain`, `--lineage`). Sources are addressed by node identity, consistent with the other channel blocks.

## Notes for review

- **`rename` is a true source-column alias.** A new optional `ColumnDecl.source_name` maps a physical input field to a differently-named exposed column, so renaming `cust_id` → `customer_id` carries the real data (not the widened sidecar). `None` means physical == exposed — byte-identical to prior behavior for every existing source. `source_name` is also hand-writable in a base `schema:` block.
- **Pipeline identity reflects patches.** Applied patches fold into `source_hash`, so a channel-patched run gets a distinct `{pipeline_hash}` (no output-path collisions, no conflated lineage); an empty/absent patch leaves the hash byte-identical.
- **New diagnostics.** Config `E230`–`E235` (unknown source / unknown column / add-collision / rename-collision / unknown array-path / bad option) and reader `E236` (an alias's exposed name collides with a real input field).
- **Scope.** Patches target top-level source nodes; sources declared inside a composition body are a documented limitation with a follow-up. The deeper format-layer structures (fixed-width / EDI positional layouts, X12/HL7 nested sections, multi-record discrimination) reuse this same framework as additional handlers — filed as follow-ups.

## Validation

- `cargo fmt --all --check`, `cargo clippy --workspace -- -D warnings` (default and `--all-targets`) — clean.
- `cargo test -p clinker-plan -p clinker-channel -p clinker -p clinker-exec` — 2082 passed, 0 failed.
- `mdbook build docs/user` — clean; the channels page documents the new block and ops.

Closes #550.
