### PR TITLE
docs(exec): reconcile node-buffer back-pressure comments to the by-design constant

### DIFF
--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1539,9 +1539,14 @@ pub(crate) fn admit_node_buffer(
     // arbitrator for every slot admission. The handle's `bytes`
     // counter seeds to the admitted byte estimate so the consumer's
     // current_usage immediately reflects the slot's footprint at
-    // policy-poll time. `can_back_pressure` is conservatively false
-    // until the static DAG analysis that classifies upstream pause
-    // reachability lands; the Priority policy then ranks node_buffer
+    // policy-poll time. `can_back_pressure` is a by-design constant
+    // false: the slot is materialized synchronously on this walk
+    // thread, so there is no separate producer thread to park, and
+    // spill is the only lever that relieves its memory — see
+    // `NodeBufferConsumer` for the full rationale. Streaming the
+    // inter-stage edges that stay materialized today (#301) is where a
+    // producer thread — and any pause-based back-pressure — would
+    // eventually come from. The Priority policy ranks node_buffer
     // consumers first among spill candidates (priority 0).
     //
     // A prior registration at the same slot (re-admit after partial

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1179,11 +1179,13 @@ impl PipelineExecutor {
             // producer arm `add_bytes` each flushed batch into this
             // handle; the writer thread holds a clone and `sub_bytes` each
             // consumed record, so the live count is "batches in flight,"
-            // never the whole stage. `can_back_pressure` is conservatively
-            // false: the bounded channel already paces the producer, and
-            // the static pause-reachability analysis that would let the
-            // arbitrator prefer pausing this slot over spilling has not
-            // landed — matching `admit_node_buffer`'s posture.
+            // never the whole stage. `can_back_pressure` is false here
+            // because the bounded channel already paces the producer at
+            // the transport layer, so an arbitrator pause of this slot
+            // would be redundant; relief is spilling the in-flight batches
+            // one at a time. Any pause-based inter-stage back-pressure
+            // would arrive with the streaming generalization tracked in
+            // #301. Matches `admit_node_buffer`'s posture.
             let charge_handle = crate::pipeline::memory::ConsumerHandle::new();
             let charge_consumer_id = memory_budget.register_consumer(Arc::new(
                 crate::executor::node_buffer::NodeBufferConsumer::new(charge_handle.clone()),

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -378,8 +378,8 @@ impl Default for PauseSignal {
 /// from the same thread that holds the operator's live state.
 ///
 /// `pause_signal` mirrors the `MemoryConsumer::pause` / `resume` signal
-/// for back-pressureable consumers (Sources, `node_buffers` slots that
-/// chain to a pauseable Source). Producer hot loops call
+/// for back-pressureable consumers — Sources, the only class the
+/// arbitrator pauses instead of spilling. Producer hot loops call
 /// `wait_while_paused()` at batch boundaries; the call blocks on a
 /// `Condvar` until the arbitrator's `resume` notifies. The fast path
 /// (not paused) is lock-free.
@@ -541,19 +541,22 @@ pub trait MemoryConsumer: Send + Sync {
     /// from a lock-free snapshot read rather than a mutable registry.
     fn try_spill(&self, target_bytes: u64) -> Result<u64, ConsumerSpillError>;
 
-    /// Whether the consumer can be paused at its inbound channel
-    /// instead of forced to spill. True for Sources and inter-stage
-    /// buffers fronted by a bounded channel; false for blocking
-    /// operators that have no upstream to gate.
+    /// Whether the arbitrator can pause the consumer's producer at its
+    /// inbound channel instead of forcing a spill. True for Sources,
+    /// whose ingest thread parks on the pause signal. A materialized
+    /// `node_buffers` slot returns false: it is filled synchronously by
+    /// the walk thread with no separate producer to park, so its only
+    /// relief is spill. The streaming handoff (a separate writer thread
+    /// behind a bounded channel) also returns false — that channel, not
+    /// an arbitrator pause, paces its producer at the transport layer.
     fn can_back_pressure(&self) -> bool;
 
     /// Pause the consumer's inbound channel. Default body is a no-op:
-    /// blocking operators that return `false` from `can_back_pressure`
-    /// inherit the default and do not need to override. Back-pressureable
-    /// consumers (Sources, `node_buffers` slots whose producer chains to
-    /// a pauseable Source) override with a real `PauseSignal::pause()`
-    /// call. Takes `&self` because the pause flag lives behind a shared
-    /// handle's atomic.
+    /// consumers that return `false` from `can_back_pressure` (blocking
+    /// operators and every materialized `node_buffers` slot) inherit the
+    /// default and do not need to override. Only Sources override with a
+    /// real `PauseSignal::pause()` call. Takes `&self` because the pause
+    /// flag lives behind a shared handle's atomic.
     fn pause(&self) {}
 
     /// Resume a previously paused consumer. Default body is a no-op,

--- a/crates/clinker-plan/src/plan/execution/explain.rs
+++ b/crates/clinker-plan/src/plan/execution/explain.rs
@@ -541,9 +541,10 @@ impl ExecutionPlanDag {
             // here is that index — stable and identical to the slot the
             // executor admits into. Every slot registers a
             // `NodeBufferConsumer` (priority 0, the cheapest spill victim);
-            // its `can_back_pressure` is the slot's own flag, today always
-            // false at the admit site, so the producer-variant suffix is
-            // informational context only — it does not flip the flag.
+            // its `can_back_pressure` is a constant `false` — a
+            // materialized node buffer has no pauseable producer — so the
+            // producer-variant suffix is informational context only; it
+            // does not flip the flag.
             let materialized_edges: Vec<(NodeIndex, NodeIndex)> = self
                 .topo_order
                 .iter()

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -1108,8 +1108,8 @@ pub(super) struct ArbitrationClass {
 /// to query. Keep the two in lock-step:
 ///
 /// - `node_buffers` slot — `executor::node_buffer::NodeBufferConsumer`
-///   (priority `0`; `can_back_pressure` is the slot's own flag, today
-///   always `false` at the admit site).
+///   (priority `0`; `can_back_pressure` is a constant `false` — a
+///   materialized node buffer has no pauseable producer).
 /// - Source ingest — `executor::source_stream::SourceConsumer`
 ///   (priority `i32::MAX`, back-pressureable; rendered `N/A` here).
 /// - hash Aggregate — `aggregation::AggregateConsumer` (priority `30`).


### PR DESCRIPTION
## Summary

`NodeBufferConsumer::can_back_pressure()` is a by-design constant `false`: a materialized node buffer is a completed intermediate built synchronously on the single walk thread, so it has no separate producer thread to pause — its memory-relief lever is spill, not back-pressure. Several comment sites still described the flag as "conservatively false until the static DAG pause-reachability analysis lands," a vestige of an earlier model. This reconciles those sites to the accurate per-site rationale so the comments agree with the code and the existing node-buffer docs (closes #455).

Comments/docs only — no runtime behavior change, and no test or snapshot change (explain output still prints `can_back_pressure=false`).

## Changes

Five comment sites now state the real reason `false` holds at each: the materialized-buffer registration path (no producer to pause; spill is the only relief lever), the streaming-Output charge site (the bounded channel already paces the producer at the transport layer), the arbitration-class and explain Buffer-Edges docs, and the `MemoryConsumer` trait docs. The phantom "static DAG pause-reachability analysis" roadmap phrasing is removed and replaced with a cross-link to #301, the actual home of any future inter-stage streaming back-pressure.

## Validation

`cargo fmt --all --check`, `cargo clippy -p clinker-exec -p clinker-plan --all-targets -D warnings`, and the `clinker-exec` + `clinker-plan` suites all pass with zero snapshot churn.
