### PR TITLE
engine: memory-arbitration resume controller with liveness guarantee and resume_threshold config

### DIFF
--- a/crates/clinker-exec/benches/arbitration_poll.rs
+++ b/crates/clinker-exec/benches/arbitration_poll.rs
@@ -53,7 +53,7 @@ impl MemoryConsumer for FakeConsumer {
 }
 
 fn build_arbitrator(n: usize) -> MemoryArbitrator {
-    let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+    let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
     for i in 0..n {
         let priority = (i % 4) as i32 * 10;
         arbitrator.register_consumer(Arc::new(FakeConsumer::new(priority)));

--- a/crates/clinker-exec/benches/deferred_buffer_pruning.rs
+++ b/crates/clinker-exec/benches/deferred_buffer_pruning.rs
@@ -49,7 +49,7 @@ fn build_wide_rows() -> Vec<(Record, u64)> {
 
 fn measure_arena_bytes(rows: &[(Record, u64)], fields: &[String]) -> u64 {
     let schema = rows[0].0.schema().clone();
-    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
     let _arena = Arena::from_records(rows, fields, &schema, &budget)
         .expect("u64::MAX budget never overflows");
     // Project per-row size against the requested field set. The cost

--- a/crates/clinker-exec/src/aggregation/hash.rs
+++ b/crates/clinker-exec/src/aggregation/hash.rs
@@ -1528,6 +1528,7 @@ mod spill_trigger_tests {
         Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
             0,
             0.8,
+            0.70,
             crate::pipeline::memory::MemoryArbitrator::default_policy(),
         ))
     }

--- a/crates/clinker-exec/src/executor/batch_handoff.rs
+++ b/crates/clinker-exec/src/executor/batch_handoff.rs
@@ -606,6 +606,7 @@ mod tests {
         let arbitrator = Arc::new(MemoryArbitrator::with_policy(
             64 * 1024 * 1024,
             0.80,
+            0.70,
             Box::new(NoOpPolicy),
         ));
         // Force the soft threshold to trip unconditionally. The streaming
@@ -712,6 +713,7 @@ mod tests {
         let arbitrator = Arc::new(MemoryArbitrator::with_policy(
             64 * 1024 * 1024,
             0.80,
+            0.70,
             Box::new(NoOpPolicy),
         ));
         arbitrator.set_limit(1);
@@ -801,6 +803,7 @@ mod tests {
         let arbitrator = Arc::new(MemoryArbitrator::with_policy(
             64 * 1024 * 1024,
             0.80,
+            0.70,
             Box::new(NoOpPolicy),
         ));
         // Force the streaming charge path onto the spill branch (the charge

--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -1094,7 +1094,7 @@ mod tests {
     fn arbitrator(soft_bytes: u64) -> MemoryArbitrator {
         // soft = limit * 0.80, so limit = soft / 0.80.
         let limit = (soft_bytes as f64 / 0.80) as u64;
-        let arb = MemoryArbitrator::with_policy(limit, 0.80, Box::new(NoOpPolicy));
+        let arb = MemoryArbitrator::with_policy(limit, 0.80, 0.70, Box::new(NoOpPolicy));
         arb.set_peak_rss_for_test(1);
         arb
     }

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1247,6 +1247,19 @@ impl<'a> ExecutorContext<'a> {
     /// registered handle (already released, or a body-port seed source).
     pub(crate) fn activate_source_for_drain(&self, source_name: &str) {
         if let Some((_, handle)) = self.source_consumers.get(source_name) {
+            // Layer 3 spill-nudge: if a prior round paused this source under
+            // genuine pressure, shed reclaimable downstream state (Priority
+            // order) before resuming it, so the resumed producer does not
+            // immediately re-trip the soft limit. Overshoot reduction only —
+            // liveness does not depend on it, so an over-target of 0 (no
+            // current pressure) is a no-op.
+            if handle.is_paused() {
+                let over = self
+                    .memory_budget
+                    .current_pressure()
+                    .saturating_sub(self.memory_budget.soft_limit());
+                self.memory_budget.spill_reclaimable(over);
+            }
             handle.set_active();
             handle.resume();
         }

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1223,8 +1223,32 @@ impl<'a> ExecutorContext<'a> {
     /// release single-shot; a repeat call for the same source is a no-op.
     pub(crate) fn release_source_consumer(&mut self, source_name: &str) {
         if let Some((id, handle)) = self.source_consumers.remove(source_name) {
+            // Resume before unregister: a prior arbitration round may have
+            // paused this source's ingest thread, and once the wrapper leaves
+            // the registry nothing else can unpark it — the thread would sit
+            // parked forever and the ingest-thread join would hang. Clearing
+            // the active flag keeps the handle tidy for any late reader.
+            handle.resume();
+            handle.clear_active();
             handle.set_bytes(0);
             self.memory_budget.unregister_consumer(id);
+        }
+    }
+
+    /// Resume-on-entry + active-exemption for a source the walk is about to
+    /// drain. Marks the source's ingest handle active — the resume
+    /// controller's pause step skips an active consumer — and resumes it in
+    /// case a prior arbitration round paused it before its drain turn.
+    ///
+    /// Together these make a paused source unable to stall the single-threaded
+    /// walk: when the walk reaches a source's drain arm it unparks the ingest
+    /// thread here and keeps it exempt for the whole drain, so the `recv()` /
+    /// `select()` it then blocks on is always fed. No-op for a source with no
+    /// registered handle (already released, or a body-port seed source).
+    pub(crate) fn activate_source_for_drain(&self, source_name: &str) {
+        if let Some((_, handle)) = self.source_consumers.get(source_name) {
+            handle.set_active();
+            handle.resume();
         }
     }
 
@@ -2154,6 +2178,15 @@ pub(crate) fn merge_fused_interleave(
                 },
             )
         };
+    // Resume-on-entry + active-exemption for EVERY predecessor Source: the
+    // `select()` below can block on any of them, so all must be exempt from a
+    // mid-walk pause and unparked if a prior round paused them. Missing even
+    // one reinstates the deadlock — `Select` would block on a paused source
+    // whose ingest thread never refills its channel. Each source's
+    // `release_source_consumer` at close clears its own flag.
+    for state in &states {
+        ctx.activate_source_for_drain(&state.source_name_string);
+    }
     let n = receivers.len();
     loop {
         // Honor cooperative shutdown at the chunk boundary before blocking on
@@ -2463,6 +2496,11 @@ pub(crate) fn transform_fused_consume(
     let timeout = ctx.idle_timeouts.get(source_name_owned.as_str()).copied();
     let has_record_seed = !ctx.record_var_seed.is_empty();
     let source_name_arc: Arc<str> = Arc::from(source_name_owned.as_str());
+    // Resume-on-entry + active-exemption: unpark the upstream Source if a
+    // prior arbitration round paused it, and mark it active so the resume
+    // controller never pauses the producer feeding the fused recv loop below.
+    // `release_source_consumer` at drain end clears the flag and resumes.
+    ctx.activate_source_for_drain(source_name_owned.as_str());
 
     // In materialized mode `output_records` accumulates emitted records
     // (records only), the input to `finalize_node_rooted_windows` and

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1118,7 +1118,7 @@ impl<'a> ExecutorContext<'a> {
             crossbeam_channel::bounded::<crate::executor::stream_event::StreamEvent>(256);
         let charge_handle = crate::pipeline::memory::ConsumerHandle::new();
         let charge_consumer_id = self.memory_budget.register_consumer(Arc::new(
-            crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone(), false),
+            crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone()),
         ));
         self.streaming_output_senders.insert(producer_idx, tx);
         self.streaming_charge_consumers
@@ -1541,7 +1541,7 @@ pub(crate) fn admit_node_buffer(
     let handle = crate::pipeline::memory::ConsumerHandle::new();
     handle.set_bytes(bytes);
     let consumer_id = ctx.memory_budget.register_consumer(Arc::new(
-        crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+        crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone()),
     ));
     ctx.node_buffer_consumer_ids
         .insert(node_idx, (consumer_id, handle.clone()));

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -1040,6 +1040,7 @@ mod tests {
         let arbitrator = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
             64,
             0.5,
+            0.4,
             Box::new(crate::pipeline::memory::NoOpPolicy),
         ));
         let tmp = tempfile::tempdir().expect("tempdir");
@@ -1120,6 +1121,7 @@ mod tests {
         let arbitrator = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
             64,
             0.5,
+            0.4,
             Box::new(crate::pipeline::memory::NoOpPolicy),
         ));
         // A one-byte disk quota: the mem-tail flush overflows it on the first
@@ -1171,6 +1173,7 @@ mod tests {
         let arbitrator = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
             64,
             0.5,
+            0.4,
             Box::new(crate::pipeline::memory::NoOpPolicy),
         ));
         let tmp = tempfile::tempdir().expect("tempdir");

--- a/crates/clinker-exec/src/executor/document_dlq.rs
+++ b/crates/clinker-exec/src/executor/document_dlq.rs
@@ -374,7 +374,7 @@ impl<'cfg> DocumentDlqDriver<'cfg> {
         buckets.entry(Arc::clone(key)).or_insert_with(|| {
             let handle = crate::pipeline::memory::ConsumerHandle::new();
             let consumer_id = arbitrator.register_consumer(Arc::new(
-                crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+                crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone()),
             ));
             DocBucket {
                 buffer: NodeBuffer::Memory(Vec::new()),
@@ -1047,7 +1047,7 @@ mod tests {
 
         let handle = crate::pipeline::memory::ConsumerHandle::new();
         let consumer_id = arbitrator.register_consumer(Arc::new(
-            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone()),
         ));
         let mut bucket = DocBucket {
             buffer: NodeBuffer::Memory(Vec::new()),
@@ -1131,7 +1131,7 @@ mod tests {
 
         let handle = crate::pipeline::memory::ConsumerHandle::new();
         let consumer_id = arbitrator.register_consumer(Arc::new(
-            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone()),
         ));
         let mut bucket = DocBucket {
             buffer: NodeBuffer::Memory(Vec::new()),
@@ -1179,7 +1179,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let handle = crate::pipeline::memory::ConsumerHandle::new();
         let consumer_id = arbitrator.register_consumer(Arc::new(
-            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone(), false),
+            crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone()),
         ));
         let mut bucket = DocBucket {
             buffer: NodeBuffer::Memory(Vec::new()),

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1620,6 +1620,7 @@ mod tests {
     mod resident_node_buffer_spill;
     mod scheduling;
     mod source_consumer_release;
+    mod source_pause_liveness;
     mod spill_backed_drain_overshoot;
     mod spill_dir_unavailable_midrun;
 }

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1186,7 +1186,7 @@ impl PipelineExecutor {
             // landed — matching `admit_node_buffer`'s posture.
             let charge_handle = crate::pipeline::memory::ConsumerHandle::new();
             let charge_consumer_id = memory_budget.register_consumer(Arc::new(
-                crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone(), false),
+                crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone()),
             ));
             let writer_charge_handle = charge_handle.clone();
             let handle = std::thread::Builder::new()

--- a/crates/clinker-exec/src/executor/node_buffer.rs
+++ b/crates/clinker-exec/src/executor/node_buffer.rs
@@ -557,25 +557,19 @@ impl Iterator for NodeBufferDrain {
 /// side. Preferred first victim under `Priority` and
 /// `BackPressurePreferred::wrapping(Priority)`.
 ///
-/// `can_back_pressure` is dynamic: `true` when the slot's producer
-/// chain terminates at a pauseable Source (no blocking operator
-/// between), `false` otherwise. Stored on construction; the
-/// dispatcher classifies the upstream topology at registration time
-/// since the DAG is static.
+/// `can_back_pressure` is a constant `false`: a node buffer is filled
+/// synchronously by the walk thread via `admit_node_buffer`, so there is
+/// no separate producer thread to park, and the walk cannot resume a pause
+/// it is itself blocked behind. Pressure on a node buffer is relieved by
+/// spilling its resident rows (`try_spill`), never by pausing — only a
+/// Source, fronted by a real producer thread, can honor a pause.
 pub struct NodeBufferConsumer {
     handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
-    back_pressureable: bool,
 }
 
 impl NodeBufferConsumer {
-    pub fn new(
-        handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
-        back_pressureable: bool,
-    ) -> Self {
-        Self {
-            handle,
-            back_pressureable,
-        }
+    pub fn new(handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>) -> Self {
+        Self { handle }
     }
 }
 
@@ -605,15 +599,7 @@ impl crate::pipeline::memory::MemoryConsumer for NodeBufferConsumer {
     }
 
     fn can_back_pressure(&self) -> bool {
-        self.back_pressureable
-    }
-
-    fn pause(&self) {
-        self.handle.pause();
-    }
-
-    fn resume(&self) {
-        self.handle.resume();
+        false
     }
 }
 
@@ -1122,23 +1108,10 @@ mod tests {
         use crate::pipeline::memory::{ConsumerHandle, MemoryConsumer};
         let handle = ConsumerHandle::new();
         handle.set_bytes(4096);
-        let consumer = NodeBufferConsumer::new(handle.clone(), false);
+        let consumer = NodeBufferConsumer::new(handle.clone());
         assert_eq!(consumer.current_usage(), 4096);
         assert_eq!(consumer.spill_priority(), 0);
         assert!(!consumer.can_back_pressure());
-    }
-
-    #[test]
-    fn node_buffer_consumer_back_pressureable_routes_pause_to_handle() {
-        use crate::pipeline::memory::{ConsumerHandle, MemoryConsumer};
-        let handle = ConsumerHandle::new();
-        let consumer = NodeBufferConsumer::new(handle.clone(), true);
-        assert!(consumer.can_back_pressure());
-        assert!(!handle.is_paused());
-        consumer.pause();
-        assert!(handle.is_paused());
-        consumer.resume();
-        assert!(!handle.is_paused());
     }
 
     #[test]
@@ -1146,7 +1119,7 @@ mod tests {
         use crate::pipeline::memory::{ConsumerHandle, ConsumerSpillError, MemoryConsumer};
         let handle = ConsumerHandle::new();
         handle.set_bytes(1024);
-        let consumer = NodeBufferConsumer::new(handle.clone(), false);
+        let consumer = NodeBufferConsumer::new(handle.clone());
         // Below-target: handle has 1024, asked for 4096.
         match consumer.try_spill(4096) {
             Err(ConsumerSpillError::BelowTarget { target, freed }) => {

--- a/crates/clinker-exec/src/executor/node_buffer.rs
+++ b/crates/clinker-exec/src/executor/node_buffer.rs
@@ -958,7 +958,7 @@ mod tests {
         };
         // A 1-byte hard limit: the growing re-materialized vector crosses it
         // at the first 1024-record poll.
-        let arb = MemoryArbitrator::with_policy(1, 0.80, Box::new(NoOpPolicy));
+        let arb = MemoryArbitrator::with_policy(1, 0.80, 0.70, Box::new(NoOpPolicy));
         match nb.drain_split_metered(&arb, "spilled_stage") {
             Err(PipelineError::MemoryBudgetExceeded { node, source, .. }) => {
                 assert_eq!(node, "spilled_stage", "the error names the draining stage");
@@ -984,8 +984,12 @@ mod tests {
             chunks: vec![spill_chunk(rows.clone())],
             pending_puncts: vec![Punctuation::document_close(Arc::clone(&ctx))],
         };
-        let arb =
-            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let arb = MemoryArbitrator::with_policy(
+            100 * 1024 * 1024 * 1024,
+            0.80,
+            0.70,
+            Box::new(NoOpPolicy),
+        );
         let (metered_recs, metered_puncts) = make()
             .drain_split_metered(&arb, "stage")
             .expect("ample-budget metered drain");
@@ -1048,7 +1052,7 @@ mod tests {
         // but their sum (two footprints) breaches it — the joint-overshoot the
         // sum-aware gate exists to catch, invisible to a bytes-only test.
         let hard = poll_footprint + poll_footprint / 2;
-        let arb = MemoryArbitrator::with_policy(hard, 0.80, Box::new(NoOpPolicy));
+        let arb = MemoryArbitrator::with_policy(hard, 0.80, 0.70, Box::new(NoOpPolicy));
         arb.register_consumer(Arc::new(FixedUsageConsumer(poll_footprint)));
 
         match nb.drain_split_metered(&arb, "joint_stage") {
@@ -1100,7 +1104,7 @@ mod tests {
         // under AND their sum under → the drain completes and yields every
         // record. Guards against the gate over-firing on a legitimate drain.
         let hard = poll_footprint * 3;
-        let arb = MemoryArbitrator::with_policy(hard, 0.80, Box::new(NoOpPolicy));
+        let arb = MemoryArbitrator::with_policy(hard, 0.80, 0.70, Box::new(NoOpPolicy));
         arb.register_consumer(Arc::new(FixedUsageConsumer(poll_footprint)));
 
         let (recs, _puncts) = nb

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -1138,7 +1138,7 @@ mod tests {
     fn arbitrator(soft_bytes: u64) -> MemoryArbitrator {
         // soft = limit * 0.80, so limit = soft / 0.80.
         let limit = (soft_bytes as f64 / 0.80) as u64;
-        let arb = MemoryArbitrator::with_policy(limit, 0.80, Box::new(NoOpPolicy));
+        let arb = MemoryArbitrator::with_policy(limit, 0.80, 0.70, Box::new(NoOpPolicy));
         // Keep the RSS arm quiet: a tiny seeded peak never trips the soft
         // limit, so the buffer's own resident-byte total governs spilling.
         arb.set_peak_rss_for_test(1);

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -417,7 +417,7 @@ mod tests {
         use crate::pipeline::memory::{MemoryArbitrator, NoOpPolicy};
 
         let schema = schema();
-        let budget = MemoryArbitrator::with_policy(64 * 1024, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(64 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         budget.set_max_spill_bytes(1);
         let spill_root = tempfile::tempdir().unwrap();
         // threshold=1 → every push spills, so the first run already crosses the

--- a/crates/clinker-exec/src/executor/source_dispatch.rs
+++ b/crates/clinker-exec/src/executor/source_dispatch.rs
@@ -133,6 +133,11 @@ pub(crate) fn dispatch_source(
         let mut last_file: Arc<str> = Arc::clone(&MERGED_SOURCE_FILE);
         let mut count: u64 = 0;
         let mut records_since_check: u32 = 0;
+        // Resume-on-entry + active-exemption: unpark this source if a prior
+        // arbitration round paused it, and mark it active so the resume
+        // controller never pauses the producer feeding the `recv()` below.
+        // `release_source_consumer` at drain end clears the flag and resumes.
+        ctx.activate_source_for_drain(name.as_str());
         loop {
             let item: Option<crate::executor::stream_event::StreamEvent> = match timeout {
                 Some(t) => match rx.recv_timeout(t) {

--- a/crates/clinker-exec/src/executor/source_stream.rs
+++ b/crates/clinker-exec/src/executor/source_stream.rs
@@ -215,6 +215,14 @@ impl crate::pipeline::memory::MemoryConsumer for SourceConsumer {
     fn resume(&self) {
         self.handle.resume();
     }
+
+    fn is_paused(&self) -> bool {
+        self.handle.is_paused()
+    }
+
+    fn is_active(&self) -> bool {
+        self.handle.is_active()
+    }
 }
 
 #[cfg(test)]

--- a/crates/clinker-exec/src/executor/tests/aggregation.rs
+++ b/crates/clinker-exec/src/executor/tests/aggregation.rs
@@ -106,6 +106,7 @@ mod dispatch {
                 crate::pipeline::memory::MemoryArbitrator::with_policy(
                     0,
                     0.8,
+                    0.70,
                     crate::pipeline::memory::MemoryArbitrator::default_policy(),
                 ),
             ),
@@ -1704,6 +1705,7 @@ mod two_phase_bytes_spill {
                 crate::pipeline::memory::MemoryArbitrator::with_policy(
                     0,
                     0.8,
+                    0.70,
                     crate::pipeline::memory::MemoryArbitrator::default_policy(),
                 ),
             ),

--- a/crates/clinker-exec/src/executor/tests/combine_consumer_lifecycle.rs
+++ b/crates/clinker-exec/src/executor/tests/combine_consumer_lifecycle.rs
@@ -38,6 +38,7 @@ fn quiet_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
     Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         crate::pipeline::memory::MemoryArbitrator::default_policy(),
     ))
 }

--- a/crates/clinker-exec/src/executor/tests/composition_port_admission_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/composition_port_admission_overshoot.rs
@@ -35,6 +35,7 @@ fn spill_tripped_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> 
     let arb = crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         Box::new(crate::pipeline::memory::Priority),
     );
     arb.set_peak_rss_for_test(90 * 1024 * 1024 * 1024);
@@ -49,6 +50,7 @@ fn abort_seeded_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
     let arb = crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         Box::new(crate::pipeline::memory::Priority),
     );
     arb.set_peak_rss_for_test(150 * 1024 * 1024 * 1024);

--- a/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/src/executor/tests/deferred_dispatch.rs
@@ -300,6 +300,7 @@ nodes:
     let arbitrator = std::sync::Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         0.80,
+        0.70,
         Box::new(crate::pipeline::memory::Priority),
     ));
     arbitrator.set_peak_rss_for_test(HARD_LIMIT + 4096);

--- a/crates/clinker-exec/src/executor/tests/diamond_node_buffer_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/diamond_node_buffer_overshoot.rs
@@ -42,6 +42,7 @@ fn spill_tripped_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> 
     let arb = crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         Box::new(crate::pipeline::memory::Priority),
     );
     // 90 GiB: above the 80 GiB soft limit, below the 100 GiB hard limit.
@@ -58,6 +59,7 @@ fn abort_seeded_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
     let arb = crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         Box::new(crate::pipeline::memory::Priority),
     );
     // 150 GiB: above the 100 GiB hard limit, so `should_abort` is true.

--- a/crates/clinker-exec/src/executor/tests/iejoin_pre_output_budget.rs
+++ b/crates/clinker-exec/src/executor/tests/iejoin_pre_output_budget.rs
@@ -50,6 +50,7 @@ fn tight_no_op_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
     Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
         TIGHT_LIMIT,
         SPILL_FRAC,
+        0.70,
         Box::new(crate::pipeline::memory::NoOpPolicy),
     ))
 }

--- a/crates/clinker-exec/src/executor/tests/nested_composition_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/nested_composition_overshoot.rs
@@ -34,6 +34,7 @@ fn spill_tripped_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> 
     let arb = crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         Box::new(crate::pipeline::memory::Priority),
     );
     arb.set_peak_rss_for_test(90 * 1024 * 1024 * 1024);

--- a/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
+++ b/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
@@ -47,7 +47,7 @@ fn memory_slot(s: &Arc<Schema>, rows: &[(i64, &str, u64)]) -> NodeBuffer {
 /// Register a `NodeBufferConsumer` sharing `handle` and return its id, so
 /// the sweep's `consumer_ids` map mirrors the production registration shape.
 fn register(arb: &MemoryArbitrator, handle: &Arc<ConsumerHandle>) -> ConsumerId {
-    arb.register_consumer(Arc::new(NodeBufferConsumer::new(handle.clone(), false)))
+    arb.register_consumer(Arc::new(NodeBufferConsumer::new(handle.clone())))
 }
 
 #[test]

--- a/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
+++ b/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
@@ -52,7 +52,7 @@ fn register(arb: &MemoryArbitrator, handle: &Arc<ConsumerHandle>) -> ConsumerId 
 
 #[test]
 fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
-    let arb = MemoryArbitrator::with_policy(64 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+    let arb = MemoryArbitrator::with_policy(64 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
     let spill_dir = tempfile::tempdir().expect("temp dir");
     let s = schema();
 
@@ -151,7 +151,7 @@ fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
 
 #[test]
 fn flagged_non_spillable_slot_is_skipped_by_sweep() {
-    let arb = MemoryArbitrator::with_policy(64 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+    let arb = MemoryArbitrator::with_policy(64 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
     let spill_dir = tempfile::tempdir().expect("temp dir");
     let s = schema();
     let idx = NodeIndex::new(0);

--- a/crates/clinker-exec/src/executor/tests/scheduling.rs
+++ b/crates/clinker-exec/src/executor/tests/scheduling.rs
@@ -134,8 +134,12 @@ fn no_estimates_reproduces_topo_order_exactly() {
         "premise broken: a non-existent path seeded a non-zero peak"
     );
 
-    let arbitrator =
-        MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, MemoryArbitrator::default_policy());
+    let arbitrator = MemoryArbitrator::with_policy(
+        512 * 1024 * 1024,
+        0.80,
+        0.70,
+        MemoryArbitrator::default_policy(),
+    );
     let all: HashSet<NodeIndex> = dag.topo_order.iter().copied().collect();
 
     let order = scheduled_pass_order(dag, &arbitrator, &all, &std::collections::HashMap::new());
@@ -203,8 +207,12 @@ fn immediate_freed_outranks_larger_subtree_reclaim_of_a_fresh_source() {
     );
     let topo_pos = |idx: NodeIndex| dag.topo_order.iter().position(|&n| n == idx).unwrap();
 
-    let arbitrator =
-        MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, MemoryArbitrator::default_policy());
+    let arbitrator = MemoryArbitrator::with_policy(
+        512 * 1024 * 1024,
+        0.80,
+        0.70,
+        MemoryArbitrator::default_policy(),
+    );
 
     // Frontier as the dispatch loop sees it once src_small is done and
     // agg_small has become runnable while src_large is still waiting.
@@ -384,7 +392,7 @@ fn headroom_fit_prefers_fitting_node_over_lower_index() {
     // `with_policy` takes the hard limit and a soft fraction; pick a hard
     // limit whose soft floor equals `soft`.
     let arbitrator =
-        MemoryArbitrator::with_policy(soft * 2, 0.50, MemoryArbitrator::default_policy());
+        MemoryArbitrator::with_policy(soft * 2, 0.50, 0.40, MemoryArbitrator::default_policy());
     assert_eq!(arbitrator.soft_limit(), soft);
     assert!(small_peak <= soft && large_peak > soft);
 
@@ -420,6 +428,7 @@ fn huge_budget_arbitrator() -> std::sync::Arc<MemoryArbitrator> {
     std::sync::Arc::new(MemoryArbitrator::with_policy(
         HUGE_HARD_LIMIT_BYTES,
         0.80,
+        0.70,
         MemoryArbitrator::default_policy(),
     ))
 }

--- a/crates/clinker-exec/src/executor/tests/source_consumer_release.rs
+++ b/crates/clinker-exec/src/executor/tests/source_consumer_release.rs
@@ -33,6 +33,7 @@ fn quiet_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
     Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         crate::pipeline::memory::MemoryArbitrator::default_policy(),
     ))
 }

--- a/crates/clinker-exec/src/executor/tests/source_pause_liveness.rs
+++ b/crates/clinker-exec/src/executor/tests/source_pause_liveness.rs
@@ -1,0 +1,396 @@
+//! Producer-pause liveness: a Source the resume controller paused mid-walk
+//! must never stall the single-threaded dispatch walk.
+//!
+//! Each test seeds sustained memory pressure through a registered,
+//! non-back-pressureable consumer pinned above the soft limit — so
+//! `current_pressure()` stays over the pause threshold without faking OS
+//! RSS — and drives a topology where one blocking-admit boundary elects a
+//! still-live Source as the pause victim. When the walk later reaches that
+//! Source's drain turn, resume-on-entry must unpark its ingest thread and
+//! active-exemption must keep it unpaused for the whole drain.
+//!
+//! Pre-change these hang: the only production `resume()` was the end-of-run
+//! teardown sweep, unreachable while the walk is blocked on a paused
+//! Source's `recv()` / `select()`. Each run is driven on a worker thread
+//! behind a deadline, so a regression fails bounded instead of hanging CI,
+//! and every test asserts exact per-source row counts so completion is
+//! proven non-vacuous. Each paused Source carries more rows than the ingest
+//! channel capacity (1024), so its producer is still backed — parked on a
+//! push — when the pause fires.
+
+use super::*;
+use clinker_bench_support::io::SharedBuffer;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Hard limit far above any real test-process RSS, so the RSS arm of the
+/// spill / abort gates stays inert and the pinned charged-byte consumer is
+/// the sole pressure signal. soft = 0.80 * 8 GiB = 6.4 GiB.
+const HARD_LIMIT: u64 = 8 * 1024 * 1024 * 1024;
+const SPILL_FRAC: f64 = 0.80;
+const RESUME_FRAC: f64 = 0.70;
+/// Pinned charged bytes: above the 6.4 GiB soft limit (so pressure holds)
+/// and well below the 8 GiB hard limit (so nothing aborts).
+const PINNED_BYTES: u64 = 7 * 1024 * 1024 * 1024;
+/// Rows for a Source that must stay producer-backed when paused — beyond
+/// the 1024-event ingest channel capacity, so its ingest thread is still
+/// parked on a push (not finished and disconnected) when the pause fires.
+const BACKED_ROWS: usize = 2048;
+/// A tiny Source that drains fast; used where a Source only needs to
+/// exist, not to be the paused-while-live victim.
+const SMALL_ROWS: usize = 3;
+const DEADLINE: Duration = Duration::from_secs(30);
+
+/// Non-back-pressureable consumer pinned at a fixed footprint. Frees
+/// nothing on spill, so pressure persists for the whole run and every
+/// blocking-admit boundary re-elects a live Source as the pause victim.
+struct PinnedPressure {
+    bytes: u64,
+}
+
+impl crate::pipeline::memory::MemoryConsumer for PinnedPressure {
+    fn current_usage(&self) -> u64 {
+        self.bytes
+    }
+    fn spill_priority(&self) -> i32 {
+        30
+    }
+    fn try_spill(&self, _t: u64) -> Result<u64, crate::pipeline::memory::ConsumerSpillError> {
+        Ok(0)
+    }
+    fn can_back_pressure(&self) -> bool {
+        false
+    }
+}
+
+/// Arbitrator under the production `pause` policy (`BackPressurePreferred
+/// -> Priority`) with the pinned-pressure consumer already registered.
+fn pinned_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
+    let arb = Arc::new(crate::pipeline::memory::MemoryArbitrator::with_policy(
+        HARD_LIMIT,
+        SPILL_FRAC,
+        RESUME_FRAC,
+        crate::pipeline::memory::MemoryArbitrator::default_policy(),
+    ));
+    arb.register_consumer(Arc::new(PinnedPressure {
+        bytes: PINNED_BYTES,
+    }));
+    arb
+}
+
+/// A CSV with `rows` `id,region` body rows.
+fn csv_rows(rows: usize) -> String {
+    let mut s = String::from("id,region\n");
+    for i in 0..rows {
+        s.push_str(&format!("e{i},north\n"));
+    }
+    s
+}
+
+fn csv_reader(name: &str, body: String) -> (String, crate::source::SourceInput) {
+    (
+        name.to_string(),
+        crate::executor::single_file_reader(
+            format!("{name}.csv"),
+            Box::new(std::io::Cursor::new(body.into_bytes())),
+        ),
+    )
+}
+
+fn sink_writers(names: &[&str]) -> HashMap<String, Box<dyn std::io::Write + Send>> {
+    names
+        .iter()
+        .map(|n| {
+            (
+                n.to_string(),
+                Box::new(SharedBuffer::new()) as Box<dyn std::io::Write + Send>,
+            )
+        })
+        .collect()
+}
+
+/// Run the pipeline on a worker thread behind [`DEADLINE`]. A run that
+/// completes returns its report; a run that hangs (a paused Source stalled
+/// the walk) trips the deadline and fails the test bounded rather than
+/// hanging CI forever.
+fn run_within_deadline(
+    yaml: &'static str,
+    readers: crate::executor::SourceReaders,
+    writers: HashMap<String, Box<dyn std::io::Write + Send>>,
+    arbitrator: Arc<crate::pipeline::memory::MemoryArbitrator>,
+    execution_id: &str,
+) -> ExecutionReport {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let execution_id = execution_id.to_string();
+    std::thread::spawn(move || {
+        let config = clinker_plan::config::parse_config(yaml).expect("parse pipeline YAML");
+        let params = PipelineRunParams {
+            execution_id,
+            batch_id: "batch-0".to_string(),
+            ..Default::default()
+        };
+        let result = PipelineExecutor::run_with_readers_writers_with_arbitrator(
+            &config,
+            readers,
+            writers.into(),
+            &params,
+            clinker_plan::config::CompileContext::default(),
+            arbitrator,
+        );
+        let _ = tx.send(result);
+    });
+    match rx.recv_timeout(DEADLINE) {
+        Ok(result) => result.expect("pipeline must run to completion"),
+        Err(_) => panic!(
+            "producer-pause liveness: the run did not complete within {DEADLINE:?} — \
+             a paused Source stalled the single-threaded walk"
+        ),
+    }
+}
+
+/// P0 repro — the non-fused Source arm. Two Sources feed a `concat` Merge
+/// (non-fused, so the Sources drain strictly sequentially). Admitting the
+/// first-dispatched Source's node buffer trips the soft limit; the resume
+/// controller pauses the still-registered second Source. Both Sources
+/// carry more than the channel capacity, so whichever drains second is
+/// paused while its producer is still backed — its drain turn hangs
+/// pre-change and must flow to EOF post-change via resume-on-entry.
+#[test]
+fn concat_merge_second_source_resumes_at_its_drain_turn() {
+    const YAML: &str = r#"
+pipeline:
+  name: source_pause_concat
+nodes:
+- type: source
+  name: src_a
+  config:
+    name: src_a
+    type: csv
+    path: src_a.csv
+    schema:
+      - { name: id, type: string }
+      - { name: region, type: string }
+- type: source
+  name: src_b
+  config:
+    name: src_b
+    type: csv
+    path: src_b.csv
+    schema:
+      - { name: id, type: string }
+      - { name: region, type: string }
+- type: merge
+  name: merged
+  inputs: [src_a, src_b]
+  config:
+    mode: concat
+- type: output
+  name: out
+  input: merged
+  config:
+    name: out
+    type: csv
+    path: out.csv
+"#;
+    let report = run_within_deadline(
+        YAML,
+        HashMap::from([
+            csv_reader("src_a", csv_rows(BACKED_ROWS)),
+            csv_reader("src_b", csv_rows(BACKED_ROWS)),
+        ]),
+        sink_writers(&["out"]),
+        pinned_arbitrator(),
+        "source-pause-concat",
+    );
+
+    assert_eq!(
+        report.per_source_record_counts.get("src_a"),
+        Some(&(BACKED_ROWS as u64)),
+        "both sources must drain fully — neither may be left paused"
+    );
+    assert_eq!(
+        report.per_source_record_counts.get("src_b"),
+        Some(&(BACKED_ROWS as u64)),
+        "the paused second source must resume at its drain turn and drain every row"
+    );
+}
+
+/// Fused `Merge.interleave` arm. A separate `Source -> Aggregate -> Output`
+/// chain (blocking, so it admits a node buffer and polls `should_spill`)
+/// pauses the first-registered interleave Source before the merge's turn.
+/// The pauser chain is declared LAST so it dispatches FIRST (the walk order
+/// follows the plan's topological order, which processes later-declared
+/// independent chains first), guaranteeing its admit runs before the fused
+/// merge. The fused arm must mark ALL its `Select` receivers active and
+/// resume them, or `Select` blocks on the paused Source forever.
+#[test]
+fn fused_interleave_sources_resume_when_paused_before_the_merge_turn() {
+    const YAML: &str = r#"
+pipeline:
+  name: source_pause_fused_merge
+nodes:
+- type: source
+  name: src_a
+  config:
+    name: src_a
+    type: csv
+    path: src_a.csv
+    schema:
+      - { name: id, type: string }
+      - { name: region, type: string }
+- type: source
+  name: src_b
+  config:
+    name: src_b
+    type: csv
+    path: src_b.csv
+    schema:
+      - { name: id, type: string }
+      - { name: region, type: string }
+- type: merge
+  name: merged
+  inputs: [src_a, src_b]
+  config:
+    mode: interleave
+- type: output
+  name: out
+  input: merged
+  config:
+    name: out
+    type: csv
+    path: out.csv
+- type: source
+  name: pre
+  config:
+    name: pre
+    type: csv
+    path: pre.csv
+    schema:
+      - { name: id, type: string }
+      - { name: region, type: string }
+- type: aggregate
+  name: agg_pre
+  input: pre
+  config:
+    group_by: [region]
+    cxl: |
+      emit region = region
+      emit n = count()
+- type: output
+  name: out_pre
+  input: agg_pre
+  config:
+    name: out_pre
+    type: csv
+    path: out_pre.csv
+"#;
+    let report = run_within_deadline(
+        YAML,
+        HashMap::from([
+            csv_reader("pre", csv_rows(SMALL_ROWS)),
+            csv_reader("src_a", csv_rows(BACKED_ROWS)),
+            csv_reader("src_b", csv_rows(SMALL_ROWS)),
+        ]),
+        sink_writers(&["out", "out_pre"]),
+        pinned_arbitrator(),
+        "source-pause-fused-merge",
+    );
+
+    assert_eq!(
+        report.per_source_record_counts.get("pre"),
+        Some(&(SMALL_ROWS as u64))
+    );
+    assert_eq!(
+        report.per_source_record_counts.get("src_a"),
+        Some(&(BACKED_ROWS as u64)),
+        "the fused-interleave Source paused before the merge turn must resume and drain fully — \
+         Select must never be left blocked on a paused receiver"
+    );
+    assert_eq!(
+        report.per_source_record_counts.get("src_b"),
+        Some(&(SMALL_ROWS as u64)),
+        "the other fused-interleave Source must drain fully too"
+    );
+}
+
+/// Fused `Source -> Transform` arm. A separate `Source -> Aggregate ->
+/// Output` chain (blocking, so it admits and polls `should_spill`), declared
+/// last so it dispatches first, pauses the fused Transform's upstream Source
+/// before the Transform's turn; the fused recv loop must resume-on-entry and
+/// mark it active, or it blocks on the paused channel forever.
+#[test]
+fn fused_transform_source_resumes_when_paused_before_its_turn() {
+    const YAML: &str = r#"
+pipeline:
+  name: source_pause_fused_transform
+nodes:
+- type: source
+  name: events
+  config:
+    name: events
+    type: csv
+    path: events.csv
+    schema:
+      - { name: id, type: string }
+      - { name: region, type: string }
+- type: transform
+  name: shape
+  input: events
+  config:
+    cxl: |
+      emit id = id
+      emit region = region
+- type: output
+  name: out
+  input: shape
+  config:
+    name: out
+    type: csv
+    path: out.csv
+- type: source
+  name: pre
+  config:
+    name: pre
+    type: csv
+    path: pre.csv
+    schema:
+      - { name: id, type: string }
+      - { name: region, type: string }
+- type: aggregate
+  name: agg_pre
+  input: pre
+  config:
+    group_by: [region]
+    cxl: |
+      emit region = region
+      emit n = count()
+- type: output
+  name: out_pre
+  input: agg_pre
+  config:
+    name: out_pre
+    type: csv
+    path: out_pre.csv
+"#;
+    let report = run_within_deadline(
+        YAML,
+        HashMap::from([
+            csv_reader("pre", csv_rows(SMALL_ROWS)),
+            csv_reader("events", csv_rows(BACKED_ROWS)),
+        ]),
+        sink_writers(&["out", "out_pre"]),
+        pinned_arbitrator(),
+        "source-pause-fused-transform",
+    );
+
+    assert_eq!(
+        report.per_source_record_counts.get("pre"),
+        Some(&(SMALL_ROWS as u64))
+    );
+    assert_eq!(
+        report.per_source_record_counts.get("events"),
+        Some(&(BACKED_ROWS as u64)),
+        "a fused-Transform Source paused before its turn must resume and drain every row"
+    );
+}

--- a/crates/clinker-exec/src/executor/tests/spill_backed_drain_overshoot.rs
+++ b/crates/clinker-exec/src/executor/tests/spill_backed_drain_overshoot.rs
@@ -50,6 +50,7 @@ fn abort_seeded_arbitrator() -> Arc<crate::pipeline::memory::MemoryArbitrator> {
     let arb = crate::pipeline::memory::MemoryArbitrator::with_policy(
         HARD_LIMIT,
         SPILL_FRAC,
+        0.70,
         Box::new(crate::pipeline::memory::Priority),
     );
     // 1 MiB: above the ~52 KiB soft threshold so the producer spills.

--- a/crates/clinker-exec/src/executor/util.rs
+++ b/crates/clinker-exec/src/executor/util.rs
@@ -352,9 +352,17 @@ pub(crate) fn build_arbitrator_from_config(
     // builder total rather than re-surfacing an already-rejected error.
     let limit = clinker_plan::config::utils::parse_memory_limit_bytes(mem.limit.as_deref())
         .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES);
+    // `resume_threshold` is validated at plan time (E324) to sit inside
+    // `(0, DEFAULT_SPILL_THRESHOLD)`; omitted → the 0.70 default. The soft
+    // fraction is the shared `DEFAULT_SPILL_THRESHOLD` constant rather than
+    // a bare literal so plan-side validation and this builder agree.
+    let resume_threshold = mem
+        .resume_threshold
+        .unwrap_or(clinker_plan::config::utils::DEFAULT_RESUME_THRESHOLD);
     crate::pipeline::memory::MemoryArbitrator::with_policy(
         limit,
-        0.80,
+        clinker_plan::config::utils::DEFAULT_SPILL_THRESHOLD,
+        resume_threshold,
         crate::pipeline::memory::build_policy(mem.backpressure),
     )
 }
@@ -389,6 +397,33 @@ nodes:
         let yaml = MINIMAL_PIPELINE.replace("__LIMIT__", limit);
         let config = clinker_plan::config::parse_config(&yaml).expect("minimal pipeline parses");
         parse_memory_limit(&config)
+    }
+
+    /// Build a pipeline-scoped arbitrator from a `memory:` inline block,
+    /// exercising the same `build_arbitrator_from_config` path production uses.
+    fn arbitrator_for_memory(memory_inline: &str) -> crate::pipeline::memory::MemoryArbitrator {
+        let yaml = MINIMAL_PIPELINE.replace(r#"memory: { limit: "__LIMIT__" }"#, memory_inline);
+        let config = clinker_plan::config::parse_config(&yaml).expect("pipeline parses");
+        super::build_arbitrator_from_config(&config)
+    }
+
+    #[test]
+    fn build_arbitrator_applies_default_resume_threshold_when_omitted() {
+        // An omitted `resume_threshold` resolves to the 0.70 default, so
+        // resume_limit = 0.70 * hard; the soft threshold stays 0.80 * hard.
+        let arb = arbitrator_for_memory(r#"memory: { limit: "512M" }"#);
+        let hard = 512 * 1024 * 1024u64;
+        assert_eq!(arb.hard_limit(), hard);
+        assert_eq!(arb.resume_limit(), (hard as f64 * 0.70) as u64);
+        assert_eq!(arb.spill_threshold_bytes(), (hard as f64 * 0.80) as u64);
+    }
+
+    #[test]
+    fn build_arbitrator_honors_custom_resume_threshold() {
+        // A set `resume_threshold` threads through to resume_limit unchanged.
+        let arb = arbitrator_for_memory(r#"memory: { limit: "512M", resume_threshold: 0.5 }"#);
+        let hard = 512 * 1024 * 1024u64;
+        assert_eq!(arb.resume_limit(), (hard as f64 * 0.5) as u64);
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/arena.rs
+++ b/crates/clinker-exec/src/pipeline/arena.rs
@@ -462,7 +462,7 @@ mod tests {
             big_csv.push_str(&format!("D{},{},Name{}\n", i % 3, i * 10, i));
         }
         let mut reader = make_csv_reader(&big_csv);
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -478,7 +478,7 @@ mod tests {
     fn test_arena_field_projection() {
         let csv = "dept,amount,name,extra\nA,100,Alice,X\nB,200,Bob,Y\n";
         let mut reader = make_csv_reader(csv);
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -508,7 +508,7 @@ mod tests {
     fn test_arena_record_view_resolve() {
         let csv = "dept,amount\nA,100\nB,200\nC,300\nD,400\nE,500\nF,600\n";
         let mut reader = make_csv_reader(csv);
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -527,7 +527,7 @@ mod tests {
     fn test_arena_record_view_missing_field() {
         let csv = "dept,amount\nA,100\n";
         let mut reader = make_csv_reader(csv);
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -560,7 +560,7 @@ mod tests {
     fn test_arena_empty_input() {
         let csv = "dept,amount\n";
         let mut reader = make_csv_reader(csv);
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let arena = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -580,7 +580,7 @@ mod tests {
             csv.push_str(&format!("Department_{},{}00\n", i, i));
         }
         let mut reader = make_csv_reader(&csv);
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let result = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -659,7 +659,7 @@ mod tests {
             second_schema: Arc::clone(&second_schema),
             emitted: 0,
         };
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let result = Arena::build(
             &mut reader,
             &["dept".into(), "amount".into()],
@@ -740,7 +740,7 @@ mod tests {
                 (Record::new(Arc::clone(&schema), v), i as u64)
             })
             .collect();
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 1.0, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 1.0, 0.70, Box::new(NoOpPolicy));
         let arena = Arena::from_records(&rows, &["id".into(), "name".into()], &schema, &budget)
             .expect("uniform-variant arena builds");
         assert_eq!(arena.record_count(), 50);

--- a/crates/clinker-exec/src/pipeline/combine.rs
+++ b/crates/clinker-exec/src/pipeline/combine.rs
@@ -1402,7 +1402,7 @@ mod tests {
     }
 
     fn test_budget(limit_bytes: u64) -> MemoryArbitrator {
-        MemoryArbitrator::with_policy(limit_bytes, 0.80, Box::new(NoOpPolicy))
+        MemoryArbitrator::with_policy(limit_bytes, 0.80, 0.70, Box::new(NoOpPolicy))
     }
 
     /// Build a single-column integer-key KeyExtractor that extracts field `name`.

--- a/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
@@ -86,7 +86,12 @@ fn compile_key(
 /// `spill_threshold_pct` is set so soft limit = 1 KiB, well below
 /// any host's resident set.
 fn tiny_budget() -> MemoryArbitrator {
-    MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.000_001, Box::new(NoOpPolicy))
+    MemoryArbitrator::with_policy(
+        10 * 1024 * 1024 * 1024,
+        0.000_001,
+        0.000_000_5,
+        Box::new(NoOpPolicy),
+    )
 }
 
 #[test]
@@ -148,7 +153,7 @@ fn pipeline_temp_dir_owns_spill_files_on_drop() {
     let schema = schema_with(&["k"]);
     // Deposit a record and force a spill so a file actually exists.
     let rec = record_for(&schema, vec![Value::Integer(7)]);
-    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
     exec.add_build_record(rec, 0, &budget).unwrap();
     exec.spill_partition(0, &budget).unwrap();
     let spilled_inside = std::fs::read_dir(&pipeline_path).unwrap().count();
@@ -187,7 +192,7 @@ fn pipeline_temp_dir_cleans_on_panic_unwind() {
         .unwrap();
         let schema = schema_with(&["k"]);
         let rec = record_for(&schema, vec![Value::Integer(99)]);
-        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         exec.add_build_record(rec, 0, &budget).unwrap();
         exec.spill_partition(0, &budget).unwrap();
         panic!("simulated mid-spill panic");
@@ -262,7 +267,8 @@ fn spill_activates_on_charged_bytes_without_rss() {
     // 1 GiB hard limit → 800 MiB soft limit, above any host's test RSS,
     // so the RSS arm of `should_spill` cannot trip. Register the handle so
     // its charged bytes flow into `sum_consumer_usage`.
-    let budget = MemoryArbitrator::with_policy(1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+    let budget =
+        MemoryArbitrator::with_policy(1024 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
     budget.register_consumer(Arc::new(GraceHashConsumer::new(consumer_handle.clone())));
     let soft = budget.soft_limit();
     assert!(
@@ -479,7 +485,7 @@ fn execute_grace_hash_partition_pair_correct() {
     let stable = StableEvalContext::test_default();
     let source_file: Arc<str> = Arc::from("test.csv");
     let ctx = EvalContext::test_with_file(&stable, &source_file, 0);
-    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
 
     // Drive everything through grace hash. body_program=None so
     // the synthetic-step concatenation path is exercised; that's
@@ -738,8 +744,12 @@ fn execute_grace_hash_spill_then_reload_correct() {
     // threshold so should_spill fires immediately (process RSS
     // far exceeds 1 KiB on any host). This decouples spill
     // activation from build abort.
-    let budget =
-        MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.000_001, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(
+        10 * 1024 * 1024 * 1024,
+        0.000_001,
+        0.000_000_5,
+        Box::new(NoOpPolicy),
+    );
 
     let mut combined_schema_builder = clinker_record::SchemaBuilder::new();
     combined_schema_builder = combined_schema_builder.with_field("dk");
@@ -923,8 +933,12 @@ fn execute_grace_hash_aborts_on_disk_quota_overflow() {
     // Memory hard limit huge so should_abort never fires; spill
     // threshold tiny so spills happen; disk quota tight so the
     // first partition flush trips it.
-    let budget =
-        MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.000_001, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(
+        10 * 1024 * 1024 * 1024,
+        0.000_001,
+        0.000_000_5,
+        Box::new(NoOpPolicy),
+    );
     budget.set_max_spill_bytes(64);
 
     let combined_schema = clinker_record::SchemaBuilder::new()
@@ -1122,7 +1136,8 @@ fn build_ondisk_immediate_write_commit_trips_disk_cap() {
     // A budget that does NOT auto-spill (soft limit ~8 GiB) so the test
     // controls exactly when a commit happens; the cap starts unlimited so
     // the manual pre-spill lands without tripping.
-    let budget = MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+    let budget =
+        MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
 
     // Top 4 bits select the partition under 4 hash-bits; 0x0…1 -> 0.
     let hash_p0 = 0x0000_0000_0000_0001u64;
@@ -1232,7 +1247,8 @@ fn probe_finalize_spill_commit_trips_disk_cap_per_partition() {
         "join_probe",
     )
     .unwrap();
-    let budget = MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+    let budget =
+        MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
 
     // Top 4 bits select the partition: 0x0…1 -> 0, 0x1000… -> 1.
     let hash_p0 = 0x0000_0000_0000_0001u64;
@@ -1372,7 +1388,7 @@ fn build_spill_reload_records_match() {
         "grace_test",
     )
     .unwrap();
-    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy)); // never spills via budget
+    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy)); // never spills via budget
     let originals: Vec<Record> = (0..16i64)
         .map(|i| {
             record_for(
@@ -1726,7 +1742,7 @@ fn test_skew_detection_triggers_bnl() {
     // Now drive BNL directly and confirm it produces the expected
     // 5 driver × 200 build = 1000 join rows.
     let mut output: Vec<(Record, RecordOrder)> = Vec::new();
-    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
     let mut stats = BnlStats::default();
     let mut body_eval: Option<ProgramEvaluator> = None;
     with_reload_context(&h, |rc| {
@@ -1783,7 +1799,7 @@ fn test_bnl_fallback_correct_output() {
 
     // Force a small chunk budget so the chunked path actually
     // splits the build into pieces (not a single chunk).
-    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
     let mut output: Vec<(Record, RecordOrder)> = Vec::new();
     let mut stats = BnlStats::default();
     let mut body_eval: Option<ProgramEvaluator> = None;
@@ -1869,6 +1885,7 @@ fn test_bnl_bounded_memory() {
     let budget = MemoryArbitrator::with_policy(
         u64::MAX,
         target_soft / (u64::MAX as f64),
+        target_soft / (u64::MAX as f64) / 2.0,
         Box::new(NoOpPolicy),
     );
     let mut output: Vec<(Record, RecordOrder)> = Vec::new();
@@ -1915,6 +1932,7 @@ fn test_bnl_bounded_memory() {
     let big_budget = MemoryArbitrator::with_policy(
         u64::MAX,
         (big_soft as f64) / (u64::MAX as f64),
+        (big_soft as f64) / (u64::MAX as f64) / 2.0,
         Box::new(NoOpPolicy),
     );
     let sp2 = spill_for_bnl(
@@ -2003,7 +2021,7 @@ fn test_bnl_result_batching() {
         .collect();
     let sp = spill_for_bnl(&h, &builds, &probes, 0, 2);
 
-    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
     let mut output: Vec<(Record, RecordOrder)> = Vec::new();
     let mut stats = BnlStats::default();
     let mut body_eval: Option<ProgramEvaluator> = None;
@@ -2068,7 +2086,7 @@ fn test_e310_hard_limit_abort() {
     let sp = spill_for_bnl(&h, &builds, &probes, 7, 2);
 
     // 1-byte hard limit → should_abort fires immediately.
-    let budget = MemoryArbitrator::with_policy(1, 1.0, Box::new(NoOpPolicy));
+    let budget = MemoryArbitrator::with_policy(1, 1.0, 0.70, Box::new(NoOpPolicy));
     let mut output: Vec<(Record, RecordOrder)> = Vec::new();
     let mut stats = BnlStats::default();
     let mut body_eval: Option<ProgramEvaluator> = None;

--- a/crates/clinker-exec/src/pipeline/iejoin.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin.rs
@@ -1439,8 +1439,12 @@ mod tests {
         // so `should_abort_local` short-circuits on the local arm WITHOUT
         // consulting RSS — the RSS-blind backstop the gate exists to
         // provide. Uses `NoOpPolicy` so no victim selection interferes.
-        let budget =
-            MemoryArbitrator::with_policy(1, 0.8, Box::new(crate::pipeline::memory::NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(
+            1,
+            0.8,
+            0.70,
+            Box::new(crate::pipeline::memory::NoOpPolicy),
+        );
         let est = iejoin_numeric_state_bytes(500, 500) as u64;
         assert!(est > 1);
         assert!(

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -383,6 +383,14 @@ pub struct ConsumerHandle {
     bytes: AtomicU64,
     spill_requested: AtomicBool,
     pause_signal: PauseSignal,
+    /// Set while the walk thread is actively draining this consumer's
+    /// channel. A Source the walk is draining is exempt from the resume
+    /// controller's pause step: pausing the producer feeding the `recv()`
+    /// the walk is blocked on would starve that `recv()` and deadlock the
+    /// single-threaded walk. Written only by the walk thread (drain-arm
+    /// entry / exit); read only by the walk thread (`reconcile_backpressure`),
+    /// so `Acquire`/`Release` is ample and no stronger ordering is needed.
+    active: AtomicBool,
 }
 
 impl ConsumerHandle {
@@ -393,6 +401,7 @@ impl ConsumerHandle {
             bytes: AtomicU64::new(0),
             spill_requested: AtomicBool::new(false),
             pause_signal: PauseSignal::new(),
+            active: AtomicBool::new(false),
         })
     }
 
@@ -468,6 +477,24 @@ impl ConsumerHandle {
     pub fn wait_while_paused(&self) {
         self.pause_signal.wait_while_paused();
     }
+
+    /// Mark this consumer as actively drained by the walk. The resume
+    /// controller's pause step skips an active consumer, so the Source the
+    /// walk is currently blocked on is never paused out from under its own
+    /// `recv()`. Set at drain-arm entry by the walk thread.
+    pub fn set_active(&self) {
+        self.active.store(true, Ordering::Release);
+    }
+
+    /// Clear the active-drain exemption once the walk leaves the drain arm.
+    pub fn clear_active(&self) {
+        self.active.store(false, Ordering::Release);
+    }
+
+    /// Whether the walk is currently draining this consumer.
+    pub fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
+    }
 }
 
 /// Memory-consuming operator that the arbitrator can interrogate and,
@@ -528,6 +555,23 @@ pub trait MemoryConsumer: Send + Sync {
     /// Resume a previously paused consumer. Default body is a no-op,
     /// mirroring `pause`.
     fn resume(&self) {}
+
+    /// Whether the consumer is currently paused. Default `false`:
+    /// consumers that return `false` from `can_back_pressure` are never
+    /// pause victims, so they inherit the default. Back-pressureable
+    /// consumers (Sources) override to route to their handle's pause flag
+    /// so the resume controller resumes only actually-paused victims.
+    fn is_paused(&self) -> bool {
+        false
+    }
+
+    /// Whether the walk thread is currently draining this consumer.
+    /// Default `false`; back-pressureable consumers override to route to
+    /// their handle's active flag so the resume controller's pause step
+    /// skips a consumer the walk is blocked on (active-exemption).
+    fn is_active(&self) -> bool {
+        false
+    }
 }
 
 /// Policy that selects which `MemoryConsumer` gives up memory when
@@ -549,6 +593,17 @@ pub trait ArbitrationPolicy: Send + Sync {
     /// Composing wrappers (`BackPressurePreferred`) recurse to spell
     /// out their inner policy, e.g. `BackPressurePreferred -> Priority`.
     fn policy_name(&self) -> Cow<'static, str>;
+
+    /// Whether this policy pauses back-pressureable producers under
+    /// pressure. The resume controller (`reconcile_backpressure`) only
+    /// pauses/resumes producers when this is true, so the `spill` knob
+    /// (bare `Priority`) keeps its documented react-only, never-pause
+    /// semantics — pressure sheds reclaimable state via spill, never by
+    /// parking a producer. Default `false`; only `BackPressurePreferred`
+    /// overrides to `true` (it is what the `pause` / `both` knobs install).
+    fn prefers_backpressure(&self) -> bool {
+        false
+    }
 }
 
 /// Policy that selects no victim under any pressure.
@@ -678,6 +733,10 @@ impl ArbitrationPolicy for BackPressurePreferred {
             self.fallback.policy_name()
         ))
     }
+
+    fn prefers_backpressure(&self) -> bool {
+        true
+    }
 }
 
 /// Build the boxed [`ArbitrationPolicy`] a `pipeline.memory.backpressure`
@@ -742,6 +801,12 @@ pub struct MemoryArbitrator {
     /// Plain `f64`: constructor-set, never reconfigured at runtime;
     /// `std` has no atomic for it and a `Mutex` would be overkill.
     spill_threshold_pct: f64,
+    /// Fraction of limit at which a producer paused under memory pressure
+    /// resumes — the low watermark of the pause/resume hysteresis band
+    /// (default 0.70). Sits strictly below `spill_threshold_pct` so the
+    /// dead zone between the two damps thrash. Same treatment as
+    /// `spill_threshold_pct`: constructor-set, never mutated at runtime.
+    resume_threshold_pct: f64,
     /// Peak RSS observed across all `observe()` / `should_spill()`
     /// calls. Sentinel `0` = never observed; the `peak_rss()` getter
     /// maps `0` back to `None` to preserve the pre-117c "platform
@@ -803,11 +868,23 @@ impl MemoryArbitrator {
     pub fn with_policy(
         limit: u64,
         spill_threshold_pct: f64,
+        resume_threshold_pct: f64,
         policy: Box<dyn ArbitrationPolicy>,
     ) -> Self {
+        // The resume watermark must sit inside `(0, spill_threshold_pct)` so
+        // it forms a hysteresis band below the pause threshold. Production
+        // values are range-checked at plan time (E324), so this documents
+        // the invariant for test callers without a runtime branch on the
+        // release path.
+        debug_assert!(
+            resume_threshold_pct > 0.0 && resume_threshold_pct < spill_threshold_pct,
+            "resume_threshold_pct ({resume_threshold_pct}) must sit in \
+             (0, spill_threshold_pct={spill_threshold_pct})"
+        );
         Self {
             limit: AtomicU64::new(limit),
             spill_threshold_pct,
+            resume_threshold_pct,
             peak_rss: AtomicU64::new(0),
             max_spill_bytes: AtomicU64::new(u64::MAX),
             cumulative_spill_bytes: AtomicU64::new(0),
@@ -865,13 +942,17 @@ impl MemoryArbitrator {
         let tripped =
             self.peak_rss.load(Ordering::Relaxed) > soft || self.sum_consumer_usage() > soft;
         if tripped {
-            // Drive the round-trip: the elected victim is paused
-            // (back-pressureable) or asked to spill (everything else).
-            // `try_spill` flips the consumer's `spill_requested` flag,
-            // which the operator's hot loop reads via
-            // `take_spill_request` and reacts to in-thread. `pause`
-            // flips the consumer's `PauseSignal`, which the
-            // producer's `wait_while_paused` blocks on.
+            // Two cooperating drivers, split by which pressure signal is
+            // sound for each. `reconcile_backpressure` pauses/resumes
+            // back-pressureable producers against CURRENT pressure with a
+            // hysteresis band — reading current (not the monotonic
+            // `peak_rss`) is what lets a paused producer ever resume.
+            // `poll_arbitration` then drives the spill arm for
+            // non-back-pressureable victims, keeping its monotone-safe
+            // peak-based trip; `try_spill` flips the victim's
+            // `spill_requested` flag, which the operator's hot loop reads
+            // via `take_spill_request` and reacts to in-thread.
+            self.reconcile_backpressure();
             self.poll_arbitration();
         }
         tripped
@@ -933,6 +1014,34 @@ impl MemoryArbitrator {
     /// Soft-limit fraction (constructor-set; default 0.80).
     pub fn spill_threshold_pct(&self) -> f64 {
         self.spill_threshold_pct
+    }
+
+    /// Resume watermark in absolute bytes: the low edge of the
+    /// pause/resume hysteresis band. A producer paused under memory
+    /// pressure resumes once `current_pressure()` recedes below this.
+    /// Equals `limit * resume_threshold_pct` (default 0.70·limit).
+    pub fn resume_limit(&self) -> u64 {
+        (self.limit.load(Ordering::Relaxed) as f64 * self.resume_threshold_pct) as u64
+    }
+
+    /// Resume-watermark fraction (constructor-set; default 0.70).
+    pub fn resume_threshold_pct(&self) -> f64 {
+        self.resume_threshold_pct
+    }
+
+    /// Current memory pressure in bytes: the fresh, non-monotonic RSS
+    /// reading maxed with the pull-mode charged-byte sum.
+    ///
+    /// Unlike `peak_rss` (monotonic — `observe()`'s `fetch_max` only ever
+    /// raises it, so a `free()` never lowers it), `rss_bytes()` falls when
+    /// memory is released — the property a resume decision needs, since a
+    /// resume keyed on the monotonic peak could never fire.
+    /// `.max(sum_consumer_usage())` keeps the RSS-independent backstop the
+    /// arbitrator already relies on: the signal still works on targets
+    /// where `rss_bytes()` is `None`, and tests can drive it
+    /// deterministically through registered-consumer bytes.
+    pub fn current_pressure(&self) -> u64 {
+        rss_bytes().unwrap_or(0).max(self.sum_consumer_usage())
     }
 
     /// Spike allowance between soft and hard limits (default 20%).
@@ -1269,20 +1378,75 @@ impl MemoryArbitrator {
             );
         }
         let victim = self.policy.select_victim(&snapshot, pressure);
-        // Round-trip: invoke the corresponding action on the elected
-        // victim through the shared `&` the snapshot provides. No
-        // exclusive access is needed — every consumer routes its
-        // mutation through atomics behind a shared handle.
+        // Spill arm only. Pausing a back-pressureable producer is owned by
+        // `reconcile_backpressure` (current pressure + hysteresis), so here
+        // the elected victim is asked to spill only when it is
+        // non-back-pressureable. The policy may still elect a
+        // back-pressureable consumer (`BackPressurePreferred` prefers one) —
+        // in that case no one spills, preserving the pause-over-spill
+        // posture the `pause`/`both` knobs mean, exactly as before this
+        // split (the pause it used to issue here now happens in
+        // `reconcile_backpressure` on the sound current-pressure signal).
+        // The action routes through the shared `&` the snapshot provides;
+        // every consumer mutates through atomics behind a shared handle, so
+        // no exclusive access is needed.
         if let Some(id) = victim
             && let Some((_, consumer)) = consumers.iter().find(|(cid, _)| *cid == id)
+            && !consumer.can_back_pressure()
         {
-            if consumer.can_back_pressure() {
-                consumer.pause();
-            } else {
-                let _ = consumer.try_spill(pressure);
-            }
+            let _ = consumer.try_spill(pressure);
         }
         victim
+    }
+
+    /// Pause/resume back-pressureable producers against CURRENT pressure
+    /// with a hysteresis band — the resume controller. Runs on the walk
+    /// thread inside `should_spill`'s tripped branch.
+    ///
+    /// - Above the soft limit: pause the first back-pressureable consumer
+    ///   the walk is NOT currently draining. Skipping an `is_active`
+    ///   consumer is load-bearing: pausing the Source feeding the `recv()`
+    ///   the single-threaded walk is blocked on would starve that `recv()`
+    ///   and deadlock. First-registered order matches the single-victim
+    ///   pause `BackPressurePreferred` has always applied.
+    /// - Below the resume watermark: resume every paused back-pressureable
+    ///   consumer (Fluent Bit / NiFi resume once downstream drains below the
+    ///   low watermark).
+    /// - In the dead zone `[resume_limit, soft_limit]`: no state change, so
+    ///   a single admit/discharge swing cannot cross both thresholds and
+    ///   thrash pause/resume every poll.
+    ///
+    /// Reads CURRENT pressure, never the monotonic `peak_rss`: `peak_rss`
+    /// only rises, so a resume keyed on it could never fire. The spill arm
+    /// (`poll_arbitration`) keeps its peak-based trip — spilling is
+    /// monotone-safe and never deadlocks. Iterates the small lock-free
+    /// consumer snapshot and mutates only shared atomics, so it stays cheap
+    /// inside the already-guarded tripped branch.
+    ///
+    /// A no-op under a non-pausing policy (`spill` / bare `Priority`), so a
+    /// `spill`-knob run never parks a producer — its pressure is shed
+    /// entirely through `poll_arbitration`'s spill arm.
+    fn reconcile_backpressure(&self) {
+        if !self.policy.prefers_backpressure() {
+            return;
+        }
+        let cur = self.current_pressure();
+        let soft = self.soft_limit();
+        let consumers = self.consumers.load();
+        if cur > soft {
+            for (_, consumer) in consumers.iter() {
+                if consumer.can_back_pressure() && !consumer.is_active() {
+                    consumer.pause();
+                    break;
+                }
+            }
+        } else if cur < self.resume_limit() {
+            for (_, consumer) in consumers.iter() {
+                if consumer.can_back_pressure() && consumer.is_paused() {
+                    consumer.resume();
+                }
+            }
+        }
     }
 }
 
@@ -1753,8 +1917,12 @@ mod tests {
         // permanently below-threshold, just for a different reason). A
         // registered consumer holding more than the soft limit must trip
         // the gate through that arm alone.
-        let arbitrator =
-            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(
+            100 * 1024 * 1024 * 1024,
+            0.80,
+            0.70,
+            Box::new(NoOpPolicy),
+        );
         let soft = arbitrator.soft_limit();
         assert!(!arbitrator.should_spill(), "empty registry must not trip");
         // Whatever RSS `observe()` just sampled is below the soft limit, so
@@ -1775,8 +1943,12 @@ mod tests {
         // Same RSS-independent backstop for the hard-abort gate; the 100
         // GiB hard limit keeps the RSS arm inert (see the sibling
         // should_spill test for why this isolates the charged-byte arm).
-        let arbitrator =
-            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(
+            100 * 1024 * 1024 * 1024,
+            0.80,
+            0.70,
+            Box::new(NoOpPolicy),
+        );
         let hard = arbitrator.hard_limit();
         assert!(!arbitrator.should_abort(), "empty registry must not abort");
         assert!(
@@ -1798,8 +1970,12 @@ mod tests {
         // empty here (the build's handle is zero-seeded until build
         // completes) and the 100 GiB limit keeps the RSS arm inert, so only
         // the `local_bytes` arm can fire.
-        let arbitrator =
-            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(
+            100 * 1024 * 1024 * 1024,
+            0.80,
+            0.70,
+            Box::new(NoOpPolicy),
+        );
         let hard = arbitrator.hard_limit();
         assert_eq!(arbitrator.sum_consumer_usage(), 0);
         assert!(
@@ -1817,8 +1993,12 @@ mod tests {
         // The streaming-stage variant carries the same backstop so a
         // streaming batch still spills itself when RSS is unavailable. The
         // 100 GiB limit keeps the RSS arm inert.
-        let arbitrator =
-            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(
+            100 * 1024 * 1024 * 1024,
+            0.80,
+            0.70,
+            Box::new(NoOpPolicy),
+        );
         let soft = arbitrator.soft_limit();
         assert!(!arbitrator.should_spill_self());
         assert!(
@@ -1838,7 +2018,7 @@ mod tests {
     #[test]
     fn test_memory_arbitrator_below_threshold() {
         let arbitrator =
-            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         assert!(!arbitrator.should_spill());
     }
 
@@ -1849,7 +2029,8 @@ mod tests {
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn test_memory_arbitrator_above_threshold() {
-        let arbitrator = MemoryArbitrator::with_policy(1024 * 1024, 0.80, Box::new(NoOpPolicy));
+        let arbitrator =
+            MemoryArbitrator::with_policy(1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         assert!(arbitrator.should_spill());
     }
 
@@ -1861,7 +2042,7 @@ mod tests {
     #[test]
     fn test_memory_arbitrator_peak_rss_tracked() {
         let arbitrator =
-            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         arbitrator.observe();
         assert!(
             arbitrator.peak_rss().is_some(),
@@ -1877,7 +2058,7 @@ mod tests {
     fn test_parse_memory_limit_default_512mb() {
         let limit = clinker_plan::config::utils::parse_memory_limit_bytes(None)
             .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES);
-        let arbitrator = MemoryArbitrator::with_policy(limit, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(limit, 0.80, 0.70, Box::new(NoOpPolicy));
         assert_eq!(arbitrator.limit(), 512 * 1024 * 1024);
         assert!((arbitrator.spill_threshold_pct() - 0.80).abs() < f64::EPSILON);
     }
@@ -1885,7 +2066,7 @@ mod tests {
     #[test]
     fn test_disk_quota_default_unlimited() {
         let arbitrator =
-            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         assert_eq!(arbitrator.disk_quota(), u64::MAX);
         assert_eq!(arbitrator.cumulative_spill_bytes(), 0);
     }
@@ -1893,7 +2074,7 @@ mod tests {
     #[test]
     fn test_record_spill_bytes_under_quota() {
         let arbitrator =
-            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         arbitrator.set_max_spill_bytes(1024);
         assert!(!arbitrator.record_spill_bytes("sort", 256));
         assert_eq!(arbitrator.cumulative_spill_bytes(), 256);
@@ -1904,7 +2085,7 @@ mod tests {
     #[test]
     fn test_record_spill_bytes_overflows_quota() {
         let arbitrator =
-            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         arbitrator.set_max_spill_bytes(1024);
         assert!(!arbitrator.record_spill_bytes("sort", 1024));
         assert!(arbitrator.record_spill_bytes("sort", 1));
@@ -1917,7 +2098,7 @@ mod tests {
         // accumulation cannot wrap below the configured quota and
         // silently disable the gate.
         let arbitrator =
-            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         arbitrator.set_max_spill_bytes(1024);
         arbitrator
             .cumulative_spill_bytes
@@ -1931,7 +2112,7 @@ mod tests {
         // Two stages spill; the per-stage breakdown keeps their totals
         // distinct and the cumulative total equals their sum.
         let arbitrator =
-            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, Box::new(NoOpPolicy));
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
         arbitrator.record_spill_bytes("sort_by_amount", 256);
         arbitrator.record_spill_bytes("dept_totals", 512);
         arbitrator.record_spill_bytes("sort_by_amount", 128);
@@ -2010,6 +2191,45 @@ mod tests {
         }
     }
 
+    /// Reclaimable, non-back-pressureable consumer that records whether the
+    /// arbitrator's spill arm reached it. Mirrors a grace-hash / aggregate
+    /// slot: it spills on demand and can never be paused, so it is the shape
+    /// `poll_arbitration` acts on.
+    struct ReclaimableMock {
+        usage: u64,
+        priority: i32,
+        spilled: AtomicBool,
+    }
+
+    impl ReclaimableMock {
+        fn new(usage: u64, priority: i32) -> Self {
+            Self {
+                usage,
+                priority,
+                spilled: AtomicBool::new(false),
+            }
+        }
+        fn was_spilled(&self) -> bool {
+            self.spilled.load(Ordering::Acquire)
+        }
+    }
+
+    impl MemoryConsumer for ReclaimableMock {
+        fn current_usage(&self) -> u64 {
+            self.usage
+        }
+        fn spill_priority(&self) -> i32 {
+            self.priority
+        }
+        fn try_spill(&self, target_bytes: u64) -> Result<u64, ConsumerSpillError> {
+            self.spilled.store(true, Ordering::Release);
+            Ok(target_bytes)
+        }
+        fn can_back_pressure(&self) -> bool {
+            false
+        }
+    }
+
     #[test]
     fn test_noop_policy_select_victim_returns_none_empty() {
         let policy = NoOpPolicy;
@@ -2045,7 +2265,7 @@ mod tests {
 
     #[test]
     fn test_with_policy_installs_chosen_policy() {
-        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         // poll_arbitration is private — exercise it through the
         // public `should_spill` path with a deliberately tiny
         // limit so the soft-threshold gate trips.
@@ -2060,7 +2280,7 @@ mod tests {
 
     #[test]
     fn test_register_consumer_assigns_monotonic_ids() {
-        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let id_a = arbitrator.register_consumer(Arc::new(MockConsumer::new(10, 0, 0)));
         let id_b = arbitrator.register_consumer(Arc::new(MockConsumer::new(20, 0, 0)));
         let id_c = arbitrator.register_consumer(Arc::new(MockConsumer::new(30, 0, 0)));
@@ -2072,7 +2292,7 @@ mod tests {
 
     #[test]
     fn test_unregister_consumer_returns_removed() {
-        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let id = arbitrator.register_consumer(Arc::new(MockConsumer::new(100, 0, 0)));
         assert_eq!(arbitrator.consumer_count(), 1);
         let removed = arbitrator.unregister_consumer(id);
@@ -2085,7 +2305,7 @@ mod tests {
 
     #[test]
     fn test_sum_consumer_usage_aggregates_registered() {
-        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         assert_eq!(arbitrator.sum_consumer_usage(), 0);
         arbitrator.register_consumer(Arc::new(MockConsumer::new(1024, 0, 0)));
         arbitrator.register_consumer(Arc::new(MockConsumer::new(4096, 0, 0)));
@@ -2102,8 +2322,12 @@ mod tests {
         const ARENA_BYTES: u64 = 8 * 1024 * 1024;
         // 100 GiB hard limit so real-process RSS cannot push peak_rss
         // above the test-seeded value via `observe()`'s `fetch_max`.
-        let arbitrator =
-            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.50, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(
+            100 * 1024 * 1024 * 1024,
+            0.50,
+            0.40,
+            Box::new(NoOpPolicy),
+        );
         arbitrator.set_peak_rss_for_test(ARENA_BYTES);
 
         // Before registration the arena contributes nothing, so the
@@ -2153,32 +2377,33 @@ mod tests {
         // preferred over a spillable consumer. Under `Priority`, lower
         // spill_priority wins; the arena's `i32::MAX - 1` sits behind a
         // grace-hash-shaped consumer at priority 10, so the policy elects
-        // the spillable. `should_spill` drives the round and acts on the
-        // victim — a back-pressureable MockConsumer gets paused, which is
-        // the observable proof it (not the arena) was elected.
+        // the spillable. `should_spill` drives the round and `poll_arbitration`
+        // asks the elected (non-back-pressureable) victim to spill — the
+        // observable proof it (not the arena) was elected. `Priority` never
+        // pauses, so `reconcile_backpressure` is a no-op here.
         // 100 GiB hard limit so real-process RSS cannot push peak_rss
         // above the test-seeded value via `observe()`'s `fetch_max`.
         let arbitrator =
-            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.50, Box::new(Priority));
+            MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.50, 0.40, Box::new(Priority));
         let arena_handle = ConsumerHandle::new();
         arena_handle.set_bytes(512 * 1024 * 1024);
         // The arena is far larger than the spillable; only the priority
         // ordering keeps it from being elected, which is the point.
         arbitrator.register_consumer(Arc::new(ArenaConsumer::new(arena_handle)));
-        let spillable = Arc::new(MockConsumer::new(1024, 10, 0));
+        let spillable = Arc::new(ReclaimableMock::new(1024, 10));
         arbitrator.register_consumer(spillable.clone());
 
         arbitrator.set_peak_rss_for_test(75 * 1024 * 1024 * 1024);
         assert!(arbitrator.should_spill());
         assert!(
-            spillable.is_paused(),
+            spillable.was_spilled(),
             "Priority must elect the spillable consumer, never the non-actionable arena"
         );
     }
 
     #[test]
     fn test_consumer_ids_are_never_reused_after_unregister() {
-        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let id_a = arbitrator.register_consumer(Arc::new(MockConsumer::new(1, 0, 0)));
         arbitrator.unregister_consumer(id_a);
         let id_b = arbitrator.register_consumer(Arc::new(MockConsumer::new(1, 0, 0)));
@@ -2190,7 +2415,7 @@ mod tests {
 
     #[test]
     fn test_register_then_unregister_leaves_empty_snapshot() {
-        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, Box::new(NoOpPolicy));
+        let arbitrator = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
         let id = arbitrator.register_consumer(Arc::new(MockConsumer::new(512, 0, 0)));
         assert_eq!(arbitrator.consumer_count(), 1);
         assert_eq!(arbitrator.sum_consumer_usage(), 512);
@@ -2219,6 +2444,7 @@ mod tests {
         let arbitrator = Arc::new(MemoryArbitrator::with_policy(
             u64::MAX,
             0.80,
+            0.70,
             Box::new(NoOpPolicy),
         ));
         let start = Arc::new(Barrier::new(2));
@@ -2542,7 +2768,7 @@ mod tests {
     fn arbitrator_with_headroom(soft: u64, used: u64) -> MemoryArbitrator {
         // soft_limit() = limit * 0.80, so set limit = soft / 0.80.
         let limit = (soft as f64 / 0.80) as u64;
-        let arb = MemoryArbitrator::with_policy(limit, 0.80, Box::new(NoOpPolicy));
+        let arb = MemoryArbitrator::with_policy(limit, 0.80, 0.70, Box::new(NoOpPolicy));
         assert_eq!(arb.soft_limit(), soft, "soft limit setup");
         if used > 0 {
             arb.register_consumer(Arc::new(MockConsumer::new(used, 0, 0)));
@@ -2686,5 +2912,121 @@ mod tests {
         );
         let chosen_again = arb.next_runnable(&[c, a, b], &hint);
         assert_eq!(chosen_again, a, "selection is independent of slice order");
+    }
+
+    #[test]
+    fn reconcile_backpressure_hysteresis_band_bounds_transitions() {
+        use crate::executor::source_stream::SourceConsumer;
+        // hard 100 GiB, spill 0.50 (soft = 50 GiB), resume 0.40
+        // (resume_limit = 40 GiB). A single registered Source drives current
+        // pressure through the `sum_consumer_usage` arm of
+        // `current_pressure()`; real RSS stays far below 40 GiB, so the band
+        // is exercised deterministically. `reconcile_backpressure` is driven
+        // directly so the dead-zone branch (called, no state change) is
+        // reached even though `should_spill` would not trip inside the band.
+        let gib = 1024u64 * 1024 * 1024;
+        let arb = MemoryArbitrator::with_policy(
+            100 * gib,
+            0.50,
+            0.40,
+            Box::new(BackPressurePreferred::wrapping(Priority)),
+        );
+        let handle = ConsumerHandle::new();
+        arb.register_consumer(Arc::new(SourceConsumer::new(handle.clone())));
+
+        // Above soft: pause. Repeated polls stay paused (single victim,
+        // idempotent) — no per-poll thrash.
+        handle.set_bytes(60 * gib);
+        for _ in 0..8 {
+            arb.reconcile_backpressure();
+            assert!(
+                handle.is_paused(),
+                "current > soft must pause and stay paused"
+            );
+        }
+        // Dead zone [resume_limit, soft] = [40, 50] GiB: reconcile is a no-op,
+        // so the pause state is unchanged.
+        handle.set_bytes(45 * gib);
+        for _ in 0..8 {
+            arb.reconcile_backpressure();
+            assert!(handle.is_paused(), "dead zone must not resume");
+        }
+        // Below resume_limit: resume. Repeated polls stay resumed.
+        handle.set_bytes(30 * gib);
+        for _ in 0..8 {
+            arb.reconcile_backpressure();
+            assert!(!handle.is_paused(), "current < resume_limit must resume");
+        }
+        // Dead zone approached from below: no re-pause.
+        handle.set_bytes(45 * gib);
+        for _ in 0..8 {
+            arb.reconcile_backpressure();
+            assert!(!handle.is_paused(), "dead zone must not re-pause");
+        }
+        // Re-crossing soft: re-pause. The pause/resume state only ever
+        // changes at a threshold crossing, never per poll within a band.
+        handle.set_bytes(60 * gib);
+        arb.reconcile_backpressure();
+        assert!(handle.is_paused(), "re-crossing soft must re-pause");
+    }
+
+    #[test]
+    fn reconcile_backpressure_exempts_the_actively_drained_source() {
+        use crate::executor::source_stream::SourceConsumer;
+        // A Source the walk is currently draining (active) is never paused,
+        // even above the soft limit: pausing the producer feeding the
+        // `recv()` the single-threaded walk is blocked on would deadlock.
+        let gib = 1024u64 * 1024 * 1024;
+        let arb = MemoryArbitrator::with_policy(
+            100 * gib,
+            0.50,
+            0.40,
+            Box::new(BackPressurePreferred::wrapping(Priority)),
+        );
+        let handle = ConsumerHandle::new();
+        arb.register_consumer(Arc::new(SourceConsumer::new(handle.clone())));
+
+        handle.set_active();
+        handle.set_bytes(60 * gib); // above soft
+        arb.reconcile_backpressure();
+        assert!(
+            !handle.is_paused(),
+            "an active source is exempt from the pause step"
+        );
+        // Once the drain arm clears the exemption, the same pressure pauses it.
+        handle.clear_active();
+        arb.reconcile_backpressure();
+        assert!(
+            handle.is_paused(),
+            "a non-active source above soft is paused"
+        );
+    }
+
+    #[test]
+    fn poll_arbitration_spills_reclaimable_but_never_pauses() {
+        use crate::executor::source_stream::SourceConsumer;
+        // After the pause/spill split, `poll_arbitration` drives spill only:
+        // it asks a non-back-pressureable victim to spill and never pauses a
+        // producer (pausing is `reconcile_backpressure`'s job on current
+        // pressure). Under bare `Priority` the reclaimable (priority 0) is
+        // elected over the Source (priority i32::MAX), so the Source is never
+        // touched.
+        let gib = 1024u64 * 1024 * 1024;
+        let arb = MemoryArbitrator::with_policy(100 * gib, 0.50, 0.40, Box::new(Priority));
+        let source_handle = ConsumerHandle::new();
+        arb.register_consumer(Arc::new(SourceConsumer::new(source_handle.clone())));
+        let reclaimable = Arc::new(ReclaimableMock::new(60 * gib, 0));
+        arb.register_consumer(reclaimable.clone());
+
+        arb.set_peak_rss_for_test(60 * gib); // trip the peak-based spill arm
+        arb.poll_arbitration();
+        assert!(
+            reclaimable.was_spilled(),
+            "poll_arbitration must spill the elected non-back-pressureable victim"
+        );
+        assert!(
+            !source_handle.is_paused(),
+            "poll_arbitration must never pause a back-pressureable producer"
+        );
     }
 }

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -205,12 +205,16 @@ fn peak_rss_bytes_impl() -> Option<u64> {
 /// unsatisfiable: the process already exceeds the ceiling with an empty
 /// pipeline, so no amount of spilling operator state or pausing producers
 /// can ever bring RSS under it. Under a producer-pausing policy (`pause`,
-/// the default, and `both`) this otherwise deadlocks — the arbitration
-/// round parks the Source on a pause that only `resume()` releases, but
-/// `resume()` fires only when RSS drops back under the threshold, which
-/// can never happen — while a blocking consumer waits forever for input.
-/// Converting that hang into an immediate [`PipelineError::UnsatisfiableMemoryBudget`]
-/// (E312) lets the operator fix the config rather than watch the run park.
+/// the default, and `both`) the run cannot make useful progress against
+/// such a budget — the arbitration round pauses producers on every poll
+/// (current pressure never recedes below the resume watermark, since even
+/// an empty pipeline sits above the limit), so the run only thrashes
+/// pause / resume / spill without ever getting under budget. Rejecting it
+/// up front as an immediate [`PipelineError::UnsatisfiableMemoryBudget`]
+/// (E312) lets the operator fix the config rather than watch the run churn.
+/// (The resume controller and its liveness backstop guarantee the walk
+/// still completes rather than deadlocking, so this is a fail-fast on an
+/// unsatisfiable config, not a deadlock-avoidance guard.)
 ///
 /// Scoped to producer-pausing policies on purpose: under `spill` (bare
 /// `Priority`) a sub-baseline budget never pauses, so it spills or aborts

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1448,6 +1448,39 @@ impl MemoryArbitrator {
             }
         }
     }
+
+    /// Best-effort spill of reclaimable (non-back-pressureable) consumers in
+    /// `Priority` order (node-buffer 0 < grace-hash 10 < sort 20 <
+    /// aggregate 30), shedding up to `target_bytes` of downstream state.
+    ///
+    /// Called at a drain arm's progress boundary, just before a Source that
+    /// a prior round paused under pressure is resumed, so the resumed
+    /// producer does not immediately re-trip the soft limit (Spark's "spill
+    /// other consumers before you proceed"). Overshoot reduction only:
+    /// liveness never depends on it — the drain arm makes progress
+    /// regardless — so a partial or zero spill is fine and no error is
+    /// surfaced. `try_spill` flips each victim's `spill_requested` flag,
+    /// which its operator reads at the next batch boundary.
+    pub fn spill_reclaimable(&self, target_bytes: u64) {
+        if target_bytes == 0 {
+            return;
+        }
+        let consumers = self.consumers.load();
+        let mut ordered: Vec<&(ConsumerId, Arc<dyn MemoryConsumer>)> = consumers
+            .iter()
+            .filter(|(_, c)| !c.can_back_pressure())
+            .collect();
+        ordered.sort_by_key(|(_, c)| c.spill_priority());
+        let mut remaining = target_bytes;
+        for (_, consumer) in ordered {
+            if remaining == 0 {
+                break;
+            }
+            if let Ok(freed) = consumer.try_spill(remaining) {
+                remaining = remaining.saturating_sub(freed);
+            }
+        }
+    }
 }
 
 /// Shared oracle for the disk-spill-cap (E320) overflow surface, so every
@@ -3027,6 +3060,37 @@ mod tests {
         assert!(
             !source_handle.is_paused(),
             "poll_arbitration must never pause a back-pressureable producer"
+        );
+    }
+
+    #[test]
+    fn spill_reclaimable_sheds_non_back_pressureable_in_priority_order() {
+        use crate::executor::source_stream::SourceConsumer;
+        // The spill-nudge targets only reclaimable (non-back-pressureable)
+        // consumers and never a Source, so a resumed producer does not
+        // immediately re-trip. A zero target is a no-op.
+        let arb = MemoryArbitrator::with_policy(
+            u64::MAX,
+            0.80,
+            0.70,
+            Box::new(BackPressurePreferred::wrapping(Priority)),
+        );
+        let source_handle = ConsumerHandle::new();
+        arb.register_consumer(Arc::new(SourceConsumer::new(source_handle.clone())));
+        let reclaimable = Arc::new(ReclaimableMock::new(4096, 0));
+        arb.register_consumer(reclaimable.clone());
+
+        arb.spill_reclaimable(0);
+        assert!(!reclaimable.was_spilled(), "a zero target must be a no-op");
+
+        arb.spill_reclaimable(4096);
+        assert!(
+            reclaimable.was_spilled(),
+            "the reclaimable consumer must be asked to spill"
+        );
+        assert!(
+            !source_handle.is_paused(),
+            "the spill-nudge must never touch a back-pressureable Source"
         );
     }
 }

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -1863,11 +1863,12 @@ mod tests {
         let source_file: Arc<str> = Arc::from("");
         let ctx = EvalContext::test_with_file(&stable, &source_file, 0);
         let mut budget = match rk.budget_bytes {
-            Some(b) => MemoryArbitrator::with_policy(b, 0.80, Box::new(NoOpPolicy)),
+            Some(b) => MemoryArbitrator::with_policy(b, 0.80, 0.70, Box::new(NoOpPolicy)),
             None => MemoryArbitrator::with_policy(
                 clinker_plan::config::utils::parse_memory_limit_bytes(None)
                     .unwrap_or(clinker_plan::config::utils::DEFAULT_MEMORY_LIMIT_BYTES),
                 0.80,
+                0.70,
                 Box::new(NoOpPolicy),
             ),
         };
@@ -2244,7 +2245,7 @@ mod tests {
     #[test]
     fn phase_a_driver_spill_past_disk_cap_fails_with_spill_cap_exceeded() {
         let mut pairs = phase_a_driver_pairs(64);
-        let budget = MemoryArbitrator::with_policy(1024, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(1024, 0.80, 0.70, Box::new(NoOpPolicy));
         budget.set_max_spill_bytes(1);
         let dir = tempfile::tempdir().unwrap();
         let handle = crate::pipeline::memory::ConsumerHandle::new();
@@ -2290,7 +2291,7 @@ mod tests {
                 (r, Value::Integer(i))
             })
             .collect();
-        let budget = MemoryArbitrator::with_policy(1024, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(1024, 0.80, 0.70, Box::new(NoOpPolicy));
         budget.set_max_spill_bytes(1);
         let dir = tempfile::tempdir().unwrap();
         let handle = crate::pipeline::memory::ConsumerHandle::new();
@@ -2324,7 +2325,7 @@ mod tests {
     #[test]
     fn phase_a_spills_into_configured_root_not_env_temp() {
         let mut pairs = phase_a_driver_pairs(64);
-        let budget = MemoryArbitrator::with_policy(1024, 0.80, Box::new(NoOpPolicy));
+        let budget = MemoryArbitrator::with_policy(1024, 0.80, 0.70, Box::new(NoOpPolicy));
         let scratch = tempfile::tempdir().unwrap();
         let spill_root = scratch.path().join("configured-root");
         std::fs::create_dir(&spill_root).unwrap();

--- a/crates/clinker-exec/src/pipeline/window_context.rs
+++ b/crates/clinker-exec/src/pipeline/window_context.rs
@@ -397,6 +397,7 @@ mod tests {
         let budget = crate::pipeline::memory::MemoryArbitrator::with_policy(
             u64::MAX,
             0.80,
+            0.70,
             Box::new(crate::pipeline::memory::NoOpPolicy),
         );
         Arena::build(

--- a/crates/clinker-exec/tests/arbitration_fast_source_slow_combine.rs
+++ b/crates/clinker-exec/tests/arbitration_fast_source_slow_combine.rs
@@ -1,17 +1,16 @@
-//! Fast-Source / slow-Combine arbitration scenario:
+//! Fast-Source / slow-Combine arbitration scenario, on current-pressure
+//! semantics:
 //!
-//! Configure a `BackPressurePreferred(Priority)` policy and register
-//! one back-pressureable consumer (Source-shaped) plus one
-//! non-back-pressureable consumer (Aggregate-shaped). When the
-//! arbitrator's peak RSS crosses the soft limit, the policy must
-//! prefer pausing the Source over forcing a spill on the Aggregate —
-//! pauses are reversible and free; spills cost disk I/O.
-//!
-//! Asserts the Source's `PauseSignal` flips after `should_spill()`
-//! returns true, demonstrating the full arbitration round-trip:
-//! policy elects victim → arbitrator invokes pause → handle's
-//! `is_paused` reads true → a producer calling `wait_while_paused`
-//! would now block until resume.
+//! Under `BackPressurePreferred(Priority)`, the resume controller pauses a
+//! back-pressureable Source when CURRENT pressure exceeds the soft limit and
+//! resumes it once current pressure recedes below the (lower) resume
+//! watermark — a hysteresis band. Pause election reads current pressure, not
+//! the monotonic peak RSS: a peak-keyed resume could never fire because
+//! `peak_rss` only rises. Current pressure is driven here through the
+//! registered consumers' charged bytes (`sum_consumer_usage`), so the band is
+//! exercised deterministically without faking OS RSS; a seeded peak keeps
+//! `should_spill` tripped so its arbitration round runs while current
+//! pressure moves across the band.
 
 use clinker_exec::executor::source_stream::SourceConsumer;
 use clinker_exec::pipeline::memory::{
@@ -20,8 +19,9 @@ use clinker_exec::pipeline::memory::{
 };
 use std::sync::Arc;
 
-/// Aggregate-shaped consumer for the test — non-back-pressureable,
-/// reports a fixed in-memory footprint via its handle.
+/// Aggregate-shaped consumer for the test — non-back-pressureable, reports a
+/// fixed in-memory footprint via its handle. Records whether the arbitrator
+/// asked it to spill so the "prefer pause over spill" posture is observable.
 struct AggregateLike {
     handle: Arc<ConsumerHandle>,
 }
@@ -42,13 +42,14 @@ impl MemoryConsumer for AggregateLike {
     }
 }
 
+const HARD: u64 = 100 * 1024 * 1024 * 1024;
+const GIB: u64 = 1024 * 1024 * 1024;
+
 #[test]
-fn back_pressure_preferred_pauses_source_under_pressure() {
-    // 100 GiB hard limit so `observe()`'s `fetch_max(real_rss, ...)`
-    // call inside `should_spill` cannot push peak_rss above what the
-    // test seeds; real process RSS during cargo test is < 1 GiB.
+fn source_pauses_on_current_pressure_and_resumes_below_the_resume_watermark() {
+    // spill 0.50 -> soft 50 GiB; resume 0.40 -> resume_limit 40 GiB.
     let arbitrator = MemoryArbitrator::with_policy(
-        100 * 1024 * 1024 * 1024,
+        HARD,
         0.50,
         0.40,
         Box::new(BackPressurePreferred::wrapping(Priority)),
@@ -58,35 +59,81 @@ fn back_pressure_preferred_pauses_source_under_pressure() {
     source_handle.set_bytes(64 * 1024);
     arbitrator.register_consumer(Arc::new(SourceConsumer::new(source_handle.clone())));
 
+    // Aggregate charged above the soft limit so `sum_consumer_usage` — and
+    // therefore `current_pressure()` — sits over the 50 GiB soft threshold.
     let aggregate_handle = ConsumerHandle::new();
-    aggregate_handle.set_bytes(256 * 1024);
+    aggregate_handle.set_bytes(60 * GIB);
+    let aggregate = Arc::new(AggregateLike {
+        handle: aggregate_handle.clone(),
+    });
+    arbitrator.register_consumer(aggregate.clone());
+
+    // A seeded peak keeps `should_spill` tripped for the whole test (peak is
+    // monotonic), so its arbitration round always runs; the pause/resume
+    // decision itself keys on CURRENT pressure, driven by the aggregate's
+    // charged bytes above.
+    arbitrator.set_peak_rss_for_test(75 * GIB);
+
+    assert!(!source_handle.is_paused(), "source must start unpaused");
+
+    // current pressure (~60 GiB) > soft (50 GiB): pause the back-pressureable
+    // Source, and do NOT spill the aggregate (prefer pause over spill).
+    assert!(arbitrator.should_spill());
+    assert!(
+        source_handle.is_paused(),
+        "current pressure over the soft limit must pause the back-pressureable Source"
+    );
+    assert!(
+        !aggregate_handle.take_spill_request(),
+        "the aggregate must not be spilled while a back-pressureable Source can be paused"
+    );
+
+    // Drop current pressure below the resume watermark (~30 GiB < 40 GiB).
+    // `should_spill` still trips (peak is monotonic), so its round runs and
+    // the resume controller unparks the Source.
+    aggregate_handle.set_bytes(30 * GIB);
+    assert!(arbitrator.should_spill());
+    assert!(
+        !source_handle.is_paused(),
+        "current pressure below the resume watermark must resume the paused Source"
+    );
+}
+
+#[test]
+fn an_actively_drained_source_is_exempt_from_pause() {
+    // A Source the walk is currently draining (active) is never paused, even
+    // above the soft limit — pausing the producer feeding the recv() the walk
+    // is blocked on would deadlock the single-threaded walk.
+    let arbitrator = MemoryArbitrator::with_policy(
+        HARD,
+        0.50,
+        0.40,
+        Box::new(BackPressurePreferred::wrapping(Priority)),
+    );
+
+    let source_handle = ConsumerHandle::new();
+    arbitrator.register_consumer(Arc::new(SourceConsumer::new(source_handle.clone())));
+
+    let aggregate_handle = ConsumerHandle::new();
+    aggregate_handle.set_bytes(60 * GIB); // current pressure over soft
     arbitrator.register_consumer(Arc::new(AggregateLike {
         handle: aggregate_handle.clone(),
     }));
 
-    // Drive peak RSS above the soft limit via the test hook so the
-    // arbitration round fires deterministically without depending on
-    // actual process RSS.
-    arbitrator.set_peak_rss_for_test(75 * 1024 * 1024 * 1024);
+    arbitrator.set_peak_rss_for_test(75 * GIB);
 
+    source_handle.set_active();
+    assert!(arbitrator.should_spill());
     assert!(
         !source_handle.is_paused(),
-        "source should not be paused before arbitration runs"
-    );
-    assert!(
-        !aggregate_handle.take_spill_request(),
-        "aggregate should not have a pending spill request before arbitration runs"
+        "an active (currently-drained) Source is exempt from the pause step"
     );
 
-    let tripped = arbitrator.should_spill();
-    assert!(tripped, "RSS above soft limit should trip should_spill");
+    // Once the drain arm clears the exemption, the same pressure pauses it.
+    source_handle.clear_active();
+    assert!(arbitrator.should_spill());
     assert!(
         source_handle.is_paused(),
-        "BackPressurePreferred policy must pause the back-pressureable Source ahead of \
-         spilling the Aggregate"
-    );
-    assert!(
-        !aggregate_handle.take_spill_request(),
-        "Aggregate should not be the spill victim while a back-pressureable consumer exists"
+        "a non-active Source above the soft limit is paused"
     );
 }

--- a/crates/clinker-exec/tests/arbitration_fast_source_slow_combine.rs
+++ b/crates/clinker-exec/tests/arbitration_fast_source_slow_combine.rs
@@ -50,6 +50,7 @@ fn back_pressure_preferred_pauses_source_under_pressure() {
     let arbitrator = MemoryArbitrator::with_policy(
         100 * 1024 * 1024 * 1024,
         0.50,
+        0.40,
         Box::new(BackPressurePreferred::wrapping(Priority)),
     );
 

--- a/crates/clinker-exec/tests/arbitration_hard_limit_overshoot.rs
+++ b/crates/clinker-exec/tests/arbitration_hard_limit_overshoot.rs
@@ -51,7 +51,7 @@ const SOFT_FRAC: f64 = 0.50; // soft = 50 GiB
 
 #[test]
 fn should_abort_trips_when_rss_exceeds_hard_limit() {
-    let arbitrator = MemoryArbitrator::with_policy(HARD_LIMIT, SOFT_FRAC, Box::new(Priority));
+    let arbitrator = MemoryArbitrator::with_policy(HARD_LIMIT, SOFT_FRAC, 0.40, Box::new(Priority));
 
     let handle = ConsumerHandle::new();
     handle.set_bytes(64 * 1024);
@@ -72,7 +72,7 @@ fn should_abort_trips_when_rss_exceeds_hard_limit() {
 fn soft_limit_arbitration_runs_before_hard_limit_aborts() {
     // The arbitrator's two-tier model: soft-limit spill attempts run
     // first; only an honest overshoot of the hard limit aborts.
-    let arbitrator = MemoryArbitrator::with_policy(HARD_LIMIT, SOFT_FRAC, Box::new(Priority));
+    let arbitrator = MemoryArbitrator::with_policy(HARD_LIMIT, SOFT_FRAC, 0.40, Box::new(Priority));
 
     let handle = ConsumerHandle::new();
     handle.set_bytes(64 * 1024);

--- a/crates/clinker-exec/tests/arbitration_two_aggregate_largest_first.rs
+++ b/crates/clinker-exec/tests/arbitration_two_aggregate_largest_first.rs
@@ -40,7 +40,7 @@ fn largest_first_picks_the_larger_aggregate() {
     // 100 GiB hard limit so real-process RSS cannot push peak_rss
     // above the test-seeded value via `observe()`'s `fetch_max`.
     let arbitrator =
-        MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.50, Box::new(LargestFirst));
+        MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.50, 0.40, Box::new(LargestFirst));
 
     // Smaller aggregate: 64 KiB
     let small_handle = ConsumerHandle::new();
@@ -81,7 +81,7 @@ fn largest_first_picks_a_new_victim_each_round() {
     // 100 GiB hard limit so real-process RSS cannot push peak_rss
     // above the test-seeded value via `observe()`'s `fetch_max`.
     let arbitrator =
-        MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.50, Box::new(LargestFirst));
+        MemoryArbitrator::with_policy(100 * 1024 * 1024 * 1024, 0.50, 0.40, Box::new(LargestFirst));
 
     let small_handle = ConsumerHandle::new();
     small_handle.set_bytes(64 * 1024);

--- a/crates/clinker-exec/tests/snapshots/cull_explain_snapshot__explain_cull_two_output_ports.snap
+++ b/crates/clinker-exec/tests/snapshots/cull_explain_snapshot__explain_cull_two_output_ports.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 2
 DAG nodes: 4
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: events

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_exec_sketches_statistics.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_exec_sketches_statistics.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 1
 DAG nodes: 4
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: orders, products

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_metadata_driven_grace_hash.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_metadata_driven_grace_hash.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 1
 DAG nodes: 4
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: orders, products

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 1
 DAG nodes: 3
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: orders

--- a/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output_sized.snap
+++ b/crates/clinker-exec/tests/snapshots/explain_arbitration__explain_source_aggregate_output_sized.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 1
 DAG nodes: 3
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: orders

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_aggregate_windowed.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_aggregate_windowed.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 1
 Output projections: 1
 DAG nodes: 4
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: sales

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_channel_target_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_channel_target_pipeline.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 1
 DAG nodes: 3
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: ingest_src

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 1
 DAG nodes: 5
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: customers_src, addresses_src

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_csv_transform_sink.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_csv_transform_sink.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 1
 Output projections: 1
 DAG nodes: 3
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: employees

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_nested_composition_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_nested_composition_pipeline.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 0
 Output projections: 1
 DAG nodes: 3
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: raw_src

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_route_fanout.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_route_fanout.snap
@@ -9,7 +9,7 @@ Indices to build: 0
 Transforms: 1
 Output projections: 2
 DAG nodes: 5
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: orders

--- a/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
+++ b/crates/clinker-exec/tests/snapshots/retraction_explain_snapshot__explain_relaxed_aggregate_buffer_mode.snap
@@ -9,7 +9,7 @@ Indices to build: 1
 Transforms: 1
 Output projections: 1
 DAG nodes: 6
-arbitration: BackPressurePreferred -> Priority
+arbitration: BackPressurePreferred -> Priority (pause at 0.80·limit, resume below 0.70·limit)
 
 Source DAG:
   Tier 0: orders

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -107,7 +107,16 @@ pub struct PipelineMeta {
 /// behavior keyed on per-operator spill priority. `both` installs
 /// `BackPressurePreferred -> LargestFirst`: pause when possible,
 /// otherwise force the largest holder regardless of priority.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+///
+/// `resume_threshold` tunes the low watermark at which a paused producer
+/// resumes under the pausing policies — the pause/resume hysteresis band
+/// runs from `resume_threshold`·limit up to the 0.80·limit soft threshold.
+/// Omitted → 0.70.
+///
+/// `PartialEq`/`Eq` derive over `Option<f64>` is sound here: the field is
+/// only ever `None` or a plan-time-validated finite value in `(0, 0.80)`,
+/// never `NaN`, so no `Eq`-violating float ever reaches the comparison.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 #[serde(default, deny_unknown_fields)]
 pub struct MemoryConfig {
     /// Hard memory limit for the arbitrator. `None` (omitted) →
@@ -118,6 +127,16 @@ pub struct MemoryConfig {
     /// default).
     #[serde(skip_serializing_if = "BackpressureKnob::is_default")]
     pub backpressure: BackpressureKnob,
+    /// Fraction of the hard `limit` at which a producer paused under memory
+    /// pressure resumes (the low watermark of the pause/resume hysteresis
+    /// band). Must sit strictly below the soft/spill fraction (0.80) and
+    /// above 0. `None` (omitted) → 0.70. Lower = a wider band (a paused
+    /// producer stays paused longer, smoother but slower to re-open);
+    /// higher = a narrower band (faster re-open, more thrash-prone).
+    /// Validated at plan time (E324); resolved to its default by the
+    /// arbitrator builder when omitted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resume_threshold: Option<f64>,
 }
 
 impl MemoryConfig {
@@ -4257,6 +4276,26 @@ pub fn reserved_names_for(scope: pipeline_node::VarScope) -> &'static [&'static 
 
 /// Post-deserialization validation.
 pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError> {
+    // Pipeline-level memory knobs. `resume_threshold` is the low watermark
+    // of the pause/resume hysteresis band; it must sit strictly inside
+    // `(0, spill_threshold)` so the resume point is below the pause point
+    // and a dead zone separates the two (anti-thrash). Rejecting a
+    // set-but-out-of-range value here — before any executor construction —
+    // surfaces a bad fraction on `--explain` and to in-process callers as a
+    // typed plan-time error rather than a runtime surprise. `None` skips the
+    // check and takes the 0.70 default at arbitrator-build time.
+    if let Some(resume) = config.pipeline.memory.resume_threshold {
+        let spill = crate::config::utils::DEFAULT_SPILL_THRESHOLD;
+        if !(resume > 0.0 && resume < spill) {
+            return Err(ConfigError::Validation(format!(
+                "[E324] pipeline.memory.resume_threshold = {resume}: must be greater than 0 \
+                 and less than the soft/spill threshold ({spill}); the resume watermark has to \
+                 sit below the pause threshold to form a hysteresis band. \
+                 See: clinker explain --code E324"
+            )));
+        }
+    }
+
     for input in config.source_configs() {
         // Matcher-exclusivity, gated on transport. A file transport
         // resolves its file set through the discovery layer's
@@ -5343,5 +5382,107 @@ nodes:
     fn output_delimiter_single_ascii_accepted() {
         parse_config(&output_options_pipeline("        delimiter: \"|\""))
             .expect("a single-byte output delimiter is valid");
+    }
+}
+
+#[cfg(test)]
+mod memory_config_resume_threshold_tests {
+    use super::MemoryConfig;
+    use crate::config::parse_config;
+
+    /// Minimal pipeline whose `pipeline.memory` block carries a
+    /// caller-supplied body (each line indented four spaces to sit under the
+    /// `memory:` key).
+    fn memory_pipeline(memory_body: &str) -> String {
+        format!(
+            r#"
+pipeline:
+  name: resume_threshold
+  memory:
+{memory_body}
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: a, type: string }}
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+        )
+    }
+
+    #[test]
+    fn omitted_resume_threshold_keeps_memory_config_default() {
+        // An unset knob leaves the whole `memory` block at its default, so
+        // `is_default()` stays truthful and no empty block is emitted.
+        let cfg = MemoryConfig::default();
+        assert!(cfg.resume_threshold.is_none());
+        assert!(cfg.is_default());
+    }
+
+    #[test]
+    fn set_resume_threshold_survives_serde_round_trip_and_unset_is_omitted() {
+        let set = MemoryConfig {
+            resume_threshold: Some(0.6),
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&set).expect("serialize");
+        let back: MemoryConfig = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.resume_threshold, Some(0.6));
+        assert_eq!(back, set);
+
+        // An unset value is omitted from serialized output (the
+        // `skip_serializing_if = "Option::is_none"` gate) so a pipeline with
+        // no memory opinions round-trips byte-identically.
+        let unset = MemoryConfig::default();
+        let json = serde_json::to_string(&unset).expect("serialize default");
+        assert!(
+            !json.contains("resume_threshold"),
+            "an unset resume_threshold must not appear in serialized output: {json}"
+        );
+    }
+
+    #[test]
+    fn in_band_resume_threshold_accepted_at_plan_time() {
+        parse_config(&memory_pipeline("    resume_threshold: 0.6"))
+            .expect("a resume_threshold strictly inside (0, 0.80) is valid");
+    }
+
+    #[test]
+    fn out_of_range_resume_threshold_rejected_at_plan_time() {
+        // Each of these violates `0 < resume < 0.80`; all must be rejected
+        // with the E324 range diagnostic before any executor construction.
+        for bad in ["0.9", "0.8", "0.0", "-0.1", "1.5"] {
+            let body = format!("    resume_threshold: {bad}");
+            let err = parse_config(&memory_pipeline(&body))
+                .expect_err(&format!("resume_threshold {bad} must be rejected"));
+            let msg = err.to_string();
+            assert!(
+                msg.contains("E324") && msg.contains("resume_threshold"),
+                "rejection must name E324 and the knob for {bad}: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn misspelled_resume_threshold_key_rejected_as_unknown_field() {
+        // `deny_unknown_fields` on `MemoryConfig` still rejects a typo'd key
+        // — the new knob does not loosen the strict memory block.
+        let err = parse_config(&memory_pipeline("    resume_treshold: 0.7"))
+            .expect_err("a misspelled memory key must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("resume_treshold") || msg.contains("unknown field"),
+            "rejection must flag the unknown field: {msg}"
+        );
     }
 }

--- a/crates/clinker-plan/src/config/utils.rs
+++ b/crates/clinker-plan/src/config/utils.rs
@@ -118,6 +118,21 @@ impl<'de> Deserialize<'de> for TimeBound {
 /// value so every consumer agrees on the default budget.
 pub const DEFAULT_MEMORY_LIMIT_BYTES: u64 = 512 * 1024 * 1024;
 
+/// Soft-limit fraction of the hard `memory.limit` at which the arbitrator
+/// begins proactive spill and pauses a back-pressureable producer (the
+/// pause watermark). Plan-time validation and the exec-side arbitrator
+/// builder both read this single value so the soft threshold has one
+/// source of truth instead of a literal duplicated across crates.
+pub const DEFAULT_SPILL_THRESHOLD: f64 = 0.80;
+
+/// Fraction of the hard `memory.limit` at which a producer paused under
+/// memory pressure resumes — the low watermark of the pause/resume
+/// hysteresis band. Sits strictly below [`DEFAULT_SPILL_THRESHOLD`] so the
+/// dead zone between the two damps thrash (a single admit/discharge cycle
+/// cannot cross both thresholds). Applied when `memory.resume_threshold`
+/// is omitted.
+pub const DEFAULT_RESUME_THRESHOLD: f64 = 0.70;
+
 /// Parse the `memory.limit` knob into a byte count.
 ///
 /// Binary units: a trailing `G`/`g`, `M`/`m`, or `K`/`k` multiplies by

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -21,6 +21,26 @@ use crate::config::{PipelineConfig, RouteMode};
 /// their projection CXL, Aggregate nodes their reduction CXL, and Route
 /// nodes an empty body (their predicates render in the plan block, not
 /// here). Other node kinds carry no CXL source and are skipped.
+/// The `arbitration:` header line for `--explain`. Names the active policy
+/// and, under a pausing policy, the pause/resume hysteresis band so an author
+/// can see the resume watermark before running. The `spill` policy never
+/// pauses, so it renders the policy name alone.
+fn arbitration_annotation(config: &PipelineConfig) -> String {
+    let knob = &config.pipeline.memory.backpressure;
+    let policy = knob.policy_name();
+    if knob.pauses_producers() {
+        let resume = config
+            .pipeline
+            .memory
+            .resume_threshold
+            .unwrap_or(crate::config::utils::DEFAULT_RESUME_THRESHOLD);
+        let spill = crate::config::utils::DEFAULT_SPILL_THRESHOLD;
+        format!("{policy} (pause at {spill:.2}·limit, resume below {resume:.2}·limit)")
+    } else {
+        policy.to_string()
+    }
+}
+
 fn transform_cxl_sources(config: &PipelineConfig) -> Vec<(String, String)> {
     use crate::config::PipelineNode;
     let mut out = Vec::new();
@@ -840,8 +860,8 @@ impl ExecutionPlanDag {
         // every combine node when the catalog is absent — so the output
         // of `explain()` already has no combine block to dedupe.
         let classes = self.classify_node_buffers(config);
-        let policy_name = config.pipeline.memory.backpressure.policy_name();
-        let mut out = self.explain(&classes, policy_name);
+        let annotation = arbitration_annotation(config);
+        let mut out = self.explain(&classes, &annotation);
         self.render_combine_section(&mut out, Some(statistics), total_memory_limit_bytes);
         render_statistics_section(&mut out, statistics);
         out
@@ -1414,8 +1434,8 @@ impl ExecutionPlanDag {
     /// Full `--explain` output combining execution plan with config context.
     pub fn explain_full(&self, config: &PipelineConfig) -> String {
         let classes = self.classify_node_buffers(config);
-        let policy_name = config.pipeline.memory.backpressure.policy_name();
-        let mut out = self.explain(&classes, policy_name);
+        let annotation = arbitration_annotation(config);
+        let mut out = self.explain(&classes, &annotation);
         if let Some(start) = out.find("=== Retraction ===\n") {
             out.truncate(start);
         }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -371,6 +371,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E319" => Some(include_str!("../../../../docs/explain/E319.md")),
         "E320" => Some(include_str!("../../../../docs/explain/E320.md")),
         "E321" => Some(include_str!("../../../../docs/explain/E321.md")),
+        "E324" => Some(include_str!("../../../../docs/explain/E324.md")),
         "E330" => Some(include_str!("../../../../docs/explain/E330.md")),
         "E331" => Some(include_str!("../../../../docs/explain/E331.md")),
         "E332" => Some(include_str!("../../../../docs/explain/E332.md")),
@@ -612,10 +613,10 @@ mod tests {
         let codes = [
             "E101", "E102", "E103", "E104", "E106", "E107", "E108", "E115", "E150b", "E150c",
             "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
-            "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E330", "E331",
-            "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341", "E342",
-            "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352", "E353",
-            "E354", "E355", "E15Y", "W101", "W302", "W305", "W306",
+            "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E324", "E330",
+            "E331", "E332", "E333", "E334", "E335", "E336", "E337", "E338", "E339", "E340", "E341",
+            "E342", "E343", "E344", "E345", "E346", "E347", "E348", "E349", "E350", "E351", "E352",
+            "E353", "E354", "E355", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/docs/explain/E312.md
+++ b/docs/explain/E312.md
@@ -11,15 +11,15 @@ of spilling operator state to disk or pausing producers can ever bring RSS
 under a ceiling the empty pipeline already exceeds.
 
 Under the default `memory.backpressure: pause` policy this is worse than a
-slow run — it is a deadlock. The arbitration round keeps electing the Source
-ingest thread as the pause victim (preferring back-pressure over forcing a
-spill), and the Source parks on a condition variable that only `resume()`
-releases. But `resume()` fires only once RSS drops back under the threshold,
-which never happens because the limit is below baseline. Meanwhile a blocking
-consumer (hash Aggregate, external sort, grace-hash / sort-merge / IEJoin /
-hash Combine) waits forever for input that the paused Source will never
-deliver. Both threads are parked permanently. Rejecting at startup converts
-that hang into an immediate, clear error.
+slow run — the run cannot make useful progress against the budget. The
+arbitration round keeps electing the Source ingest thread as the pause victim
+(preferring back-pressure over forcing a spill), but current memory never
+recedes below the resume watermark — even an empty pipeline already sits above
+the limit — so the run only churns: pause a producer, resume it at its drain
+turn, spill downstream state, and pause again, never getting under budget.
+(The resume controller and its liveness backstop keep the walk moving rather
+than deadlocking, but it makes no headway against an impossible ceiling.)
+Rejecting at startup converts that futile churn into an immediate, clear error.
 
 The startup diagnostic reports both figures:
 
@@ -69,11 +69,11 @@ pipeline:
 E312 is a startup-validation diagnostic raised after the plan compiles and
 the arbitrator is built, before any source-ingest thread spawns. The check
 compares the configured ceiling against the live `rss_bytes()` reading and
-only fires when the active backpressure policy can pause a producer
-indefinitely — the `pause` and `both` policies. The `spill` policy reacts by
-spilling rather than pausing, so a sub-baseline budget under `spill` makes
-forward progress (or aborts fast via the per-record admission charge) without
-deadlocking, and is not rejected.
+only fires under a producer-pausing policy — the `pause` and `both` policies,
+which repeatedly pause producers against a ceiling the run can never get
+under. The `spill` policy reacts by spilling rather than pausing, so a
+sub-baseline budget under `spill` makes forward progress (or aborts fast via
+the per-record admission charge), and is not rejected.
 
 On a platform where `rss_bytes()` is unavailable, the baseline cannot be
 measured and the check is skipped — the run proceeds and surfaces a

--- a/docs/explain/E324.md
+++ b/docs/explain/E324.md
@@ -1,0 +1,75 @@
+# Error E324: pipeline.memory.resume_threshold out of range
+
+## What it means
+
+The `pipeline.memory.resume_threshold` you configured is **outside the valid
+`(0, 0.80)` range**. This knob is a fraction of the hard `memory.limit`: it
+sets the *low watermark* at which a producer the arbitrator paused under
+memory pressure is allowed to resume. It has to sit strictly **below** the
+0.80·limit soft/spill threshold (the pause watermark) and strictly **above**
+0, so that the two thresholds form a hysteresis band with a dead zone
+between them.
+
+Clinker validates the value at plan time — before the run's arbitrator is
+built — so a bad fraction fails on `clinker explain` and to in-process
+callers rather than surfacing as a runtime surprise.
+
+The range is exclusive on both ends. Rejected values include `0.0`, any
+negative number, `0.80` itself, and anything above the soft threshold up to
+and past `1.0`.
+
+## Example
+
+```yaml
+# pipeline.yaml — 0.9 is above the 0.80 soft threshold, so the resume
+# watermark would sit at or above the pause watermark: no hysteresis band.
+pipeline:
+  name: too_high
+  memory:
+    limit: "512M"
+    resume_threshold: 0.9
+```
+
+```yaml
+# Corrected: a resume watermark below the 0.80 pause threshold. A paused
+# producer resumes once current pressure recedes below 0.60·limit.
+pipeline:
+  name: too_high
+  memory:
+    limit: "512M"
+    resume_threshold: 0.6
+```
+
+## How to fix
+
+1. **Pick a fraction in `(0, 0.80)`.** The default when the knob is omitted
+   is `0.70`. Lower values widen the pause/resume band (a paused producer
+   stays paused longer — smoother, slower to re-open); higher values narrow
+   it (faster re-open, more thrash-prone).
+
+2. **Omit the knob entirely** to take the `0.70` default if you have no
+   specific tuning need — an empty or absent `resume_threshold` is not
+   validated and never triggers E324.
+
+3. **Check for a typo in the key.** A misspelled key such as
+   `resume_treshold:` is rejected separately as an unknown field (the
+   `memory` block is strict), not as E324.
+
+## Technical context
+
+E324 is a config-validation diagnostic raised during plan compilation, in
+the same pass that emits the other `pipeline.*` range and structure checks.
+The bound is the soft/spill fraction (0.80): the resume watermark must sit
+below the pause watermark so that pressure has to swing the full width of
+the band to cross both thresholds, which is what prevents a single
+admit/discharge cycle from thrashing pause and resume every poll.
+
+The resume watermark is only meaningful under a producer-pausing policy
+(`memory.backpressure: pause`, the default, or `both`). Under `spill` no
+producer is ever paused, so the value is validated but unused.
+
+## See also
+
+- E312 (memory.limit is below the process baseline RSS)
+- E310 (memory-budget surface exceeded the hard limit at runtime)
+- "Memory & Backpressure" in the operations guide

--- a/docs/user/src/ops/memory.md
+++ b/docs/user/src/ops/memory.md
@@ -65,11 +65,40 @@ When memory use approaches the limit (the soft threshold is 80 % of `limit`), so
 
 | Value | Behavior |
 |-------|----------|
-| `pause` (default) | Where possible, pause an upstream reader so it stops producing until pressure eases; spill to disk only when nothing can be paused. |
+| `pause` (default) | Where possible, pause an upstream reader so it stops producing until pressure eases; when a paused reader is about to be needed, first spill downstream state and then proceed, so a pause never stalls the run. |
 | `spill` | Never pause a producer — always free memory by spilling a stage to disk. |
 | `both` | Pause where possible, otherwise spill whichever stage is holding the most memory. |
 
 `pause` is the right default for most pipelines: pausing a fast Source feeding a slow downstream stage is cheaper than writing its buffered records to disk. Reach for `spill` or `both` only when you have a specific reason to prefer a different posture — for example, `both` when one large stage dominates the budget and you want it spilled first.
+
+### How pause and resume work
+
+Under `pause` (and `both`), a producer paused because memory crossed the soft threshold is **resumed automatically once memory recedes** — it is never left parked. Pause and resume use two watermarks to avoid flapping (a *hysteresis band*):
+
+- **Pause** when live memory rises above the **soft threshold**, `0.80 × limit`.
+- **Resume** when live memory falls back below the lower **resume watermark**, `resume_threshold × limit` (default `0.70 × limit`).
+
+Between the two watermarks nothing changes, so a normal batch-to-batch swing in memory cannot make a producer flap between paused and resumed on every poll.
+
+A paused reader also never blocks the run. When the engine reaches a stage that needs a paused reader's records, it first sheds reclaimable downstream state to disk and then resumes the reader and proceeds — so `pause` throttles producers under pressure but degrades to spill-and-continue at the point it would otherwise wait, rather than stalling.
+
+### `resume_threshold`
+
+`resume_threshold` tunes the low watermark of that band, as a fraction of the hard `limit`:
+
+```yaml
+pipeline:
+  memory:
+    limit: "1G"
+    resume_threshold: 0.65   # optional — defaults to 0.70
+```
+
+- **Default:** `0.70` (omit the field to take it).
+- **Valid range:** strictly greater than `0` and strictly less than the `0.80` soft threshold, so the resume point always sits below the pause point. A value outside `(0, 0.80)` — including `0.0`, a negative, or anything `≥ 0.80` — is rejected at plan time with `E324`. A misspelled key is rejected as an unknown field.
+- **Lower** widens the band: a paused producer stays paused longer (smoother, but slower to re-open).
+- **Higher** narrows the band: faster to re-open, but more prone to flapping.
+
+Only the pausing policies (`pause`, `both`) use this watermark; under `spill` no producer is ever paused, so it has no effect.
 
 ## Streaming batch size (`batch_size`)
 


### PR DESCRIPTION
Completes the memory-arbitration backpressure story: a paused producer now has a working resume path, and a source being drained can never be left paused — eliminating the permanent-stall class where a pipeline could deadlock under memory pressure with the default `pause` policy.

## What changed

- **Resume controller.** When arbitration pauses a back-pressureable consumer at the soft limit, the same pressure checks now also *resume* paused consumers once current pressure (fresh RSS and summed consumer usage — not the monotonic peak, which can never fall) drops below a resume threshold. Pause at 80% of the hard limit, resume below the threshold — a hysteresis band that prevents pause/resume thrash.
- **Liveness guarantee.** Each drain path (source drain, fused merge-interleave over all its receivers, fused source→transform) marks its source(s) active and resumes them before blocking. An active source is exempt from pause election, so the dispatch walk provably cannot block on a producer it — or any other stage — paused. This holds independently of pressure levels or timing.
- **Shed before resume.** At the progress boundary, reclaimable state (node buffers, grace-hash, sort, aggregate — in spill-priority order) is spilled before a paused producer is resumed, so a resumed source does not immediately re-trip the limit.
- **`resume_threshold` config.** New optional `pipeline.memory.resume_threshold` (default `0.70`), validated at plan time (must be positive and below the 0.80 spill threshold; rejected with the new E324 diagnostic). The 0.80 factor now lives in one shared constant.
- **Inert surface removed.** The node-buffer consumer's pause capability was constructed un-pausable everywhere, had no waiting thread, and would self-deadlock if it ever engaged (the dispatch walk both fills and drains node buffers). It is removed; node buffers relieve pressure through their existing spill path.
- **Docs.** `memory.md` documents the resume behavior, the knob, and the corrected `pause`/`both` semantics; the E312 page and the startup-validation comment no longer describe the (now impossible) deadlock; `--explain` annotates the resume threshold.

## Validation

New liveness suite drives the exact deadlock (two sources, shared downstream tripping arbitration under a tiny budget, all three drain arms) — these hang without the fix and complete with it, under a watchdog with per-source row-count oracles. Hysteresis unit tests bound pause/resume cycling; the fast-source/slow-combine arbitration test is rewritten onto current-pressure semantics; config-knob tests cover default, custom, and plan-time-rejected values. `cargo test --workspace`, `fmt`, `clippy -D warnings`, `git diff --check` all green.

Closes #447
