### PR TITLE
batch: spill-disk-cap parity across aggregate, sort, sort-merge and grace-hash writers

### DIFF
--- a/crates/clinker-exec/src/aggregation/error.rs
+++ b/crates/clinker-exec/src/aggregation/error.rs
@@ -105,15 +105,31 @@ pub enum HashAggError {
         prev_key_debug: String,
         next_key_debug: String,
     },
+    /// A single input record's buffered contributions alone exceed the
+    /// entire memory budget. Buffer-mode aggregation must hold every raw
+    /// contribution resident to recompute `BufferRequired` bindings (`min`,
+    /// `max`, `avg`) after a retraction, so a row larger than the whole
+    /// budget has no in-budget representation and spilling cannot rescue it —
+    /// the next add of the same shape repeats the overflow. Routed by the
+    /// executor dispatch arm by error strategy: `FailFast` surfaces
+    /// `E310 MemoryBudgetExceeded`; `Continue` / `BestEffort` sends the
+    /// offending record to the DLQ. `row_charge` is the record's estimated
+    /// buffered footprint in bytes; `budget` is the configured memory limit
+    /// in bytes.
+    #[error(
+        "buffered aggregate row footprint ({row_charge} bytes) exceeds the entire memory budget ({budget} bytes)"
+    )]
+    OversizedRow { row_charge: usize, budget: usize },
 }
 
 /// Map a `HashAggError` to a `PipelineError` for the executor dispatch
 /// arm. Accumulator-finalize errors get a dedicated typed variant; a
 /// mid-run spill-directory fault maps to `PipelineError::Spill` so it
 /// renders with the same `DirUnavailable` diagnostic the node-buffer and
-/// sort paths use; the remaining cases are wrapped in `PipelineError::Eval`
-/// (data errors) or `PipelineError::Internal` (engine bugs / unsupported
-/// residuals).
+/// sort paths use; an oversized single buffered row maps to
+/// `PipelineError::MemoryBudgetExceeded` (E310); the remaining cases are
+/// wrapped in `PipelineError::Eval` (data errors) or `PipelineError::Internal`
+/// (engine bugs / unsupported residuals).
 impl From<HashAggError> for PipelineError {
     fn from(e: HashAggError) -> Self {
         match e {
@@ -163,6 +179,22 @@ impl From<HashAggError> for PipelineError {
                     "internal Clinker bug — LoserTree produced out-of-order keys: prev={prev_key_debug} next={next_key_debug}"
                 ),
             },
+            // A single row larger than the whole budget is a legitimate
+            // tiny-budget / oversized-record condition, not a Clinker bug, so
+            // it maps to E310 (`MemoryBudgetExceeded`) rather than `Internal`.
+            // `node` is left empty for the dispatch arm to stamp with the
+            // aggregate node name, matching the other budget-error sites.
+            HashAggError::OversizedRow { row_charge, budget } => {
+                PipelineError::MemoryBudgetExceeded {
+                    node: String::new(),
+                    used: row_charge as u64,
+                    limit: budget as u64,
+                    source: clinker_plan::BudgetCategory::Arena,
+                    detail: Some(format!(
+                        "a single buffered aggregate row's {row_charge}-byte footprint exceeds the whole {budget}-byte memory budget; raise memory.limit"
+                    )),
+                }
+            }
         }
     }
 }

--- a/crates/clinker-exec/src/aggregation/error.rs
+++ b/crates/clinker-exec/src/aggregation/error.rs
@@ -120,6 +120,24 @@ pub enum HashAggError {
         "buffered aggregate row footprint ({row_charge} bytes) exceeds the entire memory budget ({budget} bytes)"
     )]
     OversizedRow { row_charge: usize, budget: usize },
+    /// The cumulative on-disk size of the run's aggregate spill files crossed
+    /// the configured `storage.spill.disk_cap_bytes` quota. Distinct from a
+    /// memory-budget overflow (E310): a run can sit well inside its RSS
+    /// envelope yet exhaust local disk through an unbounded stream of spill
+    /// files. This is resource exhaustion, so it always hard-aborts the run
+    /// regardless of error strategy — never routed to the DLQ, matching the
+    /// reshape and cull spill-cap paths. `node` names the aggregate; `cap` is
+    /// the configured quota; `attempted` is the byte count of the flush that
+    /// crossed it; `current` is the cumulative total after that flush.
+    #[error(
+        "aggregate `{node}` spill exceeded the {cap}-byte disk cap (this flush {attempted} bytes, cumulative {current} bytes)"
+    )]
+    SpillCapExceeded {
+        node: String,
+        cap: u64,
+        attempted: u64,
+        current: u64,
+    },
 }
 
 /// Map a `HashAggError` to a `PipelineError` for the executor dispatch
@@ -127,8 +145,9 @@ pub enum HashAggError {
 /// mid-run spill-directory fault maps to `PipelineError::Spill` so it
 /// renders with the same `DirUnavailable` diagnostic the node-buffer and
 /// sort paths use; an oversized single buffered row maps to
-/// `PipelineError::MemoryBudgetExceeded` (E310); the remaining cases are
-/// wrapped in `PipelineError::Eval` (data errors) or `PipelineError::Internal`
+/// `PipelineError::MemoryBudgetExceeded` (E310); a spill-cap breach maps to
+/// `PipelineError::SpillCapExceeded` (E320); the remaining cases are wrapped
+/// in `PipelineError::Eval` (data errors) or `PipelineError::Internal`
 /// (engine bugs / unsupported residuals).
 impl From<HashAggError> for PipelineError {
     fn from(e: HashAggError) -> Self {
@@ -195,6 +214,12 @@ impl From<HashAggError> for PipelineError {
                     )),
                 }
             }
+            HashAggError::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => PipelineError::spill_cap_exceeded(node, cap, attempted, current),
         }
     }
 }

--- a/crates/clinker-exec/src/aggregation/hash.rs
+++ b/crates/clinker-exec/src/aggregation/hash.rs
@@ -178,6 +178,12 @@ pub struct HashAggregator {
     /// `handle.spill_requested`, which the hot loop is expected to
     /// read at batch boundaries once that integration lands.
     consumer_handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
+    /// Shared arbitrator for disk-spill-cap accounting. Each `spill()`
+    /// charges the committed spill file's on-disk byte size against it via
+    /// `record_spill_bytes`; crossing `storage.spill.disk_cap_bytes` surfaces
+    /// [`HashAggError::SpillCapExceeded`] (E320), the same accounting the
+    /// reshape and cull spill paths perform.
+    arbitrator: std::sync::Arc<crate::pipeline::memory::MemoryArbitrator>,
 }
 
 /// Construction parameters shared by [`HashAggregator::new`] and
@@ -221,6 +227,12 @@ pub struct AggregatorConfig {
     /// Shared handle mirroring `value_heap_bytes` into the
     /// pipeline-scoped arbitrator's pull-mode accounting.
     pub consumer_handle: Arc<crate::pipeline::memory::ConsumerHandle>,
+    /// Shared arbitrator the spill path charges each spill file's on-disk
+    /// byte size against, so aggregate spill volume counts toward the
+    /// pipeline-wide disk-spill cap (E320) and the per-stage `--explain`
+    /// calibration — the same accounting the reshape and cull spill paths
+    /// perform.
+    pub arbitrator: Arc<crate::pipeline::memory::MemoryArbitrator>,
 }
 
 impl HashAggregator {
@@ -240,6 +252,7 @@ impl HashAggregator {
             spill_compress,
             transform_name,
             consumer_handle,
+            arbitrator,
         } = config;
         let group_by_indices = compiled.group_by_indices.clone();
         let group_by_fields = compiled.group_by_fields.clone();
@@ -300,6 +313,7 @@ impl HashAggregator {
             buffered_groups: hashbrown::HashMap::new(),
             buffer_mode,
             consumer_handle,
+            arbitrator,
         }
     }
 
@@ -402,6 +416,14 @@ impl HashAggregator {
     /// spill writer.
     pub fn spill_files(&self) -> &[AggSpillFile] {
         &self.spill_files
+    }
+
+    /// Borrow the disk-spill-cap arbitrator so a test can seed a finite
+    /// `max_spill_bytes` and drive the aggregate's own spill-cap path in
+    /// isolation, without an upstream node-buffer racing it to a shared cap.
+    #[cfg(test)]
+    fn arbitrator_for_test(&self) -> &std::sync::Arc<crate::pipeline::memory::MemoryArbitrator> {
+        &self.arbitrator
     }
 
     /// True when the aggregator's output schema carries a synthetic
@@ -1007,7 +1029,10 @@ impl HashAggregator {
     ///    Postcard is a compact binary format with no self-describing
     ///    framing of its own; the explicit length prefix delimits records
     ///    inside the (optionally framed) record stream.
-    /// 4. Push the resulting `AggSpillFile` onto `self.spill_files`.
+    /// 4. Charge the committed spill file's on-disk byte size against the
+    ///    arbitrator's disk-spill accounting; a cap breach returns
+    ///    [`HashAggError::SpillCapExceeded`] (E320). Otherwise push the
+    ///    `AggSpillFile` onto `self.spill_files`.
     /// 5. Reset `value_heap_bytes = 0`.
     fn spill(&mut self) -> Result<(), HashAggError> {
         // 1. Drain. Buffer-mode aggregators write `SpillState::Buffered`
@@ -1067,7 +1092,24 @@ impl HashAggregator {
             writer.write_entry(&entry)?;
         }
 
-        let spill_file = writer.finish()?;
+        let (spill_file, spilled_bytes) = writer.finish()?;
+        // Charge the spill file's on-disk size against the arbitrator's
+        // per-stage and pipeline-wide totals so `--explain` calibration and
+        // the disk-spill cap both see aggregate spill volume. A cap breach is
+        // resource exhaustion: surface E320 rather than keep writing. The
+        // just-committed file drops here (auto-deleted via `TempPath`) since
+        // the run is aborting — mirrors the reshape/cull spill paths.
+        if self
+            .arbitrator
+            .record_spill_bytes(&self.transform_name, spilled_bytes)
+        {
+            return Err(HashAggError::SpillCapExceeded {
+                node: self.transform_name.clone(),
+                cap: self.arbitrator.max_spill_bytes(),
+                attempted: spilled_bytes,
+                current: self.arbitrator.cumulative_spill_bytes(),
+            });
+        }
         self.spill_files.push(spill_file);
 
         // 5. All per-group value heap bytes are now off-process.
@@ -1478,6 +1520,18 @@ mod spill_trigger_tests {
 
     /// Compile a CXL aggregate snippet against input_fields, returning a
     /// fully initialized HashAggregator ready for `add_record` calls.
+    /// An arbitrator with an unlimited disk-spill cap (`max_spill_bytes`
+    /// defaults to `u64::MAX`), so aggregators these builders produce spill
+    /// freely without tripping E320. Tests that exercise the cap seed a
+    /// finite quota through the full pipeline path instead.
+    fn unlimited_test_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
+        Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
+            0,
+            0.8,
+            crate::pipeline::memory::MemoryArbitrator::default_policy(),
+        ))
+    }
+
     fn build_test_aggregator(
         input_fields: &[(&str, Type)],
         group_by: &[&str],
@@ -1566,6 +1620,7 @@ mod spill_trigger_tests {
             spill_compress: true,
             transform_name: "test_agg".to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            arbitrator: unlimited_test_arbitrator(),
         })
     }
 
@@ -2372,6 +2427,64 @@ mod spill_trigger_tests {
         }
     }
 
+    #[test]
+    fn spill_past_disk_cap_returns_spill_cap_exceeded() {
+        // Mirrors the reshape/cull disk-cap unit tests: a one-byte disk cap
+        // must abort the aggregate's first spill flush with SpillCapExceeded
+        // (E320) rather than writing past the quota. Drives the aggregator
+        // directly so the assertion targets the aggregate's own spill charge,
+        // not an upstream node-buffer that would trip a shared cap first in a
+        // full pipeline.
+        let spill_dir = tempfile::tempdir().unwrap();
+        let mut agg = build_test_aggregator(
+            &[("k", Type::String), ("v", Type::Int)],
+            &["k"],
+            "emit k = k\nemit total = sum(v)",
+            // Tiny budget: the group-count threshold forces a spill within a
+            // few distinct keys.
+            1024,
+            Some(spill_dir.path().to_path_buf()),
+        );
+        // One-byte disk cap: the first spill's on-disk bytes already cross it.
+        agg.arbitrator_for_test().set_max_spill_bytes(1);
+
+        let input = make_schema(&["k", "v"]);
+        let stable = StableEvalContext::test_default();
+        let file: Arc<str> = Arc::from("t.csv");
+        // Many distinct keys drive the group-count spill trigger deterministically.
+        let mut caught = None;
+        for i in 0..2000u64 {
+            let r = make_record(
+                &input,
+                vec![
+                    Value::String(format!("k{i}").into()),
+                    Value::Integer(i as i64),
+                ],
+            );
+            if let Err(e) = agg.add_record(&r, i, &ctx_for(&stable, &file, i)) {
+                caught = Some(e);
+                break;
+            }
+        }
+        match caught.expect("a one-byte disk cap must abort a spill during ingest") {
+            HashAggError::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => {
+                assert_eq!(node, "test_agg", "E320 must name the aggregate node");
+                assert_eq!(cap, 1, "reported cap must equal the configured quota");
+                assert!(attempted > 0, "the overflowing flush must report its size");
+                assert!(
+                    current > cap,
+                    "cumulative spilled ({current}) must exceed the cap ({cap})"
+                );
+            }
+            other => panic!("expected SpillCapExceeded, got {other:?}"),
+        }
+    }
+
     // ----------------------------------------------------------------
     // Buffer-mode retract round-trip — feed N, retract M, finalize_in_place
     // equals feed-(N-M)-from-scratch byte-identically. One test per
@@ -2843,6 +2956,7 @@ mod spill_trigger_tests {
             spill_compress: true,
             transform_name: transform_name.to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            arbitrator: unlimited_test_arbitrator(),
         })
     }
 

--- a/crates/clinker-exec/src/aggregation/hash.rs
+++ b/crates/clinker-exec/src/aggregation/hash.rs
@@ -658,8 +658,10 @@ impl HashAggregator {
     ///
     /// 5. Evaluate every binding's argument into a `Vec<Value>` and
     ///    apply the hard-limit guard before mutating per-group state:
-    ///    if a single record's contribution exceeds the entire memory
-    ///    budget, spilling cannot rescue us and the panic fires.
+    ///    a single record whose contribution exceeds the entire memory
+    ///    budget cannot be held or spilled, so it returns
+    ///    `HashAggError::OversizedRow` for the dispatch arm to route by
+    ///    error strategy.
     /// 6. Push the per-row values onto `BufferedGroupState.contributions`
     ///    and charge `O(n_bindings × value_size)` into `value_heap_bytes`.
     /// 7. Same dual-threshold spill trigger as fold-mode.
@@ -761,18 +763,15 @@ impl HashAggregator {
         // Hard-limit guard. A single record whose contributions alone
         // exceed the entire memory budget cannot be held in memory and
         // cannot be salvaged by spilling — the very next add of the same
-        // shape will repeat the overflow. Panic loudly. The relaxed-
-        // correlation-key commit step's degrade-fallback surface will
-        // replace this guard with a strict-collateral DLQ path for the
-        // affected groups when it lands.
+        // shape would repeat the overflow. Surface a typed error the
+        // dispatch arm routes by error strategy (FailFast aborts with E310;
+        // Continue/BestEffort routes the offending record to the DLQ)
+        // rather than admitting an unaffordable contribution.
         if self.memory_budget > 0 && row_charge > self.memory_budget {
-            panic!(
-                "buffered contributions exceeded hard limit (row_charge={}, budget={}); \
-                 relaxed-correlation-key group cannot be recomputed; this is a runtime \
-                 guard until the relaxed-correlation-key commit step's degrade-fallback \
-                 lands",
-                row_charge, self.memory_budget
-            );
+            return Err(HashAggError::OversizedRow {
+                row_charge,
+                budget: self.memory_budget,
+            });
         }
         // Source identity is extracted at ingest so the buffer path's
         // retract walk can scope rewinds per source, matching the
@@ -2331,15 +2330,13 @@ mod spill_trigger_tests {
     }
 
     #[test]
-    #[should_panic(expected = "buffered contributions exceeded hard limit")]
-    fn test_buffer_mode_panics_when_single_row_exceeds_budget() {
+    fn test_buffer_mode_oversized_row_returns_typed_error() {
         // Hard-limit guard. A single record's contributions exceeding
         // the entire memory budget is the unaffordable case — spilling
         // cannot help because the just-charged row is already over the
         // hard limit and the next add of the same shape repeats the
-        // overflow. This test exercises the dedicated panic path; the
-        // `#[should_panic]` is the consumer of the runtime guard, not a
-        // demotion of a previously asserting test.
+        // overflow. The aggregator returns a typed `OversizedRow` the
+        // dispatch arm routes by error strategy, never a panic.
         let input = make_schema(&["k", "s"]);
         // Budget intentionally tiny; single record String alone exceeds it.
         let mut agg = build_test_aggregator_relaxed(
@@ -2358,12 +2355,21 @@ mod spill_trigger_tests {
             &input,
             vec![Value::String("k1".into()), Value::String(big.into())],
         );
-        // The first add_record triggers a soft spill (budget > 0 and
-        // value_heap_bytes far exceeds 40% of 16) which drains. Spill
-        // does not actually rescue because the just-charged row's
-        // contribution already exceeded the entire budget; the
-        // post-spill hard-limit guard fires the panic.
-        let _ = agg.add_record(&r, 0, &ctx_for(&stable, &file, 0));
+        // The guard fires before the row is admitted: `add_record` returns
+        // `OversizedRow` carrying the offending footprint and the budget.
+        let err = agg
+            .add_record(&r, 0, &ctx_for(&stable, &file, 0))
+            .expect_err("a 2 KiB row under a 16-byte budget must return OversizedRow");
+        match err {
+            HashAggError::OversizedRow { row_charge, budget } => {
+                assert_eq!(budget, 16, "guard reports the configured 16-byte budget");
+                assert!(
+                    row_charge > budget,
+                    "row_charge {row_charge} must exceed budget {budget}"
+                );
+            }
+            other => panic!("expected OversizedRow, got {other:?}"),
+        }
     }
 
     // ----------------------------------------------------------------

--- a/crates/clinker-exec/src/aggregation/spill.rs
+++ b/crates/clinker-exec/src/aggregation/spill.rs
@@ -220,10 +220,17 @@ impl AggSpillWriter {
         Ok(())
     }
 
-    pub(super) fn finish(self) -> Result<AggSpillFile, HashAggError> {
+    /// Finalize the spill file and return the committed handle alongside its
+    /// on-disk byte length. The length is read from the persisted temp path
+    /// after the sink flushes (including any LZ4 frame tail), so a compressed
+    /// spill charges its actual post-compression size — the shape the disk-cap
+    /// accounting in [`super::HashAggregator::spill`] charges against the
+    /// arbitrator, mirroring the reshape/cull spill paths.
+    pub(super) fn finish(self) -> Result<(AggSpillFile, u64), HashAggError> {
         let temp_file = self.sink.into_temp_file()?;
         let path = temp_file.into_temp_path();
-        Ok(AggSpillFile { path })
+        let bytes = std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0);
+        Ok((AggSpillFile { path }, bytes))
     }
 }
 
@@ -328,7 +335,7 @@ mod tests {
         for (compress, expected_tag) in [(true, FORMAT_TAG_LZ4), (false, FORMAT_TAG_UNCOMPRESSED)] {
             let mut writer = AggSpillWriter::new(None, compress).unwrap();
             writer.write_entry(&sample_entry(vec![1, 2, 3])).unwrap();
-            let file = writer.finish().unwrap();
+            let (file, _len) = writer.finish().unwrap();
             let bytes = std::fs::read(&file.path).unwrap();
             assert_eq!(
                 bytes[0], expected_tag,
@@ -362,7 +369,7 @@ mod tests {
             for i in 0u8..5 {
                 writer.write_entry(&sample_entry(vec![i])).unwrap();
             }
-            let file = writer.finish().unwrap();
+            let (file, _len) = writer.finish().unwrap();
             let mut reader = file.reader().unwrap();
             let mut read_keys = Vec::new();
             while let Some(entry) = reader.next_entry().unwrap() {
@@ -372,6 +379,30 @@ mod tests {
                 read_keys,
                 (0u8..5).map(|i| vec![i]).collect::<Vec<_>>(),
                 "compress={compress}: entries must round-trip in input order"
+            );
+        }
+    }
+
+    // `finish` reports the spill file's actual on-disk byte length so the
+    // disk-spill cap charges the exact bytes committed. The reported length
+    // must equal the file's size on disk and be non-zero for a file carrying
+    // real entries, in both the uncompressed and LZ4-framed formats.
+    #[test]
+    fn finish_reports_on_disk_byte_length() {
+        for compress in [true, false] {
+            let mut writer = AggSpillWriter::new(None, compress).unwrap();
+            for i in 0u8..8 {
+                writer.write_entry(&sample_entry(vec![i])).unwrap();
+            }
+            let (file, reported) = writer.finish().unwrap();
+            let actual = std::fs::metadata(&file.path).unwrap().len();
+            assert_eq!(
+                reported, actual,
+                "compress={compress}: finish must report the on-disk byte length"
+            );
+            assert!(
+                reported > 0,
+                "compress={compress}: a spill with entries must have a non-zero length"
             );
         }
     }

--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -263,6 +263,7 @@ pub(crate) fn dispatch_aggregation(
                 spill_compress,
                 transform_name: name.clone(),
                 consumer_handle: agg_consumer_handle,
+                arbitrator: Arc::clone(&ctx.memory_budget),
             },
         )?;
 
@@ -624,6 +625,7 @@ impl DocAggregatorFactory {
                 spill_compress: self.spill_compress,
                 transform_name: self.transform_name.clone(),
                 consumer_handle: handle,
+                arbitrator: Arc::clone(&self.arbitrator),
             },
         )?;
         Ok((stream, consumer_id))
@@ -1263,6 +1265,17 @@ fn run_streaming_aggregate_ingest(
                     let stream = tables.entry_or_make(record.doc_ctx().id(), &factory)?;
                     match stream.add_record(&record, rn, &eval_ctx, &mut out_rows) {
                         Ok(()) => effects.cursor_advances.push((source_name_arc, rn)),
+                        // A spill-cap breach hard-aborts under every strategy —
+                        // resource exhaustion never routes to the DLQ, matching
+                        // the materialized `handle_aggregate_add_error` arm.
+                        Err(e)
+                            if matches!(
+                                e,
+                                crate::aggregation::HashAggError::SpillCapExceeded { .. }
+                            ) =>
+                        {
+                            return Err(e.into());
+                        }
                         Err(e) => match strategy {
                             ErrorStrategy::FailFast => return Err(e.into()),
                             ErrorStrategy::Continue | ErrorStrategy::BestEffort => {
@@ -1457,6 +1470,7 @@ impl WindowedAggContext<'_> {
                 spill_compress,
                 transform_name: self.name.to_string(),
                 consumer_handle: agg_consumer_handle,
+                arbitrator: Arc::clone(&ctx.memory_budget),
             },
         )?;
         Ok((stream, agg_consumer_id))
@@ -1919,6 +1933,13 @@ fn handle_aggregate_add_error(
     row_num: u64,
     e: crate::aggregation::HashAggError,
 ) -> Result<(), PipelineError> {
+    // A spill-cap breach is resource exhaustion, not a per-record data fault:
+    // writing more spill files cannot recover, so it aborts the run under
+    // every error strategy and never routes to the DLQ — matching the
+    // reshape and cull spill-cap paths.
+    if matches!(e, crate::aggregation::HashAggError::SpillCapExceeded { .. }) {
+        return Err(e.into());
+    }
     match ctx.config.error_handling.strategy {
         ErrorStrategy::FailFast => Err(e.into()),
         ErrorStrategy::Continue | ErrorStrategy::BestEffort => {

--- a/crates/clinker-exec/src/executor/batch_handoff.rs
+++ b/crates/clinker-exec/src/executor/batch_handoff.rs
@@ -788,6 +788,68 @@ mod tests {
         );
     }
 
+    /// A streaming spill whose file crosses the arbitrator's disk quota
+    /// aborts the run with the structured `SpillCapExceeded` (E320) surface
+    /// instead of continuing to fill the disk. Pins the soft threshold so the
+    /// batch takes the spill path, then sets the disk cap to one byte so the
+    /// spilled run's file overflows on its first write. The overflow is a
+    /// disk-cap abort, never masqueraded as an out-of-memory E310.
+    #[test]
+    fn streaming_spill_past_disk_cap_aborts_with_e320() {
+        use crate::pipeline::memory::{MemoryArbitrator, NoOpPolicy, assert_spill_cap_overflow};
+
+        let arbitrator = Arc::new(MemoryArbitrator::with_policy(
+            64 * 1024 * 1024,
+            0.80,
+            Box::new(NoOpPolicy),
+        ));
+        // Force the streaming charge path onto the spill branch (the charge
+        // path polls `should_spill_self`, no pausing round)...
+        arbitrator.set_limit(1);
+        arbitrator.set_peak_rss_for_test(u64::MAX);
+        assert!(arbitrator.should_spill_self());
+        // ...then choke the disk quota so the first spilled run overflows.
+        arbitrator.set_max_spill_bytes(1);
+
+        let spill_dir = tempfile::tempdir().expect("temp dir");
+        let spill_root: Arc<std::path::Path> = Arc::from(spill_dir.path());
+        let handle = ConsumerHandle::new();
+        let charge = StreamingChargeHandle::new(
+            handle.clone(),
+            Arc::clone(&arbitrator),
+            spill_root,
+            "stream-spill-cap".to_string(),
+            true,
+            clinker_plan::config::CompressMode::On,
+            2,
+        );
+
+        // A records-only batch spills as a single run; that run's file
+        // crosses the one-byte cap.
+        let mut batch = EventBatch::with_capacity(4);
+        for i in 0..3 {
+            batch.push_record(rec(i), i as u64);
+        }
+
+        let routed: Arc<std::sync::Mutex<Vec<StreamEvent>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let routed_sink = Arc::clone(&routed);
+        let result = charge.charge_and_route(batch, move |event| {
+            routed_sink.lock().unwrap().push(event);
+            Ok(())
+        });
+
+        assert_spill_cap_overflow(result, &arbitrator, "stream-spill-cap", 1, spill_dir.path());
+
+        // The aborting run forwards nothing downstream: the overflow fires
+        // before any spilled record is re-read from disk and sent.
+        let out = Arc::try_unwrap(routed).unwrap().into_inner().unwrap();
+        assert!(
+            out.is_empty(),
+            "no records escape downstream once the disk cap trips"
+        );
+    }
+
     #[test]
     fn batch_len_counts_records_and_punctuations() {
         let ctx = synthetic_document_context();

--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -378,6 +378,10 @@ fn compute_drop_decisions(
             spill_compress: false,
             transform_name: format!("cull:{name}"),
             consumer_handle: handle,
+            // The predicate aggregate runs in-memory (`budget: 0`,
+            // `spill_dir: None`) so it never spills, but `AggregatorConfig`
+            // requires an arbitrator; the run's shared one is the natural fit.
+            arbitrator: Arc::clone(&ctx.memory_budget),
         },
     )?;
 

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -1104,6 +1104,59 @@ mod tests {
         );
     }
 
+    /// A per-document bucket whose spill file crosses the arbitrator's disk
+    /// quota aborts with the structured `SpillCapExceeded` (E320) surface
+    /// rather than continuing to fill the disk. Drives [`spill_bucket_in_place`]
+    /// directly with a one-byte cap so the mem-tail flush overflows on its
+    /// first write — the DLQ bucket path's own disk-cap guard, exercised in
+    /// isolation from any upstream node-buffer spill.
+    #[test]
+    fn bucket_spill_past_disk_cap_aborts_with_e320() {
+        use crate::pipeline::memory::assert_spill_cap_overflow;
+
+        let s = schema();
+        let arbitrator = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
+            64,
+            0.5,
+            Box::new(crate::pipeline::memory::NoOpPolicy),
+        ));
+        // A one-byte disk quota: the mem-tail flush overflows it on the first
+        // write, regardless of how the soft memory limit is set.
+        arbitrator.set_max_spill_bytes(1);
+        let tmp = tempfile::tempdir().expect("tempdir");
+
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let consumer_id = arbitrator.register_consumer(Arc::new(
+            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+        ));
+        let mut bucket = DocBucket {
+            buffer: NodeBuffer::Memory(Vec::new()),
+            consumer_id,
+            handle,
+            depth: 1,
+        };
+
+        for i in 0..64u64 {
+            bucket
+                .buffer
+                .push(rec(&s, i as i64, (i * 10) as i64), 1000 + i);
+        }
+
+        let result = spill_bucket_in_place(
+            &mut bucket,
+            &arbitrator,
+            "out",
+            tmp.path(),
+            clinker_plan::config::CompressMode::default(),
+            8,
+            s.column_count(),
+        );
+
+        assert_spill_cap_overflow(result, &arbitrator, "out", 1, tmp.path());
+
+        arbitrator.unregister_consumer(consumer_id);
+    }
+
     /// A clean document whose bucket SPILLED and then accumulated a resident
     /// in-memory tail (a `Mixed` buffer — memory pressure relaxed mid-
     /// document) is drained to the success sink in ARRIVAL order: the spilled

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -6,6 +6,9 @@
 //! through the permutation, and emits the ordered run. The dispatcher's
 //! `Sort` arm is a single delegating call into [`dispatch_sort`].
 
+use std::cmp::Ordering;
+use std::sync::Arc;
+
 use clinker_record::Record;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
@@ -15,6 +18,10 @@ use crate::executor::dispatch::{
     tee_emit_to_region_input_buffers,
 };
 use crate::executor::{parse_memory_limit, stage_metrics};
+use crate::pipeline::loser_tree::LoserTree;
+use crate::pipeline::sort::compare_records_by_fields;
+use crate::pipeline::spill::{SpillFile, SpillReader};
+use clinker_plan::config::SortField;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 
@@ -116,43 +123,14 @@ pub(crate) fn dispatch_sort(
         })
     })?;
 
-    let mut out: Vec<(Record, u64)> = Vec::with_capacity(sort_count as usize);
-    match sorted {
-        SortedOutput::InMemory(pairs) => {
-            for (record, row_num) in pairs {
-                out.push((record, row_num));
-            }
-        }
-        SortedOutput::Spilled(files) => {
-            // Spill files are individually sorted but not
-            // globally merged. For correctness when multiple
-            // spill files exist, a k-way merge is required.
-            // Single-file fast path is exact.
-            if files.len() > 1 {
-                return Err(PipelineError::Io(std::io::Error::other(format!(
-                    "sort enforcer '{name}' produced {} spill files; \
-                             k-way merge for enforcer sort is not yet implemented \
-                             (memory.limit too small for input)",
-                    files.len()
-                ))));
-            }
-            for file in files {
-                let reader = file.reader().map_err(|e| {
-                    PipelineError::Io(std::io::Error::other(format!(
-                        "sort enforcer '{name}' spill read failed: {e}"
-                    )))
-                })?;
-                for entry in reader {
-                    let (record, row_num) = entry.map_err(|e| {
-                        PipelineError::Io(std::io::Error::other(format!(
-                            "sort enforcer '{name}' spill decode failed: {e}"
-                        )))
-                    })?;
-                    out.push((record, row_num));
-                }
-            }
-        }
-    }
+    // Individually-sorted runs from `SortBuffer` are folded into one globally
+    // ordered run through the same LoserTree k-way merge that aggregation spill
+    // uses; a single in-memory run is already globally ordered and needs no
+    // merge.
+    let out: Vec<(Record, u64)> = match sorted {
+        SortedOutput::InMemory(pairs) => pairs,
+        SortedOutput::Spilled(files) => merge_sorted_runs(files, sort_fields)?,
+    };
     ctx.collector
         .record(sort_timer.finish(sort_count, sort_count));
     tee_emit_to_region_input_buffers(ctx, current_dag, node_idx, &out)?;
@@ -167,4 +145,222 @@ pub(crate) fn dispatch_sort(
     ctx.node_buffers.insert(node_idx, nb);
 
     Ok(())
+}
+
+/// One entry in the enforcer-sort k-way merge: a spilled record and the
+/// `row_num` payload carried through the sort permutation. `Ord` delegates to
+/// [`compare_records_by_fields`] — the exact field comparator `SortBuffer`
+/// formed each run with — so the merged order is byte-identical to a single
+/// in-memory sort. The memcmp key on
+/// [`crate::pipeline::loser_tree::MergeEntry`] is deliberately not used here:
+/// it is not provably equal to the field comparator across Integer/Decimal or
+/// float ordering, so merging on it could silently mis-order cross-type keys.
+struct Run {
+    sort_by: Arc<[SortField]>,
+    record: Record,
+    row_num: u64,
+}
+
+impl PartialEq for Run {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for Run {}
+
+impl PartialOrd for Run {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Run {
+    fn cmp(&self, other: &Self) -> Ordering {
+        compare_records_by_fields(&self.record, &other.record, &self.sort_by)
+    }
+}
+
+/// Pull the next `(record, row_num)` from one spilled run, wrapping it as a
+/// [`Run`] merge entry, or `None` at end of stream.
+fn next_run(
+    reader: &mut SpillReader<u64>,
+    sort_by: &Arc<[SortField]>,
+) -> Result<Option<Run>, PipelineError> {
+    match reader.next() {
+        None => Ok(None),
+        Some(Ok((record, row_num))) => Ok(Some(Run {
+            sort_by: Arc::clone(sort_by),
+            record,
+            row_num,
+        })),
+        Some(Err(e)) => Err(PipelineError::Io(std::io::Error::other(format!(
+            "sort enforcer spill decode failed: {e}"
+        )))),
+    }
+}
+
+/// K-way merge the individually-sorted spill runs into one globally-ordered
+/// run via a [`LoserTree`], preserving each record's `row_num` payload.
+///
+/// `SortBuffer` spills runs in input order (run 0 earliest) with a stable
+/// per-run sort, and the loser tree breaks ties by lower stream index, so
+/// equal keys emit in input order — the merged run is byte-identical to the
+/// single in-memory sort the buffer would have produced without spilling.
+///
+/// Memory model: holds one resident record per open run plus the fully
+/// materialized output, matching the already-accepted single-run spill path.
+fn merge_sorted_runs(
+    files: Vec<SpillFile<u64>>,
+    sort_by: &[SortField],
+) -> Result<Vec<(Record, u64)>, PipelineError> {
+    let sort_by: Arc<[SortField]> = Arc::from(sort_by.to_vec());
+    // Each reader owns its own file handle; `files` is held for the whole
+    // merge so the spill temp files outlive every read.
+    let mut readers: Vec<SpillReader<u64>> = files
+        .iter()
+        .map(|f| f.reader())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            PipelineError::Io(std::io::Error::other(format!(
+                "sort enforcer spill read failed: {e}"
+            )))
+        })?;
+
+    // Seed the tree with one entry per run.
+    let mut initial: Vec<Option<Run>> = Vec::with_capacity(readers.len());
+    for reader in &mut readers {
+        initial.push(next_run(reader, &sort_by)?);
+    }
+    let mut tree = LoserTree::new(initial);
+
+    let mut out: Vec<(Record, u64)> = Vec::new();
+    while tree.winner().is_some() {
+        let idx = tree.winner_index();
+        // The loser tree exposes only `&T`; clone the winning record and copy
+        // its `row_num` out before refilling from the winning run. This
+        // per-record clone mirrors the aggregation spill merge.
+        let (record, row_num) = {
+            let winner = tree.winner().expect("winner present under loop guard");
+            (winner.record.clone(), winner.row_num)
+        };
+        out.push((record, row_num));
+        let next = next_run(&mut readers[idx], &sort_by)?;
+        tree.replace_winner(next);
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
+    use clinker_plan::config::SortOrder;
+    use clinker_record::{Schema, Value};
+    use rust_decimal::Decimal;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec!["k".into(), "id".into()]))
+    }
+
+    /// A record whose sort key `k` is a `Decimal` (mantissa/10) and whose
+    /// `id` mirrors the carried `row_num` for readback.
+    fn rec(schema: &Arc<Schema>, k_mantissa: i64, id: i64) -> Record {
+        Record::new(
+            schema.clone(),
+            vec![
+                Value::Decimal(Decimal::new(k_mantissa, 1)),
+                Value::Integer(id),
+            ],
+        )
+    }
+
+    fn sort_by_k_asc() -> Vec<SortField> {
+        vec![SortField {
+            field: "k".into(),
+            order: SortOrder::Asc,
+            null_order: None,
+        }]
+    }
+
+    /// Multiple individually-sorted spill runs — with a `Decimal` sort key,
+    /// duplicate keys spanning different runs, and unsorted input within each
+    /// run — must k-way merge into one globally-ordered run that preserves
+    /// every record's `row_num` payload and emits equal keys in input order
+    /// (stable). This is the correctness the enforcer sort lost when it
+    /// rejected multi-run spills instead of merging them.
+    #[test]
+    fn merge_sorted_runs_globally_orders_stably_and_preserves_row_num() {
+        let schema = schema();
+        let sort_by = sort_by_k_asc();
+        // budget=1 is the spill-everything threshold; runs are flushed
+        // explicitly below so each carries several unsorted records.
+        let mut buf: SortBuffer<u64> =
+            SortBuffer::new(sort_by.clone(), 1, None, true, schema.clone());
+
+        // Run A: keys 3.0, 1.0, 2.0 (row_num 0,1,2).
+        buf.push(rec(&schema, 30, 0), 0);
+        buf.push(rec(&schema, 10, 1), 1);
+        buf.push(rec(&schema, 20, 2), 2);
+        buf.sort_and_spill().unwrap();
+        // Run B: keys 2.0, 1.0 (row_num 3,4) — duplicates 2.0 and 1.0 from A.
+        buf.push(rec(&schema, 20, 3), 3);
+        buf.push(rec(&schema, 10, 4), 4);
+        buf.sort_and_spill().unwrap();
+        // Run C: keys 2.0, 4.0 (row_num 5,6) — duplicate 2.0 from A and B.
+        buf.push(rec(&schema, 20, 5), 5);
+        buf.push(rec(&schema, 40, 6), 6);
+        buf.sort_and_spill().unwrap();
+
+        let files = match buf.finish().unwrap() {
+            SortedOutput::Spilled(files) => {
+                assert_eq!(files.len(), 3, "three explicit flushes → three runs");
+                files
+            }
+            SortedOutput::InMemory(_) => panic!("expected Spilled after three flushes"),
+        };
+
+        let merged = merge_sorted_runs(files, &sort_by).unwrap();
+
+        // Every input record survives the merge exactly once.
+        assert_eq!(merged.len(), 7);
+
+        // Globally ordered on the Decimal key, ascending.
+        let keys: Vec<Decimal> = merged
+            .iter()
+            .map(|(r, _)| match r.get("k") {
+                Some(Value::Decimal(d)) => *d,
+                other => panic!("expected Decimal key, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                Decimal::new(10, 1),
+                Decimal::new(10, 1),
+                Decimal::new(20, 1),
+                Decimal::new(20, 1),
+                Decimal::new(20, 1),
+                Decimal::new(30, 1),
+                Decimal::new(40, 1),
+            ],
+            "runs must merge into ascending Decimal order"
+        );
+
+        // Stable: for equal keys, records emit in input order (run 0 earliest,
+        // then input order within a run). The carried row_num payload proves it
+        // and that no record picked up another's payload through the merge.
+        let row_nums: Vec<u64> = merged.iter().map(|(_, rn)| *rn).collect();
+        assert_eq!(
+            row_nums,
+            vec![1, 4, 2, 3, 5, 0, 6],
+            "equal keys must emit in input order and carry their own row_num"
+        );
+
+        // The payload identity matches the record's `id` column for every row,
+        // confirming the pairing survived both the spill envelope and the merge.
+        for (record, row_num) in &merged {
+            assert_eq!(record.get("id"), Some(&Value::Integer(*row_num as i64)));
+        }
+    }
 }

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -90,7 +90,7 @@ pub(crate) fn dispatch_sort(
     let spill_compress = ctx
         .spill_compress
         .resolve_for_schema(schema.column_count(), ctx.batch_size as u64);
-    let mut buf: SortBuffer<u64> = SortBuffer::new(
+    let buf: SortBuffer<u64> = SortBuffer::new(
         sort_fields.clone(),
         mem_limit,
         Some(ctx.spill_root_path.to_path_buf()),
@@ -100,28 +100,18 @@ pub(crate) fn dispatch_sort(
 
     let sort_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
     let sort_count = input_records.len() as u64;
-    // CPU-bound: sort buffer push + per-batch comparison + spill
-    // I/O. The kernel owns its input (`input_records`, `buf`) and
-    // borrows nothing from `ctx`, so it runs on the shared Rayon
-    // pool; output order is fully determined by the sort itself,
-    // so pool scheduling cannot perturb it.
-    let sorted = ctx.kernel_pool.install(|| {
-        for (record, row_num) in input_records {
-            buf.push(record, row_num);
-            if buf.should_spill() {
-                buf.sort_and_spill().map_err(|e| {
-                    PipelineError::Io(std::io::Error::other(format!(
-                        "sort enforcer '{name}' spill failed: {e}"
-                    )))
-                })?;
-            }
-        }
-        buf.finish().map_err(|e| {
-            PipelineError::Io(std::io::Error::other(format!(
-                "sort enforcer '{name}' finish failed: {e}"
-            )))
-        })
-    })?;
+    // Cloned out of `ctx` so the kernel closure owns it: every spilled run
+    // (including the residue `finish` flushes) is charged against the disk
+    // quota, aborting with E320 the moment the cumulative total crosses
+    // `storage.spill.disk_cap_bytes`.
+    let budget = std::sync::Arc::clone(&ctx.memory_budget);
+    // CPU-bound: sort buffer push + per-batch comparison + spill I/O. The
+    // kernel owns its input (`input_records`, `buf`, `budget`) and borrows
+    // nothing from `ctx`, so it runs on the shared Rayon pool; output order is
+    // fully determined by the sort itself, so pool scheduling cannot perturb it.
+    let sorted = ctx
+        .kernel_pool
+        .install(move || drain_into_sort_buffer(buf, input_records, name, &budget))?;
 
     // Individually-sorted runs from `SortBuffer` are folded into one globally
     // ordered run through the same LoserTree k-way merge that aggregation spill
@@ -144,6 +134,59 @@ pub(crate) fn dispatch_sort(
     )?;
     ctx.node_buffers.insert(node_idx, nb);
 
+    Ok(())
+}
+
+/// Drain `input` into `buf`, spilling sorted runs when the buffer exceeds its
+/// budget and charging every spilled run — including the residue flushed by
+/// `finish` — against the arbitrator's disk quota. Returns the buffer's sorted
+/// output, or [`PipelineError::SpillCapExceeded`] (E320) when a spilled run
+/// crosses the configured `storage.spill.disk_cap_bytes`.
+///
+/// CPU-bound: the per-run sort runs on the caller's Rayon pool.
+fn drain_into_sort_buffer(
+    mut buf: crate::pipeline::sort_buffer::SortBuffer<u64>,
+    input: Vec<(Record, u64)>,
+    node_name: &str,
+    budget: &crate::pipeline::memory::MemoryArbitrator,
+) -> Result<crate::pipeline::sort_buffer::SortedOutput<u64>, PipelineError> {
+    for (record, row_num) in input {
+        buf.push(record, row_num);
+        if buf.should_spill() {
+            let written = buf.sort_and_spill().map_err(|e| {
+                PipelineError::Io(std::io::Error::other(format!(
+                    "sort enforcer '{node_name}' spill failed: {e}"
+                )))
+            })?;
+            charge_enforcer_spill(budget, node_name, written)?;
+        }
+    }
+    let (sorted, residue) = buf.finish().map_err(|e| {
+        PipelineError::Io(std::io::Error::other(format!(
+            "sort enforcer '{node_name}' finish failed: {e}"
+        )))
+    })?;
+    charge_enforcer_spill(budget, node_name, residue)?;
+    Ok(sorted)
+}
+
+/// Charge `written` spilled bytes for `node_name` against the disk quota,
+/// returning [`PipelineError::SpillCapExceeded`] (E320) once the running
+/// cumulative total crosses `storage.spill.disk_cap_bytes`. A zero-byte write
+/// (nothing flushed) charges nothing.
+fn charge_enforcer_spill(
+    budget: &crate::pipeline::memory::MemoryArbitrator,
+    node_name: &str,
+    written: u64,
+) -> Result<(), PipelineError> {
+    if written > 0 && budget.record_spill_bytes(node_name, written) {
+        return Err(PipelineError::spill_cap_exceeded(
+            node_name.to_string(),
+            budget.max_spill_bytes(),
+            written,
+            budget.cumulative_spill_bytes(),
+        ));
+    }
     Ok(())
 }
 
@@ -312,7 +355,7 @@ mod tests {
         buf.push(rec(&schema, 40, 6), 6);
         buf.sort_and_spill().unwrap();
 
-        let files = match buf.finish().unwrap() {
+        let files = match buf.finish().unwrap().0 {
             SortedOutput::Spilled(files) => {
                 assert_eq!(files.len(), 3, "three explicit flushes → three runs");
                 files
@@ -362,5 +405,59 @@ mod tests {
         for (record, row_num) in &merged {
             assert_eq!(record.get("id"), Some(&Value::Integer(*row_num as i64)));
         }
+    }
+
+    /// The enforcer sort must abort the spill instead of writing past
+    /// `storage.spill.disk_cap_bytes`: each spilled run is charged against the
+    /// arbitrator's disk quota, and the first run that crosses a one-byte cap
+    /// surfaces E320. Before the fix the enforcer sort never charged the
+    /// arbitrator, so it could spill unbounded regardless of the configured cap.
+    #[test]
+    fn enforcer_sort_spill_past_disk_cap_fails_with_spill_cap_exceeded() {
+        use crate::pipeline::memory::{MemoryArbitrator, NoOpPolicy};
+
+        let schema = schema();
+        let budget = MemoryArbitrator::with_policy(64 * 1024, 0.80, Box::new(NoOpPolicy));
+        budget.set_max_spill_bytes(1);
+        let spill_root = tempfile::tempdir().unwrap();
+        // threshold=1 → every push spills, so the first run already crosses the
+        // one-byte disk cap.
+        let buf: SortBuffer<u64> = SortBuffer::new(
+            sort_by_k_asc(),
+            1,
+            Some(spill_root.path().to_path_buf()),
+            true,
+            schema.clone(),
+        );
+        let input: Vec<(Record, u64)> = (0..6)
+            .map(|i| (rec(&schema, (i as i64 + 1) * 10, i as i64), i))
+            .collect();
+
+        // `SortedOutput` is not `Debug`, so match rather than `expect_err`.
+        let err = match drain_into_sort_buffer(buf, input, "enforce", &budget) {
+            Ok(_) => panic!("a one-byte disk cap must abort the enforcer sort spill"),
+            Err(e) => e,
+        };
+        match err {
+            PipelineError::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => {
+                assert_eq!(node, "enforce");
+                assert_eq!(cap, 1, "reported cap equals the configured quota");
+                assert!(attempted > 0, "the overflowing run reports its size");
+                assert!(
+                    current > cap,
+                    "cumulative spilled ({current}) must exceed the cap ({cap})"
+                );
+            }
+            other => panic!("disk-cap overflow must surface SpillCapExceeded; got {other:?}"),
+        }
+        assert!(
+            budget.cumulative_spill_bytes() > 1,
+            "cumulative_spill_bytes must reflect the overflowing write"
+        );
     }
 }

--- a/crates/clinker-exec/src/executor/tests/aggregation.rs
+++ b/crates/clinker-exec/src/executor/tests/aggregation.rs
@@ -99,6 +99,16 @@ mod dispatch {
             spill_compress: true,
             transform_name: transform_name.to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            // Unlimited disk-spill cap (`max_spill_bytes` defaults to
+            // `u64::MAX`), so these builders spill without tripping E320; the
+            // disk-cap path is exercised end-to-end through the full pipeline.
+            arbitrator: std::sync::Arc::new(
+                crate::pipeline::memory::MemoryArbitrator::with_policy(
+                    0,
+                    0.8,
+                    crate::pipeline::memory::MemoryArbitrator::default_policy(),
+                ),
+            ),
         })
     }
 
@@ -1687,6 +1697,16 @@ mod two_phase_bytes_spill {
             spill_compress: true,
             transform_name: transform_name.to_string(),
             consumer_handle: crate::pipeline::memory::ConsumerHandle::new(),
+            // Unlimited disk-spill cap (`max_spill_bytes` defaults to
+            // `u64::MAX`), so these builders spill without tripping E320; the
+            // disk-cap path is exercised end-to-end through the full pipeline.
+            arbitrator: std::sync::Arc::new(
+                crate::pipeline::memory::MemoryArbitrator::with_policy(
+                    0,
+                    0.8,
+                    crate::pipeline::memory::MemoryArbitrator::default_policy(),
+                ),
+            ),
         })
     }
 

--- a/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
@@ -259,11 +259,11 @@ pub(crate) struct GraceHashExecutor {
     partitions: Vec<PartitionState>,
     spill_dir: PathBuf,
     hash_state: RandomState,
-    /// Bytes written across every spill commit this executor has
-    /// performed. Drained by [`Self::take_spilled_bytes`] so the
-    /// caller can fold the delta into [`MemoryArbitrator::record_spill_bytes`]
-    /// and surface E310 on disk-quota overflow.
-    spilled_bytes: u64,
+    /// Combine node name, used to attribute each spill commit's bytes to
+    /// the right stage in [`MemoryArbitrator::record_spill_bytes`] and to
+    /// tag the E320 `SpillCapExceeded` surface raised when a commit crosses
+    /// the disk quota.
+    name: String,
     /// Shared with the arbitrator's `GraceHashConsumer` wrapper.
     /// `add_build_record` adds the admitted record's bytes;
     /// `spill_partition` subtracts the evicted partition's
@@ -277,6 +277,30 @@ pub(crate) struct GraceHashExecutor {
     spill_compress: bool,
 }
 
+/// Charge one finished spill file's `written` bytes against the run's
+/// disk quota at the moment the file is committed, attributing them to
+/// stage `name`. Returns [`GraceSpillError::CapExceeded`] when this commit
+/// pushed the cumulative on-disk total past the configured cap so the
+/// caller aborts here rather than after the whole build or probe phase has
+/// finished writing — the per-commit enforcement the inter-partition
+/// repartition path already applies. A free function rather than a method
+/// so callers holding a `&mut self.partitions` iterator can charge through
+/// a disjoint borrow of `self.name`.
+fn charge_grace_spill(
+    budget: &MemoryArbitrator,
+    name: &str,
+    written: u64,
+) -> Result<(), GraceSpillError> {
+    if budget.record_spill_bytes(name, written) {
+        return Err(GraceSpillError::CapExceeded {
+            attempted: written,
+            cap: budget.disk_quota(),
+            cumulative: budget.cumulative_spill_bytes(),
+        });
+    }
+    Ok(())
+}
+
 impl GraceHashExecutor {
     /// Build a fresh executor sized for `partition_bits`. The caller
     /// supplies the spill directory — a path inside the pipeline-scoped
@@ -288,6 +312,7 @@ impl GraceHashExecutor {
         spill_dir: &Path,
         consumer_handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
         spill_compress: bool,
+        name: &str,
     ) -> std::io::Result<Self> {
         let assigner = PartitionAssigner::new(partition_bits.max(1));
         let n = assigner.num_partitions();
@@ -304,7 +329,7 @@ impl GraceHashExecutor {
             partitions,
             spill_dir: spill_dir.to_path_buf(),
             hash_state: RandomState::new(),
-            spilled_bytes: 0,
+            name: name.to_string(),
             consumer_handle,
             spill_compress,
         })
@@ -314,14 +339,6 @@ impl GraceHashExecutor {
     /// Borrowed reference into the caller-owned `Arc<TempDir>`.
     pub(crate) fn spill_dir_path(&self) -> &Path {
         &self.spill_dir
-    }
-
-    /// Drain the cumulative spill-bytes counter and return it. The
-    /// caller folds the result into
-    /// [`MemoryArbitrator::record_spill_bytes`] after each operation that
-    /// may have spilled (build, probe finalize, repartition).
-    pub(crate) fn take_spilled_bytes(&mut self) -> u64 {
-        std::mem::take(&mut self.spilled_bytes)
     }
 
     /// Hash state shared by every partition. Build and probe must hash
@@ -392,7 +409,6 @@ impl GraceHashExecutor {
                 )?;
                 w.write_record(&record)?;
                 let (new_path, written) = w.finish()?;
-                self.spilled_bytes = self.spilled_bytes.saturating_add(written);
                 if let PartitionState::OnDisk {
                     build_files,
                     build_count,
@@ -404,6 +420,7 @@ impl GraceHashExecutor {
                     *build_count += 1;
                     distinct_sketch.add(hash);
                 }
+                charge_grace_spill(budget, &self.name, written)?;
             }
         }
 
@@ -432,7 +449,7 @@ impl GraceHashExecutor {
             let Some((idx, _)) = victim else {
                 return Ok(());
             };
-            self.spill_partition(idx)?;
+            self.spill_partition(idx, budget)?;
             if !budget.should_spill() {
                 return Ok(());
             }
@@ -443,7 +460,11 @@ impl GraceHashExecutor {
     /// in-memory record to a fresh spill file. The HLL sketch is
     /// preserved verbatim across the transition so the reload-phase
     /// BNL branch can read partition cardinality without rebuilding.
-    fn spill_partition(&mut self, idx: usize) -> Result<(), GraceSpillError> {
+    fn spill_partition(
+        &mut self,
+        idx: usize,
+        budget: &MemoryArbitrator,
+    ) -> Result<(), GraceSpillError> {
         let assigner_bits = self.assigner.hash_bits();
         let hash_bits = assigner_bits;
         let partition_id = idx as u16;
@@ -471,7 +492,6 @@ impl GraceHashExecutor {
             writer.write_record(&r)?;
         }
         let (path, written) = writer.finish()?;
-        self.spilled_bytes = self.spilled_bytes.saturating_add(written);
         self.partitions[idx] = PartitionState::OnDisk {
             build_files: vec![path],
             probe_writer: None,
@@ -486,6 +506,7 @@ impl GraceHashExecutor {
         // operator's live state without wrapping if estimate drift
         // ever exceeds the running total.
         self.consumer_handle.sub_bytes(bytes_estimated as u64);
+        charge_grace_spill(budget, &self.name, written)?;
         Ok(())
     }
 
@@ -596,9 +617,14 @@ impl GraceHashExecutor {
 
     /// Finalize any open probe writers so their LZ4 frames are valid
     /// before the reload phase reopens them. Build-side writers were
-    /// already finalized in `spill_partition`.
-    pub(crate) fn finalize_probe_spills(&mut self) -> Result<(), GraceSpillError> {
-        let mut written_total: u64 = 0;
+    /// already finalized in `spill_partition`. Each finished file is
+    /// charged against the disk quota as it is committed, so a probe phase
+    /// that overshoots aborts at the crossing partition rather than after
+    /// every open writer has been flushed.
+    pub(crate) fn finalize_probe_spills(
+        &mut self,
+        budget: &MemoryArbitrator,
+    ) -> Result<(), GraceSpillError> {
         for state in &mut self.partitions {
             if let PartitionState::OnDisk {
                 probe_writer,
@@ -608,11 +634,10 @@ impl GraceHashExecutor {
                 && let Some(w) = probe_writer.take()
             {
                 let (path, written) = (*w).finish()?;
-                written_total = written_total.saturating_add(written);
                 probe_files.push(path);
+                charge_grace_spill(budget, &self.name, written)?;
             }
         }
-        self.spilled_bytes = self.spilled_bytes.saturating_add(written_total);
         Ok(())
     }
 
@@ -748,13 +773,18 @@ pub(crate) fn execute_combine_grace_hash(
         .or_else(|| output_schema.cloned())
         .unwrap_or_else(|| Arc::new(Schema::new(Vec::new())));
 
-    let mut executor =
-        GraceHashExecutor::new(partition_bits, spill_dir, consumer_handle, spill_compress)
-            .map_err(|e| PipelineError::Internal {
-                op: "combine",
-                node: name.to_string(),
-                detail: format!("grace hash spill dir bind failed: {e}"),
-            })?;
+    let mut executor = GraceHashExecutor::new(
+        partition_bits,
+        spill_dir,
+        consumer_handle,
+        spill_compress,
+        name,
+    )
+    .map_err(|e| PipelineError::Internal {
+        op: "combine",
+        node: name.to_string(),
+        detail: format!("grace hash spill dir bind failed: {e}"),
+    })?;
 
     // ── Build phase ────────────────────────────────────────────────────
     //
@@ -854,15 +884,6 @@ pub(crate) fn execute_combine_grace_hash(
         }
     }
     executor.finish_build(&build_extractor, ctx, budget, name)?;
-    let build_spilled = executor.take_spilled_bytes();
-    if budget.record_spill_bytes(name, build_spilled) {
-        return Err(PipelineError::spill_cap_exceeded(
-            name,
-            budget.disk_quota(),
-            build_spilled,
-            budget.cumulative_spill_bytes(),
-        ));
-    }
 
     // ── Probe phase ───────────────────────────────────────────────────
     let mut output_records: Vec<(Record, RecordOrder)> = Vec::new();
@@ -942,17 +963,8 @@ pub(crate) fn execute_combine_grace_hash(
     }
 
     executor
-        .finalize_probe_spills()
+        .finalize_probe_spills(budget)
         .map_err(|e| grace_spill_error(e, name, "probe finalize failed"))?;
-    let probe_spilled = executor.take_spilled_bytes();
-    if budget.record_spill_bytes(name, probe_spilled) {
-        return Err(PipelineError::spill_cap_exceeded(
-            name,
-            budget.disk_quota(),
-            probe_spilled,
-            budget.cumulative_spill_bytes(),
-        ));
-    }
 
     // ── Reload phase ──────────────────────────────────────────────────
     // Process every spilled partition pair. A reloaded partition that

--- a/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
@@ -142,6 +142,7 @@ fn pipeline_temp_dir_owns_spill_files_on_drop() {
         pipeline_dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
+        "grace_test",
     )
     .unwrap();
     let schema = schema_with(&["k"]);
@@ -149,7 +150,7 @@ fn pipeline_temp_dir_owns_spill_files_on_drop() {
     let rec = record_for(&schema, vec![Value::Integer(7)]);
     let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
     exec.add_build_record(rec, 0, &budget).unwrap();
-    exec.spill_partition(0).unwrap();
+    exec.spill_partition(0, &budget).unwrap();
     let spilled_inside = std::fs::read_dir(&pipeline_path).unwrap().count();
     assert!(spilled_inside >= 1, "spill_partition must commit a file");
     drop(exec);
@@ -181,13 +182,14 @@ fn pipeline_temp_dir_cleans_on_panic_unwind() {
             pipeline_dir.path(),
             crate::pipeline::memory::ConsumerHandle::new(),
             true,
+            "grace_test",
         )
         .unwrap();
         let schema = schema_with(&["k"]);
         let rec = record_for(&schema, vec![Value::Integer(99)]);
         let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
         exec.add_build_record(rec, 0, &budget).unwrap();
-        exec.spill_partition(0).unwrap();
+        exec.spill_partition(0, &budget).unwrap();
         panic!("simulated mid-spill panic");
     }));
     assert!(result.is_err(), "panic must propagate out");
@@ -212,6 +214,7 @@ fn spill_activates_under_tiny_budget() {
         dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
+        "grace_test",
     )
     .unwrap();
     let budget = tiny_budget();
@@ -253,7 +256,8 @@ fn spill_activates_on_charged_bytes_without_rss() {
         .tempdir()
         .unwrap();
     let consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
-    let mut exec = GraceHashExecutor::new(4, dir.path(), consumer_handle.clone(), true).unwrap();
+    let mut exec =
+        GraceHashExecutor::new(4, dir.path(), consumer_handle.clone(), true, "grace_test").unwrap();
 
     // 1 GiB hard limit → 800 MiB soft limit, above any host's test RSS,
     // so the RSS arm of `should_spill` cannot trip. Register the handle so
@@ -305,6 +309,7 @@ fn lazy_probe_spill_routes_to_partition_file() {
         dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
+        "grace_test",
     )
     .unwrap();
     let budget = tiny_budget();
@@ -330,7 +335,7 @@ fn lazy_probe_spill_routes_to_partition_file() {
         .unwrap();
     assert!(matches!(outcome, ProbeOutcome::Spilled));
 
-    exec.finalize_probe_spills().unwrap();
+    exec.finalize_probe_spills(&budget).unwrap();
     match &exec.partitions[0] {
         PartitionState::OnDisk {
             probe_files,
@@ -980,6 +985,375 @@ fn execute_grace_hash_aborts_on_disk_quota_overflow() {
     );
 }
 
+/// Per-commit enforcement on the build-side eviction path: a 1-byte cap
+/// trips `spill_largest_building` -> `spill_partition` at the FIRST
+/// partition it evicts, aborting mid-build rather than after the whole
+/// build stream has been drained (the phase-boundary bug). At the method
+/// boundary the old code returned `Ok` on every record and only the
+/// driver's phase-end tally could fail; now the commit itself fails.
+#[test]
+fn build_eviction_spill_commit_trips_disk_cap_mid_stream() {
+    use crate::pipeline::grace_spill::{GraceSpillError, grace_spill_error};
+
+    let schema = schema_with(&["k", "v"]);
+    let dir = tempfile::Builder::new()
+        .prefix("gh-cap-build-")
+        .tempdir()
+        .unwrap();
+    let mut exec = GraceHashExecutor::new(
+        4,
+        dir.path(),
+        crate::pipeline::memory::ConsumerHandle::new(),
+        true,
+        "join_build",
+    )
+    .unwrap();
+
+    // Tiny soft limit so `should_spill` fires continuously; 1-byte cap so
+    // the first eviction commit overshoots; hard limit huge so
+    // `should_abort` never fires.
+    let budget = tiny_budget();
+    budget.set_max_spill_bytes(1);
+
+    let total = 4096usize;
+    let mut fed = 0usize;
+    let mut hit: Option<GraceSpillError> = None;
+    for i in 0..total as i64 {
+        let rec = record_for(
+            &schema,
+            vec![
+                Value::Integer(i),
+                Value::String(format!("row-{i:08}-pad-pad-pad").into()),
+            ],
+        );
+        let hash = (i as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+        match exec.add_build_record(rec, hash, &budget) {
+            Ok(()) => fed += 1,
+            Err(e) => {
+                hit = Some(e);
+                break;
+            }
+        }
+    }
+
+    let err = hit.expect("1-byte cap must abort the build-side eviction");
+    match &err {
+        GraceSpillError::CapExceeded {
+            attempted,
+            cap,
+            cumulative,
+        } => {
+            assert!(
+                *attempted > 0,
+                "the overflowing commit must report its size"
+            );
+            assert_eq!(*cap, 1, "cap must equal the configured quota");
+            assert!(
+                *cumulative > *cap,
+                "cumulative ({cumulative}) must exceed cap ({cap})"
+            );
+        }
+        other => panic!("build eviction overshoot must surface CapExceeded; got {other:?}"),
+    }
+
+    // Per-commit, not phase-boundary: the abort landed before the whole
+    // 4096-record stream was consumed.
+    assert!(
+        fed < total,
+        "cap must abort mid-stream, not after the full feed ({fed} of {total})"
+    );
+
+    // Exactly one commit was charged — the crossing eviction — and it was
+    // attributed to the executor's stage name. A phase-boundary check
+    // would instead have let every partition's eviction accumulate first.
+    let per_stage = budget.per_stage_spill_bytes();
+    assert_eq!(
+        per_stage.len(),
+        1,
+        "only the single crossing commit should be charged, got {per_stage:?}"
+    );
+    assert_eq!(
+        budget.cumulative_spill_bytes(),
+        per_stage["join_build"],
+        "cumulative must equal the single crossing commit's bytes"
+    );
+
+    // Field-destructure of the mapped E320 surface, mirroring the driver's
+    // `grace_spill_error` mapping.
+    match grace_spill_error(err, "join_build", "build add") {
+        PipelineError::SpillCapExceeded {
+            node,
+            cap,
+            attempted,
+            current,
+        } => {
+            assert_eq!(node, "join_build");
+            assert_eq!(cap, 1);
+            assert!(attempted > 0);
+            assert!(current > cap);
+        }
+        other => panic!("mapper must yield SpillCapExceeded; got {other:?}"),
+    }
+}
+
+/// Per-commit enforcement on the build-side OnDisk immediate-write path:
+/// once a partition is already spilled, each subsequent record streams to
+/// its own file and must charge the cap on that commit. A 1-byte cap trips
+/// on the FIRST such record rather than accumulating a fresh file per row
+/// until the phase ends.
+#[test]
+fn build_ondisk_immediate_write_commit_trips_disk_cap() {
+    use crate::pipeline::grace_spill::{GraceSpillError, grace_spill_error};
+
+    let schema = schema_with(&["k", "v"]);
+    let dir = tempfile::Builder::new()
+        .prefix("gh-cap-ondisk-")
+        .tempdir()
+        .unwrap();
+    let mut exec = GraceHashExecutor::new(
+        4,
+        dir.path(),
+        crate::pipeline::memory::ConsumerHandle::new(),
+        true,
+        "join_ondisk",
+    )
+    .unwrap();
+
+    // A budget that does NOT auto-spill (soft limit ~8 GiB) so the test
+    // controls exactly when a commit happens; the cap starts unlimited so
+    // the manual pre-spill lands without tripping.
+    let budget = MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+
+    // Top 4 bits select the partition under 4 hash-bits; 0x0…1 -> 0.
+    let hash_p0 = 0x0000_0000_0000_0001u64;
+    // Seed partition 0 and drive it OnDisk by hand — no cap trip yet.
+    exec.add_build_record(
+        record_for(
+            &schema,
+            vec![Value::Integer(0), Value::String("seed".into())],
+        ),
+        hash_p0,
+        &budget,
+    )
+    .unwrap();
+    exec.spill_partition(0, &budget).unwrap();
+    assert!(
+        matches!(exec.partitions[0], PartitionState::OnDisk { .. }),
+        "manual spill must place partition 0 on disk"
+    );
+    let after_pre_spill = budget.cumulative_spill_bytes();
+    assert!(after_pre_spill > 0, "pre-spill must have committed a file");
+
+    // Clamp the cap to 1 byte. The next record routed to the OnDisk
+    // partition streams straight to a fresh file and charges on commit,
+    // which must trip immediately.
+    budget.set_max_spill_bytes(1);
+
+    let total = 8usize;
+    let mut fed = 0usize;
+    let mut hit: Option<GraceSpillError> = None;
+    for i in 1..=total as i64 {
+        let rec = record_for(
+            &schema,
+            vec![Value::Integer(i), Value::String(format!("row-{i}").into())],
+        );
+        match exec.add_build_record(rec, hash_p0, &budget) {
+            Ok(()) => fed += 1,
+            Err(e) => {
+                hit = Some(e);
+                break;
+            }
+        }
+    }
+
+    let err = hit.expect("1-byte cap must abort the OnDisk immediate write");
+    match &err {
+        GraceSpillError::CapExceeded {
+            attempted,
+            cap,
+            cumulative,
+        } => {
+            assert!(
+                *attempted > 0,
+                "the immediate-write commit must report its size"
+            );
+            assert_eq!(*cap, 1);
+            assert!(
+                *cumulative > *cap,
+                "cumulative ({cumulative}) must exceed cap ({cap})"
+            );
+            assert!(
+                *cumulative > after_pre_spill,
+                "the immediate-write commit must add to the pre-spill total"
+            );
+        }
+        other => panic!("OnDisk immediate write overshoot must surface CapExceeded; got {other:?}"),
+    }
+    assert_eq!(
+        fed, 0,
+        "the FIRST OnDisk record must trip the cap, before the rest of the stream"
+    );
+
+    match grace_spill_error(err, "join_ondisk", "build write") {
+        PipelineError::SpillCapExceeded {
+            node,
+            cap,
+            attempted,
+            current,
+        } => {
+            assert_eq!(node, "join_ondisk");
+            assert_eq!(cap, 1);
+            assert!(attempted > 0);
+            assert!(current > cap);
+        }
+        other => panic!("mapper must yield SpillCapExceeded; got {other:?}"),
+    }
+}
+
+/// Per-commit enforcement on the probe-finalize path: each partition's
+/// buffered probe writer is committed and charged in turn, so a 1-byte cap
+/// trips on the FIRST partition finalized and leaves later partitions'
+/// writers unflushed — rather than finalizing every open writer and only
+/// then checking the total.
+#[test]
+fn probe_finalize_spill_commit_trips_disk_cap_per_partition() {
+    use crate::pipeline::grace_spill::{GraceSpillError, grace_spill_error};
+
+    let schema = schema_with(&["k"]);
+    let dir = tempfile::Builder::new()
+        .prefix("gh-cap-probe-")
+        .tempdir()
+        .unwrap();
+    let mut exec = GraceHashExecutor::new(
+        4,
+        dir.path(),
+        crate::pipeline::memory::ConsumerHandle::new(),
+        true,
+        "join_probe",
+    )
+    .unwrap();
+    let budget = MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+
+    // Top 4 bits select the partition: 0x0…1 -> 0, 0x1000… -> 1.
+    let hash_p0 = 0x0000_0000_0000_0001u64;
+    let hash_p1 = 0x1000_0000_0000_0000u64;
+
+    // Drive partitions 0 and 1 OnDisk by hand (cap unlimited during build).
+    exec.add_build_record(
+        record_for(&schema, vec![Value::Integer(0)]),
+        hash_p0,
+        &budget,
+    )
+    .unwrap();
+    exec.add_build_record(
+        record_for(&schema, vec![Value::Integer(1)]),
+        hash_p1,
+        &budget,
+    )
+    .unwrap();
+    exec.spill_partition(0, &budget).unwrap();
+    exec.spill_partition(1, &budget).unwrap();
+    assert!(matches!(exec.partitions[0], PartitionState::OnDisk { .. }));
+    assert!(matches!(exec.partitions[1], PartitionState::OnDisk { .. }));
+
+    // Route a probe record into each OnDisk partition — buffered in the
+    // partition's probe writer, not yet committed to disk.
+    assert!(matches!(
+        exec.probe_record(
+            &record_for(&schema, vec![Value::Integer(10)]),
+            &[Value::Integer(10)],
+            hash_p0
+        )
+        .unwrap(),
+        ProbeOutcome::Spilled
+    ));
+    assert!(matches!(
+        exec.probe_record(
+            &record_for(&schema, vec![Value::Integer(20)]),
+            &[Value::Integer(20)],
+            hash_p1
+        )
+        .unwrap(),
+        ProbeOutcome::Spilled
+    ));
+
+    // Clamp the cap; finalize must commit each probe file and trip on the
+    // first partition, leaving the later partition's writer open.
+    budget.set_max_spill_bytes(1);
+    let err = exec
+        .finalize_probe_spills(&budget)
+        .expect_err("1-byte cap must abort probe finalize");
+    match &err {
+        GraceSpillError::CapExceeded {
+            attempted,
+            cap,
+            cumulative,
+        } => {
+            assert!(
+                *attempted > 0,
+                "the finalized probe file must report its size"
+            );
+            assert_eq!(*cap, 1);
+            assert!(
+                *cumulative > *cap,
+                "cumulative ({cumulative}) must exceed cap ({cap})"
+            );
+        }
+        other => panic!("probe finalize overshoot must surface CapExceeded; got {other:?}"),
+    }
+
+    // Per-commit early abort: exactly one probe writer was finalized (its
+    // file committed) and the other partition's writer is still open,
+    // untouched after the loop returned on the first crossing.
+    let committed = exec
+        .partitions
+        .iter()
+        .filter(|p| {
+            matches!(
+                p,
+                PartitionState::OnDisk { probe_writer: None, probe_files, .. }
+                    if !probe_files.is_empty()
+            )
+        })
+        .count();
+    let open = exec
+        .partitions
+        .iter()
+        .filter(|p| {
+            matches!(
+                p,
+                PartitionState::OnDisk {
+                    probe_writer: Some(_),
+                    ..
+                }
+            )
+        })
+        .count();
+    assert_eq!(
+        committed, 1,
+        "only the crossing partition's probe file was committed"
+    );
+    assert_eq!(
+        open, 1,
+        "the later partition's probe writer stays open — finalize aborted mid-stream"
+    );
+
+    match grace_spill_error(err, "join_probe", "probe finalize") {
+        PipelineError::SpillCapExceeded {
+            node,
+            cap,
+            attempted,
+            current,
+        } => {
+            assert_eq!(node, "join_probe");
+            assert_eq!(cap, 1);
+            assert!(attempted > 0);
+            assert!(current > cap);
+        }
+        other => panic!("mapper must yield SpillCapExceeded; got {other:?}"),
+    }
+}
+
 /// Round-trip records through the spill writer/reader by calling
 /// `add_build_record`, `spill_largest_building`, then reloading via
 /// `drain_spilled` + `GraceSpillReader`.
@@ -995,6 +1369,7 @@ fn build_spill_reload_records_match() {
         dir.path(),
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
+        "grace_test",
     )
     .unwrap();
     let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy)); // never spills via budget
@@ -1011,7 +1386,7 @@ fn build_spill_reload_records_match() {
     }
     // Force-spill every partition.
     for idx in 0..exec.partitions.len() {
-        let _ = exec.spill_partition(idx);
+        let _ = exec.spill_partition(idx, &budget);
     }
     let spilled = exec.drain_spilled();
     let mut reloaded: Vec<Record> = Vec::new();

--- a/crates/clinker-exec/src/pipeline/grace_spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_spill.rs
@@ -162,6 +162,20 @@ pub(crate) enum GraceSpillError {
     /// A byte-stream fault during write/finalize, or an internal
     /// state-machine violation surfaced as an `io::Error`.
     Io(std::io::Error),
+    /// The cumulative on-disk spill total crossed the configured
+    /// `[storage.spill] max_bytes` quota when this commit's bytes were
+    /// charged. Distinct from [`Self::DiskFull`]: the volume still has
+    /// room, but the run's own policy ceiling was reached. `attempted` is
+    /// this commit's byte count, `cap` the configured quota, and
+    /// `cumulative` the running total after the charge. The mapper turns it
+    /// into the E320 `SpillCapExceeded` surface so the run aborts at the
+    /// commit that crossed the cap rather than after the whole phase has
+    /// finished writing.
+    CapExceeded {
+        attempted: u64,
+        cap: u64,
+        cumulative: u64,
+    },
 }
 
 impl From<std::io::Error> for GraceSpillError {
@@ -194,13 +208,19 @@ impl GraceSpillWriter {
 /// A mid-run directory fault or a full-volume fault becomes
 /// `PipelineError::Spill`, so it renders with the same `DirUnavailable` /
 /// `DiskFull` diagnostic the node-buffer, sort, and aggregate spill paths
-/// emit; a genuine byte fault or state-machine violation becomes
+/// emit; a disk-quota overshoot becomes `PipelineError::SpillCapExceeded`
+/// (E320); a genuine byte fault or state-machine violation becomes
 /// `PipelineError::Internal`.
 pub(crate) fn grace_spill_error(e: GraceSpillError, node: &str, detail: &str) -> PipelineError {
     match e {
         GraceSpillError::DirUnavailable(spill) | GraceSpillError::DiskFull(spill) => {
             PipelineError::Spill(spill)
         }
+        GraceSpillError::CapExceeded {
+            attempted,
+            cap,
+            cumulative,
+        } => PipelineError::spill_cap_exceeded(node, cap, attempted, cumulative),
         GraceSpillError::Io(io) => PipelineError::Internal {
             op: "combine",
             node: node.to_string(),

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1286,6 +1286,84 @@ impl MemoryArbitrator {
     }
 }
 
+/// Shared oracle for the disk-spill-cap (E320) overflow surface, so every
+/// spill site that charges files against the arbitrator's disk quota proves
+/// the identical invariants against one assertion.
+///
+/// Given the `Result` a spill call returned, the arbitrator it charged, and
+/// the configured spill root it wrote into, this checks that:
+/// - the error carries the [`PipelineError::SpillCapExceeded`] shape naming
+///   the spilling operator, with a positive `attempted` flush size and a
+///   `current` total past the `cap` (kept distinct from an out-of-memory
+///   E310);
+/// - the error's `current` mirrors the arbitrator's own
+///   `cumulative_spill_bytes`, which exceeds the cap and is attributed to the
+///   operator's node in the per-stage breakdown that `--explain` reads back;
+/// - the abort reclaims the overflowing flush's temp file, leaving no spill
+///   file orphaned under the configured spill root.
+#[cfg(test)]
+pub(crate) fn assert_spill_cap_overflow(
+    result: Result<(), clinker_plan::error::PipelineError>,
+    arbitrator: &MemoryArbitrator,
+    expected_node: &str,
+    expected_cap: u64,
+    spill_root: &std::path::Path,
+) {
+    use clinker_plan::error::PipelineError;
+
+    let err = result.expect_err("a flush past the disk cap must abort the run");
+    let PipelineError::SpillCapExceeded {
+        node,
+        cap,
+        attempted,
+        current,
+    } = &err
+    else {
+        panic!("disk-cap overflow must surface SpillCapExceeded; got {err:?}");
+    };
+    assert_eq!(
+        node, expected_node,
+        "the aborting error names the spilling operator"
+    );
+    assert_eq!(
+        *cap, expected_cap,
+        "the reported cap equals the configured quota"
+    );
+    assert!(
+        *attempted > 0,
+        "the overflowing flush reports its on-disk byte size"
+    );
+    assert!(
+        *current > *cap,
+        "cumulative spilled ({current}) must exceed the cap ({cap})"
+    );
+
+    assert_eq!(
+        *current,
+        arbitrator.cumulative_spill_bytes(),
+        "the error's current mirrors the arbitrator's cumulative total"
+    );
+    assert!(
+        arbitrator.cumulative_spill_bytes() > expected_cap,
+        "the arbitrator's cumulative total reflects the overflowing flush"
+    );
+    assert!(
+        arbitrator
+            .per_stage_spill_bytes()
+            .get(expected_node)
+            .is_some_and(|&bytes| bytes > 0),
+        "the overflowing flush is charged to the spilling operator's stage"
+    );
+
+    let leaked = std::fs::read_dir(spill_root)
+        .expect("the configured spill root is readable")
+        .count();
+    assert_eq!(
+        leaked, 0,
+        "the disk-cap abort leaves no spill file orphaned under the spill root"
+    );
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/clinker-exec/src/pipeline/sort_buffer.rs
+++ b/crates/clinker-exec/src/pipeline/sort_buffer.rs
@@ -87,10 +87,12 @@ impl<P: Serialize + DeserializeOwned + Send> SortBuffer<P> {
     }
 
     /// Sort the current in-memory pairs and write them to a spill file.
-    /// Clears the buffer and resets the byte counter.
-    pub fn sort_and_spill(&mut self) -> Result<(), SpillError> {
+    /// Clears the buffer and resets the byte counter. Returns the spilled
+    /// file's on-disk byte length so the caller can charge it against the
+    /// pipeline disk-spill quota; an empty buffer writes nothing and returns 0.
+    pub fn sort_and_spill(&mut self) -> Result<u64, SpillError> {
         if self.pairs.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
 
         let sort_by = &self.sort_by;
@@ -109,15 +111,24 @@ impl<P: Serialize + DeserializeOwned + Send> SortBuffer<P> {
             writer.write_pair(&record, &payload)?;
         }
         let spill_file = writer.finish()?;
+        // On-disk length after finalize (the LZ4 frame tail is flushed by
+        // `finish`), matching the byte figure the disk-cap accounting charges
+        // for every other spill op. A stat failure charges 0 rather than
+        // aborting a successful spill.
+        let written = std::fs::metadata(spill_file.path())
+            .map(|m| m.len())
+            .unwrap_or(0);
         self.spill_files.push(spill_file);
         self.bytes_used = 0;
-        Ok(())
+        Ok(written)
     }
 
     /// Finish the sort buffer. If pairs were spilled, remaining in-memory
-    /// pairs are also spilled. Returns either sorted in-memory pairs or a
-    /// list of sorted spill files for merge.
-    pub fn finish(mut self) -> Result<SortedOutput<P>, SpillError> {
+    /// pairs are also spilled. Returns the sorted output — in-memory pairs or
+    /// the list of sorted spill files for merge — paired with the byte length
+    /// of the residue run this call spilled (0 when nothing spilled here), so
+    /// the caller can charge that final run against the disk-spill quota.
+    pub fn finish(mut self) -> Result<(SortedOutput<P>, u64), SpillError> {
         if self.spill_files.is_empty() {
             let sort_by = &self.sort_by;
             // Parallel stable sort on the shared kernel pool; tie-break
@@ -125,12 +136,14 @@ impl<P: Serialize + DeserializeOwned + Send> SortBuffer<P> {
             // the in-memory result is byte-identical.
             self.pairs
                 .par_sort_by(|(a, _), (b, _)| compare_records_by_fields(a, b, sort_by));
-            Ok(SortedOutput::InMemory(self.pairs))
+            Ok((SortedOutput::InMemory(self.pairs), 0))
         } else {
-            if !self.pairs.is_empty() {
-                self.sort_and_spill()?;
-            }
-            Ok(SortedOutput::Spilled(self.spill_files))
+            let residue = if !self.pairs.is_empty() {
+                self.sort_and_spill()?
+            } else {
+                0
+            };
+            Ok((SortedOutput::Spilled(self.spill_files), residue))
         }
     }
 
@@ -256,7 +269,7 @@ mod tests {
         buf.push(make_record(&schema, "Alice", 10), ());
         buf.push(make_record(&schema, "Bob", 20), ());
 
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 assert_eq!(pairs.len(), 3);
                 assert_eq!(pairs[0].0.get("value"), Some(&Value::Integer(10)));
@@ -293,7 +306,7 @@ mod tests {
         // Push one more without spilling — finish() will spill it
         buf.push(make_record(&schema, "C", 30), ());
 
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::Spilled(files) => {
                 assert_eq!(files.len(), 3); // 2 manual spills + 1 from finish()
             }
@@ -312,7 +325,7 @@ mod tests {
         buf.sort_and_spill().unwrap();
 
         // Read back and verify sorted
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::Spilled(files) => {
                 let reader = files[0].reader().unwrap();
                 let recs: Vec<Record> = reader.map(|r| r.unwrap().0).collect();
@@ -334,7 +347,7 @@ mod tests {
         buf.push(make_record(&schema, "Charlie", 30), 100);
         buf.push(make_record(&schema, "Alice", 10), 200);
         buf.push(make_record(&schema, "Bob", 20), 300);
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 assert_eq!(pairs.len(), 3);
                 // Sorted by value asc: Alice(10,200), Bob(20,300), Charlie(30,100)
@@ -356,7 +369,7 @@ mod tests {
         buf.push(make_record(&schema, "A", 10), 200);
         buf.push(make_record(&schema, "B", 20), 300);
         buf.sort_and_spill().unwrap();
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::Spilled(files) => {
                 let reader = files[0].reader().unwrap();
                 let pairs: Vec<(Record, u64)> = reader.map(|r| r.unwrap()).collect();
@@ -377,7 +390,7 @@ mod tests {
         let schema = test_schema();
         let buf: SortBuffer<()> =
             SortBuffer::new(sort_by_value_asc(), 1_000_000, None, true, schema);
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => assert!(pairs.is_empty()),
             SortedOutput::Spilled(_) => panic!("expected InMemory"),
         }

--- a/crates/clinker-exec/src/pipeline/sort_integration.rs
+++ b/crates/clinker-exec/src/pipeline/sort_integration.rs
@@ -106,7 +106,7 @@ mod tests {
         for i in (0..100).rev() {
             buf.push(rec2(&schema, &format!("r{i}"), i), ());
         }
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 assert_eq!(pairs.len(), 100);
                 for (i, (r, _)) in pairs.iter().enumerate() {
@@ -126,7 +126,7 @@ mod tests {
         for name in &["alpha", "charlie", "bravo", "delta", "echo"] {
             buf.push(rec2(&schema, name, 0), ());
         }
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 let names: Vec<_> = pairs
                     .iter()
@@ -151,7 +151,7 @@ mod tests {
         buf.push(rec3(&schema, "A", 100, 2), ());
         buf.push(rec3(&schema, "A", 300, 3), ());
         buf.push(rec3(&schema, "B", 100, 4), ());
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 // A first (ASC), within A: 300 before 100 (DESC)
                 assert_eq!(pairs[0].0.get("dept"), Some(&Value::String("A".into())));
@@ -177,7 +177,7 @@ mod tests {
             (),
         );
         buf.push(rec2(&schema, "c", 10), ());
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 assert_eq!(pairs[0].0.get("value"), Some(&Value::Null));
                 assert_eq!(pairs[1].0.get("value"), Some(&Value::Integer(10)));
@@ -199,7 +199,7 @@ mod tests {
             (),
         );
         buf.push(rec2(&schema, "c", 10), ());
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 assert_eq!(pairs[0].0.get("value"), Some(&Value::Integer(10)));
                 assert_eq!(pairs[1].0.get("value"), Some(&Value::Integer(30)));
@@ -220,7 +220,7 @@ mod tests {
         buf.push(rec3(&schema, "A", 200, 2), ());
         buf.push(rec3(&schema, "A", 300, 3), ());
         buf.push(rec3(&schema, "A", 400, 4), ());
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 for (i, (r, _)) in pairs.iter().enumerate() {
                     assert_eq!(r.get("seq"), Some(&Value::Integer(i as i64 + 1)));
@@ -258,7 +258,7 @@ mod tests {
             buf.push(rec2(&schema, &format!("r{i}"), i), ());
             buf.sort_and_spill().unwrap();
         }
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::Spilled(files) => {
                 assert_eq!(files.len(), 32);
                 // Merge all 32 files (cascade: merge 16, then merge remaining)
@@ -296,7 +296,7 @@ mod tests {
             .collect();
         assert!(!files_before.is_empty(), "spill files should exist");
 
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::Spilled(files) => {
                 // Drop the spill files (RAII cleanup)
                 drop(files);
@@ -339,7 +339,7 @@ mod tests {
             "no spill files should be created for in-memory path"
         );
 
-        match buf.finish().unwrap() {
+        match buf.finish().unwrap().0 {
             SortedOutput::InMemory(pairs) => {
                 assert_eq!(pairs.len(), 10);
                 for (i, (r, _)) in pairs.iter().enumerate() {

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -635,6 +635,7 @@ fn execute_combine_sort_merge_with_stats(
             budget,
             spill_compress,
             &consumer_handle,
+            spill_dir,
         )?;
         sort_build_pairs_externally(
             &mut build_pairs,
@@ -643,6 +644,7 @@ fn execute_combine_sort_merge_with_stats(
             budget,
             spill_compress,
             &consumer_handle,
+            spill_dir,
         )?;
         stats.phase_a_sort_invocations = 2;
     } else {
@@ -832,6 +834,7 @@ fn sort_driver_pairs_externally(
     budget: &MemoryArbitrator,
     spill_compress: bool,
     consumer_handle: &Arc<crate::pipeline::memory::ConsumerHandle>,
+    spill_dir: &Path,
 ) -> Result<(), PipelineError> {
     if pairs.is_empty() {
         return Ok(());
@@ -861,7 +864,7 @@ fn sort_driver_pairs_externally(
     let mut buf: SortBuffer<RecordOrder> = SortBuffer::new(
         vec![sort_field],
         spill_threshold,
-        None,
+        Some(spill_dir.to_path_buf()),
         spill_compress,
         schema,
     );
@@ -883,21 +886,37 @@ fn sort_driver_pairs_externally(
         local_charged = local_charged.saturating_add(delta);
         if buf.should_spill() {
             let pre_spill = buf.bytes_used() as u64;
-            buf.sort_and_spill().map_err(|e| {
+            let written = buf.sort_and_spill().map_err(|e| {
                 PipelineError::Io(std::io::Error::other(format!(
                     "sort-merge driver phase A spill failed: {e}"
                 )))
             })?;
             consumer_handle.sub_bytes(pre_spill);
             local_charged = local_charged.saturating_sub(pre_spill);
+            if written > 0 && budget.record_spill_bytes(name, written) {
+                return Err(PipelineError::spill_cap_exceeded(
+                    name,
+                    budget.disk_quota(),
+                    written,
+                    budget.cumulative_spill_bytes(),
+                ));
+            }
         }
     }
 
-    let sorted = buf.finish().map_err(|e| {
+    let (sorted, residue) = buf.finish().map_err(|e| {
         PipelineError::Io(std::io::Error::other(format!(
             "sort-merge driver phase A finish failed: {e}"
         )))
     })?;
+    if residue > 0 && budget.record_spill_bytes(name, residue) {
+        return Err(PipelineError::spill_cap_exceeded(
+            name,
+            budget.disk_quota(),
+            residue,
+            budget.cumulative_spill_bytes(),
+        ));
+    }
 
     match sorted {
         SortedOutput::InMemory(out) => {
@@ -966,6 +985,7 @@ fn sort_build_pairs_externally(
     budget: &MemoryArbitrator,
     spill_compress: bool,
     consumer_handle: &Arc<crate::pipeline::memory::ConsumerHandle>,
+    spill_dir: &Path,
 ) -> Result<(), PipelineError> {
     if pairs.is_empty() {
         return Ok(());
@@ -989,7 +1009,7 @@ fn sort_build_pairs_externally(
     let mut buf: SortBuffer<()> = SortBuffer::new(
         vec![sort_field],
         spill_threshold,
-        None,
+        Some(spill_dir.to_path_buf()),
         spill_compress,
         schema,
     );
@@ -1004,21 +1024,37 @@ fn sort_build_pairs_externally(
         local_charged = local_charged.saturating_add(delta);
         if buf.should_spill() {
             let pre_spill = buf.bytes_used() as u64;
-            buf.sort_and_spill().map_err(|e| {
+            let written = buf.sort_and_spill().map_err(|e| {
                 PipelineError::Io(std::io::Error::other(format!(
                     "sort-merge build phase A spill failed: {e}"
                 )))
             })?;
             consumer_handle.sub_bytes(pre_spill);
             local_charged = local_charged.saturating_sub(pre_spill);
+            if written > 0 && budget.record_spill_bytes(name, written) {
+                return Err(PipelineError::spill_cap_exceeded(
+                    name,
+                    budget.disk_quota(),
+                    written,
+                    budget.cumulative_spill_bytes(),
+                ));
+            }
         }
     }
 
-    let sorted = buf.finish().map_err(|e| {
+    let (sorted, residue) = buf.finish().map_err(|e| {
         PipelineError::Io(std::io::Error::other(format!(
             "sort-merge build phase A finish failed: {e}"
         )))
     })?;
+    if residue > 0 && budget.record_spill_bytes(name, residue) {
+        return Err(PipelineError::spill_cap_exceeded(
+            name,
+            budget.disk_quota(),
+            residue,
+            budget.cumulative_spill_bytes(),
+        ));
+    }
 
     match sorted {
         SortedOutput::InMemory(out) => {
@@ -2182,5 +2218,136 @@ mod tests {
             records_b.is_empty(),
             "empty outer side must emit zero records; got: {records_b:?}"
         );
+    }
+
+    /// Build `n` phase A driver pairs whose sort key `k` is an Integer and
+    /// whose wide `pad` column pushes the accumulated buffer past the phase A
+    /// 16 KiB spill-threshold floor after a handful of records.
+    fn phase_a_driver_pairs(n: usize) -> Vec<(Record, RecordOrder, Value)> {
+        let schema = schema_with(&["k", "pad"]);
+        let pad = "x".repeat(1024);
+        (0..n)
+            .map(|i| {
+                let r = rec(
+                    &schema,
+                    vec![Value::Integer(i as i64), Value::String(pad.as_str().into())],
+                );
+                (r, i as RecordOrder, Value::Integer(i as i64))
+            })
+            .collect()
+    }
+
+    /// Phase A driver external sort must charge each spilled run against the
+    /// disk quota and abort with E320 once a run crosses the cap. Before the
+    /// fix the driver-side phase A sort spilled with zero disk-cap accounting,
+    /// so it could write past `storage.spill.disk_cap_bytes` unbounded.
+    #[test]
+    fn phase_a_driver_spill_past_disk_cap_fails_with_spill_cap_exceeded() {
+        let mut pairs = phase_a_driver_pairs(64);
+        let budget = MemoryArbitrator::with_policy(1024, 0.80, Box::new(NoOpPolicy));
+        budget.set_max_spill_bytes(1);
+        let dir = tempfile::tempdir().unwrap();
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let err = sort_driver_pairs_externally(
+            &mut pairs,
+            "sm",
+            &Some("k".to_string()),
+            &budget,
+            true,
+            &handle,
+            dir.path(),
+        )
+        .expect_err("a one-byte disk cap must abort the driver phase A spill");
+        match err {
+            PipelineError::SpillCapExceeded {
+                node,
+                cap,
+                attempted,
+                current,
+            } => {
+                assert_eq!(node, "sm");
+                assert_eq!(cap, 1, "reported cap equals the configured quota");
+                assert!(attempted > 0, "the overflowing run reports its size");
+                assert!(current > cap, "cumulative spilled must exceed the cap");
+            }
+            other => panic!("expected SpillCapExceeded; got {other:?}"),
+        }
+        drop(dir);
+    }
+
+    /// The build side mirrors the driver: each phase A spilled run is charged
+    /// and the disk cap is enforced.
+    #[test]
+    fn phase_a_build_spill_past_disk_cap_fails_with_spill_cap_exceeded() {
+        let schema = schema_with(&["k", "pad"]);
+        let pad = "x".repeat(1024);
+        let mut pairs: Vec<(Record, Value)> = (0..64i64)
+            .map(|i| {
+                let r = rec(
+                    &schema,
+                    vec![Value::Integer(i), Value::String(pad.as_str().into())],
+                );
+                (r, Value::Integer(i))
+            })
+            .collect();
+        let budget = MemoryArbitrator::with_policy(1024, 0.80, Box::new(NoOpPolicy));
+        budget.set_max_spill_bytes(1);
+        let dir = tempfile::tempdir().unwrap();
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let err = sort_build_pairs_externally(
+            &mut pairs,
+            "sm",
+            &Some("k".to_string()),
+            &budget,
+            true,
+            &handle,
+            dir.path(),
+        )
+        .expect_err("a one-byte disk cap must abort the build phase A spill");
+        match err {
+            PipelineError::SpillCapExceeded {
+                node, cap, current, ..
+            } => {
+                assert_eq!(node, "sm");
+                assert_eq!(cap, 1);
+                assert!(current > cap);
+            }
+            other => panic!("expected SpillCapExceeded; got {other:?}"),
+        }
+        drop(dir);
+    }
+
+    /// Phase A must spill into the CONFIGURED spill root, not the OS temp dir.
+    /// A configured root removed before the spill surfaces DirUnavailable; if
+    /// the sort instead fell back to `std::env::temp_dir()` (the bug) the spill
+    /// would succeed against the healthy OS temp dir and no error would surface.
+    #[test]
+    fn phase_a_spills_into_configured_root_not_env_temp() {
+        let mut pairs = phase_a_driver_pairs(64);
+        let budget = MemoryArbitrator::with_policy(1024, 0.80, Box::new(NoOpPolicy));
+        let scratch = tempfile::tempdir().unwrap();
+        let spill_root = scratch.path().join("configured-root");
+        std::fs::create_dir(&spill_root).unwrap();
+        std::fs::remove_dir(&spill_root).unwrap();
+        let handle = crate::pipeline::memory::ConsumerHandle::new();
+        let err = sort_driver_pairs_externally(
+            &mut pairs,
+            "sm",
+            &Some("k".to_string()),
+            &budget,
+            true,
+            &handle,
+            &spill_root,
+        )
+        .expect_err(
+            "phase A must spill into the configured (now-removed) root and fail \
+             DirUnavailable, proving it does not fall back to the OS temp dir",
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("became unavailable mid-run"),
+            "expected DirUnavailable from the configured root; got: {rendered}"
+        );
+        drop(scratch);
     }
 }

--- a/crates/clinker-exec/tests/aggregate_spill_cap.rs
+++ b/crates/clinker-exec/tests/aggregate_spill_cap.rs
@@ -1,0 +1,194 @@
+//! Aggregate spill files must enter the run's disk-cap accounting.
+//!
+//! A hash aggregate that outgrows its memory budget spills group state to
+//! disk. Those spill files count toward the run's cumulative on-disk spill
+//! total, so they must both:
+//!
+//! * be attributed to the aggregate node in `ExecutionReport.per_stage_spill_bytes`
+//!   (and roll into `cumulative_spill_bytes`), and
+//! * trip the configured `storage.spill.disk_cap_bytes` quota (E320) the
+//!   moment the cumulative total crosses it — a hard abort under every error
+//!   strategy, never a per-record DLQ route, mirroring the reshape/cull and
+//!   sort spill paths.
+//!
+//! The aggregate spills deterministically via the group-count threshold
+//! (RSS-independent) by feeding many distinct group keys under a clamped
+//! `memory.limit`; `backpressure: spill` keeps the non-pausing policy so the
+//! sub-baseline budget reaches the spill path instead of being rejected at
+//! startup (E312).
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{ExecutionReport, PipelineExecutor, PipelineRunParams};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+use clinker_plan::error::PipelineError;
+
+/// The aggregate node's name, shared by the pipeline template and the
+/// per-stage attribution assertion.
+const AGG_NODE: &str = "by_category";
+
+/// Group-by `count(*)` over a single in-memory CSV, output to CSV. A clamped
+/// `memory_limit` shrinks the in-memory group cap so a many-key input spills
+/// deterministically through the group-count threshold; `strategy` is the
+/// error-handling disposition under test.
+fn spill_cap_yaml(memory_limit: &str, strategy: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: agg_spill_cap
+  memory: {{ limit: "{memory_limit}", backpressure: spill }}
+error_handling:
+  strategy: {strategy}
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      glob: ./*.csv
+      files:
+        on_no_match: skip
+      schema:
+        - {{ name: category, type: string }}
+  - type: aggregate
+    name: {AGG_NODE}
+    input: events
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit n = count(*)
+  - type: output
+    name: out
+    input: {AGG_NODE}
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#
+    )
+}
+
+/// 400 rows over 200 distinct keys: enough distinct groups to overflow the
+/// clamped in-memory cap several times, so the aggregate flushes more than
+/// one spill file.
+fn many_key_csv() -> String {
+    let mut csv = String::from("category\n");
+    for i in 0..400 {
+        csv.push_str(&format!("k{}\n", i % 200));
+    }
+    csv
+}
+
+/// Compile and run the many-key aggregate pipeline, returning the raw
+/// executor result so both the success and the E320-abort assertions can
+/// inspect it.
+fn run(
+    memory_limit: &str,
+    strategy: &str,
+    disk_cap: Option<u64>,
+) -> Result<ExecutionReport, PipelineError> {
+    let yaml = spill_cap_yaml(memory_limit, strategy);
+    let config = parse_config(&yaml).expect("parse agg-spill-cap pipeline");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile agg-spill-cap pipeline");
+
+    let slots = vec![FileSlot::new(
+        PathBuf::from("events.csv"),
+        Box::new(Cursor::new(many_key_csv().into_bytes())),
+    )];
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(slots),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "e".to_string(),
+        batch_id: "b".to_string(),
+        spill_disk_cap_bytes: disk_cap,
+        ..Default::default()
+    };
+    PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+}
+
+#[test]
+fn aggregate_spill_charges_per_stage_disk_accounting() {
+    // Clamped budget, unlimited disk cap: the aggregate spills and the run
+    // completes. Its spilled bytes must be attributed to the aggregate node
+    // and roll into the pipeline-wide cumulative total.
+    let report = run("1K", "fail_fast", None).expect("run completes under an unlimited disk cap");
+    assert!(
+        report.cumulative_spill_bytes > 0,
+        "the clamped budget must force the aggregate to spill; \
+         cumulative_spill_bytes = {}",
+        report.cumulative_spill_bytes
+    );
+    let attributed = report
+        .per_stage_spill_bytes
+        .get(AGG_NODE)
+        .copied()
+        .unwrap_or(0);
+    assert!(
+        attributed > 0,
+        "aggregate spill bytes must be attributed to `{AGG_NODE}`; got per_stage_spill_bytes = {:?}",
+        report.per_stage_spill_bytes
+    );
+    let per_stage_sum: u64 = report.per_stage_spill_bytes.values().sum();
+    assert_eq!(
+        per_stage_sum, report.cumulative_spill_bytes,
+        "per-stage spill bytes must sum to the cumulative total"
+    );
+}
+
+#[test]
+fn spill_cap_aborts_the_run_under_fail_fast() {
+    // A one-byte disk cap must abort the spilling pipeline with E320 rather
+    // than writing past the quota. A tiny shared budget makes the upstream
+    // node-buffer and the aggregate both spill, so whichever crosses the cap
+    // first names the node; the aggregate's own cap charge is asserted in
+    // isolation by the `spill_past_disk_cap_returns_spill_cap_exceeded` unit
+    // test. Here the end-to-end guarantee under test is that E320 fires with
+    // the configured cap and a real overflow.
+    let err = run("1K", "fail_fast", Some(1))
+        .expect_err("a one-byte disk cap must abort the spilling run");
+    match err {
+        PipelineError::SpillCapExceeded {
+            cap,
+            attempted,
+            current,
+            ..
+        } => {
+            assert_eq!(cap, 1, "reported cap must equal the configured quota");
+            assert!(attempted > 0, "the overflowing flush must report its size");
+            assert!(
+                current > cap,
+                "cumulative spilled ({current}) must exceed the cap ({cap})"
+            );
+        }
+        other => panic!("disk-cap overflow must surface SpillCapExceeded; got {other:?}"),
+    }
+}
+
+#[test]
+fn aggregate_spill_cap_hard_aborts_under_continue() {
+    // A spill-cap breach is resource exhaustion, not a per-record data
+    // fault: even under `continue` it hard-aborts rather than routing the
+    // record to the DLQ, matching the reshape/cull spill-cap paths.
+    let err = run("1K", "continue", Some(1))
+        .expect_err("a spill-cap breach must hard-abort even under continue, not route to the DLQ");
+    assert!(
+        matches!(err, PipelineError::SpillCapExceeded { .. }),
+        "continue must still surface E320 for a disk-cap breach; got {err:?}"
+    );
+}

--- a/crates/clinker-exec/tests/correlated_dlq_retract.rs
+++ b/crates/clinker-exec/tests/correlated_dlq_retract.rs
@@ -1190,26 +1190,22 @@ O5,ENG,200
     assert!(output.contains("ENG,300"), "ENG total=300, got: {output}");
 }
 
-/// Degrade-fallback when a single record's buffer-mode contribution
-/// exceeds the entire memory budget. The aggregate runs in buffer-mode
-/// (a `BufferRequired` binding like `min`) with a memory.limit so
-/// small that any single row's per-binding charge breaches it. Today's
-/// runtime guard panics with a documented message describing the
-/// scenario; the orchestrator's degrade-fallback path is supposed to
-/// translate this into a runtime DLQ outcome treating the affected
-/// group as strict-collateral, but that translation is wired only at
-/// the per-group recompute step (see `recompute_aggregates`'s
-/// `degraded` collection), not at admission time.
+/// A single record's buffer-mode contribution that exceeds the entire
+/// memory budget must surface as a typed error or DLQ outcome, never a
+/// panic. The aggregate runs in buffer-mode (a `BufferRequired` binding
+/// like `min`) with a memory.limit so small that any single row's
+/// per-binding charge breaches it. The admission guard returns a typed
+/// `OversizedRow`, which the dispatch arm routes by error strategy: under
+/// `continue` the offending records go to the DLQ; a 100%-DLQ run can
+/// additionally trip the DLQ-rate ceiling (E315), which is itself a typed
+/// `PipelineError`.
 ///
-/// This test runs the pipeline using `std::panic::catch_unwind` so a
-/// runtime crash surfaces as a test FAILURE that points at the
-/// degrade-fallback gap rather than aborting the harness. If the
-/// pipeline completes (memory pressure manifested differently before
-/// reaching the per-row guard, e.g. via spill), the test asserts the
-/// expected DLQ shape; if the panic fires, the test surfaces the
-/// finding so the bug can be addressed in a dedicated commit.
+/// The test calls `run_pipeline` directly — no `catch_unwind` — so a panic
+/// would fail the test outright. It accepts either a clean run whose output
+/// or DLQ reflects the pressure, or a typed error; both are the
+/// architecturally-correct shapes, and neither is a crash.
 #[test]
-fn degrade_fallback_runtime_protection_or_documented_panic() {
+fn oversized_buffer_row_surfaces_typed_error_or_dlq_never_panics() {
     // `backpressure: spill` keeps the bare `Priority` policy: the 1-byte
     // budget is below the process baseline RSS, which the default `pause`
     // policy rejects at startup (E312), but this test needs the run to
@@ -1254,61 +1250,25 @@ nodes:
 "#;
     let csv = "order_id,department,amount\nO1,HR,10\nO2,HR,20\nO3,ENG,100\n";
 
-    let yaml_owned = yaml.to_string();
-    let csv_owned = csv.to_string();
-    // Run on a worker thread so a runtime guard panic surfaces as the
-    // join's Err arm rather than aborting the test harness; the join
-    // payload IS the panic payload.
-    let outcome: Result<Result<RunOutput, PipelineError>, Box<dyn std::any::Any + Send>> =
-        std::thread::spawn(move || run_pipeline(&yaml_owned, &csv_owned)).join();
-    match outcome {
-        Ok(Ok((counters, _dlq, output))) => {
-            // Pipeline completed cleanly. Memory pressure was absorbed
-            // by spill or a larger-than-expected per-row charge fit
-            // under the budget. The aggregator's output is still
-            // structurally valid — the degrade-fallback path was not
-            // exercised but no data was lost or corrupted.
+    // Direct call: a panic in the admission path would unwind through this
+    // frame and fail the test, which is exactly the regression this guards.
+    match run_pipeline(yaml, csv) {
+        Ok((counters, _dlq, output)) => {
+            // Clean run. Under `continue` the oversized rows route to the
+            // DLQ; a run that instead absorbed the pressure (spill) still
+            // produces structurally valid output. Either way no data is
+            // lost silently.
             assert!(
-                counters.dlq_count == 0 || !output.is_empty(),
+                counters.dlq_count >= 1 || !output.is_empty(),
                 "tiny-budget pipeline produced empty output AND zero DLQ entries; \
-                 expected either successful processing or surfaced failures"
+                 expected either DLQ-routed oversized rows or successful processing"
             );
         }
-        Ok(Err(_e)) => {
-            // Pipeline returned a typed error. The runtime gracefully
-            // surfaced the memory-budget exhaustion through the
-            // PipelineError type rather than crashing — the executor's
-            // structural fallback worked. This is the architecturally-
-            // correct shape: a typed error reaches the caller and the
-            // DLQ machinery decides at a higher level whether to route
-            // affected records through the DLQ. The panic guard at
-            // `add_record_buffered` would NOT be the right shape; a
-            // typed error IS the right shape, and we observe it here.
-        }
-        Err(panic_payload) => {
-            // The runtime guard at `add_record_buffered` (or any other
-            // sibling guard) fired. This is a real bug: a tiny-memory-
-            // budget pipeline should surface a typed runtime error or
-            // route the affected group's records to the DLQ as
-            // strict-collateral, not abort the executor. The
-            // architectural-rigor policy requires this be surfaced —
-            // it is NOT papered over with a `#[should_panic]` shim.
-            let msg = if let Some(s) = panic_payload.downcast_ref::<&'static str>() {
-                (*s).to_string()
-            } else if let Some(s) = panic_payload.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "<non-string panic payload>".to_string()
-            };
-            panic!(
-                "BUG SURFACED: degrade-fallback runtime path crashed instead of \
-                 routing through the typed-error/DLQ surface. The aggregator's \
-                 buffer-mode admission guard (or another runtime guard) panicked: \
-                 {msg}\n\
-                 Convert the panic to a runtime error that flows into the typed \
-                 PipelineError surface or into the DLQ via the orchestrator's \
-                 `relaxed_aggregator_degrade` list."
-            );
+        Err(_e) => {
+            // Typed error is the architecturally-correct hard-abort shape:
+            // the admission guard's `OversizedRow` maps to E310 under
+            // FailFast, and a 100%-DLQ run can trip E315 even under
+            // `continue`. Both are typed `PipelineError`s, not a crash.
         }
     }
 }

--- a/crates/clinker-exec/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/tests/deferred_dispatch.rs
@@ -245,40 +245,38 @@ nodes:
         ..Default::default()
     };
     let config = clinker_plan::config::parse_config(yaml).expect("parse");
-    // The pipeline either errors at the producer's region tee (E310 from
-    // `tee_emit_to_region_input_buffers`) or at the source's arena
-    // build (E310 from the source-rooted Phase-0 arena). Either path
-    // surfaces the E310 admission failure shape; assert the err string
-    // carries that signature.
     let result = common::run_config(&config, readers, writers, &params);
     let err = result.expect_err(
         "tight memory limit must surface as a typed admission failure on the \
          deferred buffer's projection or upstream spill path",
     );
-    // The deferred-buffer admission path raises a typed
-    // MemoryBudgetExceeded directly; an upstream sort enforcer that
-    // spilled past the budget surfaces a distinct "spill files"
-    // Compilation message with the same "memory.limit too small"
-    // semantic. Either is an acceptable observation that memory
-    // accounting fired; the test pins the failure-shape contract for
-    // the deferred buffer by destructuring on MemoryBudgetExceeded
-    // when reachable and on the spill-fallback Compilation arm
-    // otherwise.
+    // The contract this pins is that memory accounting fires and surfaces a
+    // typed error under a starvation budget — never a silent success. Under
+    // `backpressure: spill` the budget does not reject at admission; it forces
+    // operators to spill, and the failure surfaces at whichever operator hits a
+    // wall spilling cannot clear:
+    //   - the deferred-buffer arena projection raises MemoryBudgetExceeded
+    //     (BudgetCategory::Arena) directly, or
+    //   - the relaxed-CK (correlation-key) aggregate spills its group table and
+    //     then reaches its unsupported spilled-finalize path — retract-mode
+    //     finalize runs only on in-memory state — surfacing a typed
+    //     `Internal` "spilled groups" error.
+    // The enforcer correlation-sort no longer contributes a surface here: it
+    // now k-way merges its multi-run spill rather than rejecting it, so a
+    // spilling sort passes through cleanly and the pressure lands downstream.
     match &err {
         clinker_plan::error::PipelineError::MemoryBudgetExceeded {
             source: clinker_plan::BudgetCategory::Arena,
             ..
         } => {}
-        clinker_plan::error::PipelineError::Compilation { messages, .. }
-            if messages
-                .iter()
-                .any(|m| m.contains("memory.limit too small")) => {}
-        clinker_plan::error::PipelineError::Io(io_err)
-            if io_err.to_string().contains("memory.limit too small") => {}
+        clinker_plan::error::PipelineError::Internal { op, detail, .. }
+            if *op == "aggregation"
+                && detail
+                    .contains("finalize_in_place called on aggregator with spilled groups") => {}
         other => panic!(
             "memory-overflow surface must carry MemoryBudgetExceeded \
-             (BudgetCategory::Arena) or the spill-fallback admission \
-             message; got: {other:?}"
+             (BudgetCategory::Arena) or the relaxed-CK aggregate spilled-finalize \
+             limitation; got: {other:?}"
         ),
     }
     let _ = BTreeSet::<&str>::new();

--- a/docs/user/src/ops/memory.md
+++ b/docs/user/src/ops/memory.md
@@ -129,6 +129,15 @@ To influence strategy selection:
 
 Only force `streaming` when you are certain the input is sorted by the group-by keys. If the data is not sorted, results will be incorrect. Use `auto` when in doubt.
 
+### Oversized single rows
+
+An aggregate that keeps `min`, `max`, `avg`, or another value-buffering binding holds each contributing row's raw values until the group finalizes. If a **single input row's** buffered footprint is larger than the entire `memory.limit`, no amount of spilling can hold it — spill would only re-read the same oversized row. The engine surfaces this per-row overflow rather than absorbing it:
+
+- With `error_handling.strategy: fail` (the default), the run aborts with `E310 MemoryBudgetExceeded`, naming the aggregate stage and reporting the offending row's byte footprint against the budget.
+- With `strategy: continue` (or `best_effort`), the offending record is routed to the dead-letter queue under the `aggregate_finalize` category, and the run proceeds.
+
+This is almost always a sign the budget is set far too low for the record shape — raise `memory.limit` so a typical row fits comfortably.
+
 ## Compositions
 
 A composition (a reusable sub-pipeline included via `use:`) does not get its own memory budget — its operators share the parent pipeline's budget and spill to the same temporary directory. If a budget overrun happens inside a composition, the error names the composition's call-site (e.g. `enrich_call`) so you can locate it, prefixing the message with `in composition 'enrich_call': ...` when the overrun is internal to the body.


### PR DESCRIPTION
Brings spill-disk-cap accounting to parity across every operator that writes runs to disk, so the configured disk budget is honored uniformly by the aggregate, sort, sort-merge, and grace-hash paths, and oversized rows fail predictably instead of panicking.

- #677: the oversized-row panic in the aggregate spill path is replaced by a typed E310 error, routed through the standard fail-abort / continue-DLQ policy so a single too-large row no longer crashes the run.
- #685: each aggregate spill file is charged against the disk cap as it is written; exceeding the cap raises a hard-abort E320 rather than silently overrunning the budget.
- #680: the enforcer sort now k-way merges multi-run spills (LoserTree with field-comparator ordering and stable `row_num` tie-breaking) instead of erroring when more than one run is spilled.
- #686: sort and sort-merge Phase A charge each spilled run against the disk cap and write runs inside the configured spill root, keeping both paths within budget and on the intended volume.
- #687: the grace-hash path enforces the disk cap on every spill commit, so partition spilling stays within the configured budget.
- #688: adversarial overflow tests exercise the streaming-handoff and document-DLQ buckets to confirm cap enforcement holds under boundary and over-budget conditions.

Closes #677
Closes #685
Closes #680
Closes #686
Closes #687
Closes #688
Closes #683
