### PR TITLE
fix(exec): enforce the spill disk cap in reshape and cull spill writes

### DIFF
--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -879,7 +879,14 @@ fn write_spill_slice<'a>(
         .finish()
         .map_err(|e| cull_spill_error(node_name, e))?;
     let bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
-    budget.record_spill_bytes(node_name, bytes);
+    if budget.record_spill_bytes(node_name, bytes) {
+        return Err(PipelineError::spill_cap_exceeded(
+            node_name,
+            budget.max_spill_bytes(),
+            bytes,
+            budget.cumulative_spill_bytes(),
+        ));
+    }
     Ok(file)
 }
 
@@ -1001,10 +1008,22 @@ fn cull_giant_group_error(node_name: &str, group_bytes: u64, hard_limit: u64) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::memory::NoOpPolicy;
     use clinker_record::Schema;
 
     fn record(schema: &Arc<Schema>, account: Value) -> Record {
         Record::new(Arc::clone(schema), vec![account])
+    }
+
+    /// An arbitrator whose soft limit is `soft_bytes` and whose seeded peak
+    /// RSS is well below it, so spilling is driven purely by the buffer's own
+    /// resident-byte total rather than the live process RSS.
+    fn arbitrator(soft_bytes: u64) -> MemoryArbitrator {
+        // soft = limit * 0.80, so limit = soft / 0.80.
+        let limit = (soft_bytes as f64 / 0.80) as u64;
+        let arb = MemoryArbitrator::with_policy(limit, 0.80, Box::new(NoOpPolicy));
+        arb.set_peak_rss_for_test(1);
+        arb
     }
 
     // The decision aggregate groups by `value_to_group_key`, which keeps an
@@ -1039,5 +1058,54 @@ mod tests {
         };
         assert_eq!(empty, canon(&Value::String("".into())));
         assert_eq!(null, canon(&Value::Null));
+    }
+
+    // The disk-spill cap must abort the spill instead of writing past
+    // `storage.spill.disk_cap_bytes`. The bug discarded the overflow signal
+    // `record_spill_bytes` returns, so eviction kept writing unbounded.
+    #[test]
+    fn spill_past_disk_cap_fails_with_spill_cap_exceeded() {
+        let schema: Arc<Schema> = Arc::new(Schema::new(vec!["account".into()]));
+        let spill_root = tempfile::tempdir().unwrap();
+        let arb = arbitrator(512);
+        arb.set_max_spill_bytes(1);
+        let handle = ConsumerHandle::new();
+        let mut buffer = CullGroupBuffer::new(Arc::clone(&schema), true);
+        // One group, ~5 KiB resident against a 512 B soft limit, so the
+        // spill loop must evict — and the first flush already exceeds the
+        // one-byte disk cap.
+        for row_num in 0..64u64 {
+            let payload = format!("{row_num:063}");
+            buffer.push(
+                vec![GroupByKey::Str("g".into())],
+                record(&schema, Value::String(payload.into())),
+                row_num,
+            );
+        }
+        handle.set_bytes(buffer.resident_bytes() as u64);
+        let err = buffer
+            .spill_until_under_budget("cl", &arb, spill_root.path(), &handle)
+            .expect_err("a one-byte disk cap must abort the first spill write");
+        match &err {
+            PipelineError::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => {
+                assert_eq!(node, "cl");
+                assert_eq!(*cap, 1, "reported cap must equal the configured quota");
+                assert!(*attempted > 0, "the overflowing flush must report its size");
+                assert!(
+                    *current > *cap,
+                    "cumulative spilled ({current}) must exceed the cap ({cap})"
+                );
+            }
+            other => panic!("disk-cap overflow must surface SpillCapExceeded; got {other:?}"),
+        }
+        assert!(
+            arb.cumulative_spill_bytes() > 1,
+            "cumulative_spill_bytes must reflect the overflowing write"
+        );
     }
 }

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -766,7 +766,14 @@ fn write_spill_slice<'a>(
         .finish()
         .map_err(|e| reshape_spill_error(node_name, e))?;
     let bytes = std::fs::metadata(file.path()).map(|m| m.len()).unwrap_or(0);
-    budget.record_spill_bytes(node_name, bytes);
+    if budget.record_spill_bytes(node_name, bytes) {
+        return Err(PipelineError::spill_cap_exceeded(
+            node_name,
+            budget.max_spill_bytes(),
+            bytes,
+            budget.cumulative_spill_bytes(),
+        ));
+    }
     Ok(file)
 }
 
@@ -1266,6 +1273,51 @@ mod tests {
         assert!(
             detail.contains("single Reshape correlation group"),
             "the diagnostic must name the giant-group limitation: {detail}"
+        );
+    }
+
+    // The disk-spill cap must abort the spill instead of writing past
+    // `storage.spill.disk_cap_bytes`. The bug discarded the overflow signal
+    // `record_spill_bytes` returns, so eviction kept writing unbounded.
+    #[test]
+    fn spill_past_disk_cap_fails_with_spill_cap_exceeded() {
+        let schema = schema();
+        let spill_root = tempfile::tempdir().unwrap();
+        let arb = arbitrator(512);
+        arb.set_max_spill_bytes(1);
+        let handle = ConsumerHandle::new();
+        let mut buffer = ReshapeGroupBuffer::new(Arc::clone(&schema), true);
+        // One group, ~5 KiB resident against a 512 B soft limit, so the
+        // spill loop must evict — and the first flush already exceeds the
+        // one-byte disk cap.
+        for row_num in 0..64u64 {
+            let payload = format!("{row_num:063}");
+            buffer.push(single_group_key(), rec(&schema, "g", &payload), row_num);
+        }
+        handle.set_bytes(buffer.resident_bytes() as u64);
+        let err = buffer
+            .spill_until_under_budget("rs", &arb, spill_root.path(), &handle)
+            .expect_err("a one-byte disk cap must abort the first spill write");
+        match &err {
+            PipelineError::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => {
+                assert_eq!(node, "rs");
+                assert_eq!(*cap, 1, "reported cap must equal the configured quota");
+                assert!(*attempted > 0, "the overflowing flush must report its size");
+                assert!(
+                    *current > *cap,
+                    "cumulative spilled ({current}) must exceed the cap ({cap})"
+                );
+            }
+            other => panic!("disk-cap overflow must surface SpillCapExceeded; got {other:?}"),
+        }
+        assert!(
+            arb.cumulative_spill_bytes() > 1,
+            "cumulative_spill_bytes must reflect the overflowing write"
         );
     }
 }


### PR DESCRIPTION
Reshape and cull charge each spill file's on-disk size against the memory arbitrator, but both discarded the boolean `record_spill_bytes` returns when the cumulative spilled total crosses `storage.spill.disk_cap_bytes`. As a result, either operator under memory pressure kept writing spill files past the configured disk cap instead of aborting, while every other spill path (node-buffer, streaming handoff, document DLQ, grace-hash, sort-merge) already surfaced the cap breach.

Both `write_spill_slice` finalizers now check the returned signal and surface the same `SpillCapExceeded` (E320) diagnostic the other spill sites return, carrying the node name, configured cap, size of the overflowing flush, and the cumulative total. An unconfigured cap remains `u64::MAX`, so uncapped runs are unaffected. This makes reshape and cull conform to the documented `disk_cap_bytes` behavior; no docs change is needed.

Tests: one focused regression test per operator drives the group-buffer spill loop under a one-byte disk cap and asserts the exact `SpillCapExceeded` fields (node name, cap == 1, attempted > 0, cumulative > cap). Without the fix, both spill loops return `Ok` and the tests fail.

Validation: `cargo fmt --all --check`, `cargo clippy -p clinker-exec --all-targets -- -D warnings`, `cargo test -p clinker-exec` (all green), `cargo check --workspace`, `git diff --check`.

Closes #684
