### PR TITLE
clinker-record: count IndexMap structural backing in Value::heap_size

### DIFF
--- a/crates/clinker-format/src/doc_index.rs
+++ b/crates/clinker-format/src/doc_index.rs
@@ -406,4 +406,55 @@ mod tests {
         .expect("no cap means no rejection");
         assert!(idx.retained_bytes() >= 100_000);
     }
+
+    #[test]
+    fn cap_gates_on_a_scalar_map_structural_backing() {
+        // A many-field map of small scalars owns almost no key/value heap, so
+        // its retention cost is dominated by the IndexMap structural backing.
+        // Setting the cap in the gap between the key/value bytes and the full
+        // charge pins that the backing term itself decides the cap — a future
+        // change to per-entry backing can't move that boundary unnoticed.
+        let section = "Summary";
+        let build = || {
+            map(&[
+                ("a", Value::Integer(1)),
+                ("b", Value::Integer(2)),
+                ("c", Value::Integer(3)),
+                ("d", Value::Bool(true)),
+                ("e", Value::Integer(5)),
+                ("f", Value::Integer(6)),
+                ("g", Value::Bool(false)),
+                ("h", Value::Integer(8)),
+            ])
+        };
+        // `build()` is deterministic, so every instance has identical capacity
+        // and heap_size; derive the caps from one measured instance.
+        let payload = build();
+        let inner = payload.as_map().unwrap();
+        let keys_and_values: usize = inner.iter().map(|(k, v)| k.len() + v.heap_size()).sum();
+        let full_value_heap = payload.heap_size();
+        assert!(
+            full_value_heap > keys_and_values,
+            "a scalar map must carry structural backing beyond its key/value bytes"
+        );
+        let bytes_only_charge = section.len() + keys_and_values;
+        let full_charge = section.len() + full_value_heap;
+
+        // A cap above the key/value bytes but below the full charge rejects the
+        // insert: the structural backing is what tips it over.
+        let mut tight = DocArenaIndex::new(&[path(section, "a")], Some(bytes_only_charge + 1));
+        let err = tight
+            .insert(&path(section, "a"), build())
+            .expect_err("structural backing must push the charge over the cap");
+        assert!(matches!(err, FormatError::Json(msg) if msg.contains("max_index_bytes")));
+        assert!(tight.into_sections().is_empty());
+
+        // A cap equal to the full charge clears, confirming the rejection above
+        // came from the backing term rather than the bytes.
+        let mut roomy = DocArenaIndex::new(&[path(section, "a")], Some(full_charge));
+        roomy
+            .insert(&path(section, "a"), build())
+            .expect("full charge fits under a cap equal to it");
+        assert_eq!(roomy.retained_bytes(), full_charge);
+    }
 }

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -319,16 +319,12 @@ impl Record {
     pub fn estimated_heap_size(&self) -> usize {
         let values_backing = self.values.capacity() * std::mem::size_of::<Value>();
         let values_heap: usize = self.values.iter().map(Value::heap_size).sum();
-        let indexmap_heap = |m: &IndexMap<Box<str>, Value>| {
-            let entry_size = std::mem::size_of::<Box<str>>()
-                + std::mem::size_of::<Value>()
-                + std::mem::size_of::<u64>();
-            let map_backing = m.capacity() * entry_size;
-            let keys_heap: usize = m.keys().map(|k| k.len()).sum();
-            let values_heap: usize = m.values().map(Value::heap_size).sum();
-            map_backing + keys_heap + values_heap
-        };
-        let record_vars_size = self.record_vars.as_ref().map_or(0, |m| indexmap_heap(m));
+        // The `$record.<key>` vars map and any `Value::Map` field share one
+        // IndexMap-backing estimator so the two accounting paths cannot drift.
+        let record_vars_size = self
+            .record_vars
+            .as_ref()
+            .map_or(0, |m| crate::value::indexmap_heap_size(m));
         values_backing + values_heap + record_vars_size
     }
 }

--- a/crates/clinker-record/src/value.rs
+++ b/crates/clinker-record/src/value.rs
@@ -351,6 +351,27 @@ impl From<smol_str::SmolStr> for Value {
 /// `Value` has no backing storage to borrow from.
 pub static NULL: Value = Value::Null;
 
+/// Estimated heap bytes backing an `IndexMap<Box<str>, Value>`: the structural
+/// bucket array plus every key string and recursively-owned value.
+///
+/// Shared verbatim by [`Value::heap_size`] (for `Value::Map`) and
+/// `Record::estimated_heap_size` (for the `$record.<key>` vars map) so both
+/// accounting paths estimate the same IndexMap backing identically and cannot
+/// drift apart. The bucket array dominates residency for small maps: a bare
+/// `Value` is 32 bytes, but each occupied slot also carries a `Box<str>` fat
+/// pointer and a hash/index word, so counting only the entries' key/value heap
+/// undercounts a typical few-field map several-fold.
+pub(crate) fn indexmap_heap_size(m: &IndexMap<Box<str>, Value>) -> usize {
+    // Per-entry backing: the (Box<str>, Value) bucket in IndexMap's entry Vec
+    // plus one hash/index word (u64) for the parallel hashbrown index table.
+    let entry_size =
+        std::mem::size_of::<Box<str>>() + std::mem::size_of::<Value>() + std::mem::size_of::<u64>();
+    let map_backing = m.capacity() * entry_size;
+    let keys_heap: usize = m.keys().map(|k| k.len()).sum();
+    let values_heap: usize = m.values().map(Value::heap_size).sum();
+    map_backing + keys_heap + values_heap
+}
+
 impl Value {
     /// Returns the CXL type name as a static string.
     pub fn type_name(&self) -> &'static str {
@@ -381,6 +402,11 @@ impl Value {
     /// Strings store their bytes inline when short (<=23 bytes) and so
     /// contribute zero heap; heap-backed strings (the `Arc`-shared default arm
     /// or the `Box`-unique arm) charge their byte length.
+    /// Container variants charge their own structural backing on top of the
+    /// recursively-owned element heap: an `Array` counts its `Vec` capacity
+    /// (used slots plus spare) and a `Map` counts the `IndexMap` bucket array
+    /// (see `indexmap_heap_size`) — omitting either undercounts real
+    /// residency, which is what memory arbitration bounds are drawn against.
     pub fn heap_size(&self) -> usize {
         match self {
             Value::String(s) => s.heap_size(),
@@ -388,12 +414,7 @@ impl Value {
                 arr.capacity() * std::mem::size_of::<Value>()
                     + arr.iter().map(Value::heap_size).sum::<usize>()
             }
-            Value::Map(m) => {
-                // IndexMap overhead: each entry is (Box<str>, Value) = key heap + value heap
-                m.iter()
-                    .map(|(k, v)| k.len() + v.heap_size())
-                    .sum::<usize>()
-            }
+            Value::Map(m) => indexmap_heap_size(m),
             _ => 0,
         }
     }
@@ -756,6 +777,62 @@ mod tests {
         let arr2 = Value::Array(vec![Value::Integer(1), Value::String(long.into())]);
         let expected2 = 2 * std::mem::size_of::<Value>() + long.len();
         assert_eq!(arr2.heap_size(), expected2);
+    }
+
+    #[test]
+    fn test_value_heap_size_array_counts_spare_capacity() {
+        // The Vec backing charges reserved-but-unused slots, not just len:
+        // eight-slot capacity holding one element still costs eight strides.
+        let mut backing = Vec::with_capacity(8);
+        backing.push(Value::Integer(1));
+        let arr = Value::Array(backing);
+        assert_eq!(arr.heap_size(), 8 * std::mem::size_of::<Value>());
+    }
+
+    #[test]
+    fn test_value_heap_size_map_counts_structural_backing() {
+        use crate::record::Record;
+        use crate::schema::Schema;
+        use std::sync::Arc;
+
+        // Scalar values own no heap, so every reported byte is either a key
+        // string or the IndexMap bucket array — the structural backing this
+        // accounting previously omitted.
+        let map = Value::map([
+            ("alpha", Value::Integer(1)),
+            ("beta", Value::Integer(2)),
+            ("gamma", Value::Integer(3)),
+        ]);
+        let inner = map.as_map().unwrap();
+
+        // The prior undercount summed only key + value heap.
+        let keys_and_values: usize = inner.iter().map(|(k, v)| k.len() + v.heap_size()).sum();
+        // The structural term this fix restores: capacity × (Box<str> + Value +
+        // hash/index word), matching `indexmap_heap_size`.
+        let entry_size = std::mem::size_of::<Box<str>>()
+            + std::mem::size_of::<Value>()
+            + std::mem::size_of::<u64>();
+        let structural_backing = inner.capacity() * entry_size;
+
+        assert_eq!(map.heap_size(), keys_and_values + structural_backing);
+        // At least one bucket per occupied entry is charged on top of the bytes.
+        assert!(structural_backing >= inner.len() * entry_size);
+        assert!(map.heap_size() > keys_and_values);
+
+        // Cross-method agreement: a record whose only field is this map
+        // attributes exactly `map.heap_size()` to it, on top of the one-slot
+        // `Vec<Value>` backing (`vec![_]` has capacity 1).
+        let schema = Arc::new(Schema::new(vec!["m".into()]));
+        let record = Record::new(schema, vec![map.clone()]);
+        assert_eq!(
+            record.estimated_heap_size(),
+            std::mem::size_of::<Value>() + map.heap_size(),
+        );
+
+        // The map's heap equals the shared IndexMap-backing estimator that
+        // `Record::estimated_heap_size` applies to its `$record.<key>` vars map,
+        // so the two accounting paths cannot disagree on the same data.
+        assert_eq!(map.heap_size(), indexmap_heap_size(inner));
     }
 
     #[test]

--- a/crates/clinker-record/src/value.rs
+++ b/crates/clinker-record/src/value.rs
@@ -352,20 +352,29 @@ impl From<smol_str::SmolStr> for Value {
 pub static NULL: Value = Value::Null;
 
 /// Estimated heap bytes backing an `IndexMap<Box<str>, Value>`: the structural
-/// bucket array plus every key string and recursively-owned value.
+/// backing plus every key string and recursively-owned value.
 ///
 /// Shared verbatim by [`Value::heap_size`] (for `Value::Map`) and
 /// `Record::estimated_heap_size` (for the `$record.<key>` vars map) so both
 /// accounting paths estimate the same IndexMap backing identically and cannot
-/// drift apart. The bucket array dominates residency for small maps: a bare
-/// `Value` is 32 bytes, but each occupied slot also carries a `Box<str>` fat
-/// pointer and a hash/index word, so counting only the entries' key/value heap
-/// undercounts a typical few-field map several-fold.
+/// drift apart. The structural backing dominates residency for small maps: a
+/// bare `Value` is 32 bytes, but each capacity slot also carries the key
+/// pointer, the entry's cached hash word, and an index-table slot, so counting
+/// only the entries' key/value heap undercounts a typical few-field map
+/// several-fold.
 pub(crate) fn indexmap_heap_size(m: &IndexMap<Box<str>, Value>) -> usize {
-    // Per-entry backing: the (Box<str>, Value) bucket in IndexMap's entry Vec
-    // plus one hash/index word (u64) for the parallel hashbrown index table.
-    let entry_size =
-        std::mem::size_of::<Box<str>>() + std::mem::size_of::<Value>() + std::mem::size_of::<u64>();
+    // Two structures back a populated IndexMap, charged per capacity slot:
+    //   - the entries `Vec<Bucket>` element — the (Box<str>, Value) pair plus the
+    //     bucket's own cached hash word (a `u64`);
+    //   - the parallel hashbrown index table — one `usize` per slot indexing back
+    //     into the entries Vec.
+    // The index table's per-slot control byte and its power-of-two load slack are
+    // not modelled, so a fully-loaded map is under-read by a few percent — a
+    // small residual, far tighter than dropping the index table entirely.
+    let entry_size = std::mem::size_of::<Box<str>>()
+        + std::mem::size_of::<Value>()
+        + std::mem::size_of::<u64>()
+        + std::mem::size_of::<usize>();
     let map_backing = m.capacity() * entry_size;
     let keys_heap: usize = m.keys().map(|k| k.len()).sum();
     let values_heap: usize = m.values().map(Value::heap_size).sum();
@@ -796,8 +805,7 @@ mod tests {
         use std::sync::Arc;
 
         // Scalar values own no heap, so every reported byte is either a key
-        // string or the IndexMap bucket array — the structural backing this
-        // accounting previously omitted.
+        // string or the IndexMap structural backing.
         let map = Value::map([
             ("alpha", Value::Integer(1)),
             ("beta", Value::Integer(2)),
@@ -805,34 +813,29 @@ mod tests {
         ]);
         let inner = map.as_map().unwrap();
 
-        // The prior undercount summed only key + value heap.
+        // heap_size charges the structural backing on top of the key + value
+        // bytes: capacity × (key pointer + Value + bucket hash word + index slot).
         let keys_and_values: usize = inner.iter().map(|(k, v)| k.len() + v.heap_size()).sum();
-        // The structural term this fix restores: capacity × (Box<str> + Value +
-        // hash/index word), matching `indexmap_heap_size`.
         let entry_size = std::mem::size_of::<Box<str>>()
             + std::mem::size_of::<Value>()
-            + std::mem::size_of::<u64>();
+            + std::mem::size_of::<u64>()
+            + std::mem::size_of::<usize>();
         let structural_backing = inner.capacity() * entry_size;
 
         assert_eq!(map.heap_size(), keys_and_values + structural_backing);
-        // At least one bucket per occupied entry is charged on top of the bytes.
+        // At least one slot's backing per occupied entry is charged beyond the bytes.
         assert!(structural_backing >= inner.len() * entry_size);
         assert!(map.heap_size() > keys_and_values);
 
-        // Cross-method agreement: a record whose only field is this map
-        // attributes exactly `map.heap_size()` to it, on top of the one-slot
-        // `Vec<Value>` backing (`vec![_]` has capacity 1).
+        // A record whose only field is this map attributes exactly
+        // `map.heap_size()` to it, on top of the one-slot `Vec<Value>` backing
+        // (`vec![_]` has capacity 1) — the same estimator gates both paths.
         let schema = Arc::new(Schema::new(vec!["m".into()]));
         let record = Record::new(schema, vec![map.clone()]);
         assert_eq!(
             record.estimated_heap_size(),
             std::mem::size_of::<Value>() + map.heap_size(),
         );
-
-        // The map's heap equals the shared IndexMap-backing estimator that
-        // `Record::estimated_heap_size` applies to its `$record.<key>` vars map,
-        // so the two accounting paths cannot disagree on the same data.
-        assert_eq!(map.heap_size(), indexmap_heap_size(inner));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Value::heap_size` under-reported the memory footprint of `Value::Map` because it summed only the entries' key and value bytes and omitted the `IndexMap`'s own structural backing (the bucket array). The sibling `Record::estimated_heap_size` already counted that backing, so the two disagreed and any accounting path costing a bare `Value::Map` under-charged real residency several-fold. This tightens the estimate and removes the divergence.

## What changed

- Factored the `IndexMap` backing computation into one shared `indexmap_heap_size` helper and routed **both** `Value::heap_size` (Map arm) and `Record::estimated_heap_size` through it, so the two estimates cannot drift.
- The Map arm now charges `capacity × entry_size` (a `Box<str>` fat pointer + a `Value` + one hash/index word per slot) on top of the key and recursed-value heap, matching what `estimated_heap_size` already attributed to the record-vars map.
- Record accounting is numerically unchanged (same formula, now shared).

The `Value::Array` arm already charged full `Vec` capacity, so it was left as-is; a test was added to pin that behavior.

## Effect

The estimate moves strictly upward (closer to true RSS), so memory bounds that consume it fire slightly earlier — the safe, never-OOM direction. Most relevant to the combine `match: collect` accumulator, whose collected `Value::Map` rows now charge their bucket array, so its self-reported residency matches real memory and its spill/abort point lands correctly rather than several-fold late.

## Tests

No existing assertion needed re-baselining (nothing pinned an exact Map `heap_size`; inequality-based memory tests retain ample headroom). Added a unit test asserting the Map structural backing is counted and agrees with the record-vars term, and a test pinning the Array spare-capacity behavior.

Closes #874.
