### PR TITLE
fix(cxl): accept decimal in sum/avg typecheck guards

### DIFF
--- a/crates/clinker-exec/src/executor/tests/aggregation.rs
+++ b/crates/clinker-exec/src/executor/tests/aggregation.rs
@@ -20,6 +20,7 @@ mod dispatch {
     use cxl::typecheck::pass::{AggregateMode, type_check_with_mode};
     use cxl::typecheck::types::Type;
     use indexmap::IndexMap;
+    use rust_decimal::Decimal;
 
     use crate::aggregation::{AggregatorConfig, AggregatorGroupState, HashAggregator};
     use clinker_plan::config::ErrorStrategy;
@@ -930,6 +931,320 @@ nodes:
         );
         agg.flush(&ctx_for(&stable, &file, 0), &mut out).unwrap();
         assert_eq!(out.len(), groups as usize, "one row per group at the end");
+    }
+
+    // ===================================================================
+    // Exact `decimal` aggregation, end-to-end through the real
+    // Parser -> resolve -> typecheck -> extract_aggregates -> HashAggregator
+    // path. Before the typecheck guard accepted `Type::Decimal`, these
+    // pipelines were rejected at compile time, so `build_aggregator` (which
+    // `.expect("typecheck")`s) would have panicked here.
+    // ===================================================================
+
+    /// Collect a finalized aggregator's output rows into a `(key, decimal)`
+    /// map, keyed by the first output column rendered as a string. Works for
+    /// both string and decimal group keys.
+    fn decimal_totals_by_key(
+        out: &[crate::aggregation::SortRow],
+        total_idx: usize,
+    ) -> Vec<(String, Decimal)> {
+        out.iter()
+            .map(|(rec, _)| {
+                let key = rec.values()[0].to_string();
+                let total = match &rec.values()[total_idx] {
+                    Value::Decimal(d) => *d,
+                    other => panic!("expected a decimal total, got {other:?}"),
+                };
+                (key, total)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_sum_decimal_exact_total_to_the_cent_e2e() {
+        // 100 pennies == $1.00 exactly. The decimal accumulator lands on the
+        // cent; the binary-float path does not (0.01 is not representable in
+        // IEEE-754, so 100 additions drift off 1.0).
+        let input = make_schema(&["k", "amount"]);
+        let mut agg = build_aggregator(
+            &[("k", Type::String), ("amount", Type::Decimal)],
+            &["k"],
+            "emit k = k\nemit total = sum(amount)",
+            "decimal_sum_e2e",
+            64 * 1024 * 1024,
+            None,
+        );
+        let stable = StableEvalContext::test_default();
+        let file: Arc<str> = Arc::from("t.csv");
+        for i in 0..100u64 {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::String("g".into()),
+                    Value::Decimal(Decimal::new(1, 2)),
+                ], // 0.01
+            );
+            agg.add_record(&r, i, &ctx_for(&stable, &file, i)).unwrap();
+        }
+        let ctx = ctx_for(&stable, &file, 0);
+        let mut out: Vec<crate::aggregation::SortRow> = Vec::new();
+        agg.finalize(&ctx, &mut out).expect("finalize");
+        assert_eq!(out.len(), 1, "one group");
+        assert_eq!(
+            out[0].0.values()[1],
+            Value::Decimal(Decimal::new(100, 2)),
+            "exact monetary total 1.00 to the cent"
+        );
+
+        // The binary-float path drifts off the exact cent — the whole reason
+        // the decimal type exists.
+        let mut float_sum = 0.0_f64;
+        for _ in 0..100 {
+            float_sum += 0.01;
+        }
+        assert_ne!(
+            float_sum, 1.0_f64,
+            "binary float drifts ({float_sum:?}); the decimal total stays exact"
+        );
+    }
+
+    #[test]
+    fn test_avg_decimal_exact_e2e() {
+        // avg(0.10, 0.20, 0.30) == 0.60 / 3 == 0.20 exactly.
+        let input = make_schema(&["k", "amount"]);
+        let mut agg = build_aggregator(
+            &[("k", Type::String), ("amount", Type::Decimal)],
+            &["k"],
+            "emit k = k\nemit average = avg(amount)",
+            "decimal_avg_e2e",
+            64 * 1024 * 1024,
+            None,
+        );
+        let stable = StableEvalContext::test_default();
+        let file: Arc<str> = Arc::from("t.csv");
+        for (i, c) in [10i64, 20, 30].iter().enumerate() {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::String("g".into()),
+                    Value::Decimal(Decimal::new(*c, 2)),
+                ],
+            );
+            agg.add_record(&r, i as u64, &ctx_for(&stable, &file, i as u64))
+                .unwrap();
+        }
+        let ctx = ctx_for(&stable, &file, 0);
+        let mut out: Vec<crate::aggregation::SortRow> = Vec::new();
+        agg.finalize(&ctx, &mut out).expect("finalize");
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            out[0].0.values()[1],
+            Value::Decimal(Decimal::new(20, 2)),
+            "exact decimal average 0.20"
+        );
+
+        // avg over decimals computes at full precision (no binary float): the
+        // exact average of three equal-weight cents is exact, and a repeating
+        // quotient keeps every digit rather than collapsing to an f64.
+        let mut agg2 = build_aggregator(
+            &[("k", Type::String), ("amount", Type::Decimal)],
+            &["k"],
+            "emit k = k\nemit average = avg(amount)",
+            "decimal_avg_repeating_e2e",
+            64 * 1024 * 1024,
+            None,
+        );
+        // avg(1.00, 1.00, 2.00) == 4.00 / 3 == 1.3333... at full precision.
+        for (i, c) in [100i64, 100, 200].iter().enumerate() {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::String("g".into()),
+                    Value::Decimal(Decimal::new(*c, 2)),
+                ],
+            );
+            agg2.add_record(&r, i as u64, &ctx_for(&stable, &file, i as u64))
+                .unwrap();
+        }
+        let mut out2: Vec<crate::aggregation::SortRow> = Vec::new();
+        agg2.finalize(&ctx, &mut out2).expect("finalize");
+        let expected = Decimal::from(4) / Decimal::from(3);
+        assert_eq!(
+            out2[0].0.values()[1],
+            Value::Decimal(expected),
+            "avg computes the exact full-precision quotient 4/3"
+        );
+        assert!(
+            expected.scale() > 2,
+            "the exact quotient keeps its full scale"
+        );
+    }
+
+    #[test]
+    fn test_group_by_decimal_sum_e2e() {
+        // Per-group exact decimal totals.
+        let input = make_schema(&["k", "amount"]);
+        let mut agg = build_aggregator(
+            &[("k", Type::String), ("amount", Type::Decimal)],
+            &["k"],
+            "emit k = k\nemit total = sum(amount)",
+            "decimal_group_sum_e2e",
+            64 * 1024 * 1024,
+            None,
+        );
+        let stable = StableEvalContext::test_default();
+        let file: Arc<str> = Arc::from("t.csv");
+        // group "a": 1.11 + 2.22 == 3.33 ; group "b": 0.01 + 0.02 == 0.03.
+        let rows = [("a", 111i64), ("b", 1), ("a", 222), ("b", 2)];
+        for (i, (k, c)) in rows.iter().enumerate() {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::String((*k).into()),
+                    Value::Decimal(Decimal::new(*c, 2)),
+                ],
+            );
+            agg.add_record(&r, i as u64, &ctx_for(&stable, &file, i as u64))
+                .unwrap();
+        }
+        let ctx = ctx_for(&stable, &file, 0);
+        let mut out: Vec<crate::aggregation::SortRow> = Vec::new();
+        agg.finalize(&ctx, &mut out).expect("finalize");
+        let totals = decimal_totals_by_key(&out, 1);
+        assert_eq!(totals.len(), 2, "two groups");
+        let a = totals.iter().find(|(k, _)| k == "a").expect("group a");
+        let b = totals.iter().find(|(k, _)| k == "b").expect("group b");
+        assert_eq!(a.1, Decimal::new(333, 2), "group a total 3.33");
+        assert_eq!(b.1, Decimal::new(3, 2), "group b total 0.03");
+    }
+
+    #[test]
+    fn test_min_max_decimal_e2e() {
+        // min/max preserve exact decimal ordering (no numeric guard blocks
+        // them, and comparison is value-exact).
+        let input = make_schema(&["k", "amount"]);
+        let mut agg = build_aggregator(
+            &[("k", Type::String), ("amount", Type::Decimal)],
+            &["k"],
+            "emit k = k\nemit lo = min(amount)\nemit hi = max(amount)",
+            "decimal_min_max_e2e",
+            64 * 1024 * 1024,
+            None,
+        );
+        let stable = StableEvalContext::test_default();
+        let file: Arc<str> = Arc::from("t.csv");
+        for (i, c) in [125i64, 999, 1, 500].iter().enumerate() {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::String("g".into()),
+                    Value::Decimal(Decimal::new(*c, 2)),
+                ],
+            );
+            agg.add_record(&r, i as u64, &ctx_for(&stable, &file, i as u64))
+                .unwrap();
+        }
+        let ctx = ctx_for(&stable, &file, 0);
+        let mut out: Vec<crate::aggregation::SortRow> = Vec::new();
+        agg.finalize(&ctx, &mut out).expect("finalize");
+        assert_eq!(
+            out[0].0.values()[1],
+            Value::Decimal(Decimal::new(1, 2)),
+            "min 0.01"
+        );
+        assert_eq!(
+            out[0].0.values()[2],
+            Value::Decimal(Decimal::new(999, 2)),
+            "max 9.99"
+        );
+    }
+
+    #[test]
+    fn test_spilled_decimal_group_by_preserves_exactness_and_identity_e2e() {
+        // Force a spill and confirm two things survive the spill-merge:
+        //   (1) per-group decimal sums are exact (postcard+LZ4 serde of
+        //       `decimal_sum` round-trips the 16-byte form), and
+        //   (2) decimal group identity is scale-normalized — `2.50` and `2.5`
+        //       collapse into ONE group both in memory and through the exact,
+        //       order-preserving spilled group-sort key.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let input = make_schema(&["price", "amount"]);
+        let mut agg = build_aggregator(
+            &[("price", Type::Decimal), ("amount", Type::Decimal)],
+            &["price"],
+            "emit price = price\nemit total = sum(amount)",
+            "decimal_spill_group_e2e",
+            1024, // tiny budget forces spill under many groups
+            Some(tmp.path().to_path_buf()),
+        );
+        let stable = StableEvalContext::test_default();
+        let file: Arc<str> = Arc::from("t.csv");
+        let mut i = 0u64;
+        // 250 distinct whole-dollar prices, each one 0.10 amount -> total 0.10.
+        for p in 1..=250i64 {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::Decimal(Decimal::new(p * 100, 2)), // $p.00
+                    Value::Decimal(Decimal::new(10, 2)),      // 0.10
+                ],
+            );
+            agg.add_record(&r, i, &ctx_for(&stable, &file, i)).unwrap();
+            i += 1;
+        }
+        // Same value at different scales must collapse into ONE group:
+        //   price 2.50 (+0.10) and price 2.5 (+0.15) -> group 2.5, total 0.25.
+        // 2.5 is distinct from every $p.00 price above.
+        for (m, s, amt_m, amt_s) in [(250i64, 2u32, 10i64, 2u32), (25, 1, 15, 2)] {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::Decimal(Decimal::new(m, s)),
+                    Value::Decimal(Decimal::new(amt_m, amt_s)),
+                ],
+            );
+            agg.add_record(&r, i, &ctx_for(&stable, &file, i)).unwrap();
+            i += 1;
+        }
+        assert!(
+            !agg.spill_files().is_empty(),
+            "250+ decimal groups under a 1 KiB budget must spill"
+        );
+        let ctx = ctx_for(&stable, &file, 0);
+        let mut out: Vec<crate::aggregation::SortRow> = Vec::new();
+        agg.finalize(&ctx, &mut out).expect("finalize after spill");
+        // 250 whole-dollar groups + the single collapsed 2.5 group = 251.
+        assert_eq!(
+            out.len(),
+            251,
+            "2.50 and 2.5 must collapse to one group across the spill merge"
+        );
+
+        let mut found_collapsed = false;
+        for (rec, _) in &out {
+            let (price, total) = match (&rec.values()[0], &rec.values()[1]) {
+                (Value::Decimal(p), Value::Decimal(t)) => (*p, *t),
+                other => panic!("expected decimal price/total, got {other:?}"),
+            };
+            if price == Decimal::new(25, 1) {
+                assert_eq!(
+                    total,
+                    Decimal::new(25, 2),
+                    "collapsed 2.50/2.5 group summed exactly to 0.25"
+                );
+                found_collapsed = true;
+            } else {
+                assert_eq!(
+                    total,
+                    Decimal::new(10, 2),
+                    "each whole-dollar group total is exactly 0.10 through the spill"
+                );
+            }
+        }
+        assert!(
+            found_collapsed,
+            "the scale-normalized 2.5 group must survive the spill merge"
+        );
     }
 }
 

--- a/crates/clinker-exec/src/pipeline/window_context.rs
+++ b/crates/clinker-exec/src/pipeline/window_context.rs
@@ -190,9 +190,10 @@ impl<'a> WindowContext<'a, Arena> for PartitionWindowContext<'a> {
             }
         }
         if saw_decimal && count > 0 {
-            // Exact decimal quotient at full precision (rounding to a column
-            // scale happens when it lands in a scaled decimal column). Integer
-            // rows fold into the numerator exactly so they are not lost.
+            // Exact decimal quotient at full precision — a computed decimal is
+            // not re-rounded to an output-column scale (round explicitly in CXL
+            // to fix places). Integer rows fold into the numerator exactly so
+            // they are not lost.
             let numerator = add_i128_to_decimal(dec_total, int_acc);
             return match numerator.checked_div(rust_decimal::Decimal::from(count)) {
                 Some(avg) => Value::Decimal(avg),

--- a/crates/clinker-exec/tests/aggregate_integration.rs
+++ b/crates/clinker-exec/tests/aggregate_integration.rs
@@ -916,3 +916,67 @@ nodes:
         "zeta: count(*)>1 false, max(name)>'M' true: {output}"
     );
 }
+
+#[test]
+fn test_e2e_decimal_sum_avg() {
+    // Full pipeline: a `decimal` CSV source column -> aggregate sum/avg over
+    // the decimal -> CSV output. This exercises the typecheck guard fix end to
+    // end: before the guard accepted `Type::Decimal`, `sum(amount)` /
+    // `avg(amount)` failed to compile and `run_single`'s `.expect("compile")`
+    // would panic.
+    //
+    // It also pins the observable output precision:
+    //   * `sum` stays exact at the column scale (`4.00`, `0.30`);
+    //   * `avg` is the exact full-precision quotient — a computed decimal is
+    //     NOT re-rounded to an output-column scale, so `4.00 / 3` prints all
+    //     28 digits rather than `1.33`. (To round, a user rounds explicitly in
+    //     CXL; a `decimal` source column, by contrast, rounds on ingest.)
+    let yaml = r#"
+pipeline:
+  name: agg_decimal
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: in.csv
+    schema:
+      - { name: dept, type: string }
+      - { name: amount, type: decimal, scale: 2 }
+- type: aggregate
+  name: by_dept
+  input: src
+  config:
+    group_by:
+    - dept
+    cxl: 'emit dept = dept
+
+      emit total = sum(amount)
+
+      emit average = avg(amount)
+
+      '
+- type: output
+  name: out
+  input: by_dept
+  config:
+    name: out
+    type: csv
+    path: out.csv
+    include_unmapped: true
+"#;
+    // dept x: 1.00 + 1.00 + 2.00 = 4.00; avg = 4.00 / 3 (repeating).
+    // dept y: 0.10 + 0.20 = 0.30; avg = 0.15 (exact).
+    let csv = "dept,amount\nx,1.00\nx,1.00\nx,2.00\ny,0.10\ny,0.20\n";
+    let (report, output) = run_single(yaml, csv);
+    assert_eq!(report.dlq_entries.len(), 0, "no DLQ entries");
+    assert_eq!(report.counters.ok_count, 2, "two output groups");
+    assert_eq!(
+        sorted_body_lines(&output),
+        vec![
+            "x,4.00,1.3333333333333333333333333333".to_string(),
+            "y,0.30,0.15".to_string(),
+        ],
+    );
+}

--- a/crates/clinker-record/src/coercion.rs
+++ b/crates/clinker-record/src/coercion.rs
@@ -8,8 +8,9 @@ use std::str::FromStr;
 /// (banker's rounding). Unbiased over a stream of values — the accounting
 /// standard and `rust_decimal`'s own default — so summing rounded amounts does
 /// not systematically drift up or down the way round-half-away-from-zero does.
-/// Applied when coercing a value into a scaled `decimal` column and when
-/// dividing/averaging to a target scale.
+/// Applied when coercing a value into a scaled `decimal` column and by the
+/// `round()` / `round_to()` builtins. `avg` and `decimal / decimal` compute at
+/// full precision and are not rounded to a scale here.
 pub const DECIMAL_ROUNDING: RoundingStrategy = RoundingStrategy::MidpointNearestEven;
 
 /// Round a `Decimal` to `scale` fractional digits using [`DECIMAL_ROUNDING`],

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -847,12 +847,19 @@ impl<'a> TypeChecker<'a> {
                     self.check_expr(arg, is_predicate_fn);
                 }
 
-                // Check numeric requirement for sum/cumulative_sum/avg
+                // Check numeric requirement for sum/cumulative_sum/avg.
+                // `Decimal` is accepted: the window sum/cumulative_sum/avg
+                // slices accumulate decimals exactly (see `window_context`), so
+                // an exact decimal window total/average stays exact rather than
+                // routing through binary float.
                 if matches!(&**function, "sum" | "cumulative_sum" | "avg") {
                     for arg in args {
                         let arg_ty = self.get_type(arg.node_id());
                         let inner = arg_ty.unwrap_nullable();
-                        if !matches!(inner, Type::Int | Type::Float | Type::Numeric | Type::Any) {
+                        if !matches!(
+                            inner,
+                            Type::Int | Type::Float | Type::Decimal | Type::Numeric | Type::Any
+                        ) {
                             self.error(
                                 arg.span(),
                                 format!(
@@ -860,7 +867,7 @@ impl<'a> TypeChecker<'a> {
                                     function, arg_ty
                                 ),
                                 Some(
-                                    "Use a numeric field or convert with .to_int() / .to_float()"
+                                    "Use a numeric field or convert with .to_int() / .to_float() / .to_decimal()"
                                         .into(),
                                 ),
                             );
@@ -935,19 +942,26 @@ impl<'a> TypeChecker<'a> {
 
                 let ty = aggregate_return_type(name, &arg_types);
 
-                // Numeric-only guard for sum/avg/weighted_avg (same pattern as
-                // window sum/avg).
+                // Numeric guard for sum/avg (same pattern as window sum/avg).
+                // `Decimal` is accepted: the SumState/AvgState decimal paths
+                // aggregate exactly, so an exact monetary total/average stays
+                // in the decimal domain instead of being pushed through the
+                // binary-float rounding decimal exists to avoid. weighted_avg
+                // additionally rejects `decimal` — its accumulator has no exact
+                // path yet and would silently drop decimal rows.
                 match &**name {
                     "sum" | "avg" => {
                         if let Some(arg_ty) = arg_types.first() {
                             let inner = arg_ty.unwrap_nullable();
-                            if !matches!(inner, Type::Int | Type::Float | Type::Numeric | Type::Any)
-                            {
+                            if !matches!(
+                                inner,
+                                Type::Int | Type::Float | Type::Decimal | Type::Numeric | Type::Any
+                            ) {
                                 self.error(
                                     *span,
                                     format!("{name}() requires a Numeric argument, got {arg_ty}"),
                                     Some(
-                                        "Use a numeric field or convert with .to_int() / .to_float()"
+                                        "Use a numeric field or convert with .to_int() / .to_float() / .to_decimal()"
                                             .into(),
                                     ),
                                 );
@@ -961,6 +975,26 @@ impl<'a> TypeChecker<'a> {
                                 "weighted_avg() requires exactly two arguments (value, weight)"
                                     .into(),
                                 None,
+                            );
+                        } else if let Some(dec_arg) = arg_types
+                            .iter()
+                            .find(|t| matches!(t.unwrap_nullable(), Type::Decimal))
+                        {
+                            // No exact decimal weighted-average accumulator
+                            // exists yet; the float path returns Null for a
+                            // decimal value OR weight (the accumulator's
+                            // `numeric()` conversion skips a decimal in either
+                            // position). Reject loudly rather than silently lose
+                            // the total, and point at the exact routes.
+                            self.error(
+                                *span,
+                                format!(
+                                    "weighted_avg() over a decimal value or weight is not supported yet, got {dec_arg}"
+                                ),
+                                Some(
+                                    "Cast with .to_float() for a binary-float weighted average, or use sum()/avg() which stay exact over decimals"
+                                        .into(),
+                                ),
                             );
                         }
                     }
@@ -1663,6 +1697,77 @@ mod tests {
         );
         // avg over int/float is still Float.
         assert_eq!(aggregate_return_type("avg", &[Type::Int]), Type::Float);
+    }
+
+    #[test]
+    fn test_sum_avg_over_decimal_column_typechecks() {
+        // Regression for the numeric guard: `sum`/`avg` over a `decimal`
+        // column must typecheck and keep the result in the decimal domain.
+        // Before the fix the guard omitted `Type::Decimal`, so the exact
+        // monetary total was rejected with "requires a Numeric argument" and
+        // the fix-it hint steered users to `.to_float()` — reintroducing the
+        // binary-float drift the decimal type exists to prevent.
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Decimal);
+        cols.insert("dept".into(), Type::String);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let fields = ["amount", "dept"];
+
+        for (src, want) in [
+            ("emit total = sum(amount)", Type::Decimal),
+            ("emit average = avg(amount)", Type::Decimal),
+        ] {
+            let parsed = Parser::parse(src);
+            assert!(parsed.errors.is_empty());
+            let resolved = resolve_program(parsed.ast, &fields, parsed.node_count).unwrap();
+            let typed = type_check_with_mode(resolved, &schema, agg_mode(&["dept"]))
+                .unwrap_or_else(|d| {
+                    panic!(
+                        "`{src}` must typecheck over a decimal column, got: {:?}",
+                        d.iter().map(|e| &e.message).collect::<Vec<_>>()
+                    )
+                });
+            assert_eq!(
+                first_emit_expr_type(&typed),
+                want,
+                "result type for `{src}`"
+            );
+        }
+    }
+
+    #[test]
+    fn test_weighted_avg_over_decimal_rejected() {
+        // weighted_avg has no exact decimal accumulator yet; its float path
+        // silently drops a decimal in EITHER the value or the weight position
+        // (the accumulator's `numeric()` conversion skips a decimal), returning
+        // Null. Typecheck must reject it loudly rather than let a monetary
+        // weighted average be silently wrong — for a decimal value AND a
+        // decimal weight.
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Decimal);
+        cols.insert("price".into(), Type::Decimal);
+        cols.insert("qty".into(), Type::Int);
+        cols.insert("dept".into(), Type::String);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let fields = ["amount", "price", "qty", "dept"];
+
+        for src in [
+            "emit wa = weighted_avg(amount, qty)", // decimal value
+            "emit wa = weighted_avg(qty, price)",  // decimal weight
+        ] {
+            let parsed = Parser::parse(src);
+            assert!(parsed.errors.is_empty());
+            let resolved = resolve_program(parsed.ast, &fields, parsed.node_count).unwrap();
+            let errs = type_check_with_mode(resolved, &schema, agg_mode(&["dept"]))
+                .expect_err("weighted_avg over a decimal must be rejected");
+            assert!(
+                errs.iter().any(|d| d
+                    .message
+                    .contains("weighted_avg() over a decimal value or weight is not supported")),
+                "`{src}` expected a weighted_avg decimal rejection, got: {:?}",
+                errs.iter().map(|d| &d.message).collect::<Vec<_>>()
+            );
+        }
     }
 
     #[test]

--- a/docs/user/src/cxl/types.md
+++ b/docs/user/src/cxl/types.md
@@ -200,8 +200,11 @@ accounting). Writers emit the value at that scale, so `2.5` stored in a
   - `amount.to_float() * rate` — opt into binary float precision.
   - `rate.to_decimal() * amount` — bring the float into exact decimal math
     (the float→decimal step is the one acknowledged lossy conversion).
-- **Division and `avg`** compute at full precision and round to the target
-  column's `scale` when the result lands in a scaled decimal column.
+- **Division and `avg`** compute at full precision — the exact quotient, not a
+  binary-float approximation. A computed decimal keeps its full precision and
+  is not automatically rounded to a fixed number of places; round it explicitly
+  when you need fixed cents. (A `decimal` *source* column, separately, rounds
+  its parsed values to the declared `scale` on read, using banker's rounding.)
 
 Comparisons follow the same rule: `decimal < int` is fine, `decimal < float`
 requires a cast.
@@ -227,6 +230,22 @@ $ cxl eval -e 'emit total = ("19.99".to_decimal() * 3) + "4.80".to_decimal()'
 `19.99 * 3 = 59.97`, `+ 4.80 = 64.77` — exact, with no binary-float drift.
 (In a pipeline, declare the source columns `type: decimal` instead of casting;
 JSON output renders a decimal as a scale-preserving string.)
+
+### Aggregating decimals
+
+`sum`, `avg`, `min`, `max`, `count`, and `distinct` all work over a `decimal`
+column and stay exact — no binary float ever touches a running total:
+
+- `sum(amount)` and `avg(amount)` return a `decimal`. The sum is the exact
+  total to the cent; the average is the exact full-precision quotient.
+- `min` / `max` return the exact extremum, and `count` returns an integer.
+- Group-by and `distinct` keys are scale-normalized: two decimals that are
+  numerically equal group together regardless of scale, so `2.50` and `2.5`
+  fall in one group. This holds even when the aggregation spills to disk.
+
+`weighted_avg` does not yet support decimals and rejects a decimal value at
+compile time — cast with `.to_float()` for a binary-float weighted average, or
+use `sum` / `avg`, which stay exact over decimals.
 
 ## Type unification rules
 


### PR DESCRIPTION
## Summary

The exact `decimal` type shipped with `sum`/`avg` accumulators that stay exact
over decimals, but the CXL numeric guards for aggregate and window `sum`/`avg`
only admitted `Int`/`Float`/`Numeric`. `Type::Decimal` was omitted, so
`sum(<decimal>)` and `avg(<decimal>)` were rejected at typecheck — the
diagnostic even suggested `.to_float()`, which reintroduces the binary-float
rounding the decimal type exists to prevent. The canonical exact monetary
total was therefore unreachable, and the type reference already documented
decimal `avg`, so docs and behavior disagreed.

## What changed

- **Typecheck guards** now accept `Type::Decimal`:
  - aggregate `sum`/`avg` — `sum(decimal) -> decimal`, `avg(decimal) -> decimal`
    (exact full-precision quotient);
  - window `sum`/`cumulative_sum`/`avg` — the window slices already accumulate
    decimals exactly.
- **`weighted_avg` over a decimal now fails loudly** at typecheck, for a decimal
  in either the value or the weight position. It has no exact decimal
  accumulator; its float path silently dropped a decimal argument (returned
  null). Failing at compile time — with a hint to cast with `.to_float()` or
  use `sum`/`avg` — replaces a silently-wrong monetary result with a clear
  error. Exact decimal `weighted_avg` is left as follow-up.
- **Docs** (`types.md`): corrected the `avg`/division note — a computed decimal
  is exact and full-precision, and is *not* automatically rounded to an
  output-column scale (only a `decimal` *source* column rounds to its declared
  scale on read). Added an "Aggregating decimals" section covering
  sum/avg/min/max/count/distinct and the `weighted_avg` rejection. Aligned two
  code comments that had claimed computed decimals round to a column scale.

## Behavior detail: computed decimals are full-precision

`avg` and `decimal / decimal` compute the exact quotient and are **not**
re-rounded to a declared output-column scale — only source-column ingest
rounds (banker's rounding). Confirmed end to end: a `decimal` source column
aggregated through `avg` and written to CSV emits the full-precision quotient
(e.g. `4.00 / 3` prints all 28 digits), while `sum` stays exact at the column
scale (`4.00`). min/max preserve exact decimal ordering, `count` returns an
integer, and group-by / `distinct` keys are scale-normalized (`2.50` and `2.5`
group together) — including through a spill.

## Tests

End-to-end through the real typecheck -> plan -> eval path (the aggregator is
built from compiled CXL, so these would not compile before the guard fix):

- exact decimal `sum` to the cent, contrasted with binary-float drift;
- exact decimal `avg` (including a full-precision repeating quotient);
- group-by decimal `sum`; `min`/`max` over decimal;
- a **spilled** decimal group-by proving per-group exactness and that
  scale-normalized decimal group identity (`2.50` and `2.5` collapse into one
  group) survives the spill merge;
- a **full-pipeline** test (decimal CSV source -> aggregate `sum`/`avg` -> CSV
  output) that pins the observable output precision;
- typecheck regressions: `sum`/`avg` over a decimal column typecheck to
  `decimal`; `weighted_avg` over a decimal value or weight is rejected.

`cargo build --workspace`, `cargo test --workspace`, `cargo fmt --all --check`,
`cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --benches -p clinker-benchmarks`, and `mdbook build` (user +
engine) all pass.

Closes #784. Part of #515. Relates to #775.
