### PR TITLE
batch: write-boundary decimal scale rounding, strict CSV delimiter validation

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -1148,21 +1148,20 @@ enum MultiRecordKind<'a> {
 ///
 /// A declared `encoding` is resolved to a [`Charset`] here so an unsupported
 /// value fails at startup with the name the user must fix, rather than being
-/// silently dropped (the reader otherwise always decoded as UTF-8).
+/// silently dropped (the reader otherwise always decoded as UTF-8). A declared
+/// `delimiter` / `quote_char` is likewise resolved to its single byte, failing
+/// at startup on an empty, multi-character, or non-ASCII value rather than
+/// truncating it to a single (possibly wrong) byte.
 fn build_csv_reader_config(
     opts: Option<&clinker_plan::config::CsvInputOptions>,
 ) -> Result<CsvReaderConfig, PipelineError> {
     let mut config = CsvReaderConfig::default();
     if let Some(opts) = opts {
-        if let Some(ref d) = opts.delimiter
-            && let Some(b) = d.as_bytes().first()
-        {
-            config.delimiter = *b;
+        if let Some(ref d) = opts.delimiter {
+            config.delimiter = crate::executor::util::csv_single_byte("delimiter", d)?;
         }
-        if let Some(ref q) = opts.quote_char
-            && let Some(b) = q.as_bytes().first()
-        {
-            config.quote_char = *b;
+        if let Some(ref q) = opts.quote_char {
+            config.quote_char = crate::executor::util::csv_single_byte("quote_char", q)?;
         }
         if let Some(h) = opts.has_header {
             config.has_header = h;
@@ -1780,6 +1779,61 @@ nodes:
         assert!(
             msg.contains("shift_jis") && msg.contains("iso-8859-1"),
             "error must name the unsupported value and the supported set: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_csv_reader_config_resolves_single_byte_delimiter_and_quote() {
+        let opts = clinker_plan::config::CsvInputOptions {
+            delimiter: Some("|".to_string()),
+            quote_char: Some("'".to_string()),
+            ..Default::default()
+        };
+        let cfg =
+            build_csv_reader_config(Some(&opts)).expect("single-byte delimiter/quote resolve");
+        assert_eq!(cfg.delimiter, b'|');
+        assert_eq!(cfg.quote_char, b'\'');
+    }
+
+    #[test]
+    fn build_csv_reader_config_resolves_tab_delimiter() {
+        let opts = clinker_plan::config::CsvInputOptions {
+            delimiter: Some("\t".to_string()),
+            ..Default::default()
+        };
+        let cfg = build_csv_reader_config(Some(&opts)).expect("tab delimiter resolves");
+        assert_eq!(cfg.delimiter, b'\t');
+    }
+
+    #[test]
+    fn build_csv_reader_config_rejects_multichar_delimiter() {
+        let opts = clinker_plan::config::CsvInputOptions {
+            delimiter: Some("||".to_string()),
+            ..Default::default()
+        };
+        let Err(err) = build_csv_reader_config(Some(&opts)) else {
+            panic!("a multi-character delimiter must fail config build");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("delimiter") && msg.contains("one ASCII byte"),
+            "error must name the option and the requirement: {msg}"
+        );
+    }
+
+    #[test]
+    fn build_csv_reader_config_rejects_non_ascii_quote() {
+        let opts = clinker_plan::config::CsvInputOptions {
+            quote_char: Some("→".to_string()),
+            ..Default::default()
+        };
+        let Err(err) = build_csv_reader_config(Some(&opts)) else {
+            panic!("a non-ASCII quote_char must fail config build");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("quote_char") && msg.contains("one ASCII byte"),
+            "error must name the option: {msg}"
         );
     }
 }

--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -49,22 +49,27 @@ impl From<HashMap<String, Box<dyn Write + Send>>> for WriterRegistry {
     }
 }
 
-/// Build a CsvWriterConfig from CSV output options and the top-level include_header flag.
+/// Build a `CsvWriterConfig` from CSV output options and the top-level
+/// `include_header` flag.
+///
+/// Errors when a configured `delimiter` is not exactly one ASCII byte,
+/// mirroring the reader-side guard so an empty, multi-character, or non-ASCII
+/// value fails before any output bytes are written rather than being
+/// truncated to its first byte.
 fn build_csv_writer_config(
     opts: Option<&clinker_plan::config::CsvOutputOptions>,
     include_header: Option<bool>,
-) -> CsvWriterConfig {
+) -> Result<CsvWriterConfig, PipelineError> {
     let mut config = CsvWriterConfig::default();
     if let Some(h) = include_header {
         config.include_header = h;
     }
     if let Some(opts) = opts
         && let Some(ref d) = opts.delimiter
-        && let Some(b) = d.as_bytes().first()
     {
-        config.delimiter = *b;
+        config.delimiter = crate::executor::util::csv_single_byte("delimiter", d)?;
     }
-    config
+    Ok(config)
 }
 
 /// Build a JsonWriterConfig from JSON output options.
@@ -245,10 +250,10 @@ fn build_writer_factory(
     field_defs: Option<Vec<clinker_format::Column>>,
     include_engine_stamped: bool,
     reconstruct_envelope: bool,
-) -> WriterFactory {
+) -> Result<WriterFactory, PipelineError> {
     match format {
         OutputFormat::Csv(opts) => {
-            let mut csv_config = build_csv_writer_config(opts.as_ref(), include_header);
+            let mut csv_config = build_csv_writer_config(opts.as_ref(), include_header)?;
             csv_config.include_engine_stamped = include_engine_stamped;
             csv_config.envelope = resolve_envelope_spec(
                 reconstruct_envelope,
@@ -257,7 +262,7 @@ fn build_writer_factory(
             if repeat_header {
                 let shared_header: Arc<Mutex<Option<Vec<Box<str>>>>> = Arc::new(Mutex::new(None));
                 let call_count = Arc::new(AtomicU32::new(0));
-                Box::new(move |counting_writer, schema| {
+                Ok(Box::new(move |counting_writer, schema| {
                     let seq = call_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     let inner_csv =
                         CsvWriter::new(counting_writer, schema.clone(), csv_config.clone());
@@ -276,15 +281,15 @@ fn build_writer_factory(
                         }
                         Ok(Box::new(csv))
                     }
-                })
+                }))
             } else {
-                Box::new(move |counting_writer, schema| {
+                Ok(Box::new(move |counting_writer, schema| {
                     Ok(Box::new(CsvWriter::new(
                         counting_writer,
                         schema,
                         csv_config.clone(),
                     )))
-                })
+                }))
             }
         }
         OutputFormat::Json(opts) => {
@@ -294,13 +299,13 @@ fn build_writer_factory(
                 reconstruct_envelope,
                 opts.as_ref().and_then(|o| o.envelope.as_ref()),
             );
-            Box::new(move |counting_writer, schema| {
+            Ok(Box::new(move |counting_writer, schema| {
                 Ok(Box::new(JsonWriter::new(
                     counting_writer,
                     schema,
                     json_config.clone(),
                 )))
-            })
+            }))
         }
         OutputFormat::Xml(opts) => {
             let mut xml_config = build_xml_writer_config(opts.as_ref());
@@ -309,13 +314,13 @@ fn build_writer_factory(
                 reconstruct_envelope,
                 opts.as_ref().and_then(|o| o.envelope.as_ref()),
             );
-            Box::new(move |counting_writer, schema| {
+            Ok(Box::new(move |counting_writer, schema| {
                 Ok(Box::new(XmlWriter::new(
                     counting_writer,
                     schema,
                     xml_config.clone(),
                 )))
-            })
+            }))
         }
         OutputFormat::FixedWidth(opts) => {
             let mut fw_config = build_fw_writer_config(opts.as_ref());
@@ -327,23 +332,23 @@ fn build_writer_factory(
                 "fixed-width writer factory requires field_defs — \
                  build_format_writer must validate schema before calling",
             );
-            Box::new(move |counting_writer, _schema| {
+            Ok(Box::new(move |counting_writer, _schema| {
                 Ok(Box::new(FixedWidthWriter::new(
                     counting_writer,
                     fields.clone(),
                     fw_config.clone(),
                 )?))
-            })
+            }))
         }
         OutputFormat::Edifact(opts) => {
             let edi_config = build_edifact_writer_config(opts.as_ref());
-            Box::new(move |counting_writer, schema| {
+            Ok(Box::new(move |counting_writer, schema| {
                 Ok(Box::new(EdifactWriter::new(
                     counting_writer,
                     schema,
                     edi_config.clone(),
                 )))
-            })
+            }))
         }
         OutputFormat::X12(opts) => {
             // Resolve the writer config (including charset) once here so the
@@ -355,7 +360,7 @@ fn build_writer_factory(
             // first per-split writer is built (at the first record) — still
             // pre-output and never a corrupt interchange, just not at setup.
             let x12_config = build_x12_writer_config(opts.as_ref());
-            Box::new(move |counting_writer, schema| {
+            Ok(Box::new(move |counting_writer, schema| {
                 let config = x12_config
                     .as_ref()
                     .map_err(|e| clinker_format::FormatError::X12(e.to_string()))?;
@@ -364,27 +369,27 @@ fn build_writer_factory(
                     schema,
                     config.clone(),
                 )))
-            })
+            }))
         }
         OutputFormat::Hl7(opts) => {
             let hl7_config = build_hl7_writer_config(opts.as_ref());
-            Box::new(move |counting_writer, schema| {
+            Ok(Box::new(move |counting_writer, schema| {
                 Ok(Box::new(Hl7Writer::new(
                     counting_writer,
                     schema,
                     hl7_config.clone(),
                 )))
-            })
+            }))
         }
         OutputFormat::Swift(opts) => {
             let swift_config = build_swift_writer_config(opts.as_ref());
-            Box::new(move |counting_writer, schema| {
+            Ok(Box::new(move |counting_writer, schema| {
                 Ok(Box::new(SwiftWriter::new(
                     counting_writer,
                     schema,
                     swift_config.clone(),
                 )))
-            })
+            }))
         }
     }
 }
@@ -413,7 +418,7 @@ pub(crate) fn build_format_writer(
         field_defs,
         output.include_correlation_keys,
         output.reconstruct_envelope,
-    );
+    )?;
 
     if let Some(ref split) = output.split {
         let policy = build_split_policy(split);
@@ -525,5 +530,40 @@ mod tests {
         // Matches the XML reader's default so attribute fields round-trip
         // without any output-side configuration.
         assert_eq!(build_xml_writer_config(None).attribute_prefix, "@");
+    }
+
+    #[test]
+    fn csv_writer_config_defaults_delimiter_to_comma() {
+        // With no options the writer keeps the RFC 4180 comma so an existing
+        // pipeline's output is byte-identical.
+        let config = build_csv_writer_config(None, None).expect("no options resolves");
+        assert_eq!(config.delimiter, b',');
+    }
+
+    #[test]
+    fn csv_writer_config_resolves_single_byte_delimiter() {
+        let opts = clinker_plan::config::CsvOutputOptions {
+            delimiter: Some("|".into()),
+            ..Default::default()
+        };
+        let config =
+            build_csv_writer_config(Some(&opts), None).expect("single-byte delimiter resolves");
+        assert_eq!(config.delimiter, b'|');
+    }
+
+    #[test]
+    fn csv_writer_config_rejects_multichar_delimiter() {
+        let opts = clinker_plan::config::CsvOutputOptions {
+            delimiter: Some("||".into()),
+            ..Default::default()
+        };
+        let Err(err) = build_csv_writer_config(Some(&opts), None) else {
+            panic!("a multi-character output delimiter must fail config build");
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("delimiter") && msg.contains("one ASCII byte"),
+            "error must name the option and the requirement: {msg}"
+        );
     }
 }

--- a/crates/clinker-exec/src/executor/util.rs
+++ b/crates/clinker-exec/src/executor/util.rs
@@ -10,6 +10,31 @@ use indexmap::IndexMap;
 
 use clinker_plan::config::PipelineConfig;
 
+/// Resolve a CSV `delimiter` / `quote_char` string to the single ASCII byte
+/// the byte-oriented CSV reader and writer accept.
+///
+/// Plan validation already rejects any other shape, so on the run path this
+/// only ever sees a one-byte value; it exists as the lowering-side guard that
+/// turns a would-be first-byte truncation of an empty, multi-character, or
+/// non-ASCII value into a startup config error rather than silently applying
+/// the wrong byte. `field` names the option (`"delimiter"` / `"quote_char"`)
+/// for the diagnostic. Pure and non-blocking: no I/O, no allocation on the
+/// success path.
+pub(crate) fn csv_single_byte(
+    field: &str,
+    value: &str,
+) -> Result<u8, clinker_plan::error::PipelineError> {
+    let mut chars = value.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) if c.is_ascii() => Ok(c as u8),
+        _ => Err(clinker_plan::error::PipelineError::Config(
+            clinker_plan::config::ConfigError::Validation(format!(
+                "CSV {field} {value:?} must be exactly one ASCII byte"
+            )),
+        )),
+    }
+}
+
 /// Resolve the dispatch order for a topological pass via the memory
 /// arbitrator's [`next_runnable`](crate::pipeline::memory::MemoryArbitrator::next_runnable)
 /// instead of walking `topo_order` blindly.

--- a/crates/clinker-exec/src/pipeline/window_context.rs
+++ b/crates/clinker-exec/src/pipeline/window_context.rs
@@ -190,10 +190,12 @@ impl<'a> WindowContext<'a, Arena> for PartitionWindowContext<'a> {
             }
         }
         if saw_decimal && count > 0 {
-            // Exact decimal quotient at full precision — a computed decimal is
-            // not re-rounded to an output-column scale (round explicitly in CXL
-            // to fix places). Integer rows fold into the numerator exactly so
-            // they are not lost.
+            // Exact decimal quotient at full precision — inside the pipeline a
+            // computed decimal keeps every digit. A declared `scale` rounds only
+            // at the boundary it is declared on: a source column's `scale` on
+            // read, an output column's `scale` on write (applied in the output
+            // projection); mid-pipeline places still take an explicit CXL round.
+            // Integer rows fold into the numerator exactly so they are not lost.
             let numerator = add_i128_to_decimal(dec_total, int_acc);
             return match numerator.checked_div(rust_decimal::Decimal::from(count)) {
                 Some(avg) => Value::Decimal(avg),

--- a/crates/clinker-exec/src/projection.rs
+++ b/crates/clinker-exec/src/projection.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use clinker_record::{Record, SchemaBuilder, Value};
+use clinker_record::{Record, SchemaBuilder, Value, round_decimal_to_scale};
+use cxl::typecheck::Type;
 use indexmap::IndexMap;
 
 use clinker_plan::config::OutputConfig;
@@ -117,6 +118,7 @@ pub fn project_output_from_record(
         // echoing the source `UNB` header) can still resolve
         // `$doc.<section>.<field>` after projection drops engine columns.
         out.set_doc_ctx(Arc::clone(input_record.doc_ctx()));
+        round_declared_output_decimals(&mut out, config);
         return out;
     }
 
@@ -193,7 +195,51 @@ pub fn project_output_from_record(
     // envelope context forward so document-reconstructing writers still
     // resolve `$doc.<section>.<field>` on the projected record.
     out.set_doc_ctx(Arc::clone(input_record.doc_ctx()));
+    round_declared_output_decimals(&mut out, config);
     out
+}
+
+/// Enforce a declared output-column `scale` at the write boundary: each
+/// `Value::Decimal` landing in a column the output `schema:` declares as
+/// `type: decimal` with a `scale` is rescaled to that many fractional digits
+/// with the house banker's rounding ([`round_decimal_to_scale`], round-half-to-
+/// even) — bit-identical to what a source column's `scale` does on ingest.
+///
+/// This is the write side of the decimal boundary contract: decimals compute at
+/// full precision inside the pipeline (`avg`, `a / b` keep every digit) and are
+/// pinned to a declared scale only at the edge they are declared on. An output
+/// without a `schema:`, or a column without `scale`, is left at full precision.
+///
+/// Keyed by the post-mapping (output-facing) column names, so it runs after the
+/// rename/exclude rewrite has produced the final record. Only `Value::Decimal`
+/// in a `decimal`-declared, scaled column is touched — no other type coercion is
+/// performed, and a non-decimal value or a decimal in an unscaled column passes
+/// through untouched. Blocking/streaming: pure per-record transform, no
+/// buffering; cost is proportional to the declared column count and is skipped
+/// entirely for the schema-less outputs (CSV/JSON without a `schema:` block).
+fn round_declared_output_decimals(record: &mut Record, config: &OutputConfig) {
+    let Some(columns) = config.schema.as_ref().and_then(|s| s.as_columns()) else {
+        return;
+    };
+    for col in columns {
+        let Some(scale) = col.scale else {
+            continue;
+        };
+        // A nullable declaration (`type: { nullable: decimal }`) still names a
+        // decimal column — unwrap it the same way the fixed-width writer
+        // classifies numeric fields.
+        if !matches!(col.ty.unwrap_nullable(), Type::Decimal) {
+            continue;
+        }
+        // Copy the decimal out (it is `Copy`) so the immutable `get` borrow is
+        // released before the `set`; a non-decimal value in the slot is left
+        // untouched.
+        let rounded = match record.get(&col.name) {
+            Some(&Value::Decimal(d)) => round_decimal_to_scale(d, Some(scale)),
+            _ => continue,
+        };
+        record.set(&col.name, Value::Decimal(rounded));
+    }
 }
 
 #[cfg(test)]
@@ -609,6 +655,186 @@ mod tests {
             result.doc_ctx().get_section_field("unb", "e01"),
             Some(Value::String("UNOA:1".into())),
             "fast path must carry the source document context forward"
+        );
+    }
+
+    // ── Output-column decimal `scale` enforcement (write boundary) ──
+
+    use clinker_format::{Column, SourceSchema};
+    use rust_decimal::Decimal;
+
+    /// A minimal fast-path Output config (no mapping/exclude, no correlation
+    /// keys) carrying an optional output `schema:`. `cxl_emit_names = None`
+    /// keeps every user field, so a declared decimal column reaches the
+    /// rounding pass.
+    fn scale_config(schema: Option<SourceSchema>) -> OutputConfig {
+        OutputConfig {
+            name: "out".into(),
+            format: clinker_plan::config::OutputFormat::Csv(None),
+            path: "/tmp/out.csv".into(),
+            include_unmapped: false,
+            include_header: None,
+            mapping: None,
+            exclude: None,
+            sort_order: None,
+            preserve_nulls: None,
+            include_correlation_keys: false,
+            correlation_fanout_policy: None,
+            if_exists: Default::default(),
+            unique_suffix_width: 0,
+            write_meta: false,
+            reconstruct_envelope: false,
+            schema,
+            split: None,
+            notes: None,
+        }
+    }
+
+    fn decimal_col(name: &str, scale: Option<u8>) -> Column {
+        Column {
+            scale,
+            ..Column::bare(name, Type::Decimal)
+        }
+    }
+
+    fn one_field_record(name: &str, value: Value) -> Record {
+        let schema = Arc::new(Schema::new(vec![name.into()]));
+        Record::new(schema, vec![value])
+    }
+
+    /// A full-precision computed quotient (4 / 3 keeps 28 digits) is rescaled to
+    /// the declared output-column scale with banker's rounding: `1.33`.
+    #[test]
+    fn output_scale_rounds_computed_decimal() {
+        let quotient = Decimal::from(4)
+            .checked_div(Decimal::from(3))
+            .expect("4 / 3");
+        let input = one_field_record("average", Value::Decimal(quotient));
+        let schema = SourceSchema::Columns(vec![decimal_col("average", Some(2))]);
+        let out = project_output_from_record(&input, &scale_config(Some(schema)), None);
+        assert_eq!(
+            out.get("average"),
+            Some(&Value::Decimal(Decimal::new(133, 2)))
+        );
+    }
+
+    /// The write boundary uses the same round-half-to-even as ingest: a `.xx5`
+    /// midpoint rounds to the even neighbor (`2.125` → `2.12`), not away from
+    /// zero.
+    #[test]
+    fn output_scale_uses_bankers_midpoint() {
+        let input = one_field_record("m", Value::Decimal(Decimal::new(2125, 3)));
+        let schema = SourceSchema::Columns(vec![decimal_col("m", Some(2))]);
+        let out = project_output_from_record(&input, &scale_config(Some(schema)), None);
+        assert_eq!(out.get("m"), Some(&Value::Decimal(Decimal::new(212, 2))));
+
+        let input = one_field_record("m", Value::Decimal(Decimal::new(2135, 3)));
+        let schema = SourceSchema::Columns(vec![decimal_col("m", Some(2))]);
+        let out = project_output_from_record(&input, &scale_config(Some(schema)), None);
+        assert_eq!(out.get("m"), Some(&Value::Decimal(Decimal::new(214, 2))));
+    }
+
+    /// The write boundary only rounds off excess precision; it never pads a
+    /// shorter-scale value up. This is bit-identical to ingest (`2.5` coerced
+    /// into a `scale: 2` source column also stays `2.5`) — both edges route
+    /// through the same `round_decimal_to_scale`. Decimal equality ignores
+    /// scale, so the string form is the load-bearing assertion.
+    #[test]
+    fn output_scale_does_not_pad_shorter_scale() {
+        let input = one_field_record("v", Value::Decimal(Decimal::new(25, 1)));
+        let schema = SourceSchema::Columns(vec![decimal_col("v", Some(2))]);
+        let out = project_output_from_record(&input, &scale_config(Some(schema)), None);
+        let Some(Value::Decimal(d)) = out.get("v") else {
+            panic!("expected a decimal");
+        };
+        assert_eq!(
+            d.to_string(),
+            "2.5",
+            "already within scale — left untouched"
+        );
+    }
+
+    /// A `decimal` column with no declared `scale` keeps full precision — the
+    /// contract only fires where the user declared a scale.
+    #[test]
+    fn output_decimal_without_scale_keeps_full_precision() {
+        let quotient = Decimal::from(4)
+            .checked_div(Decimal::from(3))
+            .expect("4 / 3");
+        let input = one_field_record("average", Value::Decimal(quotient));
+        let schema = SourceSchema::Columns(vec![decimal_col("average", None)]);
+        let out = project_output_from_record(&input, &scale_config(Some(schema)), None);
+        assert_eq!(out.get("average"), Some(&Value::Decimal(quotient)));
+    }
+
+    /// A schema-less output (CSV/JSON without a `schema:` block) never rounds —
+    /// today's full-precision behavior is preserved.
+    #[test]
+    fn output_without_schema_keeps_full_precision() {
+        let quotient = Decimal::from(4)
+            .checked_div(Decimal::from(3))
+            .expect("4 / 3");
+        let input = one_field_record("average", Value::Decimal(quotient));
+        let out = project_output_from_record(&input, &scale_config(None), None);
+        assert_eq!(out.get("average"), Some(&Value::Decimal(quotient)));
+    }
+
+    /// Scope guard: only a `Value::Decimal` in a decimal-declared column is
+    /// touched. A `Value::Float` that lands in such a column is NOT coerced —
+    /// write-side type coercion is deliberately out of scope.
+    #[test]
+    fn output_scale_leaves_non_decimal_value_untouched() {
+        let input = one_field_record("average", Value::Float(1.3333));
+        let schema = SourceSchema::Columns(vec![decimal_col("average", Some(2))]);
+        let out = project_output_from_record(&input, &scale_config(Some(schema)), None);
+        assert_eq!(out.get("average"), Some(&Value::Float(1.3333)));
+    }
+
+    /// The rounding pass runs on the slow path too (mapping/exclude rewrite),
+    /// keyed by the post-mapping output name: a field renamed to a scaled
+    /// decimal column is rescaled.
+    #[test]
+    fn output_scale_applies_after_mapping_rename() {
+        let quotient = Decimal::from(4)
+            .checked_div(Decimal::from(3))
+            .expect("4 / 3");
+        let input = one_field_record("raw_avg", Value::Decimal(quotient));
+        let mut mapping = IndexMap::new();
+        mapping.insert("raw_avg".to_string(), "average".to_string());
+        let mut config = scale_config(Some(SourceSchema::Columns(vec![decimal_col(
+            "average",
+            Some(2),
+        )])));
+        config.mapping = Some(mapping);
+        let out = project_output_from_record(&input, &config, None);
+        assert!(out.get("raw_avg").is_none(), "field was renamed");
+        assert_eq!(
+            out.get("average"),
+            Some(&Value::Decimal(Decimal::new(133, 2)))
+        );
+    }
+
+    /// A nullable decimal column (`type: { nullable: decimal }`) still rounds —
+    /// the underlying type is unwrapped before the decimal check, matching how
+    /// the writers classify a nullable numeric field.
+    #[test]
+    fn output_scale_rounds_nullable_decimal_column() {
+        let quotient = Decimal::from(4)
+            .checked_div(Decimal::from(3))
+            .expect("4 / 3");
+        let input = one_field_record("average", Value::Decimal(quotient));
+        let col = Column {
+            scale: Some(2),
+            ..Column::bare("average", Type::nullable(Type::Decimal))
+        };
+        let out = project_output_from_record(
+            &input,
+            &scale_config(Some(SourceSchema::Columns(vec![col]))),
+            None,
+        );
+        assert_eq!(
+            out.get("average"),
+            Some(&Value::Decimal(Decimal::new(133, 2)))
         );
     }
 }

--- a/crates/clinker-exec/tests/aggregate_integration.rs
+++ b/crates/clinker-exec/tests/aggregate_integration.rs
@@ -925,12 +925,15 @@ fn test_e2e_decimal_sum_avg() {
     // `avg(amount)` failed to compile and `run_single`'s `.expect("compile")`
     // would panic.
     //
-    // It also pins the observable output precision:
+    // It also pins the observable output precision for a SCHEMA-LESS output
+    // (no output `schema:` block, so no declared output-column scale):
     //   * `sum` stays exact at the column scale (`4.00`, `0.30`);
-    //   * `avg` is the exact full-precision quotient — a computed decimal is
-    //     NOT re-rounded to an output-column scale, so `4.00 / 3` prints all
-    //     28 digits rather than `1.33`. (To round, a user rounds explicitly in
-    //     CXL; a `decimal` source column, by contrast, rounds on ingest.)
+    //   * `avg` is the exact full-precision quotient — with no declared output
+    //     scale to pin it, `4.00 / 3` prints all 28 digits rather than `1.33`.
+    //     A declared output-column scale would round it (see
+    //     `test_e2e_decimal_avg_rounds_to_output_scale`); a `decimal` source
+    //     column rounds on ingest. Inside the pipeline decimals stay full
+    //     precision either way.
     let yaml = r#"
 pipeline:
   name: agg_decimal
@@ -979,4 +982,182 @@ nodes:
             "y,0.30,0.15".to_string(),
         ],
     );
+}
+
+#[test]
+fn test_e2e_decimal_avg_rounds_to_output_scale() {
+    // Same aggregate as `test_e2e_decimal_sum_avg`, but the CSV output now
+    // declares a `schema:` giving `average` a `type: decimal, scale: 2`. The
+    // declared scale is a write-boundary contract — the full-precision quotient
+    // is rounded (banker's rounding) to two places on the way out, so `4.00 / 3`
+    // writes `1.33` rather than the 28-digit quotient. `sum` is already exact at
+    // scale 2 (`4.00`) and is unchanged.
+    let yaml = r#"
+pipeline:
+  name: agg_decimal_scaled_out
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: in.csv
+    schema:
+      - { name: dept, type: string }
+      - { name: amount, type: decimal, scale: 2 }
+- type: aggregate
+  name: by_dept
+  input: src
+  config:
+    group_by:
+    - dept
+    cxl: 'emit dept = dept
+
+      emit total = sum(amount)
+
+      emit average = avg(amount)
+
+      '
+- type: output
+  name: out
+  input: by_dept
+  config:
+    name: out
+    type: csv
+    path: out.csv
+    include_unmapped: true
+    schema:
+      - { name: dept, type: string }
+      - { name: total, type: decimal, scale: 2 }
+      - { name: average, type: decimal, scale: 2 }
+"#;
+    let csv = "dept,amount\nx,1.00\nx,1.00\nx,2.00\ny,0.10\ny,0.20\n";
+    let (report, output) = run_single(yaml, csv);
+    assert_eq!(report.dlq_entries.len(), 0, "no DLQ entries");
+    assert_eq!(report.counters.ok_count, 2, "two output groups");
+    assert_eq!(
+        sorted_body_lines(&output),
+        vec!["x,4.00,1.33".to_string(), "y,0.30,0.15".to_string()],
+        "declared output-column scale rounds the computed avg on write",
+    );
+}
+
+#[test]
+fn test_e2e_decimal_avg_rounds_to_output_scale_json() {
+    // The write-boundary rounding is format-agnostic — it runs in the shared
+    // output projection, so a JSON (ndjson) output honors the declared
+    // `average` scale identically. JSON renders a decimal as a scale-preserving
+    // string, so `1.33` appears verbatim and the 28-digit quotient never does.
+    let yaml = r#"
+pipeline:
+  name: agg_decimal_scaled_json
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: in.csv
+    schema:
+      - { name: dept, type: string }
+      - { name: amount, type: decimal, scale: 2 }
+- type: aggregate
+  name: by_dept
+  input: src
+  config:
+    group_by:
+    - dept
+    cxl: 'emit dept = dept
+
+      emit average = avg(amount)
+
+      '
+- type: output
+  name: out
+  input: by_dept
+  config:
+    name: out
+    type: json
+    options:
+      format: ndjson
+    path: out.json
+    include_unmapped: true
+    schema:
+      - { name: dept, type: string }
+      - { name: average, type: decimal, scale: 2 }
+"#;
+    let csv = "dept,amount\nx,1.00\nx,1.00\nx,2.00\ny,0.10\ny,0.20\n";
+    let (report, output) = run_single(yaml, csv);
+    assert_eq!(report.dlq_entries.len(), 0, "no DLQ entries");
+    assert!(
+        output.contains(r#""average":"1.33""#),
+        "ndjson must carry the rounded avg for dept x: {output}"
+    );
+    assert!(
+        output.contains(r#""average":"0.15""#),
+        "ndjson must carry the exact avg for dept y: {output}"
+    );
+    assert!(
+        !output.contains("1.3333"),
+        "the full-precision quotient must not survive the declared scale: {output}"
+    );
+}
+
+#[test]
+fn test_e2e_decimal_avg_rounds_to_output_scale_fixed_width() {
+    // Fixed-width makes the contract load-bearing: a numeric field that
+    // overflows its width is a hard error (truncation policy `error`), so a
+    // 28-digit quotient is unwritable into a 6-wide decimal field. Rounding the
+    // computed avg to the declared `scale: 2` on write shrinks it to `1.33`,
+    // which fits. A single group keeps the output a single deterministic line.
+    let yaml = r#"
+pipeline:
+  name: agg_decimal_scaled_fw
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: csv
+    path: in.csv
+    schema:
+      - { name: dept, type: string }
+      - { name: amount, type: decimal, scale: 2 }
+- type: aggregate
+  name: by_dept
+  input: src
+  config:
+    group_by:
+    - dept
+    cxl: 'emit dept = dept
+
+      emit total = sum(amount)
+
+      emit average = avg(amount)
+
+      '
+- type: output
+  name: out
+  input: by_dept
+  config:
+    name: out
+    type: fixed_width
+    path: out.dat
+    include_unmapped: true
+    schema:
+      - { name: dept, type: string, width: 4 }
+      - { name: total, type: decimal, scale: 2, width: 8 }
+      - { name: average, type: decimal, scale: 2, width: 6 }
+"#;
+    let csv = "dept,amount\nx,1.00\nx,1.00\nx,2.00\n";
+    let (report, output) = run_single(yaml, csv);
+    assert_eq!(
+        report.dlq_entries.len(),
+        0,
+        "the rounded avg fits the field — no error/DLQ"
+    );
+    assert_eq!(report.counters.ok_count, 1, "one output group");
+    // dept "x" left-justified in 4; total "4.00" and average "1.33" numeric
+    // right-justified in 8 and 6.
+    assert_eq!(output, "x       4.00  1.33\n");
 }

--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -218,8 +218,11 @@ impl<W: Write> FixedWidthWriter<W> {
             Value::String(s) => s.to_string(),
             Value::Integer(i) => i.to_string(),
             Value::Float(f) => f.to_string(),
-            // The decimal already carries its column scale (coercion rounds to
-            // it), and Display renders that scale, e.g. `2.50`.
+            // Rendered at the decimal's own scale via Display, e.g. `2.50`. A
+            // value routed into a `scale`-declared output column is already
+            // rescaled to that scale at the output-projection boundary (the
+            // write-side twin of source-ingest rounding), so the writer renders
+            // it verbatim rather than reinterpreting the field's scale here.
             Value::Decimal(d) => d.to_string(),
             Value::Bool(b) => b.to_string(),
             Value::Date(d) => d.format("%Y%m%d").to_string(),

--- a/crates/clinker-plan/src/config/error.rs
+++ b/crates/clinker-plan/src/config/error.rs
@@ -167,9 +167,10 @@ pub fn parse_config_with_vars(
     Ok(config)
 }
 
-/// Resolve every source's external `.schema.yaml` ([`SourceSchema::File`](crate::config::SourceSchema))
-/// to its inline form, in place, and fold each resolved schema's canonical
-/// content into `config.source_hash`.
+/// Resolve every external `.schema.yaml` ([`SourceSchema::File`](crate::config::SourceSchema))
+/// reference — on both `source` and `output` nodes — to its inline form, in
+/// place, and fold each resolved schema's canonical content into
+/// `config.source_hash`.
 ///
 /// `source_hash` is otherwise BLAKE3 over the interpolated YAML text only, so a
 /// referenced `.schema.yaml`'s content is absent from the pipeline identity and
@@ -177,50 +178,75 @@ pub fn parse_config_with_vars(
 /// output paths and conflating lineage across schema revisions. Folding the
 /// resolved content in (mirroring the channel-patch fold) closes that blind
 /// spot. Resolving in place means the config that flows to `compile` and the
-/// runtime carries inline columns, so no source schema file is re-read
-/// downstream.
+/// runtime carries inline columns, so no schema file is re-read downstream.
+///
+/// Output `schema:` references are resolved here for the same reason. The
+/// executor's write boundary reads the output schema's inline columns directly —
+/// fixed-width column widths and the declared-decimal `scale` rounding both go
+/// through [`SourceSchema::as_columns`], which yields `None` for an unresolved
+/// `File`. Resolving at load time means those passes see the declared columns
+/// whether the schema was written inline or referenced as a file, instead of the
+/// file form silently skipping the scale rounding.
 ///
 /// A config with no external schemas leaves `source_hash` byte-identical.
 fn resolve_and_hash_external_schemas(config: &mut PipelineConfig) -> Result<(), ConfigError> {
     // Pass 1: load each external schema file once (immutable walk), collecting
-    // its resolved inline form and canonical bytes for the identity fold.
+    // its resolved inline form and canonical bytes for the identity fold. Both a
+    // source `schema:` and an output `schema:` (fixed-width column widths or a
+    // declared-decimal `scale`) may name an external file.
     let mut resolved: Vec<(usize, crate::config::SourceSchema, Vec<u8>)> = Vec::new();
     for (idx, spanned) in config.nodes.iter().enumerate() {
-        if let crate::config::PipelineNode::Source {
-            header,
-            config: body,
-        } = &spanned.value
-            && let crate::config::SourceSchema::File(path) = &body.schema
-        {
-            let inline =
-                crate::schema::load_source_schema(std::path::Path::new(path)).map_err(|e| {
-                    ConfigError::Validation(format!(
-                        "source {:?}: failed to load schema file '{path}': {e}",
-                        header.name
-                    ))
-                })?;
-            let serialized = serde_json::to_vec(&inline).map_err(|e| {
+        let (path, node_label) = match &spanned.value {
+            crate::config::PipelineNode::Source {
+                header,
+                config: body,
+            } => match &body.schema {
+                crate::config::SourceSchema::File(path) => {
+                    (path.clone(), format!("source {:?}", header.name))
+                }
+                _ => continue,
+            },
+            crate::config::PipelineNode::Output {
+                header,
+                config: body,
+            } => match &body.output.schema {
+                Some(crate::config::SourceSchema::File(path)) => {
+                    (path.clone(), format!("output {:?}", header.name))
+                }
+                _ => continue,
+            },
+            _ => continue,
+        };
+        let inline =
+            crate::schema::load_source_schema(std::path::Path::new(&path)).map_err(|e| {
                 ConfigError::Validation(format!(
-                    "internal: external schema identity hashing for source {:?}: {e}",
-                    header.name
+                    "{node_label}: failed to load schema file '{path}': {e}"
                 ))
             })?;
-            resolved.push((idx, inline, serialized));
-        }
+        let serialized = serde_json::to_vec(&inline).map_err(|e| {
+            ConfigError::Validation(format!(
+                "internal: external schema identity hashing for {node_label}: {e}"
+            ))
+        })?;
+        resolved.push((idx, inline, serialized));
     }
     if resolved.is_empty() {
         return Ok(());
     }
     // Pass 2: fold the resolved content into the identity hash and write the
-    // inline schema back onto each source node.
+    // inline schema back onto each node.
     let mut hasher = blake3::Hasher::new();
     hasher.update(&config.source_hash);
     for (idx, inline, serialized) in resolved {
         hasher.update(&serialized);
-        if let crate::config::PipelineNode::Source { config: body, .. } =
-            &mut config.nodes[idx].value
-        {
-            body.schema = inline;
+        match &mut config.nodes[idx].value {
+            crate::config::PipelineNode::Source { config: body, .. } => {
+                body.schema = inline;
+            }
+            crate::config::PipelineNode::Output { config: body, .. } => {
+                body.output.schema = Some(inline);
+            }
+            _ => {}
         }
     }
     config.source_hash = *hasher.finalize().as_bytes();
@@ -295,6 +321,13 @@ mod external_schema_tests {
             .expect("source node present")
     }
 
+    fn output_schema(config: &PipelineConfig) -> Option<&crate::config::SourceSchema> {
+        config.nodes.iter().find_map(|n| match &n.value {
+            crate::config::PipelineNode::Output { config, .. } => config.output.schema.as_ref(),
+            _ => None,
+        })
+    }
+
     fn write_pipeline_referencing(
         dir: &std::path::Path,
         schema_path: &std::path::Path,
@@ -347,6 +380,63 @@ mod external_schema_tests {
         assert_ne!(
             config2.source_hash, hash_v1,
             "editing the external schema file must change source_hash"
+        );
+    }
+
+    /// An output node's external `.schema.yaml` (`SourceSchema::File`) is
+    /// resolved to its inline column list at config-load time, exactly like a
+    /// source's. Without this the write-boundary passes that read the output
+    /// schema through `as_columns()` — fixed-width column widths and the
+    /// declared-decimal `scale` rounding — silently skip a file-referenced
+    /// schema, diverging from the same schema written inline.
+    #[test]
+    fn external_output_schema_file_resolves_inline_and_folds_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        let schema_path = dir.path().join("out_cols.schema.yaml");
+        std::fs::write(
+            &schema_path,
+            "- { name: average, type: decimal, scale: 2 }\n- { name: name, type: string }\n",
+        )
+        .unwrap();
+        // A source with an inline schema and an output referencing the external
+        // schema file — isolating the output-node resolution path.
+        let pipeline = format!(
+            "pipeline:\n  name: ext_output_schema_test\n\
+             nodes:\n  - type: source\n    name: src\n    config:\n      \
+             name: src\n      type: csv\n      path: /tmp/in.csv\n      \
+             schema:\n        - {{ name: average, type: decimal, scale: 2 }}\n        \
+             - {{ name: name, type: string }}\n  - type: output\n    name: out\n    \
+             input: src\n    config:\n      name: out\n      type: csv\n      \
+             path: /tmp/out.csv\n      schema: '{}'\n",
+            schema_path.display()
+        );
+        let pipeline_path = dir.path().join("pipeline.yaml");
+        std::fs::write(&pipeline_path, pipeline).unwrap();
+
+        // Resolution: the output `File` reference is replaced by inline columns,
+        // so `as_columns()` (which the write boundary calls) now returns them.
+        let config = parse_config_with_vars(&pipeline_path, &[]).unwrap();
+        let cols = output_schema(&config)
+            .expect("output schema present")
+            .as_columns()
+            .expect("external output schema resolved to an inline column list");
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].name, "average");
+        assert_eq!(cols[0].ty, cxl::typecheck::Type::Decimal);
+        assert_eq!(cols[0].scale, Some(2));
+        let hash_v1 = config.source_hash;
+
+        // Hash fold: editing the referenced output schema changes the pipeline
+        // identity even though the pipeline YAML text is byte-identical.
+        std::fs::write(
+            &schema_path,
+            "- { name: average, type: decimal, scale: 4 }\n- { name: name, type: string }\n",
+        )
+        .unwrap();
+        let config2 = parse_config_with_vars(&pipeline_path, &[]).unwrap();
+        assert_ne!(
+            config2.source_hash, hash_v1,
+            "editing the external output schema file must change source_hash"
         );
     }
 

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -4313,6 +4313,19 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
             validate_hl7_split_fields(&input.name, opts)?;
         }
 
+        // A CSV `delimiter` / `quote_char` lowers to a single byte on the
+        // reader; reject any value that would truncate lossily so the failure
+        // is a plan diagnostic rather than a wrong byte silently applied at
+        // runtime.
+        if let InputFormat::Csv(Some(opts)) = &input.format {
+            if let Some(delimiter) = &opts.delimiter {
+                validate_csv_byte_option("source", &input.name, "delimiter", delimiter)?;
+            }
+            if let Some(quote_char) = &opts.quote_char {
+                validate_csv_byte_option("source", &input.name, "quote_char", quote_char)?;
+            }
+        }
+
         // A `json_pointer` extract must be a valid RFC 6901 pointer: either
         // empty (the whole document) or a `/`-introduced path. A slashless
         // value like `Head` decodes to zero segments — indistinguishable from
@@ -4351,6 +4364,14 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
     // rejections in lockstep; a fourth single-envelope format is one match
     // arm, not a fourth copied loop.
     for output in config.output_configs() {
+        // The CSV writer lowers `delimiter` to a single byte; reject a lossy
+        // value here for the same reason the source side does.
+        if let OutputFormat::Csv(Some(opts)) = &output.format
+            && let Some(delimiter) = &opts.delimiter
+        {
+            validate_csv_byte_option("output", &output.name, "delimiter", delimiter)?;
+        }
+
         // Each indivisible-envelope format maps to its diagnostic code, the
         // `format:` token a user wrote, and the structural-envelope phrase
         // naming why it can't be split; splittable formats yield `None`.
@@ -4905,6 +4926,33 @@ fn validate_hl7_split_fields(source_name: &str, opts: &Hl7InputOptions) -> Resul
     Ok(())
 }
 
+/// Reject a CSV `delimiter` / `quote_char` that is not exactly one ASCII byte.
+///
+/// The byte-oriented CSV reader and writer each take a single byte, so an
+/// empty, multi-character, or non-ASCII value would otherwise be silently
+/// truncated to its first byte at runtime (`"||"` acting as `|`, a `"→"`
+/// applying one byte of its UTF-8 encoding). Catching it here at plan time —
+/// before any reader or writer is constructed — turns that lossy surprise into
+/// a diagnostic naming the node, the option, and the offending value.
+/// `node_kind` is `"source"` or `"output"`; `field` is `"delimiter"` or
+/// `"quote_char"`.
+fn validate_csv_byte_option(
+    node_kind: &str,
+    node_name: &str,
+    field: &str,
+    value: &str,
+) -> Result<(), ConfigError> {
+    let mut chars = value.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) if c.is_ascii() => Ok(()),
+        _ => Err(ConfigError::Validation(format!(
+            "{node_kind} '{node_name}': `{field}: {value:?}` must be exactly one ASCII byte \
+             (for example `,`, `|`, or `\\t`); the CSV reader and writer take a single-byte \
+             {field}, so an empty, multi-character, or non-ASCII value cannot be applied"
+        ))),
+    }
+}
+
 /// Auto-extend every strict `PlanNode::Aggregation.group_by` with the
 /// `$ck.<field>` shadow column when the user-declared correlation-key
 /// field is already listed AND the parent's lattice carries that CK
@@ -5116,4 +5164,149 @@ fn extend_aggregate_group_by_with_shadow_in_body(
         parent_ck_set.insert(idx, ck);
     }
     extend_aggregate_group_by_with_shadow_for_graph(&mut body.graph, &parent_ck_set);
+}
+
+#[cfg(test)]
+mod csv_byte_option_validation_tests {
+    use crate::config::parse_config;
+
+    /// Minimal single-source, single-output CSV pipeline whose *source* carries
+    /// a caller-supplied `options:` body (each line indented eight spaces to sit
+    /// under the node's `options:` key).
+    fn source_options_pipeline(options_body: &str) -> String {
+        format!(
+            r#"
+pipeline:
+  name: csv_byte_option
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: a, type: string }}
+      options:
+{options_body}
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+        )
+    }
+
+    /// Same shape, but the caller-supplied `options:` body lives on the
+    /// *output* node so the output-side delimiter check is exercised.
+    fn output_options_pipeline(options_body: &str) -> String {
+        format!(
+            r#"
+pipeline:
+  name: csv_byte_option
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: a, type: string }}
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      options:
+{options_body}
+"#
+        )
+    }
+
+    #[test]
+    fn source_delimiter_empty_rejected() {
+        let err = parse_config(&source_options_pipeline("        delimiter: \"\""))
+            .expect_err("empty delimiter must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("delimiter") && msg.contains("one ASCII byte"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn source_delimiter_multichar_rejected() {
+        let err = parse_config(&source_options_pipeline("        delimiter: \"||\""))
+            .expect_err("multi-character delimiter must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("\"||\"") && msg.contains("one ASCII byte"),
+            "msg must name the offending value: {msg}"
+        );
+    }
+
+    #[test]
+    fn source_delimiter_non_ascii_rejected() {
+        let err = parse_config(&source_options_pipeline("        delimiter: \"→\""))
+            .expect_err("non-ASCII delimiter must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("delimiter") && msg.contains("one ASCII byte"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn source_delimiter_single_ascii_accepted() {
+        parse_config(&source_options_pipeline("        delimiter: \"|\""))
+            .expect("a single-byte pipe delimiter is valid");
+    }
+
+    #[test]
+    fn source_delimiter_tab_accepted() {
+        // A YAML double-quoted `"\t"` decodes to one tab byte (0x09) — a valid
+        // single-byte ASCII delimiter that must pass.
+        parse_config(&source_options_pipeline("        delimiter: \"\\t\""))
+            .expect("a tab delimiter is valid");
+    }
+
+    #[test]
+    fn source_quote_char_non_ascii_rejected() {
+        let err = parse_config(&source_options_pipeline("        quote_char: \"→\""))
+            .expect_err("non-ASCII quote_char must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("quote_char") && msg.contains("one ASCII byte"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn source_quote_char_single_ascii_accepted() {
+        parse_config(&source_options_pipeline("        quote_char: \"'\""))
+            .expect("a single-byte quote char is valid");
+    }
+
+    #[test]
+    fn output_delimiter_multichar_rejected() {
+        let err = parse_config(&output_options_pipeline("        delimiter: \"||\""))
+            .expect_err("multi-character output delimiter must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("output 'out'") && msg.contains("one ASCII byte"),
+            "msg must name the output and the requirement: {msg}"
+        );
+    }
+
+    #[test]
+    fn output_delimiter_single_ascii_accepted() {
+        parse_config(&output_options_pipeline("        delimiter: \"|\""))
+            .expect("a single-byte output delimiter is valid");
+    }
 }

--- a/docs/user/src/cxl/types.md
+++ b/docs/user/src/cxl/types.md
@@ -184,10 +184,14 @@ schema:
   - { name: tax_rate, type: decimal, scale: 4 }
 ```
 
-A `decimal` column parses its raw text into an exact value and rounds it to the
-column `scale` (round-half-to-even, the unbiased "banker's rounding" used in
-accounting). Writers emit the value at that scale, so `2.5` stored in a
-`scale: 2` column is written `2.50`.
+A `decimal` column parses its raw text into an exact value and rounds off any
+excess precision to the column `scale` (round-half-to-even, the unbiased
+"banker's rounding" used in accounting), so a `scale: 2` column stores `2.567`
+as `2.57`. This is one edge of a **boundary contract**: a declared `scale` pins
+a value to that many places at the boundary it is declared on — a source
+column's scale on read, an output column's scale on write (see [Aggregating
+decimals](#aggregating-decimals)) — while decimals keep full precision *inside*
+the pipeline.
 
 ### Arithmetic rules
 
@@ -201,10 +205,14 @@ accounting). Writers emit the value at that scale, so `2.5` stored in a
   - `rate.to_decimal() * amount` — bring the float into exact decimal math
     (the float→decimal step is the one acknowledged lossy conversion).
 - **Division and `avg`** compute at full precision — the exact quotient, not a
-  binary-float approximation. A computed decimal keeps its full precision and
-  is not automatically rounded to a fixed number of places; round it explicitly
-  when you need fixed cents. (A `decimal` *source* column, separately, rounds
-  its parsed values to the declared `scale` on read, using banker's rounding.)
+  binary-float approximation. Inside the pipeline a computed decimal keeps every
+  digit; it is pinned to a fixed number of places only at a boundary that
+  declares a `scale`. Declaring the *output* column `type: decimal` with a
+  `scale` rounds the value to that many places on write (banker's rounding),
+  exactly as a `decimal` *source* column rounds on read — so `avg(amount)`
+  emitted into a `scale: 2` output column writes `1.33`, not the full quotient.
+  With no declared output scale the full precision is preserved; use an explicit
+  round in CXL when you need fixed places mid-pipeline.
 
 Comparisons follow the same rule: `decimal < int` is fine, `decimal < float`
 requires a cast.
@@ -242,6 +250,16 @@ column and stay exact — no binary float ever touches a running total:
 - Group-by and `distinct` keys are scale-normalized: two decimals that are
   numerically equal group together regardless of scale, so `2.50` and `2.5`
   fall in one group. This holds even when the aggregation spills to disk.
+
+To pin an aggregate result to fixed places on the way out, declare the **output**
+column `type: decimal` with a `scale`: the value is rounded to that scale on
+write (banker's rounding), so `avg(amount)` over `1.00, 1.00, 2.00` writes `1.33`
+into a `scale: 2` output column while `sum(amount)` stays `4.00`. An output
+column with no declared scale keeps the full-precision quotient. This applies to
+every format — CSV, JSON, and fixed-width — because the rounding happens as the
+record is projected onto the output. For fixed-width output it is often
+required: a full-precision quotient overflows a narrow numeric field, which is a
+hard error, whereas the rounded value fits.
 
 `weighted_avg` also stays exact over decimals: a decimal value or weight (or
 both) gives an exact `sum(value * weight) / sum(weight)` at full division

--- a/docs/user/src/formats/csv.md
+++ b/docs/user/src/formats/csv.md
@@ -33,10 +33,15 @@ standard [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180) defaults.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `delimiter` | `,` | Field separator. Set to `\t` for TSV, `;` for semicolon-delimited exports. |
-| `quote_char` | `"` | Quote character that escapes delimiters and newlines inside a field. |
+| `delimiter` | `,` | Field separator, **exactly one ASCII byte**. Set to `\t` for TSV, `;` for semicolon-delimited exports. |
+| `quote_char` | `"` | Quote character that escapes delimiters and newlines inside a field, **exactly one ASCII byte**. |
 | `has_header` | `true` | When `true`, the first line names the columns and is consumed, not emitted. When `false`, fields bind to `schema:` positionally. |
 | `encoding` | `utf-8` | Character set each field — including the header row — is decoded through. Supported values are `utf-8` (the default) and `iso-8859-1` (aliases `latin-1`, `latin1`). See [Encoding](#encoding). |
+
+`delimiter` and `quote_char` are each a single byte on the wire, so each must
+be **exactly one ASCII character**. An empty, multi-character, or non-ASCII
+value (for example `"||"` or `"→"`) is rejected at plan validation — it is
+never silently truncated to its first byte.
 
 ## Encoding
 

--- a/docs/user/src/formats/fixed-width.md
+++ b/docs/user/src/formats/fixed-width.md
@@ -56,6 +56,17 @@ counts, `pad` must be a single-byte (ASCII) character; a multi-byte `pad`
 is rejected when the output opens. Under `truncation: error` an over-long
 value is still a hard error before any slicing.
 
+A `type: decimal` output column with a `scale` rounds its values to that
+many fractional places on write (banker's rounding), the same contract a
+`decimal` source column applies on read. This matters here: a computed
+decimal such as `avg(amount)` is a full-precision quotient that would
+overflow a narrow numeric field — a hard error under the default
+`truncation: error` for numeric fields — so declaring the field's `scale`
+shrinks it to fixed places that fit. For example, `avg` over `1.00, 1.00,
+2.00` written into `{ name: average, type: decimal, scale: 2, width: 6 }`
+emits `1.33`; without the `scale` the 28-digit quotient overflows the
+6-byte field and fails.
+
 ## Options
 
 | Option | Default | Description |

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -103,6 +103,30 @@ Set to `false` to omit the CSV header row.
 
 When `false`, null values are written as empty strings. When `true`, nulls are preserved in the output format's native null representation (e.g., `null` in JSON).
 
+### Rounding decimals to a declared scale
+
+An Output node's optional `schema:` may declare a column `type: decimal` with a
+`scale`. A `decimal` value landing in that column is rounded to the declared
+number of fractional places on write, using banker's rounding — the same
+boundary contract a `decimal` *source* column applies on read.
+
+```yaml
+    schema:
+      - { name: dept,    type: string }
+      - { name: total,   type: decimal, scale: 2 }
+      - { name: average, type: decimal, scale: 2 }
+```
+
+Decimals compute at full precision *inside* the pipeline (division and `avg`
+keep every digit), so a declared output scale is how you pin a computed result
+to fixed places at the sink: `avg(amount)` over `1.00, 1.00, 2.00` writes `1.33`
+into a `scale: 2` column, while `sum(amount)` — already at scale 2 — stays
+`4.00`. This works for every format (CSV, JSON, fixed-width); an output column
+with no declared scale, or an output with no `schema:` block at all, keeps the
+full-precision value. Only `decimal` values in `decimal`-declared columns are
+affected — no other type is coerced. See [Decimal — arithmetic
+rules](../cxl/types.md#arithmetic-rules) for the full boundary-contract model.
+
 ## Output format options
 
 ### CSV

--- a/docs/user/src/nodes/output.md
+++ b/docs/user/src/nodes/output.md
@@ -119,6 +119,11 @@ When `false`, null values are written as empty strings. When `true`, nulls are p
       delimiter: "|"
 ```
 
+`delimiter` is a single byte on the wire, so it must be **exactly one ASCII
+character** (for example `,`, `|`, or `\t`). An empty, multi-character, or
+non-ASCII value is rejected at plan validation rather than silently truncated
+to its first byte.
+
 ### JSON
 
 ```yaml


### PR DESCRIPTION
This batch groups two independent, scoped changes that share one CI and merge cycle. Each addresses a distinct write/validation boundary and carries its own tests and docs.

## feat(exec): round output decimals to a declared column scale on write

### Summary

A computed decimal (e.g. `avg(amount)` or `total / n`) emitted into an output column declared `type: decimal, scale: N` was written at full precision — a repeating quotient printed up to 28 digits, and for fixed-width output it overflowed the field and failed as a hard truncation error. Only source-column *ingest* rounded to a declared scale; the write side ignored it, so a declared output-column `scale` was an accepted-but-inert surface.

This makes a declared output-column `scale` a **write-boundary contract**, mirroring the read side: as the shared output projection builds each record, a `Value::Decimal` landing in a `decimal`-declared, scaled column is rounded to that scale with the house banker's rounding (round-half-to-even), reusing the same `round_decimal_to_scale` helper that ingest uses so the two edges are bit-identical.

### Behavior

- Boundary contract, stated once: decimals compute at **full precision inside the pipeline**; a declared `scale` rounds at the edge it is declared on — a source column's scale on read, an output column's scale on write.
- `avg(amount)` over `1.00, 1.00, 2.00` emitted into a `scale: 2` output column now writes `1.33` instead of the 28-digit quotient; `sum(amount)` is already at scale 2 (`4.00`) and is unchanged.
- The rounding runs in the one projection function every output arm shares, so it covers **CSV, JSON, and fixed-width** uniformly.
- Rounding fires only where the user declared a `scale`. An output with no `schema:` block, or a column without `scale`, keeps today's full-precision behavior. Only `Value::Decimal` values in `decimal`-declared columns are affected — no other type is coerced. A nullable declaration (`type: { nullable: decimal }`) is unwrapped before the check, matching how the writers classify a nullable numeric field.
- For fixed-width output this is often required: a full-precision quotient overflows a narrow numeric field, which is a hard error under the default `truncation: error`; the rounded value fits.

### Changes

- `crates/clinker-exec/src/projection.rs`: new `round_declared_output_decimals` pass applied at both exit points of `project_output_from_record` (the shared hook for the records-only, fan-out, envelope, document-DLQ, and streaming output arms).
- `crates/clinker-format/src/fixed_width/writer.rs`: corrected the stale decimal-rendering comment to reflect that rescaling happens at the projection boundary.
- `crates/clinker-exec/src/pipeline/window_context.rs`: extended the full-precision `avg` note to name the output boundary.
- Docs: `docs/user/src/cxl/types.md` (boundary-contract wording + Aggregating decimals), `docs/user/src/nodes/output.md` (new "Rounding decimals to a declared scale" section), `docs/user/src/formats/fixed-width.md` (write-side rounding note).

### Validation

- `cargo fmt --all --check` — clean.
- `cargo clippy -p clinker-exec -p clinker-format --all-targets -- -D warnings` — clean.
- `cargo test -p clinker-exec` and `cargo test -p clinker-format` — all pass, including 16 `projection::` unit tests (rounding, banker's midpoint `2.125→2.12`, no scale-up padding, schema-less/unscaled passthrough, non-decimal scope guard, post-mapping rename, nullable decimal) and 4 `aggregate_integration` end-to-end tests (schema-less full precision preserved; CSV/JSON/fixed-width scaled outputs write `1.33`, with the fixed-width geometry case that previously errored on truncation).
- `cargo check --workspace` — clean.

## fix(plan): reject CSV delimiter/quote that is not exactly one ASCII byte

### Summary

CSV `delimiter` and `quote_char` are declared as strings in pipeline config, but the byte-oriented CSV reader and writer each consume a single byte. Runtime lowering took `as_bytes().first()`, so:

- an empty string was silently ignored (fell back to the default),
- a multi-character value like `"||"` was truncated and behaved as `"|"`, and
- a non-ASCII value such as `"→"` applied one byte of its multi-byte UTF-8 encoding —

all with no diagnostic. The result was a valid-looking pipeline that quietly parsed data with the wrong separator.

### Change

- **Plan validation (authoritative fix).** `validate_config` now rejects a CSV `delimiter` / `quote_char` that is not exactly one ASCII character, for both source and output CSV nodes, before any reader or writer is constructed. The error names the node, the option, and the offending value (for example: `source 'orders': `delimiter: "||"` must be exactly one ASCII byte …`). Validation runs on the effective config after channel source-config patches are applied, so patched sources inherit the check.
- **Lowering hardening (defense in depth).** The reader and writer config builders now resolve each option to its single byte through a shared helper and return a startup config error on an empty, multi-character, or non-ASCII value instead of truncating it. The CSV writer-config builder and the writer factory changed from infallible to `Result`-returning, matching the reader side (which already failed startup on a bad `encoding`).

Valid single-byte delimiters and quotes — including a tab — behave exactly as before; a pipeline with no `options:` block is byte-identical (comma delimiter, double-quote quote char).

### Tests

- `clinker-plan`: plan-time acceptance/rejection cases driven through `parse_config` — rejects `""`, `"||"`, `"→"` for `delimiter` and `quote_char` (asserting the message names the value and the one-byte requirement); accepts `"|"` and a tab; covers both source and output nodes.
- `clinker-exec`: the reader- and writer-config builders resolve a single-byte delimiter/quote to the exact byte (`b'|'`, `b'\t'`, `b'\''`), keep the default comma, and error on a multi-character or non-ASCII value.

### Docs

`docs/user/src/formats/csv.md` and `docs/user/src/nodes/output.md` now state that `delimiter` and `quote_char` must each be exactly one ASCII character and that an empty, multi-character, or non-ASCII value is rejected at plan validation rather than silently truncated.

### Validation

- `cargo fmt --all --check`
- `cargo clippy -p clinker-plan -p clinker-exec --all-targets -- -D warnings`
- `cargo test -p clinker-plan` (636 tests) and `cargo test -p clinker-exec` (all suites green)
- `cargo check --workspace`
- `git diff --check`

Closes #788
Closes #716