### PR TITLE
feat(channel): resolve channel/group overlays across the run and inspection CLIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "clinker-plan",
  "clinker-record",
  "indexmap",
+ "insta",
  "miette",
  "num_cpus",
  "serde-saphyr",

--- a/crates/clinker-channel/src/discovery.rs
+++ b/crates/clinker-channel/src/discovery.rs
@@ -45,7 +45,7 @@ use crate::group::Group;
 use crate::manifest::{ChannelManifest, OverlayFile};
 
 /// Filename of the optional per-channel manifest inside each tenant folder.
-const CHANNEL_MANIFEST_FILE: &str = "channel.cfg.yaml";
+pub const CHANNEL_MANIFEST_FILE: &str = "channel.cfg.yaml";
 
 /// Filename suffix marking a group definition file.
 const GROUP_FILE_SUFFIX: &str = ".group.yaml";
@@ -145,6 +145,19 @@ pub fn channel_folder_path(channel_root: &Path, shard: ShardScheme, channel_id: 
             channel_root.join(bucket).join(channel_id)
         }
     }
+}
+
+/// The on-disk tenant folder for `channel_id` under a channel layout, resolved
+/// against the workspace root.
+///
+/// This is the folder [`resolve_channel_overlay`] probes for per-target
+/// overlays and where the optional [`CHANNEL_MANIFEST_FILE`] manifest lives.
+/// It composes [`resolve_root`] (workspace-relative-or-absolute root) with
+/// [`channel_folder_path`] (the shard-aware id→folder mapping), so callers get
+/// the same path both the run-path computed lookup and the lint scan land on.
+pub fn channel_dir(layout: &ChannelLayout, workspace_root: &Path, channel_id: &str) -> PathBuf {
+    let root = resolve_root(&layout.root, workspace_root);
+    channel_folder_path(&root, layout.shard, channel_id)
 }
 
 /// Depth (relative to the channel root) at which tenant folders sit for a

--- a/crates/clinker-channel/src/group.rs
+++ b/crates/clinker-channel/src/group.rs
@@ -32,6 +32,9 @@ use std::path::{Path, PathBuf};
 use indexmap::IndexMap;
 use serde::Deserialize;
 
+use clinker_plan::overlay_ops::OverlayOp;
+use clinker_plan::yaml::Spanned;
+
 use crate::error::ChannelError;
 use crate::manifest::ChannelVars;
 
@@ -69,10 +72,10 @@ pub struct Group {
     /// block uses (`static` / `pipeline` / `source` / `record`). Reuses the
     /// channel overlay's [`ChannelVars`](crate::manifest::ChannelVars) type.
     pub vars: ChannelVars,
-    /// Ordered override ops, preserved verbatim. The typed op vocabulary is
-    /// owned by the overlay op engine and interpreted there; this stage only
-    /// captures the raw entries without losing information.
-    pub overrides: Vec<serde_json::Value>,
+    /// Ordered override ops applied at this group's `Group` layer. Each op
+    /// keeps its source [`Spanned`] location so a later ill-typed-op
+    /// diagnostic anchors to the offending op rather than the base pipeline.
+    pub overrides: Vec<Spanned<OverlayOp>>,
 }
 
 impl Group {
@@ -120,7 +123,7 @@ struct RawGroupFile {
     #[serde(default)]
     vars: ChannelVars,
     #[serde(default)]
-    overrides: Vec<serde_json::Value>,
+    overrides: Vec<Spanned<OverlayOp>>,
 }
 
 #[derive(Deserialize)]

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -57,6 +57,7 @@ pub mod error;
 pub mod group;
 pub mod manifest;
 pub mod overlay;
+pub mod resolve;
 pub mod selector;
 pub mod staging_copy;
 
@@ -67,13 +68,16 @@ pub use derivation::{
     group_layer,
 };
 pub use discovery::{
-    DiscoveredChannel, OverlayKind, ResolvedOverlay, channel_folder_path, resolve_channel_overlay,
-    scan_channels, scan_groups,
+    CHANNEL_MANIFEST_FILE, DiscoveredChannel, OverlayKind, ResolvedOverlay, channel_dir,
+    channel_folder_path, resolve_channel_overlay, scan_channels, scan_groups,
 };
 pub use error::ChannelError;
 pub use group::Group;
 pub use manifest::{ChannelManifest, ChannelVars, ManifestHeader, OverlayFile, OverlayHeader};
 pub use overlay::{ChannelOverlayResult, apply_channel_overlay};
+pub use resolve::{
+    AppliedGroup, GroupSource, InjectedNode, OverlayResolution, ResolveError, resolve,
+};
 pub use selector::{LabelSelector, SelectorError};
 pub use staging_copy::{
     ReuseDecision, SourceStager, StagingError, StagingPlanEntry, open_source_file,

--- a/crates/clinker-channel/src/manifest.rs
+++ b/crates/clinker-channel/src/manifest.rs
@@ -25,6 +25,8 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use clinker_plan::config::ScopedVarDecl;
+use clinker_plan::overlay_ops::OverlayOp;
+use clinker_plan::yaml::Spanned;
 
 use crate::error::ChannelError;
 
@@ -38,7 +40,7 @@ use crate::error::ChannelError;
 /// vars:
 ///   static: { currency: { type: string, default: "USD" } }
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChannelManifest {
     /// The manifest header — carries the channel `name`.
@@ -57,11 +59,12 @@ pub struct ChannelManifest {
     /// `vars:` block uses.
     #[serde(default)]
     pub vars: ChannelVars,
-    /// Channel-wide ordered override op list. The element type is finalized
-    /// by CH-10 (#525); until then each op is carried as an opaque map so
-    /// this parse layer does not invent the op vocabulary.
+    /// Channel-wide ordered override op list, applied at the `ChannelWide`
+    /// layer. Each op keeps its source [`Spanned`] location so a later
+    /// ill-typed-op diagnostic anchors to the offending op rather than the
+    /// base pipeline.
     #[serde(default)]
-    pub overrides: Vec<serde_json::Value>,
+    pub overrides: Vec<Spanned<OverlayOp>>,
 }
 
 /// The `channel:` header of a manifest.
@@ -82,7 +85,7 @@ pub struct ManifestHeader {
 /// vars:   { static: { currency: { type: string, default: "USD" } } }
 /// overrides: [ ... ]
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OverlayFile {
     /// The overlay header — carries the authoritative `target`.
@@ -94,10 +97,11 @@ pub struct OverlayFile {
     /// `vars:` block uses.
     #[serde(default)]
     pub vars: ChannelVars,
-    /// Per-target ordered override op list. Opaque until CH-10 (#525) — see
-    /// [`ChannelManifest::overrides`].
+    /// Per-target ordered override op list, applied at the highest
+    /// `ChannelPerTarget` layer. Each op keeps its source [`Spanned`]
+    /// location — see [`ChannelManifest::overrides`].
     #[serde(default)]
-    pub overrides: Vec<serde_json::Value>,
+    pub overrides: Vec<Spanned<OverlayOp>>,
 }
 
 /// The `channel:` header of an overlay file.

--- a/crates/clinker-channel/src/overlay.rs
+++ b/crates/clinker-channel/src/overlay.rs
@@ -47,6 +47,8 @@ use clinker_plan::plan::{ChannelIdentity, CompiledPlan};
 use clinker_record::Value;
 
 use crate::binding::{ChannelBinding, ChannelTarget, DottedPath};
+use crate::error::ChannelError;
+use crate::manifest::ChannelVars;
 
 /// Resolved channel overlay output: typed var maps and any diagnostics
 /// raised during validation.
@@ -216,6 +218,64 @@ pub(crate) fn apply_config_clobber(
                 ));
             }
         }
+    }
+}
+
+/// Validate a raw `alias.param` config map into [`DottedPath`] keys, cloning
+/// the values. The first malformed key fails the whole map.
+///
+/// Shared by the channel-folder resolution ([`crate::resolve`]) so the
+/// channel-wide (`channel.cfg.yaml`) and per-target (`<target>.channel.yaml`)
+/// `config:` maps — which keep raw string keys at parse time — validate through
+/// the same [`DottedPath`] grammar the group and per-target layers already use.
+pub(crate) fn validate_config_keys(
+    config: &IndexMap<String, serde_json::Value>,
+) -> Result<IndexMap<DottedPath, serde_json::Value>, ChannelError> {
+    config
+        .iter()
+        .map(|(key, value)| Ok((DottedPath::try_from(key.as_str())?, value.clone())))
+        .collect()
+}
+
+/// Resolve one overlay layer's [`ChannelVars`] against the pipeline's declared
+/// registries and **merge** the results into `out` with later-layer-wins
+/// semantics (a key an earlier layer set is overwritten by this layer).
+///
+/// Reuses the same per-registry validators the per-target [`apply_channel_overlay`]
+/// path uses, so every layer (group, channel-wide, per-target) resolves vars
+/// identically. Callers apply layers in ascending precedence order so the
+/// highest layer wins each key. `source_label` names the layer for diagnostics
+/// (e.g. a group or channel name).
+pub(crate) fn resolve_vars_layer(
+    source_label: &str,
+    vars: &ChannelVars,
+    config: &PipelineConfig,
+    out: &mut ChannelOverlayResult,
+) {
+    out.static_vars.extend(resolve_static_overrides(
+        source_label,
+        &vars.static_scope,
+        config,
+        &mut out.diagnostics,
+    ));
+    out.pipeline_vars.extend(resolve_scoped_overrides(
+        source_label,
+        &vars.pipeline,
+        config,
+        VarScope::Pipeline,
+        &mut out.diagnostics,
+    ));
+    out.record_vars.extend(resolve_scoped_overrides(
+        source_label,
+        &vars.record,
+        config,
+        VarScope::Record,
+        &mut out.diagnostics,
+    ));
+    for (src, inner) in
+        resolve_source_overrides(source_label, &vars.source, config, &mut out.diagnostics)
+    {
+        out.source_vars.entry(src).or_default().extend(inner);
     }
 }
 

--- a/crates/clinker-channel/src/resolve.rs
+++ b/crates/clinker-channel/src/resolve.rs
@@ -1,0 +1,563 @@
+//! End-to-end channel/group overlay resolution for one CLI invocation.
+//!
+//! This is the seam the CLI (`run`, `explain`, `channels resolve`,
+//! `channels lint`) resolves an overlay stack through. It ties the discovery
+//! ([`crate::discovery`]), group derivation ([`crate::derivation`]), and the
+//! two application surfaces — the structural op stream ([`OverlayOp`], applied
+//! pre-compile via `CompileContext::overlay_ops`) and the `config`/`vars` value
+//! clobber ([`crate::overlay`], applied post-compile over the plan's
+//! `ProvenanceDb`) — into one resolution.
+//!
+//! # Two-phase application
+//!
+//! The two surfaces apply at different points in the compile pipeline, so a
+//! caller uses a [`OverlayResolution`] in two steps:
+//!
+//! 1. **Pre-compile:** feed [`OverlayResolution::op_stream`] into
+//!    `CompileContext::overlay_ops` so the structural ops splice into the base
+//!    AST before schema binding — the *effective* DAG is what compiles.
+//! 2. **Post-compile:** call [`OverlayResolution::apply_config_and_vars`] on the
+//!    compiled plan to clobber `config` onto its `ProvenanceDb` and resolve
+//!    `vars` into runtime values for `PipelineRunParams`.
+//!
+//! # Layer stack
+//!
+//! Both surfaces resolve through the fixed semantic order
+//! `pipeline-default < group(s) by priority < channel-wide < channel-per-target`.
+//! Groups are enumerated once (they are few, unlike the ~3,000-tenant channel
+//! tree) and either derived from the channel's `labels` or force-included by
+//! name; the channel manifest and per-target overlay supply the two channel
+//! layers. A plain invocation (no channel id, no groups) resolves to an empty
+//! stack, so the compile path is byte-identical to a bare pipeline.
+
+use std::path::Path;
+
+use clinker_core_types::{Diagnostic, LabeledSpan, Span};
+
+use clinker_plan::config::composition::LayerKind;
+use clinker_plan::config::pipeline_node::PipelineNode;
+use clinker_plan::config::{ChannelLayout, GroupLayout, PipelineConfig};
+use clinker_plan::overlay_ops::{LayeredOp, OverlayLayer, OverlayOp};
+use clinker_plan::plan::{ChannelIdentity, CompiledPlan};
+use clinker_plan::yaml::Spanned;
+
+use crate::derivation::{derive_groups, group_layer};
+use crate::discovery::{
+    CHANNEL_MANIFEST_FILE, OverlayKind, ResolvedOverlay, channel_dir, resolve_channel_overlay,
+};
+use crate::error::ChannelError;
+use crate::group::Group;
+use crate::manifest::{ChannelManifest, ChannelVars};
+use crate::overlay::{
+    ChannelOverlayResult, apply_config_clobber, resolve_vars_layer, validate_config_keys,
+};
+use crate::{apply_group_config, scan_groups};
+
+/// Why a group joined the overlay stack.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GroupSource {
+    /// The group's selector matched the channel's labels.
+    Derived,
+    /// The group was force-included by name (`--group`), regardless of selector.
+    Explicit,
+}
+
+impl GroupSource {
+    /// A short label for reporting.
+    pub fn label(self) -> &'static str {
+        match self {
+            GroupSource::Derived => "derived",
+            GroupSource::Explicit => "explicit",
+        }
+    }
+}
+
+/// One group applied to the stack, carrying the layer identities both surfaces
+/// resolve through plus the owned group for the post-compile phase.
+#[derive(Debug, Clone)]
+pub struct AppliedGroup {
+    /// Group name.
+    pub name: String,
+    /// Authored priority (higher wins among matching groups).
+    pub priority: i64,
+    /// Why this group was applied.
+    pub source: GroupSource,
+    /// Config-clobber layer (carries priority + declaration seq).
+    layer: LayerKind,
+    /// Op-stream precedence layer.
+    op_layer: OverlayLayer,
+    /// The parsed group (for `config`/`vars` application post-compile).
+    group: Group,
+}
+
+/// A node injected by an `add` op, attributed to the overlay layer / source
+/// that introduced it — the "which group added which node" report.
+#[derive(Debug, Clone)]
+pub struct InjectedNode {
+    /// Name of the injected node.
+    pub node: String,
+    /// The overlay layer whose op added it.
+    pub layer: OverlayLayer,
+    /// Human-readable source (group or channel name).
+    pub source: String,
+}
+
+/// The resolved channel context: id plus its optional manifest and per-target
+/// overlay.
+#[derive(Debug, Clone)]
+struct ChannelContext {
+    id: String,
+    manifest: Option<ChannelManifest>,
+    per_target: Option<ResolvedOverlay>,
+    /// BLAKE3 over the channel id plus the raw bytes of its manifest and
+    /// per-target overlay files. Content-sensitive so a changed overlay yields
+    /// a distinct [`ChannelIdentity`], matching the channel-file overlay path
+    /// (which hashes the `.channel.yaml` bytes) rather than a bare id hash that
+    /// would collide across edits.
+    content_hash: [u8; 32],
+}
+
+/// A fully resolved overlay stack for one (target, channel?, groups)
+/// invocation. See the module docs for the two-phase application contract.
+#[derive(Debug, Clone)]
+pub struct OverlayResolution {
+    channel: Option<ChannelContext>,
+    applied_groups: Vec<AppliedGroup>,
+    injected_nodes: Vec<InjectedNode>,
+    op_stream: Vec<LayeredOp>,
+}
+
+impl OverlayResolution {
+    /// Whether this resolution changes anything. An empty resolution means the
+    /// compile + run path is identical to a bare pipeline.
+    pub fn is_empty(&self) -> bool {
+        self.channel.is_none() && self.applied_groups.is_empty() && self.op_stream.is_empty()
+    }
+
+    /// The concatenated, layer-tagged structural op stream. Feed this into
+    /// `CompileContext::overlay_ops` before compiling so the effective DAG is
+    /// what binds and lowers.
+    pub fn op_stream(&self) -> &[LayeredOp] {
+        &self.op_stream
+    }
+
+    /// Nodes injected by `add` ops, each attributed to its source layer.
+    pub fn injected_nodes(&self) -> &[InjectedNode] {
+        &self.injected_nodes
+    }
+
+    /// The applied groups, in ascending precedence (highest-priority last).
+    pub fn applied_groups(&self) -> &[AppliedGroup] {
+        &self.applied_groups
+    }
+
+    /// The resolved channel id, if a channel was selected.
+    pub fn channel_id(&self) -> Option<&str> {
+        self.channel.as_ref().map(|c| c.id.as_str())
+    }
+
+    /// Path to the resolved per-target overlay file, if the channel overlays
+    /// this target.
+    pub fn overlay_path(&self) -> Option<&Path> {
+        self.channel
+            .as_ref()
+            .and_then(|c| c.per_target.as_ref())
+            .map(|o| o.path.as_path())
+    }
+
+    /// Apply the value-clobber surface (`config` + `vars`) of every layer over a
+    /// compiled plan's `ProvenanceDb`, resolving `vars` into runtime values.
+    ///
+    /// Layers apply in ascending precedence (groups by priority, then
+    /// channel-wide, then channel-per-target) so the highest layer wins each
+    /// key. An unknown `config` key surfaces as an `E113` diagnostic (never a
+    /// silent no-op); callers refuse to execute if any `Error` diagnostic is
+    /// present. Returns the merged runtime `vars` maps for `PipelineRunParams`.
+    pub fn apply_config_and_vars(
+        &self,
+        plan: &mut CompiledPlan,
+        config: &PipelineConfig,
+    ) -> ChannelOverlayResult {
+        let mut result = ChannelOverlayResult::default();
+
+        // Groups: ascending precedence. Config clobbers at each group's layer;
+        // vars merge with later-wins.
+        for applied in &self.applied_groups {
+            if let Err(e) = apply_group_config(
+                plan.provenance_mut(),
+                &applied.group,
+                applied.layer,
+                &mut result.diagnostics,
+            ) {
+                push_config_error(&mut result.diagnostics, &applied.name, &e);
+            }
+            resolve_vars_layer(&applied.name, &applied.group.vars, config, &mut result);
+        }
+
+        if let Some(ctx) = &self.channel {
+            // Channel-wide (manifest): applies to every pipeline this channel
+            // runs.
+            if let Some(manifest) = &ctx.manifest {
+                clobber_config(
+                    plan,
+                    &manifest.config,
+                    LayerKind::ChannelWide,
+                    &ctx.id,
+                    &mut result,
+                );
+                resolve_vars_layer(&ctx.id, &manifest.vars, config, &mut result);
+            }
+            // Per-target overlay: the highest layer.
+            if let Some(overlay) = &ctx.per_target {
+                clobber_config(
+                    plan,
+                    &overlay.overlay.config,
+                    LayerKind::ChannelPerTarget,
+                    &ctx.id,
+                    &mut result,
+                );
+                apply_overlay_vars(overlay, &ctx.id, config, &mut result);
+            }
+            plan.set_channel_identity(ChannelIdentity {
+                name: ctx.id.clone(),
+                content_hash: ctx.content_hash,
+            });
+        }
+
+        result
+    }
+}
+
+/// Clobber one raw `config` map (string keys validated into dotted paths) onto
+/// a plan's provenance at `layer`. A malformed key is a hard error surfaced as
+/// a diagnostic; an unknown-but-well-formed key is `E113` from the clobber.
+fn clobber_config(
+    plan: &mut CompiledPlan,
+    config: &indexmap::IndexMap<String, serde_json::Value>,
+    layer: LayerKind,
+    source_label: &str,
+    result: &mut ChannelOverlayResult,
+) {
+    match validate_config_keys(config) {
+        Ok(validated) => apply_config_clobber(
+            plan.provenance_mut(),
+            &validated,
+            layer,
+            false,
+            source_label,
+            &mut result.diagnostics,
+        ),
+        Err(e) => push_config_error(&mut result.diagnostics, source_label, &e),
+    }
+}
+
+/// Resolve a per-target overlay's `vars`. Var overrides are not supported on a
+/// composition overlay (E109), matching the per-target `apply_channel_overlay`
+/// path; a composition overlay carrying vars raises the diagnostic instead of
+/// silently resolving them.
+fn apply_overlay_vars(
+    overlay: &ResolvedOverlay,
+    source_label: &str,
+    config: &PipelineConfig,
+    result: &mut ChannelOverlayResult,
+) {
+    if overlay.kind == OverlayKind::Composition && vars_present(&overlay.overlay.vars) {
+        result.diagnostics.push(Diagnostic::error(
+            "E109",
+            format!(
+                "channel {source_label:?}: var overrides not supported on composition overlay {}",
+                overlay.path.display(),
+            ),
+            LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+        ));
+        return;
+    }
+    resolve_vars_layer(source_label, &overlay.overlay.vars, config, result);
+}
+
+/// Whether any of the four var scopes carries an entry.
+fn vars_present(vars: &ChannelVars) -> bool {
+    !vars.static_scope.is_empty()
+        || !vars.pipeline.is_empty()
+        || !vars.source.is_empty()
+        || !vars.record.is_empty()
+}
+
+/// Push a hard config-key error (malformed dotted path) as an `E113`
+/// diagnostic, consistent with the unknown-key path.
+fn push_config_error(diagnostics: &mut Vec<Diagnostic>, source_label: &str, err: &ChannelError) {
+    diagnostics.push(Diagnostic::error(
+        "E113",
+        format!("overlay {source_label:?}: {err}"),
+        LabeledSpan::primary(Span::SYNTHETIC, String::new()),
+    ));
+}
+
+/// A failure resolving an overlay stack before compile.
+#[derive(Debug)]
+pub enum ResolveError {
+    /// A discovery scan (groups) failed with diagnostics.
+    Scan(Vec<Diagnostic>),
+    /// A channel manifest / per-target overlay failed to load or was
+    /// ambiguous.
+    Channel(ChannelError),
+    /// One or more group selectors failed to compile or evaluate (e.g. an
+    /// unknown label). Each entry is `(group_name, reason)`.
+    Selector(Vec<(String, String)>),
+    /// An explicit `--group <name>` named no group under the group root.
+    UnknownGroup {
+        /// The requested group name.
+        name: String,
+        /// Group names that do exist, for a "did you mean" hint.
+        known: Vec<String>,
+    },
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveError::Scan(diags) => {
+                write!(f, "group discovery failed: ")?;
+                for (i, d) in diags.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "; ")?;
+                    }
+                    write!(f, "{}: {}", d.code, d.message)?;
+                }
+                Ok(())
+            }
+            ResolveError::Channel(e) => write!(f, "{e}"),
+            ResolveError::Selector(errs) => {
+                write!(f, "group selector error: ")?;
+                for (i, (name, reason)) in errs.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, "; ")?;
+                    }
+                    write!(f, "group {name:?}: {reason}")?;
+                }
+                Ok(())
+            }
+            ResolveError::UnknownGroup { name, known } => {
+                write!(f, "no group named {name:?} under the group root")?;
+                if !known.is_empty() {
+                    write!(f, " (known: {})", known.join(", "))?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+/// Resolve the overlay stack for one target.
+///
+/// `target_name` is the bare pipeline/composition stem (no extension), e.g.
+/// `order_fulfillment`. `channel_id` selects a tenant by computed path;
+/// `explicit_groups` force-includes groups by name; `auto_groups` enables
+/// selector-derived group membership (suppressed by `--no-auto-groups`).
+///
+/// Auto-derivation needs a channel manifest's `labels`, so it is a no-op when
+/// no channel is selected — explicit `--group` still applies, standalone.
+pub fn resolve(
+    workspace_root: &Path,
+    channel_layout: &ChannelLayout,
+    group_layout: &GroupLayout,
+    target_name: &str,
+    channel_id: Option<&str>,
+    explicit_groups: &[String],
+    auto_groups: bool,
+) -> Result<OverlayResolution, ResolveError> {
+    // Groups are few (bounded well below the tenant tree), so enumerating them
+    // once is fine off the channel hot path. Explicit lookup and selector
+    // derivation both read this set. Sort by name so the derivation `seq` (which
+    // breaks equal-priority ties) is a stable, portable order rather than the
+    // filesystem-dependent `scan_groups` walk order.
+    let mut all_groups = scan_groups(group_layout, workspace_root).map_err(ResolveError::Scan)?;
+    all_groups.sort_by(|a, b| a.name.cmp(&b.name));
+
+    // Channel context: manifest (labels + channel-wide overlay) + per-target
+    // overlay, both by computed path.
+    let channel = match channel_id {
+        Some(id) => {
+            let dir = channel_dir(channel_layout, workspace_root, id);
+            let manifest_path = dir.join(CHANNEL_MANIFEST_FILE);
+            let manifest = if manifest_path.is_file() {
+                Some(ChannelManifest::load(&manifest_path).map_err(ResolveError::Channel)?)
+            } else {
+                None
+            };
+            let per_target =
+                resolve_channel_overlay(channel_layout, workspace_root, id, target_name)
+                    .map_err(ResolveError::Channel)?;
+            // Content-sensitive identity: id plus the raw bytes of the channel's
+            // own overlay files (manifest + per-target). A changed overlay must
+            // yield a distinct hash so any identity-keyed cache invalidates.
+            let mut hasher = blake3::Hasher::new();
+            hasher.update(id.as_bytes());
+            if let Ok(bytes) = std::fs::read(&manifest_path) {
+                hasher.update(&bytes);
+            }
+            if let Some(overlay) = &per_target
+                && let Ok(bytes) = std::fs::read(&overlay.path)
+            {
+                hasher.update(&bytes);
+            }
+            Some(ChannelContext {
+                id: id.to_string(),
+                manifest,
+                per_target,
+                content_hash: *hasher.finalize().as_bytes(),
+            })
+        }
+        None => None,
+    };
+
+    // Labels drive selector derivation; absent manifest ⇒ no labels.
+    let labels = channel
+        .as_ref()
+        .and_then(|c| c.manifest.as_ref())
+        .map(|m| m.labels.clone())
+        .unwrap_or_default();
+
+    // Choose group indices (into `all_groups`) with the source that pulled each
+    // in. Auto-derived first (transparent; a selector error is fatal), then
+    // explicit force-includes (deduped against the derived set).
+    let mut chosen: Vec<(usize, GroupSource)> = Vec::new();
+
+    if auto_groups && channel.is_some() {
+        let derivation = derive_groups(&all_groups, &labels);
+        if derivation.has_errors() {
+            let errs = derivation
+                .errors()
+                .map(|(g, e)| (g.name.clone(), e.to_string()))
+                .collect();
+            return Err(ResolveError::Selector(errs));
+        }
+        for selection in derivation.selected() {
+            // `seq` is the group's index in `all_groups` (assigned by
+            // `derive_groups`' enumerate), so map back by index — not by name,
+            // which would collapse two same-named group files onto one.
+            let idx = selection.seq as usize;
+            chosen.push((idx, GroupSource::Derived));
+        }
+    }
+
+    for name in explicit_groups {
+        let idx = all_groups
+            .iter()
+            .position(|g| &g.name == name)
+            .ok_or_else(|| ResolveError::UnknownGroup {
+                name: name.clone(),
+                known: all_groups.iter().map(|g| g.name.clone()).collect(),
+            })?;
+        if !chosen.iter().any(|(i, _)| *i == idx) {
+            chosen.push((idx, GroupSource::Explicit));
+        }
+    }
+
+    // Materialize applied groups with their layer identities, then order by
+    // ascending precedence so the highest-priority group applies last.
+    let mut applied_groups: Vec<AppliedGroup> = chosen
+        .into_iter()
+        .map(|(idx, source)| {
+            let group = all_groups[idx].clone();
+            // Declaration-order seq = scan index; breaks equal-priority ties.
+            let seq = u32::try_from(idx).unwrap_or(u32::MAX);
+            let layer = group_layer(&group, seq);
+            // Tag the op stream with the *same* (saturated) priority the config
+            // layer carries, so both surfaces order groups whose priorities
+            // saturate to the same value identically.
+            let op_priority = match layer {
+                LayerKind::Group { priority, .. } => i64::from(priority),
+                _ => group.priority,
+            };
+            AppliedGroup {
+                name: group.name.clone(),
+                priority: group.priority,
+                source,
+                layer,
+                op_layer: OverlayLayer::Group {
+                    priority: op_priority,
+                },
+                group,
+            }
+        })
+        .collect();
+    applied_groups.sort_by_key(|a| a.layer);
+
+    // Concatenate the structural op streams in ascending precedence, tagging
+    // each op with its layer and recording every injected node.
+    let mut op_stream = Vec::new();
+    let mut injected_nodes = Vec::new();
+    for applied in &applied_groups {
+        push_ops(
+            &mut op_stream,
+            &mut injected_nodes,
+            &applied.group.overrides,
+            applied.op_layer,
+            &applied.name,
+        );
+    }
+    if let Some(ctx) = &channel {
+        if let Some(manifest) = &ctx.manifest {
+            push_ops(
+                &mut op_stream,
+                &mut injected_nodes,
+                &manifest.overrides,
+                OverlayLayer::ChannelWide,
+                &ctx.id,
+            );
+        }
+        if let Some(overlay) = &ctx.per_target {
+            push_ops(
+                &mut op_stream,
+                &mut injected_nodes,
+                &overlay.overlay.overrides,
+                OverlayLayer::ChannelPerTarget,
+                &ctx.id,
+            );
+        }
+    }
+
+    Ok(OverlayResolution {
+        channel,
+        applied_groups,
+        injected_nodes,
+        op_stream,
+    })
+}
+
+/// Tag each op in `ops` with `layer`, push it onto the stream, and record any
+/// node an `add` op introduces.
+fn push_ops(
+    op_stream: &mut Vec<LayeredOp>,
+    injected: &mut Vec<InjectedNode>,
+    ops: &[Spanned<OverlayOp>],
+    layer: OverlayLayer,
+    source: &str,
+) {
+    for op in ops {
+        if let Some(name) = injected_node_name(&op.value) {
+            injected.push(InjectedNode {
+                node: name,
+                layer,
+                source: source.to_string(),
+            });
+        }
+        op_stream.push(LayeredOp::new(layer, op.clone()));
+    }
+}
+
+/// The name an `add` op introduces: the inline node's own name, or the
+/// composition add's `alias`. Non-`add` ops introduce no node.
+fn injected_node_name(op: &OverlayOp) -> Option<String> {
+    match op {
+        OverlayOp::Add(add) => add
+            .node
+            .as_ref()
+            .map(|n: &PipelineNode| n.name().to_string())
+            .or_else(|| add.alias.clone()),
+        _ => None,
+    }
+}

--- a/crates/clinker-channel/tests/channel_manifest_test.rs
+++ b/crates/clinker-channel/tests/channel_manifest_test.rs
@@ -11,6 +11,7 @@ use std::path::PathBuf;
 
 use clinker_channel::{ChannelManifest, OverlayFile};
 use clinker_plan::config::ScopedVarType;
+use clinker_plan::overlay_ops::OverlayOp;
 
 fn manifest(yaml: &[u8]) -> ChannelManifest {
     ChannelManifest::from_yaml_bytes(yaml, PathBuf::from("channel.cfg.yaml"))
@@ -78,10 +79,18 @@ overrides:
     );
     assert_eq!(m.vars.record["tag"].var_type, ScopedVarType::String);
 
-    // `overrides` stays opaque — a list of maps, uninterpreted here.
+    // `overrides` parses into the typed op vocabulary, keeping each op's span.
     assert_eq!(m.overrides.len(), 1);
-    assert_eq!(m.overrides[0]["op"], serde_json::json!("add"));
-    assert_eq!(m.overrides[0]["alias"], serde_json::json!("fraud"));
+    match &m.overrides[0].value {
+        OverlayOp::Add(add) => {
+            assert_eq!(add.alias.as_deref(), Some("fraud"));
+            assert_eq!(
+                add.composition.as_deref(),
+                Some(std::path::Path::new("./composition/fraud.comp.yaml"))
+            );
+        }
+        other => panic!("expected add op, got {other:?}"),
+    }
 }
 
 #[test]
@@ -126,13 +135,15 @@ labels: { region: west, tier: enterprise, shard: "07" }
 "#,
     );
 
-    // Serialize the parsed manifest and read it back; labels must survive
-    // with identical order and values.
-    let json = serde_json::to_string(&m).expect("manifest serializes");
-    let round: ChannelManifest = serde_json::from_str(&json).expect("manifest re-parses");
+    // Labels are an order-preserving scalar map: round-tripping them through
+    // JSON keeps declared order and values (the manifest itself is parse-only
+    // now that `overrides` carries span-bearing typed ops).
+    let json = serde_json::to_string(&m.labels).expect("labels serialize");
+    let round: indexmap::IndexMap<String, serde_json::Value> =
+        serde_json::from_str(&json).expect("labels re-parse");
 
     let before: Vec<(&String, &serde_json::Value)> = m.labels.iter().collect();
-    let after: Vec<(&String, &serde_json::Value)> = round.labels.iter().collect();
+    let after: Vec<(&String, &serde_json::Value)> = round.iter().collect();
     assert_eq!(before, after);
     assert_eq!(
         after[2],
@@ -168,7 +179,13 @@ overrides:
         ScopedVarType::String
     );
     assert_eq!(o.overrides.len(), 1);
-    assert_eq!(o.overrides[0]["op"], serde_json::json!("set"));
+    match &o.overrides[0].value {
+        OverlayOp::Set(set) => {
+            assert_eq!(set.target, "route_priority");
+            assert_eq!(set.field, "config.cxl");
+        }
+        other => panic!("expected set op, got {other:?}"),
+    }
 }
 
 #[test]
@@ -224,23 +241,35 @@ labels: { region: west }
 }
 
 #[test]
-fn overlay_overrides_stay_opaque() {
-    // A structurally rich op list parses as opaque values without this layer
-    // asserting any op vocabulary (that is CH-10's job).
+fn overlay_overrides_parse_typed() {
+    // A structurally rich op list parses into the typed op vocabulary, each op
+    // keeping its source span. The keyed `schema:` grammar (not a list) is the
+    // canonical `patch_schema` shape.
     let o = overlay(
         br#"
 channel:
   target: ./pipeline.yaml
 overrides:
-  - { op: add, node: { type: transform, name: stamp, input: src }, after: src }
-  - { op: patch_schema, target: orders, add: [ { name: tax_exempt, type: bool } ] }
+  - { op: add, node: { type: transform, name: stamp, input: src, config: { cxl: "emit a = b" } }, after: src }
+  - { op: patch_schema, target: orders, schema: { tax_exempt: { add: { type: bool } } } }
   - { op: bypass, target: legacy_audit }
 "#,
         "pipeline.channel.yaml",
     );
 
     assert_eq!(o.overrides.len(), 3);
-    assert!(o.overrides[0].is_object());
-    assert_eq!(o.overrides[1]["op"], serde_json::json!("patch_schema"));
-    assert_eq!(o.overrides[2]["target"], serde_json::json!("legacy_audit"));
+    assert!(matches!(o.overrides[0].value, OverlayOp::Add(_)));
+    match &o.overrides[1].value {
+        OverlayOp::PatchSchema(patch) => {
+            assert_eq!(patch.target, "orders");
+            assert!(patch.schema.contains_key("tax_exempt"));
+        }
+        other => panic!("expected patch_schema op, got {other:?}"),
+    }
+    match &o.overrides[2].value {
+        OverlayOp::Bypass(bypass) => assert_eq!(bypass.target, "legacy_audit"),
+        other => panic!("expected bypass op, got {other:?}"),
+    }
+    // Ops carry a non-zero source line (span anchoring for op diagnostics).
+    assert!(o.overrides[0].referenced.line() > 0);
 }

--- a/crates/clinker-channel/tests/group_parse_test.rs
+++ b/crates/clinker-channel/tests/group_parse_test.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 
 use clinker_channel::Group;
 use clinker_plan::config::ScopedVarType;
+use clinker_plan::overlay_ops::OverlayOp;
 
 fn group(yaml: &[u8]) -> Group {
     Group::from_yaml_bytes(yaml, PathBuf::from("test.group.yaml")).expect("group YAML parses")
@@ -148,20 +149,19 @@ overrides:
     );
     assert_eq!(g.vars.record["seen"].var_type, ScopedVarType::Bool);
 
-    // Overrides are preserved verbatim, in declaration order.
+    // Overrides parse into the typed op vocabulary, in declaration order.
     assert_eq!(g.overrides.len(), 2);
-    assert_eq!(
-        g.overrides[0].get("op").and_then(|v| v.as_str()),
-        Some("add")
-    );
-    assert_eq!(
-        g.overrides[0].get("alias").and_then(|v| v.as_str()),
-        Some("fraud_check")
-    );
-    assert_eq!(
-        g.overrides[1].get("op").and_then(|v| v.as_str()),
-        Some("set")
-    );
+    match &g.overrides[0].value {
+        OverlayOp::Add(add) => {
+            assert_eq!(add.alias.as_deref(), Some("fraud_check"));
+            assert_eq!(add.after.as_deref(), Some("normalize_fields"));
+        }
+        other => panic!("expected add op, got {other:?}"),
+    }
+    match &g.overrides[1].value {
+        OverlayOp::Set(set) => assert_eq!(set.target, "route_priority"),
+        other => panic!("expected set op, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/clinker/Cargo.toml
+++ b/crates/clinker/Cargo.toml
@@ -28,3 +28,4 @@ tempfile = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+insta = "1"

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -107,6 +107,75 @@ EXAMPLES:
   clinker explain --code E105"
     )]
     Explain(ExplainArgs),
+    /// Channel/group overlay tooling: resolve one effective plan, or lint the
+    /// whole workspace.
+    #[command(
+        long_about = "\
+Inspect and validate the channel/group multi-tenant overlay system.\n\n\
+`resolve` renders the effective post-overlay DAG for one target under a chosen \
+channel and/or groups, with per-value provenance — which layer supplied each \
+value and which group injected which node. `lint` compiles every \
+(target × overlay) combination across the workspace and reports failures, the \
+CI safety net for base-change blast radius.",
+        after_long_help = "\
+EXAMPLES:
+  # What does tenant `globex` actually run for this pipeline?
+  clinker channels resolve pipeline/order_fulfillment.yaml --channel globex
+
+  # Preview a group overlay standalone (no channel)
+  clinker channels resolve pipeline/order_fulfillment.yaml --group enterprise
+
+  # Compile every channel/group overlay in the workspace and report failures
+  clinker channels lint"
+    )]
+    Channels {
+        #[command(subcommand)]
+        subcommand: ChannelsCommands,
+    },
+}
+
+/// Subcommands for `clinker channels`.
+#[derive(Subcommand, Debug)]
+pub enum ChannelsCommands {
+    /// Render the effective post-overlay plan for one target with provenance.
+    Resolve(ResolveArgs),
+    /// Compile every (target × overlay) combination and report failures.
+    Lint(LintArgs),
+}
+
+/// Arguments for `clinker channels resolve`.
+#[derive(Parser, Debug)]
+pub struct ResolveArgs {
+    /// Path to the base pipeline (or composition) YAML to resolve.
+    pub target: PathBuf,
+
+    /// Channel id to resolve the overlay stack for (folder under the channel
+    /// root). Derives matching groups from the channel's labels.
+    #[arg(long)]
+    pub channel: Option<String>,
+
+    /// Force-include a group overlay by name (repeatable), with or without a
+    /// channel.
+    #[arg(long = "group", value_name = "NAME")]
+    pub groups: Vec<String>,
+
+    /// Suppress selector-derived group membership; only explicit `--group`
+    /// overlays apply.
+    #[arg(long = "no-auto-groups")]
+    pub no_auto_groups: bool,
+
+    /// Workspace root (holds `clinker.toml` and the channel/group roots).
+    #[arg(long, default_value = ".")]
+    pub base_dir: PathBuf,
+}
+
+/// Arguments for `clinker channels lint`.
+#[derive(Parser, Debug)]
+pub struct LintArgs {
+    /// Workspace root to lint (holds `clinker.toml` and the channel/group
+    /// roots).
+    #[arg(long, default_value = ".")]
+    pub base_dir: PathBuf,
 }
 
 /// Output format for --explain.
@@ -215,6 +284,17 @@ pub struct RunArgs {
     /// are rejected.
     #[arg(long, help_heading = "Configuration")]
     pub channel: Option<PathBuf>,
+
+    /// Force-include a group overlay by name (repeatable). Applies the group's
+    /// `overrides` op stream and `config`/`vars` clobber regardless of its
+    /// selector, with or without a channel. See `clinker channels resolve`.
+    #[arg(long = "group", value_name = "NAME", help_heading = "Configuration")]
+    pub groups: Vec<String>,
+
+    /// Suppress selector-derived group membership; only explicit `--group`
+    /// overlays apply.
+    #[arg(long = "no-auto-groups", help_heading = "Configuration")]
+    pub no_auto_groups: bool,
 }
 
 impl RunArgs {
@@ -289,6 +369,16 @@ pub struct ExplainArgs {
     /// Channel YAML file to apply before provenance lookup
     #[arg(long)]
     pub channel: Option<PathBuf>,
+
+    /// Force-include a group overlay by name (repeatable) before provenance
+    /// lookup, mirroring `clinker run --group`.
+    #[arg(long = "group", value_name = "NAME")]
+    pub groups: Vec<String>,
+
+    /// Suppress selector-derived group membership; only explicit `--group`
+    /// overlays apply.
+    #[arg(long = "no-auto-groups")]
+    pub no_auto_groups: bool,
 
     /// Error/warning code to look up (e.g. "E105")
     #[arg(long)]
@@ -392,6 +482,22 @@ fn main() -> ExitCode {
                 Ok(()) => ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("clinker explain error: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+        Commands::Channels { subcommand } => {
+            tracing_subscriber::fmt()
+                .with_max_level(tracing_subscriber::filter::LevelFilter::WARN)
+                .init();
+            let result = match subcommand {
+                ChannelsCommands::Resolve(args) => run_channels_resolve(args),
+                ChannelsCommands::Lint(args) => run_channels_lint(args),
+            };
+            match result {
+                Ok(code) => ExitCode::from(code),
+                Err(e) => {
+                    eprintln!("clinker channels error: {e}");
                     ExitCode::FAILURE
                 }
             }
@@ -651,9 +757,11 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // plan-only `--explain` display path (which never ingests, so the
     // filesystem-class rejections do not apply) and seeds the run path with the
     // same resolved root the validator re-derives.
-    let storage_config = clinker_plan::config::ClinkerToml::load_from_workspace(&workspace_root)
-        .map_err(storage_config_error)?
-        .storage;
+    let clinker_toml = clinker_plan::config::ClinkerToml::load_from_workspace(&workspace_root)
+        .map_err(storage_config_error)?;
+    let channel_layout = clinker_toml.channel.clone();
+    let group_layout = clinker_toml.group.clone();
+    let storage_config = clinker_toml.storage;
     let spill_root_dir = storage_config
         .spill
         .resolve()
@@ -683,9 +791,52 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // resolve — so dataset names name the same bytes a run reads/writes. Both
     // halves are moved into `compile_ctx` next, so capture the join now.
     let lineage_base_dir = workspace_root.join(&pipeline_dir);
+
+    // Resolve the channel/group overlay stack (op stream + config/vars clobber)
+    // before building the compile context. Groups here are force-included by
+    // name (`--group`); auto-derivation keys off a channel manifest's labels,
+    // which the legacy file-based `--channel` flag does not carry, so on the run
+    // path only explicit `--group` overlays apply (full label-derivation is
+    // available via `clinker channels resolve`). An empty request resolves to
+    // an empty stack, keeping a plain run byte-identical.
+    let target_name = args
+        .config
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    let overlay_resolution = if args.groups.is_empty() {
+        None
+    } else {
+        Some(
+            clinker_channel::resolve(
+                &workspace_root,
+                &channel_layout,
+                &group_layout,
+                target_name,
+                None,
+                &args.groups,
+                !args.no_auto_groups,
+            )
+            .map_err(|e| {
+                PipelineError::Config(clinker_plan::config::ConfigError::Validation(format!(
+                    "overlay resolution failed: {e}"
+                )))
+            })?,
+        )
+    };
+    if let Some(res) = &overlay_resolution
+        && !args.quiet
+        && !res.is_empty()
+    {
+        eprintln!("clinker: applied overlay — {}", overlay_summary(res));
+    }
+
     let mut compile_ctx =
         clinker_plan::config::CompileContext::with_pipeline_dir(workspace_root, pipeline_dir);
     compile_ctx.allow_absolute_paths = args.allow_absolute_paths;
+    if let Some(res) = &overlay_resolution {
+        compile_ctx.overlay_ops = res.op_stream().to_vec();
+    }
 
     // Run identity values flow through Output path templates and the
     // provenance sidecar. Generated before --explain so resolved-path
@@ -767,6 +918,10 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                     transform_name: String::new(),
                     messages: diags.iter().map(|d| d.message.clone()).collect(),
                 })?;
+        if let Some(res) = &overlay_resolution {
+            let overlay = res.apply_config_and_vars(&mut compiled_plan, &pipeline_config);
+            abort_on_overlay_errors(&overlay)?;
+        }
         if let Some(binding) = &channel_binding {
             let overlay = clinker_channel::apply_channel_overlay(
                 &mut compiled_plan,
@@ -891,6 +1046,10 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
                     transform_name: String::new(),
                     messages: diags.iter().map(|d| d.message.clone()).collect(),
                 })?;
+        if let Some(res) = &overlay_resolution {
+            let overlay = res.apply_config_and_vars(&mut compiled_plan, cfg);
+            abort_on_overlay_errors(&overlay)?;
+        }
         if let Some(binding) = &channel_binding {
             let overlay = clinker_channel::apply_channel_overlay(&mut compiled_plan, binding, cfg);
             abort_on_overlay_errors(&overlay)?;
@@ -995,15 +1154,39 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     // preflight, and so output-side fan-out detection (§5) can read
     // `fan_out_per_source_file` flags before the writer setup decides whether
     // to open one writer or N.
-    let mut compiled_plan = pipeline_config.compile(&compile_ctx).expect("compile");
+    // The structural overlay op stream (if any) is applied inside `compile`
+    // via `compile_ctx.overlay_ops`, so a bad splice anchor or ill-typed op is
+    // a compile diagnostic, not a panic — propagate it rather than unwrapping.
+    let mut compiled_plan =
+        pipeline_config
+            .compile(&compile_ctx)
+            .map_err(|diags| PipelineError::Compilation {
+                transform_name: String::new(),
+                messages: diags.iter().map(|d| d.message.clone()).collect(),
+            })?;
+    // Group/channel-folder overlay: config/vars clobber at the lower layers.
+    // Applied before the legacy channel-file overlay so the latter (the
+    // highest layer) still wins any shared key.
+    if let Some(res) = &overlay_resolution {
+        let overlay = res.apply_config_and_vars(&mut compiled_plan, &pipeline_config);
+        abort_on_overlay_errors(&overlay)?;
+        channel_static_vars.extend(overlay.static_vars);
+        channel_pipeline_vars.extend(overlay.pipeline_vars);
+        for (src, inner) in overlay.source_vars {
+            channel_source_vars.entry(src).or_default().extend(inner);
+        }
+        channel_record_vars.extend(overlay.record_vars);
+    }
     if let Some(binding) = &channel_binding {
         let overlay =
             clinker_channel::apply_channel_overlay(&mut compiled_plan, binding, &pipeline_config);
         abort_on_overlay_errors(&overlay)?;
-        channel_static_vars = overlay.static_vars;
-        channel_pipeline_vars = overlay.pipeline_vars;
-        channel_source_vars = overlay.source_vars;
-        channel_record_vars = overlay.record_vars;
+        channel_static_vars.extend(overlay.static_vars);
+        channel_pipeline_vars.extend(overlay.pipeline_vars);
+        for (src, inner) in overlay.source_vars {
+            channel_source_vars.entry(src).or_default().extend(inner);
+        }
+        channel_record_vars.extend(overlay.record_vars);
     }
 
     // Discovery pre-pass: resolve every File source's matcher to its file set
@@ -1306,12 +1489,16 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
         spill_disk_cap_bytes,
         spill_compress: storage_config.spill.compress,
     };
+    // The executor recompiles `compiled_plan.config()` — already the effective,
+    // post-overlay config — so the context it recompiles under must NOT carry
+    // the overlay ops again (they would double-apply and collide). For a plain
+    // run this is identical to `compile_ctx.clone()` (the op stream is empty).
     let report = match PipelineExecutor::run_plan_with_readers_writers_in_context(
         &compiled_plan,
         readers,
         registry,
         &run_params,
-        compile_ctx.clone(),
+        compile_ctx.without_overlay_ops(),
     ) {
         Ok(report) => report,
         Err(e) => {
@@ -2129,13 +2316,56 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
         .strip_prefix(&workspace_root)
         .unwrap_or_else(|_| std::path::Path::new(""))
         .to_path_buf();
-    let compile_ctx =
-        clinker_plan::config::CompileContext::with_pipeline_dir(&workspace_root, pipeline_dir);
 
-    let compiled_plan = pipeline_config.compile(&compile_ctx).map_err(|diags| {
+    // Force-included group overlays (`--group`) apply their op stream and
+    // config/vars clobber before provenance is computed, mirroring `run`.
+    let clinker_toml = clinker_plan::config::ClinkerToml::load_from_workspace(&workspace_root)
+        .map_err(|e| format!("clinker.toml: {e}"))?;
+    let target_name = config_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    let overlay_resolution = if args.groups.is_empty() {
+        None
+    } else {
+        Some(
+            clinker_channel::resolve(
+                &workspace_root,
+                &clinker_toml.channel,
+                &clinker_toml.group,
+                target_name,
+                None,
+                &args.groups,
+                !args.no_auto_groups,
+            )
+            .map_err(|e| format!("overlay resolution failed: {e}"))?,
+        )
+    };
+
+    let mut compile_ctx =
+        clinker_plan::config::CompileContext::with_pipeline_dir(&workspace_root, pipeline_dir);
+    if let Some(res) = &overlay_resolution {
+        compile_ctx.overlay_ops = res.op_stream().to_vec();
+    }
+
+    let mut compiled_plan = pipeline_config.compile(&compile_ctx).map_err(|diags| {
         let messages: Vec<String> = diags.iter().map(|d| d.message.clone()).collect();
         format!("compilation failed:\n{}", messages.join("\n"))
     })?;
+
+    if let Some(res) = &overlay_resolution {
+        use clinker_core_types::Severity;
+        let overlay = res.apply_config_and_vars(&mut compiled_plan, &pipeline_config);
+        let errors: Vec<String> = overlay
+            .diagnostics
+            .iter()
+            .filter(|d| matches!(d.severity, Severity::Error))
+            .map(|d| format!("[{}] {}", d.code, d.message))
+            .collect();
+        if !errors.is_empty() {
+            return Err(format!("overlay application failed:\n{}", errors.join("\n")).into());
+        }
+    }
 
     let output =
         clinker_plan::plan::explain_provenance::explain_field_provenance(&compiled_plan, field)
@@ -2143,6 +2373,379 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
 
     print!("{output}");
     Ok(())
+}
+
+/// One-line summary of an applied overlay resolution for run/explain output.
+fn overlay_summary(res: &clinker_channel::OverlayResolution) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(id) = res.channel_id() {
+        parts.push(format!("channel {id}"));
+    }
+    if res.applied_groups().is_empty() {
+        parts.push("no groups".to_string());
+    } else {
+        let groups: Vec<String> = res
+            .applied_groups()
+            .iter()
+            .map(|g| format!("{} ({}, priority {})", g.name, g.source.label(), g.priority))
+            .collect();
+        parts.push(format!("groups: {}", groups.join(", ")));
+    }
+    parts.join("; ")
+}
+
+/// Human-readable label for an op-stream overlay layer.
+fn op_layer_label(layer: clinker_plan::overlay_ops::OverlayLayer) -> String {
+    use clinker_plan::overlay_ops::OverlayLayer;
+    match layer {
+        OverlayLayer::PipelineDefault => "pipeline-default".to_string(),
+        OverlayLayer::Group { priority } => format!("group (priority {priority})"),
+        OverlayLayer::ChannelWide => "channel-wide".to_string(),
+        OverlayLayer::ChannelPerTarget => "channel-per-target".to_string(),
+    }
+}
+
+/// Format a JSON value for the provenance table (strip quotes from strings).
+fn format_overlay_value(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::String(s) => format!("\"{s}\""),
+        other => other.to_string(),
+    }
+}
+
+/// Compile the effective (post-overlay) plan for a target under a resolution.
+///
+/// Applies the structural op stream pre-compile (via `overlay_ops`) and the
+/// `config`/`vars` clobber post-compile, returning the config, the compiled
+/// plan, and the overlay result (whose diagnostics carry any `E113`/`E109`).
+/// A compile failure (e.g. a dangling splice anchor) is a hard `Err`.
+fn compile_effective_plan(
+    base_path: &std::path::Path,
+    workspace_root: &std::path::Path,
+    res: &clinker_channel::OverlayResolution,
+) -> Result<
+    (
+        clinker_plan::config::PipelineConfig,
+        clinker_plan::plan::CompiledPlan,
+        clinker_channel::ChannelOverlayResult,
+    ),
+    String,
+> {
+    let yaml = std::fs::read_to_string(base_path)
+        .map_err(|e| format!("cannot read {}: {e}", base_path.display()))?;
+    let interpolated = clinker_plan::config::interpolate_env_vars(&yaml, &[])
+        .map_err(|e| format!("environment variable interpolation failed: {e}"))?;
+    let config: clinker_plan::config::PipelineConfig = clinker_plan::yaml::from_str(&interpolated)
+        .map_err(|e| format!("YAML parse error: {e}"))?;
+
+    let base_parent = base_path
+        .parent()
+        .unwrap_or_else(|| std::path::Path::new("."))
+        .canonicalize()
+        .unwrap_or_else(|_| std::path::PathBuf::from("."));
+    let pipeline_dir = base_parent
+        .strip_prefix(workspace_root)
+        .unwrap_or_else(|_| std::path::Path::new(""))
+        .to_path_buf();
+    let mut ctx =
+        clinker_plan::config::CompileContext::with_pipeline_dir(workspace_root, pipeline_dir);
+    ctx.overlay_ops = res.op_stream().to_vec();
+
+    let mut plan = config.compile(&ctx).map_err(|diags| {
+        let messages: Vec<String> = diags
+            .iter()
+            .map(|d| format!("[{}] {}", d.code, d.message))
+            .collect();
+        format!("compilation failed:\n{}", messages.join("\n"))
+    })?;
+    let overlay = res.apply_config_and_vars(&mut plan, &config);
+    Ok((config, plan, overlay))
+}
+
+/// Render the effective post-overlay plan with per-node/op provenance — the
+/// `channels resolve` report. Deterministic (no file sizes / timing), so it
+/// snapshots cleanly.
+fn render_resolved(
+    plan: &clinker_plan::plan::CompiledPlan,
+    overlay: &clinker_channel::ChannelOverlayResult,
+    res: &clinker_channel::OverlayResolution,
+    target_name: &str,
+) -> String {
+    use clinker_core_types::Severity;
+    use clinker_plan::config::composition::LayerKind;
+
+    let mut out = String::new();
+    out.push_str(&format!("Effective plan for `{target_name}`\n"));
+    match res.channel_id() {
+        Some(id) => out.push_str(&format!("  channel: {id}\n")),
+        None => out.push_str("  channel: <none>\n"),
+    }
+    if res.applied_groups().is_empty() {
+        out.push_str("  groups:  <none>\n");
+    } else {
+        out.push_str("  groups:\n");
+        for g in res.applied_groups() {
+            out.push_str(&format!(
+                "    - {} (priority {}, {})\n",
+                g.name,
+                g.priority,
+                g.source.label()
+            ));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("Injected nodes:\n");
+    if res.injected_nodes().is_empty() {
+        out.push_str("  <none>\n");
+    } else {
+        for inj in res.injected_nodes() {
+            out.push_str(&format!(
+                "  {} <- {} [{}]\n",
+                inj.node,
+                inj.source,
+                op_layer_label(inj.layer)
+            ));
+        }
+    }
+    out.push('\n');
+
+    out.push_str("Config provenance (overlay-affected):\n");
+    let mut rows: Vec<String> = Vec::new();
+    for ((node, param), resolved) in plan.provenance().iter() {
+        let Some(win) = resolved.winning_layer() else {
+            continue;
+        };
+        if win.kind == LayerKind::PipelineDefault {
+            continue;
+        }
+        let base = resolved
+            .layer_value(LayerKind::PipelineDefault)
+            .map(format_overlay_value)
+            .unwrap_or_else(|| "<none>".to_string());
+        rows.push(format!(
+            "  {node}.{param} = {}  [{}]  (base: {})",
+            format_overlay_value(&resolved.value),
+            win.kind,
+            base
+        ));
+    }
+    rows.sort();
+    if rows.is_empty() {
+        out.push_str("  <none>\n");
+    } else {
+        for r in rows {
+            out.push_str(&r);
+            out.push('\n');
+        }
+    }
+
+    let diags: Vec<&clinker_core_types::Diagnostic> = overlay
+        .diagnostics
+        .iter()
+        .filter(|d| matches!(d.severity, Severity::Error | Severity::Warning))
+        .collect();
+    if !diags.is_empty() {
+        out.push('\n');
+        out.push_str("Diagnostics:\n");
+        for d in diags {
+            let label = match d.severity {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Note => "note",
+            };
+            out.push_str(&format!("  {label}: [{}] {}\n", d.code, d.message));
+        }
+    }
+
+    out
+}
+
+/// `clinker channels resolve <target>` — render the effective post-overlay plan
+/// for one target with per-value provenance.
+fn run_channels_resolve(args: &ResolveArgs) -> Result<u8, Box<dyn std::error::Error>> {
+    let workspace_root = args.base_dir.canonicalize()?;
+    let clinker_toml = clinker_plan::config::ClinkerToml::load_from_workspace(&workspace_root)
+        .map_err(|e| format!("clinker.toml: {e}"))?;
+    // Strip the full `.comp.yaml` / `.yaml` suffix (not just the last
+    // extension) so a composition target `score.comp.yaml` resolves to the bare
+    // stem `score` the discovery layer expects — matching `channels lint`.
+    let file_name = args
+        .target
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or("target path has no file name")?;
+    let target_name = target_stem_of(file_name);
+
+    let res = clinker_channel::resolve(
+        &workspace_root,
+        &clinker_toml.channel,
+        &clinker_toml.group,
+        &target_name,
+        args.channel.as_deref(),
+        &args.groups,
+        !args.no_auto_groups,
+    )
+    .map_err(|e| format!("overlay resolution failed: {e}"))?;
+
+    let (config, plan, overlay) = compile_effective_plan(&args.target, &workspace_root, &res)?;
+
+    // Overlay report (deterministic) followed by the effective DAG for context.
+    print!("{}", render_resolved(&plan, &overlay, &res, &target_name));
+    println!("\nEffective DAG:");
+    print!("{}", plan.dag().explain_text(&config));
+
+    // An overlay that raised an error diagnostic (e.g. an unknown config key)
+    // resolves to a non-zero exit so `resolve` doubles as a targeted check.
+    use clinker_core_types::Severity;
+    let has_error = overlay
+        .diagnostics
+        .iter()
+        .any(|d| matches!(d.severity, Severity::Error));
+    Ok(if has_error { 1 } else { 0 })
+}
+
+/// `clinker channels lint` — compile every (target × overlay) combination in the
+/// workspace and report failures. This is the full-tree scan (kept off the run
+/// path, which resolves by computed lookup).
+fn run_channels_lint(args: &LintArgs) -> Result<u8, Box<dyn std::error::Error>> {
+    let workspace_root = args.base_dir.canonicalize()?;
+    let clinker_toml = clinker_plan::config::ClinkerToml::load_from_workspace(&workspace_root)
+        .map_err(|e| format!("clinker.toml: {e}"))?;
+
+    let channels = clinker_channel::scan_channels(&clinker_toml.channel, &workspace_root).map_err(
+        |diags| {
+            let msgs: Vec<String> = diags
+                .iter()
+                .map(|d| format!("[{}] {}", d.code, d.message))
+                .collect();
+            format!("channel scan failed:\n{}", msgs.join("\n"))
+        },
+    )?;
+
+    let mut checked = 0usize;
+    let mut failures: Vec<(String, String, Vec<String>)> = Vec::new();
+
+    for channel in &channels {
+        // Every overlay file in the tenant folder is a (channel × target) combo.
+        for overlay_path in overlay_files_in(&channel.dir) {
+            let overlay_file = match clinker_channel::OverlayFile::load(&overlay_path) {
+                Ok(o) => o,
+                Err(e) => {
+                    failures.push((
+                        channel.id.clone(),
+                        overlay_path.display().to_string(),
+                        vec![format!("overlay parse error: {e}")],
+                    ));
+                    continue;
+                }
+            };
+            let target_name = target_stem_of(&overlay_file.channel.target);
+            let base_path = channel.dir.join(&overlay_file.channel.target);
+
+            checked += 1;
+            let res = match clinker_channel::resolve(
+                &workspace_root,
+                &clinker_toml.channel,
+                &clinker_toml.group,
+                &target_name,
+                Some(&channel.id),
+                &[],
+                true,
+            ) {
+                Ok(r) => r,
+                Err(e) => {
+                    failures.push((
+                        channel.id.clone(),
+                        target_name.clone(),
+                        vec![format!("resolution failed: {e}")],
+                    ));
+                    continue;
+                }
+            };
+
+            match compile_effective_plan(&base_path, &workspace_root, &res) {
+                Ok((_, _, overlay)) => {
+                    use clinker_core_types::Severity;
+                    let errs: Vec<String> = overlay
+                        .diagnostics
+                        .iter()
+                        .filter(|d| matches!(d.severity, Severity::Error))
+                        .map(|d| format!("[{}] {}", d.code, d.message))
+                        .collect();
+                    if !errs.is_empty() {
+                        failures.push((channel.id.clone(), target_name.clone(), errs));
+                    }
+                }
+                Err(msg) => {
+                    failures.push((
+                        channel.id.clone(),
+                        target_name.clone(),
+                        msg.lines().map(str::to_string).collect(),
+                    ));
+                }
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        println!(
+            "channels lint: OK — {checked} (target × overlay) combination(s) across {} channel(s) compiled clean",
+            channels.len()
+        );
+        Ok(0)
+    } else {
+        for (channel_id, target, msgs) in &failures {
+            eprintln!("FAIL  channel `{channel_id}`  target `{target}`");
+            for m in msgs {
+                eprintln!("        {m}");
+            }
+        }
+        eprintln!(
+            "channels lint: {} failure(s) of {checked} combination(s)",
+            failures.len()
+        );
+        Ok(1)
+    }
+}
+
+/// The candidate overlay files in a tenant folder: every `*.yaml` except the
+/// `channel.cfg.yaml` manifest. Non-recursive, symlinks skipped.
+fn overlay_files_in(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let mut files = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return files;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name == clinker_channel::CHANNEL_MANIFEST_FILE {
+            continue;
+        }
+        if name.ends_with(".yaml") {
+            files.push(path);
+        }
+    }
+    files.sort();
+    files
+}
+
+/// The bare target stem of a `channel.target:` path (strip `.comp.yaml` /
+/// `.yaml` and the directory).
+fn target_stem_of(target: &str) -> String {
+    let file = std::path::Path::new(target)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(target);
+    file.strip_suffix(".comp.yaml")
+        .or_else(|| file.strip_suffix(".yaml"))
+        .unwrap_or(file)
+        .to_string()
 }
 
 #[cfg(test)]

--- a/crates/clinker/tests/channels_overlay.rs
+++ b/crates/clinker/tests/channels_overlay.rs
@@ -1,0 +1,381 @@
+//! End-to-end coverage for the channel/group overlay CLI (CH-9/CH-13/CH-14).
+//!
+//! Exercises a small multi-tenant workspace through the four surfaces the
+//! overlay system exposes: `run --group` (standalone group application),
+//! `channels resolve` (effective plan + provenance, channel-only and
+//! group-only), `channels lint` (full-tree scan), and the plain-pipeline path
+//! (which must stay unaffected by the overlay wiring).
+//!
+//! The workspace pairs a base pipeline that uses a composition `scorer` (with a
+//! `threshold` config knob) against:
+//!   - a group `enterprise` (selector `tier == "enterprise"`, priority 20) that
+//!     injects a `fraud_stamp` transform and clobbers `scorer.threshold`;
+//!   - a channel `globex` (labels `tier=enterprise`) whose manifest and
+//!     per-target overlay clobber `scorer.threshold` at the higher layers.
+
+use std::path::Path;
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+const CLINKER_TOML: &str = "[channel]\nroot = \"channel\"\n\n[group]\nroot = \"group\"\n";
+const ORDERS_CSV: &str = "order_id,amount\na1,150.0\na2,20.0\n";
+
+const COMPOSITION: &str = r#"_compose:
+  name: score
+  inputs:
+    inp:
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: float }
+  outputs:
+    out: scored
+  config_schema:
+    threshold:
+      type: float
+      default: 0.5
+nodes:
+  - type: transform
+    name: scored
+    input: inp
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit amount = amount
+"#;
+
+const PIPELINE: &str = r#"pipeline:
+  name: order_fulfillment
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: float }
+  - type: transform
+    name: normalize
+    input: orders
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit amount = amount
+  - type: composition
+    name: scorer
+    input: normalize
+    use: ../composition/score.comp.yaml
+    inputs:
+      inp: normalize
+    config:
+      threshold: 0.5
+  - type: output
+    name: out
+    input: scorer
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+const GROUP: &str = r#"group:
+  name: enterprise
+  match: 'tier == "enterprise"'
+  priority: 20
+config:
+  scorer.threshold: 0.8
+overrides:
+  - op: add
+    node:
+      type: transform
+      name: fraud_stamp
+      input: normalize
+      config:
+        cxl: |
+          emit order_id = order_id
+          emit amount = amount
+    after: normalize
+"#;
+
+const GLOBEX_MANIFEST: &str = r#"channel:
+  name: globex
+labels: { tier: enterprise, region: west }
+config:
+  scorer.threshold: 0.9
+"#;
+
+const GLOBEX_OVERLAY: &str = r#"channel:
+  target: ../../pipeline/order_fulfillment.yaml
+config:
+  scorer.threshold: 0.95
+"#;
+
+/// A manifest declaring a non-enterprise `tier` label. A channel's manifest is
+/// its label contract: without a declared `tier` the `enterprise` selector
+/// would error on the unresolved identifier rather than cleanly not match, so
+/// even the "broken" channels carry a manifest.
+fn basic_manifest(name: &str) -> String {
+    format!("channel:\n  name: {name}\nlabels: {{ tier: basic, region: west }}\n")
+}
+
+/// A per-target overlay whose `add` op splices after a node that does not
+/// exist — the dangling splice anchor lint must surface (E114).
+const DANGLING_OVERLAY: &str = r#"channel:
+  target: ../../pipeline/order_fulfillment.yaml
+overrides:
+  - op: add
+    node:
+      type: transform
+      name: dangling
+      input: ghost_node
+      config:
+        cxl: "emit order_id = order_id"
+    after: ghost_node
+"#;
+
+/// A per-target overlay with a config key matching no composition parameter —
+/// the broken-overlay lint must surface (E113).
+const BADKEY_OVERLAY: &str = r#"channel:
+  target: ../../pipeline/order_fulfillment.yaml
+config:
+  scorer.bogus_param: 0.1
+"#;
+
+/// Build the valid workspace (globex only). With `broken`, add two channels
+/// carrying intentionally invalid overlays for the lint failure test.
+fn build_workspace(root: &Path, broken: bool) {
+    write(root, "clinker.toml", CLINKER_TOML);
+    write(root, "pipeline/orders.csv", ORDERS_CSV);
+    write(root, "pipeline/order_fulfillment.yaml", PIPELINE);
+    write(root, "composition/score.comp.yaml", COMPOSITION);
+    write(root, "group/enterprise.group.yaml", GROUP);
+    write(root, "channel/globex/channel.cfg.yaml", GLOBEX_MANIFEST);
+    write(
+        root,
+        "channel/globex/order_fulfillment.channel.yaml",
+        GLOBEX_OVERLAY,
+    );
+    if broken {
+        write(
+            root,
+            "channel/dangling/channel.cfg.yaml",
+            &basic_manifest("dangling"),
+        );
+        write(
+            root,
+            "channel/dangling/order_fulfillment.channel.yaml",
+            DANGLING_OVERLAY,
+        );
+        write(
+            root,
+            "channel/badkey/channel.cfg.yaml",
+            &basic_manifest("badkey"),
+        );
+        write(
+            root,
+            "channel/badkey/order_fulfillment.channel.yaml",
+            BADKEY_OVERLAY,
+        );
+    }
+}
+
+fn pipeline_path(root: &Path) -> std::path::PathBuf {
+    root.join("pipeline/order_fulfillment.yaml")
+}
+
+#[test]
+fn plain_run_is_unaffected_by_overlay_wiring() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path(), false);
+
+    let out = Command::new(clinker_bin())
+        .arg("run")
+        .arg(pipeline_path(tmp.path()))
+        .args(["--base-dir", tmp.path().to_str().unwrap()])
+        .args(["--dry-run", "-n", "2"])
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "plain run must succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    // No overlay was requested, so the run must not announce one.
+    assert!(
+        !stderr.contains("applied overlay"),
+        "a plain run must not apply any overlay.\nstderr: {stderr}"
+    );
+}
+
+#[test]
+fn run_with_group_applies_the_overlay() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path(), false);
+
+    let out = Command::new(clinker_bin())
+        .arg("run")
+        .arg(pipeline_path(tmp.path()))
+        .args(["--base-dir", tmp.path().to_str().unwrap()])
+        .args(["--group", "enterprise"])
+        .args(["--dry-run", "-n", "2"])
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "run --group must succeed (injected node preserves the schema).\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("applied overlay") && stderr.contains("enterprise"),
+        "run --group must report the applied group.\nstderr: {stderr}"
+    );
+    // Both input records flow through the injected + composition nodes (the
+    // run completion is logged to stdout).
+    assert!(
+        stdout.contains("2 written"),
+        "the overlaid run must process both records.\nstdout: {stdout}"
+    );
+}
+
+/// Split a `channels resolve` stdout at the effective-DAG boundary, keeping the
+/// deterministic overlay report (the DAG text below carries volatile stats).
+fn overlay_report(stdout: &str) -> String {
+    stdout
+        .split("\nEffective DAG:")
+        .next()
+        .unwrap_or(stdout)
+        .to_string()
+}
+
+#[test]
+fn channels_resolve_channel_renders_provenance() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path(), false);
+
+    let out = Command::new(clinker_bin())
+        .args(["channels", "resolve"])
+        .arg(pipeline_path(tmp.path()))
+        .args(["--channel", "globex"])
+        .args(["--base-dir", tmp.path().to_str().unwrap()])
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "channels resolve --channel must succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    let report = overlay_report(&stdout);
+    // Group derived from the channel's `tier=enterprise` label.
+    assert!(
+        report.contains("enterprise (priority 20, derived)"),
+        "{report}"
+    );
+    // The group injected a node.
+    assert!(report.contains("fraud_stamp <- enterprise"), "{report}");
+    // The per-target overlay (0.95) won the 4-layer clobber over base 0.5.
+    assert!(
+        report.contains("scorer.threshold = 0.95") && report.contains("ChannelPerTarget"),
+        "{report}"
+    );
+    // The deterministic overlay report snapshots cleanly.
+    insta::assert_snapshot!("resolve_channel_globex", report);
+}
+
+#[test]
+fn channels_resolve_group_standalone() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path(), false);
+
+    let out = Command::new(clinker_bin())
+        .args(["channels", "resolve"])
+        .arg(pipeline_path(tmp.path()))
+        .args(["--group", "enterprise"])
+        .args(["--base-dir", tmp.path().to_str().unwrap()])
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        out.status.success(),
+        "group-only resolve must succeed.\n{stdout}"
+    );
+    let report = overlay_report(&stdout);
+    // No channel; the group is force-included by name.
+    assert!(report.contains("channel: <none>"), "{report}");
+    assert!(
+        report.contains("enterprise (priority 20, explicit)"),
+        "{report}"
+    );
+    // With no higher layer, the group's value wins.
+    assert!(report.contains("scorer.threshold = 0.8"), "{report}");
+    assert!(report.contains("fraud_stamp <- enterprise"), "{report}");
+}
+
+#[test]
+fn channels_lint_passes_on_valid_workspace() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path(), false);
+
+    let out = Command::new(clinker_bin())
+        .args(["channels", "lint"])
+        .args(["--base-dir", tmp.path().to_str().unwrap()])
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "lint must pass on the valid workspace.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("OK"),
+        "lint should report OK.\nstdout: {stdout}"
+    );
+}
+
+#[test]
+fn channels_lint_surfaces_broken_overlays() {
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path(), true);
+
+    let out = Command::new(clinker_bin())
+        .args(["channels", "lint"])
+        .args(["--base-dir", tmp.path().to_str().unwrap()])
+        .output()
+        .expect("spawn clinker");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "lint must fail when an overlay is broken.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    // A config key matching no composition parameter (E113).
+    assert!(
+        stderr.contains("E113") && stderr.contains("scorer.bogus_param"),
+        "lint must surface the bad config key.\nstderr: {stderr}"
+    );
+    // A splice anchor naming a node that does not exist (E114).
+    assert!(
+        stderr.contains("E114") && stderr.contains("ghost_node"),
+        "lint must surface the dangling splice anchor.\nstderr: {stderr}"
+    );
+}

--- a/crates/clinker/tests/snapshots/channels_overlay__resolve_channel_globex.snap
+++ b/crates/clinker/tests/snapshots/channels_overlay__resolve_channel_globex.snap
@@ -1,0 +1,14 @@
+---
+source: crates/clinker/tests/channels_overlay.rs
+expression: report
+---
+Effective plan for `order_fulfillment`
+  channel: globex
+  groups:
+    - enterprise (priority 20, derived)
+
+Injected nodes:
+  fraud_stamp <- enterprise [group (priority 20)]
+
+Config provenance (overlay-affected):
+  scorer.threshold = 0.95  [ChannelPerTarget]  (base: 0.5)

--- a/docs/user/src/ops/cli-reference.md
+++ b/docs/user/src/ops/cli-reference.md
@@ -37,6 +37,8 @@ clinker run [OPTIONS] <CONFIG>
 | `--force` | -- | Allow output files to be overwritten if they already exist. Without this flag, the pipeline aborts rather than clobbering existing output. |
 | `--log-level <LEVEL>` | `info` | Logging verbosity. One of: `error`, `warn`, `info`, `debug`, `trace`. |
 | `--metrics-spool-dir <DIR>` | -- | Directory for per-execution metrics files. See [Metrics & Monitoring](metrics.md). |
+| `--group <NAME>` | -- | Force-include a group overlay by name (repeatable). Applies the group's `overrides` op stream and `config`/`vars` clobber before the pipeline compiles, regardless of the group's selector. Use `clinker channels resolve` to preview the effective plan. |
+| `--no-auto-groups` | -- | Suppress selector-derived group membership; only groups named with `--group` apply. |
 
 ### Examples
 
@@ -93,6 +95,61 @@ clinker metrics collect \
   --spool-dir ./metrics/ \
   --output-file ./archive.ndjson \
   --dry-run
+```
+
+---
+
+## clinker channels
+
+Inspect and validate the channel/group multi-tenant overlay system.
+
+```bash
+clinker channels resolve <TARGET> [OPTIONS]
+clinker channels lint [OPTIONS]
+```
+
+### clinker channels resolve
+
+Renders the effective post-overlay plan for one target — the DAG plus per-value
+provenance (which layer supplied each value, and which group injected which
+node). This answers "what does tenant X actually run?".
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `<TARGET>` | -- | Path to the base pipeline (or composition) YAML to resolve (required). |
+| `--channel <ID>` | -- | Channel id to resolve for (a folder under the channel root). Matching groups are derived from the channel's labels. |
+| `--group <NAME>` | -- | Force-include a group overlay by name (repeatable), with or without a channel. |
+| `--no-auto-groups` | -- | Suppress selector-derived group membership. |
+| `--base-dir <DIR>` | `.` | Workspace root holding `clinker.toml` and the channel/group roots. |
+
+Exits non-zero when the overlay raises an error (e.g. a config key matching no
+parameter), so `resolve` doubles as a targeted check for one tenant.
+
+### clinker channels lint
+
+Compiles every (target × overlay) combination across the workspace and reports
+failures — the CI safety net for base-change blast radius. This is where the
+full-tree scan lives; the run path resolves a single channel by computed lookup.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--base-dir <DIR>` | `.` | Workspace root to lint. |
+
+Exits non-zero if any combination fails to compile or apply. Dangling splice
+anchors (an op referencing a missing node) and config keys matching no parameter
+are reported per combination.
+
+### Examples
+
+```bash
+# What does tenant `globex` actually run for this pipeline?
+clinker channels resolve pipeline/order_fulfillment.yaml --channel globex
+
+# Preview a group overlay standalone (no channel)
+clinker channels resolve pipeline/order_fulfillment.yaml --group enterprise
+
+# Compile every channel/group overlay in the workspace and report failures
+clinker channels lint
 ```
 
 ---


### PR DESCRIPTION
## Summary

Wires the channel/group multi-tenant overlay system end-to-end through the CLI. A selected channel and/or groups now resolve into a single **effective plan** that is compiled and run, and two new subcommands make that resolution inspectable and lintable at workspace scale.

## What changed

**`run` / `explain` — group overlays**
- New `--group <name>` (repeatable, force-include; works with or without a channel) and `--no-auto-groups`.
- A resolved overlay's structural `overrides` op stream is fed into the pre-compile pass via `CompileContext::overlay_ops`, so the effective DAG (with injected/replaced/removed nodes) is what binds and lowers.
- The `config` / `vars` value clobber applies over the compiled plan's provenance in fixed layer order (`pipeline-default < group(s) by priority < channel-wide < channel-per-target`); resolved `vars` flow to the executor through `PipelineRunParams`.
- A plain run (no group/channel) is byte-identical to before — an empty request resolves to an empty stack.

**`channels resolve <target> [--channel <id>] [--group <name>]`**
- Renders the effective post-overlay DAG with per-value and per-op provenance: which layer supplied each value, and which group injected which node. Reuses the provenance model behind `explain --field`. Works channel-only, group-only, and combined.

**`channels lint`**
- Compiles every `(target × overlay)` combination across the workspace and reports failures — the CI safety net for base-change blast radius. Surfaces a dangling splice anchor (an op referencing a missing node) and a config key that matches no parameter as errors. This is where the full-tree scan lives, off the run path (which resolves a channel by computed lookup).

**Overlay op serde**
- The `overrides` field on the manifest, per-target overlay, and group models is finalized from an opaque placeholder to the typed, span-bearing op vocabulary now that the op engine exists, so an ill-typed op anchors its diagnostic to the offending op rather than the base pipeline.

## Notes / scope

- This is **additive** wiring. The existing file-based channel overlay flag (source-config patches and the post-compile value overlay) is left intact; its removal belongs with the separate schema-resolver unification work, so those tests and that feature are unchanged. On the run path, group auto-derivation keys off a channel manifest's labels; full channel-id label derivation is exercised via `channels resolve`.
- The `config` / `vars` value clobber resolves onto the plan's provenance (surfaced by `channels resolve` and `explain --field`), consistent with the established overlay path. The structural `overrides` ops (add / remove / set / patch_schema) apply pre-compile and change the executed DAG — the injected-node run test proves records flow through an injected node.
- A channel's manifest is its label contract: a group selector that references a label the channel does not declare is surfaced as an error (deliberate typo-detection), which `channels lint` reports per combination.

## Testing

- New integration suite exercises the full matrix on a fixture workspace: plain run (unaffected), `run --group` (injected node executes), `channels resolve` channel-only and group-only, `channels lint` clean, and `channels lint` surfacing a bad config key and a dangling splice anchor.
- An `insta` snapshot of a resolved plan shows an injected group node plus an overridden value with its winning-layer provenance.
- `cargo test -p clinker -p clinker-channel -p clinker-plan` green; `cargo fmt --all --check` and `cargo clippy -p clinker -p clinker-channel --all-targets -- -D warnings` clean; workspace builds.
- User CLI reference updated for the new subcommands and flags.

Closes #524
Closes #528
Closes #529
Part of #515
