### PR TITLE
docs: add a top-level README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,192 @@
+# Clinker
+
+Clinker is a pure-Rust, **bounded-memory batch DAG executor** for finite,
+ETL-style jobs. It reads finite inputs (CSV, JSON/NDJSON, XML, fixed-width, and
+several EDI/messaging formats such as HL7, X12, EDIFACT, and SWIFT), drives
+them through a directed acyclic graph of transformation nodes one record at a
+time, and exits when the inputs are drained. It ships as a single static binary
+with no interpreter, no runtime, and no install dependencies.
+
+Pipelines are declared in **YAML**. Per-record transformation logic is written
+in **CXL**, a small expression language purpose-built for ETL. Planning
+(parsing, schema binding, CXL type-checking, DAG lowering) is a separate phase
+from runtime execution, so a pipeline is fully validated before any data is
+read.
+
+## Three pillars
+
+Clinker's scope is fixed by three permanent commitments; unbounded streaming,
+daemon/service mode, distributed execution, and worker-process pools are
+explicit non-goals.
+
+1. **Finite inputs.** Files are the canonical shape. Finite-cursor network
+   sources (paginated REST APIs with page/record caps) fit the same model —
+   they exhaust their cursor and hit EOF. Unbounded sources (Kafka, Kinesis,
+   `tail -f`-style followers) are out of scope.
+2. **Finite jobs.** A run begins when you invoke `clinker run`, drains the DAG,
+   and exits with a status code. There is no long-running daemon and no service
+   surface.
+3. **Single process.** One `clinker` invocation is one OS process. Parallelism
+   happens *inside* the process via `std::thread` and Rayon; Clinker does not
+   spawn worker processes or coordinate a cluster.
+
+## Why Clinker
+
+- **Single binary, zero dependencies.** No JVM, no Python, no package manager.
+  Linux, macOS, and Windows are all tested in CI.
+- **Bounded memory.** A run is charged against a configurable RSS budget
+  (default 512 MB). Non-fused stage boundaries buffer against that same
+  envelope; blocking operators (Aggregate, sort, grace-hash Combine) spill to
+  disk under memory pressure and fail fast with `E310 MemoryBudgetExceeded` at
+  the hard limit rather than OOM-killing the process.
+- **Reproducible output.** Given the same input and pipeline, Clinker produces
+  byte-identical output across runs.
+- **Operability first.** Per-stage metrics, dead-letter queues for failed
+  records, explain plans, and structured exit codes for scripting.
+
+## Binaries
+
+| Binary    | Purpose                                                    |
+|-----------|------------------------------------------------------------|
+| `clinker` | Validate and run pipelines against real data.              |
+| `cxl`     | Check, evaluate, and format CXL expressions interactively. |
+
+## A taste of Clinker
+
+Given `employees.csv`:
+
+```csv
+id,name,department,salary
+1,Alice Chen,Engineering,95000
+2,Bob Martinez,Marketing,62000
+3,Carol Johnson,Engineering,88000
+4,Dave Williams,Sales,71000
+```
+
+and this pipeline in `my_first_pipeline.yaml`:
+
+```yaml
+pipeline:
+  name: salary_report
+
+nodes:
+  - type: source
+    name: employees
+    config:
+      name: employees
+      type: csv
+      path: "./employees.csv"
+      schema:
+        - { name: id, type: int }
+        - { name: name, type: string }
+        - { name: department, type: string }
+        - { name: salary, type: int }
+
+  - type: transform
+    name: classify
+    input: employees
+    config:
+      cxl: |
+        emit id = id
+        emit name = name
+        emit department = department
+        emit salary = salary
+        emit level = if salary >= 90000 then "senior" else "junior"
+
+  - type: output
+    name: report
+    input: classify
+    config:
+      name: salary_report
+      type: csv
+      path: "./salary_report.csv"
+```
+
+run it with:
+
+```bash
+clinker run my_first_pipeline.yaml
+```
+
+which writes `salary_report.csv`:
+
+```csv
+id,name,department,salary,level
+1,Alice Chen,Engineering,95000,senior
+2,Bob Martinez,Marketing,62000,junior
+3,Carol Johnson,Engineering,88000,junior
+4,Dave Williams,Sales,71000,junior
+```
+
+Useful flags on `clinker run`:
+
+- `--dry-run` — parse the YAML, resolve the DAG, and type-check every CXL
+  expression against the declared schemas without reading any data.
+- `--dry-run -n 2` — additionally read the first two records and print the
+  results to the terminal.
+- `--explain` — print the execution plan (DAG topology, per-node strategy, and
+  schema propagation) instead of running.
+
+Beyond `run`, the CLI also offers `explain` (field provenance and error-code
+lookup), `metrics` (collect spooled execution metrics), `channels`
+(multi-tenant overlay tooling), and `refactor`.
+
+## Build from source
+
+Clinker requires **Rust 1.91+** (edition 2024). The pinned toolchain lives in
+`rust-toolchain.toml`, so `rustup` fetches the right version automatically.
+
+```bash
+git clone https://github.com/rustpunk/clinker.git
+cd clinker
+
+# Install the pipeline executor and the CXL tool
+cargo install --path crates/clinker
+cargo install --path crates/cxl-cli
+
+# Run the full workspace test suite
+cargo test --workspace
+```
+
+There are no C build dependencies.
+
+## Repository layout
+
+Clinker is a Cargo workspace. The main crates:
+
+- `crates/clinker` — the `clinker` CLI.
+- `crates/cxl`, `crates/cxl-cli` — the CXL language (parser, resolver,
+  type-checker, evaluator) and its standalone tool.
+- `crates/clinker-plan` — YAML config, validation, schema binding, CXL compile,
+  and DAG lowering into a typed `CompiledPlan`.
+- `crates/clinker-exec` — the runtime executor: operator dispatch, memory
+  arbitration, spill, backpressure, metrics, and DLQ.
+- `crates/clinker-record`, `crates/clinker-format` — the record/value model and
+  the streaming format readers/writers.
+- `crates/clinker-net`, `crates/clinker-channel`, `crates/clinker-schema`,
+  `crates/clinker-lineage` — integration crates (finite REST source,
+  multi-tenant overlays, schema workspace, column lineage).
+
+See [docs/ai/20_CRATE_MAP.md](docs/ai/20_CRATE_MAP.md) for the full crate map
+and layering rules.
+
+## Documentation
+
+- **User Guide** — authoring and running pipelines:
+  [docs/user/src/README.md](docs/user/src/README.md), starting with
+  [Your First Pipeline](docs/user/src/getting-started/first-pipeline.md) and
+  [Installation](docs/user/src/getting-started/installation.md).
+- **Engine Internals** — the execution model, memory arbitration, and operator
+  strategies: [docs/engine/src/README.md](docs/engine/src/README.md).
+- **Non-goals** — what Clinker deliberately does not do:
+  [docs/user/src/non-goals.md](docs/user/src/non-goals.md).
+- **Contributing / architecture** — [AGENTS.md](AGENTS.md) and the AI
+  onboarding docs under [docs/ai/](docs/ai/00_READ_THIS_FIRST.md).
+- **Changelog** — [CHANGELOG.md](CHANGELOG.md).
+
+Both books are mdBook projects (`docs/user`, `docs/engine`) and render with
+`mdbook build`.
+
+## License
+
+Clinker is licensed under the MIT license.

--- a/crates/clinker/tests/root_readme.rs
+++ b/crates/clinker/tests/root_readme.rs
@@ -1,0 +1,64 @@
+//! Guards the repository-root `README.md`: a GitHub visitor must land on an
+//! accurate project overview, not an empty repo home. This test pins that the
+//! root README exists and covers the topics issue #453 requires — description,
+//! quick start, build commands, and a pointer into the docs tree — so the file
+//! cannot silently regress into a stub.
+
+use std::fs;
+use std::path::PathBuf;
+
+/// Resolve the workspace-root `README.md` from this crate's manifest dir.
+/// `CARGO_MANIFEST_DIR` is `<repo>/crates/clinker`, so two parents up is the
+/// workspace root regardless of the current working directory.
+fn root_readme_path() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("crates/clinker should have a workspace root two levels up");
+    repo_root.join("README.md")
+}
+
+#[test]
+fn root_readme_exists_and_is_substantial() {
+    let path = root_readme_path();
+    let body = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("root README.md must exist at {}: {e}", path.display()));
+
+    assert!(
+        body.len() > 1000,
+        "root README.md is only {} bytes; it should be a real project overview, not a stub",
+        body.len()
+    );
+}
+
+#[test]
+fn root_readme_covers_required_topics() {
+    let path = root_readme_path();
+    let body = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("root README.md must exist at {}: {e}", path.display()));
+
+    // Each anchor maps to a topic the root README must cover.
+    let required: &[(&str, &str)] = &[
+        ("# Clinker", "a top-level heading naming the project"),
+        ("bounded-memory", "the bounded-memory architectural claim"),
+        ("CXL", "the CXL expression language"),
+        ("512", "the default memory budget"),
+        ("clinker run", "a quick-start invocation"),
+        (
+            "cargo install --path crates/clinker",
+            "a build-from-source command",
+        ),
+        (
+            "docs/user/src/README.md",
+            "a link into the user documentation",
+        ),
+    ];
+
+    for &(needle, why) in required {
+        assert!(
+            body.contains(needle),
+            "root README.md is missing {why} (expected to find {needle:?})"
+        );
+    }
+}


### PR DESCRIPTION
## What

Adds a top-level `README.md`. The repository previously had no root README, so the GitHub project page displayed no description, quick-start, or pointer to the documentation — the only README was the mdBook landing page under `docs/user/src/`, which GitHub does not render on the repo home.

## Contents

The new README covers:

- A one-paragraph description: a pure-Rust, bounded-memory batch DAG executor for finite ETL jobs, with YAML pipelines and CXL expressions.
- The three architectural pillars (finite inputs, finite jobs, single process) and the bounded-memory model.
- The two binaries (`clinker`, `cxl`).
- A runnable quick-start example (source to transform to output) with its expected output.
- Build-from-source and test commands (Rust 1.91+, edition 2024).
- A repository-layout map of the main crates.
- Links into the User Guide, the Engine Internals book, the non-goals page, the changelog, and the onboarding docs.

Every claim is grounded in existing docs and code (the user guide, `docs/ai/10_ARCHITECTURE.md`, the CLI command definitions, `Cargo.toml`, and `rust-toolchain.toml`); no features are invented.

## Test

Adds `crates/clinker/tests/root_readme.rs`, an integration test that fails when the root README is absent and passes once it exists and covers the required topics (description, quick-start command, build command, docs link), guarding against regression into a stub.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --locked --offline -- -D warnings`
- `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- `cargo test -p clinker` — all pass, including the two new tests.

Closes #453
