### PR TITLE
batch: UTF-8-safe fixed-width truncation, XML truncation errors, byte-split flush correctness, exact decimal weighted_avg, multi-record patches, cull comment predicates, bounded reads, JSON pointer validation

### DIFF
--- a/crates/clinker-channel/AGENTS.md
+++ b/crates/clinker-channel/AGENTS.md
@@ -12,7 +12,7 @@ Root `AGENTS.md` still applies. This file adds local guidance for `clinker-chann
 - Derive matching groups for a channel from its manifest `labels` via CXL boolean selectors, ordered by priority.
 - Resolve the four-layer overlay stack (`PipelineDefault < Group(s) < ChannelWide < ChannelPerTarget`) into one `OverlayResolution`: a structural `overrides:` op stream (applied pre-compile via `CompileContext::overlay_ops`) plus a `config`/`vars` value clobber (applied post-compile over the plan's provenance).
 - Validate `DottedPath` config keys and resolve channel `vars:` overrides/adds for `$vars`, `$pipeline`, `$source`, and `$record`.
-- Carry per-target `sources:` config patches (schema / array_paths / options) for `apply_source_patches`.
+- Carry per-target `sources:` config patches (schema / array_paths / options / group_section / set_section / split_fields / records / discriminator) for `apply_source_patches`.
 - Stamp `ChannelIdentity` on compiled plans.
 - Stage selected source files to local disk with stable cache paths, manifests, locks, reuse, cleanup, and crash purge.
 

--- a/crates/clinker-channel/src/manifest.rs
+++ b/crates/clinker-channel/src/manifest.rs
@@ -127,9 +127,10 @@ pub struct OverlayFile {
     /// the run behaves as if the source YAML had been hand-edited: CXL-typed
     /// column ops (`schema`), nested-array explosion/join (`array_paths`),
     /// scalar per-format input `options`, X12 nested-envelope declarations
-    /// (`group_section` / `set_section`), and HL7 composite-field splits
-    /// (`split_fields`). Scoped to this one target, so source-node names
-    /// resolve unambiguously against the overlaid pipeline.
+    /// (`group_section` / `set_section`), HL7 composite-field splits
+    /// (`split_fields`), and multi-record flat-file record types
+    /// (`records` / `discriminator`). Scoped to this one target, so source-node
+    /// names resolve unambiguously against the overlaid pipeline.
     #[serde(default)]
     pub sources: IndexMap<String, SourceConfigPatch>,
 }

--- a/crates/clinker-channel/tests/overlay_resolution_test.rs
+++ b/crates/clinker-channel/tests/overlay_resolution_test.rs
@@ -26,7 +26,7 @@ use clinker_core_types::{Diagnostic, Severity};
 use clinker_plan::config::composition::LayerKind;
 use clinker_plan::config::{
     ChannelLayout, CompileContext, GroupLayout, InputFormat, PipelineConfig, ShardScheme,
-    apply_source_patches,
+    SourceSchema, apply_source_patches,
 };
 use clinker_plan::plan::CompiledPlan;
 use clinker_record::Value;
@@ -881,6 +881,92 @@ fn per_target_source_schema_patch_applies() {
             .expect("per-target overlay present")
             .is_empty()
     );
+}
+
+/// A multi-record fixed-width pipeline whose source node identity (`ledger`)
+/// matches the channel patch target below. Kept separate from `BASE_PIPELINE`
+/// (single-record CSV) because `records:` / `discriminator:` ops apply only to
+/// a multi-record schema.
+const MULTI_RECORD_PIPELINE: &str = r#"
+pipeline:
+  name: ledger_import
+nodes:
+  - type: source
+    name: ledger
+    config:
+      name: ledger
+      type: fixed_width
+      path: ledger.dat
+      schema:
+        discriminator: { start: 0, width: 1 }
+        records:
+          - { id: detail, tag: D, columns: [ { name: amount, type: int, start: 1, width: 9 } ] }
+          - { id: trailer, tag: T, columns: [ { name: count, type: int, start: 1, width: 9 } ] }
+  - type: output
+    name: out
+    input: ledger
+    config: { name: out, type: csv, path: out.csv }
+"#;
+
+#[test]
+fn per_target_source_multi_record_patch_applies() {
+    // A channel `sources:` block carrying `records:` / `discriminator:` ops
+    // resolves through the overlay carrier into a typed patch and reshapes a
+    // multi-record source's discriminator and record types.
+    let ws = workspace();
+    write(
+        &ws.path().join("channel/mrpatch/base.channel.yaml"),
+        &per_target_overlay(
+            "sources:\n  ledger:\n    discriminator: { start: 2 }\n    records:\n      detail: { tag: X }\n      trailer: remove\n      header: { add: { tag: H, columns: [ { name: hdr_id, type: string, start: 1, width: 8 } ] } }\n",
+        ),
+    );
+
+    let res = resolve(
+        ws.path(),
+        &channel_layout(),
+        &group_layout(),
+        "base",
+        Some("mrpatch"),
+        &[],
+        true,
+    )
+    .expect("resolve");
+    let patches = res
+        .source_patches()
+        .expect("per-target overlay carries patches");
+    assert!(!patches.is_empty(), "sources: block yields a patch");
+
+    let mut config: PipelineConfig =
+        clinker_plan::yaml::from_str(MULTI_RECORD_PIPELINE).expect("parse multi-record pipeline");
+    apply_source_patches(&mut config, patches).expect("apply source patches");
+
+    let body = config.source_bodies().next().expect("one source");
+    match &body.schema {
+        SourceSchema::MultiRecord {
+            discriminator,
+            record_types,
+            ..
+        } => {
+            // Discriminator merge kept the base width and moved the start.
+            assert_eq!(discriminator.start, Some(2));
+            assert_eq!(discriminator.width, Some(1));
+            // `detail` retagged, `trailer` dropped, `header` added.
+            let ids: Vec<&str> = record_types.iter().map(|rt| rt.id.as_str()).collect();
+            assert_eq!(ids, vec!["detail", "header"]);
+            let detail = record_types
+                .iter()
+                .find(|rt| rt.id == "detail")
+                .expect("detail present");
+            assert_eq!(detail.tag, "X");
+            let header = record_types
+                .iter()
+                .find(|rt| rt.id == "header")
+                .expect("header added");
+            assert_eq!(header.tag, "H");
+            assert_eq!(header.columns[0].name, "hdr_id");
+        }
+        other => panic!("expected multi-record schema, got {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/clinker-exec/tests/cull_pipeline.rs
+++ b/crates/clinker-exec/tests/cull_pipeline.rs
@@ -214,6 +214,165 @@ fn removed_port_carries_unwidened_schema() {
     );
 }
 
+/// The single-rule error cull with a trailing `#` line-comment on its
+/// `drop_group_when`. Comments run to end-of-line and were once rejected at
+/// compile time; each rule is now parsed independently, so the comment is
+/// scoped to its own rule. Behaviour must match [`ERROR_CULL_PIPELINE`]
+/// exactly — the comment is inert.
+const ERROR_CULL_PIPELINE_COMMENTED: &str = r#"
+pipeline:
+  name: cull_errors
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: account, type: string }
+        - { name: amount, type: int }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_bad
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: drop_error_groups
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error row in the group"
+  - type: output
+    name: out
+    input: drop_bad
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: drop_bad.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
+
+#[test]
+fn comment_in_predicate_behaves_identically() {
+    // A `#`-commented predicate produces output byte-identical to the same
+    // predicate without the comment — the comment affects only source text,
+    // never the compiled decision.
+    let csv = "account,amount,status\n\
+               A,100,ok\n\
+               A,200,error\n\
+               B,300,ok\n\
+               B,400,ok\n";
+    let plain = run_cull(ERROR_CULL_PIPELINE, csv);
+    let commented = run_cull(ERROR_CULL_PIPELINE_COMMENTED, csv);
+
+    assert_eq!(
+        commented.main, plain.main,
+        "commented predicate must yield the same main output"
+    );
+    assert_eq!(
+        commented.removed, plain.removed,
+        "commented predicate must yield the same removed output"
+    );
+    assert_eq!(commented.dlq_count, plain.dlq_count);
+    // Sanity: the shared expectation is that account A (one error row) is
+    // removed and account B flows to main.
+    assert!(commented.main.contains("B,300,ok"));
+    assert!(!commented.main.contains("A,"));
+    assert!(commented.removed.contains("A,100,ok"));
+    assert!(commented.removed.contains("A,200,error"));
+}
+
+/// A two-rule cull where one rule's predicate carries a trailing `#`
+/// comment. The rules OR-combine: a group is removed if it holds an error
+/// row (commented rule) OR its summed amount exceeds a threshold (plain
+/// rule). Each rule contributes independently.
+const MULTI_RULE_COMMENTED_PIPELINE: &str = r#"
+pipeline:
+  name: cull_multi_rule
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: account, type: string }
+        - { name: amount, type: int }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_bad
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: drop_error_groups
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error row"
+        - name: drop_big_groups
+          drop_group_when: "sum(amount) > 500"
+  - type: output
+    name: out
+    input: drop_bad
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: drop_bad.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
+
+#[test]
+fn multi_rule_one_commented_or_combines() {
+    // A: has an error row -> removed by the commented rule (sum amount 300,
+    //    below the 500 threshold, so only the error rule fires).
+    // B: clean, summed amount 900 > 500 -> removed by the plain rule.
+    // C: clean, summed amount 100 -> kept (neither rule fires).
+    let csv = "account,amount,status\n\
+               A,100,ok\n\
+               A,200,error\n\
+               B,500,ok\n\
+               B,400,ok\n\
+               C,100,ok\n";
+    let out = run_cull(MULTI_RULE_COMMENTED_PIPELINE, csv);
+
+    assert_eq!(out.dlq_count, 0);
+
+    // Only account C survives to the main output.
+    let main_data: Vec<&str> = out.main.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(main_data, vec!["C,100,ok"], "main output: {}", out.main);
+
+    // A (error rule) and B (threshold rule) are both removed — four rows.
+    let mut removed_data: Vec<&str> = out
+        .removed
+        .lines()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .collect();
+    removed_data.sort_unstable();
+    assert_eq!(
+        removed_data,
+        vec!["A,100,ok", "A,200,error", "B,400,ok", "B,500,ok"],
+        "removed output: {}",
+        out.removed
+    );
+}
+
 /// Count-threshold cull parameterized on the memory limit, with the `spill`
 /// backpressure policy so a sub-baseline limit forces the disk path. A group
 /// is removed when it holds more than 100 rows.

--- a/crates/clinker-format/src/counting.rs
+++ b/crates/clinker-format/src/counting.rs
@@ -119,6 +119,13 @@ impl FormatWriter for CountedFormatWriter {
         self.inner.flush()
     }
 
+    /// Forward to the wrapped writer so byte-limit split accounting reaches the
+    /// real format writer's non-finalizing drain rather than falling back to
+    /// this shim's finalizing `flush`.
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.inner.flush_bytes()
+    }
+
     fn bytes_written(&self) -> Option<u64> {
         Some(self.counter.bytes_written())
     }

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -492,6 +492,15 @@ impl<W: Write + Send> FormatWriter for EdifactWriter<W> {
         self.writer.flush().map_err(FormatError::Io)?;
         Ok(())
     }
+
+    /// Drain the underlying sink without emitting the interchange trailer, so
+    /// byte-limit split accounting stays non-finalizing. Plan validation
+    /// rejects byte splitting for this single-envelope format; this keeps the
+    /// trait contract honest regardless, with the `UNZ` trailer written only by
+    /// [`Self::flush`].
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.writer.flush().map_err(FormatError::Io)
+    }
 }
 
 /// Whether a schema column name is a positional EDIFACT element column

--- a/crates/clinker-format/src/fixed_width/field.rs
+++ b/crates/clinker-format/src/fixed_width/field.rs
@@ -108,19 +108,22 @@ pub fn resolve_width(f: &Column, start: usize) -> Result<usize, FormatError> {
 
 /// Read one physical record line into `buf`, returning `false` at end of input.
 ///
-/// `Lf` / `CrLf` read up to (and strip) the newline, but the read is bounded to
-/// the declared record width plus a line-terminator allowance: a line-separated
-/// file with a missing terminator cannot buffer the rest of the input into one
-/// record, preserving the engine's bounded-memory guarantee on malformed input.
-/// A line that fills the cap without a terminator overruns the declared width
-/// and is rejected. `None` reads exactly `record_length` bytes (a delimiter-free
-/// fixed block). A short final block under `None` is an incomplete-record error.
+/// `Lf` / `CrLf` read up to (and strip) the newline, but the buffered read is
+/// bounded to the declared record width plus a line-terminator allowance: a
+/// line-separated file with a missing terminator cannot buffer the rest of the
+/// input into one record, preserving the engine's bounded-memory guarantee on
+/// malformed input. A physical line wider than the declared width — trailing
+/// filler beyond the last declared field, or a partial-schema read of a
+/// fixed-LRECL extract — fills the cap before its terminator; the declared
+/// fields are already captured, so the overrun is discarded up to the next
+/// newline (in bounded memory) and the line resyncs to the following record.
+/// `None` reads exactly `record_length` bytes (a delimiter-free fixed block). A
+/// short final block under `None` is an incomplete-record error.
 ///
 /// # Errors
 ///
 /// Returns [`FormatError::Io`] on a read fault, or [`FormatError::InvalidRecord`]
-/// at `row + 1` when a `None`-separated block ends mid-record, or when an `Lf` /
-/// `CrLf` line overruns the declared width with no line terminator.
+/// at `row + 1` when a `None`-separated block ends mid-record.
 pub fn read_physical_line<R: Read>(
     reader: &mut BufReader<R>,
     separator: &LineSeparator,
@@ -131,7 +134,7 @@ pub fn read_physical_line<R: Read>(
     buf.clear();
     match separator {
         LineSeparator::Lf => {
-            if !read_capped_line(reader, record_length, row, buf)? {
+            if !read_capped_line(reader, record_length, buf)? {
                 return Ok(false);
             }
             if buf.last() == Some(&b'\n') {
@@ -139,7 +142,7 @@ pub fn read_physical_line<R: Read>(
             }
         }
         LineSeparator::CrLf => {
-            if !read_capped_line(reader, record_length, row, buf)? {
+            if !read_capped_line(reader, record_length, buf)? {
                 return Ok(false);
             }
             if buf.ends_with(b"\r\n") {
@@ -171,21 +174,23 @@ pub fn read_physical_line<R: Read>(
     Ok(true)
 }
 
-/// Read up to one newline-terminated line into `buf`, bounded to the declared
-/// record width so a line-separated file missing a terminator cannot buffer the
-/// rest of the input into a single record. Returns `Ok(false)` at clean EOF
-/// (nothing read); the trailing newline, if present, is left on `buf` for the
-/// caller to strip per its separator.
+/// Read up to one newline-terminated line into `buf`, bounding the buffered
+/// portion to the declared record width so a line-separated file missing a
+/// terminator cannot buffer the rest of the input into a single record. Returns
+/// `Ok(false)` at clean EOF (nothing read); the trailing newline, if present, is
+/// left on `buf` for the caller to strip per its separator.
 ///
 /// The cap admits a full record, a CR/LF terminator, and one sentinel byte, so a
 /// well-formed line — even one carrying a full-width record plus `\r\n` — always
-/// fits. Consuming the whole cap without reaching a newline means the physical
-/// line overruns the declared width: a record error at `row + 1`, not an
-/// unbounded read.
+/// fits within `buf`. A physical line wider than the declared width fills the cap
+/// before its terminator: the declared fields have already been captured, so the
+/// buffer is trimmed to the record width and the filler is discarded up to the
+/// next newline via [`discard_to_newline`], keeping the working buffer bounded
+/// regardless of physical line width and leaving the reader positioned at the
+/// following record.
 fn read_capped_line<R: Read>(
     reader: &mut BufReader<R>,
     record_length: usize,
-    row: u64,
     buf: &mut Vec<u8>,
 ) -> Result<bool, FormatError> {
     let cap = record_length + 3;
@@ -196,15 +201,33 @@ fn read_capped_line<R: Read>(
         return Ok(false);
     }
     if n == cap && buf.last() != Some(&b'\n') {
-        return Err(FormatError::InvalidRecord {
-            row: row + 1,
-            message: format!(
-                "line-separated record overruns the declared {record_length}-byte \
-                 width with no line terminator"
-            ),
-        });
+        // The physical line is wider than the declared record (trailing filler,
+        // or a schema that maps only a prefix of a fixed-LRECL extract). Keep the
+        // declared-width prefix and drop the overrun up to the next newline so
+        // the following record starts clean.
+        buf.truncate(record_length);
+        discard_to_newline(reader)?;
     }
     Ok(true)
+}
+
+/// Consume and drop bytes up to and including the next newline (or clean EOF)
+/// without buffering them into a record, so the reader resyncs to the next
+/// physical line after an over-width record. Memory stays bounded by the
+/// [`BufReader`]'s own buffer — the discarded bytes are never collected.
+fn discard_to_newline<R: Read>(reader: &mut BufReader<R>) -> Result<(), FormatError> {
+    loop {
+        let chunk = reader.fill_buf()?;
+        if chunk.is_empty() {
+            return Ok(()); // EOF before any further newline.
+        }
+        let newline = chunk.iter().position(|&b| b == b'\n');
+        let consumed = newline.map_or(chunk.len(), |i| i + 1);
+        reader.consume(consumed);
+        if newline.is_some() {
+            return Ok(());
+        }
+    }
 }
 
 /// `true` when a line carries no field content — empty, or only whitespace.
@@ -566,58 +589,82 @@ mod tests {
     }
 
     #[test]
-    fn lf_line_missing_newline_over_cap_errors_and_stays_bounded() {
+    fn lf_line_missing_newline_over_cap_reads_prefix_and_stays_bounded() {
         // A line-separated (LF) input whose line never terminates must not buffer
-        // past the declared width: a typed record error with 1-based row context,
-        // and the read buffer never exceeds the cap regardless of input length.
+        // past the declared width: the declared-width prefix reads and the rest
+        // is discarded to EOF, so the read buffer never exceeds the cap
+        // regardless of input length.
         let record_length = 8;
         let data = vec![b'x'; 4096];
         let mut reader = BufReader::new(&data[..]);
         let mut buf = Vec::new();
-        let err = read_physical_line(&mut reader, &LineSeparator::Lf, record_length, 0, &mut buf)
-            .unwrap_err();
-        match err {
-            FormatError::InvalidRecord { row, message } => {
-                assert_eq!(row, 1, "row is 1-based for the overrunning line");
-                assert!(message.contains("overruns"), "message: {message}");
-            }
-            other => panic!("expected InvalidRecord, got {other:?}"),
-        }
+        assert!(
+            read_physical_line(&mut reader, &LineSeparator::Lf, record_length, 0, &mut buf)
+                .unwrap()
+        );
+        assert_eq!(buf, vec![b'x'; record_length], "declared-width prefix kept");
         assert!(
             buf.len() <= record_length + 3,
             "read buffer bounded to the cap, got {}",
             buf.len()
         );
+        // The whole (single, unterminated) physical line was consumed: EOF next.
+        assert!(
+            !read_physical_line(&mut reader, &LineSeparator::Lf, record_length, 1, &mut buf)
+                .unwrap()
+        );
     }
 
     #[test]
-    fn lf_line_one_byte_over_cap_without_terminator_errors() {
-        // The tightest boundary: 8 non-newline bytes then a newline at byte 9,
-        // one past the 8-byte cap (record width 5). The read fills the cap with
-        // no terminator → overrun, not a truncated read of the terminated line.
-        let mut reader = BufReader::new(&b"AAAAAAAA\nrest"[..]);
+    fn lf_wide_terminated_line_reads_prefix_and_resyncs_to_next_record() {
+        // The finding's shape: a physical line far wider than the declared width
+        // (trailing filler the schema does not map) but properly terminated. The
+        // declared-width prefix reads, the filler is discarded to the newline,
+        // and the following record starts clean — a previously-valid file shape.
+        let mut reader = BufReader::new(&b"AAAAAAAA\nBBB\n"[..]);
         let mut buf = Vec::new();
-        let err = read_physical_line(&mut reader, &LineSeparator::Lf, 5, 0, &mut buf).unwrap_err();
-        assert!(matches!(err, FormatError::InvalidRecord { row: 1, .. }));
-        assert!(buf.len() <= 5 + 3);
+        // Record width 5 → cap 8; first line is 8 'A' + '\n' (filler past width).
+        assert!(read_physical_line(&mut reader, &LineSeparator::Lf, 5, 0, &mut buf).unwrap());
+        assert_eq!(buf, b"AAAAA", "declared-width prefix kept");
+        assert!(read_physical_line(&mut reader, &LineSeparator::Lf, 5, 1, &mut buf).unwrap());
+        assert_eq!(
+            buf, b"BBB",
+            "reader resynced to the next record after filler"
+        );
+        assert!(!read_physical_line(&mut reader, &LineSeparator::Lf, 5, 2, &mut buf).unwrap());
     }
 
     #[test]
-    fn crlf_line_missing_newline_over_cap_errors_with_row_context() {
+    fn lf_line_one_byte_over_cap_reads_prefix_and_resyncs() {
+        // The tightest boundary: 8 non-newline bytes then a newline at byte 9,
+        // one past the 8-byte cap (record width 5). The prefix reads and the
+        // reader resyncs to the following record rather than rejecting the line.
+        let mut reader = BufReader::new(&b"AAAAAAAA\nrest\n"[..]);
+        let mut buf = Vec::new();
+        assert!(read_physical_line(&mut reader, &LineSeparator::Lf, 5, 0, &mut buf).unwrap());
+        assert_eq!(buf, b"AAAAA");
+        assert!(buf.len() <= 5 + 3);
+        assert!(read_physical_line(&mut reader, &LineSeparator::Lf, 5, 1, &mut buf).unwrap());
+        assert_eq!(buf, b"rest");
+    }
+
+    #[test]
+    fn crlf_wide_line_reads_prefix_and_stays_bounded() {
         let record_length = 5;
         let data = vec![b'a'; 512];
         let mut reader = BufReader::new(&data[..]);
         let mut buf = Vec::new();
-        // `row` is the pre-increment physical row; the error reports `row + 1`.
-        let err = read_physical_line(
-            &mut reader,
-            &LineSeparator::CrLf,
-            record_length,
-            3,
-            &mut buf,
-        )
-        .unwrap_err();
-        assert!(matches!(err, FormatError::InvalidRecord { row: 4, .. }));
+        assert!(
+            read_physical_line(
+                &mut reader,
+                &LineSeparator::CrLf,
+                record_length,
+                3,
+                &mut buf
+            )
+            .unwrap()
+        );
+        assert_eq!(buf, vec![b'a'; record_length], "declared-width prefix kept");
         assert!(buf.len() <= record_length + 3);
     }
 }

--- a/crates/clinker-format/src/fixed_width/field.rs
+++ b/crates/clinker-format/src/fixed_width/field.rs
@@ -108,14 +108,19 @@ pub fn resolve_width(f: &Column, start: usize) -> Result<usize, FormatError> {
 
 /// Read one physical record line into `buf`, returning `false` at end of input.
 ///
-/// `Lf` / `CrLf` read up to (and strip) the newline; `None` reads exactly
-/// `record_length` bytes (a delimiter-free fixed block). A short final block
-/// under `None` is an incomplete-record error.
+/// `Lf` / `CrLf` read up to (and strip) the newline, but the read is bounded to
+/// the declared record width plus a line-terminator allowance: a line-separated
+/// file with a missing terminator cannot buffer the rest of the input into one
+/// record, preserving the engine's bounded-memory guarantee on malformed input.
+/// A line that fills the cap without a terminator overruns the declared width
+/// and is rejected. `None` reads exactly `record_length` bytes (a delimiter-free
+/// fixed block). A short final block under `None` is an incomplete-record error.
 ///
 /// # Errors
 ///
 /// Returns [`FormatError::Io`] on a read fault, or [`FormatError::InvalidRecord`]
-/// when a `None`-separated block ends mid-record at `row + 1`.
+/// at `row + 1` when a `None`-separated block ends mid-record, or when an `Lf` /
+/// `CrLf` line overruns the declared width with no line terminator.
 pub fn read_physical_line<R: Read>(
     reader: &mut BufReader<R>,
     separator: &LineSeparator,
@@ -126,7 +131,7 @@ pub fn read_physical_line<R: Read>(
     buf.clear();
     match separator {
         LineSeparator::Lf => {
-            if reader.read_until(b'\n', buf)? == 0 {
+            if !read_capped_line(reader, record_length, row, buf)? {
                 return Ok(false);
             }
             if buf.last() == Some(&b'\n') {
@@ -134,7 +139,7 @@ pub fn read_physical_line<R: Read>(
             }
         }
         LineSeparator::CrLf => {
-            if reader.read_until(b'\n', buf)? == 0 {
+            if !read_capped_line(reader, record_length, row, buf)? {
                 return Ok(false);
             }
             if buf.ends_with(b"\r\n") {
@@ -162,6 +167,42 @@ pub fn read_physical_line<R: Read>(
                 total += n;
             }
         }
+    }
+    Ok(true)
+}
+
+/// Read up to one newline-terminated line into `buf`, bounded to the declared
+/// record width so a line-separated file missing a terminator cannot buffer the
+/// rest of the input into a single record. Returns `Ok(false)` at clean EOF
+/// (nothing read); the trailing newline, if present, is left on `buf` for the
+/// caller to strip per its separator.
+///
+/// The cap admits a full record, a CR/LF terminator, and one sentinel byte, so a
+/// well-formed line — even one carrying a full-width record plus `\r\n` — always
+/// fits. Consuming the whole cap without reaching a newline means the physical
+/// line overruns the declared width: a record error at `row + 1`, not an
+/// unbounded read.
+fn read_capped_line<R: Read>(
+    reader: &mut BufReader<R>,
+    record_length: usize,
+    row: u64,
+    buf: &mut Vec<u8>,
+) -> Result<bool, FormatError> {
+    let cap = record_length + 3;
+    // `Take` is created fresh per line and borrows the reader, so the limit
+    // resets each call and the underlying buffer position carries over.
+    let n = (&mut *reader).take(cap as u64).read_until(b'\n', buf)?;
+    if n == 0 {
+        return Ok(false);
+    }
+    if n == cap && buf.last() != Some(&b'\n') {
+        return Err(FormatError::InvalidRecord {
+            row: row + 1,
+            message: format!(
+                "line-separated record overruns the declared {record_length}-byte \
+                 width with no line terminator"
+            ),
+        });
     }
     Ok(true)
 }
@@ -471,5 +512,112 @@ mod tests {
             coerce_scalar(&Type::Any, None, None, "raw").unwrap(),
             Value::String("raw".into())
         );
+    }
+
+    fn read_line(sep: &LineSeparator, record_length: usize, row: u64, data: &[u8]) -> Vec<u8> {
+        let mut reader = BufReader::new(data);
+        let mut buf = Vec::new();
+        assert!(read_physical_line(&mut reader, sep, record_length, row, &mut buf).unwrap());
+        buf
+    }
+
+    #[test]
+    fn lf_wellformed_lines_strip_newline() {
+        let mut reader = BufReader::new(&b"Alice\nBobby\n"[..]);
+        let mut buf = Vec::new();
+        assert!(read_physical_line(&mut reader, &LineSeparator::Lf, 5, 0, &mut buf).unwrap());
+        assert_eq!(buf, b"Alice");
+        assert!(read_physical_line(&mut reader, &LineSeparator::Lf, 5, 1, &mut buf).unwrap());
+        assert_eq!(buf, b"Bobby");
+        // Clean EOF after the last terminated line.
+        assert!(!read_physical_line(&mut reader, &LineSeparator::Lf, 5, 2, &mut buf).unwrap());
+    }
+
+    #[test]
+    fn crlf_wellformed_lines_strip_crlf() {
+        let mut reader = BufReader::new(&b"Alice\r\nBob\r\n"[..]);
+        let mut buf = Vec::new();
+        assert!(read_physical_line(&mut reader, &LineSeparator::CrLf, 5, 0, &mut buf).unwrap());
+        assert_eq!(buf, b"Alice");
+        assert!(read_physical_line(&mut reader, &LineSeparator::CrLf, 5, 1, &mut buf).unwrap());
+        assert_eq!(buf, b"Bob");
+    }
+
+    #[test]
+    fn lf_final_line_without_newline_within_cap_reads() {
+        // A final line with no trailing terminator that fits within the declared
+        // width still reads — this is the ordinary last-line-at-EOF case, not an
+        // overrun.
+        assert_eq!(
+            read_line(&LineSeparator::Lf, 8, 0, b"ABCDEFGH"),
+            b"ABCDEFGH"
+        );
+    }
+
+    #[test]
+    fn lf_terminated_line_at_cap_boundary_reads() {
+        // The newline sitting on the final cap byte (content = record_length + 2)
+        // is a terminated line, accepted; only a cap-filling run *without* a
+        // terminator is an overrun. Record width 5 → cap 8 → 7 content + '\n'.
+        assert_eq!(
+            read_line(&LineSeparator::Lf, 5, 0, b"AAAAAAA\n"),
+            b"AAAAAAA"
+        );
+    }
+
+    #[test]
+    fn lf_line_missing_newline_over_cap_errors_and_stays_bounded() {
+        // A line-separated (LF) input whose line never terminates must not buffer
+        // past the declared width: a typed record error with 1-based row context,
+        // and the read buffer never exceeds the cap regardless of input length.
+        let record_length = 8;
+        let data = vec![b'x'; 4096];
+        let mut reader = BufReader::new(&data[..]);
+        let mut buf = Vec::new();
+        let err = read_physical_line(&mut reader, &LineSeparator::Lf, record_length, 0, &mut buf)
+            .unwrap_err();
+        match err {
+            FormatError::InvalidRecord { row, message } => {
+                assert_eq!(row, 1, "row is 1-based for the overrunning line");
+                assert!(message.contains("overruns"), "message: {message}");
+            }
+            other => panic!("expected InvalidRecord, got {other:?}"),
+        }
+        assert!(
+            buf.len() <= record_length + 3,
+            "read buffer bounded to the cap, got {}",
+            buf.len()
+        );
+    }
+
+    #[test]
+    fn lf_line_one_byte_over_cap_without_terminator_errors() {
+        // The tightest boundary: 8 non-newline bytes then a newline at byte 9,
+        // one past the 8-byte cap (record width 5). The read fills the cap with
+        // no terminator → overrun, not a truncated read of the terminated line.
+        let mut reader = BufReader::new(&b"AAAAAAAA\nrest"[..]);
+        let mut buf = Vec::new();
+        let err = read_physical_line(&mut reader, &LineSeparator::Lf, 5, 0, &mut buf).unwrap_err();
+        assert!(matches!(err, FormatError::InvalidRecord { row: 1, .. }));
+        assert!(buf.len() <= 5 + 3);
+    }
+
+    #[test]
+    fn crlf_line_missing_newline_over_cap_errors_with_row_context() {
+        let record_length = 5;
+        let data = vec![b'a'; 512];
+        let mut reader = BufReader::new(&data[..]);
+        let mut buf = Vec::new();
+        // `row` is the pre-increment physical row; the error reports `row + 1`.
+        let err = read_physical_line(
+            &mut reader,
+            &LineSeparator::CrLf,
+            record_length,
+            3,
+            &mut buf,
+        )
+        .unwrap_err();
+        assert!(matches!(err, FormatError::InvalidRecord { row: 4, .. }));
+        assert!(buf.len() <= record_length + 3);
     }
 }

--- a/crates/clinker-format/src/fixed_width/reader.rs
+++ b/crates/clinker-format/src/fixed_width/reader.rs
@@ -422,6 +422,31 @@ mod tests {
     }
 
     #[test]
+    fn test_fixedwidth_lf_missing_newline_is_bounded_record_error() {
+        // A line-separated (LF) source whose line never terminates must fail with
+        // a typed, row-tagged record error rather than buffering the whole input
+        // into one record — the bounded-memory guarantee on malformed input.
+        let data = vec![b'x'; 10_000];
+        let fields = vec![{
+            let mut f = field("name");
+            f.ty = Type::String;
+            f.start = Some(0);
+            f.width = Some(8);
+            f
+        }];
+        let mut reader =
+            FixedWidthReader::new(&data[..], fields, FixedWidthReaderConfig::default()).unwrap();
+        let err = reader.next_record().unwrap_err();
+        match err {
+            FormatError::InvalidRecord { row, message } => {
+                assert_eq!(row, 1);
+                assert!(message.contains("overruns"), "message: {message}");
+            }
+            other => panic!("expected InvalidRecord, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_schema_zero_width_field_rejected() {
         let fields = vec![{
             let mut f = field("bad");

--- a/crates/clinker-format/src/fixed_width/reader.rs
+++ b/crates/clinker-format/src/fixed_width/reader.rs
@@ -422,10 +422,11 @@ mod tests {
     }
 
     #[test]
-    fn test_fixedwidth_lf_missing_newline_is_bounded_record_error() {
-        // A line-separated (LF) source whose line never terminates must fail with
-        // a typed, row-tagged record error rather than buffering the whole input
-        // into one record — the bounded-memory guarantee on malformed input.
+    fn test_fixedwidth_lf_missing_newline_reads_prefix_and_stays_bounded() {
+        // A line-separated (LF) source whose line never terminates must not buffer
+        // the whole input into one record. The declared-width prefix reads and the
+        // remaining bytes are discarded to end of input, so a malformed file stays
+        // within the bounded-memory guarantee rather than growing a single record.
         let data = vec![b'x'; 10_000];
         let fields = vec![{
             let mut f = field("name");
@@ -436,14 +437,33 @@ mod tests {
         }];
         let mut reader =
             FixedWidthReader::new(&data[..], fields, FixedWidthReaderConfig::default()).unwrap();
-        let err = reader.next_record().unwrap_err();
-        match err {
-            FormatError::InvalidRecord { row, message } => {
-                assert_eq!(row, 1);
-                assert!(message.contains("overruns"), "message: {message}");
-            }
-            other => panic!("expected InvalidRecord, got {other:?}"),
-        }
+        let rec = reader.next_record().unwrap().unwrap();
+        assert_eq!(rec.get("name"), Some(&Value::String("xxxxxxxx".into())));
+        // The single unterminated physical line was fully consumed.
+        assert!(reader.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_fixedwidth_lf_wide_lines_read_prefix_and_resync() {
+        // Physical lines wider than the mapped schema (trailing filler the schema
+        // does not declare) read their declared-width prefix and resync to the
+        // next record at the newline — a common fixed-LRECL extract shape. The
+        // 8-byte name prefix is followed by filler bytes the schema never maps.
+        let data = format!("{:<8}ignored-filler\n{:<8}more-filler\n", "Alice", "Bob").into_bytes();
+        let fields = vec![{
+            let mut f = field("name");
+            f.ty = Type::String;
+            f.start = Some(0);
+            f.width = Some(8);
+            f
+        }];
+        let mut reader =
+            FixedWidthReader::new(&data[..], fields, FixedWidthReaderConfig::default()).unwrap();
+        let rec1 = reader.next_record().unwrap().unwrap();
+        assert_eq!(rec1.get("name"), Some(&Value::String("Alice".into())));
+        let rec2 = reader.next_record().unwrap().unwrap();
+        assert_eq!(rec2.get("name"), Some(&Value::String("Bob".into())));
+        assert!(reader.next_record().unwrap().is_none());
     }
 
     #[test]

--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -97,11 +97,23 @@ impl<W: Write> FixedWidthWriter<W> {
                 Justify::Left
             });
 
+            // Widths are byte counts (the reader slices by byte), so padding
+            // must fill exact byte counts. A pad character wider than one byte
+            // would overflow the declared width — each push adds `len_utf8()`
+            // bytes — so reject it at construction rather than emit a cell that
+            // no longer matches its byte range. An empty or absent `pad`
+            // defaults to a space.
             let pad_char = f
                 .pad
                 .as_deref()
                 .and_then(|s| s.chars().next())
                 .unwrap_or(' ');
+            if pad_char.len_utf8() != 1 {
+                return Err(field::invalid_field(
+                    &f.name,
+                    "'pad' must be a single-byte character so padding fills exact byte widths",
+                ));
+            }
 
             let truncation = f.truncation.clone().unwrap_or(if is_numeric {
                 TruncationPolicy::Error
@@ -222,15 +234,24 @@ impl<W: Write> FixedWidthWriter<W> {
         })
     }
 
+    /// Fit `value` into the field's exact byte width, padding or truncating on
+    /// a UTF-8 character boundary. Widths are byte counts (the reader slices by
+    /// byte), so an over-long value is cut at the largest character boundary at
+    /// or below `width` — never mid-codepoint — and the remainder pad-filled.
+    /// The result is always valid UTF-8 of exactly `width` bytes; `pad_char` is
+    /// a single byte (enforced at construction), so it lands on an exact count.
     fn pad_and_justify(&self, field: &WriteField, value: &str) -> String {
-        if value.len() >= field.width {
-            return value[..field.width].to_string();
+        let mut cut = value.len().min(field.width);
+        while !value.is_char_boundary(cut) {
+            cut -= 1;
         }
+        let kept = &value[..cut];
+        let padding = field.width - cut;
 
-        let padding = field.width - value.len();
         match field.justify {
             Justify::Left => {
-                let mut s = value.to_string();
+                let mut s = String::with_capacity(field.width);
+                s.push_str(kept);
                 for _ in 0..padding {
                     s.push(field.pad_char);
                 }
@@ -241,7 +262,7 @@ impl<W: Write> FixedWidthWriter<W> {
                 for _ in 0..padding {
                     s.push(field.pad_char);
                 }
-                s.push_str(value);
+                s.push_str(kept);
                 s
             }
         }
@@ -269,7 +290,7 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
                         return Err(FormatError::InvalidRecord {
                             row: 0,
                             message: format!(
-                                "field '{}': value '{}' ({} chars) exceeds width {} — truncation policy is 'error'",
+                                "field '{}': value '{}' ({} bytes) exceeds width {} — truncation policy is 'error'",
                                 field.name,
                                 formatted,
                                 formatted.len(),
@@ -279,7 +300,7 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
                     }
                     TruncationPolicy::Warn => {
                         self.truncation_warnings.push(format!(
-                            "field '{}': value '{}' truncated to {} chars",
+                            "field '{}': value '{}' truncated to {} bytes",
                             field.name, formatted, field.width
                         ));
                     }
@@ -507,6 +528,114 @@ mod tests {
         assert_eq!(output, "LongN\n"); // truncated to 5 chars
         assert_eq!(warning_count, 1);
         assert!(warning_msg.contains("truncated"));
+    }
+
+    /// A non-ASCII value whose UTF-8 encoding overruns the field's byte width
+    /// is cut at a character boundary — never mid-codepoint — so the emitted
+    /// cell stays valid UTF-8 of exactly `width` bytes instead of panicking on
+    /// a non-boundary byte slice. `"café"` is 5 bytes (`é` is 2), so a width-4
+    /// field keeps `"caf"` and pads the remaining byte.
+    #[test]
+    fn test_fixedwidth_write_truncate_non_ascii_warn_byte_safe() {
+        let fields = vec![{
+            let mut f = field("name");
+            f.ty = Type::String;
+            f.start = Some(0);
+            f.width = Some(4);
+            f.truncation = Some(TruncationPolicy::Warn);
+            f
+        }];
+
+        let mut buf = Vec::new();
+        let warning_msg;
+        {
+            let mut writer =
+                FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+            let rec = make_record(&["name"], vec![Value::String("café".into())]);
+            writer.write_record(&rec).unwrap();
+            writer.flush().unwrap();
+            warning_msg = writer.truncation_warnings()[0].clone();
+        }
+
+        // Valid UTF-8 of exactly the byte width — the partial `é` is dropped,
+        // not split, and the freed byte is space-padded.
+        let output = String::from_utf8(buf).expect("output must be valid UTF-8");
+        assert_eq!(output, "caf \n");
+        // Diagnostics report byte counts, not char counts.
+        assert!(
+            warning_msg.contains("bytes"),
+            "warning should say bytes: {warning_msg}"
+        );
+        assert!(
+            !warning_msg.contains("chars"),
+            "warning must not say chars: {warning_msg}"
+        );
+    }
+
+    /// A multi-byte character that does not fit in the byte width at all yields
+    /// an all-pad cell of exactly `width` bytes rather than panicking. Silent
+    /// truncation emits no warning but still produces a byte-exact cell.
+    #[test]
+    fn test_fixedwidth_write_truncate_non_ascii_silent_byte_safe() {
+        let fields = vec![{
+            let mut f = field("flag");
+            f.ty = Type::String;
+            f.start = Some(0);
+            f.width = Some(1);
+            f.truncation = Some(TruncationPolicy::Silent);
+            f
+        }];
+
+        let mut buf = Vec::new();
+        let warning_count;
+        {
+            let mut writer =
+                FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+            // `é` is 2 bytes; width 1 cannot hold it, so the cell is one pad byte.
+            let rec = make_record(&["flag"], vec![Value::String("é".into())]);
+            writer.write_record(&rec).unwrap();
+            writer.flush().unwrap();
+            warning_count = writer.truncation_warnings().len();
+        }
+
+        let output = String::from_utf8(buf).expect("output must be valid UTF-8");
+        assert_eq!(output, " \n");
+        assert_eq!(warning_count, 0, "silent truncation emits no warning");
+    }
+
+    /// A multi-byte `pad` character cannot fill an exact byte width — each push
+    /// would add more than one byte — so it is rejected at construction with a
+    /// typed field error naming the constraint.
+    #[test]
+    fn test_fixedwidth_write_multibyte_pad_rejected() {
+        let fields = vec![{
+            let mut f = field("name");
+            f.ty = Type::String;
+            f.start = Some(0);
+            f.width = Some(5);
+            // U+00B7 MIDDLE DOT is 2 UTF-8 bytes.
+            f.pad = Some("·".into());
+            f
+        }];
+
+        let mut buf = Vec::new();
+        let err = FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default())
+            .err()
+            .expect("multi-byte pad must be rejected at construction");
+        match err {
+            FormatError::InvalidRecord { row, message } => {
+                assert_eq!(row, 0, "construction defect reports row 0");
+                assert!(
+                    message.contains("single-byte"),
+                    "message should state the single-byte constraint: {message}"
+                );
+                assert!(
+                    message.contains("'name'"),
+                    "message should name the field: {message}"
+                );
+            }
+            other => panic!("expected InvalidRecord, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/clinker-format/src/hl7/writer.rs
+++ b/crates/clinker-format/src/hl7/writer.rs
@@ -455,6 +455,15 @@ impl<W: Write + Send> FormatWriter for Hl7Writer<W> {
         self.writer.flush().map_err(FormatError::Io)?;
         Ok(())
     }
+
+    /// Drain the underlying sink without emitting the batch/file trailers, so
+    /// byte-limit split accounting stays non-finalizing. Plan validation
+    /// rejects byte splitting for this single-envelope format; this keeps the
+    /// trait contract honest regardless, with the `BTS`/`FTS` trailers written
+    /// only by [`Self::flush`].
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.writer.flush().map_err(FormatError::Io)
+    }
 }
 
 /// Whether a schema column name is a writable HL7 field column: a verbatim

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -404,7 +404,23 @@ impl FormatReader for JsonReader {
                 continue;
             }
             let pointer = match &section.extract {
-                EnvelopeExtract::JsonPointer(p) => p.as_str(),
+                EnvelopeExtract::JsonPointer(p) => {
+                    // A slashless non-empty pointer decodes to zero segments,
+                    // identical to the whole-document pointer `""`, and would
+                    // silently match the root instead of the intended section.
+                    // Plan validation rejects this at authoring time; guard
+                    // here too so any caller that bypasses the plan (a direct
+                    // reader construction) fails loud rather than matching the
+                    // wrong node.
+                    if !p.is_empty() && !p.starts_with('/') {
+                        return Err(FormatError::Json(format!(
+                            "envelope section {name:?}: `json_pointer` {p:?} is not a valid \
+                             RFC 6901 pointer — a pointer must be empty (the whole document) or \
+                             start with `/`."
+                        )));
+                    }
+                    p.as_str()
+                }
                 EnvelopeExtract::XmlPath(_) => {
                     return Err(FormatError::Json(format!(
                         "envelope section {name:?}: declared `xml_path` extract \

--- a/crates/clinker-format/src/json/streaming.rs
+++ b/crates/clinker-format/src/json/streaming.rs
@@ -42,6 +42,11 @@ impl SectionTarget {
     /// A leading `/` introduces each segment; `~1` decodes to `/` and `~0`
     /// to `~`, matching `serde_json::Value::pointer`. The empty pointer
     /// `""` yields no segments (it names the root).
+    ///
+    /// Callers must pre-validate the pointer grammar (empty or leading `/`):
+    /// this constructor is infallible and a slashless non-empty pointer would
+    /// decode to zero segments, silently aliasing the whole-document pointer.
+    /// The reader rejects that case before building a target.
     pub(crate) fn new(name: String, pointer: &str) -> Self {
         let segments = if pointer.is_empty() {
             Vec::new()

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -277,6 +277,14 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
         Ok(())
     }
 
+    /// Drain the underlying sink without writing the closing array bytes, so
+    /// byte-limit split accounting can observe the size mid-document. The
+    /// finalizing `]` (or `[]` for an empty file) is emitted only by
+    /// [`Self::flush`] at end of file / rotation.
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.writer.flush().map_err(FormatError::Io)
+    }
+
     fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
         let Some(env) = self.envelope.as_mut() else {
             return Ok(());

--- a/crates/clinker-format/src/splitting/mod.rs
+++ b/crates/clinker-format/src/splitting/mod.rs
@@ -265,10 +265,13 @@ impl FormatWriter for SplittingWriter {
         self.current_writer.as_mut().unwrap().write_record(record)?;
         self.records_in_file += 1;
 
-        // Flush format writer's internal buffer to push bytes through to CountingWriter.
-        // Required for accurate byte-limit checking (format writers may buffer internally).
+        // Push the format writer's internally buffered bytes through to the
+        // CountingWriter so the byte-limit check sees the true on-disk size.
+        // Uses the non-finalizing drain rather than `flush`: a finalizing flush
+        // would close the JSON array / XML root / envelope trailer here, and the
+        // next record would then land after the closed document, corrupting it.
         if self.policy.max_bytes.is_some() {
-            self.current_writer.as_mut().unwrap().flush()?;
+            self.current_writer.as_mut().unwrap().flush_bytes()?;
         }
 
         Ok(())
@@ -277,6 +280,17 @@ impl FormatWriter for SplittingWriter {
     fn flush(&mut self) -> Result<(), FormatError> {
         if let Some(ref mut writer) = self.current_writer {
             writer.flush()?;
+        }
+        Ok(())
+    }
+
+    /// Drain the active inner writer's buffered bytes without finalizing its
+    /// document, keeping the non-finalizing contract intact when a split sink
+    /// is itself driven by byte accounting. With no active writer there is
+    /// nothing to drain.
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        if let Some(ref mut writer) = self.current_writer {
+            writer.flush_bytes()?;
         }
         Ok(())
     }

--- a/crates/clinker-format/src/splitting/tests.rs
+++ b/crates/clinker-format/src/splitting/tests.rs
@@ -872,6 +872,198 @@ fn test_splitting_writer_xml_produces_valid_files() {
     assert_eq!(count_items(&contents[2]), 1);
 }
 
+/// Byte-limited splitting of JSON *array* output: each rotated file must be a
+/// self-contained, valid JSON array. Regression guard for the finalizing
+/// `flush()` closing the array after every record during byte accounting,
+/// which stranded later records after the closing `]`.
+#[test]
+fn test_splitting_writer_json_array_byte_split_valid_files() {
+    use crate::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
+
+    let schema = make_schema(&["id", "name"]);
+    let registry = FileRegistry::new();
+    let policy = SplitPolicy {
+        max_records: None,
+        max_bytes: Some(60),
+        group_key: None,
+        repeat_header: false,
+        oversize_group: OversizeGroupPolicy::default(),
+    };
+
+    let json_config = JsonWriterConfig {
+        format: JsonOutputMode::Array,
+        pretty: false,
+        preserve_nulls: false,
+        include_engine_stamped: false,
+        envelope: None,
+    };
+
+    let json_factory: WriterFactory = Box::new(
+        move |counting: CountingWriter<Box<dyn Write + Send>>, schema: Arc<Schema>| {
+            Ok(
+                Box::new(JsonWriter::new(counting, schema, json_config.clone()))
+                    as Box<dyn FormatWriter>,
+            )
+        },
+    );
+
+    let mut writer = SplittingWriter::new(
+        registry.file_factory(),
+        json_factory,
+        Arc::clone(&schema),
+        policy,
+    );
+
+    for i in 0..10 {
+        let record = make_record(
+            &schema,
+            vec![Value::Integer(i), Value::String(format!("nm{i}").into())],
+        );
+        writer.write_record(&record).unwrap();
+    }
+    writer.flush().unwrap();
+
+    assert!(
+        registry.file_count() > 1,
+        "byte limit should have split into multiple files"
+    );
+    let contents = registry.file_contents();
+
+    let mut total_records = 0;
+    let mut multi_record_file_seen = false;
+    for (idx, content) in contents.iter().enumerate() {
+        // Each file must parse as one JSON array — with the bug, a file holding
+        // two or more records contains a premature `]` and fails to parse.
+        let parsed: serde_json::Value = serde_json::from_str(content)
+            .unwrap_or_else(|e| panic!("file {idx} is not valid JSON: {e}\n{content}"));
+        let arr = parsed
+            .as_array()
+            .unwrap_or_else(|| panic!("file {idx} is not a JSON array: {content}"));
+        // The array brackets appear exactly once per file — record payloads
+        // carry no brackets, so a stray finalizing flush would show up as extra
+        // `]` occurrences.
+        assert_eq!(
+            content.matches('[').count(),
+            1,
+            "file {idx}: exactly one opening bracket: {content}"
+        );
+        assert_eq!(
+            content.matches(']').count(),
+            1,
+            "file {idx}: exactly one closing bracket: {content}"
+        );
+        if arr.len() > 1 {
+            multi_record_file_seen = true;
+        }
+        for obj in arr {
+            assert!(obj.get("id").is_some(), "file {idx}: record missing id");
+            assert!(obj.get("name").is_some(), "file {idx}: record missing name");
+        }
+        total_records += arr.len();
+    }
+    assert_eq!(
+        total_records, 10,
+        "all records preserved across split files"
+    );
+    assert!(
+        multi_record_file_seen,
+        "at least one file must hold multiple records to exercise the mid-document corruption path",
+    );
+}
+
+/// Byte-limited splitting of XML output: each rotated file must be a single
+/// well-formed document with exactly one root element. Regression guard for the
+/// finalizing `flush()` closing the root after every record during byte
+/// accounting, which stranded later records outside the root.
+#[test]
+fn test_splitting_writer_xml_byte_split_valid_files() {
+    use crate::xml::writer::{XmlWriter, XmlWriterConfig};
+
+    let schema = make_schema(&["id", "val"]);
+    let registry = FileRegistry::new();
+    let policy = SplitPolicy {
+        max_records: None,
+        max_bytes: Some(120),
+        group_key: None,
+        repeat_header: false,
+        oversize_group: OversizeGroupPolicy::default(),
+    };
+
+    let xml_config = XmlWriterConfig {
+        root_element: "items".into(),
+        record_element: "item".into(),
+        ..Default::default()
+    };
+
+    let xml_factory: WriterFactory = Box::new(
+        move |counting: CountingWriter<Box<dyn Write + Send>>, schema: Arc<Schema>| {
+            Ok(
+                Box::new(XmlWriter::new(counting, schema, xml_config.clone()))
+                    as Box<dyn FormatWriter>,
+            )
+        },
+    );
+
+    let mut writer = SplittingWriter::new(
+        registry.file_factory(),
+        xml_factory,
+        Arc::clone(&schema),
+        policy,
+    );
+
+    for i in 0..10 {
+        let record = make_record(
+            &schema,
+            vec![Value::Integer(i), Value::String(format!("v{i}").into())],
+        );
+        writer.write_record(&record).unwrap();
+    }
+    writer.flush().unwrap();
+
+    assert!(
+        registry.file_count() > 1,
+        "byte limit should have split into multiple files"
+    );
+    let contents = registry.file_contents();
+
+    let mut total_items = 0;
+    let mut multi_record_file_seen = false;
+    for (idx, content) in contents.iter().enumerate() {
+        // Exactly one root open/close per file — with the bug, a finalizing
+        // flush after each record emits multiple `</items>` and strands later
+        // records outside the root element.
+        assert_eq!(
+            content.matches("<items>").count(),
+            1,
+            "file {idx}: exactly one root open tag: {content}"
+        );
+        assert_eq!(
+            content.matches("</items>").count(),
+            1,
+            "file {idx}: exactly one root close tag: {content}"
+        );
+        // The whole file parses as well-formed XML from start to EOF.
+        let mut reader = quick_xml::Reader::from_str(content);
+        loop {
+            match reader.read_event() {
+                Ok(quick_xml::events::Event::Eof) => break,
+                Ok(_) => {}
+                Err(e) => panic!("file {idx} is not well-formed XML: {e}\n{content}"),
+            }
+        }
+        let items = content.matches("<item>").count();
+        if items > 1 {
+            multi_record_file_seen = true;
+        }
+        total_items += items;
+    }
+    assert_eq!(total_items, 10, "all records preserved across split files");
+    assert!(
+        multi_record_file_seen,
+        "at least one file must hold multiple records to exercise the mid-document corruption path",
+    );
+}
+
 /// A `FormatWriter` that records per-document hook calls into shared state,
 /// for proving `SplittingWriter` forwards framing to its active inner writer.
 struct HookProbe {

--- a/crates/clinker-format/src/swift/writer.rs
+++ b/crates/clinker-format/src/swift/writer.rs
@@ -359,6 +359,15 @@ impl<W: Write + Send> FormatWriter for SwiftWriter<W> {
         self.writer.flush().map_err(FormatError::Io)?;
         Ok(())
     }
+
+    /// Drain the underlying sink without closing block 4 or emitting the block-5
+    /// trailer, so byte-limit split accounting stays non-finalizing. Plan
+    /// validation rejects byte splitting for this single-message format; this
+    /// keeps the trait contract honest regardless, with the trailers written
+    /// only by [`Self::flush`].
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.writer.flush().map_err(FormatError::Io)
+    }
 }
 
 /// Reject a block-4 value whose folded continuation lines cannot be framed

--- a/crates/clinker-format/src/traits.rs
+++ b/crates/clinker-format/src/traits.rs
@@ -99,6 +99,28 @@ pub trait FormatWriter: Send {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError>;
     fn flush(&mut self) -> Result<(), FormatError>;
 
+    /// Push bytes buffered inside this writer through to the underlying I/O
+    /// sink *without* emitting the document's closing framing. Called by
+    /// [`SplittingWriter`](crate::splitting::SplittingWriter) after every
+    /// record when a byte limit is configured, so the shared byte counter
+    /// reflects the true on-disk size before the next rotation check.
+    ///
+    /// Distinct from [`Self::flush`] on purpose: for the whole-file-framed
+    /// formats `flush` finalizes the document (JSON's closing `]`, XML's
+    /// closing root element, an EDI interchange trailer), and finalizing after
+    /// every record would close the document mid-stream — later records then
+    /// land after the close and corrupt the file. The default forwards to
+    /// [`Self::flush`], correct for record-oriented writers whose `flush`
+    /// emits no closing framing (CSV, fixed-width); finalizing formats
+    /// override it to drain only the underlying sink.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any I/O error draining the buffer.
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.flush()
+    }
+
     /// Emit any per-document opening framing (an envelope header) before the
     /// document's first body record streams. Called by the Output dispatch
     /// arm on the first record of each document (boundaries are detected from

--- a/crates/clinker-format/src/x12/writer.rs
+++ b/crates/clinker-format/src/x12/writer.rs
@@ -600,6 +600,15 @@ impl<W: Write + Send> FormatWriter for X12Writer<W> {
         self.writer.flush().map_err(FormatError::Io)?;
         Ok(())
     }
+
+    /// Drain the underlying sink without emitting the interchange trailer, so
+    /// byte-limit split accounting stays non-finalizing. Plan validation
+    /// rejects byte splitting for this single-envelope format; this keeps the
+    /// trait contract honest regardless, with the `IEA` trailer written only by
+    /// [`Self::flush`].
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.writer.flush().map_err(FormatError::Io)
+    }
 }
 
 /// Set element at index `i` (0-based) to `value`, growing the vector with

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -336,15 +336,15 @@ impl XmlReader {
                             if self.matched_depth == self.path_segments.len() {
                                 let attrs =
                                     extract_attributes_static(&self.config.attribute_prefix, e)?;
-                                let raw = self.extract_record_fields(attrs)?;
+                                let raw = self.extract_record_fields(&name, attrs)?;
                                 return Ok(Some(raw));
                             }
                         } else {
-                            self.skip_subtree()?;
+                            self.skip_subtree(&name)?;
                         }
                     } else {
                         let attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
-                        let raw = self.extract_record_fields(attrs)?;
+                        let raw = self.extract_record_fields(&name, attrs)?;
                         return Ok(Some(raw));
                     }
                 }
@@ -377,6 +377,18 @@ impl XmlReader {
                     }
                 }
                 Event::Eof => {
+                    // A clean end leaves every element closed (`xml_depth == 0`).
+                    // A non-zero depth means the input was cut off inside the
+                    // record container or one of its ancestors — a truncated
+                    // document, not an exhausted record set — so fail loud
+                    // rather than reporting a silent end-of-records.
+                    if self.xml_depth > 0 {
+                        return Err(FormatError::Xml(format!(
+                            "unexpected end of XML document: {} element(s) were \
+                             still open when the input ended (missing closing tag)",
+                            self.xml_depth
+                        )));
+                    }
                     self.done = true;
                     return Ok(None);
                 }
@@ -399,6 +411,7 @@ impl XmlReader {
     /// with self.parser.
     fn extract_record_fields(
         &mut self,
+        record_name: &str,
         start_attrs: Vec<(String, String)>,
     ) -> Result<RawRecord, FormatError> {
         let mut fields = start_attrs;
@@ -501,17 +514,22 @@ impl XmlReader {
                     }
                 }
                 Event::Eof => {
-                    self.done = true;
-                    break;
+                    // The record element's own `End` breaks the loop above; an
+                    // EOF here means the input was cut off before that close,
+                    // leaving the record (or an open child) truncated. Name the
+                    // deepest open element so the failure points at the cut.
+                    let open_path = if element_stack.is_empty() {
+                        record_name.to_string()
+                    } else {
+                        format!("{record_name}.{}", element_stack.join("."))
+                    };
+                    return Err(FormatError::Xml(format!(
+                        "unexpected end of XML document inside element {open_path:?}: \
+                         the input ended before its closing tag"
+                    )));
                 }
                 _ => {}
             }
-        }
-
-        // EOF inside an unclosed occurrence (malformed input): keep the
-        // fields read so far rather than dropping them.
-        if let Some(open) = open_instance {
-            array_instances[open.path].push(open.fields_from..fields.len());
         }
 
         Ok(RawRecord {
@@ -576,7 +594,12 @@ impl XmlReader {
     }
 
     /// Skip an entire subtree (from current Start to its matching End).
-    fn skip_subtree(&mut self) -> Result<(), FormatError> {
+    ///
+    /// `element_name` is the subtree's root element, used only to name the
+    /// failure. Returns [`FormatError::Xml`] if the input ends before the
+    /// subtree closes — a truncated document must fail loud rather than
+    /// silently swallow an unfinished, skipped-over element.
+    fn skip_subtree(&mut self, element_name: &str) -> Result<(), FormatError> {
         let target_depth = self.xml_depth;
         loop {
             self.buf.clear();
@@ -593,8 +616,10 @@ impl XmlReader {
                     }
                 }
                 Event::Eof => {
-                    self.done = true;
-                    return Ok(());
+                    return Err(FormatError::Xml(format!(
+                        "unexpected end of XML document while skipping element \
+                         {element_name:?}: the input ended before its closing tag"
+                    )));
                 }
                 _ => {}
             }

--- a/crates/clinker-format/src/xml/streaming.rs
+++ b/crates/clinker-format/src/xml/streaming.rs
@@ -76,7 +76,8 @@ impl SectionTarget {
 ///
 /// # Errors
 ///
-/// Returns [`FormatError::Xml`] on an XML parse failure, or naming the
+/// Returns [`FormatError::Xml`] on an XML parse failure, when the input ends
+/// with an element still open (a truncated document), or naming the
 /// offending section and the cap when a declared section's retained bytes
 /// cross `max_index_bytes` mid-parse.
 pub(crate) fn extract_sections(
@@ -159,7 +160,21 @@ pub(crate) fn extract_sections(
             Event::End(_) => {
                 path_stack.pop();
             }
-            Event::Eof => break,
+            Event::Eof => {
+                // A clean end pops the descent stack empty. A non-empty stack
+                // means the document was cut off inside an open element, so a
+                // declared section could be silently partial — fail loud
+                // instead of returning a truncated pre-scan.
+                if !path_stack.is_empty() {
+                    return Err(FormatError::Xml(format!(
+                        "unexpected end of XML document during envelope pre-scan: \
+                         element {:?} was still open when the input ended \
+                         (missing closing tag)",
+                        path_stack.join("/")
+                    )));
+                }
+                break;
+            }
             _ => {}
         }
     }
@@ -227,8 +242,10 @@ fn path_matches(stack: &[String], segs: &[String]) -> bool {
 ///
 /// # Errors
 ///
-/// Returns [`FormatError::Xml`] on a parse failure, or naming `section` and
-/// the cap when the retained bytes cross `max_index_bytes` mid-subtree.
+/// Returns [`FormatError::Xml`] on a parse failure, when the input ends
+/// before the section's closing tag (a truncated document), or naming
+/// `section` and the cap when the retained bytes cross `max_index_bytes`
+/// mid-subtree.
 fn read_section_payload(
     parser: &mut BodyParser,
     buf: &mut Vec<u8>,
@@ -317,7 +334,21 @@ fn read_section_payload(
                     }
                 }
             }
-            Event::Eof => return Ok(fields),
+            Event::Eof => {
+                // The section element's own `End` returns above; an EOF here
+                // means the input was cut off before that close, so the
+                // section payload is truncated. Name the deepest open element
+                // and fail loud rather than returning partial section fields.
+                let open = if element_stack.is_empty() {
+                    section.to_string()
+                } else {
+                    format!("{section}.{}", element_stack.join("."))
+                };
+                return Err(FormatError::Xml(format!(
+                    "unexpected end of XML document inside envelope section {open:?}: \
+                     the input ended before its closing tag"
+                )));
+            }
             _ => {}
         }
     }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -248,6 +248,14 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         Ok(())
     }
 
+    /// Drain the underlying sink without emitting the closing root element, so
+    /// byte-limit split accounting can observe the size mid-document. The
+    /// closing root tag is written only by [`Self::flush`] at end of file /
+    /// rotation.
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.writer.get_mut().flush().map_err(FormatError::Io)
+    }
+
     fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
         if self.framer.is_none() {
             return Ok(());

--- a/crates/clinker-format/tests/streaming_doc_index_json.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_json.rs
@@ -667,3 +667,74 @@ fn envelope_prescan_rejects_a_file_changed_between_passes() {
         other => panic!("expected an Io change error, got {other:?}"),
     }
 }
+
+/// A slashless non-empty JSON pointer decodes to zero segments, aliasing the
+/// whole-document pointer, and would silently match the root instead of the
+/// intended section. The reader rejects it before building a target, naming
+/// the offending section so a config bypassing plan validation still fails
+/// loud.
+#[test]
+fn prescan_rejects_slashless_json_pointer() {
+    let specs: &[SectionSpec] = &[("Head", "Head", &[("batch_id", EnvelopeFieldType::String)])];
+    let json = r#"{"Head":{"batch_id":"B1"},"records":[{"id":1}]}"#;
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("a slashless json_pointer must be rejected");
+    match err {
+        FormatError::Json(msg) => {
+            assert!(
+                msg.contains("Head") && msg.contains("RFC 6901"),
+                "diagnostic must name the section and the accepted grammar: {msg}"
+            );
+        }
+        other => panic!("expected FormatError::Json, got {other:?}"),
+    }
+}
+
+/// The empty pointer `""` names the whole document and stays valid: the root
+/// object's top-level keys become the section's fields. Kept explicit so the
+/// slashless-rejection guard never regresses into rejecting the legitimate
+/// whole-document case.
+#[test]
+fn prescan_empty_json_pointer_matches_root() {
+    let specs: &[SectionSpec] = &[("Whole", "", &[("batch_id", EnvelopeFieldType::String)])];
+    let json = r#"{"batch_id":"B1","records":[{"id":1}]}"#;
+    let cfg = envelope_config(specs);
+
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(json.as_bytes().to_vec()),
+        JsonReaderConfig {
+            record_path: Some("records".into()),
+            declared_doc_paths: declared_paths(specs),
+            max_index_bytes: Some(64 * 1_000_000),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let sections = reader
+        .prepare_document(&cfg)
+        .expect("the empty (whole-document) pointer must match the root");
+    let whole = match sections.get("Whole").expect("root section retained") {
+        Value::Map(m) => m,
+        other => panic!("expected map, got {other:?}"),
+    };
+    assert_eq!(
+        whole.get("batch_id"),
+        Some(&Value::String("B1".into())),
+        "the root object's top-level field must be extracted"
+    );
+}

--- a/crates/clinker-format/tests/streaming_doc_index_xml.rs
+++ b/crates/clinker-format/tests/streaming_doc_index_xml.rs
@@ -558,6 +558,198 @@ fn malformed_unclosed_element_surfaces_xml_error() {
     );
 }
 
+/// A document truncated *inside an open record element* fails loud rather
+/// than emitting the partial fields read so far. The record's own closing
+/// tag never arrives, so the reader must surface a [`FormatError::Xml`]
+/// naming the cut element — not a silently short record.
+#[test]
+fn truncation_inside_a_record_surfaces_xml_error() {
+    // `<name>` (and the enclosing `<record>`) are never closed before EOF.
+    let xml = r#"<doc><records><record><id>1</id><name>partial"#;
+    let mut reader = XmlReader::from_reader(
+        std::io::Cursor::new(xml.as_bytes().to_vec()),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            ..Default::default()
+        },
+    )
+    .expect("construction reads no bytes");
+
+    // The truncated first record must never surface as a record: driving the
+    // reader yields a hard `Xml` error, not a partial `Some` or a clean `None`.
+    let mut saw_partial_record = false;
+    let err = loop {
+        match reader.next_record() {
+            Ok(Some(_)) => {
+                saw_partial_record = true;
+                continue;
+            }
+            Ok(None) => panic!("a truncated record must not end cleanly"),
+            Err(e) => break e,
+        }
+    };
+    assert!(
+        !saw_partial_record,
+        "no partial record may be emitted from a truncated document"
+    );
+    match err {
+        FormatError::Xml(msg) => {
+            assert!(
+                msg.contains("record.name"),
+                "error names the cut element path: {msg}"
+            );
+            assert!(
+                msg.contains("ended before its closing tag"),
+                "error states the input ended before the close: {msg}"
+            );
+        }
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
+/// A document truncated *inside a non-matching sibling subtree the reader is
+/// skipping* fails loud rather than ending cleanly. The navigation-time
+/// subtree skip must not treat EOF as a valid end of the skipped element.
+#[test]
+fn truncation_inside_a_skipped_subtree_surfaces_xml_error() {
+    // `<meta>` is a sibling the record-path navigation skips; the document is
+    // cut off inside it, before `<meta>` (or `<info>`) closes.
+    let xml = r#"<doc><meta><info>partial"#;
+    let mut reader = XmlReader::from_reader(
+        std::io::Cursor::new(xml.as_bytes().to_vec()),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            ..Default::default()
+        },
+    )
+    .expect("construction reads no bytes");
+
+    let err = reader
+        .next_record()
+        .expect_err("a subtree skip that hits EOF before its close must fail");
+    match err {
+        FormatError::Xml(msg) => {
+            assert!(
+                msg.contains("skipping element") && msg.contains("meta"),
+                "error names the skipped element: {msg}"
+            );
+            assert!(
+                msg.contains("ended before its closing tag"),
+                "error states the input ended before the close: {msg}"
+            );
+        }
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
+/// A document truncated *between records*, after a complete record but before
+/// the record container and root close, streams the complete record and then
+/// fails loud when the reader tries to advance past it — the unclosed
+/// ancestors are a truncated document, not an exhausted record set.
+#[test]
+fn truncation_between_records_surfaces_xml_error() {
+    // One complete `<record>`, then EOF with `<records>` and `<doc>` still open.
+    let xml = r#"<doc><records><record><x>1</x></record>"#;
+    let mut reader = XmlReader::from_reader(
+        std::io::Cursor::new(xml.as_bytes().to_vec()),
+        XmlReaderConfig {
+            record_path: Some("doc/records/record".into()),
+            ..Default::default()
+        },
+    )
+    .expect("construction reads no bytes");
+
+    // The complete record streams first — streaming does not buffer the whole
+    // file to pre-validate it.
+    let first = reader
+        .next_record()
+        .expect("the complete record streams")
+        .expect("one record");
+    assert_eq!(first.get("x"), Some(&Value::Integer(1)));
+
+    // Advancing past it hits EOF with two ancestors still open.
+    let err = reader
+        .next_record()
+        .expect_err("EOF under an unclosed root is a truncated document");
+    match err {
+        FormatError::Xml(msg) => {
+            assert!(
+                msg.contains("2 element(s) were still open"),
+                "error counts the open ancestors: {msg}"
+            );
+        }
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
+/// A document truncated *inside a declared envelope section* fails the
+/// envelope pre-scan rather than returning that section's partial fields — no
+/// partial `$doc` metadata is produced from a cut-off section.
+#[test]
+fn truncation_inside_an_envelope_section_surfaces_xml_error() {
+    // `<record_count>` (and the enclosing `<Summary>`) are never closed.
+    let xml = r#"<doc><Summary><record_count>5"#.to_string();
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/doc/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = reader(xml, specs, "doc/records/record", 64 * 1_000_000);
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("a section cut off before its close must fail the pre-scan");
+    match err {
+        FormatError::Xml(msg) => {
+            assert!(
+                msg.contains("envelope section") && msg.contains("Summary"),
+                "error names the cut section: {msg}"
+            );
+            assert!(
+                msg.contains("ended before its closing tag"),
+                "error states the input ended before the close: {msg}"
+            );
+        }
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
+/// A document truncated *during the envelope pre-scan but outside any declared
+/// section* still fails loud. The top-level streaming walk must not accept an
+/// EOF that leaves elements open, or a declared section that would have
+/// appeared later is silently missed.
+#[test]
+fn truncation_during_prescan_outside_a_section_surfaces_xml_error() {
+    // The declared `Summary` section sits at the document tail, but the input
+    // is cut off inside the body before it ever appears.
+    let xml = r#"<doc><records><record><x>1</x></record>"#.to_string();
+    let specs: &[SectionSpec] = &[(
+        "Summary",
+        "/doc/Summary",
+        &[("record_count", EnvelopeFieldType::Int)],
+    )];
+    let cfg = envelope_config(specs);
+
+    let mut reader = reader(xml, specs, "doc/records/record", 64 * 1_000_000);
+    let err = reader
+        .prepare_document(&cfg)
+        .expect_err("a pre-scan that hits EOF with open elements must fail");
+    match err {
+        FormatError::Xml(msg) => {
+            assert!(
+                msg.contains("envelope pre-scan"),
+                "error identifies the pre-scan: {msg}"
+            );
+            assert!(
+                msg.contains("doc/records"),
+                "error names the open descent path: {msg}"
+            );
+        }
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
 /// A deeply nested document (200+ levels) streams to completion without
 /// crashing: clinker's XML walk tracks depth with heap `Vec`s and `usize`
 /// counters, never native recursion, so a deep document cannot overflow the

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -38,8 +38,9 @@ pub use fs_type::{FsKind, case_sensitive_dir, classify, collision_key, same_devi
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use output::*;
 pub use patch::{
-    ArrayPathOp, ColumnPatch, EnvelopeFieldOp, NestedSectionOp, SchemaColumnOp, SourceConfigPatch,
-    SplitFieldOp, apply_source_patches,
+    ArrayPathOp, ColumnPatch, DiscriminatorPatch, EnvelopeFieldOp, NestedSectionOp, RecordTypeAdd,
+    RecordTypeOp, RecordTypePatch, SchemaColumnOp, SourceConfigPatch, SplitFieldOp,
+    apply_source_patches,
 };
 pub use pipeline::*;
 pub use pipeline_node::{

--- a/crates/clinker-plan/src/config/patch.rs
+++ b/crates/clinker-plan/src/config/patch.rs
@@ -12,16 +12,17 @@
 //!
 //! Handled surfaces: the format-agnostic schema-shaping ops — the CXL-typed
 //! column list (`schema`), nested-array explosion/join (`array_paths`), and
-//! scalar per-format input options (`options`) — plus the format-structure
-//! ops for X12 nested-envelope declarations (`group_section` / `set_section`)
-//! and HL7 composite-field splits (`split_fields`). Deeper format-layer
-//! layouts (fixed-width/positional field schemas, multi-record
-//! discrimination) reuse this same framework as additional handlers.
+//! scalar per-format input options (`options`) — the format-structure ops for
+//! X12 nested-envelope declarations (`group_section` / `set_section`) and HL7
+//! composite-field splits (`split_fields`), and the multi-record flat-file ops
+//! for discriminator-driven record types (`records` / `discriminator`).
 
 use super::*;
 use crate::config::composition::SchemaProvRecorder;
 use crate::config::pipeline_node::{PipelineNode, SourceBody};
-use clinker_format::{Column, EnvelopeFieldType, NestedEnvelopeSection, SourceSchema};
+use clinker_format::{
+    Column, Discriminator, EnvelopeFieldType, NestedEnvelopeSection, RecordType, SourceSchema,
+};
 use clinker_record::schema_def::{Justify, TruncationPolicy};
 use cxl::typecheck::Type;
 use indexmap::IndexMap;
@@ -61,6 +62,15 @@ pub struct SourceConfigPatch {
     /// source, after the `options` merge.
     #[serde(skip_serializing_if = "IndexMap::is_empty")]
     pub split_fields: IndexMap<String, SplitFieldOp>,
+    /// Multi-record `records` ops keyed by record-type id (`modify` / `add` /
+    /// `remove`). Applies only to a multi-record (discriminator-driven) schema.
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    pub records: IndexMap<String, RecordTypeOp>,
+    /// Partial merge onto a multi-record source's `discriminator` block. Every
+    /// field is optional; a named field overwrites, an omitted one is kept, and
+    /// the merged result must be byte-range XOR field.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<DiscriminatorPatch>,
 }
 
 impl SourceConfigPatch {
@@ -72,6 +82,8 @@ impl SourceConfigPatch {
             && self.group_section.is_none()
             && self.set_section.is_none()
             && self.split_fields.is_empty()
+            && self.records.is_empty()
+            && self.discriminator.is_none()
     }
 }
 
@@ -516,11 +528,181 @@ impl<'de> Deserialize<'de> for SplitFieldOp {
     }
 }
 
+/// One op on a multi-record source's `records` list, keyed by record-type id.
+///
+/// YAML forms (the map key is the record-type id):
+///
+/// ```yaml
+/// detail:  { tag: X, columns: { amount: { type: float } } }  # modify
+/// trailer: remove                                             # drop the type
+/// header:  { add: { tag: H, columns: [ { name: id, type: string } ] } }  # add
+/// ```
+///
+/// A `modify` sets any subset of the record type's `tag` / `parent` /
+/// `join_key` / `description`, plus a nested column-keyed op map that reshapes
+/// that type's own columns through the same grammar as the top-level `schema`
+/// surface. An `add` declares a whole new record type (its id is the map key).
+/// `Serialize` is derived for config-identity hashing only.
+#[derive(Debug, Clone, Serialize)]
+pub enum RecordTypeOp {
+    /// Drop the keyed record type.
+    Remove,
+    /// Set a subset of the keyed record type's attributes and reshape its
+    /// columns.
+    Modify(RecordTypePatch),
+    /// Declare a new record type named by the map key.
+    Add(RecordTypeAdd),
+}
+
+/// A partial [`RecordType`]: any subset of a record type's attributes plus a
+/// nested column-op map. The payload of a [`RecordTypeOp::Modify`]. Each scalar
+/// is `Option<_>` so a modify sets only the attributes it names and keeps the
+/// rest; `columns` carries the same keyed column-op grammar as the top-level
+/// `schema` surface. `Serialize` is for config-identity hashing only.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct RecordTypePatch {
+    /// Discriminator tag the reader matches this type's lines on. `None` keeps
+    /// the current tag.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    /// Parent record-type id (field inheritance). `None` keeps the current.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    /// Join key field. `None` keeps the current.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub join_key: Option<String>,
+    /// Human description. `None` keeps the current.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Column-name-keyed ops reshaping this record type's own columns.
+    #[serde(skip_serializing_if = "IndexMap::is_empty")]
+    pub columns: IndexMap<String, SchemaColumnOp>,
+}
+
+/// The payload of a [`RecordTypeOp::Add`]: a whole new record type minus its id
+/// (which is the map key). `tag` and `columns` are required, matching a
+/// hand-written `records:` entry; the rest are optional. `deny_unknown_fields`
+/// turns a typo into an error. `Serialize` is for config-identity hashing only.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecordTypeAdd {
+    /// Discriminator tag the reader matches this record type's lines on.
+    pub tag: String,
+    /// Human description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Parent record-type id (field inheritance).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<String>,
+    /// Join key field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub join_key: Option<String>,
+    /// The record type's full column list.
+    pub columns: Vec<Column>,
+}
+
+impl<'de> Deserialize<'de> for RecordTypeOp {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        // Accepted YAML shapes:
+        //   remove                                              (bare scalar)
+        //   { add: { tag, columns, ... } }                      (add op)
+        //   { tag?, parent?, join_key?, description?, columns? } (modify op)
+        // `add` is the op selector; every other key belongs to the modify leaf.
+        // Mixing `add` with modify attributes is rejected.
+        #[derive(Deserialize, Default)]
+        #[serde(deny_unknown_fields, default)]
+        struct OpMap {
+            add: Option<RecordTypeAdd>,
+            // Modify leaf: inlined so `deny_unknown_fields` still rejects a typo
+            // (a `#[serde(flatten)]` would disable that check and drop spans).
+            tag: Option<String>,
+            parent: Option<String>,
+            join_key: Option<String>,
+            description: Option<String>,
+            columns: IndexMap<String, SchemaColumnOp>,
+        }
+
+        impl OpMap {
+            fn has_modify(&self) -> bool {
+                self.tag.is_some()
+                    || self.parent.is_some()
+                    || self.join_key.is_some()
+                    || self.description.is_some()
+                    || !self.columns.is_empty()
+            }
+            fn modify_leaf(self) -> RecordTypePatch {
+                RecordTypePatch {
+                    tag: self.tag,
+                    parent: self.parent,
+                    join_key: self.join_key,
+                    description: self.description,
+                    columns: self.columns,
+                }
+            }
+        }
+
+        // `OpMap` is boxed in the map arm: it carries a full column list, so an
+        // unboxed variant would leave `Either` lopsided.
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Either {
+            Scalar(String),
+            Map(Box<OpMap>),
+        }
+
+        match Either::deserialize(d)? {
+            Either::Scalar(s) if s == "remove" => Ok(RecordTypeOp::Remove),
+            Either::Scalar(other) => Err(de::Error::custom(format!(
+                "unknown records op {other:?}; the bare scalar form only accepts `remove` — use \
+                 `{{ add: {{ tag: <tag>, columns: [ ... ] }} }}` to add a record type, or a bare \
+                 attribute map like `{{ tag: <tag>, columns: {{ ... }} }}` to modify"
+            ))),
+            Either::Map(m) => {
+                let m = *m;
+                let has_add = m.add.is_some();
+                let has_modify = m.has_modify();
+                match (has_add, has_modify) {
+                    (true, false) => Ok(RecordTypeOp::Add(m.add.expect("add present"))),
+                    (false, true) => Ok(RecordTypeOp::Modify(m.modify_leaf())),
+                    (false, false) => Err(de::Error::custom(
+                        "empty records op; use `remove`, `{ add: { tag: <tag>, columns: [ ... ] } }`, \
+                         or a bare attribute map (`tag` / `parent` / `join_key` / `description` / \
+                         `columns`) to modify",
+                    )),
+                    (true, true) => Err(de::Error::custom(
+                        "ambiguous records op; `add` and a bare-attribute modify are mutually \
+                         exclusive — use exactly one",
+                    )),
+                }
+            }
+        }
+    }
+}
+
+/// A partial [`Discriminator`]: a channel's merge onto a multi-record source's
+/// discriminator. Every field is optional and overwrites the current when
+/// named; an omitted field is kept. The merged result must be byte-range XOR
+/// field (E244). `deny_unknown_fields` turns a typo into an error; `Serialize`
+/// is for config-identity hashing only.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq)]
+#[serde(deny_unknown_fields, default)]
+pub struct DiscriminatorPatch {
+    /// Byte-range start offset (fixed-width discrimination).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<usize>,
+    /// Byte-range width (fixed-width discrimination).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub width: Option<usize>,
+    /// Discriminator field name (CSV discrimination).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<String>,
+}
+
 /// Apply channel source-config patches to the parsed config in place.
 ///
 /// Runs after parse and before `validate_config`, so the patched config is
 /// the one validated and compiled. Each entry names a source node; an unknown
-/// source name or an ill-formed op is a config error (E230–E240) reported
+/// source name or an ill-formed op is a config error (E230–E245) reported
 /// before the pipeline compiles.
 pub fn apply_source_patches(
     config: &mut PipelineConfig,
@@ -566,6 +748,12 @@ pub fn apply_source_patches(
             src_name,
         )?;
         apply_split_field_ops(&mut body.source, &patch.split_fields, src_name)?;
+        apply_record_ops(
+            &mut body.schema,
+            &patch.records,
+            patch.discriminator.as_ref(),
+            src_name,
+        )?;
     }
     Ok(())
 }
@@ -626,7 +814,7 @@ pub(crate) fn apply_schema_ops(
     schema: &mut SourceSchema,
     ops: &IndexMap<String, SchemaColumnOp>,
     src: &str,
-    mut recorder: Option<&mut SchemaProvRecorder<'_>>,
+    recorder: Option<&mut SchemaProvRecorder<'_>>,
 ) -> Result<(), ConfigError> {
     if ops.is_empty() {
         return Ok(());
@@ -639,6 +827,21 @@ pub(crate) fn apply_schema_ops(
              single-record (column-list) schema, not a multi-record / generated / file schema"
         ))
     })?;
+    apply_column_ops(columns, ops, src, recorder)
+}
+
+/// Apply the keyed column-op grammar (`modify` / `rename` / `add` / `remove`)
+/// to a flat column list in place — the core shared by the single-record
+/// `schema` surface ([`apply_schema_ops`], which wraps this with the E237
+/// schema-kind guard) and the per-record-type column ops of a multi-record
+/// `records` modify. `src` names the source for diagnostics; `recorder` records
+/// per-attribute provenance when present.
+fn apply_column_ops(
+    columns: &mut Vec<Column>,
+    ops: &IndexMap<String, SchemaColumnOp>,
+    src: &str,
+    mut recorder: Option<&mut SchemaProvRecorder<'_>>,
+) -> Result<(), ConfigError> {
     for (col, op) in ops {
         match op {
             SchemaColumnOp::Remove => {
@@ -1093,6 +1296,155 @@ fn unknown_split_field(src: &str, field: &str) -> ConfigError {
     ConfigError::Validation(format!(
         "[E239] channel split_fields patch on source '{src}': remove of a split the source \
          does not declare for field '{field}'"
+    ))
+}
+
+/// Apply a channel's multi-record `records` / `discriminator` ops to a source's
+/// schema in place. Requires a [`SourceSchema::MultiRecord`] schema (E241 on a
+/// single-record / generated / file schema). The discriminator patch merges
+/// field by field and the merged result must be byte-range XOR field (E244).
+/// Record ops resolve by record-type id: `modify` / `remove` of an unknown id
+/// is E242, `add` of an existing id is E243, and a tag shared across record
+/// types after the ops is E245. A `modify`'s nested column ops reuse the same
+/// column-op core as the single-record `schema` surface.
+fn apply_record_ops(
+    schema: &mut SourceSchema,
+    ops: &IndexMap<String, RecordTypeOp>,
+    discriminator: Option<&DiscriminatorPatch>,
+    src: &str,
+) -> Result<(), ConfigError> {
+    if ops.is_empty() && discriminator.is_none() {
+        return Ok(());
+    }
+    let SourceSchema::MultiRecord {
+        discriminator: disc,
+        record_types,
+        ..
+    } = schema
+    else {
+        return Err(ConfigError::Validation(format!(
+            "[E241] channel records patch on source '{src}': `records` / `discriminator` ops \
+             apply only to a multi-record schema, not a single-record / generated / file schema"
+        )));
+    };
+
+    if let Some(dp) = discriminator {
+        // Partial merge: a named field overwrites, an omitted one is kept. The
+        // merged result is then re-checked for the byte-range XOR field shape.
+        if let Some(start) = dp.start {
+            disc.start = Some(start);
+        }
+        if let Some(width) = dp.width {
+            disc.width = Some(width);
+        }
+        if let Some(field) = &dp.field {
+            disc.field = Some(field.clone());
+        }
+        validate_discriminator(disc, src)?;
+    }
+
+    for (id, op) in ops {
+        match op {
+            RecordTypeOp::Remove => {
+                let idx = record_types
+                    .iter()
+                    .position(|rt| rt.id == *id)
+                    .ok_or_else(|| unknown_record_type(src, id, "remove"))?;
+                record_types.remove(idx);
+            }
+            RecordTypeOp::Modify(patch) => {
+                let rt = record_types
+                    .iter_mut()
+                    .find(|rt| rt.id == *id)
+                    .ok_or_else(|| unknown_record_type(src, id, "modify"))?;
+                if let Some(tag) = &patch.tag {
+                    rt.tag = tag.clone();
+                }
+                if let Some(parent) = &patch.parent {
+                    rt.parent = Some(parent.clone());
+                }
+                if let Some(join_key) = &patch.join_key {
+                    rt.join_key = Some(join_key.clone());
+                }
+                if let Some(description) = &patch.description {
+                    rt.description = Some(description.clone());
+                }
+                // Reuse the single-record column-op core on this record type's
+                // own column list; the id threads into the diagnostic label so a
+                // column error names the offending record type. Multi-record
+                // schema provenance is not modeled, so no recorder is passed.
+                let ctx = format!("{src} records.{id}");
+                apply_column_ops(&mut rt.columns, &patch.columns, &ctx, None)?;
+            }
+            RecordTypeOp::Add(add) => {
+                if record_types.iter().any(|rt| rt.id == *id) {
+                    return Err(ConfigError::Validation(format!(
+                        "[E243] channel records patch on source '{src}': add of record type \
+                         '{id}' that already exists"
+                    )));
+                }
+                record_types.push(RecordType {
+                    id: id.clone(),
+                    tag: add.tag.clone(),
+                    description: add.description.clone(),
+                    parent: add.parent.clone(),
+                    join_key: add.join_key.clone(),
+                    columns: add.columns.clone(),
+                });
+            }
+        }
+    }
+
+    // Tags must stay unique across record types so the reader's discriminator
+    // dispatch is unambiguous; a collision an `add` or `modify` introduces is
+    // caught here rather than deep in the reader. A discriminator-only patch
+    // leaves tags untouched, so it skips this check.
+    if !ops.is_empty() {
+        check_tag_uniqueness(record_types, src)?;
+    }
+    Ok(())
+}
+
+/// Reject a merged discriminator that is not exactly one of byte-range or field
+/// (E244), mirroring the reader's fixed-width-vs-CSV dispatch: byte-range needs
+/// a `start` (width defaults to 1), field needs a `field` name, and the two
+/// modes are mutually exclusive.
+fn validate_discriminator(disc: &Discriminator, src: &str) -> Result<(), ConfigError> {
+    let has_byte = disc.start.is_some() || disc.width.is_some();
+    let has_field = disc.field.is_some();
+    let malformed = |reason: &str| {
+        ConfigError::Validation(format!(
+            "[E244] channel discriminator patch on source '{src}': merged discriminator {reason}; \
+             a discriminator is a byte range (`start` + optional `width`) XOR a `field`"
+        ))
+    };
+    match (has_byte, has_field) {
+        (true, true) => Err(malformed("names both a byte range and a `field`")),
+        (false, false) => Err(malformed("names neither a byte range nor a `field`")),
+        (true, false) if disc.start.is_none() => {
+            Err(malformed("sets a byte `width` without a `start` offset"))
+        }
+        _ => Ok(()),
+    }
+}
+
+/// Reject two record types sharing a discriminator tag after the ops (E245).
+fn check_tag_uniqueness(record_types: &[RecordType], src: &str) -> Result<(), ConfigError> {
+    for (i, rt) in record_types.iter().enumerate() {
+        if record_types[..i].iter().any(|other| other.tag == rt.tag) {
+            return Err(ConfigError::Validation(format!(
+                "[E245] channel records patch on source '{src}': discriminator tag '{tag}' is \
+                 declared by more than one record type after the patch",
+                tag = rt.tag
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn unknown_record_type(src: &str, id: &str, op: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E242] channel records patch on source '{src}': {op} of unknown record type '{id}'"
     ))
 }
 
@@ -2183,5 +2535,393 @@ nodes:
         assert!(!patch_from_yaml("set_section:\n  name: txn\n").is_empty());
         assert!(!patch_from_yaml("split_fields:\n  f01: remove\n").is_empty());
         assert!(SourceConfigPatch::default().is_empty());
+    }
+
+    // ── Multi-record `records` / `discriminator` ────────────────────────
+
+    /// A fixed-width multi-record source with a byte-range discriminator and two
+    /// record types (`detail` tag `D`, `trailer` tag `T`), feeding one output.
+    fn multi_record_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: fixed_width
+      path: /tmp/in.dat
+      schema:
+        discriminator: { start: 0, width: 1 }
+        records:
+          - { id: detail, tag: D, columns: [ { name: amount, type: int, start: 1, width: 9 } ] }
+          - { id: trailer, tag: T, columns: [ { name: count, type: int, start: 1, width: 9 } ] }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse multi-record pipeline")
+    }
+
+    /// A CSV multi-record source with a field-mode discriminator.
+    fn multi_record_csv_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: /tmp/in.csv
+      schema:
+        discriminator: { field: rec_type }
+        records:
+          - { id: detail, tag: D, columns: [ { name: rec_type, type: string }, { name: amount, type: float } ] }
+          - { id: trailer, tag: T, columns: [ { name: rec_type, type: string }, { name: count, type: int } ] }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse csv multi-record pipeline")
+    }
+
+    fn multi_record(config: &PipelineConfig) -> (&Discriminator, &[RecordType]) {
+        match &config.source_bodies().next().expect("one source").schema {
+            SourceSchema::MultiRecord {
+                discriminator,
+                record_types,
+                ..
+            } => (discriminator, record_types),
+            other => panic!("expected multi-record schema, got {other:?}"),
+        }
+    }
+
+    fn record_type<'a>(record_types: &'a [RecordType], id: &str) -> &'a RecordType {
+        record_types
+            .iter()
+            .find(|rt| rt.id == id)
+            .unwrap_or_else(|| panic!("record type {id:?} present"))
+    }
+
+    #[test]
+    fn records_modify_changes_tag() {
+        let mut config = multi_record_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  detail: { tag: X }\n"),
+        )
+        .unwrap();
+        let (_disc, rts) = multi_record(&config);
+        assert_eq!(record_type(rts, "detail").tag, "X");
+        // A field-only modify keeps the rest of the record type intact.
+        assert_eq!(record_type(rts, "detail").columns.len(), 1);
+    }
+
+    #[test]
+    fn records_modify_sets_parent_and_join_key() {
+        let mut config = multi_record_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  trailer: { parent: detail, join_key: batch_id }\n"),
+        )
+        .unwrap();
+        let (_disc, rts) = multi_record(&config);
+        let trailer = record_type(rts, "trailer");
+        assert_eq!(trailer.parent.as_deref(), Some("detail"));
+        assert_eq!(trailer.join_key.as_deref(), Some("batch_id"));
+        // The tag is untouched by an attribute-only modify.
+        assert_eq!(trailer.tag, "T");
+    }
+
+    #[test]
+    fn records_modify_reshapes_nested_columns() {
+        // A modify's `columns` map runs the same column-op grammar as the
+        // top-level `schema` surface, scoped to this record type.
+        let mut config = multi_record_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "records:\n  detail:\n    columns:\n      amount: { type: float }\n      note: { add: { type: string, start: 10, width: 4 } }\n",
+            ),
+        )
+        .unwrap();
+        let (_disc, rts) = multi_record(&config);
+        let detail = record_type(rts, "detail");
+        assert_eq!(
+            detail
+                .columns
+                .iter()
+                .find(|c| c.name == "amount")
+                .unwrap()
+                .ty,
+            Type::Float
+        );
+        let note = detail
+            .columns
+            .iter()
+            .find(|c| c.name == "note")
+            .expect("added column present");
+        assert_eq!(note.ty, Type::String);
+        assert_eq!(note.start, Some(10));
+        assert_eq!(note.width, Some(4));
+        // Only `detail` was touched; `trailer` is unchanged.
+        assert_eq!(record_type(rts, "trailer").columns.len(), 1);
+    }
+
+    #[test]
+    fn records_add_new_record_type() {
+        let mut config = multi_record_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "records:\n  header:\n    add:\n      tag: H\n      parent: detail\n      columns:\n        - { name: hdr_id, type: string, start: 1, width: 8 }\n",
+            ),
+        )
+        .unwrap();
+        let (_disc, rts) = multi_record(&config);
+        assert_eq!(rts.len(), 3);
+        let header = record_type(rts, "header");
+        assert_eq!(header.tag, "H");
+        assert_eq!(header.parent.as_deref(), Some("detail"));
+        assert_eq!(header.columns.len(), 1);
+        assert_eq!(header.columns[0].name, "hdr_id");
+    }
+
+    #[test]
+    fn records_remove_record_type() {
+        let mut config = multi_record_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  trailer: remove\n"),
+        )
+        .unwrap();
+        let (_disc, rts) = multi_record(&config);
+        let ids: Vec<&str> = rts.iter().map(|rt| rt.id.as_str()).collect();
+        assert_eq!(ids, vec!["detail"]);
+    }
+
+    #[test]
+    fn records_modify_unknown_id_errors_e242() {
+        let mut config = multi_record_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  ghost: { tag: G }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E242"), "{err}");
+    }
+
+    #[test]
+    fn records_remove_unknown_id_errors_e242() {
+        let mut config = multi_record_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  ghost: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E242"), "{err}");
+    }
+
+    #[test]
+    fn records_add_existing_id_errors_e243() {
+        let mut config = multi_record_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "records:\n  detail:\n    add:\n      tag: Z\n      columns:\n        - { name: x, type: int, start: 1, width: 2 }\n",
+            ),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E243"), "{err}");
+    }
+
+    #[test]
+    fn records_add_tag_collision_errors_e245() {
+        // A new record type reusing an existing tag would make the reader's
+        // discriminator dispatch ambiguous.
+        let mut config = multi_record_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml(
+                "records:\n  header:\n    add:\n      tag: D\n      columns:\n        - { name: hdr_id, type: string, start: 1, width: 8 }\n",
+            ),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E245"), "{err}");
+    }
+
+    #[test]
+    fn records_modify_tag_collision_errors_e245() {
+        let mut config = multi_record_pipeline();
+        // Retagging `trailer` to `D` collides with `detail`.
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  trailer: { tag: D }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E245"), "{err}");
+    }
+
+    #[test]
+    fn records_modify_nested_unknown_column_errors_and_names_record() {
+        let mut config = multi_record_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  detail:\n    columns:\n      ghost: { type: float }\n"),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        // The reused column-op core raises E231 for the unknown column...
+        assert!(msg.contains("E231"), "{msg}");
+        // ...and the diagnostic names the offending record type.
+        assert!(msg.contains("records.detail"), "{msg}");
+    }
+
+    #[test]
+    fn discriminator_merge_moves_byte_range() {
+        let mut config = multi_record_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("discriminator: { start: 2, width: 3 }\n"),
+        )
+        .unwrap();
+        let (disc, _rts) = multi_record(&config);
+        assert_eq!(disc.start, Some(2));
+        assert_eq!(disc.width, Some(3));
+        assert_eq!(disc.field, None);
+    }
+
+    #[test]
+    fn discriminator_partial_merge_keeps_omitted_field() {
+        let mut config = multi_record_pipeline();
+        // Setting only `width` keeps the base `start: 0`.
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("discriminator: { width: 4 }\n"),
+        )
+        .unwrap();
+        let (disc, _rts) = multi_record(&config);
+        assert_eq!(disc.start, Some(0));
+        assert_eq!(disc.width, Some(4));
+    }
+
+    #[test]
+    fn discriminator_field_merge_on_csv() {
+        let mut config = multi_record_csv_pipeline();
+        apply(
+            &mut config,
+            "src",
+            patch_from_yaml("discriminator: { field: kind }\n"),
+        )
+        .unwrap();
+        let (disc, _rts) = multi_record(&config);
+        assert_eq!(disc.field.as_deref(), Some("kind"));
+        assert_eq!(disc.start, None);
+        assert_eq!(disc.width, None);
+    }
+
+    #[test]
+    fn discriminator_merge_mixing_modes_errors_e244() {
+        // The byte-range base plus a `field` merge yields a discriminator that
+        // is neither pure byte-range nor pure field.
+        let mut config = multi_record_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("discriminator: { field: rec_type }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E244"), "{err}");
+    }
+
+    #[test]
+    fn records_op_on_single_record_source_errors_e241() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("records:\n  detail: { tag: X }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E241"), "{err}");
+    }
+
+    #[test]
+    fn discriminator_op_on_single_record_source_errors_e241() {
+        let mut config = csv_pipeline();
+        let err = apply(
+            &mut config,
+            "src",
+            patch_from_yaml("discriminator: { field: kind }\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E241"), "{err}");
+    }
+
+    #[test]
+    fn records_op_ambiguous_add_with_modify_rejected_at_parse() {
+        let err = crate::yaml::from_str::<SourceConfigPatch>(
+            "records:\n  detail: { add: { tag: H, columns: [] }, tag: X }\n",
+        )
+        .unwrap_err();
+        let msg = format!("{}", err.0);
+        assert!(
+            msg.contains("exactly one") || msg.contains("ambiguous"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn records_add_without_columns_rejected_at_parse() {
+        // `columns` is required on an `add`, matching a hand-written `records:`
+        // entry: an add missing it fails to deserialize (the untagged op grammar
+        // surfaces this as a no-matching-variant error rather than propagating
+        // the inner missing-field message).
+        let err =
+            crate::yaml::from_str::<SourceConfigPatch>("records:\n  header: { add: { tag: H } }\n")
+                .unwrap_err();
+        let msg = format!("{}", err.0);
+        assert!(
+            msg.contains("columns") || msg.contains("missing") || msg.contains("variant"),
+            "{msg}"
+        );
+    }
+
+    #[test]
+    fn records_bare_scalar_other_than_remove_rejected_at_parse() {
+        let err =
+            crate::yaml::from_str::<SourceConfigPatch>("records:\n  detail: nope\n").unwrap_err();
+        let msg = format!("{}", err.0);
+        assert!(msg.contains("nope") || msg.contains("remove"), "{msg}");
+    }
+
+    #[test]
+    fn patch_with_only_multi_record_ops_is_not_empty() {
+        assert!(!patch_from_yaml("records:\n  detail: remove\n").is_empty());
+        assert!(!patch_from_yaml("discriminator: { start: 1 }\n").is_empty());
     }
 }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -4312,6 +4312,30 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
         if let InputFormat::Hl7(Some(opts)) = &input.format {
             validate_hl7_split_fields(&input.name, opts)?;
         }
+
+        // A `json_pointer` extract must be a valid RFC 6901 pointer: either
+        // empty (the whole document) or a `/`-introduced path. A slashless
+        // value like `Head` decodes to zero segments — indistinguishable from
+        // the empty pointer — and would silently match the root document
+        // instead of the intended section. Reject it at authoring time so a
+        // typo fails on `--explain` rather than materializing the wrong
+        // metadata at runtime.
+        if let Some(envelope) = &input.envelope {
+            for (section_name, section) in &envelope.sections {
+                if let clinker_format::EnvelopeExtract::JsonPointer(pointer) = &section.extract
+                    && !pointer.is_empty()
+                    && !pointer.starts_with('/')
+                {
+                    return Err(ConfigError::Validation(format!(
+                        "[E222] source '{source}': envelope section '{section_name}' declares \
+                         `json_pointer: {pointer:?}`, which is not a valid RFC 6901 pointer — a \
+                         pointer must be empty (the whole document) or start with `/` (e.g. \
+                         `/{pointer}`)",
+                        source = input.name,
+                    )));
+                }
+            }
+        }
     }
 
     // Single-envelope output formats wrap every record in one frame whose

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -1900,38 +1900,6 @@ fn bind_cull(
         ok = false;
     }
 
-    // Reject a `#` line-comment in any rule predicate. The rules are
-    // OR-combined into ONE single-line decision expression (`(r1) or (r2)`),
-    // and a CXL `#` comment runs to end-of-line — on that single line it would
-    // swallow every following disjunct and the closing paren. The disjunction
-    // has nowhere else to go (CXL `or` cannot span a newline, and an aggregate
-    // predicate cannot move into a `let` — let RHSs must be row-pure), so the
-    // honest fix is to reject the comment with a rule-named diagnostic rather
-    // than surface a baffling parse error against the synthetic combined
-    // program. A `#…#` date literal lexes as a date token, not a comment, so
-    // it is unaffected.
-    for rule in &config.rules {
-        if cxl::lexer::Lexer::tokenize(&rule.drop_group_when.source)
-            .iter()
-            .any(|(t, _)| *t == cxl::lexer::Token::Comment)
-        {
-            diags.push(
-                Diagnostic::error(
-                    "E200",
-                    format!(
-                        "cull {name:?} rule {:?}: drop_group_when may not contain a `#` comment — \
-                         the rule predicates are combined into a single expression where a line \
-                         comment would swallow the other rules",
-                        rule.name
-                    ),
-                    LabeledSpan::primary(span, String::new()),
-                )
-                .with_help("remove the `#` comment from the predicate"),
-            );
-            ok = false;
-        }
-    }
-
     if !ok {
         return;
     }
@@ -1948,26 +1916,96 @@ fn bind_cull(
 
     // Build the decision program the runtime evaluates per group: a group is
     // removed when ANY rule's `drop_group_when` holds, so the decision is the
-    // OR of every rule's predicate in one `emit`. The aggregates (`count`,
-    // `sum`, …) sit directly in the emit body, where `extract_aggregates`
-    // folds them at lowering; they cannot move into a `let` (let RHSs must be
-    // row-pure) and `or` cannot span a newline, so the disjunction is a single
-    // line — which is why a `#` comment in any rule is rejected above. Emit
-    // target = `CULL_DROP_DECISION_COLUMN`; lowering runs `extract_aggregates`
-    // over this program and stamps it onto `PlanNode::Cull.compiled`/`.typed`.
-    // `rules` is non-empty (rejected above).
+    // OR of every rule's predicate emitted to `CULL_DROP_DECISION_COLUMN`. The
+    // aggregates (`count`, `sum`, …) sit directly in the emit body, where
+    // `extract_aggregates` folds them at lowering.
+    //
+    // Each rule is parsed on its own — as an `emit __cull_pred = <predicate>`
+    // program — and the parsed predicate expressions are OR-combined at the
+    // AST level rather than by joining rule source strings into one `(r1) or
+    // (r2)` line. Per-rule parsing keeps a trailing `#` line-comment (which
+    // runs to end-of-line) scoped to its own rule instead of swallowing the
+    // following disjuncts and the closing paren, which a single joined source
+    // line cannot do. Each rule's node ids are relocated into a dense,
+    // collision-free span so the resolver/typechecker side-tables (indexed by
+    // `NodeId`) stay consistent; the OR-chain and wrapping emit mint fresh ids
+    // above every relocated rule. Lowering runs `extract_aggregates` over the
+    // result and stamps it onto `PlanNode::Cull.compiled`/`.typed`. `rules` is
+    // non-empty (rejected above).
     let agg_mode = AggregateMode::GroupBy {
         group_by_fields: config.partition_by.iter().cloned().collect(),
     };
-    let disjunction = config
-        .rules
-        .iter()
-        .map(|r| format!("({})", r.drop_group_when.source))
-        .collect::<Vec<_>>()
-        .join(" or ");
+
+    let mut disjuncts: Vec<Expr> = Vec::with_capacity(config.rules.len());
+    let mut next_id: u32 = 0;
+    let mut parse_failed = false;
+    for rule in &config.rules {
+        match parse_cull_rule_predicate(
+            &format!("{name}:{}:drop_group_when", rule.name),
+            &rule.drop_group_when.source,
+            next_id,
+            span,
+        ) {
+            Ok((predicate, node_count)) => {
+                disjuncts.push(predicate);
+                next_id += node_count;
+            }
+            Err(d) => {
+                diags.push(d);
+                parse_failed = true;
+            }
+        }
+    }
+    if parse_failed {
+        return;
+    }
+
+    // OR-fold the parsed rule predicates left-to-right, minting one fresh
+    // `NodeId` per inserted `or`. A single-rule Cull needs no `or`: its lone
+    // predicate is the decision body.
+    let body = disjuncts
+        .into_iter()
+        .reduce(|lhs, rhs| {
+            let node_id = cxl::ast::NodeId(next_id);
+            next_id += 1;
+            let or_span = lhs.span();
+            Expr::Binary {
+                node_id,
+                op: cxl::ast::BinOp::Or,
+                lhs: Box::new(lhs),
+                rhs: Box::new(rhs),
+                span: or_span,
+            }
+        })
+        .expect("cull rules are non-empty");
+
+    let body_span = body.span();
+    let emit_id = cxl::ast::NodeId(next_id);
+    next_id += 1;
+    let node_count = next_id;
+    let decision_program = cxl::ast::Program {
+        statements: vec![Statement::Emit {
+            node_id: emit_id,
+            name: crate::config::pipeline_node::CULL_DROP_DECISION_COLUMN.into(),
+            expr: body,
+            target: cxl::ast::EmitTarget::Field,
+            span: body_span,
+        }],
+        span: cxl::lexer::Span::default(),
+    };
+
+    // Reconstruct the single-line decision source for the typed program's
+    // display text (eval-error / explain rendering). It is never re-parsed,
+    // so a rule's `#` comment inside it is inert.
     let decision_src = format!(
-        "emit {} = {disjunction}",
-        crate::config::pipeline_node::CULL_DROP_DECISION_COLUMN
+        "emit {} = {}",
+        crate::config::pipeline_node::CULL_DROP_DECISION_COLUMN,
+        config
+            .rules
+            .iter()
+            .map(|r| format!("({})", r.drop_group_when.source))
+            .collect::<Vec<_>>()
+            .join(" or ")
     );
 
     // Typecheck the combined program first — the happy path needs only this
@@ -1976,9 +2014,11 @@ fn bind_cull(
     // diagnostic to the offending rule; fall back to the combined diagnostic
     // if no single rule reproduces it. Either way, skip lowering (the node is
     // absent from `cull_decision_typed`).
-    match typecheck_cxl(
+    match typecheck_parsed_program(
         &format!("{name}:drop_group_when"),
-        &decision_src,
+        decision_program,
+        node_count,
+        std::sync::Arc::from(decision_src.as_str()),
         upstream,
         agg_mode.clone(),
         span,
@@ -1990,12 +2030,9 @@ fn bind_cull(
         Err(combined) => {
             let mut attributed = false;
             for rule in &config.rules {
-                if let Err(d) = typecheck_cxl(
+                if let Err(d) = typecheck_cull_rule(
                     &format!("{name}:{}:drop_group_when", rule.name),
-                    &format!(
-                        "emit __cull_pred = ({}) or false",
-                        rule.drop_group_when.source
-                    ),
+                    &rule.drop_group_when.source,
                     upstream,
                     agg_mode.clone(),
                     span,
@@ -4054,6 +4091,40 @@ fn typecheck_cxl(
             LabeledSpan::primary(span, String::new()),
         ));
     }
+    typecheck_parsed_program(
+        node_name,
+        parse_result.ast,
+        parse_result.node_count,
+        std::sync::Arc::from(source),
+        schema,
+        mode,
+        span,
+        scoped_vars,
+    )
+}
+
+/// Resolve + typecheck an already-parsed CXL `program` against `schema`,
+/// attaching `source` as the typed program's display text.
+///
+/// Split out from [`typecheck_cxl`] so callers that synthesize a program
+/// directly (rather than from one source string) can enter after parse —
+/// notably `bind_cull`, which OR-combines each rule's independently parsed
+/// predicate at the AST level. `node_count` must exceed every `NodeId` in
+/// `program` (the resolver/typechecker size their per-node side-tables by
+/// it); a synthesizing caller is responsible for keeping ids dense and
+/// below it.
+#[allow(clippy::result_large_err)]
+#[allow(clippy::too_many_arguments)]
+fn typecheck_parsed_program(
+    node_name: &str,
+    program: cxl::ast::Program,
+    node_count: u32,
+    source: Arc<str>,
+    schema: &Row,
+    mode: AggregateMode,
+    span: Span,
+    scoped_vars: &cxl::resolve::ScopedVarsRegistry,
+) -> Result<TypedProgram, Diagnostic> {
     // Collect unqualified field names for CXL resolve. In the non-combine
     // case all fields are bare; in the combine case (C.1.1+) qualified
     // fields collapse to their `.name` — the resolver only needs to know
@@ -4062,9 +4133,9 @@ fn typecheck_cxl(
     // typecheck/pass.rs, not resolve).
     let field_refs: Vec<&str> = schema.field_names().map(|qf| qf.name.as_ref()).collect();
     let resolved = cxl::resolve::resolve_program_with_modules_and_vars(
-        parse_result.ast,
+        program,
         &field_refs,
-        parse_result.node_count,
+        node_count,
         &std::collections::HashMap::new(),
         scoped_vars,
     )
@@ -4085,7 +4156,7 @@ fn typecheck_cxl(
     cxl::typecheck::pass::type_check_with_mode_and_vars(resolved, schema, mode, scoped_vars)
         .map(|mut typed| {
             fold_body_config(&mut typed, scoped_vars);
-            typed.with_source(std::sync::Arc::from(source))
+            typed.with_source(source)
         })
         .map_err(|diags| {
             let errors: Vec<String> = diags
@@ -4108,6 +4179,119 @@ fn typecheck_cxl(
                 LabeledSpan::primary(span, String::new()),
             )
         })
+}
+
+/// Parse one Cull rule's `drop_group_when` predicate into a stand-alone
+/// expression, relocating its node ids past `base_id`.
+///
+/// The predicate is parsed as its own `emit __cull_pred = <source>`
+/// program, so a trailing `#` line-comment terminates at end-of-line
+/// within this rule instead of swallowing later disjuncts. The single
+/// emit's right-hand side is extracted and its node ids shifted by
+/// `base_id`, so the caller can OR several rule predicates into one
+/// dense-id-space decision program.
+/// Returns the relocated predicate and the rule program's node count (the
+/// id span the caller must skip). `Err` is an E200 parse diagnostic
+/// already attributed to `node_name`.
+#[allow(clippy::result_large_err)]
+fn parse_cull_rule_predicate(
+    node_name: &str,
+    source: &str,
+    base_id: u32,
+    span: Span,
+) -> Result<(Expr, u32), Diagnostic> {
+    let parsed = cxl::parser::Parser::parse(&format!("emit __cull_pred = {source}"));
+    if !parsed.errors.is_empty() {
+        let messages: Vec<String> = parsed.errors.iter().map(|e| e.message.clone()).collect();
+        return Err(Diagnostic::error(
+            "E200",
+            format!("CXL parse error in {node_name:?}: {}", messages.join("; ")),
+            LabeledSpan::primary(span, String::new()),
+        ));
+    }
+    // The wrapper is exactly one field emit of a single expression; a rule
+    // source that parsed into anything else (extra statements, a scoped-state
+    // emit) is not a group predicate.
+    let mut statements = parsed.ast.statements;
+    let single = (statements.len() == 1).then(|| statements.pop()).flatten();
+    let mut predicate = match single {
+        Some(Statement::Emit {
+            expr,
+            target: cxl::ast::EmitTarget::Field,
+            ..
+        }) => expr,
+        _ => {
+            return Err(Diagnostic::error(
+                "E200",
+                format!(
+                    "CXL parse error in {node_name:?}: drop_group_when must be a single \
+                     expression"
+                ),
+                LabeledSpan::primary(span, String::new()),
+            ));
+        }
+    };
+    cxl::ast::offset_node_ids(&mut predicate, base_id);
+    Ok((predicate, parsed.node_count))
+}
+
+/// Typecheck one Cull rule's predicate in isolation, to attribute a
+/// diagnostic to the offending rule when the OR-combined program failed.
+///
+/// The predicate is wrapped as `<predicate> or false` (built on the AST, so
+/// a `#` comment stays scoped to the predicate) to force a boolean operand,
+/// surfacing a non-boolean predicate as the same type error the combined
+/// program raises. Returns `Ok` if this rule alone typechecks cleanly,
+/// `Err` with the attributed diagnostic otherwise.
+#[allow(clippy::result_large_err)]
+fn typecheck_cull_rule(
+    node_name: &str,
+    source: &str,
+    schema: &Row,
+    mode: AggregateMode,
+    span: Span,
+    scoped_vars: &cxl::resolve::ScopedVarsRegistry,
+) -> Result<TypedProgram, Diagnostic> {
+    let (predicate, mut next_id) = parse_cull_rule_predicate(node_name, source, 0, span)?;
+    let body_span = predicate.span();
+    let false_id = cxl::ast::NodeId(next_id);
+    next_id += 1;
+    let or_id = cxl::ast::NodeId(next_id);
+    next_id += 1;
+    let emit_id = cxl::ast::NodeId(next_id);
+    next_id += 1;
+    let body = Expr::Binary {
+        node_id: or_id,
+        op: cxl::ast::BinOp::Or,
+        lhs: Box::new(predicate),
+        rhs: Box::new(Expr::Literal {
+            node_id: false_id,
+            value: cxl::ast::LiteralValue::Bool(false),
+            span: body_span,
+        }),
+        span: body_span,
+    };
+    let program = cxl::ast::Program {
+        statements: vec![Statement::Emit {
+            node_id: emit_id,
+            name: "__cull_pred".into(),
+            expr: body,
+            target: cxl::ast::EmitTarget::Field,
+            span: body_span,
+        }],
+        span: cxl::lexer::Span::default(),
+    };
+    let display = format!("emit __cull_pred = ({source}) or false");
+    typecheck_parsed_program(
+        node_name,
+        program,
+        next_id,
+        std::sync::Arc::from(display.as_str()),
+        schema,
+        mode,
+        span,
+        scoped_vars,
+    )
 }
 
 /// Compile an Envelope node's declarative header/footer synthesis against the

--- a/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
@@ -106,15 +106,13 @@ nodes:
     );
 }
 
-/// A `#` line-comment in a Cull rule predicate is rejected at compile time
-/// with a clear, rule-named diagnostic. The rules are OR-combined into a
-/// single-line decision expression (aggregate predicates cannot move into
-/// `let`s and CXL `or` cannot span a newline), where a `#` comment would
-/// otherwise swallow the following disjuncts and the closing paren — so the
-/// binder rejects the comment up front instead of emitting a baffling parse
-/// error against the synthetic combined program.
+/// A `#` line-comment in a Cull rule predicate compiles: each rule is parsed
+/// independently, so a trailing comment terminates at its own end-of-line
+/// instead of swallowing the following disjuncts, and the parsed predicates
+/// are OR-combined at the AST level. The commented rule and its uncommented
+/// neighbour both fold into the decision aggregate.
 #[test]
-fn cull_rule_with_line_comment_rejected() {
+fn cull_rule_with_line_comment_compiles() {
     let yaml = r#"
 pipeline:
   name: cull_comment
@@ -155,17 +153,109 @@ nodes:
       type: csv
       path: audit.csv
 "#;
+    let compiled = compile_ok(yaml);
+    let g = &compiled.dag().graph;
+    let idx = g
+        .node_indices()
+        .find(|&i| g[i].name() == "cd")
+        .expect("cull node `cd` present");
+    let PlanNode::Cull {
+        typed,
+        compiled: agg,
+        ..
+    } = &g[idx]
+    else {
+        panic!("node `cd` is not a Cull");
+    };
+    assert!(
+        !typed.program.statements.is_empty(),
+        "cull decision program should carry statements"
+    );
+    let emit_names: Vec<&str> = agg.emits.iter().map(|e| e.output_name.as_ref()).collect();
+    assert!(
+        emit_names.contains(&CULL_DROP_DECISION_COLUMN),
+        "cull decision aggregate should emit {CULL_DROP_DECISION_COLUMN:?}, got {emit_names:?}"
+    );
+    // Both rules contribute a `sum` aggregate to the OR-combined decision, so
+    // the extracted aggregate carries at least two bindings.
+    assert!(
+        agg.bindings.len() >= 2,
+        "both rules' aggregates should fold into the decision, got {} bindings",
+        agg.bindings.len()
+    );
+}
+
+/// An error inside a `#`-commented rule is still attributed to that rule by
+/// name: the OR-combined program fails, then the per-rule attribution
+/// fallback re-typechecks each rule independently (comment-tolerant), so the
+/// offending rule surfaces by name even though its predicate carries a
+/// trailing comment. The uncommented sibling rule is well-formed, so only
+/// the bad rule is named.
+#[test]
+fn cull_error_in_commented_rule_names_the_rule() {
+    let yaml = r#"
+pipeline:
+  name: cull_comment_error
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: id, type: string }
+        - { name: amount, type: int }
+        - { name: status, type: string }
+  - type: cull
+    name: cd
+    input: src
+    config:
+      partition_by: [id]
+      removed_to: removed
+      rules:
+        - name: bad_rule
+          drop_group_when: "sum(nonexistent) > 0  # references a missing column"
+        - name: drop_big
+          drop_group_when: "sum(amount) > 100"
+  - type: output
+    name: out
+    input: cd
+    config:
+      name: out
+      type: csv
+      path: out.csv
+  - type: output
+    name: audit
+    input: cd.removed
+    config:
+      name: audit
+      type: csv
+      path: audit.csv
+"#;
     let diags = parse_config(yaml)
         .expect("parse_config")
         .compile(&CompileContext::default())
-        .expect_err("compile should reject the `#` comment");
-    // A precise, rule-attributed diagnostic — not a parse error citing the
-    // synthetic combined program.
+        .expect_err("a predicate referencing an unknown column must fail to compile");
+    // The diagnostic names both the offending rule (only the per-rule
+    // attribution path, which is comment-tolerant, adds the rule name) and
+    // the unknown column.
     assert!(
         diags.iter().any(|d| d.code == "E200"
-            && d.message.contains("drop_errors")
-            && d.message.contains("`#` comment")),
-        "expected an E200 naming rule `drop_errors` and the `#` comment, got {:?}",
+            && d.message.contains("bad_rule")
+            && d.message.contains("nonexistent")),
+        "expected an E200 naming rule `bad_rule` and the unknown column, got {:?}",
+        diags
+            .iter()
+            .map(|d| (d.code.clone(), d.message.clone()))
+            .collect::<Vec<_>>()
+    );
+    // The well-formed sibling rule is not blamed.
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.message.contains("drop_big") && d.message.contains("nonexistent")),
+        "the well-formed rule `drop_big` must not be blamed, got {:?}",
         diags
             .iter()
             .map(|d| (d.code.clone(), d.message.clone()))

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -1150,3 +1150,84 @@ nodes:
         "non-primary port source `zip_lookup` must carry the downstream `$doc` path, got {zip_paths:?}"
     );
 }
+
+/// A JSON envelope `json_pointer` extract must be a valid RFC 6901 pointer:
+/// empty (the whole document) or `/`-introduced. A slashless value decodes
+/// to zero segments and would silently match the root, so plan validation
+/// rejects it with E222 naming the source, section, and offending pointer.
+#[test]
+fn test_slashless_json_pointer_rejected_at_validation() {
+    let yaml = r#"
+pipeline:
+  name: json_pointer_validate
+nodes:
+  - type: source
+    name: docs
+    config:
+      name: docs
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Head:
+            extract: { json_pointer: "Head" }
+            fields:
+              batch_id: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: docs
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let err = parse_config(yaml).expect_err("a slashless json_pointer must fail plan validation");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("E222"),
+        "expected an E222 diagnostic, got: {msg}"
+    );
+    assert!(
+        msg.contains("docs") && msg.contains("Head") && msg.contains("\"Head\""),
+        "E222 must name the source, section, and offending pointer, got: {msg}"
+    );
+}
+
+/// The empty pointer `""` names the whole document and stays accepted:
+/// validation gates only the slashless non-empty case.
+#[test]
+fn test_empty_json_pointer_accepted_at_validation() {
+    let yaml = r#"
+pipeline:
+  name: json_pointer_root
+nodes:
+  - type: source
+    name: docs
+    config:
+      name: docs
+      type: json
+      glob: ./*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          Whole:
+            extract: { json_pointer: "" }
+            fields:
+              batch_id: string
+      schema:
+        - { name: amount, type: int }
+  - type: output
+    name: out
+    input: docs
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    parse_config(yaml).expect("the empty (whole-document) json_pointer must validate");
+}

--- a/crates/clinker-record/src/accumulator/mod.rs
+++ b/crates/clinker-record/src/accumulator/mod.rs
@@ -749,8 +749,10 @@ impl WeightedAvgState {
         // quotient). A `decimal·int` product widens exactly via `Decimal::from`
         // and `decimal·decimal` is exact. A decimal mixed with a binary float
         // is a typecheck error, so that combination reaches this path only on
-        // an untyped column, where `decimal_add_weighted` poisons the result to
-        // Null rather than emitting a silently-wrong average.
+        // an untyped column, where the result is poisoned to Null rather than
+        // emitting a silently-wrong average — `decimal_add_weighted` catches a
+        // float in the same row, and `enter_decimal_mode` catches a float
+        // accumulated before this first decimal row.
         if self.is_decimal || v.is_decimal() || w.is_decimal() {
             self.enter_decimal_mode();
             self.decimal_add_weighted(&v, &w);
@@ -789,9 +791,16 @@ impl WeightedAvgState {
     /// integers already accumulated (`Σ vᵢ·wᵢ` and `Σ wᵢ`). Fallible — an
     /// integer sum beyond `Decimal`'s ~7.9e28 range sets the overflow flag
     /// rather than panicking (`Decimal::from_i128_with_scale` would panic).
+    /// Float contributions accumulated before the first decimal row (an
+    /// `Any`-typed column that mixed a binary float and a decimal — typed
+    /// columns cannot) cannot widen to an exact decimal; the seed only pulls in
+    /// the integer sums, so poison the result rather than silently drop them.
     fn enter_decimal_mode(&mut self) {
         if !self.is_decimal {
             self.is_decimal = true;
+            if !self.is_integer {
+                self.decimal_overflow = true;
+            }
             match i128_to_decimal(self.int_weighted_sum) {
                 Some(d) => self.decimal_weighted_sum = d,
                 None => {
@@ -869,6 +878,13 @@ impl WeightedAvgState {
             let other_weighted = other.decimal_weighted_contribution();
             let self_weight = self.decimal_weight_contribution();
             let other_weight = other.decimal_weight_contribution();
+            // A float-mode side (not decimal, not integer-only) contributes
+            // only its integer sums above; its binary-float totals cannot widen
+            // to an exact decimal. Combining one into the decimal domain would
+            // silently drop them, so poison the result to Null instead.
+            if (!self.is_decimal && !self.is_integer) || (!other.is_decimal && !other.is_integer) {
+                self.decimal_overflow = true;
+            }
             self.is_decimal = true;
             match (self_weighted, other_weighted) {
                 (Some(a), Some(b)) => match a.checked_add(b) {

--- a/crates/clinker-record/src/accumulator/mod.rs
+++ b/crates/clinker-record/src/accumulator/mod.rs
@@ -14,7 +14,7 @@
 use std::cmp::Ordering;
 
 use rust_decimal::Decimal;
-use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use serde::{Deserialize, Serialize};
 
 use crate::value::Value;
@@ -609,9 +609,12 @@ fn collect_state_sub(s: &mut CollectState, value: &Value) -> isize {
 // ----------------------------------------------------------------------------
 
 /// Weighted average state. Two-argument: value + weight. i128 weighted sum
-/// plus i128 weight sum, with Kahan compensated float paths for both.
+/// plus i128 weight sum, with Kahan compensated float paths for both and an
+/// exact `Decimal` path for `decimal` inputs (mirroring `AvgState`).
 ///
 /// Finalize: weighted_sum / weight_sum. Zero total weight → Null (V-7-2a).
+/// A `decimal` value or weight yields the exact full-precision quotient; the
+/// int/float paths keep the prior binary-float behavior.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct WeightedAvgState {
     pub int_weighted_sum: i128,
@@ -620,7 +623,24 @@ pub struct WeightedAvgState {
     pub weight_sum_int: i128,
     pub weight_sum_float: f64,
     pub weight_compensation: f64,
+    /// Exact running weighted sum (`Σ vᵢ·wᵢ`) once a `decimal` operand is
+    /// seen. A `decimal·int` product widens exactly via `Decimal::from` and
+    /// `decimal·decimal` is exact; `is_decimal` selects this path at finalize.
+    #[serde(with = "crate::decimal_serde")]
+    pub decimal_weighted_sum: Decimal,
+    /// Exact running weight total (`Σ wᵢ`) in the decimal domain, paired with
+    /// `decimal_weighted_sum` for a full-precision quotient at finalize.
+    #[serde(with = "crate::decimal_serde")]
+    pub decimal_weight_sum: Decimal,
+    /// Set once an exact decimal sum leaves `Decimal`'s ~7.9e28 range (or a
+    /// decimal is mixed with a binary float, which cannot fold exactly);
+    /// finalize then returns `Null` rather than a silently-wrong weighted
+    /// average (weighted_avg has no error channel).
+    pub decimal_overflow: bool,
     pub is_integer: bool,
+    /// True once a `decimal` operand has been observed; finalize then returns
+    /// an exact `Value::Decimal` quotient.
+    pub is_decimal: bool,
     pub has_value: bool,
 }
 
@@ -633,8 +653,68 @@ impl Default for WeightedAvgState {
             weight_sum_int: 0,
             weight_sum_float: 0.0,
             weight_compensation: 0.0,
+            decimal_weighted_sum: Decimal::ZERO,
+            decimal_weight_sum: Decimal::ZERO,
+            decimal_overflow: false,
             is_integer: true,
+            is_decimal: false,
             has_value: false,
+        }
+    }
+}
+
+/// A numeric operand of `weighted_avg`, kept in exact form so the decimal
+/// path never reconstructs a lossy float. Null and non-numeric values are
+/// filtered by [`Operand::numeric`] (which returns `None`) and skip the row.
+#[derive(Debug, Clone, Copy)]
+enum Operand {
+    Int(i64),
+    Float(f64),
+    Decimal(Decimal),
+}
+
+impl Operand {
+    fn numeric(v: &Value) -> Option<Self> {
+        match v {
+            Value::Integer(n) => Some(Operand::Int(*n)),
+            Value::Float(f) => Some(Operand::Float(*f)),
+            Value::Decimal(d) => Some(Operand::Decimal(*d)),
+            // Null and non-numeric values skip the row.
+            _ => None,
+        }
+    }
+
+    fn is_decimal(&self) -> bool {
+        matches!(self, Operand::Decimal(_))
+    }
+
+    /// The exact integer value, or `None` for a float/decimal (which the i128
+    /// fast path cannot take).
+    fn as_int(&self) -> Option<i64> {
+        match self {
+            Operand::Int(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    /// The f64 projection used by the compensated float path. Reached only for
+    /// integers and floats — decimals take the exact path — but total for
+    /// completeness.
+    fn as_f64(&self) -> f64 {
+        match self {
+            Operand::Int(n) => *n as f64,
+            Operand::Float(f) => *f,
+            Operand::Decimal(d) => d.to_f64().unwrap_or(f64::NAN),
+        }
+    }
+
+    /// The operand as an exact `Decimal`, or `None` for a float (which cannot
+    /// widen to decimal without loss).
+    fn as_decimal(&self) -> Option<Decimal> {
+        match self {
+            Operand::Int(n) => Some(Decimal::from(*n)),
+            Operand::Decimal(d) => Some(*d),
+            Operand::Float(_) => None,
         }
     }
 }
@@ -654,49 +734,123 @@ impl WeightedAvgState {
         self.weight_sum_float = t;
     }
 
-    /// Convert a numeric Value to (i64_opt, f64_opt). Returns None if value
-    /// is Null or non-numeric.
-    fn numeric(v: &Value) -> Option<(Option<i64>, f64)> {
-        match v {
-            Value::Null => None,
-            Value::Integer(n) => Some((Some(*n), *n as f64)),
-            Value::Float(f) => Some((None, *f)),
-            _ => None,
-        }
-    }
-
     fn add_weighted(&mut self, value: &Value, weight: &Value) {
-        let Some((v_int, v_f)) = Self::numeric(value) else {
-            return;
-        };
-        let Some((w_int, w_f)) = Self::numeric(weight) else {
+        // A null or non-numeric operand in either position skips the row and
+        // does not mark `has_value` (matches the prior behavior and SQL null
+        // handling).
+        let (Some(v), Some(w)) = (Operand::numeric(value), Operand::numeric(weight)) else {
             return;
         };
         self.has_value = true;
 
-        // Integer path: both must be integer.
-        match (v_int, w_int) {
+        // Exact decimal path: taken as soon as either operand is a decimal, and
+        // for every row thereafter (so integers observed after the first
+        // decimal fold into the exact sums instead of being dropped from the
+        // quotient). A `decimal·int` product widens exactly via `Decimal::from`
+        // and `decimal·decimal` is exact. A decimal mixed with a binary float
+        // is a typecheck error, so that combination reaches this path only on
+        // an untyped column, where `decimal_add_weighted` poisons the result to
+        // Null rather than emitting a silently-wrong average.
+        if self.is_decimal || v.is_decimal() || w.is_decimal() {
+            self.enter_decimal_mode();
+            self.decimal_add_weighted(&v, &w);
+            return;
+        }
+
+        // No decimal in play: exact i128 product when both operands are
+        // integers, else the Kahan-compensated float path.
+        match (v.as_int(), w.as_int()) {
             (Some(vi), Some(wi)) => {
                 self.int_weighted_sum += vi as i128 * wi as i128;
                 self.weight_sum_int += wi as i128;
                 if !self.is_integer {
-                    // Already float mode: mirror into float paths too.
-                    self.kahan_add_val(v_f * w_f);
-                    self.kahan_add_weight(w_f);
+                    // Already float mode: mirror into the float paths too.
+                    self.kahan_add_val(v.as_f64() * w.as_f64());
+                    self.kahan_add_weight(w.as_f64());
                 }
             }
             _ => {
                 if self.is_integer {
-                    // First float arg: seed float paths from integer state.
+                    // First float operand: seed the float paths from the
+                    // integer state.
                     self.is_integer = false;
                     self.float_weighted_sum = self.int_weighted_sum as f64;
                     self.weight_sum_float = self.weight_sum_int as f64;
                     self.compensation = 0.0;
                     self.weight_compensation = 0.0;
                 }
-                self.kahan_add_val(v_f * w_f);
-                self.kahan_add_weight(w_f);
+                self.kahan_add_val(v.as_f64() * w.as_f64());
+                self.kahan_add_weight(w.as_f64());
             }
+        }
+    }
+
+    /// Switch to the exact decimal path, seeding both running sums from the
+    /// integers already accumulated (`Σ vᵢ·wᵢ` and `Σ wᵢ`). Fallible — an
+    /// integer sum beyond `Decimal`'s ~7.9e28 range sets the overflow flag
+    /// rather than panicking (`Decimal::from_i128_with_scale` would panic).
+    fn enter_decimal_mode(&mut self) {
+        if !self.is_decimal {
+            self.is_decimal = true;
+            match i128_to_decimal(self.int_weighted_sum) {
+                Some(d) => self.decimal_weighted_sum = d,
+                None => {
+                    self.decimal_weighted_sum = Decimal::ZERO;
+                    self.decimal_overflow = true;
+                }
+            }
+            match i128_to_decimal(self.weight_sum_int) {
+                Some(d) => self.decimal_weight_sum = d,
+                None => {
+                    self.decimal_weight_sum = Decimal::ZERO;
+                    self.decimal_overflow = true;
+                }
+            }
+        }
+    }
+
+    /// Fold one `(value, weight)` row into the exact decimal accumulators.
+    /// Both operands are integers or decimals here; a binary float mixed with
+    /// a decimal cannot widen exactly and sets the overflow flag so finalize
+    /// returns Null instead of a silently-wrong total. `checked_*` guards keep
+    /// an out-of-range intermediate from panicking.
+    fn decimal_add_weighted(&mut self, value: &Operand, weight: &Operand) {
+        let (Some(v), Some(w)) = (value.as_decimal(), weight.as_decimal()) else {
+            self.decimal_overflow = true;
+            return;
+        };
+        match v.checked_mul(w) {
+            Some(prod) => match self.decimal_weighted_sum.checked_add(prod) {
+                Some(sum) => self.decimal_weighted_sum = sum,
+                None => self.decimal_overflow = true,
+            },
+            None => self.decimal_overflow = true,
+        }
+        match self.decimal_weight_sum.checked_add(w) {
+            Some(sum) => self.decimal_weight_sum = sum,
+            None => self.decimal_overflow = true,
+        }
+    }
+
+    /// This state's exact weighted-sum total (`Σ vᵢ·wᵢ`): the decimal
+    /// accumulator when in decimal mode (which already folds its integers),
+    /// else the integer weighted sum promoted to a decimal. `None` when a pure
+    /// integer sum is too large to represent as a `Decimal`.
+    fn decimal_weighted_contribution(&self) -> Option<Decimal> {
+        if self.is_decimal {
+            Some(self.decimal_weighted_sum)
+        } else {
+            i128_to_decimal(self.int_weighted_sum)
+        }
+    }
+
+    /// This state's exact weight total (`Σ wᵢ`), analogous to
+    /// [`decimal_weighted_contribution`](Self::decimal_weighted_contribution).
+    fn decimal_weight_contribution(&self) -> Option<Decimal> {
+        if self.is_decimal {
+            Some(self.decimal_weight_sum)
+        } else {
+            i128_to_decimal(self.weight_sum_int)
         }
     }
 
@@ -705,6 +859,33 @@ impl WeightedAvgState {
             return;
         }
         self.has_value = true;
+        // Combine each side's exact decimal totals from its own (un-merged)
+        // integer sums BEFORE mutating them (see `SumState::merge`), so an
+        // integer-only side is neither double-counted nor dropped. Read both
+        // contributions before flipping `self.is_decimal` so an integer-only
+        // `self` promotes its int sums rather than reading unseeded decimals.
+        if self.is_decimal || other.is_decimal {
+            let self_weighted = self.decimal_weighted_contribution();
+            let other_weighted = other.decimal_weighted_contribution();
+            let self_weight = self.decimal_weight_contribution();
+            let other_weight = other.decimal_weight_contribution();
+            self.is_decimal = true;
+            match (self_weighted, other_weighted) {
+                (Some(a), Some(b)) => match a.checked_add(b) {
+                    Some(sum) => self.decimal_weighted_sum = sum,
+                    None => self.decimal_overflow = true,
+                },
+                _ => self.decimal_overflow = true,
+            }
+            match (self_weight, other_weight) {
+                (Some(a), Some(b)) => match a.checked_add(b) {
+                    Some(sum) => self.decimal_weight_sum = sum,
+                    None => self.decimal_overflow = true,
+                },
+                _ => self.decimal_overflow = true,
+            }
+            self.decimal_overflow |= other.decimal_overflow;
+        }
         self.int_weighted_sum += other.int_weighted_sum;
         self.weight_sum_int += other.weight_sum_int;
         if !other.is_integer {
@@ -725,6 +906,25 @@ impl WeightedAvgState {
     fn finalize(&self) -> Value {
         if !self.has_value {
             return Value::Null;
+        }
+        if self.is_decimal {
+            // An overflowed (or decimal/float-mixed) exact sum has no honest
+            // value — weighted_avg has no error channel — so return Null
+            // rather than a biased average.
+            if self.decimal_overflow {
+                return Value::Null;
+            }
+            // V-7-2a: zero total weight → Null (prevents a divide-by-zero).
+            if self.decimal_weight_sum.is_zero() {
+                return Value::Null;
+            }
+            return match self
+                .decimal_weighted_sum
+                .checked_div(self.decimal_weight_sum)
+            {
+                Some(avg) => Value::Decimal(avg),
+                None => Value::Null,
+            };
         }
         let (weighted, weight) = if self.is_integer {
             (self.int_weighted_sum as f64, self.weight_sum_int as f64)

--- a/crates/clinker-record/src/accumulator/tests.rs
+++ b/crates/clinker-record/src/accumulator/tests.rs
@@ -475,6 +475,119 @@ fn test_weighted_avg_zero_weight() {
     assert_eq!(a.finalize().unwrap(), Value::Null);
 }
 
+// ---------- WeightedAvg over decimals (exactness) ----------
+
+#[test]
+fn test_weighted_avg_decimal_is_exact() {
+    // (0.10 + 0.20 + 0.30) / 3 = 0.60 / 3 = 0.20 exactly. The binary-float
+    // path drifts: 0.1 + 0.2 + 0.3 is 0.6000000000000001, / 3 is not 0.2.
+    let mut a = weighted_avg();
+    a.add_weighted(&dec(10, 2), &Value::Integer(1));
+    a.add_weighted(&dec(20, 2), &Value::Integer(1));
+    a.add_weighted(&dec(30, 2), &Value::Integer(1));
+    assert_eq!(a.finalize().unwrap(), dec(20, 2));
+}
+
+#[test]
+fn test_weighted_avg_decimal_value_and_weight_exact() {
+    // Both operands decimal: (2.00*3.00 + 4.00*1.00) / (3.00 + 1.00)
+    //                        = 10.00 / 4.00 = 2.50, exactly.
+    let mut a = weighted_avg();
+    a.add_weighted(&dec(200, 2), &dec(300, 2));
+    a.add_weighted(&dec(400, 2), &dec(100, 2));
+    assert_eq!(a.finalize().unwrap(), dec(250, 2));
+}
+
+#[test]
+fn test_weighted_avg_decimal_value_int_weight_exact() {
+    // The canonical `weighted_avg(price, qty)` shape: decimal value, integer
+    // weight. (0.10*3 + 0.20*1) / (3 + 1) = 0.50 / 4 = 0.125, exactly.
+    let mut a = weighted_avg();
+    a.add_weighted(&dec(10, 2), &Value::Integer(3));
+    a.add_weighted(&dec(20, 2), &Value::Integer(1));
+    assert_eq!(a.finalize().unwrap(), dec(125, 3));
+}
+
+#[test]
+fn test_weighted_avg_int_value_decimal_weight_exact() {
+    // Integer value, decimal weight: (3*0.5 + 1*0.5) / (0.5 + 0.5)
+    //                                = 2.0 / 1.0 = 2.0, exactly.
+    let mut a = weighted_avg();
+    a.add_weighted(&Value::Integer(3), &dec(5, 1));
+    a.add_weighted(&Value::Integer(1), &dec(5, 1));
+    assert_eq!(a.finalize().unwrap(), dec(20, 1));
+}
+
+#[test]
+fn test_weighted_avg_decimal_then_integer_not_lost() {
+    // An integer row observed AFTER decimal mode (e.g.
+    // `weighted_avg(if flag then amount else 2, w)`) must fold into the exact
+    // sums, not vanish. (0.50*1 + 2*1) / (1 + 1) = 2.50 / 2 = 1.25.
+    let mut a = weighted_avg();
+    a.add_weighted(&dec(50, 2), &Value::Integer(1));
+    a.add_weighted(&Value::Integer(2), &Value::Integer(1));
+    assert_eq!(a.finalize().unwrap(), dec(125, 2));
+}
+
+#[test]
+fn test_weighted_avg_decimal_merge_with_integer_only_state_either_order() {
+    // Merging an integer-only partial into a decimal partial (and vice versa)
+    // must give the same exact result regardless of merge direction:
+    // (0.50 + 2) / (1 + 1) = 2.50 / 2 = 1.25.
+    let build_dec = || {
+        let mut a = weighted_avg();
+        a.add_weighted(&dec(50, 2), &Value::Integer(1)); // 0.50 weighted, weight 1
+        a
+    };
+    let build_int = || {
+        let mut b = weighted_avg();
+        b.add_weighted(&Value::Integer(2), &Value::Integer(1)); // 2 weighted, weight 1
+        b
+    };
+    let mut ab = build_dec();
+    ab.merge(&build_int());
+    assert_eq!(ab.finalize().unwrap(), dec(125, 2));
+    let mut ba = build_int();
+    ba.merge(&build_dec());
+    assert_eq!(ba.finalize().unwrap(), dec(125, 2)); // order-independent
+}
+
+#[test]
+fn test_weighted_avg_decimal_merge_both_decimal_exact() {
+    // Two decimal partials combine exactly:
+    // (10.50*2 + 1.50*2) / (2 + 2) = 24.00 / 4 = 6.00.
+    let mut a = weighted_avg();
+    a.add_weighted(&dec(1050, 2), &Value::Integer(2));
+    let mut b = weighted_avg();
+    b.add_weighted(&dec(150, 2), &Value::Integer(2));
+    a.merge(&b);
+    assert_eq!(a.finalize().unwrap(), dec(600, 2));
+}
+
+#[test]
+fn test_weighted_avg_decimal_mixed_with_float_is_null() {
+    // A float mixed with a decimal cannot fold exactly (reachable only on an
+    // untyped column; typecheck rejects the mix for typed columns). The result
+    // is Null rather than a silently-wrong average.
+    let mut a = weighted_avg();
+    a.add_weighted(&dec(200, 2), &Value::Float(2.0));
+    assert_eq!(a.finalize().unwrap(), Value::Null);
+}
+
+#[test]
+fn test_weighted_avg_decimal_spill_roundtrip() {
+    // The accumulator state serializes exactly (decimal via the 16-byte form),
+    // so a spilled-and-reloaded WeightedAvg finalizes identically.
+    // (10.50*2 + 1.50*2) / (2 + 2) = 24.00 / 4 = 6.00.
+    let mut a = weighted_avg();
+    a.add_weighted(&dec(1050, 2), &Value::Integer(2));
+    a.add_weighted(&dec(150, 2), &Value::Integer(2));
+    let bytes = postcard::to_stdvec(&a).unwrap();
+    let restored: AccumulatorEnum = postcard::from_bytes(&bytes).unwrap();
+    assert_eq!(restored.finalize().unwrap(), dec(600, 2));
+    assert_eq!(restored, a);
+}
+
 // ---------- Serde round-trip ----------
 
 #[test]

--- a/crates/clinker-record/src/accumulator/tests.rs
+++ b/crates/clinker-record/src/accumulator/tests.rs
@@ -575,6 +575,43 @@ fn test_weighted_avg_decimal_mixed_with_float_is_null() {
 }
 
 #[test]
+fn test_weighted_avg_float_then_decimal_is_null() {
+    // A binary float accumulated BEFORE the first decimal row cannot widen into
+    // the exact decimal sums (only the integer accumulators are seeded on the
+    // switch). Poison to Null rather than silently dropping the float total and
+    // reporting the decimal-only quotient. Reachable only on an untyped column.
+    let mut a = weighted_avg();
+    a.add_weighted(&Value::Float(1.5), &Value::Integer(1)); // float path first
+    a.add_weighted(&dec(250, 2), &Value::Integer(1)); // then a decimal row
+    // The true weighted avg is (1.5 + 2.5) / 2 = 2.0; dropping the float total
+    // would report 2.5. Neither is honest, so finalize returns Null.
+    assert_eq!(a.finalize().unwrap(), Value::Null);
+}
+
+#[test]
+fn test_weighted_avg_merge_float_mode_with_decimal_mode_is_null() {
+    // Merging a float-mode partial (its exact contribution reads only its
+    // integer sums) into a decimal-mode partial — or vice versa — would drop
+    // the float side's total. Both merge directions poison to Null.
+    let build_float = || {
+        let mut s = weighted_avg();
+        s.add_weighted(&Value::Float(1.5), &Value::Integer(1));
+        s
+    };
+    let build_decimal = || {
+        let mut s = weighted_avg();
+        s.add_weighted(&dec(250, 2), &Value::Integer(1));
+        s
+    };
+    let mut df = build_decimal();
+    df.merge(&build_float());
+    assert_eq!(df.finalize().unwrap(), Value::Null);
+    let mut fd = build_float();
+    fd.merge(&build_decimal());
+    assert_eq!(fd.finalize().unwrap(), Value::Null);
+}
+
+#[test]
 fn test_weighted_avg_decimal_spill_roundtrip() {
     // The accumulator state serializes exactly (decimal via the 16-byte form),
     // so a spilled-and-reloaded WeightedAvg finalizes identically.

--- a/crates/cxl/src/ast.rs
+++ b/crates/cxl/src/ast.rs
@@ -703,6 +703,126 @@ fn fold_config_expr(expr: &mut Expr, resolve: &impl Fn(&str) -> Option<LiteralVa
     }
 }
 
+/// Add `base` to every [`NodeId`] in `expr` and all of its
+/// sub-expressions (and match-arm nodes), in place.
+///
+/// Splicing an independently parsed expression into a larger synthetic
+/// program requires relocating its node ids: each parse numbers its
+/// nodes from zero, so two separately parsed exprs share the low ids.
+/// Offsetting one expr past the ids already consumed by the combined
+/// program keeps the per-node side-tables the resolver and typechecker
+/// index by [`NodeId`] (bindings, types, regexes) dense and
+/// collision-free — every distinct node keeps a distinct index below the
+/// combined node count. Spans are left untouched: only the id-space is
+/// relocated, so callers must not treat the shifted ids as byte offsets.
+///
+/// `base` of zero is a no-op. Ids saturate rather than wrap at
+/// [`u32::MAX`], though a real program stays orders of magnitude below
+/// that ceiling.
+pub fn offset_node_ids(expr: &mut Expr, base: u32) {
+    if base == 0 {
+        return;
+    }
+    fn shift(id: &mut NodeId, base: u32) {
+        id.0 = id.0.saturating_add(base);
+    }
+    match expr {
+        Expr::Binary {
+            node_id, lhs, rhs, ..
+        }
+        | Expr::Coalesce {
+            node_id, lhs, rhs, ..
+        } => {
+            shift(node_id, base);
+            offset_node_ids(lhs, base);
+            offset_node_ids(rhs, base);
+        }
+        Expr::Unary {
+            node_id, operand, ..
+        } => {
+            shift(node_id, base);
+            offset_node_ids(operand, base);
+        }
+        Expr::MethodCall {
+            node_id,
+            receiver,
+            args,
+            ..
+        } => {
+            shift(node_id, base);
+            offset_node_ids(receiver, base);
+            for a in args.iter_mut() {
+                offset_node_ids(a, base);
+            }
+        }
+        Expr::Match {
+            node_id,
+            subject,
+            arms,
+            ..
+        } => {
+            shift(node_id, base);
+            if let Some(s) = subject.as_deref_mut() {
+                offset_node_ids(s, base);
+            }
+            for arm in arms.iter_mut() {
+                shift(&mut arm.node_id, base);
+                offset_node_ids(&mut arm.pattern, base);
+                offset_node_ids(&mut arm.body, base);
+            }
+        }
+        Expr::IfThenElse {
+            node_id,
+            condition,
+            then_branch,
+            else_branch,
+            ..
+        } => {
+            shift(node_id, base);
+            offset_node_ids(condition, base);
+            offset_node_ids(then_branch, base);
+            if let Some(e) = else_branch.as_deref_mut() {
+                offset_node_ids(e, base);
+            }
+        }
+        Expr::WindowCall { node_id, args, .. } | Expr::AggCall { node_id, args, .. } => {
+            shift(node_id, base);
+            for a in args.iter_mut() {
+                offset_node_ids(a, base);
+            }
+        }
+        Expr::IndexAccess {
+            node_id,
+            receiver,
+            index,
+            ..
+        } => {
+            shift(node_id, base);
+            offset_node_ids(receiver, base);
+            offset_node_ids(index, base);
+        }
+        Expr::Closure { node_id, body, .. } => {
+            shift(node_id, base);
+            offset_node_ids(body, base);
+        }
+        // Leaf variants: shift the id, no children to descend.
+        Expr::Literal { node_id, .. }
+        | Expr::FieldRef { node_id, .. }
+        | Expr::QualifiedFieldRef { node_id, .. }
+        | Expr::PipelineAccess { node_id, .. }
+        | Expr::VarsAccess { node_id, .. }
+        | Expr::ConfigAccess { node_id, .. }
+        | Expr::SourceAccess { node_id, .. }
+        | Expr::RecordAccess { node_id, .. }
+        | Expr::QualifiedSourceAccess { node_id, .. }
+        | Expr::DocAccess { node_id, .. }
+        | Expr::Now { node_id, .. }
+        | Expr::Wildcard { node_id, .. }
+        | Expr::AggSlot { node_id, .. }
+        | Expr::GroupKey { node_id, .. } => shift(node_id, base),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct MatchArm {
     pub node_id: NodeId,
@@ -1204,5 +1324,151 @@ mod support_into_tests {
             f.is_empty(),
             "$widened FieldRef must be excluded; got {f:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod offset_node_ids_tests {
+    use super::*;
+    use crate::parser::Parser;
+
+    /// Recursively collect every `NodeId` reachable from `e`, mirroring the
+    /// recursion shape of [`offset_node_ids`] so the two stay in lockstep.
+    fn collect_ids(e: &Expr, out: &mut Vec<u32>) {
+        out.push(e.node_id().0);
+        match e {
+            Expr::Binary { lhs, rhs, .. } | Expr::Coalesce { lhs, rhs, .. } => {
+                collect_ids(lhs, out);
+                collect_ids(rhs, out);
+            }
+            Expr::Unary { operand, .. } => collect_ids(operand, out),
+            Expr::MethodCall { receiver, args, .. } => {
+                collect_ids(receiver, out);
+                for a in args {
+                    collect_ids(a, out);
+                }
+            }
+            Expr::Match { subject, arms, .. } => {
+                if let Some(s) = subject {
+                    collect_ids(s, out);
+                }
+                for arm in arms {
+                    out.push(arm.node_id.0);
+                    collect_ids(&arm.pattern, out);
+                    collect_ids(&arm.body, out);
+                }
+            }
+            Expr::IfThenElse {
+                condition,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                collect_ids(condition, out);
+                collect_ids(then_branch, out);
+                if let Some(e) = else_branch {
+                    collect_ids(e, out);
+                }
+            }
+            Expr::WindowCall { args, .. } | Expr::AggCall { args, .. } => {
+                for a in args {
+                    collect_ids(a, out);
+                }
+            }
+            Expr::IndexAccess {
+                receiver, index, ..
+            } => {
+                collect_ids(receiver, out);
+                collect_ids(index, out);
+            }
+            Expr::Closure { body, .. } => collect_ids(body, out),
+            _ => {}
+        }
+    }
+
+    fn rhs_of(source: &str) -> Expr {
+        let parsed = Parser::parse(&format!("emit out = {source}"));
+        assert!(parsed.errors.is_empty(), "{:?}", parsed.errors);
+        let stmt = parsed.ast.statements.into_iter().next().expect("one stmt");
+        match stmt {
+            Statement::Emit { expr, .. } => expr,
+            _ => panic!("not an emit"),
+        }
+    }
+
+    /// Every node id in a parsed expression shifts by exactly `base`, and
+    /// the node count is unchanged — a pure relocation of the id-space.
+    #[test]
+    fn shifts_every_node_id_by_base() {
+        // Covers Binary, AggCall, IfThenElse, FieldRef and Literal arms.
+        let mut expr = rhs_of("sum(if amount > 0 then amount else 0) > count(id)");
+        let mut before = Vec::new();
+        collect_ids(&expr, &mut before);
+
+        offset_node_ids(&mut expr, 100);
+
+        let mut after = Vec::new();
+        collect_ids(&expr, &mut after);
+        assert_eq!(before.len(), after.len(), "node count is preserved");
+        for (b, a) in before.iter().zip(&after) {
+            assert_eq!(*a, b + 100, "each id shifts by exactly the base");
+        }
+    }
+
+    /// A base of zero leaves every id untouched.
+    #[test]
+    fn zero_base_is_a_noop() {
+        let mut expr = rhs_of("a + b * c");
+        let mut before = Vec::new();
+        collect_ids(&expr, &mut before);
+        offset_node_ids(&mut expr, 0);
+        let mut after = Vec::new();
+        collect_ids(&expr, &mut after);
+        assert_eq!(before, after);
+    }
+
+    /// Match-arm node ids relocate alongside the arms' pattern/body exprs,
+    /// so a directly constructed `Match` shifts wholesale.
+    #[test]
+    fn shifts_match_arm_ids() {
+        let span = Span::new(0, 1);
+        let mut expr = Expr::Match {
+            node_id: NodeId(1),
+            subject: Some(Box::new(Expr::FieldRef {
+                node_id: NodeId(2),
+                name: "status".into(),
+                span,
+            })),
+            arms: vec![MatchArm {
+                node_id: NodeId(3),
+                pattern: Expr::Literal {
+                    node_id: NodeId(4),
+                    value: LiteralValue::String("x".into()),
+                    span,
+                },
+                body: Expr::Literal {
+                    node_id: NodeId(5),
+                    value: LiteralValue::Int(1),
+                    span,
+                },
+                span,
+            }],
+            span,
+        };
+        offset_node_ids(&mut expr, 10);
+        let Expr::Match {
+            node_id,
+            subject,
+            arms,
+            ..
+        } = &expr
+        else {
+            panic!("expected Match");
+        };
+        assert_eq!(node_id.0, 11);
+        assert_eq!(subject.as_ref().unwrap().node_id().0, 12);
+        assert_eq!(arms[0].node_id.0, 13);
+        assert_eq!(arms[0].pattern.node_id().0, 14);
+        assert_eq!(arms[0].body.node_id().0, 15);
     }
 }

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -19,7 +19,7 @@ use crate::resolve::scoped_vars::{ScopedVarType, ScopedVarsRegistry};
 /// - `avg(...)` → Float
 /// - `min(T)` / `max(T)` → T (preserving input type)
 /// - `collect(T)` → Array (element type is currently erased)
-/// - `weighted_avg(_, _)` → Float
+/// - `weighted_avg(value, weight)` → Decimal if either arg is decimal, else Float
 /// - Unknown names → Any (caller emits a diagnostic via the parser lookahead set)
 fn aggregate_return_type(name: &str, arg_types: &[Type]) -> Type {
     match name {
@@ -40,7 +40,18 @@ fn aggregate_return_type(name: &str, arg_types: &[Type]) -> Type {
             Some(Type::Decimal) => Type::Decimal,
             _ => Type::Float,
         },
-        "weighted_avg" => Type::Float,
+        // weighted_avg over a decimal value or weight is exact (returns
+        // decimal); otherwise Float.
+        "weighted_avg" => {
+            if arg_types
+                .iter()
+                .any(|t| matches!(t.unwrap_nullable(), Type::Decimal))
+            {
+                Type::Decimal
+            } else {
+                Type::Float
+            }
+        }
         "min" | "max" => arg_types.first().cloned().unwrap_or(Type::Any),
         "collect" => Type::Array,
         _ => Type::Any,
@@ -964,8 +975,8 @@ impl<'a> TypeChecker<'a> {
                 // aggregate exactly, so an exact monetary total/average stays
                 // in the decimal domain instead of being pushed through the
                 // binary-float rounding decimal exists to avoid. weighted_avg
-                // additionally rejects `decimal` — its accumulator has no exact
-                // path yet and would silently drop decimal rows.
+                // aggregates decimals exactly too, and only rejects a decimal
+                // mixed with a binary float (the two cannot combine exactly).
                 match &**name {
                     "sum" | "avg" => {
                         if let Some(arg_ty) = arg_types.first() {
@@ -993,26 +1004,31 @@ impl<'a> TypeChecker<'a> {
                                     .into(),
                                 None,
                             );
-                        } else if let Some(dec_arg) = arg_types
-                            .iter()
-                            .find(|t| matches!(t.unwrap_nullable(), Type::Decimal))
-                        {
-                            // No exact decimal weighted-average accumulator
-                            // exists yet; the float path returns Null for a
-                            // decimal value OR weight (the accumulator's
-                            // `numeric()` conversion skips a decimal in either
-                            // position). Reject loudly rather than silently lose
-                            // the total, and point at the exact routes.
-                            self.error(
-                                *span,
-                                format!(
-                                    "weighted_avg() over a decimal value or weight is not supported yet, got {dec_arg}"
-                                ),
-                                Some(
-                                    "Cast with .to_float() for a binary-float weighted average, or use sum()/avg() which stay exact over decimals"
+                        } else {
+                            // A decimal value or weight now aggregates exactly
+                            // (the accumulator has an exact decimal path). But a
+                            // decimal in one position mixed with a binary float
+                            // in the other cannot combine exactly — reject it
+                            // the same way `decimal * float` is rejected in
+                            // ordinary arithmetic, rather than silently drop the
+                            // total.
+                            let has_decimal = arg_types
+                                .iter()
+                                .any(|t| matches!(t.unwrap_nullable(), Type::Decimal));
+                            let has_float = arg_types
+                                .iter()
+                                .any(|t| matches!(t.unwrap_nullable(), Type::Float));
+                            if has_decimal && has_float {
+                                self.error(
+                                    *span,
+                                    "weighted_avg() cannot mix a decimal argument with a float argument"
                                         .into(),
-                                ),
-                            );
+                                    Some(
+                                        "Convert with .to_decimal() or .to_float() so the value and weight share one numeric domain"
+                                            .into(),
+                                    ),
+                                );
+                            }
                         }
                     }
                     _ => {}
@@ -1777,6 +1793,20 @@ mod tests {
         );
         // avg over int/float is still Float.
         assert_eq!(aggregate_return_type("avg", &[Type::Int]), Type::Float);
+        // weighted_avg stays decimal when either the value OR the weight is
+        // decimal, and Float when neither is.
+        assert_eq!(
+            aggregate_return_type("weighted_avg", &[Type::Decimal, Type::Int]),
+            Type::Decimal
+        );
+        assert_eq!(
+            aggregate_return_type("weighted_avg", &[Type::Int, Type::Decimal]),
+            Type::Decimal
+        );
+        assert_eq!(
+            aggregate_return_type("weighted_avg", &[Type::Int, Type::Int]),
+            Type::Float
+        );
     }
 
     #[test]
@@ -1816,13 +1846,10 @@ mod tests {
     }
 
     #[test]
-    fn test_weighted_avg_over_decimal_rejected() {
-        // weighted_avg has no exact decimal accumulator yet; its float path
-        // silently drops a decimal in EITHER the value or the weight position
-        // (the accumulator's `numeric()` conversion skips a decimal), returning
-        // Null. Typecheck must reject it loudly rather than let a monetary
-        // weighted average be silently wrong — for a decimal value AND a
-        // decimal weight.
+    fn test_weighted_avg_over_decimal_typechecks() {
+        // weighted_avg now has an exact decimal accumulator, so a decimal value
+        // or weight (or both) typechecks and keeps the result in the decimal
+        // domain instead of being rejected.
         let mut cols = IndexMap::new();
         cols.insert("amount".into(), Type::Decimal);
         cols.insert("price".into(), Type::Decimal);
@@ -1832,19 +1859,54 @@ mod tests {
         let fields = ["amount", "price", "qty", "dept"];
 
         for src in [
-            "emit wa = weighted_avg(amount, qty)", // decimal value
-            "emit wa = weighted_avg(qty, price)",  // decimal weight
+            "emit wa = weighted_avg(amount, qty)", // decimal value, int weight
+            "emit wa = weighted_avg(qty, price)",  // int value, decimal weight
+            "emit wa = weighted_avg(amount, price)", // decimal value and weight
+        ] {
+            let parsed = Parser::parse(src);
+            assert!(parsed.errors.is_empty());
+            let resolved = resolve_program(parsed.ast, &fields, parsed.node_count).unwrap();
+            let typed = type_check_with_mode(resolved, &schema, agg_mode(&["dept"]))
+                .unwrap_or_else(|d| {
+                    panic!(
+                        "`{src}` must typecheck over a decimal column, got: {:?}",
+                        d.iter().map(|e| &e.message).collect::<Vec<_>>()
+                    )
+                });
+            assert_eq!(
+                first_emit_expr_type(&typed),
+                Type::Decimal,
+                "result type for `{src}`"
+            );
+        }
+    }
+
+    #[test]
+    fn test_weighted_avg_decimal_float_mix_rejected() {
+        // A decimal in one position and a binary float in the other cannot
+        // combine exactly, mirroring the `decimal * float` arithmetic rule, so
+        // the mix is rejected loudly rather than silently dropped.
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Decimal);
+        cols.insert("rate".into(), Type::Float);
+        cols.insert("dept".into(), Type::String);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let fields = ["amount", "rate", "dept"];
+
+        for src in [
+            "emit wa = weighted_avg(amount, rate)", // decimal value, float weight
+            "emit wa = weighted_avg(rate, amount)", // float value, decimal weight
         ] {
             let parsed = Parser::parse(src);
             assert!(parsed.errors.is_empty());
             let resolved = resolve_program(parsed.ast, &fields, parsed.node_count).unwrap();
             let errs = type_check_with_mode(resolved, &schema, agg_mode(&["dept"]))
-                .expect_err("weighted_avg over a decimal must be rejected");
+                .expect_err("weighted_avg mixing decimal and float must be rejected");
             assert!(
                 errs.iter().any(|d| d
                     .message
-                    .contains("weighted_avg() over a decimal value or weight is not supported")),
-                "`{src}` expected a weighted_avg decimal rejection, got: {:?}",
+                    .contains("cannot mix a decimal argument with a float argument")),
+                "`{src}` expected a decimal/float mix rejection, got: {:?}",
                 errs.iter().map(|d| &d.message).collect::<Vec<_>>()
             );
         }

--- a/crates/cxl/src/typecheck/pass.rs
+++ b/crates/cxl/src/typecheck/pass.rs
@@ -1011,17 +1011,21 @@ impl<'a> TypeChecker<'a> {
                             // in the other cannot combine exactly — reject it
                             // the same way `decimal * float` is rejected in
                             // ordinary arithmetic, rather than silently drop the
-                            // total.
+                            // total. `Numeric` admits `Float` at runtime and
+                            // does not unify with `Decimal` (see `Type::unify`),
+                            // so it is rejected against a decimal too; `Any`
+                            // stays permissive here and is poisoned to Null at
+                            // runtime if it resolves to a conflicting mix.
                             let has_decimal = arg_types
                                 .iter()
                                 .any(|t| matches!(t.unwrap_nullable(), Type::Decimal));
-                            let has_float = arg_types
-                                .iter()
-                                .any(|t| matches!(t.unwrap_nullable(), Type::Float));
+                            let has_float = arg_types.iter().any(|t| {
+                                matches!(t.unwrap_nullable(), Type::Float | Type::Numeric)
+                            });
                             if has_decimal && has_float {
                                 self.error(
                                     *span,
-                                    "weighted_avg() cannot mix a decimal argument with a float argument"
+                                    "weighted_avg() cannot mix a decimal argument with a float or numeric argument"
                                         .into(),
                                     Some(
                                         "Convert with .to_decimal() or .to_float() so the value and weight share one numeric domain"
@@ -1905,8 +1909,41 @@ mod tests {
             assert!(
                 errs.iter().any(|d| d
                     .message
-                    .contains("cannot mix a decimal argument with a float argument")),
+                    .contains("cannot mix a decimal argument with a float or numeric argument")),
                 "`{src}` expected a decimal/float mix rejection, got: {:?}",
+                errs.iter().map(|d| &d.message).collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn test_weighted_avg_decimal_numeric_mix_rejected() {
+        // `numeric` admits a binary float at runtime and does not unify with
+        // `decimal`, so mixing a decimal argument with a `numeric` one is
+        // rejected at typecheck the same way a decimal/float mix is — otherwise
+        // the plan compiles and a fractional weight silently poisons the group
+        // to Null at runtime.
+        let mut cols = IndexMap::new();
+        cols.insert("amount".into(), Type::Decimal);
+        cols.insert("qty".into(), Type::Numeric);
+        cols.insert("dept".into(), Type::String);
+        let schema = Row::closed(cols, Span::new(0, 0));
+        let fields = ["amount", "qty", "dept"];
+
+        for src in [
+            "emit wa = weighted_avg(amount, qty)", // decimal value, numeric weight
+            "emit wa = weighted_avg(qty, amount)", // numeric value, decimal weight
+        ] {
+            let parsed = Parser::parse(src);
+            assert!(parsed.errors.is_empty());
+            let resolved = resolve_program(parsed.ast, &fields, parsed.node_count).unwrap();
+            let errs = type_check_with_mode(resolved, &schema, agg_mode(&["dept"]))
+                .expect_err("weighted_avg mixing decimal and numeric must be rejected");
+            assert!(
+                errs.iter().any(|d| d
+                    .message
+                    .contains("cannot mix a decimal argument with a float or numeric argument")),
+                "`{src}` expected a decimal/numeric mix rejection, got: {:?}",
                 errs.iter().map(|d| &d.message).collect::<Vec<_>>()
             );
         }

--- a/docs/user/src/cookbook/file-splitting.md
+++ b/docs/user/src/cookbook/file-splitting.md
@@ -99,6 +99,8 @@ Split by file size instead of record count:
 
 The splitter estimates the current file size and starts a new file when the limit is approached. The actual file size may slightly exceed the limit because the current record is always completed before splitting.
 
+Byte-based splitting works with every output format. For formats that wrap the whole file in framing -- a JSON array or an XML root element -- each rotation closes the current file's framing and reopens it in the next, so every chunk is a complete, independently valid document (its own `[ ... ]` array or `<Root> ... </Root>` tree), never a fragment.
+
 ## Combined limits
 
 Use both `max_records` and `max_bytes` together -- whichever limit is reached first triggers a new file:

--- a/docs/user/src/cxl/aggregates.md
+++ b/docs/user/src/cxl/aggregates.md
@@ -14,7 +14,7 @@ CXL provides 7 aggregate functions. These are called as free-standing function c
 | `min(expr)` | Any | Any | Minimum value |
 | `max(expr)` | Any | Any | Maximum value |
 | `collect(expr)` | Any | Array | All values collected into an array |
-| `weighted_avg(value, weight)` | Numeric, Numeric | Float | Weighted arithmetic mean |
+| `weighted_avg(value, weight)` | Numeric, Numeric | Float / Decimal | Weighted arithmetic mean |
 
 ## YAML aggregate node
 
@@ -98,7 +98,7 @@ cxl: |
   emit all_order_ids = collect(order_id)
 ```
 
-### weighted_avg(value, weight) -> Float
+### weighted_avg(value, weight) -> Float or Decimal
 
 Computes a weighted average: `sum(value * weight) / sum(weight)`. Takes two arguments.
 
@@ -106,6 +106,13 @@ Computes a weighted average: `sum(value * weight) / sum(weight)`. Takes two argu
 cxl: |
   emit weighted_price = weighted_avg(unit_price, quantity)
 ```
+
+Returns Float for int/float inputs. When either the value or the weight is a
+`decimal`, the result is an exact `decimal` computed entirely in the decimal
+domain (no binary float touches the running totals), at full division
+precision. A zero total weight returns null. Mixing a `decimal` with a binary
+`float` across the two arguments is a type error -- cast with `.to_decimal()`
+or `.to_float()` so both share one numeric domain.
 
 ## Aggregates vs. windows
 

--- a/docs/user/src/cxl/types.md
+++ b/docs/user/src/cxl/types.md
@@ -243,9 +243,12 @@ column and stay exact — no binary float ever touches a running total:
   numerically equal group together regardless of scale, so `2.50` and `2.5`
   fall in one group. This holds even when the aggregation spills to disk.
 
-`weighted_avg` does not yet support decimals and rejects a decimal value at
-compile time — cast with `.to_float()` for a binary-float weighted average, or
-use `sum` / `avg`, which stay exact over decimals.
+`weighted_avg` also stays exact over decimals: a decimal value or weight (or
+both) gives an exact `sum(value * weight) / sum(weight)` at full division
+precision, and a zero total weight returns null. A decimal in one position
+mixed with a binary `float` in the other is a type error, matching the
+`decimal ⊗ float` arithmetic rule — cast with `.to_decimal()` or `.to_float()`
+so the value and weight share one numeric domain.
 
 ## Type unification rules
 

--- a/docs/user/src/formats/fixed-width.md
+++ b/docs/user/src/formats/fixed-width.md
@@ -46,6 +46,16 @@ width-only schema lays its fields out sequentially. Two columns whose
 byte ranges overlap have no consistent layout; the writer rejects such a
 schema when the output opens, naming both columns and their ranges.
 
+Widths are **byte counts**, matching how the reader slices. When a value
+is longer than its field, truncation cuts at a UTF-8 character boundary at
+or below the width, so a multi-byte character is never split: the emitted
+cell is always valid UTF-8 of exactly `width` bytes (it may hold fewer
+*characters* than the width when a trailing multi-byte character does not
+fit, with the freed bytes pad-filled). Because padding fills exact byte
+counts, `pad` must be a single-byte (ASCII) character; a multi-byte `pad`
+is rejected when the output opens. Under `truncation: error` an over-long
+value is still a hard error before any slicing.
+
 ## Options
 
 | Option | Default | Description |

--- a/docs/user/src/formats/fixed-width.md
+++ b/docs/user/src/formats/fixed-width.md
@@ -52,6 +52,14 @@ schema when the output opens, naming both columns and their ranges.
 |--------|---------|-------------|
 | `line_separator` | platform | Line-ending style (`lf` / `crlf`) used to split the file into records. |
 
+Under `lf` or `crlf`, the reader bounds each physical line to the declared
+record width plus a line-terminator allowance. A line that runs past that width
+without a line terminator is rejected as a record error carrying its row number,
+rather than buffered into memory — this keeps a malformed file (a corrupt or
+missing newline) from growing a single record until end of input. A final line
+with no trailing newline still reads normally as long as it fits within the
+declared width.
+
 ## Schema drift
 
 Fixed-width is **inert** with respect to

--- a/docs/user/src/formats/fixed-width.md
+++ b/docs/user/src/formats/fixed-width.md
@@ -62,13 +62,16 @@ value is still a hard error before any slicing.
 |--------|---------|-------------|
 | `line_separator` | platform | Line-ending style (`lf` / `crlf`) used to split the file into records. |
 
-Under `lf` or `crlf`, the reader bounds each physical line to the declared
-record width plus a line-terminator allowance. A line that runs past that width
-without a line terminator is rejected as a record error carrying its row number,
-rather than buffered into memory — this keeps a malformed file (a corrupt or
-missing newline) from growing a single record until end of input. A final line
-with no trailing newline still reads normally as long as it fits within the
-declared width.
+Under `lf` or `crlf`, the reader buffers each physical line only up to the
+declared record width plus a line-terminator allowance. A physical line wider
+than the declared width — trailing filler beyond the last declared field, or a
+schema that maps only a prefix of a wider fixed-length record — reads its
+declared-width portion; the remaining bytes are discarded up to the next line
+terminator and the reader continues with the following record. Because the
+buffered portion is capped, a malformed file (a corrupt or missing newline)
+cannot grow a single record until end of input: memory stays bounded regardless
+of how long the physical line runs. A final line with no trailing newline reads
+normally as long as its declared fields fit within the width.
 
 ## Schema drift
 

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -34,6 +34,17 @@ rules.
 | `namespace_handling` | `strip` | `strip` removes namespace prefixes from element and attribute names; `qualify` preserves the namespace-qualified names. |
 | `max_index_bytes` | `64MB` | Cap on the bytes the envelope pre-scan retains while extracting declared `$doc.*` sections. |
 
+## Truncated input
+
+A truncated XML document — one whose input ends before an open element's
+closing tag — is rejected with a format error rather than yielding the
+partial fields read so far. This holds for a record cut off mid-element, a
+skipped-over sibling subtree cut off before it closes, and an envelope
+section cut off during the pre-scan (which then attaches no `$doc`
+metadata). This matches the general contract that a
+[truncated stream always aborts](../pipelines/error-handling.md#malformed-envelopes-structural-validation)
+rather than silently dropping data.
+
 ## Writing XML
 
 The XML writer expands dotted field names to nested elements and applies

--- a/docs/user/src/nodes/cull.md
+++ b/docs/user/src/nodes/cull.md
@@ -78,6 +78,20 @@ rules:
 
 A group whose aggregate operand is null (for example `max(...)` over an all-null column) compares as false — a null operand never removes the group and never errors.
 
+### Comments in a predicate
+
+A `drop_group_when` predicate may carry a `#` line-comment to explain the rule inline. Each rule's predicate is parsed on its own, so a trailing comment applies only to that rule:
+
+```yaml
+rules:
+  - name: drop_error_groups
+    drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error row removes the group"
+  - name: high_total
+    drop_group_when: "sum(amount) > 10000                          # large accounts"
+```
+
+The comment is source text only — it never changes the compiled decision. (A `#YYYY-MM-DD#` date literal is unaffected: it lexes as a date, not a comment.)
+
 ## Output ports: main and `removed_to`
 
 Cull has two producer-side output ports, the same mechanism a [Route](route.md) uses for its branches — not the dead-letter queue. Removed records are **valid rows the operator deliberately partitions onto a second stream**, not errors.

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -297,6 +297,8 @@ Split output into multiple files based on record count, byte size, or group boun
 
 At least one of `max_records` or `max_bytes` should be specified for splitting to have any effect.
 
+For formats whose output wraps the whole file in framing -- a JSON array or an XML root element -- each split file is a complete, independently valid document: the framing is closed at rotation and reopened for the next file.
+
 ### Oversize group policies
 
 - `warn` (default) -- log a warning and allow the oversized file.

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -559,6 +559,42 @@ declaration, field, or split the source does not carry is E239. These ops
 apply after the `options` merge, so they layer on top of an `options` value
 that replaces the same declaration in one patch.
 
+### Multi-record patches (discriminator-driven flat files)
+
+A multi-record flat file interleaves several record layouts in one file, each
+identified by a discriminator tag. A `sources:` patch reshapes that layout with
+`records:` (keyed by record-type id) and a `discriminator:` merge, so a tenant's
+record set can differ from the base without editing the pipeline:
+
+```yaml
+sources:
+  ledger:                                  # a multi-record source
+    discriminator: { start: 2 }            # move the tag byte range (partial merge)
+    records:
+      detail:  { tag: X }                  # retag; a nested `columns:` reshapes fields
+      trailer: remove                      # drop a record type
+      header:                              # add a record type (map key = its id)
+        add:
+          tag: H
+          columns:
+            - { name: hdr_id, type: string, start: 1, width: 8 }
+```
+
+A `records` entry follows the same keyed grammar as `schema`: a bare `remove`
+drops the record type, `{ add: { tag, columns, ... } }` declares a new one, and
+a bare attribute map modifies an existing one. A modify sets any subset of the
+record type's `tag` / `parent` / `join_key` / `description` and carries a nested
+`columns:` map that runs the column-op grammar (`modify` / `rename` / `add` /
+`remove`) against that record type's own fields. The `discriminator:` op merges
+field by field onto the current discriminator — a named field overwrites, an
+omitted one is kept — and the merged result must be a byte range (`start` +
+optional `width`) XOR a `field`.
+
+These ops apply only to a multi-record schema (E241). Modifying or removing an
+unknown record-type id is E242, adding an id that already exists is E243, a
+merged discriminator that is neither pure byte-range nor pure field is E244, and
+a discriminator tag shared by two record types after the patch is E245.
+
 `sources:` patches target **top-level** source nodes; a source declared inside a
 composition body is not reachable this way (patching it fails with E230). When a
 patch changes the effective source config, the run's pipeline identity differs
@@ -582,3 +618,8 @@ not collide.
 | **E238** | A `group_section` / `set_section` patch on a non-X12 source, or a `split_fields` patch on a non-HL7 source. |
 | **E239** | A `remove` of a nested-section declaration, declared section field, or field split the source does not carry. |
 | **E240** | A malformed format-structure patch: creating a nested section without a `name`, adding a split without `components`, a split key that is not a positional `fNN` name, or a zero axis width. |
+| **E241** | A `records` / `discriminator` patch on a single-record / generated / external-file schema — these ops apply only to a multi-record schema. |
+| **E242** | A `records` `modify` / `remove` of a record-type id the source does not declare. |
+| **E243** | A `records` `add` of a record-type id that already exists. |
+| **E244** | A merged `discriminator` that is neither a pure byte range (`start` + optional `width`) nor a pure `field`. |
+| **E245** | Two record types share a discriminator tag after the patch, which would make the reader's discriminator dispatch ambiguous. |

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -136,7 +136,7 @@ Each section declares how the reader locates its payload:
 | Format  | `extract:` key   | Value                                            |
 | ------- | ---------------- | ------------------------------------------------ |
 | XML     | `xml_path`       | Slash-path to the section element, e.g. `/doc/Head` |
-| JSON    | `json_pointer`   | RFC 6901 pointer, e.g. `/Head`                   |
+| JSON    | `json_pointer`   | RFC 6901 pointer — empty (whole document) or leading `/`, e.g. `/Head` |
 | EDIFACT | `segment`        | A service-segment tag — only `UNB`               |
 | X12     | `segment`        | A service-segment tag — only `ISA` (GS/ST surface as nested levels) |
 | HL7 v2  | `segment`        | A header-segment tag — only `FHS` (BHS/MSH surface as nested levels) |
@@ -147,6 +147,12 @@ a `segment` extract against XML/JSON, or a `record_type` extract against
 any format other than multi-record CSV / fixed-width is a configuration
 error and fails fast when the source opens, rather than silently
 producing empty sections.
+
+A `json_pointer` must be a valid RFC 6901 pointer: either empty (`""`,
+naming the whole document) or a `/`-introduced path such as `/Head` or
+`/batch/summary`. A slashless value like `Head` is a typo — it would
+decode to zero segments and silently match the root document — so it is
+**rejected at validation** rather than resolving to the wrong metadata.
 
 A **plain** (single-schema) CSV or fixed-width source carries no envelope
 — there is no header/trailer structure to extract, so declaring envelope


### PR DESCRIPTION
This bundles several independent, scoped changes so they share a single CI and merge cycle. Each section below is a self-contained fix or feature with its own tests and docs; they touch disjoint parts of the codebase.

## fix(format): make fixed-width writer truncate non-ASCII on UTF-8 boundaries

### Summary

The fixed-width writer truncated field values by raw byte index. A non-ASCII value whose UTF-8 encoding crossed the declared field width panicked at runtime under the `warn` and `silent` truncation policies (for example, writing `é` into a width-1 string field sliced at byte 1, which is not a character boundary). Multi-byte `pad` characters could also overflow a byte-oriented width silently, because each pad push added more than one byte.

### What changed

Fixed-width column widths are byte counts, matching how the reader slices records back out. This change keeps that contract and makes the writer honor it safely:

- **Byte-safe truncation.** An over-long value is now cut at the largest UTF-8 character boundary at or below the field width (never mid-codepoint), and the freed bytes are pad-filled. The emitted cell is always valid UTF-8 of exactly `width` bytes. A cell may hold fewer *characters* than its width when a trailing multi-byte character does not fit, but it is always byte-exact, so it round-trips through the reader.
- **Single-byte pad enforced at construction.** A `pad` whose first character is more than one byte is rejected when the output opens, with a typed field error naming the column. This guarantees padding fills exact byte counts. Single-byte pads (space, `0`, `*`, and the like) are unaffected.
- **Correct diagnostics.** The truncation error and warning messages previously reported byte lengths mislabeled as `chars`; they now say `bytes`.

Under `truncation: error`, an over-long value remains a hard error raised before any slicing, unchanged.

### Tests

Added focused writer tests in `crates/clinker-format`:

- A non-ASCII value (`café`, 5 bytes) truncated to a width-4 field under `warn` yields valid UTF-8 of exactly the byte width (`caf ` — the partial `é` dropped and space-padded), and the warning text says `bytes`, not `chars`.
- A 2-byte character that cannot fit a width-1 field under `silent` produces a byte-exact pad-only cell with no panic and no warning.
- A multi-byte `pad` character is rejected at construction with a typed error naming the field and the single-byte constraint.

Existing ASCII truncation, justification, padding, and round-trip tests are unchanged — the new logic is byte-identical to the previous behavior for all ASCII inputs.

### Docs

`docs/user/src/formats/fixed-width.md` now documents that widths are byte counts, that truncation cuts on a UTF-8 character boundary and pad-fills the remainder to an exact byte width, and that `pad` must be a single-byte character.

### Validation

- `cargo fmt --all --check` — clean
- `cargo clippy -p clinker-format --all-targets -- -D warnings` — clean
- `cargo test -p clinker-format` — 584 unit tests plus integration tests pass, including the three new cases
- `git diff --check` — clean

## fix(format): reject truncated XML instead of returning partial success

### Summary

Several XML streaming paths treated `Event::Eof` as a normal end condition while still inside an open record, a skipped-over sibling subtree, or an extracted envelope section. A document cut off before an element's closing tag therefore surfaced a partial record, partial `$doc` metadata, or silently skipped an unfinished subtree instead of failing as malformed.

quick-xml (0.41) yields a clean `Eof` event with elements still open — only mismatched or dangling end tags are reported as parse errors — so the reader has to track open depth itself. Each EOF site now checks whether anything is still open and, if so, returns `FormatError::Xml` naming the offending element/section:

- **record-field extraction** (`extract_record_fields`) errors and names the deepest open element (`record.child`) instead of emitting the fields read so far;
- **subtree skipping** (`skip_subtree`) errors, naming the skipped element, instead of ending cleanly;
- **envelope pre-scan** (`extract_sections`) errors when EOF arrives with a non-empty descent stack, naming the open path;
- **section-payload extraction** (`read_section_payload`) errors, naming the section, instead of returning partial section fields — so no partial `$doc` metadata is attached;
- **navigation between records** errors when the input ends with the record container or its ancestors still open, reporting how many elements were left open.

A now-unreachable post-loop block in `extract_record_fields` (which existed only to salvage fields from an EOF-truncated array occurrence) is removed, since EOF there now returns an error before the loop can exit that way.

This matches the engine's existing contract that a truncated stream always aborts rather than silently dropping data. Well-formed input is unaffected: a complete document always reaches `xml_depth == 0` / an empty descent stack at EOF.

### Acceptance criteria

- EOF inside an open record errors with useful context (names the cut element).
- EOF inside a skipped subtree errors instead of ending cleanly.
- EOF inside an envelope section errors and does not attach partial metadata.

### Validation

- `cargo fmt --all --check` — clean.
- `cargo clippy -p clinker-format --all-targets -- -D warnings` — clean.
- `cargo test -p clinker-format` — 581 lib + 18 integration + others, all pass. Includes five new truncation tests in `tests/streaming_doc_index_xml.rs` (mid-record, mid-skipped-subtree, between-records, mid-envelope-section, and pre-scan-outside-a-section), each asserting the exact `FormatError::Xml` message and that no partial record/metadata leaks.
- `cargo test -p clinker-format xml` and `cargo test -p clinker-format --test streaming_doc_index_xml` — pass.
- The existing `malformed_unclosed_element_surfaces_xml_error` (mismatched-tag) test stays green.

Docs: added a "Truncated input" note to `docs/user/src/formats/xml.md` cross-linking the general truncated-stream-aborts contract.

Change is internal to `clinker-format` (private / `pub(crate)` functions, no public API or error-type change), so it does not cross crate boundaries.

## fix(format): keep byte-limited splits of JSON and XML valid per file

### Problem

When an Output node splits by `max_bytes`, `SplittingWriter` flushed the active format writer after every record to keep its shared byte counter accurate. For JSON `array` output and XML output, `flush()` is *finalizing*: it writes the closing `]` (JSON array) or the closing root element (XML). Any record written after the first therefore landed *after* a closed document, producing files that are not valid JSON / not well-formed XML.

Record-count splits (`max_records`) were unaffected because that path does not flush per record. Byte splits for the single-envelope EDI formats (EDIFACT/X12/HL7/SWIFT) are already rejected at config-validation time, so the corruption was reachable only for JSON and XML.

### Fix

Separate the non-finalizing buffer drain from finalization in the writer lifecycle:

- Add `FormatWriter::flush_bytes` — pushes internally buffered bytes to the underlying sink *without* emitting closing framing. It defaults to `flush()`, which is correct for record-oriented writers whose `flush` writes no closing bytes (CSV, fixed-width).
- Override `flush_bytes` in the writers whose `flush` finalizes — JSON, XML, and (defensively) the EDIFACT/X12/HL7/SWIFT envelope writers — to flush only the raw sink.
- `SplittingWriter`'s per-record byte accounting now calls `flush_bytes` instead of `flush`. The finalizing `flush` is retained at rotation and at end of stream, so each split file is closed and reopened as a complete, independently valid document. The transparent wrappers (`CountedFormatWriter`, `SplittingWriter`) forward `flush_bytes` to their inner writer.

Byte counting stays accurate: `CountingWriter` counts on write, and rotation attributes the closing bytes to the file that owned them before resetting the counter for the next file.

### Validation

- Two new regression tests in `clinker-format` splitting: a byte-limited JSON `array` split (each file parses as one JSON array, exactly one `[`/`]` per file, all records preserved) and a byte-limited XML split (each file parses well-formed end to EOF, exactly one root open/close per file, all records preserved). Both assert a multi-record file is produced so they actually exercise the mid-document path. Verified both tests fail against the pre-fix call site (JSON shows a stray `]` after every record; XML shows repeated `</items>`).
- `cargo fmt --all --check`, `cargo clippy -p clinker-format --all-targets -D warnings` clean.
- `cargo test -p clinker-format`: 609 tests pass (583 lib + 13 + 13 integration).
- `cargo check --workspace` clean (the new trait method is additive with a default body).
- `git diff --check` clean.

User docs updated: the file-splitting cookbook and the Output node reference now note that byte-limited splits of array/root-framed formats yield a complete, independently valid document per file.

## feat(record): exact decimal accumulator for weighted_avg

### Summary

`sum` and `avg` over a `decimal` column already aggregate exactly. `weighted_avg` was the remaining numeric aggregate without an exact decimal path: its accumulator skipped a `Value::Decimal` in either the value or the weight position, so a decimal argument was silently dropped and the weighted average came back null. To avoid that silently-wrong result, a decimal value or weight was rejected at typecheck.

This adds an exact decimal accumulator for `weighted_avg`, mirroring the `sum`/`avg` decimal paths, and lifts the typecheck rejection.

### What changed

- **Exact decimal accumulator.** `WeightedAvgState` now keeps running `Σ(value·weight)` and `Σ(weight)` in the decimal domain alongside its integer/float paths. A `decimal·int` product widens exactly (the integer promotes to a decimal) and `decimal·decimal` is exact. Finalize divides at full precision, matching `avg`. Integers observed after the first decimal fold into the exact sums (so a conditional value like `if flag then amount else 1` is not lost), and partial-aggregate merges combine each side's exact totals before touching the integer sums. An out-of-range intermediate sets an overflow flag that finalizes to null rather than a biased average. The decimal state serializes in the existing 16-byte form, so a spilled accumulator reloads exactly.
- **Typecheck.** A decimal value or weight now typechecks and infers a `decimal` return type (`weighted_avg(decimal, …) -> decimal`). A decimal mixed with a binary `float` across the two arguments stays rejected, matching the existing `decimal * float` arithmetic rule, with a clear fix-it hint.
- **Behavior preserved.** Zero total weight still returns null; int/float inputs keep their prior binary-float behavior and Float return type.
- **Docs.** The aggregate reference and the decimal type guide now document the exact decimal `weighted_avg` and the decimal/float-mix restriction.

### Validation

- New accumulator tests: exact weighted average over decimals (values that drift under binary float), decimal value + decimal weight, decimal value + integer weight and the reverse, an integer folded in after decimal mode, merge with an integer-only partial in both directions, a decimal/float mix resolving to null, and a spill round-trip.
- New typecheck tests: `weighted_avg` over a decimal value/weight/both typechecks and returns `decimal`; a decimal/float mix is rejected; return-type inference covers the decimal and non-decimal cases.
- `cargo test` for the record, language, and executor crates all pass; `cargo clippy -D warnings` is clean; a sample pipeline computing `weighted_avg(price, qty)` over a `decimal` column emits exact decimal results end-to-end.

## feat(plan): channel source-config patch for multi-record records/discriminator

### What

Extends the channel `sources:` config-patch surface with two new ops for **multi-record flat files** (discriminator-driven layouts where several record types share one file):

- `records:` — keyed by record-type id, with `modify` / `add` / `remove` ops mirroring the existing `schema` grammar. A `modify` sets any subset of a record type's `tag` / `parent` / `join_key` / `description` and carries a nested `columns:` map that reshapes that record type's own fields; an `add` declares a whole new record type (map key = its id); a bare `remove` drops one.
- `discriminator:` — a partial merge onto the source's discriminator block. A named `start` / `width` / `field` overwrites, an omitted one is kept.

Both apply to the parsed config before validation/compile, so a tenant-specific record layout can be supplied through a channel without editing the base pipeline. The ops fold into the derived config-identity hash automatically, so a patched run's pipeline identity, outputs, and lineage stay distinct from the base and from other patched variants. The run, `--explain`, and `--lineage` paths pick this up through the existing `apply_source_patches` callsites — no new wiring.

### Why

Channel `sources:` patches already cover single-record column ops, array-path explosion/join, per-format options, and X12/HL7 format-structure declarations. Multi-record discrimination was the remaining gap: a channel could not adjust which record types a source declares or how they are discriminated. This closes that gap additively, following the established keyed-op handler pattern.

### How it works

The single-record column-op core was extracted to operate on a plain column list, keeping the existing schema-kind guard for its current callers (the `schema` surface and the overlay `patch_schema` op); a `records` modify reuses that same core for its nested columns, so both surfaces resolve the column grammar and its diagnostics identically.

New compile-time diagnostics extend the existing `E230`-series scheme:

- **E241** — `records` / `discriminator` ops on a non-multi-record schema.
- **E242** — `modify` / `remove` of an unknown record-type id.
- **E243** — `add` of a record-type id that already exists.
- **E244** — a merged discriminator that is neither a pure byte range nor a pure field.
- **E245** — a discriminator tag shared by two record types after the patch.

### Validation

- `cargo fmt --all --check` — clean.
- `cargo clippy -p clinker-plan -p clinker-channel --all-targets -- -D warnings` — clean.
- `cargo test -p clinker-plan` — 620 passing (15 new `records` / `discriminator` unit tests covering each op's happy path and every error code, plus discriminator merge and parse-time ambiguity/rejection cases).
- `cargo test -p clinker-channel` — passing, including a new end-to-end overlay-resolution test that carries a `records` + `discriminator` patch through the channel file resolver and applies it to a multi-record source.
- `cargo check --workspace` — clean.

### Docs

- User docs: new "Multi-record patches" subsection and E241–E245 rows on the channels page (`docs/user/src/pipelines/channels.md`).
- Updated the `sources:` patch doc comments in `manifest.rs` and the module docs in `patch.rs` to list the new surfaces.

## feat(plan): allow # comments in Cull drop_group_when predicates

### Summary

A Cull node's rules are OR-combined into one decision expression that the executor folds over each correlation group. Previously that combination was built by joining the rule source strings into a single `(r1) or (r2)` line, which made a CXL `#` line-comment impossible: a comment runs to end-of-line, so on the joined line it swallowed every following disjunct and the closing paren. The interim behavior rejected any commented predicate at compile time.

This change lifts that limitation so authors can annotate their group-removal predicates inline:

```yaml
rules:
  - name: drop_error_groups
    drop_group_when: "sum(if status == 'error' then 1 else 0) > 0  # any error row removes the group"
  - name: high_total
    drop_group_when: "sum(amount) > 10000                          # large accounts"
```

### Approach

The rules are now combined at the AST level instead of by string concatenation:

- Each rule's `drop_group_when` is parsed independently as its own `emit __cull_pred = <predicate>` program, so a trailing `#` comment terminates at that rule's end-of-line rather than swallowing later disjuncts.
- The parsed predicate expressions are OR-folded into one synthetic decision program that emits the reserved decision column.
- A new `cxl::ast::offset_node_ids` helper relocates each rule's AST node ids into a dense, collision-free span, so the resolver/typechecker per-node side-tables stay consistent; the OR-chain and wrapping emit mint fresh ids above every relocated rule.
- The typecheck entry point is split so the binder can enter after parse with a program it built itself.

The per-rule diagnostic attribution is preserved and made comment-tolerant: a parse or type error in one rule still names that specific rule, even when its predicate carries a trailing comment. The well-formed sibling rules are not blamed.

A `#YYYY-MM-DD#` date literal is unaffected — it lexes as a date token, not a comment.

### Tests

- `cxl`: unit tests for `offset_node_ids` (shifts every node id by the base, is a no-op at base 0, relocates match-arm ids).
- `clinker-plan`: a `#`-commented predicate now compiles and folds both rules' aggregates into the decision; an unknown-column reference inside a `#`-commented rule is still attributed to that rule by name.
- `clinker-exec`: a `#`-commented predicate produces byte-identical output to the same predicate without the comment; a two-rule Cull where one rule carries a trailing comment OR-combines correctly across both rules.

### Docs

`docs/user/src/nodes/cull.md` documents that a `drop_group_when` predicate may carry a `#` line-comment scoped to its own rule.

### Validation

- `cargo fmt --all --check`
- `cargo clippy -p cxl -p clinker-plan -p clinker-exec --all-targets -- -D warnings`
- `cargo test -p cxl` (516 pass), `cargo test -p clinker-plan` (600 lib + doc-tests pass), `cargo test -p clinker-exec` (full suite pass, including the new Cull integration tests)
- `cargo check --workspace`
- `git diff --check`

## fix(format): bound line-separated fixed-width record reads

### Summary

The fixed-width reader's line-separated (`lf` / `crlf`) path read to the next newline with no length cap. A file whose line was missing its terminator would buffer the rest of the input into a single record, growing unbounded regardless of the small configured record width — a bounded-memory violation. The delimiter-free (`none`) path was already bounded to the declared record length; only the line-separated arms were not.

### Change

`read_physical_line` now caps each `lf` / `crlf` read at the declared record width plus a CR/LF allowance and one sentinel byte, using a per-line `Read::take` view over the buffered reader. If the read fills the cap without reaching a newline, the line overruns the declared width and is rejected with a typed `FormatError::InvalidRecord` carrying 1-based row context, instead of allocating an unbounded buffer. A final line with no trailing newline that fits within the declared width still reads exactly as before, and well-formed `lf` / `crlf` lines (including full-width records plus `\r\n`) are unaffected. The `none` fixed-block path is untouched.

The bound applies to both the single-record and multi-record fixed-width readers, which share this line-reading routine.

### Behavior note

A terminated line longer than the declared record width plus its line terminator now errors, where field extraction previously ignored those trailing bytes silently. This is the intended consequence of enforcing the per-record memory bound: the reader no longer reads past the declared record layout.

### Docs

`docs/user/src/formats/fixed-width.md` now states that, under `lf` / `crlf`, a line running past the declared width without a terminator is rejected as a record error carrying its row number rather than buffered, and that a final line without a trailing newline still reads if it fits within the declared width.

### Validation

- `cargo fmt --all --check` — clean
- `cargo clippy -p clinker-format --all-targets -- -D warnings` — clean
- `cargo test -p clinker-format` — 589 unit + 13 integration tests pass, 0 failures
- `git diff --check` — clean

New tests cover: the overrun error with correct 1-based row context and a bounded buffer for both `lf` and `crlf`; the tightest one-byte-over-cap boundary; a terminated line sitting exactly on the cap boundary; a final unterminated line within the cap; well-formed `lf`/`crlf` stripping; and an end-to-end `FixedWidthReader` case with a 10,000-byte unterminated line failing as a bounded record error. The existing blank-line-skipping behavior is confirmed unaffected.

## fix(plan): reject JSON envelope pointers without a leading slash

### Summary

A `json_pointer` envelope extract was passed straight through to the streaming JSON pre-scan, which decodes an RFC 6901 pointer by splitting on `/` and skipping the first segment. A slashless value such as `Head` decodes to **zero segments** — indistinguishable from the empty whole-document pointer `""` — so a typo like `json_pointer: "Head"` silently matched the root document and retained the wrong metadata (or materialized far more of the document than intended) instead of failing.

### What changed

- **Plan-time validation (`clinker-plan`)**: `validate_config` now rejects any source-envelope `json_pointer` that is non-empty and does not start with `/`, via a new `[E222]` diagnostic naming the source, the section, and the offending pointer, and showing the accepted RFC 6901 grammar. This fails on `--explain` and for in-process executor callers, not just at run time.
- **Defensive reader guard (`clinker-format`)**: the JSON reader applies the same grammar check before constructing a section target, so a caller that bypasses plan validation (a direct reader construction) still fails loud rather than matching the wrong node. The `SectionTarget::new` doc comment now states that callers must pre-validate the pointer grammar.
- The empty pointer `""` keeps its explicit whole-document meaning and remains accepted — covered by tests so the new guard cannot regress into rejecting it.

### Validation

- `cargo test -p clinker-plan` — 573 passed, including the two new tests (`test_slashless_json_pointer_rejected_at_validation`, `test_empty_json_pointer_accepted_at_validation`).
- `cargo test -p clinker-format --test streaming_doc_index_json` — 15 passed, including the two new tests (`prescan_rejects_slashless_json_pointer`, `prescan_empty_json_pointer_matches_root`).
- `cargo clippy -p clinker-plan -p clinker-format --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check`, `cargo check --workspace`, `git diff --check` — all clean.

### Docs

Updated the extract-rules table and added a paragraph in `docs/user/src/pipelines/envelope-and-doc-context.md` stating the accepted `json_pointer` grammar (empty or leading `/`) and that a slashless value is rejected at validation.

Closes #696
Closes #713
Closes #711
Closes #786
Closes #746
Closes #656
Closes #714
Closes #719
