### PR TITLE
docs(cli): correct --help to call clinker a bounded-memory batch engine

### DIFF
--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -10,15 +10,19 @@ use clinker_plan::error::PipelineError;
 
 mod refactor;
 
-/// CXL streaming ETL engine.
+/// Bounded-memory batch ETL engine for CXL pipelines.
 #[derive(Parser, Debug)]
 #[command(
     name = "clinker",
     version,
-    about = "CXL streaming ETL engine",
+    about = "Bounded-memory batch ETL engine for CXL pipelines",
     long_about = "\
-Clinker is a streaming ETL engine that reads tabular data (CSV, NDJSON), \
-applies CXL transformation expressions, and writes the results to output files.\n\n\
+Clinker is a bounded-memory, single-process batch ETL engine. It reads finite \
+tabular inputs (CSV, NDJSON), applies CXL transformation expressions to each \
+record, and writes the results to output files. A run is a finite job: sources \
+read until EOF, the DAG drains, and the process exits — it is not a \
+long-running stream processor. Records are evaluated one at a time within that \
+bounded run, so memory stays capped regardless of input size.\n\n\
 Pipelines are defined in YAML configuration files that specify inputs, outputs, \
 field mappings with CXL expressions, and optional channel overrides for \
 multi-tenant customization.",

--- a/crates/clinker/tests/help_wording.rs
+++ b/crates/clinker/tests/help_wording.rs
@@ -1,0 +1,66 @@
+//! `clinker --help` must describe the tool the way the docs do: a
+//! bounded-memory finite-batch ETL engine, not a "streaming ETL engine".
+//! `docs/user/src/non-goals.md` lists unbounded stream processing as an
+//! explicit non-goal, so the CLI summary contradicting that is a bug
+//! (issue #451). These tests pin the wording at the CLI boundary.
+
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+/// Run `clinker <flag>` and return its stdout with runs of whitespace
+/// collapsed to single spaces. clap reflows `long_about` to a
+/// width-dependent line length, so normalizing here keeps the substring
+/// checks independent of where any given clap version wraps a line.
+fn help_stdout_normalized(flag: &str) -> String {
+    let output = Command::new(clinker_bin())
+        .arg(flag)
+        .output()
+        .expect("run clinker help");
+    assert!(
+        output.status.success(),
+        "`clinker {flag}` should exit 0, got {:?}\nstderr: {}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("help output is utf-8");
+    stdout.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// The short `-h` summary (clap `about`) frames Clinker as a batch engine.
+#[test]
+fn short_help_uses_batch_framing() {
+    let stdout = help_stdout_normalized("-h");
+    assert!(
+        stdout.contains("batch"),
+        "`clinker -h` summary should call Clinker a batch engine.\nstdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("streaming ETL engine"),
+        "`clinker -h` must not call Clinker a \"streaming ETL engine\".\nstdout: {stdout}"
+    );
+}
+
+/// The long `--help` text (clap `long_about`) frames Clinker as a bounded
+/// finite-batch job and explicitly disclaims stream-processor semantics, so
+/// it reads consistently with the non-goals doc.
+#[test]
+fn long_help_disclaims_stream_processing() {
+    let stdout = help_stdout_normalized("--help");
+    assert!(
+        stdout.contains("batch"),
+        "`clinker --help` should describe a batch engine.\nstdout: {stdout}"
+    );
+    assert!(
+        !stdout.contains("streaming ETL engine"),
+        "`clinker --help` must not call Clinker a \"streaming ETL engine\".\nstdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("not a long-running stream processor"),
+        "`clinker --help` should explicitly disclaim long-running stream \
+         processing so per-record evaluation is not misread as event-stream \
+         processing.\nstdout: {stdout}"
+    );
+}


### PR DESCRIPTION
## Problem

`clinker --help` described the tool as a **"CXL streaming ETL engine"** (clap `about` / `long_about` in `crates/clinker/src/main.rs`). That contradicts the user documentation: the book intro (`docs/user/src/README.md`) and `docs/user/src/non-goals.md` commit to Clinker being a **bounded-memory, finite batch DAG executor** and explicitly list unbounded stream processing (Kafka/Kinesis/SSE, `tail -f` followers, wall-clock watermarking) as an architectural non-goal. So a user reading `--help` was told the opposite of the docs.

## Change

- Reword the clap `about`, `long_about`, and the `Cli` doc comment to the accurate framing: a bounded-memory, single-process **batch** ETL engine whose run is a finite job — sources read until EOF, the DAG drains, the process exits.
- The long help now states plainly that records are evaluated one at a time *within that bounded run*, so the per-record evaluation is not misread as event-stream processing, and adds an explicit "it is not a long-running stream processor" clause matching the non-goals page.
- Add a CLI-boundary test (`crates/clinker/tests/help_wording.rs`) that runs `clinker -h` and `clinker --help`, pins the batch framing, and asserts the "streaming ETL engine" phrasing is gone. The test collapses whitespace before matching so it is independent of where clap wraps help lines.

No behavior, config, or output surface changes — only the help text and its test. No existing `--help` snapshot exists, so none needed updating.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --locked --offline -- -D warnings`
- `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- `cargo test -p clinker --locked --offline` (all pass, including the two new tests; the new tests fail against the pre-change wording and pass after)

Closes #451