### PR TITLE
clinker-channel: group serde model (group/*.group.yaml)

### DIFF
--- a/crates/clinker-channel/src/group.rs
+++ b/crates/clinker-channel/src/group.rs
@@ -88,7 +88,7 @@ impl Group {
         })?;
         let raw: RawGroupFile =
             clinker_plan::yaml::from_str(text).map_err(|e| ChannelError::Yaml {
-                path: source_path.clone(),
+                path: source_path,
                 source: Box::new(e.0),
             })?;
 

--- a/crates/clinker-channel/src/group.rs
+++ b/crates/clinker-channel/src/group.rs
@@ -1,0 +1,134 @@
+//! Group serde model (`group/*.group.yaml`).
+//!
+//! A group is a reusable overlay layer that sits between the pipeline default
+//! and the channel layers in the fixed precedence order
+//! `pipeline-default < group(s) by priority < channel-wide < channel-per-target`.
+//! It carries the same two overlay surfaces every layer carries — a value
+//! clobber (`config:` / `vars:`) and an ordered op list (`overrides:`).
+//!
+//! A group plays two roles under one concept:
+//!
+//! - **Selector-derived grouping** — when `match:` is present, the group is
+//!   selected automatically for every channel whose `labels` satisfy the CXL
+//!   boolean. Multiple matching groups are ordered by `priority` (higher wins).
+//! - **Explicit-only profile/variant** — when `match:` is absent, the group is
+//!   never auto-selected; it applies only when invoked by name (`--group`).
+//!
+//! Groups are channel-agnostic: their overrides never read channel labels, so a
+//! group can run standalone.
+//!
+//! This module is **parse only**. The `match:` selector is a CXL boolean string
+//! here; compiling and evaluating it against a channel's labels happens later.
+//! The `overrides:` entries are preserved verbatim as raw values; the typed op
+//! vocabulary (`add` / `remove` / `replace` / `set` / `patch_schema` / `bypass`)
+//! is owned by the overlay op engine and interpreted there, not here.
+//!
+//! The four-scope `vars:` surface reuses [`ChannelVars`](crate::manifest::ChannelVars),
+//! the same value-clobber vars type the channel manifest and per-target overlay
+//! files use — a group's vars are identical in shape to a channel's.
+
+use std::path::{Path, PathBuf};
+
+use indexmap::IndexMap;
+use serde::Deserialize;
+
+use crate::error::ChannelError;
+use crate::manifest::ChannelVars;
+
+/// Priority applied to a group that omits `priority:`.
+///
+/// Higher priority wins among multiple matching groups, so the baseline is the
+/// lowest rung: an unprioritized group is overridden by any group that opts
+/// into an explicit positive priority.
+const DEFAULT_GROUP_PRIORITY: i64 = 0;
+
+fn default_priority() -> i64 {
+    DEFAULT_GROUP_PRIORITY
+}
+
+/// A parsed `group/*.group.yaml` file.
+///
+/// The fields mirror the canonical group schema. `config` / `vars` are the
+/// value-clobber surface; `overrides` is the ordered op-list surface preserved
+/// verbatim for the op engine to interpret.
+#[derive(Debug, Clone)]
+pub struct Group {
+    /// Group identifier (`group.name`). Also the handle used by `--group`.
+    pub name: String,
+    /// Optional CXL boolean over channel `labels` (YAML `group.match`). `None`
+    /// means the group is explicit-only (never auto-selected). The expression
+    /// is stored as text here and compiled later.
+    pub selector: Option<String>,
+    /// Selection priority (`group.priority`); higher wins among multiple
+    /// matching groups. Defaults to [`DEFAULT_GROUP_PRIORITY`] when absent.
+    pub priority: i64,
+    /// Value-clobber config surface. Keys are `alias.param` dotted paths (kept
+    /// as raw strings here; dotted-path validation happens at apply time).
+    pub config: IndexMap<String, serde_json::Value>,
+    /// Value-clobber vars surface, in the same four scopes a pipeline's `vars:`
+    /// block uses (`static` / `pipeline` / `source` / `record`). Reuses the
+    /// channel overlay's [`ChannelVars`](crate::manifest::ChannelVars) type.
+    pub vars: ChannelVars,
+    /// Ordered override ops, preserved verbatim. The typed op vocabulary is
+    /// owned by the overlay op engine and interpreted there; this stage only
+    /// captures the raw entries without losing information.
+    pub overrides: Vec<serde_json::Value>,
+}
+
+impl Group {
+    /// Parse a `group/*.group.yaml` from raw bytes.
+    ///
+    /// `source_path` is used only for diagnostic context on parse failure. All
+    /// parsing goes through [`clinker_plan::yaml::from_str`] so the shared
+    /// parse budget applies.
+    pub fn from_yaml_bytes(bytes: &[u8], source_path: PathBuf) -> Result<Self, ChannelError> {
+        let text = std::str::from_utf8(bytes).map_err(|e| ChannelError::Utf8 {
+            path: source_path.clone(),
+            source: e,
+        })?;
+        let raw: RawGroupFile =
+            clinker_plan::yaml::from_str(text).map_err(|e| ChannelError::Yaml {
+                path: source_path.clone(),
+                source: Box::new(e.0),
+            })?;
+
+        Ok(Group {
+            name: raw.group.name,
+            selector: raw.group.selector,
+            priority: raw.group.priority,
+            config: raw.config,
+            vars: raw.vars,
+            overrides: raw.overrides,
+        })
+    }
+
+    /// Load and parse a single `group/*.group.yaml` file from disk.
+    pub fn load(path: &Path) -> Result<Self, ChannelError> {
+        let bytes = std::fs::read(path)?;
+        Self::from_yaml_bytes(&bytes, path.to_path_buf())
+    }
+}
+
+// ── Serde intermediate types ────────────────────────────────────────────
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawGroupFile {
+    group: RawGroupMeta,
+    #[serde(default)]
+    config: IndexMap<String, serde_json::Value>,
+    #[serde(default)]
+    vars: ChannelVars,
+    #[serde(default)]
+    overrides: Vec<serde_json::Value>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawGroupMeta {
+    name: String,
+    #[serde(default, rename = "match")]
+    selector: Option<String>,
+    #[serde(default = "default_priority")]
+    priority: i64,
+}

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -52,6 +52,7 @@
 
 pub mod binding;
 pub mod error;
+pub mod group;
 pub mod manifest;
 pub mod overlay;
 pub mod staging_copy;
@@ -61,6 +62,7 @@ pub use binding::{
     ChannelBinding, ChannelTarget, DottedPath, scan_workspace_channels, validate_channel_bindings,
 };
 pub use error::ChannelError;
+pub use group::Group;
 pub use manifest::{ChannelManifest, ChannelVars, ManifestHeader, OverlayFile, OverlayHeader};
 pub use overlay::{ChannelOverlayResult, apply_channel_overlay};
 pub use staging_copy::{

--- a/crates/clinker-channel/tests/group_parse_test.rs
+++ b/crates/clinker-channel/tests/group_parse_test.rs
@@ -1,0 +1,208 @@
+//! Parse coverage for the `group/*.group.yaml` serde model (issue #518, CH-3).
+//!
+//! These tests pin the on-the-wire YAML surface for a group: the
+//! `group.name` / `group.match` / `group.priority` header, the value-clobber
+//! `config:` / `vars:` surfaces, and the verbatim `overrides:` op list. The
+//! `match:` selector is a CXL boolean string (compiled elsewhere) and the
+//! `overrides:` entries are preserved raw here — this stage is parse only.
+//!
+//! The four-scope `vars:` surface reuses the channel overlay's `ChannelVars`
+//! type, so the static scope is read via `vars.static_scope`.
+
+use std::path::PathBuf;
+
+use clinker_channel::Group;
+use clinker_plan::config::ScopedVarType;
+
+fn group(yaml: &[u8]) -> Group {
+    Group::from_yaml_bytes(yaml, PathBuf::from("test.group.yaml")).expect("group YAML parses")
+}
+
+#[test]
+fn no_selector_group_defaults_priority_and_has_no_match() {
+    // A selector-less group is explicit-only: `match` is absent, and with
+    // `priority` also absent the default (0) is applied.
+    let g = group(
+        br#"
+group:
+  name: nightly
+"#,
+    );
+
+    assert_eq!(g.name, "nightly");
+    assert_eq!(g.selector, None, "absent `match` parses as None");
+    assert_eq!(g.priority, 0, "absent `priority` defaults to 0");
+    assert!(g.config.is_empty());
+    assert!(g.overrides.is_empty());
+    assert!(g.vars.static_scope.is_empty());
+    assert!(g.vars.pipeline.is_empty());
+    assert!(g.vars.source.is_empty());
+    assert!(g.vars.record.is_empty());
+}
+
+#[test]
+fn multi_key_match_selector_is_preserved_verbatim() {
+    // A `match` referencing several label keys is stored as the raw CXL string.
+    let expr = r#"tier == "enterprise" && region == "west""#;
+    let g = group(
+        br#"
+group:
+  name: enterprise_west
+  match: 'tier == "enterprise" && region == "west"'
+  priority: 30
+"#,
+    );
+
+    assert_eq!(g.selector.as_deref(), Some(expr));
+    assert_eq!(g.priority, 30);
+}
+
+#[test]
+fn explicit_priority_overrides_default() {
+    let g = group(
+        br#"
+group:
+  name: high
+  priority: 100
+"#,
+    );
+    assert_eq!(g.priority, 100);
+    assert_eq!(g.selector, None);
+}
+
+#[test]
+fn negative_priority_is_accepted() {
+    // `priority` is a signed i64; a group can deliberately sit below the
+    // unprioritized baseline.
+    let g = group(
+        br#"
+group:
+  name: fallback
+  priority: -5
+"#,
+    );
+    assert_eq!(g.priority, -5);
+}
+
+#[test]
+fn full_group_parses_all_surfaces() {
+    let g = group(
+        br#"
+group:
+  name: enterprise
+  match: 'tier == "enterprise"'
+  priority: 20
+config:
+  fraud_check.threshold: 0.9
+  region: west
+vars:
+  static:
+    currency: { type: string, default: "USD" }
+  pipeline:
+    batch_size: { type: int, default: 500 }
+  source:
+    orders:
+      cutoff: { type: date }
+  record:
+    seen: { type: bool, default: false }
+overrides:
+  - op: add
+    composition: ../composition/fraud_check.comp.yaml
+    alias: fraud_check
+    after: normalize_fields
+    config: { threshold: 0.80 }
+  - op: set
+    target: route_priority
+    field: config.cxl
+    value: "emit x = 1"
+"#,
+    );
+
+    assert_eq!(g.name, "enterprise");
+    assert_eq!(g.selector.as_deref(), Some(r#"tier == "enterprise""#));
+    assert_eq!(g.priority, 20);
+
+    // Value-clobber config keeps dotted keys as raw strings.
+    assert_eq!(
+        g.config
+            .get("fraud_check.threshold")
+            .and_then(|v| v.as_f64()),
+        Some(0.9)
+    );
+    assert_eq!(
+        g.config.get("region").and_then(|v| v.as_str()),
+        Some("west")
+    );
+
+    // Vars parse into ScopedVarDecl across all four scopes.
+    let currency = &g.vars.static_scope["currency"];
+    assert_eq!(currency.var_type, ScopedVarType::String);
+    assert_eq!(
+        currency.default.as_ref().and_then(|v| v.as_str()),
+        Some("USD")
+    );
+    assert_eq!(g.vars.pipeline["batch_size"].var_type, ScopedVarType::Int);
+    assert_eq!(
+        g.vars.source["orders"]["cutoff"].var_type,
+        ScopedVarType::Date
+    );
+    assert_eq!(g.vars.record["seen"].var_type, ScopedVarType::Bool);
+
+    // Overrides are preserved verbatim, in declaration order.
+    assert_eq!(g.overrides.len(), 2);
+    assert_eq!(
+        g.overrides[0].get("op").and_then(|v| v.as_str()),
+        Some("add")
+    );
+    assert_eq!(
+        g.overrides[0].get("alias").and_then(|v| v.as_str()),
+        Some("fraud_check")
+    );
+    assert_eq!(
+        g.overrides[1].get("op").and_then(|v| v.as_str()),
+        Some("set")
+    );
+}
+
+#[test]
+fn unknown_top_level_key_is_a_parse_error() {
+    // deny_unknown_fields rejects a stray top-level key (e.g. a typo of
+    // `overrides`), rather than silently dropping it.
+    let err = Group::from_yaml_bytes(
+        br#"
+group:
+  name: typo
+overides: []
+"#,
+        PathBuf::from("bad.group.yaml"),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("YAML parse error"), "{err}");
+}
+
+#[test]
+fn unknown_group_header_key_is_a_parse_error() {
+    let err = Group::from_yaml_bytes(
+        br#"
+group:
+  name: bad
+  weight: 5
+"#,
+        PathBuf::from("bad.group.yaml"),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("YAML parse error"), "{err}");
+}
+
+#[test]
+fn missing_name_is_a_parse_error() {
+    let err = Group::from_yaml_bytes(
+        br#"
+group:
+  priority: 10
+"#,
+        PathBuf::from("bad.group.yaml"),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("YAML parse error"), "{err}");
+}


### PR DESCRIPTION
## What

Adds a parse-only serde model for group overlay files (`group/*.group.yaml`) in `clinker-channel`, plus its parse-coverage tests.

A group is a reusable overlay layer that sits between the pipeline default and the channel layers in the fixed precedence order `pipeline-default < group(s) by priority < channel-wide < channel-per-target`. It carries the same two overlay surfaces every layer carries: a value clobber (`config:` / `vars:`) and an ordered op list (`overrides:`).

`Group` fields:

- `name` — group identifier, and the handle used to invoke a group explicitly.
- `match` (optional, stored as `selector`) — a CXL boolean over a channel's `labels`. When present, the group is auto-selected for every channel whose labels satisfy it; when absent, the group is explicit-only (never auto-selected).
- `priority` (signed `i64`, defaults to `0`) — orders multiple matching groups; higher wins.
- `config` / `vars` — the value-clobber overlay surfaces.
- `overrides` — an ordered override op list, preserved verbatim.

## Why

`match` is optional and `priority` is explicit because a group serves two roles under one construct: a selector-derived tenant grouping (when `match` is present) and an explicitly-invoked profile/variant (when absent). Collapsing both roles into one construct avoids maintaining two parallel override systems, and groups stay channel-agnostic in their overrides, which is what lets a group run standalone.

## Scope

Parse only. The `match` selector is stored as text (compiled and evaluated against labels downstream); the `overrides` entries are preserved verbatim (the typed op vocabulary is owned by the overlay op engine and interpreted there). Parsing goes through the shared budgeted YAML entry point, and the four-scope `vars:` surface reuses the existing channel-overlay `ChannelVars` type rather than duplicating it. `deny_unknown_fields` rejects stray keys at the file, header, and vars levels.

## Tests

`crates/clinker-channel/tests/group_parse_test.rs` covers: a no-selector group, a multi-key `match`, the `priority` default when absent plus explicit and negative values, a full group exercising every surface (all four vars scopes + config + overrides), and rejection of unknown top-level / unknown header / missing-name keys.

Validated: `cargo fmt --all --check`, `cargo test -p clinker-channel`, `cargo clippy -p clinker-channel --all-targets -- -D warnings` — all clean.

Closes #518
Part of #515