### PR TITLE
fix(plan): wire injected `add composition` overlay ops into the data path

### DIFF
--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -644,7 +644,7 @@ impl PipelineConfig {
         // `bind_schema` pass below, anchored to the op because the engine stamps
         // each injected / replaced node with the op's source location.
         if !ctx.overlay_ops.is_empty() {
-            let effective = self.with_structural_overlay(&ctx.overlay_ops)?;
+            let effective = self.with_structural_overlay(&ctx.overlay_ops, ctx)?;
             return effective.compile_with_diagnostics(&ctx.without_overlay_ops());
         }
 
@@ -2254,20 +2254,78 @@ impl PipelineConfig {
     fn with_structural_overlay(
         &self,
         ops: &[crate::overlay_ops::LayeredOp],
+        ctx: &CompileContext,
     ) -> Result<PipelineConfig, Vec<clinker_core_types::Diagnostic>> {
         use clinker_core_types::{Diagnostic, LabeledSpan};
+
+        // Resolve each `add composition` op's declared input ports so the engine
+        // binds the splice anchor to the composition's input port — the same
+        // call-site `inputs:` binding a hand-authored composition node carries.
+        // Without it an injected composition keeps an empty `inputs:` map, gets
+        // no incoming edge, and sits dead in the data path (issue #768).
+        let comp_ports = self.resolve_injected_composition_ports(ops, ctx);
 
         let mut effective = self.clone();
         let base_nodes = std::mem::take(&mut effective.nodes);
         effective.nodes =
-            crate::overlay_ops::apply_overlay_ops(base_nodes, ops.to_vec()).map_err(|err| {
-                vec![Diagnostic::error(
-                    "E114",
-                    err.to_string(),
-                    LabeledSpan::primary(err.span(), String::new()),
-                )]
-            })?;
+            crate::overlay_ops::apply_overlay_ops_with_ports(base_nodes, ops.to_vec(), &comp_ports)
+                .map_err(|err| {
+                    vec![Diagnostic::error(
+                        "E114",
+                        err.to_string(),
+                        LabeledSpan::primary(err.span(), String::new()),
+                    )]
+                })?;
         Ok(effective)
+    }
+
+    /// Resolve the declared input-port names for every `add composition` op in
+    /// the stream, keyed by the op's raw `composition:` path.
+    ///
+    /// Scans workspace composition signatures the same way the ordinary compile
+    /// path does, resolving each op's `composition:` reference through the
+    /// shared [`resolve_use_path`](crate::plan::bind_schema::resolve_use_path)
+    /// (top-level `origin_dir` is the pipeline directory). Best-effort: a scan
+    /// failure or unresolved reference yields no entry, leaving the injected
+    /// node's `inputs:` empty so the real diagnostic surfaces later in
+    /// `bind_schema`. Streams with no composition adds skip the scan entirely.
+    fn resolve_injected_composition_ports(
+        &self,
+        ops: &[crate::overlay_ops::LayeredOp],
+        ctx: &CompileContext,
+    ) -> crate::overlay_ops::CompositionInputPorts {
+        use crate::config::composition::scan_workspace_signatures;
+        use crate::overlay_ops::OverlayOp;
+
+        let comp_paths: Vec<std::path::PathBuf> = ops
+            .iter()
+            .filter_map(|layered| match &layered.op.value {
+                OverlayOp::Add(add) => add.composition.clone(),
+                _ => None,
+            })
+            .collect();
+        if comp_paths.is_empty() {
+            return crate::overlay_ops::CompositionInputPorts::new();
+        }
+
+        let table = match scan_workspace_signatures(ctx.workspace_root()) {
+            Ok(table) => table,
+            Err(_) => return crate::overlay_ops::CompositionInputPorts::new(),
+        };
+
+        let mut ports = crate::overlay_ops::CompositionInputPorts::new();
+        for path in comp_paths {
+            let key = crate::plan::bind_schema::resolve_use_path(
+                &path,
+                &ctx.pipeline_dir,
+                ctx.workspace_root(),
+                &table,
+            );
+            if let Some(sig) = table.get(&key) {
+                ports.insert(path, sig.inputs.keys().cloned().collect());
+            }
+        }
+        ports
     }
 }
 

--- a/crates/clinker-plan/src/lib.rs
+++ b/crates/clinker-plan/src/lib.rs
@@ -24,8 +24,8 @@ pub use config::{
 };
 pub use error::PipelineError;
 pub use overlay_ops::{
-    AddOp, BypassOp, LayeredOp, OverlayLayer, OverlayOp, OverlayOpError, PatchSchemaOp, RemoveOp,
-    ReplaceOp, SetOp, apply_overlay_ops,
+    AddOp, BypassOp, CompositionInputPorts, LayeredOp, OverlayLayer, OverlayOp, OverlayOpError,
+    PatchSchemaOp, RemoveOp, ReplaceOp, SetOp, apply_overlay_ops, apply_overlay_ops_with_ports,
 };
 pub use plan::{
     BoundBody, ColumnLookup, CompositionBodyId, QualifiedField, Row, RowTail, TailVarId,

--- a/crates/clinker-plan/src/overlay_ops.rs
+++ b/crates/clinker-plan/src/overlay_ops.rs
@@ -36,7 +36,7 @@
 //! source-config patch pass). Each `op:` discriminant slots into
 //! `RawOverlayOp::into_op` and [`apply_overlay_ops`].
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use indexmap::IndexMap;
@@ -608,6 +608,16 @@ impl std::error::Error for OverlayOpError {}
 // Engine
 // ---------------------------------------------------------------------
 
+/// Declared input port names for each composition an `add composition` op may
+/// splice in, keyed by the op's raw `composition:` path (exactly as the op
+/// carries it). The overlay driver builds this by scanning workspace
+/// composition signatures before applying ops, so an injected composition's
+/// `inputs:` port map can be populated the same way a hand-authored call
+/// site's is. A path absent from the map — or one whose composition declares
+/// zero or more than one input port — leaves the injected node's `inputs:`
+/// empty, deferring the real port diagnostic to `bind_schema`.
+pub type CompositionInputPorts = HashMap<PathBuf, Vec<String>>;
+
 /// Apply a stream of layered overlay ops to a base node list, returning the
 /// transformed list.
 ///
@@ -616,9 +626,28 @@ impl std::error::Error for OverlayOpError {}
 /// order the caller concatenated the ops in. Every op must resolve against a
 /// live node — a missing splice anchor, remove/replace target, or dangling
 /// reference is a hard [`OverlayOpError`], never a silent no-op.
+///
+/// Injected compositions get empty `inputs:` port maps; use
+/// [`apply_overlay_ops_with_ports`] to bind each splice anchor to the
+/// composition's declared input port.
 pub fn apply_overlay_ops(
+    nodes: Vec<Spanned<PipelineNode>>,
+    ops: Vec<LayeredOp>,
+) -> Result<Vec<Spanned<PipelineNode>>, OverlayOpError> {
+    apply_overlay_ops_with_ports(nodes, ops, &CompositionInputPorts::new())
+}
+
+/// [`apply_overlay_ops`] with composition input-port bindings.
+///
+/// For each `add composition` op whose `composition:` path resolves in `ports`
+/// to a single declared input port, the injected node's `inputs:` map binds
+/// that port to the splice anchor — the same call-site binding a hand-authored
+/// composition node carries — so the injected node is fed by the top-level edge
+/// wiring instead of being left a dead, unfed node.
+pub fn apply_overlay_ops_with_ports(
     mut nodes: Vec<Spanned<PipelineNode>>,
     mut ops: Vec<LayeredOp>,
+    ports: &CompositionInputPorts,
 ) -> Result<Vec<Spanned<PipelineNode>>, OverlayOpError> {
     // Stable sort by layer: cross-layer order follows fixed semantic
     // precedence, while ops sharing a layer keep the caller's declaration
@@ -629,7 +658,7 @@ pub fn apply_overlay_ops(
         let loc = layered.op.referenced;
         let span = span_from_loc(loc);
         match layered.op.value {
-            OverlayOp::Add(add) => apply_add(&mut nodes, add, loc, span)?,
+            OverlayOp::Add(add) => apply_add(&mut nodes, add, ports, loc, span)?,
             OverlayOp::Remove(remove) => apply_remove(&mut nodes, remove, span)?,
             OverlayOp::Replace(replace) => apply_replace(&mut nodes, replace, loc, span)?,
             OverlayOp::Set(set) => apply_set(&mut nodes, set, loc, span)?,
@@ -729,6 +758,7 @@ impl AddOp {
     fn build_node(
         &self,
         input: Option<NodeInput>,
+        ports: &CompositionInputPorts,
         loc: Location,
         span: Span,
     ) -> Result<PipelineNode, OverlayOpError> {
@@ -757,11 +787,21 @@ impl AddOp {
                     message: "a `composition` add requires an `alias`".to_string(),
                     span,
                 })?;
+                // Bind the splice anchor to the composition's sole declared
+                // input port. A composition with zero or several input ports
+                // can't be fed by a single splice anchor, so `inputs:` stays
+                // empty and `bind_schema` reports any unbound required port
+                // (E104) against the op's span.
+                let input_port = match ports.get(path.as_path()).map(Vec::as_slice) {
+                    Some([only]) => Some(only.clone()),
+                    _ => None,
+                };
                 Ok(build_composition_node(
                     alias,
                     path.clone(),
                     self.config.clone(),
                     input,
+                    input_port,
                     loc,
                 ))
             }
@@ -780,8 +820,20 @@ fn build_composition_node(
     use_path: PathBuf,
     config: IndexMap<String, serde_json::Value>,
     input: NodeInput,
+    input_port: Option<String>,
     loc: Location,
 ) -> PipelineNode {
+    // A composition consumes through its named-port `inputs:` map — the
+    // authoritative call-site binding the top-level edge wiring reads to feed
+    // it. `header.input` is the YAML-shape obligation the shared `NodeHeader`
+    // carries and drives consumer rewiring, but it produces no incoming edge on
+    // its own. Binding the sole input port to the splice anchor here is what
+    // makes the injected node wire up like a hand-authored call site instead of
+    // sitting dead with no producer.
+    let mut inputs = IndexMap::new();
+    if let Some(port) = input_port {
+        inputs.insert(port, node_input_ref(&input));
+    }
     PipelineNode::Composition {
         header: NodeHeader {
             name: alias.clone(),
@@ -791,7 +843,7 @@ fn build_composition_node(
         },
         r#use: use_path,
         alias: Some(alias),
-        inputs: IndexMap::new(),
+        inputs,
         outputs: IndexMap::new(),
         config,
         resources: IndexMap::new(),
@@ -799,9 +851,20 @@ fn build_composition_node(
     }
 }
 
+/// Render a [`NodeInput`] as the plain upstream-reference string a composition
+/// `inputs:` map stores: `Single("x")` → `"x"`, `Port { node, port }` →
+/// `"node.port"` (the same shape the top-level edge wiring strips a port from).
+fn node_input_ref(input: &NodeInput) -> String {
+    match input {
+        NodeInput::Single(name) => name.clone(),
+        NodeInput::Port { node, port } => format!("{node}.{port}"),
+    }
+}
+
 fn apply_add(
     nodes: &mut Vec<Spanned<PipelineNode>>,
     add: AddOp,
+    ports: &CompositionInputPorts,
     loc: Location,
     span: Span,
 ) -> Result<(), OverlayOpError> {
@@ -825,7 +888,7 @@ fn apply_add(
             for node in nodes.iter_mut() {
                 reroute_single_ref(&mut node.value, &anchor, &name);
             }
-            let node = add.build_node(Some(NodeInput::Single(anchor)), loc, span)?;
+            let node = add.build_node(Some(NodeInput::Single(anchor)), ports, loc, span)?;
             nodes.insert(anchor_idx + 1, Spanned::new(node, loc, loc));
         }
         Splice::Before(anchor) => {
@@ -845,18 +908,25 @@ fn apply_add(
                     context: "a `before` splice".to_string(),
                     span,
                 })?;
+            let former_upstream = node_input_ref(&anchor_input);
             nodes[anchor_idx]
                 .value
                 .set_primary_input(NodeInput::Single(name.clone()));
-            let node = add.build_node(Some(anchor_input), loc, span)?;
+            // For a composition anchor, `set_primary_input` moves only
+            // `header.input`; the real edge lives in its `inputs:` map, so
+            // repoint the port bound to the former upstream onto the new node
+            // too — otherwise the anchor keeps reading its old upstream and the
+            // injected node is bypassed.
+            reroute_composition_inputs(&mut nodes[anchor_idx].value, &former_upstream, &name);
+            let node = add.build_node(Some(anchor_input), ports, loc, span)?;
             nodes.insert(anchor_idx, Spanned::new(node, loc, loc));
         }
         Splice::ExplicitInput(input) => {
-            let node = add.build_node(Some(input), loc, span)?;
+            let node = add.build_node(Some(input), ports, loc, span)?;
             nodes.push(Spanned::new(node, loc, loc));
         }
         Splice::NodeDeclared => {
-            let node = add.build_node(None, loc, span)?;
+            let node = add.build_node(None, ports, loc, span)?;
             nodes.push(Spanned::new(node, loc, loc));
         }
     }
@@ -1120,6 +1190,12 @@ fn reroute_single_ref(node: &mut PipelineNode, from: &str, to: &str) {
         }
     }
 
+    // A composition consumes through its named-port `inputs:` map, not
+    // `header.input` (which produces no incoming edge), so its real upstream
+    // edge follows this repoint, not the `header.input` repoint below. Run it
+    // first so the borrow ends before the `match` re-borrows `node`.
+    reroute_composition_inputs(node, from, to);
+
     match node {
         PipelineNode::Source { .. } => {}
         PipelineNode::Transform { header, .. }
@@ -1146,6 +1222,26 @@ fn reroute_single_ref(node: &mut PipelineNode, from: &str, to: &str) {
             }
             if let Some(t) = header.trailer.as_mut() {
                 repoint(&mut t.value, from, to);
+            }
+        }
+    }
+}
+
+/// Repoint a composition's named-port `inputs:` map: any port bound to `from`
+/// is rebound to `to`. No-op for non-composition nodes and for port-qualified
+/// values (`from.port`), matching [`reroute_single_ref`]'s exact-match policy.
+///
+/// The `inputs:` map is a composition's authoritative call-site binding — the
+/// map the top-level edge wiring reads to feed each port — whereas
+/// `header.input` produces no edge. Both an `after` splice (via
+/// [`reroute_single_ref`]) and a `before` splice must repoint it, or a
+/// composition consumer keeps reading the spliced-out anchor directly and the
+/// injected node is bypassed.
+fn reroute_composition_inputs(node: &mut PipelineNode, from: &str, to: &str) {
+    if let PipelineNode::Composition { inputs, .. } = node {
+        for upstream in inputs.values_mut() {
+            if upstream == from {
+                *upstream = to.to_string();
             }
         }
     }
@@ -1416,6 +1512,146 @@ config:
         }
         // sink was rewired onto the injected composition.
         assert_eq!(out[3].value.direct_input_names(), vec!["fraud_check"]);
+    }
+
+    /// A base whose downstream consumer of `normalize` is a composition, so the
+    /// splice must both feed the injected composition and repoint the consumer's
+    /// named-port `inputs:` map — the two halves of the issue #768 fix.
+    fn composition_consumer_base() -> Vec<Spanned<PipelineNode>> {
+        parse_nodes(
+            r#"
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: order_id, type: string }
+  - type: transform
+    name: normalize
+    input: orders
+    config:
+      cxl: "emit order_id = order_id"
+  - type: composition
+    name: scorer
+    input: normalize
+    use: ../composition/score.comp.yaml
+    inputs:
+      inp: normalize
+"#,
+        )
+    }
+
+    /// The composition node named `name`'s `(header input, inputs map)`.
+    fn composition_wiring(
+        nodes: &[Spanned<PipelineNode>],
+        name: &str,
+    ) -> (NodeInput, IndexMap<String, String>) {
+        match &nodes.iter().find(|n| n.value.name() == name).unwrap().value {
+            PipelineNode::Composition { header, inputs, .. } => {
+                (header.input.value.clone(), inputs.clone())
+            }
+            other => panic!("expected composition {name:?}, got {}", other.type_tag()),
+        }
+    }
+
+    #[test]
+    fn add_composition_binds_input_port_and_reroutes_downstream_composition() {
+        let base = composition_consumer_base();
+        let op = parse_op(
+            r#"
+op: add
+composition: ../composition/screen.comp.yaml
+alias: screen
+after: normalize
+"#,
+        );
+        let mut ports = CompositionInputPorts::new();
+        ports.insert(
+            PathBuf::from("../composition/screen.comp.yaml"),
+            vec!["inp".to_string()],
+        );
+
+        let out = apply_overlay_ops_with_ports(base, one(op), &ports).expect("apply");
+
+        assert_eq!(names(&out), vec!["orders", "normalize", "screen", "scorer"]);
+
+        // The injected composition's sole input port is bound to the splice
+        // anchor, so the top-level edge wiring feeds it (defect 1).
+        let (screen_header, screen_inputs) = composition_wiring(&out, "screen");
+        assert_eq!(screen_header, NodeInput::Single("normalize".into()));
+        assert_eq!(
+            screen_inputs.get("inp").map(String::as_str),
+            Some("normalize")
+        );
+        assert_eq!(screen_inputs.len(), 1);
+
+        // The downstream composition consumer's named-port `inputs:` map follows
+        // the rewire onto the injected node — not just its header input (defect 2).
+        let (scorer_header, scorer_inputs) = composition_wiring(&out, "scorer");
+        assert_eq!(scorer_header, NodeInput::Single("screen".into()));
+        assert_eq!(scorer_inputs.get("inp").map(String::as_str), Some("screen"));
+    }
+
+    #[test]
+    fn add_composition_without_resolved_ports_leaves_inputs_empty() {
+        // With no port info (the 2-arg entry point), the injected composition
+        // keeps an empty `inputs:` map; `bind_schema` then surfaces the real
+        // port diagnostic against the op span rather than the engine guessing.
+        let base = composition_consumer_base();
+        let op = parse_op(
+            r#"
+op: add
+composition: ../composition/screen.comp.yaml
+alias: screen
+after: normalize
+"#,
+        );
+        let out = apply_overlay_ops(base, one(op)).expect("apply");
+        let (_, screen_inputs) = composition_wiring(&out, "screen");
+        assert!(screen_inputs.is_empty());
+    }
+
+    #[test]
+    fn add_composition_before_composition_anchor_reroutes_inputs_map() {
+        // A `before` splice in front of a composition anchor must repoint the
+        // anchor's named-port `inputs:` map (which carries the real edge), not
+        // just its `header.input` — otherwise the anchor keeps reading its old
+        // upstream directly and the injected composition is bypassed.
+        let base = composition_consumer_base();
+        let op = parse_op(
+            r#"
+op: add
+composition: ../composition/screen.comp.yaml
+alias: screen
+before: scorer
+"#,
+        );
+        let mut ports = CompositionInputPorts::new();
+        ports.insert(
+            PathBuf::from("../composition/screen.comp.yaml"),
+            vec!["inp".to_string()],
+        );
+
+        let out = apply_overlay_ops_with_ports(base, one(op), &ports).expect("apply");
+
+        assert_eq!(names(&out), vec!["orders", "normalize", "screen", "scorer"]);
+
+        // The injected node takes over the anchor's former upstream (`normalize`).
+        let (screen_header, screen_inputs) = composition_wiring(&out, "screen");
+        assert_eq!(screen_header, NodeInput::Single("normalize".into()));
+        assert_eq!(
+            screen_inputs.get("inp").map(String::as_str),
+            Some("normalize")
+        );
+
+        // The anchor now reads the injected node through both its header input
+        // and its `inputs:` map — the map is what actually feeds it.
+        let (scorer_header, scorer_inputs) = composition_wiring(&out, "scorer");
+        assert_eq!(scorer_header, NodeInput::Single("screen".into()));
+        assert_eq!(scorer_inputs.get("inp").map(String::as_str), Some("screen"));
     }
 
     #[test]

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -3597,7 +3597,7 @@ fn check_w101_shadows(
 /// 2. Try the normalized path directly against the symbol table.
 ///
 /// Falls back to the normalized path for the E103 diagnostic.
-fn resolve_use_path(
+pub(crate) fn resolve_use_path(
     use_path: &Path,
     origin_dir: &Path,
     workspace_root: &Path,

--- a/crates/clinker/tests/channels_overlay.rs
+++ b/crates/clinker/tests/channels_overlay.rs
@@ -9,7 +9,8 @@
 //! The workspace pairs a base pipeline that uses a composition `scorer` (with a
 //! `threshold` config knob) against:
 //!   - a group `enterprise` (selector `tier == "enterprise"`, priority 20) that
-//!     injects a `fraud_stamp` transform and clobbers `scorer.threshold`;
+//!     splices a `screen` composition into the consumed path and clobbers
+//!     `scorer.threshold`;
 //!   - a channel `globex` (labels `tier=enterprise`) whose manifest and
 //!     per-target overlay clobber `scorer.threshold` at the higher layers.
 
@@ -88,6 +89,29 @@ nodes:
       path: out.csv
 "#;
 
+/// The screening composition the `enterprise` group splices into the consumed
+/// data path (issue #768): it zeroes any amount at or above 100 and passes the
+/// rest through. Its input port `inp` is bound to the splice anchor, and its
+/// output feeds the base pipeline's `scorer` composition.
+const SCREEN_COMPOSITION: &str = r#"_compose:
+  name: screen
+  inputs:
+    inp:
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: float }
+  outputs:
+    out: screened
+nodes:
+  - type: transform
+    name: screened
+    input: inp
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit amount = if amount >= 100.0 then 0.0 else amount
+"#;
+
 const GROUP: &str = r#"group:
   name: enterprise
   match: 'tier == "enterprise"'
@@ -96,14 +120,8 @@ config:
   scorer.threshold: 0.8
 overrides:
   - op: add
-    node:
-      type: transform
-      name: fraud_stamp
-      input: normalize
-      config:
-        cxl: |
-          emit order_id = order_id
-          emit amount = amount
+    composition: ../composition/screen.comp.yaml
+    alias: screen
     after: normalize
 "#;
 
@@ -158,6 +176,7 @@ fn build_workspace(root: &Path, broken: bool) {
     write(root, "pipeline/orders.csv", ORDERS_CSV);
     write(root, "pipeline/order_fulfillment.yaml", PIPELINE);
     write(root, "composition/score.comp.yaml", COMPOSITION);
+    write(root, "composition/screen.comp.yaml", SCREEN_COMPOSITION);
     write(root, "group/enterprise.group.yaml", GROUP);
     write(root, "channel/globex/channel.cfg.yaml", GLOBEX_MANIFEST);
     write(
@@ -220,16 +239,25 @@ fn plain_run_is_unaffected_by_overlay_wiring() {
 }
 
 #[test]
-fn run_with_group_applies_the_overlay() {
+fn run_with_group_splices_composition_into_consumed_path() {
+    // The `enterprise` group splices the `screen` composition in after
+    // `normalize`, so the effective path is `orders → normalize → screen →
+    // scorer → out`. This is a real run (not `--dry-run`): the output proves the
+    // injected composition's transform actually executes and its rows flow
+    // downstream through `scorer`, the fix for issue #768. Before the fix the
+    // injected composition was left unfed and bypassed — `scorer` read
+    // `normalize` directly, so `a1` would keep its unscreened amount `150`.
     let tmp = tempfile::tempdir().unwrap();
     build_workspace(tmp.path(), false);
 
+    // Run from the workspace dir so the output node's relative `out.csv` path
+    // (resolved against the process cwd) lands inside the tempdir.
     let out = Command::new(clinker_bin())
+        .current_dir(tmp.path())
         .arg("run")
         .arg(pipeline_path(tmp.path()))
         .args(["--base-dir", tmp.path().to_str().unwrap()])
         .args(["--group", "enterprise"])
-        .args(["--dry-run", "-n", "2"])
         .output()
         .expect("spawn clinker");
 
@@ -237,17 +265,32 @@ fn run_with_group_applies_the_overlay() {
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         out.status.success(),
-        "run --group must succeed (injected node preserves the schema).\nstdout: {stdout}\nstderr: {stderr}"
+        "run --group must succeed.\nstdout: {stdout}\nstderr: {stderr}"
     );
     assert!(
         stderr.contains("applied overlay") && stderr.contains("enterprise"),
         "run --group must report the applied group.\nstderr: {stderr}"
     );
-    // Both input records flow through the injected + composition nodes (the
-    // run completion is logged to stdout).
     assert!(
         stdout.contains("2 written"),
         "the overlaid run must process both records.\nstdout: {stdout}"
+    );
+
+    // The output path resolves against the base dir; `screen` zeroed the
+    // at-or-above-100 amount (`a1`: 150 → 0) and passed the rest through
+    // (`a2`: 20). Both prove the injected composition ran in the consumed path.
+    let output = std::fs::read_to_string(tmp.path().join("out.csv")).expect("read out.csv");
+    assert!(
+        output.contains("a1,0"),
+        "screen must zero a1's amount (150 → 0) in the consumed path.\nout.csv:\n{output}"
+    );
+    assert!(
+        output.contains("a2,20"),
+        "screen must pass a2's amount through unchanged.\nout.csv:\n{output}"
+    );
+    assert!(
+        !output.contains("a1,150"),
+        "a1's unscreened amount must not survive — screen would be bypassed.\nout.csv:\n{output}"
     );
 }
 
@@ -287,8 +330,8 @@ fn channels_resolve_channel_renders_provenance() {
         report.contains("enterprise (priority 20, derived)"),
         "{report}"
     );
-    // The group injected a node.
-    assert!(report.contains("fraud_stamp <- enterprise"), "{report}");
+    // The group injected the screening composition.
+    assert!(report.contains("screen <- enterprise"), "{report}");
     // The per-target overlay (0.95) won the 4-layer clobber over base 0.5.
     assert!(
         report.contains("scorer.threshold = 0.95") && report.contains("ChannelPerTarget"),
@@ -325,7 +368,7 @@ fn channels_resolve_group_standalone() {
     );
     // With no higher layer, the group's value wins.
     assert!(report.contains("scorer.threshold = 0.8"), "{report}");
-    assert!(report.contains("fraud_stamp <- enterprise"), "{report}");
+    assert!(report.contains("screen <- enterprise"), "{report}");
 }
 
 #[test]

--- a/crates/clinker/tests/snapshots/channels_overlay__resolve_channel_globex.snap
+++ b/crates/clinker/tests/snapshots/channels_overlay__resolve_channel_globex.snap
@@ -8,7 +8,7 @@ Effective plan for `order_fulfillment`
     - enterprise (priority 20, derived)
 
 Injected nodes:
-  fraud_stamp <- enterprise [group (priority 20)]
+  screen <- enterprise [group (priority 20)]
 
 Config provenance (overlay-affected):
   scorer.threshold = 0.95  [ChannelPerTarget]  (base: 0.5)


### PR DESCRIPTION
## Summary

An `overrides: [{op: add, composition: <path>, alias: <name>, after/before: <node>}]`
op splices a reusable composition into a pipeline's effective plan, but the
injected node could not be wired into the data flow. Placed in a consumed path
it produced no rows (`N total, 0 ok, 0 written`); placed as a branch it silently
did nothing. This restores structural composition injection — a headline
capability of the overlay op engine — so an injected composition behaves like a
hand-authored call site.

## Root cause

A composition is fed through its named-port `inputs:` map, which is what the
top-level edge wiring reads to build a composition's incoming edges;
`header.input` produces no edge on its own. The op engine built the injected
composition node with an **empty `inputs:` map**, so it never received an
incoming edge and sat dead in the graph.

Two coupled defects:

1. The injected composition had no `inputs:` binding, so nothing fed it.
2. The splice repointed only `header.input` on downstream consumers. A
   downstream **composition** consumer reads through its own `inputs:` map, so
   it kept reading the splice anchor directly and bypassed the injected node.

## Fix

- Resolve each `add composition` op's declared input port from the workspace
  composition signatures (scanned before the op stream is applied) and bind the
  splice anchor to that port, so the injected node carries the same call-site
  `inputs:` binding a hand-authored composition node would.
- Repoint a downstream composition's `inputs:` map onto the injected node for
  both `after` and `before` splices, via a shared helper, so it consumes the
  injected node instead of the anchor.

A composition with zero or several input ports can't be fed by a single splice
anchor, so its `inputs:` map is left empty and schema binding reports any
unbound required port against the offending op's span. Unrelated ops (inline
`add`, `remove`, `replace`, `set`, `bypass`, `patch_schema`) are unchanged, and
a plain pipeline with no overlay ops compiles exactly as before.

## Testing

- New unit coverage for the injected `inputs:` port binding and the downstream
  composition reroute, for both `after` and `before` splices, plus the
  no-signature fallback (empty `inputs:`, real diagnostic deferred to binding).
- The overlay integration test now splices a screening composition into the
  consumed path and asserts, from a real run's output, that the injected
  composition's transform executes and its rows flow downstream (a value at or
  above the screen threshold is zeroed, the rest pass through).
- `cargo build --workspace`, `cargo test -p clinker-plan -p clinker`,
  `cargo fmt --all --check`, and `cargo clippy -p clinker-plan --all-targets -- -D warnings`
  all pass.

## Follow-ups (out of scope here)

- A hand-authored composition with a single **optional** input port and no
  `inputs:` map hits the same unfed-node shape with no diagnostic; a
  default-single-port binding in schema resolution would cover both the injected
  and hand-authored cases.
- `remove`'s dangling-reference guard scans only `header.input`, so a downstream
  composition referencing a removed node solely through its `inputs:` map
  escapes it.

Closes #768
Part of #515
