### PR TITLE
Generalize config provenance to a type-parametric layer stack

### DIFF
--- a/crates/clinker-channel/AGENTS.md
+++ b/crates/clinker-channel/AGENTS.md
@@ -10,7 +10,7 @@ Root `AGENTS.md` still applies. This file adds local guidance for `clinker-chann
 
 - Parse `.channel.yaml` files into `ChannelBinding` values and compute raw-file BLAKE3 channel hashes.
 - Validate `DottedPath` keys, channel var names, channel targets, and composition config keys.
-- Apply `ChannelDefault` / `ChannelFixed` config layers to `CompiledPlan` provenance.
+- Clobber a channel's `config` onto `CompiledPlan` provenance at the `ChannelPerTarget` layer (`config.fixed` sets the layer's `fixed` lock).
 - Resolve channel `vars:` overrides/adds for `$vars`, `$pipeline`, `$source`, and `$record`.
 - Stamp `ChannelIdentity` on compiled plans.
 - Stage selected source files to local disk with stable cache paths, manifests, locks, reuse, cleanup, and crash purge.
@@ -54,7 +54,8 @@ Current normal dependencies are intentional: `clinker-plan`, `clinker-core-types
 - Channels override declared config/resource surfaces only; no mid-graph patching or sealed composition-internal access.
 - `DottedPath` is strict: one or two segments, no empty/edge/consecutive dots, and only ASCII alphanumeric, underscore, or dot.
 - Workspace channel scans are bounded and do not follow symlinks.
-- `ChannelDefault` and `ChannelFixed` must preserve provenance precedence; fixed wins over default.
+- Config resolves through the fixed semantic layer order `PipelineDefault < Group(s) < ChannelWide < ChannelPerTarget` (clobber, never deep-merge); a `fixed` value locks against every higher-precedence layer.
+- A channel `config` key that matches no compiled-plan parameter is a hard error (E113), never a silent no-op.
 - Channel `vars:` on composition targets currently errors.
 - Var overrides must match declared types and use planner scoped-var checking/coercion helpers.
 - Source-scoped var overrides must name an existing source node.

--- a/crates/clinker-channel/benches/channel_merge.rs
+++ b/crates/clinker-channel/benches/channel_merge.rs
@@ -53,7 +53,7 @@ fn bench_channel_merge(c: &mut Criterion) {
                         format!("param{i}"),
                         ResolvedValue::new(
                             serde_json::json!(0),
-                            LayerKind::CompositionDefault,
+                            LayerKind::PipelineDefault,
                             Span::SYNTHETIC,
                         ),
                     );

--- a/crates/clinker-channel/src/binding.rs
+++ b/crates/clinker-channel/src/binding.rs
@@ -106,10 +106,11 @@ pub enum ChannelTarget {
 
 /// A parsed `.channel.yaml` file.
 ///
-/// The `config_default` / `config_fixed` split maps to `LayerKind::ChannelDefault`
-/// and `LayerKind::ChannelFixed` respectively; channel-fixed layers merge with
-/// deterministic precedence over variable (default) layers. Resources follow
-/// the same split pattern.
+/// A per-target overlay resolves onto the `LayerKind::ChannelPerTarget` layer.
+/// The `config_default` / `config_fixed` split maps to that layer's `fixed`
+/// lock flag: `config_fixed` values are applied as fixed (locking against every
+/// higher-precedence layer), `config_default` values non-fixed. Resources
+/// follow the same split pattern.
 #[derive(Debug, Clone)]
 pub struct ChannelBinding {
     pub name: String,

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -18,19 +18,19 @@
 //! - **`channel.name:`** — human-readable channel identifier.
 //! - **`channel.target:`** — path to the target pipeline or composition
 //!   (each channel file declares exactly one target).
-//! - **`config.default:`** — values applied as `ChannelDefault` provenance
-//!   layer. These can be overridden by `ChannelFixed` or `InspectorEdit`.
-//! - **`config.fixed:`** — values applied as `ChannelFixed` provenance layer.
-//!   These win over all other layers and cannot be overridden.
+//! - **`config.default:`** — values applied non-fixed on the channel's overlay
+//!   layer. A later, higher-precedence layer may override them.
+//! - **`config.fixed:`** — values applied with the `fixed` lock set on the same
+//!   layer. A fixed value cannot be overridden by any higher-precedence layer.
 //!
 //! ## `fixed` vs `default` distinction
 //!
-//! `ChannelFixed` is the highest-priority override — it represents a
-//! hard-pinned value that the channel author does not want changed.
-//! `ChannelDefault` provides a fallback that can still be overridden by
-//! higher-priority layers. The provenance chain is bounded at 4 layers,
-//! applied in strict precedence order (later layers win):
-//! `CompositionDefault → ChannelDefault → ChannelFixed → InspectorEdit`.
+//! `fixed` is not a separate layer — it is a lock flag on the value. A fixed
+//! value is hard-pinned: no higher-precedence layer may change it. A default
+//! value is a fallback that a higher layer may still override. Config resolves
+//! through a fixed *semantic* layer order (never lexical or positional); higher
+//! layers win unless a lower one is `fixed`:
+//! `PipelineDefault < Group(s) by priority < ChannelWide < ChannelPerTarget`.
 //!
 //! ## Sealed composition internals
 //!

--- a/crates/clinker-channel/src/overlay.rs
+++ b/crates/clinker-channel/src/overlay.rs
@@ -1,12 +1,37 @@
 //! Channel overlay merge.
 //!
-//! Applies a [`ChannelBinding`] to a [`CompiledPlan`], overlaying config
-//! values as `ChannelDefault` or `ChannelFixed` provenance layers on the
-//! plan's [`ProvenanceDb`](clinker_plan::config::composition::ProvenanceDb),
-//! and resolving channel-supplied var
-//! overrides/adds for the four scoped registries (`$vars.*`,
-//! `$pipeline.*`, `$source.*`, `$record.*`) against the pipeline's
-//! declarations. Stamps a [`ChannelIdentity`] for cache-keying.
+//! Applies a [`ChannelBinding`] to a [`CompiledPlan`] as a layered **clobber**
+//! over the plan's
+//! [`ProvenanceDb`](clinker_plan::config::composition::ProvenanceDb): a higher
+//! layer's value fully *replaces* the lower one (never a deep-merge), and each
+//! resolved value maps to exactly one winning layer.
+//!
+//! # Layer stack
+//!
+//! Config resolves through a fixed *semantic* order of layers — never lexical
+//! or positional — encoded by
+//! [`LayerKind`](clinker_plan::config::composition::LayerKind):
+//!
+//! ```text
+//! PipelineDefault  <  Group(s) by priority  <  ChannelWide  <  ChannelPerTarget
+//! ```
+//!
+//! - **PipelineDefault** is the base layer, already recorded in the plan's
+//!   `ProvenanceDb` by composition compile.
+//! - **Group** (selector-derived) and **ChannelWide** (`channel.cfg.yaml`
+//!   manifest) layers plug into the same [`apply_config_clobber`] engine — it
+//!   resolves at any `LayerKind`, so those layers need no new resolution logic
+//!   once their sources are wired in by later stages.
+//! - **ChannelPerTarget** is the per-target `.channel.yaml` binding this
+//!   function overlays. Its `config.default` / `config.fixed` split maps to the
+//!   within-layer `fixed` lock flag: a `fixed` value cannot be overridden by
+//!   any higher-precedence layer.
+//!
+//! Also resolves channel-supplied var overrides/adds for the four scoped
+//! registries (`$vars.*`, `$pipeline.*`, `$source.*`, `$record.*`) against the
+//! pipeline's declarations (these flow to the executor as runtime values via
+//! `PipelineRunParams`, not into the AST), and stamps a [`ChannelIdentity`] for
+//! cache-keying.
 
 use indexmap::IndexMap;
 
@@ -44,17 +69,19 @@ pub struct ChannelOverlayResult {
 ///
 /// Performs three things:
 ///
-/// 1. Overlays `config.default` / `config.fixed` onto the plan's
-///    [`ProvenanceDb`](clinker_plan::config::composition::ProvenanceDb) as
-///    `ChannelDefault` / `ChannelFixed` layers
-///    (W103 for keys not matched in the plan).
+/// 1. Clobbers `config.default` / `config.fixed` onto the plan's
+///    [`ProvenanceDb`](clinker_plan::config::composition::ProvenanceDb) at the
+///    `ChannelPerTarget` layer. `default` is applied first (non-fixed), then
+///    `fixed` (locking), so a key present in both resolves to the fixed value
+///    (fixed wins over default within the layer). A key matching no plan
+///    parameter is a hard error (E113).
 /// 2. Resolves the channel's `vars:` block against the pipeline's
 ///    declared registries — typecheck on override (E107), reserved
 ///    name guard (E110), unknown source-node guard (E111),
 ///    composition-target guard (E109).
 /// 3. Stamps `ChannelIdentity` on the plan.
 ///
-/// Returns the typed var maps even when diagnostics include warnings;
+/// Returns the typed var maps even when diagnostics include errors;
 /// callers should refuse to execute if any `Severity::Error` is present.
 pub fn apply_channel_overlay(
     plan: &mut CompiledPlan,
@@ -63,17 +90,23 @@ pub fn apply_channel_overlay(
 ) -> ChannelOverlayResult {
     let mut result = ChannelOverlayResult::default();
 
-    apply_config_layer(
+    // A per-target `.channel.yaml` overlays the ChannelPerTarget layer, the
+    // highest in the stack. `default` first (non-fixed) then `fixed` (locking):
+    // for a key present in both, the fixed value wins by replacing in place and
+    // setting the lock, matching the historical `fixed > default` precedence.
+    apply_config_clobber(
         plan,
         &binding.config_default,
-        LayerKind::ChannelDefault,
+        LayerKind::ChannelPerTarget,
+        false,
         &binding.name,
         &mut result.diagnostics,
     );
-    apply_config_layer(
+    apply_config_clobber(
         plan,
         &binding.config_fixed,
-        LayerKind::ChannelFixed,
+        LayerKind::ChannelPerTarget,
+        true,
         &binding.name,
         &mut result.diagnostics,
     );
@@ -134,10 +167,20 @@ pub fn apply_channel_overlay(
     result
 }
 
-fn apply_config_layer(
+/// Clobber a channel config map onto the plan's provenance as one layer.
+///
+/// Each `alias.param` key selects a single `(node, param)` provenance entry and
+/// *replaces* its value at `kind` (clobber, never deep-merge). When `fixed` is
+/// set the layer locks its value against every higher-precedence layer.
+///
+/// A key that matches no entry in the compiled plan is a hard error (E113, the
+/// promotion of the former W103 warning): at multi-tenant scale a misspelled
+/// key must fail loudly rather than silently no-op.
+fn apply_config_clobber(
     plan: &mut CompiledPlan,
     config: &IndexMap<DottedPath, serde_json::Value>,
     kind: LayerKind,
+    fixed: bool,
     channel_name: &str,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
@@ -151,11 +194,15 @@ fn apply_config_layer(
 
         match provenance.get_mut(node_name, param_name) {
             Some(resolved) => {
-                resolved.apply_layer(value.clone(), kind, Span::SYNTHETIC);
+                if fixed {
+                    resolved.apply_layer_fixed(value.clone(), kind, Span::SYNTHETIC);
+                } else {
+                    resolved.apply_layer(value.clone(), kind, Span::SYNTHETIC);
+                }
             }
             None => {
-                diagnostics.push(Diagnostic::warning(
-                    "W103",
+                diagnostics.push(Diagnostic::error(
+                    "E113",
                     format!(
                         "channel {:?}: config key {:?} does not match any \
                          composition parameter in the compiled plan",

--- a/crates/clinker-channel/tests/channel_merge_test.rs
+++ b/crates/clinker-channel/tests/channel_merge_test.rs
@@ -43,7 +43,7 @@ fn compile_fixture(
 #[test]
 fn test_channel_overlay_applies_fixed_binding_wins() {
     // nested_composition_pipeline has composition `nested_process` with
-    // `strict_mode: false` at the call site (CompositionDefault).
+    // `strict_mode: false` at the call site (PipelineDefault).
     let (config, mut plan) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
 
     // Verify provenance exists before overlay
@@ -75,8 +75,12 @@ config:
     let winner = resolved.winning_layer().expect("should have a winner");
     assert_eq!(
         winner.kind,
-        LayerKind::ChannelFixed,
-        "ChannelFixed should win over CompositionDefault"
+        LayerKind::ChannelPerTarget,
+        "fixed ChannelPerTarget should win over PipelineDefault"
+    );
+    assert!(
+        winner.fixed,
+        "the winning layer should carry the fixed lock from config.fixed"
     );
     assert_eq!(
         resolved.value,
@@ -87,34 +91,25 @@ config:
 
 #[test]
 fn test_channel_overlay_default_does_not_override_fixed() {
+    // `config.default` and `config.fixed` land on the same ChannelPerTarget
+    // layer; the split maps to the layer's `fixed` lock. When a key appears in
+    // both, the fixed value wins — it locks against the default within the
+    // layer, regardless of which was authored first.
     let (config, mut plan) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
 
-    // First apply a ChannelFixed layer
-    let fixed_yaml = br#"
+    let yaml = br#"
 channel:
-  name: test_fixed_first
-  target: ./pipelines/nested_composition_pipeline.yaml
-config:
-  fixed:
-    nested_process.strict_mode: true
-"#;
-    let fixed_binding =
-        ChannelBinding::from_yaml_bytes(fixed_yaml, PathBuf::from("fixed.channel.yaml")).unwrap();
-    apply_channel_overlay(&mut plan, &fixed_binding, &config);
-
-    // Now apply a ChannelDefault layer — it should NOT override the fixed winner
-    let default_yaml = br#"
-channel:
-  name: test_default_after
+  name: test_default_and_fixed
   target: ./pipelines/nested_composition_pipeline.yaml
 config:
   default:
     nested_process.strict_mode: false
+  fixed:
+    nested_process.strict_mode: true
 "#;
-    let default_binding =
-        ChannelBinding::from_yaml_bytes(default_yaml, PathBuf::from("default.channel.yaml"))
-            .unwrap();
-    apply_channel_overlay(&mut plan, &default_binding, &config);
+    let binding =
+        ChannelBinding::from_yaml_bytes(yaml, PathBuf::from("both.channel.yaml")).unwrap();
+    apply_channel_overlay(&mut plan, &binding, &config);
 
     let resolved = plan
         .provenance()
@@ -124,13 +119,17 @@ config:
     let winner = resolved.winning_layer().expect("should have a winner");
     assert_eq!(
         winner.kind,
-        LayerKind::ChannelFixed,
-        "ChannelFixed should still win after ChannelDefault applied"
+        LayerKind::ChannelPerTarget,
+        "the fixed ChannelPerTarget value should win over the default"
+    );
+    assert!(
+        winner.fixed,
+        "the winning layer should carry the fixed lock"
     );
     assert_eq!(
         resolved.value,
         serde_json::json!(true),
-        "value should remain at the ChannelFixed value"
+        "value should remain at the fixed value, not the default"
     );
 }
 
@@ -166,20 +165,13 @@ config:
 }
 
 #[test]
-fn test_channel_overlay_applies_all_six_fixtures_without_errors() {
-    // The 6 channel fixtures target various pipelines. For overlay testing,
-    // we apply each to a compiled plan. Some fixture keys may not match
-    // provenance entries (warnings are OK), but no errors should occur.
-    //
-    // Pipeline targets:
-    // - acme_prod/staging/empty_defaults → channel_target_pipeline.yaml
-    //   (no compositions, so no provenance entries — all keys emit warnings)
-    // - beta_prod/staging → composition_pipeline.yaml
-    //   (enrich1 has validation errors so no provenance for it; addr_norm has provenance)
-    // - comp_direct → targets composition directly, not a pipeline
-    //
-    // We apply each to nested_composition_pipeline which has provenance for
-    // nested_process.strict_mode. Keys won't match but that's OK — no errors.
+fn test_channel_overlay_unmatched_keys_are_hard_errors() {
+    // The 6 channel fixtures each carry `config` keys targeting other pipelines.
+    // Applied to nested_composition_pipeline — whose only tracked parameter is
+    // `nested_process.strict_mode` — none of their keys match. Promoting the
+    // former W103 warning to the E113 hard error means every unmatched key now
+    // aborts the run instead of silently no-op'ing. Identity is still stamped so
+    // downstream diagnostics can name the channel.
 
     let all_fixtures = [
         "acme_prod.channel.yaml",
@@ -198,21 +190,26 @@ fn test_channel_overlay_applies_all_six_fixtures_without_errors() {
         let (config, mut plan) = compile_fixture("pipelines/nested_composition_pipeline.yaml");
         let result = apply_channel_overlay(&mut plan, &binding, &config);
 
-        // Channel identity should be stamped
+        // Channel identity is stamped regardless of overlay diagnostics.
         assert!(
             plan.channel_identity().is_some(),
             "{channel_name}: should have channel identity after overlay"
         );
 
-        // No error-severity diagnostics
+        // Every unmatched config key is an E113 hard error; no other error
+        // codes are expected from these config-only, pipeline-target channels.
         let errors: Vec<_> = result
             .diagnostics
             .iter()
             .filter(|d| matches!(d.severity, clinker_core_types::Severity::Error))
             .collect();
         assert!(
-            errors.is_empty(),
-            "{channel_name}: should have no errors, got: {errors:?}"
+            !errors.is_empty(),
+            "{channel_name}: unmatched config keys must produce E113 errors"
+        );
+        assert!(
+            errors.iter().all(|d| d.code == "E113"),
+            "{channel_name}: config-key mismatches must all be E113, got: {errors:?}"
         );
     }
 }

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -26,6 +26,7 @@
 //! | `E109`      | error    | Ambiguous column reference (declared vs pass-through in open row) |
 //! | `E111`      | error    | Composition body has zero nodes (rejected at bind time) |
 //! | `E112`      | error    | Runtime composition recursion depth exceeded |
+//! | `E113`      | error    | Channel `config`/override key matches no parameter in the compiled plan (unknown key) |
 //! | `E200`      | error    | CXL type error (compile-time typecheck failure)      |
 //! | `E201`      | error    | Source declaration missing required `schema:` field  |
 //! | `E210`      | error    | Source declares more than one of `{path,glob,regex,paths}` |
@@ -304,6 +305,7 @@ mod diagnostic_tests {
         let source = include_str!("diagnostic.rs");
         for code in [
             "E101", "E102", "E103", "E104", "E105", "E106", "E107", "E108", "E109", "E111", "E112",
+            "E113",
         ] {
             let pattern = format!("`{code}`");
             assert!(

--- a/crates/clinker-exec/benches/provenance.rs
+++ b/crates/clinker-exec/benches/provenance.rs
@@ -12,16 +12,23 @@ fn bench_apply_layer_full_stack(c: &mut Criterion) {
         b.iter(|| {
             let mut rv = ResolvedValue::new(
                 serde_json::json!(42),
-                LayerKind::CompositionDefault,
+                LayerKind::PipelineDefault,
                 test_span(),
             );
             rv.apply_layer(
                 serde_json::json!(43),
-                LayerKind::ChannelDefault,
+                LayerKind::Group {
+                    priority: 10,
+                    seq: 0,
+                },
                 test_span(),
             );
-            rv.apply_layer(serde_json::json!(44), LayerKind::ChannelFixed, test_span());
-            rv.apply_layer(serde_json::json!(45), LayerKind::InspectorEdit, test_span());
+            rv.apply_layer(serde_json::json!(44), LayerKind::ChannelWide, test_span());
+            rv.apply_layer(
+                serde_json::json!(45),
+                LayerKind::ChannelPerTarget,
+                test_span(),
+            );
             black_box(&rv);
         })
     });
@@ -38,7 +45,7 @@ fn bench_provenance_db_insert_50(c: &mut Criterion) {
                     format!("param_{i}"),
                     ResolvedValue::new(
                         serde_json::json!(i),
-                        LayerKind::CompositionDefault,
+                        LayerKind::PipelineDefault,
                         test_span(),
                     ),
                 );

--- a/crates/clinker-exec/tests/pre_lift_baselines.rs
+++ b/crates/clinker-exec/tests/pre_lift_baselines.rs
@@ -725,7 +725,7 @@ fn test_all_14_fixtures_have_baseline() {
 }
 
 /// Gate test: channel overlay on a pipeline produces a provenance chain with
-/// ChannelFixed layer recorded in the compiled plan.
+/// a fixed ChannelPerTarget layer recorded in the compiled plan.
 #[test]
 fn test_channel_overlay_provenance_chain_recorded_in_baseline() {
     use clinker_channel::binding::ChannelBinding;
@@ -742,7 +742,7 @@ fn test_channel_overlay_provenance_chain_recorded_in_baseline() {
     );
     let mut plan = clinker_plan::config::PipelineConfig::compile(&config, &ctx).expect("compile");
 
-    // Apply the acme_prod channel (which has ChannelFixed bindings) but
+    // Apply the acme_prod channel (which has `config.fixed` bindings) but
     // adapted to target this pipeline's provenance entries.
     let channel_yaml = br#"
 channel:
@@ -760,27 +760,28 @@ config:
 
     let _result = apply_channel_overlay(&mut plan, &binding, &config);
 
-    // Verify the provenance chain contains a ChannelFixed layer
+    // Verify the provenance chain contains a fixed ChannelPerTarget layer
     let resolved = plan
         .provenance()
         .get("nested_process", "strict_mode")
         .expect("nested_process.strict_mode must exist in provenance");
 
-    let has_channel_fixed = resolved
+    let has_fixed_per_target = resolved
         .provenance
         .iter()
-        .any(|l| l.kind == LayerKind::ChannelFixed);
+        .any(|l| l.kind == LayerKind::ChannelPerTarget && l.fixed);
     assert!(
-        has_channel_fixed,
-        "provenance chain must contain a ChannelFixed layer"
+        has_fixed_per_target,
+        "provenance chain must contain a fixed ChannelPerTarget layer"
     );
 
     let winner = resolved.winning_layer().expect("must have a winner");
     assert_eq!(
         winner.kind,
-        LayerKind::ChannelFixed,
-        "ChannelFixed must be the winning layer"
+        LayerKind::ChannelPerTarget,
+        "the fixed ChannelPerTarget layer must be the winner"
     );
+    assert!(winner.fixed, "the winning layer must carry the fixed lock");
 
     // Verify channel identity is stamped
     let identity = plan

--- a/crates/clinker-exec/tests/provenance_test.rs
+++ b/crates/clinker-exec/tests/provenance_test.rs
@@ -25,81 +25,102 @@ fn parse_pipeline(yaml: &str) -> clinker_plan::config::PipelineConfig {
 
 #[test]
 fn test_resolved_value_initial_layer_wins() {
-    let rv = ResolvedValue::new(42, LayerKind::CompositionDefault, test_span());
+    let rv = ResolvedValue::new(42, LayerKind::PipelineDefault, test_span());
     let winner = rv.winning_layer().expect("must have a winner");
-    assert_eq!(winner.kind, LayerKind::CompositionDefault);
+    assert_eq!(winner.kind, LayerKind::PipelineDefault);
     assert!(winner.won);
     assert_eq!(rv.value, 42);
 }
 
 #[test]
-fn test_apply_layer_channel_fixed_wins_over_composition_default() {
-    let mut rv = ResolvedValue::new(10, LayerKind::CompositionDefault, test_span());
-    rv.apply_layer(99, LayerKind::ChannelFixed, test_span());
+fn test_apply_layer_fixed_channel_wins_over_pipeline_default() {
+    let mut rv = ResolvedValue::new(10, LayerKind::PipelineDefault, test_span());
+    rv.apply_layer_fixed(99, LayerKind::ChannelPerTarget, test_span());
 
-    assert_eq!(rv.value, 99, "ChannelFixed value should win");
+    assert_eq!(rv.value, 99, "fixed ChannelPerTarget value should win");
     let winner = rv.winning_layer().expect("must have a winner");
-    assert_eq!(winner.kind, LayerKind::ChannelFixed);
+    assert_eq!(winner.kind, LayerKind::ChannelPerTarget);
 
-    let comp = rv
+    let base = rv
         .provenance
         .iter()
-        .find(|l| l.kind == LayerKind::CompositionDefault)
-        .expect("CompositionDefault layer must still exist");
-    assert!(!comp.won);
+        .find(|l| l.kind == LayerKind::PipelineDefault)
+        .expect("PipelineDefault layer must still exist");
+    assert!(!base.won);
 }
 
 #[test]
-fn test_apply_layer_channel_default_does_not_win_over_fixed() {
-    let mut rv = ResolvedValue::new(10, LayerKind::ChannelFixed, test_span());
-    rv.apply_layer(20, LayerKind::ChannelDefault, test_span());
+fn test_non_fixed_higher_does_not_override_fixed_lower() {
+    // A `fixed` lower layer locks its value against every higher-precedence
+    // layer applied afterwards, regardless of application order.
+    let mut rv = ResolvedValue::new_fixed(10, LayerKind::PipelineDefault, test_span());
+    rv.apply_layer(20, LayerKind::ChannelPerTarget, test_span());
 
-    assert_eq!(rv.value, 10, "ChannelFixed value should be retained");
+    assert_eq!(
+        rv.value, 10,
+        "fixed PipelineDefault value should be retained"
+    );
     let winner = rv.winning_layer().expect("must have a winner");
-    assert_eq!(winner.kind, LayerKind::ChannelFixed);
+    assert_eq!(winner.kind, LayerKind::PipelineDefault);
 
-    let ch_default = rv
+    let higher = rv
         .provenance
         .iter()
-        .find(|l| l.kind == LayerKind::ChannelDefault)
-        .expect("ChannelDefault layer must exist");
-    assert!(!ch_default.won);
+        .find(|l| l.kind == LayerKind::ChannelPerTarget)
+        .expect("ChannelPerTarget layer must exist");
+    assert!(!higher.won);
 }
 
 #[test]
-fn test_resolved_value_provenance_chain_bounded_at_4() {
-    let mut rv = ResolvedValue::new(1, LayerKind::CompositionDefault, test_span());
-    rv.apply_layer(2, LayerKind::ChannelDefault, test_span());
-    rv.apply_layer(3, LayerKind::ChannelFixed, test_span());
-    rv.apply_layer(4, LayerKind::InspectorEdit, test_span());
+fn test_provenance_chain_accumulates_distinct_layers() {
+    // The chain is no longer capped at a fixed count: it holds one entry per
+    // distinct layer, and a same-kind re-apply replaces in place.
+    let mut rv = ResolvedValue::new(1, LayerKind::PipelineDefault, test_span());
+    rv.apply_layer(
+        2,
+        LayerKind::Group {
+            priority: 10,
+            seq: 0,
+        },
+        test_span(),
+    );
+    rv.apply_layer(3, LayerKind::ChannelWide, test_span());
+    rv.apply_layer(4, LayerKind::ChannelPerTarget, test_span());
 
-    assert_eq!(rv.provenance.len(), 4, "exactly 4 layers, one per kind");
-    assert_eq!(rv.value, 4, "InspectorEdit value should win");
-
-    let winner = rv.winning_layer().expect("must have a winner");
-    assert_eq!(winner.kind, LayerKind::InspectorEdit);
-
-    // Re-apply same kind: should replace in place, not push.
-    rv.apply_layer(5, LayerKind::InspectorEdit, test_span());
     assert_eq!(
         rv.provenance.len(),
         4,
-        "still 4 layers after same-kind re-apply"
+        "four distinct layers, one entry each"
+    );
+    assert_eq!(
+        rv.value, 4,
+        "highest-precedence ChannelPerTarget value wins"
+    );
+
+    let winner = rv.winning_layer().expect("must have a winner");
+    assert_eq!(winner.kind, LayerKind::ChannelPerTarget);
+
+    // Re-apply same kind: should replace in place, not push.
+    rv.apply_layer(5, LayerKind::ChannelPerTarget, test_span());
+    assert_eq!(
+        rv.provenance.len(),
+        4,
+        "still four layers after same-kind re-apply"
     );
     assert_eq!(rv.value, 5, "replaced value should be updated");
 }
 
 #[test]
-fn test_apply_layer_inspector_edit_wins_over_channel_fixed() {
-    let mut rv = ResolvedValue::new(10, LayerKind::ChannelFixed, test_span());
-    rv.apply_layer(99, LayerKind::InspectorEdit, test_span());
+fn test_channel_per_target_wins_over_channel_wide() {
+    let mut rv = ResolvedValue::new(10, LayerKind::ChannelWide, test_span());
+    rv.apply_layer(99, LayerKind::ChannelPerTarget, test_span());
 
     assert_eq!(
         rv.value, 99,
-        "InspectorEdit value should win over ChannelFixed"
+        "ChannelPerTarget value should win over ChannelWide"
     );
     let winner = rv.winning_layer().expect("must have a winner");
-    assert_eq!(winner.kind, LayerKind::InspectorEdit);
+    assert_eq!(winner.kind, LayerKind::ChannelPerTarget);
 }
 
 // ---------------------------------------------------------------------
@@ -129,7 +150,7 @@ fn test_compiled_plan_composition_params_carry_provenance() {
 
     assert_eq!(entry.value, serde_json::json!(false));
     let winner = entry.winning_layer().expect("must have a winner");
-    assert_eq!(winner.kind, LayerKind::CompositionDefault);
+    assert_eq!(winner.kind, LayerKind::PipelineDefault);
     assert!(winner.won);
 
     // Verify provenance is non-empty overall.

--- a/crates/clinker-plan/src/config/composition/provenance.rs
+++ b/crates/clinker-plan/src/config/composition/provenance.rs
@@ -1,10 +1,36 @@
 //! Provenance tracking for resolved configuration values.
 //!
 //! Each config value in a compiled pipeline carries a [`ResolvedValue`] wrapper
-//! that records which configuration layer (composition default, channel default,
-//! channel fixed, inspector edit) contributed the winning value. The provenance
-//! chain is stored in a side-table [`ProvenanceDb`], separate from
+//! that records which configuration layer contributed the winning value. The
+//! provenance chain is stored in a side-table [`ProvenanceDb`], separate from
 //! [`CompiledPlan`](crate::plan::compiled::CompiledPlan).
+//!
+//! # Layer stack
+//!
+//! The composition overlay resolves values through a fixed *semantic* order of
+//! layers (never lexical or positional), encoded by [`LayerKind`]:
+//!
+//! ```text
+//! PipelineDefault  <  Group(s) by priority  <  ChannelWide  <  ChannelPerTarget
+//! ```
+//!
+//! Groups are *dynamic*: any number of groups may match a channel, so `Group`
+//! carries its `priority` (higher wins) and a declaration-order source id
+//! (`seq`, later declaration wins ties). Every group is a distinct layer.
+//!
+//! A layer may additionally be marked **`fixed`**: a fixed value locks the
+//! resolution against every higher-precedence layer — nothing downstream may
+//! override it. When several layers are fixed, the lowest-precedence fixed
+//! layer wins, because it locked the value first.
+//!
+//! # Generic over the layer kind
+//!
+//! [`ResolvedValue`] and [`ProvenanceLayer`] are generic over the layer-kind
+//! type `L` (any `Copy + Ord`). The composition overlay instantiates them with
+//! [`LayerKind`]; a future schema-attribute resolver can reuse the *same*
+//! implementation with a `SchemaLayer` kind and zero duplication. Precedence,
+//! `fixed`-lock semantics, and single-winner selection are all defined purely
+//! in terms of `L: Ord`.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -12,30 +38,55 @@ use std::fmt;
 use clinker_core_types::span::Span;
 
 // Keep ProvenanceLayer at or under 64 bytes — the provenance side-table
-// is sized for this footprint.
+// is sized for this footprint. Checked for the composition instantiation
+// (`ProvenanceLayer<LayerKind>`), the widest layer kind in the crate.
 const _: () = assert!(std::mem::size_of::<ProvenanceLayer>() <= 64);
 
 /// Which configuration layer contributed a value.
 ///
-/// Priority is encoded in discriminant order via `PartialOrd`/`Ord` derives:
-/// `CompositionDefault (0) < ChannelDefault (1) < ChannelFixed (2) < InspectorEdit (3)`.
-/// Higher-priority layers win over lower-priority ones during [`ResolvedValue::apply_layer`].
+/// Precedence is encoded via the derived `Ord`, which orders enum variants by
+/// declaration order and struct-variant fields top-to-bottom:
+///
+/// ```text
+/// PipelineDefault < Group { priority, seq } < ChannelWide < ChannelPerTarget
+/// ```
+///
+/// Among `Group` variants, `priority` is compared first (higher priority is a
+/// greater layer, so it wins), then `seq` (the group's declaration-order source
+/// id; a later declaration is greater and wins ties). Higher-precedence layers
+/// win over lower-precedence ones during [`ResolvedValue::apply_layer`], unless
+/// a lower layer is `fixed`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(u8)]
 pub enum LayerKind {
-    CompositionDefault = 0,
-    ChannelDefault = 1,
-    ChannelFixed = 2,
-    InspectorEdit = 3,
+    /// Base layer: a pipeline's own authored defaults / composition call-site
+    /// values.
+    PipelineDefault,
+    /// A matching group overlay. `priority` (higher wins) then `seq` (the
+    /// group's declaration-order source id, later wins) determine ordering
+    /// among multiple matching groups.
+    Group {
+        /// Group priority; higher wins among multiple matching groups.
+        priority: i32,
+        /// Declaration-order source id of the group; breaks priority ties with
+        /// later-declared groups winning.
+        seq: u32,
+    },
+    /// Channel-wide overrides (`channel.cfg.yaml`), applied to every pipeline
+    /// the channel runs.
+    ChannelWide,
+    /// Channel per-target overrides (`<target>.channel.yaml`).
+    ChannelPerTarget,
 }
 
 impl fmt::Display for LayerKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            LayerKind::CompositionDefault => write!(f, "CompositionDefault"),
-            LayerKind::ChannelDefault => write!(f, "ChannelDefault"),
-            LayerKind::ChannelFixed => write!(f, "ChannelFixed"),
-            LayerKind::InspectorEdit => write!(f, "InspectorEdit"),
+            LayerKind::PipelineDefault => write!(f, "PipelineDefault"),
+            LayerKind::Group { priority, seq } => {
+                write!(f, "Group #{seq} (priority {priority})")
+            }
+            LayerKind::ChannelWide => write!(f, "ChannelWide"),
+            LayerKind::ChannelPerTarget => write!(f, "ChannelPerTarget"),
         }
     }
 }
@@ -44,111 +95,155 @@ impl fmt::Display for LayerKind {
 ///
 /// The `won` flag marks the layer whose value was selected. Exactly one layer
 /// in a [`ResolvedValue`]'s provenance chain has `won == true`.
+///
+/// Generic over the layer-kind `L`; the composition overlay uses the default
+/// [`LayerKind`].
 #[derive(Debug, Clone)]
-pub struct ProvenanceLayer {
+pub struct ProvenanceLayer<L = LayerKind> {
     /// Source span of the value's origin in the YAML file. File identity
     /// is resolved via `SourceDb.path(span.file)` at render time.
     pub span: Span,
     /// Which configuration layer this value came from.
-    pub kind: LayerKind,
+    pub kind: L,
+    /// Whether this layer locks its value against every higher-precedence
+    /// layer. A `fixed` layer cannot be overridden by anything downstream.
+    pub fixed: bool,
     /// Whether this layer's value was selected as the winner.
     pub won: bool,
 }
 
 /// A config value together with its full provenance chain.
 ///
-/// Inspired by figment's `Metadata` model. The `won` flag is Clinker's
-/// addition — it makes the winning layer explicit for tooling inspectors
-/// panel without requiring the inspector to re-run priority logic.
+/// The `won` flag makes the winning layer explicit for tooling inspectors
+/// without requiring the inspector to re-run priority logic.
 ///
-/// The provenance chain is bounded at 4 entries (one per [`LayerKind`]).
+/// Generic over the value type `T` and the layer-kind `L` (defaulting to
+/// [`LayerKind`]). The provenance chain length is *not* fixed: it grows with
+/// the number of matching group layers.
 #[derive(Debug, Clone)]
-pub struct ResolvedValue<T> {
+pub struct ResolvedValue<T, L = LayerKind> {
     /// The winning value after all layers have been applied.
     pub value: T,
     /// Ordered provenance chain. Each entry records a layer's contribution.
-    /// At most 4 entries (one per [`LayerKind`]). Exactly one has `won == true`.
-    pub provenance: Vec<ProvenanceLayer>,
-    /// Per-layer values keyed by [`LayerKind`]. Stores the value contributed
-    /// by each layer so `--explain --field` can display shadowed values.
-    /// Kept separate from [`ProvenanceLayer`] to preserve its 64-byte size.
-    pub layer_values: HashMap<LayerKind, T>,
+    /// Exactly one entry has `won == true`.
+    pub provenance: Vec<ProvenanceLayer<L>>,
+    /// Per-layer values in application order. Stores the value contributed by
+    /// each layer so `--explain --field` can display shadowed values. Kept as
+    /// an ordered collection (not a fixed-size map) so multiple `Group` layers
+    /// each keep their own entry, and separate from [`ProvenanceLayer`] to
+    /// preserve its 64-byte size.
+    pub layer_values: Vec<(L, T)>,
 }
 
-impl<T: Clone> ResolvedValue<T> {
+impl<T: Clone, L: Copy + Ord> ResolvedValue<T, L> {
     /// Create a new resolved value with a single provenance layer.
     /// The initial layer is always the winner.
-    pub fn new(value: T, kind: LayerKind, span: Span) -> Self {
-        let mut layer_values = HashMap::new();
-        layer_values.insert(kind, value.clone());
+    pub fn new(value: T, kind: L, span: Span) -> Self {
+        Self::with_fixed(value, kind, span, false)
+    }
+
+    /// Create a new resolved value whose sole layer is `fixed` — it locks the
+    /// value against any higher-precedence layer applied later.
+    pub fn new_fixed(value: T, kind: L, span: Span) -> Self {
+        Self::with_fixed(value, kind, span, true)
+    }
+
+    fn with_fixed(value: T, kind: L, span: Span, fixed: bool) -> Self {
         Self {
-            value,
             provenance: vec![ProvenanceLayer {
                 span,
                 kind,
+                fixed,
                 won: true,
             }],
-            layer_values,
+            layer_values: vec![(kind, value.clone())],
+            value,
         }
     }
 
     /// Returns the layer that won (the one with `won == true`).
-    pub fn winning_layer(&self) -> Option<&ProvenanceLayer> {
+    pub fn winning_layer(&self) -> Option<&ProvenanceLayer<L>> {
         self.provenance.iter().find(|l| l.won)
     }
 
-    /// Apply a new layer on top. The new layer wins if its [`LayerKind`]
-    /// is >= the current winner's kind (higher or equal priority wins).
+    /// Apply a new (non-fixed) layer on top. The new layer wins if it is the
+    /// highest-precedence layer and no lower layer is `fixed`.
     ///
-    /// Same-kind layers replace in place: the span is updated and
-    /// the value is replaced if the new layer wins.
-    pub fn apply_layer(&mut self, value: T, kind: LayerKind, span: Span) {
-        debug_assert!(
-            self.provenance.len() <= 4,
-            "provenance chain exceeds 4-layer bound"
-        );
+    /// Same-kind layers replace in place: the span/value are updated. A `Group`
+    /// with a distinct `(priority, seq)` is a distinct layer and is appended.
+    pub fn apply_layer(&mut self, value: T, kind: L, span: Span) {
+        self.apply_layer_inner(value, kind, span, false);
+    }
 
-        // Store this layer's value before any winner computation.
-        self.layer_values.insert(kind, value.clone());
+    /// Apply a new `fixed` layer on top. A fixed layer locks its value against
+    /// every higher-precedence layer applied afterwards.
+    pub fn apply_layer_fixed(&mut self, value: T, kind: L, span: Span) {
+        self.apply_layer_inner(value, kind, span, true);
+    }
 
-        // Find existing entry for this kind (same-kind replace-in-place).
-        let existing_idx = self.provenance.iter().position(|l| l.kind == kind);
-
-        if let Some(idx) = existing_idx {
-            // Replace in place: update span, recalculate winner.
-            self.provenance[idx].span = span;
-        } else {
-            // New kind: push a new entry.
-            self.provenance.push(ProvenanceLayer {
-                span,
-                kind,
-                won: false,
-            });
+    fn apply_layer_inner(&mut self, value: T, kind: L, span: Span, fixed: bool) {
+        // Record this layer's value (same-kind replace-in-place).
+        match self.layer_values.iter_mut().find(|(k, _)| *k == kind) {
+            Some(slot) => slot.1 = value,
+            None => self.layer_values.push((kind, value)),
         }
 
-        // Recompute winner: highest LayerKind wins.
-        let winning_kind = self
+        // Record/replace the provenance entry for this kind.
+        match self.provenance.iter_mut().find(|l| l.kind == kind) {
+            Some(existing) => {
+                existing.span = span;
+                existing.fixed = fixed;
+            }
+            None => self.provenance.push(ProvenanceLayer {
+                span,
+                kind,
+                fixed,
+                won: false,
+            }),
+        }
+
+        self.recompute_winner();
+    }
+
+    /// The winning layer kind: the lowest-precedence `fixed` layer if any layer
+    /// is fixed (it locked the value against everything downstream), otherwise
+    /// the highest-precedence layer. Deterministic from the layer set alone —
+    /// independent of application order.
+    fn winner_kind(&self) -> L {
+        if let Some(locked) = self
             .provenance
+            .iter()
+            .filter(|l| l.fixed)
+            .map(|l| l.kind)
+            .min()
+        {
+            return locked;
+        }
+        self.provenance
             .iter()
             .map(|l| l.kind)
             .max()
-            .expect("provenance is non-empty");
+            .expect("provenance chain is non-empty")
+    }
 
-        let new_layer_wins = kind >= winning_kind;
-
+    /// Recompute `won` flags and the resolved `value` from the current layer
+    /// set. Exactly one layer wins (layer kinds are unique per value).
+    fn recompute_winner(&mut self) {
+        let winner = self.winner_kind();
         for layer in &mut self.provenance {
-            layer.won = layer.kind == winning_kind;
+            layer.won = layer.kind == winner;
         }
-
-        // Update value if the new/replaced layer is the winner.
-        if new_layer_wins {
-            self.value = value;
+        if let Some((_, value)) = self.layer_values.iter().find(|(k, _)| *k == winner) {
+            self.value = value.clone();
         }
     }
 
     /// Look up the value contributed by a specific layer kind.
-    pub fn layer_value(&self, kind: LayerKind) -> Option<&T> {
-        self.layer_values.get(&kind)
+    pub fn layer_value(&self, kind: L) -> Option<&T> {
+        self.layer_values
+            .iter()
+            .find(|(k, _)| *k == kind)
+            .map(|(_, v)| v)
     }
 }
 
@@ -185,8 +280,8 @@ impl ProvenanceDb {
             .get(&(node_name.to_owned(), param_name.to_owned()))
     }
 
-    /// Mutable lookup for `(node_name, param_name)`. Used by channel overlay
-    /// to apply `ChannelDefault`/`ChannelFixed` layers.
+    /// Mutable lookup for `(node_name, param_name)`. Used by the channel overlay
+    /// to apply `ChannelWide`/`ChannelPerTarget` layers.
     pub fn get_mut(
         &mut self,
         node_name: &str,
@@ -233,5 +328,212 @@ impl ProvenanceDb {
     /// Whether the provenance table is empty.
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn span(line: u32) -> Span {
+        Span::line_only(line)
+    }
+
+    fn group(priority: i32, seq: u32) -> LayerKind {
+        LayerKind::Group { priority, seq }
+    }
+
+    // ── LayerKind precedence ─────────────────────────────────────────────
+
+    #[test]
+    fn layer_kind_total_order_across_stack() {
+        assert!(LayerKind::PipelineDefault < group(0, 0));
+        assert!(group(1000, 999) < LayerKind::ChannelWide);
+        assert!(LayerKind::ChannelWide < LayerKind::ChannelPerTarget);
+    }
+
+    #[test]
+    fn group_ordering_priority_then_declaration() {
+        // Higher priority is a greater layer.
+        assert!(group(10, 5) < group(20, 0));
+        // Equal priority: later declaration (higher seq) is greater.
+        assert!(group(20, 1) < group(20, 2));
+    }
+
+    // ── Precedence resolution ────────────────────────────────────────────
+
+    #[test]
+    fn higher_layer_wins_over_lower() {
+        let mut rv = ResolvedValue::new(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer(2, LayerKind::ChannelWide, span(2));
+        assert_eq!(rv.value, 2);
+        assert_eq!(rv.winning_layer().unwrap().kind, LayerKind::ChannelWide);
+    }
+
+    #[test]
+    fn full_stack_precedence_channel_per_target_wins() {
+        let mut rv = ResolvedValue::new(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer(2, group(20, 0), span(2));
+        rv.apply_layer(3, LayerKind::ChannelWide, span(3));
+        rv.apply_layer(4, LayerKind::ChannelPerTarget, span(4));
+        assert_eq!(rv.value, 4);
+        assert_eq!(
+            rv.winning_layer().unwrap().kind,
+            LayerKind::ChannelPerTarget
+        );
+    }
+
+    #[test]
+    fn lower_layer_applied_later_does_not_win() {
+        // Applying a lower-precedence layer after a higher one must not flip
+        // the winner — precedence is semantic, not positional.
+        let mut rv = ResolvedValue::new(1, LayerKind::ChannelPerTarget, span(1));
+        rv.apply_layer(2, LayerKind::PipelineDefault, span(2));
+        assert_eq!(rv.value, 1);
+        assert_eq!(
+            rv.winning_layer().unwrap().kind,
+            LayerKind::ChannelPerTarget
+        );
+    }
+
+    // ── Multiple groups ──────────────────────────────────────────────────
+
+    #[test]
+    fn multiple_groups_highest_priority_wins() {
+        let mut rv = ResolvedValue::new(0, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer(10, group(10, 0), span(2));
+        rv.apply_layer(30, group(30, 1), span(3));
+        rv.apply_layer(20, group(20, 2), span(4));
+        assert_eq!(rv.value, 30, "priority 30 group must win");
+        assert_eq!(rv.winning_layer().unwrap().kind, group(30, 1));
+        // Every group keeps its own shadowed value.
+        assert_eq!(rv.layer_value(group(10, 0)), Some(&10));
+        assert_eq!(rv.layer_value(group(20, 2)), Some(&20));
+        assert_eq!(rv.layer_value(group(30, 1)), Some(&30));
+    }
+
+    #[test]
+    fn groups_same_priority_later_declaration_wins() {
+        let mut rv = ResolvedValue::new(0, LayerKind::PipelineDefault, span(1));
+        // Apply in reverse declaration order to prove ordering is by seq, not
+        // application order.
+        rv.apply_layer(200, group(20, 2), span(2));
+        rv.apply_layer(100, group(20, 1), span(3));
+        assert_eq!(rv.value, 200, "later-declared group (seq 2) must win");
+        assert_eq!(rv.winning_layer().unwrap().kind, group(20, 2));
+    }
+
+    // ── Fixed lock ───────────────────────────────────────────────────────
+
+    #[test]
+    fn fixed_lower_layer_wins_over_higher() {
+        let mut rv = ResolvedValue::new_fixed(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer(2, LayerKind::ChannelPerTarget, span(2));
+        assert_eq!(rv.value, 1, "fixed PipelineDefault must not be overridden");
+        assert_eq!(rv.winning_layer().unwrap().kind, LayerKind::PipelineDefault);
+    }
+
+    #[test]
+    fn fixed_applied_mid_stack_locks_downstream() {
+        let mut rv = ResolvedValue::new(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer_fixed(2, LayerKind::ChannelWide, span(2));
+        rv.apply_layer(3, LayerKind::ChannelPerTarget, span(3));
+        assert_eq!(rv.value, 2, "fixed ChannelWide locks out ChannelPerTarget");
+        assert_eq!(rv.winning_layer().unwrap().kind, LayerKind::ChannelWide);
+    }
+
+    #[test]
+    fn lowest_fixed_layer_wins_among_several_fixed() {
+        let mut rv = ResolvedValue::new_fixed(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer_fixed(2, LayerKind::ChannelWide, span(2));
+        assert_eq!(
+            rv.value, 1,
+            "lowest-precedence fixed layer locked the value first"
+        );
+        assert_eq!(rv.winning_layer().unwrap().kind, LayerKind::PipelineDefault);
+    }
+
+    #[test]
+    fn non_fixed_higher_still_wins_when_lower_not_fixed() {
+        let mut rv = ResolvedValue::new(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer_fixed(2, LayerKind::ChannelPerTarget, span(2));
+        assert_eq!(rv.value, 2);
+        assert_eq!(
+            rv.winning_layer().unwrap().kind,
+            LayerKind::ChannelPerTarget
+        );
+    }
+
+    // ── Exactly-one-winner invariant ─────────────────────────────────────
+
+    #[test]
+    fn exactly_one_winning_layer() {
+        let mut rv = ResolvedValue::new(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer(2, group(10, 0), span(2));
+        rv.apply_layer_fixed(3, group(20, 1), span(3));
+        rv.apply_layer(4, LayerKind::ChannelWide, span(4));
+        rv.apply_layer(5, LayerKind::ChannelPerTarget, span(5));
+        let winners = rv.provenance.iter().filter(|l| l.won).count();
+        assert_eq!(winners, 1, "exactly one layer must win");
+        // The fixed group locks out both channel layers.
+        assert_eq!(rv.value, 3);
+        assert_eq!(rv.winning_layer().unwrap().kind, group(20, 1));
+    }
+
+    #[test]
+    fn same_kind_replaces_in_place() {
+        let mut rv = ResolvedValue::new(1, LayerKind::ChannelWide, span(1));
+        rv.apply_layer(2, LayerKind::ChannelWide, span(9));
+        assert_eq!(rv.value, 2);
+        // A single ChannelWide provenance entry, with the updated span.
+        let entries: Vec<_> = rv
+            .provenance
+            .iter()
+            .filter(|l| l.kind == LayerKind::ChannelWide)
+            .collect();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].span, span(9));
+    }
+
+    // ── Shadowed value retention ─────────────────────────────────────────
+
+    #[test]
+    fn shadowed_layer_values_are_retained() {
+        let mut rv = ResolvedValue::new(1, LayerKind::PipelineDefault, span(1));
+        rv.apply_layer(2, LayerKind::ChannelPerTarget, span(2));
+        assert_eq!(rv.layer_value(LayerKind::PipelineDefault), Some(&1));
+        assert_eq!(rv.layer_value(LayerKind::ChannelPerTarget), Some(&2));
+    }
+
+    // ── Generic reuse over a different layer kind ────────────────────────
+
+    #[test]
+    fn generic_over_arbitrary_layer_kind() {
+        // A stand-in for the future SchemaLayer proves the implementation is
+        // reused with zero duplication for any `Copy + Ord` layer kind.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+        enum SchemaLayer {
+            Base,
+            Pipeline,
+            Group,
+            Channel,
+        }
+
+        let mut rv = ResolvedValue::<&str, SchemaLayer>::new("base", SchemaLayer::Base, span(1));
+        rv.apply_layer("pipeline", SchemaLayer::Pipeline, span(2));
+        rv.apply_layer_fixed("group", SchemaLayer::Group, span(3));
+        rv.apply_layer("channel", SchemaLayer::Channel, span(4));
+        assert_eq!(rv.value, "group", "fixed group layer locks out channel");
+        assert_eq!(rv.winning_layer().unwrap().kind, SchemaLayer::Group);
+        assert_eq!(rv.provenance.iter().filter(|l| l.won).count(), 1);
+    }
+
+    #[test]
+    fn provenance_layer_fits_in_cache_budget() {
+        assert!(
+            std::mem::size_of::<ProvenanceLayer>() <= 64,
+            "ProvenanceLayer must fit in 64 bytes, got {}",
+            std::mem::size_of::<ProvenanceLayer>()
+        );
     }
 }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -3268,8 +3268,8 @@ fn validate_resources(
 /// - The call-site override if present, or
 /// - The signature's default if present.
 ///
-/// All values at this stage are tagged as [`LayerKind::CompositionDefault`]
-/// since channel-level resolution is not yet wired.
+/// All values at this stage are tagged as [`LayerKind::PipelineDefault`]
+/// since channel/group-level resolution is layered on afterwards.
 fn populate_config_provenance(
     call_site: &IndexMap<String, serde_json::Value>,
     signature: &CompositionSignature,
@@ -3300,7 +3300,7 @@ fn populate_config_provenance(
         provenance.insert(
             node_name.to_owned(),
             param_name.clone(),
-            ResolvedValue::new(resolved_value, LayerKind::CompositionDefault, value_span),
+            ResolvedValue::new(resolved_value, LayerKind::PipelineDefault, value_span),
         );
     }
 }

--- a/crates/clinker-plan/src/plan/compiled.rs
+++ b/crates/clinker-plan/src/plan/compiled.rs
@@ -131,8 +131,8 @@ impl CompiledPlan {
     }
 
     /// Mutable access to the provenance side-table for channel overlay
-    /// application. The overlay applies `ChannelDefault`/`ChannelFixed`
-    /// layers to existing `ResolvedValue` entries.
+    /// application. The overlay applies `ChannelWide`/`ChannelPerTarget`
+    /// layers (optionally `fixed`) to existing `ResolvedValue` entries.
     pub fn provenance_mut(&mut self) -> &mut ProvenanceDb {
         &mut self.provenance
     }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -99,9 +99,9 @@ fn format_span(span: Span) -> String {
 ///   Resolved value: 0.92
 ///
 ///   Provenance chain (outermost to innermost):
-///   [WON] ChannelFixed     →  0.92  (line 12)
-///         ChannelDefault   →  0.85  (shadowed)  (line 15)
-///         CompositionDefault →  0.75  (shadowed)  (line 8)
+///   [WON] ChannelPerTarget →  0.92  (line 12)
+///         ChannelWide      →  0.85  (shadowed)  (line 15)
+///         PipelineDefault  →  0.75  (shadowed)  (line 8)
 /// ```
 pub fn explain_field_provenance(
     plan: &CompiledPlan,
@@ -300,11 +300,11 @@ mod tests {
     fn test_layer_value_stored_on_new() {
         let rv = ResolvedValue::new(
             serde_json::json!(0.75),
-            LayerKind::CompositionDefault,
+            LayerKind::PipelineDefault,
             Span::line_only(8),
         );
         assert_eq!(
-            rv.layer_value(LayerKind::CompositionDefault),
+            rv.layer_value(LayerKind::PipelineDefault),
             Some(&serde_json::json!(0.75))
         );
     }
@@ -313,23 +313,23 @@ mod tests {
     fn test_layer_value_stored_on_apply() {
         let mut rv = ResolvedValue::new(
             serde_json::json!(0.75),
-            LayerKind::CompositionDefault,
+            LayerKind::PipelineDefault,
             Span::line_only(8),
         );
         rv.apply_layer(
             serde_json::json!(0.92),
-            LayerKind::ChannelFixed,
+            LayerKind::ChannelPerTarget,
             Span::line_only(12),
         );
         assert_eq!(
-            rv.layer_value(LayerKind::CompositionDefault),
+            rv.layer_value(LayerKind::PipelineDefault),
             Some(&serde_json::json!(0.75))
         );
         assert_eq!(
-            rv.layer_value(LayerKind::ChannelFixed),
+            rv.layer_value(LayerKind::ChannelPerTarget),
             Some(&serde_json::json!(0.92))
         );
-        assert!(rv.provenance.iter().find(|l| l.won).unwrap().kind == LayerKind::ChannelFixed);
+        assert!(rv.provenance.iter().find(|l| l.won).unwrap().kind == LayerKind::ChannelPerTarget);
     }
 
     #[test]

--- a/crates/clinker-plan/src/plan/extraction.rs
+++ b/crates/clinker-plan/src/plan/extraction.rs
@@ -579,7 +579,7 @@ mod tests {
             "fuzzy_threshold".to_owned(),
             ResolvedValue::new(
                 serde_json::json!(0.85),
-                LayerKind::CompositionDefault,
+                LayerKind::PipelineDefault,
                 Span::line_only(10),
             ),
         );

--- a/crates/clinker/tests/explain_provenance_test.rs
+++ b/crates/clinker/tests/explain_provenance_test.rs
@@ -23,7 +23,7 @@ fn fixture_root() -> PathBuf {
 fn test_explain_field_provenance_shows_winning_layer() {
     // The nested_composition_pipeline.yaml has composition node
     // "nested_process" with config param "strict_mode" (default: false,
-    // call-site: false). Provenance should show CompositionDefault as winner.
+    // call-site: false). Provenance should show PipelineDefault as winner.
     let fixture_dir = fixture_root();
     let pipeline_path = fixture_dir.join("pipelines/nested_composition_pipeline.yaml");
     let output = Command::new(clinker_bin())
@@ -52,8 +52,8 @@ fn test_explain_field_provenance_shows_winning_layer() {
 
     // Must show the winning layer kind
     assert!(
-        stdout.contains("CompositionDefault"),
-        "output must show CompositionDefault layer.\nstdout: {stdout}"
+        stdout.contains("PipelineDefault"),
+        "output must show PipelineDefault layer.\nstdout: {stdout}"
     );
 
     // Must show the field path header

--- a/docs/explain/E105.md
+++ b/docs/explain/E105.md
@@ -24,12 +24,13 @@ and use only valid keys.
 
 ## Technical context
 
-Channel bindings are validated against the target's declared config schema
-during Phase 1. Per LD-16c-4, each `.channel.yaml` targets exactly one
-pipeline or composition. Per LD-16c-8, there is no channel layering —
-each channel file is self-contained, keeping the provenance chain bounded
-at 4 layer kinds (CompositionDefault, ChannelDefault, ChannelFixed,
-InspectorEdit).
+Channel bindings are validated against the target's declared config schema.
+Each `.channel.yaml` targets exactly one pipeline or composition. A channel's
+`config` values resolve through a fixed semantic layer order
+(`PipelineDefault < Group(s) by priority < ChannelWide < ChannelPerTarget`) as
+a clobber — a higher layer's value fully replaces the lower one, and each
+resolved value maps to exactly one winning layer. E105 rejects a key that is
+not declared in the target's config schema before any layering happens.
 
 ## See also
 

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -106,7 +106,7 @@ Channels that target a `.comp.yaml` may not carry a `vars:` block (composition v
 | **E234** | `array_paths` patch `remove` of a path with no matching entry. |
 | **E235** | `options` patch sets an unknown or mistyped option key for the source's format. |
 | **E236** | A renamed/aliased column's exposed name collides with a real input field, which would mislocate that field. Raised at read time. |
-| **W103** | Channel `config.*` key did not match any composition parameter in the compiled plan. |
+| **E113** | Channel `config.*` key matches no composition parameter in the compiled plan. A misspelled or stale key aborts the run instead of silently doing nothing. |
 | **W104** | `channel.target` does not match the `<config>` argument passed to `clinker run`. |
 
 ### Cross-Transform declaration uniqueness


### PR DESCRIPTION
## What

Generalize the config-value provenance model in `clinker-plan` so the
layer-kind is a **type parameter**, and replace the four fixed layer variants
with the multi-tenant overlay stack.

- `ResolvedValue<T, L = LayerKind>` and `ProvenanceLayer<L = LayerKind>` are now
  generic over any `L: Copy + Ord`. Precedence, `fixed`-lock resolution, and
  single-winner selection are defined purely in terms of `L: Ord`, so a future
  schema-attribute resolver can reuse the exact same implementation with its own
  layer kind and **zero duplication**. The composition instantiation keeps the
  default `L = LayerKind`, so existing `ResolvedValue<serde_json::Value>`
  spellings are unchanged.
- The composition `LayerKind` becomes the semantic stack
  `PipelineDefault < Group { priority, seq } < ChannelWide < ChannelPerTarget`.
  Groups are **dynamic**: any number may match a tenant, ordered by `priority`
  (higher wins) then a declaration-order source id `seq` (later declaration wins
  ties). Every matching group is its own layer.
- A layer may be `fixed`, locking its value against every higher-precedence
  layer ("nothing downstream may override"). When several layers are fixed, the
  lowest-precedence one wins because it locked the value first. Resolution is
  **order-independent** — decided by the layer set, never by application order
  or file position.
- `layer_values` is now an ordered `Vec<(L, T)>` (was a fixed-size map), so each
  matching group keeps its own shadowed value for `explain --field`.
- The `ProvenanceLayer <= 64-byte` compile-time size assertion is preserved.

## Why

The overlay clobbers (each value fully replaces, never deep-merges), so
provenance must stay 1:1 — every resolved value maps to exactly one source
layer, making "where did this value come from?" answerable with a single layer.
Precedence is a fixed *semantic* total order rather than lexical/positional,
avoiding the position-dependent precedence traps common in layered-config
systems. Making the layer kind a type parameter lets the upcoming per-attribute
schema resolver reuse this machinery instead of copying it.

## Tests

Added unit tests in `provenance.rs` covering: total-order precedence across the
stack; multiple groups ordered by priority then declaration order; the `fixed`
lock winning over later/higher layers (including lowest-fixed-wins among several
fixed layers); the exactly-one-winning-layer invariant; same-kind
replace-in-place; shadowed-value retention; and generic reuse over an arbitrary
`Copy + Ord` layer kind (a stand-in for the future schema layer).

`cargo test -p clinker-plan` and `cargo clippy -p clinker-plan --all-targets -- -D warnings`
are green; `cargo fmt --all --check` is clean.

## Scope note

This is a scoped rip of the provenance model only. The old variant names
(`CompositionDefault`/`ChannelDefault`/`ChannelFixed`/`InspectorEdit`) are gone,
so the channel-overlay and downstream consumers that still reference them are
updated by their own follow-up changes as the overlay engine is wired onto this
new model; this change deliberately does not touch those crates.

Part of #515
