### PR TITLE
chore(deps): upgrade quick-xml to 0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1481,9 +1481,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 serial_test = "3"
 petgraph = "0.8"
 fastrand = "2"
-quick-xml = "0.37"
+quick-xml = "0.41"
 # Synchronous HTTP client for the `rest` source transport. rustls + ring
 # only (pure-Rust TLS) — `default-features = false` drops the native-tls
 # path so no openssl/native-tls/cmake enters the graph.

--- a/crates/clinker-format/Cargo.toml
+++ b/crates/clinker-format/Cargo.toml
@@ -11,7 +11,7 @@ cxl = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 csv = "1"
-quick-xml = "0.37"
+quick-xml = "0.41"
 chrono = { workspace = true }
 miette = { workspace = true }
 tracing = { workspace = true }

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -25,7 +25,8 @@ use std::sync::Arc;
 
 use indexmap::IndexMap;
 use quick_xml::Reader as XmlParser;
-use quick_xml::events::Event;
+use quick_xml::escape;
+use quick_xml::events::{BytesRef, Event};
 
 use clinker_record::{Record, Schema, SchemaBuilder, Value};
 
@@ -229,8 +230,12 @@ impl XmlReader {
     /// Returns [`FormatError::Io`] if the source cannot be opened.
     fn open_body(source: &ReopenableSource) -> Result<(BodyParser, SourceIdentity), FormatError> {
         let (buf, identity) = Self::open_buf(source)?;
-        let mut parser = XmlParser::from_reader(buf);
-        parser.config_mut().trim_text(true);
+        let parser = XmlParser::from_reader(buf);
+        // Text-node whitespace is trimmed when a run is finalized
+        // ([`finalize_text_run`]), not per parser event: quick-xml splits a
+        // text node into `Text` + `GeneralRef` fragments, and per-fragment
+        // trimming would eat whitespace adjacent to a reference. Trimming the
+        // reassembled raw node instead keeps reference-produced whitespace.
         Ok((parser, identity))
     }
 
@@ -298,6 +303,7 @@ impl XmlReader {
                     return Ok(None);
                 }
                 Event::Text(_)
+                | Event::GeneralRef(_)
                 | Event::CData(_)
                 | Event::Comment(_)
                 | Event::Decl(_)
@@ -318,6 +324,12 @@ impl XmlReader {
         let mut fields = start_attrs;
         let record_depth = self.xml_depth;
         let mut element_stack: Vec<String> = Vec::new();
+        // Raw source form of the current text node, accumulated across the
+        // `Text` + `GeneralRef` fragment run quick-xml splits a text node into.
+        // Flushed — trimmed and reference-resolved — at the next structural
+        // event, yielding one field per text node exactly as a single `Text`
+        // event did before the 0.41 reference split.
+        let mut text_run = String::new();
         let mut buf2 = Vec::new();
 
         loop {
@@ -326,6 +338,12 @@ impl XmlReader {
                 .parser
                 .read_event_into(&mut buf2)
                 .map_err(|e| FormatError::Xml(e.to_string()))?;
+
+            // Any event other than a text fragment terminates the current text
+            // node; resolve and push it before handling the structural event.
+            if !matches!(&event, Event::Text(_) | Event::GeneralRef(_)) {
+                flush_text_field(&mut fields, &element_stack, &mut text_run)?;
+            }
 
             match event {
                 Event::Start(ref e) => {
@@ -359,16 +377,10 @@ impl XmlReader {
                     }
                 }
                 Event::Text(ref t) => {
-                    let text = t
-                        .unescape()
-                        .map_err(|e| FormatError::Xml(e.to_string()))?
-                        .into_owned();
-                    if !text.is_empty() {
-                        let field_name = element_stack.join(".");
-                        if !field_name.is_empty() {
-                            fields.push((field_name, text));
-                        }
-                    }
+                    text_run.push_str(&t.decode().map_err(|e| FormatError::Xml(e.to_string()))?);
+                }
+                Event::GeneralRef(ref r) => {
+                    append_general_ref(&mut text_run, r)?;
                 }
                 Event::CData(ref cd) => {
                     let text = String::from_utf8_lossy(cd.as_ref()).into_owned();
@@ -629,13 +641,75 @@ pub(crate) fn extract_attributes_static(
     for attr in elem.attributes() {
         let attr = attr.map_err(|e| FormatError::Xml(e.to_string()))?;
         let key = String::from_utf8_lossy(attr.key.as_ref()).into_owned();
-        let val = attr
-            .unescape_value()
+        // Resolve entity and character references over the UTF-8-decoded raw
+        // value — the exact behavior of the removed `unescape_value()`. The
+        // `normalized_value` replacement additionally collapses literal tab / CR
+        // / LF to a space (XML attribute-value normalization), which would alter
+        // attribute values carrying literal whitespace, so it is not used here.
+        let decoded = std::str::from_utf8(attr.value.as_ref())
+            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        let val = escape::unescape(decoded)
             .map_err(|e| FormatError::Xml(e.to_string()))?
             .into_owned();
         attrs.push((format!("{prefix}{key}"), val));
     }
     Ok(attrs)
+}
+
+/// True for the whitespace characters XML (and quick-xml's `trim_text`)
+/// trims from a text node: space, tab, carriage return, line feed.
+fn is_xml_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\r' | '\n')
+}
+
+/// Append a general or character reference to a raw text run in its source
+/// form (`&name;`), so it resolves alongside the rest of the run in
+/// [`finalize_text_run`].
+///
+/// quick-xml emits each `&name;` in a text node as its own `GeneralRef`
+/// event carrying just the inner `name` (`amp`, `#65`, `#x41`, …); rewrapping
+/// it lets one [`escape::unescape`] pass decode the whole node.
+pub(crate) fn append_general_ref(raw: &mut String, r: &BytesRef) -> Result<(), FormatError> {
+    let name = r.decode().map_err(|e| FormatError::Xml(e.to_string()))?;
+    raw.push('&');
+    raw.push_str(&name);
+    raw.push(';');
+    Ok(())
+}
+
+/// Resolve one accumulated text node's raw source form into its final value.
+///
+/// Reproduces the pre-0.41 `trim_text(true)` + `BytesText::unescape()`
+/// behavior: the raw node — `Text` fragments verbatim, each reference rewrapped
+/// as `&name;` by [`append_general_ref`] — is edge-trimmed on the XML
+/// whitespace set, then predefined entities and character references are
+/// resolved by [`escape::unescape`]. Trimming the reassembled raw node (rather
+/// than each fragment) preserves whitespace produced by a reference such as
+/// `&#32;`, and an unknown entity still errors, exactly as before.
+pub(crate) fn finalize_text_run(raw: &str) -> Result<String, FormatError> {
+    let trimmed = raw.trim_matches(is_xml_whitespace);
+    let value = escape::unescape(trimmed).map_err(|e| FormatError::Xml(e.to_string()))?;
+    Ok(value.into_owned())
+}
+
+/// Resolve the current text run and push it, if non-empty, as a field keyed by
+/// the innermost open element's dotted path. Text directly under the record
+/// element (empty path) or an empty resolved value pushes nothing. Clears
+/// `text_run` for the next node.
+fn flush_text_field(
+    fields: &mut Vec<(String, String)>,
+    element_stack: &[String],
+    text_run: &mut String,
+) -> Result<(), FormatError> {
+    let value = finalize_text_run(text_run)?;
+    text_run.clear();
+    if !value.is_empty() {
+        let field_name = element_stack.join(".");
+        if !field_name.is_empty() {
+            fields.push((field_name, value));
+        }
+    }
+    Ok(())
 }
 
 /// Consume a single leading UTF-8 BOM from a freshly opened reader, if present.
@@ -1191,5 +1265,83 @@ mod tests {
         let r2 = r.next_record().unwrap().unwrap();
         assert_eq!(r2.get("name"), Some(&Value::String("Bob".into())));
         assert_eq!(r2.get("bonus"), Some(&Value::String("flagged".into())));
+    }
+
+    #[test]
+    fn test_xml_reads_entities_and_char_refs_in_element_text() {
+        // Predefined entities and character references in element text decode
+        // to their characters. quick-xml emits each reference as its own event
+        // separate from the surrounding text; the reader reassembles the whole
+        // text node before decoding, so a value split across references is
+        // recovered intact rather than truncated at the first fragment.
+        let xml = r#"<Root><Item><amp>a &amp; b</amp><lt>&lt;tag&gt;</lt><num>&#65;&#66;</num></Item></Root>"#;
+        let mut r = reader_from_str(xml, default_config_with_path("Root/Item"));
+        let _s = r.schema().unwrap();
+        let rec = r.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("amp"), Some(&Value::String("a & b".into())));
+        assert_eq!(rec.get("lt"), Some(&Value::String("<tag>".into())));
+        assert_eq!(rec.get("num"), Some(&Value::String("AB".into())));
+    }
+
+    #[test]
+    fn test_xml_text_trims_source_whitespace_but_preserves_reference_whitespace() {
+        // Text-node whitespace trimming applies to the source bytes, not the
+        // decoded value: literal leading/trailing whitespace is trimmed, but
+        // whitespace that surrounds — or is produced by — a reference is kept.
+        let xml = concat!(
+            "<Root><Item>",
+            "<pad>  hello  </pad>",       // literal edge whitespace trimmed
+            "<around>x &amp; y</around>", // spaces around an entity preserved
+            "<charws>&#32;hi</charws>",   // leading space from a char ref preserved
+            "</Item></Root>",
+        );
+        let mut r = reader_from_str(xml, default_config_with_path("Root/Item"));
+        let _s = r.schema().unwrap();
+        let rec = r.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("pad"), Some(&Value::String("hello".into())));
+        assert_eq!(rec.get("around"), Some(&Value::String("x & y".into())));
+        assert_eq!(rec.get("charws"), Some(&Value::String(" hi".into())));
+    }
+
+    #[test]
+    fn test_xml_attribute_preserves_literal_whitespace() {
+        // Attribute decoding resolves references only; it does not apply XML
+        // attribute-value whitespace normalization, so a literal newline or tab
+        // inside a value is preserved rather than collapsed to a space.
+        let xml = "<Root><Item title=\"Hello\nWorld\" tab=\"a\tb\"/></Root>";
+        let mut r = reader_from_str(xml, default_config_with_path("Root/Item"));
+        let _s = r.schema().unwrap();
+        let rec = r.next_record().unwrap().unwrap();
+        assert_eq!(
+            rec.get("@title"),
+            Some(&Value::String("Hello\nWorld".into()))
+        );
+        assert_eq!(rec.get("@tab"), Some(&Value::String("a\tb".into())));
+    }
+
+    #[test]
+    fn test_xml_attribute_resolves_entities_and_char_refs() {
+        // Predefined entities and character references in an attribute value
+        // decode to their characters, matching the prior `unescape_value`.
+        let xml = r#"<Root><Item note="a &amp; b &#65;"/></Root>"#;
+        let mut r = reader_from_str(xml, default_config_with_path("Root/Item"));
+        let _s = r.schema().unwrap();
+        let rec = r.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("@note"), Some(&Value::String("a & b A".into())));
+    }
+
+    #[test]
+    fn test_xml_unknown_entity_in_text_errors() {
+        // An unrecognized general entity in element text is rejected, matching
+        // the strict decoding the reader applied before the parser upgrade.
+        // Schema inference reads the first record eagerly, so the error may
+        // surface from either `schema` or `next_record`.
+        let xml = r#"<Root><Item><v>&nope;</v></Item></Root>"#;
+        let mut r = reader_from_str(xml, default_config_with_path("Root/Item"));
+        let outcome = match r.schema() {
+            Err(e) => Err(e),
+            Ok(_) => r.next_record(),
+        };
+        assert!(matches!(outcome, Err(FormatError::Xml(_))));
     }
 }

--- a/crates/clinker-format/src/xml/streaming.rs
+++ b/crates/clinker-format/src/xml/streaming.rs
@@ -27,7 +27,10 @@ use quick_xml::Reader as XmlParser;
 use quick_xml::events::Event;
 
 use crate::error::FormatError;
-use crate::xml::reader::{BodyParser, NamespaceMode, elem_name_static, extract_attributes_static};
+use crate::xml::reader::{
+    BodyParser, NamespaceMode, append_general_ref, elem_name_static, extract_attributes_static,
+    finalize_text_run,
+};
 
 /// One matched section's name paired with its flat `(field, raw_string)`
 /// payload, as produced by [`extract_sections`].
@@ -83,8 +86,10 @@ pub(crate) fn extract_sections(
     attr_prefix: &str,
     max_index_bytes: Option<usize>,
 ) -> Result<Vec<MatchedSection>, FormatError> {
+    // Text nodes are trimmed when a run is finalized in `read_section_payload`,
+    // not per parser event, so reference-adjacent whitespace survives the
+    // `Text`/`GeneralRef` fragment split (see `finalize_text_run`).
     let mut parser = XmlParser::from_reader(reader);
-    parser.config_mut().trim_text(true);
 
     let parse_ctx = SectionParseCtx { ns, attr_prefix };
     let mut path_stack: Vec<String> = Vec::new();
@@ -236,11 +241,30 @@ fn read_section_payload(
     let mut fields: Vec<(String, String)> = seed;
     let mut element_stack: Vec<String> = Vec::new();
     let mut depth_here = section_depth;
+    // Raw source form of the current text node, accumulated across the
+    // `Text` + `GeneralRef` fragments quick-xml splits a text node into and
+    // flushed at the next structural event — see `read::finalize_text_run`.
+    let mut text_run = String::new();
     loop {
         buf.clear();
         let event = parser
             .read_event_into(buf)
             .map_err(|e| FormatError::Xml(e.to_string()))?;
+
+        // Any event other than a text fragment ends the current text node;
+        // resolve, charge, and retain it before handling the structural event.
+        if !matches!(&event, Event::Text(_) | Event::GeneralRef(_)) {
+            let value = finalize_text_run(&text_run)?;
+            text_run.clear();
+            if !value.is_empty() {
+                let field_name = element_stack.join(".");
+                if !field_name.is_empty() {
+                    charge.charge(field_name.len() + value.len(), section)?;
+                    fields.push((field_name, value));
+                }
+            }
+        }
+
         match event {
             Event::Start(ref e) => {
                 depth_here += 1;
@@ -278,17 +302,10 @@ fn read_section_payload(
                 }
             }
             Event::Text(ref t) => {
-                let text = t
-                    .unescape()
-                    .map_err(|e| FormatError::Xml(e.to_string()))?
-                    .into_owned();
-                if !text.is_empty() {
-                    let field_name = element_stack.join(".");
-                    if !field_name.is_empty() {
-                        charge.charge(field_name.len() + text.len(), section)?;
-                        fields.push((field_name, text));
-                    }
-                }
+                text_run.push_str(&t.decode().map_err(|e| FormatError::Xml(e.to_string()))?);
+            }
+            Event::GeneralRef(ref r) => {
+                append_general_ref(&mut text_run, r)?;
             }
             Event::CData(ref cd) => {
                 let text = String::from_utf8_lossy(cd.as_ref()).into_owned();


### PR DESCRIPTION
## Why

`quick-xml` 0.37 is flagged by two RUSTSEC advisories, which fail the workspace `cargo-deny` advisories check and turn every open PR red on the `deny` gate:

- **RUSTSEC-2026-0194** — quadratic runtime in the duplicate-attribute check.
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation (memory-exhaustion DoS).

Both are fixed in `quick-xml >= 0.41.0`. This bumps the pin to `0.41` in the workspace root and in `clinker-format`, regenerates `Cargo.lock` (resolves `0.41.0`; the crate's only dependency, `memchr`, is unchanged), and adapts the XML usage sites. No new dependency is introduced.

## API changes adapted (behavior preserved)

The 0.41 reader API changed in two ways that affect `clinker-format`'s XML reader and streaming envelope pre-scan. Both were adapted to preserve the previous read behavior exactly:

- **General/character references are now separate events.** 0.41 splits `&amp;`, `&lt;`, `&#65;`, etc. out of `Event::Text` into a new `Event::GeneralRef`, and removed `BytesText::unescape()`. The reader now reassembles each text node from its `Text` + `GeneralRef` fragments in raw source form and resolves it once through `quick_xml::escape::unescape` — the same routine the old `unescape()` used. Whitespace trimming moved from the parser config onto the reassembled node, so whitespace produced by a reference (e.g. `&#32;`) is preserved rather than trimmed per fragment. One field is still produced per text node, in the same order.
- **Attribute decoding.** `Attribute::unescape_value()` is deprecated in favor of `normalized_value()`, but `normalized_value()` additionally applies XML attribute-value normalization (collapsing literal tab/CR/LF to a space). To keep the prior output byte-for-byte, attribute values are decoded with `quick_xml::escape::unescape` over the UTF-8 raw value — entity and character-reference resolution only, no whitespace normalization.

The writer required no changes; its `BytesText`/`BytesStart`/`Writer` APIs are unchanged and still escape output identically.

## Behavior preservation

The full `clinker-format` XML suite is the behavior guard and stays green, including the round-trip, escaping, CDATA, namespace, and envelope pre-scan tests. New regression tests cover the paths the upgrade touched:

- entity and character-reference decoding in both element text and attribute values,
- source-whitespace trimming vs. reference-produced whitespace (`x &amp; y` → `x & y`, `&#32;hi` → ` hi`),
- literal tab/newline preservation in attribute values,
- unknown-entity rejection still errors.

## Validation

- `cargo test -p clinker-format` — green (unit + XML/JSON streaming integration tests, plus the new regression tests).
- `cargo test -p clinker-exec` XML integration tests (format dispatch, streaming arms, envelope/doc-context) — green.
- `cargo check -p clinker-bench-support` and its tests — green.
- `cargo clippy -p clinker-format --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `cargo deny check advisories` — advisories ok (both advisories cleared).
