### PR TITLE
engine: bound k-way spill merge to a fixed fan-in via cascaded multi-pass merge (#868)

### DIFF
--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -1981,9 +1981,21 @@ fn drain_block_band_output(
                 // The k-way run merge is lazy — one resident record per open
                 // run — so streaming its rows through the batcher keeps the
                 // spilled result bounded, never re-materializing the slice.
+                let merge_compress = ctx.spill_compress.resolve_for_schema(
+                    files
+                        .first()
+                        .map(|f| f.schema().column_count())
+                        .unwrap_or(0),
+                    batch_size as u64,
+                );
                 let merger = crate::pipeline::spill_merge::SortedRunMerger::new_payload_ordered(
                     files,
                     "iejoin block-band output merge",
+                    crate::pipeline::spill_merge::MergeBudget {
+                        budget: &ctx.memory_budget,
+                        node: combine_name,
+                        compress: merge_compress,
+                    },
                 )?;
                 stream_block_band_rows(
                     &sender,
@@ -2019,14 +2031,33 @@ fn drain_block_band_output(
                 // lazily when the downstream drains — one resident record per open
                 // run — so a blocking consumer stays bounded and the result is
                 // never re-serialized to a second chunk.
-                adopt_spilled_runs_into_node_buffer(ctx, node_idx, files, row_count, puncts)?
+                adopt_spilled_runs_into_node_buffer(
+                    ctx,
+                    node_idx,
+                    combine_name,
+                    files,
+                    row_count,
+                    puncts,
+                )?
             } else {
                 // A window root, a cross-region tee, or a non-spillable slot needs
                 // the whole slice; those surfaces are O(N) regardless, so
                 // re-materialize the sorted stream once and admit it in memory.
+                let merge_compress = ctx.spill_compress.resolve_for_schema(
+                    files
+                        .first()
+                        .map(|f| f.schema().column_count())
+                        .unwrap_or(0),
+                    ctx.batch_size as u64,
+                );
                 let merger = crate::pipeline::spill_merge::SortedRunMerger::new_payload_ordered(
                     files,
                     "iejoin block-band output merge",
+                    crate::pipeline::spill_merge::MergeBudget {
+                        budget: &ctx.memory_budget,
+                        node: combine_name,
+                        compress: merge_compress,
+                    },
                 )?;
                 let mut rows: Vec<(Record, u64)> = Vec::new();
                 for item in merger {
@@ -2154,6 +2185,7 @@ fn node_tees_to_deferred_region(current_dag: &ExecutionPlanDag, node_idx: NodeIn
 fn adopt_spilled_runs_into_node_buffer(
     ctx: &mut ExecutorContext<'_>,
     node_idx: NodeIndex,
+    combine_name: &str,
     files: Vec<crate::pipeline::spill::SpillFile<(RecordOrder, u64, u64)>>,
     row_count: u64,
     puncts: Vec<crate::executor::stream_event::Punctuation>,
@@ -2173,7 +2205,28 @@ fn adopt_spilled_runs_into_node_buffer(
     ctx.node_buffer_consumer_ids
         .insert(node_idx, (consumer_id, handle));
     ctx.memory_budget.sample_peak_consumer_usage();
-    Ok(NodeBuffer::merge_spilled(files, row_count, puncts))
+    // Park a charging context on the slot so that if this adopted run set is too
+    // fragmented, the drain's k-way merge folds it down under the disk quota
+    // (E320), charging the intermediate runs to this combine node — matching the
+    // compression of the runs it adopts.
+    let merge_compress = ctx.spill_compress.resolve_for_schema(
+        files
+            .first()
+            .map(|f| f.schema().column_count())
+            .unwrap_or(0),
+        ctx.batch_size as u64,
+    );
+    let merge_budget = crate::pipeline::spill_merge::OwnedMergeBudget::new(
+        Arc::clone(&ctx.memory_budget),
+        Arc::from(combine_name),
+        merge_compress,
+    );
+    Ok(NodeBuffer::merge_spilled(
+        files,
+        row_count,
+        puncts,
+        merge_budget,
+    ))
 }
 
 fn dispatch_combine_output_error(

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -1909,6 +1909,26 @@ enum BlockBandDrain {
     Buffered(crate::executor::node_buffer::NodeBuffer),
 }
 
+/// Resolve the spill-compression mode for a k-way merge over `files`: the
+/// output-column width (from any surviving run's schema) against `batch_size`,
+/// exactly as the emit-phase sort chose it, so an intermediate cascade run and
+/// the run being merged share one on-disk format. The three block-band output
+/// drains — streaming, materialize, and adopt-on-drain — resolve it through this
+/// one helper so they stay in lockstep with each other and with `--explain`.
+fn merge_compress_for<P>(
+    ctx: &ExecutorContext<'_>,
+    files: &[crate::pipeline::spill::SpillFile<P>],
+    batch_size: usize,
+) -> bool {
+    ctx.spill_compress.resolve_for_schema(
+        files
+            .first()
+            .map(|f| f.schema().column_count())
+            .unwrap_or(0),
+        batch_size as u64,
+    )
+}
+
 /// Drain a pure-range block-band combine's bounded, payload-sorted output,
 /// preserving the deterministic `(driver order, driver_idx, build_idx)` order
 /// the sort realized.
@@ -1981,13 +2001,7 @@ fn drain_block_band_output(
                 // The k-way run merge is lazy — one resident record per open
                 // run — so streaming its rows through the batcher keeps the
                 // spilled result bounded, never re-materializing the slice.
-                let merge_compress = ctx.spill_compress.resolve_for_schema(
-                    files
-                        .first()
-                        .map(|f| f.schema().column_count())
-                        .unwrap_or(0),
-                    batch_size as u64,
-                );
+                let merge_compress = merge_compress_for(ctx, &files, batch_size);
                 let merger = crate::pipeline::spill_merge::SortedRunMerger::new_payload_ordered(
                     files,
                     "iejoin block-band output merge",
@@ -2043,13 +2057,7 @@ fn drain_block_band_output(
                 // A window root, a cross-region tee, or a non-spillable slot needs
                 // the whole slice; those surfaces are O(N) regardless, so
                 // re-materialize the sorted stream once and admit it in memory.
-                let merge_compress = ctx.spill_compress.resolve_for_schema(
-                    files
-                        .first()
-                        .map(|f| f.schema().column_count())
-                        .unwrap_or(0),
-                    ctx.batch_size as u64,
-                );
+                let merge_compress = merge_compress_for(ctx, &files, ctx.batch_size);
                 let merger = crate::pipeline::spill_merge::SortedRunMerger::new_payload_ordered(
                     files,
                     "iejoin block-band output merge",
@@ -2209,13 +2217,7 @@ fn adopt_spilled_runs_into_node_buffer(
     // fragmented, the drain's k-way merge folds it down under the disk quota
     // (E320), charging the intermediate runs to this combine node — matching the
     // compression of the runs it adopts.
-    let merge_compress = ctx.spill_compress.resolve_for_schema(
-        files
-            .first()
-            .map(|f| f.schema().column_count())
-            .unwrap_or(0),
-        ctx.batch_size as u64,
-    );
+    let merge_compress = merge_compress_for(ctx, &files, ctx.batch_size);
     let merge_budget = crate::pipeline::spill_merge::OwnedMergeBudget::new(
         Arc::clone(&ctx.memory_budget),
         Arc::from(combine_name),

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -133,11 +133,12 @@ pub(crate) struct DispatchOutcome {
     /// landed"). The synthetic `MERGED_SOURCE_NAME` slot is filtered
     /// out on the way through.
     pub(crate) per_source_dlq_counts: BTreeMap<String, u64>,
-    /// Saturating sum of bytes the run committed to spill files across
-    /// every spill site (node_buffer admission, grace-hash partition
-    /// flush, sort-merge external sort). Read from `MemoryArbitrator`'s
-    /// running total at dispatch close so an aborted run still
-    /// reports the last committed value.
+    /// Bytes the run committed to spill files across every spill site
+    /// (node_buffer admission, grace-hash partition flush, sort-merge external
+    /// sort), net of any released when a run was unlinked — so a cascaded k-way
+    /// merge's transient intermediate runs do not inflate it. Read from
+    /// `MemoryArbitrator`'s running total at dispatch close so an aborted run
+    /// still reports the last committed value.
     pub(crate) cumulative_spill_bytes: u64,
     /// Per-stage on-disk spill totals, keyed by the spilling node's name.
     /// The sum equals `cumulative_spill_bytes`; this breakdown is what an

--- a/crates/clinker-exec/src/executor/node_buffer.rs
+++ b/crates/clinker-exec/src/executor/node_buffer.rs
@@ -25,7 +25,7 @@ use clinker_record::{Record, Value};
 
 use crate::executor::stream_event::{Punctuation, StreamEvent};
 use crate::pipeline::spill::{SpillFile, SpillReader};
-use crate::pipeline::spill_merge::SortedRunMerger;
+use crate::pipeline::spill_merge::{OwnedMergeBudget, SortedRunMerger};
 use clinker_plan::error::PipelineError;
 
 /// Body records paired with the punctuations preserved from a buffer
@@ -98,6 +98,10 @@ pub(crate) enum NodeBuffer {
         runs: Vec<SpillFile<(u64, u64, u64)>>,
         row_count: u64,
         pending_puncts: Vec<Punctuation>,
+        /// Charging context for the lazy fold-down: if the adopted runs are too
+        /// fragmented, the drain's k-way merge cascades them, and the
+        /// intermediate runs charge this node's disk quota through here.
+        merge_budget: OwnedMergeBudget,
     },
 }
 
@@ -125,6 +129,7 @@ impl NodeBuffer {
         runs: Vec<SpillFile<(u64, u64, u64)>>,
         row_count: u64,
         pending_puncts: Vec<Punctuation>,
+        merge_budget: OwnedMergeBudget,
     ) -> Self {
         if runs.is_empty() || row_count == 0 {
             return Self::memory_from_records_and_puncts(Vec::new(), pending_puncts);
@@ -133,6 +138,7 @@ impl NodeBuffer {
             runs,
             row_count,
             pending_puncts,
+            merge_budget,
         }
     }
 
@@ -525,12 +531,14 @@ impl NodeBuffer {
                 runs,
                 row_count: _,
                 pending_puncts,
+                merge_budget,
             } => {
                 return NodeBufferDrain::Merged {
                     runs: Some(runs),
                     merger: None,
                     pending_puncts: pending_puncts.into_iter(),
                     done: false,
+                    merge_budget,
                 };
             }
         };
@@ -578,6 +586,9 @@ pub(crate) enum NodeBufferDrain {
         /// stops rather than falling through to the trailing punctuations over a
         /// broken merge.
         done: bool,
+        /// Charging context lent to the merge open so a fragmented adopted-run
+        /// set folds down under the disk quota (E320) at drain.
+        merge_budget: OwnedMergeBudget,
     },
 }
 
@@ -631,6 +642,7 @@ impl Iterator for NodeBufferDrain {
                 merger,
                 pending_puncts,
                 done,
+                merge_budget,
             } => {
                 if *done {
                     return None;
@@ -638,12 +650,15 @@ impl Iterator for NodeBufferDrain {
                 // Open the k-way merge on the first record poll; a failed open
                 // is deferred here (keeping `drain` infallible) and latches
                 // `done` so the trailing puncts never drain over a broken merge.
+                // The merge folds an over-fragmented run set down under the disk
+                // quota, charging intermediate runs through the parked budget.
                 if merger.is_none()
                     && let Some(files) = runs.take()
                 {
                     match SortedRunMerger::new_payload_ordered(
                         files,
                         "iejoin block-band output merge",
+                        merge_budget.as_borrowed(),
                     ) {
                         Ok(m) => *merger = Some(m),
                         Err(e) => {
@@ -1289,8 +1304,12 @@ mod tests {
 
         let s = schema();
         let ctx = synthetic_document_context();
-        let arb =
-            MemoryArbitrator::with_policy(1024 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
+        let arb = std::sync::Arc::new(MemoryArbitrator::with_policy(
+            1024 * 1024 * 1024,
+            0.80,
+            0.70,
+            Box::new(NoOpPolicy),
+        ));
 
         // (order, driver_idx, build_idx) payloads. `order` repeats (5 and 2
         // thrice) so ties exist; `driver_idx` is unique across every row, so the
@@ -1340,8 +1359,18 @@ mod tests {
         // (a) no-double-charge: adopting + draining the runs adds not a
         // single byte to the cumulative spill total.
         let before = arb.cumulative_spill_bytes();
-        let nb =
-            NodeBuffer::merge_spilled(files, row_count, vec![Punctuation::document_close(ctx)]);
+        // Few runs (< the merge fan-in) so the drain's k-way merge is a single
+        // pass: it writes no intermediate runs and charges nothing further.
+        let nb = NodeBuffer::merge_spilled(
+            files,
+            row_count,
+            vec![Punctuation::document_close(ctx)],
+            crate::pipeline::spill_merge::OwnedMergeBudget::new(
+                std::sync::Arc::clone(&arb),
+                std::sync::Arc::from("banded"),
+                true,
+            ),
+        );
         let (drained, puncts) = nb.drain_split().unwrap();
         assert_eq!(
             arb.cumulative_spill_bytes(),

--- a/crates/clinker-exec/src/executor/params.rs
+++ b/crates/clinker-exec/src/executor/params.rs
@@ -143,11 +143,12 @@ pub struct ExecutionReport {
     /// `counters.dlq_count` minus any entries the executor failed to
     /// attribute to a declared source.
     pub per_source_dlq_counts: BTreeMap<String, u64>,
-    /// Saturating sum of bytes committed to spill files across every
-    /// spill site (`node_buffers` admission, grace-hash partition
-    /// flush, sort-merge external sort). Sourced from
-    /// `MemoryArbitrator`'s running total at dispatch close; an aborted
-    /// run still surfaces the last committed value.
+    /// Bytes committed to spill files across every spill site
+    /// (`node_buffers` admission, grace-hash partition flush, sort-merge
+    /// external sort), net of any released as a run was unlinked — so a
+    /// cascaded k-way merge's transient intermediate runs do not inflate it.
+    /// Sourced from `MemoryArbitrator`'s running total at dispatch close; an
+    /// aborted run still surfaces the last committed value.
     pub cumulative_spill_bytes: u64,
     /// Per-stage on-disk spill totals, keyed by the spilling node's name.
     /// The sum of the values equals [`Self::cumulative_spill_bytes`]; this

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -113,7 +113,19 @@ pub(crate) fn dispatch_sort(
     // merge.
     let out: Vec<(Record, u64)> = match sorted {
         SortedOutput::InMemory(pairs) => pairs,
-        SortedOutput::Spilled(files) => merge_sorted_runs(files, sort_fields, "sort enforcer")?,
+        // A high-fragmentation spill folds down through a bounded-fan-in cascade
+        // before the final merge; intermediate runs charge this node's disk
+        // quota exactly like the runs above.
+        SortedOutput::Spilled(files) => merge_sorted_runs(
+            files,
+            sort_fields,
+            "sort enforcer",
+            crate::pipeline::spill_merge::MergeBudget {
+                budget: &ctx.memory_budget,
+                node: name,
+                compress: spill_compress,
+            },
+        )?,
     };
     ctx.collector
         .record(sort_timer.finish(sort_count, sort_count));

--- a/crates/clinker-exec/src/pipeline/iejoin/block.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin/block.rs
@@ -95,7 +95,7 @@ use crate::executor::combine::CombineResolverMapping;
 use crate::pipeline::memory::{ConsumerHandle, MemoryArbitrator};
 use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
 use crate::pipeline::spill::{SpillFile, SpillWriter};
-use crate::pipeline::spill_merge::SortedRunMerger;
+use crate::pipeline::spill_merge::{MergeBudget, SortedRunMerger};
 
 use super::{
     BlockBandOutput, CollectFlush, DriverRef, EmitBatch, EmitConfig, EmitSink, Evaluators,
@@ -1128,7 +1128,15 @@ fn finish_and_slice<P: Serialize + DeserializeOwned + Send + Ord>(
         }
         SortedOutput::Spilled(files) => {
             ctx.consumer.sub_bytes(pre_finish);
-            let merger = SortedRunMerger::new_payload_ordered(files, "iejoin block-band merge")?;
+            let merger = SortedRunMerger::new_payload_ordered(
+                files,
+                "iejoin block-band merge",
+                MergeBudget {
+                    budget: ctx.budget,
+                    node: ctx.name,
+                    compress: ctx.spill_compress,
+                },
+            )?;
             (SortedStream::Spilled(merger), false)
         }
     };
@@ -1482,7 +1490,19 @@ mod tests {
                 .map(|(record, (order, _, _))| (record, order))
                 .collect()),
             SortedOutput::Spilled(files) => {
-                let merger = SortedRunMerger::new_payload_ordered(files, "block-band test drain")?;
+                // The cascade only charges intermediate runs, which this small
+                // fixture never produces; a roomy unlimited-quota arbitrator
+                // keeps the test's focus on emitted order.
+                let arb = arbitrator(u64::MAX);
+                let merger = SortedRunMerger::new_payload_ordered(
+                    files,
+                    "block-band test drain",
+                    MergeBudget {
+                        budget: &arb,
+                        node: "block-band test drain",
+                        compress: true,
+                    },
+                )?;
                 let mut rows = Vec::new();
                 for item in merger {
                     let (record, (order, _, _)) = item?;

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1135,9 +1135,12 @@ impl MemoryArbitrator {
         self.max_spill_bytes.store(n, Ordering::Relaxed);
     }
 
-    /// Cumulative spill bytes recorded so far across every spill
-    /// operator polling this arbitrator. Equals the sum of every entry
-    /// in [`Self::per_stage_spill_bytes`].
+    /// Bytes currently on disk across every spill operator polling this
+    /// arbitrator: the sum of every [`Self::record_spill_bytes`] charge minus
+    /// every [`Self::release_spill_bytes`] release. Equals the sum of every
+    /// entry in [`Self::per_stage_spill_bytes`]. For spill paths that never
+    /// unlink a run before the run ends (all but the cascaded k-way merge) no
+    /// release fires, so this is exactly the monotonic total those paths wrote.
     pub fn cumulative_spill_bytes(&self) -> u64 {
         self.cumulative_spill_bytes.load(Ordering::Relaxed)
     }
@@ -1165,6 +1168,14 @@ impl MemoryArbitrator {
     /// breakdown attributes the bytes to the exact stage that wrote them.
     /// Saturating-add via `fetch_update` keeps an overflowing pipeline
     /// from wrapping back below the quota silently.
+    ///
+    /// The disk cap bounds *concurrent* on-disk spill (how much a run holds at
+    /// once), so a caller that later unlinks a run it charged here releases the
+    /// bytes with [`Self::release_spill_bytes`]; the counter then tracks current
+    /// on-disk usage. A spill site that never deletes a run before the run ends
+    /// (every existing spill path except the cascaded k-way merge) never
+    /// releases, so for it current stays equal to the monotonic total — the
+    /// historical behavior, unchanged.
     pub fn record_spill_bytes(&self, node: &str, n: u64) -> bool {
         let _ =
             self.cumulative_spill_bytes
@@ -1181,6 +1192,38 @@ impl MemoryArbitrator {
         }
         self.cumulative_spill_bytes.load(Ordering::Relaxed)
             > self.max_spill_bytes.load(Ordering::Relaxed)
+    }
+
+    /// Release `n` bytes previously charged via [`Self::record_spill_bytes`] for
+    /// `node`, because a run that held those bytes was unlinked from disk. The
+    /// pipeline-wide cumulative total and the stage's entry both drop by `n`, so
+    /// the disk-cap counter reflects the bytes still on disk rather than every
+    /// byte ever written.
+    ///
+    /// Only the cascaded k-way spill merge calls this: when it folds a group of
+    /// runs into one intermediate run it unlinks the consumed runs, and their
+    /// bytes were charged (by this same merge for a prior-pass intermediate, or
+    /// by the operator that spilled the originals) against `node`. No cap check
+    /// here — releasing bytes can only move the total further under the cap.
+    /// Saturating-sub floors at zero, so an over-release (a run whose bytes were
+    /// never charged to this node) cannot wrap the counter below other stages'
+    /// live charges.
+    pub fn release_spill_bytes(&self, node: &str, n: u64) {
+        if n == 0 {
+            return;
+        }
+        let _ =
+            self.cumulative_spill_bytes
+                .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |cur| {
+                    Some(cur.saturating_sub(n))
+                });
+        let mut per_stage = self
+            .per_stage_spill_bytes
+            .lock()
+            .expect("per_stage_spill_bytes mutex poisoned");
+        if let Some(entry) = per_stage.get_mut(node) {
+            *entry = entry.saturating_sub(n);
+        }
     }
 
     /// Register a consumer with the arbitrator. Returns a fresh
@@ -2281,6 +2324,45 @@ mod tests {
             arbitrator.cumulative_spill_bytes(),
             "the per-stage totals must sum to the pipeline-wide cumulative total"
         );
+    }
+
+    #[test]
+    fn test_release_spill_bytes_tracks_current_on_disk() {
+        // Charge two runs, then release one (as the cascade does when it unlinks
+        // a consumed run): the cumulative total and the stage entry both drop by
+        // the released bytes, so the counter reflects what is still on disk.
+        let arbitrator =
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
+        arbitrator.record_spill_bytes("merge", 1000);
+        arbitrator.record_spill_bytes("merge", 400);
+        assert_eq!(arbitrator.cumulative_spill_bytes(), 1400);
+        arbitrator.release_spill_bytes("merge", 1000);
+        assert_eq!(arbitrator.cumulative_spill_bytes(), 400);
+        assert_eq!(
+            arbitrator.per_stage_spill_bytes().get("merge"),
+            Some(&400),
+            "the stage entry drops with the pipeline-wide total"
+        );
+    }
+
+    #[test]
+    fn test_release_spill_bytes_saturates_at_zero() {
+        // Releasing more than was charged (a run whose bytes were not charged to
+        // this node) floors at zero rather than wrapping the counter under other
+        // stages' live charges.
+        let arbitrator =
+            MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
+        arbitrator.record_spill_bytes("a", 200);
+        arbitrator.record_spill_bytes("b", 300);
+        arbitrator.release_spill_bytes("a", 10_000);
+        assert_eq!(
+            arbitrator.per_stage_spill_bytes().get("a"),
+            Some(&0),
+            "an over-release floors the stage entry at zero"
+        );
+        // The pipeline-wide counter also floors at zero on the over-release; the
+        // guard is the floor, not per-stage bookkeeping of other nodes.
+        assert_eq!(arbitrator.cumulative_spill_bytes(), 0);
     }
 
     #[test]

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -55,7 +55,7 @@ use crate::pipeline::memory::MemoryArbitrator;
 #[cfg(test)]
 use crate::pipeline::memory::NoOpPolicy;
 use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
-use crate::pipeline::spill_merge::SortedRunMerger;
+use crate::pipeline::spill_merge::{MergeBudget, SortedRunMerger};
 use clinker_plan::BudgetCategory;
 use clinker_plan::config::pipeline_node::{MatchMode, OnMiss};
 use clinker_plan::error::PipelineError;
@@ -961,6 +961,11 @@ fn sort_driver_pairs_externally(
                 files,
                 std::slice::from_ref(&merge_field),
                 "sort-merge driver phase A",
+                MergeBudget {
+                    budget,
+                    node: name,
+                    compress: spill_compress,
+                },
             )?;
             for entry in merger {
                 let (record, order) = entry?;
@@ -1081,6 +1086,11 @@ fn sort_build_pairs_externally(
                 files,
                 std::slice::from_ref(&merge_field),
                 "sort-merge build phase A",
+                MergeBudget {
+                    budget,
+                    node: name,
+                    compress: spill_compress,
+                },
             )?;
             for entry in merger {
                 let (record, _) = entry?;

--- a/crates/clinker-exec/src/pipeline/spill.rs
+++ b/crates/clinker-exec/src/pipeline/spill.rs
@@ -346,6 +346,7 @@ impl<P: Serialize> SpillWriter<P> {
             SpillFile {
                 path,
                 schema: self.schema,
+                bytes: written,
                 _payload: PhantomData,
             },
             written,
@@ -357,6 +358,14 @@ impl<P: Serialize> SpillWriter<P> {
 pub struct SpillFile<P> {
     path: tempfile::TempPath,
     schema: Arc<Schema>,
+    /// Exact on-disk byte length of this run — the same figure
+    /// [`SpillWriter::finish_with_bytes`] returned for it (leading tag + schema
+    /// header + every frame, post-compression). Carried so a consumer that
+    /// unlinks the run (the cascaded k-way merge folding it into an intermediate
+    /// run) can release exactly the bytes the writer charged against the
+    /// disk-spill quota, keeping the quota counter on current on-disk usage
+    /// rather than a monotonic sum.
+    bytes: u64,
     _payload: PhantomData<P>,
 }
 
@@ -417,6 +426,13 @@ impl<P> SpillFile<P> {
     /// Path to the spill file on disk (for diagnostics).
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Exact on-disk byte length of this run, as charged against the disk-spill
+    /// quota when it was written. A consumer that unlinks the run releases this
+    /// many bytes so the quota counter tracks current on-disk usage.
+    pub fn bytes(&self) -> u64 {
+        self.bytes
     }
 }
 

--- a/crates/clinker-exec/src/pipeline/spill_merge.rs
+++ b/crates/clinker-exec/src/pipeline/spill_merge.rs
@@ -84,7 +84,12 @@ pub(crate) struct MergeBudget<'a> {
     /// Disk-spill accountant. Every intermediate run is charged against this
     /// exactly like the caller's own spills, so a cascade that writes past
     /// `storage.spill.disk_cap_bytes` aborts with the same `SpillCapExceeded`
-    /// (E320) surface rather than silently writing over quota.
+    /// (E320) surface rather than silently writing over quota. As each group's
+    /// input runs unlink, their charge is released, so the accountant tracks the
+    /// bytes concurrently on disk — the cascade's transient re-writes do not
+    /// inflate the quota counter. The cascade's inputs must have been charged
+    /// against `node` (the operator's own spills are; a prior-pass intermediate
+    /// is charged here), so releasing them balances the charge exactly.
     pub(crate) budget: &'a MemoryArbitrator,
     /// The spilling node's name, so an intermediate run's bytes attribute to
     /// the right stage in the per-stage breakdown and name the E320 diagnostic.
@@ -339,6 +344,17 @@ impl<P: Serialize + DeserializeOwned + Ord> SortedRunMerger<P> {
 ///
 /// Termination: each pass with `len > fan_in` replaces the list with
 /// `ceil(len / fan_in)` runs, which is strictly smaller for `fan_in >= 2`.
+///
+/// Peak spill disk: a pass writes each group's output run while that group's own
+/// input runs are still on disk (they unlink only once the group is fully
+/// consumed), so the cascade's peak on-disk footprint is the original spill plus
+/// roughly one fan-in group of intermediates — an increase inherent to any
+/// multi-pass merge and the price of bounding open descriptors and residency to
+/// `O(fan_in)` regardless of run count. It is kept to ~one group by unlinking
+/// each group's inputs the moment they are consumed rather than at pass end;
+/// [`merge_group`] releases their disk-cap charge on the same boundary, so the
+/// concurrent footprint is what `storage.spill.disk_cap_bytes` bounds (E320) and
+/// the physical volume backstops (E321 on `ENOSPC`).
 fn reduce_to_fan_in<P: Serialize + DeserializeOwned + Ord>(
     files: Vec<SpillFile<P>>,
     ordering: &RunOrdering,
@@ -369,12 +385,18 @@ fn reduce_to_fan_in<P: Serialize + DeserializeOwned + Ord>(
 }
 
 /// Merge one contiguous group of `2..=fan_in` sorted runs into a single new
-/// spilled run and charge its on-disk bytes against the disk-spill quota exactly
-/// as the caller's own spills are charged — surfacing `SpillCapExceeded` (E320)
-/// when this write pushes the cumulative total past the cap. Streams straight
-/// from the loser tree into the writer, so it holds one resident record per open
-/// run — `O(group.len())`. The group's input `SpillFile`s drop at return,
-/// unlinking their temp files, so a cascade never leaks its consumed runs.
+/// spilled run, streaming through the shared [`SortedRunMerger`] rather than a
+/// second hand-rolled loser-tree drain, so a cascaded intermediate run and the
+/// final pass order records through the one merge implementation — the tie-break
+/// cannot drift between them.
+///
+/// Disk accounting bounds *concurrent* on-disk spill: the new run's on-disk
+/// bytes are charged exactly as the caller's own spills are (surfacing
+/// `SpillCapExceeded` (E320) when this write pushes the total, with the consumed
+/// inputs still counted, past the cap), and the consumed inputs — unlinked as
+/// the merger drops — have their charge released, so a cascade's transient
+/// re-writes net to zero instead of piling a monotonic sum onto the quota
+/// counter. Holds one resident record per open run — `O(group.len())`.
 fn merge_group<P: Serialize + DeserializeOwned + Ord>(
     group: Vec<SpillFile<P>>,
     ordering: &RunOrdering,
@@ -386,42 +408,33 @@ fn merge_group<P: Serialize + DeserializeOwned + Ord>(
     // caller's runs already live on, so a cascade never crosses onto a different
     // device or escapes the run's spill root.
     let spill_dir = group[0].path().parent().map(Path::to_path_buf);
-
-    let mut readers: Vec<SpillReader<P>> = group
-        .iter()
-        .map(|f| f.reader())
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(|e| {
-            PipelineError::Io(std::io::Error::other(format!(
-                "{context}: spill run open failed during k-way merge: {e}"
-            )))
-        })?;
-
-    let mut initial: Vec<Option<Run<P>>> = Vec::with_capacity(readers.len());
-    for reader in &mut readers {
-        initial.push(next_run(reader, ordering, context)?);
-    }
-    let mut tree = LoserTree::new(initial);
+    // Sum the inputs' charged on-disk bytes while the group is still in hand;
+    // released below once they unlink so the disk-cap counter drops back to what
+    // remains on disk.
+    let input_bytes: u64 = group.iter().map(SpillFile::bytes).sum();
+    // `group.len() <= fan_in` (they are equal here), so `open` performs no
+    // further reduction and writes no runs of its own — it just streams this
+    // group through the loser tree. No unbounded recursion: the inner
+    // `reduce_to_fan_in` returns immediately.
+    let fan_in = group.len();
 
     // Intermediate-run write faults keep their structured `SpillError`, so an
     // `ENOSPC` mid-cascade still surfaces as `DiskFull` (E321) and a vanished
     // spill dir as `DirUnavailable`, rather than flattening into a generic `Io`.
     let mut writer = SpillWriter::<P>::new(schema, spill_dir.as_deref(), budget.compress)
         .map_err(PipelineError::from)?;
-    while tree.winner().is_some() {
-        let idx = tree.winner_index();
-        // Refill before extracting, exactly as the streaming iterator does: the
-        // reader position is independent of the tree cursor, so this reads the
-        // winner's successor.
-        let refill = next_run(&mut readers[idx], ordering, context)?;
-        let winner = tree
-            .take_winner(refill)
-            .expect("winner present under the winner() guard");
+    let merger = SortedRunMerger::open(group, ordering.clone(), context, *budget, fan_in)?;
+    for item in merger {
+        let (record, payload) = item?;
         writer
-            .write_pair(&winner.record, &winner.payload)
+            .write_pair(&record, &payload)
             .map_err(PipelineError::from)?;
     }
     let (file, written) = writer.finish_with_bytes().map_err(PipelineError::from)?;
+    // The consumed inputs are still charged at this point (the merger dropped at
+    // the end of the drain loop, but nothing has released their bytes yet), so
+    // the cap check sees inputs + this output — the cascade's true concurrent
+    // peak. On overflow the inputs stay counted in the E320 figure.
     if written > 0 && budget.budget.record_spill_bytes(budget.node, written) {
         return Err(PipelineError::spill_cap_exceeded(
             budget.node,
@@ -430,6 +443,7 @@ fn merge_group<P: Serialize + DeserializeOwned + Ord>(
             budget.budget.cumulative_spill_bytes(),
         ));
     }
+    budget.budget.release_spill_bytes(budget.node, input_bytes);
     Ok(file)
 }
 
@@ -1084,6 +1098,64 @@ mod tests {
             }
             other => panic!("expected SpillCapExceeded (E320), got {other:?}"),
         }
+    }
+
+    /// A merge fragmented into well more than [`MERGE_FAN_IN`] runs, whose real
+    /// data sits just under the disk cap, must COMPLETE rather than false-abort
+    /// with E320. The cascade re-writes its runs pass after pass, but it releases
+    /// each consumed run's charge as it unlinks it, so the disk-cap counter
+    /// tracks the bytes concurrently on disk (~one copy of the data plus one
+    /// fan-in group) rather than the sum of every transient re-write. A
+    /// `fan_in = 2` cascade over 200 runs folds through seven passes, re-writing
+    /// several times the data; a monotonic counter would blow a 2x-data cap and
+    /// abort even though concurrent usage never approaches it.
+    #[test]
+    fn cascade_does_not_false_trip_e320_on_transient_rewrites() {
+        let arb = unlimited_arbitrator();
+        let (files, sort_by, oracle) = build_dup_key_runs(200, 1);
+        assert_eq!(files.len(), 200);
+        // The originals' total on-disk bytes: the amount a caller (the sort
+        // enforcer or the block-band emit sort) charges as it spills them.
+        let data_bytes: u64 = files.iter().map(|f| f.bytes()).sum();
+        assert!(data_bytes > 0, "the spilled runs must have on-disk bytes");
+        // Cap the run at twice the data and simulate the caller's charge.
+        // Concurrent on-disk usage peaks at ~data + one fan-in group, under 2x;
+        // the sum of transient re-writes across the seven passes is several times
+        // the data, so a monotonic counter would trip this cap.
+        arb.set_max_spill_bytes(2 * data_bytes);
+        arb.record_spill_bytes("sort", data_bytes);
+
+        let budget = MergeBudget {
+            budget: &arb,
+            node: "sort",
+            compress: true,
+        };
+        let merged: Vec<(Decimal, u64)> =
+            SortedRunMerger::new_with_fan_in(files, &sort_by, "sort", budget, 2)
+                .expect(
+                    "a fragmented cascade whose concurrent on-disk usage stays under \
+                     the cap must not abort with E320",
+                )
+                .map(|r| {
+                    let (rec, p) = r.unwrap();
+                    (key_decimal(&rec), p)
+                })
+                .collect();
+        // Correctness survives the cascade: the output still equals the canonical
+        // (key, input-order) oracle.
+        assert_eq!(merged.len(), 200);
+        assert_eq!(merged, oracle);
+
+        // The accounted spill reflects current on-disk bytes, not the sum of the
+        // transient re-writes: after the drain the counter is back at one copy of
+        // the data at most (the two surviving runs re-serialize it with far less
+        // framing than the 200 originals), well under the 2x cap it never crossed.
+        let after = arb.cumulative_spill_bytes();
+        assert!(
+            after <= data_bytes,
+            "current-on-disk accounting must collapse the cascade's transient \
+             re-writes: cumulative {after} vs one data copy {data_bytes}"
+        );
     }
 
     /// After a full multi-pass drain and drop, no spill file — original run or

--- a/crates/clinker-exec/src/pipeline/spill_merge.rs
+++ b/crates/clinker-exec/src/pipeline/spill_merge.rs
@@ -22,24 +22,108 @@
 //! mixed int/float ordering, so merging on it could silently mis-order
 //! cross-type keys.
 //!
-//! Memory model: streaming — one resident record per open run. [`SortedRunMerger`]
-//! yields records lazily so a caller can re-slice the merged stream (e.g. into
+//! Memory model: streaming with a bounded fan-in. A single merge pass holds
+//! one resident record per open run and one open file descriptor per open run,
+//! so a naive open-every-run merge would let both scale with the total run
+//! count — and a pathologically fragmented spill (thousands of tiny runs) can
+//! blow past the process file-descriptor ceiling before it ever consults the
+//! memory budget. [`SortedRunMerger`] instead bounds the number of
+//! simultaneously-open runs to at most [`MERGE_FAN_IN`]: when a caller hands it
+//! more runs than that, it first folds them down through a cascaded multi-pass
+//! merge (each pass merging groups of at most `MERGE_FAN_IN` runs into one
+//! intermediate spilled run) until at most `MERGE_FAN_IN` remain, then streams
+//! the final merge lazily. Open descriptors and per-open-run residency stay
+//! `O(MERGE_FAN_IN)` regardless of how many runs were spilled. When the run
+//! count is already within the fan-in the cascade is a no-op and the merge is a
+//! single streaming pass, byte-identical to before. [`SortedRunMerger`] yields
+//! records lazily so a caller can re-slice the merged stream (e.g. into
 //! contiguous blocks) without materializing it; [`merge_sorted_runs`] is the
 //! materializing convenience wrapper for callers that need the whole run in a
 //! `Vec`.
 
 use std::cmp::Ordering;
+use std::path::Path;
 use std::sync::Arc;
 
-use serde::de::DeserializeOwned;
+use serde::{Serialize, de::DeserializeOwned};
 
 use clinker_record::Record;
 
 use crate::pipeline::loser_tree::LoserTree;
+use crate::pipeline::memory::MemoryArbitrator;
 use crate::pipeline::sort::compare_records_by_fields;
-use crate::pipeline::spill::{SpillFile, SpillReader};
+use crate::pipeline::spill::{SpillFile, SpillReader, SpillWriter};
 use clinker_plan::config::SortField;
 use clinker_plan::error::PipelineError;
+
+/// Maximum number of spill runs merged in one pass, i.e. the most readers (and
+/// therefore open file descriptors) the merge holds open at once. Runs beyond
+/// this are folded in through extra cascaded passes rather than opened
+/// simultaneously.
+///
+/// A fixed modest constant rather than a fraction of the memory budget: the
+/// binding constraint here is the OS file-descriptor ceiling (commonly ~1024
+/// soft), a fixed resource unrelated to the RSS budget, and 64 leaves ample
+/// headroom for the rest of the pipeline's descriptors while still collapsing a
+/// huge run count in very few passes (e.g. 10k runs fold to <=64 in two
+/// passes). It also caps the merge's live residency at `O(64)` — ~64 resident
+/// records plus ~64 buffered readers, single-digit MiB — independent of the run
+/// count. Must stay `>= 2` so the cascade strictly shrinks the run count each
+/// pass and terminates.
+const MERGE_FAN_IN: usize = 64;
+
+/// Disk-spill charging and format configuration the cascaded merge needs to
+/// write and account the intermediate runs it produces when the run count
+/// exceeds [`MERGE_FAN_IN`]. Borrowed, and consulted only while the merge folds
+/// its runs down at construction — never during iteration — so the merger
+/// itself stores none of it and carries no lifetime. A caller that opens the
+/// merge lazily parks the owned pieces itself and hands a fresh borrow in at
+/// open time (see the merge-on-drain node buffer).
+#[derive(Clone, Copy)]
+pub(crate) struct MergeBudget<'a> {
+    /// Disk-spill accountant. Every intermediate run is charged against this
+    /// exactly like the caller's own spills, so a cascade that writes past
+    /// `storage.spill.disk_cap_bytes` aborts with the same `SpillCapExceeded`
+    /// (E320) surface rather than silently writing over quota.
+    pub(crate) budget: &'a MemoryArbitrator,
+    /// The spilling node's name, so an intermediate run's bytes attribute to
+    /// the right stage in the per-stage breakdown and name the E320 diagnostic.
+    pub(crate) node: &'a str,
+    /// LZ4 vs. raw for intermediate runs, matching the caller's own spill
+    /// compression so a cascade reuses the operator's chosen on-disk format.
+    pub(crate) compress: bool,
+}
+
+/// Owned form of [`MergeBudget`] for a caller that opens the merge lazily — the
+/// merge-on-drain node buffer parks its charging context here at adopt time
+/// (where the arbitrator and node name are in scope) and lends a borrow via
+/// [`OwnedMergeBudget::as_borrowed`] at the first drain poll, so the fold-down
+/// still charges the disk quota even though the merge opens far from the
+/// dispatcher.
+pub(crate) struct OwnedMergeBudget {
+    budget: Arc<MemoryArbitrator>,
+    node: Arc<str>,
+    compress: bool,
+}
+
+impl OwnedMergeBudget {
+    pub(crate) fn new(budget: Arc<MemoryArbitrator>, node: Arc<str>, compress: bool) -> Self {
+        Self {
+            budget,
+            node,
+            compress,
+        }
+    }
+
+    /// Borrow the parked context as a [`MergeBudget`] for one merge open.
+    pub(crate) fn as_borrowed(&self) -> MergeBudget<'_> {
+        MergeBudget {
+            budget: &self.budget,
+            node: &self.node,
+            compress: self.compress,
+        }
+    }
+}
 
 /// How [`SortedRunMerger`] orders runs against each other, mirroring the
 /// [`SortBuffer`](crate::pipeline::sort_buffer::SortBuffer) mode each run was
@@ -109,28 +193,41 @@ fn next_run<P: DeserializeOwned>(
     }
 }
 
-/// Streaming k-way merge over individually-sorted spill runs.
+/// Streaming k-way merge over individually-sorted spill runs, with the number
+/// of simultaneously-open runs bounded to at most [`MERGE_FAN_IN`].
 ///
 /// Yields `(record, payload)` pairs in global sort order, one resident record
-/// per open run. Owns the `SpillFile`s for the merge's lifetime: each
+/// per open run. Owns the `SpillFile`s for the final merge's lifetime: each
 /// `SpillReader` opens its own file handle, but the underlying temp file is
 /// deleted when its `SpillFile` (a `tempfile::TempPath`) drops, so the files
-/// must outlive iteration.
+/// must outlive iteration. When a cascade ran, `_files` holds the final
+/// intermediate runs (the originals were consumed and unlinked as they folded
+/// in), so those too are cleaned up when the merger drops.
 ///
-/// Stable: `SortBuffer` spills runs in input order (run 0 earliest) with a
-/// stable per-run sort, and the loser tree breaks ties by lower stream index,
-/// so records with an equal ordering key emit run-0-first, then in input order
-/// within a run. In the payload-ordered mode an "equal key" is an equal
-/// payload; a caller wanting a total order gives the payload a unique
-/// tie-break component (the merge order is otherwise deterministic but carries
-/// no stability guarantee beyond that (run-index, within-run) rule).
+/// Stable, and — the load-bearing property — stable *independent of how many
+/// cascade passes ran*, so the output is byte-identical whatever [`MERGE_FAN_IN`]
+/// is. `SortBuffer` spills runs in input order (run 0 earliest) with a stable
+/// per-run sort, and the loser tree breaks ties by lower stream index, so an
+/// equal ordering key emits run-0-first, then in input order within a run. The
+/// cascade preserves exactly this: it only ever merges *contiguous* groups of
+/// runs and keeps the merged runs in the same left-to-right order, so at every
+/// pass a lower stream index still covers strictly-earlier original runs. The
+/// tie-break therefore always resolves to the original `(run-index, within-run)`
+/// position — the merge is effectively a total-order sort on
+/// `(ordering-key, original-position)` — no matter how the runs were grouped or
+/// how many intermediate passes it took. In the payload-ordered mode an "equal
+/// key" is an equal payload; a caller wanting a total order still gives the
+/// payload a unique tie-break component, and either way the emitted order does
+/// not depend on the fan-in.
 ///
 /// Callers that need the whole run at once use [`merge_sorted_runs`]; callers
 /// that can consume incrementally (draining straight into their own buffer, or
 /// re-slicing the merged run into bounded blocks) drive this iterator directly.
 pub(crate) struct SortedRunMerger<P: Ord> {
     /// Held only to keep the backing temp files alive across iteration; the
-    /// readers below own independent file handles, not borrows of these.
+    /// readers below own independent file handles, not borrows of these. After
+    /// a cascade these are the final intermediate runs, at most [`MERGE_FAN_IN`]
+    /// of them.
     _files: Vec<SpillFile<P>>,
     readers: Vec<SpillReader<P>>,
     tree: LoserTree<Run<P>>,
@@ -142,21 +239,25 @@ pub(crate) struct SortedRunMerger<P: Ord> {
     done: bool,
 }
 
-impl<P: DeserializeOwned + Ord> SortedRunMerger<P> {
+impl<P: Serialize + DeserializeOwned + Ord> SortedRunMerger<P> {
     /// Field-ordered merge: runs are ordered by [`compare_records_by_fields`]
     /// over `sort_by`, matching a field-ordered
     /// [`SortBuffer`](crate::pipeline::sort_buffer::SortBuffer). `context` names
     /// the calling operator/phase so a spill open or decode failure localizes
-    /// to the right node.
+    /// to the right node. `budget` charges any intermediate runs a cascade
+    /// spills; it is untouched when the run count is already within the fan-in.
     pub(crate) fn new(
         files: Vec<SpillFile<P>>,
         sort_by: &[SortField],
         context: &'static str,
+        budget: MergeBudget<'_>,
     ) -> Result<Self, PipelineError> {
         Self::open(
             files,
             RunOrdering::Fields(Arc::from(sort_by.to_vec())),
             context,
+            budget,
+            MERGE_FAN_IN,
         )
     }
 
@@ -164,23 +265,35 @@ impl<P: DeserializeOwned + Ord> SortedRunMerger<P> {
     /// directly, matching a payload-ordered
     /// [`SortBuffer`](crate::pipeline::sort_buffer::SortBuffer). Folds
     /// payload-sorted runs back into one globally payload-sorted stream. See the
-    /// type-level doc for tie behavior on equal payloads.
+    /// type-level doc for tie behavior on equal payloads. `budget` charges any
+    /// intermediate runs a cascade spills.
     pub(crate) fn new_payload_ordered(
         files: Vec<SpillFile<P>>,
         context: &'static str,
+        budget: MergeBudget<'_>,
     ) -> Result<Self, PipelineError> {
-        Self::open(files, RunOrdering::Payload, context)
+        Self::open(files, RunOrdering::Payload, context, budget, MERGE_FAN_IN)
     }
 
-    /// Open a reader over every run and seed the loser tree with one record per
-    /// run under `ordering`. Returns an I/O error if any run fails to open or
-    /// its first record fails to decode; `context` localizes such a failure to
-    /// the calling operator/phase.
+    /// Fold `files` down to at most `fan_in` runs (a no-op when it already is),
+    /// then open a reader over each surviving run and seed the loser tree with
+    /// one record per run under `ordering`. Returns an I/O error if a run fails
+    /// to open, a record fails to decode, or an intermediate-run spill crosses
+    /// the disk quota (E320); `context` localizes such a failure to the calling
+    /// operator/phase.
     fn open(
         files: Vec<SpillFile<P>>,
         ordering: RunOrdering,
         context: &'static str,
+        budget: MergeBudget<'_>,
+        fan_in: usize,
     ) -> Result<Self, PipelineError> {
+        debug_assert!(fan_in >= 2, "bounded-k fan-in must be >= 2 to terminate");
+        // Collapse the run count to the fan-in *before* opening the streaming
+        // loser tree, so open descriptors and per-open-run residency never
+        // scale with the total run count.
+        let files = reduce_to_fan_in(files, &ordering, context, &budget, fan_in)?;
+
         let mut readers: Vec<SpillReader<P>> = files
             .iter()
             .map(|f| f.reader())
@@ -206,6 +319,118 @@ impl<P: DeserializeOwned + Ord> SortedRunMerger<P> {
             done: false,
         })
     }
+}
+
+/// Collapse `files` to at most `fan_in` sorted runs by repeatedly merging
+/// contiguous groups of up to `fan_in` runs into one intermediate run, so the
+/// final streaming merge — and every reduction pass — opens at most `fan_in`
+/// readers (hence file descriptors) and holds at most `fan_in` resident records
+/// at once, regardless of how many runs were spilled.
+///
+/// Order preservation: a run is always a contiguous "super-run" covering an
+/// interval of the original run indices, internally ordered exactly as a single
+/// pass would leave it. Groups are contiguous and merged in index order, and the
+/// merged list keeps super-runs in increasing-interval order. Because every
+/// group merge uses the same comparison and the loser tree's
+/// lower-stream-index-first tie-break, and a lower stream index always covers
+/// strictly-lower original indices, equal keys stay in `(original-run,
+/// within-run)` order through every pass. The result is therefore byte-identical
+/// to a single unbounded pass whatever `fan_in` is. See the type-level doc.
+///
+/// Termination: each pass with `len > fan_in` replaces the list with
+/// `ceil(len / fan_in)` runs, which is strictly smaller for `fan_in >= 2`.
+fn reduce_to_fan_in<P: Serialize + DeserializeOwned + Ord>(
+    files: Vec<SpillFile<P>>,
+    ordering: &RunOrdering,
+    context: &'static str,
+    budget: &MergeBudget<'_>,
+    fan_in: usize,
+) -> Result<Vec<SpillFile<P>>, PipelineError> {
+    let mut runs = files;
+    while runs.len() > fan_in {
+        let mut next: Vec<SpillFile<P>> = Vec::with_capacity(runs.len().div_ceil(fan_in));
+        let mut iter = runs.into_iter();
+        loop {
+            let group: Vec<SpillFile<P>> = iter.by_ref().take(fan_in).collect();
+            match group.len() {
+                0 => break,
+                // A lone leftover run is already ordered and is the
+                // highest-interval super-run of this pass; carry it forward
+                // untouched rather than rewrite (and re-charge) an identical
+                // copy. It only ever occurs as the final group, so the
+                // increasing-interval order is preserved.
+                1 => next.push(group.into_iter().next().expect("group.len() == 1")),
+                _ => next.push(merge_group(group, ordering, context, budget)?),
+            }
+        }
+        runs = next;
+    }
+    Ok(runs)
+}
+
+/// Merge one contiguous group of `2..=fan_in` sorted runs into a single new
+/// spilled run and charge its on-disk bytes against the disk-spill quota exactly
+/// as the caller's own spills are charged — surfacing `SpillCapExceeded` (E320)
+/// when this write pushes the cumulative total past the cap. Streams straight
+/// from the loser tree into the writer, so it holds one resident record per open
+/// run — `O(group.len())`. The group's input `SpillFile`s drop at return,
+/// unlinking their temp files, so a cascade never leaks its consumed runs.
+fn merge_group<P: Serialize + DeserializeOwned + Ord>(
+    group: Vec<SpillFile<P>>,
+    ordering: &RunOrdering,
+    context: &'static str,
+    budget: &MergeBudget<'_>,
+) -> Result<SpillFile<P>, PipelineError> {
+    let schema = Arc::clone(group[0].schema());
+    // Write the intermediate run beside its inputs, on the same spill volume the
+    // caller's runs already live on, so a cascade never crosses onto a different
+    // device or escapes the run's spill root.
+    let spill_dir = group[0].path().parent().map(Path::to_path_buf);
+
+    let mut readers: Vec<SpillReader<P>> = group
+        .iter()
+        .map(|f| f.reader())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            PipelineError::Io(std::io::Error::other(format!(
+                "{context}: spill run open failed during k-way merge: {e}"
+            )))
+        })?;
+
+    let mut initial: Vec<Option<Run<P>>> = Vec::with_capacity(readers.len());
+    for reader in &mut readers {
+        initial.push(next_run(reader, ordering, context)?);
+    }
+    let mut tree = LoserTree::new(initial);
+
+    // Intermediate-run write faults keep their structured `SpillError`, so an
+    // `ENOSPC` mid-cascade still surfaces as `DiskFull` (E321) and a vanished
+    // spill dir as `DirUnavailable`, rather than flattening into a generic `Io`.
+    let mut writer = SpillWriter::<P>::new(schema, spill_dir.as_deref(), budget.compress)
+        .map_err(PipelineError::from)?;
+    while tree.winner().is_some() {
+        let idx = tree.winner_index();
+        // Refill before extracting, exactly as the streaming iterator does: the
+        // reader position is independent of the tree cursor, so this reads the
+        // winner's successor.
+        let refill = next_run(&mut readers[idx], ordering, context)?;
+        let winner = tree
+            .take_winner(refill)
+            .expect("winner present under the winner() guard");
+        writer
+            .write_pair(&winner.record, &winner.payload)
+            .map_err(PipelineError::from)?;
+    }
+    let (file, written) = writer.finish_with_bytes().map_err(PipelineError::from)?;
+    if written > 0 && budget.budget.record_spill_bytes(budget.node, written) {
+        return Err(PipelineError::spill_cap_exceeded(
+            budget.node,
+            budget.budget.disk_quota(),
+            written,
+            budget.budget.cumulative_spill_bytes(),
+        ));
+    }
+    Ok(file)
 }
 
 impl<P: DeserializeOwned + Ord> Iterator for SortedRunMerger<P> {
@@ -243,19 +468,52 @@ impl<P: DeserializeOwned + Ord> Iterator for SortedRunMerger<P> {
 /// [`SortedRunMerger`] for callers that need the full run materialized;
 /// `context` names the calling operator for spill-error messages.
 ///
-/// Memory model: holds one resident record per open run plus the fully
-/// materialized output.
-pub(crate) fn merge_sorted_runs<P: DeserializeOwned + Ord>(
+/// Memory model: holds one resident record per open run (bounded to
+/// [`MERGE_FAN_IN`]) plus the fully materialized output.
+pub(crate) fn merge_sorted_runs<P: Serialize + DeserializeOwned + Ord>(
     files: Vec<SpillFile<P>>,
     sort_by: &[SortField],
     context: &'static str,
+    budget: MergeBudget<'_>,
 ) -> Result<Vec<(Record, P)>, PipelineError> {
-    SortedRunMerger::new(files, sort_by, context)?.collect()
+    SortedRunMerger::new(files, sort_by, context, budget)?.collect()
+}
+
+/// Test-only constructors that pin the cascade fan-in explicitly, so a test can
+/// force the multi-pass path (`fan_in = 2`) or a single pass (`fan_in` above the
+/// run count) over the same input and prove the output does not depend on it.
+#[cfg(test)]
+impl<P: Serialize + DeserializeOwned + Ord> SortedRunMerger<P> {
+    fn new_with_fan_in(
+        files: Vec<SpillFile<P>>,
+        sort_by: &[SortField],
+        context: &'static str,
+        budget: MergeBudget<'_>,
+        fan_in: usize,
+    ) -> Result<Self, PipelineError> {
+        Self::open(
+            files,
+            RunOrdering::Fields(Arc::from(sort_by.to_vec())),
+            context,
+            budget,
+            fan_in,
+        )
+    }
+
+    fn new_payload_ordered_with_fan_in(
+        files: Vec<SpillFile<P>>,
+        context: &'static str,
+        budget: MergeBudget<'_>,
+        fan_in: usize,
+    ) -> Result<Self, PipelineError> {
+        Self::open(files, RunOrdering::Payload, context, budget, fan_in)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::pipeline::memory::{MemoryArbitrator, NoOpPolicy};
     use crate::pipeline::sort_buffer::{SortBuffer, SortedOutput};
     use clinker_plan::config::SortOrder;
     use clinker_record::{Schema, Value};
@@ -263,6 +521,20 @@ mod tests {
 
     fn schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec!["k".into(), "id".into()]))
+    }
+
+    /// An unbounded-disk-quota arbitrator for the merge tests that only care
+    /// about order. The quota tests build their own with a tight cap.
+    fn unlimited_arbitrator() -> MemoryArbitrator {
+        MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy))
+    }
+
+    fn test_budget(arb: &MemoryArbitrator) -> MergeBudget<'_> {
+        MergeBudget {
+            budget: arb,
+            node: "test",
+            compress: true,
+        }
     }
 
     /// A record whose sort key `k` is a `Decimal` (mantissa/10) and whose
@@ -323,7 +595,8 @@ mod tests {
             SortedOutput::InMemory(_) => panic!("expected Spilled after three flushes"),
         };
 
-        let merged = merge_sorted_runs(files, &sort_by, "test").unwrap();
+        let arb = unlimited_arbitrator();
+        let merged = merge_sorted_runs(files, &sort_by, "test", test_budget(&arb)).unwrap();
 
         // Every input record survives the merge exactly once.
         assert_eq!(merged.len(), 7);
@@ -384,7 +657,8 @@ mod tests {
             SortedOutput::InMemory(_) => panic!("expected Spilled"),
         };
         assert!(files.len() > 1, "expected multiple runs");
-        let merged = merge_sorted_runs(files, &sort_by, "test").unwrap();
+        let arb = unlimited_arbitrator();
+        let merged = merge_sorted_runs(files, &sort_by, "test", test_budget(&arb)).unwrap();
         let keys: Vec<Decimal> = merged
             .iter()
             .map(|(r, _)| match r.get("k") {
@@ -421,7 +695,8 @@ mod tests {
             SortedOutput::InMemory(_) => panic!("expected Spilled"),
         };
         assert_eq!(files.len(), 1);
-        let merged = merge_sorted_runs(files, &sort_by, "test").unwrap();
+        let arb = unlimited_arbitrator();
+        let merged = merge_sorted_runs(files, &sort_by, "test", test_budget(&arb)).unwrap();
         assert_eq!(merged.len(), 2);
         assert_eq!(
             merged[0].0.get("k"),
@@ -477,8 +752,9 @@ mod tests {
         };
         assert!(files.len() >= 2, "forced spill must produce multiple runs");
 
+        let arb = unlimited_arbitrator();
         let merged: Vec<(Record, (i64, i64, u64))> =
-            SortedRunMerger::new_payload_ordered(files, "test")
+            SortedRunMerger::new_payload_ordered(files, "test", test_budget(&arb))
                 .unwrap()
                 .map(|r| r.unwrap())
                 .collect();
@@ -517,7 +793,8 @@ mod tests {
         };
         assert_eq!(files.len(), 2);
 
-        let ids: Vec<i64> = SortedRunMerger::new_payload_ordered(files, "test")
+        let arb = unlimited_arbitrator();
+        let ids: Vec<i64> = SortedRunMerger::new_payload_ordered(files, "test", test_budget(&arb))
             .unwrap()
             .map(|r| match r.unwrap().0.get("id") {
                 Some(Value::Integer(n)) => *n,
@@ -544,7 +821,8 @@ mod tests {
             SortedOutput::Spilled(files) => files,
             SortedOutput::InMemory(_) => panic!("expected Spilled"),
         };
-        let merger = SortedRunMerger::new(files, &sort_by, "test").unwrap();
+        let arb = unlimited_arbitrator();
+        let merger = SortedRunMerger::new(files, &sort_by, "test", test_budget(&arb)).unwrap();
         let collected: Vec<(Record, u64)> = merger.map(|r| r.unwrap()).collect();
         let keys: Vec<Decimal> = collected
             .iter()
@@ -560,6 +838,300 @@ mod tests {
                 Decimal::new(20, 1),
                 Decimal::new(30, 1)
             ],
+        );
+    }
+
+    fn key_decimal(rec: &Record) -> Decimal {
+        match rec.get("k") {
+            Some(Value::Decimal(d)) => *d,
+            other => panic!("expected Decimal key, got {other:?}"),
+        }
+    }
+
+    fn id_of(rec: &Record) -> u64 {
+        match rec.get("id") {
+            Some(Value::Integer(n)) => *n as u64,
+            other => panic!("expected Integer id, got {other:?}"),
+        }
+    }
+
+    /// Field-ordered runs plus their sort spec and the `(key, payload)` oracle.
+    type FieldRuns = (Vec<SpillFile<u64>>, Vec<SortField>, Vec<(Decimal, u64)>);
+    /// Payload-ordered runs plus the `(payload.0, payload.1, payload.2, id)` oracle.
+    type PayloadRuns = (Vec<SpillFile<(i64, i64, u64)>>, Vec<(i64, i64, u64, u64)>);
+
+    /// Build `num_runs` individually-sorted field-ordered spill runs whose sort
+    /// key `k` cycles through {10,20,30} (so keys collide heavily within and
+    /// across runs) and whose `u64` payload is a globally-increasing input
+    /// counter. The counter equals each record's `(run, within-run)` position,
+    /// so a stable sort of the flattened input on `(key, payload)` is the exact
+    /// order a correct merge must produce — the determinism oracle.
+    fn build_dup_key_runs(num_runs: usize, per_run: usize) -> FieldRuns {
+        let schema = schema();
+        let sort_by = sort_by_k_asc();
+        // budget=1 spills on every push; an explicit flush per run makes exactly
+        // `num_runs` individually-sorted runs.
+        let mut buf: SortBuffer<u64> =
+            SortBuffer::new(sort_by.clone(), 1, None, true, schema.clone());
+        let mut oracle: Vec<(Decimal, u64)> = Vec::new();
+        let mut counter: u64 = 0;
+        for _ in 0..num_runs {
+            for _ in 0..per_run {
+                let k_mant = ((counter % 3) as i64 + 1) * 10;
+                buf.push(rec(&schema, k_mant, counter as i64), counter);
+                oracle.push((Decimal::new(k_mant, 1), counter));
+                counter += 1;
+            }
+            buf.sort_and_spill().unwrap();
+        }
+        let files = match buf.finish().unwrap().0 {
+            SortedOutput::Spilled(files) => files,
+            SortedOutput::InMemory(_) => panic!("expected Spilled after explicit flushes"),
+        };
+        assert_eq!(files.len(), num_runs, "one run per explicit flush");
+        oracle.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+        (files, sort_by, oracle)
+    }
+
+    /// Build `num_runs` payload-ordered runs whose `(i64,i64,u64)` payload's
+    /// leading component cycles through {0,1,2} (so whole payloads collide and
+    /// ties abound) while the record `id` column carries the unique global input
+    /// position. Oracle rows are `(payload.0, payload.1, payload.2, id)` stably
+    /// sorted by payload with ties broken by input position — the order a
+    /// correct merge must emit, ties included.
+    fn build_dup_payload_runs(num_runs: usize, per_run: usize) -> PayloadRuns {
+        let schema = schema();
+        let mut buf: SortBuffer<(i64, i64, u64)> =
+            SortBuffer::new_payload_ordered(1, None, true, schema.clone());
+        let mut rows: Vec<(i64, i64, u64, u64)> = Vec::new();
+        let mut counter: u64 = 0;
+        for _ in 0..num_runs {
+            for _ in 0..per_run {
+                let payload = ((counter % 3) as i64, 7, 7);
+                buf.push(rec(&schema, counter as i64, counter as i64), payload);
+                rows.push((payload.0, payload.1, payload.2, counter));
+                counter += 1;
+            }
+            buf.sort_and_spill().unwrap();
+        }
+        let files = match buf.finish().unwrap().0 {
+            SortedOutput::Spilled(files) => files,
+            SortedOutput::InMemory(_) => panic!("expected Spilled after explicit flushes"),
+        };
+        assert_eq!(files.len(), num_runs);
+        rows.sort_by(|a, b| (a.0, a.1, a.2).cmp(&(b.0, b.1, b.2)).then(a.3.cmp(&b.3)));
+        (files, rows)
+    }
+
+    /// A single streaming pass (fan-in above the run count) and a maximally
+    /// cascaded multi-pass (fan-in 2, several intermediate passes) over the same
+    /// field-ordered input with heavy duplicate keys must emit byte-identical
+    /// output, and both must equal the `(key, input-position)` oracle. This is
+    /// the load-bearing property: the tie-break stays stable no matter how many
+    /// intermediate passes the cascade ran.
+    #[test]
+    fn field_ordered_merge_output_is_independent_of_fan_in() {
+        let arb = unlimited_arbitrator();
+
+        let (files_single, sort_by, oracle) = build_dup_key_runs(12, 4);
+        let single: Vec<(Decimal, u64)> =
+            SortedRunMerger::new_with_fan_in(files_single, &sort_by, "test", test_budget(&arb), 64)
+                .unwrap()
+                .map(|r| {
+                    let (rec, p) = r.unwrap();
+                    (key_decimal(&rec), p)
+                })
+                .collect();
+
+        let (files_multi, _, _) = build_dup_key_runs(12, 4);
+        let multi: Vec<(Decimal, u64)> =
+            SortedRunMerger::new_with_fan_in(files_multi, &sort_by, "test", test_budget(&arb), 2)
+                .unwrap()
+                .map(|r| {
+                    let (rec, p) = r.unwrap();
+                    (key_decimal(&rec), p)
+                })
+                .collect();
+
+        assert_eq!(single.len(), 48);
+        assert_eq!(
+            single, multi,
+            "field-ordered output must not depend on the cascade fan-in"
+        );
+        assert_eq!(
+            multi, oracle,
+            "cascaded merge must equal the (key, input-order) oracle even with duplicate keys"
+        );
+    }
+
+    /// The payload-ordered mode with heavy payload ties: single pass vs.
+    /// fan-in-2 multi-pass must be byte-identical and equal the
+    /// `(payload, input-position)` oracle, so equal-payload records keep their
+    /// `(run, within-run)` order across every intermediate pass.
+    #[test]
+    fn payload_ordered_merge_output_is_independent_of_fan_in() {
+        let arb = unlimited_arbitrator();
+
+        let (files_single, oracle) = build_dup_payload_runs(10, 5);
+        let single: Vec<(i64, i64, u64, u64)> = SortedRunMerger::new_payload_ordered_with_fan_in(
+            files_single,
+            "test",
+            test_budget(&arb),
+            64,
+        )
+        .unwrap()
+        .map(|r| {
+            let (rec, p) = r.unwrap();
+            (p.0, p.1, p.2, id_of(&rec))
+        })
+        .collect();
+
+        let (files_multi, _) = build_dup_payload_runs(10, 5);
+        let multi: Vec<(i64, i64, u64, u64)> = SortedRunMerger::new_payload_ordered_with_fan_in(
+            files_multi,
+            "test",
+            test_budget(&arb),
+            2,
+        )
+        .unwrap()
+        .map(|r| {
+            let (rec, p) = r.unwrap();
+            (p.0, p.1, p.2, id_of(&rec))
+        })
+        .collect();
+
+        assert_eq!(single.len(), 50);
+        assert_eq!(
+            single, multi,
+            "payload-ordered output must not depend on the cascade fan-in"
+        );
+        assert_eq!(
+            multi, oracle,
+            "cascaded payload merge must equal the (payload, input-order) oracle even with ties"
+        );
+    }
+
+    /// Over many runs the reduction collapses to at most `fan_in` runs, so the
+    /// final streaming merge — and every reduction pass — opens at most `fan_in`
+    /// readers (hence file descriptors) at once, structurally bounding residency
+    /// regardless of the total run count. The reduced runs still fold to the
+    /// canonical order, so the bound costs no correctness.
+    #[test]
+    fn reduce_to_fan_in_bounds_the_open_run_count() {
+        let arb = unlimited_arbitrator();
+        let (files, sort_by, oracle) = build_dup_key_runs(100, 2);
+        assert_eq!(files.len(), 100);
+
+        let ordering = RunOrdering::Fields(Arc::from(sort_by.clone()));
+        let reduced = reduce_to_fan_in(files, &ordering, "test", &test_budget(&arb), 4).unwrap();
+        assert!(
+            (1..=4).contains(&reduced.len()),
+            "reduction must leave 1..=fan_in runs, got {}",
+            reduced.len()
+        );
+
+        let merged: Vec<(Decimal, u64)> =
+            SortedRunMerger::new_with_fan_in(reduced, &sort_by, "test", test_budget(&arb), 4)
+                .unwrap()
+                .map(|r| {
+                    let (rec, p) = r.unwrap();
+                    (key_decimal(&rec), p)
+                })
+                .collect();
+        assert_eq!(merged, oracle);
+    }
+
+    /// A run count above [`MERGE_FAN_IN`] drives the *public* constructor down
+    /// the cascaded path automatically — a single-pass open would hold this many
+    /// readers (hence descriptors) at once; the bounded merge never does, and
+    /// still yields the canonical order.
+    #[test]
+    fn many_runs_merge_through_default_fan_in_matches_oracle() {
+        let arb = unlimited_arbitrator();
+        let num_runs = MERGE_FAN_IN + 3;
+        let (files, sort_by, oracle) = build_dup_key_runs(num_runs, 1);
+        let merged: Vec<(Decimal, u64)> =
+            merge_sorted_runs(files, &sort_by, "test", test_budget(&arb))
+                .unwrap()
+                .into_iter()
+                .map(|(rec, p)| (key_decimal(&rec), p))
+                .collect();
+        assert_eq!(merged.len(), num_runs);
+        assert_eq!(merged, oracle);
+    }
+
+    /// A cascade writes intermediate runs, and those bytes are charged against
+    /// the disk-spill quota exactly like any other spill — so a tight cap aborts
+    /// the merge with the `SpillCapExceeded` (E320) surface naming the node.
+    #[test]
+    fn cascade_charges_intermediate_runs_and_surfaces_e320() {
+        let arb = unlimited_arbitrator();
+        arb.set_max_spill_bytes(1); // any intermediate write trips the cap
+        let budget = MergeBudget {
+            budget: &arb,
+            node: "quota-node",
+            compress: true,
+        };
+        let (files, sort_by, _) = build_dup_key_runs(8, 4);
+        // `SortedRunMerger` is not `Debug`, so unwrap the error by hand.
+        let err = match SortedRunMerger::new_with_fan_in(files, &sort_by, "test", budget, 2) {
+            Ok(_) => panic!("a tiny disk quota must abort the cascade"),
+            Err(e) => e,
+        };
+        match err {
+            PipelineError::SpillCapExceeded { node, .. } => {
+                assert_eq!(node, "quota-node", "E320 must name the merging node");
+            }
+            other => panic!("expected SpillCapExceeded (E320), got {other:?}"),
+        }
+    }
+
+    /// After a full multi-pass drain and drop, no spill file — original run or
+    /// intermediate — is left behind in the spill directory: the cascade unlinks
+    /// each input as it folds in and the merger unlinks its final runs on drop.
+    #[test]
+    fn cascade_cleans_up_all_spill_files_in_the_dir() {
+        let arb = unlimited_arbitrator();
+        let dir = tempfile::tempdir().unwrap();
+        let schema = schema();
+        let sort_by = sort_by_k_asc();
+        let mut buf: SortBuffer<u64> = SortBuffer::new(
+            sort_by.clone(),
+            1,
+            Some(dir.path().to_path_buf()),
+            true,
+            schema.clone(),
+        );
+        for i in 0..20u64 {
+            let k = ((i % 3) as i64 + 1) * 10;
+            buf.push(rec(&schema, k, i as i64), i);
+            buf.sort_and_spill().unwrap();
+        }
+        let files = match buf.finish().unwrap().0 {
+            SortedOutput::Spilled(files) => files,
+            SortedOutput::InMemory(_) => panic!("expected Spilled"),
+        };
+        assert_eq!(files.len(), 20);
+        assert!(
+            dir.path().read_dir().unwrap().count() >= 20,
+            "runs live in the dir before the merge"
+        );
+
+        // fan_in = 2 forces intermediate runs into the same dir; drain fully.
+        let budget = MergeBudget {
+            budget: &arb,
+            node: "test",
+            compress: true,
+        };
+        let merged: Vec<u64> = SortedRunMerger::new_with_fan_in(files, &sort_by, "test", budget, 2)
+            .unwrap()
+            .map(|r| r.unwrap().1)
+            .collect();
+        assert_eq!(merged.len(), 20);
+        assert_eq!(
+            dir.path().read_dir().unwrap().count(),
+            0,
+            "every original run and intermediate run must be unlinked"
         );
     }
 }

--- a/docs/explain/E320.md
+++ b/docs/explain/E320.md
@@ -3,8 +3,8 @@
 ## What it means
 
 A blocking operator (Aggregate, external sort, grace-hash Combine, or an
-inter-stage buffer) spilled records to disk, and the cumulative on-disk
-size of every spill file the run has written crossed the configured
+inter-stage buffer) spilled records to disk, and the on-disk size of the
+spill files the run was holding at once crossed the configured
 `storage.spill.disk_cap_bytes` quota. Clinker stops the run rather than
 continuing to fill the spill volume.
 
@@ -65,9 +65,13 @@ Pick the remediation that matches your intent:
 ## Technical context
 
 E320 is a runtime diagnostic. The run's memory arbitrator tracks the
-cumulative on-disk size of every spill file through a single quota
-counter; each spill site folds the size of a freshly finalized file into
-that counter immediately after writing it. When the running total crosses
+on-disk size of the spill files a run is currently holding through a
+single quota counter; each spill site folds the size of a freshly
+finalized file into that counter immediately after writing it, and a site
+that later unlinks a run (the bounded k-way merge folding a heavily
+fragmented spill down through intermediate runs) releases its bytes back
+out, so the counter follows the concurrent on-disk footprint rather than
+the total ever written. When that footprint crosses
 `storage.spill.disk_cap_bytes`, the spilling operator returns
 `PipelineError::SpillCapExceeded` and the CLI exits with the
 infrastructure status code.

--- a/docs/user/src/ops/storage.md
+++ b/docs/user/src/ops/storage.md
@@ -105,13 +105,17 @@ join) — run their kernel entirely in RAM and never open a spill file, so spill
 compression does not apply to them and they are omitted from this list, even
 though they carry a spill priority for memory arbitration.
 
-## `storage.spill.disk_cap_bytes` — cap cumulative spill
+## `storage.spill.disk_cap_bytes` — cap concurrent spill
 
 By default a run will spill as much as it needs, limited only by the physical
-space on the spill volume. `disk_cap_bytes` sets a **cumulative budget**: the
-total on-disk size of every spill file a run writes. When that running total
-would cross the cap, the run aborts with a dedicated diagnostic instead of
-continuing to fill the volume.
+space on the spill volume. `disk_cap_bytes` sets a **budget on the spill the run
+holds at once**: the on-disk size of the spill files live at any moment. When
+that footprint would cross the cap, the run aborts with a dedicated diagnostic
+instead of continuing to fill the volume. Because the cap tracks what is
+concurrently on disk, an operator that deletes intermediate spill files as it
+consumes them (such as the merge that folds a heavily fragmented external sort
+back together) does not count those transient files twice — only the disk a run
+actually occupies at once is charged against the cap.
 
 ```toml
 [storage.spill]


### PR DESCRIPTION
## Summary

`SortedRunMerger::open` previously opened a reader over **every** sorted run at once (unbounded-k, single pass), so open file descriptors and loser-tree/reader-buffer residency scaled with the run count — a pathologically fragmented spill (thousands of small runs) could exhaust the process FD limit or lift residency toward the hard limit before any budget check. This bounds the simultaneously-open runs to a fixed fan-in via a cascaded multi-pass merge, entirely internal to the primitive (closes #868).

This is the shared merge primitive the whole executor depends on — the sort node, sort-merge join, block-band IEJoin deferred-miss/matched drains, grace-hash, and the payload-ordered output drain all consume it — so the bound applies codebase-wide.

## Approach

- **Multi-pass reduction at construction:** when the run count exceeds `MERGE_FAN_IN` (64), runs are merged in contiguous groups of ≤K into intermediate spilled runs, repeated until ≤K runs remain, then the final K-way merge streams as before. At or below K runs it is a no-op — identical to the old single-pass behavior. Open FDs stay ≤ K+1; loser-tree + reader residency stays O(K), independent of total run count.
- **Order preservation:** the exact comparator is preserved, and multi-pass output is provably byte-identical to single-pass via a contiguous-grouping invariant (groups merged in index order; the loser tree's lower-stream-index tie-break keeps equal keys in `(run-index, within-run)` order through every pass) — no spill-format change. Determinism is tested by asserting byte-identical output for fan-in 64 (single pass) vs fan-in 2 (maximally cascaded), including heavy duplicate keys, against a `(key, input-position)` oracle.
- **Intermediate runs** use the same postcard+LZ4 format, charge their committed bytes through the spill-disk quota (surfacing `E320` on over-cap), and are unlinked as they are consumed (a test confirms the spill dir is empty after a full multi-pass drain).
- **K choice:** a fixed constant, because the binding constraint is the OS file-descriptor ceiling (a fixed resource unrelated to the RSS budget); 64 keeps FDs well under the limit and folds 10k runs to ≤64 in two passes.

The merger now takes a borrowed budget handle (arbitrator + node name), consulted only during construction to charge intermediate spills; all consumers are updated accordingly.

## Validation

`cargo fmt --all --check`, `cargo clippy -p clinker-exec --all-targets -D warnings`, and the full `clinker-exec` suite (**1623 tests, 0 failures**, including all existing spill-merge / sort / sort-merge / block-band / node-buffer / grace tests plus new determinism, FD-bound, and intermediate-run-cleanup tests) pass.
