### PR TITLE
batch: fixed-width byte positions, XML array_paths and attribute round-trip, X12 delimiter preservation, composition-body validation, decimal round typing, channel structure patches

### DIFF
--- a/crates/clinker-channel/src/manifest.rs
+++ b/crates/clinker-channel/src/manifest.rs
@@ -125,9 +125,11 @@ pub struct OverlayFile {
     /// parsed pipeline config before validation/compile (via
     /// [`apply_source_patches`](clinker_plan::config::apply_source_patches)), so
     /// the run behaves as if the source YAML had been hand-edited: CXL-typed
-    /// column ops (`schema`), nested-array explosion/join (`array_paths`), and
-    /// scalar per-format input `options`. Scoped to this one target, so
-    /// source-node names resolve unambiguously against the overlaid pipeline.
+    /// column ops (`schema`), nested-array explosion/join (`array_paths`),
+    /// scalar per-format input `options`, X12 nested-envelope declarations
+    /// (`group_section` / `set_section`), and HL7 composite-field splits
+    /// (`split_fields`). Scoped to this one target, so source-node names
+    /// resolve unambiguously against the overlaid pipeline.
     #[serde(default)]
     pub sources: IndexMap<String, SourceConfigPatch>,
 }

--- a/crates/clinker-channel/tests/overlay_resolution_test.rs
+++ b/crates/clinker-channel/tests/overlay_resolution_test.rs
@@ -913,3 +913,132 @@ fn per_target_source_options_patch_applies() {
         other => panic!("expected csv options, got {other:?}"),
     }
 }
+
+/// A pipeline carrying the format-structure patch surfaces: an X12 source
+/// with a typed `GS` declaration and an HL7 source with one composite-field
+/// split.
+const EDI_PIPELINE: &str = r#"
+pipeline:
+  name: edi
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      path: po.x12
+      options:
+        group_section:
+          name: grp
+          fields:
+            e06: string
+      schema:
+        - { name: seg_id, type: string }
+  - type: source
+    name: messages
+    config:
+      name: messages
+      type: hl7
+      path: msgs.hl7
+      options:
+        split_fields:
+          - { field: f03, components: 5 }
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out_x12
+    input: interchange
+    config: { name: out_x12, type: csv, path: out1.csv }
+  - type: output
+    name: out_hl7
+    input: messages
+    config: { name: out_hl7, type: csv, path: out2.csv }
+"#;
+
+#[test]
+fn per_target_source_format_structure_patch_applies() {
+    let ws = workspace();
+    write(&ws.path().join("pipeline/edi.yaml"), EDI_PIPELINE);
+    write(
+        &ws.path().join("channel/patch/edi.channel.yaml"),
+        "channel:\n  target: ../../pipeline/edi.yaml\n\
+         sources:\n\
+         \x20 interchange:\n\
+         \x20   group_section:\n\
+         \x20     name: fg\n\
+         \x20     fields:\n\
+         \x20       e04: int\n\
+         \x20   set_section:\n\
+         \x20     name: txn\n\
+         \x20     fields:\n\
+         \x20       e01: string\n\
+         \x20 messages:\n\
+         \x20   split_fields:\n\
+         \x20     f08: { components: 3 }\n\
+         \x20     f03: remove\n",
+    );
+
+    let res = resolve(
+        ws.path(),
+        &channel_layout(),
+        &group_layout(),
+        "edi",
+        Some("patch"),
+        &[],
+        true,
+    )
+    .expect("resolve");
+    let patches = res
+        .source_patches()
+        .expect("per-target overlay carries patches");
+
+    let yaml = fs::read_to_string(ws.path().join("pipeline/edi.yaml")).expect("read edi pipeline");
+    let mut config: PipelineConfig = clinker_plan::yaml::from_str(&yaml).expect("parse");
+    apply_source_patches(&mut config, patches).expect("apply source patches");
+
+    let x12 = config
+        .source_configs()
+        .find(|s| s.name == "interchange")
+        .expect("x12 source");
+    match &x12.format {
+        InputFormat::X12(Some(opts)) => {
+            // The keyed modify renamed the GS declaration and added a typed
+            // field alongside the base one.
+            let group = opts.group_section.as_ref().expect("group_section kept");
+            assert_eq!(group.name, "fg");
+            assert_eq!(
+                serde_json::to_value(&group.fields).expect("serialize fields"),
+                json!({ "e06": "string", "e04": "int" })
+            );
+            // The set op created the previously-undeclared ST declaration.
+            let set = opts.set_section.as_ref().expect("set_section created");
+            assert_eq!(set.name, "txn");
+            assert_eq!(
+                serde_json::to_value(&set.fields).expect("serialize fields"),
+                json!({ "e01": "string" })
+            );
+        }
+        other => panic!("expected x12 options, got {other:?}"),
+    }
+
+    let hl7 = config
+        .source_configs()
+        .find(|s| s.name == "messages")
+        .expect("hl7 source");
+    match &hl7.format {
+        InputFormat::Hl7(Some(opts)) => {
+            let splits = opts.split_fields.as_deref().expect("splits declared");
+            assert_eq!(splits.len(), 1, "f03 removed, f08 added: {splits:?}");
+            assert_eq!(splits[0].field, "f08");
+            assert_eq!(
+                (
+                    splits[0].components,
+                    splits[0].subcomponents,
+                    splits[0].repetitions
+                ),
+                (3, 1, 1)
+            );
+        }
+        other => panic!("expected hl7 options, got {other:?}"),
+    }
+}

--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -26,6 +26,7 @@
 //! | `E111`      | error    | Composition body has zero nodes (rejected at bind time) |
 //! | `E112`      | error    | Runtime composition recursion depth exceeded |
 //! | `E113`      | error    | Channel `config`/override key matches no parameter in the compiled plan (unknown key) |
+//! | `E115`      | error    | Composition body node fails node-scoped config validation (same checks as top-level nodes) |
 //! | `E200`      | error    | CXL type error (compile-time typecheck failure)      |
 //! | `E201`      | error    | Source declaration missing required `schema:` field  |
 //! | `E210`      | error    | Source declares more than one of `{path,glob,regex,paths}` |
@@ -304,6 +305,7 @@ mod diagnostic_tests {
         let source = include_str!("diagnostic.rs");
         for code in [
             "E101", "E102", "E103", "E104", "E106", "E107", "E108", "E109", "E111", "E112", "E113",
+            "E115",
         ] {
             let pattern = format!("`{code}`");
             assert!(

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -98,6 +98,9 @@ fn build_xml_writer_config(
         if let Some(ref rec) = opts.record_element {
             config.record_element = rec.clone();
         }
+        if let Some(ref prefix) = opts.attribute_prefix {
+            config.attribute_prefix = prefix.clone();
+        }
     }
     config
 }
@@ -500,5 +503,27 @@ fn apply_split_naming(base_path: &str, naming: &str, seq: u32) -> String {
     match parent.to_str() {
         Some(p) if !p.is_empty() => format!("{p}/{filename}"),
         _ => filename,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xml_writer_config_plumbs_attribute_prefix() {
+        let opts = clinker_plan::config::XmlOutputOptions {
+            attribute_prefix: Some("_".into()),
+            ..Default::default()
+        };
+        let config = build_xml_writer_config(Some(&opts));
+        assert_eq!(config.attribute_prefix, "_");
+    }
+
+    #[test]
+    fn xml_writer_config_defaults_attribute_prefix_to_at_sign() {
+        // Matches the XML reader's default so attribute fields round-trip
+        // without any output-side configuration.
+        assert_eq!(build_xml_writer_config(None).attribute_prefix, "@");
     }
 }

--- a/crates/clinker-exec/tests/x12_pipeline.rs
+++ b/crates/clinker-exec/tests/x12_pipeline.rs
@@ -342,6 +342,68 @@ nodes:
 }
 
 #[test]
+fn x12_custom_delimiter_round_trip_is_byte_identical() {
+    // An interchange declaring '|' element, '^' sub-element, and '!'
+    // terminator delimiters in its ISA header must reconstruct with those
+    // exact bytes when the output echoes the header from the source's
+    // `$doc` section — not with the writer's `*`/`:`/`~` defaults.
+    let custom = "ISA|00|          |00|          |ZZ|SENDER         \
+        |ZZ|RECEIVER       |240101|1200|U|00401|000000001|0|P|^!\
+        GS|PO|SENDER|RECEIVER|20240101|1200|1|X|004010!\
+        ST|850|0001!\
+        BEG|00|NE|PO12345||20240101!\
+        PO1|1|10|EA|9.99!\
+        SE|4|0001!\
+        GE|1|1!\
+        IEA|1|000000001!";
+    let yaml = r#"
+pipeline:
+  name: x12_custom_delims
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      glob: ./*.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields:
+              e13: string
+      schema:
+        - { name: seg_id, type: string }
+        - { name: set_ref, type: string }
+        - { name: set_type, type: string }
+        - { name: e01, type: string }
+        - { name: e02, type: string }
+        - { name: e03, type: string }
+        - { name: e04, type: string }
+        - { name: e05, type: string }
+  - type: output
+    name: out
+    input: interchange
+    config:
+      name: out
+      type: x12
+      path: out.x12
+      include_unmapped: true
+      options:
+        interchange_from_doc: interchange
+        group_header: ["PO", "SENDER", "RECEIVER", "20240101", "1200", "1", "X", "004010"]
+        segment_newline: false
+"#;
+    let (report, output) =
+        run(yaml, "interchange", custom, "po.x12", "out").expect("run custom-delimiter round-trip");
+    assert_eq!(report.counters.dlq_count, 0);
+    assert_eq!(
+        output, custom,
+        "custom-delimiter interchange must round-trip byte-for-byte"
+    );
+}
+
+#[test]
 fn x12_multi_set_multi_group_round_trips() {
     // A two-group interchange: the first group holds two transaction sets,
     // the second holds one. The reader surfaces each GS/ST as a nested

--- a/crates/clinker-format/src/fixed_width/field.rs
+++ b/crates/clinker-format/src/fixed_width/field.rs
@@ -52,25 +52,7 @@ impl ResolvedField {
             .start
             .ok_or_else(|| invalid_field(&f.name, "must have 'start'"))?;
 
-        let width = match (f.width, f.end) {
-            (Some(_), Some(_)) => {
-                return Err(invalid_field(
-                    &f.name,
-                    "'width' and 'end' are mutually exclusive — declare one",
-                ));
-            }
-            (Some(w), None) => w,
-            (None, Some(end)) => end
-                .checked_sub(start)
-                .ok_or_else(|| invalid_field(&f.name, "'end' must be >= 'start'"))?,
-            (None, None) => {
-                return Err(invalid_field(&f.name, "must have 'width' or 'end'"));
-            }
-        };
-
-        if width == 0 {
-            return Err(invalid_field(&f.name, "width must be > 0"));
-        }
+        let width = resolve_width(f, start)?;
 
         Ok(ResolvedField {
             name: f.name.clone(),
@@ -89,6 +71,39 @@ impl ResolvedField {
     pub fn end(&self) -> usize {
         self.start + self.width
     }
+}
+
+/// Resolve a column's declared `width` / `end` into a concrete byte width
+/// from `start`, the one resolution shared by the read and write paths so a
+/// schema means the same byte ranges in both directions.
+///
+/// # Errors
+///
+/// Returns [`FormatError::InvalidRecord`] when the column declares both
+/// `width` and `end`, declares neither, declares `end < start`, or resolves
+/// to a zero width.
+pub fn resolve_width(f: &Column, start: usize) -> Result<usize, FormatError> {
+    let width = match (f.width, f.end) {
+        (Some(_), Some(_)) => {
+            return Err(invalid_field(
+                &f.name,
+                "'width' and 'end' are mutually exclusive — declare one",
+            ));
+        }
+        (Some(w), None) => w,
+        (None, Some(end)) => end
+            .checked_sub(start)
+            .ok_or_else(|| invalid_field(&f.name, "'end' must be >= 'start'"))?,
+        (None, None) => {
+            return Err(invalid_field(&f.name, "must have 'width' or 'end'"));
+        }
+    };
+
+    if width == 0 {
+        return Err(invalid_field(&f.name, "width must be > 0"));
+    }
+
+    Ok(width)
 }
 
 /// Read one physical record line into `buf`, returning `false` at end of input.
@@ -343,8 +358,8 @@ fn with_field(name: &str, message: &str) -> String {
 }
 
 /// Build an [`FormatError::InvalidRecord`] for a construction-time field defect
-/// (row 0 — no record is being read yet).
-fn invalid_field(name: &str, problem: &str) -> FormatError {
+/// (row 0 — no record is being read or written yet).
+pub(crate) fn invalid_field(name: &str, problem: &str) -> FormatError {
     FormatError::InvalidRecord {
         row: 0,
         message: format!("field '{name}': fixed-width field {problem}"),

--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -6,6 +6,7 @@ use cxl::typecheck::Type;
 
 use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 use crate::error::FormatError;
+use crate::fixed_width::field;
 use crate::schema::Column;
 use crate::traits::FormatWriter;
 
@@ -33,6 +34,9 @@ impl Default for FixedWidthWriterConfig {
 /// Pre-resolved field for writing.
 struct WriteField {
     name: String,
+    /// 0-based byte offset of the field's first cell byte within the record,
+    /// resolved with the same semantics the reader slices by.
+    start: usize,
     width: usize,
     justify: Justify,
     pad_char: char,
@@ -41,6 +45,13 @@ struct WriteField {
 
 /// Schema-driven fixed-width record writer.
 /// Type-aware truncation: numeric -> Error, string -> Warn (configurable per field).
+///
+/// Every field is emitted at its declared byte range (`start` plus
+/// `width`/`end`, resolved with the reader's semantics), independent of
+/// declaration order; gaps between declared ranges are space-filled so a
+/// written record reads back under the same schema. Overlapping ranges are
+/// rejected at construction. A column omitting `start` continues at the
+/// previous column's end (sequential layout).
 ///
 /// Under `reconstruct_envelope`, `begin_document` emits the header section's
 /// field values as one leading line and `end_document` the footer's as one
@@ -62,52 +73,73 @@ impl<W: Write> FixedWidthWriter<W> {
         fields: Vec<Column>,
         config: FixedWidthWriterConfig,
     ) -> Result<Self, FormatError> {
-        let resolved: Vec<WriteField> = fields
-            .iter()
-            .map(|f| {
-                let width = f
-                    .width
-                    .or_else(|| f.end.and_then(|e| e.checked_sub(f.start.unwrap_or(0))))
-                    .ok_or_else(|| FormatError::InvalidRecord {
-                        row: 0,
-                        message: format!(
-                            "field '{}': fixed-width field must have 'width' or 'end'",
-                            f.name
-                        ),
-                    })?;
+        // Byte positions resolve exactly as the reader's (`start` plus
+        // `width`/`end`), so what this writer emits at a range is what the
+        // reader slices back out. A column omitting `start` continues at the
+        // previous column's end, keeping a width-only schema sequential.
+        let mut resolved: Vec<WriteField> = Vec::with_capacity(fields.len());
+        let mut next_start = 0usize;
+        for f in &fields {
+            let start = f.start.unwrap_or(next_start);
+            let width = field::resolve_width(f, start)?;
+            next_start = start
+                .checked_add(width)
+                .ok_or_else(|| field::invalid_field(&f.name, "'start' + width overflows"))?;
 
-                let is_numeric = matches!(
-                    f.ty.unwrap_nullable(),
-                    Type::Int | Type::Float | Type::Decimal | Type::Numeric
-                );
+            let is_numeric = matches!(
+                f.ty.unwrap_nullable(),
+                Type::Int | Type::Float | Type::Decimal | Type::Numeric
+            );
 
-                let justify = f.justify.clone().unwrap_or(if is_numeric {
-                    Justify::Right
-                } else {
-                    Justify::Left
-                });
+            let justify = f.justify.clone().unwrap_or(if is_numeric {
+                Justify::Right
+            } else {
+                Justify::Left
+            });
 
-                let pad_char = f
-                    .pad
-                    .as_deref()
-                    .and_then(|s| s.chars().next())
-                    .unwrap_or(' ');
+            let pad_char = f
+                .pad
+                .as_deref()
+                .and_then(|s| s.chars().next())
+                .unwrap_or(' ');
 
-                let truncation = f.truncation.clone().unwrap_or(if is_numeric {
-                    TruncationPolicy::Error
-                } else {
-                    TruncationPolicy::Warn
-                });
+            let truncation = f.truncation.clone().unwrap_or(if is_numeric {
+                TruncationPolicy::Error
+            } else {
+                TruncationPolicy::Warn
+            });
 
-                Ok(WriteField {
-                    name: f.name.clone(),
-                    width,
-                    justify,
-                    pad_char,
-                    truncation,
-                })
-            })
-            .collect::<Result<_, FormatError>>()?;
+            resolved.push(WriteField {
+                name: f.name.clone(),
+                start,
+                width,
+                justify,
+                pad_char,
+                truncation,
+            });
+        }
+
+        // Emit in byte order regardless of declaration order. Overlapping
+        // ranges have no consistent byte layout — later bytes would clobber
+        // earlier ones — so they are a construction defect, not a per-record
+        // surprise.
+        resolved.sort_by_key(|f| f.start);
+        for pair in resolved.windows(2) {
+            let (prev, next) = (&pair[0], &pair[1]);
+            if next.start < prev.start + prev.width {
+                return Err(field::invalid_field(
+                    &next.name,
+                    &format!(
+                        "range {}..{} overlaps field '{}' ({}..{})",
+                        next.start,
+                        next.start + next.width,
+                        prev.name,
+                        prev.start,
+                        prev.start + prev.width
+                    ),
+                ));
+            }
+        }
 
         let framer = config
             .envelope
@@ -218,7 +250,14 @@ impl<W: Write> FixedWidthWriter<W> {
 
 impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        // Fields are sorted by `start` and non-overlapping (enforced at
+        // construction), so a cursor walk left-to-right space-fills any byte
+        // range the schema leaves undeclared and lands every cell at the
+        // position the reader slices.
+        let mut cursor = 0usize;
         for field in &self.fields {
+            write_gap(&mut self.writer, field.start - cursor)?;
+
             let value = record.get(&field.name).cloned().unwrap_or(Value::Null);
 
             let formatted = self.format_value(field, &value)?;
@@ -243,20 +282,14 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
                             "field '{}': value '{}' truncated to {} chars",
                             field.name, formatted, field.width
                         ));
-                        let padded = self.pad_and_justify(field, &formatted);
-                        self.writer.write_all(padded.as_bytes())?;
-                        continue;
                     }
-                    TruncationPolicy::Silent => {
-                        let padded = self.pad_and_justify(field, &formatted);
-                        self.writer.write_all(padded.as_bytes())?;
-                        continue;
-                    }
+                    TruncationPolicy::Silent => {}
                 }
             }
 
             let padded = self.pad_and_justify(field, &formatted);
             self.writer.write_all(padded.as_bytes())?;
+            cursor = field.start + field.width;
         }
 
         // Write line separator
@@ -301,6 +334,19 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
         }
         Ok(())
     }
+}
+
+/// Space-fill the `len`-byte gap between the write cursor and the next
+/// field's start, in bounded chunks so an arbitrarily wide gap stays O(1)
+/// memory with no per-record allocation.
+fn write_gap<W: Write>(writer: &mut W, mut len: usize) -> Result<(), FormatError> {
+    const FILL: [u8; 64] = [b' '; 64];
+    while len > 0 {
+        let n = len.min(FILL.len());
+        writer.write_all(&FILL[..n])?;
+        len -= n;
+    }
+    Ok(())
 }
 
 /// Stringify an envelope section value for a fixed-width header/trailer line.
@@ -573,6 +619,274 @@ mod tests {
             }
             other => panic!("expected UnserializableMapValue, got {other:?}"),
         }
+    }
+
+    /// A schema whose declared ranges leave a gap emits the gap as spaces so
+    /// each field lands at the byte position the reader slices — the
+    /// round-trip the sequential emitter used to break by writing the fields
+    /// adjacent. `b` declares `end` (not `width`) to pin end-resolution to
+    /// the same byte range on both sides.
+    #[test]
+    fn test_fixedwidth_write_gapped_starts_roundtrip() {
+        use crate::fixed_width::reader::{FixedWidthReader, FixedWidthReaderConfig};
+        use crate::traits::FormatReader;
+
+        let fields = vec![
+            {
+                let mut f = field("a");
+                f.ty = Type::String;
+                f.start = Some(0);
+                f.width = Some(2);
+                f
+            },
+            {
+                let mut f = field("b");
+                f.ty = Type::String;
+                f.start = Some(5);
+                f.end = Some(7);
+                f
+            },
+        ];
+        let read_fields = fields.clone();
+
+        let mut buf = Vec::new();
+        {
+            let mut writer =
+                FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+            let rec = make_record(
+                &["a", "b"],
+                vec![Value::String("AB".into()), Value::String("CD".into())],
+            );
+            writer.write_record(&rec).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let output = String::from_utf8(buf.clone()).unwrap();
+        assert_eq!(output, "AB   CD\n", "bytes 2..5 must be space-filled");
+
+        let mut reader = FixedWidthReader::new(
+            buf.as_slice(),
+            read_fields,
+            FixedWidthReaderConfig::default(),
+        )
+        .unwrap();
+        let roundtrip = reader.next_record().unwrap().unwrap();
+        assert_eq!(roundtrip.get("a"), Some(&Value::String("AB".into())));
+        assert_eq!(roundtrip.get("b"), Some(&Value::String("CD".into())));
+    }
+
+    /// Fields declared out of byte order are emitted at their declared
+    /// positions, not in declaration order.
+    #[test]
+    fn test_fixedwidth_write_out_of_order_starts_roundtrip() {
+        use crate::fixed_width::reader::{FixedWidthReader, FixedWidthReaderConfig};
+        use crate::traits::FormatReader;
+
+        let fields = vec![
+            {
+                let mut f = field("b");
+                f.ty = Type::String;
+                f.start = Some(5);
+                f.width = Some(5);
+                f
+            },
+            {
+                let mut f = field("a");
+                f.ty = Type::String;
+                f.start = Some(0);
+                f.width = Some(5);
+                f
+            },
+        ];
+        let read_fields = fields.clone();
+
+        let mut buf = Vec::new();
+        {
+            let mut writer =
+                FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+            let rec = make_record(
+                &["a", "b"],
+                vec![Value::String("Alice".into()), Value::String("Bob".into())],
+            );
+            writer.write_record(&rec).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let output = String::from_utf8(buf.clone()).unwrap();
+        assert_eq!(output, "AliceBob  \n", "a occupies 0..5, b occupies 5..10");
+
+        let mut reader = FixedWidthReader::new(
+            buf.as_slice(),
+            read_fields,
+            FixedWidthReaderConfig::default(),
+        )
+        .unwrap();
+        let roundtrip = reader.next_record().unwrap().unwrap();
+        assert_eq!(roundtrip.get("a"), Some(&Value::String("Alice".into())));
+        assert_eq!(roundtrip.get("b"), Some(&Value::String("Bob".into())));
+    }
+
+    /// A gap wider than the fill chunk is still fully space-filled (exercises
+    /// the chunked gap writer across more than one chunk).
+    #[test]
+    fn test_fixedwidth_write_wide_gap_fully_space_filled() {
+        let fields = vec![
+            {
+                let mut f = field("a");
+                f.ty = Type::String;
+                f.start = Some(0);
+                f.width = Some(2);
+                f
+            },
+            {
+                let mut f = field("b");
+                f.ty = Type::String;
+                f.start = Some(100);
+                f.width = Some(2);
+                f
+            },
+        ];
+
+        let mut buf = Vec::new();
+        {
+            let mut writer =
+                FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+            let rec = make_record(
+                &["a", "b"],
+                vec![Value::String("XX".into()), Value::String("YY".into())],
+            );
+            writer.write_record(&rec).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(output.len(), 103, "2 + 98-space gap + 2 + newline");
+        assert_eq!(&output[..2], "XX");
+        assert!(
+            output[2..100].bytes().all(|b| b == b' '),
+            "bytes 2..100 must all be spaces"
+        );
+        assert_eq!(&output[100..102], "YY");
+    }
+
+    /// Overlapping declared ranges have no consistent byte layout and are a
+    /// typed construction error naming both fields.
+    #[test]
+    fn test_fixedwidth_write_overlapping_fields_rejected() {
+        let fields = vec![
+            {
+                let mut f = field("a");
+                f.ty = Type::String;
+                f.start = Some(0);
+                f.width = Some(5);
+                f
+            },
+            {
+                let mut f = field("b");
+                f.ty = Type::String;
+                f.start = Some(3);
+                f.width = Some(5);
+                f
+            },
+        ];
+
+        let mut buf = Vec::new();
+        let err = FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default())
+            .err()
+            .expect("overlapping ranges must be rejected at construction");
+        match err {
+            FormatError::InvalidRecord { row, message } => {
+                assert_eq!(row, 0, "construction defect reports row 0");
+                assert!(
+                    message.contains("'b'") && message.contains("'a'"),
+                    "message should name both fields: {message}"
+                );
+                assert!(
+                    message.contains("3..8") && message.contains("0..5"),
+                    "message should carry both ranges: {message}"
+                );
+            }
+            other => panic!("expected InvalidRecord, got {other:?}"),
+        }
+    }
+
+    /// The writer enforces the reader's `width`/`end` mutual exclusivity, so
+    /// a schema that would be rejected on read is rejected on write too.
+    #[test]
+    fn test_fixedwidth_write_width_and_end_together_rejected() {
+        let fields = vec![{
+            let mut f = field("a");
+            f.ty = Type::String;
+            f.start = Some(0);
+            f.width = Some(5);
+            f.end = Some(5);
+            f
+        }];
+
+        let mut buf = Vec::new();
+        let err = FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default())
+            .err()
+            .expect("width+end together must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mutually exclusive"),
+            "error should state the exclusivity: {msg}"
+        );
+    }
+
+    /// Columns that omit `start` keep the sequential layout: each continues
+    /// at the previous column's end.
+    #[test]
+    fn test_fixedwidth_write_startless_schema_stays_sequential() {
+        let fields = vec![
+            {
+                let mut f = field("a");
+                f.ty = Type::String;
+                f.width = Some(3);
+                f
+            },
+            {
+                let mut f = field("b");
+                f.ty = Type::Int;
+                f.width = Some(4);
+                f
+            },
+        ];
+
+        let mut buf = Vec::new();
+        {
+            let mut writer =
+                FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+            let rec = make_record(
+                &["a", "b"],
+                vec![Value::String("x".into()), Value::Integer(42)],
+            );
+            writer.write_record(&rec).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(output, "x    42\n", "a at 0..3, b at 3..7, no gap");
+    }
+
+    /// A declared range whose end exceeds `usize::MAX` cannot exist; it is a
+    /// typed construction error rather than an arithmetic wrap.
+    #[test]
+    fn test_fixedwidth_write_range_end_overflow_rejected() {
+        let fields = vec![{
+            let mut f = field("a");
+            f.ty = Type::String;
+            f.start = Some(usize::MAX);
+            f.width = Some(2);
+            f
+        }];
+
+        let mut buf = Vec::new();
+        let err = FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default())
+            .err()
+            .expect("overflowing range must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("overflows"), "error should say so: {msg}");
     }
 
     use crate::envelope_writer::test_doc_with_sections as doc_with_sections;

--- a/crates/clinker-format/src/splitting/tests.rs
+++ b/crates/clinker-format/src/splitting/tests.rs
@@ -818,9 +818,7 @@ fn test_splitting_writer_xml_produces_valid_files() {
     let xml_config = XmlWriterConfig {
         root_element: "items".into(),
         record_element: "item".into(),
-        preserve_nulls: false,
-        include_engine_stamped: false,
-        envelope: None,
+        ..Default::default()
     };
 
     let xml_factory: WriterFactory = Box::new(

--- a/crates/clinker-format/src/x12/mod.rs
+++ b/crates/clinker-format/src/x12/mod.rs
@@ -43,3 +43,14 @@ pub use writer::{X12Writer, X12WriterConfig};
 /// envelope field and never surfaces in CXL `$doc.<section>.<field>`
 /// typechecking.
 pub(crate) const RAW_ELEMENTS_KEY: &str = "$raw";
+
+/// Engine-internal key under which the reader stashes the discovered
+/// delimiter set beside the raw `ISA` elements, as a three-element array of
+/// integer bytes `[element, subelement, terminator]`. The element separator
+/// and segment terminator are not `ISA` data elements — they live between
+/// and after them — so the raw element list alone cannot reproduce a
+/// custom-delimited wire shape; the writer adopts this set when echoing the
+/// header via `interchange_from_doc`. Engine-namespaced like
+/// [`RAW_ELEMENTS_KEY`]: not user-declarable and invisible to CXL `$doc`
+/// typechecking.
+pub(crate) const DELIMITERS_KEY: &str = "$delims";

--- a/crates/clinker-format/src/x12/reader.rs
+++ b/crates/clinker-format/src/x12/reader.rs
@@ -39,8 +39,8 @@ use crate::envelope::{
 use crate::error::FormatError;
 use crate::schema::Column;
 use crate::traits::FormatReader;
-use crate::x12::RAW_ELEMENTS_KEY;
 use crate::x12::tokenizer::{ParsedSegment, SegmentTokenizer, split_isa, split_segment};
+use crate::x12::{DELIMITERS_KEY, RAW_ELEMENTS_KEY};
 use cxl::typecheck::Type;
 
 /// Default ceiling on the number of positional element columns the record
@@ -533,6 +533,15 @@ impl<R: Read + Send> FormatReader for X12Reader<R> {
                 .map(|e| Value::String(e.as_str().into()))
                 .collect();
             typed.insert(Box::from(RAW_ELEMENTS_KEY), Value::Array(raw_elements));
+            // The element separator and segment terminator are not ISA data
+            // elements — they sit between and after them — so the raw list
+            // alone cannot reproduce a custom-delimited wire shape. Carry
+            // the discovered delimiter set beside it so the writer emits
+            // the reconstructed interchange with the original bytes.
+            typed.insert(
+                Box::from(DELIMITERS_KEY),
+                self.tokenizer.delimiters().to_doc_value(),
+            );
             out.insert(Box::from(name.as_str()), Value::Map(Box::new(typed)));
         }
         Ok(out)
@@ -1168,6 +1177,111 @@ mod tests {
         let mut r = reader(&interchange());
         let err = r.prepare_document(&cfg).unwrap_err();
         assert!(matches!(err, FormatError::X12(m) if m.contains("non-`segment`")));
+    }
+
+    #[test]
+    fn prepare_document_stamps_discovered_delimiters() {
+        // The ISA section carries the discovered delimiter set as integer
+        // bytes beside the raw element list, so a writer can reproduce the
+        // wire shape — the separator and terminator are not ISA elements.
+        let cfg = isa_section(&[("e13", EnvelopeFieldType::String)]);
+        let mut r = reader(&interchange());
+        let sections = r.prepare_document(&cfg).unwrap();
+        let interchange = match sections.get("interchange").unwrap() {
+            Value::Map(m) => m,
+            other => panic!("expected map, got {other:?}"),
+        };
+        assert_eq!(
+            interchange.get(DELIMITERS_KEY),
+            Some(&Value::Array(vec![
+                Value::Integer(i64::from(b'*')),
+                Value::Integer(i64::from(b':')),
+                Value::Integer(i64::from(b'~')),
+            ])),
+            "delimiter stamp must carry [element, subelement, terminator] bytes"
+        );
+    }
+
+    /// The [`interchange`] fixture under custom delimiters: `|` element,
+    /// `^` sub-element, `!` terminator.
+    fn custom_delim_interchange() -> String {
+        let isa = "ISA|00|          |00|          |ZZ|SENDER         \
+            |ZZ|RECEIVER       |240101|1200|U|00401|000000001|0|P|^!";
+        assert_eq!(isa.len(), 106, "custom ISA fixture must be 106 bytes");
+        format!(
+            "{isa}\
+            GS|PO|SENDER|RECEIVER|20240101|1200|1|X|004010!\
+            ST|850|0001!\
+            BEG|00|NE|PO12345||20240101!\
+            PO1|1|10|EA|9.99!\
+            SE|4|0001!\
+            GE|1|1!\
+            IEA|1|000000001!"
+        )
+    }
+
+    /// The headline delimiter acceptance: a custom-delimiter interchange
+    /// read into `$doc` and re-emitted via `interchange_from_doc`
+    /// reproduces the input byte-for-byte — element separator, sub-element
+    /// separator, and segment terminator all preserved.
+    #[test]
+    fn custom_delimiter_round_trip_is_byte_identical() {
+        use crate::traits::FormatWriter;
+        use crate::x12::writer::{X12Writer, X12WriterConfig};
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
+
+        let input = custom_delim_interchange();
+
+        let cfg = isa_section(&[("e13", EnvelopeFieldType::String)]);
+        let mut r = reader(&input);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 3); // ST, BEG, PO1
+
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.x12"),
+            EnvelopeRecord::from_sections(sections),
+        ));
+        let schema = r.schema().unwrap();
+        let out = {
+            let mut buf = Vec::new();
+            let mut w = X12Writer::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                X12WriterConfig {
+                    interchange_from_doc: Some("interchange".into()),
+                    group_header: Some(vec![
+                        "PO".into(),
+                        "SENDER".into(),
+                        "RECEIVER".into(),
+                        "20240101".into(),
+                        "1200".into(),
+                        "1".into(),
+                        "X".into(),
+                        "004010".into(),
+                    ]),
+                    segment_newline: false,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+        assert_eq!(
+            out, input,
+            "custom delimiters must round-trip byte-for-byte"
+        );
+
+        // The emitted interchange re-parses cleanly under its own header.
+        let recs2 = collect(&out);
+        assert_eq!(recs2.len(), 3);
+        assert_eq!(recs2[2].get("seg_id"), Some(&Value::String("PO1".into())));
     }
 
     /// Full reader → `$doc` → writer → reader round-trip exercising the

--- a/crates/clinker-format/src/x12/tokenizer.rs
+++ b/crates/clinker-format/src/x12/tokenizer.rs
@@ -27,6 +27,8 @@
 
 use std::io::{BufRead, Read};
 
+use clinker_record::Value;
+
 use crate::charset::Charset;
 use crate::error::FormatError;
 use crate::segment_tokenizer::{
@@ -72,6 +74,50 @@ pub(crate) struct Delimiters {
     pub subelement: u8,
     /// Segment terminator.
     pub terminator: u8,
+}
+
+impl Delimiters {
+    /// Encode the delimiter set as its `$doc` carrier value: a
+    /// three-element array of integer bytes `[element, subelement,
+    /// terminator]`. Bytes, not characters — a delimiter byte (a `\n`
+    /// terminator, say) need not be printable text.
+    pub(crate) fn to_doc_value(self) -> Value {
+        Value::Array(vec![
+            Value::Integer(i64::from(self.element)),
+            Value::Integer(i64::from(self.subelement)),
+            Value::Integer(i64::from(self.terminator)),
+        ])
+    }
+
+    /// Decode a delimiter set from its `$doc` carrier value. The key is
+    /// engine-namespaced and only ever written by [`Self::to_doc_value`],
+    /// so any other shape signals a corrupted document context; the error
+    /// message describes the malformation for the caller to wrap.
+    pub(crate) fn from_doc_value(value: &Value) -> Result<Self, String> {
+        let Value::Array(items) = value else {
+            return Err(format!(
+                "expected a three-element byte array, found {value:?}"
+            ));
+        };
+        let byte = |i: usize, role: &str| -> Result<u8, String> {
+            match items.get(i) {
+                Some(Value::Integer(n)) => u8::try_from(*n)
+                    .map_err(|_| format!("{role} delimiter {n} is not a byte (0..=255)")),
+                other => Err(format!("{role} delimiter is {other:?}, expected a byte")),
+            }
+        };
+        if items.len() != 3 {
+            return Err(format!(
+                "expected a three-element byte array, found {} elements",
+                items.len()
+            ));
+        }
+        Ok(Self {
+            element: byte(0, "element")?,
+            subelement: byte(1, "sub-element")?,
+            terminator: byte(2, "segment-terminator")?,
+        })
+    }
 }
 
 /// Streaming X12 segment reader.
@@ -484,6 +530,55 @@ mod tests {
         let _ = t.read_isa_header().unwrap();
         let err = t.next_segment().unwrap_err();
         assert!(matches!(err, FormatError::X12(m) if m.contains("cap")));
+    }
+
+    #[test]
+    fn delimiter_doc_value_round_trips() {
+        let d = Delimiters {
+            element: b'|',
+            subelement: b'^',
+            terminator: b'\n',
+        };
+        assert_eq!(
+            d.to_doc_value(),
+            Value::Array(vec![
+                Value::Integer(124),
+                Value::Integer(94),
+                Value::Integer(10),
+            ])
+        );
+        assert_eq!(Delimiters::from_doc_value(&d.to_doc_value()).unwrap(), d);
+    }
+
+    #[test]
+    fn delimiter_doc_value_rejects_malformed_shapes() {
+        // Non-array carrier.
+        assert!(Delimiters::from_doc_value(&Value::String("junk".into())).is_err());
+        // Wrong arity.
+        assert!(
+            Delimiters::from_doc_value(&Value::Array(
+                vec![Value::Integer(42), Value::Integer(58),]
+            ))
+            .is_err()
+        );
+        // Out-of-byte-range integer.
+        assert!(
+            Delimiters::from_doc_value(&Value::Array(vec![
+                Value::Integer(300),
+                Value::Integer(58),
+                Value::Integer(126),
+            ]))
+            .is_err()
+        );
+        // Non-integer element.
+        assert!(
+            Delimiters::from_doc_value(&Value::Array(vec![
+                Value::String("*".into()),
+                Value::Integer(58),
+                Value::Integer(126),
+            ]))
+            .is_err()
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/x12/writer.rs
+++ b/crates/clinker-format/src/x12/writer.rs
@@ -39,14 +39,15 @@ use clinker_record::{Record, Schema, Value};
 use crate::charset::Charset;
 use crate::error::FormatError;
 use crate::traits::FormatWriter;
-use crate::x12::RAW_ELEMENTS_KEY;
 use crate::x12::tokenizer::Delimiters;
+use crate::x12::{DELIMITERS_KEY, RAW_ELEMENTS_KEY};
 
-/// Default X12 service delimiters used when no `ISA` header dictates
-/// otherwise: `*` element, `:` sub-element, `~` terminator. When the
-/// header is echoed from a `$doc` section, its `ISA16` sub-element byte
-/// overrides the default; the literal-`interchange` path keeps these
-/// defaults.
+/// Default X12 service delimiters: `*` element, `:` sub-element, `~`
+/// terminator. A `$doc` section produced by the X12 reader carries the
+/// source interchange's discovered delimiter set, which the
+/// `interchange_from_doc` path adopts wholesale before the first segment
+/// is written; the literal-`interchange` path and a hand-authored section
+/// (no delimiter stamp) keep these defaults.
 fn default_delimiters() -> Delimiters {
     Delimiters {
         element: b'*',
@@ -207,15 +208,45 @@ impl<W: Write> X12Writer<W> {
         self.header_written = true;
 
         let isa_elements = self.resolve_isa_elements(record)?;
+        // Adopting the source delimiter set must precede the first
+        // write_segment so the ISA itself — and every segment after it —
+        // emits with the original bytes, keeping the header's declared
+        // delimiters self-consistent with the interchange on re-read.
+        self.adopt_doc_delimiters(record)?;
         // The ISA control number (ISA13, element index 12) is echoed in
         // the IEA trailer; default to empty when the header is short.
         self.isa_control_number = isa_elements.get(12).cloned().unwrap_or_default();
         // The ISA is written verbatim with the writer's element separator
         // and terminator; its fields are fixed-width control values, never
-        // trailing-empty. ISA16 declares the sub-element separator, but the
-        // writer keeps the element separator and terminator at their
-        // defaults so the header is self-consistent on re-read.
+        // trailing-empty.
         self.write_segment("ISA", &isa_elements)?;
+        Ok(())
+    }
+
+    /// Adopt the source interchange's delimiter set when echoing the
+    /// header from a `$doc` section the X12 reader produced. The reader
+    /// stashes the discovered `[element, subelement, terminator]` bytes
+    /// beside the raw `ISA` elements; adopting them here means the whole
+    /// reconstructed interchange — header, envelopes, and body — emits
+    /// with the original bytes, and the delimiter-in-data rejection checks
+    /// the bytes actually in effect. The literal-`interchange` path and a
+    /// section without the stamp (hand-authored `$doc` fields) keep the
+    /// defaults.
+    fn adopt_doc_delimiters(&mut self, record: &Record) -> Result<(), FormatError> {
+        if self.config.interchange.is_some() {
+            return Ok(());
+        }
+        let Some(section) = &self.config.interchange_from_doc else {
+            return Ok(());
+        };
+        let Some(stamp) = record.doc_ctx().get_section_field(section, DELIMITERS_KEY) else {
+            return Ok(());
+        };
+        self.delims = Delimiters::from_doc_value(&stamp).map_err(|e| {
+            FormatError::X12(format!(
+                "section {section:?}: malformed delimiter stamp {DELIMITERS_KEY:?}: {e}"
+            ))
+        })?;
         Ok(())
     }
 
@@ -751,40 +782,175 @@ mod tests {
         assert!(out.contains("IEA*1*000000001~"), "{out}");
     }
 
-    #[test]
-    fn isa_echoed_from_doc_section() {
-        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord, Value as RecVal};
+    /// Build a document context carrying an `interchange` section with the
+    /// given raw `ISA` element list and, optionally, a delimiter stamp —
+    /// the shape the X12 reader's `prepare_document` produces.
+    fn doc_ctx_with_isa(
+        elements: &[&str],
+        stamp: Option<Value>,
+    ) -> Arc<clinker_record::DocumentContext> {
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
         use indexmap::IndexMap;
 
-        let s = schema();
-        let raw = RecVal::Array(
-            ISA_ELEMENTS
+        let raw = Value::Array(
+            elements
                 .iter()
-                .map(|e| RecVal::String((*e).into()))
+                .map(|e| Value::String((*e).into()))
                 .collect(),
         );
-        let mut isa: IndexMap<Box<str>, RecVal> = IndexMap::new();
+        let mut isa: IndexMap<Box<str>, Value> = IndexMap::new();
         isa.insert(super::RAW_ELEMENTS_KEY.into(), raw);
-        let mut sections: IndexMap<Box<str>, RecVal> = IndexMap::new();
-        sections.insert("interchange".into(), RecVal::Map(Box::new(isa)));
-        let ctx = Arc::new(DocumentContext::new(
+        if let Some(v) = stamp {
+            isa.insert(super::DELIMITERS_KEY.into(), v);
+        }
+        let mut sections: IndexMap<Box<str>, Value> = IndexMap::new();
+        sections.insert("interchange".into(), Value::Map(Box::new(isa)));
+        Arc::new(DocumentContext::new(
             DocumentId::next(),
             Arc::from("orders.x12"),
             EnvelopeRecord::from_sections(sections),
-        ));
+        ))
+    }
 
-        let mut record = body(&s, "BEG", "0001", "850", &["00"]);
-        record.set_doc_ctx(ctx);
-
-        let cfg = X12WriterConfig {
+    fn from_doc_config() -> X12WriterConfig {
+        X12WriterConfig {
             interchange_from_doc: Some("interchange".into()),
             group_header: Some(GS_HEADER.iter().map(|s| s.to_string()).collect()),
             segment_newline: false,
             ..Default::default()
-        };
-        let out = write_all(cfg, &[record], &s);
+        }
+    }
+
+    #[test]
+    fn isa_echoed_from_doc_section() {
+        let s = schema();
+        let mut record = body(&s, "BEG", "0001", "850", &["00"]);
+        record.set_doc_ctx(doc_ctx_with_isa(ISA_ELEMENTS, None));
+
+        let out = write_all(from_doc_config(), &[record], &s);
         assert!(out.contains("000000001"), "{out}");
         assert!(out.contains("IEA*1*000000001~"), "{out}");
+        // A section without a delimiter stamp (hand-authored `$doc` fields)
+        // keeps the default `*`/`~` delimiters.
+        assert!(out.starts_with("ISA*00*"), "{out}");
+    }
+
+    /// The [`ISA_ELEMENTS`] fixture under `|`/`^`/`!` delimiters — `ISA16`
+    /// (the declared sub-element separator) is `^` instead of `:`.
+    const CUSTOM_DELIM_ISA_ELEMENTS: &[&str] = &[
+        "00",
+        "          ",
+        "00",
+        "          ",
+        "ZZ",
+        "SENDER         ",
+        "ZZ",
+        "RECEIVER       ",
+        "240101",
+        "1200",
+        "U",
+        "00401",
+        "000000001",
+        "0",
+        "P",
+        "^",
+    ];
+
+    fn custom_delims() -> Delimiters {
+        Delimiters {
+            element: b'|',
+            subelement: b'^',
+            terminator: b'!',
+        }
+    }
+
+    #[test]
+    fn doc_delimiter_stamp_reconstructs_with_source_delimiters() {
+        // A section carrying the reader's delimiter stamp emits the whole
+        // interchange — ISA, envelopes, and body — with the source's
+        // delimiter bytes, not the writer defaults.
+        let s = schema();
+        let mut record = body(&s, "BEG", "0001", "850", &["00"]);
+        record.set_doc_ctx(doc_ctx_with_isa(
+            CUSTOM_DELIM_ISA_ELEMENTS,
+            Some(custom_delims().to_doc_value()),
+        ));
+
+        let out = write_all(from_doc_config(), &[record], &s);
+        assert_eq!(
+            out,
+            "ISA|00|          |00|          |ZZ|SENDER         \
+             |ZZ|RECEIVER       |240101|1200|U|00401|000000001|0|P|^!\
+             GS|PO|SENDER|RECEIVER|20240101|1200|1|X|004010!\
+             ST|850|0001!BEG|00!SE|3|0001!GE|1|1!IEA|1|000000001!"
+        );
+    }
+
+    #[test]
+    fn literal_interchange_ignores_doc_delimiter_stamp() {
+        // The literal `interchange` config wins over the doc section
+        // entirely, delimiters included: output keeps the defaults even
+        // when the record's context carries a custom stamp.
+        let s = schema();
+        let mut record = body(&s, "BEG", "0001", "850", &["00"]);
+        record.set_doc_ctx(doc_ctx_with_isa(
+            CUSTOM_DELIM_ISA_ELEMENTS,
+            Some(custom_delims().to_doc_value()),
+        ));
+
+        let mut cfg = literal_config();
+        cfg.interchange_from_doc = Some("interchange".into());
+        let out = write_all(cfg, &[record], &s);
+        assert!(out.starts_with("ISA*00*"), "{out}");
+        assert!(out.contains("IEA*1*000000001~"), "{out}");
+        assert!(!out.contains('|'), "custom bytes must not leak: {out}");
+    }
+
+    #[test]
+    fn adopted_delimiters_drive_delimiter_in_data_rejection() {
+        // Under the adopted '|' element separator, a '*' in data is plain
+        // text; a '|' is the structural byte that must be rejected.
+        let s = schema();
+        let stamped_body = |element: &str| {
+            let mut record = body(&s, "BEG", "0001", "850", &[element]);
+            record.set_doc_ctx(doc_ctx_with_isa(
+                CUSTOM_DELIM_ISA_ELEMENTS,
+                Some(custom_delims().to_doc_value()),
+            ));
+            record
+        };
+
+        let out = write_all(from_doc_config(), &[stamped_body("A*B")], &s);
+        assert!(out.contains("BEG|A*B!"), "{out}");
+
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&s), from_doc_config());
+        let err = w.write_record(&stamped_body("A|B")).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("element") && m.contains("no escape")),
+            "expected rejection on the adopted element byte, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn malformed_delimiter_stamp_errors() {
+        // The stamp key is engine-internal, so a non-conforming value is
+        // corruption — rejected with a precise error, never silently
+        // defaulted.
+        let s = schema();
+        let mut record = body(&s, "BEG", "0001", "850", &["00"]);
+        record.set_doc_ctx(doc_ctx_with_isa(
+            ISA_ELEMENTS,
+            Some(Value::String("junk".into())),
+        ));
+
+        let mut buf = Vec::new();
+        let mut w = X12Writer::new(Cursor::new(&mut buf), Arc::clone(&s), from_doc_config());
+        let err = w.write_record(&record).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::X12(m) if m.contains("malformed delimiter stamp")),
+            "expected a stamp-shape error, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -933,6 +933,15 @@ fn explode_array_path(
     out: &mut Vec<Vec<IndexedField>>,
 ) {
     let anchor = instances[0].start;
+    // Any-occurrence membership, precomputed once: probing every range from
+    // inside the per-occurrence loop would make the fan-out quadratic in the
+    // occurrence count. Ranges are recorded in document order, so the last
+    // range's end spans them all.
+    let span = instances.last().map_or(0, |r| r.end);
+    let mut in_occurrence = vec![false; span];
+    for range in instances {
+        in_occurrence[range.clone()].fill(true);
+    }
     for instance in instances {
         let mut head: Vec<IndexedField> = Vec::new();
         let mut inside: Vec<IndexedField> = Vec::new();
@@ -941,7 +950,7 @@ fn explode_array_path(
             let idx = field.0;
             if instance.contains(&idx) {
                 inside.push(field.clone());
-            } else if instances.iter().any(|r| r.contains(&idx)) {
+            } else if idx < span && in_occurrence[idx] {
                 // A different occurrence of this path: not part of this output.
                 continue;
             } else if idx < anchor {

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -1,13 +1,16 @@
 //! Streaming XML reader using quick-xml's pull parser.
 //!
 //! Navigates to `record_path`, extracts attributes with configurable prefix,
-//! flattens nested elements with `.` separator, handles namespaces.
+//! flattens nested elements with `.` separator, handles namespaces, and
+//! applies `array_paths` explode/join to repeated child elements.
 //!
 //! **O(1 record) memory, no whole-document buffer:** the body walks the
 //! document element-at-a-time from a freshly re-opened `BufReader` —
 //! quick-xml's `read_event_into` pulls one event at a time, so only a single
 //! record's `element_stack` plus the event buffer is live at once, never the
-//! whole input.
+//! whole input. An array-path explode fans one record element out into
+//! several records; the expansion queue is bounded by that one element's
+//! fan-out, never the whole input.
 //!
 //! Envelope-aware sources run a streaming pre-scan before any body record
 //! emits: it walks the document once over its *own* freshly re-opened reader,
@@ -20,7 +23,9 @@
 //! whole-file byte buffer is retained for a file-backed input. See
 //! [`crate::xml::streaming`] for the event-driven pruned-extraction pass.
 
+use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read};
+use std::ops::Range;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -91,6 +96,48 @@ pub enum XmlArrayMode {
     Join,
 }
 
+/// One record element's raw extraction: flattened `(key, value)` pairs in
+/// document order with repeated keys intact, plus the field ranges covered
+/// by each configured array path's element occurrences.
+struct RawRecord {
+    fields: Vec<(String, String)>,
+    /// Index-aligned with `XmlReaderConfig::array_paths`: for each configured
+    /// path, the half-open ranges into `fields` spanning each occurrence of
+    /// that element, in document order. An occurrence with no extracted
+    /// fields (`<Item></Item>`) contributes an empty range, so an explode
+    /// still emits a record for it.
+    array_instances: Vec<Vec<Range<usize>>>,
+}
+
+impl RawRecord {
+    /// A raw record with no array-path occurrences — an attributes-only
+    /// record element has no child elements for a path to match.
+    fn without_instances(fields: Vec<(String, String)>, path_count: usize) -> Self {
+        RawRecord {
+            fields,
+            array_instances: vec![Vec::new(); path_count],
+        }
+    }
+}
+
+/// A flattened field tagged with its index in the original extraction, so
+/// array-path occurrence ranges (recorded against that original order) stay
+/// meaningful across the sequential per-path fan-out.
+type IndexedField = (usize, String, String);
+
+/// An array-path element currently being extracted. Configured paths never
+/// nest (validated at construction), so at most one occurrence is open at a
+/// time.
+struct OpenInstance {
+    /// Index into `XmlReaderConfig::array_paths`.
+    path: usize,
+    /// First field index belonging to this occurrence.
+    fields_from: usize,
+    /// `element_stack` length while this occurrence's element is open; the
+    /// occurrence closes when the stack shrinks below it.
+    stack_len: usize,
+}
+
 /// A quick-xml pull parser over a re-opened, BOM-stripped `BufReader`.
 ///
 /// Both the body parser and the envelope pre-scan parse over this same reader
@@ -110,7 +157,7 @@ pub(crate) type BodyParser = XmlParser<BufReader<Box<dyn Read + Send>>>;
 /// The envelope pre-scan retains only the declared sections' subtrees, each
 /// bounded by `max_index_bytes` (charged incrementally, aborting mid-parse on
 /// an oversized section), so held memory is O(declared sections) plus one
-/// live record while the reader exists.
+/// live record's array-path expansion while the reader exists.
 pub struct XmlReader {
     /// The re-openable byte source. Body iteration and the envelope pre-scan
     /// each open their own fresh [`Read`] from it, so no whole-document buffer
@@ -131,8 +178,11 @@ pub struct XmlReader {
     matched_depth: usize,
     /// Current XML depth (incremented on Start, decremented on End).
     xml_depth: usize,
-    /// Pending records from first-record schema inference.
-    pending: Option<Record>,
+    /// Expanded records awaiting emission: schema inference reads the first
+    /// record element eagerly, and an array-path explode fans one element
+    /// out into several records. Bounded by one element's expansion, never
+    /// the whole input.
+    pending: VecDeque<Record>,
     /// Whether we've finished all records.
     done: bool,
 }
@@ -153,6 +203,28 @@ impl XmlReader {
         source: ReopenableSource,
         config: XmlReaderConfig,
     ) -> Result<Self, FormatError> {
+        // Array paths must name disjoint element groups: occurrence tracking
+        // during extraction assigns each field to at most one configured
+        // path, and a duplicated path would fan the same group out twice.
+        // Reject the ambiguous configs before reading any input.
+        for (i, a) in config.array_paths.iter().enumerate() {
+            for b in &config.array_paths[i + 1..] {
+                if a.path == b.path {
+                    return Err(FormatError::Xml(format!(
+                        "array_paths: path {:?} is declared more than once",
+                        a.path
+                    )));
+                }
+                if under_array_path(&a.path, &b.path) || under_array_path(&b.path, &a.path) {
+                    return Err(FormatError::Xml(format!(
+                        "array_paths: paths {:?} and {:?} nest; XML array paths \
+                         must name disjoint (non-nested) element groups",
+                        a.path, b.path
+                    )));
+                }
+            }
+        }
+
         // XML runs two passes (envelope pre-scan + body stream), so the source
         // must be re-openable. A `Path`/`Buffered` source passes through; a
         // pathless `OneShot` is buffered here, on the reader-building thread —
@@ -176,7 +248,7 @@ impl XmlReader {
             path_segments,
             matched_depth: 0,
             xml_depth: 0,
-            pending: None,
+            pending: VecDeque::new(),
             done: false,
         })
     }
@@ -241,7 +313,7 @@ impl XmlReader {
 
     /// Navigate to the record_path and read one complete record element.
     /// Returns None when no more records exist.
-    fn read_next_record_raw(&mut self) -> Result<Option<Vec<(String, String)>>, FormatError> {
+    fn read_next_record_raw(&mut self) -> Result<Option<RawRecord>, FormatError> {
         if self.done {
             return Ok(None);
         }
@@ -264,16 +336,16 @@ impl XmlReader {
                             if self.matched_depth == self.path_segments.len() {
                                 let attrs =
                                     extract_attributes_static(&self.config.attribute_prefix, e)?;
-                                let fields = self.extract_record_fields(attrs)?;
-                                return Ok(Some(fields));
+                                let raw = self.extract_record_fields(attrs)?;
+                                return Ok(Some(raw));
                             }
                         } else {
                             self.skip_subtree()?;
                         }
                     } else {
                         let attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
-                        let fields = self.extract_record_fields(attrs)?;
-                        return Ok(Some(fields));
+                        let raw = self.extract_record_fields(attrs)?;
+                        return Ok(Some(raw));
                     }
                 }
                 Event::Empty(ref e) => {
@@ -285,11 +357,17 @@ impl XmlReader {
                         {
                             let fields =
                                 extract_attributes_static(&self.config.attribute_prefix, e)?;
-                            return Ok(Some(fields));
+                            return Ok(Some(RawRecord::without_instances(
+                                fields,
+                                self.config.array_paths.len(),
+                            )));
                         }
                     } else {
                         let fields = extract_attributes_static(&self.config.attribute_prefix, e)?;
-                        return Ok(Some(fields));
+                        return Ok(Some(RawRecord::without_instances(
+                            fields,
+                            self.config.array_paths.len(),
+                        )));
                     }
                 }
                 Event::End(_) => {
@@ -315,13 +393,18 @@ impl XmlReader {
         }
     }
 
-    /// Extract all fields from a record element (attributes + nested children).
-    /// Uses a separate buffer to avoid borrow conflicts with self.parser.
+    /// Extract all fields from a record element (attributes + nested children),
+    /// tracking the field ranges each configured array path's element
+    /// occurrences cover. Uses a separate buffer to avoid borrow conflicts
+    /// with self.parser.
     fn extract_record_fields(
         &mut self,
         start_attrs: Vec<(String, String)>,
-    ) -> Result<Vec<(String, String)>, FormatError> {
+    ) -> Result<RawRecord, FormatError> {
         let mut fields = start_attrs;
+        let mut array_instances: Vec<Vec<Range<usize>>> =
+            vec![Vec::new(); self.config.array_paths.len()];
+        let mut open_instance: Option<OpenInstance> = None;
         let record_depth = self.xml_depth;
         let mut element_stack: Vec<String> = Vec::new();
         // Raw source form of the current text node, accumulated across the
@@ -350,8 +433,20 @@ impl XmlReader {
                     self.xml_depth += 1;
                     let name = elem_name_static(&self.config.namespace_handling, &e.name());
                     element_stack.push(name);
-                    let child_attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
                     let prefix = element_stack.join(".");
+                    // Opening an element named by an array path starts a new
+                    // occurrence; the attributes pushed below are its first
+                    // fields. Paths never nest, so one open slot suffices.
+                    if open_instance.is_none()
+                        && let Some(pi) = self.array_path_index(&prefix)
+                    {
+                        open_instance = Some(OpenInstance {
+                            path: pi,
+                            fields_from: fields.len(),
+                            stack_len: element_stack.len(),
+                        });
+                    }
+                    let child_attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
                     for (key, val) in child_attrs {
                         fields.push((format!("{prefix}.{key}"), val));
                     }
@@ -362,6 +457,12 @@ impl XmlReader {
                         break;
                     }
                     element_stack.pop();
+                    if let Some(ref open) = open_instance
+                        && element_stack.len() < open.stack_len
+                    {
+                        array_instances[open.path].push(open.fields_from..fields.len());
+                        open_instance = None;
+                    }
                 }
                 Event::Empty(ref e) => {
                     let name = elem_name_static(&self.config.namespace_handling, &e.name());
@@ -370,10 +471,18 @@ impl XmlReader {
                     } else {
                         format!("{}.{name}", element_stack.join("."))
                     };
+                    let instance_from = fields.len();
                     fields.push((prefix.clone(), String::new()));
                     let child_attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
                     for (key, val) in child_attrs {
                         fields.push((format!("{prefix}.{key}"), val));
+                    }
+                    // A self-closing element named by an array path is a
+                    // complete occurrence on its own.
+                    if open_instance.is_none()
+                        && let Some(pi) = self.array_path_index(&prefix)
+                    {
+                        array_instances[pi].push(instance_from..fields.len());
                     }
                 }
                 Event::Text(ref t) => {
@@ -399,7 +508,71 @@ impl XmlReader {
             }
         }
 
-        Ok(fields)
+        // EOF inside an unclosed occurrence (malformed input): keep the
+        // fields read so far rather than dropping them.
+        if let Some(open) = open_instance {
+            array_instances[open.path].push(open.fields_from..fields.len());
+        }
+
+        Ok(RawRecord {
+            fields,
+            array_instances,
+        })
+    }
+
+    /// Index of the configured array path exactly matching this dotted
+    /// element path, if any.
+    fn array_path_index(&self, dotted: &str) -> Option<usize> {
+        self.config
+            .array_paths
+            .iter()
+            .position(|ap| ap.path == dotted)
+    }
+
+    /// Expand one raw record through the configured array paths, applied in
+    /// declaration order. `join` collapses each repeated flattened key under
+    /// the path into one separator-joined value at its first position;
+    /// `explode` emits one output per element occurrence, duplicating every
+    /// field outside the path onto each. A record with no occurrence of a
+    /// path passes through that path unchanged. Memory is bounded by one
+    /// record's fan-out (the product of exploded occurrence counts).
+    fn apply_array_paths(&self, raw: RawRecord) -> Vec<Vec<(String, String)>> {
+        if self.config.array_paths.is_empty() {
+            return vec![raw.fields];
+        }
+
+        let mut result: Vec<Vec<IndexedField>> = vec![
+            raw.fields
+                .into_iter()
+                .enumerate()
+                .map(|(i, (k, v))| (i, k, v))
+                .collect(),
+        ];
+        for (ap, instances) in self.config.array_paths.iter().zip(&raw.array_instances) {
+            let mut next = Vec::new();
+            for rec in result {
+                match ap.mode {
+                    XmlArrayMode::Join => {
+                        next.push(join_array_path(rec, &ap.path, &ap.separator));
+                    }
+                    XmlArrayMode::Explode => {
+                        // No occurrence in this record: XML cannot
+                        // distinguish an empty repetition from an absent
+                        // element, so the record passes through unchanged.
+                        if instances.is_empty() {
+                            next.push(rec);
+                        } else {
+                            explode_array_path(&rec, instances, &mut next);
+                        }
+                    }
+                }
+            }
+            result = next;
+        }
+        result
+            .into_iter()
+            .map(|rec| rec.into_iter().map(|(_, k, v)| (k, v)).collect())
+            .collect()
     }
 
     /// Skip an entire subtree (from current Start to its matching End).
@@ -456,7 +629,7 @@ impl FormatReader for XmlReader {
 
         let first = self.read_next_record_raw()?;
         let first = match first {
-            Some(fields) => fields,
+            Some(raw) => raw,
             None => {
                 let s = SchemaBuilder::new().build();
                 self.schema = Some(Arc::clone(&s));
@@ -465,9 +638,16 @@ impl FormatReader for XmlReader {
             }
         };
 
-        // Infer schema from first record's field names (preserving order)
+        // Infer schema from the first expanded record's field names
+        // (preserving order). Array paths apply before inference, so an
+        // explode's fanned-out columns and a join's collapsed column are
+        // what the schema reflects.
+        let expanded = self.apply_array_paths(first);
+        let empty = Vec::new();
         let mut seen = std::collections::HashSet::new();
-        let schema = first
+        let schema = expanded
+            .first()
+            .unwrap_or(&empty)
             .iter()
             .filter_map(|(k, _)| {
                 if seen.insert(k.clone()) {
@@ -480,8 +660,11 @@ impl FormatReader for XmlReader {
             .build();
         self.schema = Some(Arc::clone(&schema));
 
-        // Buffer the first record
-        self.pending = Some(self.fields_to_record(first)?);
+        // Buffer every record the first element expanded to.
+        for fields in expanded {
+            let record = self.fields_to_record(fields)?;
+            self.pending.push_back(record);
+        }
 
         Ok(schema)
     }
@@ -491,14 +674,18 @@ impl FormatReader for XmlReader {
             self.schema()?;
         }
 
-        if let Some(pending) = self.pending.take() {
-            return Ok(Some(pending));
-        }
-
-        let fields = self.read_next_record_raw()?;
-        match fields {
-            Some(f) => Ok(Some(self.fields_to_record(f)?)),
-            None => Ok(None),
+        loop {
+            if let Some(record) = self.pending.pop_front() {
+                return Ok(Some(record));
+            }
+            let raw = match self.read_next_record_raw()? {
+                Some(r) => r,
+                None => return Ok(None),
+            };
+            for fields in self.apply_array_paths(raw) {
+                let record = self.fields_to_record(fields)?;
+                self.pending.push_back(record);
+            }
         }
     }
 
@@ -690,6 +877,83 @@ pub(crate) fn finalize_text_run(raw: &str) -> Result<String, FormatError> {
     let trimmed = raw.trim_matches(is_xml_whitespace);
     let value = escape::unescape(trimmed).map_err(|e| FormatError::Xml(e.to_string()))?;
     Ok(value.into_owned())
+}
+
+/// True when a flattened key sits at or under an array path: the key IS the
+/// path (the element's own text) or extends it past a dot (its children and
+/// attributes). Also the nesting test between two configured paths, since a
+/// path is itself a dotted element path.
+fn under_array_path(key: &str, path: &str) -> bool {
+    key.strip_prefix(path)
+        .is_some_and(|rest| rest.is_empty() || rest.starts_with('.'))
+}
+
+/// Collapse every repeated flattened key under `path` into one field whose
+/// value is the occurrences' values joined with `sep`, placed at the key's
+/// first position. A key occurring once keeps its value (a join of one).
+/// Fields outside the path pass through unchanged.
+fn join_array_path(rec: Vec<IndexedField>, path: &str, sep: &str) -> Vec<IndexedField> {
+    let mut joined: IndexMap<String, String> = IndexMap::new();
+    for (_, key, value) in &rec {
+        if under_array_path(key, path) {
+            match joined.entry(key.clone()) {
+                indexmap::map::Entry::Occupied(mut e) => {
+                    let acc = e.get_mut();
+                    acc.push_str(sep);
+                    acc.push_str(value);
+                }
+                indexmap::map::Entry::Vacant(e) => {
+                    e.insert(value.clone());
+                }
+            }
+        }
+    }
+    let mut out = Vec::with_capacity(rec.len());
+    for (idx, key, value) in rec {
+        if under_array_path(&key, path) {
+            // First occurrence carries the joined value; later occurrences
+            // were already folded into it.
+            if let Some(v) = joined.swap_remove(&key) {
+                out.push((idx, key, v));
+            }
+        } else {
+            out.push((idx, key, value));
+        }
+    }
+    out
+}
+
+/// Fan one record out to one output per element occurrence of an exploded
+/// path: each output keeps that occurrence's fields plus every field outside
+/// the path's occurrences. Occurrence fields are spliced where the first
+/// occurrence sat, so all fanned-out siblings share one column order.
+fn explode_array_path(
+    rec: &[IndexedField],
+    instances: &[Range<usize>],
+    out: &mut Vec<Vec<IndexedField>>,
+) {
+    let anchor = instances[0].start;
+    for instance in instances {
+        let mut head: Vec<IndexedField> = Vec::new();
+        let mut inside: Vec<IndexedField> = Vec::new();
+        let mut tail: Vec<IndexedField> = Vec::new();
+        for field in rec {
+            let idx = field.0;
+            if instance.contains(&idx) {
+                inside.push(field.clone());
+            } else if instances.iter().any(|r| r.contains(&idx)) {
+                // A different occurrence of this path: not part of this output.
+                continue;
+            } else if idx < anchor {
+                head.push(field.clone());
+            } else {
+                tail.push(field.clone());
+            }
+        }
+        head.extend(inside);
+        head.extend(tail);
+        out.push(head);
+    }
 }
 
 /// Resolve the current text run and push it, if non-empty, as a field keyed by
@@ -1199,30 +1463,283 @@ mod tests {
         assert_eq!(r1.get("Address.State"), Some(&Value::String("NY".into())));
     }
 
+    /// A reader config over `record_path` with the given array paths.
+    fn array_path_config(record_path: &str, paths: Vec<XmlArrayPath>) -> XmlReaderConfig {
+        XmlReaderConfig {
+            record_path: Some(record_path.into()),
+            array_paths: paths,
+            ..Default::default()
+        }
+    }
+
+    fn explode(path: &str) -> XmlArrayPath {
+        XmlArrayPath {
+            path: path.into(),
+            mode: XmlArrayMode::Explode,
+            separator: ",".into(),
+        }
+    }
+
+    fn join(path: &str, separator: &str) -> XmlArrayPath {
+        XmlArrayPath {
+            path: path.into(),
+            mode: XmlArrayMode::Join,
+            separator: separator.into(),
+        }
+    }
+
+    fn column_names(schema: &Schema) -> Vec<&str> {
+        schema.columns().iter().map(|c| &**c).collect()
+    }
+
     #[test]
     fn test_xml_array_paths_explode() {
-        // Repeating <Item> elements — each becomes a separate field (accumulated)
-        // For true explode, we'd need array_paths config. For now, test that
-        // repeating elements produce the last value (simple case).
-        let xml = r#"<Root><Order><id>1</id><Item><name>A</name></Item><Item><name>B</name></Item></Order></Root>"#;
-        let mut r = reader_from_str(xml, default_config_with_path("Root/Order"));
-        let _s = r.schema().unwrap();
+        // Repeated <Item> children fan out into one record per occurrence;
+        // the parent's fields are duplicated onto each, and the exploded
+        // fields keep their full dotted names.
+        let xml = r#"<Root><Order><id>1</id><Item><name>A</name><qty>2</qty></Item><Item><name>B</name><qty>3</qty></Item></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item")]);
+        let mut r = reader_from_str(xml, config);
+        let s = r.schema().unwrap();
+        // Schema reflects the first exploded record's columns.
+        assert_eq!(column_names(&s), ["id", "Item.name", "Item.qty"]);
+
         let r1 = r.next_record().unwrap().unwrap();
-        // Both items write to "Item.name" — last one wins in the simple model
         assert_eq!(r1.get("id"), Some(&Value::Integer(1)));
-        // Item.name will have one of the values (last write wins)
-        assert!(r1.get("Item.name").is_some());
+        assert_eq!(r1.get("Item.name"), Some(&Value::String("A".into())));
+        assert_eq!(r1.get("Item.qty"), Some(&Value::Integer(2)));
+
+        let r2 = r.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("id"), Some(&Value::Integer(1)));
+        assert_eq!(r2.get("Item.name"), Some(&Value::String("B".into())));
+        assert_eq!(r2.get("Item.qty"), Some(&Value::Integer(3)));
+
+        assert!(r.next_record().unwrap().is_none());
     }
 
     #[test]
     fn test_xml_array_paths_join() {
-        // Multiple child elements with same name — values concatenated by last-write
-        let xml = r#"<Root><Row><Tag>a</Tag><Tag>b</Tag><Tag>c</Tag></Row></Root>"#;
-        let mut r = reader_from_str(xml, default_config_with_path("Root/Row"));
-        let _s = r.schema().unwrap();
+        // Repeated scalar children collapse into one separator-joined field;
+        // a custom separator is honored.
+        let xml = r#"<Root><Row><id>7</id><Tag>a</Tag><Tag>b</Tag><Tag>c</Tag></Row></Root>"#;
+        let config = array_path_config("Root/Row", vec![join("Tag", "|")]);
+        let mut r = reader_from_str(xml, config);
+        let s = r.schema().unwrap();
+        assert_eq!(column_names(&s), ["id", "Tag"]);
+
         let r1 = r.next_record().unwrap().unwrap();
-        // With simple extraction, repeated "Tag" fields — last value wins
-        assert!(r1.get("Tag").is_some());
+        assert_eq!(r1.get("id"), Some(&Value::Integer(7)));
+        assert_eq!(r1.get("Tag"), Some(&Value::String("a|b|c".into())));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_array_paths_join_container_joins_each_subfield() {
+        // Joining a container element concatenates each repeated flattened
+        // key under it independently, in document order.
+        let xml = r#"<Root><Order><id>1</id><Item><name>A</name><qty>2</qty></Item><Item><name>B</name><qty>3</qty></Item></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![join("Item", ",")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("id"), Some(&Value::Integer(1)));
+        assert_eq!(r1.get("Item.name"), Some(&Value::String("A,B".into())));
+        assert_eq!(r1.get("Item.qty"), Some(&Value::String("2,3".into())));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_array_paths_explode_repeated_scalar() {
+        // A repeated scalar element explodes to one record per value, keyed
+        // by the element's own path.
+        let xml = r#"<Root><Row><id>7</id><Tag>a</Tag><Tag>b</Tag></Row></Root>"#;
+        let config = array_path_config("Root/Row", vec![explode("Tag")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("id"), Some(&Value::Integer(7)));
+        assert_eq!(r1.get("Tag"), Some(&Value::String("a".into())));
+        let r2 = r.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("id"), Some(&Value::Integer(7)));
+        assert_eq!(r2.get("Tag"), Some(&Value::String("b".into())));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_array_paths_explode_carries_instance_attributes() {
+        // Attributes on the repeated element belong to their occurrence, not
+        // to the shared parent fields.
+        let xml = r#"<Root><Order><id>1</id><Item sku="X"><name>A</name></Item><Item sku="Y"><name>B</name></Item></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("Item.@sku"), Some(&Value::String("X".into())));
+        assert_eq!(r1.get("Item.name"), Some(&Value::String("A".into())));
+        let r2 = r.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("Item.@sku"), Some(&Value::String("Y".into())));
+        assert_eq!(r2.get("Item.name"), Some(&Value::String("B".into())));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_array_paths_explode_empty_occurrence_yields_parent_only_record() {
+        // An occurrence with no content (`<Item></Item>`) still fans out to
+        // its own record — one carrying just the parent fields.
+        let xml =
+            r#"<Root><Order><id>1</id><Item><name>A</name></Item><Item></Item></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("id"), Some(&Value::Integer(1)));
+        assert_eq!(r1.get("Item.name"), Some(&Value::String("A".into())));
+        let r2 = r.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("id"), Some(&Value::Integer(1)));
+        assert_eq!(r2.get("Item.name"), None);
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_array_paths_explode_absent_element_passes_record_through() {
+        // XML cannot distinguish an empty repetition from an absent element,
+        // so a record with no occurrence of the path is emitted unchanged.
+        let xml = r#"<Root><Order><id>1</id></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("id"), Some(&Value::Integer(1)));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_array_paths_explode_matches_dotted_nested_path() {
+        // The path is the repeated element's dotted path relative to the
+        // record element, matching the flattened field names.
+        let xml = r#"<Root><Order><id>1</id><Items><Item><name>A</name></Item><Item><name>B</name></Item></Items></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Items.Item")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("Items.Item.name"), Some(&Value::String("A".into())));
+        let r2 = r.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("Items.Item.name"), Some(&Value::String("B".into())));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_unmatched_repeated_keys_keep_first_value() {
+        // Repeated keys NOT named by any array path keep the existing
+        // duplicate-key collapse: the first value wins, on every fanned-out
+        // record.
+        let xml = r#"<Root><Row><Dup>x</Dup><Dup>y</Dup><Tag>a</Tag><Tag>b</Tag></Row></Root>"#;
+        let config = array_path_config("Root/Row", vec![explode("Tag")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("Dup"), Some(&Value::String("x".into())));
+        assert_eq!(r1.get("Tag"), Some(&Value::String("a".into())));
+        let r2 = r.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("Dup"), Some(&Value::String("x".into())));
+        assert_eq!(r2.get("Tag"), Some(&Value::String("b".into())));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_array_paths_compose_across_disjoint_paths() {
+        // Paths apply in declaration order over the fan-out: the joined Tag
+        // value lands on every exploded Item record.
+        let xml = r#"<Root><Order><id>1</id><Item><name>A</name></Item><Item><name>B</name></Item><Tag>x</Tag><Tag>y</Tag></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item"), join("Tag", ",")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(r1.get("Item.name"), Some(&Value::String("A".into())));
+        assert_eq!(r1.get("Tag"), Some(&Value::String("x,y".into())));
+        let r2 = r.next_record().unwrap().unwrap();
+        assert_eq!(r2.get("Item.name"), Some(&Value::String("B".into())));
+        assert_eq!(r2.get("Tag"), Some(&Value::String("x,y".into())));
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn xml_two_explode_paths_fan_out_cartesian() {
+        // Two exploded paths multiply, mirroring the JSON reader's
+        // sequential fan-out: every A occurrence pairs with every B
+        // occurrence.
+        let xml = r#"<Root><Order><A>1</A><A>2</A><B>x</B><B>y</B></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("A"), explode("B")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let mut pairs = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            pairs.push((rec.get("A").cloned(), rec.get("B").cloned()));
+        }
+        let expected: Vec<(Option<Value>, Option<Value>)> =
+            [(1, "x"), (1, "y"), (2, "x"), (2, "y")]
+                .into_iter()
+                .map(|(a, b)| (Some(Value::Integer(a)), Some(Value::String(b.into()))))
+                .collect();
+        assert_eq!(pairs, expected);
+    }
+
+    #[test]
+    fn xml_explode_spans_multiple_record_elements() {
+        // The expansion queue drains per record element: two Orders with two
+        // Items each yield four records, in document order.
+        let xml = r#"<Root>
+            <Order><id>1</id><Item><name>A</name></Item><Item><name>B</name></Item></Order>
+            <Order><id>2</id><Item><name>C</name></Item><Item><name>D</name></Item></Order>
+        </Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item")]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let mut rows = Vec::new();
+        while let Some(rec) = r.next_record().unwrap() {
+            rows.push((rec.get("id").cloned(), rec.get("Item.name").cloned()));
+        }
+        let expected: Vec<(Option<Value>, Option<Value>)> =
+            [(1, "A"), (1, "B"), (2, "C"), (2, "D")]
+                .into_iter()
+                .map(|(id, name)| (Some(Value::Integer(id)), Some(Value::String(name.into()))))
+                .collect();
+        assert_eq!(rows, expected);
+    }
+
+    #[test]
+    fn xml_nested_array_paths_rejected_at_construction() {
+        // One configured path extending another means their element groups
+        // nest; occurrence tracking assumes disjoint groups, so the config
+        // is rejected before any input is read.
+        let xml = r#"<Root><Order><Item><part>p</part></Item></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item"), explode("Item.part")]);
+        let err = match XmlReader::from_reader(Cursor::new(xml.as_bytes().to_vec()), config) {
+            Ok(_) => panic!("nested array paths must be rejected"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, FormatError::Xml(msg) if msg.contains("nest")));
+    }
+
+    #[test]
+    fn xml_duplicate_array_paths_rejected_at_construction() {
+        let xml = r#"<Root><Order><Item>a</Item></Order></Root>"#;
+        let config = array_path_config("Root/Order", vec![explode("Item"), join("Item", ",")]);
+        let err = match XmlReader::from_reader(Cursor::new(xml.as_bytes().to_vec()), config) {
+            Ok(_) => panic!("duplicate array paths must be rejected"),
+            Err(e) => e,
+        };
+        assert!(matches!(err, FormatError::Xml(msg) if msg.contains("more than once")));
     }
 
     #[test]

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -1,5 +1,6 @@
 //! XML writer with configurable root/record elements, dotted field expansion
-//! to nested elements, null handling, and proper escaping.
+//! to nested elements, attribute-prefixed fields emitted as XML attributes,
+//! null handling, and proper escaping.
 //!
 //! Under `reconstruct_envelope`, each document is wrapped in a `<Document>`
 //! element inside the root: `begin_document` opens `<Document>` and emits the
@@ -24,6 +25,14 @@ pub struct XmlWriterConfig {
     pub root_element: String,
     pub record_element: String,
     pub preserve_nulls: bool,
+    /// Field-name prefix that marks a field as an XML attribute of its
+    /// enclosing element rather than a child element. Mirrors the reader's
+    /// `attribute_prefix` (default `@`) so attribute-derived fields
+    /// round-trip: a top-level `@id` attaches to the record element's start
+    /// tag, a nested `Address.@type` attaches to the `<Address>` branch.
+    /// An empty prefix disables attribute classification entirely — every
+    /// field emits as an element.
+    pub attribute_prefix: String,
     /// Whether engine-stamped schema columns (`$ck.<field>` correlation
     /// snapshots) emit as nested elements. Defaults to `false` so
     /// engine-internal namespaces stay out of the XML output.
@@ -41,6 +50,7 @@ impl Default for XmlWriterConfig {
             root_element: "Root".into(),
             record_element: "Record".into(),
             preserve_nulls: false,
+            attribute_prefix: "@".into(),
             include_engine_stamped: false,
             envelope: None,
         }
@@ -96,12 +106,19 @@ impl<W: Write> XmlWriter<W> {
         if let Some((field, ref v)) = count_value {
             pairs.push((field, v));
         }
-        let tree = build_field_tree(&pairs, self.config.preserve_nulls)?;
-        let start = BytesStart::new(wrapper);
+        let tree = build_field_tree(
+            &pairs,
+            self.config.preserve_nulls,
+            &self.config.attribute_prefix,
+        )?;
+        let mut start = BytesStart::new(wrapper);
+        for (key, value) in &tree.attrs {
+            start.push_attribute((key.as_str(), value.as_str()));
+        }
         self.writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
-        self.write_field_tree(&tree)?;
+        self.write_field_tree(&tree.children)?;
         let end = BytesEnd::new(wrapper);
         self.writer
             .write_event(Event::End(end))
@@ -120,20 +137,23 @@ impl<W: Write> XmlWriter<W> {
         Ok(())
     }
 
-    /// Collects schema fields as (name, value) pairs, then writes them as
-    /// nested XML elements. Engine-stamped columns are stripped from the
-    /// default output; callers opt in via `include_engine_stamped`.
-    fn write_fields(&mut self, record: &Record) -> Result<(), FormatError> {
+    /// Collects schema fields as (name, value) pairs and builds the record's
+    /// element body — attributes plus child nodes — before any bytes are
+    /// emitted, so record-level attributes can ride the record start tag.
+    /// Engine-stamped columns are stripped from the default output; callers
+    /// opt in via `include_engine_stamped`.
+    fn build_record_tree(&self, record: &Record) -> Result<ElementBody, FormatError> {
         let fields: Vec<(&str, &Value)> = if self.config.include_engine_stamped {
             record.iter_all_fields().collect()
         } else {
             record.iter_user_fields().collect()
         };
 
-        let tree = build_field_tree(&fields, self.config.preserve_nulls)?;
-        self.write_field_tree(&tree)?;
-
-        Ok(())
+        build_field_tree(
+            &fields,
+            self.config.preserve_nulls,
+            &self.config.attribute_prefix,
+        )
     }
 
     /// Recursively write a field tree as nested XML elements.
@@ -162,16 +182,27 @@ impl<W: Write> XmlWriter<W> {
                             .map_err(|e| FormatError::Xml(e.to_string()))?;
                     }
                 }
-                FieldNode::Branch { name, children } => {
-                    let start = BytesStart::new(name.as_str());
-                    self.writer
-                        .write_event(Event::Start(start))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    self.write_field_tree(children)?;
-                    let end = BytesEnd::new(name.as_str());
-                    self.writer
-                        .write_event(Event::End(end))
-                        .map_err(|e| FormatError::Xml(e.to_string()))?;
+                FieldNode::Branch { name, body } => {
+                    let mut start = BytesStart::new(name.as_str());
+                    for (key, value) in &body.attrs {
+                        start.push_attribute((key.as_str(), value.as_str()));
+                    }
+                    if body.children.is_empty() {
+                        // Attribute-only branch: nothing nests inside, so the
+                        // element self-closes carrying its attributes.
+                        self.writer
+                            .write_event(Event::Empty(start))
+                            .map_err(|e| FormatError::Xml(e.to_string()))?;
+                    } else {
+                        self.writer
+                            .write_event(Event::Start(start))
+                            .map_err(|e| FormatError::Xml(e.to_string()))?;
+                        self.write_field_tree(&body.children)?;
+                        let end = BytesEnd::new(name.as_str());
+                        self.writer
+                            .write_event(Event::End(end))
+                            .map_err(|e| FormatError::Xml(e.to_string()))?;
+                    }
                 }
             }
         }
@@ -181,14 +212,23 @@ impl<W: Write> XmlWriter<W> {
 
 impl<W: Write + Send> FormatWriter for XmlWriter<W> {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        // The tree is built before the record start tag is emitted:
+        // attribute-classified fields must be known when the tag opens, and
+        // a rejected field (map payload, malformed attribute path) must not
+        // leave a dangling half-written record behind.
+        let tree = self.build_record_tree(record)?;
+
         self.write_header()?;
 
-        let start = BytesStart::new(&*self.config.record_element);
+        let mut start = BytesStart::new(&*self.config.record_element);
+        for (key, value) in &tree.attrs {
+            start.push_attribute((key.as_str(), value.as_str()));
+        }
         self.writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
 
-        self.write_fields(record)?;
+        self.write_field_tree(&tree.children)?;
 
         let end = BytesEnd::new(&*self.config.record_element);
         self.writer
@@ -262,64 +302,119 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
 
 // ── Field tree for dotted name → nested element expansion ────────────
 
-enum FieldNode {
-    Leaf {
-        name: String,
-        text: String,
-    },
-    Branch {
-        name: String,
-        children: Vec<FieldNode>,
-    },
+/// One element's content: the attributes attached to its start tag plus its
+/// child nodes. The whole body is materialized before the element's start
+/// tag is emitted, because attributes have to be known at that point.
+#[derive(Default)]
+struct ElementBody {
+    attrs: Vec<(String, String)>,
+    children: Vec<FieldNode>,
 }
 
-/// Build a tree from dotted field names. Fields with shared prefixes
-/// are grouped under a single parent branch.
-/// E.g., `Address.City` and `Address.State` → Branch("Address", [Leaf("City"), Leaf("State")])
+enum FieldNode {
+    Leaf { name: String, text: String },
+    Branch { name: String, body: ElementBody },
+}
+
+/// Build an element body from dotted field names. Fields with shared
+/// prefixes are grouped under a single parent branch
+/// (`Address.City` + `Address.State` → one `Address` branch with two leaf
+/// children), and a field whose final segment carries the attribute prefix
+/// becomes an attribute of its enclosing element instead of a child
+/// (`@id` → attribute on the returned body, `Address.@type` → attribute on
+/// the `Address` branch).
+///
+/// Null attribute fields are dropped even under `preserve_nulls` — a null
+/// element round-trips as a self-closing tag, but an attribute has no
+/// present-but-empty form that reads back as null.
 ///
 /// Returns `FormatError::UnserializableMapValue` if any field carries
 /// a `Value::Map` payload — XML elements have no canonical scalar
 /// serialization for a map, and `value_to_text` raises from the Map
-/// arm directly.
+/// arm directly. Returns `FormatError::Xml` for a malformed attribute
+/// path (a prefixed segment with children nested under it, or a bare
+/// prefix with no attribute name).
 fn build_field_tree(
     fields: &[(&str, &Value)],
     preserve_nulls: bool,
-) -> Result<Vec<FieldNode>, FormatError> {
-    let mut roots: Vec<FieldNode> = Vec::new();
+    attribute_prefix: &str,
+) -> Result<ElementBody, FormatError> {
+    let mut root = ElementBody::default();
 
     for &(name, val) in fields {
-        if val.is_null() && !preserve_nulls {
+        if val.is_null() && (!preserve_nulls || is_attribute_path(name, attribute_prefix)) {
             continue;
         }
         let text = value_to_text(name, val)?;
-        insert_field(&mut roots, name, &text);
+        insert_field(&mut root, name, name, &text, attribute_prefix)?;
     }
 
-    Ok(roots)
+    Ok(root)
+}
+
+/// True when the path's final segment is attribute-classified — i.e. a
+/// non-empty prefix marks it as an attribute of its enclosing element.
+fn is_attribute_path(path: &str, attribute_prefix: &str) -> bool {
+    !attribute_prefix.is_empty()
+        && path
+            .rsplit('.')
+            .next()
+            .is_some_and(|segment| segment.starts_with(attribute_prefix))
 }
 
 /// Insert a dotted field name into the tree, creating branches as needed.
-fn insert_field(nodes: &mut Vec<FieldNode>, path: &str, text: &str) {
+/// An attribute-prefixed segment must be the path's final segment (an
+/// attribute is a leaf — nothing can nest under it); `field` is the full
+/// original field name, carried for error messages.
+fn insert_field(
+    body: &mut ElementBody,
+    field: &str,
+    path: &str,
+    text: &str,
+    attribute_prefix: &str,
+) -> Result<(), FormatError> {
     if let Some((first, rest)) = path.split_once('.') {
+        if !attribute_prefix.is_empty() && first.starts_with(attribute_prefix) {
+            return Err(FormatError::Xml(format!(
+                "field '{field}': attribute-prefixed segment '{first}' \
+                 cannot have fields nested under it — an XML attribute is a leaf"
+            )));
+        }
         // Find or create a branch for `first`
-        let branch = nodes
+        let branch = body
+            .children
             .iter_mut()
             .find(|n| matches!(n, FieldNode::Branch { name, .. } if name == first));
-        if let Some(FieldNode::Branch { children, .. }) = branch {
-            insert_field(children, rest, text);
+        if let Some(FieldNode::Branch {
+            body: branch_body, ..
+        }) = branch
+        {
+            insert_field(branch_body, field, rest, text, attribute_prefix)
         } else {
-            let mut children = Vec::new();
-            insert_field(&mut children, rest, text);
-            nodes.push(FieldNode::Branch {
+            let mut branch_body = ElementBody::default();
+            insert_field(&mut branch_body, field, rest, text, attribute_prefix)?;
+            body.children.push(FieldNode::Branch {
                 name: first.to_string(),
-                children,
+                body: branch_body,
             });
+            Ok(())
         }
+    } else if !attribute_prefix.is_empty() && path.starts_with(attribute_prefix) {
+        let attr_name = &path[attribute_prefix.len()..];
+        if attr_name.is_empty() {
+            return Err(FormatError::Xml(format!(
+                "field '{field}': attribute prefix '{attribute_prefix}' \
+                 carries no attribute name"
+            )));
+        }
+        body.attrs.push((attr_name.to_string(), text.to_string()));
+        Ok(())
     } else {
-        nodes.push(FieldNode::Leaf {
+        body.children.push(FieldNode::Leaf {
             name: path.to_string(),
             text: text.to_string(),
         });
+        Ok(())
     }
 }
 
@@ -583,6 +678,192 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_xml_write_attribute_prefixed_field_as_record_attribute() {
+        let schema = Arc::new(Schema::new(vec!["@id".into(), "name".into()]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::Integer(7), Value::String("A".into())],
+        );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            r#"<Root><Record id="7"><name>A</name></Record></Root>"#
+        );
+    }
+
+    #[test]
+    fn test_xml_write_nested_attribute_attaches_to_branch() {
+        let schema = Arc::new(Schema::new(vec![
+            "Address.@type".into(),
+            "Address.City".into(),
+        ]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::String("home".into()), Value::String("NYC".into())],
+        );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            r#"<Root><Record><Address type="home"><City>NYC</City></Address></Record></Root>"#
+        );
+    }
+
+    #[test]
+    fn test_xml_write_attribute_only_branch_self_closes() {
+        let schema = Arc::new(Schema::new(vec!["Address.@type".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::String("home".into())]);
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            r#"<Root><Record><Address type="home"/></Record></Root>"#
+        );
+    }
+
+    #[test]
+    fn test_xml_write_custom_attribute_prefix() {
+        let schema = Arc::new(Schema::new(vec!["_id".into(), "name".into()]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::Integer(7), Value::String("A".into())],
+        );
+        let config = XmlWriterConfig {
+            attribute_prefix: "_".into(),
+            ..Default::default()
+        };
+        let output = write_records(config, &[record], &schema);
+        assert_eq!(
+            output,
+            r#"<Root><Record id="7"><name>A</name></Record></Root>"#
+        );
+    }
+
+    #[test]
+    fn test_xml_write_default_prefix_leaves_underscore_field_as_element() {
+        // Only the configured prefix classifies a field as an attribute;
+        // `_id` is a valid element name under the default `@` prefix.
+        let schema = Arc::new(Schema::new(vec!["_id".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Integer(7)]);
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(output, "<Root><Record><_id>7</_id></Record></Root>");
+    }
+
+    #[test]
+    fn test_xml_write_empty_prefix_disables_attribute_classification() {
+        let schema = Arc::new(Schema::new(vec!["_id".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Integer(7)]);
+        let config = XmlWriterConfig {
+            attribute_prefix: String::new(),
+            ..Default::default()
+        };
+        let output = write_records(config, &[record], &schema);
+        assert_eq!(output, "<Root><Record><_id>7</_id></Record></Root>");
+    }
+
+    #[test]
+    fn test_xml_write_null_attribute_dropped_even_with_preserve_nulls() {
+        // A null element round-trips as a self-closing tag; an attribute
+        // has no form that reads back as null, so it is dropped instead of
+        // being emitted as an empty string.
+        let schema = Arc::new(Schema::new(vec!["@id".into(), "name".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Null, Value::Null]);
+        let config = XmlWriterConfig {
+            preserve_nulls: true,
+            ..Default::default()
+        };
+        let output = write_records(config, &[record], &schema);
+        assert_eq!(output, "<Root><Record><name/></Record></Root>");
+    }
+
+    #[test]
+    fn test_xml_write_attribute_value_escaped() {
+        let schema = Arc::new(Schema::new(vec!["@note".into()]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::String(r#"a & "b" <c>"#.into())],
+        );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert!(output.contains("&amp;"), "& should be escaped: {output}");
+        assert!(output.contains("&quot;"), "\" should be escaped: {output}");
+        assert!(output.contains("&lt;"), "< should be escaped: {output}");
+        assert!(
+            !output.contains(r#"a & "b""#),
+            "raw attribute value should not appear: {output}"
+        );
+    }
+
+    #[test]
+    fn test_xml_write_map_valued_attribute_rejected() {
+        use indexmap::IndexMap;
+        let schema = Arc::new(Schema::new(vec!["@meta".into()]));
+        let mut sidecar: IndexMap<Box<str>, Value> = IndexMap::new();
+        sidecar.insert("a".into(), Value::Integer(1));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Map(Box::new(sidecar))]);
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::UnserializableMapValue { format, column } => {
+                assert_eq!(format, "XML");
+                assert_eq!(column, "@meta");
+            }
+            other => panic!("expected UnserializableMapValue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_xml_write_attribute_segment_with_children_rejected() {
+        // `@a.b` would need `@a` to be an element to hold `b` — an
+        // attribute is a leaf, so the field is rejected instead of
+        // emitting an `<@a>` element (invalid XML name).
+        let schema = Arc::new(Schema::new(vec!["@a.b".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Integer(1)]);
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::Xml(msg) => {
+                assert!(
+                    msg.contains("'@a.b'") && msg.contains("'@a'"),
+                    "message names the field and offending segment: {msg}"
+                );
+            }
+            other => panic!("expected FormatError::Xml, got {other:?}"),
+        }
+        drop(writer);
+        assert!(
+            buf.is_empty(),
+            "rejected record must not leave partial output behind"
+        );
+    }
+
+    #[test]
+    fn test_xml_attribute_roundtrip_reader_writer() {
+        // The reader flattens attributes to `@`-prefixed fields; writing
+        // those records back must restore them as attributes, never emit
+        // an `@`-named element.
+        let input = r#"<Root><Record id="7" status="open"><name>A</name><Address type="home"><City>NYC</City></Address></Record></Root>"#;
+        let cursor = std::io::Cursor::new(input.as_bytes().to_vec());
+        let mut reader = XmlReader::from_reader(
+            cursor,
+            XmlReaderConfig {
+                record_path: Some("Root/Record".into()),
+                ..Default::default()
+            },
+        )
+        .expect("XML buffer read");
+        let schema = reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert!(reader.next_record().unwrap().is_none());
+
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(output, input);
+        assert!(
+            !output.contains("<@"),
+            "no @-named element may be emitted: {output}"
+        );
+    }
+
     use crate::envelope_writer::test_doc_with_sections as doc_with_sections;
 
     #[test]
@@ -631,6 +912,42 @@ mod tests {
         // The whole thing is valid XML wrapped in the root.
         assert!(
             out.contains("<Root>") && out.contains("</Root>"),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn xml_envelope_section_attribute_field_attaches_to_wrapper() {
+        // Attribute-prefixed section fields (an XML envelope section read
+        // with attributes) attach to the section wrapper's start tag.
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = XmlWriterConfig {
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: None,
+                footer_record_count_field: None,
+            }),
+            ..Default::default()
+        };
+        let doc = doc_with_sections(&[(
+            "Head",
+            &[
+                ("@version", Value::String("1.1".into())),
+                ("batch_id", Value::String("A".into())),
+            ],
+        )]);
+        let mut buf = Vec::new();
+        {
+            let mut w = XmlWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc).unwrap();
+            w.write_record(&Record::new(Arc::clone(&schema), vec![Value::Integer(10)]))
+                .unwrap();
+            w.end_document(&doc).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert!(
+            out.contains(r#"<header version="1.1"><batch_id>A</batch_id></header>"#),
             "got: {out}"
         );
     }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -8,11 +8,14 @@
 //! between; `end_document` emits a `<footer>` element (section fields plus the
 //! streaming record count) and closes `</Document>`. No document is buffered.
 
+use std::borrow::Cow;
 use std::io::Write;
 use std::sync::Arc;
 
 use quick_xml::Writer as XmlEmitter;
+use quick_xml::events::attributes::Attribute;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+use quick_xml::name::QName;
 
 use clinker_record::{DocumentContext, Record, Schema, Value};
 
@@ -112,9 +115,7 @@ impl<W: Write> XmlWriter<W> {
             &self.config.attribute_prefix,
         )?;
         let mut start = BytesStart::new(wrapper);
-        for (key, value) in &tree.attrs {
-            start.push_attribute((key.as_str(), value.as_str()));
-        }
+        push_attributes(&mut start, &tree.attrs);
         self.writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
@@ -184,9 +185,7 @@ impl<W: Write> XmlWriter<W> {
                 }
                 FieldNode::Branch { name, body } => {
                     let mut start = BytesStart::new(name.as_str());
-                    for (key, value) in &body.attrs {
-                        start.push_attribute((key.as_str(), value.as_str()));
-                    }
+                    push_attributes(&mut start, &body.attrs);
                     if body.children.is_empty() {
                         // Attribute-only branch: nothing nests inside, so the
                         // element self-closes carrying its attributes.
@@ -221,9 +220,7 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         self.write_header()?;
 
         let mut start = BytesStart::new(&*self.config.record_element);
-        for (key, value) in &tree.attrs {
-            start.push_attribute((key.as_str(), value.as_str()));
-        }
+        push_attributes(&mut start, &tree.attrs);
         self.writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
@@ -350,6 +347,44 @@ fn build_field_tree(
     }
 
     Ok(root)
+}
+
+/// Push name/value attributes onto an element's start tag, escaping each
+/// value.
+///
+/// quick-xml's `(&str, &str)` attribute conversion escapes only the five
+/// predefined entities, leaving literal tab / CR / LF untouched — a
+/// conformant parser then collapses those to spaces (XML attribute-value
+/// normalization), silently altering values that carry literal whitespace.
+/// They are written as character references instead, which both clinker's
+/// reader and any conformant parser resolve back to the exact bytes.
+fn push_attributes(start: &mut BytesStart, attrs: &[(String, String)]) {
+    for (key, value) in attrs {
+        start.push_attribute(Attribute {
+            key: QName(key.as_bytes()),
+            value: Cow::Owned(escape_attribute_value(value).into_bytes()),
+        });
+    }
+}
+
+/// Escape an attribute value: the five predefined entities plus literal
+/// tab / CR / LF as character references (see [`push_attributes`]).
+fn escape_attribute_value(raw: &str) -> String {
+    let mut escaped = String::with_capacity(raw.len());
+    for c in raw.chars() {
+        match c {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            '\t' => escaped.push_str("&#9;"),
+            '\n' => escaped.push_str("&#10;"),
+            '\r' => escaped.push_str("&#13;"),
+            other => escaped.push(other),
+        }
+    }
+    escaped
 }
 
 /// True when the path's final segment is attribute-classified — i.e. a
@@ -780,15 +815,45 @@ mod tests {
         let schema = Arc::new(Schema::new(vec!["@note".into()]));
         let record = Record::new(
             Arc::clone(&schema),
-            vec![Value::String(r#"a & "b" <c>"#.into())],
+            vec![Value::String("a & \"b\" <c>\td\ne".into())],
         );
         let output = write_records(XmlWriterConfig::default(), &[record], &schema);
-        assert!(output.contains("&amp;"), "& should be escaped: {output}");
-        assert!(output.contains("&quot;"), "\" should be escaped: {output}");
-        assert!(output.contains("&lt;"), "< should be escaped: {output}");
-        assert!(
-            !output.contains(r#"a & "b""#),
-            "raw attribute value should not appear: {output}"
+        assert_eq!(
+            output,
+            r#"<Root><Record note="a &amp; &quot;b&quot; &lt;c&gt;&#9;d&#10;e"></Record></Root>"#
+        );
+    }
+
+    #[test]
+    fn test_xml_attribute_whitespace_roundtrips_exactly() {
+        // Literal tab / LF in an attribute value are written as character
+        // references — a conformant parser would collapse the raw characters
+        // to spaces (attribute-value normalization), but references resolve
+        // back to the exact bytes.
+        let schema = Arc::new(Schema::new(vec!["@note".into(), "name".into()]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("line1\nline2\tend".into()),
+                Value::String("A".into()),
+            ],
+        );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+
+        let cursor = std::io::Cursor::new(output.into_bytes());
+        let mut reader = XmlReader::from_reader(
+            cursor,
+            XmlReaderConfig {
+                record_path: Some("Root/Record".into()),
+                ..Default::default()
+            },
+        )
+        .expect("XML buffer read");
+        let _s = reader.schema().unwrap();
+        let read_back = reader.next_record().unwrap().unwrap();
+        assert_eq!(
+            read_back.get("@note"),
+            Some(&Value::String("line1\nline2\tend".into()))
         );
     }
 

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -38,7 +38,8 @@ pub use fs_type::{FsKind, case_sensitive_dir, classify, collision_key, same_devi
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use output::*;
 pub use patch::{
-    ArrayPathOp, ColumnPatch, SchemaColumnOp, SourceConfigPatch, apply_source_patches,
+    ArrayPathOp, ColumnPatch, EnvelopeFieldOp, NestedSectionOp, SchemaColumnOp, SourceConfigPatch,
+    SplitFieldOp, apply_source_patches,
 };
 pub use pipeline::*;
 pub use pipeline_node::{

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -246,6 +246,11 @@ pub struct XmlOutputOptions {
     pub root_element: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_element: Option<String>,
+    /// Field-name prefix marking a field as an XML attribute of its
+    /// enclosing element rather than a child element (default `@`,
+    /// mirroring the XML source option so attribute fields round-trip).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub attribute_prefix: Option<String>,
     /// Per-document envelope reconstruction. With this set and
     /// `reconstruct_envelope: true`, each document is wrapped in its own
     /// `<record_element-doc>`-style frame carrying the header section, the
@@ -425,4 +430,25 @@ pub struct SwiftOutputOptions {
     /// Name of a `$doc` section to echo the block-5 body from.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trailer_from_doc: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xml_output_options_parse_attribute_prefix() {
+        let opts: XmlOutputOptions =
+            crate::yaml::from_str("record_element: row\nattribute_prefix: \"_\"\n").unwrap();
+        assert_eq!(opts.attribute_prefix, Some("_".to_string()));
+        assert_eq!(opts.record_element, Some("row".to_string()));
+    }
+
+    #[test]
+    fn xml_output_options_attribute_prefix_absent_is_none() {
+        // Genuinely optional — an omitted prefix leaves `None`, so the
+        // writer applies its documented `@` default.
+        let opts: XmlOutputOptions = crate::yaml::from_str("record_element: row\n").unwrap();
+        assert_eq!(opts.attribute_prefix, None);
+    }
 }

--- a/crates/clinker-plan/src/config/patch.rs
+++ b/crates/clinker-plan/src/config/patch.rs
@@ -10,16 +10,18 @@
 //! the span-aware `Spanned<PipelineNode>` structure is preserved, never
 //! round-tripped through a span-losing intermediate value.
 //!
-//! v1 handles the format-agnostic schema-shaping surfaces: the CXL-typed
+//! Handled surfaces: the format-agnostic schema-shaping ops — the CXL-typed
 //! column list (`schema`), nested-array explosion/join (`array_paths`), and
-//! scalar per-format input options (`options`). Deeper format-layer layouts
-//! (fixed-width/positional field schemas, X12/HL7 nested sections, multi-record
+//! scalar per-format input options (`options`) — plus the format-structure
+//! ops for X12 nested-envelope declarations (`group_section` / `set_section`)
+//! and HL7 composite-field splits (`split_fields`). Deeper format-layer
+//! layouts (fixed-width/positional field schemas, multi-record
 //! discrimination) reuse this same framework as additional handlers.
 
 use super::*;
 use crate::config::composition::SchemaProvRecorder;
 use crate::config::pipeline_node::{PipelineNode, SourceBody};
-use clinker_format::{Column, SourceSchema};
+use clinker_format::{Column, EnvelopeFieldType, NestedEnvelopeSection, SourceSchema};
 use clinker_record::schema_def::{Justify, TruncationPolicy};
 use cxl::typecheck::Type;
 use indexmap::IndexMap;
@@ -44,12 +46,32 @@ pub struct SourceConfigPatch {
     /// source's current options and re-validated through the format's option
     /// struct, so an unknown key is rejected exactly as in hand-written config.
     pub options: IndexMap<String, serde_json::Value>,
+    /// Op on the X12 `GS` functional-group nested-envelope declaration
+    /// (`set`/modify/`remove`). Applies only to an `x12` source. Applied after
+    /// the `options` merge, so a keyed op layers on top of an `options`-blob
+    /// replacement of the same declaration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_section: Option<NestedSectionOp>,
+    /// Op on the X12 `ST` transaction-set nested-envelope declaration,
+    /// mirroring `group_section`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub set_section: Option<NestedSectionOp>,
+    /// HL7 composite-field split ops keyed by positional field name (`f08`):
+    /// set-by-key (add-or-modify) or `remove`. Applies only to an `hl7`
+    /// source, after the `options` merge.
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    pub split_fields: IndexMap<String, SplitFieldOp>,
 }
 
 impl SourceConfigPatch {
     /// Whether this patch carries no ops — a no-op the apply pass can skip.
     pub fn is_empty(&self) -> bool {
-        self.schema.is_empty() && self.array_paths.is_empty() && self.options.is_empty()
+        self.schema.is_empty()
+            && self.array_paths.is_empty()
+            && self.options.is_empty()
+            && self.group_section.is_none()
+            && self.set_section.is_none()
+            && self.split_fields.is_empty()
     }
 }
 
@@ -322,11 +344,183 @@ impl<'de> Deserialize<'de> for ArrayPathOp {
     }
 }
 
+/// One op on an X12 nested-envelope declaration (`group_section` /
+/// `set_section`) — a whole [`NestedEnvelopeSection`], not a keyed map,
+/// because each X12 source carries at most one declaration per level.
+///
+/// YAML forms:
+///
+/// ```yaml
+/// group_section: remove                       # drop the declaration
+/// group_section:                              # set / modify
+///   name: fg                                  # optional on an existing declaration
+///   fields:
+///     e06: string                             # set/add a typed field
+///     e05: remove                             # drop a declared field
+/// ```
+///
+/// On an **existing** declaration an omitted `name` keeps the current one and
+/// each field op applies individually; on an **absent** declaration the op
+/// creates it, so `name` is required and a field `remove` is an error.
+/// `Serialize` is derived for config-identity hashing only.
+#[derive(Debug, Clone, Serialize)]
+pub enum NestedSectionOp {
+    /// Drop the declaration entirely, reverting the level to its default
+    /// positional section.
+    Remove,
+    /// Create the declaration or modify the existing one.
+    Set {
+        /// Section name `$doc.<name>.<field>` resolves under. `None` = keep
+        /// current (existing declaration only).
+        name: Option<String>,
+        /// Per-field ops, keyed by positional element name (`e06`).
+        fields: IndexMap<String, EnvelopeFieldOp>,
+    },
+}
+
+impl<'de> Deserialize<'de> for NestedSectionOp {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Two accepted YAML shapes:
+        //   remove                       (bare scalar)
+        //   { name?, fields? }           (declaration map)
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct SetMap {
+            #[serde(default)]
+            name: Option<String>,
+            #[serde(default)]
+            fields: IndexMap<String, EnvelopeFieldOp>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Either {
+            Scalar(String),
+            Map(SetMap),
+        }
+
+        match Either::deserialize(d)? {
+            Either::Scalar(s) if s == "remove" => Ok(NestedSectionOp::Remove),
+            Either::Scalar(other) => Err(de::Error::custom(format!(
+                "unknown nested-section op {other:?}; the bare scalar form only accepts \
+                 `remove` — use `{{ name: <section>, fields: {{ e06: string }} }}` to set or \
+                 modify the declaration"
+            ))),
+            Either::Map(m) => Ok(NestedSectionOp::Set {
+                name: m.name,
+                fields: m.fields,
+            }),
+        }
+    }
+}
+
+/// One per-field op inside a [`NestedSectionOp::Set`]'s `fields` map: set the
+/// field's envelope type, or drop the field from the declaration.
+/// `Serialize` is derived for config-identity hashing only.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub enum EnvelopeFieldOp {
+    /// Drop the keyed field from the declaration.
+    Remove,
+    /// Set (add-or-replace) the keyed field's envelope type.
+    Set(EnvelopeFieldType),
+}
+
+impl<'de> Deserialize<'de> for EnvelopeFieldOp {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // A bare scalar: `remove`, or an envelope field type name.
+        let s = String::deserialize(d)?;
+        if s == "remove" {
+            return Ok(EnvelopeFieldOp::Remove);
+        }
+        EnvelopeFieldType::deserialize(de::value::StrDeserializer::<D::Error>::new(&s))
+            .map(EnvelopeFieldOp::Set)
+            .map_err(|_| {
+                de::Error::custom(format!(
+                    "unknown envelope field op {s:?}; use a field type (`string`, `int`, \
+                     `float`, `bool`, `date`, `date_time`) to set the field, or `remove` to \
+                     drop it"
+                ))
+            })
+    }
+}
+
+/// One HL7 composite-field split op, keyed by positional field name (`f08`).
+///
+/// YAML forms (the map key is the field name):
+///
+/// ```yaml
+/// f08: { components: 3 }                     # add-or-modify a split
+/// f03: remove                                # drop a declared split
+/// ```
+///
+/// The key resolves by wire position, so `f8` and `f08` address the same
+/// split. `Serialize` is derived for config-identity hashing only.
+#[derive(Debug, Clone, Serialize)]
+pub enum SplitFieldOp {
+    /// Drop the keyed split declaration, restoring the verbatim `fNN` column.
+    Remove,
+    /// Add-or-modify the keyed split. Each axis is optional so a partial
+    /// modify keeps the omitted axis: on an **existing** split an omitted
+    /// axis retains its current width; on a **new** split `components` is
+    /// required and an omitted `subcomponents`/`repetitions` defaults to 1,
+    /// exactly as in hand-written config.
+    Set {
+        /// Component columns (the `^` axis); `None` = keep current /
+        /// required (new).
+        components: Option<usize>,
+        /// Sub-component columns per component (the `&` axis); `None` =
+        /// keep current / 1 (new).
+        subcomponents: Option<usize>,
+        /// Repetition columns (the `~` axis); `None` = keep current / 1
+        /// (new).
+        repetitions: Option<usize>,
+    },
+}
+
+impl<'de> Deserialize<'de> for SplitFieldOp {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Two accepted YAML shapes:
+        //   remove                                     (bare scalar)
+        //   { components?, subcomponents?, repetitions? }   (split map)
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct SetMap {
+            #[serde(default)]
+            components: Option<usize>,
+            #[serde(default)]
+            subcomponents: Option<usize>,
+            #[serde(default)]
+            repetitions: Option<usize>,
+        }
+
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Either {
+            Scalar(String),
+            Map(SetMap),
+        }
+
+        match Either::deserialize(d)? {
+            Either::Scalar(s) if s == "remove" => Ok(SplitFieldOp::Remove),
+            Either::Scalar(other) => Err(de::Error::custom(format!(
+                "unknown split_fields op {other:?}; the bare scalar form only accepts `remove` \
+                 — use `{{ components: <n>, subcomponents: <n>, repetitions: <n> }}` to add or \
+                 modify a split"
+            ))),
+            Either::Map(m) => Ok(SplitFieldOp::Set {
+                components: m.components,
+                subcomponents: m.subcomponents,
+                repetitions: m.repetitions,
+            }),
+        }
+    }
+}
+
 /// Apply channel source-config patches to the parsed config in place.
 ///
 /// Runs after parse and before `validate_config`, so the patched config is
 /// the one validated and compiled. Each entry names a source node; an unknown
-/// source name or an ill-formed op is a config error (E230–E235) reported
+/// source name or an ill-formed op is a config error (E230–E240) reported
 /// before the pipeline compiles.
 pub fn apply_source_patches(
     config: &mut PipelineConfig,
@@ -356,6 +550,22 @@ pub fn apply_source_patches(
         apply_schema_ops(&mut body.schema, &patch.schema, src_name, None)?;
         apply_array_path_ops(&mut body.source, &patch.array_paths, src_name)?;
         apply_option_ops(&mut body.source, &patch.options, src_name)?;
+        // Format-structure ops apply after the options merge so a keyed op
+        // layers deterministically on top of an `options`-blob replacement of
+        // the same declaration in the same patch.
+        apply_nested_section_op(
+            &mut body.source,
+            patch.group_section.as_ref(),
+            X12SectionSlot::Group,
+            src_name,
+        )?;
+        apply_nested_section_op(
+            &mut body.source,
+            patch.set_section.as_ref(),
+            X12SectionSlot::Set,
+            src_name,
+        )?;
+        apply_split_field_ops(&mut body.source, &patch.split_fields, src_name)?;
     }
     Ok(())
 }
@@ -659,6 +869,230 @@ fn options_rejected(src: &str, fmt: &str, err: &serde_json::Error) -> ConfigErro
 fn options_internal(src: &str, err: &serde_json::Error) -> ConfigError {
     ConfigError::Validation(format!(
         "[E235] channel options patch on source '{src}': could not read current options: {err}"
+    ))
+}
+
+/// Which X12 nested-envelope declaration a [`NestedSectionOp`] targets.
+#[derive(Clone, Copy)]
+enum X12SectionSlot {
+    /// The `GS` functional-group level (`group_section`).
+    Group,
+    /// The `ST` transaction-set level (`set_section`).
+    Set,
+}
+
+impl X12SectionSlot {
+    /// The patch key, used verbatim in diagnostics.
+    fn key(self) -> &'static str {
+        match self {
+            X12SectionSlot::Group => "group_section",
+            X12SectionSlot::Set => "set_section",
+        }
+    }
+
+    /// The targeted declaration on the source's X12 options.
+    fn slot(self, opts: &mut X12InputOptions) -> &mut Option<NestedEnvelopeSection> {
+        match self {
+            X12SectionSlot::Group => &mut opts.group_section,
+            X12SectionSlot::Set => &mut opts.set_section,
+        }
+    }
+}
+
+/// Apply one `group_section` / `set_section` op to the source's X12 options
+/// in place. A non-X12 source is rejected (E238); a `remove` of an absent
+/// declaration or field is E239; creating a declaration without a `name` is
+/// E240.
+fn apply_nested_section_op(
+    source: &mut SourceConfig,
+    op: Option<&NestedSectionOp>,
+    which: X12SectionSlot,
+    src: &str,
+) -> Result<(), ConfigError> {
+    let Some(op) = op else {
+        return Ok(());
+    };
+    let fmt = source.format.format_name();
+    let InputFormat::X12(opts) = &mut source.format else {
+        return Err(ConfigError::Validation(format!(
+            "[E238] channel {key} patch on source '{src}': X12 nested-envelope section ops \
+             apply only to an `x12` source (source format is {fmt})",
+            key = which.key(),
+        )));
+    };
+    match op {
+        NestedSectionOp::Remove => {
+            let removed = opts.as_mut().and_then(|o| which.slot(o).take());
+            if removed.is_none() {
+                return Err(ConfigError::Validation(format!(
+                    "[E239] channel {key} patch on source '{src}': remove of a declaration the \
+                     source does not carry",
+                    key = which.key(),
+                )));
+            }
+        }
+        NestedSectionOp::Set { name, fields } => {
+            let slot = which.slot(opts.get_or_insert_with(Default::default));
+            match slot {
+                Some(existing) => {
+                    if let Some(n) = name {
+                        existing.name = n.clone();
+                    }
+                    for (field, field_op) in fields {
+                        match field_op {
+                            EnvelopeFieldOp::Set(ty) => {
+                                existing.fields.insert(field.clone(), *ty);
+                            }
+                            EnvelopeFieldOp::Remove => {
+                                if existing.fields.shift_remove(field).is_none() {
+                                    return Err(unknown_nested_field(src, which, field));
+                                }
+                            }
+                        }
+                    }
+                }
+                None => {
+                    let name = name.clone().ok_or_else(|| {
+                        ConfigError::Validation(format!(
+                            "[E240] channel {key} patch on source '{src}': the source declares \
+                             no {key} yet, so the patch creates one and must carry a `name`",
+                            key = which.key(),
+                        ))
+                    })?;
+                    let mut new_fields = IndexMap::new();
+                    for (field, field_op) in fields {
+                        match field_op {
+                            EnvelopeFieldOp::Set(ty) => {
+                                new_fields.insert(field.clone(), *ty);
+                            }
+                            EnvelopeFieldOp::Remove => {
+                                return Err(unknown_nested_field(src, which, field));
+                            }
+                        }
+                    }
+                    *slot = Some(NestedEnvelopeSection {
+                        name,
+                        fields: new_fields,
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn unknown_nested_field(src: &str, which: X12SectionSlot, field: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E239] channel {key} patch on source '{src}': remove of unknown field '{field}'",
+        key = which.key(),
+    ))
+}
+
+/// Apply field-name-keyed composite-split ops to the source's HL7 options in
+/// place. A non-HL7 source is rejected (E238); a `remove` of an undeclared
+/// split is E239; a malformed op — a key that is not a positional `fNN` name,
+/// an added split without `components`, or a zero axis width — is E240. Keys
+/// resolve by wire position, so `f8` addresses a split declared as `f08`.
+/// Bounds against `max_fields` and duplicate-target detection stay with
+/// `validate_config`, which runs on the patched result.
+fn apply_split_field_ops(
+    source: &mut SourceConfig,
+    ops: &IndexMap<String, SplitFieldOp>,
+    src: &str,
+) -> Result<(), ConfigError> {
+    if ops.is_empty() {
+        return Ok(());
+    }
+    let fmt = source.format.format_name();
+    let InputFormat::Hl7(opts) = &mut source.format else {
+        return Err(ConfigError::Validation(format!(
+            "[E238] channel split_fields patch on source '{src}': HL7 composite-field split \
+             ops apply only to an `hl7` source (source format is {fmt})"
+        )));
+    };
+    for (field, op) in ops {
+        let position = Hl7FieldSplitOption::parse_field_position(field).ok_or_else(|| {
+            ConfigError::Validation(format!(
+                "[E240] channel split_fields patch on source '{src}': {field:?} is not a \
+                 positional `fNN` column name (e.g. `f08`)"
+            ))
+        })?;
+        match op {
+            SplitFieldOp::Remove => {
+                let Some(entries) = opts.as_mut().and_then(|o| o.split_fields.as_mut()) else {
+                    return Err(unknown_split_field(src, field));
+                };
+                let Some(idx) = entries
+                    .iter()
+                    .position(|s| s.field_position() == Some(position))
+                else {
+                    return Err(unknown_split_field(src, field));
+                };
+                entries.remove(idx);
+            }
+            SplitFieldOp::Set {
+                components,
+                subcomponents,
+                repetitions,
+            } => {
+                // Only the widths this op itself writes are checked here, so
+                // the diagnostic blames the patch and never a pre-existing
+                // declaration (validate_config re-checks the whole result).
+                for (axis, provided) in [
+                    ("components", components),
+                    ("subcomponents", subcomponents),
+                    ("repetitions", repetitions),
+                ] {
+                    if *provided == Some(0) {
+                        return Err(ConfigError::Validation(format!(
+                            "[E240] channel split_fields patch on source '{src}': split field \
+                             '{field}' sets `{axis}: 0`; every axis width must be at least 1"
+                        )));
+                    }
+                }
+                let entries = opts
+                    .get_or_insert_with(Default::default)
+                    .split_fields
+                    .get_or_insert_with(Vec::new);
+                if let Some(existing) = entries
+                    .iter_mut()
+                    .find(|s| s.field_position() == Some(position))
+                {
+                    // Partial modify: an omitted axis keeps its current width.
+                    if let Some(c) = components {
+                        existing.components = *c;
+                    }
+                    if let Some(s) = subcomponents {
+                        existing.subcomponents = *s;
+                    }
+                    if let Some(r) = repetitions {
+                        existing.repetitions = *r;
+                    }
+                } else {
+                    let components = components.ok_or_else(|| {
+                        ConfigError::Validation(format!(
+                            "[E240] channel split_fields patch on source '{src}': the source \
+                             declares no split for field '{field}' yet, so the patch adds one \
+                             and must carry `components`"
+                        ))
+                    })?;
+                    entries.push(Hl7FieldSplitOption {
+                        field: field.clone(),
+                        components,
+                        subcomponents: subcomponents.unwrap_or(1),
+                        repetitions: repetitions.unwrap_or(1),
+                    });
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn unknown_split_field(src: &str, field: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E239] channel split_fields patch on source '{src}': remove of a split the source \
+         does not declare for field '{field}'"
     ))
 }
 
@@ -1362,5 +1796,392 @@ nodes:
             "{}",
             err.0
         );
+    }
+
+    /// An X12 source declaring a typed `group_section` (`set_section` left
+    /// undeclared), feeding one output.
+    fn x12_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: x12
+      path: /tmp/in.x12
+      options:
+        group_section:
+          name: grp
+          fields:
+            e06: string
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse x12 pipeline")
+    }
+
+    fn x12_options(config: &PipelineConfig) -> &X12InputOptions {
+        match &config.source_configs().next().expect("one source").format {
+            InputFormat::X12(Some(opts)) => opts,
+            other => panic!("expected x12 options, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nested_section_modify_patches_name_and_fields() {
+        let mut config = x12_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "group_section:\n  name: fg\n  fields:\n    e06: int\n    e07: string\n",
+            ),
+        )
+        .unwrap();
+        let section = x12_options(&config).group_section.as_ref().unwrap();
+        assert_eq!(section.name, "fg");
+        assert_eq!(section.fields.get("e06"), Some(&EnvelopeFieldType::Int));
+        assert_eq!(section.fields.get("e07"), Some(&EnvelopeFieldType::String));
+        assert_eq!(section.fields.len(), 2);
+    }
+
+    #[test]
+    fn nested_section_modify_keeps_omitted_name() {
+        // A field-only modify must not clobber the declaration's name.
+        let mut config = x12_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("group_section:\n  fields:\n    e07: date\n"),
+        )
+        .unwrap();
+        let section = x12_options(&config).group_section.as_ref().unwrap();
+        assert_eq!(section.name, "grp");
+        assert_eq!(section.fields.get("e06"), Some(&EnvelopeFieldType::String));
+        assert_eq!(section.fields.get("e07"), Some(&EnvelopeFieldType::Date));
+    }
+
+    #[test]
+    fn nested_section_field_remove_drops_field() {
+        let mut config = x12_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("group_section:\n  fields:\n    e06: remove\n"),
+        )
+        .unwrap();
+        let section = x12_options(&config).group_section.as_ref().unwrap();
+        assert_eq!(section.name, "grp");
+        assert!(section.fields.is_empty());
+    }
+
+    #[test]
+    fn nested_section_field_remove_unknown_errors_e239() {
+        let mut config = x12_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("group_section:\n  fields:\n    e99: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E239"), "{err}");
+    }
+
+    #[test]
+    fn nested_section_remove_drops_declaration() {
+        let mut config = x12_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("group_section: remove\n"),
+        )
+        .unwrap();
+        assert!(x12_options(&config).group_section.is_none());
+    }
+
+    #[test]
+    fn nested_section_remove_absent_errors_e239() {
+        // `set_section` is not declared on the fixture source.
+        let mut config = x12_pipeline();
+        let err = apply(&mut config, "src", patch_from_yaml("set_section: remove\n")).unwrap_err();
+        assert!(err.to_string().contains("E239"), "{err}");
+    }
+
+    #[test]
+    fn nested_section_create_sets_declaration() {
+        let mut config = x12_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "set_section:\n  name: txn\n  fields:\n    e01: string\n    e02: int\n",
+            ),
+        )
+        .unwrap();
+        let section = x12_options(&config).set_section.as_ref().unwrap();
+        assert_eq!(section.name, "txn");
+        assert_eq!(section.fields.get("e01"), Some(&EnvelopeFieldType::String));
+        assert_eq!(section.fields.get("e02"), Some(&EnvelopeFieldType::Int));
+    }
+
+    #[test]
+    fn nested_section_create_requires_name_e240() {
+        let mut config = x12_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("set_section:\n  fields:\n    e01: string\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E240"), "{err}");
+    }
+
+    #[test]
+    fn nested_section_create_with_field_remove_errors_e239() {
+        // A field `remove` while creating a new declaration removes a field
+        // that cannot exist yet.
+        let mut config = x12_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("set_section:\n  name: txn\n  fields:\n    e01: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E239"), "{err}");
+    }
+
+    #[test]
+    fn nested_section_on_non_x12_errors_e238() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("group_section:\n  name: fg\n"),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("E238"), "{msg}");
+        assert!(msg.contains("csv"), "names the actual format: {msg}");
+    }
+
+    #[test]
+    fn nested_section_unknown_key_rejected_at_parse() {
+        let err =
+            crate::yaml::from_str::<SourceConfigPatch>("group_section:\n  nam: fg\n").unwrap_err();
+        let msg = format!("{}", err.0);
+        assert!(msg.contains("nam") || msg.contains("unknown"), "{msg}");
+    }
+
+    #[test]
+    fn nested_section_unknown_field_type_rejected_at_parse() {
+        let err = crate::yaml::from_str::<SourceConfigPatch>(
+            "group_section:\n  fields:\n    e01: strin\n",
+        )
+        .unwrap_err();
+        let msg = format!("{}", err.0);
+        assert!(msg.contains("strin"), "{msg}");
+    }
+
+    #[test]
+    fn nested_section_applies_after_options_blob() {
+        // A patch carrying BOTH an `options`-blob replacement of the
+        // declaration and a keyed op: the keyed op wins because it applies
+        // after the options merge.
+        let mut config = x12_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "options:\n  group_section: { name: blob, fields: { e01: string } }\ngroup_section:\n  name: keyed\n",
+            ),
+        )
+        .unwrap();
+        let section = x12_options(&config).group_section.as_ref().unwrap();
+        assert_eq!(section.name, "keyed");
+        // The blob-replaced fields survive the field-less keyed rename.
+        assert_eq!(section.fields.get("e01"), Some(&EnvelopeFieldType::String));
+        assert_eq!(section.fields.len(), 1);
+    }
+
+    /// An HL7 source declaring one composite-field split (`f03`), feeding one
+    /// output.
+    fn hl7_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: hl7
+      path: /tmp/in.hl7
+      options:
+        split_fields:
+          - { field: f03, components: 5 }
+      schema:
+        - { name: seg_id, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse hl7 pipeline")
+    }
+
+    fn hl7_splits(config: &PipelineConfig) -> Vec<(String, usize, usize, usize)> {
+        match &config.source_configs().next().expect("one source").format {
+            InputFormat::Hl7(Some(opts)) => opts
+                .split_fields
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .map(|s| (s.field, s.components, s.subcomponents, s.repetitions))
+                .collect(),
+            other => panic!("expected hl7 options, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn split_fields_add_new_entry() {
+        let mut config = hl7_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f08: { components: 2 }\n"),
+        )
+        .unwrap();
+        let splits = hl7_splits(&config);
+        assert_eq!(splits.len(), 2);
+        // New entry: omitted subcomponents/repetitions default to 1, exactly
+        // as in hand-written config.
+        assert!(splits.contains(&("f08".to_string(), 2, 1, 1)), "{splits:?}");
+    }
+
+    #[test]
+    fn split_fields_partial_modify_keeps_omitted_axes() {
+        let mut config = hl7_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f03: { subcomponents: 2 }\n"),
+        )
+        .unwrap();
+        // components stays 5 — a partial modify must not reset it.
+        assert_eq!(hl7_splits(&config), vec![("f03".to_string(), 5, 2, 1)]);
+    }
+
+    #[test]
+    fn split_fields_key_resolves_by_wire_position() {
+        // `f3` and `f03` name the same wire position, so the patch modifies
+        // the existing declaration rather than adding a duplicate split.
+        let mut config = hl7_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f3: { repetitions: 4 }\n"),
+        )
+        .unwrap();
+        assert_eq!(hl7_splits(&config), vec![("f03".to_string(), 5, 1, 4)]);
+    }
+
+    #[test]
+    fn split_fields_remove_entry() {
+        let mut config = hl7_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f03: remove\n"),
+        )
+        .unwrap();
+        assert!(hl7_splits(&config).is_empty());
+    }
+
+    #[test]
+    fn split_fields_remove_unknown_errors_e239() {
+        let mut config = hl7_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f09: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E239"), "{err}");
+    }
+
+    #[test]
+    fn split_fields_add_requires_components_e240() {
+        let mut config = hl7_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f08: { repetitions: 2 }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E240"), "{err}");
+    }
+
+    #[test]
+    fn split_fields_malformed_key_errors_e240() {
+        let mut config = hl7_pipeline();
+        for key in ["q08", "f", "f0", "f1x"] {
+            let err = apply(
+                &mut config,
+                "src",
+                patch_from_yaml(&format!("split_fields:\n  {key}: {{ components: 2 }}\n")),
+            )
+            .unwrap_err();
+            assert!(err.to_string().contains("E240"), "key {key:?}: {err}");
+        }
+    }
+
+    #[test]
+    fn split_fields_zero_axis_errors_e240() {
+        let mut config = hl7_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f03: { components: 0 }\n"),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("E240"), "{msg}");
+        assert!(msg.contains("components"), "names the zero axis: {msg}");
+    }
+
+    #[test]
+    fn split_fields_on_non_hl7_errors_e238() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("split_fields:\n  f08: { components: 2 }\n"),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("E238"), "{msg}");
+        assert!(msg.contains("csv"), "names the actual format: {msg}");
+    }
+
+    #[test]
+    fn patch_with_only_structure_ops_is_not_empty() {
+        // If `is_empty` misses a format-structure op the apply pass would
+        // silently skip it.
+        assert!(!patch_from_yaml("group_section: remove\n").is_empty());
+        assert!(!patch_from_yaml("set_section:\n  name: txn\n").is_empty());
+        assert!(!patch_from_yaml("split_fields:\n  f01: remove\n").is_empty());
+        assert!(SourceConfigPatch::default().is_empty());
     }
 }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -4652,27 +4652,77 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         }
     }
 
+    // Node-scoped checks (wired Envelope trailer, Transform `declares:`,
+    // log directives, per-Transform `batch_size`) live in
+    // `validate_node_configs`, which composition-body binding also runs
+    // over `.comp.yaml` body nodes — a body node is held to exactly the
+    // same checks as a top-level node. Surface the first violation as
+    // the validation error, matching the fail-fast shape of the checks
+    // above.
+    if let Some(violation) = validate_node_configs(&config.nodes).into_iter().next() {
+        return Err(ConfigError::Validation(violation.message));
+    }
+
+    validate_unique_scoped_declarations(config)?;
+
+    // Reject a zero pipeline-level `batch_size`: a zero-event batch
+    // never flushes, so it would accumulate a whole stage in memory —
+    // the inverse of the streaming handoff's purpose. Omitting the knob
+    // (`None`) inherits the built-in default and is the common case.
+    // The per-Transform override is checked in `validate_node_configs`.
+    if config.pipeline.batch_size == Some(0) {
+        return Err(ConfigError::Validation(
+            "pipeline.batch_size must be >= 1 (omit it to use the default)".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// A node-scoped config violation found by [`validate_node_configs`]:
+/// the offending node's index in the validated slice plus the same
+/// human-readable message top-level validation reports.
+pub(crate) struct NodeConfigViolation {
+    /// Index into the node slice passed to [`validate_node_configs`],
+    /// so callers can anchor a diagnostic span to the offending node.
+    pub(crate) node_index: usize,
+    pub(crate) message: String,
+}
+
+/// Node-scoped config checks that need only the node list — no
+/// source/output/pipeline context. Shared by top-level
+/// [`validate_config`] (which surfaces the first violation as
+/// [`ConfigError::Validation`]) and composition-body binding (which
+/// surfaces every violation as an `E115` diagnostic), so a node inside
+/// a `.comp.yaml` body cannot bypass a check a top-level node would
+/// fail.
+pub(crate) fn validate_node_configs(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeConfigViolation> {
+    let mut violations = Vec::new();
+
     // Reject a wired `trailer:` port on an Envelope node. A wired `header:` is
-    // now a real port (it replaces each body grain's ambient envelope with a
+    // a real port (it replaces each body grain's ambient envelope with a
     // grain-matched header record), but `trailer:` has no draining path yet, so
     // a wired value would silently do nothing. The undeclared-producer case for
-    // a wired `header:` is caught earlier by the unified input-reference pass
+    // a wired `header:` is caught by the unified input-reference pass
     // (E004), exactly as for any other consumer input.
-    for spanned in &config.nodes {
+    for (node_index, spanned) in nodes.iter().enumerate() {
         if let PipelineNode::Envelope { header, .. } = &spanned.value
             && header.trailer.is_some()
         {
-            return Err(ConfigError::Validation(format!(
-                "envelope node '{}': explicit `trailer` input wiring is not yet supported — \
-                 omit it to frame with the body's own envelope",
-                header.name
-            )));
+            violations.push(NodeConfigViolation {
+                node_index,
+                message: format!(
+                    "envelope node '{}': explicit `trailer` input wiring is not yet supported — \
+                     omit it to frame with the body's own envelope",
+                    header.name
+                ),
+            });
         }
     }
 
     // Validate per-Transform `declares:` entries: reserved-name
     // collisions per-scope, and default-type matches.
-    for spanned in &config.nodes {
+    for (node_index, spanned) in nodes.iter().enumerate() {
         let PipelineNode::Transform {
             header,
             config: body,
@@ -4687,26 +4737,38 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                 pipeline_node::VarScope::Record => "record",
             };
             if reserved_names_for(entry.scope).contains(&entry.name.as_str()) {
-                return Err(ConfigError::Validation(format!(
-                    "transform '{}': declares: '{}' is a reserved ${} member name and cannot be used as a variable",
-                    header.name, entry.name, scope_label,
-                )));
+                violations.push(NodeConfigViolation {
+                    node_index,
+                    message: format!(
+                        "transform '{}': declares: '{}' is a reserved ${} member name and cannot be used as a variable",
+                        header.name, entry.name, scope_label,
+                    ),
+                });
             }
-            if let Some(default) = &entry.default {
-                check_scoped_var_default(
+            if let Some(default) = &entry.default
+                && let Err(err) = check_scoped_var_default(
                     &format!("transform '{}' declares", header.name),
                     &entry.name,
                     entry.var_type,
                     default,
-                )?;
+                )
+            {
+                violations.push(NodeConfigViolation {
+                    node_index,
+                    // `check_scoped_var_default` only ever constructs the
+                    // `Validation` variant; unwrap it so the message is not
+                    // double-prefixed when the caller re-wraps it.
+                    message: match err {
+                        ConfigError::Validation(msg) => msg,
+                        other => other.to_string(),
+                    },
+                });
             }
         }
     }
 
-    validate_unique_scoped_declarations(config)?;
-
     // Validate log directives on Transform nodes.
-    for spanned in &config.nodes {
+    for (node_index, spanned) in nodes.iter().enumerate() {
         if let PipelineNode::Transform {
             header,
             config: body,
@@ -4716,49 +4778,50 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
             for (i, d) in directives.iter().enumerate() {
                 if let Some(every) = d.every {
                     if every == 0 {
-                        return Err(ConfigError::Validation(format!(
-                            "transform '{}': log directive #{}: every must be >= 1",
-                            header.name,
-                            i + 1,
-                        )));
-                    }
-                    if d.when != LogTiming::PerRecord {
-                        return Err(ConfigError::Validation(format!(
-                            "transform '{}': log directive #{}: 'every' is only valid with when: per_record",
-                            header.name,
-                            i + 1,
-                        )));
+                        violations.push(NodeConfigViolation {
+                            node_index,
+                            message: format!(
+                                "transform '{}': log directive #{}: every must be >= 1",
+                                header.name,
+                                i + 1,
+                            ),
+                        });
+                    } else if d.when != LogTiming::PerRecord {
+                        violations.push(NodeConfigViolation {
+                            node_index,
+                            message: format!(
+                                "transform '{}': log directive #{}: 'every' is only valid with when: per_record",
+                                header.name,
+                                i + 1,
+                            ),
+                        });
                     }
                 }
             }
         }
     }
 
-    // Reject a zero `batch_size` at both the pipeline level and any
-    // per-Transform override: a zero-event batch never flushes, so it
-    // would accumulate a whole stage in memory — the inverse of the
-    // streaming handoff's purpose. Omitting the knob (`None`) inherits
-    // the built-in default and is the common case.
-    if config.pipeline.batch_size == Some(0) {
-        return Err(ConfigError::Validation(
-            "pipeline.batch_size must be >= 1 (omit it to use the default)".to_string(),
-        ));
-    }
-    for spanned in &config.nodes {
+    // Reject a zero per-Transform `batch_size` override — same
+    // never-flushes hazard as the pipeline-level knob, checked in
+    // `validate_config`.
+    for (node_index, spanned) in nodes.iter().enumerate() {
         if let PipelineNode::Transform {
             header,
             config: body,
         } = &spanned.value
             && body.batch_size == Some(0)
         {
-            return Err(ConfigError::Validation(format!(
-                "transform '{}': batch_size must be >= 1 (omit it to inherit pipeline.batch_size)",
-                header.name,
-            )));
+            violations.push(NodeConfigViolation {
+                node_index,
+                message: format!(
+                    "transform '{}': batch_size must be >= 1 (omit it to inherit pipeline.batch_size)",
+                    header.name,
+                ),
+            });
         }
     }
 
-    Ok(())
+    violations
 }
 
 /// Validate an HL7 source's `split_fields` declarations: each names a

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -732,7 +732,16 @@ impl Hl7FieldSplitOption {
     /// `None` when it is not an `f`-prefixed digit run or names position 0.
     /// Config validation rejects a `None` before the reader is built.
     pub fn field_position(&self) -> Option<usize> {
-        let rest = self.field.strip_prefix('f')?;
+        Self::parse_field_position(&self.field)
+    }
+
+    /// Parse a 1-based wire field position from a positional `fNN` column
+    /// name (`f08` → 8), or `None` when the name is not an `f`-prefixed
+    /// digit run or names position 0. Shared with the channel `split_fields`
+    /// patch handler so a patch key resolves exactly like a declared
+    /// `field:` name.
+    pub fn parse_field_position(name: &str) -> Option<usize> {
+        let rest = name.strip_prefix('f')?;
         if rest.is_empty() || !rest.bytes().all(|b| b.is_ascii_digit()) {
             return None;
         }

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -2740,6 +2740,36 @@ fn bind_composition(
             None => return,
         };
 
+    // 7b. Body nodes never flow through top-level config validation
+    // (`validate_config` sees only the call-site pipeline's own nodes),
+    // so run the shared node-scoped checks here. Without this pass a
+    // body Envelope with a wired `trailer:` — or a Transform with a
+    // reserved `declares:` name, a mistyped declare default, a zero
+    // `batch_size`, or an invalid log directive — reaches the executor
+    // and dies as an internal error instead of a compile diagnostic.
+    // Emit one E115 per violation and abandon the body, mirroring the
+    // other early-outs.
+    {
+        let violations = crate::config::pipeline::validate_node_configs(&body_file.nodes);
+        if !violations.is_empty() {
+            for violation in violations {
+                diags.push(Diagnostic::error(
+                    "E115",
+                    format!(
+                        "composition node {node_name:?}: body file {}: {}",
+                        resolved_path.display(),
+                        violation.message
+                    ),
+                    LabeledSpan::primary(
+                        span_for_node(&body_file.nodes[violation.node_index]),
+                        String::new(),
+                    ),
+                ));
+            }
+            return;
+        }
+    }
+
     // 8. Enter nested scope.
     let body_id = artifacts.fresh_body_id();
 

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -354,6 +354,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E106" => Some(include_str!("../../../../docs/explain/E106.md")),
         "E107" => Some(include_str!("../../../../docs/explain/E107.md")),
         "E108" => Some(include_str!("../../../../docs/explain/E108.md")),
+        "E115" => Some(include_str!("../../../../docs/explain/E115.md")),
         "E300" => Some(include_str!("../../../../docs/explain/E300.md")),
         "E301" => Some(include_str!("../../../../docs/explain/E301.md")),
         "E303" => Some(include_str!("../../../../docs/explain/E303.md")),
@@ -609,12 +610,12 @@ mod tests {
     #[test]
     fn test_explain_docs_all_have_required_sections() {
         let codes = [
-            "E101", "E102", "E103", "E104", "E106", "E107", "E108", "E150b", "E150c", "E150d",
-            "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308", "E309",
-            "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331", "E332",
-            "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342", "E343",
-            "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352", "E353", "E354",
-            "E355", "E15Y", "W101", "W302", "W305", "W306",
+            "E101", "E102", "E103", "E104", "E106", "E107", "E108", "E115", "E150b", "E150c",
+            "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
+            "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
+            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
+            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352", "E353",
+            "E354", "E355", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
@@ -1,0 +1,196 @@
+//! Composition-body nodes must pass the same node-scoped config checks
+//! as top-level nodes (E115).
+//!
+//! Top-level `validate_config` runs before compile on the call-site
+//! pipeline's own nodes only; composition bodies are re-read and parsed
+//! during binding on a path that historically skipped those checks. A
+//! body Envelope with a wired `trailer:` therefore sailed past the
+//! top-level "not yet supported" rejection and reached the executor,
+//! where it died as an internal error (the envelope dispatch expects a
+//! single body predecessor and finds two). `bind_composition` now runs
+//! the shared `validate_node_configs` pass over body nodes and rejects
+//! each violation with an E115 diagnostic at compile time.
+
+use std::path::PathBuf;
+
+use crate::config::{CompileContext, PipelineConfig, parse_config};
+
+/// Write a `.comp.yaml` body and a pipeline invoking it, and return the
+/// compile-ready pieces. The body's `nodes:` section is caller-supplied
+/// so each test exercises a different body-node violation.
+fn workspace_with_body(body_nodes: &str, output_node: &str) -> (tempfile::TempDir, PipelineConfig) {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    std::fs::write(
+        comp_dir.join("framed_body.comp.yaml"),
+        format!(
+            r#"_compose:
+  name: framed_body
+  inputs:
+    inp:
+      schema:
+        - {{ name: id, type: string }}
+        - {{ name: val, type: int }}
+  outputs:
+    out: {output_node}
+  config_schema: {{}}
+
+nodes:
+{body_nodes}"#
+        ),
+    )
+    .expect("write comp");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    let yaml = r#"
+pipeline:
+  name: body_node_config_demo
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - { name: id, type: string }
+        - { name: val, type: int }
+  - type: composition
+    name: body
+    input: src
+    use: ../compositions/framed_body.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out_body
+    input: body
+    config:
+      name: out_body
+      type: csv
+      path: out_body.csv
+      include_unmapped: true
+"#;
+
+    let config: PipelineConfig = parse_config(yaml).expect("parse top-level pipeline");
+    (workspace, config)
+}
+
+/// A body Envelope wiring the `trailer:` port fails compile with an
+/// E115 diagnostic carrying the same "not yet supported" wording the
+/// top-level rejection uses — instead of reaching the executor and
+/// dying as an internal error.
+#[test]
+fn body_envelope_wired_trailer_rejected_with_e115() {
+    let (workspace, config) = workspace_with_body(
+        r#"  - type: transform
+    name: shape
+    input: inp
+    config:
+      cxl: |
+        emit id = id
+        emit val = val
+  - type: envelope
+    name: framed
+    body: shape
+    trailer: shape
+    config:
+      strategy: preserve
+"#,
+        "framed",
+    );
+
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    let err = config
+        .compile(&ctx)
+        .expect_err("a body envelope with a wired trailer must fail to compile");
+
+    let diag = err.iter().find(|d| d.code == "E115").unwrap_or_else(|| {
+        panic!("expected an E115 diagnostic for the wired body trailer; got: {err:?}")
+    });
+    assert!(
+        diag.message.contains("envelope node 'framed'")
+            && diag.message.contains("`trailer`")
+            && diag.message.contains("not yet supported"),
+        "the E115 message must carry the top-level not-yet-supported trailer wording: {:?}",
+        diag.message
+    );
+    assert!(
+        diag.message.contains("framed_body.comp.yaml"),
+        "the E115 message must name the offending body file: {:?}",
+        diag.message
+    );
+}
+
+/// A body Envelope wiring only the `header:` port still compiles — a
+/// wired header is a real, supported port, so body binding must not
+/// reject more than the top level does.
+#[test]
+fn body_envelope_wired_header_still_compiles() {
+    let (workspace, config) = workspace_with_body(
+        r#"  - type: transform
+    name: shape
+    input: inp
+    config:
+      cxl: |
+        emit id = id
+        emit val = val
+  - type: transform
+    name: hdr
+    input: inp
+    config:
+      cxl: |
+        emit id = id
+  - type: envelope
+    name: framed
+    body: shape
+    header: hdr
+    config:
+      strategy: preserve
+"#,
+        "framed",
+    );
+
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    config
+        .compile(&ctx)
+        .expect("a body envelope with only a wired header must compile");
+}
+
+/// The shared pass covers every node-scoped check, not just the
+/// Envelope trailer: a body Transform with `batch_size: 0` is rejected
+/// with the same message top-level validation produces.
+#[test]
+fn body_transform_zero_batch_size_rejected_with_e115() {
+    let (workspace, config) = workspace_with_body(
+        r#"  - type: transform
+    name: shape
+    input: inp
+    config:
+      batch_size: 0
+      cxl: |
+        emit id = id
+        emit val = val
+"#,
+        "shape",
+    );
+
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    let err = config
+        .compile(&ctx)
+        .expect_err("a body transform with batch_size 0 must fail to compile");
+
+    let diag = err.iter().find(|d| d.code == "E115").unwrap_or_else(|| {
+        panic!("expected an E115 diagnostic for the zero body batch_size; got: {err:?}")
+    });
+    assert!(
+        diag.message
+            .contains("transform 'shape': batch_size must be >= 1"),
+        "the E115 message must carry the top-level batch_size wording: {:?}",
+        diag.message
+    );
+}

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -1,3 +1,4 @@
+mod body_node_config_validation;
 mod bound_schemas;
 mod ck_aligned_partition;
 mod ck_lattice;

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2460,7 +2460,7 @@ fn run_explain(args: &ExplainArgs) -> Result<(), Box<dyn std::error::Error>> {
             }
             None => {
                 return Err(format!(
-                    "unknown diagnostic code '{code}'. Valid codes: E101-E104, E106-E108, \
+                    "unknown diagnostic code '{code}'. Valid codes: E101-E104, E106-E108, E115, \
                      E150b-E150e, E15Y, E300/E301/E303-E313/E319, E320/E321/E323, E330-E354, \
                      W101/W302/W305/W306"
                 )

--- a/crates/cxl/src/eval/tests.rs
+++ b/crates/cxl/src/eval/tests.rs
@@ -183,6 +183,30 @@ fn test_eval_decimal_comparison_and_round() {
 }
 
 #[test]
+fn test_eval_decimal_round_to_stays_decimal_and_composes() {
+    // round_to on a decimal rounds exactly (banker's rounding) and stays in
+    // the decimal domain rather than converting to a binary float.
+    let r = eval_single(
+        "emit v = x.round_to(2)",
+        &["x"],
+        HashMap::from([("x".into(), dec(19995, 3))]), // 19.995 -> 20.00 (half-even)
+    );
+    assert_eq!(r, dec(2000, 2));
+
+    // The rounded decimal composes with another decimal without a cast, and
+    // the sum is exact.
+    let total = eval_single(
+        "emit total = amount.round_to(2) + fee",
+        &["amount", "fee"],
+        HashMap::from([
+            ("amount".into(), dec(2125, 3)), // 2.125 -> 2.12 (half-even)
+            ("fee".into(), dec(50, 2)),
+        ]),
+    );
+    assert_eq!(total, dec(262, 2));
+}
+
+#[test]
 fn test_eval_arithmetic_null_propagation() {
     // Null + 1 → Null
     let v = eval_single(

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -807,7 +807,24 @@ impl<'a> TypeChecker<'a> {
 
                 // Look up return type from registry
                 let ty = if let Some(def) = self.registry.lookup_method(method) {
-                    Type::from_type_tag(def.return_type)
+                    // An exact-decimal receiver stays in the decimal domain
+                    // for the numeric methods whose evaluation is closed over
+                    // decimals: abs, whole-valued ceil/floor, and banker's
+                    // rounding for round/round_to. The registry declares
+                    // these over the general Numeric receiver with
+                    // Float/Int/Numeric results; taking that at face value
+                    // here would poison decimal composition downstream,
+                    // because decimal deliberately never unifies with float
+                    // or the Numeric supertype. clamp/min/max are excluded:
+                    // their evaluation may return an argument value, so the
+                    // result is not guaranteed to be a decimal.
+                    if matches!(recv_ty.unwrap_nullable(), Type::Decimal)
+                        && matches!(&**method, "abs" | "ceil" | "floor" | "round" | "round_to")
+                    {
+                        Type::Decimal
+                    } else {
+                        Type::from_type_tag(def.return_type)
+                    }
                 } else {
                     Type::Any
                 };
@@ -1674,6 +1691,69 @@ mod tests {
             &schema,
         );
         assert_eq!(first_emit_expr_type(&typed), Type::Float);
+    }
+
+    #[test]
+    fn test_typecheck_decimal_receiver_numeric_methods_stay_decimal() {
+        // The registry types these methods over the general Numeric receiver
+        // (round/round_to → Float, ceil/floor → Int, abs → Numeric), but their
+        // evaluation keeps a decimal receiver in the decimal domain, so the
+        // inferred type must too.
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Decimal);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        for src in [
+            "emit v = amount.round_to(2)",
+            "emit v = amount.round(2)",
+            "emit v = amount.abs()",
+            "emit v = amount.ceil()",
+            "emit v = amount.floor()",
+        ] {
+            let typed = typecheck_ok(src, &["amount"], &schema);
+            assert_eq!(
+                first_emit_expr_type(&typed),
+                Type::Decimal,
+                "result type for `{src}`"
+            );
+        }
+    }
+
+    #[test]
+    fn test_typecheck_decimal_round_to_composes_with_decimal() {
+        // Regression: `round_to` used to take the registry's Float return at
+        // face value on a decimal receiver, so composing the result with
+        // another decimal was rejected as a decimal/float mix.
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Decimal);
+        cols.insert("fee".into(), Type::Decimal);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let typed = typecheck_ok(
+            "emit total = amount.round_to(2) + fee",
+            &["amount", "fee"],
+            &schema,
+        );
+        assert_eq!(first_emit_expr_type(&typed), Type::Decimal);
+    }
+
+    #[test]
+    fn test_typecheck_float_round_to_unchanged() {
+        // Float receivers keep the registry's Float return type.
+        let mut cols = IndexMap::new();
+        cols.insert("rate".into(), Type::Float);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let typed = typecheck_ok("emit v = rate.round_to(2)", &["rate"], &schema);
+        assert_eq!(first_emit_expr_type(&typed), Type::Float);
+    }
+
+    #[test]
+    fn test_typecheck_nullable_decimal_round_to_is_nullable_decimal() {
+        // Null propagation still applies on top of the decimal
+        // specialization: a nullable decimal receiver yields decimal?.
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::nullable(Type::Decimal));
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let typed = typecheck_ok("emit v = amount.round_to(2)", &["amount"], &schema);
+        assert_eq!(first_emit_expr_type(&typed), Type::nullable(Type::Decimal));
     }
 
     #[test]

--- a/docs/explain/E115.md
+++ b/docs/explain/E115.md
@@ -1,0 +1,62 @@
+# Error E115: Composition body node fails node-config validation
+
+## What it means
+
+A node inside a composition body (`.comp.yaml`) failed one of the
+node-scoped configuration checks that every top-level pipeline node must
+pass. Body nodes are held to exactly the same rules; the message names
+the offending node and the specific violation. The checks are:
+
+- An `envelope` node wires the `trailer:` input port, which is not yet
+  supported (a wired `header:` is fine).
+- A `transform` declares a scoped variable whose name is reserved
+  (`declares:` colliding with a built-in `$pipeline.*` / `$source.*` /
+  `$record.*` member), or whose `default` does not match its declared
+  type.
+- A `transform` log directive is invalid (`every: 0`, or `every` used
+  with a `when:` other than `per_record`).
+- A `transform` sets `batch_size: 0`, which would never flush.
+
+## Example
+
+```yaml
+# Inside my_comp.comp.yaml:
+nodes:
+  - type: transform
+    name: shape
+    input: inp
+    config:
+      cxl: "emit id = id"
+  - type: envelope
+    name: framed
+    body: shape
+    trailer: shape   # ERROR: wired trailer is not yet supported
+    config:
+      strategy: preserve
+```
+
+## How to fix
+
+Apply the same fix the equivalent top-level diagnostic asks for — the
+E115 message embeds it. For the example above: remove the `trailer:`
+wiring so the envelope frames with the body's own envelope. For a
+reserved `declares:` name, rename the variable; for a mistyped default,
+match the declared type; for `every: 0` or a zero `batch_size`, use a
+value of at least 1 (or omit the field).
+
+## Technical context
+
+Top-level nodes pass through config validation when the pipeline YAML
+is loaded, before compilation begins. Composition bodies are parsed
+later, during plan binding, on a path that historically skipped those
+node-scoped checks — so an invalid body node could reach the executor
+and fail there as an internal error instead of a clean compile
+diagnostic. Body binding now runs the same node-scoped validation the
+top level uses and reports each violation as an E115 anchored to the
+offending body node, keeping the two surfaces from drifting apart.
+
+## See also
+
+- E101 (composition body parse error)
+- E108 (composition body references enclosing scope)
+- E111 (composition body has zero nodes)

--- a/docs/user/src/cxl/builtins-numeric.md
+++ b/docs/user/src/cxl/builtins-numeric.md
@@ -6,6 +6,9 @@ CXL provides 8 built-in methods for numeric operations. These methods work on bo
 [`decimal`](types.md#the-decimal-type) receiver and return an exact decimal
 result — `d.round(2)` rounds `d` to two fractional digits using banker's
 rounding, staying in the decimal domain rather than converting to a float.
+The type checker infers `decimal` for these calls as well, so the result
+composes with other decimals without a cast:
+`amount.round_to(2) + fee` typechecks when both columns are `decimal`.
 
 ## abs() -> Numeric
 
@@ -82,6 +85,8 @@ $ cxl eval -e 'emit result = (-3.2).floor()'
 ## round([decimals: Int]) -> Float
 
 Rounds to the specified number of decimal places. Default is 0 decimal places.
+On a `decimal` receiver the result is a `decimal` (exact banker's rounding),
+not a float.
 
 ```bash
 $ cxl eval -e 'emit result = 3.456.round()'
@@ -106,6 +111,8 @@ $ cxl eval -e 'emit result = 3.456.round(2)'
 ## round_to(decimals: Int) -> Float
 
 Rounds to the specified number of decimal places. Unlike `round()`, the `decimals` argument is required.
+On a `decimal` receiver the result is a `decimal` (exact banker's rounding),
+not a float.
 
 ```bash
 $ cxl eval -e 'emit result = 3.14159.round_to(3)'

--- a/docs/user/src/formats/fixed-width.md
+++ b/docs/user/src/formats/fixed-width.md
@@ -33,6 +33,19 @@ declaration carries both the byte range and the CXL type, the physical layout
 and the types can never drift apart. A layout shared across pipelines can live
 in an external `.schema.yaml` file referenced by `schema: layout.schema.yaml`.
 
+## Writing fixed-width output
+
+A fixed-width **output** node declares the same column layout in its
+`schema:`. The writer places every field at its declared byte range —
+`start` plus `width` (or `end`), resolved exactly as the reader slices —
+regardless of the order the columns are declared in, so a file written
+with a schema reads back under that same schema. Byte ranges the layout
+leaves undeclared (a gap between fields) are filled with spaces. A column
+that omits `start` continues at the previous column's end, so a
+width-only schema lays its fields out sequentially. Two columns whose
+byte ranges overlap have no consistent layout; the writer rejects such a
+schema when the output opens, naming both columns and their ranges.
+
 ## Options
 
 | Option | Default | Description |

--- a/docs/user/src/formats/x12.md
+++ b/docs/user/src/formats/x12.md
@@ -32,6 +32,13 @@ The `ISA13` interchange control number is located as the 13th element of
 the header split on the discovered element separator — structurally, not by
 an absolute byte offset — so producer padding quirks do not misalign it.
 
+On output, an X12 sink that echoes the header via `interchange_from_doc`
+also adopts the source's discovered delimiter set, so a reconstructed
+interchange keeps the exact element separator, sub-element separator, and
+segment terminator bytes it arrived with (see [Writing
+X12](#writing-x12)). The literal `interchange` option keeps the writer's
+`*`/`:`/`~` defaults.
+
 ### No escape character
 
 X12 has **no** release/escape character (EDIFACT's `?` has no X12
@@ -333,9 +340,13 @@ That context is populated by a source's `ISA` envelope section (declare a
 `segment: "ISA"` envelope section on the source) and travels with every
 body record through the pipeline — including to a sink that sits directly
 downstream of the source with no intervening Transform. The reader stashes
-the complete, ordered `ISA` element list, so the reconstructed header is
-faithful. Supply `interchange` literal elements instead when the records
-have no source `ISA` section to echo.
+the complete, ordered `ISA` element list together with the delimiter set it
+discovered from the header, so the reconstructed header is faithful and the
+whole output interchange — header, envelopes, and body — is emitted with the
+original element separator, sub-element separator, and segment terminator
+rather than the writer's `*`/`:`/`~` defaults. Supply `interchange` literal
+elements instead when the records have no source `ISA` section to echo;
+that path keeps the default delimiters.
 
 ## Limitations
 

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -39,8 +39,60 @@ rules.
 When a record element contains repeated child elements, the
 [`array_paths`](../nodes/source.md#array-paths) field on the source
 controls whether each repetition **explodes** into its own record or
-**joins** into a delimited string. That field is shared with the JSON
-reader and documented on the Source Nodes page.
+**joins** into a delimited string. The field is shared with the JSON
+reader; the XML-specific matching rules are below.
+
+An entry's `path` is the repeated element's dotted path **relative to the
+record element** — the same form the flattened field names use. For a
+record element `<Order>` containing repeated `<Item>` children, the path
+is `Item`; for `<Order><Items><Item>…`, it is `Items.Item`.
+
+```yaml
+- type: source
+  name: orders
+  config:
+    name: orders
+    type: xml
+    path: "./data/orders.xml"
+    options:
+      record_path: "Orders/Order"
+    schema:
+      - { name: id, type: int }
+      - { name: "Item.name", type: string }
+      - { name: "Item.qty", type: int }
+      - { name: "Tag", type: string }
+    array_paths:
+      - path: "Item"
+        mode: explode          # one output record per <Item> occurrence
+      - path: "Tag"
+        mode: join             # <Tag>a</Tag><Tag>b</Tag> -> "a,b"
+        separator: ","
+```
+
+**`explode`** emits one output record per occurrence of the element. Each
+output carries that occurrence's fields — which keep their full dotted
+names (`Item.name`, `Item.@sku`), including the element's attributes —
+plus every field outside the path, duplicated onto each record. An
+occurrence with no content (`<Item></Item>`) still emits a record, one
+carrying only the fields outside the path. A record with **no** occurrence
+of the element passes through unchanged: XML cannot distinguish an empty
+repetition from an absent element.
+
+**`join`** concatenates values instead of fanning out. Every repeated
+flattened field at or under the path is collapsed independently into a
+single field whose value joins the occurrences' values with `separator`
+(default `,`), in document order: repeated `<Tag>` text joins under `Tag`,
+and repeated `<Item><name>` children join under `Item.name`.
+
+Entries apply in declaration order, so a join's collapsed value lands on
+every record an earlier explode fanned out, and two exploded paths
+multiply. Paths must name **disjoint** element groups — a duplicated path,
+or one path extending another (`Item` and `Item.part`), is rejected when
+the source opens.
+
+Repeated fields *not* named by any array path keep the default
+duplicate-key collapse: the first value wins and later repetitions are
+dropped.
 
 ## Bounding envelope retention: `max_index_bytes`
 

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -34,6 +34,48 @@ rules.
 | `namespace_handling` | `strip` | `strip` removes namespace prefixes from element and attribute names; `qualify` preserves the namespace-qualified names. |
 | `max_index_bytes` | `64MB` | Cap on the bytes the envelope pre-scan retains while extracting declared `$doc.*` sections. |
 
+## Writing XML
+
+The XML writer expands dotted field names to nested elements and applies
+the same `attribute_prefix` convention in reverse: a field whose final
+path segment carries the prefix is emitted as an XML **attribute** of its
+enclosing element instead of a child element. A top-level `@id` attaches
+to the record element's start tag; a nested `Address.@type` attaches to
+the `<Address>` element. Records read from an XML source therefore
+round-trip — `<Record id="7"><name>A</name></Record>` reads and writes
+back unchanged, and the writer never emits an `@`-named element.
+
+```yaml
+- type: output
+  name: xml_out
+  input: processed
+  config:
+    name: xml_out
+    type: xml
+    path: "./output/result.xml"
+    options:
+      root_element: "Root"              # default Root
+      record_element: "Record"          # default Record
+      attribute_prefix: "@"             # matches the source-side prefix
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `root_element` | `Root` | Name of the document root element wrapping all records. |
+| `record_element` | `Record` | Name of the element emitted per record. |
+| `attribute_prefix` | `@` | Prefix marking a field as an attribute of its enclosing element. Set it to the same value as the source-side prefix when round-tripping; an empty string disables attribute classification (every field emits as an element). |
+
+Attribute handling details:
+
+- A **null** attribute field is dropped even under `preserve_nulls: true` —
+  a null element round-trips as a self-closing tag, but an attribute has
+  no form that reads back as null.
+- A field with children nested under an attribute-prefixed segment
+  (e.g. `@a.b`) is rejected with a format error: an XML attribute is a
+  leaf and cannot contain elements.
+- An element with only attribute fields and no children self-closes:
+  `Address.@type` alone emits `<Address type="home"/>`.
+
 ## Nested arrays
 
 When a record element contains repeated child elements, the

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -150,7 +150,13 @@ When `false`, null values are written as empty strings. When `true`, nulls are p
     options:
       root_element: "data"
       record_element: "row"
+      attribute_prefix: "@"    # emit @-prefixed fields as XML attributes
 ```
+
+Fields whose final path segment carries the `attribute_prefix` (default
+`@`, matching the XML source option) are emitted as XML attributes of
+their enclosing element, so attribute fields read from an XML source
+round-trip. See [XML Format](../formats/xml.md#writing-xml) for details.
 
 ### Fixed-width
 

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -167,7 +167,10 @@ When `false`, null values are written as empty strings. When `true`, nulls are p
       line_separator: crlf
 ```
 
-Fixed-width output requires a format schema defining field positions and widths.
+Fixed-width output requires a format schema defining field positions and
+widths. Fields land at their declared byte ranges with gaps space-filled —
+see [Fixed-Width Format](../formats/fixed-width.md#writing-fixed-width-output)
+for the layout semantics.
 
 ### EDIFACT
 

--- a/docs/user/src/nodes/source.md
+++ b/docs/user/src/nodes/source.md
@@ -254,7 +254,9 @@ the planner rejects this with
 
 ## Array paths
 
-For nested data (JSON/XML sources with embedded arrays), `array_paths` controls how nested arrays are handled:
+For nested data (JSON/XML sources with embedded repetition), `array_paths`
+controls whether each repetition becomes its own record or collapses into
+a delimited string:
 
 ```yaml
 - type: source
@@ -269,12 +271,38 @@ For nested data (JSON/XML sources with embedded arrays), `array_paths` controls 
       - { name: line_item, type: string }
       - { name: line_amount, type: float }
     array_paths:
-      - path: "$.line_items"
+      - path: "line_items"
         mode: explode         # One output record per array element
-      - path: "$.tags"
+      - path: "tags"
         mode: join            # Concatenate array elements into a string
         separator: ","
 ```
 
-- `explode` (default) -- produces one output record per array element, with parent fields repeated.
-- `join` -- concatenates array elements into a single string using the specified `separator`.
+- `explode` (default) -- produces one output record per array element,
+  with parent fields repeated onto each.
+- `join` -- concatenates the array's elements into a single string using
+  the specified `separator` (default `,`).
+
+Entries apply in declaration order: a join's collapsed value lands on
+every record an earlier explode fanned out, and two exploded paths
+multiply.
+
+The `path` is a flattened field name, in the same dotted form the source's
+field names use — there is no `$.` sigil.
+
+**JSON** — the path names the field holding the array (`line_items`, or
+`order.line_items` for an array nested under an object). Exploding an
+array of objects hoists each element's keys onto the output record
+(`{"line_item": …}` becomes a top-level `line_item` field); exploding an
+array of scalars keeps the value under the path's own name. An empty
+array explodes to no records (the parent record is suppressed) and joins
+to an empty string; a record without the field passes through unchanged.
+
+**XML** — the path is the repeated child element's dotted path relative to
+the record element (`Item`, or `Items.Item` when nested). Exploded fields
+keep their full dotted names (`Item.name`); join collapses each repeated
+flattened field under the path independently. Repetition and absence are
+indistinguishable in XML, so a record without the element always passes
+through unchanged, and paths must name disjoint (non-nested) element
+groups. See [XML Format](../formats/xml.md#nested-arrays) for the full
+rules.

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -525,6 +525,40 @@ schema:
   - { name: customer_id, type: string, source_name: cust_id }
 ```
 
+### Format-structure patches (X12 / HL7 v2)
+
+Beyond the format-agnostic ops above, a `sources:` patch can reshape the
+format-layer structures an X12 or HL7 source declares in its `options:` block —
+with keyed add/modify/remove grammar instead of blob-replacing the whole
+options map:
+
+```yaml
+sources:
+  interchange:                             # an X12 source
+    group_section:                         # the GS functional-group declaration
+      name: fg                             # rename the section (omit to keep)
+      fields:
+        e04: int                           # set/add a typed field
+        e05: remove                        # drop a declared field
+    set_section: remove                    # drop the whole ST declaration
+  messages:                                # an HL7 v2 source
+    split_fields:                          # keyed by positional field name
+      f08: { components: 3 }               # add-or-modify a composite split
+      f03: remove                          # drop a declared split
+```
+
+`group_section` / `set_section` patch the X12 nested-envelope declarations (the
+`GS` functional-group and `ST` transaction-set levels); `split_fields` patches
+the HL7 composite-field splits, keyed by positional field name and resolved by
+wire position (`f8` and `f08` address the same split). Each op applies only to
+a source of the matching format (anything else is E238). The set form is a
+partial modify on an existing declaration — an omitted `name` or axis width
+keeps its current value — and creates the declaration when absent, in which
+case `name` (X12) or `components` (HL7) is required (E240). Removing a
+declaration, field, or split the source does not carry is E239. These ops
+apply after the `options` merge, so they layer on top of an `options` value
+that replaces the same declaration in one patch.
+
 `sources:` patches target **top-level** source nodes; a source declared inside a
 composition body is not reachable this way (patching it fails with E230). When a
 patch changes the effective source config, the run's pipeline identity differs
@@ -544,3 +578,7 @@ not collide.
 | **E234** | An `array_paths` `remove` of a path with no matching entry. |
 | **E235** | An `options` patch sets an unknown or mistyped option key for the source's format. |
 | **E236** | A renamed/aliased column's exposed name collides with a real input field, which would mislocate that field. Raised at read time. |
+| **E237** | A `schema` patch on a multi-record / generated / external-file schema — column ops apply only to a single-record column list. |
+| **E238** | A `group_section` / `set_section` patch on a non-X12 source, or a `split_fields` patch on a non-HL7 source. |
+| **E239** | A `remove` of a nested-section declaration, declared section field, or field split the source does not carry. |
+| **E240** | A malformed format-structure patch: creating a nested section without a `name`, adding a split without `components`, a split key that is not a positional `fNN` name, or a zero axis width. |

--- a/docs/user/src/pipelines/compositions.md
+++ b/docs/user/src/pipelines/compositions.md
@@ -56,6 +56,17 @@ composition:
 
 A composition body reads its own config parameters as [`$config.<param>`](../cxl/system-variables.md#config-composition-config-parameters). The planner constant-folds each reference to the value resolved for that instantiation — the call site's `config:` value, or a [channel/group](channels.md) `config:` override, or the declared default — so the same composition used with different `config:` compiles to different bodies. Because the resolution happens per instantiation, a channel or group `config:` override changes what the body computes, not just the reported provenance.
 
+### Body validation
+
+Nodes inside a composition body are validated with the same node-scoped
+config checks as top-level pipeline nodes. A body node that would be
+rejected at the top level — an `envelope` wiring the not-yet-supported
+`trailer:` port, a `transform` declaring a reserved variable name or a
+default that does not match its declared type, an invalid log
+directive, or a `batch_size: 0` — fails compilation with an `E115`
+diagnostic naming the composition call site, the body file, and the
+violation. Run `clinker explain --code E115` for details.
+
 ## Advanced wiring
 
 For compositions with multiple input or output ports, the node supports explicit port bindings:


### PR DESCRIPTION
This batch bundles several independent, scoped changes that share one CI and merge cycle. Each section below stands on its own; they touch disjoint areas of the codebase (fixed-width, XML, X12/HL7, CXL typing, and composition-body validation) and were reviewed separately.

## fix(format): honor declared byte positions in the fixed-width writer

### What

The fixed-width reader slices each field at the exact byte range resolved from `start` + `width`/`end`, but the writer resolved only widths and emitted fields sequentially in declaration order. Any output schema with gaps or nonzero start offsets did not round-trip: the writer put bytes where the reader would never look (e.g. `a {start: 0, width: 2}` and `b {start: 5, width: 2}` were written adjacent, while the reader expects `b` at bytes 5..7).

### Changes

- The `width`/`end` resolution the reader used is extracted into a shared `resolve_width` in `fixed_width/field.rs`, so both directions resolve a column to the same byte range — including the `width`/`end` mutual exclusivity, `end >= start`, and `width > 0` rules the writer previously ignored.
- `FixedWidthWriter` now resolves each column to a concrete `start`: a declared `start` is honored; a column omitting `start` continues at the previous column's end, so existing width-only output schemas keep their sequential layout byte-for-byte.
- Fields are emitted sorted by `start` regardless of declaration order, and gaps between declared ranges are space-filled in bounded chunks (O(1) memory), so every cell lands at the position the reader slices back out.
- Overlapping ranges are rejected at writer construction with a typed error naming both fields and their ranges; a range whose end would overflow `usize` is likewise a construction error instead of an arithmetic wrap.

### Behavior changes beyond the fix

Consistency with the reader means the writer now rejects three schema shapes it previously accepted silently: `width` and `end` declared together (`width` used to win), zero-width columns, and `end`-only columns measured from byte 0 instead of the column's resolved start. All three produced files unreadable under the same schema, so nothing that round-tripped before is affected.

### Validation

- New writer tests: a gapped schema round-trips through `FixedWidthReader` with exact byte assertions, out-of-declaration-order starts round-trip, a gap wider than the fill chunk is fully space-filled, overlap / `width`+`end` / overflow are typed construction errors, and a start-less schema's output is byte-identical to the previous sequential layout.
- `cargo fmt --all --check`, `cargo clippy -p clinker-format --all-targets -- -D warnings`, the full `cargo test -p clinker-format` suite, the fixed-width integration tests in `clinker-exec` (`format_dispatch`, `multi_record_pipeline`, `output_envelope_seam`), and `cargo check --workspace` all pass.

User docs: `docs/user/src/formats/fixed-width.md` gains a "Writing fixed-width output" section documenting byte positioning, gap fill, and overlap rejection; the output-node page links to it.

## fix(format): apply XML array_paths explode/join in the reader

`XmlReaderConfig` carried `array_paths`, source lowering populated it from YAML, and the user docs promised explode/join for repeated XML children — but the reader never read the field. Repeated child elements fell through the duplicate-key collapse and silently kept only the first value.

### What changed

- **Occurrence tracking during extraction** (`crates/clinker-format/src/xml/reader.rs`): record extraction now records, for each configured array path, the field ranges covered by each occurrence of that element (a path is the repeated element's dotted path relative to the record element, e.g. `Item` or `Items.Item`). Raw extraction already preserved repeated keys; the ranges give explode its per-occurrence grouping, so heterogeneous occurrences (`<Item><name/></Item><Item><qty/></Item>`) split correctly instead of being zipped by key.
- **Expansion before emission**: paths apply in declaration order, mirroring the JSON reader's sequential fan-out. `explode` emits one record per occurrence — occurrence fields keep their full dotted names (`Item.name`, `Item.@sku`) and fields outside the path are duplicated onto each output; an empty occurrence (`<Item></Item>`) still emits a record; a record with no occurrence passes through unchanged (XML cannot distinguish empty repetition from absence). `join` collapses each repeated flattened key at or under the path into one separator-joined value at its first position. The single pending record became a `VecDeque` drained by `schema()`/`next_record()`, bounded by one element's expansion.
- **Rejected ambiguous configs**: duplicated paths, or one path nesting inside another (`Item` and `Item.part`), are rejected when the source opens — occurrence tracking assigns each field to at most one path. Repeated keys not named by any path keep the existing first-value-wins collapse.
- **Docs** (`docs/user/src/formats/xml.md`, `docs/user/src/nodes/source.md`): the XML "Nested arrays" section now states the exact matching semantics with a worked example, and the shared Array-paths section documents JSON and XML behavior separately. The JSON examples previously showed `$.`-prefixed paths, which the reader never matched (paths are flattened field names); the examples now show the form that works.
- Schema inference reflects the first expanded record, so explode/join column shapes are what downstream sees, matching the JSON reader.

### Validation

- `cargo test -p clinker-format` — 573 tests green, including 14 new/rewritten array-path tests covering explode (multi-occurrence, scalars, attributes, empty occurrence, absent element, dotted paths, multi-record), join (custom separator, container subfields), unmatched duplicate-key interaction, multi-path composition, cartesian fan-out, and construction-time rejection of nested/duplicated paths. The two prior tests that asserted the collapse behavior as a known gap were replaced with exact-value assertions.
- `cargo test -p clinker-plan` — green; `cargo test -p clinker --test channel_source_patch` — green (channel-driven `array_paths` patches still lower correctly).
- `cargo clippy -p clinker-format --all-targets -- -D warnings`, `cargo fmt --all --check`, `cargo check --workspace`, `mdbook build docs/user` — all clean.

## fix(format): emit attribute-prefixed fields as XML attributes on write

### Problem

The XML reader flattens element attributes into fields under a configurable prefix (default `@`), but the XML writer treated every field name as an element path. Round-tripping a record read from `<Record id="7"><name>A</name></Record>` therefore emitted an invalid `<@id>7</@id>` element — quick-xml performs no name validation, so the corruption only surfaced in downstream consumers.

### Change

The writer now mirrors the reader's convention: a field whose final dotted segment carries the configured `attribute_prefix` is emitted as an XML attribute of its enclosing element.

- A top-level `@id` attaches to the record element's start tag; a nested `Address.@type` attaches to the `<Address>` branch element.
- An element left with only attributes and no children self-closes (`<Address type="home"/>`).
- Envelope section wrappers (`reconstruct_envelope`) get the same treatment, so attribute-carrying `$doc` sections round-trip too.
- The prefix is configurable per XML output (`options.attribute_prefix`, default `@`, mirroring the source-side option) and plumbed through the writer registry; an empty prefix disables classification entirely.

Two rules keep round-trips faithful:

- A **null** attribute field is dropped even under `preserve_nulls: true` — an attribute has no form that reads back as null, and emitting `id=""` would corrupt null into an empty string.
- A field nesting children under an attribute-prefixed segment (e.g. `@a.b`) is rejected with a clear format error instead of emitting an invalid element name. `Value::Map` rejection is unchanged and applies to attribute fields as well.

Attribute values escape the five predefined entities plus literal tab/CR/LF as character references (`&#9;` `&#10;` `&#13;`) — a conformant parser collapses raw whitespace in attribute values to spaces (attribute-value normalization), which would have silently altered whitespace-carrying values on round-trip.

Because the record's field tree is now built before its start tag opens, a rejected record no longer leaves a dangling half-written `<Record>` behind.

### Validation

- `cargo test -p clinker-format` (574 tests, including 15 new writer tests: default/custom/empty prefix, nested and attribute-only branches, null-attribute drop, map rejection, malformed-path rejection, escaping, byte-exact reader round-trips including whitespace)
- `cargo test -p clinker-plan` (596 tests, new `XmlOutputOptions.attribute_prefix` parse tests)
- `cargo test -p clinker-exec` (new registry plumbing tests)
- `cargo clippy -p clinker-format -p clinker-plan -p clinker-exec --all-targets -- -D warnings`
- `cargo check --workspace`, `cargo fmt --all --check`, `git diff --check`

Docs: `docs/user/src/formats/xml.md` gains a "Writing XML" section with the output-options table and round-trip notes; the XML output example in `docs/user/src/nodes/output.md` now shows `attribute_prefix`.

## fix(plan): validate composition-body nodes with the top-level node-config checks

### Problem

Top-level pipeline validation rejects an Envelope node with a wired `trailer:` port with a clear "not yet supported" error, but composition bodies (`.comp.yaml`) are parsed on a separate binding path that never ran those node-scoped checks. A body Envelope wiring `trailer:` therefore bypassed the rejection and reached the executor, where it failed as an internal error (the envelope dispatch expects a single body predecessor and finds two) instead of a compile diagnostic. The same gap let a body Transform carry a reserved `declares:` name, a declare default that mismatches its declared type, an invalid log directive, or a zero `batch_size` past compile.

### Change

- Extracted the node-scoped checks from `validate_config` into a shared `validate_node_configs(nodes) -> Vec<NodeConfigViolation>` helper (wired Envelope trailer, Transform `declares:` reserved-name/default-type, log directives, per-Transform `batch_size`). Top-level validation behavior and messages are unchanged — it surfaces the first violation as the same `ConfigError::Validation`.
- `bind_composition` now runs the helper over every parsed body's nodes (including nested compositions, via recursion) right after the body parse, emitting one `E115` diagnostic per violation — naming the call site, the body file, and the violation, anchored to the offending body node's line — and abandoning the body like the other bind-time early-outs. A body Envelope wiring only `header:` still compiles, matching the top level (wired header is a real, supported port).
- Registered `E115` in the diagnostic registry, wired it into `clinker explain --code` with a new `docs/explain/E115.md` page, and documented body validation in the compositions user guide.

### Validation

- New bind-level tests: body Envelope with wired `trailer:` fails with E115 carrying the top-level wording; body Envelope with wired `header:` only still compiles; body Transform with `batch_size: 0` fails with E115.
- `cargo fmt --all --check`, `cargo clippy -p clinker-plan -p clinker-core-types -p clinker --all-targets -- -D warnings`, `cargo test -p clinker-plan` (574 passed), `cargo test -p clinker-core-types`, `cargo test -p clinker`, `cargo test -p clinker-channel`, `cargo test -p clinker-exec` (1478 passed), `cargo check --workspace` — all green.

## fix(cxl): keep decimal receivers decimal in numeric method return types

`round(n)` / `round_to(n)` are registered with a `Float` return type (and `ceil`/`floor` with `Int`, `abs` with `Numeric`), but their evaluation keeps a `decimal` receiver in the decimal domain: exact `abs`, whole-valued `ceil`/`floor`, and banker's rounding for `round`/`round_to`. Because `decimal` deliberately never unifies with `float` or the `Numeric` supertype, the checker's registry-declared return type made compositions like `amount.round_to(2) + fee` a spurious decimal/float type error even though both operands are decimals at runtime — contradicting the numeric-builtins docs, which promise these methods stay in the decimal domain.

### Change

- `crates/cxl/src/typecheck/pass.rs`: in the `MethodCall` arm, after the registry lookup, specialize the return type to `Decimal` when the receiver (nullable-unwrapped) is `Decimal` and the method is one of `abs`/`ceil`/`floor`/`round`/`round_to`. Nullable-receiver propagation still applies on top, so a nullable decimal receiver yields `decimal?`. Registry definitions are unchanged; non-decimal receivers keep the registry types.
- `clamp`/`min`/`max` are deliberately excluded: their evaluation may return an argument value, so a decimal result is not guaranteed for a decimal receiver.
- `docs/user/src/cxl/builtins-numeric.md`: state that the type checker infers `decimal` for these calls and that `round`/`round_to` on a decimal produce a decimal.

### Tests

- Typecheck (`pass.rs`): all five methods on a `decimal` column infer `Decimal`; `amount.round_to(2) + fee` composes when both columns are decimal (regression for the reported error); `float.round_to(2)` stays `Float`; a nullable decimal receiver infers `decimal?`.
- Eval (`eval/tests.rs`): `round_to` on a decimal returns an exact `Value::Decimal` with banker's rounding (`19.995 -> 20.00` half-even), and the rounded result sums exactly with another decimal.
- Verified the new typecheck tests fail when the specialization is disabled.

### Validation

`cargo fmt --all --check`, `cargo clippy -p cxl --all-targets -- -D warnings`, and `cargo test -p cxl` (513 passed) are green.

## feat(plan): channel source patches for X12 nested sections and HL7 field splits

A channel `sources.<src>` patch could previously reach the X12 `group_section`/`set_section` declarations and HL7 `split_fields` only by blob-replacing the whole `options:` map via raw values — no keyed add/modify/remove grammar and no targeted diagnostics. This adds three keyed patch surfaces mirroring the existing `schema`/`array_paths` grammar:

- **`group_section` / `set_section`** (X12): `remove` drops the nested-envelope declaration; a map form is a set — on an existing declaration it patches `name` (omit to keep) and individual typed `fields` entries (`e06: string` to set, `e05: remove` to drop); on an absent declaration it creates one, requiring a `name`.
- **`split_fields`** (HL7 v2): keyed by positional field name and resolved by wire position (`f8` and `f08` address the same split). A map form is add-or-modify — a partial modify keeps omitted axis widths; a new split requires `components`, with `subcomponents`/`repetitions` defaulting to 1 exactly as in hand-written config. `remove` drops a declared split.

New compile-time diagnostics continue the source-patch scheme and name the source and op:

- **E238** — op on a source of the wrong format (`group_section`/`set_section` on non-X12, `split_fields` on non-HL7).
- **E239** — `remove` of a declaration, declared section field, or split the source does not carry.
- **E240** — malformed op: creating a section without a `name`, adding a split without `components`, a key that is not a positional `fNN` name, or a zero axis width.

The handlers dispatch inside the shared `apply_source_patches` pass, after the `options` merge — so a keyed op layers deterministically on top of an `options`-blob replacement of the same declaration in one patch, and the run, `--explain`, and `--lineage` paths all inherit the behavior automatically. Patches not using the new fields serialize byte-identically, so existing channel-patched pipelines keep their identity hashes.

Docs: the channels page gains a format-structure patch section and E237–E240 rows in the diagnostics table.

Validation: `cargo fmt --all --check`; `cargo clippy -p clinker-plan -p clinker-channel --all-targets -- -D warnings`; `cargo test -p clinker-plan` (596 tests) and `cargo test -p clinker-channel` (141 tests) including 23 new unit tests covering every op's happy path, format mismatch, absent-removal, and malformed-op errors, plus an end-to-end overlay-resolution case patching an X12 and an HL7 source through a channel file; `cargo check --workspace`.

## fix(format): preserve custom ISA delimiters when reconstructing X12 from doc context

The X12 reader discovers the element separator, sub-element separator, and segment terminator from the fixed 106-byte ISA header, but the writer always emitted with its `*`/`:`/`~` defaults. An interchange using custom delimiters (`|`/`^`/`!`, say) that was read and reconstructed via `interchange_from_doc` came back with a different delimiter set — a changed wire shape that breaks downstream systems expecting the original bytes.

The element separator and segment terminator are not ISA data elements (they sit between and after them), so the raw element list the reader already stashes for header reconstruction cannot carry them.

**Changes**

- The reader now stamps the discovered delimiter set beside the raw ISA element list in the ISA `$doc` section, as an engine-internal `$delims` field holding the three `[element, subelement, terminator]` bytes. Like `$raw`, the `$`-prefixed key is not user-declarable, never surfaces in CXL `$doc` typechecking, and is excluded from semantic header-identity comparison.
- The writer's `interchange_from_doc` path adopts the stamped set before emitting the first segment, so the whole reconstructed interchange — ISA header, GS/GE, ST/SE, body, and IEA — uses the source bytes, and the delimiter-in-data rejection now checks the bytes actually in effect (a `*` in data is legal under a `|` element separator; a `|` is rejected).
- The literal `interchange` option and hand-authored doc sections (no stamp) keep the defaults, so existing output is byte-unchanged. A malformed stamp is rejected with a precise error rather than silently defaulted.
- Corrects a stale writer doc comment that claimed the echoed ISA16 byte already overrode the sub-element default.
- The `Delimiters` doc-value encode/decode pair lives in one place on the type so the carrier layout cannot drift between reader and writer.

**Tests**

- Writer unit tests: byte-exact reconstruction under a `|`/`^`/`!` stamp; literal-`interchange` precedence over a stamped section; stamp-less doc sections keep defaults; delimiter-in-data rejection follows the adopted bytes; malformed-stamp error.
- Reader unit tests: `prepare_document` stamps the exact discovered byte values; full read → `$doc` → write round-trip of a custom-delimiter interchange asserts byte-for-byte identity and clean re-parse.
- Tokenizer unit tests: doc-value round-trip and malformed-shape rejection (wrong carrier type, arity, out-of-range byte, non-integer element).
- End-to-end pipeline test: an X12→X12 pipeline over a custom-delimiter interchange reproduces the input byte-for-byte.

**Docs**

- `docs/user/src/formats/x12.md`: the delimiter section and the `interchange_from_doc` round-trip section now describe delimiter preservation and the literal-path default behavior.

**Validation**

`cargo fmt --all --check`, `cargo clippy -p clinker-format -p clinker-exec --all-targets -- -D warnings`, `cargo test -p clinker-format` (569 tests), `cargo test -p clinker-exec` (all suites, including the 11 `x12_pipeline` integration tests), `cargo check --workspace`, `git diff --check` — all green.

Closes #695
Closes #712
Closes #697
Closes #599
Closes #787
Closes #745
Closes #698
