### PR TITLE
fix(exec): port-aware node-buffer keys so multi-output fan-in keeps every port

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -453,7 +453,7 @@ fn finalize_aggregate_emit(
             input_puncts,
             node_buffer_spill_allowed(current_dag, node_idx),
         )?;
-        ctx.node_buffers.insert(node_idx, nb);
+        ctx.node_buffers.insert(node_idx.into(), nb);
     } else {
         // Streaming-Output handoff: a streaming-strategy
         // aggregate (the planner certified pre-sorted input)
@@ -506,7 +506,7 @@ fn finalize_aggregate_emit(
             input_puncts,
             node_buffer_spill_allowed(current_dag, node_idx),
         )?;
-        ctx.node_buffers.insert(node_idx, nb);
+        ctx.node_buffers.insert(node_idx.into(), nb);
     }
 
     Ok(())

--- a/crates/clinker-exec/src/executor/combine.rs
+++ b/crates/clinker-exec/src/executor/combine.rs
@@ -252,6 +252,7 @@ mod tests {
         }
         CombineInput {
             upstream_name: Arc::from(name),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(declared, CxlSpan::new(0, 0)),
         }
     }

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -18,7 +18,7 @@ use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, advance_cursor, drain_node_buffer_slot,
+    ExecutorContext, NodeBufferKey, admit_node_buffer, advance_cursor, drain_node_buffer_slot,
     finalize_node_rooted_windows, node_buffer_spill_allowed, push_dlq,
     record_error_to_buffer_if_grouped, source_file_arc_of, source_name_arc_of,
     stream_linear_producer_emit, tee_emit_to_region_input_buffers,
@@ -29,7 +29,33 @@ use crate::pipeline::iejoin::RecordOrder;
 use clinker_plan::BudgetCategory;
 use clinker_plan::config::ErrorStrategy;
 use clinker_plan::error::PipelineError;
-use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
+use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, matches_upstream_name};
+
+/// The producer output port a combine input qualifier draws from, read off the
+/// combine node's `input:` map. `Some(port)` for a `<producer>.<port>`
+/// reference (a Cull `removed_to` / Route branch), `None` for a bare producer
+/// reference. Used to disambiguate a driver/build pair that resolves to the
+/// same predecessor node via two different ports.
+fn combine_input_port(
+    config: &clinker_plan::config::PipelineConfig,
+    combine_name: &str,
+    qualifier: &str,
+) -> Option<String> {
+    use clinker_plan::config::PipelineNode;
+    use clinker_plan::config::node_header::NodeInput;
+    config
+        .nodes
+        .iter()
+        .find_map(|spanned| match &spanned.value {
+            PipelineNode::Combine { header, .. } if header.name == combine_name => {
+                header.input.get(qualifier).and_then(|ni| match &ni.value {
+                    NodeInput::Port { port, .. } => Some(port.clone()),
+                    NodeInput::Single(_) => None,
+                })
+            }
+            _ => None,
+        })
+}
 
 /// Cap on matches collected per driver row under `match: collect` before
 /// truncation. 10K mirrors the module constants in `pipeline/combine.rs`
@@ -194,37 +220,56 @@ pub(crate) fn dispatch_combine(
     // any such Sort as an alias for its prefix-stripped
     // upstream lets the combine arm transparently resolve
     // through the splice. See `plan::execution::CORRELATION_SORT_PREFIX`.
-    let predecessors: Vec<NodeIndex> = current_dag
-        .graph
-        .neighbors_directed(node_idx, Direction::Incoming)
-        .collect();
-    let predecessor_matches = |p: NodeIndex, target: &str| -> bool {
-        clinker_plan::plan::execution::matches_upstream_name(current_dag.graph[p].name(), target)
+    // Resolve each side to its incoming edge, so the drain reads the exact
+    // producer-port slot the edge carries. When the driver and build sides
+    // resolve to the SAME predecessor node via different output ports — a
+    // Combine drawing a Cull's `main` and `removed_to`, or two Route branches —
+    // name matching alone cannot tell them apart, so disambiguate by the
+    // qualifier's declared port (read off the combine node's `input:` map).
+    // A single matching edge is used directly, which keeps a spliced
+    // passthrough (e.g. `inject_correlation_sort`) working: its edge carries
+    // `producer_port: None` and the passthrough re-materialised the records
+    // into its own `(idx, None)` slot.
+    use petgraph::visit::EdgeRef;
+    let driver_port_ref = combine_input_port(ctx.config, name, driving_input.as_str());
+    let build_port_ref = combine_input_port(ctx.config, name, build_qualifier.as_str());
+    let resolve_side = |upstream: &str,
+                        port_ref: Option<&str>,
+                        side: &str|
+     -> Result<(NodeIndex, Option<Box<str>>), PipelineError> {
+        let candidates: Vec<_> = current_dag
+            .graph
+            .edges_directed(node_idx, Direction::Incoming)
+            .filter(|e| matches_upstream_name(current_dag.graph[e.source()].name(), upstream))
+            .collect();
+        let chosen = if candidates.len() > 1 {
+            candidates
+                .iter()
+                .find(|e| e.weight().producer_port.as_deref() == port_ref)
+                .or_else(|| candidates.first())
+        } else {
+            candidates.first()
+        };
+        chosen
+            .map(|e| {
+                (
+                    e.source(),
+                    e.weight().producer_port.as_deref().map(Box::from),
+                )
+            })
+            .ok_or_else(|| PipelineError::Internal {
+                op: "combine",
+                node: name.clone(),
+                detail: format!(
+                    "combine {side} upstream {upstream:?} is not an \
+                         incoming neighbor in the DAG"
+                ),
+            })
     };
-    let driver_pred = predecessors
-        .iter()
-        .copied()
-        .find(|p| predecessor_matches(*p, driver_upstream))
-        .ok_or_else(|| PipelineError::Internal {
-            op: "combine",
-            node: name.clone(),
-            detail: format!(
-                "combine driver upstream {driver_upstream:?} is not an \
-                         incoming neighbor in the DAG"
-            ),
-        })?;
-    let build_pred = predecessors
-        .iter()
-        .copied()
-        .find(|p| predecessor_matches(*p, build_upstream))
-        .ok_or_else(|| PipelineError::Internal {
-            op: "combine",
-            node: name.clone(),
-            detail: format!(
-                "combine build upstream {build_upstream:?} is not an \
-                         incoming neighbor in the DAG"
-            ),
-        })?;
+    let (driver_pred, driver_port) =
+        resolve_side(driver_upstream, driver_port_ref.as_deref(), "driver")?;
+    let (build_pred, build_port) =
+        resolve_side(build_upstream, build_port_ref.as_deref(), "build")?;
 
     // Streaming-probe detection (issue #300). When the driver predecessor
     // is the certified probe-side streaming producer for this Combine
@@ -266,7 +311,10 @@ pub(crate) fn dispatch_combine(
     ) = if streaming_probe_driver.is_some() {
         (Vec::new(), Vec::new())
     } else {
-        match drain_node_buffer_slot(ctx, driver_pred) {
+        match drain_node_buffer_slot(
+            ctx,
+            NodeBufferKey::with_port(driver_pred, driver_port.as_deref()),
+        ) {
             Some(nb) => nb.drain_split()?,
             None => (Vec::new(), Vec::new()),
         }
@@ -274,7 +322,10 @@ pub(crate) fn dispatch_combine(
     let (build_buf, build_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match drain_node_buffer_slot(ctx, build_pred) {
+    ) = match drain_node_buffer_slot(
+        ctx,
+        NodeBufferKey::with_port(build_pred, build_port.as_deref()),
+    ) {
         Some(nb) => nb.drain_split()?,
         None => (Vec::new(), Vec::new()),
     };
@@ -551,7 +602,7 @@ pub(crate) fn dispatch_combine(
                         nb
                     }
                 };
-                ctx.node_buffers.insert(node_idx, nb);
+                ctx.node_buffers.insert(node_idx.into(), nb);
                 // Combine arm clean-exit: drop the per-fold cursor
                 // snapshot. Every emitted record has cleared into
                 // `node_buffers` without rewind, so the snapshot is
@@ -691,7 +742,7 @@ pub(crate) fn dispatch_combine(
                     combined_puncts,
                     node_buffer_spill_allowed(current_dag, node_idx),
                 )?;
-                ctx.node_buffers.insert(node_idx, nb);
+                ctx.node_buffers.insert(node_idx.into(), nb);
                 // Combine arm clean-exit: drop the per-fold cursor
                 // snapshot. Mirrors the inline arm's post-emit
                 // clear so non-inline strategies do not leak
@@ -832,7 +883,7 @@ pub(crate) fn dispatch_combine(
                         let probe_records_out = nb.len_hint() as u64;
                         ctx.collector
                             .record(probe_timer.finish(probe_records_in, probe_records_out));
-                        ctx.node_buffers.insert(node_idx, nb);
+                        ctx.node_buffers.insert(node_idx.into(), nb);
                     }
                 }
                 // Combine arm clean-exit: drop the per-fold cursor snapshot.
@@ -1114,7 +1165,7 @@ pub(crate) fn dispatch_combine(
             combined_puncts,
             node_buffer_spill_allowed(current_dag, node_idx),
         )?;
-        ctx.node_buffers.insert(node_idx, nb);
+        ctx.node_buffers.insert(node_idx.into(), nb);
         // Drop the per-fold cursor snapshot: every emitted record
         // has cleared into `node_buffers` without rewind, so the
         // snapshot is no longer needed. The rewind path on a
@@ -2206,7 +2257,7 @@ fn adopt_spilled_runs_into_node_buffer(
     // Register the slot's node-buffer consumer at zero resident bytes so its
     // later drain unregisters through the same path `admit_node_buffer` sets up.
     // A prior registration at this slot is replaced first.
-    if let Some((prev_id, _)) = ctx.node_buffer_consumer_ids.remove(&node_idx) {
+    if let Some((prev_id, _)) = ctx.node_buffer_consumer_ids.remove(&node_idx.into()) {
         ctx.memory_budget.unregister_consumer(prev_id);
     }
     let handle = crate::pipeline::memory::ConsumerHandle::new();
@@ -2215,7 +2266,7 @@ fn adopt_spilled_runs_into_node_buffer(
         .memory_budget
         .register_consumer(Arc::new(NodeBufferConsumer::new(handle.clone())));
     ctx.node_buffer_consumer_ids
-        .insert(node_idx, (consumer_id, handle));
+        .insert(node_idx.into(), (consumer_id, handle));
     ctx.memory_budget.sample_peak_consumer_usage();
     // Park a charging context on the slot so that if this adopted run set is too
     // fragmented, the drain's k-way merge folds it down under the disk quota

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -31,32 +31,6 @@ use clinker_plan::config::ErrorStrategy;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, matches_upstream_name};
 
-/// The producer output port a combine input qualifier draws from, read off the
-/// combine node's `input:` map. `Some(port)` for a `<producer>.<port>`
-/// reference (a Cull `removed_to` / Route branch), `None` for a bare producer
-/// reference. Used to disambiguate a driver/build pair that resolves to the
-/// same predecessor node via two different ports.
-fn combine_input_port(
-    config: &clinker_plan::config::PipelineConfig,
-    combine_name: &str,
-    qualifier: &str,
-) -> Option<String> {
-    use clinker_plan::config::PipelineNode;
-    use clinker_plan::config::node_header::NodeInput;
-    config
-        .nodes
-        .iter()
-        .find_map(|spanned| match &spanned.value {
-            PipelineNode::Combine { header, .. } if header.name == combine_name => {
-                header.input.get(qualifier).and_then(|ni| match &ni.value {
-                    NodeInput::Port { port, .. } => Some(port.clone()),
-                    NodeInput::Single(_) => None,
-                })
-            }
-            _ => None,
-        })
-}
-
 /// Cap on matches collected per driver row under `match: collect` before
 /// truncation. 10K mirrors the module constants in `pipeline/combine.rs`
 /// and aligns with DataFusion's collect-list bound.
@@ -231,8 +205,14 @@ pub(crate) fn dispatch_combine(
     // `producer_port: None` and the passthrough re-materialised the records
     // into its own `(idx, None)` slot.
     use petgraph::visit::EdgeRef;
-    let driver_port_ref = combine_input_port(ctx.config, name, driving_input.as_str());
-    let build_port_ref = combine_input_port(ctx.config, name, build_qualifier.as_str());
+    // The qualifier's declared producer port, read off the node's own
+    // `combine_inputs` so it is scope-correct inside a composition body (a
+    // by-name lookup into `ctx.config.nodes` would miss a body combine, or
+    // resolve to a same-named top-level one).
+    let driver_port_ref = combine_inputs[driving_input.as_str()].producer_port.clone();
+    let build_port_ref = combine_inputs[build_qualifier.as_str()]
+        .producer_port
+        .clone();
     let resolve_side = |upstream: &str,
                         port_ref: Option<&str>,
                         side: &str|

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -18,7 +18,7 @@ use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
-    ExecutorContext, NodeBufferKey, admit_node_buffer, advance_cursor, drain_node_buffer_slot,
+    ExecutorContext, NodeBufferKey, admit_node_buffer, advance_cursor, drain_or_clone_shared_input,
     finalize_node_rooted_windows, node_buffer_spill_allowed, push_dlq,
     record_error_to_buffer_if_grouped, source_file_arc_of, source_name_arc_of,
     stream_linear_producer_emit, tee_emit_to_region_input_buffers,
@@ -308,8 +308,9 @@ pub(crate) fn dispatch_combine(
     ) = if streaming_probe_driver.is_some() {
         (Vec::new(), Vec::new())
     } else {
-        match drain_node_buffer_slot(
+        match drain_or_clone_shared_input(
             ctx,
+            current_dag,
             NodeBufferKey::with_port(driver_pred, driver_port.as_deref()),
         ) {
             Some(nb) => nb.drain_split()?,
@@ -319,8 +320,9 @@ pub(crate) fn dispatch_combine(
     let (build_buf, build_puncts): (
         Vec<(Record, u64)>,
         Vec<crate::executor::stream_event::Punctuation>,
-    ) = match drain_node_buffer_slot(
+    ) = match drain_or_clone_shared_input(
         ctx,
+        current_dag,
         NodeBufferKey::with_port(build_pred, build_port.as_deref()),
     ) {
         Some(nb) => nb.drain_split()?,

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -222,29 +222,46 @@ pub(crate) fn dispatch_combine(
             .edges_directed(node_idx, Direction::Incoming)
             .filter(|e| matches_upstream_name(current_dag.graph[e.source()].name(), upstream))
             .collect();
-        let chosen = if candidates.len() > 1 {
-            candidates
-                .iter()
-                .find(|e| e.weight().producer_port.as_deref() == port_ref)
-                .or_else(|| candidates.first())
-        } else {
-            candidates.first()
-        };
-        chosen
-            .map(|e| {
-                (
-                    e.source(),
-                    e.weight().producer_port.as_deref().map(Box::from),
-                )
-            })
-            .ok_or_else(|| PipelineError::Internal {
+        let chosen = if candidates.len() == 1 {
+            // Single candidate: the declared port is not needed to
+            // disambiguate, and a spliced single-output passthrough
+            // (`inject_correlation_sort`) carries `producer_port: None` even
+            // when the qualifier named a port — so use the one edge directly.
+            candidates[0]
+        } else if candidates.is_empty() {
+            return Err(PipelineError::Internal {
                 op: "combine",
                 node: name.clone(),
                 detail: format!(
                     "combine {side} upstream {upstream:?} is not an \
                          incoming neighbor in the DAG"
                 ),
-            })
+            });
+        } else {
+            // Driver and build resolve to the same predecessor via distinct
+            // output ports (a Cull's `main` + `removed_to`, or two Route
+            // branches): the qualifier's declared port must identify exactly
+            // one incoming edge. A miss means the node's declared port and the
+            // DAG edge tag disagree — an invariant violation surfaced loud
+            // rather than silently draining an arbitrary port's slot.
+            *candidates
+                .iter()
+                .find(|e| e.weight().producer_port.as_deref() == port_ref)
+                .ok_or_else(|| PipelineError::Internal {
+                    op: "combine",
+                    node: name.clone(),
+                    detail: format!(
+                        "combine {side} input {upstream:?} declares producer port \
+                         {port_ref:?}, which matched none of the {} incoming edges \
+                         from that node",
+                        candidates.len()
+                    ),
+                })?
+        };
+        Ok((
+            chosen.source(),
+            chosen.weight().producer_port.as_deref().map(Box::from),
+        ))
     };
     let (driver_pred, driver_port) =
         resolve_side(driver_upstream, driver_port_ref.as_deref(), "driver")?;

--- a/crates/clinker-exec/src/executor/commit/dispatch.rs
+++ b/crates/clinker-exec/src/executor/commit/dispatch.rs
@@ -43,7 +43,9 @@ use petgraph::visit::{EdgeRef, Topo};
 
 use super::DlqEvent;
 use super::detect::RetractScope;
-use crate::executor::dispatch::{ExecutorContext, dispatch_plan_node, drain_node_buffer_slot};
+use crate::executor::dispatch::{
+    ExecutorContext, NodeBufferKey, dispatch_plan_node, drain_node_buffer_slot,
+};
 use crate::executor::node_buffer::NodeBuffer;
 use clinker_plan::error::PipelineError;
 use clinker_plan::plan::CompositionBodyId;
@@ -324,15 +326,17 @@ fn seed_cross_region_inputs_for(
         let Some(parked) = ctx.region_input_buffers.remove(&key) else {
             continue;
         };
-        // Append onto the source node's buffer so the consumer's
-        // existing predecessor-walk logic resolves them. Per-row
-        // attribution flows through the slot's registered
+        // Append onto the source node's buffer, keyed by the crossing edge's
+        // producer output port so a multi-output source (Route branch / Cull
+        // port) lands in the exact slot the consumer's edge-based drain reads.
+        // Per-row attribution flows through the slot's registered
         // `NodeBufferConsumer` once `admit_node_buffer` re-keys this
         // slot at the next bulk admission; the arbitrator's
         // `should_abort` poll guards the pipeline-wide hard limit.
+        let producer_port = current_dag.graph[edge_id].producer_port.as_deref();
         let slot = ctx
             .node_buffers
-            .entry(source_idx)
+            .entry(NodeBufferKey::with_port(source_idx, producer_port))
             .or_insert_with(|| NodeBuffer::Memory(Vec::new()));
         for (record, rn) in parked {
             slot.push(record, rn);
@@ -391,7 +395,7 @@ fn recurse_into_body(
     // collide numerically). Restore on every exit. The paired
     // consumer-id map swaps alongside so body-scope NodeBufferConsumer
     // registrations don't survive into the parent scope's arbitrator.
-    let body_buffers: HashMap<NodeIndex, NodeBuffer> = HashMap::new();
+    let body_buffers: HashMap<NodeBufferKey, NodeBuffer> = HashMap::new();
     let saved_buffers = std::mem::replace(&mut ctx.node_buffers, body_buffers);
     let saved_consumer_ids = std::mem::take(&mut ctx.node_buffer_consumer_ids);
     // Window-arena consumer ids are keyed by slot index, which the body
@@ -464,7 +468,7 @@ fn recurse_into_body(
         // body region.
         for body_region in body_dag.deferred_regions.values() {
             let producer = body_region.producer;
-            if ctx.node_buffers.contains_key(&producer) {
+            if ctx.node_buffers.contains_key(&producer.into()) {
                 continue;
             }
             if !ctx.relaxed_aggregator_states.contains_key(&producer) {
@@ -540,7 +544,7 @@ fn recurse_into_body(
         // batch boundaries.
         let slot = ctx
             .node_buffers
-            .entry(composition_idx)
+            .entry(composition_idx.into())
             .or_insert_with(|| NodeBuffer::Memory(Vec::new()));
         for (record, rn) in harvested {
             slot.push(record, rn);

--- a/crates/clinker-exec/src/executor/commit/dispatch.rs
+++ b/crates/clinker-exec/src/executor/commit/dispatch.rs
@@ -326,17 +326,21 @@ fn seed_cross_region_inputs_for(
         let Some(parked) = ctx.region_input_buffers.remove(&key) else {
             continue;
         };
-        // Append onto the source node's buffer, keyed by the crossing edge's
-        // producer output port so a multi-output source (Route branch / Cull
-        // port) lands in the exact slot the consumer's edge-based drain reads.
-        // Per-row attribution flows through the slot's registered
-        // `NodeBufferConsumer` once `admit_node_buffer` re-keys this
-        // slot at the next bulk admission; the arbitrator's
-        // `should_abort` poll guards the pipeline-wide hard limit.
+        // Re-seed the source node's buffer keyed by the crossing edge's producer
+        // output port, so a multi-output source (Route branch / Cull port) lands
+        // in the exact slot the consumer's edge-based drain reads. The parked
+        // tee holds exactly the records this crossing edge delivered on the
+        // forward pass, so REPLACE the slot rather than append: the forward-pass
+        // producer emit left its own copy in this same slot (the member-clear
+        // above only drains member/output slots, not an upstream producer's
+        // port slot), and appending would double it. Draining first also
+        // releases that forward copy's registered `NodeBufferConsumer`.
         let producer_port = current_dag.graph[edge_id].producer_port.as_deref();
+        let slot_key = NodeBufferKey::with_port(source_idx, producer_port);
+        drain_node_buffer_slot(ctx, slot_key.clone());
         let slot = ctx
             .node_buffers
-            .entry(NodeBufferKey::with_port(source_idx, producer_port))
+            .entry(slot_key)
             .or_insert_with(|| NodeBuffer::Memory(Vec::new()));
         for (record, rn) in parked {
             slot.push(record, rn);

--- a/crates/clinker-exec/src/executor/commit/dispatch.rs
+++ b/crates/clinker-exec/src/executor/commit/dispatch.rs
@@ -44,7 +44,7 @@ use petgraph::visit::{EdgeRef, Topo};
 use super::DlqEvent;
 use super::detect::RetractScope;
 use crate::executor::dispatch::{
-    ExecutorContext, NodeBufferKey, dispatch_plan_node, drain_node_buffer_slot,
+    ExecutorContext, NodeBufferKey, admit_node_buffer, dispatch_plan_node, drain_node_buffer_slot,
 };
 use crate::executor::node_buffer::NodeBuffer;
 use clinker_plan::error::PipelineError;
@@ -219,14 +219,29 @@ fn dispatch_one_region(
     // (and similar own-buffer-write arms) parks records into
     // `node_buffers[succ_idx]` BEFORE the consumer arm gets a chance
     // to short-circuit, so the slot carries pre-recompute records the
-    // commit pass must not re-read. The producer's slot is preserved
-    // — `recompute_aggregates` populates it with the post-recompute
-    // narrow rows.
+    // commit pass must not re-read. This includes any `(member, Some(port))`
+    // port slots a member Route/Cull wrote for an in-region Merge/Combine —
+    // draining only the `(member, None)` slot would leave those stale. The
+    // producer's slot is preserved — `recompute_aggregates` populates it with
+    // the post-recompute narrow rows.
+    let stale_ported: Vec<NodeBufferKey> = ctx
+        .node_buffers
+        .keys()
+        .filter(|k| {
+            k.producer_port.is_some()
+                && k.node != region.producer
+                && (region.members.contains(&k.node) || region.outputs.contains(&k.node))
+        })
+        .cloned()
+        .collect();
     for &m in &region.members {
         drain_node_buffer_slot(ctx, m);
     }
     for &o in &region.outputs {
         drain_node_buffer_slot(ctx, o);
+    }
+    for k in stale_ported {
+        drain_node_buffer_slot(ctx, k);
     }
 
     let active_body = ctx.window_runtime.active_stack.last().copied();
@@ -331,20 +346,26 @@ fn seed_cross_region_inputs_for(
         // in the exact slot the consumer's edge-based drain reads. The parked
         // tee holds exactly the records this crossing edge delivered on the
         // forward pass, so REPLACE the slot rather than append: the forward-pass
-        // producer emit left its own copy in this same slot (the member-clear
-        // above only drains member/output slots, not an upstream producer's
-        // port slot), and appending would double it. Draining first also
-        // releases that forward copy's registered `NodeBufferConsumer`.
+        // producer emit left its own copy in this same slot, and appending would
+        // double it. Draining first releases that forward copy's registered
+        // consumer; `admit_node_buffer` then re-registers the re-seeded slot so
+        // its bytes are attributed and bound-checked like every other slot (a
+        // raw insert would leave the replayed records off the arbitrator's
+        // books). The slot is non-spillable — the consumer edge carries a
+        // producer port — so `spill_allowed` is false.
         let producer_port = current_dag.graph[edge_id].producer_port.as_deref();
         let slot_key = NodeBufferKey::with_port(source_idx, producer_port);
         drain_node_buffer_slot(ctx, slot_key.clone());
-        let slot = ctx
-            .node_buffers
-            .entry(slot_key)
-            .or_insert_with(|| NodeBuffer::Memory(Vec::new()));
-        for (record, rn) in parked {
-            slot.push(record, rn);
-        }
+        let source_name = current_dag.graph[source_idx].name();
+        let nb = admit_node_buffer(
+            ctx,
+            source_name,
+            slot_key.clone(),
+            parked,
+            Vec::new(),
+            false,
+        )?;
+        ctx.node_buffers.insert(slot_key, nb);
     }
 
     Ok(())
@@ -402,6 +423,10 @@ fn recurse_into_body(
     let body_buffers: HashMap<NodeBufferKey, NodeBuffer> = HashMap::new();
     let saved_buffers = std::mem::replace(&mut ctx.node_buffers, body_buffers);
     let saved_consumer_ids = std::mem::take(&mut ctx.node_buffer_consumer_ids);
+    // Shared-input drain counts key by the body-local `NodeBufferKey` space;
+    // swap alongside `node_buffers` so a body fanout does not collide with a
+    // parent count.
+    let saved_shared_drains = std::mem::take(&mut ctx.shared_input_drains);
     // Window-arena consumer ids are keyed by slot index, which the body
     // re-uses from zero just like its window-runtime overlay. Swap to a
     // fresh map so a body slot-0 arena registration does not clobber the
@@ -535,6 +560,7 @@ fn recurse_into_body(
     ctx.source_records = saved_combine;
     ctx.node_buffers = saved_buffers;
     ctx.node_buffer_consumer_ids = saved_consumer_ids;
+    ctx.shared_input_drains = saved_shared_drains;
     ctx.window_arena_consumer_ids = saved_arena_ids;
 
     let harvested = walk_and_harvest?;

--- a/crates/clinker-exec/src/executor/commit/recompute_agg.rs
+++ b/crates/clinker-exec/src/executor/commit/recompute_agg.rs
@@ -249,6 +249,6 @@ pub(crate) fn emit_post_recompute(
         // aggregate output.
         HashAggError::Spill(format!("post-recompute node-buffer admission: {e}"))
     })?;
-    ctx.node_buffers.insert(agg_idx, nb);
+    ctx.node_buffers.insert(agg_idx.into(), nb);
     Ok(emitted)
 }

--- a/crates/clinker-exec/src/executor/composition_dispatch.rs
+++ b/crates/clinker-exec/src/executor/composition_dispatch.rs
@@ -308,6 +308,10 @@ fn execute_composition_body(
     // not top-level sources. Any non-port-seeded body Source surfaces
     // as the defense-in-depth `Internal` error from the Source arm.
     let saved_buffers = std::mem::replace(&mut ctx.node_buffers, body_buffers);
+    // Shared-input drain counts key by the body-local `NodeBufferKey` space, so
+    // swap to a fresh map alongside `node_buffers` — a pending parent fanout
+    // count must not collide with a body slot of the same index/port.
+    let saved_shared_drains = std::mem::take(&mut ctx.shared_input_drains);
     let saved_combine = std::mem::take(&mut ctx.source_records);
     // Window-arena consumer ids key by slot index, which the body
     // re-uses from zero alongside its window-runtime overlay. Swap to a
@@ -410,6 +414,7 @@ fn execute_composition_body(
     // sync by hand on every exit path through this function.
     ctx.recursion_depth = ctx.recursion_depth.saturating_sub(1);
     ctx.node_buffers = saved_buffers;
+    ctx.shared_input_drains = saved_shared_drains;
     ctx.source_records = saved_combine;
     ctx.current_body_node_input_refs = saved_body_refs;
     // Unregister body-local window-arena consumers and restore the

--- a/crates/clinker-exec/src/executor/composition_dispatch.rs
+++ b/crates/clinker-exec/src/executor/composition_dispatch.rs
@@ -17,7 +17,7 @@ use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, dispatch_plan_node, drain_node_buffer_slot,
+    ExecutorContext, NodeBufferKey, admit_node_buffer, dispatch_plan_node, drain_node_buffer_slot,
     finalize_node_rooted_windows, node_buffer_spill_allowed, tee_emit_to_region_input_buffers,
 };
 use crate::executor::node_buffer::NodeBuffer;
@@ -84,7 +84,7 @@ pub(crate) fn dispatch_composition(
         // by their producer's buffer until `collect_port_records`
         // claims them below.
         if let Some(&first_pred) = predecessors.first()
-            && let Some(records) = ctx.node_buffers.get(&first_pred)
+            && let Some(records) = ctx.node_buffers.get(&first_pred.into())
         {
             for (record, _) in records.peek_mem_records() {
                 check_input_schema(
@@ -142,7 +142,7 @@ pub(crate) fn dispatch_composition(
         Vec::new(),
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
 
     Ok(())
 }
@@ -208,7 +208,7 @@ fn collect_port_records(
         // errors that bubble out of `execute_composition_body`'s
         // topo walk get that wrapper. Detail string discriminates
         // this site from the generic admit in `admit_node_buffer`.
-        let cloned_with_bytes = ctx.node_buffers.get(&edge.source()).map(|nb| {
+        let cloned_with_bytes = ctx.node_buffers.get(&edge.source().into()).map(|nb| {
             // Composition port seeding clones records only; the
             // composition body operates inside its own document-
             // boundary scope and re-emits punctuations at the call-
@@ -284,13 +284,13 @@ fn execute_composition_body(
     }
 
     // Seed body-scope buffers from parent records keyed by port.
-    let mut body_buffers: HashMap<NodeIndex, NodeBuffer> = HashMap::new();
+    let mut body_buffers: HashMap<NodeBufferKey, NodeBuffer> = HashMap::new();
     for (port_name, records) in port_records {
         let body_idx = bound_body
             .port_name_to_node_idx
             .get(port_name.as_str())
             .ok_or_else(|| PipelineError::compose_unknown_port(composition_name, &port_name))?;
-        body_buffers.insert(*body_idx, NodeBuffer::memory_from_records(records));
+        body_buffers.insert((*body_idx).into(), NodeBuffer::memory_from_records(records));
     }
 
     // Pick the body's terminal output node. The bind-time alias

--- a/crates/clinker-exec/src/executor/cull_dispatch.rs
+++ b/crates/clinker-exec/src/executor/cull_dispatch.rs
@@ -66,8 +66,8 @@ use petgraph::graph::NodeIndex;
 use petgraph::visit::EdgeRef;
 
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, drain_node_buffer_slot, node_buffer_spill_allowed,
-    source_file_arc_of, source_name_arc_of,
+    ExecutorContext, NodeBufferKey, admit_node_buffer, drain_node_buffer_slot,
+    node_buffer_spill_allowed, source_file_arc_of, source_name_arc_of,
 };
 use crate::pipeline::memory::{
     ConsumerHandle, ConsumerSpillError, MemoryArbitrator, MemoryConsumer,
@@ -471,16 +471,14 @@ fn compute_drop_decisions(
 /// draws removed rows; every other successor (the bare main reference, tagged
 /// `None`) draws kept rows.
 ///
-/// Records are accumulated **per successor across both ports** before a single
-/// admission, so a node drawing from both ports lands the union in one slot —
-/// the second port's records never overwrite the first's (the per-successor
-/// accumulation Route uses for its branches).
-///
 /// Where the records land depends on how the successor reads its input. A
 /// single-output consumer (Transform / Output / Reshape / Cull) checks its own
-/// `node_buffers` slot first, so its records go there. A multi-input consumer
-/// (Merge / Combine) reads its *predecessor's* slot directly, so its records go
-/// into this Cull's own slot (`node_idx`) instead. Both ports broadcast
+/// `node_buffers` slot first, so its port-selected records go into the
+/// successor's own slot (`(succ, None)`). A multi-input consumer (Merge /
+/// Combine) reads its *predecessor's* slot directly, keyed by the incoming
+/// edge's producer port, so each distinct producer port lands in this Cull's
+/// own `(node_idx, Some(port))` slot — the `main` and `removed_to` ports stay
+/// separate, which a Combine build side depends on. Both ports broadcast
 /// `input_puncts` so each downstream subgraph drives its own per-document
 /// accumulators.
 #[allow(clippy::too_many_arguments)]
@@ -494,51 +492,53 @@ fn emit_ports(
     removed: Vec<(Record, u64)>,
     input_puncts: Vec<crate::executor::stream_event::Punctuation>,
 ) -> Result<(), PipelineError> {
-    // Accumulate each successor's port-selected records keyed by successor
-    // index. The edge's `producer_port` tag is the source of truth:
-    // `Some(removed_to)` → removed rows, anything else (the untagged main
-    // reference) → kept rows. A record set is cloned into a successor's bucket
-    // only when that successor draws the matching port, so the bucket is the
-    // exact set the port selected; a node drawing both ports gets the union.
+    // The edge's `producer_port` tag selects the record set: `Some(removed_to)`
+    // → removed rows, anything else (the untagged main reference, or an
+    // explicit `main`) → kept rows.
     let removed_port = config.removed_to.as_str();
-    let mut succ_records: HashMap<NodeIndex, Vec<(Record, u64)>> = HashMap::new();
-    let mut succ_order: Vec<NodeIndex> = Vec::new();
-    for edge in current_dag
-        .graph
-        .edges_directed(node_idx, Direction::Outgoing)
-    {
-        let succ = edge.target();
-        if !succ_records.contains_key(&succ) {
-            succ_order.push(succ);
-        }
-        let bucket = succ_records.entry(succ).or_default();
-        match edge.weight().producer_port.as_deref() {
-            Some(port) if port == removed_port => bucket.extend(removed.iter().cloned()),
-            _ => bucket.extend(kept.iter().cloned()),
-        }
-    }
+    let is_removed_port = |port: Option<&str>| matches!(port, Some(p) if p == removed_port);
 
     let cull_region_producer = current_dag.deferred_region_at(node_idx).map(|r| r.producer);
     let active_body = ctx.window_runtime.active_stack.last().copied();
-    // Records destined for a predecessor-slot reader (Merge / Combine)
-    // accumulate into this Cull's own slot, where that consumer drains them.
-    let mut predecessor_slot: Vec<(Record, u64)> = Vec::new();
-    let mut wrote_predecessor_slot = false;
-    // Iterate in first-seen successor order so admission is deterministic.
-    for succ in succ_order {
-        let records = succ_records.remove(&succ).unwrap_or_default();
+
+    // Predecessor-slot readers (Merge / Combine) drain by incoming edge, so one
+    // slot per distinct producer output port lands in this Cull's own slot
+    // keyed `(node_idx, Some(port))`. Materialize each port's set once (multiple
+    // consumers of the same port share the slot, as they did pre-port). Own-slot
+    // readers admit inline into their own slot.
+    let mut pred_ports: Vec<Option<Box<str>>> = Vec::new();
+    // Collect outgoing edges first so the mutable `ctx` admissions below do not
+    // overlap the immutable graph borrow.
+    let outgoing: Vec<(NodeIndex, Option<Box<str>>, petgraph::graph::EdgeIndex)> = current_dag
+        .graph
+        .edges_directed(node_idx, Direction::Outgoing)
+        .map(|edge| {
+            (
+                edge.target(),
+                edge.weight().producer_port.as_deref().map(Box::from),
+                edge.id(),
+            )
+        })
+        .collect();
+
+    for (succ, port, edge_id) in outgoing {
+        let records: &Vec<(Record, u64)> = if is_removed_port(port.as_deref()) {
+            &removed
+        } else {
+            &kept
+        };
         // Cross-region tee: a successor inside a deferred region this Cull is
-        // not in needs the port-selected records parked on the matching
-        // outgoing edge so the commit-time deferred dispatcher receives exactly
-        // them. In-region and non-deferred edges skip the tee; their
-        // `node_buffers` slot already covers them.
+        // not in needs this port's records parked on the matching outgoing edge
+        // so the commit-time deferred dispatcher receives exactly them.
+        // In-region and non-deferred edges skip the tee; their `node_buffers`
+        // slot already covers them.
         let succ_region_producer = current_dag.deferred_region_at(succ).map(|r| r.producer);
         let crosses = match (cull_region_producer, succ_region_producer) {
             (None, Some(_)) => true,
             (Some(p), Some(t)) if p != t => true,
             _ => false,
         };
-        if crosses && let Some(edge) = current_dag.graph.find_edge(node_idx, succ) {
+        if crosses {
             let row_bytes_each: u64 = records
                 .first()
                 .map(|(rec, _)| {
@@ -546,7 +546,7 @@ fn emit_ports(
                         + std::mem::size_of::<(Record, u64)>()) as u64
                 })
                 .unwrap_or(0);
-            for (record, rn) in &records {
+            for (record, rn) in records {
                 // Fail loud if an oversized cross-region tee would blow the
                 // budget, mirroring the Route tee — parking unbounded records
                 // into `region_input_buffers` must not silently overshoot.
@@ -560,18 +560,18 @@ fn emit_ports(
                     });
                 }
                 ctx.region_input_buffers
-                    .entry((active_body, edge))
+                    .entry((active_body, edge_id))
                     .or_default()
                     .push((record.clone(), *rn));
             }
         }
         if reads_predecessor_slot(&current_dag.graph[succ]) {
-            // Merge / Combine drains its predecessor's slot, not its own, so
-            // its records join this Cull's slot (deduped across such
-            // successors into one accumulation — they all read the same slot).
-            predecessor_slot.extend(records);
-            wrote_predecessor_slot = true;
+            if !pred_ports.contains(&port) {
+                pred_ports.push(port);
+            }
         } else {
+            // Own-slot reader: its port-selected records go into its own slot.
+            let records = records.clone();
             let nb = admit_node_buffer(
                 ctx,
                 name,
@@ -580,19 +580,26 @@ fn emit_ports(
                 input_puncts.clone(),
                 node_buffer_spill_allowed(current_dag, succ),
             )?;
-            ctx.node_buffers.insert(succ, nb);
+            ctx.node_buffers.insert(succ.into(), nb);
         }
     }
-    if wrote_predecessor_slot {
+    let spill_allowed = node_buffer_spill_allowed(current_dag, node_idx);
+    for port in pred_ports {
+        let records = if is_removed_port(port.as_deref()) {
+            removed.clone()
+        } else {
+            kept.clone()
+        };
+        let key = NodeBufferKey::with_port(node_idx, port.as_deref());
         let nb = admit_node_buffer(
             ctx,
             name,
-            node_idx,
-            predecessor_slot,
-            input_puncts,
-            node_buffer_spill_allowed(current_dag, node_idx),
+            key.clone(),
+            records,
+            input_puncts.clone(),
+            spill_allowed,
         )?;
-        ctx.node_buffers.insert(node_idx, nb);
+        ctx.node_buffers.insert(key, nb);
     }
     Ok(())
 }
@@ -602,7 +609,7 @@ fn emit_ports(
 /// directly; every other consumer (Transform / Output / Reshape / Cull / Sort
 /// / Aggregation) checks its own slot first, so a producer writes into the
 /// consumer's slot for those.
-fn reads_predecessor_slot(node: &PlanNode) -> bool {
+pub(crate) fn reads_predecessor_slot(node: &PlanNode) -> bool {
     matches!(node, PlanNode::Merge { .. } | PlanNode::Combine { .. })
 }
 

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -446,6 +446,44 @@ use clinker_plan::plan::composition_body::CompositionBodies;
 use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
 use clinker_record::Schema;
 
+/// Key for a `node_buffers` slot.
+///
+/// A single-output producer keys its slot by node index alone; the
+/// `From<NodeIndex>` conversion yields `producer_port: None`, so every
+/// single-output insert/get/drain stays byte-identical to the pre-port model.
+/// A multi-output producer (a [`PlanNode::Route`] branch or a
+/// [`PlanNode::Cull`] `main` / `removed_to` port) writes each port to its own
+/// `(node, Some(port))` slot, and a predecessor-slot consumer (Merge / Combine)
+/// drains the slot named by its incoming edge's
+/// [`producer_port`](clinker_plan::plan::execution::PlanEdge::producer_port).
+/// Keeping `node_buffers` and `node_buffer_consumer_ids` keyed by the same type
+/// keeps the arbitrator's consumer registry aligned with the live slot map.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub(crate) struct NodeBufferKey {
+    pub(crate) node: NodeIndex,
+    pub(crate) producer_port: Option<Box<str>>,
+}
+
+impl NodeBufferKey {
+    /// Slot for `node` on producer output `port`; `None` is the single unnamed
+    /// output (identical to `NodeBufferKey::from(node)`).
+    pub(crate) fn with_port(node: NodeIndex, port: Option<&str>) -> Self {
+        Self {
+            node,
+            producer_port: port.map(Box::from),
+        }
+    }
+}
+
+impl From<NodeIndex> for NodeBufferKey {
+    fn from(node: NodeIndex) -> Self {
+        Self {
+            node,
+            producer_port: None,
+        }
+    }
+}
+
 /// Mutable per-walk and borrowed plan-time state passed to
 /// [`dispatch_plan_node`].
 ///
@@ -513,7 +551,7 @@ pub(crate) struct ExecutorContext<'a> {
     pub(crate) strategy: ErrorStrategy,
 
     // Owned mutable per-walk state.
-    pub(crate) node_buffers: HashMap<NodeIndex, NodeBuffer>,
+    pub(crate) node_buffers: HashMap<NodeBufferKey, NodeBuffer>,
     /// Per-slot consumer registration for `node_buffers`. `admit_node_buffer`
     /// registers a `NodeBufferConsumer` with the pipeline-scoped arbitrator
     /// and stores both the returned `ConsumerId` (used to `unregister_consumer`
@@ -523,7 +561,7 @@ pub(crate) struct ExecutorContext<'a> {
     /// `node_buffers` so a body walk does not pollute the parent scope's
     /// registry.
     pub(crate) node_buffer_consumer_ids: HashMap<
-        NodeIndex,
+        NodeBufferKey,
         (
             crate::pipeline::memory::ConsumerId,
             std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
@@ -1515,22 +1553,24 @@ pub(crate) fn node_buffer_spill_allowed(
 /// so the arbitrator's registry stays aligned with the live slot map.
 pub(crate) fn drain_node_buffer_slot(
     ctx: &mut ExecutorContext<'_>,
-    node_idx: NodeIndex,
+    key: impl Into<NodeBufferKey>,
 ) -> Option<NodeBuffer> {
-    if let Some((id, _)) = ctx.node_buffer_consumer_ids.remove(&node_idx) {
+    let key = key.into();
+    if let Some((id, _)) = ctx.node_buffer_consumer_ids.remove(&key) {
         ctx.memory_budget.unregister_consumer(id);
     }
-    ctx.node_buffers.remove(&node_idx)
+    ctx.node_buffers.remove(&key)
 }
 
 pub(crate) fn admit_node_buffer(
     ctx: &mut ExecutorContext<'_>,
     node_name: &str,
-    node_idx: NodeIndex,
+    key: impl Into<NodeBufferKey>,
     rows: Vec<(Record, u64)>,
     puncts: Vec<crate::executor::stream_event::Punctuation>,
     spill_allowed: bool,
 ) -> Result<NodeBuffer, PipelineError> {
+    let node_idx = key.into();
     if rows.is_empty() && puncts.is_empty() {
         return Ok(NodeBuffer::Memory(Vec::new()));
     }
@@ -2757,7 +2797,7 @@ pub(crate) fn transform_fused_consume(
         forwarded_puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
     Ok(())
 }
 
@@ -2818,9 +2858,9 @@ fn service_node_buffer_spill_requests(
 /// between two admissions with real record footprints.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn service_pending_node_buffer_spills(
-    node_buffers: &mut HashMap<NodeIndex, NodeBuffer>,
+    node_buffers: &mut HashMap<NodeBufferKey, NodeBuffer>,
     consumer_ids: &HashMap<
-        NodeIndex,
+        NodeBufferKey,
         (
             crate::pipeline::memory::ConsumerId,
             Arc<crate::pipeline::memory::ConsumerHandle>,
@@ -2837,36 +2877,36 @@ pub(crate) fn service_pending_node_buffer_spills(
     // that are eligible to spill (resident `Memory` + single-drain
     // topology). `take_spill_request` read-and-clears the flag for every
     // flagged slot, spillable or not, so a non-spillable flag does not spin.
-    let mut to_spill: Vec<NodeIndex> = Vec::new();
-    for (idx, (_id, handle)) in consumer_ids {
+    let mut to_spill: Vec<NodeBufferKey> = Vec::new();
+    for (key, (_id, handle)) in consumer_ids {
         if handle.take_spill_request()
-            && matches!(node_buffers.get(idx), Some(NodeBuffer::Memory(_)))
-            && is_spill_allowed(*idx)
+            && matches!(node_buffers.get(key), Some(NodeBuffer::Memory(_)))
+            && is_spill_allowed(key.node)
         {
-            to_spill.push(*idx);
+            to_spill.push(key.clone());
         }
     }
     // Phase 2: flush each elected slot. Single-threaded dispatch means
     // nothing mutated the slot between the two phases, so it is still the
     // `Memory` variant Phase 1 saw.
-    for idx in to_spill {
+    for key in to_spill {
         let Some(handle) = consumer_ids
-            .get(&idx)
+            .get(&key)
             .map(|(_id, handle)| Arc::clone(handle))
         else {
             continue;
         };
-        let Some(buffer) = node_buffers.remove(&idx) else {
+        let Some(buffer) = node_buffers.remove(&key) else {
             continue;
         };
-        let name = node_name(idx);
+        let name = node_name(key.node);
         // Resolve the compression mode against this slot's schema width and
         // the run's batch size, matching the admission path so the on-disk
         // format agrees with what `--explain` projects.
         let column_count = buffer.first_record_column_count();
         let compress = spill_compress.resolve_for_schema(column_count, batch_size as u64);
         let (spilled, file_bytes) = buffer.spill_resident_memory(Some(spill_root), compress)?;
-        node_buffers.insert(idx, spilled);
+        node_buffers.insert(key, spilled);
         if file_bytes > 0 {
             // Rows are on disk now; the slot's in-memory charge is zero.
             handle.set_bytes(0);

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1570,7 +1570,7 @@ pub(crate) fn admit_node_buffer(
     puncts: Vec<crate::executor::stream_event::Punctuation>,
     spill_allowed: bool,
 ) -> Result<NodeBuffer, PipelineError> {
-    let node_idx = key.into();
+    let slot_key = key.into();
     if rows.is_empty() && puncts.is_empty() {
         return Ok(NodeBuffer::Memory(Vec::new()));
     }
@@ -1593,7 +1593,7 @@ pub(crate) fn admit_node_buffer(
     // discharge — e.g. the post-recompute aggregate emit path)
     // unregisters first so the arbitrator's registry holds exactly
     // one wrapper per live slot.
-    if let Some((prev_id, _)) = ctx.node_buffer_consumer_ids.remove(&node_idx) {
+    if let Some((prev_id, _)) = ctx.node_buffer_consumer_ids.remove(&slot_key) {
         ctx.memory_budget.unregister_consumer(prev_id);
     }
     let handle = crate::pipeline::memory::ConsumerHandle::new();
@@ -1602,7 +1602,7 @@ pub(crate) fn admit_node_buffer(
         crate::executor::node_buffer::NodeBufferConsumer::new(handle.clone()),
     ));
     ctx.node_buffer_consumer_ids
-        .insert(node_idx, (consumer_id, handle.clone()));
+        .insert(slot_key, (consumer_id, handle.clone()));
     // Raise the run's high-water mark now that this slot's charge has
     // joined the registry. Sampling at admission (not only on streaming
     // batch charges) makes `peak_consumer_usage_bytes` a faithful peak

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -1600,6 +1600,11 @@ pub(crate) fn drain_or_clone_shared_input(
                 )
         })
         .count();
+    // Single consumer (the overwhelming common case): plain drain, no counting.
+    // This also covers the two paths that count a consumer but skip its drain —
+    // a streaming-probe driver (its producer is certified single-outgoing-edge,
+    // so `total_consumers == 1`) and a fused-Source Merge (streams live channels,
+    // materializes no `(source, None)` slot) — so neither can stall the counter.
     if total_consumers <= 1 {
         return drain_node_buffer_slot(ctx, key);
     }
@@ -1609,6 +1614,10 @@ pub(crate) fn drain_or_clone_shared_input(
         ctx.shared_input_drains.remove(&key);
         drain_node_buffer_slot(ctx, key)
     } else {
+        // The clone is a transient owned buffer drained immediately by this
+        // consumer; the original slot keeps its registered charge until the last
+        // consumer removes it, so the shared data stays accounted once. The
+        // clone is deliberately not admitted (at most one exists at a time).
         ctx.node_buffers
             .get(&key)
             .map(|nb| NodeBuffer::Memory(nb.clone_memory_only()))

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -567,6 +567,12 @@ pub(crate) struct ExecutorContext<'a> {
             std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
         ),
     >,
+    /// Count of consumers that have already drained a shared predecessor-slot
+    /// (a producer output port fanned out to more than one Merge/Combine).
+    /// `drain_or_clone_shared_input` clones the slot for every consumer except
+    /// the last, which removes it — the count makes "who is last" independent
+    /// of the memory-arbitrated dispatch order.
+    pub(crate) shared_input_drains: HashMap<NodeBufferKey, usize>,
     /// Per-slot consumer registration for window-runtime arenas.
     /// `finalize_node_rooted_windows` registers an `ArenaConsumer` with
     /// the pipeline-scoped arbitrator after each arena builds and stores
@@ -1560,6 +1566,53 @@ pub(crate) fn drain_node_buffer_slot(
         ctx.memory_budget.unregister_consumer(id);
     }
     ctx.node_buffers.remove(&key)
+}
+
+/// Take a predecessor-slot reader's input from `key`, cloning the slot (leaving
+/// it intact) when other predecessor-slot consumers of the SAME
+/// `(producer, port)` slot still need it — so one producer output port fanned
+/// out to several Merge/Combine consumers reaches all of them, not just the
+/// first to drain. The last consumer to drain (the one after which the tracked
+/// drain count reaches the total number of such consumers) removes the slot;
+/// every earlier one clones. Counting drains rather than comparing `NodeIndex`
+/// keeps this correct under the memory-arbitrated dispatch order, which is not
+/// `NodeIndex`-monotonic.
+///
+/// A fanned port has more than one outgoing edge on its producer, so
+/// [`node_buffer_spill_allowed`] keeps the slot unspilled; the clone therefore
+/// never reaches `clone_memory_only`'s spill panic. The clone preserves
+/// punctuations (it copies the full `StreamEvent` vector), which the Output
+/// fan-out path does not need but a multi-input consumer does.
+pub(crate) fn drain_or_clone_shared_input(
+    ctx: &mut ExecutorContext<'_>,
+    current_dag: &ExecutionPlanDag,
+    key: NodeBufferKey,
+) -> Option<NodeBuffer> {
+    use petgraph::visit::EdgeRef;
+    let port = key.producer_port.as_deref();
+    let total_consumers = current_dag
+        .graph
+        .edges_directed(key.node, Direction::Outgoing)
+        .filter(|e| {
+            e.weight().producer_port.as_deref() == port
+                && crate::executor::cull_dispatch::reads_predecessor_slot(
+                    &current_dag.graph[e.target()],
+                )
+        })
+        .count();
+    if total_consumers <= 1 {
+        return drain_node_buffer_slot(ctx, key);
+    }
+    let drained = ctx.shared_input_drains.entry(key.clone()).or_insert(0);
+    *drained += 1;
+    if *drained >= total_consumers {
+        ctx.shared_input_drains.remove(&key);
+        drain_node_buffer_slot(ctx, key)
+    } else {
+        ctx.node_buffers
+            .get(&key)
+            .map(|nb| NodeBuffer::Memory(nb.clone_memory_only()))
+    }
 }
 
 pub(crate) fn admit_node_buffer(

--- a/crates/clinker-exec/src/executor/envelope_dispatch.rs
+++ b/crates/clinker-exec/src/executor/envelope_dispatch.rs
@@ -189,7 +189,7 @@ pub(crate) fn dispatch_envelope(
         puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
     Ok(())
 }
 

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -16,7 +16,7 @@ use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
     ExecutorContext, FusedMergeOutput, MergeStreamHandoff, NodeBufferKey, admit_node_buffer,
-    drain_node_buffer_slot, finalize_node_rooted_windows, merge_fused_interleave,
+    drain_or_clone_shared_input, finalize_node_rooted_windows, merge_fused_interleave,
     node_buffer_spill_allowed, stream_linear_producer_emit, tee_emit_to_region_input_buffers,
 };
 use crate::executor::schema_check::check_input_schema;
@@ -34,7 +34,14 @@ pub(crate) fn dispatch_merge(
     node_idx: NodeIndex,
     node: &PlanNode,
 ) -> Result<(), PipelineError> {
-    let PlanNode::Merge { ref name, .. } = *node else {
+    let PlanNode::Merge {
+        ref name,
+        mode,
+        interleave_seed,
+        input_order: ref declaration_order,
+        ..
+    } = *node
+    else {
         unreachable!("dispatch_merge called with non-Merge node");
     };
     // Two architectural modes for a Merge arm:
@@ -64,34 +71,10 @@ pub(crate) fn dispatch_merge(
         .neighbors_directed(node_idx, Direction::Incoming)
         .collect();
 
-    let (declaration_order, mode, interleave_seed): (
-        Vec<String>,
-        clinker_plan::config::MergeMode,
-        Option<u64>,
-    ) = {
-        use clinker_plan::config::PipelineNode;
-        use clinker_plan::config::node_header::NodeInput;
-        ctx.config
-            .nodes
-            .iter()
-            .find_map(|spanned| match &spanned.value {
-                PipelineNode::Merge { header, config, .. } if header.name == *name => {
-                    let order = header
-                        .inputs
-                        .iter()
-                        .map(|ni| match &ni.value {
-                            NodeInput::Single(s) => s.clone(),
-                            NodeInput::Port { node, port } => {
-                                format!("{node}.{port}")
-                            }
-                        })
-                        .collect();
-                    Some((order, config.mode, config.interleave_seed))
-                }
-                _ => None,
-            })
-            .unwrap_or_else(|| (Vec::new(), clinker_plan::config::MergeMode::Concat, None))
-    };
+    // `mode`, `interleave_seed`, and `declaration_order` are read off the node
+    // (destructured above) so a Merge inside a composition body resolves them
+    // scope-correctly; a by-name lookup into the top-level `ctx.config.nodes`
+    // would miss body nodes and silently fall back to Concat / empty order.
 
     // Sort predecessors by declaration order
     let mut sorted_preds = predecessors.clone();
@@ -100,39 +83,6 @@ pub(crate) fn dispatch_merge(
         declaration_order
             .iter()
             .position(|d| d == pred_name)
-            .unwrap_or(usize::MAX)
-    });
-
-    // Ordered incoming inputs as `(source, producer_port)` — one per incoming
-    // edge, keyed by the producer output port the edge draws. A Merge that
-    // draws several ports of one producer (Route branches, or a Cull's `main`
-    // and `removed_to`) has several edges from the same source, each landing in
-    // a distinct `(source, Some(port))` slot; draining per edge keeps every
-    // port. Ordered by declaration order of the `node.port` (or bare `node`)
-    // reference so Concat output is deterministic and byte-stable for the
-    // single-output case.
-    use petgraph::visit::EdgeRef;
-    let mut ordered_inputs: Vec<(NodeIndex, Option<Box<str>>)> = current_dag
-        .graph
-        .edges_directed(node_idx, Direction::Incoming)
-        .map(|e| {
-            (
-                e.source(),
-                e.weight().producer_port.as_deref().map(Box::from),
-            )
-        })
-        .collect();
-    ordered_inputs.sort_by_key(|(src, port)| {
-        let node_name = current_dag.graph[*src].name();
-        declaration_order
-            .iter()
-            .position(|d| match d.split_once('.') {
-                Some((decl_node, decl_port)) => {
-                    matches_upstream_name(node_name, decl_node)
-                        && port.as_deref() == Some(decl_port)
-                }
-                None => matches_upstream_name(node_name, d) && port.is_none(),
-            })
             .unwrap_or(usize::MAX)
     });
 
@@ -205,6 +155,39 @@ pub(crate) fn dispatch_merge(
         )?
     } else {
         nonfused_sender = streaming_sender;
+        // Ordered incoming inputs as `(source, producer_port)` — one per incoming
+        // edge, keyed by the producer output port the edge draws. A Merge that
+        // draws several ports of one producer (Route branches, or a Cull's `main`
+        // and `removed_to`) has several edges from the same source, each landing
+        // in a distinct `(source, Some(port))` slot; draining per edge keeps
+        // every port. Ordered by declaration order of the `node.port` (or bare
+        // `node`) reference so Concat output is deterministic and byte-stable for
+        // the single-output case. Built only on the non-fused path (the fused
+        // path uses `sorted_preds` and never reads this).
+        use petgraph::visit::EdgeRef;
+        let mut ordered_inputs: Vec<(NodeIndex, Option<Box<str>>)> = current_dag
+            .graph
+            .edges_directed(node_idx, Direction::Incoming)
+            .map(|e| {
+                (
+                    e.source(),
+                    e.weight().producer_port.as_deref().map(Box::from),
+                )
+            })
+            .collect();
+        ordered_inputs.sort_by_key(|(src, port)| {
+            let node_name = current_dag.graph[*src].name();
+            declaration_order
+                .iter()
+                .position(|d| match d.split_once('.') {
+                    Some((decl_node, decl_port)) => {
+                        matches_upstream_name(node_name, decl_node)
+                            && port.as_deref() == Some(decl_port)
+                    }
+                    None => matches_upstream_name(node_name, d) && port.is_none(),
+                })
+                .unwrap_or(usize::MAX)
+        });
         let total: usize = ordered_inputs
             .iter()
             .map(|(src, port)| {
@@ -245,9 +228,11 @@ pub(crate) fn dispatch_merge(
             clinker_plan::config::MergeMode::Concat => {
                 for (src, port) in &ordered_inputs {
                     let upstream_name = current_dag.graph[*src].name().to_string();
-                    if let Some(buf) =
-                        drain_node_buffer_slot(ctx, NodeBufferKey::with_port(*src, port.as_deref()))
-                    {
+                    if let Some(buf) = drain_or_clone_shared_input(
+                        ctx,
+                        current_dag,
+                        NodeBufferKey::with_port(*src, port.as_deref()),
+                    ) {
                         for event in buf.drain() {
                             match event? {
                                 crate::executor::stream_event::StreamEvent::Record(record, rn) => {
@@ -276,8 +261,9 @@ pub(crate) fn dispatch_merge(
                     .iter()
                     .map(
                         |(src, port)| -> Result<VecDeque<(Record, u64)>, PipelineError> {
-                            match drain_node_buffer_slot(
+                            match drain_or_clone_shared_input(
                                 ctx,
+                                current_dag,
                                 NodeBufferKey::with_port(*src, port.as_deref()),
                             ) {
                                 Some(nb) => {

--- a/crates/clinker-exec/src/executor/merge_dispatch.rs
+++ b/crates/clinker-exec/src/executor/merge_dispatch.rs
@@ -15,13 +15,13 @@ use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
 use crate::executor::dispatch::{
-    ExecutorContext, FusedMergeOutput, MergeStreamHandoff, admit_node_buffer,
+    ExecutorContext, FusedMergeOutput, MergeStreamHandoff, NodeBufferKey, admit_node_buffer,
     drain_node_buffer_slot, finalize_node_rooted_windows, merge_fused_interleave,
     node_buffer_spill_allowed, stream_linear_producer_emit, tee_emit_to_region_input_buffers,
 };
 use crate::executor::schema_check::check_input_schema;
 use clinker_plan::error::PipelineError;
-use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode};
+use clinker_plan::plan::execution::{ExecutionPlanDag, PlanNode, matches_upstream_name};
 
 /// Execute the `Merge` arm for `node_idx`: concatenate predecessor buffers
 /// in declaration order (Concat), round-robin across them (Interleave), or —
@@ -103,6 +103,39 @@ pub(crate) fn dispatch_merge(
             .unwrap_or(usize::MAX)
     });
 
+    // Ordered incoming inputs as `(source, producer_port)` — one per incoming
+    // edge, keyed by the producer output port the edge draws. A Merge that
+    // draws several ports of one producer (Route branches, or a Cull's `main`
+    // and `removed_to`) has several edges from the same source, each landing in
+    // a distinct `(source, Some(port))` slot; draining per edge keeps every
+    // port. Ordered by declaration order of the `node.port` (or bare `node`)
+    // reference so Concat output is deterministic and byte-stable for the
+    // single-output case.
+    use petgraph::visit::EdgeRef;
+    let mut ordered_inputs: Vec<(NodeIndex, Option<Box<str>>)> = current_dag
+        .graph
+        .edges_directed(node_idx, Direction::Incoming)
+        .map(|e| {
+            (
+                e.source(),
+                e.weight().producer_port.as_deref().map(Box::from),
+            )
+        })
+        .collect();
+    ordered_inputs.sort_by_key(|(src, port)| {
+        let node_name = current_dag.graph[*src].name();
+        declaration_order
+            .iter()
+            .position(|d| match d.split_once('.') {
+                Some((decl_node, decl_port)) => {
+                    matches_upstream_name(node_name, decl_node)
+                        && port.as_deref() == Some(decl_port)
+                }
+                None => matches_upstream_name(node_name, d) && port.is_none(),
+            })
+            .unwrap_or(usize::MAX)
+    });
+
     let merge_output_schema = current_dag.graph[node_idx].stored_output_schema().cloned();
     // Detect fused mode: every predecessor is a Source whose
     // name is in `ctx.fused_sources`. The pre-pass at executor
@@ -172,9 +205,13 @@ pub(crate) fn dispatch_merge(
         )?
     } else {
         nonfused_sender = streaming_sender;
-        let total: usize = sorted_preds
+        let total: usize = ordered_inputs
             .iter()
-            .map(|p| ctx.node_buffers.get(p).map_or(0, |b| b.len_hint()))
+            .map(|(src, port)| {
+                ctx.node_buffers
+                    .get(&NodeBufferKey::with_port(*src, port.as_deref()))
+                    .map_or(0, |b| b.len_hint())
+            })
             .sum();
         let mut merged = Vec::with_capacity(total);
         let emit = |merged: &mut Vec<(Record, u64)>,
@@ -206,9 +243,11 @@ pub(crate) fn dispatch_merge(
         // `DocumentClose` traverses downstream exactly once.
         match mode {
             clinker_plan::config::MergeMode::Concat => {
-                for pred in &sorted_preds {
-                    let upstream_name = current_dag.graph[*pred].name().to_string();
-                    if let Some(buf) = drain_node_buffer_slot(ctx, *pred) {
+                for (src, port) in &ordered_inputs {
+                    let upstream_name = current_dag.graph[*src].name().to_string();
+                    if let Some(buf) =
+                        drain_node_buffer_slot(ctx, NodeBufferKey::with_port(*src, port.as_deref()))
+                    {
                         for event in buf.drain() {
                             match event? {
                                 crate::executor::stream_event::StreamEvent::Record(record, rn) => {
@@ -229,22 +268,27 @@ pub(crate) fn dispatch_merge(
                 // those); the inputs are produced by upstream
                 // operator arms that wrote to `node_buffers`.
                 use std::collections::VecDeque;
-                let upstream_names: Vec<String> = sorted_preds
+                let upstream_names: Vec<String> = ordered_inputs
                     .iter()
-                    .map(|p| current_dag.graph[*p].name().to_string())
+                    .map(|(src, _)| current_dag.graph[*src].name().to_string())
                     .collect();
-                let mut deques: Vec<VecDeque<(Record, u64)>> = sorted_preds
+                let mut deques: Vec<VecDeque<(Record, u64)>> = ordered_inputs
                     .iter()
-                    .map(|pred| -> Result<VecDeque<(Record, u64)>, PipelineError> {
-                        match drain_node_buffer_slot(ctx, *pred) {
-                            Some(nb) => {
-                                let (records, puncts) = nb.drain_split()?;
-                                all_puncts.extend(puncts);
-                                Ok(VecDeque::from(records))
+                    .map(
+                        |(src, port)| -> Result<VecDeque<(Record, u64)>, PipelineError> {
+                            match drain_node_buffer_slot(
+                                ctx,
+                                NodeBufferKey::with_port(*src, port.as_deref()),
+                            ) {
+                                Some(nb) => {
+                                    let (records, puncts) = nb.drain_split()?;
+                                    all_puncts.extend(puncts);
+                                    Ok(VecDeque::from(records))
+                                }
+                                None => Ok(VecDeque::new()),
                             }
-                            None => Ok(VecDeque::new()),
-                        }
-                    })
+                        },
+                    )
                     .collect::<Result<Vec<_>, _>>()?;
                 let mut rng = interleave_seed.map(fastrand::Rng::with_seed);
                 let mut cursor = 0usize;
@@ -344,7 +388,7 @@ pub(crate) fn dispatch_merge(
         deduped_puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
 
     Ok(())
 }

--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1220,6 +1220,7 @@ impl PipelineExecutor {
 
             node_buffers: HashMap::new(),
             node_buffer_consumer_ids: HashMap::new(),
+            shared_input_drains: HashMap::new(),
             window_arena_consumer_ids: HashMap::new(),
             source_records,
             source_consumers,

--- a/crates/clinker-exec/src/executor/output_dispatch.rs
+++ b/crates/clinker-exec/src/executor/output_dispatch.rs
@@ -172,7 +172,7 @@ pub(crate) fn dispatch_output(
                     // that need the document boundary read it from
                     // the non-cloned (last-consumer) drain through
                     // their own arm.
-                    let cloned = ctx.node_buffers.get(&p).map(|nb| {
+                    let cloned = ctx.node_buffers.get(&p.into()).map(|nb| {
                         nb.clone_memory_only()
                             .into_iter()
                             .filter_map(|e| e.into_record())
@@ -823,7 +823,11 @@ fn drain_output_input_event_iter(
             if let Some(nb) = drain_node_buffer_slot(ctx, p) {
                 return Box::new(nb.drain());
             }
-        } else if let Some(cloned) = ctx.node_buffers.get(&p).map(|nb| nb.clone_memory_only()) {
+        } else if let Some(cloned) = ctx
+            .node_buffers
+            .get(&p.into())
+            .map(|nb| nb.clone_memory_only())
+        {
             return Box::new(cloned.into_iter().map(Ok));
         }
     }

--- a/crates/clinker-exec/src/executor/reshape_dispatch.rs
+++ b/crates/clinker-exec/src/executor/reshape_dispatch.rs
@@ -210,7 +210,7 @@ pub(crate) fn dispatch_reshape(
             input_puncts,
             node_buffer_spill_allowed(current_dag, node_idx),
         )?;
-        ctx.node_buffers.insert(node_idx, nb);
+        ctx.node_buffers.insert(node_idx.into(), nb);
         return Ok(());
     }
 
@@ -339,7 +339,7 @@ fn run_reshape_grouped(
         input_puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
     Ok(())
 }
 

--- a/crates/clinker-exec/src/executor/route_dispatch.rs
+++ b/crates/clinker-exec/src/executor/route_dispatch.rs
@@ -262,7 +262,10 @@ pub(crate) fn dispatch_route(
     // last into this Route's own per-branch slots.
     let mut pred_branches: Vec<String> = Vec::new();
     for (branch, succ_idx, edge_id) in outgoing {
-        let records = branch_records.get(&branch).cloned().unwrap_or_default();
+        // Borrow the branch's record set; it is cloned only at the own-slot
+        // admit below (a predecessor-slot reader re-reads it in the second loop
+        // instead), so a non-crossing Merge/Combine branch costs no clone here.
+        let records: &[(Record, u64)] = branch_records.get(&branch).map_or(&[], |v| v.as_slice());
         let succ_region_producer = current_dag.deferred_region_at(succ_idx).map(|r| r.producer);
         let crosses = match (route_region_producer, succ_region_producer) {
             (None, Some(_)) => true,
@@ -277,7 +280,7 @@ pub(crate) fn dispatch_route(
                         + std::mem::size_of::<(Record, u64)>()) as u64
                 })
                 .unwrap_or(0);
-            for (record, rn) in &records {
+            for (record, rn) in records {
                 if row_bytes_each > 0 && ctx.memory_budget.should_abort() {
                     return Err(PipelineError::MemoryBudgetExceeded {
                         node: name.to_string(),
@@ -305,7 +308,7 @@ pub(crate) fn dispatch_route(
                 ctx,
                 name,
                 succ_idx,
-                records,
+                records.to_vec(),
                 input_puncts.clone(),
                 node_buffer_spill_allowed(current_dag, succ_idx),
             )?;

--- a/crates/clinker-exec/src/executor/route_dispatch.rs
+++ b/crates/clinker-exec/src/executor/route_dispatch.rs
@@ -12,8 +12,9 @@ use clinker_record::{Record, Value};
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
 
+use crate::executor::cull_dispatch::reads_predecessor_slot;
 use crate::executor::dispatch::{
-    ExecutorContext, admit_node_buffer, advance_cursor, drain_node_buffer_slot,
+    ExecutorContext, NodeBufferKey, admit_node_buffer, advance_cursor, drain_node_buffer_slot,
     node_buffer_spill_allowed, push_dlq, record_error_to_buffer_if_grouped, source_file_arc_of,
     source_name_arc_of, stream_linear_producer_emit,
 };
@@ -82,12 +83,6 @@ pub(crate) fn dispatch_route(
         }
     }
 
-    // Get successor nodes (branch transform nodes)
-    let successors: Vec<NodeIndex> = current_dag
-        .graph
-        .neighbors_directed(node_idx, Direction::Outgoing)
-        .collect();
-
     // Map each branch output port to the successor(s) that draw from it.
     //
     // The producer-port tag on each outgoing edge is the single source
@@ -108,10 +103,13 @@ pub(crate) fn dispatch_route(
         }
     }
 
-    // Initialize per-successor buffers
-    let mut branch_buffers: HashMap<NodeIndex, Vec<_>> = HashMap::new();
-    for &succ in &successors {
-        branch_buffers.insert(succ, Vec::new());
+    // Records matched to each consumer-bearing branch (producer output port),
+    // keyed by branch name. Keeping records per port — rather than unioned per
+    // successor — lets a predecessor-slot reader (Merge / Combine) that draws
+    // several branches of this Route drain each port's slot separately.
+    let mut branch_records: HashMap<String, Vec<(Record, u64)>> = HashMap::new();
+    for branch in branch_to_succ.keys() {
+        branch_records.insert((*branch).to_string(), Vec::new());
     }
 
     // Build the per-record evaluator bundle off the node's own typed branch
@@ -140,13 +138,8 @@ pub(crate) fn dispatch_route(
         match route_result {
             Ok(targets) => {
                 for target in &targets {
-                    if let Some(succs) = branch_to_succ.get(target.as_str()) {
-                        for &succ in succs {
-                            branch_buffers
-                                .entry(succ)
-                                .or_default()
-                                .push((record.clone(), rn));
-                        }
+                    if let Some(buf) = branch_records.get_mut(target.as_str()) {
+                        buf.push((record.clone(), rn));
                     }
                     // Exclusive mode: stop after first match
                     if mode == clinker_plan::config::RouteMode::Exclusive {
@@ -230,37 +223,61 @@ pub(crate) fn dispatch_route(
         let charge = ctx
             .streaming_charge_handle(node_idx, name, spill_allowed)
             .expect("streaming sender implies a registered charge consumer");
-        let merged: Vec<(Record, u64)> = branch_buffers.into_values().flatten().collect();
+        let merged: Vec<(Record, u64)> = branch_records.into_values().flatten().collect();
         stream_linear_producer_emit(&sender, batch_size, name, merged, input_puncts, &charge)?;
         return Ok(());
     }
 
-    // Put branch buffers into node_buffers keyed by successor.
-    // For successors that fall inside a deferred region while
-    // this Route does not, also park the per-branch records on
-    // the matching outgoing edge so the commit-time deferred
-    // dispatcher receives the same records the forward branch
-    // assignment selected. Internal-region edges and edges
-    // between two non-deferred operators skip the tee — the
-    // node_buffers entry already covers them.
+    // Deliver each branch's records to its consumers.
+    //
+    // An own-slot reader (Transform / Output / Reshape / …) checks its own
+    // slot first, so its branch's records go into the successor's own slot
+    // `(succ, None)`. A predecessor-slot reader (Merge / Combine) drains by
+    // incoming edge, so each branch it draws lands in this Route's own slot
+    // keyed `(node_idx, Some(branch))` — a Merge or Combine drawing several
+    // branches of this Route keeps them separate rather than unioned.
+    //
+    // For successors that fall inside a deferred region while this Route does
+    // not, also park the branch's records on the matching outgoing edge so the
+    // commit-time deferred dispatcher receives the same records the forward
+    // assignment selected. Internal-region edges and edges between two
+    // non-deferred operators skip the tee — the `node_buffers` entry already
+    // covers them.
     let route_region_producer = current_dag.deferred_region_at(node_idx).map(|r| r.producer);
     let active_body = ctx.window_runtime.active_stack.last().copied();
-    for (succ_idx, buf) in branch_buffers {
+    // Collect outgoing (branch, successor, edge) triples before the mutable
+    // admissions below so the immutable graph borrow does not overlap them.
+    let outgoing: Vec<(String, NodeIndex, petgraph::graph::EdgeIndex)> = current_dag
+        .graph
+        .edges_directed(node_idx, Direction::Outgoing)
+        .filter_map(|edge| {
+            edge.weight()
+                .producer_port
+                .as_deref()
+                .map(|branch| (branch.to_string(), edge.target(), edge.id()))
+        })
+        .collect();
+
+    // Distinct branches whose records feed a predecessor-slot reader, admitted
+    // last into this Route's own per-branch slots.
+    let mut pred_branches: Vec<String> = Vec::new();
+    for (branch, succ_idx, edge_id) in outgoing {
+        let records = branch_records.get(&branch).cloned().unwrap_or_default();
         let succ_region_producer = current_dag.deferred_region_at(succ_idx).map(|r| r.producer);
         let crosses = match (route_region_producer, succ_region_producer) {
             (None, Some(_)) => true,
             (Some(p), Some(t)) if p != t => true,
             _ => false,
         };
-        if crosses && let Some(edge) = current_dag.graph.find_edge(node_idx, succ_idx) {
-            let row_bytes_each: u64 = buf
+        if crosses {
+            let row_bytes_each: u64 = records
                 .first()
                 .map(|(rec, _)| {
                     (std::mem::size_of::<Value>() * rec.schema().column_count()
                         + std::mem::size_of::<(Record, u64)>()) as u64
                 })
                 .unwrap_or(0);
-            for (record, rn) in &buf {
+            for (record, rn) in &records {
                 if row_bytes_each > 0 && ctx.memory_budget.should_abort() {
                     return Err(PipelineError::MemoryBudgetExceeded {
                         node: name.to_string(),
@@ -271,24 +288,43 @@ pub(crate) fn dispatch_route(
                     });
                 }
                 ctx.region_input_buffers
-                    .entry((active_body, edge))
+                    .entry((active_body, edge_id))
                     .or_default()
                     .push((record.clone(), *rn));
             }
         }
-        // Route broadcasts punctuations to every branch — each
-        // downstream subgraph needs the same document-boundary
-        // signal to drive its own per-document accumulators
-        // and writers.
+        // Route broadcasts punctuations to every branch — each downstream
+        // subgraph needs the same document-boundary signal to drive its own
+        // per-document accumulators and writers.
+        if reads_predecessor_slot(&current_dag.graph[succ_idx]) {
+            if !pred_branches.contains(&branch) {
+                pred_branches.push(branch);
+            }
+        } else {
+            let nb = admit_node_buffer(
+                ctx,
+                name,
+                succ_idx,
+                records,
+                input_puncts.clone(),
+                node_buffer_spill_allowed(current_dag, succ_idx),
+            )?;
+            ctx.node_buffers.insert(succ_idx.into(), nb);
+        }
+    }
+    let spill_allowed = node_buffer_spill_allowed(current_dag, node_idx);
+    for branch in pred_branches {
+        let records = branch_records.get(&branch).cloned().unwrap_or_default();
+        let key = NodeBufferKey::with_port(node_idx, Some(branch.as_str()));
         let nb = admit_node_buffer(
             ctx,
             name,
-            succ_idx,
-            buf,
+            key.clone(),
+            records,
             input_puncts.clone(),
-            node_buffer_spill_allowed(current_dag, succ_idx),
+            spill_allowed,
         )?;
-        ctx.node_buffers.insert(succ_idx, nb);
+        ctx.node_buffers.insert(key, nb);
     }
 
     Ok(())

--- a/crates/clinker-exec/src/executor/sort_dispatch.rs
+++ b/crates/clinker-exec/src/executor/sort_dispatch.rs
@@ -73,7 +73,7 @@ pub(crate) fn dispatch_sort(
             input_puncts,
             node_buffer_spill_allowed(current_dag, node_idx),
         )?;
-        ctx.node_buffers.insert(node_idx, nb);
+        ctx.node_buffers.insert(node_idx.into(), nb);
         return Ok(());
     }
 
@@ -138,7 +138,7 @@ pub(crate) fn dispatch_sort(
         input_puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
 
     Ok(())
 }

--- a/crates/clinker-exec/src/executor/source_dispatch.rs
+++ b/crates/clinker-exec/src/executor/source_dispatch.rs
@@ -230,7 +230,7 @@ pub(crate) fn dispatch_source(
         source_puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
 
     Ok(())
 }

--- a/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
+++ b/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use petgraph::graph::NodeIndex;
 
-use crate::executor::dispatch::service_pending_node_buffer_spills;
+use crate::executor::dispatch::{NodeBufferKey, service_pending_node_buffer_spills};
 use crate::executor::node_buffer::{NodeBuffer, NodeBufferConsumer, record_byte_cost};
 use crate::pipeline::memory::{ConsumerHandle, ConsumerId, MemoryArbitrator, NoOpPolicy};
 
@@ -61,12 +61,12 @@ fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
 
     // Slot A: three records, elected as victim. Slot B: one record, never
     // flagged — its presence proves the sweep touches only flagged slots.
-    let mut node_buffers: HashMap<NodeIndex, NodeBuffer> = HashMap::new();
+    let mut node_buffers: HashMap<NodeBufferKey, NodeBuffer> = HashMap::new();
     node_buffers.insert(
-        idx_a,
+        idx_a.into(),
         memory_slot(&s, &[(1, "a", 10), (2, "b", 11), (3, "c", 12)]),
     );
-    node_buffers.insert(idx_b, memory_slot(&s, &[(9, "z", 99)]));
+    node_buffers.insert(idx_b.into(), memory_slot(&s, &[(9, "z", 99)]));
 
     let handle_a = ConsumerHandle::new();
     handle_a.set_bytes(record_byte_cost(2) * 3);
@@ -75,9 +75,10 @@ fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
     handle_b.set_bytes(record_byte_cost(2));
     let id_b = register(&arb, &handle_b);
 
-    let mut consumer_ids: HashMap<NodeIndex, (ConsumerId, Arc<ConsumerHandle>)> = HashMap::new();
-    consumer_ids.insert(idx_a, (id_a, handle_a.clone()));
-    consumer_ids.insert(idx_b, (id_b, handle_b.clone()));
+    let mut consumer_ids: HashMap<NodeBufferKey, (ConsumerId, Arc<ConsumerHandle>)> =
+        HashMap::new();
+    consumer_ids.insert(idx_a.into(), (id_a, handle_a.clone()));
+    consumer_ids.insert(idx_b.into(), (id_b, handle_b.clone()));
 
     // The arbitration round elected A and flipped its spill-request flag; the
     // sweep is the half that actually frees the bytes.
@@ -103,7 +104,10 @@ fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
 
     // A transitioned Memory → Spilled and its in-memory charge is discharged.
     assert!(
-        matches!(node_buffers.get(&idx_a), Some(NodeBuffer::Spilled { .. })),
+        matches!(
+            node_buffers.get(&idx_a.into()),
+            Some(NodeBuffer::Spilled { .. })
+        ),
         "the elected resident slot must spill to disk"
     );
     assert_eq!(
@@ -113,7 +117,7 @@ fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
     );
     // B was never flagged: still resident, still charged.
     assert!(
-        matches!(node_buffers.get(&idx_b), Some(NodeBuffer::Memory(_))),
+        matches!(node_buffers.get(&idx_b.into()), Some(NodeBuffer::Memory(_))),
         "an unflagged slot must stay resident"
     );
     assert!(handle_b.bytes() > 0, "the unflagged slot keeps its charge");
@@ -134,7 +138,7 @@ fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
     );
 
     // A's records round-trip from disk in arrival order with values intact.
-    let a = node_buffers.remove(&idx_a).expect("slot A present");
+    let a = node_buffers.remove(&idx_a.into()).expect("slot A present");
     let (records, _puncts) = a.drain_split().expect("drain spilled slot");
     let rns: Vec<u64> = records.iter().map(|(_, rn)| *rn).collect();
     assert_eq!(
@@ -159,14 +163,15 @@ fn flagged_non_spillable_slot_is_skipped_by_sweep() {
     // A fan-out / composition-port slot: its consumer would reach
     // `clone_memory_only`, which panics on a spill-backed variant, so the
     // sweep must never spill it even when the arbitrator flags it.
-    let mut node_buffers: HashMap<NodeIndex, NodeBuffer> = HashMap::new();
-    node_buffers.insert(idx, memory_slot(&s, &[(1, "a", 1), (2, "b", 2)]));
+    let mut node_buffers: HashMap<NodeBufferKey, NodeBuffer> = HashMap::new();
+    node_buffers.insert(idx.into(), memory_slot(&s, &[(1, "a", 1), (2, "b", 2)]));
 
     let handle = ConsumerHandle::new();
     handle.set_bytes(record_byte_cost(2) * 2);
     let id = register(&arb, &handle);
-    let mut consumer_ids: HashMap<NodeIndex, (ConsumerId, Arc<ConsumerHandle>)> = HashMap::new();
-    consumer_ids.insert(idx, (id, handle.clone()));
+    let mut consumer_ids: HashMap<NodeBufferKey, (ConsumerId, Arc<ConsumerHandle>)> =
+        HashMap::new();
+    consumer_ids.insert(idx.into(), (id, handle.clone()));
 
     handle.request_spill();
 
@@ -183,7 +188,7 @@ fn flagged_non_spillable_slot_is_skipped_by_sweep() {
     .expect("sweep skips non-spillable slots without error");
 
     assert!(
-        matches!(node_buffers.get(&idx), Some(NodeBuffer::Memory(_))),
+        matches!(node_buffers.get(&idx.into()), Some(NodeBuffer::Memory(_))),
         "a non-spillable slot must stay resident (spilling it would later panic)"
     );
     assert!(handle.bytes() > 0, "its charge is untouched");

--- a/crates/clinker-exec/src/executor/transform_dispatch.rs
+++ b/crates/clinker-exec/src/executor/transform_dispatch.rs
@@ -104,7 +104,7 @@ pub(crate) fn dispatch_transform(
                 input_puncts,
                 node_buffer_spill_allowed(current_dag, node_idx),
             )?;
-            ctx.node_buffers.insert(node_idx, nb);
+            ctx.node_buffers.insert(node_idx.into(), nb);
             return Ok(());
         }
     };
@@ -285,7 +285,7 @@ pub(crate) fn dispatch_transform(
         input_puncts,
         node_buffer_spill_allowed(current_dag, node_idx),
     )?;
-    ctx.node_buffers.insert(node_idx, nb);
+    ctx.node_buffers.insert(node_idx.into(), nb);
 
     Ok(())
 }

--- a/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
@@ -469,6 +469,7 @@ fn execute_grace_hash_partition_pair_correct() {
         "orders".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("orders"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(driver_row_cols, CxlSpan::new(0, 0)),
         },
     );
@@ -476,6 +477,7 @@ fn execute_grace_hash_partition_pair_correct() {
         "products".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("products"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(build_row_cols, CxlSpan::new(0, 0)),
         },
     );
@@ -724,6 +726,7 @@ fn execute_grace_hash_spill_then_reload_correct() {
         "orders".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("orders"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(driver_row_cols, CxlSpan::new(0, 0)),
         },
     );
@@ -731,6 +734,7 @@ fn execute_grace_hash_spill_then_reload_correct() {
         "products".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("products"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(build_row_cols, CxlSpan::new(0, 0)),
         },
     );
@@ -915,6 +919,7 @@ fn execute_grace_hash_aborts_on_disk_quota_overflow() {
         "orders".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("orders"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(driver_row_cols, CxlSpan::new(0, 0)),
         },
     );
@@ -922,6 +927,7 @@ fn execute_grace_hash_aborts_on_disk_quota_overflow() {
         "products".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("products"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(build_row_cols, CxlSpan::new(0, 0)),
         },
     );
@@ -1555,6 +1561,7 @@ fn build_bnl_harness() -> BnlHarness {
         "orders".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("orders"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(driver_row_cols, CxlSpan::new(0, 0)),
         },
     );
@@ -1562,6 +1569,7 @@ fn build_bnl_harness() -> BnlHarness {
         "products".to_string(),
         clinker_plan::plan::combine::CombineInput {
             upstream_name: Arc::from("products"),
+            producer_port: None,
             row: clinker_plan::plan::row_type::Row::closed(build_row_cols, CxlSpan::new(0, 0)),
         },
     );

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -2214,6 +2214,7 @@ mod tests {
             left_qual.to_string(),
             CombineInput {
                 upstream_name: Arc::from(left_qual),
+                producer_port: None,
                 row: left_row,
             },
         );
@@ -2221,6 +2222,7 @@ mod tests {
             right_qual.to_string(),
             CombineInput {
                 upstream_name: Arc::from(right_qual),
+                producer_port: None,
                 row: right_row,
             },
         );

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -5396,6 +5396,7 @@ nodes:
                 q.to_string(),
                 CombineInput {
                     upstream_name: Arc::from(q),
+                    producer_port: None,
                     row: Row::closed(row_fields, CxlSpan::new(0, 0)),
                 },
             );

--- a/crates/clinker-exec/tests/composition_executor_test.rs
+++ b/crates/clinker-exec/tests/composition_executor_test.rs
@@ -467,3 +467,61 @@ nodes:
         "error must wrap inner failure with composition name; got: {msg}"
     );
 }
+
+#[test]
+fn composition_body_merge_uses_declared_interleave_mode() {
+    // The body's Merge declares `mode: interleave`. Because merge mode is now
+    // carried on the plan node (not looked up by name in the top-level config,
+    // which does not contain body nodes), the body Merge round-robins its two
+    // branches. A regression to the name lookup would miss the body node,
+    // default to Concat, and emit lo,lo,hi,hi instead of lo,hi,lo,hi.
+    let yaml = r#"
+pipeline:
+  name: composition_body_merge_interleave
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: a, type: int }
+  - type: composition
+    name: split_merge
+    input: src
+    use: ../compositions/exec_merge_interleave_check.comp.yaml
+    inputs:
+      inp: src
+  - type: output
+    name: out
+    input: split_merge
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      include_unmapped: true
+"#;
+    // Route sends a<10 to `lo`, a>=10 to `hi`: lo_branch=[5,6], hi_branch=[15,16].
+    let csv_input = "a\n5\n15\n6\n16\n";
+    let (_report, output) = run_with_composition(yaml, csv_input);
+
+    let buckets: Vec<&str> = output
+        .lines()
+        .filter_map(|l| {
+            if l.contains("lo") {
+                Some("lo")
+            } else if l.contains("hi") {
+                Some("hi")
+            } else {
+                None
+            }
+        })
+        .collect();
+    assert_eq!(
+        buckets,
+        vec!["lo", "hi", "lo", "hi"],
+        "body Merge must interleave (round-robin) per its declared mode, not \
+         concatenate:\n{output}"
+    );
+}

--- a/crates/clinker-exec/tests/deferred_dispatch.rs
+++ b/crates/clinker-exec/tests/deferred_dispatch.rs
@@ -470,6 +470,152 @@ ENG,500
     );
 }
 
+/// The build side of a Combine that is a deferred-region member is replayed
+/// at commit through the cross-region tee. That replay must deliver each
+/// build row EXACTLY ONCE: the forward pass also left the producer's copy in
+/// its port slot, so the commit re-seed must replace it, not append. Under
+/// `match: all` a doubled build side is observable — every driver row would
+/// fan out to two identical matches instead of one. With a single build row
+/// per key, the correct output is one row per department; a double would
+/// yield two.
+#[test]
+fn combine_match_all_in_deferred_region_replays_build_side_once() {
+    let yaml = r#"
+pipeline:
+  name: combine_deferred_region_match_all
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: orders
+  config:
+    name: orders
+    path: orders.csv
+    correlation_key: order_id
+    type: csv
+    schema:
+      - { name: order_id, type: string }
+      - { name: department, type: string }
+      - { name: amount, type: int }
+- type: aggregate
+  name: dept_totals
+  input: orders
+  config:
+    group_by: [department]
+    cxl: |
+      emit department = department
+      emit total = sum(amount)
+- type: transform
+  name: probe_xform
+  input: dept_totals
+  config:
+    cxl: |
+      emit department = department
+      emit total = total
+- type: source
+  name: dept_lookup
+  config:
+    name: dept_lookup
+    path: dept_lookup.csv
+    type: csv
+    schema:
+      - { name: department, type: string }
+      - { name: budget, type: int }
+- type: combine
+  name: enriched
+  input:
+    p: probe_xform
+    b: dept_lookup
+  config:
+    where: 'p.department == b.department'
+    match: all
+    on_miss: skip
+    cxl: |
+      emit department = p.department
+      emit total = p.total
+      emit budget = b.budget
+    propagate_ck: driver
+- type: output
+  name: out
+  input: enriched
+  config:
+    name: out
+    path: out.csv
+    type: csv
+    include_unmapped: true
+"#;
+    let orders_csv = "\
+order_id,department,amount
+o1,HR,10
+o2,HR,20
+o3,ENG,100
+o4,ENG,200
+";
+    let lookup_csv = "\
+department,budget
+HR,100
+ENG,500
+";
+    let config = clinker_plan::config::parse_config(yaml).expect("parse");
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([
+        (
+            "orders".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "test.csv",
+                Box::new(std::io::Cursor::new(orders_csv.as_bytes().to_vec())),
+            ),
+        ),
+        (
+            "dept_lookup".to_string(),
+            clinker_exec::executor::single_file_reader(
+                "test.csv",
+                Box::new(std::io::Cursor::new(lookup_csv.as_bytes().to_vec())),
+            ),
+        ),
+    ]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: Default::default(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = common::run_config(&config, readers, writers, &params)
+        .expect("combine-in-region match:all pipeline must converge");
+
+    let written = buf.as_string();
+    let rows: Vec<&str> = written.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert_eq!(
+        report.counters.dlq_count, 0,
+        "no errors expected; got {}",
+        report.counters.dlq_count
+    );
+    // One build row per department, so `match: all` yields exactly one output
+    // row per department. A doubled cross-region build replay would produce two
+    // per department (four total).
+    assert_eq!(
+        rows.len(),
+        2,
+        "each department must match its single build row exactly once (no \
+         cross-region build duplication): {written}"
+    );
+    assert_eq!(
+        rows.iter().filter(|r| r.starts_with("HR,")).count(),
+        1,
+        "HR must appear once: {written}"
+    );
+    assert_eq!(
+        rows.iter().filter(|r| r.starts_with("ENG,")).count(),
+        1,
+        "ENG must appear once: {written}"
+    );
+}
+
 /// Two-level nested composition wrapping a relaxed-CK Aggregate at the
 /// inner body's terminal output port, with a parent-side Transform that
 /// mutates the body Aggregate's emit. The commit-pass harvest chain

--- a/crates/clinker-exec/tests/fixtures/compositions/exec_merge_interleave_check.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/exec_merge_interleave_check.comp.yaml
@@ -1,0 +1,43 @@
+# Body containing route -> 2 transform branches -> interleave merge. The body
+# merge declares `mode: interleave`; the executor must read that mode off the
+# node (scope-correct) rather than a by-name lookup into the top-level config,
+# which would miss this body node and fall back to Concat. With interleave the
+# two branches round-robin (lo, hi, lo, hi); Concat would emit lo, lo, hi, hi.
+_compose:
+  name: exec_merge_interleave_check
+  inputs:
+    inp:
+      schema:
+        - { name: a, type: int }
+  outputs:
+    out: merged
+  config_schema: {}
+
+nodes:
+  - type: route
+    name: split
+    input: inp
+    config:
+      conditions:
+        lo: "a.to_int() < 10"
+        hi: "a.to_int() >= 10"
+      default: lo
+  - type: transform
+    name: lo_branch
+    input: split.lo
+    config:
+      cxl: |
+        emit a = a
+        emit bucket = "lo"
+  - type: transform
+    name: hi_branch
+    input: split.hi
+    config:
+      cxl: |
+        emit a = a
+        emit bucket = "hi"
+  - type: merge
+    name: merged
+    inputs: [lo_branch, hi_branch]
+    config:
+      mode: interleave

--- a/crates/clinker-exec/tests/multiport_node_buffer.rs
+++ b/crates/clinker-exec/tests/multiport_node_buffer.rs
@@ -516,3 +516,68 @@ fn combine_driver_and_build_from_same_route_resolve_by_port() {
         out["out"]
     );
 }
+
+// ── Test 7: one producer port fanned out to two predecessor-slot readers ──
+
+const ROUTE_BRANCH_FANOUT_TWO_MERGES: &str = r#"
+pipeline:
+  name: route_branch_fanout_two_merges
+nodes:
+  - type: source
+    name: a
+    config: { name: a, type: csv, path: a.csv, schema: [ { name: k, type: string }, { name: v, type: int } ] }
+  - type: source
+    name: b
+    config: { name: b, type: csv, path: b.csv, schema: [ { name: k, type: string }, { name: v, type: int } ] }
+  - type: source
+    name: c
+    config: { name: c, type: csv, path: c.csv, schema: [ { name: k, type: string }, { name: v, type: int } ] }
+  - type: route
+    name: splitter
+    input: a
+    config:
+      conditions:
+        big: "v >= 10"
+      default: small
+  - type: merge
+    name: m1
+    inputs: [splitter.big, b]
+  - type: merge
+    name: m2
+    inputs: [splitter.big, c]
+  - type: output
+    name: out1
+    input: m1
+    config: { name: out1, type: csv, path: o1.csv }
+  - type: output
+    name: out2
+    input: m2
+    config: { name: out2, type: csv, path: o2.csv }
+"#;
+
+#[test]
+fn route_branch_fanned_to_two_merges_reaches_both() {
+    // A single Route branch (`splitter.big`) feeds TWO Merge consumers. They
+    // share one `(splitter, "big")` slot; the first to drain must clone it so
+    // the second still sees the records, rather than draining it empty. Both
+    // merges must therefore carry the big-branch row plus their own input.
+    let a = "k,v\nx,15\n";
+    let b = "k,v\nb1,1\n";
+    let c = "k,v\nc1,2\n";
+    let (out, dlq) = run(
+        ROUTE_BRANCH_FANOUT_TWO_MERGES,
+        &[("a", a), ("b", b), ("c", c)],
+        &["out1", "out2"],
+    );
+    assert_eq!(dlq, 0, "no DLQ entries");
+    assert!(
+        out["out1"].contains("x,15") && out["out1"].contains("b1,1"),
+        "m1 must see the shared route.big row and its own input b:\n{}",
+        out["out1"]
+    );
+    assert!(
+        out["out2"].contains("x,15") && out["out2"].contains("c1,2"),
+        "m2 must see the shared route.big row and its own input c:\n{}",
+        out["out2"]
+    );
+}

--- a/crates/clinker-exec/tests/multiport_node_buffer.rs
+++ b/crates/clinker-exec/tests/multiport_node_buffer.rs
@@ -1,0 +1,518 @@
+//! Multi-output-port fan-in integration tests (issue #514).
+//!
+//! A single Merge or Combine that consumes more than one output port of the
+//! same multi-output producer (a Route node's branches, or a Cull node's
+//! `main` + `removed_to` ports) must observe every port. Before the
+//! port-aware node-buffer key these consumers double-drained one un-ported
+//! slot: the first drain took the union, the second found nothing, so one
+//! port's records were silently dropped.
+//!
+//! - `route_two_branches_into_one_merge_unions_both` — Route → one Merge from
+//!   two branches; the merged output must be the multiset union of both.
+//! - `cull_both_ports_into_one_combine_sees_both_sides` — Cull `main` +
+//!   `removed_to` → one Combine; the join must observe the build (removed)
+//!   side, which is empty under the bug.
+//! - `merge_of_two_distinct_sources_is_unchanged` — single-output regression:
+//!   a Merge of two distinct sources routes through the `producer_port: None`
+//!   default path and stays byte-identical.
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// Run `yaml` with the given `(source_name, csv)` readers, capturing every
+/// named output writer. Returns each output's rendered string keyed by output
+/// node name. Panics on run failure.
+fn run(yaml: &str, sources: &[(&str, &str)], outputs: &[&str]) -> (HashMap<String, String>, usize) {
+    let config = parse_config(yaml).expect("fixture pipeline must parse");
+    let plan = config
+        .compile(&CompileContext::default())
+        .expect("fixture pipeline must compile");
+
+    let mut readers: SourceReaders = HashMap::new();
+    for (name, csv) in sources {
+        readers.insert(
+            (*name).to_string(),
+            clinker_exec::executor::single_file_reader(
+                "test.csv",
+                Box::new(std::io::Cursor::new(csv.as_bytes().to_vec())),
+            ),
+        );
+    }
+
+    let bufs: HashMap<String, SharedBuffer> = outputs
+        .iter()
+        .map(|o| ((*o).to_string(), SharedBuffer::new()))
+        .collect();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = bufs
+        .iter()
+        .map(|(name, buf)| {
+            (
+                name.clone(),
+                Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+            )
+        })
+        .collect();
+
+    let params = PipelineRunParams {
+        execution_id: "multiport-test".to_string(),
+        batch_id: "multiport-test".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+    let report = PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &params)
+        .expect("multiport run");
+    let rendered = bufs
+        .into_iter()
+        .map(|(name, buf)| (name, buf.as_string()))
+        .collect();
+    (rendered, report.dlq_entries.len())
+}
+
+/// Data rows (header stripped, blank lines dropped), sorted for multiset
+/// comparison.
+fn sorted_data_rows(rendered: &str) -> Vec<String> {
+    let mut rows: Vec<String> = rendered
+        .lines()
+        .skip(1)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect();
+    rows.sort();
+    rows
+}
+
+// ── Test 1: Route → one Merge from two branches ──────────────────────────
+
+const ROUTE_TWO_BRANCH_MERGE: &str = r#"
+pipeline:
+  name: route_two_branch_merge
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: id, type: string }
+        - { name: region, type: string }
+  - type: route
+    name: by_region
+    input: events
+    config:
+      mode: exclusive
+      conditions:
+        a: "region == \"a\""
+        b: "region == \"b\""
+      default: a
+  - type: merge
+    name: recombined
+    inputs: [by_region.a, by_region.b]
+  - type: output
+    name: out
+    input: recombined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn route_two_branches_into_one_merge_unions_both() {
+    // Three rows route to branch `a`, two rows to branch `b`. A single Merge
+    // draws both branches, so its output must carry all five rows — every
+    // branch observed, nothing dropped.
+    let csv = "id,region\n\
+               r1,a\n\
+               r2,a\n\
+               r3,a\n\
+               r4,b\n\
+               r5,b\n";
+    let (out, dlq) = run(ROUTE_TWO_BRANCH_MERGE, &[("events", csv)], &["out"]);
+    assert_eq!(dlq, 0, "no DLQ entries");
+
+    let rows = sorted_data_rows(&out["out"]);
+    assert_eq!(
+        rows,
+        vec![
+            "r1,a".to_string(),
+            "r2,a".to_string(),
+            "r3,a".to_string(),
+            "r4,b".to_string(),
+            "r5,b".to_string(),
+        ],
+        "the Merge of both Route branches must carry the union of both ports \
+         (3 from branch `a` + 2 from branch `b`), not drop a port: {}",
+        out["out"]
+    );
+}
+
+// ── Test 2: Cull main + removed_to → one Combine ─────────────────────────
+
+const CULL_BOTH_PORTS_COMBINE: &str = r#"
+pipeline:
+  name: cull_both_ports_combine
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: account, type: string }
+        - { name: region, type: string }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_bad
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: any_error
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+  - type: combine
+    name: joined
+    input:
+      kept: drop_bad
+      dropped: drop_bad.removed
+    config:
+      where: "kept.region == dropped.region"
+      match: all
+      on_miss: skip
+      drive: kept
+      cxl: |
+        emit region = kept.region
+        emit kept_account = kept.account
+        emit dropped_account = dropped.account
+        emit dropped_status = dropped.status
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn cull_both_ports_into_one_combine_sees_both_sides() {
+    // Account A holds an error row → the whole A group goes to the `removed`
+    // port (the Combine build side). Account B is clean → it goes to the
+    // `main`/kept port (the Combine driver side). Both share region `east`, so
+    // the driver (kept B) inner-joins each removed-port A row.
+    //
+    // Correct: two matched rows (B × A/ok, B × A/error) — the build side is
+    // observed. Under the bug the build side drains an already-emptied slot, so
+    // no driver row matches and `on_miss: skip` yields zero rows.
+    let csv = "account,region,status\n\
+               A,east,ok\n\
+               A,east,error\n\
+               B,east,ok\n";
+    let (out, dlq) = run(CULL_BOTH_PORTS_COMBINE, &[("events", csv)], &["out"]);
+    assert_eq!(dlq, 0, "no DLQ entries");
+
+    let rows = sorted_data_rows(&out["out"]);
+    assert_eq!(
+        rows,
+        vec!["east,B,A,error".to_string(), "east,B,A,ok".to_string(),],
+        "the Combine must observe the removed (build) port: the kept driver row \
+         (B) joins both removed-port rows (A/ok, A/error). An empty build side \
+         drops every match: {}",
+        out["out"]
+    );
+}
+
+// ── Test 3: single-output Merge regression ───────────────────────────────
+
+const MERGE_TWO_DISTINCT_SOURCES: &str = r#"
+pipeline:
+  name: merge_two_distinct_sources
+nodes:
+  - type: source
+    name: left
+    config:
+      name: left
+      type: csv
+      path: test.csv
+      schema:
+        - { name: k, type: string }
+        - { name: v, type: int }
+  - type: source
+    name: right
+    config:
+      name: right
+      type: csv
+      path: test.csv
+      schema:
+        - { name: k, type: string }
+        - { name: v, type: int }
+  - type: merge
+    name: both
+    inputs: [left, right]
+  - type: output
+    name: out
+    input: both
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn merge_of_two_distinct_sources_is_unchanged() {
+    // Two distinct single-output sources feed one Merge. Every edge carries
+    // `producer_port: None`, so this exercises the unchanged default path. The
+    // declaration-order concat output must be byte-identical to the expected
+    // rendering.
+    let left = "k,v\n\
+                a,1\n\
+                b,2\n";
+    let right = "k,v\n\
+                 c,3\n\
+                 d,4\n";
+    let (out, dlq) = run(
+        MERGE_TWO_DISTINCT_SOURCES,
+        &[("left", left), ("right", right)],
+        &["out"],
+    );
+    assert_eq!(dlq, 0, "no DLQ entries");
+    assert_eq!(
+        out["out"], "k,v\na,1\nb,2\nc,3\nd,4\n",
+        "concat Merge of two single-output sources must be byte-identical: {}",
+        out["out"]
+    );
+}
+
+// ── Test 4: inclusive-mode Route, a record matching both branches ────────
+
+const INCLUSIVE_ROUTE_BOTH_BRANCHES_MERGE: &str = r#"
+pipeline:
+  name: inclusive_route_both_branches
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: id, type: string }
+        - { name: value, type: int }
+  - type: route
+    name: by_value
+    input: events
+    config:
+      mode: inclusive
+      conditions:
+        hi: "value >= 10"
+        big: "value >= 100"
+      default: none
+  - type: merge
+    name: recombined
+    inputs: [by_value.hi, by_value.big]
+  - type: output
+    name: out
+    input: recombined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn inclusive_route_duplicates_a_row_across_both_merged_branches() {
+    // Inclusive mode: a record matching two branches flows down BOTH. A Merge of
+    // both branches must therefore carry that record twice — once per branch —
+    // and must not dedup. `value=100` matches `hi` and `big`; `value=50` matches
+    // only `hi`; `value=5` matches neither (goes to the unreferenced `none`
+    // default, so it reaches the Merge zero times).
+    let csv = "id,value\n\
+               a,100\n\
+               b,50\n\
+               c,5\n";
+    let (out, dlq) = run(
+        INCLUSIVE_ROUTE_BOTH_BRANCHES_MERGE,
+        &[("events", csv)],
+        &["out"],
+    );
+    assert_eq!(dlq, 0, "no DLQ entries");
+
+    let rows = sorted_data_rows(&out["out"]);
+    assert_eq!(
+        rows,
+        vec!["a,100".to_string(), "a,100".to_string(), "b,50".to_string(),],
+        "inclusive Route must duplicate the both-branch row (a) across the two \
+         merged ports and keep the single-branch row (b) once: {}",
+        out["out"]
+    );
+}
+
+// ── Test 5: spliced passthrough between a Cull port and a Combine ─────────
+
+const CULL_PORT_THROUGH_PASSTHROUGH_COMBINE: &str = r#"
+pipeline:
+  name: cull_port_through_passthrough
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: account, type: string }
+        - { name: region, type: string }
+        - { name: status, type: string }
+  - type: cull
+    name: drop_bad
+    input: events
+    config:
+      partition_by: [account]
+      removed_to: removed
+      rules:
+        - name: any_error
+          drop_group_when: "sum(if status == 'error' then 1 else 0) > 0"
+  - type: transform
+    name: relay
+    input: drop_bad.removed
+    config:
+      cxl: |
+        emit account = account
+        emit region = region
+        emit status = status
+  - type: combine
+    name: joined
+    input:
+      kept: drop_bad
+      dropped: relay
+    config:
+      where: "kept.region == dropped.region"
+      match: all
+      on_miss: skip
+      drive: kept
+      cxl: |
+        emit region = kept.region
+        emit kept_account = kept.account
+        emit dropped_account = dropped.account
+        emit dropped_status = dropped.status
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn combine_build_side_reaches_through_a_passthrough_transform() {
+    // The Combine build side draws the Cull `removed` port through a
+    // single-output passthrough Transform (`relay`). The build predecessor is
+    // the Transform (a distinct node, resolved by name), so its slot is keyed
+    // `(relay, None)` — the removed records must survive the extra hop and the
+    // driver (kept) must still join them.
+    let csv = "account,region,status\n\
+               A,east,ok\n\
+               A,east,error\n\
+               B,east,ok\n";
+    let (out, dlq) = run(
+        CULL_PORT_THROUGH_PASSTHROUGH_COMBINE,
+        &[("events", csv)],
+        &["out"],
+    );
+    assert_eq!(dlq, 0, "no DLQ entries");
+
+    let rows = sorted_data_rows(&out["out"]);
+    assert_eq!(
+        rows,
+        vec!["east,B,A,error".to_string(), "east,B,A,ok".to_string()],
+        "the removed port routed through a passthrough Transform must still \
+         reach the Combine build side: {}",
+        out["out"]
+    );
+}
+
+// ── Test 6: Combine driver + build both from the same Route ──────────────
+
+const ROUTE_TWO_BRANCHES_ONE_COMBINE: &str = r#"
+pipeline:
+  name: route_two_branches_one_combine
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: test.csv
+      schema:
+        - { name: key, type: string }
+        - { name: side, type: string }
+  - type: route
+    name: by_side
+    input: events
+    config:
+      mode: exclusive
+      conditions:
+        left: "side == \"L\""
+        right: "side == \"R\""
+      default: left
+  - type: combine
+    name: joined
+    input:
+      l: by_side.left
+      r: by_side.right
+    config:
+      where: "l.key == r.key"
+      match: all
+      on_miss: skip
+      drive: l
+      cxl: |
+        emit key = l.key
+        emit left_side = l.side
+        emit right_side = r.side
+      propagate_ck: driver
+  - type: output
+    name: out
+    input: joined
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn combine_driver_and_build_from_same_route_resolve_by_port() {
+    // The Combine draws its driver from `by_side.left` and its build from
+    // `by_side.right` — both ports of the SAME Route node. Driver and build
+    // resolve to the same predecessor NodeIndex, so the slot key's port
+    // component is what keeps them apart: driver drains `(route, left)`, build
+    // drains `(route, right)`. Records with a shared `key` across the two
+    // branches must join.
+    let csv = "key,side\n\
+               1,L\n\
+               1,R\n\
+               2,L\n";
+    let (out, dlq) = run(ROUTE_TWO_BRANCHES_ONE_COMBINE, &[("events", csv)], &["out"]);
+    assert_eq!(dlq, 0, "no DLQ entries");
+
+    let rows = sorted_data_rows(&out["out"]);
+    assert_eq!(
+        rows,
+        vec!["1,L,R".to_string()],
+        "key=1 exists on both the left (driver) and right (build) Route ports, \
+         so the port-keyed slots must let them join (key=2 has no right side): {}",
+        out["out"]
+    );
+}

--- a/crates/clinker-lineage/src/dataset.rs
+++ b/crates/clinker-lineage/src/dataset.rs
@@ -317,6 +317,9 @@ mod tests {
             name: name.to_string(),
             id: PlanNodeId::new(0),
             span: Span::SYNTHETIC,
+            mode: clinker_plan::config::MergeMode::Concat,
+            interleave_seed: None,
+            input_order: Vec::new(),
             output_schema: Arc::new(Schema::new(vec![])),
         }
     }

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -3881,12 +3881,30 @@ pub(crate) fn lower_node_to_plan_node(
                 branch_programs,
             })
         }
-        PipelineNode::Merge { .. } => Some(PlanNode::Merge {
-            name: name.to_string(),
-            id,
-            span,
-            output_schema: schema_from_bound(),
-        }),
+        PipelineNode::Merge { header, config } => {
+            // Carry mode + declaration order onto the node so a Merge inside a
+            // composition body resolves them scope-correctly (the executor's
+            // by-name lookup into the top-level config misses body nodes).
+            let input_order = header
+                .inputs
+                .iter()
+                .map(|ni| match &ni.value {
+                    crate::config::node_header::NodeInput::Single(s) => s.clone(),
+                    crate::config::node_header::NodeInput::Port { node, port } => {
+                        format!("{node}.{port}")
+                    }
+                })
+                .collect();
+            Some(PlanNode::Merge {
+                name: name.to_string(),
+                id,
+                span,
+                mode: config.mode,
+                interleave_seed: config.interleave_seed,
+                input_order,
+                output_schema: schema_from_bound(),
+            })
+        }
         PipelineNode::Composition { .. } => {
             // Look up the body assigned by bind_composition. If binding
             // failed (E102–E109), there's no entry — omit the node from

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -5079,10 +5079,15 @@ fn bind_combine(
             // in the C.1.0 corrective (Decisions Log #15).
             merged_declared.insert(qf, ty.clone());
         }
+        let producer_port = match &node_input_spanned.value {
+            crate::config::node_header::NodeInput::Port { port, .. } => Some(port.clone()),
+            crate::config::node_header::NodeInput::Single(_) => None,
+        };
         combine_inputs_entries.insert(
             qualifier.clone(),
             CombineInput {
                 upstream_name: Arc::from(upstream_target),
+                producer_port,
                 row: upstream_row.clone(),
             },
         );

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -325,6 +325,14 @@ pub struct CombineInput {
     /// Name of the upstream node this input resolves to. Looked up in
     /// the DAG's `node_by_name` table when a `NodeIndex` is needed.
     pub upstream_name: Arc<str>,
+    /// Producer output port this input draws from: `Some(port)` for a
+    /// `<producer>.<port>` reference (a Cull `removed_to` / Route branch),
+    /// `None` for a bare producer reference. Carried on the node so the
+    /// combine dispatcher can disambiguate a driver/build pair that resolves
+    /// to the same predecessor node via two different ports — scope-correctly,
+    /// including inside a composition body where the node's `input:` map is not
+    /// in the top-level `config.nodes`.
+    pub producer_port: Option<String>,
     /// Schema of the upstream row, cloned at bind_schema time. Used by
     /// C.2+ execution strategies without having to re-traverse
     /// `schema_by_name`.
@@ -2374,10 +2382,16 @@ pub(crate) fn decompose_nary_combines(
             } else {
                 steps[i - 1].intermediate_row.clone()
             };
-            let driver_upstream: Arc<str> = if i == 0 {
-                Arc::clone(&inputs.get(&driving).unwrap().upstream_name)
+            let (driver_upstream, driver_producer_port): (Arc<str>, Option<String>) = if i == 0 {
+                let driver_meta = inputs.get(&driving).unwrap();
+                (
+                    Arc::clone(&driver_meta.upstream_name),
+                    driver_meta.producer_port.clone(),
+                )
             } else {
-                Arc::from(steps[i - 1].name.as_str())
+                // Later steps draw the driver from the prior step's single
+                // unnamed output.
+                (Arc::from(steps[i - 1].name.as_str()), None)
             };
             let build_meta = inputs
                 .get(&step.build_input)
@@ -2388,6 +2402,7 @@ pub(crate) fn decompose_nary_combines(
                 step.driving_input.clone(),
                 CombineInput {
                     upstream_name: driver_upstream,
+                    producer_port: driver_producer_port,
                     row: driver_row,
                 },
             );
@@ -2395,6 +2410,7 @@ pub(crate) fn decompose_nary_combines(
                 step.build_input.clone(),
                 CombineInput {
                     upstream_name: Arc::clone(&build_meta.upstream_name),
+                    producer_port: build_meta.producer_port.clone(),
                     row: build_meta.row.clone(),
                 },
             );
@@ -2760,6 +2776,7 @@ mod tests {
             qualifier.to_string(),
             CombineInput {
                 upstream_name: Arc::from(qualifier),
+                producer_port: None,
                 row,
             },
         )
@@ -2896,6 +2913,7 @@ mod tests {
                 (*qual).to_string(),
                 CombineInput {
                     upstream_name: Arc::from(*qual),
+                    producer_port: None,
                     row: Row::closed(IndexMap::new(), CxlSpan::new(0, 0)),
                 },
             );
@@ -3231,6 +3249,7 @@ mod tests {
                 (*qual).to_string(),
                 CombineInput {
                     upstream_name: Arc::from(*qual),
+                    producer_port: None,
                     row: Row::closed(row_fields, CxlSpan::new(0, 0)),
                 },
             );
@@ -3673,6 +3692,7 @@ mod tests {
                 q.to_string(),
                 CombineInput {
                     upstream_name: Arc::from(q),
+                    producer_port: None,
                     row: Row::closed(row_fields, cxl::lexer::Span::new(0, 0)),
                 },
             );
@@ -3772,6 +3792,7 @@ mod tests {
                 q.to_string(),
                 CombineInput {
                     upstream_name: Arc::from(q),
+                    producer_port: None,
                     row: Row::closed(row_fields, cxl::lexer::Span::new(0, 0)),
                 },
             );

--- a/crates/clinker-plan/src/plan/combine.rs
+++ b/crates/clinker-plan/src/plan/combine.rs
@@ -2326,13 +2326,22 @@ pub(crate) fn decompose_nary_combines(
             node_by_name.get(upstream_name).copied()
         };
         for (i, step) in steps.iter().enumerate() {
-            let driver_idx = if i == 0 {
+            // Carry the producer output port onto the step edge when the driver
+            // draws a multi-output producer's port (a Cull `removed_to` / Route
+            // branch); step i>0 draws the prior step's single unnamed output, so
+            // no port. Without this the edge tag disagrees with the step's
+            // `combine_inputs.producer_port` and `resolve_side` cannot pick the
+            // right slot for a step that draws two ports of one producer.
+            let (driver_idx, driver_producer_port) = if i == 0 {
                 let original_driver_input = inputs
                     .get(&driving)
                     .expect("driver qualifier present in combine_inputs");
-                resolve_chain_input(original_driver_input.upstream_name.as_ref())
+                (
+                    resolve_chain_input(original_driver_input.upstream_name.as_ref()),
+                    original_driver_input.producer_port.clone(),
+                )
             } else {
-                Some(step_indices[i - 1])
+                (Some(step_indices[i - 1]), None)
             };
             let build_input_meta = inputs
                 .get(&step.build_input)
@@ -2346,7 +2355,7 @@ pub(crate) fn decompose_nary_combines(
                     PlanEdge {
                         dependency_type: DependencyType::Data,
                         port: None,
-                        producer_port: None,
+                        producer_port: driver_producer_port,
                     },
                 );
             }
@@ -2357,7 +2366,7 @@ pub(crate) fn decompose_nary_combines(
                     PlanEdge {
                         dependency_type: DependencyType::Data,
                         port: None,
-                        producer_port: None,
+                        producer_port: build_input_meta.producer_port.clone(),
                     },
                 );
             }

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -184,6 +184,20 @@ pub enum PlanNode {
         id: PlanNodeId,
         #[serde(skip)]
         span: Span,
+        /// Merge combination mode (concat / interleave). Carried on the node so
+        /// a Merge inside a composition body resolves it scope-correctly — the
+        /// executor otherwise looks it up by name in the top-level
+        /// `PipelineConfig.nodes`, which does not contain body nodes.
+        #[serde(skip)]
+        mode: crate::config::MergeMode,
+        /// Deterministic interleave seed, when configured.
+        #[serde(skip)]
+        interleave_seed: Option<u64>,
+        /// Input references in declaration order (`node` or `node.port`), used
+        /// to order Concat output. Carried on the node for the same
+        /// scope-correctness reason as `mode`.
+        #[serde(skip)]
+        input_order: Vec<String>,
         /// Canonical output schema adopted from `input[0]`. All Merge inputs
         /// are structurally equal per the Merge contract (validated in
         /// `bind_schema`); picking one canonical `Arc` lets Merge emit every


### PR DESCRIPTION
Closes #514.

## Problem

When a single `merge` or `combine` node consumed **more than one output port of the same multi-output producer** — a `route` node's branches, or a `cull` node's `main` + `removed_to` ports — records from one port were silently dropped, producing wrong or empty output.

The inter-stage record buffers (`node_buffers`) and their paired memory-arbitration consumer registry were keyed by producer node index alone, with no port component. The producer unioned both ports into one slot and the consumer double-drained that single key: the first drain took the whole union, the second found nothing. Concretely:

- A `combine` whose driver and build sides both referenced the same `cull` (e.g. `cull` and `cull.removed`) resolved both to one predecessor slot, so the build side drained empty and the join produced no matches.
- A `merge` fed by two branches of one `route` received nothing at all.

## Fix

Thread a port-aware key end to end:

- Introduce `NodeBufferKey { node, producer_port }`. `From<NodeIndex>` yields `producer_port: None`, so every single-output slot stays keyed exactly as before.
- `cull` and `route` now write each output port destined for a predecessor-slot consumer (`merge`/`combine`) into its own `(producer, port)` slot instead of a union. Own-slot consumers (transform/output/reshape/cull/sort/aggregate) are unchanged. Inclusive-mode `route` duplication is preserved — a record matching two branches still appears on both.
- `merge` and `combine` drain by incoming edge, keying each slot on that edge's `producer_port`. A spliced single-output passthrough keeps working: its edge carries `producer_port: None` and it re-materialises records into its own unported slot.
- `node_buffers` and its consumer registry stay key-identical, so the memory arbitrator's registry never desyncs; the resident-slot spill sweep and the composition/commit body-scope buffer swaps move to the new key type.

Two adjacent correctness gaps were fixed while completing this:

- The `combine` driver/build port disambiguation now reads the port off the node's own input metadata rather than a by-name lookup into the top-level node list, so it is correct for a `combine` inside a composition body.
- A `combine`/`merge` that is a member of a deferred (windowed / correlation-key) region replays its cross-region inputs at commit; that replay now replaces the producer's forward-pass slot instead of appending to it, so a build row that crosses a region boundary is delivered exactly once (previously doubled under `match: all`).

## Testing

- New integration coverage in `crates/clinker-exec/tests/multiport_node_buffer.rs`: route to merge from two branches (multiset union), cull `main`+`removed_to` to combine (the join observes both sides), a single-output merge regression (byte-identical output), inclusive-mode route duplication, a passthrough hop, and a combine drawing two ports of one route.
- A new deferred-region test in `crates/clinker-exec/tests/deferred_dispatch.rs` asserting a cross-region build side is replayed exactly once under `match: all`.
- The two port-dropping cases were confirmed to fail before the fix (empty output) and pass after.
- `cargo test -p clinker-exec` (1712 tests) and `cargo test -p clinker-plan` green; `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` clean.


---

## Additional fixes from review

A max-effort review of the port-keying change surfaced adjacent correctness gaps in the same multi-output-port area; they are fixed here so the behaviour is coherent end to end:

- **Combine port disambiguation fails loud.** When a Combine's driver and build sides resolve to the same predecessor via distinct ports, a declared port matching no incoming edge now returns an internal error instead of silently draining an arbitrary port's slot.
- **One producer port fanned out to several `merge`/`combine` consumers reaches all of them.** The shared per-port slot used to be removed by the first consumer to drain; it is now cloned (records and punctuations) for every consumer except the last, tracked by a drain count so correctness does not depend on dispatch order.
- **A `merge` inside a composition body respects its declared `mode` / interleave seed / input order.** These were previously looked up by name in the top-level config (which omits body nodes) and fell back to concat; they are now carried on the plan node.
- **N-ary `combine` decomposition** carries each step input's producer port, so a decomposed step drawing two ports of one producer resolves the right slot.
- **Deferred-region commit hygiene:** the member clear also clears members' per-port slots, and the cross-region replay accounts its slot through the memory arbitrator.
- Minor: `merge` builds its ordered input list only on the non-fused path; a redundant per-branch clone in `route` was removed.

Not fixed (out of scope, filed as a follow-up): a `route` branch / `cull` port feeding a **composition input port** is rejected at compile time (no bound schema for the port reference). Supporting that topology needs composition-input schema binding for producer ports, which is a separate change.

Coverage added for the port fanout and the composition-body interleave merge. Full workspace test suite, clippy `--all-targets`, and fmt are green.
