### PR TITLE
batch: AvgState decimal guards, combine consumer funnel, XML attribute validation, fixed-width reader guard, EDIFACT trailer strictness, timing-flake hardening

### DIFF
--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -812,263 +812,269 @@ pub(crate) fn dispatch_combine(
     let inline_consumer_id = ctx.memory_budget.register_consumer(Arc::new(
         crate::pipeline::combine::CombineHashConsumer::new(inline_consumer_handle.clone()),
     ));
-
-    // Hash-build phase — drain the build buffer into the
-    // pipeline-scoped MemoryArbitrator-governed
-    // CombineHashTable. The stage timer covers the full
-    // build walk; on a budget abort the timer is dropped
-    // without recording (matches the `StageTimer` "no
-    // report on error" contract documented at its
-    // definition). Arc-clone the pipeline-scoped handle
-    // so subsequent `&mut ctx` borrows for cursor advance
-    // are not blocked by an immutable borrow of `ctx`.
-    let budget = ctx.memory_budget.clone();
-    // Per-source cursor advance for both build and driver.
-    // Source→Combine direct paths bypass the Transform /
-    // Aggregate advance points so the cursor never moved off
-    // zero for those records; this is the operator-entry
-    // advance that catches the gap. The inline arm's driver
-    // loop below does not advance per-row inline, so this is
-    // the single advance point for driver and build alike.
-    for (rec, rn) in &driver_buf {
-        advance_cursor(ctx, &source_name_arc_of(rec), *rn);
-    }
-    for (rec, rn) in &build_buf {
-        advance_cursor(ctx, &source_name_arc_of(rec), *rn);
-    }
-    let build_records: Vec<Record> = build_buf.into_iter().map(|(r, _)| r).collect();
-    let build_records_in = build_records.len() as u64;
-    let estimated_rows = Some(build_records.len());
-    let hash_table_ctx = ctx.merged_eval_ctx();
-    let build_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::CombineBuild {
-        name: name.clone(),
-    });
-    let hash_table = CombineHashTable::build(
-        build_records,
-        &build_extractor,
-        &hash_table_ctx,
-        &budget,
-        estimated_rows,
-    )
-    .map_err(|e| PipelineError::MemoryBudgetExceeded {
-        node: name.clone(),
-        used: budget.peak_rss().unwrap_or(0),
-        limit: budget.hard_limit(),
-        source: BudgetCategory::Arena,
-        detail: Some(format!("combine build: {e}")),
-    })?;
-    let build_records_out = hash_table.len() as u64;
-    // Mirror the freshly-built table's footprint into the
-    // consumer handle so the arbitrator's pull-mode
-    // `current_usage` reads the inline-combine's in-memory
-    // bytes for the duration of the probe loop. The probe
-    // loop is read-only on the table so no further updates
-    // are needed; arm exit below unregisters the consumer.
-    inline_consumer_handle.set_bytes(hash_table.memory_bytes() as u64);
-    ctx.collector
-        .record(build_timer.finish(build_records_in, build_records_out));
-
-    // Body typed program (only used when the body is not empty —
-    // `match: collect` and body-less synthetic N-ary steps leave it
-    // `None`). Read off the node; shared with the streaming-probe thread
-    // via the kernel.
-    let body_program = body_typed_on_node.clone();
-
-    // The probe matching kernel — owns the materialized hash table and
-    // every per-combine artifact the probe reads, and holds no
-    // `&mut ExecutorContext`. The materialized loop below and the
-    // streaming-probe thread both drive it, so the two paths return a
-    // byte-identical result set.
-    let kernel = CombineProbeKernel {
-        name,
-        hash_table: &hash_table,
-        resolver_mapping: &resolver_mapping,
-        probe_extractor: &probe_extractor,
-        decomposed,
-        body_program,
-        combine_output_schema: combine_output_schema.clone(),
-        build_qualifier: &build_qualifier,
-        match_mode: *match_mode,
-        on_miss: *on_miss,
-        propagate_ck,
-        fail_fast: ctx.strategy == ErrorStrategy::FailFast,
-    };
-
-    // Per-driver probe loop. Stage timer covers the full per-driver
-    // iteration; on early-return via the 10K-cadence E310 abort or a
-    // residual/body eval error, the timer is dropped without recording.
-    let mut probe_records_in = driver_buf.len() as u64;
-    let probe_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::CombineProbe {
-        name: name.clone(),
-    });
-    let output_records: Vec<(Record, u64)> = if let Some(driver_producer) = streaming_probe_driver {
-        // Streaming-probe path: the build side is materialized into the
-        // hash table above; now spawn the probe consumer on its own thread,
-        // redispatch the driver producer to stream into the bounded channel,
-        // and collect the probe output. The kernel + `&budget` move into the
-        // thread; counter/cursor/DLQ effects replay onto `ctx` after the
-        // join inside the helper.
-        let streamed = run_streaming_combine_probe(
-            ctx,
-            current_dag,
-            node_idx,
-            driver_producer,
-            name,
-            &kernel,
+    // Every exit past this registration must unregister the
+    // consumer, so the hash-build-through-admit body runs inside a
+    // closure whose Result is captured: the clean return, the
+    // streaming-handoff early return, and every `?` early-return
+    // funnel through the single `unregister_consumer` call below, so
+    // a finished inline hash-combine never lingers in the arbitrator's
+    // registry.
+    let result = (|| -> Result<(), PipelineError> {
+        // Hash-build phase — drain the build buffer into the
+        // pipeline-scoped MemoryArbitrator-governed
+        // CombineHashTable. The stage timer covers the full
+        // build walk; on a budget abort the timer is dropped
+        // without recording (matches the `StageTimer` "no
+        // report on error" contract documented at its
+        // definition). Arc-clone the pipeline-scoped handle
+        // so subsequent `&mut ctx` borrows for cursor advance
+        // are not blocked by an immutable borrow of `ctx`.
+        let budget = ctx.memory_budget.clone();
+        // Per-source cursor advance for both build and driver.
+        // Source→Combine direct paths bypass the Transform /
+        // Aggregate advance points so the cursor never moved off
+        // zero for those records; this is the operator-entry
+        // advance that catches the gap. The inline arm's driver
+        // loop below does not advance per-row inline, so this is
+        // the single advance point for driver and build alike.
+        for (rec, rn) in &driver_buf {
+            advance_cursor(ctx, &source_name_arc_of(rec), *rn);
+        }
+        for (rec, rn) in &build_buf {
+            advance_cursor(ctx, &source_name_arc_of(rec), *rn);
+        }
+        let build_records: Vec<Record> = build_buf.into_iter().map(|(r, _)| r).collect();
+        let build_records_in = build_records.len() as u64;
+        let estimated_rows = Some(build_records.len());
+        let hash_table_ctx = ctx.merged_eval_ctx();
+        let build_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::CombineBuild {
+            name: name.clone(),
+        });
+        let hash_table = CombineHashTable::build(
+            build_records,
+            &build_extractor,
+            &hash_table_ctx,
             &budget,
-        )?;
-        // The driver streamed its records over the channel, so the input
-        // count comes from the probe thread rather than a pre-drained Vec.
-        probe_records_in = streamed.input_count;
-        // The driver's punctuations arrived over the channel during the
-        // probe and were collected by the probe thread. Reconcile them now
-        // with the retained build-side punctuations — same fold as the
-        // materialized path, so a document spanning both inputs collapses
-        // to one open + one close and a side-local document forwards its
-        // close.
-        combined_puncts = crate::executor::stream_event::reconcile_document_boundaries(
-            streamed
-                .driver_puncts
-                .into_iter()
-                .chain(std::mem::take(&mut build_puncts_retained)),
-        );
-        streamed.output_records
-    } else {
-        let mut output_records = Vec::with_capacity(driver_buf.len());
-        let mut emitted_since_check: usize = 0;
-        let mut probe_counters = ProbeCounters::default();
-        // Reused across every probe iteration to avoid an allocation per
-        // driver row. `KeyExtractor::extract_into` pushes onto the end; the
-        // kernel clears it before each call.
-        let mut probe_keys_buf: Vec<Value> = Vec::with_capacity(probe_extractor.len());
+            estimated_rows,
+        )
+        .map_err(|e| PipelineError::MemoryBudgetExceeded {
+            node: name.clone(),
+            used: budget.peak_rss().unwrap_or(0),
+            limit: budget.hard_limit(),
+            source: BudgetCategory::Arena,
+            detail: Some(format!("combine build: {e}")),
+        })?;
+        let build_records_out = hash_table.len() as u64;
+        // Mirror the freshly-built table's footprint into the
+        // consumer handle so the arbitrator's pull-mode
+        // `current_usage` reads the inline-combine's in-memory
+        // bytes for the duration of the probe loop. The probe
+        // loop is read-only on the table so no further updates
+        // are needed; arm exit below unregisters the consumer.
+        inline_consumer_handle.set_bytes(hash_table.memory_bytes() as u64);
+        ctx.collector
+            .record(build_timer.finish(build_records_in, build_records_out));
 
-        for (probe_record, rn) in driver_buf {
-            let source_file_arc = source_file_arc_of(&probe_record);
-            let source_name_arc = source_name_arc_of(&probe_record);
-            let before = output_records.len();
-            let eval_ctx = ctx.eval_ctx_for_record(
-                &source_file_arc,
-                &source_name_arc,
-                rn,
-                probe_record.doc_ctx(),
-            );
-            let step = kernel.probe_row(
-                &eval_ctx,
-                &probe_record,
-                rn,
-                &mut probe_keys_buf,
-                &mut probe_counters,
-                &mut output_records,
-            )?;
-            if let ProbeRowStep::Deferred(f) = step {
-                let f = *f;
-                dispatch_combine_output_error(
+        // Body typed program (only used when the body is not empty —
+        // `match: collect` and body-less synthetic N-ary steps leave it
+        // `None`). Read off the node; shared with the streaming-probe thread
+        // via the kernel.
+        let body_program = body_typed_on_node.clone();
+
+        // The probe matching kernel — owns the materialized hash table and
+        // every per-combine artifact the probe reads, and holds no
+        // `&mut ExecutorContext`. The materialized loop below and the
+        // streaming-probe thread both drive it, so the two paths return a
+        // byte-identical result set.
+        let kernel = CombineProbeKernel {
+            name,
+            hash_table: &hash_table,
+            resolver_mapping: &resolver_mapping,
+            probe_extractor: &probe_extractor,
+            decomposed,
+            body_program,
+            combine_output_schema: combine_output_schema.clone(),
+            build_qualifier: &build_qualifier,
+            match_mode: *match_mode,
+            on_miss: *on_miss,
+            propagate_ck,
+            fail_fast: ctx.strategy == ErrorStrategy::FailFast,
+        };
+
+        // Per-driver probe loop. Stage timer covers the full per-driver
+        // iteration; on early-return via the 10K-cadence E310 abort or a
+        // residual/body eval error, the timer is dropped without recording.
+        let mut probe_records_in = driver_buf.len() as u64;
+        let probe_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::CombineProbe {
+            name: name.clone(),
+        });
+        let output_records: Vec<(Record, u64)> =
+            if let Some(driver_producer) = streaming_probe_driver {
+                // Streaming-probe path: the build side is materialized into the
+                // hash table above; now spawn the probe consumer on its own thread,
+                // redispatch the driver producer to stream into the bounded channel,
+                // and collect the probe output. The kernel + `&budget` move into the
+                // thread; counter/cursor/DLQ effects replay onto `ctx` after the
+                // join inside the helper.
+                let streamed = run_streaming_combine_probe(
                     ctx,
+                    current_dag,
                     node_idx,
-                    &f.probe_record,
-                    f.rn,
-                    f.matched_build.as_ref(),
+                    driver_producer,
                     name,
-                    f.error,
+                    &kernel,
+                    &budget,
                 )?;
-                // A deferred failure routes the whole driver row to the DLQ;
-                // no output rows survive for it.
-                output_records.truncate(before);
-                continue;
-            }
-            emitted_since_check += output_records.len() - before;
+                // The driver streamed its records over the channel, so the input
+                // count comes from the probe thread rather than a pre-drained Vec.
+                probe_records_in = streamed.input_count;
+                // The driver's punctuations arrived over the channel during the
+                // probe and were collected by the probe thread. Reconcile them now
+                // with the retained build-side punctuations — same fold as the
+                // materialized path, so a document spanning both inputs collapses
+                // to one open + one close and a side-local document forwards its
+                // close.
+                combined_puncts = crate::executor::stream_event::reconcile_document_boundaries(
+                    streamed
+                        .driver_puncts
+                        .into_iter()
+                        .chain(std::mem::take(&mut build_puncts_retained)),
+                );
+                streamed.output_records
+            } else {
+                let mut output_records = Vec::with_capacity(driver_buf.len());
+                let mut emitted_since_check: usize = 0;
+                let mut probe_counters = ProbeCounters::default();
+                // Reused across every probe iteration to avoid an allocation per
+                // driver row. `KeyExtractor::extract_into` pushes onto the end; the
+                // kernel clears it before each call.
+                let mut probe_keys_buf: Vec<Value> = Vec::with_capacity(probe_extractor.len());
 
-            // Budget check every 10K emitted records to bound memory under
-            // fan-out. The build phase polls `should_abort` every 10K
-            // inserts inside `CombineHashTable::build`; this covers the
-            // symmetric probe-side risk where a small build × large driver
-            // fan-out can blow RSS even though the table itself is bounded.
-            if emitted_since_check >= 10_000 && budget.should_abort() {
-                return Err(PipelineError::MemoryBudgetExceeded {
-                    node: name.clone(),
-                    used: budget.peak_rss().unwrap_or(0),
-                    limit: budget.hard_limit(),
-                    source: BudgetCategory::Arena,
-                    detail: Some("combine probe RSS abort".to_string()),
-                });
-            }
-            if emitted_since_check >= 10_000 {
-                emitted_since_check = 0;
-            }
+                for (probe_record, rn) in driver_buf {
+                    let source_file_arc = source_file_arc_of(&probe_record);
+                    let source_name_arc = source_name_arc_of(&probe_record);
+                    let before = output_records.len();
+                    let eval_ctx = ctx.eval_ctx_for_record(
+                        &source_file_arc,
+                        &source_name_arc,
+                        rn,
+                        probe_record.doc_ctx(),
+                    );
+                    let step = kernel.probe_row(
+                        &eval_ctx,
+                        &probe_record,
+                        rn,
+                        &mut probe_keys_buf,
+                        &mut probe_counters,
+                        &mut output_records,
+                    )?;
+                    if let ProbeRowStep::Deferred(f) = step {
+                        let f = *f;
+                        dispatch_combine_output_error(
+                            ctx,
+                            node_idx,
+                            &f.probe_record,
+                            f.rn,
+                            f.matched_build.as_ref(),
+                            name,
+                            f.error,
+                        )?;
+                        // A deferred failure routes the whole driver row to the DLQ;
+                        // no output rows survive for it.
+                        output_records.truncate(before);
+                        continue;
+                    }
+                    emitted_since_check += output_records.len() - before;
+
+                    // Budget check every 10K emitted records to bound memory under
+                    // fan-out. The build phase polls `should_abort` every 10K
+                    // inserts inside `CombineHashTable::build`; this covers the
+                    // symmetric probe-side risk where a small build × large driver
+                    // fan-out can blow RSS even though the table itself is bounded.
+                    if emitted_since_check >= 10_000 && budget.should_abort() {
+                        return Err(PipelineError::MemoryBudgetExceeded {
+                            node: name.clone(),
+                            used: budget.peak_rss().unwrap_or(0),
+                            limit: budget.hard_limit(),
+                            source: BudgetCategory::Arena,
+                            detail: Some("combine probe RSS abort".to_string()),
+                        });
+                    }
+                    if emitted_since_check >= 10_000 {
+                        emitted_since_check = 0;
+                    }
+                }
+
+                // Fold the probe kernel's `distinct` / `filtered` skip counts into
+                // the run counters — applied after the loop, the same place the
+                // per-row `ctx.counters.*` increments used to live.
+                ctx.counters.filtered_count += probe_counters.filtered;
+                ctx.counters.distinct_count += probe_counters.distinct;
+                output_records
+            };
+
+        let probe_records_out = output_records.len() as u64;
+        ctx.collector
+            .record(probe_timer.finish(probe_records_in, probe_records_out));
+
+        // Streaming-Output handoff: an inline hash build-probe combine
+        // whose sole downstream is a streaming-eligible Output
+        // installed its sender under our `node_idx`. The build side is
+        // already fully materialized in the hash table and the whole
+        // probe emit is already collected into `output_records`, so
+        // this does not shrink the combine's own working set; what it
+        // saves is the second copy — hand `output_records` straight to
+        // the writer thread over the bounded channel rather than
+        // admitting a charged `node_buffers` slot the Output would
+        // re-drain, and overlap the writer with the next topo node.
+        // The eligibility predicate certified this combine roots no
+        // window and tees to no deferred region, so the helper calls
+        // below are correctly skipped. The reconciled document boundaries
+        // are forwarded on the inline path just like the materialized arms,
+        // so a per-document Aggregate reached through this streamed handoff
+        // flushes per document; a terminal writer downstream consumes them
+        // harmlessly. The per-fold snapshot is dropped here; the
+        // hash-table consumer is released by the shared unregister
+        // funnel every exit from this arm passes through.
+        if let Some(sender) = ctx.take_streaming_sender(node_idx) {
+            let batch_size = ctx.batch_size;
+            let spill_allowed = node_buffer_spill_allowed(current_dag, node_idx);
+            let charge = ctx
+                .streaming_charge_handle(node_idx, name, spill_allowed)
+                .expect("streaming sender implies a registered charge consumer");
+            stream_linear_producer_emit(
+                &sender,
+                batch_size,
+                name,
+                output_records,
+                combined_puncts,
+                &charge,
+            )?;
+            ctx.combine_input_snapshots.remove(&node_idx);
+            return Ok(());
         }
 
-        // Fold the probe kernel's `distinct` / `filtered` skip counts into
-        // the run counters — applied after the loop, the same place the
-        // per-row `ctx.counters.*` increments used to live.
-        ctx.counters.filtered_count += probe_counters.filtered;
-        ctx.counters.distinct_count += probe_counters.distinct;
-        output_records
-    };
-
-    let probe_records_out = output_records.len() as u64;
-    ctx.collector
-        .record(probe_timer.finish(probe_records_in, probe_records_out));
-
-    // Streaming-Output handoff: an inline hash build-probe combine
-    // whose sole downstream is a streaming-eligible Output
-    // installed its sender under our `node_idx`. The build side is
-    // already fully materialized in the hash table and the whole
-    // probe emit is already collected into `output_records`, so
-    // this does not shrink the combine's own working set; what it
-    // saves is the second copy — hand `output_records` straight to
-    // the writer thread over the bounded channel rather than
-    // admitting a charged `node_buffers` slot the Output would
-    // re-drain, and overlap the writer with the next topo node.
-    // The eligibility predicate certified this combine roots no
-    // window and tees to no deferred region, so the helper calls
-    // below are correctly skipped. The reconciled document boundaries
-    // are forwarded on the inline path just like the materialized arms,
-    // so a per-document Aggregate reached through this streamed handoff
-    // flushes per document; a terminal writer downstream consumes them
-    // harmlessly. The per-fold snapshot and hash-table consumer are
-    // still released before the streaming return.
-    if let Some(sender) = ctx.take_streaming_sender(node_idx) {
-        let batch_size = ctx.batch_size;
-        let spill_allowed = node_buffer_spill_allowed(current_dag, node_idx);
-        let charge = ctx
-            .streaming_charge_handle(node_idx, name, spill_allowed)
-            .expect("streaming sender implies a registered charge consumer");
-        stream_linear_producer_emit(
-            &sender,
-            batch_size,
+        finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
+        tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
+        let nb = admit_node_buffer(
+            ctx,
             name,
+            node_idx,
             output_records,
             combined_puncts,
-            &charge,
+            node_buffer_spill_allowed(current_dag, node_idx),
         )?;
+        ctx.node_buffers.insert(node_idx, nb);
+        // Drop the per-fold cursor snapshot: every emitted record
+        // has cleared into `node_buffers` without rewind, so the
+        // snapshot is no longer needed. The rewind path on a
+        // Combine-output-row failure reads and restores this entry
+        // before clearing.
         ctx.combine_input_snapshots.remove(&node_idx);
-        ctx.memory_budget.unregister_consumer(inline_consumer_id);
-        return Ok(());
-    }
-
-    finalize_node_rooted_windows(ctx, current_dag, node_idx, &output_records)?;
-    tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &output_records)?;
-    let nb = admit_node_buffer(
-        ctx,
-        name,
-        node_idx,
-        output_records,
-        combined_puncts,
-        node_buffer_spill_allowed(current_dag, node_idx),
-    )?;
-    ctx.node_buffers.insert(node_idx, nb);
-    // Drop the per-fold cursor snapshot: every emitted record
-    // has cleared into `node_buffers` without rewind, so the
-    // snapshot is no longer needed. The rewind path on a
-    // Combine-output-row failure reads and restores this entry
-    // before clearing.
-    ctx.combine_input_snapshots.remove(&node_idx);
-    // The hash table goes out of scope when this arm returns;
-    // unregister its consumer so the arbitrator's registry
-    // tracks live tables only.
+        Ok(())
+    })();
     ctx.memory_budget.unregister_consumer(inline_consumer_id);
-
-    Ok(())
+    result
 }
 
 /// Result of a streaming-probe run handed back to [`dispatch_combine`]:

--- a/crates/clinker-exec/src/executor/tests/combine_consumer_lifecycle.rs
+++ b/crates/clinker-exec/src/executor/tests/combine_consumer_lifecycle.rs
@@ -1,22 +1,23 @@
-//! Non-inline Combine branch consumer lifecycle.
+//! Combine branch consumer lifecycle.
 //!
-//! The IEJoin, GraceHash, and SortMerge combine branches each register a
-//! `MemoryConsumer` with the pipeline-scoped arbitrator before running
-//! their kernel. Each branch must unregister that consumer when it exits —
-//! on the clean path and on every `?` early-return between registration
-//! and the arm's return — or the wrapper lingers in the arbitrator's
-//! registry for the rest of the run, growing the victim-selection surface
-//! and (once the handle carries live bytes) charging finished join state
-//! into `sum_consumer_usage`.
+//! The inline `HashBuildProbe`, IEJoin, GraceHash, and SortMerge combine
+//! branches each register a `MemoryConsumer` with the pipeline-scoped
+//! arbitrator before running their kernel. Each branch must unregister that
+//! consumer when it exits — on the clean path and on every `?` early-return
+//! between registration and the arm's return — or the wrapper lingers in the
+//! arbitrator's registry for the rest of the run, growing the
+//! victim-selection surface and (once the handle carries live bytes)
+//! charging finished join state into `sum_consumer_usage`.
 //!
 //! Each test forces one strategy through the planner (a two-range
 //! predicate selects IEJoin, a single-range presorted predicate selects
 //! SortMerge, a `strategy: grace_hash` hint on a pure-equi predicate
-//! selects GraceHash), asserts the compiled node actually carries that
+//! selects GraceHash, a pure-equi predicate with no hint selects the inline
+//! HashBuildProbe branch), asserts the compiled node actually carries that
 //! strategy so the run is not vacuous, then runs with an injected
-//! arbitrator and asserts the registry is empty afterward. The final test
-//! drives a branch to a hard error (`on_miss: error` with an unmatched
-//! driver row) and asserts the registry is still empty — proving the
+//! arbitrator and asserts the registry is empty afterward. The error-exit
+//! tests drive a branch to a hard error (`on_miss: error` with an unmatched
+//! driver row) and assert the registry is still empty — proving the
 //! unregister funnels through the error exit too.
 
 use super::*;
@@ -474,6 +475,189 @@ nodes:
         arb.consumer_count(),
         0,
         "the IEJoin branch's consumer must be unregistered even when the branch exits via error"
+    );
+    assert_eq!(arb.sum_consumer_usage(), 0);
+}
+
+/// A pure-equi predicate with no `strategy` hint and inputs well under the
+/// grace-hash threshold routes to the inline `HashBuildProbe` branch. After
+/// the probe completes and its output drains downstream, the arbitrator
+/// registry must hold no inline-combine consumer.
+#[test]
+fn inline_hash_branch_unregisters_its_consumer_on_clean_exit() {
+    let yaml = r#"
+pipeline:
+  name: combine_lifecycle_inline_hash
+nodes:
+- type: source
+  name: orders
+  config:
+    name: orders
+    type: csv
+    path: orders.csv
+    schema:
+      - { name: order_id, type: string }
+      - { name: product_id, type: string }
+- type: source
+  name: products
+  config:
+    name: products
+    type: csv
+    path: products.csv
+    schema:
+      - { name: product_id, type: string }
+      - { name: name, type: string }
+- type: combine
+  name: enriched
+  input:
+    orders: orders
+    products: products
+  config:
+    where: "orders.product_id == products.product_id"
+    match: first
+    on_miss: null_fields
+    cxl: |
+      emit order_id = orders.order_id
+      emit product_id = orders.product_id
+      emit name = products.name
+    propagate_ck: driver
+- type: output
+  name: out
+  input: enriched
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    assert!(
+        matches!(
+            compiled_combine_strategy(yaml, "enriched"),
+            CombineStrategy::HashBuildProbe
+        ),
+        "a pure-equi predicate with no strategy hint must select the inline HashBuildProbe branch \
+         for this test to exercise it"
+    );
+
+    let arb = quiet_arbitrator();
+    let report = run(
+        yaml,
+        HashMap::from([
+            csv_reader("orders", ORDERS_EQUI_CSV),
+            csv_reader("products", PRODUCTS_EQUI_CSV),
+        ]),
+        sink_writer("out"),
+        Arc::clone(&arb),
+    )
+    .expect("pipeline must run");
+
+    assert_eq!(
+        report.counters.total_count, 4,
+        "both sources must ingest so the inline HashBuildProbe branch actually runs"
+    );
+    assert_eq!(
+        arb.consumer_count(),
+        0,
+        "the inline HashBuildProbe branch's consumer must be unregistered after the branch exits"
+    );
+    assert_eq!(arb.sum_consumer_usage(), 0);
+}
+
+const ORDERS_EQUI_DISJOINT_CSV: &str = "\
+order_id,product_id
+o1,p1
+o2,p2
+";
+
+const PRODUCTS_EQUI_DISJOINT_CSV: &str = "\
+product_id,name
+p8,sprocket
+p9,flange
+";
+
+/// The unregister must also cover the inline branch's error exit: an inline
+/// `HashBuildProbe` combine whose `on_miss: error` fires on an unmatched
+/// driver row returns through the probe kernel's `?`, and the branch must
+/// still unregister its consumer before propagating the error. The build
+/// side has already mirrored its hash-table bytes into the consumer handle
+/// when the probe row misses, so a leaked consumer would keep that finished
+/// join state summed into the registry for the rest of the run. The two
+/// inputs share no join key, so the first driver row misses regardless of
+/// which side the planner drives from.
+#[test]
+fn inline_hash_branch_unregisters_its_consumer_on_error_exit() {
+    let yaml = r#"
+pipeline:
+  name: combine_lifecycle_inline_hash_error
+nodes:
+- type: source
+  name: orders
+  config:
+    name: orders
+    type: csv
+    path: orders.csv
+    schema:
+      - { name: order_id, type: string }
+      - { name: product_id, type: string }
+- type: source
+  name: products
+  config:
+    name: products
+    type: csv
+    path: products.csv
+    schema:
+      - { name: product_id, type: string }
+      - { name: name, type: string }
+- type: combine
+  name: enriched
+  input:
+    orders: orders
+    products: products
+  config:
+    where: "orders.product_id == products.product_id"
+    match: first
+    on_miss: error
+    cxl: |
+      emit order_id = orders.order_id
+      emit product_id = orders.product_id
+      emit name = products.name
+    propagate_ck: driver
+- type: output
+  name: out
+  input: enriched
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    assert!(
+        matches!(
+            compiled_combine_strategy(yaml, "enriched"),
+            CombineStrategy::HashBuildProbe
+        ),
+        "a pure-equi predicate with no strategy hint must select the inline HashBuildProbe branch \
+         for this test to exercise its error exit"
+    );
+
+    let arb = quiet_arbitrator();
+    let result = run(
+        yaml,
+        HashMap::from([
+            csv_reader("orders", ORDERS_EQUI_DISJOINT_CSV),
+            csv_reader("products", PRODUCTS_EQUI_DISJOINT_CSV),
+        ]),
+        sink_writer("out"),
+        Arc::clone(&arb),
+    );
+
+    assert!(
+        matches!(result, Err(PipelineError::CombineMissingMatch { .. })),
+        "the unmatched driver row under on_miss: error must fail the run, got {result:?}"
+    );
+    assert_eq!(
+        arb.consumer_count(),
+        0,
+        "the inline HashBuildProbe branch's consumer must be unregistered even when the branch \
+         exits via error"
     );
     assert_eq!(arb.sum_consumer_usage(), 0);
 }

--- a/crates/clinker-exec/src/pipeline/sysstats.rs
+++ b/crates/clinker-exec/src/pipeline/sysstats.rs
@@ -286,18 +286,31 @@ mod tests {
     #[test]
     fn cpu_times_increases_after_busy_loop() {
         let Some(before) = cpu_times() else { return };
-        // Spin in user space for ~50 ms.
-        let start = std::time::Instant::now();
+        // Poll until the user-time reading advances rather than spinning a
+        // fixed wall-clock window and asserting an absolute delta. The
+        // counter's resolution is platform-dependent — Windows' GetProcessTimes
+        // is quantized to the ~15.6ms scheduler tick, so a fixed 50ms spin can
+        // register a sub-threshold delta when the thread is descheduled under
+        // runner contention. Spinning until the counter ticks over (bounded by
+        // a generous wall-clock cap) removes that race while still proving that
+        // cpu_times() reflects real work: if the reading never advances within
+        // the cap, the assertion fails.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut after = cpu_times().unwrap();
         let mut x: u64 = 0;
-        while start.elapsed() < std::time::Duration::from_millis(50) {
-            x = x.wrapping_add(1);
-            std::hint::black_box(&x);
+        while after.user_ns <= before.user_ns && std::time::Instant::now() < deadline {
+            // A chunk of user-space work between reads; sized large enough to
+            // accrue schedulable CPU time on coarse-grained clocks.
+            for _ in 0..1_000_000 {
+                x = x.wrapping_add(1);
+                std::hint::black_box(&x);
+            }
+            after = cpu_times().unwrap();
         }
-        let after = cpu_times().unwrap();
         let delta = after.user_ns.saturating_sub(before.user_ns);
         assert!(
-            delta >= 25_000_000,
-            "expected ≥25ms user CPU delta after 50ms spin, got {delta} ns"
+            delta > 0,
+            "expected user CPU time to advance after a busy loop, got {delta} ns"
         );
     }
 

--- a/crates/clinker-exec/tests/merge_interleave.rs
+++ b/crates/clinker-exec/tests/merge_interleave.rs
@@ -222,85 +222,218 @@ fn seeded_interleave_is_reproducible() {
     assert_eq!(first.len(), 10);
 }
 
-/// Live-channel back-pressure: a slow `src_a` (50 ms sleep at the
-/// reader between every record) does not block `src_b` from
-/// flowing through the Merge.interleave arm.
+/// `std::io::Read` adapter for the gated back-pressure test's fast
+/// side. Delivers `csv` in row-sized chunks (split on `\n`), then fires
+/// `notify` exactly once on the terminating EOF read. Because the signal
+/// rides on EOF, every byte of this source has reached the CSV reader
+/// before it fires — so the peer waiting on the other end of the channel
+/// only unblocks once this source is fully drained into the merge. No
+/// sleeps: delivery is paced by the merge's consumption, not wall clock.
+struct NotifyOnEofReader {
+    bytes: Vec<u8>,
+    pos: usize,
+    notify: Option<std::sync::mpsc::Sender<()>>,
+}
+
+impl NotifyOnEofReader {
+    fn new(csv: &str, notify: std::sync::mpsc::Sender<()>) -> Self {
+        Self {
+            bytes: csv.as_bytes().to_vec(),
+            pos: 0,
+            notify: Some(notify),
+        }
+    }
+}
+
+impl std::io::Read for NotifyOnEofReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.bytes.len() {
+            // The CSV reader has taken every byte; release the gated peer
+            // once. A dropped receiver (test already finished) is benign.
+            if let Some(tx) = self.notify.take() {
+                let _ = tx.send(());
+            }
+            return Ok(0);
+        }
+        let remaining = &self.bytes[self.pos..];
+        let chunk_end = remaining
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| p + 1)
+            .unwrap_or(remaining.len());
+        let n = chunk_end.min(buf.len());
+        buf[..n].copy_from_slice(&remaining[..n]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+/// `std::io::Read` adapter for the gated back-pressure test's slow side.
+/// Delivers the CSV header, then blocks once on `gate` before yielding
+/// any body byte. The paired [`NotifyOnEofReader`] fires `gate` only
+/// after its own source has been fully read, so this source contributes
+/// no record to the merge until its peer is drained — a deterministic
+/// stand-in for "this upstream is slow" that never depends on timer
+/// resolution. `recv_timeout` bounds the wait purely as an anti-hang
+/// guard; a healthy run releases the gate in microseconds.
+struct GatedBodyReader {
+    bytes: Vec<u8>,
+    pos: usize,
+    header_end: usize,
+    gate: Option<std::sync::mpsc::Receiver<()>>,
+}
+
+impl GatedBodyReader {
+    fn new(csv: &str, gate: std::sync::mpsc::Receiver<()>) -> Self {
+        let bytes = csv.as_bytes().to_vec();
+        let header_end = bytes
+            .iter()
+            .position(|&b| b == b'\n')
+            .map(|p| p + 1)
+            .unwrap_or(bytes.len());
+        Self {
+            bytes,
+            pos: 0,
+            header_end,
+            gate: Some(gate),
+        }
+    }
+}
+
+impl std::io::Read for GatedBodyReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if self.pos >= self.bytes.len() {
+            return Ok(0);
+        }
+        // Block at the header/body boundary: the header reaches the CSV
+        // reader (schema setup) but no record does until the gate fires.
+        if self.pos >= self.header_end
+            && let Some(rx) = self.gate.take()
+        {
+            let _ = rx.recv_timeout(Duration::from_secs(30));
+        }
+        // Cap the pre-gate read at the header boundary so a large caller
+        // buffer cannot pull body bytes ahead of the block.
+        let limit = if self.pos < self.header_end {
+            self.header_end
+        } else {
+            self.bytes.len()
+        };
+        let end = limit.min(self.pos + buf.len());
+        let n = end - self.pos;
+        buf[..n].copy_from_slice(&self.bytes[self.pos..end]);
+        self.pos += n;
+        Ok(n)
+    }
+}
+
+/// Live-channel back-pressure: a source that yields no record until its
+/// peer has fully drained does not block that peer from flowing through
+/// the `Merge.interleave` arm.
 ///
+/// `src_a`'s reader delivers only the CSV header, then blocks on an mpsc
+/// gate; `src_b`'s reader fires that gate exactly once, on its own EOF,
+/// after every `src_b` byte has reached the CSV reader. So `src_a`
+/// contributes no record to the merge until `src_b` is fully drained.
 /// The interleave arm reads whichever source channel is ready via a
-/// crossbeam `Select`, so `src_b`'s records arrive into the Merge fold
-/// immediately while `src_a` is still sleeping between rows. The arm
-/// pulls every `src_b` record in the first ~5 ms, then waits 50 ms for
-/// each `src_a` record. Result: every `src_b` record sits in the first
-/// half of the output stream.
+/// crossbeam `Select`, so it pulls `src_b`'s records in a burst while
+/// `src_a` is still gated.
 ///
-/// Discriminator: the position of the last `b-` tag in the output must
-/// be `< 5` (first half of 10 total records). A regime that pre-buffers
-/// each source into a Vec and round-robins them would place the last
-/// `b-` at position 9; readiness-driven selection places it at the
-/// front.
+/// The gate replaces an earlier wall-clock design (a 50 ms per-row sleep
+/// on `src_a` plus a "last b-tag lands in the first half" position
+/// check). That discriminator was timing-dependent by construction and
+/// flaked on coarse-timer platforms. The gate makes the ordering
+/// pressure deterministic and the assertions below are structural,
+/// mirroring `interleave_fairness_under_four_predecessors` in this file:
+///
+/// - per-source FIFO is preserved for both sources;
+/// - every input record appears exactly once;
+/// - the longest same-source run is `>= 2`. A regression that
+///   pre-buffers each source into a `Vec` and strictly round-robins them
+///   would emit `b, a, b, a, …` — a longest run of 1 — even though
+///   `src_b` was ready first. Readiness-driven selection instead pulls
+///   at least two `src_b` records before the gated `src_a` can deliver
+///   its first (the gate forces the first record to be `b`, and
+///   `src_a`'s wake-parse-enqueue chain cannot outrace the merge draining
+///   one already-buffered `src_b`), so the longest run is at least 2.
+///   This lower bound holds under uniform runner slowdown because both
+///   the merge's per-select gap and `src_a`'s startup scale together.
 #[test]
 fn interleave_does_not_block_peer_on_slow_source() {
-    use std::time::Instant;
-
     let yaml = pipeline_yaml("mode: interleave");
     let config = parse_config(&yaml).unwrap();
     let plan = config.compile(&CompileContext::default()).unwrap();
+
+    // src_b fires this gate on EOF; src_a blocks on it before yielding
+    // any body row.
+    let (gate_tx, gate_rx) = std::sync::mpsc::channel::<()>();
     let readers: SourceReaders = HashMap::from([
         (
             "src_a".to_string(),
-            // 5 records, each preceded by 50 ms — total ~250 ms.
-            clinker_exec::executor::SourceInput::Files(vec![slow_slot(
-                "a",
-                &src_a_csv(5),
-                Duration::from_millis(50),
+            SourceInput::Files(vec![FileSlot::new(
+                PathBuf::from("a.csv"),
+                Box::new(GatedBodyReader::new(&src_a_csv(5), gate_rx)),
             )]),
         ),
         (
             "src_b".to_string(),
-            // 5 records, produced as fast as the channel admits.
-            clinker_exec::executor::SourceInput::Files(vec![slot("b", &src_b_csv(5))]),
+            SourceInput::Files(vec![FileSlot::new(
+                PathBuf::from("b.csv"),
+                Box::new(NotifyOnEofReader::new(&src_b_csv(5), gate_tx)),
+            )]),
         ),
     ]);
     let buf = SharedBuffer::new();
     let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
         HashMap::from([("out".to_string(), writer(&buf))]);
 
-    let start = Instant::now();
     let report =
         PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
             .expect("pipeline executes");
-    let elapsed = start.elapsed();
 
     assert_eq!(report.counters.dlq_count, 0);
     let output = buf.as_string();
     let body: Vec<String> = output.lines().skip(1).map(|s| s.to_string()).collect();
     assert_eq!(body.len(), 10, "expected 10 records, got {body:?}");
+
+    // Per-source FIFO survives the interleave for both sources.
     assert_per_source_fifo(&body);
 
-    // Discriminator assertion: the LAST b-tag must appear in the
-    // first half of the output. Pre-buffered round-robin would place
-    // it at the back; readiness-driven selection places it at the front.
-    let last_b_pos = body
-        .iter()
-        .rposition(|row| tag_of(row).starts_with("b-"))
-        .expect("at least one b-tag in output");
-    assert!(
-        last_b_pos < 5,
-        "Merge.interleave failed to back-pressure: last src_b record \
-         landed at position {last_b_pos} (>=5) in {body:?}. \
-         Pre-buffered round-robin would place b records throughout \
-         the output; readiness-driven selection concentrates them at \
-         the front because src_a is still sleeping when src_b finishes \
-         producing."
+    // Full record set: every input record appears exactly once.
+    let mut tags: Vec<&str> = body.iter().map(|r| tag_of(r)).collect();
+    tags.sort();
+    assert_eq!(
+        tags,
+        vec![
+            "a-1", "a-2", "a-3", "a-4", "a-5", "b-1", "b-2", "b-3", "b-4", "b-5"
+        ],
+        "every input record must appear exactly once"
     );
 
-    // Sanity: pipeline finished within a reasonable window. 5 ×
-    // 50 ms slow-side delays + overhead should fit well under 2 s
-    // even under CI jitter; failure here suggests something
-    // hangs.
+    // Discriminator: readiness-driven selection pulls at least two
+    // gate-ready src_b records before the blocked src_a yields its first,
+    // so the longest same-source run is at least 2. A pre-buffered strict
+    // round-robin regression would alternate `b, a, b, a, …` — a longest
+    // run of 1 — and fail here.
+    let mut run_prefix: Option<char> = None;
+    let mut run_len = 0usize;
+    let mut max_run = 0usize;
+    for row in &body {
+        let p = tag_of(row).chars().next().expect("non-empty tag");
+        if Some(p) == run_prefix {
+            run_len += 1;
+        } else {
+            run_prefix = Some(p);
+            run_len = 1;
+        }
+        max_run = max_run.max(run_len);
+    }
     assert!(
-        elapsed < Duration::from_secs(2),
-        "pipeline took {elapsed:?}, expected < 2s",
+        max_run >= 2,
+        "longest contiguous same-source run is {max_run} (<2): the merge \
+         emitted a strict b/a alternation, which means it pre-buffered and \
+         round-robined the sources instead of pulling the ready src_b \
+         records as they arrived. output: {body:?}",
     );
 }
 

--- a/crates/clinker-format/src/edifact/tokenizer.rs
+++ b/crates/clinker-format/src/edifact/tokenizer.rs
@@ -497,4 +497,30 @@ mod tests {
         let err = t.next_segment().unwrap_err();
         assert!(matches!(err, FormatError::Edifact(m) if m.contains("ASCII")));
     }
+
+    #[test]
+    fn dangling_release_after_trailer_is_truncation() {
+        // A complete UNB..UNZ interchange followed by a bare release char
+        // with no terminator: the stray release byte is literal trailing
+        // content, so the read after the trailer reports an unterminated
+        // (truncated) segment rather than a clean end of stream. Stray bytes
+        // after the trailer cannot be silently dropped.
+        let mut t = tok(b"UNB+UNOA:1'UNZ+1+1'?");
+        assert_eq!(t.next_segment().unwrap().unwrap(), "UNB+UNOA:1");
+        assert_eq!(t.next_segment().unwrap().unwrap(), "UNZ+1+1");
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(msg) if msg.contains("truncated")));
+    }
+
+    #[test]
+    fn clean_trailer_terminated_interchange_ends_at_eof() {
+        // The contrast to the dangling-release case: when the UNZ trailer
+        // carries its terminator and nothing follows, the read after it is a
+        // clean end of stream, not a truncation error — the new rejection
+        // triggers only on the stray byte, not on a well-formed trailer.
+        let mut t = tok(b"UNB+UNOA:1'UNZ+1+1'");
+        assert_eq!(t.next_segment().unwrap().unwrap(), "UNB+UNOA:1");
+        assert_eq!(t.next_segment().unwrap().unwrap(), "UNZ+1+1");
+        assert!(t.next_segment().unwrap().is_none());
+    }
 }

--- a/crates/clinker-format/src/fixed_width/field.rs
+++ b/crates/clinker-format/src/fixed_width/field.rs
@@ -54,6 +54,13 @@ impl ResolvedField {
 
         let width = resolve_width(f, start)?;
 
+        // `end()` is computed once per record on the hot read path, so the range
+        // must be provably representable at construction to keep that a plain add
+        // rather than a wrap. Mirrors the write path's identical guard.
+        start
+            .checked_add(width)
+            .ok_or_else(|| invalid_field(&f.name, "'start' + width overflows"))?;
+
         Ok(ResolvedField {
             name: f.name.clone(),
             start,

--- a/crates/clinker-format/src/fixed_width/reader.rs
+++ b/crates/clinker-format/src/fixed_width/reader.rs
@@ -482,4 +482,24 @@ mod tests {
         };
         assert!(msg.contains("width"), "error should mention width: {msg}");
     }
+
+    /// A declared range whose end exceeds `usize::MAX` cannot exist; the reader
+    /// rejects it at construction so `field.end()` stays a non-wrapping add on
+    /// the per-record read path, matching the write path's guard.
+    #[test]
+    fn test_fixedwidth_read_range_end_overflow_rejected() {
+        let fields = vec![{
+            let mut f = field("bad");
+            f.start = Some(usize::MAX);
+            f.width = Some(2);
+            f
+        }];
+
+        let result = FixedWidthReader::new(&b""[..], fields, FixedWidthReaderConfig::default());
+        let msg = match result {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("expected error for overflowing range"),
+        };
+        assert!(msg.contains("overflows"), "error should say so: {msg}");
+    }
 }

--- a/crates/clinker-format/src/segment_tokenizer.rs
+++ b/crates/clinker-format/src/segment_tokenizer.rs
@@ -145,10 +145,16 @@ pub(crate) fn read_raw_segment<R: BufRead>(
     loop {
         let buf = reader.fill_buf()?;
         if buf.is_empty() {
-            // A release char dangling at EOF has nothing to escape and no
-            // following byte to carry, so the segment ends exactly at the
-            // bytes already accumulated — the dangling release is dropped,
-            // never counted toward an empty-vs-pending decision.
+            // A release char dangling at EOF has nothing to escape, but it is
+            // still a byte the producer wrote, so it is flushed into the
+            // segment as literal trailing content rather than discarded. A
+            // lone dangling release therefore reads as unterminated content
+            // (one byte pending, no terminator) instead of a clean end of
+            // stream — under RejectUnterminated that surfaces as truncation,
+            // so a stray release byte after the trailer cannot silently vanish.
+            if let Some(rel) = pending_release.take() {
+                raw.push(rel);
+            }
             if raw.is_empty() {
                 return Ok(None);
             }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -405,6 +405,56 @@ fn is_attribute_path(path: &str, attribute_prefix: &str) -> bool {
             .is_some_and(|segment| segment.starts_with(attribute_prefix))
 }
 
+/// True when `c` may begin an XML 1.0 `Name` (the `NameStartChar`
+/// production). Covers the full Unicode ranges so an attribute name that
+/// round-tripped from a source document with non-ASCII names is not
+/// rejected on write-back.
+fn is_xml_name_start_char(c: char) -> bool {
+    matches!(c,
+        ':' | 'A'..='Z' | '_' | 'a'..='z'
+        | '\u{C0}'..='\u{D6}'
+        | '\u{D8}'..='\u{F6}'
+        | '\u{F8}'..='\u{2FF}'
+        | '\u{370}'..='\u{37D}'
+        | '\u{37F}'..='\u{1FFF}'
+        | '\u{200C}'..='\u{200D}'
+        | '\u{2070}'..='\u{218F}'
+        | '\u{2C00}'..='\u{2FEF}'
+        | '\u{3001}'..='\u{D7FF}'
+        | '\u{F900}'..='\u{FDCF}'
+        | '\u{FDF0}'..='\u{FFFD}'
+        | '\u{10000}'..='\u{EFFFF}'
+    )
+}
+
+/// True when `c` may appear after the first character of an XML 1.0 `Name`
+/// (the `NameChar` production).
+fn is_xml_name_char(c: char) -> bool {
+    is_xml_name_start_char(c)
+        || matches!(c,
+            '-' | '.' | '0'..='9'
+            | '\u{B7}'
+            | '\u{0300}'..='\u{036F}'
+            | '\u{203F}'..='\u{2040}'
+        )
+}
+
+/// True when `name` is a well-formed XML 1.0 `Name`: a `NameStartChar`
+/// followed by zero or more `NameChar`. Empty names are rejected.
+///
+/// quick-xml wraps attribute names as raw bytes (`QName`) without any
+/// well-formedness check, so an illegal name (e.g. one containing a space
+/// or `=`) would otherwise be written verbatim into the start tag and
+/// corrupt the document.
+fn is_valid_xml_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(first) if is_xml_name_start_char(first) => {}
+        _ => return false,
+    }
+    chars.all(is_xml_name_char)
+}
+
 /// Insert a dotted field name into the tree, creating branches as needed.
 /// An attribute-prefixed segment must be the path's final segment (an
 /// attribute is a leaf — nothing can nest under it); `field` is the full
@@ -448,6 +498,12 @@ fn insert_field(
             return Err(FormatError::Xml(format!(
                 "field '{field}': attribute prefix '{attribute_prefix}' \
                  carries no attribute name"
+            )));
+        }
+        if !is_valid_xml_name(attr_name) {
+            return Err(FormatError::Xml(format!(
+                "field '{field}': attribute name '{attr_name}' is not a \
+                 well-formed XML name"
             )));
         }
         body.attrs.push((attr_name.to_string(), text.to_string()));
@@ -908,6 +964,72 @@ mod tests {
             buf.is_empty(),
             "rejected record must not leave partial output behind"
         );
+    }
+
+    /// Assert that writing a single record whose only field is `field`
+    /// fails with `FormatError::Xml` mentioning both the field and the
+    /// stripped attribute name, and leaves no partial bytes behind.
+    fn assert_attribute_name_rejected(field: &str, attr_name: &str) {
+        let schema = Arc::new(Schema::new(vec![field.into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Integer(1)]);
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::Xml(msg) => {
+                assert!(
+                    msg.contains(field) && msg.contains(attr_name),
+                    "message names the field and offending attribute name: {msg}"
+                );
+                assert!(
+                    msg.contains("well-formed XML name"),
+                    "message explains the failure is a malformed name: {msg}"
+                );
+            }
+            other => panic!("expected FormatError::Xml, got {other:?}"),
+        }
+        drop(writer);
+        assert!(
+            buf.is_empty(),
+            "rejected record must not leave partial output behind"
+        );
+    }
+
+    #[test]
+    fn test_xml_write_attribute_name_with_whitespace_rejected() {
+        // A space is not an XML NameChar; writing it unvalidated would emit
+        // `<Record foo bar="1">`, splitting one attribute into two tokens.
+        assert_attribute_name_rejected("@foo bar", "foo bar");
+    }
+
+    #[test]
+    fn test_xml_write_attribute_name_with_metacharacters_rejected() {
+        for (field, name) in [
+            ("@a=b", "a=b"),
+            ("@a\"b", "a\"b"),
+            ("@a/b", "a/b"),
+            ("@a>b", "a>b"),
+        ] {
+            assert_attribute_name_rejected(field, name);
+        }
+    }
+
+    #[test]
+    fn test_xml_write_attribute_name_starting_with_digit_rejected() {
+        // A digit is a NameChar but not a NameStartChar, so `1st` cannot
+        // begin an XML name.
+        assert_attribute_name_rejected("@1st", "1st");
+    }
+
+    #[test]
+    fn test_xml_write_attribute_name_with_unicode_start_char_accepted() {
+        // `é` (U+00E9) is a valid NameStartChar, so a non-ASCII attribute
+        // name that round-tripped from a source document writes back
+        // unchanged rather than being rejected.
+        let schema = Arc::new(Schema::new(vec!["@café".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Integer(1)]);
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(output, r#"<Root><Record café="1"></Record></Root>"#);
     }
 
     #[test]

--- a/crates/clinker-record/src/accumulator/mod.rs
+++ b/crates/clinker-record/src/accumulator/mod.rs
@@ -409,6 +409,12 @@ impl AvgState {
                     self.compensation = 0.0;
                 }
                 self.kahan_add(*f);
+                if self.is_decimal {
+                    // A binary float observed after decimal mode lands only in
+                    // the Kahan float sum, which the decimal quotient never
+                    // reads; poison rather than silently drop it from the avg.
+                    self.decimal_overflow = true;
+                }
             }
             Value::Decimal(d) => {
                 self.has_value = true;
@@ -422,10 +428,16 @@ impl AvgState {
 
     /// Enter the exact decimal path, seeding from the integers already summed
     /// (fallible — an out-of-range integer sum sets the overflow flag rather
-    /// than panicking).
+    /// than panicking). A binary float accumulated before the first decimal row
+    /// (an `Any`-typed column that mixed a float and a decimal — typed columns
+    /// cannot) cannot widen to an exact decimal; the seed pulls in only the
+    /// integer sum, so poison the result rather than silently drop the float.
     fn enter_decimal_mode(&mut self) {
         if !self.is_decimal {
             self.is_decimal = true;
+            if !self.is_integer {
+                self.decimal_overflow = true;
+            }
             match i128_to_decimal(self.int_sum) {
                 Some(d) => self.decimal_sum = d,
                 None => {
@@ -464,6 +476,13 @@ impl AvgState {
             // `SumState::merge`).
             let self_dec = self.decimal_contribution();
             let other_dec = other.decimal_contribution();
+            // A float-mode side (not decimal, not integer-only) contributes only
+            // its integer sum above; its binary-float total cannot widen to an
+            // exact decimal. Combining one into the decimal domain would silently
+            // drop it, so poison the result to Null instead.
+            if (!self.is_decimal && !self.is_integer) || (!other.is_decimal && !other.is_integer) {
+                self.decimal_overflow = true;
+            }
             self.is_decimal = true;
             match (self_dec, other_dec) {
                 (Some(a), Some(b)) => match a.checked_add(b) {

--- a/crates/clinker-record/src/accumulator/tests.rs
+++ b/crates/clinker-record/src/accumulator/tests.rs
@@ -143,6 +143,55 @@ fn test_avg_decimal_merge_with_integer_only_state() {
 }
 
 #[test]
+fn test_avg_float_then_decimal_is_null() {
+    // A binary float accumulated BEFORE the first decimal row cannot widen into
+    // the exact decimal sum (only the integer sum is seeded on the switch).
+    // Poison to Null rather than silently dropping the float and reporting the
+    // decimal-only quotient. Reachable only on an untyped column; typecheck
+    // rejects a float/decimal mix for typed columns.
+    let mut a = avg();
+    add_all(&mut a, &[Value::Float(1.5), dec(250, 2)]);
+    // The true avg is (1.5 + 2.5) / 2 = 2.0; dropping the float would report
+    // 2.5 / 2 = 1.25. Neither is honest, so finalize returns Null.
+    assert_eq!(a.finalize().unwrap(), Value::Null);
+}
+
+#[test]
+fn test_avg_decimal_then_float_is_null() {
+    // A binary float observed AFTER decimal mode lands only in the Kahan float
+    // sum, which the decimal quotient never reads. Poison to Null rather than
+    // silently dropping it. Reachable only on an untyped column.
+    let mut a = avg();
+    add_all(&mut a, &[dec(200, 2), Value::Float(1.5)]);
+    // The true avg is (2.0 + 1.5) / 2 = 1.75; dropping the float would report
+    // 2.0 / 2 = 1.0. Neither is honest, so finalize returns Null.
+    assert_eq!(a.finalize().unwrap(), Value::Null);
+}
+
+#[test]
+fn test_avg_merge_float_mode_with_decimal_mode_is_null() {
+    // Merging a float-mode partial (its exact contribution reads only its
+    // integer sum) into a decimal-mode partial — or vice versa — would drop the
+    // float side's total. Both merge directions poison to Null.
+    let build_float = || {
+        let mut s = avg();
+        add_all(&mut s, &[Value::Float(1.5)]);
+        s
+    };
+    let build_decimal = || {
+        let mut s = avg();
+        add_all(&mut s, &[dec(250, 2)]);
+        s
+    };
+    let mut df = build_decimal();
+    df.merge(&build_float());
+    assert_eq!(df.finalize().unwrap(), Value::Null);
+    let mut fd = build_float();
+    fd.merge(&build_decimal());
+    assert_eq!(fd.finalize().unwrap(), Value::Null);
+}
+
+#[test]
 fn test_sum_decimal_spill_roundtrip() {
     // The accumulator state serializes exactly (decimal via the 16-byte form),
     // so a spilled-and-reloaded Sum finalizes identically.

--- a/docs/user/src/formats/edifact.md
+++ b/docs/user/src/formats/edifact.md
@@ -147,7 +147,9 @@ such interchanges still validate and round-trip with the trailer echoing
 the correct reference.
 
 A missing `UNZ` at end of input is a truncation error; content after the
-`UNZ` trailer is rejected.
+`UNZ` trailer is rejected — including a lone stray release character with
+no following segment, which is treated as unterminated (truncated) content
+rather than silently dropped.
 
 ### Routing a count mismatch to the DLQ
 

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -84,6 +84,12 @@ Attribute handling details:
 - A field with children nested under an attribute-prefixed segment
   (e.g. `@a.b`) is rejected with a format error: an XML attribute is a
   leaf and cannot contain elements.
+- The attribute name (the segment after the prefix) must be a well-formed
+  XML name — a letter, `_`, or `:` followed by letters, digits, `-`, `.`,
+  or `:`. A name with a space, `=`, quote, `/`, `>`, or a leading digit
+  (e.g. `@foo bar`, `@1st`) is rejected with a format error rather than
+  emitting a malformed start tag. Non-ASCII letters are accepted, so an
+  attribute name read from a source document round-trips unchanged.
 - An element with only attribute fields and no children self-closes:
   `Address.@type` alone emits `<Address type="home"/>`.
 


### PR DESCRIPTION
Batches seven independent, footprint-disjoint fixes and test-hardening changes. Each unit was developed on its own branch and verified in isolation; this branch merges them and re-runs the full gauntlet (`fmt`, `clippy -D warnings`, tests for the touched crates, `cargo check --workspace`, `git diff --check`) on the combined result.

## What changed

- **AvgState silently mis-averaged mixed float/decimal input (#802).** On untyped/`Any` columns that mix `Value::Float` and `Value::Decimal`, the average accumulator computed an exact decimal quotient but silently dropped the running binary-float contributions while still counting those rows — a biased average. Mixing binary floats into an exact decimal average is not representable exactly, so the accumulator now poisons the exact quotient in every mixed path (either add order, and merges in both directions) and finalizes `Value::Null` instead of a wrong number — the same contract `weighted_avg` already follows. Pure-float, pure-decimal, and integer-mixed averages are unchanged.
- **Memory-arbitrator consumer leak in the inline combine arm (#803).** The inline `HashBuildProbe` combine path registered a `CombineHashConsumer` before running the build/probe body but only unregistered it on the streaming exit path, leaking a consumer registration on every early-error exit. Unregistration is now funneled so every exit unregisters exactly once, matching the sibling join arms.
- **XML writer accepted malformed attribute names (#804).** The XML writer escaped attribute *values* but passed attribute *names* straight into the underlying `QName` as raw bytes with no well-formedness check, so a schema field like `@foo bar` or `@1st` could emit non-well-formed XML. Attribute names are now validated against the XML 1.0 Name production and rejected with a clear error before any bytes are written.
- **Fixed-width reader missing overflow guard (#812).** The fixed-width reader's field resolution did not reject schemas whose `start + width` overflows `usize`, unlike the writer, which already guarded this. The reader now mirrors the writer's guard and rejects such schemas instead of risking overflow.
- **EDIFACT dangling release byte at EOF (#724).** A lone EDIFACT release (escape) byte trailing the `UNZ` interchange — with nothing to escape and no segment terminator — was previously dropped without a trace. It now counts as unterminated trailing content and the read fails with a truncation error, consistent with how other stray content after the trailer is rejected; nothing legal can follow `UNZ` except a new interchange or EOF. This also delivers the test coverage tracked by #439.
- **Timing-flaky test: peer non-blocking on slow source (#807).** Hardened `interleave_does_not_block_peer_on_slow_source` (test-only, no runtime change): removed the per-row wall-clock sleep and the timing-dependent ordering assertion, replacing them with a deterministic gate and structural interleaving assertions.
- **Timing-flaky test: CPU-time advancement (#815).** Hardened `cpu_times_increases_after_busy_loop` (test-only): replaced the fixed 50 ms spin plus absolute nanosecond floor with a poll-until-advance loop, removing the wall-clock dependency that made the test flaky on loaded CI.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test -p clinker-record -p clinker-format -p clinker-exec -p clinker-plan`, `cargo check --workspace`, and `git diff --check` all pass on the merged branch.

Closes #802
Closes #803
Closes #804
Closes #807
Closes #815
Closes #812
Closes #724
Closes #439
