### PR TITLE
engine: complete multi-run k-way merge for sort-merge Phase A external sort

### DIFF
--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -6,9 +6,6 @@
 //! through the permutation, and emits the ordered run. The dispatcher's
 //! `Sort` arm is a single delegating call into [`dispatch_sort`].
 
-use std::cmp::Ordering;
-use std::sync::Arc;
-
 use clinker_record::Record;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
@@ -18,10 +15,7 @@ use crate::executor::dispatch::{
     tee_emit_to_region_input_buffers,
 };
 use crate::executor::{parse_memory_limit, stage_metrics};
-use crate::pipeline::loser_tree::LoserTree;
-use crate::pipeline::sort::compare_records_by_fields;
-use crate::pipeline::spill::{SpillFile, SpillReader};
-use clinker_plan::config::SortField;
+use crate::pipeline::spill_merge::merge_sorted_runs;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 
@@ -190,115 +184,13 @@ fn charge_enforcer_spill(
     Ok(())
 }
 
-/// One entry in the enforcer-sort k-way merge: a spilled record and the
-/// `row_num` payload carried through the sort permutation. `Ord` delegates to
-/// [`compare_records_by_fields`] — the exact field comparator `SortBuffer`
-/// formed each run with — so the merged order is byte-identical to a single
-/// in-memory sort. The memcmp key on
-/// [`crate::pipeline::loser_tree::MergeEntry`] is deliberately not used here:
-/// it is not provably equal to the field comparator across Integer/Decimal or
-/// float ordering, so merging on it could silently mis-order cross-type keys.
-struct Run {
-    sort_by: Arc<[SortField]>,
-    record: Record,
-    row_num: u64,
-}
-
-impl PartialEq for Run {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-
-impl Eq for Run {}
-
-impl PartialOrd for Run {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Run {
-    fn cmp(&self, other: &Self) -> Ordering {
-        compare_records_by_fields(&self.record, &other.record, &self.sort_by)
-    }
-}
-
-/// Pull the next `(record, row_num)` from one spilled run, wrapping it as a
-/// [`Run`] merge entry, or `None` at end of stream.
-fn next_run(
-    reader: &mut SpillReader<u64>,
-    sort_by: &Arc<[SortField]>,
-) -> Result<Option<Run>, PipelineError> {
-    match reader.next() {
-        None => Ok(None),
-        Some(Ok((record, row_num))) => Ok(Some(Run {
-            sort_by: Arc::clone(sort_by),
-            record,
-            row_num,
-        })),
-        Some(Err(e)) => Err(PipelineError::Io(std::io::Error::other(format!(
-            "sort enforcer spill decode failed: {e}"
-        )))),
-    }
-}
-
-/// K-way merge the individually-sorted spill runs into one globally-ordered
-/// run via a [`LoserTree`], preserving each record's `row_num` payload.
-///
-/// `SortBuffer` spills runs in input order (run 0 earliest) with a stable
-/// per-run sort, and the loser tree breaks ties by lower stream index, so
-/// equal keys emit in input order — the merged run is byte-identical to the
-/// single in-memory sort the buffer would have produced without spilling.
-///
-/// Memory model: holds one resident record per open run plus the fully
-/// materialized output, matching the already-accepted single-run spill path.
-fn merge_sorted_runs(
-    files: Vec<SpillFile<u64>>,
-    sort_by: &[SortField],
-) -> Result<Vec<(Record, u64)>, PipelineError> {
-    let sort_by: Arc<[SortField]> = Arc::from(sort_by.to_vec());
-    // Each reader owns its own file handle; `files` is held for the whole
-    // merge so the spill temp files outlive every read.
-    let mut readers: Vec<SpillReader<u64>> = files
-        .iter()
-        .map(|f| f.reader())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| {
-            PipelineError::Io(std::io::Error::other(format!(
-                "sort enforcer spill read failed: {e}"
-            )))
-        })?;
-
-    // Seed the tree with one entry per run.
-    let mut initial: Vec<Option<Run>> = Vec::with_capacity(readers.len());
-    for reader in &mut readers {
-        initial.push(next_run(reader, &sort_by)?);
-    }
-    let mut tree = LoserTree::new(initial);
-
-    let mut out: Vec<(Record, u64)> = Vec::new();
-    while tree.winner().is_some() {
-        let idx = tree.winner_index();
-        // The loser tree exposes only `&T`; clone the winning record and copy
-        // its `row_num` out before refilling from the winning run. This
-        // per-record clone mirrors the aggregation spill merge.
-        let (record, row_num) = {
-            let winner = tree.winner().expect("winner present under loop guard");
-            (winner.record.clone(), winner.row_num)
-        };
-        out.push((record, row_num));
-        let next = next_run(&mut readers[idx], &sort_by)?;
-        tree.replace_winner(next);
-    }
-    Ok(out)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
-    use clinker_plan::config::SortOrder;
+    use std::sync::Arc;
+
+    use crate::pipeline::sort_buffer::SortBuffer;
+    use clinker_plan::config::{SortField, SortOrder};
     use clinker_record::{Schema, Value};
     use rust_decimal::Decimal;
 
@@ -324,87 +216,6 @@ mod tests {
             order: SortOrder::Asc,
             null_order: None,
         }]
-    }
-
-    /// Multiple individually-sorted spill runs — with a `Decimal` sort key,
-    /// duplicate keys spanning different runs, and unsorted input within each
-    /// run — must k-way merge into one globally-ordered run that preserves
-    /// every record's `row_num` payload and emits equal keys in input order
-    /// (stable). This is the correctness the enforcer sort lost when it
-    /// rejected multi-run spills instead of merging them.
-    #[test]
-    fn merge_sorted_runs_globally_orders_stably_and_preserves_row_num() {
-        let schema = schema();
-        let sort_by = sort_by_k_asc();
-        // budget=1 is the spill-everything threshold; runs are flushed
-        // explicitly below so each carries several unsorted records.
-        let mut buf: SortBuffer<u64> =
-            SortBuffer::new(sort_by.clone(), 1, None, true, schema.clone());
-
-        // Run A: keys 3.0, 1.0, 2.0 (row_num 0,1,2).
-        buf.push(rec(&schema, 30, 0), 0);
-        buf.push(rec(&schema, 10, 1), 1);
-        buf.push(rec(&schema, 20, 2), 2);
-        buf.sort_and_spill().unwrap();
-        // Run B: keys 2.0, 1.0 (row_num 3,4) — duplicates 2.0 and 1.0 from A.
-        buf.push(rec(&schema, 20, 3), 3);
-        buf.push(rec(&schema, 10, 4), 4);
-        buf.sort_and_spill().unwrap();
-        // Run C: keys 2.0, 4.0 (row_num 5,6) — duplicate 2.0 from A and B.
-        buf.push(rec(&schema, 20, 5), 5);
-        buf.push(rec(&schema, 40, 6), 6);
-        buf.sort_and_spill().unwrap();
-
-        let files = match buf.finish().unwrap().0 {
-            SortedOutput::Spilled(files) => {
-                assert_eq!(files.len(), 3, "three explicit flushes → three runs");
-                files
-            }
-            SortedOutput::InMemory(_) => panic!("expected Spilled after three flushes"),
-        };
-
-        let merged = merge_sorted_runs(files, &sort_by).unwrap();
-
-        // Every input record survives the merge exactly once.
-        assert_eq!(merged.len(), 7);
-
-        // Globally ordered on the Decimal key, ascending.
-        let keys: Vec<Decimal> = merged
-            .iter()
-            .map(|(r, _)| match r.get("k") {
-                Some(Value::Decimal(d)) => *d,
-                other => panic!("expected Decimal key, got {other:?}"),
-            })
-            .collect();
-        assert_eq!(
-            keys,
-            vec![
-                Decimal::new(10, 1),
-                Decimal::new(10, 1),
-                Decimal::new(20, 1),
-                Decimal::new(20, 1),
-                Decimal::new(20, 1),
-                Decimal::new(30, 1),
-                Decimal::new(40, 1),
-            ],
-            "runs must merge into ascending Decimal order"
-        );
-
-        // Stable: for equal keys, records emit in input order (run 0 earliest,
-        // then input order within a run). The carried row_num payload proves it
-        // and that no record picked up another's payload through the merge.
-        let row_nums: Vec<u64> = merged.iter().map(|(_, rn)| *rn).collect();
-        assert_eq!(
-            row_nums,
-            vec![1, 4, 2, 3, 5, 0, 6],
-            "equal keys must emit in input order and carry their own row_num"
-        );
-
-        // The payload identity matches the record's `id` column for every row,
-        // confirming the pairing survived both the spill envelope and the merge.
-        for (record, row_num) in &merged {
-            assert_eq!(record.get("id"), Some(&Value::Integer(*row_num as i64)));
-        }
     }
 
     /// The enforcer sort must abort the spill instead of writing past

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -113,7 +113,7 @@ pub(crate) fn dispatch_sort(
     // merge.
     let out: Vec<(Record, u64)> = match sorted {
         SortedOutput::InMemory(pairs) => pairs,
-        SortedOutput::Spilled(files) => merge_sorted_runs(files, sort_fields)?,
+        SortedOutput::Spilled(files) => merge_sorted_runs(files, sort_fields, "sort enforcer")?,
     };
     ctx.collector
         .record(sort_timer.finish(sort_count, sort_count));

--- a/crates/clinker-exec/src/pipeline/loser_tree.rs
+++ b/crates/clinker-exec/src/pipeline/loser_tree.rs
@@ -83,6 +83,22 @@ impl<T: Ord> LoserTree<T> {
         self.update_loser_tree();
     }
 
+    /// Like [`replace_winner`](Self::replace_winner), but returns the outgoing
+    /// winner entry by value instead of dropping it. Lets a merge move the
+    /// winning `(record, payload)` out of the tree rather than cloning it —
+    /// the tree exposes only `&T` through [`winner`](Self::winner), so a
+    /// caller that needs the owned entry would otherwise pay a clone.
+    /// Returns `None` when all streams are already exhausted.
+    pub fn take_winner(&mut self, entry: Option<T>) -> Option<T> {
+        if self.cursors.is_empty() {
+            return None;
+        }
+        let winner_idx = self.tree[0];
+        let old = std::mem::replace(&mut self.cursors[winner_idx], entry);
+        self.update_loser_tree();
+        old
+    }
+
     fn init_loser_tree(&mut self) {
         if self.cursors.is_empty() {
             return;
@@ -244,6 +260,47 @@ mod tests {
         assert_eq!(lt.winner().unwrap().key, vec![43]);
         lt.replace_winner(None);
         assert!(lt.winner().is_none());
+    }
+
+    #[test]
+    fn test_loser_tree_take_winner_moves_entry_out() {
+        // take_winner returns the outgoing winner by value and advances the
+        // tree identically to replace_winner.
+        let mut lt = LoserTree::new(vec![entry(1), entry(2), entry(3)]);
+        let out = lt.take_winner(entry(4)).expect("winner present");
+        assert_eq!(out.key, vec![1]); // moved-out old winner
+        assert_eq!(
+            out.record.get("v"),
+            Some(&clinker_record::Value::Integer(1))
+        );
+        // Stream 0 now holds 4; the new winner is stream 1 (key 2).
+        assert_eq!(lt.winner().unwrap().key, vec![2]);
+        assert_eq!(lt.winner_index(), 1);
+    }
+
+    #[test]
+    fn test_loser_tree_take_winner_full_drain() {
+        // Draining via take_winner yields every entry in merge order.
+        let mut lt = LoserTree::new(vec![entry(1), entry(2), entry(3)]);
+        let streams: Vec<Vec<u8>> = vec![vec![4, 7], vec![5, 8], vec![6, 9]];
+        let mut iters: Vec<std::vec::IntoIter<u8>> =
+            streams.into_iter().map(|s| s.into_iter()).collect();
+        let mut result = Vec::new();
+        while lt.winner().is_some() {
+            let idx = lt.winner_index();
+            let next = iters[idx].next().map(|k| MergeEntry {
+                key: vec![k],
+                record: {
+                    use clinker_record::{Record, Schema, Value};
+                    use std::sync::Arc;
+                    let s = Arc::new(Schema::new(vec!["v".into()]));
+                    Record::new(s, vec![Value::Integer(k as i64)])
+                },
+            });
+            let winner = lt.take_winner(next).expect("winner present under guard");
+            result.push(winner.key[0]);
+        }
+        assert_eq!(result, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/loser_tree.rs
+++ b/crates/clinker-exec/src/pipeline/loser_tree.rs
@@ -41,7 +41,8 @@ impl Ord for MergeEntry {
 /// After initialization, `winner()` returns the smallest element.
 /// Call `replace_winner(next)` to advance: supply the next element
 /// from the winning stream (or `None` if exhausted), and the tree
-/// replays to find the new winner.
+/// replays to find the new winner. `take_winner(next)` advances the
+/// same way but returns the outgoing winner by value.
 pub struct LoserTree<T: Ord> {
     /// Internal nodes. `tree[0]` holds the overall winner index.
     /// `tree[1..k]` hold loser indices at each internal node.

--- a/crates/clinker-exec/src/pipeline/mod.rs
+++ b/crates/clinker-exec/src/pipeline/mod.rs
@@ -14,6 +14,7 @@ mod sort_integration;
 pub mod sort_key;
 pub mod sort_merge_join;
 pub mod spill;
+pub mod spill_merge;
 pub mod streaming_merge;
 pub mod sysstats;
 pub mod take;

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -55,6 +55,7 @@ use crate::pipeline::memory::MemoryArbitrator;
 #[cfg(test)]
 use crate::pipeline::memory::NoOpPolicy;
 use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
+use crate::pipeline::spill_merge::merge_sorted_runs;
 use clinker_plan::BudgetCategory;
 use clinker_plan::config::pipeline_node::{MatchMode, OnMiss};
 use clinker_plan::error::PipelineError;
@@ -937,45 +938,27 @@ fn sort_driver_pairs_externally(
             }
         }
         SortedOutput::Spilled(files) => {
-            // `buf.finish()` may have spilled the in-memory residue
-            // we last charged into `local_charged`. Those bytes are
-            // now off-process; the records flow back from disk into
-            // `pairs` below and re-charge per-record.
+            // `buf.finish()` spilled every record we last charged into
+            // `local_charged`; those bytes are now off-process. The
+            // records flow back from disk through the k-way merge below
+            // and re-charge per-record.
             consumer_handle.sub_bytes(local_charged);
-            // Single-file path is exact (the buffer sort is stable).
-            // Multi-file would need a k-way merge via `LoserTree`; the
-            // matching-run spill is independent and handled in Phase B,
-            // so a true k-way merge over Phase A spill files is the
-            // next-iteration improvement. Today we surface the limit
-            // explicitly so a future enlargement of the soft limit (or
-            // a user `memory.limit:` increase) lets the workload run.
-            if files.len() > 1 {
-                return Err(PipelineError::Io(std::io::Error::other(format!(
-                    "sort-merge driver phase A produced {} spill files; multi-file \
-                     k-way merge is wired but not yet enabled — increase the \
-                     pipeline `memory.limit:` so the sort fits in a single chunk",
-                    files.len()
-                ))));
-            }
-            for file in files {
-                let reader = file.reader().map_err(|e| {
-                    PipelineError::Io(std::io::Error::other(format!(
-                        "sort-merge driver phase A spill read failed: {e}"
-                    )))
-                })?;
-                for entry in reader {
-                    let (record, order) = entry.map_err(|e| {
-                        PipelineError::Io(std::io::Error::other(format!(
-                            "sort-merge driver phase A spill decode failed: {e}"
-                        )))
-                    })?;
-                    let key = record.get(field).cloned().unwrap_or(Value::Null);
-                    let bytes = std::mem::size_of::<Record>()
-                        + record.estimated_heap_size()
-                        + std::mem::size_of::<RecordOrder>();
-                    consumer_handle.add_bytes(bytes as u64);
-                    pairs.push((record, order, key));
-                }
+            // Fold the individually-sorted runs into one globally-ordered
+            // stream via the shared LoserTree k-way merge. `SortBuffer`
+            // already sorted each run on `field`, so the merge preserves
+            // that order across runs (a single run is an identity pass).
+            let merge_field = clinker_plan::config::SortField {
+                field: field.clone(),
+                order: clinker_plan::config::SortOrder::Asc,
+                null_order: None,
+            };
+            for (record, order) in merge_sorted_runs(files, std::slice::from_ref(&merge_field))? {
+                let key = record.get(field).cloned().unwrap_or(Value::Null);
+                let bytes = std::mem::size_of::<Record>()
+                    + record.estimated_heap_size()
+                    + std::mem::size_of::<RecordOrder>();
+                consumer_handle.add_bytes(bytes as u64);
+                pairs.push((record, order, key));
             }
         }
     }
@@ -1072,31 +1055,19 @@ fn sort_build_pairs_externally(
         }
         SortedOutput::Spilled(files) => {
             consumer_handle.sub_bytes(local_charged);
-            if files.len() > 1 {
-                return Err(PipelineError::Io(std::io::Error::other(format!(
-                    "sort-merge build phase A produced {} spill files; multi-file \
-                     k-way merge is wired but not yet enabled — increase the \
-                     pipeline `memory.limit:` so the sort fits in a single chunk",
-                    files.len()
-                ))));
-            }
-            for file in files {
-                let reader = file.reader().map_err(|e| {
-                    PipelineError::Io(std::io::Error::other(format!(
-                        "sort-merge build phase A spill read failed: {e}"
-                    )))
-                })?;
-                for entry in reader {
-                    let (record, _) = entry.map_err(|e| {
-                        PipelineError::Io(std::io::Error::other(format!(
-                            "sort-merge build phase A spill decode failed: {e}"
-                        )))
-                    })?;
-                    let key = record.get(field).cloned().unwrap_or(Value::Null);
-                    let bytes = std::mem::size_of::<Record>() + record.estimated_heap_size();
-                    consumer_handle.add_bytes(bytes as u64);
-                    pairs.push((record, key));
-                }
+            // Fold the individually-sorted runs into one globally-ordered
+            // stream via the shared LoserTree k-way merge (single-run input
+            // is an identity pass). The build side carries a unit payload.
+            let merge_field = clinker_plan::config::SortField {
+                field: field.clone(),
+                order: clinker_plan::config::SortOrder::Asc,
+                null_order: None,
+            };
+            for (record, _) in merge_sorted_runs(files, std::slice::from_ref(&merge_field))? {
+                let key = record.get(field).cloned().unwrap_or(Value::Null);
+                let bytes = std::mem::size_of::<Record>() + record.estimated_heap_size();
+                consumer_handle.add_bytes(bytes as u64);
+                pairs.push((record, key));
             }
         }
     }
@@ -2104,6 +2075,132 @@ mod tests {
             small_stats.matching_run_spills, 0,
             "small-build run must not spill"
         );
+    }
+
+    /// Phase A external sort spilling to MULTIPLE runs per side must k-way
+    /// merge them into one globally-ordered stream — the join result is
+    /// identical to the same inputs sorted entirely in memory, and matches a
+    /// brute-force oracle. Before the multi-file merge was wired, a >1-run
+    /// Phase A spill returned a hard error ("multi-file k-way merge is wired
+    /// but not yet enabled"); this drives the completed merge end-to-end.
+    #[test]
+    fn test_sort_merge_phase_a_multi_file_spill() {
+        let drivers_schema = schema_with(&["k", "pad"]);
+        let builds_schema = schema_with(&["k", "pad"]);
+        // ~1.2 KiB pad per row inflates each side well past the Phase A spill
+        // threshold at the 128 KiB budget (soft_limit / 2 ≈ 51 KiB), forcing
+        // several sorted runs per side and thus the k-way merge. The match set
+        // is kept tiny (only the low-key drivers beat the high-key builds) so
+        // the O(N·M) output stays under the same budget's output guard — this
+        // test targets the input axis, not the output axis.
+        let pad = "x".repeat(1200);
+        let n = 100i64;
+        // First `matching_lo` drivers have a low key that beats the builds;
+        // the rest have a key no build can exceed. Symmetrically only the first
+        // `matching_hi` builds carry a key the low drivers beat.
+        let matching_lo = 4i64;
+        let matching_hi = 4i64;
+        let driver_keys: Vec<i64> = (0..n)
+            .map(|i| if i < matching_lo { 0 } else { 1_000_000 })
+            .collect();
+        let build_keys: Vec<i64> = (0..n)
+            .map(|j| if j < matching_hi { 10 } else { -1_000_000 })
+            .collect();
+
+        let make_inputs = || {
+            let driver: Vec<(Record, RecordOrder)> = driver_keys
+                .iter()
+                .enumerate()
+                .map(|(i, &k)| {
+                    (
+                        rec(
+                            &drivers_schema,
+                            vec![Value::Integer(k), Value::String(pad.clone().into())],
+                        ),
+                        i as RecordOrder,
+                    )
+                })
+                .collect();
+            let build: Vec<Record> = build_keys
+                .iter()
+                .map(|&k| {
+                    rec(
+                        &builds_schema,
+                        vec![Value::Integer(k), Value::String(pad.clone().into())],
+                    )
+                })
+                .collect();
+            (driver, build)
+        };
+
+        // Brute-force oracle for `drivers.k < builds.k`: each satisfying build
+        // emits one row tagged with the driver's original order.
+        let mut oracle_orders: Vec<RecordOrder> = Vec::new();
+        for (i, &dk) in driver_keys.iter().enumerate() {
+            let matches = build_keys.iter().filter(|&&bk| dk < bk).count();
+            oracle_orders.extend(std::iter::repeat_n(i as RecordOrder, matches));
+        }
+        oracle_orders.sort_unstable();
+        assert_eq!(
+            oracle_orders.len(),
+            (matching_lo * matching_hi) as usize,
+            "oracle match count is the low-driver × high-build product"
+        );
+
+        let compile = || {
+            let typed = compile_pure_range(
+                "filter drivers.k < builds.k",
+                &[
+                    ("drivers", "k", cxl::typecheck::Type::Int),
+                    ("builds", "k", cxl::typecheck::Type::Int),
+                ],
+            );
+            let rc = extract_range_conjunct(&typed, "drivers", "builds");
+            decomposed_pure_range(rc, Arc::clone(&typed))
+        };
+
+        let run = |budget_bytes: Option<u64>| {
+            let (driver, build) = make_inputs();
+            run_kernel(RunKernel {
+                driver_records: driver,
+                build_records: build,
+                decomposed: compile(),
+                driver_qual: "drivers",
+                build_qual: "builds",
+                driver_schema: &drivers_schema,
+                build_schema: &builds_schema,
+                match_mode: MatchMode::All,
+                on_miss: OnMiss::Skip,
+                presorted: false,
+                body_program: None,
+                budget_bytes,
+            })
+        };
+
+        // Constrained budget → Phase A spills several runs per side and k-way
+        // merges them; the small match set keeps the output under the guard.
+        let (spilled_records, spilled_stats) = run(Some(128 * 1024));
+        // Default (large) budget → Phase A sorts entirely in memory.
+        let (in_mem_records, in_mem_stats) = run(None);
+
+        // Phase A external sort ran on both (not the presorted skip).
+        assert_eq!(spilled_stats.phase_a_sort_invocations, 2);
+        assert_eq!(in_mem_stats.phase_a_sort_invocations, 2);
+
+        // Same match count as the oracle, both ways.
+        assert_eq!(spilled_records.len(), oracle_orders.len());
+        assert_eq!(in_mem_records.len(), oracle_orders.len());
+
+        // The multiset of emitted driver-order tags matches the oracle exactly,
+        // so the multi-run merge admitted precisely the same pairs the
+        // in-memory sort did.
+        let mut spilled_orders: Vec<RecordOrder> =
+            spilled_records.iter().map(|(_, o)| *o).collect();
+        spilled_orders.sort_unstable();
+        let mut in_mem_orders: Vec<RecordOrder> = in_mem_records.iter().map(|(_, o)| *o).collect();
+        in_mem_orders.sort_unstable();
+        assert_eq!(spilled_orders, oracle_orders);
+        assert_eq!(in_mem_orders, oracle_orders);
     }
 
     /// Pre-sorted inputs skip Phase A external sort. Verified by

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -55,7 +55,7 @@ use crate::pipeline::memory::MemoryArbitrator;
 #[cfg(test)]
 use crate::pipeline::memory::NoOpPolicy;
 use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
-use crate::pipeline::spill_merge::merge_sorted_runs;
+use crate::pipeline::spill_merge::SortedRunMerger;
 use clinker_plan::BudgetCategory;
 use clinker_plan::config::pipeline_node::{MatchMode, OnMiss};
 use clinker_plan::error::PipelineError;
@@ -939,20 +939,31 @@ fn sort_driver_pairs_externally(
         }
         SortedOutput::Spilled(files) => {
             // `buf.finish()` spilled every record we last charged into
-            // `local_charged`; those bytes are now off-process. The
-            // records flow back from disk through the k-way merge below
-            // and re-charge per-record.
+            // `local_charged`; those bytes are now off-process. Stream the
+            // records back through the k-way merge below and re-charge each as
+            // it lands, so the arbitrator tracks this side's residence as it
+            // grows rather than in one late jump.
             consumer_handle.sub_bytes(local_charged);
             // Fold the individually-sorted runs into one globally-ordered
-            // stream via the shared LoserTree k-way merge. `SortBuffer`
-            // already sorted each run on `field`, so the merge preserves
-            // that order across runs (a single run is an identity pass).
+            // stream via the shared LoserTree k-way merge, draining it record
+            // by record. `SortBuffer` already sorted each run on `field`, so the
+            // merge preserves that order across runs (a single run is an
+            // identity pass). Phase B walks `driver_pairs` as a fully-resident
+            // slice, so the merged side lands entirely in memory here; the
+            // per-record charge keeps the arbitrator's accounting accurate as
+            // it does.
             let merge_field = clinker_plan::config::SortField {
                 field: field.clone(),
                 order: clinker_plan::config::SortOrder::Asc,
                 null_order: None,
             };
-            for (record, order) in merge_sorted_runs(files, std::slice::from_ref(&merge_field))? {
+            let merger = SortedRunMerger::new(
+                files,
+                std::slice::from_ref(&merge_field),
+                "sort-merge driver phase A",
+            )?;
+            for entry in merger {
+                let (record, order) = entry?;
                 let key = record.get(field).cloned().unwrap_or(Value::Null);
                 let bytes = std::mem::size_of::<Record>()
                     + record.estimated_heap_size()
@@ -1056,14 +1067,23 @@ fn sort_build_pairs_externally(
         SortedOutput::Spilled(files) => {
             consumer_handle.sub_bytes(local_charged);
             // Fold the individually-sorted runs into one globally-ordered
-            // stream via the shared LoserTree k-way merge (single-run input
-            // is an identity pass). The build side carries a unit payload.
+            // stream via the shared LoserTree k-way merge, draining it record
+            // by record (single-run input is an identity pass). The build side
+            // carries a unit payload. As on the driver side, Phase B walks the
+            // full `build_pairs` slice, so the merged side is held resident and
+            // charged per record as it lands.
             let merge_field = clinker_plan::config::SortField {
                 field: field.clone(),
                 order: clinker_plan::config::SortOrder::Asc,
                 null_order: None,
             };
-            for (record, _) in merge_sorted_runs(files, std::slice::from_ref(&merge_field))? {
+            let merger = SortedRunMerger::new(
+                files,
+                std::slice::from_ref(&merge_field),
+                "sort-merge build phase A",
+            )?;
+            for entry in merger {
+                let (record, _) = entry?;
                 let key = record.get(field).cloned().unwrap_or(Value::Null);
                 let bytes = std::mem::size_of::<Record>() + record.estimated_heap_size();
                 consumer_handle.add_bytes(bytes as u64);

--- a/crates/clinker-exec/src/pipeline/spill_merge.rs
+++ b/crates/clinker-exec/src/pipeline/spill_merge.rs
@@ -67,10 +67,12 @@ impl<P> Ord for Run<P> {
 }
 
 /// Pull the next `(record, payload)` from one spilled run, wrapping it as a
-/// [`Run`] merge entry, or `None` at end of stream.
+/// [`Run`] merge entry, or `None` at end of stream. `context` names the
+/// calling operator/phase so a decode failure localizes to the right node.
 fn next_run<P: DeserializeOwned>(
     reader: &mut SpillReader<P>,
     sort_by: &Arc<[SortField]>,
+    context: &'static str,
 ) -> Result<Option<Run<P>>, PipelineError> {
     match reader.next() {
         None => Ok(None),
@@ -80,7 +82,7 @@ fn next_run<P: DeserializeOwned>(
             payload,
         })),
         Some(Err(e)) => Err(PipelineError::Io(std::io::Error::other(format!(
-            "spill run decode failed during k-way merge: {e}"
+            "{context}: spill run decode failed during k-way merge: {e}"
         )))),
     }
 }
@@ -97,17 +99,18 @@ fn next_run<P: DeserializeOwned>(
 /// stable per-run sort, and the loser tree breaks ties by lower stream index,
 /// so equal keys emit in input order.
 ///
-/// Module-private: the only current consumer is [`merge_sorted_runs`], which
-/// materializes the stream. The lazy form exists so a later caller can
-/// re-slice the merged run into bounded blocks; that caller widens the
-/// visibility when it lands.
-struct SortedRunMerger<P> {
+/// Callers that need the whole run at once use [`merge_sorted_runs`]; callers
+/// that can consume incrementally (draining straight into their own buffer, or
+/// re-slicing the merged run into bounded blocks) drive this iterator directly.
+pub(crate) struct SortedRunMerger<P> {
     /// Held only to keep the backing temp files alive across iteration; the
     /// readers below own independent file handles, not borrows of these.
     _files: Vec<SpillFile<P>>,
     readers: Vec<SpillReader<P>>,
     tree: LoserTree<Run<P>>,
     sort_by: Arc<[SortField]>,
+    /// Names the calling operator/phase for decode-error messages.
+    context: &'static str,
     /// Latches once a decode error has been surfaced so `next` stops rather
     /// than re-polling an already-failed reader.
     done: bool,
@@ -115,9 +118,14 @@ struct SortedRunMerger<P> {
 
 impl<P: DeserializeOwned> SortedRunMerger<P> {
     /// Open a reader over every run and seed the loser tree with one record
-    /// per run. Returns an I/O error if any run fails to open or its first
-    /// record fails to decode.
-    fn new(files: Vec<SpillFile<P>>, sort_by: &[SortField]) -> Result<Self, PipelineError> {
+    /// per run. `context` names the calling operator/phase so a spill open or
+    /// decode failure localizes to the right node. Returns an I/O error if any
+    /// run fails to open or its first record fails to decode.
+    pub(crate) fn new(
+        files: Vec<SpillFile<P>>,
+        sort_by: &[SortField],
+        context: &'static str,
+    ) -> Result<Self, PipelineError> {
         let sort_by: Arc<[SortField]> = Arc::from(sort_by.to_vec());
         let mut readers: Vec<SpillReader<P>> = files
             .iter()
@@ -125,13 +133,13 @@ impl<P: DeserializeOwned> SortedRunMerger<P> {
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| {
                 PipelineError::Io(std::io::Error::other(format!(
-                    "spill run open failed during k-way merge: {e}"
+                    "{context}: spill run open failed during k-way merge: {e}"
                 )))
             })?;
 
         let mut initial: Vec<Option<Run<P>>> = Vec::with_capacity(readers.len());
         for reader in &mut readers {
-            initial.push(next_run(reader, &sort_by)?);
+            initial.push(next_run(reader, &sort_by, context)?);
         }
         let tree = LoserTree::new(initial);
 
@@ -140,6 +148,7 @@ impl<P: DeserializeOwned> SortedRunMerger<P> {
             readers,
             tree,
             sort_by,
+            context,
             done: false,
         })
     }
@@ -160,7 +169,7 @@ impl<P: DeserializeOwned> Iterator for SortedRunMerger<P> {
         // winner's successor. A decode error aborts the whole merge — the
         // partial output the caller has collected is discarded when it
         // propagates the `Err`.
-        let refill = match next_run(&mut self.readers[idx], &self.sort_by) {
+        let refill = match next_run(&mut self.readers[idx], &self.sort_by, self.context) {
             Ok(next) => next,
             Err(e) => {
                 self.done = true;
@@ -177,15 +186,17 @@ impl<P: DeserializeOwned> Iterator for SortedRunMerger<P> {
 
 /// K-way merge the individually-sorted spill runs into one globally-ordered
 /// `Vec`, preserving each record's payload. Convenience wrapper over
-/// [`SortedRunMerger`] for callers that need the full run materialized.
+/// [`SortedRunMerger`] for callers that need the full run materialized;
+/// `context` names the calling operator for spill-error messages.
 ///
 /// Memory model: holds one resident record per open run plus the fully
 /// materialized output.
 pub(crate) fn merge_sorted_runs<P: DeserializeOwned>(
     files: Vec<SpillFile<P>>,
     sort_by: &[SortField],
+    context: &'static str,
 ) -> Result<Vec<(Record, P)>, PipelineError> {
-    SortedRunMerger::new(files, sort_by)?.collect()
+    SortedRunMerger::new(files, sort_by, context)?.collect()
 }
 
 #[cfg(test)]
@@ -258,7 +269,7 @@ mod tests {
             SortedOutput::InMemory(_) => panic!("expected Spilled after three flushes"),
         };
 
-        let merged = merge_sorted_runs(files, &sort_by).unwrap();
+        let merged = merge_sorted_runs(files, &sort_by, "test").unwrap();
 
         // Every input record survives the merge exactly once.
         assert_eq!(merged.len(), 7);
@@ -319,7 +330,7 @@ mod tests {
             SortedOutput::InMemory(_) => panic!("expected Spilled"),
         };
         assert!(files.len() > 1, "expected multiple runs");
-        let merged = merge_sorted_runs(files, &sort_by).unwrap();
+        let merged = merge_sorted_runs(files, &sort_by, "test").unwrap();
         let keys: Vec<Decimal> = merged
             .iter()
             .map(|(r, _)| match r.get("k") {
@@ -356,7 +367,7 @@ mod tests {
             SortedOutput::InMemory(_) => panic!("expected Spilled"),
         };
         assert_eq!(files.len(), 1);
-        let merged = merge_sorted_runs(files, &sort_by).unwrap();
+        let merged = merge_sorted_runs(files, &sort_by, "test").unwrap();
         assert_eq!(merged.len(), 2);
         assert_eq!(
             merged[0].0.get("k"),
@@ -384,7 +395,7 @@ mod tests {
             SortedOutput::Spilled(files) => files,
             SortedOutput::InMemory(_) => panic!("expected Spilled"),
         };
-        let merger = SortedRunMerger::new(files, &sort_by).unwrap();
+        let merger = SortedRunMerger::new(files, &sort_by, "test").unwrap();
         let collected: Vec<(Record, u64)> = merger.map(|r| r.unwrap()).collect();
         let keys: Vec<Decimal> = collected
             .iter()

--- a/crates/clinker-exec/src/pipeline/spill_merge.rs
+++ b/crates/clinker-exec/src/pipeline/spill_merge.rs
@@ -1,0 +1,405 @@
+//! K-way merge over individually-sorted spill runs.
+//!
+//! [`SortBuffer`](crate::pipeline::sort_buffer::SortBuffer) flushes its
+//! overflow as a sequence of internally-sorted spill runs; folding them back
+//! into one globally-ordered stream is a k-way merge. This module owns the
+//! single production implementation, shared by every operator that
+//! external-sorts through `SortBuffer` and then has to merge the resulting
+//! runs — the `Sort` DAG node and the sort-merge combine's Phase A external
+//! sort.
+//!
+//! Ordering is by [`compare_records_by_fields`] — the exact field comparator
+//! `SortBuffer` formed each run with — so the merged order is byte-identical to
+//! the single in-memory sort the buffer would have produced without spilling.
+//! The memcomparable byte key on
+//! [`crate::pipeline::loser_tree::MergeEntry`] is deliberately not used here:
+//! it is not provably equal to the field comparator across Integer/Decimal or
+//! mixed int/float ordering, so merging on it could silently mis-order
+//! cross-type keys.
+//!
+//! Memory model: streaming — one resident record per open run. [`SortedRunMerger`]
+//! yields records lazily so a caller can re-slice the merged stream (e.g. into
+//! contiguous blocks) without materializing it; [`merge_sorted_runs`] is the
+//! materializing convenience wrapper for callers that need the whole run in a
+//! `Vec`.
+
+use std::cmp::Ordering;
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+
+use clinker_record::Record;
+
+use crate::pipeline::loser_tree::LoserTree;
+use crate::pipeline::sort::compare_records_by_fields;
+use crate::pipeline::spill::{SpillFile, SpillReader};
+use clinker_plan::config::SortField;
+use clinker_plan::error::PipelineError;
+
+/// One entry in the k-way merge: a spilled record and the payload `P` carried
+/// through the sort permutation. `Ord` delegates to
+/// [`compare_records_by_fields`] against the shared `sort_by`, so the merged
+/// order matches every run's internal sort exactly.
+struct Run<P> {
+    sort_by: Arc<[SortField]>,
+    record: Record,
+    payload: P,
+}
+
+impl<P> PartialEq for Run<P> {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl<P> Eq for Run<P> {}
+
+impl<P> PartialOrd for Run<P> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<P> Ord for Run<P> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        compare_records_by_fields(&self.record, &other.record, &self.sort_by)
+    }
+}
+
+/// Pull the next `(record, payload)` from one spilled run, wrapping it as a
+/// [`Run`] merge entry, or `None` at end of stream.
+fn next_run<P: DeserializeOwned>(
+    reader: &mut SpillReader<P>,
+    sort_by: &Arc<[SortField]>,
+) -> Result<Option<Run<P>>, PipelineError> {
+    match reader.next() {
+        None => Ok(None),
+        Some(Ok((record, payload))) => Ok(Some(Run {
+            sort_by: Arc::clone(sort_by),
+            record,
+            payload,
+        })),
+        Some(Err(e)) => Err(PipelineError::Io(std::io::Error::other(format!(
+            "spill run decode failed during k-way merge: {e}"
+        )))),
+    }
+}
+
+/// Streaming k-way merge over individually-sorted spill runs.
+///
+/// Yields `(record, payload)` pairs in global sort order, one resident record
+/// per open run. Owns the `SpillFile`s for the merge's lifetime: each
+/// `SpillReader` opens its own file handle, but the underlying temp file is
+/// deleted when its `SpillFile` (a `tempfile::TempPath`) drops, so the files
+/// must outlive iteration.
+///
+/// Stable: `SortBuffer` spills runs in input order (run 0 earliest) with a
+/// stable per-run sort, and the loser tree breaks ties by lower stream index,
+/// so equal keys emit in input order.
+///
+/// Module-private: the only current consumer is [`merge_sorted_runs`], which
+/// materializes the stream. The lazy form exists so a later caller can
+/// re-slice the merged run into bounded blocks; that caller widens the
+/// visibility when it lands.
+struct SortedRunMerger<P> {
+    /// Held only to keep the backing temp files alive across iteration; the
+    /// readers below own independent file handles, not borrows of these.
+    _files: Vec<SpillFile<P>>,
+    readers: Vec<SpillReader<P>>,
+    tree: LoserTree<Run<P>>,
+    sort_by: Arc<[SortField]>,
+    /// Latches once a decode error has been surfaced so `next` stops rather
+    /// than re-polling an already-failed reader.
+    done: bool,
+}
+
+impl<P: DeserializeOwned> SortedRunMerger<P> {
+    /// Open a reader over every run and seed the loser tree with one record
+    /// per run. Returns an I/O error if any run fails to open or its first
+    /// record fails to decode.
+    fn new(files: Vec<SpillFile<P>>, sort_by: &[SortField]) -> Result<Self, PipelineError> {
+        let sort_by: Arc<[SortField]> = Arc::from(sort_by.to_vec());
+        let mut readers: Vec<SpillReader<P>> = files
+            .iter()
+            .map(|f| f.reader())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| {
+                PipelineError::Io(std::io::Error::other(format!(
+                    "spill run open failed during k-way merge: {e}"
+                )))
+            })?;
+
+        let mut initial: Vec<Option<Run<P>>> = Vec::with_capacity(readers.len());
+        for reader in &mut readers {
+            initial.push(next_run(reader, &sort_by)?);
+        }
+        let tree = LoserTree::new(initial);
+
+        Ok(Self {
+            _files: files,
+            readers,
+            tree,
+            sort_by,
+            done: false,
+        })
+    }
+}
+
+impl<P: DeserializeOwned> Iterator for SortedRunMerger<P> {
+    type Item = Result<(Record, P), PipelineError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        // All runs exhausted → merge complete.
+        self.tree.winner()?;
+        let idx = self.tree.winner_index();
+        // Refill the winning run before extracting the current winner: the
+        // reader position is independent of the tree cursor, so this reads the
+        // winner's successor. A decode error aborts the whole merge — the
+        // partial output the caller has collected is discarded when it
+        // propagates the `Err`.
+        let refill = match next_run(&mut self.readers[idx], &self.sort_by) {
+            Ok(next) => next,
+            Err(e) => {
+                self.done = true;
+                return Some(Err(e));
+            }
+        };
+        let winner = self
+            .tree
+            .take_winner(refill)
+            .expect("winner present under the winner() guard above");
+        Some(Ok((winner.record, winner.payload)))
+    }
+}
+
+/// K-way merge the individually-sorted spill runs into one globally-ordered
+/// `Vec`, preserving each record's payload. Convenience wrapper over
+/// [`SortedRunMerger`] for callers that need the full run materialized.
+///
+/// Memory model: holds one resident record per open run plus the fully
+/// materialized output.
+pub(crate) fn merge_sorted_runs<P: DeserializeOwned>(
+    files: Vec<SpillFile<P>>,
+    sort_by: &[SortField],
+) -> Result<Vec<(Record, P)>, PipelineError> {
+    SortedRunMerger::new(files, sort_by)?.collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
+    use clinker_plan::config::SortOrder;
+    use clinker_record::{Schema, Value};
+    use rust_decimal::Decimal;
+
+    fn schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec!["k".into(), "id".into()]))
+    }
+
+    /// A record whose sort key `k` is a `Decimal` (mantissa/10) and whose
+    /// `id` mirrors the carried payload for readback.
+    fn rec(schema: &Arc<Schema>, k_mantissa: i64, id: i64) -> Record {
+        Record::new(
+            schema.clone(),
+            vec![
+                Value::Decimal(Decimal::new(k_mantissa, 1)),
+                Value::Integer(id),
+            ],
+        )
+    }
+
+    fn sort_by_k_asc() -> Vec<SortField> {
+        vec![SortField {
+            field: "k".into(),
+            order: SortOrder::Asc,
+            null_order: None,
+        }]
+    }
+
+    /// Multiple individually-sorted spill runs — with a `Decimal` sort key,
+    /// duplicate keys spanning different runs, and unsorted input within each
+    /// run — must k-way merge into one globally-ordered run that preserves
+    /// every record's payload and emits equal keys in input order (stable).
+    /// This is the correctness the enforcer sort and the sort-merge Phase A
+    /// external sort lost when they rejected multi-run spills instead of
+    /// merging them.
+    #[test]
+    fn merge_sorted_runs_globally_orders_stably_and_preserves_payload() {
+        let schema = schema();
+        let sort_by = sort_by_k_asc();
+        // budget=1 is the spill-everything threshold; runs are flushed
+        // explicitly below so each carries several unsorted records.
+        let mut buf: SortBuffer<u64> =
+            SortBuffer::new(sort_by.clone(), 1, None, true, schema.clone());
+
+        // Run A: keys 3.0, 1.0, 2.0 (payload 0,1,2).
+        buf.push(rec(&schema, 30, 0), 0);
+        buf.push(rec(&schema, 10, 1), 1);
+        buf.push(rec(&schema, 20, 2), 2);
+        buf.sort_and_spill().unwrap();
+        // Run B: keys 2.0, 1.0 (payload 3,4) — duplicates 2.0 and 1.0 from A.
+        buf.push(rec(&schema, 20, 3), 3);
+        buf.push(rec(&schema, 10, 4), 4);
+        buf.sort_and_spill().unwrap();
+        // Run C: keys 2.0, 4.0 (payload 5,6) — duplicate 2.0 from A and B.
+        buf.push(rec(&schema, 20, 5), 5);
+        buf.push(rec(&schema, 40, 6), 6);
+        buf.sort_and_spill().unwrap();
+
+        let files = match buf.finish().unwrap().0 {
+            SortedOutput::Spilled(files) => {
+                assert_eq!(files.len(), 3, "three explicit flushes → three runs");
+                files
+            }
+            SortedOutput::InMemory(_) => panic!("expected Spilled after three flushes"),
+        };
+
+        let merged = merge_sorted_runs(files, &sort_by).unwrap();
+
+        // Every input record survives the merge exactly once.
+        assert_eq!(merged.len(), 7);
+
+        // Globally ordered on the Decimal key, ascending.
+        let keys: Vec<Decimal> = merged
+            .iter()
+            .map(|(r, _)| match r.get("k") {
+                Some(Value::Decimal(d)) => *d,
+                other => panic!("expected Decimal key, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                Decimal::new(10, 1),
+                Decimal::new(10, 1),
+                Decimal::new(20, 1),
+                Decimal::new(20, 1),
+                Decimal::new(20, 1),
+                Decimal::new(30, 1),
+                Decimal::new(40, 1),
+            ],
+        );
+
+        // Stable: for equal keys, records emit in input order (run 0 earliest,
+        // then input order within a run). The carried payload proves it and
+        // that no record picked up another's payload through the merge.
+        let payloads: Vec<u64> = merged.iter().map(|(_, p)| *p).collect();
+        assert_eq!(
+            payloads,
+            vec![1, 4, 2, 3, 5, 0, 6],
+            "equal keys must emit in input order and carry their own payload"
+        );
+
+        // The payload identity matches the record's `id` column for every row,
+        // confirming the pairing survived both the spill envelope and the merge.
+        for (record, payload) in &merged {
+            assert_eq!(record.get("id"), Some(&Value::Integer(*payload as i64)));
+        }
+    }
+
+    /// The unit `()` payload (the sort-merge build side carries no order tag)
+    /// round-trips through a multi-run merge.
+    #[test]
+    fn merge_sorted_runs_unit_payload_orders_globally() {
+        let schema = schema();
+        let sort_by = sort_by_k_asc();
+        let mut buf: SortBuffer<()> =
+            SortBuffer::new(sort_by.clone(), 1, None, true, schema.clone());
+        // Interleaved keys across four explicit runs.
+        for (i, k) in [50, 10, 40, 20, 30, 0].into_iter().enumerate() {
+            buf.push(rec(&schema, k, i as i64), ());
+            buf.sort_and_spill().unwrap();
+        }
+        let files = match buf.finish().unwrap().0 {
+            SortedOutput::Spilled(files) => files,
+            SortedOutput::InMemory(_) => panic!("expected Spilled"),
+        };
+        assert!(files.len() > 1, "expected multiple runs");
+        let merged = merge_sorted_runs(files, &sort_by).unwrap();
+        let keys: Vec<Decimal> = merged
+            .iter()
+            .map(|(r, _)| match r.get("k") {
+                Some(Value::Decimal(d)) => *d,
+                other => panic!("expected Decimal, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                Decimal::new(0, 1),
+                Decimal::new(10, 1),
+                Decimal::new(20, 1),
+                Decimal::new(30, 1),
+                Decimal::new(40, 1),
+                Decimal::new(50, 1),
+            ],
+        );
+    }
+
+    /// A single run is already globally ordered; the merger is an identity
+    /// pass over it (k=1).
+    #[test]
+    fn merge_sorted_runs_single_run_is_identity() {
+        let schema = schema();
+        let sort_by = sort_by_k_asc();
+        let mut buf: SortBuffer<u64> =
+            SortBuffer::new(sort_by.clone(), 1_000_000, None, true, schema.clone());
+        buf.push(rec(&schema, 30, 0), 0);
+        buf.push(rec(&schema, 10, 1), 1);
+        buf.sort_and_spill().unwrap(); // force a single explicit run
+        let files = match buf.finish().unwrap().0 {
+            SortedOutput::Spilled(files) => files,
+            SortedOutput::InMemory(_) => panic!("expected Spilled"),
+        };
+        assert_eq!(files.len(), 1);
+        let merged = merge_sorted_runs(files, &sort_by).unwrap();
+        assert_eq!(merged.len(), 2);
+        assert_eq!(
+            merged[0].0.get("k"),
+            Some(&Value::Decimal(Decimal::new(10, 1)))
+        );
+        assert_eq!(
+            merged[1].0.get("k"),
+            Some(&Value::Decimal(Decimal::new(30, 1)))
+        );
+    }
+
+    /// The streaming iterator yields the same global order as the
+    /// materializing wrapper, one record at a time.
+    #[test]
+    fn sorted_run_merger_streams_in_order() {
+        let schema = schema();
+        let sort_by = sort_by_k_asc();
+        let mut buf: SortBuffer<u64> =
+            SortBuffer::new(sort_by.clone(), 1, None, true, schema.clone());
+        for (i, k) in [30, 10, 20].into_iter().enumerate() {
+            buf.push(rec(&schema, k, i as i64), i as u64);
+            buf.sort_and_spill().unwrap();
+        }
+        let files = match buf.finish().unwrap().0 {
+            SortedOutput::Spilled(files) => files,
+            SortedOutput::InMemory(_) => panic!("expected Spilled"),
+        };
+        let merger = SortedRunMerger::new(files, &sort_by).unwrap();
+        let collected: Vec<(Record, u64)> = merger.map(|r| r.unwrap()).collect();
+        let keys: Vec<Decimal> = collected
+            .iter()
+            .map(|(r, _)| match r.get("k") {
+                Some(Value::Decimal(d)) => *d,
+                other => panic!("expected Decimal, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            keys,
+            vec![
+                Decimal::new(10, 1),
+                Decimal::new(20, 1),
+                Decimal::new(30, 1)
+            ],
+        );
+    }
+}


### PR DESCRIPTION
Closes #847. First split of #846 (bounded-memory IEJoin, input axis): the reusable multi-run merge substrate, plus a standalone fix to the sort-merge combine.

## Problem

The sort-merge combine externally sorts each side (Phase A) through the shared sort buffer, spilling sorted runs to disk when a side exceeds its memory budget. When a side overflowed into more than one run, Phase A aborted instead of merging them:

> sort-merge ... phase A produced N spill files; multi-file k-way merge is wired but not yet enabled — increase the pipeline `memory.limit:` so the sort fits in a single chunk

So a large pure-range join failed under a realistic memory budget, even though the loser-tree k-way merge it needed already existed (the Sort node and hash-aggregation spill both use one).

## Change

- **Merge the runs.** Fold the individually-sorted runs into one globally-ordered stream via a loser-tree k-way merge. Rather than add a second copy, hoist the Sort node's merge (previously hardcoded to a `u64` payload) into a new `pipeline::spill_merge` module generalized over the carried payload — the driver side carries its order tag, the build side carries no payload. `sort_dispatch` now calls the shared implementation; its private copy is deleted.
- **Order by the field comparator, not the byte key.** The merge orders records with the same `compare_records_by_fields` comparator each run was sorted with, not the memcomparable byte key. The two can disagree on `Decimal` and mixed int/float sort columns, so ordering by the comparator keeps the merge correct there.
- **Stream it.** The module exposes a streaming `SortedRunMerger` (one resident record per open run) plus a materializing wrapper. Phase A drains the streamer straight into its side buffer, charging the memory consumer per record as the side re-materializes and never holding a transient second full-length copy. The Sort node keeps the materializing wrapper.
- Spill open/decode failures carry a per-operator context label so they name the failing operator and phase. `LoserTree` gains a `take_winner` that moves the winning entry out of the tree instead of cloning it.

The sort-merge Phase A driver and build sides now merge multi-run spills; the single-run and fully-in-memory paths are unchanged.

## Tests

- Multi-run merge for both the unit and order-tag payloads, including duplicate keys spanning runs and stable equal-key ordering; single-run identity; the streaming iterator.
- A sort-merge join whose Phase A external sort spills several runs per side now completes and returns the same result as the fully in-memory sort and a brute-force oracle.

## Scope / limitations

- Streamed output (the O(N·M) result axis) and the contiguous-block band join remain in #846 as separate follow-ups.
- The sort-merge join's Phase B two-cursor walk holds each merged side resident, so a side larger than the budget is materialized in RAM — unchanged from the pre-existing single-run and in-memory paths, which already did this. Bounding that input residence (a streaming Phase B) is separate sort-merge-join work, tracked in #848.

## Validation

`cargo fmt --all --check`, `cargo clippy -p clinker-exec --all-targets -- -D warnings`, `cargo test -p clinker-exec` (all green), `git diff --check` — clean.
