### PR TITLE
engine: unify match:first on post-match-projection semantics (#855)

### DIFF
--- a/crates/clinker-exec/src/pipeline/iejoin.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin.rs
@@ -1617,16 +1617,18 @@ fn emit_pairs(
                 // Block path: hold the minimum-build-index candidate; emit at
                 // the driver block's finalize.
                 Some(idx) => state.note_first_candidate(key, idx, build_record),
-                // Equi+range path: first-visited wins. Emit immediately and
-                // dedup; a body eval that skips leaves the driver open to the
-                // next pair.
+                // Equi+range path: the first predicate-matching build is the
+                // selection and the body is a post-match projection. Mark the
+                // driver matched before the body runs, so a body skip drops
+                // only this row without reopening the driver to a later build
+                // or routing it to on_miss; the already-matched guard then
+                // skips every remaining pair for this driver.
                 None => {
                     if state.matched[key] {
                         continue;
                     }
-                    if emit_match_row(cfg, evals, dref, build_record, 0, sink)? {
-                        state.matched[key] = true;
-                    }
+                    state.matched[key] = true;
+                    emit_match_row(cfg, evals, dref, build_record, 0, sink)?;
                 }
             },
             MatchMode::All => {

--- a/crates/clinker-exec/src/pipeline/iejoin/block.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin/block.rs
@@ -1508,9 +1508,11 @@ fn finalize_driver_block(
         MatchMode::First => {
             for (di, (record, payload)) in driver_loaded.iter().enumerate() {
                 match state.take_first_candidate(di) {
-                    // Emit the minimum-build-index candidate. A body eval that
-                    // skips it leaves the driver a miss (no other candidate is
-                    // held), routed to the deferred on_miss dispatch.
+                    // A held candidate means this driver matched the predicate:
+                    // its minimum-build-index match is the selection and the
+                    // body is a post-match projection. Run it once and discard
+                    // the emit/skip result — a body skip drops only this output
+                    // row, it does not turn a matched driver into a miss.
                     Some((bidx, build)) => {
                         let dref = DriverRef {
                             record,
@@ -1518,10 +1520,11 @@ fn finalize_driver_block(
                             key: di,
                             driver_idx: payload.2,
                         };
-                        if !emit_match_row(cfg, evals, &dref, &build, bidx, sink)? {
-                            note_unmatched(pile, record, payload.3, payload.2)?;
-                        }
+                        emit_match_row(cfg, evals, &dref, &build, bidx, sink)?;
                     }
+                    // No candidate held: the driver matched no build predicate,
+                    // a genuine zero-match routed to the deferred on_miss
+                    // dispatch.
                     None => note_unmatched(pile, record, payload.3, payload.2)?,
                 }
             }

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -1816,6 +1816,9 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
 
         MatchMode::First | MatchMode::All => {
             let mut emitted_any = false;
+            // Loop-invariant: First commits to one build and treats the body as a
+            // post-match projection; All scans every window entry.
+            let select_first = matches!(match_mode, MatchMode::First);
             for entry in window.replay(mspill) {
                 let (inner, _build_key, build_idx) = entry?;
                 let out_key = (driver_order, driver_idx, build_idx);
@@ -1856,7 +1859,6 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
                     // match up front so a body skip drops only this row instead
                     // of falling through to on_miss, then stop after this one
                     // build rather than retrying a later match.
-                    let select_first = matches!(match_mode, MatchMode::First);
                     if select_first {
                         emitted_any = true;
                     }
@@ -1907,12 +1909,10 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
                                 error: e,
                             });
                             failure_tags.push(out_key);
-                            // First already committed to this build; the
-                            // deferred dead-letter above is its only output. All
-                            // keeps scanning the remaining window entries.
-                            if !select_first {
-                                continue;
-                            }
+                            // First already committed to this build; the deferred
+                            // dead-letter above is its only output and the trailing
+                            // break stops the scan. All falls through to the next
+                            // window entry.
                         }
                     }
                     if select_first {
@@ -1941,7 +1941,7 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
                     let rec = Record::new(Arc::clone(target_schema), values);
                     push_output_row(output, rec, out_key, mspill)?;
                     emitted_any = true;
-                    if matches!(match_mode, MatchMode::First) {
+                    if select_first {
                         break;
                     }
                 } else {
@@ -1950,7 +1950,7 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
                     // verbatim.
                     push_output_row(output, driver_record.clone(), out_key, mspill)?;
                     emitted_any = true;
-                    if matches!(match_mode, MatchMode::First) {
+                    if select_first {
                         break;
                     }
                 }

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -1851,6 +1851,15 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
                 }
 
                 if let Some(evaluator) = body_eval.as_deref_mut() {
+                    // First selects this residual-passing build and treats the
+                    // body as a post-match projection: record the predicate
+                    // match up front so a body skip drops only this row instead
+                    // of falling through to on_miss, then stop after this one
+                    // build rather than retrying a later match.
+                    let select_first = matches!(match_mode, MatchMode::First);
+                    if select_first {
+                        emitted_any = true;
+                    }
                     let resolver =
                         CombineResolver::new(resolver_mapping, driver_record, Some(&inner));
                     match evaluator.eval_record::<NullStorage>(ctx, &resolver, None) {
@@ -1876,9 +1885,6 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
                             );
                             push_output_row(output, rec, out_key, mspill)?;
                             emitted_any = true;
-                            if matches!(match_mode, MatchMode::First) {
-                                break;
-                            }
                         }
                         Ok(EvalResult::Skip(SkipReason::Filtered)) => {}
                         Ok(EvalResult::Skip(SkipReason::Duplicate)) => {}
@@ -1901,8 +1907,16 @@ fn emit_for_driver(args: EmitDriverArgs<'_, '_>) -> Result<(), PipelineError> {
                                 error: e,
                             });
                             failure_tags.push(out_key);
-                            continue;
+                            // First already committed to this build; the
+                            // deferred dead-letter above is its only output. All
+                            // keeps scanning the remaining window entries.
+                            if !select_first {
+                                continue;
+                            }
                         }
+                    }
+                    if select_first {
+                        break;
                     }
                 } else if let Some(target_schema) = ectx.output_schema {
                     // Body-less synthetic chain step: concatenate driver and

--- a/crates/clinker-exec/tests/combine_match_first_body_skip.rs
+++ b/crates/clinker-exec/tests/combine_match_first_body_skip.rs
@@ -1,0 +1,680 @@
+//! `match: first` treats the combine body as a post-match projection: the first
+//! predicate-matching build is selected, the body runs once, and a body that
+//! skips (or a recoverable body-error defer) drops only that output row. It does
+//! NOT retry a later build and does NOT route the driver to `on_miss` — `on_miss`
+//! fires only for drivers with zero predicate matches.
+//!
+//! These tests pin that semantics identically across all five physical combine
+//! strategies. Each pipeline joins one driver whose chosen build emits (`keep=1`),
+//! one whose chosen build skips (`keep=0`), and — except under `on_miss: error` —
+//! one that matches no build at all. The body is
+//! `filter builds.keep.is_null() or builds.keep == 1`: a matched `keep=1` build
+//! emits the row, a matched `keep=0` build skips it, and a true miss (whose build
+//! side is null on the `on_miss` path) passes the filter and emits under
+//! `null_fields`.
+//!
+//! The `keep=0` skip driver is therefore observable. Under the retired
+//! retry/route-to-miss reading it would surface as a `null_fields` row (the miss
+//! body sees a null build and passes the filter) or abort under `on_miss: error`;
+//! under the post-match-projection reading it silently produces nothing. Each
+//! driver matches exactly one build, so the "first" selection is deterministic
+//! regardless of which strategy visits builds in which order.
+
+use std::collections::HashMap;
+use std::io::{Cursor, Write};
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{
+    PipelineExecutor, PipelineRunParams, SourceReaders, single_file_reader,
+};
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// Outcome of one successful pipeline run.
+struct RunOutcome {
+    /// Full primary-output CSV text (header included).
+    output: String,
+    /// Total committed spill bytes for the run.
+    spill_bytes: u64,
+}
+
+/// Compile and execute `yaml` over the named in-memory CSV inputs, returning the
+/// captured `out` CSV and spill total, or the formatted pipeline error.
+fn try_run(yaml: &str, inputs: &[(&str, String)]) -> Result<RunOutcome, String> {
+    let config = parse_config(yaml).map_err(|e| format!("parse: {e:?}"))?;
+    let plan = config
+        .compile(&CompileContext::default())
+        .map_err(|e| format!("compile: {e:?}"))?;
+    let readers: SourceReaders = inputs
+        .iter()
+        .map(|(name, data)| {
+            (
+                (*name).to_string(),
+                single_file_reader("test.csv", Box::new(Cursor::new(data.as_bytes().to_vec()))),
+            )
+        })
+        .collect();
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "mb-f-855".to_string(),
+        batch_id: "mb-f-855-batch".to_string(),
+        ..Default::default()
+    };
+    match PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params) {
+        Ok(report) => Ok(RunOutcome {
+            output: buf.as_string(),
+            spill_bytes: report.cumulative_spill_bytes,
+        }),
+        Err(e) => Err(format!("run: {e:?}")),
+    }
+}
+
+/// Parse an output CSV into a header-skipped, sorted `Vec` of rows so two runs
+/// compare as record sets independent of each strategy's emission order.
+fn sorted_rows(csv: &str) -> Vec<Vec<String>> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .from_reader(csv.as_bytes());
+    let mut out: Vec<Vec<String>> = rdr
+        .records()
+        .map(|r| {
+            r.expect("output row parses")
+                .iter()
+                .map(String::from)
+                .collect()
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Assert the compiled Combine selects `expected_tag` (the `[combine:<tag>]`
+/// glyph in `--explain`), so each pipeline forces the strategy it claims.
+fn assert_strategy(yaml: &str, expected_tag: &str) {
+    let config = parse_config(yaml).expect("parse for explain");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("compile for explain");
+    let (dag, _) = PipelineExecutor::explain_plan_dag(&plan).expect("explain dag");
+    let explain = dag.explain_text(&config);
+    assert!(
+        explain.contains(&format!("[combine:{expected_tag}]")),
+        "expected [combine:{expected_tag}], got explain:\n{explain}"
+    );
+}
+
+/// The shared post-match-projection body: emit `did` unless the *matched* build
+/// carries `keep = 0`. A null build (the `on_miss` path) passes via `is_null`.
+const BODY: &str =
+    "        filter builds.keep.is_null() or builds.keep == 1\n        emit did = drivers.did\n";
+
+/// One physical-strategy scenario: its `--explain` tag, a YAML builder taking the
+/// `on_miss` policy, and driver / build CSV builders taking `include_miss`.
+struct Scenario {
+    tag: &'static str,
+    yaml: fn(&str) -> String,
+    drivers: fn(bool) -> String,
+    builds: fn() -> String,
+}
+
+// ── in-memory hash (pure-equi) ────────────────────────────────────────────────
+
+fn hash_yaml(on_miss: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: mb_f_855_hash
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      path: drivers.csv
+      schema:
+        - {{ name: did, type: int }}
+        - {{ name: mk, type: int }}
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      path: builds.csv
+      schema:
+        - {{ name: bid, type: int }}
+        - {{ name: mk, type: int }}
+        - {{ name: keep, type: int }}
+  - type: combine
+    name: j
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "drivers.mk == builds.mk"
+      match: first
+      on_miss: {on_miss}
+      propagate_ck: driver
+      cxl: |
+{BODY}
+  - type: output
+    name: out
+    input: j
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+fn hash_drivers(include_miss: bool) -> String {
+    let mut s = String::from("did,mk\n10,1\n20,2\n");
+    if include_miss {
+        s.push_str("30,9\n");
+    }
+    s
+}
+
+fn hash_builds() -> String {
+    String::from("bid,mk,keep\n100,1,1\n200,2,0\n")
+}
+
+// ── grace hash (pure-equi, forced) ────────────────────────────────────────────
+
+fn grace_yaml(on_miss: &str) -> String {
+    // Identical to the pure-equi hash pipeline plus the `strategy: grace_hash`
+    // hint, so the two differ only in physical strategy.
+    format!(
+        r#"
+pipeline:
+  name: mb_f_855_grace
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      path: drivers.csv
+      schema:
+        - {{ name: did, type: int }}
+        - {{ name: mk, type: int }}
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      path: builds.csv
+      schema:
+        - {{ name: bid, type: int }}
+        - {{ name: mk, type: int }}
+        - {{ name: keep, type: int }}
+  - type: combine
+    name: j
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "drivers.mk == builds.mk"
+      match: first
+      on_miss: {on_miss}
+      strategy: grace_hash
+      propagate_ck: driver
+      cxl: |
+{BODY}
+  - type: output
+    name: out
+    input: j
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+// ── sort-merge (pure-range, single inequality, presorted) ─────────────────────
+
+fn sort_merge_yaml(on_miss: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: mb_f_855_sort_merge
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      path: drivers.csv
+      sort_order:
+        - field: v
+      schema:
+        - {{ name: did, type: int }}
+        - {{ name: v, type: int }}
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      path: builds.csv
+      sort_order:
+        - field: hi
+      schema:
+        - {{ name: bid, type: int }}
+        - {{ name: hi, type: int }}
+        - {{ name: keep, type: int }}
+  - type: combine
+    name: j
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "drivers.v < builds.hi"
+      match: first
+      on_miss: {on_miss}
+      propagate_ck: driver
+      cxl: |
+{BODY}
+  - type: output
+    name: out
+    input: j
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+/// Ascending by `v`. `v=1` sees only the `hi=50` (keep=1) build first; `v=60`
+/// clears `hi=50` and lands on the `hi=100` (keep=0) build; `v=200` clears both.
+fn sort_merge_drivers(include_miss: bool) -> String {
+    let mut s = String::from("did,v\n10,1\n20,60\n");
+    if include_miss {
+        s.push_str("30,200\n");
+    }
+    s
+}
+
+fn sort_merge_builds() -> String {
+    String::from("bid,hi,keep\n100,50,1\n200,100,0\n")
+}
+
+// ── hash-partitioned IEJoin (equi + range) ────────────────────────────────────
+
+fn equi_range_yaml(on_miss: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: mb_f_855_equi_range
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      path: drivers.csv
+      schema:
+        - {{ name: did, type: int }}
+        - {{ name: mk, type: int }}
+        - {{ name: v, type: int }}
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      path: builds.csv
+      schema:
+        - {{ name: bid, type: int }}
+        - {{ name: mk, type: int }}
+        - {{ name: hi, type: int }}
+        - {{ name: keep, type: int }}
+  - type: combine
+    name: j
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "drivers.mk == builds.mk and drivers.v < builds.hi"
+      match: first
+      on_miss: {on_miss}
+      propagate_ck: driver
+      cxl: |
+{BODY}
+  - type: output
+    name: out
+    input: j
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+fn equi_range_drivers(include_miss: bool) -> String {
+    let mut s = String::from("did,mk,v\n10,1,1\n20,2,2\n");
+    if include_miss {
+        s.push_str("30,9,1\n");
+    }
+    s
+}
+
+fn equi_range_builds() -> String {
+    String::from("bid,mk,hi,keep\n100,1,100,1\n200,2,100,0\n")
+}
+
+// ── block-band IEJoin (pure-range, two-conjunct band) ─────────────────────────
+
+fn block_yaml(on_miss: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: mb_f_855_block
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      path: drivers.csv
+      schema:
+        - {{ name: did, type: int }}
+        - {{ name: v, type: int }}
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      path: builds.csv
+      schema:
+        - {{ name: bid, type: int }}
+        - {{ name: lo, type: int }}
+        - {{ name: hi, type: int }}
+        - {{ name: keep, type: int }}
+  - type: combine
+    name: j
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "drivers.v >= builds.lo and drivers.v < builds.hi"
+      match: first
+      on_miss: {on_miss}
+      propagate_ck: driver
+      cxl: |
+{BODY}
+  - type: output
+    name: out
+    input: j
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+fn block_drivers(include_miss: bool) -> String {
+    let mut s = String::from("did,v\n10,10\n20,60\n");
+    if include_miss {
+        s.push_str("30,200\n");
+    }
+    s
+}
+
+fn block_builds() -> String {
+    // Disjoint bands: [0,50) keep=1, [50,100) keep=0.
+    String::from("bid,lo,hi,keep\n100,0,50,1\n200,50,100,0\n")
+}
+
+fn scenarios() -> Vec<Scenario> {
+    vec![
+        Scenario {
+            tag: "hash_build_probe",
+            yaml: hash_yaml,
+            drivers: hash_drivers,
+            builds: hash_builds,
+        },
+        Scenario {
+            tag: "grace_hash",
+            yaml: grace_yaml,
+            drivers: hash_drivers,
+            builds: hash_builds,
+        },
+        Scenario {
+            tag: "sort_merge",
+            yaml: sort_merge_yaml,
+            drivers: sort_merge_drivers,
+            builds: sort_merge_builds,
+        },
+        Scenario {
+            tag: "hash_partition_iejoin",
+            yaml: equi_range_yaml,
+            drivers: equi_range_drivers,
+            builds: equi_range_builds,
+        },
+        Scenario {
+            tag: "iejoin",
+            yaml: block_yaml,
+            drivers: block_drivers,
+            builds: block_builds,
+        },
+    ]
+}
+
+/// Every strategy forces the tag it claims — proof the differential test truly
+/// spans all five physical paths rather than the same one five times.
+#[test]
+fn each_pipeline_forces_its_strategy() {
+    for s in scenarios() {
+        assert_strategy(&(s.yaml)("skip"), s.tag);
+    }
+}
+
+/// `on_miss: skip` — the skip driver and the true miss both vanish, so every
+/// strategy emits exactly the `keep=1` driver.
+#[test]
+fn body_skip_identical_across_strategies_on_miss_skip() {
+    let expected = vec![vec!["10".to_string()]];
+    for s in scenarios() {
+        let inputs = [("drivers", (s.drivers)(true)), ("builds", (s.builds)())];
+        let out = try_run(&(s.yaml)("skip"), &inputs)
+            .unwrap_or_else(|e| panic!("[{}] run failed: {e}", s.tag));
+        assert_eq!(
+            sorted_rows(&out.output),
+            expected,
+            "[{}] on_miss:skip output diverged",
+            s.tag
+        );
+    }
+}
+
+/// `on_miss: null_fields` — the true miss (did 30) emits through the null-build
+/// path; the `keep=0` skip driver (did 20) must NOT appear. The retired reading
+/// would surface did 20 as a null-fields row, so this is the discriminating case.
+#[test]
+fn body_skip_identical_across_strategies_on_miss_null_fields() {
+    let expected = vec![vec!["10".to_string()], vec!["30".to_string()]];
+    for s in scenarios() {
+        let inputs = [("drivers", (s.drivers)(true)), ("builds", (s.builds)())];
+        let out = try_run(&(s.yaml)("null_fields"), &inputs)
+            .unwrap_or_else(|e| panic!("[{}] run failed: {e}", s.tag));
+        assert_eq!(
+            sorted_rows(&out.output),
+            expected,
+            "[{}] on_miss:null_fields must emit the miss but not the body-skip driver",
+            s.tag
+        );
+    }
+}
+
+/// `on_miss: error` with no true miss — the `keep=0` body skip must not be
+/// mistaken for a miss, so the run succeeds and emits only the `keep=1` driver.
+/// Under the retired reading the skip driver would route to `on_miss: error` and
+/// abort the pipeline.
+#[test]
+fn body_skip_does_not_trip_on_miss_error_across_strategies() {
+    let expected = vec![vec!["10".to_string()]];
+    for s in scenarios() {
+        let inputs = [("drivers", (s.drivers)(false)), ("builds", (s.builds)())];
+        let out = try_run(&(s.yaml)("error"), &inputs).unwrap_or_else(|e| {
+            panic!(
+                "[{}] a body-skip driver must not trip on_miss:error: {e}",
+                s.tag
+            )
+        });
+        assert_eq!(
+            sorted_rows(&out.output),
+            expected,
+            "[{}] on_miss:error output diverged",
+            s.tag
+        );
+    }
+}
+
+// ── block path: byte-identical across memory budgets ──────────────────────────
+
+/// Tight budget: the block-band external-sort threshold (`soft / 4`) binds and
+/// the sides spill. Under `backpressure: spill` a sub-baseline-RSS limit is not
+/// rejected at startup but completes by spilling.
+const TIGHT_LIMIT: &str = "1M";
+/// Roomy budget: everything stays resident, so no block-band spill occurs.
+const ROOMY_LIMIT: &str = "512M";
+
+/// A fixed prime stride so driver keys tile `[0, span)` and overflow the tight
+/// `soft / 4` sort threshold into multiple blocks and spilled runs.
+fn tiled_key(i: i64, span: i64) -> i64 {
+    i.wrapping_mul(2_617).rem_euclid(span)
+}
+
+const BLOCK_BUDGET_YAML: &str = r#"
+pipeline:
+  name: mb_f_855_block_budget
+  memory: { limit: "__LIMIT__", backpressure: spill }
+nodes:
+  - type: source
+    name: drivers
+    config:
+      name: drivers
+      type: csv
+      path: drivers.csv
+      schema:
+        - { name: did, type: int }
+        - { name: v, type: int }
+  - type: source
+    name: builds
+    config:
+      name: builds
+      type: csv
+      path: builds.csv
+      schema:
+        - { name: bid, type: int }
+        - { name: lo, type: int }
+        - { name: hi, type: int }
+        - { name: keep, type: int }
+  - type: combine
+    name: j
+    input:
+      drivers: drivers
+      builds: builds
+    config:
+      where: "drivers.v >= builds.lo and drivers.v < builds.hi"
+      match: first
+      on_miss: null_fields
+      propagate_ck: driver
+      cxl: |
+        filter builds.keep.is_null() or builds.keep == 1
+        emit did = drivers.did
+  - type: output
+    name: out
+    input: j
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+/// Build the block-band budget workload: `n_bands` disjoint bands tiling
+/// `[0, span)` with alternating `keep`, `n_drivers` drivers tiled across the
+/// span, plus `n_miss` out-of-range drivers. Returns the driver/build CSVs and
+/// the expected sorted `did` output under `on_miss: null_fields` (drivers whose
+/// band keeps, plus every out-of-range miss).
+fn block_budget_workload(
+    n_drivers: i64,
+    n_bands: i64,
+    span: i64,
+    n_miss: i64,
+) -> (String, String, Vec<Vec<String>>) {
+    let bstep = span / n_bands;
+    let mut build_csv = String::from("bid,lo,hi,keep\n");
+    for b in 0..n_bands {
+        let keep = if b % 2 == 0 { 1 } else { 0 };
+        build_csv.push_str(&format!(
+            "{},{},{},{}\n",
+            b,
+            b * bstep,
+            b * bstep + bstep,
+            keep
+        ));
+    }
+
+    let mut driver_csv = String::from("did,v\n");
+    let mut expected: Vec<Vec<String>> = Vec::new();
+    for i in 0..n_drivers {
+        let v = tiled_key(i, span);
+        driver_csv.push_str(&format!("{i},{v}\n"));
+        // Which band does v fall in, and does that band keep?
+        let band = v / bstep;
+        if band % 2 == 0 {
+            expected.push(vec![i.to_string()]);
+        }
+    }
+    for j in 0..n_miss {
+        let did = n_drivers + j;
+        driver_csv.push_str(&format!("{did},{span}\n")); // v == span → no band → miss
+        // null_fields miss: the null-build path passes the filter and emits.
+        expected.push(vec![did.to_string()]);
+    }
+    expected.sort();
+    (driver_csv, build_csv, expected)
+}
+
+/// The block-band path emits byte-identical output whether it spills (tight
+/// budget) or stays resident (roomy budget), and the retired retry/route-to-miss
+/// reading is absent at both: `keep=0` bands drop their drivers silently while
+/// out-of-range misses emit under `null_fields`. The tight run must actually
+/// spill so the two layouts genuinely differ.
+#[test]
+fn block_path_body_skip_byte_identical_across_budgets() {
+    let (driver_csv, build_csv, expected) = block_budget_workload(8_000, 40, 1_000, 200);
+    let inputs = [("drivers", driver_csv), ("builds", build_csv)];
+
+    let tight = try_run(
+        &BLOCK_BUDGET_YAML.replace("__LIMIT__", TIGHT_LIMIT),
+        &inputs,
+    )
+    .expect("tight-budget block run");
+    let roomy = try_run(
+        &BLOCK_BUDGET_YAML.replace("__LIMIT__", ROOMY_LIMIT),
+        &inputs,
+    )
+    .expect("roomy-budget block run");
+
+    assert!(
+        tight.spill_bytes > 0,
+        "the tight budget must spill the block-band sides to disk"
+    );
+    assert_eq!(
+        tight.output, roomy.output,
+        "block-band output must be byte-identical across memory budgets"
+    );
+    assert_eq!(
+        sorted_rows(&tight.output),
+        expected,
+        "block-band body-skip output diverged from the oracle"
+    );
+}

--- a/crates/clinker-exec/tests/combine_match_first_body_skip.rs
+++ b/crates/clinker-exec/tests/combine_match_first_body_skip.rs
@@ -536,6 +536,80 @@ fn body_skip_does_not_trip_on_miss_error_across_strategies() {
     }
 }
 
+// ── no retry to a later matching build ────────────────────────────────────────
+
+// The differential scenarios above give each driver exactly one matching build,
+// so they cannot see the "no retry" half of the contract: a regression that
+// reopened a body-skipping driver to its next match would still match one build
+// and emit nothing extra. These tests give one driver TWO matching builds where
+// the first-selected build's body SKIPS (`keep = 0`) and a later matching build
+// WOULD emit (`keep = 1`). Behavior A commits to the first selection, so the
+// driver produces NO row. The retired retry reading would fall through to the
+// `keep = 1` build and emit it — the exact regression these tests must catch.
+//
+// Each strategy defines "first" differently, so each fixture places the
+// `keep = 0` build where that strategy looks first:
+//   * sort-merge and equi+range visit a driver's matches in ascending range-key
+//     (`hi`) order, so the lower-`hi` build is `keep = 0`;
+//   * the block-band path selects the minimum build input index, so the
+//     first-listed (overlapping) build is `keep = 0`.
+// `on_miss: error` would abort if either fixture's matched driver were mistaken
+// for a miss, so a success with zero output rows also proves the driver is not
+// routed to on_miss.
+
+/// No output rows once the header line is dropped.
+fn assert_no_rows(outcome: &RunOutcome, tag: &str) {
+    let rows = sorted_rows(&outcome.output);
+    assert!(
+        rows.is_empty(),
+        "[{tag}] a body-skipping first selection must not retry a later matching \
+         build; got rows: {rows:?}"
+    );
+}
+
+/// sort-merge: `drivers.v < builds.hi`. The driver `v = 10` matches both builds;
+/// the lower-`hi` (=50) build is visited first and skips (`keep = 0`), while the
+/// `hi = 100` build would emit. No retry ⇒ no row.
+#[test]
+fn sort_merge_first_skip_does_not_retry_later_build() {
+    let yaml = sort_merge_yaml("error");
+    assert_strategy(&yaml, "sort_merge");
+    let drivers = String::from("did,v\n10,10\n");
+    let builds = String::from("bid,hi,keep\n100,50,0\n200,100,1\n");
+    let inputs = [("drivers", drivers), ("builds", builds)];
+    let out = try_run(&yaml, &inputs).expect("sort-merge no-retry run");
+    assert_no_rows(&out, "sort_merge");
+}
+
+/// equi+range IEJoin: `drivers.mk == builds.mk and drivers.v < builds.hi`. Within
+/// the `mk = 1` group the driver `v = 10` matches both builds; the lower-`hi`
+/// (=50) build is visited first and skips, the `hi = 100` build would emit.
+#[test]
+fn equi_range_first_skip_does_not_retry_later_build() {
+    let yaml = equi_range_yaml("error");
+    assert_strategy(&yaml, "hash_partition_iejoin");
+    let drivers = String::from("did,mk,v\n10,1,10\n");
+    let builds = String::from("bid,mk,hi,keep\n100,1,50,0\n200,1,100,1\n");
+    let inputs = [("drivers", drivers), ("builds", builds)];
+    let out = try_run(&yaml, &inputs).expect("equi+range no-retry run");
+    assert_no_rows(&out, "hash_partition_iejoin");
+}
+
+/// block-band IEJoin: `drivers.v >= builds.lo and drivers.v < builds.hi`. Two
+/// overlapping bands both contain `v = 10`; the minimum-input-index band
+/// (`bid = 100`) is `keep = 0` and skips, the higher-index band (`bid = 200`)
+/// would emit. Minimum-index selection ⇒ no retry ⇒ no row.
+#[test]
+fn block_band_first_skip_does_not_retry_higher_index_build() {
+    let yaml = block_yaml("error");
+    assert_strategy(&yaml, "iejoin");
+    let drivers = String::from("did,v\n10,10\n");
+    let builds = String::from("bid,lo,hi,keep\n100,0,100,0\n200,0,100,1\n");
+    let inputs = [("drivers", drivers), ("builds", builds)];
+    let out = try_run(&yaml, &inputs).expect("block-band no-retry run");
+    assert_no_rows(&out, "iejoin");
+}
+
 // ── block path: byte-identical across memory budgets ──────────────────────────
 
 /// Tight budget: the block-band external-sort threshold (`soft / 4`) binds and

--- a/docs/engine/src/combine-internals.md
+++ b/docs/engine/src/combine-internals.md
@@ -14,6 +14,15 @@ The `where:` expression is a CXL boolean evaluated for every candidate record pa
 
 At least one cross-input equality is required for every Combine, except for pure-range predicates, which IEJoin handles without an equi conjunct.
 
+## Match selection versus the projection body
+
+Every strategy separates two steps: **match selection** (the `where:` predicate, including any residual re-check) chooses which build records pair with a driver, and the **`cxl:` body** projects each selected pair into an output row. Under `match: first` this distinction is load-bearing and is contractually uniform across all five physical paths — in-memory hash build-probe, grace-hash, sort-merge, hash-partitioned IEJoin (equi+range), and block-band IEJoin (pure-range):
+
+- **Selection is deterministic and budget-stable.** `first` picks a single predicate-matching build in a fixed order — the block-band path holds the minimum build-input-index candidate, sort-merge takes the lowest range-key match, and the hash paths take the first probe hit — so the chosen build is a function of the data, not of the memory-derived block/spill layout.
+- **The body runs once, as a post-match projection.** A body that skips the chosen build (a `filter` that fails, an `EvalResult::Skip`) or defers on a recoverable error drops **only that output row**. The engine does not retry a later matching build, and it does not route the driver to `on_miss`: the driver matched the predicate, so it is not a zero-match driver. `on_miss` dispatch is gated purely on whether *selection* found anything — the hash and grace paths test `matched.is_empty()`, the block path routes only drivers that held no candidate, and sort-merge / equi+range mark the driver satisfied the moment a predicate-matching build is selected, before the body runs.
+
+The earlier divergence — where the IEJoin and sort-merge paths retried later builds or routed an all-body-skip driver to `on_miss` while the hash paths did not — is retired; all strategies now match the hash paths and the User Guide.
+
 ## Strategy hint
 
 The `strategy` config field carries a hint; the planner has final say.

--- a/docs/user/src/nodes/combine.md
+++ b/docs/user/src/nodes/combine.md
@@ -96,6 +96,8 @@ Emit one output row per driver record, using the first matching build-side recor
       emit product_name = products.product_name
 ```
 
+The `where:` predicate selects the match; the `cxl:` body is a **post-match projection** that runs once on the chosen build record. Selection and projection are separate steps: if the body filters the row out (a `filter` that fails, or a body that emits nothing), that one output row is dropped. The combine does **not** fall back to a later matching build, and the driver is **not** treated as unmatched — it matched the predicate, the body just produced no row. `on_miss` (below) never fires for such a driver; it fires only when the predicate matched nothing at all. This holds identically for every join strategy the planner may pick.
+
 ### `match: all`
 
 Emit one output row for every matching build-side record. 1:N fan-out -- if a driver record matches three build records, three rows are emitted.
@@ -126,7 +128,7 @@ Use `collect` when you need the set of matches as a single structured value; use
 
 ## Unmatched records (`on_miss`)
 
-`on_miss` controls what happens to driver records with zero matches:
+`on_miss` controls what happens to driver records with **zero predicate matches** — drivers for which no build-side record satisfied `where:`. A driver that matched the predicate but whose `cxl:` body skipped the row (see [`match: first`](#match-first)) is **not** a miss and never reaches `on_miss`; it simply produces no output row.
 
 | Value | Semantics |
 |-------|-----------|

--- a/docs/user/src/nodes/combine.md
+++ b/docs/user/src/nodes/combine.md
@@ -50,7 +50,7 @@ Iteration order in the `input:` map is preserved and used as the default driver-
 |-------|----------|---------|-------------|
 | `where` | Yes | -- | CXL boolean expression matching records across inputs. Must contain at least one cross-input equality. |
 | `match` | No | `first` | Match cardinality: `first`, `all`, or `collect`. |
-| `on_miss` | No | `null_fields` | Driver-record handling on zero matches: `null_fields`, `skip`, or `error`. |
+| `on_miss` | No | `null_fields` | Driver-record handling on zero predicate matches: `null_fields`, `skip`, or `error`. |
 | `cxl` | Yes (except under `match: collect`) | -- | Emit statements defining the output row. Empty under `match: collect`. |
 | `drive` | No | first input | Explicit driver-input qualifier. Overrides the iteration-order default. |
 | `strategy` | No | `auto` | Execution strategy hint: `auto` or `grace_hash`. |
@@ -97,6 +97,8 @@ Emit one output row per driver record, using the first matching build-side recor
 ```
 
 The `where:` predicate selects the match; the `cxl:` body is a **post-match projection** that runs once on the chosen build record. Selection and projection are separate steps: if the body filters the row out (a `filter` that fails, or a body that emits nothing), that one output row is dropped. The combine does **not** fall back to a later matching build, and the driver is **not** treated as unmatched — it matched the predicate, the body just produced no row. `on_miss` (below) never fires for such a driver; it fires only when the predicate matched nothing at all. This holds identically for every join strategy the planner may pick.
+
+> **Behavior change.** This is a change in observable output for existing pipelines that use a range or equi+range `where:` predicate. On the strategies the planner picks for those predicates (sort-merge and hash-partitioned range joins), a driver that matched the predicate but whose body skipped every candidate was previously routed to `on_miss` — firing `null_fields`, `skip`, or `error`. It now silently produces no row, matching the equality-join strategies. A pipeline that relied on the old routing (for example, `on_miss: error` tripping on a body-skipped driver) no longer sees it.
 
 ### `match: all`
 

--- a/docs/user/src/nodes/combine.md
+++ b/docs/user/src/nodes/combine.md
@@ -98,7 +98,7 @@ Emit one output row per driver record, using the first matching build-side recor
 
 The `where:` predicate selects the match; the `cxl:` body is a **post-match projection** that runs once on the chosen build record. Selection and projection are separate steps: if the body filters the row out (a `filter` that fails, or a body that emits nothing), that one output row is dropped. The combine does **not** fall back to a later matching build, and the driver is **not** treated as unmatched — it matched the predicate, the body just produced no row. `on_miss` (below) never fires for such a driver; it fires only when the predicate matched nothing at all. This holds identically for every join strategy the planner may pick.
 
-> **Behavior change.** This is a change in observable output for existing pipelines that use a range or equi+range `where:` predicate. On the strategies the planner picks for those predicates (sort-merge and hash-partitioned range joins), a driver that matched the predicate but whose body skipped every candidate was previously routed to `on_miss` — firing `null_fields`, `skip`, or `error`. It now silently produces no row, matching the equality-join strategies. A pipeline that relied on the old routing (for example, `on_miss: error` tripping on a body-skipped driver) no longer sees it.
+> **Behavior change.** This is a change in observable output for existing pipelines whose `where:` predicate carries a range, equi+range, or single-inequality comparison — the shapes the planner runs as a sort-merge join or an IEJoin (both the pure-range block-band path and the equi+range hash-partitioned path). On any of those three strategies, a driver that matched the predicate but whose body skipped every candidate was previously routed to `on_miss` — firing `null_fields`, `skip`, or `error`. It now silently produces no row, matching the pure-equality strategies (in-memory hash and grace hash), which already behaved this way and are unchanged. A pipeline that relied on the old routing (for example, `on_miss: error` tripping on a body-skipped driver) no longer sees it.
 
 ### `match: all`
 
@@ -130,7 +130,7 @@ Use `collect` when you need the set of matches as a single structured value; use
 
 ## Unmatched records (`on_miss`)
 
-`on_miss` controls what happens to driver records with **zero predicate matches** — drivers for which no build-side record satisfied `where:`. A driver that matched the predicate but whose `cxl:` body skipped the row (see [`match: first`](#match-first)) is **not** a miss and never reaches `on_miss`; it simply produces no output row.
+`on_miss` controls what happens to driver records with **zero predicate matches** — drivers for which no build-side record satisfied `where:`. A driver that matched the predicate but whose `cxl:` body skipped the row (see [`match: first`](#match-first)) is **not** a miss and never reaches `on_miss`; it simply produces no output row. On sort-merge and IEJoin strategies this is a recent change — see the behavior-change note under [`match: first`](#match-first).
 
 | Value | Semantics |
 |-------|-----------|


### PR DESCRIPTION
## Summary

Unifies `match: first` semantics across all combine strategies on a single rule: the combine **body is a post-match projection**, not part of match selection (closes #855).

`match: first` selects the first predicate-matching build row in a deterministic, budget-stable order, runs the body once, and if the body **skips** (or a recoverable body error defers), that output row is dropped — **without** retrying a later build and **without** routing the driver to `on_miss`, because the driver did match the predicate. `on_miss` fires only for drivers with **zero** predicate matches.

The in-memory hash and grace-hash paths already behaved this way; this brings the IEJoin equi+range path, the IEJoin pure-range block-band path, and the sort-merge join into line with them and with the documented contract.

## Behavior change (intended; greenfield)

On the equi+range IEJoin and sort-merge paths, a driver whose every predicate-matching build's body skips now produces no row silently, instead of being routed to `on_miss` (no null-fields fill, no error). This aligns those paths with the hash paths and the docs.

## Changes

- IEJoin equi+range `emit_pairs` First arm, IEJoin block-band `finalize_driver_block` First arm, and the sort-merge `emit_for_driver` First branch: mark the driver matched on the first predicate-matching build (independent of the body outcome), run the body once, drop the row on a skip, and never route a predicate-matched driver to `on_miss`. The block path keeps its bounded single-held-candidate design.
- A new differential test drives a body-skipping `match: first` combine through all five physical strategies (hash, grace-hash, sort-merge, equi+range IEJoin, block-band IEJoin) for `on_miss` in {skip, null_fields, error}, plus a tight-vs-roomy budget byte-identity check on the block path — asserting an all-body-skip driver produces no row and never appears in `on_miss` output.
- User and engine docs describe the post-match-projection contract.

## Validation

`cargo fmt --all --check`, `cargo clippy -p clinker-exec --all-targets -D warnings`, and the full `clinker-exec` suite pass; reverting the fixes fails 3 of the 5 differential tests (proving each site is exercised).
