### PR TITLE
feat(cxl): apply channel/group config overrides via a $config namespace

### DIFF
--- a/crates/clinker-channel/src/binding.rs
+++ b/crates/clinker-channel/src/binding.rs
@@ -199,6 +199,24 @@ impl ChannelBinding {
         let bytes = std::fs::read(path)?;
         Self::from_yaml_bytes(&bytes, path.to_path_buf())
     }
+
+    /// Resolve the winning composition `config:` value per node for the
+    /// pre-compile `$config.<param>` fold, keyed
+    /// `composition-node-name -> param -> value`.
+    ///
+    /// Applies `config.default` then `config.fixed` at the `ChannelPerTarget`
+    /// layer (fixed wins within the layer), matching the order
+    /// [`apply_channel_overlay`](crate::apply_channel_overlay) clobbers onto the
+    /// `ProvenanceDb`, so the folded value agrees with the rendered `[WON]`
+    /// layer. Feeds
+    /// [`CompileContext::config_overrides`](clinker_plan::config::CompileContext).
+    pub fn effective_config(&self) -> clinker_plan::config::ConfigOverrides {
+        use clinker_plan::config::composition::LayerKind;
+        let mut eff = crate::overlay::EffectiveConfig::default();
+        eff.apply_dotted(&self.config_default, LayerKind::ChannelPerTarget, false);
+        eff.apply_dotted(&self.config_fixed, LayerKind::ChannelPerTarget, true);
+        eff.into_overrides()
+    }
 }
 
 // ── Serde intermediate types ────────────────────────────────────────────

--- a/crates/clinker-channel/src/lib.rs
+++ b/crates/clinker-channel/src/lib.rs
@@ -74,7 +74,7 @@ pub use discovery::{
 pub use error::ChannelError;
 pub use group::Group;
 pub use manifest::{ChannelManifest, ChannelVars, ManifestHeader, OverlayFile, OverlayHeader};
-pub use overlay::{ChannelOverlayResult, apply_channel_overlay};
+pub use overlay::{ChannelOverlayResult, apply_channel_overlay, merge_config_overrides};
 pub use resolve::{
     AppliedGroup, GroupSource, InjectedNode, OverlayResolution, ResolveError, resolve,
 };

--- a/crates/clinker-channel/src/overlay.rs
+++ b/crates/clinker-channel/src/overlay.rs
@@ -33,11 +33,14 @@
 //! `PipelineRunParams`, not into the AST), and stamps a [`ChannelIdentity`] for
 //! cache-keying.
 
+use std::collections::HashMap;
+
 use indexmap::IndexMap;
 
 use clinker_core_types::Span;
 use clinker_core_types::{Diagnostic, LabeledSpan};
-use clinker_plan::config::composition::{LayerKind, ProvenanceDb};
+use clinker_plan::config::ConfigOverrides;
+use clinker_plan::config::composition::{LayerKind, ProvenanceDb, ResolvedValue};
 use clinker_plan::config::pipeline_node::{PipelineNode, VarScope};
 use clinker_plan::config::{
     PipelineConfig, ScopedVarDecl, ScopedVarType, check_scoped_var_default,
@@ -217,6 +220,109 @@ pub(crate) fn apply_config_clobber(
                     LabeledSpan::primary(Span::SYNTHETIC, String::new()),
                 ));
             }
+        }
+    }
+}
+
+/// Resolve the winning `config:` value per `(node, param)` across overlay
+/// layers, for the pre-compile constant fold of `$config.<param>` in a
+/// composition body.
+///
+/// Reuses the same [`ResolvedValue`] winner logic the post-compile
+/// [`ProvenanceDb`] path uses, applied in the identical ascending-precedence
+/// order (`apply_config_and_vars`: groups → channel-wide → per-target; the
+/// legacy binding: `config.default` → `config.fixed`). Resolving the fold value
+/// and the rendered provenance from the same layer machinery keeps the executed
+/// value and the `channels resolve` / `explain --field` `[WON]` layer in
+/// agreement.
+#[derive(Default)]
+pub(crate) struct EffectiveConfig {
+    winners: HashMap<(String, String), ResolvedValue<serde_json::Value>>,
+}
+
+impl EffectiveConfig {
+    /// Apply one layer's raw string-keyed `config:` map. A malformed key is
+    /// skipped (it surfaces as a diagnostic on the clobber path); a
+    /// single-segment key targets no composition node and never folds.
+    pub(crate) fn apply(
+        &mut self,
+        config: &IndexMap<String, serde_json::Value>,
+        kind: LayerKind,
+        fixed: bool,
+    ) {
+        for (key, value) in config {
+            let Ok(dotted) = DottedPath::try_from(key.as_str()) else {
+                continue;
+            };
+            if let (Some(node), param) = dotted.segments() {
+                self.insert(node, param, value, kind, fixed);
+            }
+        }
+    }
+
+    /// Apply one layer's already-validated dotted-keyed `config:` map.
+    pub(crate) fn apply_dotted(
+        &mut self,
+        config: &IndexMap<DottedPath, serde_json::Value>,
+        kind: LayerKind,
+        fixed: bool,
+    ) {
+        for (dotted, value) in config {
+            if let (Some(node), param) = dotted.segments() {
+                self.insert(node, param, value, kind, fixed);
+            }
+        }
+    }
+
+    fn insert(
+        &mut self,
+        node: &str,
+        param: &str,
+        value: &serde_json::Value,
+        kind: LayerKind,
+        fixed: bool,
+    ) {
+        self.winners
+            .entry((node.to_string(), param.to_string()))
+            .and_modify(|rv| {
+                if fixed {
+                    rv.apply_layer_fixed(value.clone(), kind, Span::SYNTHETIC);
+                } else {
+                    rv.apply_layer(value.clone(), kind, Span::SYNTHETIC);
+                }
+            })
+            .or_insert_with(|| {
+                // Preserve the `fixed` lock on the first-touched layer too, so a
+                // fixed lower tier keeps winning over a later higher tier —
+                // matching `ResolvedValue::winner_kind`, which the ProvenanceDb
+                // path uses.
+                if fixed {
+                    ResolvedValue::new_fixed(value.clone(), kind, Span::SYNTHETIC)
+                } else {
+                    ResolvedValue::new(value.clone(), kind, Span::SYNTHETIC)
+                }
+            });
+    }
+
+    /// Collapse to the per-node winning values for
+    /// [`CompileContext::config_overrides`](clinker_plan::config::CompileContext).
+    pub(crate) fn into_overrides(self) -> ConfigOverrides {
+        let mut out = ConfigOverrides::new();
+        for ((node, param), rv) in self.winners {
+            out.entry(node).or_default().insert(param, rv.value);
+        }
+        out
+    }
+}
+
+/// Merge `higher` config overrides over `base`, resolving each `(node, param)`
+/// to the higher map's value. Used to layer the legacy channel-file binding
+/// (highest precedence) over the channel/group folder resolution.
+pub fn merge_config_overrides(base: &mut ConfigOverrides, higher: ConfigOverrides) {
+    for (node, params) in higher {
+        let entry = base.entry(node).or_default();
+        for (param, value) in params {
+            entry.insert(param, value);
         }
     }
 }

--- a/crates/clinker-channel/src/resolve.rs
+++ b/crates/clinker-channel/src/resolve.rs
@@ -49,7 +49,8 @@ use crate::error::ChannelError;
 use crate::group::Group;
 use crate::manifest::{ChannelManifest, ChannelVars};
 use crate::overlay::{
-    ChannelOverlayResult, apply_config_clobber, resolve_vars_layer, validate_config_keys,
+    ChannelOverlayResult, EffectiveConfig, apply_config_clobber, resolve_vars_layer,
+    validate_config_keys,
 };
 use crate::{apply_group_config, scan_groups};
 
@@ -163,6 +164,33 @@ impl OverlayResolution {
             .as_ref()
             .and_then(|c| c.per_target.as_ref())
             .map(|o| o.path.as_path())
+    }
+
+    /// Resolve the winning composition `config:` value per node for the
+    /// pre-compile `$config.<param>` fold, keyed
+    /// `composition-node-name -> param -> value`.
+    ///
+    /// Applies the same layers in the same ascending-precedence order as
+    /// [`Self::apply_config_and_vars`] (groups by priority → channel-wide →
+    /// per-target), so the folded value matches the layer the `ProvenanceDb`
+    /// renders as `[WON]`. The map feeds
+    /// [`CompileContext::config_overrides`](clinker_plan::config::CompileContext);
+    /// the provenance chain is still recorded separately by
+    /// `apply_config_and_vars`, so this does not double-apply the override.
+    pub fn effective_config_overrides(&self) -> clinker_plan::config::ConfigOverrides {
+        let mut eff = EffectiveConfig::default();
+        for applied in &self.applied_groups {
+            eff.apply(&applied.group.config, applied.layer, false);
+        }
+        if let Some(ctx) = &self.channel {
+            if let Some(manifest) = &ctx.manifest {
+                eff.apply(&manifest.config, LayerKind::ChannelWide, false);
+            }
+            if let Some(overlay) = &ctx.per_target {
+                eff.apply(&overlay.overlay.config, LayerKind::ChannelPerTarget, false);
+            }
+        }
+        eff.into_overrides()
     }
 
     /// Apply the value-clobber surface (`config` + `vars`) of every layer over a

--- a/crates/clinker-channel/src/selector.rs
+++ b/crates/clinker-channel/src/selector.rs
@@ -281,6 +281,7 @@ fn reject_non_label(expr: &Expr) -> Result<(), SelectorError> {
         // non-deterministic) and have no place in a label selector.
         Expr::PipelineAccess { .. } => Err(SelectorError::ForbiddenReference("$pipeline")),
         Expr::VarsAccess { .. } => Err(SelectorError::ForbiddenReference("$vars")),
+        Expr::ConfigAccess { .. } => Err(SelectorError::ForbiddenReference("$config")),
         Expr::SourceAccess { .. } | Expr::QualifiedSourceAccess { .. } => {
             Err(SelectorError::ForbiddenReference("$source"))
         }

--- a/crates/clinker-exec/src/aggregation/mod.rs
+++ b/crates/clinker-exec/src/aggregation/mod.rs
@@ -157,6 +157,7 @@ pub fn eval_expr_in_agg_scope(
         }
         Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }

--- a/crates/clinker-plan/src/config/compile_context.rs
+++ b/crates/clinker-plan/src/config/compile_context.rs
@@ -10,12 +10,20 @@
 //! which reads CWD at call time — a convenience that is explicitly not
 //! sanctioned for production callers.
 //!
-//! Field cap: 5. If growth pressure exceeds that, split the context
+//! Field cap: 6. If growth pressure exceeds that, split the context
 //! into purpose-specific bags rather than letting it sprawl.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use indexmap::IndexMap;
+
 use crate::overlay_ops::LayeredOp;
+
+/// Per-composition-node config clobbers resolved from the channel/group
+/// overlay stack, keyed `composition-node-name -> param -> winning value`.
+/// See [`CompileContext::config_overrides`].
+pub type ConfigOverrides = HashMap<String, IndexMap<String, serde_json::Value>>;
 
 /// Per-compile configuration threaded through `PipelineConfig::compile`.
 #[derive(Debug, Clone)]
@@ -44,6 +52,18 @@ pub struct CompileContext {
     /// is what gets typechecked and lowered. Empty (the default) means "no
     /// overlay": the compile path is byte-identical to a plain pipeline.
     pub overlay_ops: Vec<LayeredOp>,
+    /// Resolved channel/group `config:` clobbers per composition node, the
+    /// value-clobber counterpart to [`Self::overlay_ops`]. `compile` folds
+    /// each `$config.<param>` in a composition body to the winning value here
+    /// (falling back to the call-site `config:` and then the signature
+    /// default), so an overridden config param changes the compiled body.
+    ///
+    /// The `ProvenanceDb` still records the full layer chain separately (via
+    /// the post-compile overlay), so `channels resolve` / `explain --field`
+    /// keep reporting which layer supplied each value. Empty (the default)
+    /// means "no overlay": the compile path is byte-identical to a plain
+    /// pipeline.
+    pub config_overrides: ConfigOverrides,
 }
 
 impl CompileContext {
@@ -56,6 +76,7 @@ impl CompileContext {
             pipeline_dir: PathBuf::new(),
             allow_absolute_paths: false,
             overlay_ops: Vec::new(),
+            config_overrides: ConfigOverrides::new(),
         }
     }
 
@@ -69,6 +90,7 @@ impl CompileContext {
             pipeline_dir: pipeline_dir.into(),
             allow_absolute_paths: false,
             overlay_ops: Vec::new(),
+            config_overrides: ConfigOverrides::new(),
         }
     }
 
@@ -84,13 +106,16 @@ impl CompileContext {
     /// it uses this to recurse without re-applying (and thus doubling) the
     /// ops it already spliced in.
     pub fn without_overlay_ops(&self) -> Self {
-        // Clone only the cheap fields; the whole point is to drop the ops, so
-        // copying them via `..self.clone()` just to discard them is wasted work.
+        // Drop only the structural ops. `config_overrides` must survive: the
+        // effective plan produced by splicing the ops is recompiled through
+        // this context, and its composition bodies still fold `$config`
+        // against the resolved value clobbers.
         Self {
             workspace_root: self.workspace_root.clone(),
             pipeline_dir: self.pipeline_dir.clone(),
             allow_absolute_paths: self.allow_absolute_paths,
             overlay_ops: Vec::new(),
+            config_overrides: self.config_overrides.clone(),
         }
     }
 }
@@ -104,6 +129,7 @@ impl Default for CompileContext {
             pipeline_dir: PathBuf::new(),
             allow_absolute_paths: false,
             overlay_ops: Vec::new(),
+            config_overrides: ConfigOverrides::new(),
         }
     }
 }

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -21,7 +21,7 @@ pub mod utils;
 
 pub use crate::plan::index::AnalyticWindowSpec;
 pub use aggregate::*;
-pub use compile_context::CompileContext;
+pub use compile_context::{CompileContext, ConfigOverrides};
 pub use composition::{
     CompositionFile, CompositionSignature, CompositionSymbolTable, LayerKind, NodeRef, OutputAlias,
     ParamDecl, ParamName, ParamType, PortDecl, PortName, ProvenanceDb, ProvenanceLayer,

--- a/crates/clinker-plan/src/config/scoped_var.rs
+++ b/crates/clinker-plan/src/config/scoped_var.rs
@@ -78,6 +78,11 @@ pub fn build_scoped_vars_registry(
                     .collect()
             })
             .unwrap_or_default(),
+        // `$config.*` is composition-body-only; a top-level pipeline
+        // declares no config schema, so both tiers stay empty and the
+        // resolver rejects any `$config.*` read here.
+        config: indexmap::IndexMap::new(),
+        config_fold: indexmap::IndexMap::new(),
     };
     for spanned in nodes {
         if let PipelineNode::Transform { config, .. } = &spanned.value {

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -20,16 +20,16 @@ use std::num::NonZeroU32;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use cxl::ast::{Expr, Statement};
+use cxl::ast::{Expr, LiteralValue, Statement};
 use cxl::typecheck::{
     AggregateMode, ColumnLookup, QualifiedField, Row, RowTail, Type, TypedProgram,
 };
 use indexmap::IndexMap;
 
-use crate::config::compile_context::CompileContext;
+use crate::config::compile_context::{CompileContext, ConfigOverrides};
 use crate::config::composition::{
     CompositionFile, CompositionSignature, CompositionSymbolTable, LayerKind, OutputAlias,
-    PortDecl, ProvenanceDb, ResolvedValue,
+    ParamType, PortDecl, ProvenanceDb, ResolvedValue,
 };
 use crate::config::node_header::CombineHeader;
 use crate::config::pipeline_node::{
@@ -928,6 +928,94 @@ fn build_body_scoped_vars(
     registry
 }
 
+/// Populate the body registry's `$config.<param>` tiers for one composition
+/// instantiation.
+///
+/// `config` carries the declared type of every param (so the resolver
+/// accepts `$config.<param>` and rejects unknown ones, and the typechecker
+/// types each read); `config_fold` carries the resolved literal the planner
+/// folds each read to. Resolution precedence, highest first:
+/// channel/group `config:` clobber → call-site `config:` → signature default
+/// → `null`. An absent value folds to `null`, matching the `$vars.*`
+/// missing-read convention.
+fn populate_body_config(
+    registry: &mut cxl::resolve::ScopedVarsRegistry,
+    signature: &CompositionSignature,
+    node_name: &str,
+    call_config: &IndexMap<String, serde_json::Value>,
+    config_overrides: &ConfigOverrides,
+) {
+    let node_overrides = config_overrides.get(node_name);
+    for (param_name, decl) in &signature.config_schema {
+        registry
+            .config
+            .insert(param_name.clone(), param_type_to_scoped(decl.param_type));
+
+        let resolved = node_overrides
+            .and_then(|m| m.get(param_name))
+            .or_else(|| call_config.get(param_name))
+            .or(decl.default.as_ref());
+        let literal = match resolved {
+            Some(value) => config_value_to_literal(value, decl.param_type),
+            None => LiteralValue::Null,
+        };
+        registry.config_fold.insert(param_name.clone(), literal);
+    }
+}
+
+/// Map a composition config [`ParamType`] to the CXL scoped-var type used by
+/// the resolver / typechecker. `path` is a string at the CXL layer.
+fn param_type_to_scoped(param_type: ParamType) -> cxl::resolve::ScopedVarType {
+    use cxl::resolve::ScopedVarType;
+    match param_type {
+        ParamType::String | ParamType::Path => ScopedVarType::String,
+        ParamType::Int => ScopedVarType::Int,
+        ParamType::Float => ScopedVarType::Float,
+        ParamType::Bool => ScopedVarType::Bool,
+    }
+}
+
+/// Coerce a resolved config value to the CXL literal the fold substitutes,
+/// driven by the param's declared type. Values are already type-validated
+/// (signature-load and `validate_config`), so a shape mismatch here can only
+/// be a `null`/absent value, which folds to [`LiteralValue::Null`].
+fn config_value_to_literal(value: &serde_json::Value, param_type: ParamType) -> LiteralValue {
+    if value.is_null() {
+        return LiteralValue::Null;
+    }
+    match param_type {
+        ParamType::Int => value
+            .as_i64()
+            .map(LiteralValue::Int)
+            .or_else(|| value.as_f64().map(|f| LiteralValue::Int(f as i64)))
+            .unwrap_or(LiteralValue::Null),
+        ParamType::Float => value
+            .as_f64()
+            .map(LiteralValue::Float)
+            .unwrap_or(LiteralValue::Null),
+        ParamType::Bool => value
+            .as_bool()
+            .map(LiteralValue::Bool)
+            .unwrap_or(LiteralValue::Null),
+        ParamType::String | ParamType::Path => value
+            .as_str()
+            .map(|s| LiteralValue::String(s.into()))
+            .unwrap_or(LiteralValue::Null),
+    }
+}
+
+/// Constant-fold every `$config.<param>` in a freshly typechecked body
+/// program to its resolved literal. A no-op outside a composition body
+/// (empty `config_fold`), so a plain pipeline compiles byte-identically.
+fn fold_body_config(typed: &mut TypedProgram, scoped_vars: &cxl::resolve::ScopedVarsRegistry) {
+    if scoped_vars.config_fold.is_empty() {
+        return;
+    }
+    cxl::ast::fold_config_program(&mut typed.program, &|param| {
+        scoped_vars.config_fold.get(param).cloned()
+    });
+}
+
 fn span_for_node(spanned: &Spanned<PipelineNode>) -> Span {
     let line = spanned.referenced.line() as u32;
     if line > 0 {
@@ -1023,9 +1111,11 @@ fn collect_scope_reads_in_expr(expr: &Expr, out: &mut Vec<(crate::config::VarSco
         | Expr::GroupKey { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::DocAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::VarsAccess { .. } => {
             // $vars.* reads are global static config — no producer, no
-            // DAG-descendant rule applies. Skipped from the scope-read
+            // DAG-descendant rule applies. $config.* is folded to a literal
+            // before this walk runs. Both are skipped from the scope-read
             // accounting that drives E170/E171/E175 validation.
         }
     }
@@ -2667,13 +2757,25 @@ fn bind_composition(
     // Mismatches (parent missing the var, or type doesn't match) emit
     // E174.
     let saved_scoped_vars = std::mem::take(&mut bind_ctx.scoped_vars);
-    bind_ctx.scoped_vars = build_body_scoped_vars(
+    let mut body_scoped_vars = build_body_scoped_vars(
         &signature.scoped_vars_schema,
         &saved_scoped_vars,
         &signature.name,
         span,
         diags,
     );
+    // Wire `$config.<param>` for this instantiation's body: the declared
+    // types drive resolve/typecheck, and the resolved values drive the
+    // compile-time fold (see `fold_body_config`). Two call sites of the same
+    // composition with different config therefore compile to different bodies.
+    populate_body_config(
+        &mut body_scoped_vars,
+        signature,
+        node_name,
+        call_config,
+        &bind_ctx.ctx.config_overrides,
+    );
+    bind_ctx.scoped_vars = body_scoped_vars;
     // The new enclosing_scope is the parent's node names (for E108).
     bind_ctx.enclosing_scope_names = parent_schema_by_name.keys().cloned().collect();
     // Also include the enclosing scope's names so nested compositions
@@ -3854,7 +3956,10 @@ fn typecheck_cxl(
         )
     })?;
     cxl::typecheck::pass::type_check_with_mode_and_vars(resolved, schema, mode, scoped_vars)
-        .map(|typed| typed.with_source(std::sync::Arc::from(source)))
+        .map(|mut typed| {
+            fold_body_config(&mut typed, scoped_vars);
+            typed.with_source(std::sync::Arc::from(source))
+        })
         .map_err(|diags| {
             let errors: Vec<String> = diags
                 .iter()
@@ -4074,6 +4179,7 @@ fn first_body_field_ref(expr: &Expr) -> Option<String> {
         Expr::Literal { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }
@@ -4930,7 +5036,10 @@ fn typecheck_combine_where(
         cxl::typecheck::pass::AggregateMode::Row,
         scoped_vars,
     ) {
-        Ok(typed) => Ok(typed.with_source(std::sync::Arc::from(wrapped.as_str()))),
+        Ok(mut typed) => {
+            fold_body_config(&mut typed, scoped_vars);
+            Ok(typed.with_source(std::sync::Arc::from(wrapped.as_str())))
+        }
         Err(type_diags) => {
             let mut out = Vec::new();
             for td in type_diags.into_iter().filter(|d| !d.is_warning) {
@@ -5092,6 +5201,7 @@ fn walk_for_unknown_refs(expr: &Expr, cx: CombineWalkContext<'_>, diags: &mut Ve
         | Expr::Literal { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -415,6 +415,7 @@ fn collect_qualifiers_inner(expr: &Expr, out: &mut HashSet<Arc<str>>) {
         | Expr::Literal { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }

--- a/crates/clinker-plan/src/plan/tests/config_fold.rs
+++ b/crates/clinker-plan/src/plan/tests/config_fold.rs
@@ -1,0 +1,220 @@
+//! Compile-time constant folding of `$config.<param>` in composition bodies
+//! (issue #765).
+//!
+//! `$config.<param>` reads in a composition body are folded to the
+//! instantiation's resolved config value after typecheck, so two call sites of
+//! the same composition with different `config:` compile to different bodies,
+//! and an undeclared `$config.<param>` is a compile error.
+
+use std::path::PathBuf;
+
+use super::deferred_region::bind_schema_with_dir;
+use crate::config::{CompileContext, parse_config};
+
+const GATE_COMP: &str = r#"_compose:
+  name: gate
+  inputs:
+    inp:
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: float }
+  outputs:
+    out: gated
+  config_schema:
+    min_amount:
+      type: float
+      default: 0.0
+nodes:
+  - type: transform
+    name: gated
+    input: inp
+    config:
+      cxl: |
+        filter val >= $config.min_amount
+        emit id = id
+        emit val = val
+"#;
+
+fn write_gate(workspace: &std::path::Path) {
+    let comp_dir = workspace.join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    std::fs::write(comp_dir.join("gate.comp.yaml"), GATE_COMP).expect("write comp");
+    std::fs::create_dir_all(workspace.join("pipelines")).expect("mkdir pipelines");
+}
+
+/// The folded `filter` literal of a composition instantiation's `gated` body
+/// transform, as a debug string of the typed program.
+fn body_program_debug(
+    artifacts: &crate::plan::bind_schema::CompileArtifacts,
+    config: &crate::config::PipelineConfig,
+    comp_node: &str,
+) -> String {
+    let comp_id = artifacts
+        .top_level_id(&config.nodes, comp_node)
+        .unwrap_or_else(|| panic!("composition id for {comp_node:?}"));
+    let body_id = artifacts
+        .composition_body_assignments
+        .get(&comp_id)
+        .copied()
+        .unwrap_or_else(|| panic!("body assignment for {comp_node:?}"));
+    let body = artifacts
+        .body_of(body_id)
+        .unwrap_or_else(|| panic!("bound body for {comp_node:?}"));
+    let idx = body
+        .name_to_idx
+        .get("gated")
+        .copied()
+        .expect("body `gated` node index");
+    let node_id = body.graph[idx].id();
+    let prog = artifacts
+        .typed_get(node_id)
+        .expect("body `gated` typed program");
+    format!("{:?}", prog.program)
+}
+
+#[test]
+fn two_instantiations_fold_to_different_bodies() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    write_gate(workspace.path());
+
+    // The same composition used twice with different call-site `config:`.
+    let yaml = r#"
+pipeline:
+  name: two_gates
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: float }
+  - type: composition
+    name: gate_low
+    input: src
+    use: ../compositions/gate.comp.yaml
+    inputs:
+      inp: src
+    config:
+      min_amount: 10.0
+  - type: composition
+    name: gate_high
+    input: src
+    use: ../compositions/gate.comp.yaml
+    inputs:
+      inp: src
+    config:
+      min_amount: 100.0
+  - type: output
+    name: out_low
+    input: gate_low
+    config:
+      name: out_low
+      type: csv
+      path: out_low.csv
+  - type: output
+    name: out_high
+    input: gate_high
+    config:
+      name: out_high
+      type: csv
+      path: out_high.csv
+"#;
+    let (artifacts, config) = bind_schema_with_dir(yaml, workspace.path());
+
+    let low = body_program_debug(&artifacts, &config, "gate_low");
+    let high = body_program_debug(&artifacts, &config, "gate_high");
+
+    // No `$config` survives — it is folded to a literal before storage.
+    assert!(
+        !low.contains("ConfigAccess") && !high.contains("ConfigAccess"),
+        "no ConfigAccess may remain after folding.\nlow: {low}\nhigh: {high}"
+    );
+    // Each instantiation baked in its own resolved threshold.
+    assert!(
+        low.contains("Float(10.0)"),
+        "gate_low must fold $config.min_amount to 10.0.\nlow: {low}"
+    );
+    assert!(
+        high.contains("Float(100.0)"),
+        "gate_high must fold $config.min_amount to 100.0.\nhigh: {high}"
+    );
+    assert_ne!(
+        low, high,
+        "two instantiations with different config must compile to different bodies"
+    );
+}
+
+#[test]
+fn unknown_config_param_is_a_compile_error() {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    // A gate whose body reads a param NOT in its config schema.
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    std::fs::write(
+        comp_dir.join("gate.comp.yaml"),
+        r#"_compose:
+  name: gate
+  inputs:
+    inp:
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: float }
+  outputs:
+    out: gated
+  config_schema:
+    min_amount:
+      type: float
+      default: 0.0
+nodes:
+  - type: transform
+    name: gated
+    input: inp
+    config:
+      cxl: |
+        filter val >= $config.cutoff
+        emit id = id
+"#,
+    )
+    .expect("write comp");
+    std::fs::create_dir_all(workspace.path().join("pipelines")).expect("mkdir pipelines");
+
+    let yaml = r#"
+pipeline:
+  name: bad_config
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: float }
+  - type: composition
+    name: gate
+    input: src
+    use: ../compositions/gate.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out
+    input: gate
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse");
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    let result = config.compile(&ctx);
+    let diags = result.expect_err("an undeclared $config param must fail compilation");
+    assert!(
+        diags.iter().any(|d| d.message.contains("$config.cutoff")),
+        "compile error must name the unknown $config param: {:?}",
+        diags.iter().map(|d| &d.message).collect::<Vec<_>>()
+    );
+}

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -2,6 +2,7 @@ mod ck_aligned_partition;
 mod ck_lattice;
 mod combine_body_typed_on_node;
 mod combine_where_scoped_key;
+mod config_fold;
 mod cull_reshape_compiled_on_node;
 mod cull_validation;
 mod dag;

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -961,6 +961,17 @@ fn run(args: &RunArgs) -> Result<u8, PipelineError> {
     compile_ctx.allow_absolute_paths = args.allow_absolute_paths;
     if let Some(res) = &overlay_resolution {
         compile_ctx.overlay_ops = res.op_stream().to_vec();
+        // Resolve the winning `config:` value per composition node so the
+        // compile-time fold substitutes it into `$config.<param>` reads. The
+        // ProvenanceDb still records the full layer chain (post-compile
+        // overlay), so this drives execution without double-applying to it.
+        compile_ctx.config_overrides = res.effective_config_overrides();
+    }
+    if let Some(binding) = &channel_binding {
+        clinker_channel::merge_config_overrides(
+            &mut compile_ctx.config_overrides,
+            binding.effective_config(),
+        );
     }
 
     // Run identity values flow through Output path templates and the

--- a/crates/clinker/src/refactor.rs
+++ b/crates/clinker/src/refactor.rs
@@ -770,6 +770,7 @@ fn collect_qualifier_ranges_expr(
         | Expr::FieldRef { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::RecordAccess { .. }
         | Expr::QualifiedSourceAccess { .. }

--- a/crates/clinker/tests/config_namespace.rs
+++ b/crates/clinker/tests/config_namespace.rs
@@ -1,0 +1,212 @@
+//! End-to-end proof that a channel/group `config:` override of a composition
+//! parameter changes executed behaviour, not just the rendered provenance
+//! (issue #765).
+//!
+//! The workspace pairs a base pipeline that uses a `gate` composition whose
+//! body filters rows against `$config.min_amount` against a standalone group
+//! `big_orders` that clobbers `gate.min_amount`. A plain run keeps every row
+//! (default threshold `0`); `run --group big_orders` drops the rows below the
+//! overridden threshold, and `channels resolve --group big_orders` reports the
+//! override winning over the base default.
+
+use std::path::Path;
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+fn write(root: &Path, rel: &str, content: &str) {
+    let path = root.join(rel);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, content).unwrap();
+}
+
+const CLINKER_TOML: &str = "[channel]\nroot = \"channel\"\n\n[group]\nroot = \"group\"\n";
+const ORDERS_CSV: &str = "order_id,amount\na1,150.0\na2,20.0\na3,200.0\n";
+
+/// The `gate` composition: its body reads `$config.min_amount` in a `filter`,
+/// so the resolved config value directly gates which rows survive. The base
+/// pipeline calls it with `min_amount: 0.0`, keeping everything.
+const COMPOSITION: &str = r#"_compose:
+  name: gate
+  inputs:
+    inp:
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: float }
+  outputs:
+    out: gated
+  config_schema:
+    min_amount:
+      type: float
+      default: 0.0
+nodes:
+  - type: transform
+    name: gated
+    input: inp
+    config:
+      cxl: |
+        filter amount >= $config.min_amount
+        emit order_id = order_id
+        emit amount = amount
+"#;
+
+const PIPELINE: &str = r#"pipeline:
+  name: order_fulfillment
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: orders.csv
+      schema:
+        - { name: order_id, type: string }
+        - { name: amount, type: float }
+  - type: transform
+    name: normalize
+    input: orders
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit amount = amount
+  - type: composition
+    name: gate
+    input: normalize
+    use: ../composition/gate.comp.yaml
+    inputs:
+      inp: normalize
+    config:
+      min_amount: 0.0
+  - type: output
+    name: out
+    input: gate
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+/// A standalone group (no selector — applied by explicit `--group`) that
+/// clobbers the `gate.min_amount` config param up to `100`.
+const GROUP: &str = r#"group:
+  name: big_orders
+  priority: 20
+config:
+  gate.min_amount: 100.0
+"#;
+
+fn build_workspace(root: &Path) {
+    write(root, "clinker.toml", CLINKER_TOML);
+    write(root, "pipeline/orders.csv", ORDERS_CSV);
+    write(root, "pipeline/order_fulfillment.yaml", PIPELINE);
+    write(root, "composition/gate.comp.yaml", COMPOSITION);
+    write(root, "group/big_orders.group.yaml", GROUP);
+}
+
+fn pipeline_path(root: &Path) -> std::path::PathBuf {
+    root.join("pipeline/order_fulfillment.yaml")
+}
+
+fn run_and_read_output(root: &Path, extra_args: &[&str]) -> (String, String) {
+    let out = Command::new(clinker_bin())
+        .current_dir(root)
+        .arg("run")
+        .arg(pipeline_path(root))
+        .args(["--base-dir", root.to_str().unwrap()])
+        .args(extra_args)
+        .output()
+        .expect("spawn clinker");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        out.status.success(),
+        "run must succeed (args {extra_args:?}).\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    let output = std::fs::read_to_string(root.join("out.csv")).unwrap_or_else(|_| String::new());
+    (output, stderr)
+}
+
+#[test]
+fn base_default_keeps_every_row() {
+    // No overlay: the fold substitutes the call-site default `min_amount: 0.0`,
+    // so `filter amount >= 0.0` keeps all three rows. This is the baseline the
+    // override must diverge from.
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path());
+
+    let (output, _stderr) = run_and_read_output(tmp.path(), &[]);
+    assert!(
+        output.contains("a1,150"),
+        "base run keeps a1.\nout.csv:\n{output}"
+    );
+    assert!(
+        output.contains("a2,20"),
+        "base run keeps a2.\nout.csv:\n{output}"
+    );
+    assert!(
+        output.contains("a3,200"),
+        "base run keeps a3.\nout.csv:\n{output}"
+    );
+}
+
+#[test]
+fn group_config_override_changes_executed_rows() {
+    // `run --group big_orders` clobbers `gate.min_amount` to 100. The composition
+    // body's `filter amount >= $config.min_amount` is folded to `>= 100`, so the
+    // `a2` row (amount 20) is dropped — a runtime behaviour change driven purely
+    // by the config override, which #765's provenance-only path could not do.
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path());
+
+    let (output, stderr) = run_and_read_output(tmp.path(), &["--group", "big_orders"]);
+    assert!(
+        stderr.contains("applied overlay") && stderr.contains("big_orders"),
+        "run --group must report the applied group.\nstderr: {stderr}"
+    );
+    assert!(
+        output.contains("a1,150"),
+        "a1 (150 >= 100) survives the overridden gate.\nout.csv:\n{output}"
+    );
+    assert!(
+        output.contains("a3,200"),
+        "a3 (200 >= 100) survives the overridden gate.\nout.csv:\n{output}"
+    );
+    assert!(
+        !output.contains("a2,20"),
+        "a2 (20 < 100) must be dropped by the overridden gate — the override must \
+         reach execution, not just provenance.\nout.csv:\n{output}"
+    );
+}
+
+#[test]
+fn channels_resolve_reports_config_override_and_base() {
+    // The other half of the contract: the override must remain visible in the
+    // resolved provenance, winning over the composition default.
+    let tmp = tempfile::tempdir().unwrap();
+    build_workspace(tmp.path());
+
+    let out = Command::new(clinker_bin())
+        .current_dir(tmp.path())
+        .args(["channels", "resolve"])
+        .arg(pipeline_path(tmp.path()))
+        .args(["--base-dir", tmp.path().to_str().unwrap()])
+        .args(["--group", "big_orders"])
+        .output()
+        .expect("spawn clinker");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "channels resolve must succeed.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("gate.min_amount = 100"),
+        "resolve must show the overridden value.\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("base: 0"),
+        "resolve must still show the composition default as the base layer.\nstdout: {stdout}"
+    );
+}

--- a/crates/cxl-cli/src/main.rs
+++ b/crates/cxl-cli/src/main.rs
@@ -651,6 +651,7 @@ fn format_expr(expr: &cxl::ast::Expr) -> String {
         cxl::ast::Expr::Wildcard { .. } => "_".into(),
         cxl::ast::Expr::PipelineAccess { field, .. } => format!("$pipeline.{}", field),
         cxl::ast::Expr::VarsAccess { key, .. } => format!("$vars.{}", key),
+        cxl::ast::Expr::ConfigAccess { param, .. } => format!("$config.{}", param),
         cxl::ast::Expr::SourceAccess { field, .. } => format!("$source.{}", field),
         cxl::ast::Expr::QualifiedSourceAccess {
             input_name, field, ..

--- a/crates/cxl/src/analyzer/visitor.rs
+++ b/crates/cxl/src/analyzer/visitor.rs
@@ -129,6 +129,7 @@ pub fn walk_expr<V: Visitor + ?Sized>(visitor: &mut V, expr: &Expr) {
         | Expr::QualifiedFieldRef { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }

--- a/crates/cxl/src/ast.rs
+++ b/crates/cxl/src/ast.rs
@@ -251,6 +251,23 @@ pub enum Expr {
         key: Box<str>,
         span: Span,
     },
+    /// Composition configuration parameter: `$config.<param>`. Reads a
+    /// value declared in the enclosing composition's `_compose.config_schema`
+    /// and resolved for this instantiation (signature default, call-site
+    /// `config:`, or channel/group `config:` clobber). Valid only inside a
+    /// composition body; a top-level pipeline declares no config schema, so
+    /// the resolver rejects `$config.*` there.
+    ///
+    /// This variant never reaches evaluation: the planner constant-folds
+    /// each `$config.<param>` to the instantiation's resolved value (an
+    /// [`Expr::Literal`]) at compile time, so two instantiations with
+    /// different config compile to different bodies with no runtime
+    /// plumbing.
+    ConfigAccess {
+        node_id: NodeId,
+        param: Box<str>,
+        span: Span,
+    },
     /// Per-record source provenance: `$source.file`, `$source.row`.
     /// Distinct namespace from `$pipeline.*` (pipeline-stable per-run state)
     /// because per-record values cannot be pipeline-scope when one Source
@@ -377,6 +394,7 @@ impl Expr {
             | Expr::WindowCall { span, .. }
             | Expr::PipelineAccess { span, .. }
             | Expr::VarsAccess { span, .. }
+            | Expr::ConfigAccess { span, .. }
             | Expr::SourceAccess { span, .. }
             | Expr::RecordAccess { span, .. }
             | Expr::QualifiedSourceAccess { span, .. }
@@ -406,6 +424,7 @@ impl Expr {
             | Expr::WindowCall { node_id, .. }
             | Expr::PipelineAccess { node_id, .. }
             | Expr::VarsAccess { node_id, .. }
+            | Expr::ConfigAccess { node_id, .. }
             | Expr::SourceAccess { node_id, .. }
             | Expr::RecordAccess { node_id, .. }
             | Expr::QualifiedSourceAccess { node_id, .. }
@@ -502,6 +521,7 @@ impl Expr {
             Expr::Closure { body, .. } => body.support_into(fields),
             Expr::PipelineAccess { .. }
             | Expr::VarsAccess { .. }
+            | Expr::ConfigAccess { .. }
             | Expr::SourceAccess { .. }
             | Expr::RecordAccess { .. }
             | Expr::QualifiedSourceAccess { .. }
@@ -563,6 +583,123 @@ pub fn program_support_into(program: &Program, fields: &mut std::collections::Ha
                 program_support_into(&inner, fields);
             }
         }
+    }
+}
+
+/// Constant-fold every `$config.<param>` ([`Expr::ConfigAccess`]) in a
+/// [`Program`] to the literal value `resolve` returns for that param.
+///
+/// The planner calls this once per composition instantiation, after the
+/// body program has typechecked, so `$config` never reaches evaluation:
+/// two instantiations with different resolved config fold to different
+/// literals — and therefore different compiled bodies — with no runtime
+/// plumbing. `resolve` returns `None` only for a param outside the
+/// composition's declared config schema; the resolver has already
+/// rejected such a read, so a valid typechecked program never leaves a
+/// `ConfigAccess` unfolded.
+pub fn fold_config_program(program: &mut Program, resolve: &impl Fn(&str) -> Option<LiteralValue>) {
+    for stmt in &mut program.statements {
+        fold_config_stmt(stmt, resolve);
+    }
+}
+
+fn fold_config_stmt(stmt: &mut Statement, resolve: &impl Fn(&str) -> Option<LiteralValue>) {
+    match stmt {
+        Statement::Emit { expr, .. }
+        | Statement::Let { expr, .. }
+        | Statement::ExprStmt { expr, .. } => fold_config_expr(expr, resolve),
+        Statement::Filter { predicate, .. } => fold_config_expr(predicate, resolve),
+        Statement::Trace { guard, message, .. } => {
+            if let Some(g) = guard.as_mut() {
+                fold_config_expr(g, resolve);
+            }
+            fold_config_expr(message, resolve);
+        }
+        Statement::EmitEach { source, body, .. } | Statement::ExplodeOuter { source, body, .. } => {
+            fold_config_expr(source, resolve);
+            for inner in body.iter_mut() {
+                fold_config_stmt(inner, resolve);
+            }
+        }
+        Statement::Distinct { .. } | Statement::UseStmt { .. } => {}
+    }
+}
+
+/// Recursively fold `$config.<param>` inside one expression, mirroring the
+/// recursion shape of [`walk_expr`](crate::analyzer::visitor::walk_expr).
+fn fold_config_expr(expr: &mut Expr, resolve: &impl Fn(&str) -> Option<LiteralValue>) {
+    match expr {
+        Expr::ConfigAccess {
+            node_id,
+            param,
+            span,
+        } => {
+            if let Some(value) = resolve(param) {
+                *expr = Expr::Literal {
+                    node_id: *node_id,
+                    value,
+                    span: *span,
+                };
+            }
+        }
+        Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
+            fold_config_expr(lhs, resolve);
+            fold_config_expr(rhs, resolve);
+        }
+        Expr::Unary { operand, .. } => fold_config_expr(operand, resolve),
+        Expr::MethodCall { receiver, args, .. } => {
+            fold_config_expr(receiver, resolve);
+            for a in args.iter_mut() {
+                fold_config_expr(a, resolve);
+            }
+        }
+        Expr::Match { subject, arms, .. } => {
+            if let Some(s) = subject.as_deref_mut() {
+                fold_config_expr(s, resolve);
+            }
+            for arm in arms.iter_mut() {
+                fold_config_expr(&mut arm.pattern, resolve);
+                fold_config_expr(&mut arm.body, resolve);
+            }
+        }
+        Expr::IfThenElse {
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            fold_config_expr(condition, resolve);
+            fold_config_expr(then_branch, resolve);
+            if let Some(e) = else_branch.as_deref_mut() {
+                fold_config_expr(e, resolve);
+            }
+        }
+        Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
+            for a in args.iter_mut() {
+                fold_config_expr(a, resolve);
+            }
+        }
+        Expr::IndexAccess {
+            receiver, index, ..
+        } => {
+            fold_config_expr(receiver, resolve);
+            fold_config_expr(index, resolve);
+        }
+        Expr::Closure { body, .. } => fold_config_expr(body, resolve),
+        // Leaves and non-`$config` namespaces hold no `ConfigAccess`.
+        Expr::Literal { .. }
+        | Expr::FieldRef { .. }
+        | Expr::QualifiedFieldRef { .. }
+        | Expr::PipelineAccess { .. }
+        | Expr::VarsAccess { .. }
+        | Expr::SourceAccess { .. }
+        | Expr::QualifiedSourceAccess { .. }
+        | Expr::RecordAccess { .. }
+        | Expr::DocAccess { .. }
+        | Expr::Now { .. }
+        | Expr::Wildcard { .. }
+        | Expr::AggSlot { .. }
+        | Expr::GroupKey { .. } => {}
     }
 }
 

--- a/crates/cxl/src/eval/compiled.rs
+++ b/crates/cxl/src/eval/compiled.rs
@@ -913,6 +913,18 @@ fn compile_expr<S: RecordStorage + 'static>(typed: &TypedProgram, expr: &Expr) -
                     .unwrap_or(Value::Null))
             })
         }
+        Expr::ConfigAccess { param, .. } => {
+            // `$config.<param>` is a compile-time constant: the planner folds
+            // every occurrence to an `Expr::Literal` after typecheck (see
+            // `fold_config_program`), so no `ConfigAccess` ever reaches
+            // lowering. Reaching here means a body CXL program was lowered
+            // without folding — a planner invariant violation, not a runtime
+            // condition.
+            unreachable!(
+                "$config.{param} reached evaluation unfolded; the planner must \
+                 constant-fold every $config reference before lowering"
+            )
+        }
         Expr::SourceAccess { field, .. } => {
             let field = field.to_string();
             Box::new(move |frame| Ok(frame.ctx.resolve_source(&field).unwrap_or(Value::Null)))

--- a/crates/cxl/src/module_eval.rs
+++ b/crates/cxl/src/module_eval.rs
@@ -155,6 +155,7 @@ fn walk_expr(expr: &Expr, refs: &mut Vec<String>) {
         }
         Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }
@@ -282,6 +283,7 @@ fn contains_self_call(fn_name: &str, expr: &Expr) -> bool {
         | Expr::Literal { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }

--- a/crates/cxl/src/parser.rs
+++ b/crates/cxl/src/parser.rs
@@ -1090,7 +1090,7 @@ impl Parser {
             Token::Dollar => {
                 self.advance(); // consume '$'
                 let ns = self.expect_ident(
-                    "system namespace (pipeline, vars, source, record, window, doc)",
+                    "system namespace (pipeline, vars, config, source, record, window, doc)",
                 )?;
                 self.expect_token(&Token::Dot, "'.'")?;
 
@@ -1112,6 +1112,16 @@ impl Parser {
                         Ok(Expr::VarsAccess {
                             node_id: nid,
                             key: key.into(),
+                            span: Span::new(start.start as usize, end.end as usize),
+                        })
+                    }
+                    "config" => {
+                        let nid = self.alloc_id();
+                        let param = self.expect_ident("config parameter name")?;
+                        let end = self.prev_span();
+                        Ok(Expr::ConfigAccess {
+                            node_id: nid,
+                            param: param.into(),
                             span: Span::new(start.start as usize, end.end as usize),
                         })
                     }
@@ -1191,9 +1201,10 @@ impl Parser {
                     }
                     other => Err(self.error(
                         &format!("unknown system namespace '${other}'"),
-                        "Valid system namespaces are: pipeline, source, record, window, doc",
-                        "Use $pipeline.field, $source.field, $record.field, $window.fn(), or \
-                         $doc.<section>.<field>",
+                        "Valid system namespaces are: pipeline, vars, config, source, record, \
+                         window, doc",
+                        "Use $pipeline.field, $vars.key, $config.param, $source.field, \
+                         $record.field, $window.fn(), or $doc.<section>.<field>",
                     )),
                 }
             }
@@ -2062,6 +2073,41 @@ mod tests {
             }
             _ => panic!("expected PipelineAccess"),
         }
+    }
+
+    #[test]
+    fn test_parse_config_access() {
+        let r = parse_ok("let x = $config.threshold");
+        let expr = let_expr(&r);
+        match expr {
+            Expr::ConfigAccess { param, .. } => {
+                assert_eq!(&**param, "threshold");
+            }
+            _ => panic!("expected ConfigAccess"),
+        }
+    }
+
+    #[test]
+    fn test_fold_config_program_replaces_config_access() {
+        use crate::ast::{LiteralValue, fold_config_program};
+        let r = parse_ok("filter amount >= $config.min_amount");
+        let mut program = r.ast;
+        fold_config_program(&mut program, &|param| match param {
+            "min_amount" => Some(LiteralValue::Float(100.0)),
+            _ => None,
+        });
+        // No `ConfigAccess` may remain after folding.
+        let mut fields = std::collections::HashSet::new();
+        crate::ast::program_support_into(&program, &mut fields);
+        let rendered = format!("{:?}", program);
+        assert!(
+            !rendered.contains("ConfigAccess"),
+            "fold must replace every $config read with a literal: {rendered}"
+        );
+        assert!(
+            rendered.contains("Float(100.0)"),
+            "folded literal must carry the resolved value: {rendered}"
+        );
     }
 
     #[test]

--- a/crates/cxl/src/plan/extract_aggregates.rs
+++ b/crates/cxl/src/plan/extract_aggregates.rs
@@ -218,6 +218,7 @@ fn extract_aggs_from_expr(
         | Expr::QualifiedFieldRef { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }
@@ -371,6 +372,7 @@ fn rewrite_group_key_refs(
         | Expr::Literal { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }
@@ -466,6 +468,7 @@ fn substitute_let_bindings(expr: &mut Expr, let_bindings: &HashMap<Box<str>, Exp
         | Expr::QualifiedFieldRef { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }
@@ -520,6 +523,7 @@ fn contains_agg_call(expr: &Expr) -> bool {
         | Expr::QualifiedFieldRef { .. }
         | Expr::PipelineAccess { .. }
         | Expr::VarsAccess { .. }
+        | Expr::ConfigAccess { .. }
         | Expr::SourceAccess { .. }
         | Expr::QualifiedSourceAccess { .. }
         | Expr::RecordAccess { .. }
@@ -588,6 +592,9 @@ fn write_struct_form(buf: &mut String, expr: &Expr) {
         }
         Expr::VarsAccess { key, .. } => {
             let _ = write!(buf, "v:{key}");
+        }
+        Expr::ConfigAccess { param, .. } => {
+            let _ = write!(buf, "cfg:{param}");
         }
         Expr::SourceAccess { field, .. } => {
             let _ = write!(buf, "s:{field}");

--- a/crates/cxl/src/resolve/pass.rs
+++ b/crates/cxl/src/resolve/pass.rs
@@ -377,6 +377,35 @@ impl<'a> Resolver<'a> {
                     });
                 }
             }
+            Expr::ConfigAccess {
+                node_id,
+                param,
+                span,
+            } => {
+                if self.scoped_vars.config.contains_key(&**param) {
+                    self.bind(*node_id, ResolvedBinding::PipelineMember);
+                } else {
+                    let declared: Vec<&str> =
+                        self.scoped_vars.config.keys().map(|s| s.as_str()).collect();
+                    // `$config.*` is only meaningful inside a composition body,
+                    // where the registry carries that composition's declared
+                    // config params. A top-level pipeline has an empty config
+                    // registry, so every `$config.*` read falls here.
+                    self.diagnostics.push(ResolveDiagnostic {
+                        span: *span,
+                        message: format!("unknown config parameter '$config.{param}'"),
+                        help: best_match(param, &declared, 3)
+                            .map(|s| format!("did you mean '$config.{s}'?"))
+                            .or_else(|| {
+                                Some(
+                                    "declare it in the composition's `_compose.config_schema`; \
+                                     `$config.*` is only available inside a composition body"
+                                        .into(),
+                                )
+                            }),
+                    });
+                }
+            }
             Expr::SourceAccess {
                 node_id,
                 field,
@@ -844,6 +873,68 @@ mod tests {
         assert!(
             has_pipeline,
             "Expected PipelineMember binding for declared fuzzy_score"
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_top_level_rejected() {
+        // `$config.*` outside a composition body: the default (top-level)
+        // registry declares no config params, so every read is rejected.
+        let diags = resolve_err("filter amount >= $config.threshold", &["amount"]);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.message.contains("$config.threshold")),
+            "expected diagnostic for $config outside a composition: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_config_unknown_param_rejected() {
+        use crate::resolve::scoped_vars::ScopedVarType;
+        let mut registry = ScopedVarsRegistry::default();
+        registry
+            .config
+            .insert("threshold".to_string(), ScopedVarType::Float);
+        let parsed = Parser::parse("filter amount >= $config.cutoff");
+        assert!(parsed.errors.is_empty());
+        let diags = resolve_program_with_modules_and_vars(
+            parsed.ast,
+            &["amount"],
+            parsed.node_count,
+            &HashMap::new(),
+            &registry,
+        )
+        .expect_err("an undeclared $config param must be a resolve error");
+        assert!(
+            diags.iter().any(|d| d.message.contains("$config.cutoff")),
+            "expected diagnostic for unknown $config param: {diags:?}"
+        );
+    }
+
+    #[test]
+    fn test_resolve_declared_config_param() {
+        use crate::resolve::scoped_vars::ScopedVarType;
+        let mut registry = ScopedVarsRegistry::default();
+        registry
+            .config
+            .insert("threshold".to_string(), ScopedVarType::Float);
+        let parsed = Parser::parse("filter amount >= $config.threshold");
+        assert!(parsed.errors.is_empty());
+        let resolved = resolve_program_with_modules_and_vars(
+            parsed.ast,
+            &["amount"],
+            parsed.node_count,
+            &HashMap::new(),
+            &registry,
+        )
+        .expect("declared $config param should resolve");
+        assert!(
+            resolved
+                .bindings
+                .iter()
+                .any(|b| matches!(b, Some(ResolvedBinding::PipelineMember))),
+            "expected PipelineMember binding for declared $config.threshold"
         );
     }
 

--- a/crates/cxl/src/resolve/scoped_vars.rs
+++ b/crates/cxl/src/resolve/scoped_vars.rs
@@ -26,6 +26,8 @@
 
 use indexmap::IndexMap;
 
+use crate::ast::LiteralValue;
+
 /// Scoped-variable primitive type set.
 ///
 /// Mirrors `clinker_plan::config::ScopedVarType`. Conversion to the CXL
@@ -67,6 +69,19 @@ pub struct ScopedVarsRegistry {
     /// above (which are producer-written); a `$vars.*` read is global
     /// and DAG-position-independent.
     pub static_vars: IndexMap<String, ScopedVarType>,
+    /// Composition config parameters read via `$config.<param>`. Declared
+    /// types drive resolve (unknown param → error) and typecheck. Empty
+    /// outside a composition body, so a top-level `$config.*` read is
+    /// rejected. Paired with [`Self::config_fold`], which carries each
+    /// param's resolved literal for the compile-time constant fold.
+    pub config: IndexMap<String, ScopedVarType>,
+    /// Resolved literal value per `$config.<param>` for THIS composition
+    /// instantiation (signature default, call-site `config:`, or
+    /// channel/group `config:` clobber). The planner folds each
+    /// `$config.<param>` to this literal after typecheck; the values are
+    /// per-instantiation, so `config_fold` is never shared across
+    /// composition call sites.
+    pub config_fold: IndexMap<String, LiteralValue>,
 }
 
 /// Per-scope tag for `ScopedVarsRegistry::hidden_lookup`.

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -506,6 +506,22 @@ impl<'a> TypeChecker<'a> {
                 ty
             }
 
+            Expr::ConfigAccess { node_id, param, .. } => {
+                // Type from the composition's declared config schema. An
+                // unknown param was already rejected by the resolver, so the
+                // `Any` fallback only shields the typecheck pass from cascading
+                // on an already-diagnosed read.
+                let ty = self
+                    .scoped_vars
+                    .config
+                    .get(&**param)
+                    .copied()
+                    .map(scoped_var_type_to_type)
+                    .unwrap_or(Type::Any);
+                self.set_type(*node_id, ty.clone());
+                ty
+            }
+
             Expr::SourceAccess { node_id, field, .. } => {
                 let ty = match &**field {
                     "file" | "path" | "batch" | "name" => Type::String,
@@ -1195,6 +1211,7 @@ impl<'a> TypeChecker<'a> {
             | Expr::QualifiedFieldRef { .. }
             | Expr::PipelineAccess { .. }
             | Expr::VarsAccess { .. }
+            | Expr::ConfigAccess { .. }
             | Expr::SourceAccess { .. }
             | Expr::QualifiedSourceAccess { .. }
             | Expr::RecordAccess { .. }

--- a/docs/user/src/cxl/overview.md
+++ b/docs/user/src/cxl/overview.md
@@ -40,6 +40,7 @@ CXL provides built-in namespaces for accessing pipeline state, metadata, and win
 - `$record.*` -- per-record scoped state (travels with the record, never an output column)
 - `$window.*` -- window function calls
 - `$vars.*` -- static, channel-overridable configuration
+- `$config.*` -- a composition's config parameters, read inside its body (constant-folded per instantiation)
 
 ```bash
 $ cxl eval -e 'emit name = $pipeline.name'

--- a/docs/user/src/cxl/system-variables.md
+++ b/docs/user/src/cxl/system-variables.md
@@ -96,6 +96,33 @@ emit currency = $vars.output_currency
 
 Variables provide a clean way to externalize configuration from CXL logic. Combined with [channels](../pipelines/channels.md), different variable sets can parameterize the same pipeline for different environments or clients.
 
+## $config.* -- Composition config parameters
+<a id="config-composition-config-parameters"></a>
+
+`$config.<param>` reads a [composition](../pipelines/compositions.md)'s declared config parameter from **inside that composition's body**. It is only available in a composition body — a top-level pipeline declares no config schema, so `$config.*` there is a compile error.
+
+Each parameter is declared in the composition's `_compose.config_schema:` block, then read from the body's CXL:
+
+```yaml
+# in fraud_check.comp.yaml
+_compose:
+  name: fraud_check
+  config_schema:
+    threshold: { type: float, default: 0.8 }
+nodes:
+  - type: transform
+    name: flag
+    input: inp
+    config:
+      cxl: |
+        emit order_id = order_id
+        emit flagged = score >= $config.threshold
+```
+
+Unlike `$vars.*` (which flows to the executor as a runtime value), `$config.<param>` is **constant-folded at compile time**: each reference is replaced by the value resolved for that instantiation, so two call sites of the same composition with different `config:` compile to different bodies. The resolution precedence, highest first, is a [channel/group](../pipelines/channels.md) `config:` clobber, then the call site's `config:`, then the signature default.
+
+Because the value is resolved per instantiation, overriding a config knob via a channel or group `config:` value clobber changes what the composition body computes — the override is applied to execution, and the winning layer is still recorded in the provenance side-table for `channels resolve` / `explain --field`.
+
 ## $record.* -- Per-record scoped state
 
 `$record.*` is a per-record key-value store that travels with the record through the pipeline but never serializes as an output column. It is the mechanism for tagging records with quality flags, routing hints, or audit information that should not appear in the final output unless explicitly re-emitted as a regular column.

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -101,6 +101,13 @@ config:
   scorer.threshold: 0.95     # override the `threshold` knob of the `scorer` composition node
 ```
 
+The override changes executed behavior, not just the rendered provenance: the
+composition body reads the knob as [`$config.<param>`](../cxl/system-variables.md#config-composition-config-parameters),
+which the planner constant-folds to the resolved value for that instantiation at
+compile time. The winning layer is still recorded in the provenance side-table,
+so `channels resolve` / `explain --field` continue to report which layer supplied
+the value.
+
 A `config:` key that matches no parameter in the compiled plan is a hard error
 ([E113](#diagnostics)) — a misspelled or stale key aborts the run rather than
 silently doing nothing.
@@ -492,17 +499,8 @@ not collide.
 
 ## Known behavior notes
 
-Two current gaps are tracked as follow-up issues; both surface in the overlay
+One current gap is tracked as a follow-up issue; it surfaces in the overlay
 tooling today:
-
-- **`config:` value overrides are provenance-only, not yet applied at runtime.**
-  A `config:` value clobber currently writes to the compiled plan's provenance
-  side-table — so `channels resolve` and `explain --field` *report* the
-  overridden value and its winning layer — but lowering and the executor do not
-  yet read it, so the overridden composition parameter does not change executed
-  behavior. `vars:` overrides and the structural `overrides:` ops *do* reach
-  runtime. This is inherited from the value-clobber mechanism; making `config:`
-  values functional at runtime is tracked in issue #765.
 
 - **A legacy single-file channel path still coexists.**<a id="legacy-channel-file-path"></a>
   `run --channel <FILE>` / `explain --channel <FILE>` accept a single channel

--- a/docs/user/src/pipelines/compositions.md
+++ b/docs/user/src/pipelines/compositions.md
@@ -52,6 +52,10 @@ composition:
 | `produces` | Yes | Output fields the composition adds to the record (name + type) |
 | `params` | No | Configurable parameters with optional defaults |
 
+### Reading config parameters in the body
+
+A composition body reads its own config parameters as [`$config.<param>`](../cxl/system-variables.md#config-composition-config-parameters). The planner constant-folds each reference to the value resolved for that instantiation — the call site's `config:` value, or a [channel/group](channels.md) `config:` override, or the declared default — so the same composition used with different `config:` compiles to different bodies. Because the resolution happens per instantiation, a channel or group `config:` override changes what the body computes, not just the reported provenance.
+
 ## Advanced wiring
 
 For compositions with multiple input or output ports, the node supports explicit port bindings:


### PR DESCRIPTION
## Summary

Channel and group `config:` value overrides were **reported but inert**: a
`config:` clobber wrote only to the compiled plan's provenance side-table, so
`channels resolve` / `explain --field` showed the overridden composition
parameter and its winning layer, but lowering and the executor never read it —
the override did not change what a run produced.

This makes those overrides functional by giving composition bodies a way to
read their own config parameters, and folding the resolved value into the body
at compile time.

## What changed

- **New `$config.<param>` CXL namespace.** A composition body reads its declared
  config parameters as `$config.<param>` (mirroring `$vars.<key>`). It is valid
  only inside a composition body; a top-level pipeline declares no config
  schema, so `$config.*` there is a compile error, and an undeclared
  `$config.<param>` is a compile error with a "did you mean" suggestion.

- **Compile-time constant fold.** Each `$config.<param>` is resolved to the
  value for that instantiation and folded to a literal after typecheck, so it
  never reaches the runtime. Two call sites of the same composition with
  different `config:` compile to different bodies. Resolution precedence,
  highest first: channel/group `config:` clobber → call-site `config:` →
  signature default.

- **Winning value resolved pre-compile.** The effective config value per
  composition node is resolved from the channel/group overlay before compile
  (reusing the same layer-precedence winner logic the provenance table uses)
  and threaded through the compile context. The provenance layer chain is still
  recorded separately by the existing post-compile overlay, so the winning
  layer shown by `channels resolve` / `explain --field` and the value the run
  executes stay in agreement — the override is applied once, to execution.

- **Plain pipelines are unaffected.** With no overlay, compilation is
  byte-identical; the unknown-config-key hard error (E113) is unchanged.

## Verification

- `cargo build --workspace`, `cargo fmt --all --check`, and
  `cargo clippy --workspace --all-targets -- -D warnings` are clean.
- New tests:
  - end-to-end run — a composition body filters rows on `$config.min_amount`;
    a plain run keeps every row, `run --group` (overriding the parameter) drops
    the sub-threshold row, and `channels resolve` reports the override winning
    over the base default;
  - compile-level — two instantiations fold to different bodies, and an
    undeclared `$config.<param>` fails compilation;
  - unit — parser, fold, and resolver (top-level rejection, unknown-param
    rejection, valid resolution).
- Existing provenance and overlay tests (including the `channels resolve`
  snapshot) still pass — the base provenance layer is untouched.

## Docs

- CXL system-variable reference and overview document the `$config.*`
  namespace.
- The channels guide and compositions guide note that a `config:` override now
  changes execution, and the "provenance-only" caveat is removed.

Closes #765
Part of #515
