### PR TITLE
fix(format): reject stray arrays in non-JSON writers, validate XML tag names

### DIFF
--- a/benches/pipelines/combine/equi_2input_collect.yaml
+++ b/benches/pipelines/combine/equi_2input_collect.yaml
@@ -4,6 +4,9 @@
 # Stresses the Collect per-group cap and array-valued output path.
 # `cxl:` must be empty under collect — the executor synthesizes the
 # output schema as {driver fields..., <build_qualifier>: Array}.
+# Output is NDJSON: the tabular writers reject an array-valued field,
+# so a `collect` result is routed to a format that serializes arrays
+# natively.
 
 pipeline:
   name: bench-combine-equi-2input-collect
@@ -54,6 +57,8 @@ nodes:
     input: gather_trips
     config:
       name: drivers_with_trips_out
-      type: csv
-      path: bench://output.csv
+      type: json
+      options:
+        format: ndjson
+      path: bench://output.ndjson
       include_unmapped: true

--- a/benches/pipelines/cxl_ops/string_methods.yaml
+++ b/benches/pipelines/cxl_ops/string_methods.yaml
@@ -14,6 +14,9 @@ nodes:
         - { name: f0, type: string }
         - { name: f1, type: string }
 
+  # `split` returns an array; the CSV sink rejects an array-valued field,
+  # so the result is joined back to a scalar to keep this a tabular
+  # CSV-output workload (route to JSON instead to keep the raw array).
   - type: transform
     name: strings
     input: source
@@ -32,7 +35,7 @@ nodes:
         emit s_sw = f1.starts_with("a")
         emit s_ct = f1.contains("e")
         emit s_find = f1.find("e")
-        emit s_split = f1.split(",")
+        emit s_split = f1.split(",").join(";")
 
   - type: output
     name: sink

--- a/crates/clinker-exec/src/executor/tests/scheduling.rs
+++ b/crates/clinker-exec/src/executor/tests/scheduling.rs
@@ -515,8 +515,8 @@ nodes:
     input: agg
     config:
       name: out
-      type: csv
-      path: out.csv
+      type: json
+      path: out.json
       include_unmapped: true
 "#;
 
@@ -617,8 +617,8 @@ nodes:
     input: agg
     config:
       name: out
-      type: csv
-      path: out.csv
+      type: json
+      path: out.json
       include_unmapped: true
 "#;
 

--- a/crates/clinker-exec/tests/aggregate_integration.rs
+++ b/crates/clinker-exec/tests/aggregate_integration.rs
@@ -221,8 +221,9 @@ nodes:
 
 #[test]
 fn test_e2e_aggregate_collect() {
-    // Collect produces a JSON-array-like string in CSV output. We assert
-    // length and membership rather than exact serialization to avoid
+    // Collect produces a `Value::Array`, which the non-JSON writers reject as
+    // a stray collection (see #46); a JSON output serializes it natively. We
+    // assert membership per group rather than exact serialization to avoid
     // coupling to formatter details.
     let yaml = r#"
 pipeline:
@@ -263,29 +264,32 @@ nodes:
   input: by_dept
   config:
     name: out
-    type: csv
-    path: out.csv
+    type: json
+    path: out.json
     include_unmapped: true
 "#;
     let csv = "dept,name\neng,Alice\neng,Bob\nsales,Carol\n";
     let (report, output) = run_single(yaml, csv);
     assert_eq!(report.dlq_entries.len(), 0);
     assert_eq!(report.counters.ok_count, 2);
-    let body = sorted_body_lines(&output);
-    assert_eq!(body.len(), 2);
-    let eng_line = body
-        .iter()
-        .find(|l| l.starts_with("eng,"))
-        .expect("eng row");
+    // The JSON array output writes one object per group on its own line, with
+    // the collected names as a native JSON array.
+    let eng_line = output
+        .lines()
+        .find(|l| l.contains(r#""dept":"eng""#))
+        .expect("eng object");
     assert!(
         eng_line.contains("Alice") && eng_line.contains("Bob"),
-        "eng line missing collected names: {eng_line}"
+        "eng object missing collected names: {eng_line}"
     );
-    let sales_line = body
-        .iter()
-        .find(|l| l.starts_with("sales,"))
-        .expect("sales row");
-    assert!(sales_line.contains("Carol"));
+    let sales_line = output
+        .lines()
+        .find(|l| l.contains(r#""dept":"sales""#))
+        .expect("sales object");
+    assert!(
+        sales_line.contains("Carol"),
+        "sales object missing collected name: {sales_line}"
+    );
 }
 
 #[test]

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -3414,8 +3414,10 @@ nodes:
     input: collected
     config:
       name: collected_out
-      type: csv
-      path: collected.csv
+      type: json
+      options:
+        format: ndjson
+      path: collected.ndjson
       include_unmapped: true
 "#;
         let orders = "order_id,product_id,amount\nORD-1,PROD-A,10\n";
@@ -3427,8 +3429,9 @@ nodes:
         )
         .expect("match:collect must run");
         let out = result.primary_output();
-        // The array serializes as bracketed content in CSV; each
-        // matched build record appears as a nested map representation.
+        // A non-JSON writer rejects the collect `Value::Array`; NDJSON
+        // serializes it natively, with each matched build record a nested
+        // JSON object inside the array.
         assert!(
             out.contains("Widget"),
             "collect array should carry Widget; got: {out:?}"
@@ -3437,8 +3440,9 @@ nodes:
             out.contains("WidgetV2"),
             "collect array should carry WidgetV2; got: {out:?}"
         );
-        // Exactly one output row per driver record under Collect.
-        let data_rows = out.lines().skip(1).filter(|l| !l.is_empty()).count();
+        // Exactly one output record per driver under Collect (NDJSON emits one
+        // JSON object per line, with no header row).
+        let data_rows = out.lines().filter(|l| !l.trim().is_empty()).count();
         assert_eq!(data_rows, 1, "match:collect emits one row per driver");
     }
 
@@ -3487,8 +3491,10 @@ nodes:
     input: collected
     config:
       name: collected_out
-      type: csv
-      path: collected_empty.csv
+      type: json
+      options:
+        format: ndjson
+      path: collected_empty.ndjson
       include_unmapped: true
 "#;
         // ORD-1's product_id is PROD-X — no matching build row.
@@ -3501,13 +3507,12 @@ nodes:
         )
         .expect("collect empty-array must run");
         let out = result.primary_output();
-        // Exactly one data row (the driver row, with an empty array).
-        let data_rows = out.lines().skip(1).filter(|l| !l.is_empty()).count();
+        // Exactly one data record (the driver row, with an empty array).
+        let data_rows = out.lines().filter(|l| !l.trim().is_empty()).count();
         assert_eq!(data_rows, 1, "collect emits the driver row even on miss");
-        // The `products` column carries the array serialization. Empty
-        // array stringifies as `[]` in Value::Display; verify we see
-        // `[]` and not `null` in the row.
-        let data = out.lines().nth(1).unwrap_or("");
+        // The `products` field carries the array serialization. An empty
+        // match serializes as a native empty JSON array `[]`, not `null`.
+        let data = out.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
         assert!(
             data.contains("[]"),
             "empty-match collect must emit `[]`, not null; got row: {data:?}",
@@ -3559,8 +3564,10 @@ nodes:
     input: collected
     config:
       name: collected_out
-      type: csv
-      path: collected_cap.csv
+      type: json
+      options:
+        format: ndjson
+      path: collected_cap.ndjson
       include_unmapped: true
 "#;
         let orders = "order_id,product_id,amount\nORD-1,PROD-A,10\n";
@@ -3575,8 +3582,8 @@ nodes:
         )
         .expect("collect cap must run");
         let out = result.primary_output();
-        // The driver row is emitted.
-        let data_rows = out.lines().skip(1).filter(|l| !l.is_empty()).count();
+        // The driver row is emitted (NDJSON: one JSON object per line).
+        let data_rows = out.lines().filter(|l| !l.trim().is_empty()).count();
         assert_eq!(data_rows, 1, "collect emits one row per driver");
         // Expect exactly 10_000 occurrences of the substring `Widget-`
         // in the serialized array — the 10_001st match was truncated.

--- a/crates/clinker-exec/tests/composition_combine_test.rs
+++ b/crates/clinker-exec/tests/composition_combine_test.rs
@@ -355,8 +355,10 @@ nodes:
     input: collect_call
     config:
       name: out
-      type: csv
-      path: out.csv
+      type: json
+      options:
+        format: ndjson
+      path: out.ndjson
       include_unmapped: true
 "#;
     // Driver row 1 matches two build rows (A → Widget, A → WidgetPro);
@@ -368,21 +370,22 @@ nodes:
         &[("orders_src", orders_csv), ("products_src", products_csv)],
     );
 
-    // Driver columns appear in the output header; the build-side
-    // qualifier (`products`) appears as the trailing Array column.
+    // Driver columns appear as object keys; the build-side qualifier
+    // (`products`) is the collect Array field a non-JSON writer would
+    // reject, serialized natively here as an NDJSON array.
     assert!(
         output.contains("order_id"),
-        "output header must include driver column order_id; got:\n{output}"
+        "output must include driver column order_id; got:\n{output}"
     );
     assert!(
         output.contains("products"),
-        "output header must include collect-mode trailing array column \
-         named after the build qualifier; got:\n{output}"
+        "output must include collect-mode array field named after the build \
+         qualifier; got:\n{output}"
     );
     // Each driver row shows up once in the output — collect emits
     // ONE row per driver regardless of match count.
-    let order_1_count = output.matches("\n1,").count();
-    let order_2_count = output.matches("\n2,").count();
+    let order_1_count = output.matches(r#""order_id":"1""#).count();
+    let order_2_count = output.matches(r#""order_id":"2""#).count();
     assert_eq!(
         order_1_count, 1,
         "driver row 1 must appear exactly once; got:\n{output}"
@@ -391,10 +394,8 @@ nodes:
         order_2_count, 1,
         "driver row 2 must appear exactly once; got:\n{output}"
     );
-    // Both build rows for product_id=A must be encoded in row 1's
-    // trailing array column. CSV array encoding is implementation-
-    // defined, but both build names must appear somewhere in the
-    // text serialisation.
+    // Both build rows for product_id=A must be encoded in row 1's array
+    // field; both build names must appear in the JSON serialization.
     assert!(
         output.contains("Widget"),
         "row for A must reference build product 'Widget'; got:\n{output}"

--- a/crates/clinker-exec/tests/scheduling_heavy_first_peak.rs
+++ b/crates/clinker-exec/tests/scheduling_heavy_first_peak.rs
@@ -115,8 +115,8 @@ nodes:
     input: joined
     config:
       name: out
-      type: csv
-      path: out.csv
+      type: json
+      path: out.json
       include_unmapped: true
 "#
     )

--- a/crates/clinker-format/src/csv/writer.rs
+++ b/crates/clinker-format/src/csv/writer.rs
@@ -368,13 +368,15 @@ fn value_to_csv_cell(col: &str, value: &Value) -> Result<String, FormatError> {
 /// Append a Value's CSV cell rendering to `buf`. Sharing one renderer keeps the
 /// record hot path and the envelope section path byte-identical.
 ///
-/// `Value::Map` has no canonical scalar serialization for a CSV cell
-/// (silently JSON-encoding hides routing bugs — e.g. a `$widened`
-/// sidecar reaching the writer without the projection layer's
-/// `include_unmapped: true` expansion), so this returns
-/// `FormatError::UnserializableMapValue` carrying the offending
-/// column. CSV is the single point of truth for map rejection on
-/// this path; there is no upstream pre-walk.
+/// `Value::Map` and `Value::Array` have no canonical scalar serialization
+/// for a CSV cell (silently JSON-encoding either one hides routing bugs —
+/// e.g. a `$widened` sidecar reaching the writer without the projection
+/// layer's `include_unmapped: true` expansion for a map, or a
+/// `match: collect` combine output misrouted to CSV for an array), so this
+/// returns `FormatError::UnserializableMapValue` /
+/// `FormatError::UnserializableArrayValue` carrying the offending column.
+/// CSV is the single point of truth for collection rejection on this path;
+/// there is no upstream pre-walk.
 fn write_csv_cell(buf: &mut String, col: &str, value: &Value) -> Result<(), FormatError> {
     use std::fmt::Write as _;
     match value {
@@ -397,7 +399,12 @@ fn write_csv_cell(buf: &mut String, col: &str, value: &Value) -> Result<(), Form
         Value::DateTime(dt) => {
             let _ = write!(buf, "{}", dt.format("%Y-%m-%dT%H:%M:%S"));
         }
-        Value::Array(arr) => buf.push_str(&serde_json::to_string(arr).unwrap_or_default()),
+        Value::Array(_) => {
+            return Err(FormatError::UnserializableArrayValue {
+                format: "CSV",
+                column: col.to_string(),
+            });
+        }
         Value::Map(_) => {
             return Err(FormatError::UnserializableMapValue {
                 format: "CSV",
@@ -722,6 +729,40 @@ mod tests {
             }
             other => panic!("expected UnserializableMapValue, got {other:?}"),
         }
+    }
+
+    /// CSV writer rejects `Value::Array` payloads with
+    /// `FormatError::UnserializableArrayValue`, parallel to the map
+    /// rejection. A stray array at a CSV cell (e.g. a `match: collect`
+    /// combine output misrouted to CSV) previously JSON-encoded into a
+    /// single cell, silently hiding the misroute.
+    #[test]
+    fn test_csv_writer_rejects_array_value() {
+        let schema = make_schema(&["id", "tags"]);
+        let record = make_record(
+            &schema,
+            vec![
+                Value::Integer(7),
+                Value::Array(vec![Value::String("a".into()), Value::String("b".into())]),
+            ],
+        );
+        let mut buf = Vec::new();
+        let mut writer = CsvWriter::new(&mut buf, Arc::clone(&schema), CsvWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::UnserializableArrayValue { format, column } => {
+                assert_eq!(format, "CSV");
+                assert_eq!(column, "tags");
+            }
+            other => panic!("expected UnserializableArrayValue, got {other:?}"),
+        }
+        // The header row wrote before the failing cell, but no body row with a
+        // JSON-encoded array cell was emitted.
+        drop(writer);
+        assert!(
+            !String::from_utf8_lossy(&buf).contains("[\"a\""),
+            "the array must not be JSON-encoded into a cell"
+        );
     }
 
     use crate::envelope_writer::test_doc_with_sections as doc_with_sections;

--- a/crates/clinker-format/src/doc_index.rs
+++ b/crates/clinker-format/src/doc_index.rs
@@ -21,8 +21,6 @@ use clinker_record::Value;
 use cxl::analyzer::doc_paths::DocPath;
 use indexmap::IndexMap;
 
-use crate::error::FormatError;
-
 /// Compact, path-pruned retention of a document's declared `$doc.*`
 /// subtrees.
 ///
@@ -142,10 +140,15 @@ impl DocArenaIndex {
     ///
     /// # Errors
     ///
-    /// Returns [`FormatError::Json`] naming the offending section and the
+    /// Returns a format-neutral message naming the offending section and the
     /// cap when retaining `value` would push total retained bytes past
-    /// `max_index_bytes`.
-    pub fn insert(&mut self, path: &DocPath, value: Value) -> Result<(), FormatError> {
+    /// `max_index_bytes`. The message carries no format label: the calling
+    /// reader wraps it in its own `FormatError` variant (`FormatError::Json`
+    /// for the JSON reader, `FormatError::Xml` for the XML reader), so the
+    /// surfaced error matches the format that built the index — mirroring how
+    /// the readers wrap the `String` a section-coercion helper returns. This
+    /// keeps `DocArenaIndex` parser-agnostic (no format enum baked in).
+    pub fn insert(&mut self, path: &DocPath, value: Value) -> Result<(), String> {
         // `Value::heap_size` is the canonical real-heap-bytes estimate the
         // engine uses for allocation accounting elsewhere; reuse it so the
         // index cap measures the same bytes the RSS budget does. Add the
@@ -155,13 +158,13 @@ impl DocArenaIndex {
         if let Some(cap) = self.max_index_bytes
             && projected > cap
         {
-            return Err(FormatError::Json(format!(
+            return Err(format!(
                 "envelope document-index cap exceeded: retaining section {section:?} \
                  ({charge} bytes) would push the index to {projected} bytes, over the \
                  {cap}-byte `max_index_bytes` cap. Raise `max_index_bytes` on the source, \
                  or narrow the `$doc.*` paths the pipeline reads.",
                 section = path.section,
-            )));
+            ));
         }
         self.retained_bytes = projected;
         self.sections.insert(path.section.clone(), value);
@@ -359,18 +362,38 @@ mod tests {
         let err = idx
             .insert(&path("Big", "blob"), payload)
             .expect_err("over-cap insert must error");
-        match err {
-            FormatError::Json(msg) => {
-                assert!(
-                    msg.contains("max_index_bytes"),
-                    "message names the cap: {msg}"
-                );
-                assert!(msg.contains("Big"), "message names the section: {msg}");
-            }
-            other => panic!("expected FormatError::Json, got {other:?}"),
-        }
+        assert!(
+            err.contains("max_index_bytes"),
+            "message names the cap: {err}"
+        );
+        assert!(err.contains("Big"), "message names the section: {err}");
         // The over-cap value was not stored.
         assert!(idx.into_sections().is_empty());
+    }
+
+    /// The cap-exceeded error is a bare, format-neutral message — it names the
+    /// section and cap but no format, so each reader wraps it in its own
+    /// `FormatError` variant (`Json` for JSON, `Xml` for XML). Regression
+    /// guard for the hardcoded-`FormatError::Json` bug that surfaced a
+    /// JSON-flavored error even when the XML reader built the index.
+    #[test]
+    fn insert_cap_error_is_format_neutral() {
+        let mut idx = DocArenaIndex::new(&[path("Big", "blob")], Some(64));
+        let payload = map(&[("blob", Value::String("z".repeat(10_000).into()))]);
+        // The return type itself is format-neutral: a plain `String`, not a
+        // `FormatError`.
+        let err: String = idx
+            .insert(&path("Big", "blob"), payload)
+            .expect_err("over-cap insert must error");
+        assert!(err.contains("max_index_bytes"), "names the cap: {err}");
+        assert!(err.contains("Big"), "names the section: {err}");
+        // The message must not pre-label a format; the owning reader supplies
+        // that when it wraps the string in its `FormatError` variant.
+        assert!(
+            !err.contains("JSON"),
+            "message must not hardcode JSON: {err}"
+        );
+        assert!(!err.contains("XML"), "message must not hardcode XML: {err}");
     }
 
     #[test]
@@ -389,7 +412,10 @@ mod tests {
                 map(&[("y", Value::String("b".repeat(400).into()))]),
             )
             .expect_err("second insert tips the running total over the cap");
-        assert!(matches!(err, FormatError::Json(msg) if msg.contains("B")));
+        assert!(
+            err.contains("B"),
+            "message names the tipping section: {err}"
+        );
         // Only the first section survived.
         let sections = idx.into_sections();
         assert_eq!(sections.len(), 1);
@@ -446,7 +472,7 @@ mod tests {
         let err = tight
             .insert(&path(section, "a"), build())
             .expect_err("structural backing must push the charge over the cap");
-        assert!(matches!(err, FormatError::Json(msg) if msg.contains("max_index_bytes")));
+        assert!(err.contains("max_index_bytes"), "cap named: {err}");
         assert!(tight.into_sections().is_empty());
 
         // A cap equal to the full charge clears, confirming the rejection above

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -116,6 +116,27 @@ pub enum FormatError {
         format: &'static str,
         column: String,
     },
+    /// A non-JSON writer (CSV / XML / fixed-width) was handed a record
+    /// carrying a `Value::Array` payload at a regular column slot.
+    /// JSON / NDJSON writers serialize arrays natively; the other formats
+    /// have no canonical scalar serialization for an array and would
+    /// otherwise silently degrade it — JSON-encoding the array into a
+    /// single cell (CSV), comma-joining its elements inside one element
+    /// (XML), or emitting an empty field (fixed-width). A stray array
+    /// reaching a non-JSON writer is far more often a routing bug (e.g. a
+    /// `match: collect` combine output sent to CSV) than a deliberate
+    /// choice, so raise it explicitly rather than hide the misroute.
+    ///
+    /// Routes to fix this at the user level:
+    ///
+    /// - Coerce the array to a scalar in CXL (`to_string`, or an
+    ///   equivalent join / aggregate) before the emit.
+    /// - Or route to a self-describing format (JSON / NDJSON) that
+    ///   serializes arrays natively.
+    UnserializableArrayValue {
+        format: &'static str,
+        column: String,
+    },
     /// A tabular / positional writer (CSV under envelope framing, or
     /// fixed-width) was handed a record carrying a user column its output
     /// column set does not declare. Such a writer emits a FIXED column set —
@@ -190,6 +211,14 @@ impl fmt::Display for FormatError {
                  If this is the `$widened` auto_widen sidecar, set `include_unmapped: true` on \
                  the Output node to expand the map to top-level columns before write. If the \
                  user emitted a map explicitly, coerce to a scalar in CXL before the emit."
+            ),
+            Self::UnserializableArrayValue { format, column } => write!(
+                f,
+                "{format} writer cannot serialize a `Value::Array` payload at column {column:?}. \
+                 A stray array reaching a non-JSON writer is usually a routing bug (e.g. a \
+                 `match: collect` combine output sent to CSV). Coerce the array to a scalar in \
+                 CXL (`to_string`, or an equivalent join) before the emit, or route to a \
+                 self-describing format (JSON / NDJSON) that serializes arrays natively."
             ),
             Self::SchemaDrift { format, column } => write!(
                 f,

--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -202,11 +202,13 @@ impl<W: Write> FixedWidthWriter<W> {
     /// column. The fixed-width writer is the single point of truth
     /// for map rejection on this path; there is no upstream pre-walk.
     ///
-    /// `Value::Array` retains the prior empty-cell shape because
-    /// fixed-width's strict positional layout makes JSON-in-cell
-    /// unworkable. Users who need an array's contents in a
-    /// fixed-width field must coerce to a scalar in CXL before
-    /// the emit.
+    /// `Value::Array` is rejected the same way
+    /// (`FormatError::UnserializableArrayValue`): fixed-width's strict
+    /// positional layout has no scalar rendering for an array, and the prior
+    /// empty-cell shape silently dropped the payload — hiding a misroute
+    /// (e.g. a `match: collect` combine output sent to a fixed-width
+    /// output). Users who need an array's contents in a fixed-width field
+    /// must coerce to a scalar in CXL before the emit.
     fn format_value(&self, field: &WriteField, value: &Value) -> Result<String, FormatError> {
         Ok(match value {
             Value::Null => String::new(),
@@ -222,7 +224,12 @@ impl<W: Write> FixedWidthWriter<W> {
             Value::Bool(b) => b.to_string(),
             Value::Date(d) => d.format("%Y%m%d").to_string(),
             Value::DateTime(dt) => dt.format("%Y%m%d%H%M%S").to_string(),
-            Value::Array(_) => String::new(),
+            Value::Array(_) => {
+                return Err(FormatError::UnserializableArrayValue {
+                    format: "fixed-width",
+                    column: field.name.clone(),
+                });
+            }
             Value::Map(_) => {
                 return Err(FormatError::UnserializableMapValue {
                     format: "fixed-width",
@@ -864,6 +871,39 @@ mod tests {
                 assert_eq!(column, "payload");
             }
             other => panic!("expected UnserializableMapValue, got {other:?}"),
+        }
+    }
+
+    /// Fixed-width writer rejects `Value::Array` payloads with
+    /// `FormatError::UnserializableArrayValue`, parallel to the map
+    /// rejection. The prior behavior emitted an empty positional cell for
+    /// any array, silently dropping the payload and hiding a misroute (e.g.
+    /// a `match: collect` combine output sent to a fixed-width output).
+    #[test]
+    fn test_fixed_width_writer_rejects_array_value() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::Integer(7),
+                Value::Array(vec![Value::String("a".into()), Value::String("b".into())]),
+            ],
+        );
+        let mut id_field = field("id");
+        id_field.width = Some(5);
+        let mut tags_field = field("tags");
+        tags_field.width = Some(10);
+        let fields = vec![id_field, tags_field];
+        let mut buf = Vec::new();
+        let mut writer =
+            FixedWidthWriter::new(&mut buf, fields, FixedWidthWriterConfig::default()).unwrap();
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::UnserializableArrayValue { format, column } => {
+                assert_eq!(format, "fixed-width");
+                assert_eq!(column, "tags");
+            }
+            other => panic!("expected UnserializableArrayValue, got {other:?}"),
         }
     }
 

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -486,7 +486,9 @@ impl FormatReader for JsonReader {
             };
             let typed = coerce_json_section_fields(name, payload_obj, &section.fields, &index)?;
             let path = doc_path_for_section(name);
-            index.insert(&path, Value::Map(Box::new(typed)))?;
+            index
+                .insert(&path, Value::Map(Box::new(typed)))
+                .map_err(FormatError::Json)?;
         }
         Ok(index.into_sections())
     }

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -804,7 +804,9 @@ impl FormatReader for XmlReader {
             let typed =
                 coerce_section_fields(payload, &section.fields).map_err(FormatError::Xml)?;
             let path = doc_path_for_section(&name);
-            index.insert(&path, Value::Map(Box::new(typed)))?;
+            index
+                .insert(&path, Value::Map(Box::new(typed)))
+                .map_err(FormatError::Xml)?;
         }
         Ok(index.into_sections())
     }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -188,6 +188,13 @@ impl<W: Write> XmlWriter<W> {
 
     fn write_header(&mut self) -> Result<(), FormatError> {
         if !self.header_written {
+            // The root and record element names come straight from config into
+            // `BytesStart::new`; validate them before opening the root so a
+            // malformed configured name fails loud rather than corrupting the
+            // document. Both are checked here, once, before any record element
+            // is emitted (every write path opens the header first).
+            check_xml_name(&self.config.root_element, "root element")?;
+            check_xml_name(&self.config.record_element, "record element")?;
             self.header_written = true;
             let start = BytesStart::new(&self.config.root_element);
             self.writer
@@ -522,6 +529,23 @@ fn is_valid_xml_name(name: &str) -> bool {
     chars.all(is_xml_name_char)
 }
 
+/// Reject a tag name quick-xml would otherwise write verbatim into a start
+/// tag via `BytesStart::new`. Element (leaf / branch) names derive from
+/// user field names and the configured root / record element names, so a
+/// name with a leading digit, a space, or an illegal character (e.g. a
+/// field literally named `1st` or `a b`) would emit malformed markup while
+/// still reporting run success. `context` describes the name's origin for
+/// the diagnostic (e.g. `"field 'X': element"`, `"root element"`).
+fn check_xml_name(name: &str, context: &str) -> Result<(), FormatError> {
+    if is_valid_xml_name(name) {
+        Ok(())
+    } else {
+        Err(FormatError::Xml(format!(
+            "{context} name '{name}' is not a well-formed XML name"
+        )))
+    }
+}
+
 /// Insert a dotted field name into the tree, creating branches as needed.
 /// An attribute-prefixed segment must be the path's final segment (an
 /// attribute is a leaf — nothing can nest under it); `field` is the full
@@ -540,6 +564,7 @@ fn insert_field(
                  cannot have fields nested under it — an XML attribute is a leaf"
             )));
         }
+        check_xml_name(first, &format!("field '{field}': element"))?;
         // Find or create a branch for `first`
         let branch = body
             .children
@@ -576,6 +601,7 @@ fn insert_field(
         body.attrs.push((attr_name.to_string(), text.to_string()));
         Ok(())
     } else {
+        check_xml_name(path, &format!("field '{field}': element"))?;
         body.children.push(FieldNode::Leaf {
             name: path.to_string(),
             text: text.to_string(),
@@ -586,16 +612,15 @@ fn insert_field(
 
 /// Convert a clinker Value to XML text content.
 ///
-/// `Value::Map` has no canonical scalar serialization for an XML
-/// element body (silently JSON-encoding hides routing bugs — e.g. a
-/// `$widened` sidecar reaching the writer without
-/// `include_unmapped: true` expansion), so this returns
-/// `FormatError::UnserializableMapValue` carrying the offending
-/// column. XML is the single point of truth for map rejection on
-/// this path; there is no upstream pre-walk.
-///
-/// Array elements that themselves contain a `Value::Map` propagate
-/// the same rejection (the array is joined element-wise).
+/// `Value::Map` and `Value::Array` have no canonical scalar serialization
+/// for an XML element body (silently JSON-encoding a map, or comma-joining
+/// an array, hides routing bugs — e.g. a `$widened` sidecar reaching the
+/// writer without `include_unmapped: true` expansion for a map, or a
+/// `match: collect` combine output misrouted to XML for an array), so this
+/// returns `FormatError::UnserializableMapValue` /
+/// `FormatError::UnserializableArrayValue` carrying the offending column.
+/// XML is the single point of truth for collection rejection on this path;
+/// there is no upstream pre-walk.
 fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
     let mut buf = String::new();
     write_value_text(&mut buf, col, val)?;
@@ -604,8 +629,8 @@ fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
 
 /// Render a clinker Value as XML text content into `buf` (appending). Shares
 /// its logic with [`value_to_text`] so the record fast path and the envelope
-/// section path stay byte-identical. `Value::Map` is rejected exactly as
-/// `value_to_text` documents.
+/// section path stay byte-identical. `Value::Map` and `Value::Array` are
+/// rejected exactly as `value_to_text` documents.
 fn write_value_text(buf: &mut String, col: &str, val: &Value) -> Result<(), FormatError> {
     use std::fmt::Write as _;
     match val {
@@ -629,13 +654,11 @@ fn write_value_text(buf: &mut String, col: &str, val: &Value) -> Result<(), Form
         Value::DateTime(dt) => {
             let _ = write!(buf, "{dt}");
         }
-        Value::Array(arr) => {
-            for (idx, v) in arr.iter().enumerate() {
-                if idx > 0 {
-                    buf.push(',');
-                }
-                write_value_text(buf, col, v)?;
-            }
+        Value::Array(_) => {
+            return Err(FormatError::UnserializableArrayValue {
+                format: "XML",
+                column: col.to_string(),
+            });
         }
         Value::Map(_) => {
             return Err(FormatError::UnserializableMapValue {
@@ -736,6 +759,7 @@ fn plan_insert_field(
                  cannot have fields nested under it — an XML attribute is a leaf"
             )));
         }
+        check_xml_name(first, &format!("field '{field}': element"))?;
         let branch = body
             .children
             .iter_mut()
@@ -789,6 +813,7 @@ fn plan_insert_field(
         });
         Ok(())
     } else {
+        check_xml_name(path, &format!("field '{field}': element"))?;
         body.children.push(PlanNode::Leaf {
             name: path.to_string(),
             field: field_index,
@@ -1153,6 +1178,156 @@ mod tests {
             }
             other => panic!("expected UnserializableMapValue, got {other:?}"),
         }
+    }
+
+    /// XML writer rejects `Value::Array` payloads with
+    /// `FormatError::UnserializableArrayValue`, parallel to the map
+    /// rejection. The prior behavior comma-joined the array's elements
+    /// inside a single element, silently hiding a misroute (e.g. a
+    /// `match: collect` combine output sent to XML). `fill_values` runs
+    /// before any bytes, so the rejected record leaves no partial output.
+    #[test]
+    fn test_xml_writer_rejects_array_value() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![
+                Value::Integer(7),
+                Value::Array(vec![Value::String("a".into()), Value::String("b".into())]),
+            ],
+        );
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::UnserializableArrayValue { format, column } => {
+                assert_eq!(format, "XML");
+                assert_eq!(column, "tags");
+            }
+            other => panic!("expected UnserializableArrayValue, got {other:?}"),
+        }
+        drop(writer);
+        assert!(
+            buf.is_empty(),
+            "rejected record must not leave partial output behind"
+        );
+    }
+
+    /// Assert that writing a single record whose only field is `field`
+    /// fails with `FormatError::Xml` naming the field and explaining the
+    /// malformed element name, leaving no partial bytes behind.
+    fn assert_element_name_rejected(field: &str) {
+        let schema = Arc::new(Schema::new(vec![field.into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Integer(1)]);
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::Xml(msg) => {
+                assert!(msg.contains(field), "message names the field: {msg}");
+                assert!(
+                    msg.contains("well-formed XML name"),
+                    "message explains the failure is a malformed name: {msg}"
+                );
+            }
+            other => panic!("expected FormatError::Xml, got {other:?}"),
+        }
+        drop(writer);
+        assert!(
+            buf.is_empty(),
+            "rejected record must not leave partial output behind"
+        );
+    }
+
+    #[test]
+    fn test_xml_write_leaf_element_name_starting_with_digit_rejected() {
+        // A digit is a NameChar but not a NameStartChar, so a field literally
+        // named `1st` cannot become an XML element `<1st>`.
+        assert_element_name_rejected("1st");
+    }
+
+    #[test]
+    fn test_xml_write_leaf_element_name_with_space_rejected() {
+        // A space is not an XML NameChar; writing it unvalidated would emit
+        // `<first name>`, corrupting the start tag.
+        assert_element_name_rejected("first name");
+    }
+
+    #[test]
+    fn test_xml_write_branch_element_name_invalid_rejected() {
+        // The dotted branch segment `1bad` cannot begin an XML name, so
+        // `1bad.city` is rejected before an `<1bad>` branch is emitted.
+        assert_element_name_rejected("1bad.city");
+    }
+
+    #[test]
+    fn test_xml_write_unicode_leaf_element_name_accepted() {
+        // `café` is a well-formed XML name (`é` is a NameChar), so the new
+        // element-name validation does not over-reject non-ASCII field names.
+        let schema = Arc::new(Schema::new(vec!["café".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::Integer(1)]);
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(output, "<Root><Record><café>1</café></Record></Root>");
+    }
+
+    #[test]
+    fn test_xml_write_invalid_record_element_name_rejected() {
+        // The configured record element name flows straight into
+        // `BytesStart::new`; a malformed one fails loud before any output.
+        let schema = Arc::new(Schema::new(vec!["name".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::String("A".into())]);
+        let config = XmlWriterConfig {
+            record_element: "1record".into(),
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), config);
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::Xml(msg) => {
+                assert!(
+                    msg.contains("record element"),
+                    "message names the record element: {msg}"
+                );
+                assert!(msg.contains("1record"), "message names the value: {msg}");
+            }
+            other => panic!("expected FormatError::Xml, got {other:?}"),
+        }
+        drop(writer);
+        assert!(
+            buf.is_empty(),
+            "no output before a rejected record element name"
+        );
+    }
+
+    #[test]
+    fn test_xml_write_invalid_root_element_name_rejected() {
+        // The configured root element name is validated at header open, so a
+        // malformed one fails loud rather than emitting `<1root>`.
+        let schema = Arc::new(Schema::new(vec!["name".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::String("A".into())]);
+        let config = XmlWriterConfig {
+            root_element: "1root".into(),
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), config);
+        let err = writer.write_record(&record).unwrap_err();
+        match err {
+            FormatError::Xml(msg) => {
+                assert!(
+                    msg.contains("root element"),
+                    "message names the root element: {msg}"
+                );
+                assert!(msg.contains("1root"), "message names the value: {msg}");
+            }
+            other => panic!("expected FormatError::Xml, got {other:?}"),
+        }
+        drop(writer);
+        assert!(
+            buf.is_empty(),
+            "no output before a rejected root element name"
+        );
     }
 
     #[test]

--- a/crates/clinker-format/tests/writer_array_rejection.rs
+++ b/crates/clinker-format/tests/writer_array_rejection.rs
@@ -1,0 +1,134 @@
+//! Crate-boundary rejection of `Value::Array` payloads in the non-JSON
+//! writers (CSV / XML / fixed-width), parallel to the shipped `Value::Map`
+//! rejection.
+//!
+//! A stray array reaching one of these writers — most often a `match: collect`
+//! combine output misrouted to a tabular / positional format — is surfaced as
+//! an explicit `FormatError::UnserializableArrayValue` naming the offending
+//! column, rather than silently degraded (JSON-encoded into a CSV cell,
+//! comma-joined inside an XML element, or dropped to an empty fixed-width
+//! field). The error message lists the two user remedies: coerce the array to
+//! a scalar in CXL (`to_string`), or route to a self-describing JSON output.
+//! JSON output itself is unaffected — it serializes arrays natively. See #46.
+
+use std::sync::Arc;
+
+use clinker_format::csv::{CsvWriter, CsvWriterConfig};
+use clinker_format::fixed_width::{FixedWidthWriter, FixedWidthWriterConfig};
+use clinker_format::json::writer::{JsonWriter, JsonWriterConfig};
+use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
+use clinker_format::{Column, FormatError, FormatWriter};
+use clinker_record::{Record, Schema, Value};
+use cxl::typecheck::Type;
+
+/// A two-column record whose second column (`tags`) carries a `Value::Array`,
+/// the shape a `match: collect` combine build side produces.
+fn record_with_array() -> (Arc<Schema>, Record) {
+    let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+    let record = Record::new(
+        Arc::clone(&schema),
+        vec![
+            Value::Integer(7),
+            Value::Array(vec![Value::String("a".into()), Value::String("b".into())]),
+        ],
+    );
+    (schema, record)
+}
+
+/// Both user remedies named in the acceptance criteria must appear in the
+/// surfaced message: CXL coercion (`to_string`) and JSON output.
+fn assert_lists_remedies(err: &FormatError) {
+    let msg = err.to_string();
+    assert!(
+        msg.contains("to_string"),
+        "message lists the CXL-coercion remedy: {msg}"
+    );
+    assert!(
+        msg.contains("JSON"),
+        "message lists the JSON-output remedy: {msg}"
+    );
+}
+
+#[test]
+fn csv_writer_rejects_array_payload() {
+    let (schema, record) = record_with_array();
+    let mut buf = Vec::new();
+    let mut writer = CsvWriter::new(&mut buf, Arc::clone(&schema), CsvWriterConfig::default());
+    let err = writer.write_record(&record).unwrap_err();
+    assert!(
+        matches!(&err, FormatError::UnserializableArrayValue { format, column }
+            if *format == "CSV" && column == "tags"),
+        "expected UnserializableArrayValue for CSV/tags, got {err:?}"
+    );
+    assert_lists_remedies(&err);
+    // The array must not have been JSON-encoded into a cell.
+    drop(writer);
+    assert!(
+        !String::from_utf8_lossy(&buf).contains("[\"a\""),
+        "the array must not be JSON-encoded into a CSV cell"
+    );
+}
+
+#[test]
+fn xml_writer_rejects_array_payload() {
+    let (schema, record) = record_with_array();
+    let mut buf = Vec::new();
+    let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+    let err = writer.write_record(&record).unwrap_err();
+    assert!(
+        matches!(&err, FormatError::UnserializableArrayValue { format, column }
+            if *format == "XML" && column == "tags"),
+        "expected UnserializableArrayValue for XML/tags, got {err:?}"
+    );
+    assert_lists_remedies(&err);
+    // The XML writer fills and validates every value before emitting any byte,
+    // so a rejected record leaves no partial output.
+    drop(writer);
+    assert!(
+        buf.is_empty(),
+        "rejected record leaves no partial XML output"
+    );
+}
+
+#[test]
+fn fixed_width_writer_rejects_array_payload() {
+    let (_schema, record) = record_with_array();
+    let mut id = Column::bare("id", Type::Int);
+    id.start = Some(0);
+    id.width = Some(5);
+    let mut tags = Column::bare("tags", Type::String);
+    tags.start = Some(5);
+    tags.width = Some(10);
+    let mut buf = Vec::new();
+    let mut writer =
+        FixedWidthWriter::new(&mut buf, vec![id, tags], FixedWidthWriterConfig::default())
+            .expect("fixed-width writer constructs from a valid layout");
+    let err = writer.write_record(&record).unwrap_err();
+    assert!(
+        matches!(&err, FormatError::UnserializableArrayValue { format, column }
+            if *format == "fixed-width" && column == "tags"),
+        "expected UnserializableArrayValue for fixed-width/tags, got {err:?}"
+    );
+    assert_lists_remedies(&err);
+}
+
+/// A JSON writer serializes an array natively — the rejection is specific to
+/// the non-self-describing formats, so JSON output is unchanged (criterion 3).
+#[test]
+fn json_writer_serializes_array_natively() {
+    let (schema, record) = record_with_array();
+    let mut buf = Vec::new();
+    {
+        let mut writer =
+            JsonWriter::new(&mut buf, Arc::clone(&schema), JsonWriterConfig::default());
+        writer
+            .write_record(&record)
+            .expect("JSON writer serializes an array natively");
+        writer.flush().expect("flush succeeds");
+    }
+    let out = String::from_utf8(buf).expect("JSON output is UTF-8");
+    assert!(
+        out.contains('[') && out.contains("\"a\"") && out.contains("\"b\""),
+        "the array serializes as a native JSON array: {out}"
+    );
+}

--- a/crates/clinker/tests/channel_source_patch.rs
+++ b/crates/clinker/tests/channel_source_patch.rs
@@ -246,6 +246,8 @@ nodes:
       path: in.json
       options:
         record_path: small.rows
+      array_paths:
+        - { path: tags, mode: join }
       schema:
         - { name: id, type: string }
         - { name: tags, type: array }
@@ -271,7 +273,9 @@ sources:
 ",
     );
 
-    // Base: record_path points at the single-row array; no explosion.
+    // Base: record_path points at the single-row array; `tags` joins to a
+    // scalar cell (non-JSON writers reject a stray `Value::Array`, so an
+    // unexploded array column must collapse to a scalar before the CSV emit).
     let base = run_in(p, &[]);
     assert!(base.status.success(), "base json run failed");
     let base_out = std::fs::read_to_string(p.join("out.csv")).expect("read out.csv");
@@ -279,7 +283,8 @@ sources:
     assert_eq!(base_rows, 1, "base output:\n{base_out}");
 
     // Channel: record_path override selects the three-row array, and the
-    // array_paths explode fans each record out per tag → 4 rows.
+    // array_paths op flips `tags` from join to explode, fanning each record
+    // out per tag → 4 rows.
     let patched = run_in(p, &["--channel", "jfix"]);
     assert!(
         patched.status.success(),

--- a/docs/user/src/cxl/aggregates.md
+++ b/docs/user/src/cxl/aggregates.md
@@ -98,6 +98,11 @@ cxl: |
   emit all_order_ids = collect(order_id)
 ```
 
+Because `collect` emits an array, route the result to a JSON output
+(which serializes arrays natively) or coerce it to a scalar in a
+downstream `Transform` (for example `emit ids = all_order_ids.join(";")`).
+The CSV, XML, and fixed-width writers reject an array-valued field.
+
 ### weighted_avg(value, weight) -> Float or Decimal
 
 Computes a weighted average: `sum(value * weight) / sum(weight)`. Takes two arguments.
@@ -172,6 +177,11 @@ pipeline:
     - name: output
       type: output
       input: monthly_summary
-      format: csv
-      path: summary.csv
+      format: json
+      path: summary.json
 ```
+
+This pipeline outputs JSON because `all_reps = collect(sales_rep)`
+emits an array, which the tabular writers (CSV/XML/fixed-width)
+reject; drop the `collect` binding or coerce it with a downstream
+`Transform` to keep a CSV sink.

--- a/docs/user/src/cxl/windows.md
+++ b/docs/user/src/cxl/windows.md
@@ -221,6 +221,12 @@ Collects distinct values of the field in the window into an array.
 emit unique_regions = $window.distinct(region)
 ```
 
+`$window.collect` and `$window.distinct` emit arrays. The CSV, XML,
+and fixed-width writers reject an array-valued field, so route such a
+result to a JSON output, or coerce the emitted array to a scalar in a
+downstream `Transform` (for example `emit regions = unique_regions.join(";")`)
+before a tabular sink.
+
 ## Complete example
 
 ```yaml

--- a/docs/user/src/nodes/aggregate.md
+++ b/docs/user/src/nodes/aggregate.md
@@ -381,6 +381,13 @@ cargo run -p clinker -- run examples/pipelines/multi_source_session.yaml
   input: account_summary
   config:
     name: summary_output
-    type: csv
-    path: "./output/account_summary.csv"
+    type: json
+    path: "./output/account_summary.json"
 ```
+
+The output is JSON because `collect(category)` emits an array. The
+CSV, XML, and fixed-width writers reject an array-valued field (a
+stray collection reaching a tabular sink is treated as a routing
+bug); route such a pipeline to JSON, which serializes arrays
+natively, or coerce the array to a scalar first with a downstream
+`Transform` (for example `emit categories = categories.join(";")`).

--- a/examples/pipelines/retract-demo/README.md
+++ b/examples/pipelines/retract-demo/README.md
@@ -58,17 +58,25 @@ HR group:
 
 ```
 department,day,total,min_amount,n,order_ids,anomaly_check
-ENG,2024-01-01,500,500,1,"[{""String"":""O05""}]",0
-ENG,2024-01-02,1190,440,2,"[{""String"":""O06""},{""String"":""O07""}]",0
-ENG,2024-01-03,940,330,2,"[{""String"":""O10""},{""String"":""O11""}]",0
+ENG,2024-01-01,500,500,1,O05,0
+ENG,2024-01-02,1190,440,2,O06;O07,0
+ENG,2024-01-03,940,330,2,O10;O11,0
 ```
+
+The `order_ids` cell is the aggregate's `collect(order_id)` binding
+joined into a `;`-separated scalar by the `dept_validate` Transform.
+The CSV writer rejects a raw array field (a stray collection reaching
+a tabular sink is treated as a routing bug), so a `collect` result
+bound for CSV/XML/fixed-width output is coerced to a scalar first —
+here with `order_ids.join(";")`; route to JSON output instead if you
+want the array serialized natively.
 
 If you remove the BAD row from `data/orders.csv` and rerun, the
 post-aggregate failures fire on the same three HR groups (the
 predicate is a property of the surviving totals, not of the
 sentinel) and the writer payload is bit-for-bit identical to the
 retract-corrected run. The smoke test at
-`crates/clinker-core/tests/retract_demo_smoke.rs` asserts this
+`crates/clinker-exec/tests/retract_demo_smoke.rs` asserts this
 equivalence.
 
 ## Inspect the plan

--- a/examples/pipelines/retract-demo/README.md
+++ b/examples/pipelines/retract-demo/README.md
@@ -44,11 +44,12 @@ cargo run -p clinker -- run pipeline.yaml
 You should see something like:
 
 ```
-INFO clinker: Pipeline complete: 12 total, 3 ok, 3 written, 4 dlq
+INFO clinker: Pipeline complete: 24 total, 3 ok, 3 written, 4 dlq
 ```
 
-12 source rows produce 6 initial aggregate output rows (one per
-`(department, day)` group). The post-aggregate `dept_validate`
+The 24 total counts both inputs (12 orders joined with 12 audit
+events). The 12 orders produce 6 initial aggregate output rows (one
+per `(department, day)` group). The post-aggregate `dept_validate`
 predicate fails on every HR group; the synthetic-CK fan-out
 retracts the contributing source rows so the final report
 `output/report.csv` contains only the three ENG rows. The DLQ
@@ -57,10 +58,10 @@ sentinel) plus one `transform:dept_validate` trigger per failing
 HR group:
 
 ```
-department,day,total,min_amount,n,order_ids,anomaly_check
-ENG,2024-01-01,500,500,1,O05,0
-ENG,2024-01-02,1190,440,2,O06;O07,0
-ENG,2024-01-03,940,330,2,O10;O11,0
+department,day,total,min_amount,n,order_ids,$ck.aggregate.dept_totals,anomaly_check
+ENG,2024-01-01,500,500,1,O05,3,0
+ENG,2024-01-02,1190,440,2,O06;O07,4,0
+ENG,2024-01-03,940,330,2,O10;O11,5,0
 ```
 
 The `order_ids` cell is the aggregate's `collect(order_id)` binding
@@ -69,7 +70,10 @@ The CSV writer rejects a raw array field (a stray collection reaching
 a tabular sink is treated as a routing bug), so a `collect` result
 bound for CSV/XML/fixed-width output is coerced to a scalar first —
 here with `order_ids.join(";")`; route to JSON output instead if you
-want the array serialized natively.
+want the array serialized natively. The trailing
+`$ck.aggregate.dept_totals` column is the relaxed-CK aggregate's
+synthetic lineage key, surfaced here only because the Output sets
+`include_correlation_keys: true` (it is hidden from default writers).
 
 If you remove the BAD row from `data/orders.csv` and rerun, the
 post-aggregate failures fire on the same three HR groups (the

--- a/examples/pipelines/retract-demo/pipeline.yaml
+++ b/examples/pipelines/retract-demo/pipeline.yaml
@@ -158,6 +158,12 @@ nodes:
   # to the original orders rows — every row that fed the failing
   # group lands in the DLQ alongside the aggregate output row,
   # matching the upstream-failure DLQ-fan-out semantic.
+  #
+  # This Transform also joins `order_ids` (the aggregate's
+  # `collect(order_id)` array) into a `;`-separated scalar: the CSV
+  # sink rejects a raw array cell, so a `collect` binding bound for a
+  # tabular output must be coerced to a scalar here (or the Output
+  # routed to JSON, which serializes arrays natively).
   - type: transform
     name: dept_validate
     input: dept_totals
@@ -168,7 +174,7 @@ nodes:
         emit total = total
         emit min_amount = min_amount
         emit n = n
-        emit order_ids = order_ids
+        emit order_ids = order_ids.join(";")
         emit anomaly_check = if total < 500 then "x".to_int() else 0
 
   # Sink. `include_correlation_keys: true` surfaces the `$ck.*`


### PR DESCRIPTION
## Summary

Fixes three related correctness gaps in the `clinker-format` writers and the
document-index backstop, and migrates every in-tree pipeline that relied on the
old silently-degrading behavior. Each format fix is small and independently
reviewable; they are grouped because they all harden the format layer against
silently-wrong output.

## Breaking change

The CSV, XML, and fixed-width writers now **reject** a `Value::Array` payload
at a column slot instead of silently degrading it. Any pipeline that emits an
array-valued field (a `collect(...)` aggregate, a `match: collect` combine, a
`$window.collect` / `$window.distinct`, or `str.split(...)`) into one of these
tabular formats now fails fast with a format error rather than writing
malformed output.

To migrate an existing pipeline, either:

- **Coerce the array to a scalar before the sink** — most simply a downstream
  Transform, e.g. `emit ids = ids.join(",")` (a `.join()` chained directly
  inside an aggregate/window emit is not supported; do it in a following
  Transform), or
- **Route to a self-describing format** — JSON or NDJSON serializes arrays
  natively.

The JSON / NDJSON writers are unchanged.

## 1. Reject `Value::Array` in non-JSON writers (#46)

The CSV, XML, and fixed-width writers already reject a stray `Value::Map`
payload at a column slot. The array half of that same pattern was still
silently degraded:

- CSV JSON-encoded the array into a single cell,
- XML comma-joined its elements inside one element,
- fixed-width emitted an empty field.

A stray array reaching a non-JSON writer is far more often a routing bug (e.g.
a `match: collect` combine output sent to CSV) than a deliberate choice, so
silent degrading hides the misroute. All three writers now raise a new
`FormatError::UnserializableArrayValue` naming the offending column, with a
message listing the two remedies: coerce the array to a scalar in CXL
(`to_string` or an equivalent join), or route to a self-describing format
(JSON / NDJSON) that serializes arrays natively. The JSON writer is unchanged
and serializes arrays natively.

## 2. Validate element / leaf / branch tag names in the XML writer (#831)

The XML writer validated attribute names but wrote element names straight into
the start tag via `BytesStart::new`. A field whose name is not a valid XML
element name (leading digit, embedded space, illegal character) produced
malformed markup while still reporting run success. The existing XML-name
predicate is now applied to leaf and branch element names (derived from field
names) and to the configured root and record element names. An invalid name
surfaces a clear writer error before any bytes are emitted, rather than
corrupting the document.

## 3. Format-neutral `DocArenaIndex` cap-exceeded error (#508)

`DocArenaIndex::insert` is the parser-agnostic backstop that charges a finished
envelope-section subtree against `max_index_bytes`. Its cap-exceeded error was
hardcoded to the JSON variant, so an XML envelope that tripped the cap at this
backstop surfaced a JSON-flavored message. `insert` now returns a
format-neutral string that each reader wraps in its own `FormatError` variant
(`Json` for the JSON reader, `Xml` for the XML reader) — mirroring how the
readers already wrap the string a section-coercion helper returns. The index
stays parser-agnostic; JSON behavior is unchanged.

## Downstream consumer migration

The array rejection turned every pre-existing pipeline that routed an
array-valued field to a tabular sink into a runtime error. Each such consumer
is migrated to the new design in this PR — routing to JSON/NDJSON where the
array itself is the point, or coercing to a scalar where a tabular output is
the representative shape — with no weakened, ignored, or `should_panic`
assertions:

- **End-to-end tests** — the channel source-patch test (the base pipeline now
  joins the array to a scalar CSV cell; the channel overlay flips it to
  explode); the scheduler consumer-release and heavy-first-peak tests, and the
  aggregate/combine/composition `collect` tests (routed to JSON/NDJSON, with
  row-count and membership assertions adapted to the JSON shape).
- **Benchmark fixtures** — the `match: collect` combine fixture (routed to
  NDJSON, since the collected array is the fixture's point) and the
  string-methods fixture (its one `split` emit joined back to a scalar to keep
  the CSV-output workload representative).
- **Runnable example** — the `retract-demo` pipeline coerces its
  `collect(order_id)` result to a `;`-joined scalar in its existing validation
  Transform, keeping the CSV report; its README output block is regenerated
  byte-for-byte from an actual run (the old block showed the pre-fix
  leaked-internal-repr cell).
- **User guide** — the CXL aggregate/window pages and the aggregate node page
  route their `collect` examples to JSON and note the array-serialization
  constraint.

## Tests

- Unit tests in each writer mirroring the existing map-rejection tests, plus
  XML element-name and configured-element-name rejection tests and a
  positive test that a valid non-ASCII element name is still accepted.
- A crate-boundary integration test (`tests/writer_array_rejection.rs`)
  covering all four formats: CSV / XML / fixed-width reject the array and list
  both remedies; JSON serializes it natively.
- A regression test that the document-index cap error is format-neutral.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace` and
`cargo clippy --workspace --all-targets` (both `-D warnings`), the full
`cargo test --workspace`, and `cargo test --benches -p clinker-benchmarks`
(which pre-flights every `benches/pipelines/**` config) all pass. CI is green
on Linux, macOS, and Windows.

Closes #46, #831, #508

Closes #831
Closes #508