### PR TITLE
Channel-centric discovery and computed-path overlay resolution

### DIFF
--- a/crates/clinker-channel/AGENTS.md
+++ b/crates/clinker-channel/AGENTS.md
@@ -19,7 +19,9 @@ Root `AGENTS.md` still applies. This file adds local guidance for `clinker-chann
 
 - `ChannelBinding`, `ChannelTarget`, `DottedPath`
 - `ChannelBinding::{from_yaml_bytes, load}`
-- `scan_workspace_channels`, `validate_channel_bindings`
+- `validate_channel_bindings`
+- `resolve_channel_overlay`, `scan_channels`, `scan_groups`, `channel_folder_path`
+- `DiscoveredChannel`, `ResolvedOverlay`, `OverlayKind`
 - `apply_channel_overlay`, `ChannelOverlayResult`
 - `SourceStager`, `StagingPlanEntry`, `ReuseDecision`, `open_source_file`
 - `ChannelError`, `StagingError`
@@ -27,7 +29,8 @@ Root `AGENTS.md` still applies. This file adds local guidance for `clinker-chann
 ## Internal module map
 
 - `src/lib.rs`: channel authoring guide and crate-root re-exports.
-- `src/binding.rs`: channel YAML parsing, target classification, dotted-path validation, workspace scan, and composition-target validation.
+- `src/binding.rs`: channel YAML parsing, target classification, dotted-path validation, and composition-target validation.
+- `src/discovery.rs`: channel-centric layout discovery — folder-per-tenant channel scan, group scan, and computed-path per-target overlay resolution with ambiguity/disagreement diagnostics.
 - `src/overlay.rs`: provenance overlay merge, channel identity stamping, scoped-var overlay validation/coercion.
 - `src/staging_copy.rs`: source staging protocol, cache layout, manifests, advisory locks, reuse prediction, cleanup, crash purge, and platform open/fsync helpers.
 - `src/error.rs`: channel parse and validation errors.

--- a/crates/clinker-channel/src/binding.rs
+++ b/crates/clinker-channel/src/binding.rs
@@ -306,77 +306,6 @@ fn validate_var_names<'a>(names: impl IntoIterator<Item = &'a String>) -> Result
 
 // ── Channel validation ─────────────────────────────────────────────────
 
-/// Maximum number of `.channel.yaml` files per workspace scan.
-const WORKSPACE_CHANNEL_BUDGET: usize = 50;
-
-/// Maximum filesystem depth for channel workspace walks.
-const WORKSPACE_CHANNEL_MAX_DEPTH: usize = 16;
-
-/// Scan a workspace root for `.channel.yaml` files and parse each into a
-/// [`ChannelBinding`].
-///
-/// Companion to `scan_workspace_signatures` in clinker-plan — uses the
-/// same walkdir + budget pattern. Symlinks rejected, depth bounded.
-pub fn scan_workspace_channels(
-    workspace_root: &Path,
-) -> Result<Vec<ChannelBinding>, Vec<Diagnostic>> {
-    use walkdir::WalkDir;
-
-    if !workspace_root.exists() {
-        return Ok(Vec::new());
-    }
-
-    let mut bindings = Vec::new();
-    let mut diagnostics: Vec<Diagnostic> = Vec::new();
-
-    let walker = WalkDir::new(workspace_root)
-        .follow_links(false)
-        .max_depth(WORKSPACE_CHANNEL_MAX_DEPTH)
-        .into_iter();
-
-    for entry in walker {
-        let entry = match entry {
-            Ok(e) => e,
-            Err(_) => continue,
-        };
-
-        if !entry.file_type().is_file() {
-            continue;
-        }
-
-        let path = entry.path();
-        if !is_channel_yaml(path) {
-            continue;
-        }
-
-        if bindings.len() >= WORKSPACE_CHANNEL_BUDGET {
-            diagnostics.push(Diagnostic::error(
-                "E101",
-                format!(
-                    "channel file budget exceeded: more than {WORKSPACE_CHANNEL_BUDGET} \
-                     .channel.yaml files in workspace"
-                ),
-                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
-            ));
-            return Err(diagnostics);
-        }
-
-        match ChannelBinding::load(path) {
-            Ok(binding) => bindings.push(binding),
-            Err(e) => {
-                diagnostics.push(Diagnostic::error(
-                    "E101",
-                    format!("failed to parse {}: {e}", path.display()),
-                    LabeledSpan::primary(Span::SYNTHETIC, String::new()),
-                ));
-                return Err(diagnostics);
-            }
-        }
-    }
-
-    Ok(bindings)
-}
-
 /// Validate channel bindings against the composition symbol table.
 ///
 /// For composition targets: verifies the target exists in the symbol table
@@ -482,13 +411,6 @@ fn validate_config_keys(
             ));
         }
     }
-}
-
-fn is_channel_yaml(path: &Path) -> bool {
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .map(|n| n.ends_with(".channel.yaml"))
-        .unwrap_or(false)
 }
 
 /// Normalize a target path for lookup in the composition symbol table.

--- a/crates/clinker-channel/src/discovery.rs
+++ b/crates/clinker-channel/src/discovery.rs
@@ -1,0 +1,469 @@
+//! Channel/group discovery and computed-path overlay resolution.
+//!
+//! This module replaces the old whole-workspace `*.channel.yaml` glob-scan
+//! with the channel-centric layout the multi-tenant overlay system uses:
+//!
+//! - **Per-target overlay resolution is a computed path, not a scan.** Given a
+//!   channel id and a target name, [`resolve_channel_overlay`] builds the exact
+//!   on-disk folder (`<channel-root>/<shard>/<id>/`) and probes the three
+//!   candidate overlay filenames directly, so `--channel <id>` resolves in
+//!   O(1) directory lookups regardless of how many tenants exist. Enumerating
+//!   ~3,000 channels with a workspace glob (the old model, capped at 50 files)
+//!   never has to happen on the run path.
+//! - **The full scan survives only for `channels lint`.** [`scan_channels`]
+//!   and [`scan_groups`] walk the channel and group roots to enumerate every
+//!   tenant folder and group definition. They keep the bounded, symlink-free
+//!   walk pattern of `scan_workspace_signatures` in clinker-plan, with a
+//!   budget sized for the lint use case rather than the run path.
+//!
+//! Roots and the directory-sharding scheme come from CH-1's
+//! [`ChannelLayout`]/[`GroupLayout`] (`clinker.toml`). A relative root is
+//! resolved against the workspace root here (the layout stores it verbatim).
+//!
+//! ## Overlay candidate filenames and ambiguity
+//!
+//! A per-target overlay may be written with a suffix that documents its kind
+//! (`<target>.channel.yaml` for a pipeline, `<target>.comp.yaml` for a
+//! composition) or as a bare `<target>.yaml`. The suffix is optional: the
+//! overlay's `channel.target:` field is authoritative. Resolution therefore
+//! treats two situations as hard errors rather than silently picking one:
+//!
+//! - **Multiple candidate files** for one target (e.g. both
+//!   `orders.channel.yaml` and `orders.yaml`) — [`ChannelError::AmbiguousOverlay`].
+//! - **Filename disagrees with `target:`** — a `.comp.yaml` file whose target
+//!   names a pipeline, or a filename stem that does not match the target file
+//!   stem — [`ChannelError::OverlayTargetMismatch`].
+
+use std::path::{Path, PathBuf};
+
+use clinker_core_types::{Diagnostic, LabeledSpan, Span};
+use clinker_plan::config::{ChannelLayout, GroupLayout, ShardScheme};
+
+use crate::error::ChannelError;
+use crate::group::Group;
+use crate::manifest::{ChannelManifest, OverlayFile};
+
+/// Filename of the optional per-channel manifest inside each tenant folder.
+const CHANNEL_MANIFEST_FILE: &str = "channel.cfg.yaml";
+
+/// Filename suffix marking a group definition file.
+const GROUP_FILE_SUFFIX: &str = ".group.yaml";
+
+/// Maximum number of channel folders the lint scan enumerates before failing.
+///
+/// The run path never scans (it resolves by computed path), so this budget
+/// only bounds `channels lint`. It is sized well above the epic's ~3,000
+/// channels-per-pipeline target so a real workspace never trips it, while a
+/// pathological tree still cannot exhaust resources.
+const CHANNEL_SCAN_BUDGET: usize = 100_000;
+
+/// Maximum number of group files the lint scan enumerates before failing.
+const GROUP_SCAN_BUDGET: usize = 10_000;
+
+/// Maximum filesystem depth for the group-root walk. Groups live directly
+/// under the group root, but a bounded recursive walk tolerates light
+/// sub-foldering without following symlink loops or depth bombs.
+const GROUP_WALK_MAX_DEPTH: usize = 16;
+
+// ── Overlay kind ────────────────────────────────────────────────────────
+
+/// What a resolved per-target overlay overlays: a pipeline or a composition.
+///
+/// Derived from the overlay's authoritative `channel.target:` path (a
+/// `.comp.yaml` target is a composition; anything else is a pipeline), then
+/// cross-checked against the optional filename suffix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverlayKind {
+    /// The overlay targets a base pipeline (`<target>.channel.yaml` / bare).
+    Pipeline,
+    /// The overlay targets a composition (`<target>.comp.yaml` / bare).
+    Composition,
+}
+
+// ── Discovered channel ──────────────────────────────────────────────────
+
+/// One tenant folder found by [`scan_channels`].
+///
+/// The folder name *is* the channel id; the manifest is optional (present only
+/// when the channel carries labels or channel-wide overlays).
+#[derive(Debug, Clone)]
+pub struct DiscoveredChannel {
+    /// Channel id — the tenant folder name.
+    pub id: String,
+    /// Absolute (root-resolved) path to the tenant folder.
+    pub dir: PathBuf,
+    /// Parsed `channel.cfg.yaml`, or `None` when the folder has no manifest.
+    pub manifest: Option<ChannelManifest>,
+}
+
+/// A per-target overlay resolved by [`resolve_channel_overlay`].
+#[derive(Debug, Clone)]
+pub struct ResolvedOverlay {
+    /// Path to the overlay file that was loaded.
+    pub path: PathBuf,
+    /// Whether the overlay targets a pipeline or a composition (from the
+    /// authoritative `channel.target:`).
+    pub kind: OverlayKind,
+    /// The parsed overlay body.
+    pub overlay: OverlayFile,
+}
+
+// ── Root / folder path computation ──────────────────────────────────────
+
+/// Resolve a layout root against the workspace root: absolute roots are used
+/// verbatim, relative roots are joined onto the workspace root.
+fn resolve_root(root: &Path, workspace_root: &Path) -> PathBuf {
+    if root.is_absolute() {
+        root.to_path_buf()
+    } else {
+        workspace_root.join(root)
+    }
+}
+
+/// Compute the on-disk folder for a channel id under a shard scheme.
+///
+/// This is the canonical id→folder mapping the whole overlay system resolves
+/// through; folder materialization must place channels at exactly these paths.
+///
+/// - `None` — `<root>/<id>/`
+/// - `FirstChar` — `<root>/<first-char>/<id>/`
+/// - `Hash` — `<root>/<bucket>/<id>/`, where `bucket` is the first BLAKE3 byte
+///   of the id rendered as two lowercase hex digits (256 buckets), spreading
+///   ids evenly regardless of prefix skew.
+///
+/// See [`ShardScheme`] for the scheme definitions.
+pub fn channel_folder_path(channel_root: &Path, shard: ShardScheme, channel_id: &str) -> PathBuf {
+    match shard {
+        ShardScheme::None => channel_root.join(channel_id),
+        ShardScheme::FirstChar => match channel_id.chars().next() {
+            Some(first) => channel_root.join(first.to_string()).join(channel_id),
+            None => channel_root.join(channel_id),
+        },
+        ShardScheme::Hash => {
+            let bucket = format!("{:02x}", blake3::hash(channel_id.as_bytes()).as_bytes()[0]);
+            channel_root.join(bucket).join(channel_id)
+        }
+    }
+}
+
+/// Depth (relative to the channel root) at which tenant folders sit for a
+/// shard scheme: flat layouts put them one level down, sharded layouts two.
+fn channel_folder_depth(shard: ShardScheme) -> usize {
+    match shard {
+        ShardScheme::None => 1,
+        ShardScheme::FirstChar | ShardScheme::Hash => 2,
+    }
+}
+
+// ── Overlay filename / target classification ────────────────────────────
+
+/// Classify a per-target overlay filename by its suffix. A suffixed filename
+/// pins a kind; a bare `<target>.yaml` returns `None` (kind unconstrained by
+/// the filename, taken from `target:` alone).
+fn classify_filename_kind(file_name: &str) -> Option<OverlayKind> {
+    if file_name.ends_with(".comp.yaml") {
+        Some(OverlayKind::Composition)
+    } else if file_name.ends_with(".channel.yaml") {
+        Some(OverlayKind::Pipeline)
+    } else {
+        None
+    }
+}
+
+/// Classify the authoritative `channel.target:` path: a `.comp.yaml` target is
+/// a composition, anything else a pipeline.
+fn classify_target_kind(target: &str) -> OverlayKind {
+    if target.ends_with(".comp.yaml") {
+        OverlayKind::Composition
+    } else {
+        OverlayKind::Pipeline
+    }
+}
+
+/// The file stem of a `channel.target:` path — its file name with the
+/// `.comp.yaml` or `.yaml` suffix stripped.
+fn target_stem(target: &str) -> &str {
+    let file = Path::new(target)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(target);
+    file.strip_suffix(".comp.yaml")
+        .or_else(|| file.strip_suffix(".yaml"))
+        .unwrap_or(file)
+}
+
+// ── Computed-path overlay resolution ────────────────────────────────────
+
+/// Resolve a channel's overlay for one target by computed path.
+///
+/// Builds `<channel-root>/<shard>/<id>/` and probes the three candidate
+/// filenames for `target_name` — `<target>.channel.yaml`, `<target>.comp.yaml`,
+/// then bare `<target>.yaml`. Returns:
+///
+/// - `Ok(None)` when the tenant has no overlay for this target (a channel need
+///   not override every pipeline);
+/// - `Ok(Some(_))` for exactly one candidate whose `channel.target:` agrees
+///   with its filename (kind and stem);
+/// - `Err(ChannelError::AmbiguousOverlay)` when more than one candidate exists;
+/// - `Err(ChannelError::OverlayTargetMismatch)` when the sole candidate's
+///   filename suffix or stem disagrees with its `channel.target:`.
+///
+/// `target_name` is the bare target stem (no extension), e.g.
+/// `order_fulfillment`.
+pub fn resolve_channel_overlay(
+    layout: &ChannelLayout,
+    workspace_root: &Path,
+    channel_id: &str,
+    target_name: &str,
+) -> Result<Option<ResolvedOverlay>, ChannelError> {
+    let root = resolve_root(&layout.root, workspace_root);
+    let dir = channel_folder_path(&root, layout.shard, channel_id);
+
+    // Ordered by suffix specificity; ordering only affects which candidate a
+    // future single-match convention would prefer — with more than one present
+    // we error regardless of order.
+    let candidates = [
+        dir.join(format!("{target_name}.channel.yaml")),
+        dir.join(format!("{target_name}.comp.yaml")),
+        dir.join(format!("{target_name}.yaml")),
+    ];
+
+    let mut present: Vec<PathBuf> = candidates.into_iter().filter(|p| p.is_file()).collect();
+
+    match present.len() {
+        0 => Ok(None),
+        1 => {
+            let path = present.remove(0);
+            let overlay = OverlayFile::load(&path)?;
+            let kind = verify_overlay_agreement(&path, &overlay, target_name)?;
+            Ok(Some(ResolvedOverlay {
+                path,
+                kind,
+                overlay,
+            }))
+        }
+        _ => Err(ChannelError::AmbiguousOverlay {
+            channel_id: channel_id.to_string(),
+            target: target_name.to_string(),
+            candidates: present,
+        }),
+    }
+}
+
+/// Verify the sole candidate's filename agrees with its authoritative
+/// `channel.target:` and return the target's kind.
+///
+/// A suffixed filename must match the target kind (`.comp.yaml`↔composition,
+/// `.channel.yaml`↔pipeline); a bare `.yaml` file constrains nothing by
+/// suffix. In all cases the filename stem must equal the target file stem, so
+/// `orders.channel.yaml` cannot silently overlay a differently-named pipeline.
+fn verify_overlay_agreement(
+    path: &Path,
+    overlay: &OverlayFile,
+    target_name: &str,
+) -> Result<OverlayKind, ChannelError> {
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+    let declared = overlay.channel.target.as_str();
+    let target_kind = classify_target_kind(declared);
+
+    if let Some(filename_kind) = classify_filename_kind(file_name)
+        && filename_kind != target_kind
+    {
+        return Err(ChannelError::OverlayTargetMismatch {
+            path: path.to_path_buf(),
+            declared: declared.to_string(),
+            reason: format!(
+                "filename suffix marks a {} overlay but target: names a {}",
+                kind_label(filename_kind),
+                kind_label(target_kind),
+            ),
+        });
+    }
+
+    let stem = target_stem(declared);
+    if stem != target_name {
+        return Err(ChannelError::OverlayTargetMismatch {
+            path: path.to_path_buf(),
+            declared: declared.to_string(),
+            reason: format!("filename stem {target_name:?} does not match target stem {stem:?}"),
+        });
+    }
+
+    Ok(target_kind)
+}
+
+fn kind_label(kind: OverlayKind) -> &'static str {
+    match kind {
+        OverlayKind::Pipeline => "pipeline",
+        OverlayKind::Composition => "composition",
+    }
+}
+
+// ── Lint scans ──────────────────────────────────────────────────────────
+
+/// Enumerate every tenant folder under the channel root, loading each folder's
+/// optional `channel.cfg.yaml` manifest.
+///
+/// This is the `channels lint` enumeration path; the run path resolves by
+/// computed path instead (see [`resolve_channel_overlay`]). Tenant folders sit
+/// at [`channel_folder_depth`] under the root for the configured shard scheme.
+/// The walk rejects symlinks and is bounded by depth and [`CHANNEL_SCAN_BUDGET`].
+///
+/// A nonexistent channel root yields an empty list (a workspace may not have a
+/// channel tree yet). A manifest parse error fails the scan with `E121`; a
+/// budget overrun fails with `E120`.
+pub fn scan_channels(
+    layout: &ChannelLayout,
+    workspace_root: &Path,
+) -> Result<Vec<DiscoveredChannel>, Vec<Diagnostic>> {
+    use walkdir::WalkDir;
+
+    let root = resolve_root(&layout.root, workspace_root);
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let depth = channel_folder_depth(layout.shard);
+    let mut channels = Vec::new();
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+    let walker = WalkDir::new(&root)
+        .follow_links(false)
+        .max_depth(depth)
+        .into_iter();
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            // Broken symlink / permission denied on a candidate: skip it, the
+            // scan itself is not fatal on per-entry IO errors.
+            Err(_) => continue,
+        };
+
+        // Only leaf tenant folders at the shard depth are channels; reject
+        // symlinks explicitly (belt-and-suspenders with follow_links(false)).
+        if entry.depth() != depth || entry.file_type().is_symlink() || !entry.file_type().is_dir() {
+            continue;
+        }
+
+        let dir = entry.path();
+        let Some(id) = dir.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        if channels.len() >= CHANNEL_SCAN_BUDGET {
+            diagnostics.push(Diagnostic::error(
+                "E120",
+                format!(
+                    "channel folder budget exceeded: more than {CHANNEL_SCAN_BUDGET} \
+                     tenant folders under {}",
+                    root.display()
+                ),
+                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+            return Err(diagnostics);
+        }
+
+        let manifest_path = dir.join(CHANNEL_MANIFEST_FILE);
+        let manifest = if manifest_path.is_file() {
+            match ChannelManifest::load(&manifest_path) {
+                Ok(m) => Some(m),
+                Err(e) => {
+                    diagnostics.push(Diagnostic::error(
+                        "E121",
+                        format!("failed to parse {}: {e}", manifest_path.display()),
+                        LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+                    ));
+                    return Err(diagnostics);
+                }
+            }
+        } else {
+            None
+        };
+
+        channels.push(DiscoveredChannel {
+            id: id.to_string(),
+            dir: dir.to_path_buf(),
+            manifest,
+        });
+    }
+
+    Ok(channels)
+}
+
+/// Enumerate every `*.group.yaml` definition under the group root.
+///
+/// Mirrors [`scan_channels`]: bounded, symlink-free walk. A nonexistent group
+/// root yields an empty list. A parse error fails with `E123`; a budget
+/// overrun fails with `E122`.
+pub fn scan_groups(
+    layout: &GroupLayout,
+    workspace_root: &Path,
+) -> Result<Vec<Group>, Vec<Diagnostic>> {
+    use walkdir::WalkDir;
+
+    let root = resolve_root(&layout.root, workspace_root);
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut groups = Vec::new();
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+    let walker = WalkDir::new(&root)
+        .follow_links(false)
+        .max_depth(GROUP_WALK_MAX_DEPTH)
+        .into_iter();
+
+    for entry in walker {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+
+        let file_type = entry.file_type();
+        if file_type.is_symlink() || !file_type.is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        let is_group = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| n.ends_with(GROUP_FILE_SUFFIX))
+            .unwrap_or(false);
+        if !is_group {
+            continue;
+        }
+
+        if groups.len() >= GROUP_SCAN_BUDGET {
+            diagnostics.push(Diagnostic::error(
+                "E122",
+                format!(
+                    "group file budget exceeded: more than {GROUP_SCAN_BUDGET} \
+                     {GROUP_FILE_SUFFIX} files under {}",
+                    root.display()
+                ),
+                LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+            ));
+            return Err(diagnostics);
+        }
+
+        match Group::load(path) {
+            Ok(group) => groups.push(group),
+            Err(e) => {
+                diagnostics.push(Diagnostic::error(
+                    "E123",
+                    format!("failed to parse {}: {e}", path.display()),
+                    LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+                ));
+                return Err(diagnostics);
+            }
+        }
+    }
+
+    Ok(groups)
+}

--- a/crates/clinker-channel/src/discovery.rs
+++ b/crates/clinker-channel/src/discovery.rs
@@ -16,9 +16,10 @@
 //!   walk pattern of `scan_workspace_signatures` in clinker-plan, with a
 //!   budget sized for the lint use case rather than the run path.
 //!
-//! Roots and the directory-sharding scheme come from CH-1's
-//! [`ChannelLayout`]/[`GroupLayout`] (`clinker.toml`). A relative root is
-//! resolved against the workspace root here (the layout stores it verbatim).
+//! Roots and the directory-sharding scheme come from the
+//! [`ChannelLayout`]/[`GroupLayout`] sections of `clinker.toml`. A relative
+//! root is resolved against the workspace root here (the layout stores it
+//! verbatim).
 //!
 //! ## Overlay candidate filenames and ambiguity
 //!

--- a/crates/clinker-channel/src/error.rs
+++ b/crates/clinker-channel/src/error.rs
@@ -19,4 +19,21 @@ pub enum ChannelError {
     InvalidDottedPath { path: String, reason: String },
     #[error("invalid var name `{name}`: {reason}")]
     InvalidVarName { name: String, reason: String },
+    #[error(
+        "channel `{channel_id}`: multiple overlay candidates for target `{target}`: {}",
+        .candidates.iter().map(|p| p.display().to_string()).collect::<Vec<_>>().join(", ")
+    )]
+    AmbiguousOverlay {
+        channel_id: String,
+        target: String,
+        candidates: Vec<PathBuf>,
+    },
+    #[error(
+        "overlay {path} declares target `{declared}` that disagrees with its filename: {reason}"
+    )]
+    OverlayTargetMismatch {
+        path: PathBuf,
+        declared: String,
+        reason: String,
+    },
 }

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -51,6 +51,7 @@
 //! recompilation is skipped when the channel content has not changed.
 
 pub mod binding;
+pub mod discovery;
 pub mod error;
 pub mod group;
 pub mod manifest;
@@ -59,8 +60,10 @@ pub mod selector;
 pub mod staging_copy;
 
 // Explicit re-exports at crate root.
-pub use binding::{
-    ChannelBinding, ChannelTarget, DottedPath, scan_workspace_channels, validate_channel_bindings,
+pub use binding::{ChannelBinding, ChannelTarget, DottedPath, validate_channel_bindings};
+pub use discovery::{
+    DiscoveredChannel, OverlayKind, ResolvedOverlay, channel_folder_path, resolve_channel_overlay,
+    scan_channels, scan_groups,
 };
 pub use error::ChannelError;
 pub use group::Group;

--- a/crates/clinker-channel/tests/discovery_test.rs
+++ b/crates/clinker-channel/tests/discovery_test.rs
@@ -1,0 +1,386 @@
+//! Channel/group discovery + computed-path overlay resolution (CH-4).
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use clinker_channel::discovery::{
+    DiscoveredChannel, OverlayKind, channel_folder_path, resolve_channel_overlay, scan_channels,
+    scan_groups,
+};
+use clinker_channel::error::ChannelError;
+use clinker_plan::config::{ChannelLayout, GroupLayout, ShardScheme};
+
+/// A workspace whose channel/group roots default to `channel`/`group`.
+fn workspace() -> tempfile::TempDir {
+    tempfile::tempdir().expect("tempdir")
+}
+
+fn channel_layout(shard: ShardScheme) -> ChannelLayout {
+    ChannelLayout {
+        root: PathBuf::from("channel"),
+        shard,
+    }
+}
+
+fn group_layout() -> GroupLayout {
+    GroupLayout {
+        root: PathBuf::from("group"),
+    }
+}
+
+fn write(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create dirs");
+    }
+    fs::write(path, contents).expect("write file");
+}
+
+/// Create a tenant folder for `id` at the sharded computed path and return it.
+fn tenant_dir(ws: &Path, shard: ShardScheme, id: &str) -> PathBuf {
+    let dir = channel_folder_path(&ws.join("channel"), shard, id);
+    fs::create_dir_all(&dir).expect("create tenant dir");
+    dir
+}
+
+fn overlay_yaml(target: &str) -> String {
+    format!("channel:\n  target: {target}\nconfig: {{ fraud_check.threshold: 0.9 }}\n")
+}
+
+// ── Computed-path resolution ────────────────────────────────────────────
+
+#[test]
+fn resolves_channel_suffixed_overlay_by_tenant_id() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    write(
+        &dir.join("orders.channel.yaml"),
+        &overlay_yaml("../../pipeline/orders.yaml"),
+    );
+
+    let resolved = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect("resolution should succeed")
+    .expect("overlay should be found");
+
+    assert_eq!(resolved.kind, OverlayKind::Pipeline);
+    assert_eq!(resolved.path, dir.join("orders.channel.yaml"));
+    assert_eq!(
+        resolved.overlay.channel.target,
+        "../../pipeline/orders.yaml"
+    );
+}
+
+#[test]
+fn resolves_bare_yaml_overlay() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    write(
+        &dir.join("orders.yaml"),
+        &overlay_yaml("../../pipeline/orders.yaml"),
+    );
+
+    let resolved = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect("resolution should succeed")
+    .expect("overlay should be found");
+
+    // Bare filename: kind comes from the authoritative target path.
+    assert_eq!(resolved.kind, OverlayKind::Pipeline);
+}
+
+#[test]
+fn resolves_composition_overlay() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    write(
+        &dir.join("fraud_check.comp.yaml"),
+        &overlay_yaml("../../composition/fraud_check.comp.yaml"),
+    );
+
+    let resolved = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "globex",
+        "fraud_check",
+    )
+    .expect("resolution should succeed")
+    .expect("overlay should be found");
+
+    assert_eq!(resolved.kind, OverlayKind::Composition);
+}
+
+#[test]
+fn resolves_under_first_char_shard() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::FirstChar, "globex");
+    // FirstChar places the tenant under channel/g/globex/.
+    assert_eq!(dir, ws.path().join("channel").join("g").join("globex"));
+    write(
+        &dir.join("orders.channel.yaml"),
+        &overlay_yaml("../../../pipeline/orders.yaml"),
+    );
+
+    let resolved = resolve_channel_overlay(
+        &channel_layout(ShardScheme::FirstChar),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect("resolution should succeed")
+    .expect("overlay should be found");
+    assert_eq!(resolved.kind, OverlayKind::Pipeline);
+}
+
+#[test]
+fn resolves_under_hash_shard() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::Hash, "globex");
+    write(
+        &dir.join("orders.channel.yaml"),
+        &overlay_yaml("../../../pipeline/orders.yaml"),
+    );
+
+    let resolved = resolve_channel_overlay(
+        &channel_layout(ShardScheme::Hash),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect("resolution should succeed")
+    .expect("overlay should be found");
+    assert_eq!(resolved.kind, OverlayKind::Pipeline);
+}
+
+#[test]
+fn missing_overlay_resolves_to_none() {
+    let ws = workspace();
+    tenant_dir(ws.path(), ShardScheme::None, "globex");
+
+    let resolved = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect("resolution should succeed");
+    assert!(resolved.is_none());
+}
+
+#[test]
+fn absent_tenant_folder_resolves_to_none() {
+    let ws = workspace();
+    // No tenant folder created at all.
+    let resolved = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "nobody",
+        "orders",
+    )
+    .expect("resolution should succeed");
+    assert!(resolved.is_none());
+}
+
+// ── Ambiguity + disagreement errors ─────────────────────────────────────
+
+#[test]
+fn two_candidate_files_for_one_target_is_ambiguous() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    write(
+        &dir.join("orders.channel.yaml"),
+        &overlay_yaml("../../pipeline/orders.yaml"),
+    );
+    write(
+        &dir.join("orders.yaml"),
+        &overlay_yaml("../../pipeline/orders.yaml"),
+    );
+
+    let err = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect_err("two candidates must be ambiguous");
+    match err {
+        ChannelError::AmbiguousOverlay {
+            channel_id,
+            target,
+            candidates,
+        } => {
+            assert_eq!(channel_id, "globex");
+            assert_eq!(target, "orders");
+            assert_eq!(candidates.len(), 2);
+        }
+        other => panic!("expected AmbiguousOverlay, got {other:?}"),
+    }
+}
+
+#[test]
+fn filename_kind_disagreeing_with_target_errors() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    // `.comp.yaml` filename but the target names a pipeline.
+    write(
+        &dir.join("orders.comp.yaml"),
+        &overlay_yaml("../../pipeline/orders.yaml"),
+    );
+
+    let err = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect_err("filename/target kind mismatch must error");
+    assert!(matches!(err, ChannelError::OverlayTargetMismatch { .. }));
+}
+
+#[test]
+fn filename_stem_disagreeing_with_target_errors() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    // Filename stem `orders` but the target's stem is `shipping`.
+    write(
+        &dir.join("orders.channel.yaml"),
+        &overlay_yaml("../../pipeline/shipping.yaml"),
+    );
+
+    let err = resolve_channel_overlay(
+        &channel_layout(ShardScheme::None),
+        ws.path(),
+        "globex",
+        "orders",
+    )
+    .expect_err("filename/target stem mismatch must error");
+    assert!(matches!(err, ChannelError::OverlayTargetMismatch { .. }));
+}
+
+// ── Lint scans ──────────────────────────────────────────────────────────
+
+fn ids(channels: &[DiscoveredChannel]) -> Vec<String> {
+    let mut v: Vec<String> = channels.iter().map(|c| c.id.clone()).collect();
+    v.sort();
+    v
+}
+
+#[test]
+fn scan_channels_enumerates_tenant_folders_and_loads_manifests() {
+    let ws = workspace();
+    let globex = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    write(
+        &globex.join("channel.cfg.yaml"),
+        "channel:\n  name: globex\nlabels: { region: west }\n",
+    );
+    // acme has no manifest — still a discovered channel.
+    tenant_dir(ws.path(), ShardScheme::None, "acme");
+
+    let channels =
+        scan_channels(&channel_layout(ShardScheme::None), ws.path()).expect("scan should succeed");
+    assert_eq!(
+        ids(&channels),
+        vec!["acme".to_string(), "globex".to_string()]
+    );
+
+    let globex = channels.iter().find(|c| c.id == "globex").unwrap();
+    let manifest = globex.manifest.as_ref().expect("globex has a manifest");
+    assert_eq!(manifest.channel.name, "globex");
+
+    let acme = channels.iter().find(|c| c.id == "acme").unwrap();
+    assert!(acme.manifest.is_none());
+}
+
+#[test]
+fn scan_channels_enumerates_under_first_char_shard() {
+    let ws = workspace();
+    tenant_dir(ws.path(), ShardScheme::FirstChar, "globex");
+    tenant_dir(ws.path(), ShardScheme::FirstChar, "acme");
+
+    let channels = scan_channels(&channel_layout(ShardScheme::FirstChar), ws.path())
+        .expect("scan should succeed");
+    assert_eq!(
+        ids(&channels),
+        vec!["acme".to_string(), "globex".to_string()]
+    );
+}
+
+#[test]
+fn scan_channels_bad_manifest_fails_with_e121() {
+    let ws = workspace();
+    let dir = tenant_dir(ws.path(), ShardScheme::None, "globex");
+    write(
+        &dir.join("channel.cfg.yaml"),
+        "channel:\n  not_name: oops\n",
+    );
+
+    let diags =
+        scan_channels(&channel_layout(ShardScheme::None), ws.path()).expect_err("bad manifest");
+    assert!(diags.iter().any(|d| d.code == "E121"));
+}
+
+#[test]
+fn scan_channels_absent_root_is_empty() {
+    let ws = workspace();
+    let channels =
+        scan_channels(&channel_layout(ShardScheme::None), ws.path()).expect("scan should succeed");
+    assert!(channels.is_empty());
+}
+
+#[test]
+fn scan_groups_enumerates_group_files() {
+    let ws = workspace();
+    write(
+        &ws.path().join("group").join("enterprise.group.yaml"),
+        "group:\n  name: enterprise\n  match: 'tier == \"enterprise\"'\n  priority: 20\n",
+    );
+    write(
+        &ws.path().join("group").join("baseline.group.yaml"),
+        "group:\n  name: baseline\n",
+    );
+    // A non-group file is ignored.
+    write(&ws.path().join("group").join("README.md"), "not a group\n");
+
+    let groups = scan_groups(&group_layout(), ws.path()).expect("scan should succeed");
+    let mut names: Vec<String> = groups.iter().map(|g| g.name.clone()).collect();
+    names.sort();
+    assert_eq!(
+        names,
+        vec!["baseline".to_string(), "enterprise".to_string()]
+    );
+
+    let enterprise = groups.iter().find(|g| g.name == "enterprise").unwrap();
+    assert_eq!(
+        enterprise.selector.as_deref(),
+        Some("tier == \"enterprise\"")
+    );
+    assert_eq!(enterprise.priority, 20);
+
+    let baseline = groups.iter().find(|g| g.name == "baseline").unwrap();
+    assert!(baseline.selector.is_none());
+}
+
+#[test]
+fn scan_groups_bad_file_fails_with_e123() {
+    let ws = workspace();
+    write(
+        &ws.path().join("group").join("broken.group.yaml"),
+        "group:\n  nope: 1\n",
+    );
+    let diags = scan_groups(&group_layout(), ws.path()).expect_err("bad group");
+    assert!(diags.iter().any(|d| d.code == "E123"));
+}
+
+#[test]
+fn scan_groups_absent_root_is_empty() {
+    let ws = workspace();
+    let groups = scan_groups(&group_layout(), ws.path()).expect("scan should succeed");
+    assert!(groups.is_empty());
+}

--- a/crates/clinker-channel/tests/discovery_test.rs
+++ b/crates/clinker-channel/tests/discovery_test.rs
@@ -1,4 +1,4 @@
-//! Channel/group discovery + computed-path overlay resolution (CH-4).
+//! Channel/group discovery + computed-path overlay resolution.
 
 use std::fs;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## What

Replaces the whole-workspace `*.channel.yaml` glob-scan (previously capped at 50 files) with the channel-centric discovery the multi-tenant overlay layout requires.

**Computed-path per-target resolution.** `resolve_channel_overlay(layout, workspace_root, channel_id, target_name)` builds the exact on-disk tenant folder (`<channel-root>/<shard>/<id>/`) and probes the three candidate overlay filenames directly — `<target>.channel.yaml`, `<target>.comp.yaml`, then bare `<target>.yaml`. This makes `--channel <id>` resolution O(1) in directory lookups regardless of how many tenants exist, so a workspace with thousands of per-tenant channels never pays an O(N) scan on the run path.

**Authoritative `target:` with hard ambiguity errors.** The overlay's `channel.target:` field is authoritative; the filename suffix is optional documentation. Resolution refuses to silently pick when things disagree:
- multiple candidate files for one target -> `ChannelError::AmbiguousOverlay`
- a filename whose suffix or stem disagrees with the declared target -> `ChannelError::OverlayTargetMismatch`

**Lint enumeration survives.** `scan_channels` (folder-per-tenant) and `scan_groups` walk the channel and group roots for the lint path, keeping the bounded, symlink-free walk pattern used elsewhere in the workspace, with budgets sized for enumeration rather than the run path. Each tenant folder's optional `channel.cfg.yaml` manifest is loaded when present.

**Canonical id->folder mapping.** `channel_folder_path` exposes the flat / first-character / 256-bucket BLAKE3-hash shard schemes so folder materialization and resolution share one rule.

Roots and the shard scheme are read from the `[channel]` / `[group]` sections of `clinker.toml`.

## Scope

Discovery only. The existing value-overlay application (`apply_channel_overlay`) and per-source patch handling are untouched. The old `scan_workspace_channels` (and its 50-file budget, depth cap, and suffix-only matcher) is removed; it had no callers beyond its re-export.

## Why

Keyed lookup of "tenant X's overlay for pipeline Y" must be a computed path rather than a filesystem enumeration: enumeration is O(N) on any filesystem and the old 50-file budget could not serve thousands of channels. Ambiguity is a hard error rather than a silent pick so resolution is never surprising.

## Tests

`crates/clinker-channel/tests/discovery_test.rs` (17 tests): computed-path resolution for channel/comp/bare overlays; first-char and hash shard schemes; not-found -> `None`; the two ambiguity/disagreement error paths; folder-per-tenant and group enumeration (including sharded layout, missing manifest, bad-manifest and bad-group diagnostics, and absent roots).

`cargo test -p clinker-channel`, `cargo clippy -p clinker-channel --all-targets -- -D warnings`, and `cargo fmt --all --check` are green; `cargo build --workspace` compiles.

Part of #515