### PR TITLE
batch: format-writer hot-path de-allocation across JSON, XML, CSV and fixed-width

### DIFF
--- a/crates/clinker-format/benches/io_throughput.rs
+++ b/crates/clinker-format/benches/io_throughput.rs
@@ -1,12 +1,15 @@
 use clinker_bench_support::{CsvPayload, MEDIUM, RecordFactory, SMALL};
 use clinker_format::csv::reader::{CsvReader, CsvReaderConfig};
 use clinker_format::csv::writer::{CsvWriter, CsvWriterConfig};
+use clinker_format::fixed_width::writer::{FixedWidthWriter, FixedWidthWriterConfig};
 use clinker_format::json::reader::{JsonReader, JsonReaderConfig};
 use clinker_format::json::writer::{JsonWriter, JsonWriterConfig};
+use clinker_format::schema::Column;
 use clinker_format::traits::{FormatReader, FormatWriter};
 use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
 use clinker_record::{Record, Schema, Value};
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use cxl::typecheck::Type;
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -262,6 +265,57 @@ fn bench_xml_write(c: &mut Criterion) {
     group.finish();
 }
 
+// ── Fixed-width Write ──────────────────────────────────────────────
+
+fn bench_fixed_width_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fixed_width_write");
+    for field_count in [10usize, 50] {
+        // Columns f0..fN matching RecordFactory output: even fields are ints
+        // (width 10), odd fields strings (width 20) — wide enough that the
+        // seeded values never trip the numeric truncation-error policy.
+        let columns: Vec<Column> = (0..field_count)
+            .map(|i| {
+                let (ty, width) = if i % 2 == 0 {
+                    (Type::Int, 10)
+                } else {
+                    (Type::String, 20)
+                };
+                // Omit `start` so columns lay out sequentially (each continues
+                // at the previous column's end).
+                let mut col = Column::bare(format!("f{i}"), ty);
+                col.width = Some(width);
+                col
+            })
+            .collect();
+
+        let mut factory = RecordFactory::new(field_count, 16, 0.0, 42);
+        let records = factory.generate(MEDIUM);
+
+        group.throughput(Throughput::Elements(MEDIUM as u64));
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("{field_count}f")),
+            &records,
+            |b, recs| {
+                b.iter(|| {
+                    let buf = Vec::with_capacity(MEDIUM * field_count * 20);
+                    let mut writer = FixedWidthWriter::new(
+                        buf,
+                        columns.clone(),
+                        FixedWidthWriterConfig::default(),
+                    )
+                    .unwrap();
+                    for rec in recs {
+                        writer.write_record(rec).unwrap();
+                    }
+                    writer.flush().unwrap();
+                    black_box(writer);
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_csv_read,
@@ -270,5 +324,6 @@ criterion_group!(
     bench_json_array_read,
     bench_json_write,
     bench_xml_write,
+    bench_fixed_width_write,
 );
 criterion_main!(benches);

--- a/crates/clinker-format/benches/io_throughput.rs
+++ b/crates/clinker-format/benches/io_throughput.rs
@@ -4,6 +4,8 @@ use clinker_format::csv::writer::{CsvWriter, CsvWriterConfig};
 use clinker_format::json::reader::{JsonReader, JsonReaderConfig};
 use clinker_format::json::writer::{JsonWriter, JsonWriterConfig};
 use clinker_format::traits::{FormatReader, FormatWriter};
+use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
+use clinker_record::{Record, Schema, Value};
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use std::io::Cursor;
 use std::sync::Arc;
@@ -177,6 +179,89 @@ fn bench_json_write(c: &mut Criterion) {
     group.finish();
 }
 
+// ── XML Write ──────────────────────────────────────────────────────
+
+/// Build `count` records over a dotted + attribute schema (shared-prefix
+/// branches with their own attributes), the shape the precompiled tree plan
+/// targets. Values vary per record so the fill path does real work.
+fn dotted_records(count: usize) -> (Arc<Schema>, Vec<Record>) {
+    let schema = Arc::new(Schema::new(vec![
+        "@id".into(),
+        "name".into(),
+        "Address.@type".into(),
+        "Address.City".into(),
+        "Address.State".into(),
+        "Contact.Email".into(),
+        "Contact.Phone".into(),
+    ]));
+    let records = (0..count)
+        .map(|i| {
+            Record::new(
+                Arc::clone(&schema),
+                vec![
+                    Value::Integer(i as i64),
+                    Value::String(format!("name{i}").into()),
+                    Value::String("home".into()),
+                    Value::String(format!("city{i}").into()),
+                    Value::String("NY".into()),
+                    Value::String(format!("user{i}@example.com").into()),
+                    Value::String("555-0100".into()),
+                ],
+            )
+        })
+        .collect();
+    (schema, records)
+}
+
+fn bench_xml_write(c: &mut Criterion) {
+    let mut group = c.benchmark_group("xml_write");
+
+    // Flat-wide: many top-level fields. The old per-record tree build paid an
+    // O(fields^2) sibling scan here, which the plan eliminates.
+    let mut factory = RecordFactory::new(50, 16, 0.0, 42);
+    let flat_records = factory.generate(MEDIUM);
+    let flat_schema = factory.schema().clone();
+    group.throughput(Throughput::Elements(MEDIUM as u64));
+    group.bench_with_input(
+        BenchmarkId::from_parameter("flat_50f"),
+        &flat_records,
+        |b, recs| {
+            b.iter(|| {
+                let buf = Vec::with_capacity(MEDIUM * 50 * 20);
+                let mut writer =
+                    XmlWriter::new(buf, Arc::clone(&flat_schema), XmlWriterConfig::default());
+                for rec in recs {
+                    writer.write_record(rec).unwrap();
+                }
+                writer.flush().unwrap();
+                black_box(writer);
+            });
+        },
+    );
+
+    // Dotted + attribute: nested branches with attributes, the classic XML
+    // shape whose per-node name allocation the plan removes.
+    let (dotted_schema, dotted_records) = dotted_records(MEDIUM);
+    group.bench_with_input(
+        BenchmarkId::from_parameter("dotted_7f"),
+        &dotted_records,
+        |b, recs| {
+            b.iter(|| {
+                let buf = Vec::with_capacity(MEDIUM * 200);
+                let mut writer =
+                    XmlWriter::new(buf, Arc::clone(&dotted_schema), XmlWriterConfig::default());
+                for rec in recs {
+                    writer.write_record(rec).unwrap();
+                }
+                writer.flush().unwrap();
+                black_box(writer);
+            });
+        },
+    );
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_csv_read,
@@ -184,5 +269,6 @@ criterion_group!(
     bench_json_ndjson_read,
     bench_json_array_read,
     bench_json_write,
+    bench_xml_write,
 );
 criterion_main!(benches);

--- a/crates/clinker-format/benches/io_throughput.rs
+++ b/crates/clinker-format/benches/io_throughput.rs
@@ -146,28 +146,33 @@ fn bench_json_array_read(c: &mut Criterion) {
 
 fn bench_json_write(c: &mut Criterion) {
     let mut group = c.benchmark_group("json_write");
-    for record_count in [SMALL, MEDIUM] {
-        let mut factory = RecordFactory::new(10, 16, 0.0, 42);
+    // (label, record_count, field_count, string_len). The first two rows keep
+    // the original 10-field/16-char shape as the no-regression oracle; the
+    // wide (many-field) and long-value rows are where eliminating the
+    // per-record `serde_json::Value` tree pays off.
+    for (label, record_count, field_count, string_len) in [
+        ("small_10f_16c", SMALL, 10, 16),
+        ("medium_10f_16c", MEDIUM, 10, 16),
+        ("medium_50f_16c", MEDIUM, 50, 16),
+        ("medium_10f_256c", MEDIUM, 10, 256),
+    ] {
+        let mut factory = RecordFactory::new(field_count, string_len, 0.0, 42);
         let records = factory.generate(record_count);
         let schema = factory.schema().clone();
 
         group.throughput(Throughput::Elements(record_count as u64));
-        group.bench_with_input(
-            BenchmarkId::from_parameter(record_count),
-            &records,
-            |b, recs| {
-                b.iter(|| {
-                    let buf = Vec::with_capacity(record_count * 200);
-                    let mut writer =
-                        JsonWriter::new(buf, Arc::clone(&schema), JsonWriterConfig::default());
-                    for rec in recs {
-                        writer.write_record(rec).unwrap();
-                    }
-                    writer.flush().unwrap();
-                    black_box(writer);
-                });
-            },
-        );
+        group.bench_with_input(BenchmarkId::from_parameter(label), &records, |b, recs| {
+            b.iter(|| {
+                let buf = Vec::with_capacity(record_count * field_count * string_len);
+                let mut writer =
+                    JsonWriter::new(buf, Arc::clone(&schema), JsonWriterConfig::default());
+                for rec in recs {
+                    writer.write_record(rec).unwrap();
+                }
+                writer.flush().unwrap();
+                black_box(writer);
+            });
+        });
     }
     group.finish();
 }

--- a/crates/clinker-format/src/counting.rs
+++ b/crates/clinker-format/src/counting.rs
@@ -216,35 +216,7 @@ mod tests {
         assert!(bytes > 0, "should have written some bytes");
     }
 
-    /// A `FormatWriter` that records every hook call, so a wrapper test can
-    /// prove per-document framing reaches the inner writer.
-    struct HookProbe {
-        log: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    }
-
-    impl FormatWriter for HookProbe {
-        fn write_record(&mut self, _record: &Record) -> Result<(), FormatError> {
-            self.log.lock().unwrap().push("write".into());
-            Ok(())
-        }
-        fn flush(&mut self) -> Result<(), FormatError> {
-            Ok(())
-        }
-        fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
-            self.log
-                .lock()
-                .unwrap()
-                .push(format!("begin:{}", doc.source_file()));
-            Ok(())
-        }
-        fn end_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
-            self.log
-                .lock()
-                .unwrap()
-                .push(format!("end:{}", doc.source_file()));
-            Ok(())
-        }
-    }
+    use crate::traits::test_support::HookProbe;
 
     #[test]
     fn counted_format_writer_forwards_document_hooks_to_inner() {
@@ -253,9 +225,7 @@ mod tests {
         use clinker_record::{DocumentId, EnvelopeRecord};
 
         let log = Arc::new(Mutex::new(Vec::new()));
-        let probe = HookProbe {
-            log: Arc::clone(&log),
-        };
+        let probe = HookProbe::with_log(Arc::clone(&log));
         let mut counted = CountedFormatWriter::new(Box::new(probe), SharedByteCounter::new());
 
         let doc = DocumentContext::new(
@@ -272,6 +242,24 @@ mod tests {
             *log.lock().unwrap(),
             vec!["begin:file.x12", "end:file.x12"],
             "begin/end_document forward through the counting wrapper",
+        );
+    }
+
+    #[test]
+    fn counted_format_writer_forwards_flush_bytes_to_inner() {
+        use std::sync::{Arc, Mutex};
+
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let probe = HookProbe::with_log(Arc::clone(&log));
+        let mut counted = CountedFormatWriter::new(Box::new(probe), SharedByteCounter::new());
+
+        // `flush_bytes` must reach the inner writer's non-finalizing drain, not
+        // fall back to the finalizing `flush` default.
+        counted.flush_bytes().unwrap();
+        assert_eq!(
+            *log.lock().unwrap(),
+            vec!["flush_bytes"],
+            "flush_bytes forwards through the counting wrapper without finalizing",
         );
     }
 }

--- a/crates/clinker-format/src/csv/writer.rs
+++ b/crates/clinker-format/src/csv/writer.rs
@@ -54,6 +54,15 @@ pub struct CsvWriter<W: Write> {
     schema: Arc<Schema>,
     config: CsvWriterConfig,
     header_written: bool,
+    /// Indices into `schema.columns()` of the columns actually emitted (after
+    /// engine-stamped filtering), computed once at construction. Both the
+    /// header row and every body row derive their column set from this, so no
+    /// per-record filtering allocation is needed.
+    column_indices: Vec<usize>,
+    /// Reusable per-record cell buffer, one `String` per emitted column. Each
+    /// row clears and rewrites these in place, retaining their capacity across
+    /// records rather than allocating a fresh row vector every record.
+    row_buf: Vec<String>,
     /// Per-document envelope framer, present only when `config.envelope` is.
     framer: Option<EnvelopeFramer>,
 }
@@ -74,11 +83,15 @@ impl<W: Write> CsvWriter<W> {
             .delimiter(config.delimiter)
             .flexible(framer.is_some())
             .from_writer(writer);
+        let column_indices = filtered_column_indices(&schema, config.include_engine_stamped);
+        let row_buf = vec![String::new(); column_indices.len()];
         Self {
             inner,
             schema,
             config,
             header_written: false,
+            column_indices,
+            row_buf,
             framer,
         }
     }
@@ -129,30 +142,42 @@ impl<W: Write + Send> FormatWriter for CsvWriter<W> {
         // header row, giving documents inconsistent layouts (header row only
         // on the first). The per-document envelope header section replaces it.
         if self.config.include_header && !self.header_written && self.framer.is_none() {
-            let header: Vec<&str> =
-                filtered_header_columns(&self.schema, self.config.include_engine_stamped);
+            // One-time header row, derived from the precomputed column indices.
+            let header: Vec<&str> = self
+                .column_indices
+                .iter()
+                .map(|&i| self.schema.columns()[i].as_ref())
+                .collect();
             self.inner.write_record(&header)?;
             self.header_written = true;
         }
 
-        // Body cells follow the writer's pinned schema — the same
-        // column set and order the header row was built from — not
-        // the record's own schema, which an upstream projection or
-        // widening may order differently for the same fields. Fields
-        // the record lacks emit an empty cell (an explicit Null),
-        // matching the fixed-width writer's missing-field policy.
-        let columns = filtered_header_columns(&self.schema, self.config.include_engine_stamped);
-        let mut fields: Vec<String> = Vec::with_capacity(columns.len());
-        for col in columns {
-            let cell = match record.get(col) {
-                Some(v) => value_to_csv_cell(col, v)?,
-                None => String::new(),
-            };
-            fields.push(cell);
+        // Body cells follow the writer's pinned schema — the same column set
+        // and order the header row was built from — not the record's own
+        // schema, which an upstream projection or widening may order
+        // differently for the same fields. Fields the record lacks emit an
+        // empty cell (an explicit Null), matching the fixed-width writer's
+        // missing-field policy. Each cell is written into the reusable row
+        // buffer (cleared first, so a failed map cell never leaves stale bytes).
+        let Self {
+            inner,
+            schema,
+            column_indices,
+            row_buf,
+            framer,
+            ..
+        } = self;
+        let columns = schema.columns();
+        for (slot, &idx) in row_buf.iter_mut().zip(column_indices.iter()) {
+            let col = columns[idx].as_ref();
+            slot.clear();
+            if let Some(v) = record.get(col) {
+                write_csv_cell(slot, col, v)?;
+            }
         }
 
-        self.inner.write_record(&fields)?;
-        if let Some(framer) = self.framer.as_mut() {
+        inner.write_record(&*row_buf)?;
+        if let Some(framer) = framer.as_mut() {
             framer.count_record();
         }
         Ok(())
@@ -250,9 +275,10 @@ impl<W: Write + Send> FormatWriter for HeaderCapturingCsvWriter<W> {
     }
 }
 
-/// Build the CSV header name list from `schema`, optionally including
-/// engine-stamped columns.
-fn filtered_header_columns(schema: &Arc<Schema>, include_engine_stamped: bool) -> Vec<&str> {
+/// The indices into `schema.columns()` of the columns the CSV writer emits,
+/// after filtering engine-stamped columns unless opted in. Computed once and
+/// reused for both the header row and every body row.
+fn filtered_column_indices(schema: &Arc<Schema>, include_engine_stamped: bool) -> Vec<usize> {
     schema
         .columns()
         .iter()
@@ -263,11 +289,21 @@ fn filtered_header_columns(schema: &Arc<Schema>, include_engine_stamped: bool) -
                     .field_metadata(*i)
                     .is_none_or(|m| !m.is_engine_stamped())
         })
-        .map(|(_, c)| c.as_ref())
+        .map(|(i, _)| i)
         .collect()
 }
 
-/// Serialize a Value to a CSV cell string.
+/// Serialize a Value into a CSV cell string. Thin owned-`String` wrapper over
+/// [`write_csv_cell`], used by the envelope section-row path (not the record
+/// hot path).
+fn value_to_csv_cell(col: &str, value: &Value) -> Result<String, FormatError> {
+    let mut buf = String::new();
+    write_csv_cell(&mut buf, col, value)?;
+    Ok(buf)
+}
+
+/// Append a Value's CSV cell rendering to `buf`. Sharing one renderer keeps the
+/// record hot path and the envelope section path byte-identical.
 ///
 /// `Value::Map` has no canonical scalar serialization for a CSV cell
 /// (silently JSON-encoding hides routing bugs — e.g. a `$widened`
@@ -276,25 +312,37 @@ fn filtered_header_columns(schema: &Arc<Schema>, include_engine_stamped: bool) -
 /// `FormatError::UnserializableMapValue` carrying the offending
 /// column. CSV is the single point of truth for map rejection on
 /// this path; there is no upstream pre-walk.
-fn value_to_csv_cell(col: &str, value: &Value) -> Result<String, FormatError> {
-    Ok(match value {
-        Value::Null => String::new(),
-        Value::Bool(b) => if *b { "true" } else { "false" }.into(),
-        Value::Integer(n) => n.to_string(),
-        Value::Float(f) => f.to_string(),
+fn write_csv_cell(buf: &mut String, col: &str, value: &Value) -> Result<(), FormatError> {
+    use std::fmt::Write as _;
+    match value {
+        Value::Null => {}
+        Value::Bool(b) => buf.push_str(if *b { "true" } else { "false" }),
+        Value::Integer(n) => {
+            let _ = write!(buf, "{n}");
+        }
+        Value::Float(f) => {
+            let _ = write!(buf, "{f}");
+        }
         // A decimal carries its own (column) scale; Display preserves it.
-        Value::Decimal(d) => d.to_string(),
-        Value::String(s) => s.to_string(),
-        Value::Date(d) => d.format("%Y-%m-%d").to_string(),
-        Value::DateTime(dt) => dt.format("%Y-%m-%dT%H:%M:%S").to_string(),
-        Value::Array(arr) => serde_json::to_string(arr).unwrap_or_default(),
+        Value::Decimal(d) => {
+            let _ = write!(buf, "{d}");
+        }
+        Value::String(s) => buf.push_str(s.as_str()),
+        Value::Date(d) => {
+            let _ = write!(buf, "{}", d.format("%Y-%m-%d"));
+        }
+        Value::DateTime(dt) => {
+            let _ = write!(buf, "{}", dt.format("%Y-%m-%dT%H:%M:%S"));
+        }
+        Value::Array(arr) => buf.push_str(&serde_json::to_string(arr).unwrap_or_default()),
         Value::Map(_) => {
             return Err(FormatError::UnserializableMapValue {
                 format: "CSV",
                 column: col.to_string(),
             });
         }
-    })
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -508,6 +556,29 @@ mod tests {
         );
         let output = write_to_string(&writer_schema, CsvWriterConfig::default(), &[record]);
         assert_eq!(output, "a,b\nA,B\n");
+    }
+
+    /// The reusable row buffer must be cleared per cell, so a short value
+    /// following a long value in the same column carries no leftover bytes —
+    /// the canonical buffer-reuse bug.
+    #[test]
+    fn test_csv_writer_row_buffer_reuse_no_stale_bytes() {
+        let schema = make_schema(&["v", "w"]);
+        let records = vec![
+            make_record(
+                &schema,
+                vec![
+                    Value::String("a-very-long-value-here".into()),
+                    Value::String("xxxxxxxx".into()),
+                ],
+            ),
+            make_record(
+                &schema,
+                vec![Value::String("hi".into()), Value::String("y".into())],
+            ),
+        ];
+        let output = write_to_string(&schema, CsvWriterConfig::default(), &records);
+        assert_eq!(output, "v,w\na-very-long-value-here,xxxxxxxx\nhi,y\n");
     }
 
     #[test]

--- a/crates/clinker-format/src/csv/writer.rs
+++ b/crates/clinker-format/src/csv/writer.rs
@@ -273,6 +273,30 @@ impl<W: Write + Send> FormatWriter for HeaderCapturingCsvWriter<W> {
     fn flush(&mut self) -> Result<(), FormatError> {
         self.inner.flush()
     }
+
+    /// Forward the non-finalizing drain to the inner CSV writer so byte-limit
+    /// split accounting sees the true on-disk size (see the wrapper-delegation
+    /// contract on [`FormatWriter::flush_bytes`]).
+    fn flush_bytes(&mut self) -> Result<(), FormatError> {
+        self.inner.flush_bytes()
+    }
+
+    /// Forward per-document opening framing to the inner CSV writer; without
+    /// this the envelope header row would be silently dropped when a split CSV
+    /// output reconstructs an envelope.
+    fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        self.inner.begin_document(doc)
+    }
+
+    /// Forward per-document closing framing to the inner CSV writer; see
+    /// [`Self::begin_document`].
+    fn end_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+        self.inner.end_document(doc)
+    }
+
+    fn bytes_written(&self) -> Option<u64> {
+        self.inner.bytes_written()
+    }
 }
 
 /// The indices into `schema.columns()` of the columns the CSV writer emits,
@@ -694,6 +718,45 @@ mod tests {
         }
         let out = String::from_utf8(buf).unwrap();
         assert_eq!(out, "A\n10\n20\nSUM,2\n", "got: {out}");
+    }
+
+    /// `HeaderCapturingCsvWriter` must forward `begin_document`/`end_document`
+    /// to its inner CSV writer: with an envelope spec the inner writer emits a
+    /// header row on begin and a footer row on end, so the wrapped output must
+    /// match the un-wrapped enveloped writer's framing rather than dropping it.
+    #[test]
+    fn header_capturing_csv_writer_forwards_document_framing() {
+        let schema = make_schema(&["amount"]);
+        let config = CsvWriterConfig {
+            include_header: false,
+            envelope: Some(OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: Some("count".into()),
+            }),
+            ..Default::default()
+        };
+        let doc = doc_with_sections(&[
+            ("Head", &[("batch_id", Value::String("A".into()))]),
+            ("Foot", &[("checksum", Value::String("SUM".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let inner = CsvWriter::new(&mut buf, Arc::clone(&schema), config);
+            let shared_header = Arc::new(Mutex::new(None));
+            let mut writer =
+                HeaderCapturingCsvWriter::new(inner, Arc::clone(&schema), shared_header);
+            writer.begin_document(&doc).unwrap();
+            writer
+                .write_record(&make_record(&schema, vec![Value::Integer(10)]))
+                .unwrap();
+            writer
+                .write_record(&make_record(&schema, vec![Value::Integer(20)]))
+                .unwrap();
+            writer.end_document(&doc).unwrap();
+            writer.flush().unwrap();
+        }
+        assert_eq!(String::from_utf8(buf).unwrap(), "A\n10\n20\nSUM,2\n");
     }
 
     #[test]

--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -278,13 +278,18 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
         // construction), so a cursor walk left-to-right space-fills any byte
         // range the schema leaves undeclared and lands every cell at the
         // position the reader slices.
+        // A record missing a schema field emits a Null cell; borrow a shared
+        // Null rather than cloning the record's value per field (`format_value`
+        // only needs `&Value`, and Array/Map values would otherwise be
+        // deep-cloned just to be discarded or rejected).
+        let null = Value::Null;
         let mut cursor = 0usize;
         for field in &self.fields {
             write_gap(&mut self.writer, field.start - cursor)?;
 
-            let value = record.get(&field.name).cloned().unwrap_or(Value::Null);
+            let value = record.get(&field.name).unwrap_or(&null);
 
-            let formatted = self.format_value(field, &value)?;
+            let formatted = self.format_value(field, value)?;
 
             // Check truncation
             if formatted.len() > field.width {
@@ -453,6 +458,60 @@ mod tests {
         let output = String::from_utf8(buf).unwrap();
         // id(5) + name(10) + amount(8) = 23 chars + \n
         assert_eq!(output, "00042Alice         99.5\n");
+    }
+
+    /// Multiple records over a multi-field schema emit byte-exact output,
+    /// including a record whose value for a field is missing (borrowed Null
+    /// cell) — the value path the clone elimination touches.
+    #[test]
+    fn test_fixedwidth_write_multi_record_output_identity() {
+        let fields = vec![
+            {
+                let mut f = field("id");
+                f.ty = Type::Int;
+                f.start = Some(0);
+                f.width = Some(5);
+                f.justify = Some(Justify::Right);
+                f.pad = Some("0".into());
+                f
+            },
+            {
+                let mut f = field("name");
+                f.ty = Type::String;
+                f.start = Some(5);
+                f.width = Some(10);
+                f
+            },
+        ];
+
+        let mut buf = Vec::new();
+        {
+            let mut writer =
+                FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+            writer
+                .write_record(&make_record(
+                    &["id", "name"],
+                    vec![Value::Integer(1), Value::String("Alice".into())],
+                ))
+                .unwrap();
+            writer
+                .write_record(&make_record(
+                    &["id", "name"],
+                    vec![Value::Integer(22), Value::String("Bob".into())],
+                ))
+                .unwrap();
+            // Record missing `name`: its cell is a borrowed Null (empty, padded).
+            writer
+                .write_record(&make_record(&["id"], vec![Value::Integer(333)]))
+                .unwrap();
+            writer.flush().unwrap();
+        }
+
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            output,
+            "00001Alice     \n00022Bob       \n00333          \n"
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -69,6 +69,12 @@ pub struct JsonWriter<W: Write> {
     /// Per-document envelope framer + state machine, present only when
     /// `config.envelope` is. Drives the per-document-object reframe.
     envelope: Option<EnvelopeState>,
+    /// Reusable serialization buffer. Each record is serialized straight into
+    /// this `Vec` (via a borrowing `serde::Serialize` impl, no intermediate
+    /// `serde_json::Value` tree) and then written to the sink; the allocation
+    /// is retained across records so per-record cost is amortized. Bounded by
+    /// the widest single record, never the whole stream.
+    scratch: Vec<u8>,
 }
 
 /// Per-document-object framing state for the envelope reframe. Tracks the
@@ -102,39 +108,39 @@ impl<W: Write> JsonWriter<W> {
             config,
             records_written: 0,
             envelope,
+            scratch: Vec::new(),
         }
     }
 
-    /// Serializes a record to a JSON object in schema-column order.
-    /// `preserve_nulls: false` omits keys with Null values. Engine-stamped
-    /// columns are stripped from the default output; callers opt in via
-    /// `include_engine_stamped`.
+    /// Serialize a record as a JSON object into the reusable `scratch` buffer
+    /// in schema-column order. `preserve_nulls: false` omits keys with Null
+    /// values. Engine-stamped columns are stripped from the default output;
+    /// callers opt in via `include_engine_stamped`. Keys borrow the schema's
+    /// column names and values borrow the record's [`Value`]s, so no
+    /// intermediate `serde_json::Value` tree is built.
+    ///
+    /// The buffer is cleared first, and the sink is written only by the caller
+    /// on success, so a mid-record error (non-finite float) leaves no partial
+    /// bytes downstream.
     ///
     /// # Errors
     ///
     /// Returns [`FormatError::Json`] when a field holds a non-finite float
     /// (NaN or an infinity), which JSON cannot represent.
-    fn record_to_json(&self, record: &Record) -> Result<serde_json::Value, FormatError> {
-        use serde_json::{Map, Value as Jv};
-
-        let mut obj = Map::with_capacity(record.field_count());
-        let emit = |obj: &mut Map<String, Jv>, col: &str, val: &Value| -> Result<(), FormatError> {
-            if !self.config.preserve_nulls && val.is_null() {
-                return Ok(());
-            }
-            obj.insert(col.to_string(), clinker_to_json(val)?);
-            Ok(())
+    fn serialize_record(&mut self, record: &Record) -> Result<(), FormatError> {
+        use serde::Serialize as _;
+        self.scratch.clear();
+        let obj = RecordObjectSer {
+            record,
+            preserve_nulls: self.config.preserve_nulls,
+            include_engine_stamped: self.config.include_engine_stamped,
         };
-        if self.config.include_engine_stamped {
-            for (col, val) in record.iter_all_fields() {
-                emit(&mut obj, col, val)?;
-            }
+        let result = if self.config.pretty {
+            obj.serialize(&mut serde_json::Serializer::pretty(&mut self.scratch))
         } else {
-            for (col, val) in record.iter_user_fields() {
-                emit(&mut obj, col, val)?;
-            }
-        }
-        Ok(Jv::Object(obj))
+            obj.serialize(&mut serde_json::Serializer::new(&mut self.scratch))
+        };
+        result.map_err(|e| FormatError::Json(e.to_string()))
     }
 
     /// Serialize a JSON value with the configured pretty/compact mode.
@@ -186,11 +192,13 @@ impl<W: Write> JsonWriter<W> {
     /// depth safety net: it raises a clean error rather than writing record
     /// bytes outside any `{...,"body":[` object (which would be malformed JSON).
     fn write_enveloped_record(&mut self, record: &Record) -> Result<(), FormatError> {
-        let json_val = self.record_to_json(record)?;
-        let serialized = self.serialize_value(&json_val)?;
+        self.serialize_record(record)?;
+        // Read the framer state through a shared borrow that ends before the
+        // sink writes, so the `envelope`, `writer`, and `scratch` field borrows
+        // stay disjoint.
         let env = self
             .envelope
-            .as_mut()
+            .as_ref()
             .expect("write_enveloped_record only called with an envelope state");
         if !env.doc_open {
             return Err(FormatError::Json(
@@ -199,13 +207,18 @@ impl<W: Write> JsonWriter<W> {
                     .to_string(),
             ));
         }
-        if env.framer.record_count() > 0 {
+        let need_comma = env.framer.record_count() > 0;
+        if need_comma {
             self.writer.write_all(b",").map_err(FormatError::Io)?;
         }
         self.writer
-            .write_all(serialized.as_bytes())
+            .write_all(&self.scratch)
             .map_err(FormatError::Io)?;
-        env.framer.count_record();
+        self.envelope
+            .as_mut()
+            .expect("envelope state present after doc-open guard")
+            .framer
+            .count_record();
         Ok(())
     }
 }
@@ -220,8 +233,7 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
             return self.write_enveloped_record(record);
         }
 
-        let json_val = self.record_to_json(record)?;
-        let serialized = self.serialize_value(&json_val)?;
+        self.serialize_record(record)?;
 
         match self.config.format {
             JsonOutputMode::Array => {
@@ -231,7 +243,7 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
                     self.writer.write_all(b",\n").map_err(FormatError::Io)?;
                 }
                 self.writer
-                    .write_all(serialized.as_bytes())
+                    .write_all(&self.scratch)
                     .map_err(FormatError::Io)?;
             }
             JsonOutputMode::Ndjson => {
@@ -239,7 +251,7 @@ impl<W: Write + Send> FormatWriter for JsonWriter<W> {
                     self.writer.write_all(b"\n").map_err(FormatError::Io)?;
                 }
                 self.writer
-                    .write_all(serialized.as_bytes())
+                    .write_all(&self.scratch)
                     .map_err(FormatError::Io)?;
             }
         }
@@ -411,6 +423,94 @@ fn clinker_to_json(val: &Value) -> Result<serde_json::Value, FormatError> {
             Jv::Object(obj)
         }
     })
+}
+
+/// Borrows a record and serializes its fields as a JSON object directly to the
+/// target serializer, with no intermediate `serde_json::Value` tree. Keys
+/// borrow the schema's column names; values borrow the record's [`Value`]s via
+/// [`ValueSer`]. Mirrors the field selection of the (removed) `record_to_json`:
+/// honors `preserve_nulls` (skips null fields when false) and
+/// `include_engine_stamped` (whether `$`-namespaced correlation columns
+/// appear).
+struct RecordObjectSer<'a> {
+    record: &'a Record,
+    preserve_nulls: bool,
+    include_engine_stamped: bool,
+}
+
+impl serde::Serialize for RecordObjectSer<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        // `None` length hint: serde_json ignores it, and the exact post-null-
+        // skip entry count would need a second pass over the fields.
+        let mut map = serializer.serialize_map(None)?;
+        if self.include_engine_stamped {
+            for (col, val) in self.record.iter_all_fields() {
+                if !self.preserve_nulls && val.is_null() {
+                    continue;
+                }
+                map.serialize_entry(col, &ValueSer(val))?;
+            }
+        } else {
+            for (col, val) in self.record.iter_user_fields() {
+                if !self.preserve_nulls && val.is_null() {
+                    continue;
+                }
+                map.serialize_entry(col, &ValueSer(val))?;
+            }
+        }
+        map.end()
+    }
+}
+
+/// Borrows a clinker [`Value`] and serializes it directly, mirroring
+/// [`clinker_to_json`] variant-for-variant without allocating an intermediate
+/// `serde_json::Value`. A non-finite float is rejected with the same message
+/// `clinker_to_json` raises, surfaced through the serializer's error type so it
+/// arrives at the caller as [`FormatError::Json`] with identical text.
+struct ValueSer<'a>(&'a Value);
+
+impl serde::Serialize for ValueSer<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::{Error as _, SerializeMap, SerializeSeq};
+        match self.0 {
+            Value::Null => serializer.serialize_unit(),
+            Value::Bool(b) => serializer.serialize_bool(*b),
+            Value::Integer(i) => serializer.serialize_i64(*i),
+            Value::Float(f) => {
+                // serde_json's default would silently coerce a non-finite float
+                // to `null`, indistinguishable from a source null on read-back;
+                // reject with the same text `clinker_to_json` uses.
+                if !f.is_finite() {
+                    return Err(S::Error::custom(format!(
+                        "non-finite float {f} has no JSON representation; \
+                         filter or replace the value before the JSON output"
+                    )));
+                }
+                serializer.serialize_f64(*f)
+            }
+            // JSON has no exact-decimal type; emit the scale-preserving string
+            // form (matches `clinker_to_json`).
+            Value::Decimal(d) => serializer.serialize_str(&d.to_string()),
+            Value::String(s) => serializer.serialize_str(s.as_str()),
+            Value::Date(d) => serializer.serialize_str(&d.to_string()),
+            Value::DateTime(dt) => serializer.serialize_str(&dt.to_string()),
+            Value::Array(arr) => {
+                let mut seq = serializer.serialize_seq(Some(arr.len()))?;
+                for v in arr {
+                    seq.serialize_element(&ValueSer(v))?;
+                }
+                seq.end()
+            }
+            Value::Map(m) => {
+                let mut map = serializer.serialize_map(Some(m.len()))?;
+                for (k, v) in m.iter() {
+                    map.serialize_entry(k.as_ref(), &ValueSer(v))?;
+                }
+                map.end()
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -598,6 +698,51 @@ mod tests {
         assert_eq!(r1.get("active"), Some(&Value::Bool(true)));
         assert_eq!(r2.get("name"), Some(&Value::String("Bob".into())));
         assert_eq!(r2.get("age"), Some(&Value::Integer(25)));
+    }
+
+    #[test]
+    fn test_json_write_wide_and_long_value_roundtrip() {
+        // Exercises the buffer-reuse serialize path across a reused writer with
+        // a wide schema and a long string value, then reads back to confirm the
+        // scratch buffer is fully rewritten per record (no stale-byte bleed) and
+        // the round-trip is faithful.
+        let cols: Vec<Box<str>> = (0..40).map(|i| format!("c{i}").into()).collect();
+        let schema = Arc::new(Schema::new(cols));
+        let long = "x".repeat(500);
+        let mk = |seed: i64, tail: &str| {
+            let mut vals: Vec<Value> = (0..40).map(|i| Value::Integer(seed + i as i64)).collect();
+            // Overwrite one column with a long string to stress the value path.
+            vals[17] = Value::String(format!("{long}-{tail}").into());
+            Record::new(Arc::clone(&schema), vals)
+        };
+        let records = vec![mk(0, "first"), mk(100, "second")];
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            preserve_nulls: true,
+            ..Default::default()
+        };
+        let written = write_records(config, &records, &schema);
+
+        let mut reader = JsonReader::from_reader(
+            std::io::Cursor::new(written.into_bytes()),
+            JsonReaderConfig::default(),
+        )
+        .unwrap();
+        let _s = reader.schema().unwrap();
+        let r0 = reader.next_record().unwrap().unwrap();
+        let r1 = reader.next_record().unwrap().unwrap();
+        assert!(reader.next_record().unwrap().is_none());
+        assert_eq!(r0.get("c0"), Some(&Value::Integer(0)));
+        assert_eq!(r0.get("c39"), Some(&Value::Integer(39)));
+        assert_eq!(
+            r0.get("c17"),
+            Some(&Value::String(format!("{long}-first").into()))
+        );
+        assert_eq!(r1.get("c0"), Some(&Value::Integer(100)));
+        assert_eq!(
+            r1.get("c17"),
+            Some(&Value::String(format!("{long}-second").into()))
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/splitting/tests.rs
+++ b/crates/clinker-format/src/splitting/tests.rs
@@ -1064,48 +1064,19 @@ fn test_splitting_writer_xml_byte_split_valid_files() {
     );
 }
 
-/// A `FormatWriter` that records per-document hook calls into shared state,
-/// for proving `SplittingWriter` forwards framing to its active inner writer.
-struct HookProbe {
-    log: Arc<Mutex<Vec<String>>>,
-}
+use crate::traits::test_support::HookProbe;
 
-impl FormatWriter for HookProbe {
-    fn write_record(&mut self, _record: &Record) -> Result<(), FormatError> {
-        self.log.lock().unwrap().push("write".into());
-        Ok(())
-    }
-    fn flush(&mut self) -> Result<(), FormatError> {
-        Ok(())
-    }
-    fn begin_document(&mut self, doc: &clinker_record::DocumentContext) -> Result<(), FormatError> {
-        self.log
-            .lock()
-            .unwrap()
-            .push(format!("begin:{}", doc.source_file()));
-        Ok(())
-    }
-    fn end_document(&mut self, doc: &clinker_record::DocumentContext) -> Result<(), FormatError> {
-        self.log
-            .lock()
-            .unwrap()
-            .push(format!("end:{}", doc.source_file()));
-        Ok(())
-    }
-}
-
-#[test]
-fn splitting_writer_forwards_document_hooks_to_active_inner() {
-    use clinker_record::{DocumentId, EnvelopeRecord};
-
+/// Build a `SplittingWriter` whose inner writer is a shared [`HookProbe`], plus
+/// the log it records into. `max_bytes: None` so `write_record` performs no
+/// implicit `flush_bytes`, keeping the log a faithful record of the hooks the
+/// test itself drives.
+fn hook_probe_splitter() -> (SplittingWriter, Arc<Mutex<Vec<String>>>) {
     let schema = make_schema(&["id"]);
     let registry = FileRegistry::new();
     let log = Arc::new(Mutex::new(Vec::new()));
     let log_for_factory = Arc::clone(&log);
     let writer_factory: WriterFactory = Box::new(move |_counting, _schema| {
-        Ok(Box::new(HookProbe {
-            log: Arc::clone(&log_for_factory),
-        }) as Box<dyn FormatWriter>)
+        Ok(Box::new(HookProbe::with_log(Arc::clone(&log_for_factory))) as Box<dyn FormatWriter>)
     });
     let policy = SplitPolicy {
         max_records: None,
@@ -1114,7 +1085,15 @@ fn splitting_writer_forwards_document_hooks_to_active_inner() {
         repeat_header: false,
         oversize_group: OversizeGroupPolicy::default(),
     };
-    let mut writer = SplittingWriter::new(registry.file_factory(), writer_factory, schema, policy);
+    let writer = SplittingWriter::new(registry.file_factory(), writer_factory, schema, policy);
+    (writer, log)
+}
+
+#[test]
+fn splitting_writer_forwards_document_hooks_to_active_inner() {
+    use clinker_record::{DocumentId, EnvelopeRecord};
+
+    let (mut writer, log) = hook_probe_splitter();
 
     let doc = DocumentContext::new(
         DocumentId::next(),
@@ -1130,6 +1109,29 @@ fn splitting_writer_forwards_document_hooks_to_active_inner() {
         *log.lock().unwrap(),
         vec!["begin:file.x12", "end:file.x12"],
         "begin/end_document forward to the splitter's active inner writer",
+    );
+}
+
+#[test]
+fn splitting_writer_forwards_flush_bytes_to_active_inner() {
+    use clinker_record::{DocumentId, EnvelopeRecord};
+
+    let (mut writer, log) = hook_probe_splitter();
+
+    let doc = DocumentContext::new(
+        DocumentId::next(),
+        Arc::from("file.x12"),
+        EnvelopeRecord::empty(),
+    );
+    // Open the first file via `begin_document`, then `flush_bytes` must reach
+    // the active inner writer's non-finalizing drain.
+    writer.begin_document(&doc).unwrap();
+    writer.flush_bytes().unwrap();
+
+    assert_eq!(
+        *log.lock().unwrap(),
+        vec!["begin:file.x12", "flush_bytes"],
+        "flush_bytes forwards to the splitter's active inner writer",
     );
 }
 

--- a/crates/clinker-format/src/traits.rs
+++ b/crates/clinker-format/src/traits.rs
@@ -117,6 +117,13 @@ pub trait FormatWriter: Send {
     /// emits no closing framing (CSV, fixed-width); finalizing formats
     /// override it to drain only the underlying sink.
     ///
+    /// Wrapper writers that hold an inner writer
+    /// ([`CountedFormatWriter`](crate::counting::CountedFormatWriter),
+    /// [`SplittingWriter`](crate::splitting::SplittingWriter),
+    /// `HeaderCapturingCsvWriter`) must delegate to the inner writer's
+    /// `flush_bytes` — taking this default would replace a finalizing inner
+    /// writer's non-finalizing drain with its finalizing `flush`.
+    ///
     /// # Errors
     ///
     /// Surfaces any I/O error draining the buffer.
@@ -138,6 +145,12 @@ pub trait FormatWriter: Send {
     /// (every writer today) ignores document boundaries entirely, leaving its
     /// output byte-identical to the boundary-unaware path.
     ///
+    /// Wrapper writers that hold an inner writer
+    /// ([`CountedFormatWriter`](crate::counting::CountedFormatWriter),
+    /// [`SplittingWriter`](crate::splitting::SplittingWriter),
+    /// `HeaderCapturingCsvWriter`) must forward this hook to the inner writer,
+    /// or an enveloped inner writer's per-document framing is silently dropped.
+    ///
     /// # Errors
     ///
     /// Surfaces any I/O error emitting the opening framing.
@@ -151,7 +164,8 @@ pub trait FormatWriter: Send {
     /// `source_file` differs, or the input is exhausted — paired with the
     /// [`Self::begin_document`] that opened it.
     ///
-    /// Default impl is a no-op, mirroring [`Self::begin_document`].
+    /// Default impl is a no-op, mirroring [`Self::begin_document`]; wrapper
+    /// writers holding an inner writer must forward it for the same reason.
     ///
     /// # Errors
     ///
@@ -164,7 +178,71 @@ pub trait FormatWriter: Send {
     /// Returns `None` if byte counting is not enabled for this writer.
     /// Used by `SplittingWriter` for byte-limit rotation and by `StageMetrics`
     /// for per-stage write accounting.
+    ///
+    /// A wrapper writer holding an inner writer must forward this hook so a
+    /// byte-counting inner writer's total is not masked by this `None` default.
     fn bytes_written(&self) -> Option<u64> {
         None
+    }
+}
+
+/// Shared test fixtures for the `FormatWriter` wrapper-delegation contract.
+#[cfg(test)]
+pub(crate) mod test_support {
+    use std::sync::{Arc, Mutex};
+
+    use clinker_record::{DocumentContext, Record};
+
+    use crate::error::FormatError;
+    use crate::traits::FormatWriter;
+
+    /// A `FormatWriter` that appends a label for every lifecycle hook it
+    /// receives into a shared log, so a wrapper test can prove the wrapper
+    /// delegates each hook to its inner writer rather than silently taking a
+    /// trait default. Labels: `write`, `flush`, `flush_bytes`, `begin:<file>`,
+    /// `end:<file>`. Shared by the `CountedFormatWriter` and `SplittingWriter`
+    /// delegation tests so both assert against one fixture.
+    pub(crate) struct HookProbe {
+        log: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl HookProbe {
+        /// Build a probe that records into `log`, letting a caller (e.g. a
+        /// split writer factory) construct the probe while retaining its own
+        /// handle on the shared log.
+        pub(crate) fn with_log(log: Arc<Mutex<Vec<String>>>) -> Self {
+            Self { log }
+        }
+
+        fn record(&self, entry: impl Into<String>) {
+            self.log.lock().unwrap().push(entry.into());
+        }
+    }
+
+    impl FormatWriter for HookProbe {
+        fn write_record(&mut self, _record: &Record) -> Result<(), FormatError> {
+            self.record("write");
+            Ok(())
+        }
+
+        fn flush(&mut self) -> Result<(), FormatError> {
+            self.record("flush");
+            Ok(())
+        }
+
+        fn flush_bytes(&mut self) -> Result<(), FormatError> {
+            self.record("flush_bytes");
+            Ok(())
+        }
+
+        fn begin_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+            self.record(format!("begin:{}", doc.source_file()));
+            Ok(())
+        }
+
+        fn end_document(&mut self, doc: &DocumentContext) -> Result<(), FormatError> {
+            self.record(format!("end:{}", doc.source_file()));
+            Ok(())
+        }
     }
 }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -71,6 +71,19 @@ pub struct XmlWriter<W: Write> {
     header_written: bool,
     /// Per-document envelope framer, present only when `config.envelope` is.
     framer: Option<EnvelopeFramer>,
+    /// Precompiled element-tree shape for the record body, memoized by schema
+    /// identity. The tree SHAPE (dotted-branch nesting, attribute-vs-element
+    /// classification, element names, ordering, attribute-name validity) is a
+    /// pure function of the schema's column names + config, independent of
+    /// per-record values, so it is built once and reused across records. Built
+    /// lazily on the first `write_record` from `record.schema()` and rebuilt on
+    /// a schema-identity change, so a multi-schema output stays correct.
+    plan_cache: Option<PlanCache>,
+    /// Reusable per-record value buffer, one slot per field in iterator order.
+    /// Each slot's `String` capacity is retained across records so filling a
+    /// record's values reuses the allocation rather than building a fresh owned
+    /// tree. Bounded by the widest single record.
+    fill: FillBuf,
 }
 
 impl<W: Write> XmlWriter<W> {
@@ -85,7 +98,53 @@ impl<W: Write> XmlWriter<W> {
             config,
             header_written: false,
             framer,
+            plan_cache: None,
+            fill: FillBuf::new(),
         }
+    }
+
+    /// Ensure `plan_cache` holds a tree plan for this record's schema. The plan
+    /// is rebuilt only when the schema identity changes (`Arc::ptr_eq`), so a
+    /// single-schema stream builds it once. Attribute-name validation happens
+    /// here (at build time), before any bytes are written, so a malformed
+    /// attribute name still fails `write_record` cleanly.
+    fn ensure_plan(&mut self, record: &Record) -> Result<(), FormatError> {
+        let schema = record.schema();
+        let current = self
+            .plan_cache
+            .as_ref()
+            .is_some_and(|c| Arc::ptr_eq(&c.schema, schema));
+        if !current {
+            self.plan_cache = Some(build_plan_cache(record, &self.config)?);
+        }
+        Ok(())
+    }
+
+    /// Fill the reusable `fill` buffer with this record's rendered field values
+    /// and per-field presence, in the same iterator order the plan indexes.
+    /// Runs before any bytes are emitted, so a `Value::Map` field (rejected by
+    /// [`write_value_text`]) fails the record without leaving partial output.
+    fn fill_values(&mut self, record: &Record) -> Result<(), FormatError> {
+        let Self {
+            plan_cache,
+            fill,
+            config,
+            ..
+        } = self;
+        let cache = plan_cache.as_ref().expect("plan built before fill_values");
+        let flags = &cache.field_is_attr;
+        let preserve = config.preserve_nulls;
+        fill.reset(flags.len());
+        if config.include_engine_stamped {
+            for (i, (name, val)) in record.iter_all_fields().enumerate() {
+                fill_slot(&mut fill.slots[i], flags[i], preserve, name, val)?;
+            }
+        } else {
+            for (i, (name, val)) in record.iter_user_fields().enumerate() {
+                fill_slot(&mut fill.slots[i], flags[i], preserve, name, val)?;
+            }
+        }
+        Ok(())
     }
 
     /// Emit a `<wrapper>…</wrapper>` element whose children are the section's
@@ -136,25 +195,6 @@ impl<W: Write> XmlWriter<W> {
                 .map_err(|e| FormatError::Xml(e.to_string()))?;
         }
         Ok(())
-    }
-
-    /// Collects schema fields as (name, value) pairs and builds the record's
-    /// element body — attributes plus child nodes — before any bytes are
-    /// emitted, so record-level attributes can ride the record start tag.
-    /// Engine-stamped columns are stripped from the default output; callers
-    /// opt in via `include_engine_stamped`.
-    fn build_record_tree(&self, record: &Record) -> Result<ElementBody, FormatError> {
-        let fields: Vec<(&str, &Value)> = if self.config.include_engine_stamped {
-            record.iter_all_fields().collect()
-        } else {
-            record.iter_user_fields().collect()
-        };
-
-        build_field_tree(
-            &fields,
-            self.config.preserve_nulls,
-            &self.config.attribute_prefix,
-        )
     }
 
     /// Recursively write a field tree as nested XML elements.
@@ -211,28 +251,42 @@ impl<W: Write> XmlWriter<W> {
 
 impl<W: Write + Send> FormatWriter for XmlWriter<W> {
     fn write_record(&mut self, record: &Record) -> Result<(), FormatError> {
-        // The tree is built before the record start tag is emitted:
-        // attribute-classified fields must be known when the tag opens, and
-        // a rejected field (map payload, malformed attribute path) must not
-        // leave a dangling half-written record behind.
-        let tree = self.build_record_tree(record)?;
+        // Both the plan build and the value fill run before the record start
+        // tag is emitted: attribute-classified fields must be known when the
+        // tag opens, and a rejected field (map payload, malformed attribute
+        // name) must not leave a dangling half-written record behind.
+        self.ensure_plan(record)?;
+        self.fill_values(record)?;
 
         self.write_header()?;
 
-        let mut start = BytesStart::new(&*self.config.record_element);
-        push_attributes(&mut start, &tree.attrs);
-        self.writer
-            .write_event(Event::Start(start))
-            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        // Disjoint field borrows: the sink writes (`writer`) need the plan
+        // (`plan_cache`) and the filled values (`fill`) live at the same time.
+        let Self {
+            writer,
+            plan_cache,
+            fill,
+            config,
+            framer,
+            ..
+        } = self;
+        let plan = &plan_cache.as_ref().expect("plan built above").plan;
 
-        self.write_field_tree(&tree.children)?;
+        let mut start = BytesStart::new(&*config.record_element);
+        for attr in &plan.root.attrs {
+            if fill.emits(attr.field) {
+                push_one_attribute(&mut start, &attr.name, fill.text(attr.field));
+            }
+        }
+        writer.write_event(Event::Start(start)).map_err(xml_err)?;
 
-        let end = BytesEnd::new(&*self.config.record_element);
-        self.writer
-            .write_event(Event::End(end))
-            .map_err(|e| FormatError::Xml(e.to_string()))?;
+        emit_body(writer, &plan.root, fill)?;
 
-        if let Some(framer) = self.framer.as_mut() {
+        writer
+            .write_event(Event::End(BytesEnd::new(&*config.record_element)))
+            .map_err(xml_err)?;
+
+        if let Some(framer) = framer.as_mut() {
             framer.count_record();
         }
         Ok(())
@@ -368,11 +422,24 @@ fn build_field_tree(
 /// reader and any conformant parser resolve back to the exact bytes.
 fn push_attributes(start: &mut BytesStart, attrs: &[(String, String)]) {
     for (key, value) in attrs {
-        start.push_attribute(Attribute {
-            key: QName(key.as_bytes()),
-            value: Cow::Owned(escape_attribute_value(value).into_bytes()),
-        });
+        push_one_attribute(start, key, value);
     }
+}
+
+/// Push a single name/value attribute onto an element's start tag, escaping the
+/// value (see [`push_attributes`] for why literal whitespace is emitted as
+/// character references).
+fn push_one_attribute(start: &mut BytesStart, key: &str, value: &str) {
+    start.push_attribute(Attribute {
+        key: QName(key.as_bytes()),
+        value: Cow::Owned(escape_attribute_value(value).into_bytes()),
+    });
+}
+
+/// Map an emitter error into [`FormatError::Xml`]. The emitter surfaces
+/// `std::io::Error`; its `Display` carries the underlying cause.
+fn xml_err<E: std::fmt::Display>(e: E) -> FormatError {
+    FormatError::Xml(e.to_string())
 }
 
 /// Escape an attribute value: the five predefined entities plus literal
@@ -530,27 +597,338 @@ fn insert_field(
 /// Array elements that themselves contain a `Value::Map` propagate
 /// the same rejection (the array is joined element-wise).
 fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
-    Ok(match val {
-        Value::Null => String::new(),
-        Value::Bool(b) => b.to_string(),
-        Value::Integer(i) => i.to_string(),
-        Value::Float(f) => f.to_string(),
-        Value::Decimal(d) => d.to_string(),
-        Value::String(s) => s.to_string(),
-        Value::Date(d) => d.to_string(),
-        Value::DateTime(dt) => dt.to_string(),
-        Value::Array(arr) => arr
-            .iter()
-            .map(|v| value_to_text(col, v))
-            .collect::<Result<Vec<_>, _>>()?
-            .join(","),
+    let mut buf = String::new();
+    write_value_text(&mut buf, col, val)?;
+    Ok(buf)
+}
+
+/// Render a clinker Value as XML text content into `buf` (appending). Shares
+/// its logic with [`value_to_text`] so the record fast path and the envelope
+/// section path stay byte-identical. `Value::Map` is rejected exactly as
+/// `value_to_text` documents.
+fn write_value_text(buf: &mut String, col: &str, val: &Value) -> Result<(), FormatError> {
+    use std::fmt::Write as _;
+    match val {
+        Value::Null => {}
+        Value::Bool(b) => {
+            let _ = write!(buf, "{b}");
+        }
+        Value::Integer(i) => {
+            let _ = write!(buf, "{i}");
+        }
+        Value::Float(f) => {
+            let _ = write!(buf, "{f}");
+        }
+        Value::Decimal(d) => {
+            let _ = write!(buf, "{d}");
+        }
+        Value::String(s) => buf.push_str(s.as_str()),
+        Value::Date(d) => {
+            let _ = write!(buf, "{d}");
+        }
+        Value::DateTime(dt) => {
+            let _ = write!(buf, "{dt}");
+        }
+        Value::Array(arr) => {
+            for (idx, v) in arr.iter().enumerate() {
+                if idx > 0 {
+                    buf.push(',');
+                }
+                write_value_text(buf, col, v)?;
+            }
+        }
         Value::Map(_) => {
             return Err(FormatError::UnserializableMapValue {
                 format: "XML",
                 column: col.to_string(),
             });
         }
+    }
+    Ok(())
+}
+
+// ── Precompiled record tree plan ─────────────────────────────────────
+
+/// A record's precompiled element-tree shape: the record element's body
+/// (attributes + child nodes) with per-node element names and the field index
+/// each terminal reads its value from. Built once per schema identity.
+struct TreePlan {
+    root: PlanBody,
+}
+
+/// One element's precompiled body: the attributes on its start tag plus its
+/// child nodes. Values are not stored — each terminal carries the field index
+/// to read from the per-record fill buffer.
+#[derive(Default)]
+struct PlanBody {
+    attrs: Vec<PlanAttr>,
+    children: Vec<PlanNode>,
+}
+
+/// A precompiled attribute: its (validated) XML name and the field index whose
+/// value fills it.
+struct PlanAttr {
+    name: String,
+    field: usize,
+}
+
+/// A precompiled child node: a leaf element or a nested branch.
+enum PlanNode {
+    Leaf { name: String, field: usize },
+    Branch { name: String, body: PlanBody },
+}
+
+/// The memoized plan plus the identity it was built for. `field_is_attr` marks,
+/// per field iterator position, whether that field is an attribute (drops null
+/// unconditionally) versus an element leaf (drops null only when
+/// `preserve_nulls` is false).
+struct PlanCache {
+    schema: Arc<Schema>,
+    plan: TreePlan,
+    field_is_attr: Vec<bool>,
+}
+
+/// Build the tree plan for a record's schema. Walks the fields in iterator
+/// order (position = field index) and classifies each into the element tree,
+/// validating attribute names up front. Mirrors [`build_field_tree`]'s shape
+/// exactly so output stays byte-identical.
+fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCache, FormatError> {
+    let names: Vec<&str> = if config.include_engine_stamped {
+        record.iter_all_fields().map(|(name, _)| name).collect()
+    } else {
+        record.iter_user_fields().map(|(name, _)| name).collect()
+    };
+    let mut root = PlanBody::default();
+    let mut field_is_attr = vec![false; names.len()];
+    for (i, name) in names.iter().enumerate() {
+        plan_insert_field(
+            &mut root,
+            i,
+            name,
+            name,
+            &config.attribute_prefix,
+            &mut field_is_attr,
+        )?;
+    }
+    Ok(PlanCache {
+        schema: Arc::clone(record.schema()),
+        plan: TreePlan { root },
+        field_is_attr,
     })
+}
+
+/// Insert a dotted field name into the plan, creating branches as needed —
+/// the plan-time twin of [`insert_field`], storing the field index in place of
+/// a rendered value. Attribute-prefixed segments must be terminal, and
+/// attribute names are validated here (once) rather than per record.
+fn plan_insert_field(
+    body: &mut PlanBody,
+    field_index: usize,
+    field: &str,
+    path: &str,
+    attribute_prefix: &str,
+    field_is_attr: &mut [bool],
+) -> Result<(), FormatError> {
+    if let Some((first, rest)) = path.split_once('.') {
+        if !attribute_prefix.is_empty() && first.starts_with(attribute_prefix) {
+            return Err(FormatError::Xml(format!(
+                "field '{field}': attribute-prefixed segment '{first}' \
+                 cannot have fields nested under it — an XML attribute is a leaf"
+            )));
+        }
+        let branch = body
+            .children
+            .iter_mut()
+            .find(|n| matches!(n, PlanNode::Branch { name, .. } if name == first));
+        if let Some(PlanNode::Branch {
+            body: branch_body, ..
+        }) = branch
+        {
+            plan_insert_field(
+                branch_body,
+                field_index,
+                field,
+                rest,
+                attribute_prefix,
+                field_is_attr,
+            )
+        } else {
+            let mut branch_body = PlanBody::default();
+            plan_insert_field(
+                &mut branch_body,
+                field_index,
+                field,
+                rest,
+                attribute_prefix,
+                field_is_attr,
+            )?;
+            body.children.push(PlanNode::Branch {
+                name: first.to_string(),
+                body: branch_body,
+            });
+            Ok(())
+        }
+    } else if !attribute_prefix.is_empty() && path.starts_with(attribute_prefix) {
+        let attr_name = &path[attribute_prefix.len()..];
+        if attr_name.is_empty() {
+            return Err(FormatError::Xml(format!(
+                "field '{field}': attribute prefix '{attribute_prefix}' \
+                 carries no attribute name"
+            )));
+        }
+        if !is_valid_xml_name(attr_name) {
+            return Err(FormatError::Xml(format!(
+                "field '{field}': attribute name '{attr_name}' is not a \
+                 well-formed XML name"
+            )));
+        }
+        field_is_attr[field_index] = true;
+        body.attrs.push(PlanAttr {
+            name: attr_name.to_string(),
+            field: field_index,
+        });
+        Ok(())
+    } else {
+        body.children.push(PlanNode::Leaf {
+            name: path.to_string(),
+            field: field_index,
+        });
+        Ok(())
+    }
+}
+
+/// Per-record scratch, one slot per field in iterator order. Slot `String`
+/// capacity is retained across records (only the length is reset) so filling a
+/// record reuses allocations. `emits` records whether the field appears in
+/// output for this record (null handling); `text` holds its rendered value.
+struct FillBuf {
+    slots: Vec<FillSlot>,
+}
+
+#[derive(Default)]
+struct FillSlot {
+    text: String,
+    emits: bool,
+}
+
+impl FillBuf {
+    fn new() -> Self {
+        Self { slots: Vec::new() }
+    }
+
+    /// Ensure at least `n` slots exist (reusing existing `String` capacity),
+    /// ready to be overwritten for the current record. Every index in `0..n`
+    /// is written by `fill_values` before it is read, so stale contents beyond
+    /// a shrink never surface.
+    fn reset(&mut self, n: usize) {
+        if self.slots.len() < n {
+            self.slots.resize_with(n, FillSlot::default);
+        }
+    }
+
+    fn emits(&self, field: usize) -> bool {
+        self.slots[field].emits
+    }
+
+    fn text(&self, field: usize) -> &str {
+        &self.slots[field].text
+    }
+}
+
+/// Fill a single slot with a field's presence and rendered text. A field is
+/// dropped (`emits = false`) when it is a null attribute, or a null element
+/// under `preserve_nulls: false`; otherwise its text is rendered (a preserved
+/// null element renders to the empty string, emitted as a self-closing tag).
+fn fill_slot(
+    slot: &mut FillSlot,
+    is_attr: bool,
+    preserve_nulls: bool,
+    name: &str,
+    val: &Value,
+) -> Result<(), FormatError> {
+    let skip = if is_attr {
+        val.is_null()
+    } else {
+        val.is_null() && !preserve_nulls
+    };
+    slot.emits = !skip;
+    slot.text.clear();
+    if !skip {
+        write_value_text(&mut slot.text, name, val)?;
+    }
+    Ok(())
+}
+
+/// Emit a body's child nodes (its start-tag attributes are handled by the
+/// caller). A branch is emitted only when it has at least one emitting
+/// attribute or child, and self-closes when it has no emitting children —
+/// matching the pruning `build_field_tree` performs by never inserting a
+/// dropped field.
+fn emit_body<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    body: &PlanBody,
+    fill: &FillBuf,
+) -> Result<(), FormatError> {
+    for child in &body.children {
+        match child {
+            PlanNode::Leaf { name, field } => {
+                if !fill.emits(*field) {
+                    continue;
+                }
+                let text = fill.text(*field);
+                if text.is_empty() {
+                    writer
+                        .write_event(Event::Empty(BytesStart::new(name.as_str())))
+                        .map_err(xml_err)?;
+                } else {
+                    writer
+                        .write_event(Event::Start(BytesStart::new(name.as_str())))
+                        .map_err(xml_err)?;
+                    writer
+                        .write_event(Event::Text(BytesText::new(text)))
+                        .map_err(xml_err)?;
+                    writer
+                        .write_event(Event::End(BytesEnd::new(name.as_str())))
+                        .map_err(xml_err)?;
+                }
+            }
+            PlanNode::Branch { name, body } => {
+                let has_attrs = body.attrs.iter().any(|a| fill.emits(a.field));
+                let has_children = body.children.iter().any(|c| node_emits(c, fill));
+                if !has_attrs && !has_children {
+                    continue;
+                }
+                let mut start = BytesStart::new(name.as_str());
+                for attr in &body.attrs {
+                    if fill.emits(attr.field) {
+                        push_one_attribute(&mut start, &attr.name, fill.text(attr.field));
+                    }
+                }
+                if has_children {
+                    writer.write_event(Event::Start(start)).map_err(xml_err)?;
+                    emit_body(writer, body, fill)?;
+                    writer
+                        .write_event(Event::End(BytesEnd::new(name.as_str())))
+                        .map_err(xml_err)?;
+                } else {
+                    writer.write_event(Event::Empty(start)).map_err(xml_err)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Whether a node contributes any output for the current record: a leaf emits
+/// per its fill slot; a branch emits when any attribute or descendant does.
+fn node_emits(node: &PlanNode, fill: &FillBuf) -> bool {
+    match node {
+        PlanNode::Leaf { field, .. } => fill.emits(*field),
+        PlanNode::Branch { body, .. } => {
+            body.attrs.iter().any(|a| fill.emits(a.field))
+                || body.children.iter().any(|c| node_emits(c, fill))
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1056,6 +1434,98 @@ mod tests {
         assert!(
             !output.contains("<@"),
             "no @-named element may be emitted: {output}"
+        );
+    }
+
+    #[test]
+    fn test_xml_write_wide_dotted_and_attribute_golden() {
+        // Golden byte-exact output for a wide schema mixing top-level fields,
+        // record attributes, and shared-prefix dotted branches with their own
+        // attributes — the shape the precompiled plan targets.
+        let schema = Arc::new(Schema::new(vec![
+            "@id".into(),
+            "name".into(),
+            "Address.@type".into(),
+            "Address.City".into(),
+            "Address.State".into(),
+            "Contact.Email".into(),
+        ]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::Integer(7),
+                Value::String("Alice".into()),
+                Value::String("home".into()),
+                Value::String("NYC".into()),
+                Value::String("NY".into()),
+                Value::String("a@example.com".into()),
+            ],
+        );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            r#"<Root><Record id="7"><name>Alice</name><Address type="home"><City>NYC</City><State>NY</State></Address><Contact><Email>a@example.com</Email></Contact></Record></Root>"#
+        );
+    }
+
+    #[test]
+    fn test_xml_write_plan_reused_across_records() {
+        // The plan is memoized by schema identity, so many records of one
+        // schema reuse it. Each record must still render its own values.
+        let schema = Arc::new(Schema::new(vec!["Address.City".into(), "name".into()]));
+        let records: Vec<Record> = [("NYC", "Alice"), ("LA", "Bob"), ("SF", "Carol")]
+            .into_iter()
+            .map(|(city, name)| {
+                Record::new(
+                    Arc::clone(&schema),
+                    vec![Value::String(city.into()), Value::String(name.into())],
+                )
+            })
+            .collect();
+        let output = write_records(XmlWriterConfig::default(), &records, &schema);
+        assert_eq!(
+            output,
+            "<Root>\
+             <Record><Address><City>NYC</City></Address><name>Alice</name></Record>\
+             <Record><Address><City>LA</City></Address><name>Bob</name></Record>\
+             <Record><Address><City>SF</City></Address><name>Carol</name></Record>\
+             </Root>"
+        );
+    }
+
+    #[test]
+    fn test_xml_write_all_null_branch_suppressed_across_records() {
+        // Under preserve_nulls:false a branch whose descendants are all null is
+        // never opened; a later record filling the same branch still emits it.
+        // Exercises per-record presence pruning over the shared plan.
+        let schema = Arc::new(Schema::new(vec![
+            "Address.City".into(),
+            "Address.State".into(),
+            "name".into(),
+        ]));
+        let all_null_branch = Record::new(
+            Arc::clone(&schema),
+            vec![Value::Null, Value::Null, Value::String("Alice".into())],
+        );
+        let branch_present = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::String("NYC".into()),
+                Value::Null,
+                Value::String("Bob".into()),
+            ],
+        );
+        let output = write_records(
+            XmlWriterConfig::default(),
+            &[all_null_branch, branch_present],
+            &schema,
+        );
+        assert_eq!(
+            output,
+            "<Root>\
+             <Record><name>Alice</name></Record>\
+             <Record><Address><City>NYC</City></Address><name>Bob</name></Record>\
+             </Root>"
         );
     }
 


### PR DESCRIPTION
Removes the per-record materialization overhead in all four flat-file writers, with criterion before/after evidence per commit. Output is byte-identical across the exact-output, round-trip, envelope, and golden suites, with two deliberate edge improvements in the XML writer: (1) element ordering for a non-contiguous dotted group whose leading members are null in a given record now follows the schema's group position deterministically, where it previously varied per row with the first non-null member; (2) an invalid attribute name declared in the schema now fails the first record written (before any bytes), instead of succeeding until the first record with a non-null value for that column reached it mid-stream.

## What changed

- **JSON (#702):** the writer built a full `serde_json::Value` tree plus an intermediate `String` for every record. A borrowing `Serialize` implementation now streams each record's fields straight into a reusable scratch buffer; non-finite floats are still rejected with the identical error. Throughput: −82% time on 10-field records, −81% on 50-field, −60% on 256-column long rows.
- **XML (#703):** the writer rebuilt an owned field tree per record with per-node name allocations and a quadratic sibling scan. The tree shape (element names, attribute classification and validation) is now precompiled once per schema and memoized; each record only fills values into the precompiled plan. All-null branch suppression behavior is reproduced exactly. Throughput: −63% (50-field flat), −60% (dotted paths).
- **CSV (#704):** the historically-reported boxed iterator was already gone; the remaining per-record cost was column lookups and a fresh row vector per record. Column indices are precomputed and a reusable row buffer is cleared per cell. Throughput: −37% to −45% across shapes.
- **Fixed-width (#705):** dropped the per-field value clone (borrow + shared null fallback). Schema-index caching was deliberately left out: the auto-widen sidecar can reorder record keys per row, so a cached column position is unsound — the clone elimination is the safe half. Throughput: −33/−34%.
- **Wrapper lifecycle (#722):** the `FormatWriter` wrapper-delegation contract (begin/end document, `flush_bytes`, `bytes_written`) is now documented on the trait and exercised by shared hook-probe tests; the header-capturing CSV wrapper gained the missing delegations. No behavior change.

The `io_throughput` bench gained wide/long JSON shapes and new XML and fixed-width groups so these paths stay measured.

Closes #702
Closes #703
Closes #704
Closes #705
Closes #722
Closes #693
