### PR TITLE
chore: ignore mdbook output under docs/*/book/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 !.claude/skills/post-impl-followup/
 lancedb/
 docs/internal/
-docs/book/
+docs/*/book/
 !docs/ai/
 !docs/ai/**
 target/


### PR DESCRIPTION
Building either guide (`mdbook build` from `docs/user/` or `docs/engine/`) writes generated HTML to `docs/user/book/` / `docs/engine/book/`, but `.gitignore` only covered the legacy `docs/book/` path — a leftover from before the docs reorganization in #495 removed the root `docs/book.toml`. The generated trees therefore showed up as untracked in `git status` and risked being swept into commits.

This generalizes the rule to `docs/*/book/`, covering both current books and any future sibling mdbook under `docs/`. The legacy `docs/book/` rule is dropped rather than kept: nothing at HEAD produces that path (no `book.toml` exists at `docs/`, and neither book config overrides `build-dir`).

Validation:
- Built both books (`mdbook build` in `docs/user` and `docs/engine`); `git status --short` shows no untracked `book/` trees.
- `git check-ignore -v docs/user/book/index.html docs/engine/book/index.html` both match the new rule.
- `git diff --check` passes; the change touches only `.gitignore`.

Closes #601
