### PR TITLE
Channel manifest + overlay-file serde types

### DIFF
--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -52,6 +52,7 @@
 
 pub mod binding;
 pub mod error;
+pub mod manifest;
 pub mod overlay;
 pub mod staging_copy;
 
@@ -60,6 +61,7 @@ pub use binding::{
     ChannelBinding, ChannelTarget, DottedPath, scan_workspace_channels, validate_channel_bindings,
 };
 pub use error::ChannelError;
+pub use manifest::{ChannelManifest, ChannelVars, ManifestHeader, OverlayFile, OverlayHeader};
 pub use overlay::{ChannelOverlayResult, apply_channel_overlay};
 pub use staging_copy::{
     ReuseDecision, SourceStager, StagingError, StagingPlanEntry, open_source_file,

--- a/crates/clinker-channel/src/manifest.rs
+++ b/crates/clinker-channel/src/manifest.rs
@@ -1,0 +1,178 @@
+//! Channel manifest and per-target overlay serde types.
+//!
+//! These model the on-the-wire YAML of the channel-centric overlay layout:
+//!
+//! - [`ChannelManifest`] models `channel.cfg.yaml` — a per-channel manifest
+//!   carrying identity `labels`, plus optional channel-wide `config`, `vars`,
+//!   and `overrides` that apply to every pipeline this channel runs. The
+//!   manifest is optional per channel: the containing folder name *is* the
+//!   channel id, so a manifest is only needed when a channel has labels or
+//!   channel-wide overlays.
+//! - [`OverlayFile`] models a per-target overlay file — `<target>.channel.yaml`
+//!   (pipeline overlay), `<target>.comp.yaml` (composition overlay), or a bare
+//!   `<target>.yaml`. The `channel.target:` field is authoritative; the
+//!   filename suffix is optional and secondary (it only aids reading a file
+//!   out of context, e.g. in a diff).
+//!
+//! Both parse through `clinker_plan::yaml::from_str` (serde-saphyr, budgeted).
+//! This module is parse-only: it defines the wire shapes and nothing else.
+//! Key validation (dotted-path `config` keys, label scalar-ness), layer
+//! resolution, and override application all live in later stages.
+
+use std::path::{Path, PathBuf};
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use clinker_plan::config::ScopedVarDecl;
+
+use crate::error::ChannelError;
+
+/// A parsed `channel.cfg.yaml` manifest.
+///
+/// ```yaml
+/// channel:
+///   name: globex
+/// labels: { region: west, tier: enterprise }
+/// config: { fraud_check.threshold: 0.9 }
+/// vars:
+///   static: { currency: { type: string, default: "USD" } }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChannelManifest {
+    /// The manifest header — carries the channel `name`.
+    pub channel: ManifestHeader,
+    /// Channel identity labels, order-preserving. Labels drive group
+    /// selectors; they are identity, never a pipeline override. Values are
+    /// kept opaque here — scalar-ness is enforced by a later stage.
+    #[serde(default)]
+    pub labels: IndexMap<String, serde_json::Value>,
+    /// Channel-wide config clobber values, keyed by `alias.param` dotted
+    /// path. Keys stay raw strings here; dotted-path validation is a later
+    /// stage's concern.
+    #[serde(default)]
+    pub config: IndexMap<String, serde_json::Value>,
+    /// Channel-wide var overlays, using the same four scopes a pipeline's
+    /// `vars:` block uses.
+    #[serde(default)]
+    pub vars: ChannelVars,
+    /// Channel-wide ordered override op list. The element type is finalized
+    /// by CH-10 (#525); until then each op is carried as an opaque map so
+    /// this parse layer does not invent the op vocabulary.
+    #[serde(default)]
+    pub overrides: Vec<serde_json::Value>,
+}
+
+/// The `channel:` header of a manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ManifestHeader {
+    /// Human-readable channel identifier.
+    pub name: String,
+}
+
+/// A parsed per-target overlay file (`<target>.channel.yaml` /
+/// `<target>.comp.yaml` / bare `<target>.yaml`).
+///
+/// ```yaml
+/// channel:
+///   target: ../../pipeline/order_fulfillment.yaml
+/// config: { fraud_check.threshold: 0.95 }
+/// vars:   { static: { currency: { type: string, default: "USD" } } }
+/// overrides: [ ... ]
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OverlayFile {
+    /// The overlay header — carries the authoritative `target`.
+    pub channel: OverlayHeader,
+    /// Per-target config clobber values, keyed by `alias.param` dotted path.
+    #[serde(default)]
+    pub config: IndexMap<String, serde_json::Value>,
+    /// Per-target var overlays, using the same four scopes a pipeline's
+    /// `vars:` block uses.
+    #[serde(default)]
+    pub vars: ChannelVars,
+    /// Per-target ordered override op list. Opaque until CH-10 (#525) — see
+    /// [`ChannelManifest::overrides`].
+    #[serde(default)]
+    pub overrides: Vec<serde_json::Value>,
+}
+
+/// The `channel:` header of an overlay file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OverlayHeader {
+    /// Path to the overlaid pipeline or composition. Authoritative: the
+    /// parsed value comes from the YAML, independent of the enclosing
+    /// filename. The filename suffix (`.channel.yaml` / `.comp.yaml` /
+    /// bare `.yaml`) is optional and, when present, must agree.
+    pub target: String,
+}
+
+/// Var overlays, mirroring the four scopes a pipeline's `vars:` block uses
+/// (`$vars.*` / `$pipeline.*` / `$source.*` / `$record.*`). Each leaf is a
+/// [`ScopedVarDecl`] (`{ type, default }`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChannelVars {
+    /// `$vars.*` static-config overlays, keyed by var name.
+    #[serde(default, rename = "static")]
+    pub static_scope: IndexMap<String, ScopedVarDecl>,
+    /// `$pipeline.*` overlays, keyed by var name.
+    #[serde(default)]
+    pub pipeline: IndexMap<String, ScopedVarDecl>,
+    /// `$source.<src>.*` overlays: outer key is the source-node name, inner
+    /// key is the var name.
+    #[serde(default)]
+    pub source: IndexMap<String, IndexMap<String, ScopedVarDecl>>,
+    /// `$record.*` overlays, keyed by var name.
+    #[serde(default)]
+    pub record: IndexMap<String, ScopedVarDecl>,
+}
+
+impl ChannelManifest {
+    /// Parse a `channel.cfg.yaml` manifest from raw bytes. `source_path` is
+    /// used only for diagnostic context.
+    pub fn from_yaml_bytes(bytes: &[u8], source_path: PathBuf) -> Result<Self, ChannelError> {
+        parse_yaml(bytes, source_path)
+    }
+
+    /// Load and parse a `channel.cfg.yaml` manifest from disk.
+    pub fn load(path: &Path) -> Result<Self, ChannelError> {
+        let bytes = std::fs::read(path)?;
+        Self::from_yaml_bytes(&bytes, path.to_path_buf())
+    }
+}
+
+impl OverlayFile {
+    /// Parse a per-target overlay file from raw bytes. `source_path` is used
+    /// only for diagnostic context — the overlay `target` comes from the YAML
+    /// body, never from the filename.
+    pub fn from_yaml_bytes(bytes: &[u8], source_path: PathBuf) -> Result<Self, ChannelError> {
+        parse_yaml(bytes, source_path)
+    }
+
+    /// Load and parse a per-target overlay file from disk.
+    pub fn load(path: &Path) -> Result<Self, ChannelError> {
+        let bytes = std::fs::read(path)?;
+        Self::from_yaml_bytes(&bytes, path.to_path_buf())
+    }
+}
+
+/// Shared parse path for both file kinds: UTF-8 check, then the canonical
+/// budgeted YAML chokepoint.
+fn parse_yaml<T>(bytes: &[u8], source_path: PathBuf) -> Result<T, ChannelError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let text = std::str::from_utf8(bytes).map_err(|e| ChannelError::Utf8 {
+        path: source_path.clone(),
+        source: e,
+    })?;
+    clinker_plan::yaml::from_str(text).map_err(|e| ChannelError::Yaml {
+        path: source_path,
+        source: Box::new(e.0),
+    })
+}

--- a/crates/clinker-channel/tests/channel_manifest_test.rs
+++ b/crates/clinker-channel/tests/channel_manifest_test.rs
@@ -1,0 +1,246 @@
+//! Parse coverage for the channel-centric overlay serde types (issue #517).
+//!
+//! Pins the on-the-wire YAML surface for `channel.cfg.yaml` manifests
+//! ([`ChannelManifest`]) and per-target overlay files ([`OverlayFile`]).
+//! These types are parse-only; layer resolution and override application
+//! live in later stages, so the assertions here stay at the deserialized
+//! shape: header fields, label order/values, the four var scopes, and the
+//! opaque `overrides` list.
+
+use std::path::PathBuf;
+
+use clinker_channel::{ChannelManifest, OverlayFile};
+use clinker_plan::config::ScopedVarType;
+
+fn manifest(yaml: &[u8]) -> ChannelManifest {
+    ChannelManifest::from_yaml_bytes(yaml, PathBuf::from("channel.cfg.yaml"))
+        .expect("manifest YAML parses")
+}
+
+fn overlay(yaml: &[u8], name: &str) -> OverlayFile {
+    OverlayFile::from_yaml_bytes(yaml, PathBuf::from(name)).expect("overlay YAML parses")
+}
+
+#[test]
+fn parses_full_manifest() {
+    let m = manifest(
+        br#"
+channel:
+  name: globex
+labels: { region: west, tier: enterprise }
+config:
+  fraud_check.threshold: 0.9
+vars:
+  static:
+    currency: { type: string, default: "USD" }
+  pipeline:
+    retries: { type: int }
+  source:
+    orders:
+      cutoff: { type: int, default: 100 }
+  record:
+    tag: { type: string, default: "batch" }
+overrides:
+  - { op: add, composition: ./composition/fraud.comp.yaml, alias: fraud }
+"#,
+    );
+
+    assert_eq!(m.channel.name, "globex");
+
+    // Labels preserve declared order and scalar values.
+    let labels: Vec<(&str, &serde_json::Value)> =
+        m.labels.iter().map(|(k, v)| (k.as_str(), v)).collect();
+    assert_eq!(labels[0].0, "region");
+    assert_eq!(labels[0].1, &serde_json::json!("west"));
+    assert_eq!(labels[1].0, "tier");
+    assert_eq!(labels[1].1, &serde_json::json!("enterprise"));
+
+    // Channel-wide config keeps raw dotted-path keys.
+    assert_eq!(
+        m.config.get("fraud_check.threshold"),
+        Some(&serde_json::json!(0.9))
+    );
+
+    // All four var scopes populate.
+    assert_eq!(
+        m.vars.static_scope["currency"].var_type,
+        ScopedVarType::String
+    );
+    assert_eq!(
+        m.vars.static_scope["currency"].default,
+        Some(serde_json::json!("USD"))
+    );
+    assert_eq!(m.vars.pipeline["retries"].var_type, ScopedVarType::Int);
+    assert!(m.vars.pipeline["retries"].default.is_none());
+    assert_eq!(
+        m.vars.source["orders"]["cutoff"].var_type,
+        ScopedVarType::Int
+    );
+    assert_eq!(m.vars.record["tag"].var_type, ScopedVarType::String);
+
+    // `overrides` stays opaque — a list of maps, uninterpreted here.
+    assert_eq!(m.overrides.len(), 1);
+    assert_eq!(m.overrides[0]["op"], serde_json::json!("add"));
+    assert_eq!(m.overrides[0]["alias"], serde_json::json!("fraud"));
+}
+
+#[test]
+fn parses_minimal_manifest() {
+    // Only the header is required; every other block defaults to empty.
+    let m = manifest(
+        br#"
+channel:
+  name: acme
+"#,
+    );
+    assert_eq!(m.channel.name, "acme");
+    assert!(m.labels.is_empty());
+    assert!(m.config.is_empty());
+    assert!(m.vars.static_scope.is_empty());
+    assert!(m.vars.pipeline.is_empty());
+    assert!(m.vars.source.is_empty());
+    assert!(m.vars.record.is_empty());
+    assert!(m.overrides.is_empty());
+}
+
+#[test]
+fn manifest_rejects_unknown_top_level_field() {
+    let err = ChannelManifest::from_yaml_bytes(
+        br#"
+channel:
+  name: acme
+lables: { region: west }
+"#,
+        PathBuf::from("channel.cfg.yaml"),
+    );
+    assert!(err.is_err(), "typo'd top-level key must be rejected");
+}
+
+#[test]
+fn manifest_labels_round_trip() {
+    let m = manifest(
+        br#"
+channel:
+  name: globex
+labels: { region: west, tier: enterprise, shard: "07" }
+"#,
+    );
+
+    // Serialize the parsed manifest and read it back; labels must survive
+    // with identical order and values.
+    let json = serde_json::to_string(&m).expect("manifest serializes");
+    let round: ChannelManifest = serde_json::from_str(&json).expect("manifest re-parses");
+
+    let before: Vec<(&String, &serde_json::Value)> = m.labels.iter().collect();
+    let after: Vec<(&String, &serde_json::Value)> = round.labels.iter().collect();
+    assert_eq!(before, after);
+    assert_eq!(
+        after[2],
+        (&"shard".to_string(), &serde_json::json!("07")),
+        "quoted scalar label round-trips as a string, order preserved"
+    );
+}
+
+#[test]
+fn parses_full_overlay() {
+    let o = overlay(
+        br#"
+channel:
+  target: ../../pipeline/order_fulfillment.yaml
+config:
+  fraud_check.threshold: 0.95
+vars:
+  static:
+    currency: { type: string, default: "EUR" }
+overrides:
+  - { op: set, target: route_priority, field: config.cxl, value: "emit _route = a" }
+"#,
+        "order_fulfillment.channel.yaml",
+    );
+
+    assert_eq!(o.channel.target, "../../pipeline/order_fulfillment.yaml");
+    assert_eq!(
+        o.config.get("fraud_check.threshold"),
+        Some(&serde_json::json!(0.95))
+    );
+    assert_eq!(
+        o.vars.static_scope["currency"].var_type,
+        ScopedVarType::String
+    );
+    assert_eq!(o.overrides.len(), 1);
+    assert_eq!(o.overrides[0]["op"], serde_json::json!("set"));
+}
+
+#[test]
+fn overlay_target_is_authoritative_over_filename() {
+    // Identical body under each of the three filename forms; the parsed
+    // target comes from the YAML, so it is identical across all of them.
+    let body = br#"
+channel:
+  target: ../../pipeline/order_fulfillment.yaml
+config: {}
+"#;
+
+    let as_channel = overlay(body, "anything.channel.yaml");
+    let as_comp = overlay(body, "anything.comp.yaml");
+    let as_bare = overlay(body, "anything.yaml");
+
+    assert_eq!(
+        as_channel.channel.target,
+        "../../pipeline/order_fulfillment.yaml"
+    );
+    assert_eq!(as_comp.channel.target, as_channel.channel.target);
+    assert_eq!(as_bare.channel.target, as_channel.channel.target);
+
+    // Even when the filename stem disagrees with the target stem, the YAML
+    // wins: parsing does not derive the target from the filename.
+    let mismatched = overlay(
+        br#"
+channel:
+  target: ../../composition/tax_calc.comp.yaml
+"#,
+        "order_fulfillment.channel.yaml",
+    );
+    assert_eq!(
+        mismatched.channel.target,
+        "../../composition/tax_calc.comp.yaml"
+    );
+}
+
+#[test]
+fn overlay_rejects_unknown_top_level_field() {
+    let err = OverlayFile::from_yaml_bytes(
+        br#"
+channel:
+  target: ./pipeline.yaml
+labels: { region: west }
+"#,
+        PathBuf::from("pipeline.channel.yaml"),
+    );
+    assert!(
+        err.is_err(),
+        "overlay files carry no `labels:` block — labels live on the manifest"
+    );
+}
+
+#[test]
+fn overlay_overrides_stay_opaque() {
+    // A structurally rich op list parses as opaque values without this layer
+    // asserting any op vocabulary (that is CH-10's job).
+    let o = overlay(
+        br#"
+channel:
+  target: ./pipeline.yaml
+overrides:
+  - { op: add, node: { type: transform, name: stamp, input: src }, after: src }
+  - { op: patch_schema, target: orders, add: [ { name: tax_exempt, type: bool } ] }
+  - { op: bypass, target: legacy_audit }
+"#,
+        "pipeline.channel.yaml",
+    );
+
+    assert_eq!(o.overrides.len(), 3);
+    assert!(o.overrides[0].is_object());
+    assert_eq!(o.overrides[1]["op"], serde_json::json!("patch_schema"));
+    assert_eq!(o.overrides[2]["target"], serde_json::json!("legacy_audit"));
+}


### PR DESCRIPTION
Adds parse-only serde models for the channel-centric overlay layout. Implements CH-2 (#517).

## What

- `ChannelManifest` models `channel.cfg.yaml`: identity `labels` (order-preserving), plus optional channel-wide `config`, `vars`, and `overrides` that apply to every pipeline the channel runs. The manifest is optional per channel — the containing folder name is the channel id, so a manifest is only needed when a channel carries labels or channel-wide overlays.
- `OverlayFile` models a per-target overlay file — `<target>.channel.yaml` (pipeline overlay), `<target>.comp.yaml` (composition overlay), or a bare `<target>.yaml`. The `channel.target:` field is authoritative and independent of the filename; the suffix is optional and only aids reading a file out of context.
- `ChannelVars` carries the same four var scopes a pipeline's `vars:` block uses (static / pipeline / source / record), reusing the existing `ScopedVarDecl`.

## Why

These are the wire shapes that let independent later stages (layer resolution, the override op engine, workspace discovery) converge on one schema. Keeping `target:` authoritative over the filename gives authors bare-name ergonomics while the explicit suffix stays available for files viewed out of context.

## Notes

- Parsing goes through the budgeted `clinker_plan::yaml::from_str` chokepoint and reuses the existing `ChannelError` variants; top-level fields are strict (`deny_unknown_fields`).
- The `overrides` element type is not yet finalized, so each op is carried as an opaque value — this layer does not invent the op vocabulary.

## Tests

Focused parse coverage: full and minimal manifests, all three overlay filename forms, target-is-authoritative-over-filename (including a filename/target mismatch), label round-trip with order preservation, strict unknown-field rejection on both file kinds, and opaque `overrides` passthrough. `cargo test -p clinker-channel`, `cargo clippy -p clinker-channel --all-targets -- -D warnings`, and `cargo fmt --all --check` are green.

Part of #515