### PR TITLE
Apply resolved overlay op stream pre-compile (CH-12)

### DIFF
--- a/crates/clinker-plan/src/config/compile_context.rs
+++ b/crates/clinker-plan/src/config/compile_context.rs
@@ -15,6 +15,8 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::overlay_ops::LayeredOp;
+
 /// Per-compile configuration threaded through `PipelineConfig::compile`.
 #[derive(Debug, Clone)]
 pub struct CompileContext {
@@ -32,6 +34,16 @@ pub struct CompileContext {
     /// Wired from the `--allow-absolute-paths` CLI flag and/or
     /// the `CLINKER_ALLOW_ABSOLUTE_PATHS` env var.
     pub allow_absolute_paths: bool,
+    /// Resolved structural overlay ops for the channel/group multi-tenant
+    /// system, already concatenated across every applicable layer (each op
+    /// still tagged with its own [`OverlayLayer`](crate::overlay_ops::OverlayLayer)
+    /// so the engine can re-establish the fixed layer-precedence order).
+    ///
+    /// When non-empty, `compile` splices these into a working copy of the
+    /// base AST before schema binding, so the effective (post-overlay) DAG
+    /// is what gets typechecked and lowered. Empty (the default) means "no
+    /// overlay": the compile path is byte-identical to a plain pipeline.
+    pub overlay_ops: Vec<LayeredOp>,
 }
 
 impl CompileContext {
@@ -43,6 +55,7 @@ impl CompileContext {
             workspace_root: workspace_root.into(),
             pipeline_dir: PathBuf::new(),
             allow_absolute_paths: false,
+            overlay_ops: Vec::new(),
         }
     }
 
@@ -55,12 +68,30 @@ impl CompileContext {
             workspace_root: workspace_root.into(),
             pipeline_dir: pipeline_dir.into(),
             allow_absolute_paths: false,
+            overlay_ops: Vec::new(),
         }
     }
 
     /// Workspace root accessor.
     pub fn workspace_root(&self) -> &Path {
         &self.workspace_root
+    }
+
+    /// A copy of this context with the overlay ops cleared.
+    ///
+    /// The pre-compile overlay pass applies the ops to a working copy of the
+    /// AST and then compiles that effective plan through the ordinary path;
+    /// it uses this to recurse without re-applying (and thus doubling) the
+    /// ops it already spliced in.
+    pub fn without_overlay_ops(&self) -> Self {
+        // Clone only the cheap fields; the whole point is to drop the ops, so
+        // copying them via `..self.clone()` just to discard them is wasted work.
+        Self {
+            workspace_root: self.workspace_root.clone(),
+            pipeline_dir: self.pipeline_dir.clone(),
+            allow_absolute_paths: self.allow_absolute_paths,
+            overlay_ops: Vec::new(),
+        }
     }
 }
 
@@ -72,6 +103,7 @@ impl Default for CompileContext {
             workspace_root: std::env::current_dir().unwrap_or_default(),
             pipeline_dir: PathBuf::new(),
             allow_absolute_paths: false,
+            overlay_ops: Vec::new(),
         }
     }
 }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -625,6 +625,29 @@ impl PipelineConfig {
         use petgraph::graph::{DiGraph, NodeIndex};
         use std::collections::HashMap;
 
+        // Stage 0: pre-compile structural overlay pass (channel/group system).
+        //
+        // When the compile context carries resolved overlay ops, splice them
+        // into a working copy of the base AST and compile the EFFECTIVE plan
+        // through the ordinary path below — so schema binding, typecheck, and
+        // lowering all see the post-overlay DAG. The op stream is re-ordered by
+        // the engine into fixed (layer-precedence, declaration) order, so the
+        // result depends only on each op's layer identity, never on the order
+        // the layers were concatenated in. A plain pipeline (no overlay ops)
+        // skips this branch entirely and compiles byte-identically to before.
+        //
+        // Two failure surfaces stay anchored to the offending op, not the base
+        // pipeline: a structural op that cannot apply (missing target, orphaning
+        // remove, breaking schema patch) fails here with an op-spanned E114;
+        // ill-typed CXL introduced by an op (a bad `set config.cxl`, a spliced
+        // node whose body does not typecheck) is caught unchanged by the normal
+        // `bind_schema` pass below, anchored to the op because the engine stamps
+        // each injected / replaced node with the op's source location.
+        if !ctx.overlay_ops.is_empty() {
+            let effective = self.with_structural_overlay(&ctx.overlay_ops)?;
+            return effective.compile_with_diagnostics(&ctx.without_overlay_ops());
+        }
+
         // Stage 1-4: name/topology/path validation pre-pass.
         let mut diags = self.compile_topology_only(ctx);
         // Hard-error stop: stages 1-4 already collected; stage 5
@@ -2216,6 +2239,35 @@ impl PipelineConfig {
 
         let plan = CompiledPlan::from_compile(dag, runtime_config, artifacts);
         Ok((plan, diags))
+    }
+
+    /// Apply resolved structural overlay ops to a working copy of this
+    /// pipeline, returning the effective config to compile.
+    ///
+    /// The op engine folds the (layer-tagged) op stream over the node list in
+    /// fixed layer-precedence order; a failure to apply an op is mapped to an
+    /// `E114` diagnostic anchored to that op's source span, so the error points
+    /// at the offending overlay op rather than the base pipeline. This is a
+    /// pure transform on the AST — `config` / `vars` value clobber and the
+    /// runtime `vars` that flow to the executor via `PipelineRunParams` are
+    /// resolved on separate surfaces and never enter the AST here.
+    fn with_structural_overlay(
+        &self,
+        ops: &[crate::overlay_ops::LayeredOp],
+    ) -> Result<PipelineConfig, Vec<clinker_core_types::Diagnostic>> {
+        use clinker_core_types::{Diagnostic, LabeledSpan};
+
+        let mut effective = self.clone();
+        let base_nodes = std::mem::take(&mut effective.nodes);
+        effective.nodes =
+            crate::overlay_ops::apply_overlay_ops(base_nodes, ops.to_vec()).map_err(|err| {
+                vec![Diagnostic::error(
+                    "E114",
+                    err.to_string(),
+                    LabeledSpan::primary(err.span(), String::new()),
+                )]
+            })?;
+        Ok(effective)
     }
 }
 

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -12,6 +12,7 @@ mod dup_body_node_name;
 mod envelope_synthesis;
 mod explain_buffer_class;
 mod explain_polish;
+mod overlay_compile;
 mod plan_time_window_root;
 mod predicate_support;
 mod reshape_validation;

--- a/crates/clinker-plan/src/plan/tests/overlay_compile.rs
+++ b/crates/clinker-plan/src/plan/tests/overlay_compile.rs
@@ -1,0 +1,253 @@
+//! Pre-compile structural overlay pass wired into `compile_with_diagnostics`.
+//!
+//! These tests exercise the seam that splices a resolved channel/group
+//! `overrides:` op stream into the base AST *before* schema binding, so the
+//! effective (post-overlay) DAG is what gets typechecked and lowered. They
+//! pin three behaviors from the epic's normative resolution semantics:
+//!
+//! - a base pipeline plus a group op plus a channel override compiles to the
+//!   expected effective plan (the injected node and the overridden logic both
+//!   land in the compiled `CompiledPlan`);
+//! - an op that cannot apply (here an orphaning `remove`) fails with a
+//!   diagnostic anchored to the offending op's span, not the base pipeline;
+//! - ill-typed CXL introduced by an op is caught by the ordinary `bind_schema`
+//!   pass, still anchored to the op because the engine stamps each spliced node
+//!   with the op's source location;
+//! - a plain pipeline with no overlay ops is unaffected (the pass is a no-op).
+
+use crate::config::pipeline_node::PipelineNode;
+use crate::config::{CompileContext, parse_config};
+use crate::overlay_ops::{LayeredOp, OverlayLayer, OverlayOp};
+use crate::plan::CompiledPlan;
+use crate::yaml::Spanned;
+
+/// A three-node linear pipeline: `orders -> normalize -> sink`.
+const BASE: &str = r#"
+pipeline:
+  name: overlay_base
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: int }
+  - type: transform
+    name: normalize
+    input: orders
+    config:
+      cxl: "emit order_id = order_id\nemit amount = amount"
+  - type: output
+    name: sink
+    input: normalize
+    config:
+      name: sink
+      type: csv
+      path: out.csv
+"#;
+
+/// Parse one `Spanned<OverlayOp>` from a bare op mapping.
+fn parse_op(yaml: &str) -> Spanned<OverlayOp> {
+    crate::yaml::from_str::<Spanned<OverlayOp>>(yaml).expect("parse op")
+}
+
+/// Compile `BASE` with the given resolved overlay op stream.
+fn compile_with_ops(
+    ops: Vec<LayeredOp>,
+) -> Result<CompiledPlan, Vec<clinker_core_types::Diagnostic>> {
+    let config = parse_config(BASE).expect("parse base config");
+    let ctx = CompileContext {
+        overlay_ops: ops,
+        ..CompileContext::default()
+    };
+    config.compile(&ctx)
+}
+
+/// Node names of the compiled plan's effective (post-overlay) config, in order.
+fn effective_names(plan: &CompiledPlan) -> Vec<String> {
+    plan.config()
+        .nodes
+        .iter()
+        .map(|n| n.value.name().to_string())
+        .collect()
+}
+
+/// The CXL source of a named transform in the effective config.
+fn transform_cxl(plan: &CompiledPlan, name: &str) -> String {
+    let node = plan
+        .config()
+        .nodes
+        .iter()
+        .find(|n| n.value.name() == name)
+        .unwrap_or_else(|| panic!("node {name:?} present"));
+    match &node.value {
+        PipelineNode::Transform { config, .. } => config.cxl.source.clone(),
+        other => panic!(
+            "node {name:?} is a {} node, not a transform",
+            other.type_tag()
+        ),
+    }
+}
+
+/// Direct input names of a named node in the effective config.
+fn inputs_of(plan: &CompiledPlan, name: &str) -> Vec<String> {
+    plan.config()
+        .nodes
+        .iter()
+        .find(|n| n.value.name() == name)
+        .unwrap_or_else(|| panic!("node {name:?} present"))
+        .value
+        .direct_input_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+// ── end-to-end: base + group op + channel override ────────────────────────
+
+#[test]
+fn base_plus_group_add_and_channel_set_compiles_effective_plan() {
+    // A group-layer `add` splices `enrich` after `normalize`; a
+    // channel-per-target `set` rewrites `normalize`'s CXL. Both must land in
+    // the compiled effective plan, and the higher-precedence channel op is
+    // applied to the same base node the group op read from.
+    let group_add = LayeredOp::new(
+        OverlayLayer::Group { priority: 10 },
+        parse_op(
+            r#"
+op: add
+node:
+  type: transform
+  name: enrich
+  input: normalize
+  config:
+    cxl: "emit order_id = order_id\nemit amount = amount"
+after: normalize
+"#,
+        ),
+    );
+    let channel_set = LayeredOp::new(
+        OverlayLayer::ChannelPerTarget,
+        parse_op(
+            r#"
+op: set
+target: normalize
+field: config.cxl
+value: "emit order_id = order_id\nemit amount = amount * 2"
+"#,
+        ),
+    );
+
+    let plan = compile_with_ops(vec![group_add, channel_set]).expect("effective plan compiles");
+
+    // `enrich` was spliced in after `normalize`, and `sink` was rewired onto it.
+    assert_eq!(
+        effective_names(&plan),
+        vec!["orders", "normalize", "enrich", "sink"],
+    );
+    assert_eq!(inputs_of(&plan, "enrich"), vec!["normalize"]);
+    assert_eq!(inputs_of(&plan, "sink"), vec!["enrich"]);
+
+    // The channel `set` override replaced `normalize`'s logic wholesale.
+    assert_eq!(
+        transform_cxl(&plan, "normalize"),
+        "emit order_id = order_id\nemit amount = amount * 2",
+    );
+    // The group-added node kept the logic the op declared.
+    assert_eq!(
+        transform_cxl(&plan, "enrich"),
+        "emit order_id = order_id\nemit amount = amount",
+    );
+}
+
+// ── ill-typed op: structural failure anchored to the op ───────────────────
+
+#[test]
+fn orphaning_remove_errors_with_op_spanned_diagnostic() {
+    // Removing `normalize` without rewiring `sink` leaves a dangling reference;
+    // the engine rejects it and the diagnostic must anchor to the op's line,
+    // never to the base pipeline's `normalize` declaration.
+    let op = parse_op(
+        r#"
+op: remove
+target: normalize
+"#,
+    );
+    let op_line = op.referenced.line() as u32;
+    assert!(op_line > 0, "op should carry a real source line");
+
+    let diags = compile_with_ops(vec![LayeredOp::new(OverlayLayer::ChannelPerTarget, op)])
+        .expect_err("orphaning remove must fail compilation");
+
+    let e114 = diags
+        .iter()
+        .find(|d| d.code == "E114")
+        .expect("overlay-op failure reported as E114");
+    assert_eq!(
+        e114.primary.span.synthetic_line_number(),
+        Some(op_line),
+        "the diagnostic must be anchored to the offending op, not the base pipeline",
+    );
+    assert!(
+        e114.message.contains("normalize"),
+        "message should name the dangling target: {}",
+        e114.message,
+    );
+}
+
+// ── ill-typed op: bad CXL caught by bind_schema, anchored to the op ────────
+
+#[test]
+fn spliced_bad_cxl_errors_anchored_to_op() {
+    // The op engine does not typecheck CXL, so a spliced node with a bad body
+    // applies structurally and then fails in the ordinary `bind_schema` pass.
+    // Because the engine stamps the injected node with the op's location, that
+    // typecheck diagnostic (E200) still points at the op, not the base.
+    let op = parse_op(
+        r#"
+op: add
+node:
+  type: transform
+  name: broken
+  input: normalize
+  config:
+    cxl: "emit oops = nonexistent_field"
+after: normalize
+"#,
+    );
+    let op_line = op.referenced.line() as u32;
+    assert!(op_line > 0, "op should carry a real source line");
+
+    let diags = compile_with_ops(vec![LayeredOp::new(OverlayLayer::ChannelPerTarget, op)])
+        .expect_err("spliced bad CXL must fail compilation");
+
+    let cxl_err = diags
+        .iter()
+        .find(|d| d.code == "E200" && d.primary.span.synthetic_line_number() == Some(op_line))
+        .unwrap_or_else(|| {
+            panic!("expected an op-spanned CXL diagnostic at line {op_line}, got: {diags:?}")
+        });
+    assert!(
+        cxl_err.message.contains("broken"),
+        "diagnostic should name the spliced node: {}",
+        cxl_err.message,
+    );
+}
+
+// ── no overlay: plain pipeline unaffected ─────────────────────────────────
+
+#[test]
+fn plain_pipeline_without_overlay_is_unaffected() {
+    // With no overlay ops the pre-compile pass is skipped entirely: the
+    // compiled plan carries exactly the declared nodes, no injections.
+    let plan = compile_with_ops(Vec::new()).expect("plain pipeline compiles");
+    assert_eq!(effective_names(&plan), vec!["orders", "normalize", "sink"]);
+    assert_eq!(
+        transform_cxl(&plan, "normalize"),
+        "emit order_id = order_id\nemit amount = amount",
+    );
+    assert_eq!(inputs_of(&plan, "sink"), vec!["normalize"]);
+}


### PR DESCRIPTION
## What

Wires the channel/group structural overlay `overrides:` op stream into pipeline compilation. When a compile context carries resolved overlay ops, the compiler splices them into a working copy of the base node list **before** schema binding, then compiles the effective (post-overlay) DAG through the unchanged typecheck/lower path — so the effective plan is what actually runs.

Structural ops (`add` / `remove` / `replace` / `set` / `bypass` / `patch_schema`) mutate the typed DAG — topology, source schema, CXL — all of which must be typechecked. Applying them pre-compile lets the ordinary `bind_schema` pass act as the safety net: an overlay cannot produce something that would not compile by hand, and failures are attributed to the offending op rather than the base pipeline.

## How

- `CompileContext` gains an `overlay_ops` input (empty by default). The op engine re-orders the layer-tagged stream into fixed `(layer-precedence, declaration)` order, so the result depends only on each op's layer identity, never on concatenation order.
- A plain pipeline with no overlay ops skips the pass entirely and compiles byte-identically to before.
- Op-application failures (missing target, orphaning `remove`, breaking schema patch) surface as an `E114` diagnostic anchored to the offending op's span.
- Ill-typed CXL introduced by an op (a bad `set config.cxl`, a spliced node whose body does not typecheck) is caught unchanged by the normal `bind_schema` pass, still anchored to the op — the engine stamps each injected/replaced node with the op's source location.
- One effective plan per invocation.

Value `config`/`vars` clobber and the runtime `vars` that flow to the executor via `PipelineRunParams` are resolved on separate surfaces and do not enter the AST here.

## Tests

New `overlay_compile` suite covering the acceptance criteria end-to-end:

- base + a group `add` + a channel `set` compiles to the expected effective plan (injected node spliced and consumers rewired, overridden CXL present);
- an orphaning `remove` fails with an op-spanned `E114` diagnostic (asserted against the op's line, not the base);
- a spliced node with bad CXL fails in `bind_schema` with an op-spanned `E200`;
- a plain pipeline with no overlay ops is unaffected.

`cargo fmt --all --check`, `cargo clippy -p clinker-plan --all-targets -- -D warnings`, and `cargo test -p clinker-plan` are green; `cargo check --workspace --all-targets` confirms no downstream breakage from the `CompileContext` addition.

Part of #515
Closes #527