### PR TITLE
fix(exec): order-preserving float encoding for range-join keys (#446)

### DIFF
--- a/crates/clinker-exec/proptest-regressions/pipeline/sort_merge_join.txt
+++ b/crates/clinker-exec/proptest-regressions/pipeline/sort_merge_join.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 3407ac0360e0bf8f3b528396f94b57b255cc8faa37d490bf74a78790a1d4f507 # shrinks to a = -2.2250738585072014e-308, b = -0.0, op = Lt
+cc 1b2d70cd87c7e6868d1a225afb6a2241e1967f3219efb8b6a04bf58bdaa470c9 # shrinks to left = [-1.0], right = [-2.0], op = Lt

--- a/crates/clinker-exec/src/pipeline/iejoin.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin.rs
@@ -1258,7 +1258,7 @@ fn value_to_i64(v: &Value) -> Option<i64> {
         Value::Integer(i) => Some(*i),
         Value::Float(f) => {
             if f.is_finite() {
-                Some(f.to_bits() as i64)
+                Some(crate::pipeline::sort_key::float_to_orderable_i64(*f))
             } else {
                 None
             }
@@ -1471,6 +1471,14 @@ mod tests {
                 TOp::Ge => a >= b,
             }
         }
+        fn apply_f64(self, a: f64, b: f64) -> bool {
+            match self {
+                TOp::Lt => a < b,
+                TOp::Le => a <= b,
+                TOp::Gt => a > b,
+                TOp::Ge => a >= b,
+            }
+        }
         fn to_range(self) -> RangeOp {
             match self {
                 TOp::Lt => RangeOp::Lt,
@@ -1632,6 +1640,92 @@ mod tests {
                     .into_iter()
                     .collect();
             let expected = nested_loop(&left, &right, op1, op2);
+            prop_assert_eq!(actual, expected);
+        }
+    }
+
+    /// One float proptest case: left/right float rows and the two range
+    /// operators of the band predicate.
+    type FloatJoinCase = (Vec<(f64, f64)>, Vec<(f64, f64)>, TOp, TOp);
+
+    /// Brute-force nested-loop join over the ORIGINAL float values. The
+    /// kernel compares `value_to_i64`-encoded keys, so agreement with this
+    /// oracle is exactly the order-preservation property under test.
+    fn nested_loop_f64(
+        left: &[(f64, f64)],
+        right: &[(f64, f64)],
+        op1: TOp,
+        op2: TOp,
+    ) -> HashSet<(usize, usize)> {
+        let mut out = HashSet::new();
+        for (li, l) in left.iter().enumerate() {
+            for (ri, r) in right.iter().enumerate() {
+                if op1.apply_f64(l.0, r.0) && op2.apply_f64(l.1, r.1) {
+                    out.insert((li, ri));
+                }
+            }
+        }
+        out
+    }
+
+    /// Finite `f64` sample skewed toward small recurring integers (so
+    /// duplicate keys and boundary equality get exercised), the signed
+    /// zeros, subnormals, and a wide continuous spread reaching large
+    /// magnitudes of both signs. The negative values are the whole point:
+    /// a raw `to_bits() as i64` encoding is only non-monotone once the
+    /// sign bit is set, so a strategy without negatives cannot catch it.
+    fn arb_float_key() -> impl Strategy<Value = f64> {
+        prop_oneof![
+            4 => (-8i64..8).prop_map(|n| n as f64),
+            1 => Just(0.0f64),
+            1 => Just(-0.0f64),
+            1 => Just(f64::MIN_POSITIVE),
+            1 => Just(-f64::MIN_POSITIVE),
+            2 => -1.0e6f64..1.0e6,
+        ]
+    }
+
+    fn arb_float_inputs() -> impl Strategy<Value = FloatJoinCase> {
+        let op = prop_oneof![Just(TOp::Lt), Just(TOp::Le), Just(TOp::Gt), Just(TOp::Ge)];
+        (
+            prop::collection::vec((arb_float_key(), arb_float_key()), 0..40),
+            prop::collection::vec((arb_float_key(), arb_float_key()), 0..40),
+            op.clone(),
+            op,
+        )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+        /// The kernel result over `value_to_i64`-encoded float keys must
+        /// equal the float nested-loop oracle for every operator pair,
+        /// including negatives and signed zeros. Under the old
+        /// `f.to_bits() as i64` arm this diverged: among negative floats a
+        /// larger magnitude encodes to a larger i64, inverting their order,
+        /// and `-0.0` encodes to `i64::MIN` rather than `0` — so range
+        /// matches over negative keys went wrong.
+        #[test]
+        fn proptest_iejoin_float_keys_match_nested_loop(
+            (left, right, op1, op2) in arb_float_inputs()
+        ) {
+            // Every generated value is finite, so `value_to_i64` is `Some`.
+            let enc = |rows: &[(f64, f64)]| -> Vec<(i64, i64)> {
+                rows.iter()
+                    .map(|&(a, b)| {
+                        (
+                            value_to_i64(&Value::Float(a)).unwrap(),
+                            value_to_i64(&Value::Float(b)).unwrap(),
+                        )
+                    })
+                    .collect()
+            };
+            let left_i = enc(&left);
+            let right_i = enc(&right);
+            let actual: HashSet<(usize, usize)> =
+                iejoin_numeric(&left_i, &right_i, op1.to_range(), op2.to_range())
+                    .into_iter()
+                    .collect();
+            let expected = nested_loop_f64(&left, &right, op1, op2);
             prop_assert_eq!(actual, expected);
         }
     }

--- a/crates/clinker-exec/src/pipeline/sort_key.rs
+++ b/crates/clinker-exec/src/pipeline/sort_key.rs
@@ -153,18 +153,44 @@ fn mul_u128_to_u256_be(a: u128, b: u128) -> [u8; 32] {
     out
 }
 
-/// Append the order-preserving 8-byte memcomparable encoding of an `f64`.
-fn encode_f64_order(f: f64, buf: &mut Vec<u8>) {
-    // Canonicalize -0.0 → 0.0 so byte order agrees with semantic equality
-    // (`-0.0 == 0.0` per IEEE). Matches `value_to_group_key`.
+/// Order-preserving `f64` → `u64`: the *unsigned* ordering of the result
+/// matches IEEE-754 ordering over finite values. `-0.0` canonicalizes to
+/// `+0.0` so signed zeros compare equal, agreeing with `value_to_group_key`.
+///
+/// This is the single source of the float bit-twiddle. The memcomparable
+/// byte key ([`encode_f64_order`]) and the range-join kernels' signed
+/// [`float_to_orderable_i64`] both derive from it, so a monotone float
+/// order is guaranteed identically everywhere it matters.
+#[inline]
+fn f64_to_orderable_u64(f: f64) -> u64 {
     let f = if f == 0.0 { 0.0 } else { f };
     let bits = f.to_bits();
-    let encoded = if bits >> 63 == 1 {
-        bits ^ u64::MAX // negative: flip all bits
+    if bits >> 63 == 1 {
+        bits ^ u64::MAX // negative: flip all bits — larger magnitude sorts earlier
     } else {
         bits ^ (1 << 63) // positive/zero: flip sign bit only
-    };
-    buf.extend_from_slice(&encoded.to_be_bytes());
+    }
+}
+
+/// Order-preserving `f64` → `i64`: signed-`i64` comparison of the result
+/// matches IEEE-754 ordering over finite values. `-0.0` encodes equal to
+/// `+0.0`.
+///
+/// The range-join kernels carry keys as `i64` and compare them directly,
+/// so they need a monotone `i64` rather than the memcomparable byte key.
+/// A raw `f.to_bits() as i64` is NOT monotone: IEEE negatives set the sign
+/// bit, so their bit patterns grow as the value shrinks, and any range
+/// predicate over a float column with negative values would match wrongly.
+#[inline]
+pub(crate) fn float_to_orderable_i64(f: f64) -> i64 {
+    // Flip the high bit to turn the unsigned-ordered u64 into a
+    // two's-complement-ordered i64 (smallest u64 → i64::MIN).
+    (f64_to_orderable_u64(f) ^ (1 << 63)) as i64
+}
+
+/// Append the order-preserving 8-byte memcomparable encoding of an `f64`.
+fn encode_f64_order(f: f64, buf: &mut Vec<u8>) {
+    buf.extend_from_slice(&f64_to_orderable_u64(f).to_be_bytes());
 }
 
 /// Owning wrapper around a `Vec<SortField>` that encodes and compares
@@ -299,6 +325,62 @@ mod tests {
         let mut buf = Vec::new();
         encode_value(&Value::Decimal(d), &mut buf);
         buf
+    }
+
+    #[test]
+    fn float_to_orderable_i64_preserves_order() {
+        // Smallest positive subnormal and its negation bracket zero more
+        // tightly than any normal value can.
+        let smallest_subnormal = f64::from_bits(1);
+        // Strictly ascending in IEEE order, except the signed-zero pair,
+        // which is equal. Spans both signs, subnormals, and the extremes.
+        let ascending = [
+            f64::MIN,
+            -1.0e300,
+            -2.0,
+            -1.0,
+            -f64::MIN_POSITIVE,
+            -smallest_subnormal,
+            -0.0,
+            0.0,
+            smallest_subnormal,
+            f64::MIN_POSITIVE,
+            1.0,
+            2.0,
+            1.0e300,
+            f64::MAX,
+        ];
+        let encoded: Vec<i64> = ascending
+            .iter()
+            .map(|&f| float_to_orderable_i64(f))
+            .collect();
+        for (i, w) in encoded.windows(2).enumerate() {
+            // Only the -0.0/+0.0 adjacency is an equality; every other
+            // adjacency is a strict increase.
+            let signed_zero_pair = ascending[i] == 0.0 && ascending[i + 1] == 0.0;
+            if signed_zero_pair {
+                assert_eq!(w[0], w[1], "signed zeros must encode to the same i64");
+            } else {
+                assert!(
+                    w[0] < w[1],
+                    "encoding not order-preserving at {}: {} then {} → {} then {}",
+                    i,
+                    ascending[i],
+                    ascending[i + 1],
+                    w[0],
+                    w[1]
+                );
+            }
+        }
+        // The raw `f.to_bits() as i64` this replaced fails two ways, each
+        // pinned by an assert here: `-0.0` maps to `i64::MIN` instead of
+        // `0`, and among negatives a larger magnitude maps to a larger i64,
+        // inverting their order. Cross-sign order happened to survive the
+        // old cast (negatives already sat below positives), so the middle
+        // assert is only a sanity check, not a discriminator.
+        assert_eq!(float_to_orderable_i64(-0.0), float_to_orderable_i64(0.0));
+        assert!(float_to_orderable_i64(-1.0) < float_to_orderable_i64(1.0));
+        assert!(float_to_orderable_i64(-1.0e300) < float_to_orderable_i64(-2.0));
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -307,21 +307,28 @@ fn is_orderable(v: &Value) -> bool {
     }
 }
 
-/// Compare two range key values under the IEJoin numeric-coercion
-/// convention (i64-encoded, float bit-cast). NULLs and non-orderables
-/// are filtered before this is called.
+/// Compare two range key values by mapping each to a monotone `i64`
+/// *within its own type*: integers as-is, floats through the
+/// order-preserving `float_to_orderable_i64` encoding, dates/datetimes as
+/// their epoch counts. NULLs and non-orderables are filtered before this
+/// is called.
+///
+/// There is no cross-type coercion here: an integer and a float are NOT
+/// brought onto a common numeric scale, so this assumes both keys of an
+/// axis share a type. A mixed int/float range axis is not currently
+/// guarded at plan time and would compare in disjoint encoding spaces.
 fn cmp_range_keys(a: &Value, b: &Value) -> Ordering {
     use chrono::Datelike;
     let ai = match a {
         Value::Integer(i) => *i,
-        Value::Float(f) => f.to_bits() as i64,
+        Value::Float(f) => crate::pipeline::sort_key::float_to_orderable_i64(*f),
         Value::Date(d) => d.num_days_from_ce() as i64,
         Value::DateTime(dt) => dt.and_utc().timestamp_micros(),
         _ => 0,
     };
     let bi = match b {
         Value::Integer(i) => *i,
-        Value::Float(f) => f.to_bits() as i64,
+        Value::Float(f) => crate::pipeline::sort_key::float_to_orderable_i64(*f),
         Value::Date(d) => d.num_days_from_ce() as i64,
         Value::DateTime(dt) => dt.and_utc().timestamp_micros(),
         _ => 0,
@@ -2350,5 +2357,105 @@ mod tests {
             "expected DirUnavailable from the configured root; got: {rendered}"
         );
         drop(scratch);
+    }
+
+    /// Range-key comparison over float `Value`s must agree with native f64
+    /// order across the sign boundary. Isolated in its own module so the
+    /// proptest prelude imports stay local.
+    mod float_range_keys {
+        use super::super::{RangeOp, apply_op, cmp_range_keys};
+        use clinker_record::Value;
+        use proptest::prelude::*;
+        use std::collections::HashSet;
+
+        /// Finite `f64` sample skewed toward small recurring integers (so
+        /// duplicate keys and boundary equality get exercised), the signed
+        /// zeros, subnormals, and a wide continuous spread reaching large
+        /// magnitudes of both signs. The negative values are the whole
+        /// point: the old `f.to_bits() as i64` encoding is only
+        /// non-monotone once the sign bit is set.
+        fn arb_float_key() -> impl Strategy<Value = f64> {
+            prop_oneof![
+                4 => (-8i64..8).prop_map(|n| n as f64),
+                1 => Just(0.0f64),
+                1 => Just(-0.0f64),
+                1 => Just(f64::MIN_POSITIVE),
+                1 => Just(-f64::MIN_POSITIVE),
+                2 => -1.0e6f64..1.0e6,
+            ]
+        }
+
+        fn arb_op() -> impl Strategy<Value = RangeOp> {
+            prop_oneof![
+                Just(RangeOp::Lt),
+                Just(RangeOp::Le),
+                Just(RangeOp::Gt),
+                Just(RangeOp::Ge),
+            ]
+        }
+
+        fn apply_op_f64(a: f64, op: RangeOp, b: f64) -> bool {
+            match op {
+                RangeOp::Lt => a < b,
+                RangeOp::Le => a <= b,
+                RangeOp::Gt => a > b,
+                RangeOp::Ge => a >= b,
+            }
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(256))]
+
+            /// `apply_op` (and thus `cmp_range_keys`) over float keys must
+            /// match native f64 comparison for every operator, including
+            /// across the sign boundary and the signed-zero pair.
+            #[test]
+            fn apply_op_matches_native_f64(
+                a in arb_float_key(),
+                b in arb_float_key(),
+                op in arb_op(),
+            ) {
+                prop_assert_eq!(
+                    apply_op(&Value::Float(a), op, &Value::Float(b)),
+                    apply_op_f64(a, op, b)
+                );
+                // Ordering agrees too, treating signed zeros as equal.
+                let native = a.partial_cmp(&b).unwrap();
+                prop_assert_eq!(
+                    cmp_range_keys(&Value::Float(a), &Value::Float(b)),
+                    native
+                );
+            }
+
+            /// Float-key range matching via `apply_op` (the predicate the
+            /// Phase-B merge walk applies per candidate pair) must equal the
+            /// brute-force native-f64 nested-loop oracle for every operator.
+            /// This pins the range-key encoding seam; it does not drive the
+            /// Phase-A external sort or the merge walk itself.
+            #[test]
+            fn range_join_matches_nested_loop(
+                left in prop::collection::vec(arb_float_key(), 0..40),
+                right in prop::collection::vec(arb_float_key(), 0..40),
+                op in arb_op(),
+            ) {
+                let mut actual: HashSet<(usize, usize)> = HashSet::new();
+                for (li, &l) in left.iter().enumerate() {
+                    for (ri, &r) in right.iter().enumerate() {
+                        if apply_op(&Value::Float(l), op, &Value::Float(r)) {
+                            actual.insert((li, ri));
+                        }
+                    }
+                }
+                let mut expected: HashSet<(usize, usize)> = HashSet::new();
+                for (li, &l) in left.iter().enumerate() {
+                    for (ri, &r) in right.iter().enumerate() {
+                        if apply_op_f64(l, op, r) {
+                            expected.insert((li, ri));
+                        }
+                    }
+                }
+                prop_assert_eq!(actual, expected);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

The IEJoin and sort-merge-join range kernels encoded `Value::Float` range keys with `f.to_bits() as i64`. That transform is not monotonic for negative floats: IEEE-754 negatives set the sign bit, so their bit patterns increase in magnitude as the value decreases and exceed every positive value. Any range/inequality `Combine` (`<`, `>`, `<=`, `>=`) over a float column containing negative values **silently returned wrong matches** — missing and/or spurious pairs.

The combine range proptests used integer keys only, so the negative-float reversal was never exercised.

## Fix

Float range keys are now encoded through a single shared `float_to_orderable_i64` (in `sort_key.rs`):

- flip all bits for negatives, flip the sign bit for non-negatives, then reinterpret the resulting unsigned-ordered `u64` as a two's-complement-ordered `i64`, so signed `i64` comparison matches IEEE-754 order;
- `-0.0` canonicalizes to `+0.0`.

Both range kernels (`iejoin.rs`, `sort_merge_join.rs`) call this helper, and the memcomparable sort-key float encoder now derives from the same transform — byte-identical output, so aggregation-spill group identity and merge ordering are unchanged. Integer / Date / DateTime encodings are untouched; Decimal remains non-orderable.

## Tests

- New float-key proptests (negatives, `-0.0`, subnormals) in both kernels, checked against a nested-loop oracle across all range-operator combinations.
- A direct monotonicity unit test for the encoder.
- Restoring the old `to_bits() as i64` cast makes the new proptests fail (shrunk counterexamples involve negative floats); the fix makes them pass. Regression seeds for the two counterexamples are checked in.

`clinker-exec` test suite, clippy (`-D warnings`), fmt, and `git diff --check` are all green.

## Follow-up

Range predicates that mix an integer column with a float column (e.g. `l.int_col > r.float_col`) are routed to these kernels and compared in disjoint encoding spaces, producing wrong results and diverging from the hash-join residual path. This is pre-existing (the old cast had the same cross-type flaw) and is tracked in #844.

Closes #446.
