### PR TITLE
batch: fatal composition-binding diagnostics, channel patches for composition-body sources

### DIFF
--- a/crates/clinker-exec/tests/composition_executor_test.rs
+++ b/crates/clinker-exec/tests/composition_executor_test.rs
@@ -138,6 +138,52 @@ nodes:
 }
 
 #[test]
+fn test_unresolvable_composition_use_fails_run_instead_of_empty_output() {
+    // A composition whose `use:` names a `.comp.yaml` that does not exist
+    // in the workspace. Compile must fail with the binding diagnostic so
+    // the run aborts loudly — the earlier behavior omitted the composition
+    // node and let the run "succeed" writing zero records to `out`, a
+    // silent empty output indistinguishable from an empty input.
+    let yaml = r#"
+pipeline:
+  name: composition_executor_unresolvable
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: a, type: int }
+  - type: composition
+    name: missing_call
+    input: src
+    use: ../compositions/does_not_exist.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out
+    input: missing_call
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse pipeline yaml");
+    let root = fixture_workspace_root();
+    let ctx = CompileContext::with_pipeline_dir(&root, PathBuf::from("pipelines"));
+
+    let diags = config
+        .compile(&ctx)
+        .expect_err("an unresolvable composition `use:` must fail compile, not run empty");
+    assert!(
+        diags.iter().any(|d| d.code == "E103"),
+        "compile must surface E103 for the unresolvable `use:` path; got: {diags:?}"
+    );
+}
+
+#[test]
 fn test_nested_composition_body_executes() {
     // A composition body whose first node is itself a composition.
     // The body executor must recurse into the inner body so the

--- a/crates/clinker-exec/tests/fixtures/pipelines/composition_pipeline.yaml
+++ b/crates/clinker-exec/tests/fixtures/pipelines/composition_pipeline.yaml
@@ -35,6 +35,7 @@ nodes:
       addresses: addresses_src
     config:
       fuzzy_threshold: 0.9
+      lookup_table: "customers_lookup.csv"
 
   - type: composition
     name: addr_norm

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
@@ -8,21 +8,13 @@ Mode: Streaming
 Indices to build: 0
 Transforms: 0
 Output projections: 1
-DAG nodes: 4
+DAG nodes: 5
 arbitration: BackPressurePreferred -> Priority
 
 Source DAG:
   Tier 0: customers_src, addresses_src
 
 === Physical Properties ===
-
-output.enriched_out:
-  ordering: <none>
-  ordering_provenance: NoOrdering
-  partitioning: Single
-  partitioning_provenance: SingleStream
-  buffer: streaming
-  arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
 source.addresses_src:
   ordering: <none>
@@ -48,11 +40,39 @@ source.customers_src:
   buffer: materialized
   arbitration: spill_priority=N/A, can_back_pressure=true, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
 
+composition.enrich1:
+  ordering: <none>
+  ordering_provenance: NoOrdering
+  partitioning: Single
+  partitioning_provenance: SingleStream
+  buffer: materialized
+  arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
+
+output.enriched_out:
+  ordering: <none>
+  ordering_provenance: NoOrdering
+  partitioning: Single
+  partitioning_provenance: SingleStream
+  buffer: streaming
+  arbitration: spill_priority=N/A, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B, predicted_subtree_reclaim=0B
+
 === Buffer Edges ===
 
 edge source.addresses_src -> composition.addr_norm:
   buffer: node_buffer (slot=1)
   arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
+
+edge source.addresses_src -> composition.enrich1:
+  buffer: node_buffer (slot=1)
+  arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
+
+edge source.customers_src -> composition.enrich1:
+  buffer: node_buffer (slot=0)
+  arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: source)
+
+edge composition.enrich1 -> output.enriched_out:
+  buffer: node_buffer (slot=2)
+  arbitration: spill_priority=0, can_back_pressure=false, predicted_peak=0B, predicted_freed=0B (producer: composition)
 
 === CXL Expressions ===
 
@@ -66,7 +86,8 @@ Worker threads: 4
 
 === DAG Topology ===
 
-  ● [output] enriched_out (line:48)
   ● [source] addresses_src (line:17)
-  │ [composition:body=<ID>] addr_norm (line:39)
+  │ [composition:body=<ID>] addr_norm (line:40)
   ● [source] customers_src (line:7)
+  │ [composition:body=<ID>] enrich1 (line:29)
+  │ [output] enriched_out (line:49)

--- a/crates/clinker-plan/src/config/compile_context.rs
+++ b/crates/clinker-plan/src/config/compile_context.rs
@@ -64,6 +64,14 @@ pub struct CompileContext {
     /// means "no overlay": the compile path is byte-identical to a plain
     /// pipeline.
     pub config_overrides: ConfigOverrides,
+    /// Channel `sources:` patches addressed at a source declared inside a
+    /// composition body, keyed `composition-node-name -> inner-source-name ->
+    /// patch`. `apply_source_patches` cannot apply these at patch time (the
+    /// body is expanded only during compile), so it stashes them on the config;
+    /// `compile` threads them here so `bind_composition` can apply each to the
+    /// freshly re-read body before it binds. Empty (the default) means "no
+    /// deferred body-source patches": the compile path is unchanged.
+    pub body_source_patches: crate::config::patch::BodySourcePatchMap,
 }
 
 impl CompileContext {
@@ -77,6 +85,7 @@ impl CompileContext {
             allow_absolute_paths: false,
             overlay_ops: Vec::new(),
             config_overrides: ConfigOverrides::new(),
+            body_source_patches: crate::config::patch::BodySourcePatchMap::new(),
         }
     }
 
@@ -91,6 +100,7 @@ impl CompileContext {
             allow_absolute_paths: false,
             overlay_ops: Vec::new(),
             config_overrides: ConfigOverrides::new(),
+            body_source_patches: crate::config::patch::BodySourcePatchMap::new(),
         }
     }
 
@@ -109,13 +119,16 @@ impl CompileContext {
         // Drop only the structural ops. `config_overrides` must survive: the
         // effective plan produced by splicing the ops is recompiled through
         // this context, and its composition bodies still fold `$config`
-        // against the resolved value clobbers.
+        // against the resolved value clobbers. `body_source_patches` is
+        // re-derived from the effective config by the recursive compile, so it
+        // need not carry here, but preserving it keeps the context faithful.
         Self {
             workspace_root: self.workspace_root.clone(),
             pipeline_dir: self.pipeline_dir.clone(),
             allow_absolute_paths: self.allow_absolute_paths,
             overlay_ops: Vec::new(),
             config_overrides: self.config_overrides.clone(),
+            body_source_patches: self.body_source_patches.clone(),
         }
     }
 }
@@ -130,6 +143,7 @@ impl Default for CompileContext {
             allow_absolute_paths: false,
             overlay_ops: Vec::new(),
             config_overrides: ConfigOverrides::new(),
+            body_source_patches: crate::config::patch::BodySourcePatchMap::new(),
         }
     }
 }

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -38,9 +38,9 @@ pub use fs_type::{FsKind, case_sensitive_dir, classify, collision_key, same_devi
 pub use node_header::{MergeHeader, NodeHeader, NodeInput, SourceHeader};
 pub use output::*;
 pub use patch::{
-    ArrayPathOp, ColumnPatch, DiscriminatorPatch, EnvelopeFieldOp, NestedSectionOp, RecordTypeAdd,
-    RecordTypeOp, RecordTypePatch, SchemaColumnOp, SourceConfigPatch, SplitFieldOp,
-    apply_source_patches,
+    ArrayPathOp, BodySourcePatchMap, ColumnPatch, DiscriminatorPatch, EnvelopeFieldOp,
+    NestedSectionOp, RecordTypeAdd, RecordTypeOp, RecordTypePatch, SchemaColumnOp,
+    SourceConfigPatch, SplitFieldOp, apply_source_patches,
 };
 pub use pipeline::*;
 pub use pipeline_node::{

--- a/crates/clinker-plan/src/config/patch.rs
+++ b/crates/clinker-plan/src/config/patch.rs
@@ -20,6 +20,7 @@
 use super::*;
 use crate::config::composition::SchemaProvRecorder;
 use crate::config::pipeline_node::{PipelineNode, SourceBody};
+use crate::yaml::Spanned;
 use clinker_format::{
     Column, Discriminator, EnvelopeFieldType, NestedEnvelopeSection, RecordType, SourceSchema,
 };
@@ -698,75 +699,187 @@ pub struct DiscriminatorPatch {
     pub field: Option<String>,
 }
 
+/// Deferred channel `sources:` patches addressed at a source declared inside a
+/// composition body, keyed `composition-node-name -> inner-source-name ->
+/// patch`. Mirrors [`ConfigOverrides`](crate::config::ConfigOverrides).
+///
+/// A qualified `<composition>.<source>` patch key cannot be applied at patch
+/// time: the composition body is expanded only during compile, so its source
+/// nodes are not in `config.nodes` yet. [`apply_source_patches`] validates the
+/// composition alias and stashes the patch here; `bind_composition` applies it
+/// to the freshly re-read body before the body binds.
+pub type BodySourcePatchMap = IndexMap<String, IndexMap<String, SourceConfigPatch>>;
+
 /// Apply channel source-config patches to the parsed config in place.
 ///
 /// Runs after parse and before `validate_config`, so the patched config is
-/// the one validated and compiled. Each entry names a source node; an unknown
-/// source name or an ill-formed op is a config error (E230–E245) reported
+/// the one validated and compiled. A plain key names a top-level source node; a
+/// qualified `<composition>.<source>` key names a source inside that
+/// composition's body and is deferred to compile (see [`BodySourcePatchMap`]).
+/// An unknown target or an ill-formed op is a config error (E230–E245) reported
 /// before the pipeline compiles.
 pub fn apply_source_patches(
     config: &mut PipelineConfig,
     patches: &IndexMap<String, SourceConfigPatch>,
 ) -> Result<(), ConfigError> {
-    // Whether the pipeline calls any composition. Sources declared inside a
-    // composition body are not present in `config.nodes` at patch time (the
-    // body is expanded only during compile), so a patch targeting one cannot be
-    // resolved here — the unknown-source error explains that rather than
-    // implying a typo. Computed once so the per-source lookup can stay a plain
-    // borrow.
+    // Whether the pipeline calls any composition. A plain patch key that names
+    // no top-level source gets a hint pointing at the qualified-key form when
+    // the pipeline has compositions, rather than implying a bare typo. Computed
+    // once so the per-source lookup can stay a plain borrow.
     let has_composition = config
         .nodes
         .iter()
         .any(|n| matches!(n.value, PipelineNode::Composition { .. }));
 
-    for (src_name, patch) in patches {
+    for (key, patch) in patches {
+        // A qualified `<composition>.<source>` key targets a source inside a
+        // composition body. That body is expanded only during compile, so the
+        // target cannot resolve against `config.nodes` here; validate the
+        // composition alias now and defer the patch to `bind_composition`,
+        // which applies it after re-reading the body.
+        if let Some((alias, inner)) = split_qualified_key(key)? {
+            if !is_composition_node(config, alias) {
+                return Err(unknown_composition_alias(key, alias));
+            }
+            config
+                .body_source_patches
+                .entry(alias.to_string())
+                .or_default()
+                .insert(inner.to_string(), patch.clone());
+            continue;
+        }
+
         if patch.is_empty() {
             // Still resolve the source so an empty patch on a typo'd name
             // fails rather than passing silently.
-            source_body_mut(config, src_name)
-                .ok_or_else(|| unknown_source(src_name, has_composition))?;
+            source_body_mut(config, key).ok_or_else(|| unknown_source(key, has_composition))?;
             continue;
         }
-        let body = source_body_mut(config, src_name)
-            .ok_or_else(|| unknown_source(src_name, has_composition))?;
-        apply_schema_ops(&mut body.schema, &patch.schema, src_name, None)?;
-        apply_array_path_ops(&mut body.source, &patch.array_paths, src_name)?;
-        apply_option_ops(&mut body.source, &patch.options, src_name)?;
-        // Format-structure ops apply after the options merge so a keyed op
-        // layers deterministically on top of an `options`-blob replacement of
-        // the same declaration in the same patch.
-        apply_nested_section_op(
-            &mut body.source,
-            patch.group_section.as_ref(),
-            X12SectionSlot::Group,
-            src_name,
-        )?;
-        apply_nested_section_op(
-            &mut body.source,
-            patch.set_section.as_ref(),
-            X12SectionSlot::Set,
-            src_name,
-        )?;
-        apply_split_field_ops(&mut body.source, &patch.split_fields, src_name)?;
-        apply_record_ops(
-            &mut body.schema,
-            &patch.records,
-            patch.discriminator.as_ref(),
-            src_name,
-        )?;
+        let body =
+            source_body_mut(config, key).ok_or_else(|| unknown_source(key, has_composition))?;
+        apply_patch_to_source_body(body, patch, key)?;
     }
     Ok(())
 }
 
-/// Locate a source node's body by its node identity (`header.name`).
+/// Apply every op carried by `patch` to one source's parsed body in place.
+///
+/// The shared core of the top-level channel `sources:` pass and the deferred
+/// composition-body pass: both resolve a source node — top-level or inside an
+/// expanded body — to its [`SourceBody`] and layer the identical op grammar
+/// over it, so a body source patches byte-for-byte the way a top-level one
+/// does. `src` names the source for the op diagnostics.
+///
+/// Format-structure ops apply after the `options` merge so a keyed op layers
+/// deterministically on top of an `options`-blob replacement of the same
+/// declaration in the same patch.
+pub(crate) fn apply_patch_to_source_body(
+    body: &mut SourceBody,
+    patch: &SourceConfigPatch,
+    src: &str,
+) -> Result<(), ConfigError> {
+    apply_schema_ops(&mut body.schema, &patch.schema, src, None)?;
+    apply_array_path_ops(&mut body.source, &patch.array_paths, src)?;
+    apply_option_ops(&mut body.source, &patch.options, src)?;
+    apply_nested_section_op(
+        &mut body.source,
+        patch.group_section.as_ref(),
+        X12SectionSlot::Group,
+        src,
+    )?;
+    apply_nested_section_op(
+        &mut body.source,
+        patch.set_section.as_ref(),
+        X12SectionSlot::Set,
+        src,
+    )?;
+    apply_split_field_ops(&mut body.source, &patch.split_fields, src)?;
+    apply_record_ops(
+        &mut body.schema,
+        &patch.records,
+        patch.discriminator.as_ref(),
+        src,
+    )?;
+    Ok(())
+}
+
+/// Split a channel `sources:` key into an optional `(composition, source)`
+/// pair. Node names cannot contain dots, so a single dot marks a
+/// composition-body target and no dot marks a plain top-level source.
+///
+/// - `Ok(None)` — no dot: a plain top-level source key.
+/// - `Ok(Some((composition, source)))` — exactly one dot.
+/// - `Err(_)` — an empty segment, or more than one dot (a source inside a
+///   nested composition body, which is not addressable).
+fn split_qualified_key(key: &str) -> Result<Option<(&str, &str)>, ConfigError> {
+    match key.split_once('.') {
+        None => Ok(None),
+        Some((alias, rest)) => {
+            if rest.contains('.') {
+                return Err(nested_body_source(key));
+            }
+            if alias.is_empty() || rest.is_empty() {
+                return Err(malformed_qualified_key(key));
+            }
+            Ok(Some((alias, rest)))
+        }
+    }
+}
+
+/// Whether a composition call-site node by this name exists in the pipeline.
+fn is_composition_node(config: &PipelineConfig, name: &str) -> bool {
+    config.nodes.iter().any(|spanned| {
+        matches!(&spanned.value, PipelineNode::Composition { header, .. } if header.name == name)
+    })
+}
+
+fn unknown_composition_alias(key: &str, alias: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E230] channel source patch key '{key}' targets a source in composition '{alias}', \
+         but no composition node by that name exists in the pipeline"
+    ))
+}
+
+fn nested_body_source(key: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E230] channel source patch key '{key}': a source inside a nested composition body is \
+         not addressable; use '<composition>.<source>' to patch a source one level inside a \
+         composition body"
+    ))
+}
+
+fn malformed_qualified_key(key: &str) -> ConfigError {
+    ConfigError::Validation(format!(
+        "[E230] channel source patch key '{key}' is malformed; use '<source>' for a top-level \
+         source or '<composition>.<source>' for a source inside a composition body"
+    ))
+}
+
+/// Split a `[CODE] message` diagnostic string into its bracketed E-code and the
+/// remaining message. Channel-patch [`ConfigError`]s embed their stable E-code
+/// as a `[E2xx]` prefix; the composition-body patch pass re-emits an op failure
+/// as a structured `Diagnostic` and lifts the code back out here, so a
+/// body-source op error carries the same code a top-level one would. Falls back
+/// to the generic source-patch code when no prefix is present.
+pub(crate) fn split_diagnostic_code(msg: &str) -> (&str, &str) {
+    match msg.strip_prefix('[').and_then(|rest| rest.split_once(']')) {
+        Some((code, tail)) => (code, tail.trim_start()),
+        None => ("E230", msg),
+    }
+}
+
+/// Locate a source node's body by its node identity (`header.name`) in a node
+/// list. Shared by the top-level patch pass and the composition-body pass.
 ///
 /// The channel system keys sources by node identity — the `name:` on the node
 /// header — which can differ from the nested `config.name:`. Every other
 /// channel block (`vars.source`, E111) resolves the same way, so the patch
 /// target resolves by `header.name` for consistency.
-fn source_body_mut<'a>(config: &'a mut PipelineConfig, name: &str) -> Option<&'a mut SourceBody> {
-    config
-        .nodes
+pub(crate) fn source_body_in_nodes<'a>(
+    nodes: &'a mut [Spanned<PipelineNode>],
+    name: &str,
+) -> Option<&'a mut SourceBody> {
+    nodes
         .iter_mut()
         .find_map(|spanned| match &mut spanned.value {
             PipelineNode::Source {
@@ -777,11 +890,14 @@ fn source_body_mut<'a>(config: &'a mut PipelineConfig, name: &str) -> Option<&'a
         })
 }
 
+fn source_body_mut<'a>(config: &'a mut PipelineConfig, name: &str) -> Option<&'a mut SourceBody> {
+    source_body_in_nodes(&mut config.nodes, name)
+}
+
 fn unknown_source(src_name: &str, has_composition: bool) -> ConfigError {
     let hint = if has_composition {
-        " (a source declared inside a composition body is not yet patchable by a \
-         channel `sources:` block — patch the composition's own source, or lift it \
-         to the top-level pipeline)"
+        " (to patch a source declared inside a composition body, qualify the key as \
+         `<composition-node>.<source>`)"
     } else {
         ""
     };
@@ -1919,6 +2035,106 @@ nodes:
             msg.contains("composition"),
             "expected a composition-body hint: {msg}"
         );
+    }
+
+    /// A pipeline that invokes a composition named `comp`, for the qualified
+    /// `<composition>.<source>` body-source patch-key tests.
+    fn composition_call_pipeline() -> PipelineConfig {
+        let yaml = "\
+pipeline:
+  name: qualified_patch_test
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: /tmp/in.csv
+      schema:
+        - { name: id, type: string }
+  - type: composition
+    name: comp
+    input: src
+    use: ./thing.comp.yaml
+    inputs:
+      driver: src
+  - type: output
+    name: out
+    input: comp
+    config:
+      name: out
+      type: csv
+      path: /tmp/out.csv
+";
+        crate::yaml::from_str(yaml).expect("parse composition pipeline")
+    }
+
+    #[test]
+    fn qualified_key_defers_body_source_patch() {
+        // `comp.ref` names the composition `comp` (present) and its body source
+        // `ref`; the patch is stashed for compile, not applied to any top-level
+        // source.
+        let mut config = composition_call_pipeline();
+        apply(
+            &mut config,
+            "comp.ref",
+            patch_from_yaml("schema:\n  id: remove\n"),
+        )
+        .expect("a qualified patch on a real composition defers cleanly");
+        let deferred = config
+            .body_source_patches
+            .get("comp")
+            .expect("deferred under the composition node name");
+        assert!(
+            deferred.contains_key("ref"),
+            "deferred patch keyed by the inner source name"
+        );
+    }
+
+    #[test]
+    fn qualified_key_unknown_composition_errors_e230() {
+        let mut config = composition_call_pipeline();
+        let err = apply(
+            &mut config,
+            "ghost.ref",
+            patch_from_yaml("schema:\n  id: remove\n"),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("E230"), "{msg}");
+        assert!(
+            msg.contains("ghost"),
+            "must name the missing composition: {msg}"
+        );
+    }
+
+    #[test]
+    fn nested_multidot_key_rejected_e230() {
+        let mut config = composition_call_pipeline();
+        let err = apply(
+            &mut config,
+            "comp.inner.ref",
+            patch_from_yaml("schema:\n  id: remove\n"),
+        )
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("E230"), "{msg}");
+        assert!(
+            msg.contains("nested"),
+            "must explain a nested body source is not addressable: {msg}"
+        );
+    }
+
+    #[test]
+    fn empty_segment_qualified_key_rejected_e230() {
+        let mut config = composition_call_pipeline();
+        let err = apply(
+            &mut config,
+            "comp.",
+            patch_from_yaml("schema:\n  id: remove\n"),
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("E230"), "{err}");
     }
 
     /// A JSON source declaring a `record_path` option and one array-path entry.

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -36,6 +36,14 @@ pub struct PipelineConfig {
     /// sidecars without needing to re-read the source.
     #[serde(skip)]
     pub source_hash: [u8; 32],
+    /// Channel `sources:` patches whose qualified key (`<composition>.<source>`)
+    /// addressed a source declared inside a composition body. Those bodies are
+    /// not expanded into `nodes` at patch time, so `apply_source_patches`
+    /// stashes them here for `bind_composition` to apply after re-reading each
+    /// body. Empty for a plain pipeline or a channel that only patches
+    /// top-level sources.
+    #[serde(skip)]
+    pub body_source_patches: crate::config::patch::BodySourcePatchMap,
 }
 
 /// Pipeline-level metadata and global settings.
@@ -708,10 +716,25 @@ impl PipelineConfig {
         // populating CompileArtifacts.composition_bodies.
         let scoped_vars_registry =
             build_scoped_vars_registry(self.pipeline.vars.as_ref(), &self.nodes);
+        // Channel `sources:` patches addressed at a source inside a composition
+        // body were deferred by `apply_source_patches` (the body is expanded
+        // only here). Thread them to `bind_composition` through the compile
+        // context so each body binds in its patched form. A plain pipeline —
+        // or a channel that only patches top-level sources — leaves the map
+        // empty and reuses the incoming context untouched.
+        let patched_ctx;
+        let bind_ctx = if self.body_source_patches.is_empty() {
+            ctx
+        } else {
+            let mut c = ctx.clone();
+            c.body_source_patches = self.body_source_patches.clone();
+            patched_ctx = c;
+            &patched_ctx
+        };
         let mut artifacts = crate::plan::bind_schema::bind_schema(
             &self.nodes,
             &mut diags,
-            ctx,
+            bind_ctx,
             &symbol_table,
             &ctx.pipeline_dir,
             scoped_vars_registry,

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -592,8 +592,10 @@ impl PipelineConfig {
     ///
     /// On error, returns the accumulated diagnostics from the topology
     /// pre-pass plus any per-variant lowering errors. Composition binding
-    /// errors (E102–E109) are non-fatal — the composition node is silently
-    /// omitted from the DAG.
+    /// errors (E102–E109) are fatal: an unresolvable `use:` or an
+    /// ill-bound call site fails compile rather than dropping the
+    /// composition node and letting the run write zero records with no
+    /// diagnostic.
     pub fn compile(
         &self,
         ctx: &CompileContext,
@@ -726,10 +728,13 @@ impl PipelineConfig {
             &mut diags,
         );
 
-        // Only abort on non-composition CXL errors (E200/E201) and
-        // source-CK validation errors (E153). Composition binding
-        // errors (E102–E109) are non-fatal for the rest of the pipeline
-        // — the composition node is omitted from the DAG.
+        // Early-abort optimization: CXL type errors (E200/E201), source-CK
+        // validation errors (E153), and DLQ/output-path errors
+        // (E317/E318) make per-variant lowering meaningless, so stop here
+        // rather than lowering a plan that cannot run. Every other
+        // error-severity diagnostic — composition-binding errors
+        // (E102–E109) included — is caught by the post-lowering gate,
+        // which lets lowering accumulate the full diagnostic set first.
         let has_cxl_errors = diags.iter().any(|d| {
             matches!(d.severity, clinker_core_types::Severity::Error)
                 && matches!(d.code.as_str(), "E200" | "E201" | "E153" | "E317" | "E318")
@@ -1829,10 +1834,9 @@ impl PipelineConfig {
         // executor inherits the parent's WindowRuntime via
         // `Arc::clone` at recursion entry. The pass only short-
         // circuits on errors it itself emits (E003 / E150d at body
-        // root); existing E102-E109 from bind_composition stay
-        // non-fatal here, mirroring the post-bind-schema gate above
-        // that lets composition-binding errors land as soft
-        // diagnostics while CXL errors hard-stop.
+        // root). Any E102-E109 from bind_composition are already in
+        // `diags` and are caught by the post-lowering gate below; this
+        // pass only needs to surface the window-rooting errors it adds.
         let pre_pass_diag_count = diags.len();
         crate::plan::execution::resolve_composition_body_windows(&dag, &mut artifacts, &mut diags);
         if diags[pre_pass_diag_count..]
@@ -2209,13 +2213,16 @@ impl PipelineConfig {
             &dag, &artifacts,
         ));
 
-        // If lowering accumulated any non-composition error-severity
-        // diagnostics, return them. Composition binding errors
-        // (E102–E109) are non-fatal — the composition node is silently
-        // omitted from the DAG. Warnings do not block.
-        let has_fatal_errors = diags.iter().any(|d| {
-            matches!(d.severity, clinker_core_types::Severity::Error) && !d.code.starts_with("E10")
-        });
+        // Any error-severity diagnostic accumulated through binding and
+        // lowering is fatal, composition-binding errors (E102–E109)
+        // included. An unresolvable `use:` or an ill-bound call site drops
+        // the composition node from the lowered DAG above; letting compile
+        // still succeed there produced a run that wrote zero records with
+        // no diagnostic — indistinguishable from empty input. Warnings do
+        // not block.
+        let has_fatal_errors = diags
+            .iter()
+            .any(|d| matches!(d.severity, clinker_core_types::Severity::Error));
         if has_fatal_errors {
             return Err(diags);
         }
@@ -3786,8 +3793,10 @@ pub(crate) fn lower_node_to_plan_node(
         }),
         PipelineNode::Composition { .. } => {
             // Look up the body assigned by bind_composition. If binding
-            // failed (E102–E109), there's no entry — silently omit the
-            // node (the binding errors already surfaced in Stage 4.5).
+            // failed (E102–E109), there's no entry — omit the node from
+            // this partial DAG. The binding errors are already in `diags`
+            // and the post-lowering gate turns them into a compile
+            // failure, so the omission is never observed by a run.
             let body_id = artifacts
                 .composition_body_assignments
                 .get(&id)

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -2785,7 +2785,19 @@ fn bind_composition(
     // binds, exactly as a top-level source patch shapes a top-level source
     // before it binds. An unknown inner source or a failed op abandons the
     // body with a spanned diagnostic naming the call site and body file.
-    if let Some(inner_patches) = bind_ctx.ctx.body_source_patches.get(node_name) {
+    //
+    // Gate on `depth == 0`: a qualified key names a TOP-LEVEL composition node
+    // (`apply_source_patches` validates the alias against `config.nodes` only,
+    // and a two-dot key naming a source inside a *nested* body is rejected).
+    // The patch map is keyed by bare node name, so without this gate a patch
+    // keyed for a top-level composition would also match a same-named
+    // composition node nested inside another body and mutate the wrong body.
+    // `depth` is 0 here only for top-level call sites — it is incremented at
+    // step 8 before recursing into a body — so this restricts application to
+    // the top-level composition the qualified key actually addresses.
+    if bind_ctx.depth == 0
+        && let Some(inner_patches) = bind_ctx.ctx.body_source_patches.get(node_name)
+    {
         for (inner_source, patch) in inner_patches {
             let Some(source_body) =
                 crate::config::patch::source_body_in_nodes(&mut body_file.nodes, inner_source)

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -2771,11 +2771,60 @@ fn bind_composition(
     };
 
     // 7. Re-read body from disk.
-    let body_file =
+    let mut body_file =
         match read_and_parse_body(&signature.source_path, artifacts, node_name, span, diags) {
             Some(f) => f,
             None => return,
         };
+
+    // 7a. Apply any channel `sources:` patch addressed at a source declared
+    // inside this composition body (qualified key `<this-node>.<inner-source>`).
+    // These could not be applied at patch time because the body is expanded
+    // only here; apply them to the freshly re-read body so its source nodes
+    // carry the channel's schema / options / array changes before the body
+    // binds, exactly as a top-level source patch shapes a top-level source
+    // before it binds. An unknown inner source or a failed op abandons the
+    // body with a spanned diagnostic naming the call site and body file.
+    if let Some(inner_patches) = bind_ctx.ctx.body_source_patches.get(node_name) {
+        for (inner_source, patch) in inner_patches {
+            let Some(source_body) =
+                crate::config::patch::source_body_in_nodes(&mut body_file.nodes, inner_source)
+            else {
+                // Match the channel-patch family: the E-code is embedded in the
+                // message so it survives the messages-only compile-error render,
+                // as the top-level `[E230]` unknown-source error does.
+                diags.push(Diagnostic::error(
+                    "E230",
+                    format!(
+                        "[E230] composition node {node_name:?}: body file {}: channel source \
+                         patch targets unknown source {inner_source:?}: no source node by that \
+                         name in the composition body",
+                        resolved_path.display()
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                ));
+                return;
+            };
+            if let Err(err) =
+                crate::config::patch::apply_patch_to_source_body(source_body, patch, inner_source)
+            {
+                let raw = match err {
+                    crate::config::ConfigError::Validation(m) => m,
+                    other => other.to_string(),
+                };
+                let (code, detail) = crate::config::patch::split_diagnostic_code(&raw);
+                diags.push(Diagnostic::error(
+                    code,
+                    format!(
+                        "[{code}] composition node {node_name:?}: body file {}: {detail}",
+                        resolved_path.display()
+                    ),
+                    LabeledSpan::primary(span, String::new()),
+                ));
+                return;
+            }
+        }
+    }
 
     // 7b. Body nodes never flow through top-level config validation
     // (`validate_config` sees only the call-site pipeline's own nodes),

--- a/crates/clinker-plan/src/plan/tests/composition_binding_fatal.rs
+++ b/crates/clinker-plan/src/plan/tests/composition_binding_fatal.rs
@@ -1,0 +1,113 @@
+//! Composition-binding errors (E102–E109) are fatal at compile.
+//!
+//! A composition whose `use:` cannot be resolved — or whose call site is
+//! otherwise ill-bound — drops the composition node from the lowered DAG.
+//! Compile used to still succeed there, so a run wrote zero records to the
+//! downstream output with no diagnostic: a silent-empty-output failure the
+//! caller could not tell apart from an empty input. `compile` now returns
+//! the binding diagnostic instead, so the pipeline fails loudly. A body
+//! that binds cleanly is unaffected and still compiles.
+
+use std::path::PathBuf;
+
+use crate::config::{CompileContext, PipelineConfig, parse_config};
+
+/// Build a workspace with one composition body and a pipeline whose
+/// single composition node invokes `use_path`. The output reads from the
+/// composition, so an omitted composition node is what produces the
+/// silent-empty-output symptom this gate closes.
+fn workspace_with_use(use_path: &str) -> (tempfile::TempDir, PipelineConfig) {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    std::fs::write(
+        comp_dir.join("passthrough.comp.yaml"),
+        r#"_compose:
+  name: passthrough
+  inputs:
+    inp:
+      schema:
+        - { name: id, type: string }
+  outputs:
+    out: shape
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: shape
+    input: inp
+    config:
+      cxl: |
+        emit id = id
+"#,
+    )
+    .expect("write comp");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    let yaml = format!(
+        r#"
+pipeline:
+  name: composition_binding_fatal_demo
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: src.csv
+      schema:
+        - {{ name: id, type: string }}
+  - type: composition
+    name: body
+    input: src
+    use: {use_path}
+    inputs:
+      inp: src
+  - type: output
+    name: out_body
+    input: body
+    config:
+      name: out_body
+      type: csv
+      path: out_body.csv
+"#
+    );
+
+    let config: PipelineConfig = parse_config(&yaml).expect("parse top-level pipeline");
+    (workspace, config)
+}
+
+/// An unresolvable `use:` path fails compile with a spanned E103 instead
+/// of silently omitting the composition and letting the run write nothing.
+#[test]
+fn unresolvable_use_path_fails_compile_with_e103() {
+    let (workspace, config) = workspace_with_use("../compositions/nonexistent.comp.yaml");
+
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    let err = config
+        .compile(&ctx)
+        .expect_err("an unresolvable composition `use:` must fail to compile");
+
+    let diag = err.iter().find(|d| d.code == "E103").unwrap_or_else(|| {
+        panic!("expected an E103 diagnostic for the unresolvable `use:` path; got: {err:?}")
+    });
+    assert!(
+        diag.message.contains("body"),
+        "the E103 message must name the offending composition node: {:?}",
+        diag.message
+    );
+}
+
+/// A composition whose `use:` resolves to a body that binds cleanly still
+/// compiles — the fatal gate rejects only error-severity diagnostics.
+#[test]
+fn resolvable_use_path_still_compiles() {
+    let (workspace, config) = workspace_with_use("../compositions/passthrough.comp.yaml");
+
+    let ctx = CompileContext::with_pipeline_dir(workspace.path(), PathBuf::from("pipelines"));
+    config
+        .compile(&ctx)
+        .expect("a composition whose body binds cleanly must compile");
+}

--- a/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
+++ b/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
@@ -166,6 +166,176 @@ fn unknown_inner_source_fails_at_bind_with_e230() {
     );
 }
 
+/// Build a workspace whose pipeline has a top-level composition `enrich` (body
+/// source `ref`, patch target) alongside a top-level composition `wrap` whose
+/// body contains a *nested* composition node that also happens to be named
+/// `enrich` but resolves to a different body with no source `ref`. Exercises the
+/// name-collision path: a patch keyed `enrich.ref` must reach only the top-level
+/// `enrich` body, never the same-named nested node inside `wrap`'s body.
+fn workspace_with_shadowed_nested_enrich() -> (tempfile::TempDir, PipelineConfig) {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+
+    // Top-level `enrich` target: body source `ref` (schema `raw`) feeds a
+    // transform that reads `code`, so the body binds only once a patch renames
+    // `raw` -> `code`.
+    std::fs::write(
+        comp_dir.join("with_ref.comp.yaml"),
+        r#"_compose:
+  name: with_ref
+  inputs:
+    driver:
+      schema:
+        - { name: x, type: int }
+  outputs:
+    out: shape
+  config_schema: {}
+
+nodes:
+  - type: source
+    name: ref
+    config:
+      name: ref
+      type: csv
+      path: ref.csv
+      schema:
+        - { name: raw, type: string }
+  - type: transform
+    name: shape
+    input: ref
+    config:
+      cxl: |
+        emit label = code
+"#,
+    )
+    .expect("write with_ref");
+
+    // `wrap`'s body holds a nested composition node named `enrich` that resolves
+    // to `passthru.comp.yaml` — a body with NO source `ref`. If the deferred
+    // `enrich.ref` patch leaked into this nested node it would fail to find `ref`
+    // and abort the compile with E230.
+    std::fs::write(
+        comp_dir.join("wrap.comp.yaml"),
+        r#"_compose:
+  name: wrap
+  inputs:
+    driver:
+      schema:
+        - { name: x, type: int }
+  outputs:
+    out: wrap_tag
+  config_schema: {}
+
+nodes:
+  - type: composition
+    name: enrich
+    input: driver
+    use: ./passthru.comp.yaml
+    inputs:
+      driver: driver
+  - type: transform
+    name: wrap_tag
+    input: enrich
+    config:
+      cxl: |
+        emit y2 = y
+"#,
+    )
+    .expect("write wrap");
+
+    std::fs::write(
+        comp_dir.join("passthru.comp.yaml"),
+        r#"_compose:
+  name: passthru
+  inputs:
+    driver:
+      schema:
+        - { name: x, type: int }
+  outputs:
+    out: proj
+  config_schema: {}
+
+nodes:
+  - type: transform
+    name: proj
+    input: driver
+    config:
+      cxl: |
+        emit y = x
+"#,
+    )
+    .expect("write passthru");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    let yaml = r#"
+pipeline:
+  name: shadowed_nested_enrich_demo
+nodes:
+  - type: source
+    name: drv
+    config:
+      name: drv
+      type: csv
+      path: drv.csv
+      schema:
+        - { name: x, type: int }
+  - type: composition
+    name: enrich
+    input: drv
+    use: ../compositions/with_ref.comp.yaml
+    inputs:
+      driver: drv
+  - type: composition
+    name: wrap
+    input: drv
+    use: ../compositions/wrap.comp.yaml
+    inputs:
+      driver: drv
+  - type: output
+    name: out_enrich
+    input: enrich
+    config:
+      name: out_enrich
+      type: csv
+      path: out_enrich.csv
+  - type: output
+    name: out_wrap
+    input: wrap
+    config:
+      name: out_wrap
+      type: csv
+      path: out_wrap.csv
+"#;
+    let config: PipelineConfig = crate::config::parse_config(yaml).expect("parse pipeline");
+    (workspace, config)
+}
+
+/// A patch keyed `enrich.ref` must reach only the top-level composition `enrich`,
+/// not a same-named composition node nested inside another body. Without the
+/// top-level gate, `bind_composition` matches the patch on the nested `enrich`
+/// (bound at depth >= 1) and applies it to a body that declares no source `ref`,
+/// aborting the compile with a spurious E230. With the gate, only the top-level
+/// `enrich` body is patched and the whole pipeline compiles.
+#[test]
+fn body_source_patch_does_not_leak_into_shadowed_nested_composition() {
+    let (ws, mut config) = workspace_with_shadowed_nested_enrich();
+    apply_source_patches(
+        &mut config,
+        &qualified("enrich.ref", "schema:\n  raw: { rename: code }\n"),
+    )
+    .expect("apply defers the qualified patch");
+    let ctx = CompileContext::with_pipeline_dir(ws.path(), PathBuf::from("pipelines"));
+    config.compile(&ctx).unwrap_or_else(|d| {
+        panic!(
+            "the `enrich.ref` patch must target only the top-level `enrich` body \
+             and leave the same-named nested composition untouched: {d:?}"
+        )
+    });
+}
+
 /// A schema op that is ill-formed against the body source (removing a column
 /// that does not exist) fails compile with the same stable op code (E231) a
 /// top-level source patch would produce, re-anchored to the composition.

--- a/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
+++ b/crates/clinker-plan/src/plan/tests/composition_source_patch.rs
@@ -1,0 +1,188 @@
+//! Channel `sources:` patches addressed at a source declared inside a
+//! composition body via a qualified `<composition>.<source>` key.
+//!
+//! A body-declared source is not in `config.nodes` at patch time (the body is
+//! expanded only during compile), so `apply_source_patches` validates the
+//! composition alias and defers the patch; `bind_composition` applies it to the
+//! freshly re-read body before the body binds. These tests drive the full
+//! parse -> apply_source_patches -> compile flow and observe the patch at the
+//! level a body source is observable: its schema seeds the body's binding, so a
+//! patch that fixes the body source's schema makes an otherwise-failing body
+//! bind. (A body source binds but does not run today; a data run through a body
+//! source awaits body-source runtime support.)
+
+use std::path::PathBuf;
+
+use indexmap::IndexMap;
+
+use crate::config::{CompileContext, PipelineConfig, SourceConfigPatch, apply_source_patches};
+
+/// Build a workspace with a composition body that declares its own source
+/// `ref` and a transform reading it (`emit label = code`), plus the invoking
+/// pipeline whose composition node is named `enrich`. `ref_schema` is the body
+/// source's declared schema block so a test can start it wrong and let a patch
+/// fix it. Returns the temp workspace and the parsed pipeline config.
+fn workspace_with_body_source(ref_schema: &str) -> (tempfile::TempDir, PipelineConfig) {
+    let workspace = tempfile::tempdir().expect("tempdir");
+    let comp_dir = workspace.path().join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("mkdir compositions");
+    std::fs::write(
+        comp_dir.join("with_ref.comp.yaml"),
+        format!(
+            r#"_compose:
+  name: with_ref
+  inputs:
+    driver:
+      schema:
+        - {{ name: x, type: int }}
+  outputs:
+    out: shape
+  config_schema: {{}}
+
+nodes:
+  - type: source
+    name: ref
+    config:
+      name: ref
+      type: csv
+      path: ref.csv
+      schema:
+{ref_schema}
+  - type: transform
+    name: shape
+    input: ref
+    config:
+      cxl: |
+        emit label = code
+"#
+        ),
+    )
+    .expect("write comp");
+
+    let pipelines_dir = workspace.path().join("pipelines");
+    std::fs::create_dir_all(&pipelines_dir).expect("mkdir pipelines");
+
+    let yaml = r#"
+pipeline:
+  name: composition_source_patch_demo
+nodes:
+  - type: source
+    name: drv
+    config:
+      name: drv
+      type: csv
+      path: drv.csv
+      schema:
+        - { name: x, type: int }
+  - type: composition
+    name: enrich
+    input: drv
+    use: ../compositions/with_ref.comp.yaml
+    inputs:
+      driver: drv
+  - type: output
+    name: out
+    input: enrich
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config: PipelineConfig = crate::config::parse_config(yaml).expect("parse pipeline");
+    (workspace, config)
+}
+
+fn patch_from_yaml(yaml: &str) -> SourceConfigPatch {
+    crate::yaml::from_str(yaml).expect("parse patch")
+}
+
+fn qualified(key: &str, patch_yaml: &str) -> IndexMap<String, SourceConfigPatch> {
+    let mut patches = IndexMap::new();
+    patches.insert(key.to_string(), patch_from_yaml(patch_yaml));
+    patches
+}
+
+/// A channel `sources:` patch qualified `enrich.ref` reaches the source `ref`
+/// declared inside composition `enrich`'s body and applies before the body
+/// binds: the body fails to bind without it (the transform reads `code`, which
+/// the base source schema lacks) and binds with it (the patch renames the
+/// column to `code`).
+#[test]
+fn body_source_patch_reaches_and_fixes_binding() {
+    // Base: source `ref` declares `raw`; the body transform `emit label = code`
+    // references a column the body source does not carry, so the body fails.
+    let (base_ws, base_config) =
+        workspace_with_body_source("        - { name: raw, type: string }");
+    let base_ctx = CompileContext::with_pipeline_dir(base_ws.path(), PathBuf::from("pipelines"));
+    assert!(
+        base_config.compile(&base_ctx).is_err(),
+        "the body must fail to bind before the patch renames the source column"
+    );
+
+    // Patched: rename the body source column `raw` -> `code`, so the transform
+    // resolves and the body binds.
+    let (ws, mut config) = workspace_with_body_source("        - { name: raw, type: string }");
+    apply_source_patches(
+        &mut config,
+        &qualified("enrich.ref", "schema:\n  raw: { rename: code }\n"),
+    )
+    .expect("apply defers the qualified patch");
+    assert!(
+        config
+            .body_source_patches
+            .get("enrich")
+            .is_some_and(|m| m.contains_key("ref")),
+        "the qualified patch is deferred under the composition node name"
+    );
+    let ctx = CompileContext::with_pipeline_dir(ws.path(), PathBuf::from("pipelines"));
+    config
+        .compile(&ctx)
+        .unwrap_or_else(|d| panic!("the patched body source must let the body bind: {d:?}"));
+}
+
+/// A qualified key whose composition exists but whose inner source name does
+/// not fails compile with a spanned E230 that names the missing source, the
+/// composition, and the body file — instead of silently ignoring the patch.
+#[test]
+fn unknown_inner_source_fails_at_bind_with_e230() {
+    let (ws, mut config) = workspace_with_body_source("        - { name: code, type: string }");
+    apply_source_patches(
+        &mut config,
+        &qualified("enrich.nonexistent", "schema:\n  code: remove\n"),
+    )
+    .expect("apply defers (enrich is a composition; inner name is checked at bind)");
+    let ctx = CompileContext::with_pipeline_dir(ws.path(), PathBuf::from("pipelines"));
+    let diags = config
+        .compile(&ctx)
+        .expect_err("an unknown inner source must fail compile");
+    let e230 = diags
+        .iter()
+        .find(|d| d.code == "E230")
+        .unwrap_or_else(|| panic!("expected E230 for the unknown body source; got: {diags:?}"));
+    assert!(
+        e230.message.contains("nonexistent") && e230.message.contains("with_ref.comp.yaml"),
+        "E230 must name the missing source and the body file: {}",
+        e230.message
+    );
+}
+
+/// A schema op that is ill-formed against the body source (removing a column
+/// that does not exist) fails compile with the same stable op code (E231) a
+/// top-level source patch would produce, re-anchored to the composition.
+#[test]
+fn body_source_patch_op_error_carries_stable_code() {
+    let (ws, mut config) = workspace_with_body_source("        - { name: code, type: string }");
+    apply_source_patches(
+        &mut config,
+        &qualified("enrich.ref", "schema:\n  missing: remove\n"),
+    )
+    .expect("apply defers");
+    let ctx = CompileContext::with_pipeline_dir(ws.path(), PathBuf::from("pipelines"));
+    let diags = config
+        .compile(&ctx)
+        .expect_err("removing an unknown body-source column must fail compile");
+    assert!(
+        diags.iter().any(|d| d.code == "E231"),
+        "expected the E231 unknown-column code, got: {diags:?}"
+    );
+}

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -4,6 +4,7 @@ mod ck_aligned_partition;
 mod ck_lattice;
 mod combine_body_typed_on_node;
 mod combine_where_scoped_key;
+mod composition_binding_fatal;
 mod config_fold;
 mod cull_reshape_compiled_on_node;
 mod cull_validation;

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -5,6 +5,7 @@ mod ck_lattice;
 mod combine_body_typed_on_node;
 mod combine_where_scoped_key;
 mod composition_binding_fatal;
+mod composition_source_patch;
 mod config_fold;
 mod cull_reshape_compiled_on_node;
 mod cull_validation;

--- a/crates/clinker/tests/channel_source_patch.rs
+++ b/crates/clinker/tests/channel_source_patch.rs
@@ -476,3 +476,140 @@ nodes:
     let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(stderr.contains("E230"), "stderr:\n{stderr}");
 }
+
+// ── Composition-body source patches ─────────────────────────────────────────
+//
+// A channel `sources:` key qualified `<composition>.<source>` patches a source
+// declared inside that composition's body. The body is expanded only during
+// compile, so the patch is deferred and applied when the body is re-read. A
+// body-declared source binds (its schema seeds the body) but does not run
+// today, so these drive the compile-only `--explain` path — which flows through
+// the same channel resolution and body-source patch application a run would.
+
+/// The invoking pipeline: a composition `enrich` whose body reads its own
+/// declared source `ref`.
+const COMP_PIPELINE: &str = "\
+pipeline:
+  name: body_source_patch
+nodes:
+  - type: source
+    name: drv
+    config:
+      name: drv
+      type: csv
+      path: drv.csv
+      schema:
+        - { name: x, type: int }
+  - type: composition
+    name: enrich
+    input: drv
+    use: ./compositions/with_ref.comp.yaml
+    inputs:
+      driver: drv
+  - type: output
+    name: out
+    input: enrich
+    config:
+      name: out
+      type: csv
+      path: out.csv
+";
+
+/// Write a `with_ref.comp.yaml` under `dir/compositions/` whose body source
+/// `ref` declares `ref_schema`. The body transform emits `label = code`, so the
+/// body binds only when the source carries a `code` column.
+fn write_comp(dir: &Path, ref_schema: &str) {
+    let comp_dir = dir.join("compositions");
+    std::fs::create_dir_all(&comp_dir).expect("create compositions dir");
+    let yaml = format!(
+        "\
+_compose:
+  name: with_ref
+  inputs:
+    driver:
+      schema:
+        - {{ name: x, type: int }}
+  outputs:
+    out: shape
+  config_schema: {{}}
+
+nodes:
+  - type: source
+    name: ref
+    config:
+      name: ref
+      type: csv
+      path: ref.csv
+      schema:
+{ref_schema}
+  - type: transform
+    name: shape
+    input: ref
+    config:
+      cxl: |
+        emit label = code
+"
+    );
+    std::fs::write(comp_dir.join("with_ref.comp.yaml"), yaml).expect("write comp");
+}
+
+/// A channel `sources:` patch qualified `enrich.ref` reaches the source inside
+/// composition `enrich`'s body: the body fails to compile without it (the
+/// source lacks `code`) and compiles with it (the patch renames `raw` -> `code`).
+#[test]
+fn channel_patches_composition_body_source() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "pipe.yaml", COMP_PIPELINE);
+    write_comp(p, "        - { name: raw, type: string }");
+    write_channel(
+        p,
+        "fix",
+        "sources:\n  enrich.ref:\n    schema:\n      raw: { rename: code }\n",
+    );
+
+    // Base compile fails: the body source has no `code` column for `shape`.
+    let base = run_in(p, &["--explain"]);
+    assert!(
+        !base.status.success(),
+        "base --explain should fail before the body source is patched"
+    );
+
+    // The qualified channel patch renames the body source column, so the body
+    // binds and the effective plan compiles.
+    let patched = run_in(p, &["--channel", "fix", "--explain"]);
+    assert!(
+        patched.status.success(),
+        "patched --explain failed:\n{}",
+        String::from_utf8_lossy(&patched.stderr)
+    );
+}
+
+/// A channel patch whose composition exists but whose inner source name does
+/// not fails compile with E230, naming the missing source — not silently
+/// ignored.
+#[test]
+fn channel_patch_unknown_body_source_fails_with_e230() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(p, "pipe.yaml", COMP_PIPELINE);
+    // A valid body source, so the only error is the unknown patch target.
+    write_comp(p, "        - { name: code, type: string }");
+    write_channel(
+        p,
+        "bad",
+        "sources:\n  enrich.ghost:\n    schema:\n      code: remove\n",
+    );
+
+    let out = run_in(p, &["--channel", "bad", "--explain"]);
+    assert!(
+        !out.status.success(),
+        "a patch on an unknown body source should fail compile"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("E230"), "stderr:\n{stderr}");
+    assert!(
+        stderr.contains("ghost"),
+        "E230 must name the missing source:\n{stderr}"
+    );
+}

--- a/docs/explain/E103.md
+++ b/docs/explain/E103.md
@@ -1,12 +1,29 @@
-# Error E103: Call site or channel binds undeclared input/config/resource
+# Error E103: Composition `use:` unresolved, or call site binds undeclared input/config/resource
 
 ## What it means
 
-A composition call site (in a pipeline) or a channel binding references
-an input, config param, or resource that does not exist in the target
-composition's signature.
+Either:
+
+- a composition call site's `use:` path does not resolve to any
+  `.comp.yaml` in the workspace (a typo, a wrong relative prefix, or a
+  missing file); or
+- a composition call site (in a pipeline) or a channel binding references
+  an input, config param, or resource that does not exist in the target
+  composition's signature.
+
+Both are fatal: compilation fails and the run aborts. An unresolved `use:`
+does **not** silently drop the composition and leave the downstream output
+writing zero records — the pipeline fails loudly with this diagnostic so
+the empty output cannot be mistaken for an empty input.
 
 ## Example
+
+```yaml
+- type: composition
+  name: enrich
+  input: src
+  use: ./customer_enrich.comp.yaml  # no such .comp.yaml in the workspace
+```
 
 ```yaml
 - type: composition
@@ -19,8 +36,14 @@ composition's signature.
 
 ## How to fix
 
-Check the target composition's `_compose.config_schema:` (or `inputs:` /
-`resources_schema:`) and use only declared parameter names.
+For an unresolved `use:`, check that the path points at an existing
+`.comp.yaml` under the workspace root — the value is resolved relative to
+the pipeline file's directory (see the compositions guide for the full
+resolution order).
+
+For an undeclared binding, check the target composition's
+`_compose.config_schema:` (or `inputs:` / `resources_schema:`) and use
+only declared parameter names.
 
 ## Technical context
 

--- a/docs/user/src/pipelines/channels.md
+++ b/docs/user/src/pipelines/channels.md
@@ -595,11 +595,38 @@ unknown record-type id is E242, adding an id that already exists is E243, a
 merged discriminator that is neither pure byte-range nor pure field is E244, and
 a discriminator tag shared by two record types after the patch is E245.
 
-`sources:` patches target **top-level** source nodes; a source declared inside a
-composition body is not reachable this way (patching it fails with E230). When a
-patch changes the effective source config, the run's pipeline identity differs
-from the base and from other patched variants, so their outputs and lineage do
-not collide.
+### Sources inside a composition body
+
+A plain `sources:` key names a **top-level** source node. To patch a source
+declared inside a composition body, qualify the key with the composition
+call-site node name: `<composition-node>.<source>`. The composition body is
+expanded during compile, so the patch is applied to the body's source when the
+body is bound — before the body typechecks — exactly as a top-level patch shapes
+a top-level source before it binds:
+
+```yaml
+sources:
+  enrich.lookups:                          # source `lookups` inside composition node `enrich`
+    schema:
+      code: { rename: lookup_code }
+```
+
+Resolution is one level deep: the qualifier must name a composition node in the
+pipeline (an unknown composition — or a nested `a.b.c` key naming a source inside
+a *nested* composition body — is E230), and the source half must name a source
+node declared in that composition's body (an unknown one is E230, naming the body
+file). A plain unqualified key still targets a top-level source, and a name that
+matches no top-level source still fails with E230 — now hinting at the qualified
+form when the pipeline has compositions.
+
+> **Note:** a body-declared source binds (its schema seeds the body) but is not
+> yet fed at runtime — the engine ingests only top-level sources — so a channel
+> patch to a body source is applied and observable at compile (`--explain`),
+> while a data run through a body source awaits body-source runtime support.
+
+When a patch changes the effective source config, the run's pipeline identity
+differs from the base and from other patched variants, so their outputs and
+lineage do not collide.
 
 ## Diagnostics
 
@@ -607,7 +634,7 @@ not collide.
 |------|---------|
 | **E113** | A `config:` / override key matches no composition parameter in the compiled plan. A misspelled or stale key aborts the run instead of silently doing nothing. |
 | **E114** | An overlay op failed to apply (missing splice anchor, duplicate node name, missing/removed `target`, invalid `set` field, invalid `bypass` node). The diagnostic is anchored to the offending op's source span, not the base pipeline. |
-| **E230** | A source patch (`sources.<src>` or `patch_schema`) targets a source-node name not present in the pipeline. |
+| **E230** | A source patch (`sources.<src>` or `patch_schema`) targets a source that does not exist: an unknown top-level source, an unknown composition for a qualified `<composition>.<source>` key, a `<composition>.<source>` naming no source in that composition's body, or a nested (`a.b.c`) key. |
 | **E231** | A schema `rename` / `modify` / `remove` of a column that does not exist. |
 | **E232** | A schema `add` of a column name that already exists. |
 | **E233** | A schema `rename` whose target name collides with an existing column. |

--- a/docs/user/src/pipelines/compositions.md
+++ b/docs/user/src/pipelines/compositions.md
@@ -17,6 +17,20 @@ A composition node in your pipeline references an external `.comp.yaml` file:
 
 The `use:` field points to the composition definition file. The `config:` block passes parameters that customize the composition's behavior for this specific invocation.
 
+### Resolving the `use:` path
+
+A `use:` value names a `.comp.yaml` in the workspace. It is resolved
+relative to the directory of the pipeline file being compiled, then
+against the set of `.comp.yaml` files discovered under the workspace root,
+finally falling back to a filename match. A `use:` that resolves to no
+`.comp.yaml` — a typo, a wrong relative prefix, or a file that does not
+exist — fails compilation with a spanned `E103` diagnostic naming the
+composition node. The whole run aborts loudly; it does not silently drop
+the composition and write an empty output. The same holds for the other
+composition-binding errors (`E102`–`E109`): an ill-bound call site fails
+compile rather than producing a run that writes zero records. Run
+`clinker explain --code E103` for details.
+
 ## Composition definition file
 
 A `.comp.yaml` file declares the composition's interface -- what fields it requires from upstream and what fields it produces:


### PR DESCRIPTION
Independent, scoped changes sharing one CI and merge cycle. Each section below is a self-contained change against a separate issue; they touch disjoint parts of the plan/compile path.

## fix(plan): fail compile on composition-binding errors instead of silently dropping the node

An unresolvable `use:` or an ill-bound composition call site pushed an E102-E109 diagnostic, but compile treated the whole E10x code range as non-fatal: it dropped the composition node from the lowered DAG and the run "succeeded", writing zero records to the downstream output with no diagnostic — a silent empty output indistinguishable from empty input. The post-lowering compile gate carved E10x out (`!code.starts_with("E10")`); the fix removes that carve-out so any error-severity diagnostic — composition-binding errors included — fails compile. The run now aborts loudly with the spanned diagnostic (E103 for an unresolved `use:`).

Shape chosen: unconditional fatal (no strict-vs-tolerant mode flag). Explain and lineage compile through the same path and already fail on every other compile error; tolerating only E10x was the exact silent-empty-output bug, so failing uniformly is both simpler and more correct. The early-abort gate (E200/E201/E153/E317/E318) is unchanged, so lowering still accumulates the full diagnostic set before the post-lowering gate fires.

A test fixture (`composition_pipeline.yaml`) was under-bound (missing the required `lookup_table` config on `enrich1`) and only compiled via the swallowed E104; its explain baseline captured a DAG whose output had no producer. The fixture now supplies the required param and the regenerated baseline shows the fully connected DAG.

Tests: a compile-gate test in clinker-plan (unresolvable `use:` -> E103; resolvable body still compiles) and an end-to-end test in clinker-exec (an unresolvable `use:` fails the run instead of writing empty output). Docs: the E103 explain page and the compositions guide document the `use:` resolution order and the loud-failure behavior.

## feat(plan): channel source patches reach sources declared inside composition bodies

A channel `sources:` block could only patch top-level source nodes; a source declared inside a composition body was rejected with `[E230]` and a "not yet patchable" hint, because the body is expanded only during compile and is absent from the config at patch time. This adds qualified-key addressing `<composition-node>.<source>`, mirroring the `config:` block's `alias.param` grammar. `apply_source_patches` splits a qualified key, validates the qualifier names a composition node (unknown composition, nested `a.b.c`, or empty segment -> E230), and defers the patch on the config; `compile` threads deferred patches into the compile context, and `bind_composition` applies each to the freshly re-read body source before the body binds — reusing the same op grammar a top-level patch uses. An unknown inner source or an ill-formed op fails compile with a spanned diagnostic naming the composition and body file, carrying the same stable code a top-level patch would. Unqualified keys keep today's behavior; the E230 hint now points at the qualified form.

Scope note: a body-declared source binds (its schema seeds the body) but is not yet fed at runtime — the engine ingests only top-level sources, so a non-port-seeded body source hits a defense-in-depth internal error at run time. This is a pre-existing limitation independent of this change. The patch therefore reaches and applies to a body source observably at compile (`--explain`); a data run through a body source awaits body-source runtime support (follow-up). Tests validate at that level: plan-level (a qualified patch gates the body's binding; unknown inner source and ill-formed op fail with the right codes) and CLI end-to-end through channel resolution via `--explain`. The channels guide documents the addressing form and the compile-level scope.

Closes #637
Closes #747
