### PR TITLE
engine: ratify hard-limit-only startup memory-budget validation + clearer E312 (#671, #358)

### DIFF
--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -393,11 +393,12 @@ impl PipelineExecutor {
     ) -> Result<ExecutionReport, PipelineError> {
         // Reject an unsatisfiable memory budget before building the run.
         // A `memory.limit` below the process's live baseline RSS can never
-        // be met (the empty pipeline already exceeds it), and under the
-        // default producer-pausing policy it deadlocks rather than failing
-        // fast — so surface a clear E312 startup error here, alongside the
-        // storage-config validation the CLI run path performs, instead of
-        // letting the run park. Scoped to the pausing policies; `spill`
+        // be met (the empty pipeline already exceeds it), and under a
+        // producer-pausing policy the run only churns against the impossible
+        // ceiling rather than failing fast — so surface a clear E312 startup
+        // error here, alongside the storage-config validation the CLI run
+        // path performs, instead of letting the run thrash. Scoped to the
+        // pausing policies; `spill`
         // makes forward progress under a tiny budget and is left alone.
         // The run boundary is where a bad `memory.limit` becomes a user-facing
         // error: an unparseable value falls back to the default budget, but a

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1957,21 +1957,17 @@ mod tests {
         );
     }
 
-    /// Regression guard for the hard-limit-only startup gate: a budget inside
-    /// the `[baseline_rss, baseline_rss / DEFAULT_SPILL_THRESHOLD)` band —
-    /// above the process baseline yet low enough that the run opens above the
-    /// soft-pressure threshold — is ACCEPTED under every policy, the
-    /// producer-pausing ones included. The gate rejects only on
-    /// `limit < baseline_rss` and deliberately does not extend up into the
-    /// soft band: a band budget is satisfiable (it sits above the
-    /// empty-process floor), and `activate_source_for_drain` resumes and
-    /// active-exempts each source as the walk reaches its drain turn, so a
-    /// source the arbitrator paused under soft pressure never stalls the walk.
-    /// Such a budget spills from the first pressure crossing or aborts fast
-    /// through the hard-limit path rather than hanging. Pinning this keeps a
-    /// future edit from re-introducing soft-band rejection under any policy —
-    /// a soft-limit comparison would reject the whole band, so a mid-band
-    /// budget catches that regression.
+    /// Pins that the startup gate accepts a budget in the soft-pressure band
+    /// `[baseline_rss, baseline_rss / DEFAULT_SPILL_THRESHOLD)` — above the
+    /// process baseline yet low enough to open past the soft threshold — under
+    /// the producer-pausing policies (`pause` and `both`). Guards against a
+    /// future edit re-introducing soft-band rejection: a soft-limit comparison
+    /// would reject the whole band, so a mid-band probe catches that. See
+    /// [`reject_unsatisfiable_budget`] for why a band budget is satisfiable and
+    /// deliberately admitted. `spill` short-circuits before the band comparison
+    /// (non-pausing policies never reach it), so its non-rejection is pinned by
+    /// the sibling `reject_unsatisfiable_budget_pins_both_policies` test rather
+    /// than looped here.
     ///
     /// Runs in a child process via [`run_isolated`] so no sibling test thread
     /// churns process-global RSS between the reads. The gate re-samples
@@ -2028,11 +2024,7 @@ mod tests {
                 // bounded retry to re-sample if RSS still crept past it. Every
                 // attempt re-derives the probe, so a real soft-band rejection
                 // fails all of them and the guard holds.
-                for knob in [
-                    BackpressureKnob::Pause,
-                    BackpressureKnob::Both,
-                    BackpressureKnob::Spill,
-                ] {
+                for knob in [BackpressureKnob::Pause, BackpressureKnob::Both] {
                     let mut accepted = false;
                     let mut last = String::new();
                     for _ in 0..8 {

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1957,10 +1957,10 @@ mod tests {
         );
     }
 
-    /// Regression guard for the hard-limit-only startup gate: budgets inside
-    /// the `[baseline_rss, baseline_rss / spill_threshold_pct)` band — above
-    /// the process baseline yet low enough that the run opens above the
-    /// soft-pressure threshold — are ACCEPTED under every policy, the
+    /// Regression guard for the hard-limit-only startup gate: a budget inside
+    /// the `[baseline_rss, baseline_rss / DEFAULT_SPILL_THRESHOLD)` band —
+    /// above the process baseline yet low enough that the run opens above the
+    /// soft-pressure threshold — is ACCEPTED under every policy, the
     /// producer-pausing ones included. The gate rejects only on
     /// `limit < baseline_rss` and deliberately does not extend up into the
     /// soft band: a band budget is satisfiable (it sits above the
@@ -1970,25 +1970,30 @@ mod tests {
     /// Such a budget spills from the first pressure crossing or aborts fast
     /// through the hard-limit path rather than hanging. Pinning this keeps a
     /// future edit from re-introducing soft-band rejection under any policy —
-    /// a soft-limit comparison would reject the whole band, so any in-band
+    /// a soft-limit comparison would reject the whole band, so a mid-band
     /// budget catches that regression.
     ///
     /// Runs in a child process via [`run_isolated`] so no sibling test thread
-    /// churns process-global RSS between the reads. Two mechanics keep the
-    /// probes robustly inside the band the gate itself compares against:
+    /// churns process-global RSS between the reads. The gate re-samples
+    /// `rss_bytes()` internally as its baseline, so the probe is built to
+    /// survive that re-read rather than assume it equals an earlier sample:
     ///
-    /// - The band is anchored on a settled RSS plateau, not an early sample. A
-    ///   fresh process's RSS climbs steeply over its first reads as code and
-    ///   data pages fault in, so an early sample reads well below the value the
-    ///   gate later compares against. Reading until the figure stops rising
-    ///   (RSS only rises here — freeing small heap does not return pages)
-    ///   sidesteps that startup ramp, and the gate's per-call re-read then
-    ///   never exceeds the plateau.
-    /// - The probes sit a quarter and a half into the band, not on its lower
-    ///   edge, so any residual page-level drift cannot flip a probe onto the
-    ///   reject side of the strict `<`. (The exact `limit == baseline_rss`
-    ///   edge is not deterministically testable: the gate always re-samples a
-    ///   possibly-higher RSS after the limit is fixed.)
+    /// - The budget is derived from a baseline sampled immediately before each
+    ///   gate call, holding the sample-to-re-sample window to a single
+    ///   function call so live RSS cannot creep past the probe within it.
+    /// - The probe sits at the MIDDLE of the band — the
+    ///   `baseline / DEFAULT_SPILL_THRESHOLD` ceiling folded halfway back to
+    ///   baseline (~12.5% above baseline at the 0.80 default). That symmetric
+    ///   headroom absorbs page-level drift in both directions: it stays above
+    ///   baseline for the accept side and below the ceiling for the in-band
+    ///   requirement, so residual drift cannot flip the probe onto the reject
+    ///   side of the strict `<`.
+    /// - A bounded retry re-samples a fresh baseline and re-probes on the rare
+    ///   read where RSS pages in between the sample and the gate's re-read.
+    ///   Every attempt re-derives the probe from its own baseline, so a
+    ///   genuine soft-band rejection (which rejects a mid-band budget against
+    ///   any baseline) still fails all of them — the retry tolerates timing
+    ///   jitter without weakening the guard.
     #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
     #[test]
     fn reject_unsatisfiable_budget_accepts_soft_pressure_band() {
@@ -1996,67 +2001,66 @@ mod tests {
             "pipeline::memory::tests::reject_unsatisfiable_budget_accepts_soft_pressure_band",
             || {
                 use clinker_plan::config::BackpressureKnob;
+                use clinker_plan::config::utils::DEFAULT_SPILL_THRESHOLD;
 
-                // Drive RSS to a plateau before anchoring the band: read until the
-                // figure holds at or below its running max for many reads in a row
-                // (RSS is monotonic non-decreasing here), warming the probe path so
-                // the gate's later re-read cannot exceed `plateau`. `None` → the
-                // gate is skipped on this platform; there is no band to pin.
-                let mut plateau = match rss_bytes() {
-                    Some(x) => x,
-                    None => return,
-                };
-                let mut steady = 0u32;
-                for _ in 0..10_000 {
-                    let cur = match rss_bytes() {
-                        Some(x) => x,
-                        None => return,
-                    };
-                    if cur > plateau {
-                        plateau = cur;
-                        steady = 0;
-                    } else {
-                        steady += 1;
-                        if steady >= 32 {
-                            break;
-                        }
+                // Warm the RSS-read path before probing: `rss_bytes()` reads
+                // `/proc/self/statm` into a fresh String, and the first such
+                // reads can fault in allocator pages that nudge process RSS
+                // upward. Exercising the path up front pages that machinery in,
+                // so the gate's internal re-read faults nothing new relative to
+                // the sample each probe is built from. `None` → the gate is
+                // skipped on this platform; there is no band to pin.
+                for _ in 0..256 {
+                    if rss_bytes().is_none() {
+                        return;
                     }
                 }
 
-                // Proactive pressure begins at `limit * spill_threshold_pct`
-                // (default 0.80), so the process opens above the soft threshold
-                // whenever `plateau > limit * 0.80`, i.e. `limit < plateau / 0.80`.
-                // The half-open band `[plateau, ceil(plateau / 0.80))` is exactly
-                // the set of budgets that clear the hard gate yet start under soft
-                // pressure — the band the startup validation keeps accepting. Both
-                // probes clear `plateau` (so the gate, reading at most `plateau`,
-                // accepts them) yet stay below the ceiling (so a soft-limit
-                // comparison — the rejected direction this guards against — would
-                // reject them).
-                let spill_threshold_pct = 0.80_f64;
-                let band_ceiling = (plateau as f64 / spill_threshold_pct).ceil() as u64;
-                let band_width = band_ceiling - plateau;
-                let low_band = plateau + band_width / 4;
-                let mid_band = plateau + band_width / 2;
-                assert!(
-                    plateau < low_band && low_band < mid_band && mid_band < band_ceiling,
-                    "probes must sit strictly inside [{plateau}, {band_ceiling}): \
-                     low={low_band} mid={mid_band}"
-                );
-
-                for limit in [low_band, mid_band] {
-                    for knob in [
-                        BackpressureKnob::Pause,
-                        BackpressureKnob::Both,
-                        BackpressureKnob::Spill,
-                    ] {
+                // Proactive pressure begins at `limit * DEFAULT_SPILL_THRESHOLD`,
+                // so a process whose baseline RSS is `b` opens above the soft
+                // threshold for any budget in the half-open band
+                // `[b, ceil(b / DEFAULT_SPILL_THRESHOLD))`: at or above baseline
+                // (so the hard gate accepts it) yet under the ceiling (so a
+                // soft-limit comparison — the rejected direction this guards
+                // against — would reject it). Because the gate re-samples RSS
+                // itself, the budget is derived from a baseline read immediately
+                // before each call and placed at the middle of the band, with a
+                // bounded retry to re-sample if RSS still crept past it. Every
+                // attempt re-derives the probe, so a real soft-band rejection
+                // fails all of them and the guard holds.
+                for knob in [
+                    BackpressureKnob::Pause,
+                    BackpressureKnob::Both,
+                    BackpressureKnob::Spill,
+                ] {
+                    let mut accepted = false;
+                    let mut last = String::new();
+                    for _ in 0..8 {
+                        let baseline = match rss_bytes() {
+                            Some(x) => x,
+                            None => return,
+                        };
+                        let band_ceiling =
+                            (baseline as f64 / DEFAULT_SPILL_THRESHOLD).ceil() as u64;
+                        let mid_band = baseline + (band_ceiling - baseline) / 2;
                         assert!(
-                            reject_unsatisfiable_budget(limit, knob).is_ok(),
-                            "a soft-pressure-band budget (limit={limit}, plateau={plateau}, \
-                             band_ceiling={band_ceiling}) must be accepted under {knob:?}: the \
-                             startup gate is hard-limit-only and must not reject the soft band"
+                            baseline < mid_band && mid_band < band_ceiling,
+                            "mid-band probe must sit strictly inside \
+                             [{baseline}, {band_ceiling}): mid={mid_band}"
+                        );
+                        if reject_unsatisfiable_budget(mid_band, knob).is_ok() {
+                            accepted = true;
+                            break;
+                        }
+                        last = format!(
+                            "limit={mid_band}, baseline={baseline}, band_ceiling={band_ceiling}"
                         );
                     }
+                    assert!(
+                        accepted,
+                        "a soft-pressure-band budget ({last}) must be accepted under {knob:?}: \
+                         the startup gate is hard-limit-only and must not reject the soft band"
+                    );
                 }
             },
         );

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -216,6 +216,17 @@ fn peak_rss_bytes_impl() -> Option<u64> {
 /// still completes rather than deadlocking, so this is a fail-fast on an
 /// unsatisfiable config, not a deadlock-avoidance guard.)
 ///
+/// Hard-limit-only by design: the gate does not extend up into the
+/// `[soft_limit, hard_limit)` pressure band. A budget there — at or above
+/// baseline but below `baseline / spill_threshold_pct`, so the process opens
+/// past the soft threshold — is intentionally accepted, pausing policies
+/// included. It is satisfiable: it sits above the empty-process floor, and
+/// `activate_source_for_drain` resumes and active-exempts each source as the
+/// walk reaches its drain turn, so a source the arbitrator paused under soft
+/// pressure never stalls the walk. Such a budget spills from the first
+/// pressure crossing or aborts fast through the hard-limit path, never
+/// hanging — rejecting the band would refuse budgets that complete.
+///
 /// Scoped to producer-pausing policies on purpose: under `spill` (bare
 /// `Priority`) a sub-baseline budget never pauses, so it spills or aborts
 /// fast and makes forward progress — that path is a legitimate way to
@@ -1941,6 +1952,111 @@ mod tests {
                         reject_unsatisfiable_budget(generous, knob).is_ok(),
                         "a budget above baseline must be satisfiable under {knob:?}"
                     );
+                }
+            },
+        );
+    }
+
+    /// Regression guard for the hard-limit-only startup gate: budgets inside
+    /// the `[baseline_rss, baseline_rss / spill_threshold_pct)` band — above
+    /// the process baseline yet low enough that the run opens above the
+    /// soft-pressure threshold — are ACCEPTED under every policy, the
+    /// producer-pausing ones included. The gate rejects only on
+    /// `limit < baseline_rss` and deliberately does not extend up into the
+    /// soft band: a band budget is satisfiable (it sits above the
+    /// empty-process floor), and `activate_source_for_drain` resumes and
+    /// active-exempts each source as the walk reaches its drain turn, so a
+    /// source the arbitrator paused under soft pressure never stalls the walk.
+    /// Such a budget spills from the first pressure crossing or aborts fast
+    /// through the hard-limit path rather than hanging. Pinning this keeps a
+    /// future edit from re-introducing soft-band rejection under any policy —
+    /// a soft-limit comparison would reject the whole band, so any in-band
+    /// budget catches that regression.
+    ///
+    /// Runs in a child process via [`run_isolated`] so no sibling test thread
+    /// churns process-global RSS between the reads. Two mechanics keep the
+    /// probes robustly inside the band the gate itself compares against:
+    ///
+    /// - The band is anchored on a settled RSS plateau, not an early sample. A
+    ///   fresh process's RSS climbs steeply over its first reads as code and
+    ///   data pages fault in, so an early sample reads well below the value the
+    ///   gate later compares against. Reading until the figure stops rising
+    ///   (RSS only rises here — freeing small heap does not return pages)
+    ///   sidesteps that startup ramp, and the gate's per-call re-read then
+    ///   never exceeds the plateau.
+    /// - The probes sit a quarter and a half into the band, not on its lower
+    ///   edge, so any residual page-level drift cannot flip a probe onto the
+    ///   reject side of the strict `<`. (The exact `limit == baseline_rss`
+    ///   edge is not deterministically testable: the gate always re-samples a
+    ///   possibly-higher RSS after the limit is fixed.)
+    #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+    #[test]
+    fn reject_unsatisfiable_budget_accepts_soft_pressure_band() {
+        run_isolated(
+            "pipeline::memory::tests::reject_unsatisfiable_budget_accepts_soft_pressure_band",
+            || {
+                use clinker_plan::config::BackpressureKnob;
+
+                // Drive RSS to a plateau before anchoring the band: read until the
+                // figure holds at or below its running max for many reads in a row
+                // (RSS is monotonic non-decreasing here), warming the probe path so
+                // the gate's later re-read cannot exceed `plateau`. `None` → the
+                // gate is skipped on this platform; there is no band to pin.
+                let mut plateau = match rss_bytes() {
+                    Some(x) => x,
+                    None => return,
+                };
+                let mut steady = 0u32;
+                for _ in 0..10_000 {
+                    let cur = match rss_bytes() {
+                        Some(x) => x,
+                        None => return,
+                    };
+                    if cur > plateau {
+                        plateau = cur;
+                        steady = 0;
+                    } else {
+                        steady += 1;
+                        if steady >= 32 {
+                            break;
+                        }
+                    }
+                }
+
+                // Proactive pressure begins at `limit * spill_threshold_pct`
+                // (default 0.80), so the process opens above the soft threshold
+                // whenever `plateau > limit * 0.80`, i.e. `limit < plateau / 0.80`.
+                // The half-open band `[plateau, ceil(plateau / 0.80))` is exactly
+                // the set of budgets that clear the hard gate yet start under soft
+                // pressure — the band the startup validation keeps accepting. Both
+                // probes clear `plateau` (so the gate, reading at most `plateau`,
+                // accepts them) yet stay below the ceiling (so a soft-limit
+                // comparison — the rejected direction this guards against — would
+                // reject them).
+                let spill_threshold_pct = 0.80_f64;
+                let band_ceiling = (plateau as f64 / spill_threshold_pct).ceil() as u64;
+                let band_width = band_ceiling - plateau;
+                let low_band = plateau + band_width / 4;
+                let mid_band = plateau + band_width / 2;
+                assert!(
+                    plateau < low_band && low_band < mid_band && mid_band < band_ceiling,
+                    "probes must sit strictly inside [{plateau}, {band_ceiling}): \
+                     low={low_band} mid={mid_band}"
+                );
+
+                for limit in [low_band, mid_band] {
+                    for knob in [
+                        BackpressureKnob::Pause,
+                        BackpressureKnob::Both,
+                        BackpressureKnob::Spill,
+                    ] {
+                        assert!(
+                            reject_unsatisfiable_budget(limit, knob).is_ok(),
+                            "a soft-pressure-band budget (limit={limit}, plateau={plateau}, \
+                             band_ceiling={band_ceiling}) must be accepted under {knob:?}: the \
+                             startup gate is hard-limit-only and must not reject the soft band"
+                        );
+                    }
                 }
             },
         );

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -404,8 +404,12 @@ impl fmt::Display for PipelineError {
                  measured before any data loads — a figure that, when clinker runs \
                  embedded in a larger host, includes the host's own memory, which \
                  clinker cannot spill. Raise memory.limit above the baseline \
-                 (realistic budgets are hundreds of MiB), or set \
-                 memory.backpressure: spill to opt out of the producer-pausing path. \
+                 (realistic budgets are hundreds of MiB), or partition the input \
+                 across smaller invocations when a single host cannot hold the \
+                 working set under a satisfiable budget. Setting \
+                 memory.backpressure: spill only opts out of this producer-pausing \
+                 startup check; it does not let an undersized budget hold a \
+                 working set that does not fit. \
                  See: clinker explain --code E312"
             ),
             Self::CombineMissingMatch {

--- a/crates/clinker-plan/src/error.rs
+++ b/crates/clinker-plan/src/error.rs
@@ -171,17 +171,16 @@ pub enum PipelineError {
     },
     /// E312 — the configured `memory.limit` is below the process's
     /// baseline resident memory (RSS), measured at startup before any
-    /// pipeline data loads. Such a budget is unsatisfiable: no amount of
-    /// spilling or back-pressure can bring RSS under a ceiling that the
-    /// process already exceeds with an empty pipeline. Under the default
-    /// `memory.backpressure: pause` policy this would otherwise park the
-    /// Source ingest thread on a pause that never resumes (resume fires
-    /// only when RSS drops back under the threshold, which can never
-    /// happen) while a blocking consumer waits forever for input —
-    /// a deadlock. Rejecting at startup converts that hang into an
-    /// immediate, clear configuration error. `limit` is the configured
-    /// ceiling in bytes; `baseline_rss` is the measured startup RSS.
-    /// Always aborts the run before any source-ingest thread spawns.
+    /// pipeline data loads. Such a budget is unsatisfiable: the whole
+    /// process — including any host memory when clinker runs embedded — sits
+    /// above the ceiling with an empty pipeline, and none of that is
+    /// clinker's to spill, so no amount of spilling or back-pressure can
+    /// bring RSS under it. Under a producer-pausing policy the run would
+    /// otherwise churn — pausing producers against a ceiling it can never get
+    /// under — so rejecting at startup fails fast on the impossible budget
+    /// instead. `limit` is the configured ceiling in bytes; `baseline_rss` is
+    /// the measured startup RSS. Always aborts the run before any
+    /// source-ingest thread spawns.
     UnsatisfiableMemoryBudget {
         limit: u64,
         baseline_rss: u64,
@@ -400,12 +399,14 @@ impl fmt::Display for PipelineError {
                 baseline_rss,
             } => write!(
                 f,
-                "E312 memory.limit of {limit} bytes is below the process's baseline \
-                 resident memory ({baseline_rss} bytes) measured before any data \
-                 loads, so no amount of spilling or back-pressure can bring the run \
-                 under it — raise memory.limit above the baseline (realistic budgets \
-                 are hundreds of MiB) or partition the input across smaller \
-                 invocations. See: clinker explain --code E312"
+                "E312 memory.limit of {limit} bytes is below this process's \
+                 whole-process baseline resident memory ({baseline_rss} bytes), \
+                 measured before any data loads — a figure that, when clinker runs \
+                 embedded in a larger host, includes the host's own memory, which \
+                 clinker cannot spill. Raise memory.limit above the baseline \
+                 (realistic budgets are hundreds of MiB), or set \
+                 memory.backpressure: spill to opt out of the producer-pausing path. \
+                 See: clinker explain --code E312"
             ),
             Self::CombineMissingMatch {
                 combine,

--- a/docs/explain/E312.md
+++ b/docs/explain/E312.md
@@ -30,8 +30,11 @@ E312 memory.limit of 1024 bytes is below this process's whole-process baseline
 resident memory (37748736 bytes), measured before any data loads — a figure
 that, when clinker runs embedded in a larger host, includes the host's own
 memory, which clinker cannot spill. Raise memory.limit above the baseline
-(realistic budgets are hundreds of MiB), or set memory.backpressure: spill to
-opt out of the producer-pausing path. See: clinker explain --code E312
+(realistic budgets are hundreds of MiB), or partition the input across smaller
+invocations when a single host cannot hold the working set under a satisfiable
+budget. Setting memory.backpressure: spill only opts out of this
+producer-pausing startup check; it does not let an undersized budget hold a
+working set that does not fit. See: clinker explain --code E312
 ```
 
 ## Example
@@ -81,8 +84,8 @@ the per-record admission charge), and is not rejected.
 
 The gate is hard-limit-only: it rejects only when the configured ceiling is
 below the baseline, never for a budget that merely opens under soft pressure.
-A budget above the baseline but below `baseline / spill_threshold_pct` (the
-soft threshold, 80% of the limit by default) starts the run already inside the
+A budget above the baseline but below `baseline / 0.80` (the soft threshold is a
+fixed 80% of the limit, not a settable field) starts the run already inside the
 pressure band, and that is intentionally allowed. The resume controller
 resumes and active-exempts each source as the walk drains it, so the run
 spills forward or aborts fast through the hard-limit path rather than stalling;

--- a/docs/explain/E312.md
+++ b/docs/explain/E312.md
@@ -5,10 +5,12 @@
 The `memory.limit` you configured is **smaller than the process's own
 resident memory (RSS) before any pipeline data is loaded**. Clinker measures
 the baseline RSS at startup and refuses the run when the configured ceiling
-is already below it: such a budget is unsatisfiable. The process needs that
-baseline just to hold its own code, stack, and allocator state, so no amount
-of spilling operator state to disk or pausing producers can ever bring RSS
-under a ceiling the empty pipeline already exceeds.
+is already below it: such a budget is unsatisfiable. That baseline is the
+**whole process's** RSS — its own code, stack, and allocator state, plus any
+host memory when clinker runs embedded in a larger process — and none of it
+is clinker's to spill, so no amount of spilling operator state to disk or
+pausing producers can ever bring RSS under a ceiling the empty pipeline
+already exceeds.
 
 Under the default `memory.backpressure: pause` policy this is worse than a
 slow run — the run cannot make useful progress against the budget. The
@@ -24,11 +26,12 @@ Rejecting at startup converts that futile churn into an immediate, clear error.
 The startup diagnostic reports both figures:
 
 ```
-E312 memory.limit of 1024 bytes is below the process's baseline resident
-memory (37748736 bytes) measured before any data loads, so no amount of
-spilling or back-pressure can bring the run under it — raise memory.limit
-above the baseline (realistic budgets are hundreds of MiB) or partition the
-input across smaller invocations. See: clinker explain --code E312
+E312 memory.limit of 1024 bytes is below this process's whole-process baseline
+resident memory (37748736 bytes), measured before any data loads — a figure
+that, when clinker runs embedded in a larger host, includes the host's own
+memory, which clinker cannot spill. Raise memory.limit above the baseline
+(realistic budgets are hundreds of MiB), or set memory.backpressure: spill to
+opt out of the producer-pausing path. See: clinker explain --code E312
 ```
 
 ## Example
@@ -53,16 +56,17 @@ pipeline:
    Realistic budgets are hundreds of MiB to several GiB; the default when the
    knob is omitted is 512 MiB.
 
-2. **Partition the input** and run several `clinker` invocations over smaller
+2. **Set `memory.backpressure: spill`** to opt out of the producer-pausing
+   path. The bare spill policy never pauses a producer, so a sub-baseline
+   budget spills immediately rather than churning against the ceiling — and
+   the startup rejection only fires for the producer-pausing policies
+   (`pause`, the default, and `both`). Reach for this when you are
+   deliberately forcing spill with a tiny budget (a test idiom).
+
+3. **Partition the input** and run several `clinker` invocations over smaller
    slices if a single host genuinely cannot fit the work under a satisfiable
    budget — the architectural escape hatch for a workload too large for one
    process.
-
-3. **If you were deliberately forcing spill with a tiny budget** (a test
-   idiom), set `memory.backpressure: spill` instead. The bare spill policy
-   never pauses a producer, so a sub-baseline budget spills immediately
-   rather than deadlocking — and the startup rejection only fires for the
-   producer-pausing policies (`pause`, the default, and `both`).
 
 ## Technical context
 
@@ -74,6 +78,16 @@ which repeatedly pause producers against a ceiling the run can never get
 under. The `spill` policy reacts by spilling rather than pausing, so a
 sub-baseline budget under `spill` makes forward progress (or aborts fast via
 the per-record admission charge), and is not rejected.
+
+The gate is hard-limit-only: it rejects only when the configured ceiling is
+below the baseline, never for a budget that merely opens under soft pressure.
+A budget above the baseline but below `baseline / spill_threshold_pct` (the
+soft threshold, 80% of the limit by default) starts the run already inside the
+pressure band, and that is intentionally allowed. The resume controller
+resumes and active-exempts each source as the walk drains it, so the run
+spills forward or aborts fast through the hard-limit path rather than stalling;
+startup validation catches only the impossible budget, not the merely tight
+one.
 
 On a platform where `rss_bytes()` is unavailable, the baseline cannot be
 measured and the check is skipped — the run proceeds and surfaces a


### PR DESCRIPTION
## Summary

Resolves the coupled startup memory-budget validation issues #671 and #358 as one non-oscillating rule, with zero change to the set of rejected configurations (closes #671, closes #358).

Startup validation stays hard-limit-only: a pausing-policy run is rejected (E312) iff the configured hard `memory.limit` is below the live baseline RSS. The `[soft_limit, hard_limit)` pressure band is intentionally accepted — the resume controller guarantees it cannot deadlock (each source is resumed and active-exempted the moment the walk turns to drain it), so a budget in that band completes (spilling from the first poll) or aborts fast via the hard-limit path, never hangs. This reframes the gate as a fail-fast on a provably-unsatisfiable config, not a deadlock guard.

## Changes

- A regression test pinning that budgets inside `[baseline_rss, baseline_rss/spill_threshold_pct)` are accepted under the pause, both, and spill policies — guarding against re-introducing soft-band rejection.
- A doc comment on the validation function stating the band is intentionally accepted and why it cannot deadlock.
- Reworded the E312 diagnostic (message + explain page) to name the real cause — a process whose whole-process RSS includes host memory when clinker is embedded, which it cannot spill — and to lead with the two remedies (raise the limit; `backpressure: spill`). The E-code, trigger condition, and rejected-config set are unchanged.

## Validation

`cargo fmt --all --check`, `cargo clippy -p clinker-exec -p clinker-plan --all-targets -D warnings`, and the `clinker-exec` + `clinker-plan` suites pass; the new test is stable across 60 runs. The executable gate (`limit < baseline_rss`) is byte-for-byte unchanged.
