### PR TITLE
fix(plan): correct envelope $doc validation for composition ports, name collisions, and EDI segment tiers

### DIFF
--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -2814,9 +2814,7 @@ fn trace_output_lineage(config: &PipelineConfig, output_name: &str) -> OutputLin
             PipelineNode::Source { .. } => {
                 feeding_sources.insert(node_name.to_string());
             }
-            PipelineNode::Aggregate { .. }
-            | PipelineNode::Combine { .. }
-            | PipelineNode::Composition { .. } => {
+            PipelineNode::Aggregate { .. } | PipelineNode::Combine { .. } => {
                 // Record the first stripper found (deterministic by the
                 // declaration-order traversal seed), but keep walking so the
                 // feeding-source set stays complete for the E346 scoping.
@@ -2825,6 +2823,21 @@ fn trace_output_lineage(config: &PipelineConfig, output_name: &str) -> OutputLin
                 }
                 for up in node.direct_input_names() {
                     stack.push(up);
+                }
+            }
+            PipelineNode::Composition { inputs, .. } => {
+                // A Composition is a lineage stripper, but its feeding sources
+                // reach through EVERY bound `inputs:` port, not just the single
+                // primary port `direct_input_names` reports (`header.input`). A
+                // header/footer section declared on a source bound to a
+                // non-primary port is genuinely reachable, so the E346 scoping
+                // must union all ports — matching the all-ports resolution
+                // `build_node_source_sets` uses for the register / E348 passes.
+                if lineage_stripper.is_none() {
+                    lineage_stripper = Some(node_name.to_string());
+                }
+                for upstream in inputs.values() {
+                    stack.push(upstream.split('.').next().unwrap_or(upstream));
                 }
             }
             _ => {
@@ -3158,6 +3171,30 @@ fn doc_schema_for(source: &crate::config::SourceConfig) -> DocSchema {
     }
 }
 
+/// The single file-level header segment tag a segment/positional EDI format
+/// exposes as a declared `envelope.sections` entry, or `None` for a format
+/// with no such restriction.
+///
+/// Mirrors the readers' `prepare_document` check: X12 serves only `ISA`,
+/// EDIFACT only `UNB`, HL7 only `FHS` — the one segment each resolves from its
+/// bounded header pre-scan. Every other segment (and every non-`segment`
+/// extract) is rejected at read time; [`validate_config`] uses this to reject
+/// it at plan time instead (`E357`). SWIFT is deliberately absent: its reader
+/// serves declared sections under user-chosen or default block labels, so it
+/// has no single file-level tag to enforce.
+fn edi_file_level_segment(format: &InputFormat) -> Option<&'static str> {
+    match format {
+        InputFormat::X12(_) => Some("ISA"),
+        InputFormat::Edifact(_) => Some("UNB"),
+        InputFormat::Hl7(_) => Some("FHS"),
+        InputFormat::Csv(_)
+        | InputFormat::Json(_)
+        | InputFormat::Xml(_)
+        | InputFormat::FixedWidth(_)
+        | InputFormat::Swift(_) => None,
+    }
+}
+
 /// A rejected `$doc` path: the diagnostic code, formatted message, and
 /// fix-it help text. The code distinguishes a closed-schema rejection
 /// (`E341`) from a segment/positional one (`E348`).
@@ -3230,8 +3267,14 @@ fn closed_doc_path_problem(
 /// - a **synthesized level given a typed nested schema** (X12
 ///   `group_section` / `set_section`) is closed to its declared fields.
 ///
+/// When a declared `envelope.sections` name collides with a synthesized
+/// level (the engine reserves no names, so this is legal), the reader exposes
+/// BOTH views, so the field check is their UNION: a field valid under the
+/// declared closed view OR the synthesized level view resolves. The declared
+/// view is not allowed to shadow the synthesized positional access.
+///
 /// Returns the `E348` diagnostic content for a section outside the known
-/// set, or a field that section's reader will not serve.
+/// set, or a field neither view's reader will serve.
 fn segment_positional_doc_path_problem(
     source: &crate::config::SourceConfig,
     schema: &SegmentPositionalSchema,
@@ -3280,26 +3323,26 @@ fn segment_positional_doc_path_problem(
         });
     }
 
-    // A declared file-level section (`ISA`/`UNB`/`FHS`) is closed: the
-    // reader serves only its declared fields.
-    if let Some(section) = declared_section {
-        if section.fields.contains_key(field_name) {
-            return None;
-        }
-        return Some(undeclared_field_in_closed_section(
-            source_name,
-            format,
-            section_name,
-            field_name,
-            "`envelope.sections`",
-        ));
+    // A field resolves at run time if EITHER the declared closed view OR the
+    // synthesized level view serves it. When a declared `envelope.sections`
+    // name collides with a synthesized level (e.g. a user names a declared
+    // section `transaction_set`), the reader exposes BOTH — the declared
+    // file-level section and the synthesized positional level — so a field
+    // valid under either must be accepted. Resolving declared-first would let
+    // the closed declared view shadow the synthesized positional access and
+    // reject a legitimate `eNN`/`fNN` element the reader would serve.
+
+    // Declared closed view: a declared file-level section serves only its
+    // declared fields.
+    if declared_section.is_some_and(|s| s.fields.contains_key(field_name)) {
+        return None;
     }
 
-    // A synthesized nested level: closed to its declared schema if it has
-    // one, else keyed by positional elements up to the bound. `synthesized`
-    // is `Some` here — the both-`None` case returned above, and the
-    // `declared_section` case returned just above — but match it rather than
-    // unwrap so the exhaustive path is explicit.
+    // Not served by the declared view (no declared section for this name, or
+    // the field is not one it declares). Fall through to the synthesized level,
+    // which may serve the field even when a same-named declared section does
+    // not: closed to its declared schema if it has one, else keyed by
+    // positional elements up to the bound.
     match synthesized.map(|s| &s.fields) {
         Some(SynthesizedFields::Declared(fields)) => {
             if fields.iter().any(|f| f == field_name) {
@@ -3321,7 +3364,16 @@ fn segment_positional_doc_path_problem(
             schema.positional_prefix,
             schema.max_positional,
         ),
-        None => None,
+        // No synthesized level for this name — the section is a declared
+        // file-level section only (the both-`None` case returned earlier), and
+        // the declared view above already rejected the field, so it is a typo.
+        None => Some(undeclared_field_in_closed_section(
+            source_name,
+            format,
+            section_name,
+            field_name,
+            "`envelope.sections`",
+        )),
     }
 }
 
@@ -4490,6 +4542,52 @@ pub(crate) fn validate_config(config: &PipelineConfig) -> Result<(), ConfigError
                          `/{pointer}`)",
                         source = input.name,
                     )));
+                }
+            }
+
+            // For X12 / EDIFACT / HL7, only the file-level header segment is
+            // extractable as a declared envelope section: X12 `ISA`, EDIFACT
+            // `UNB`, HL7 `FHS`. The readers reject any other `extract.segment:`
+            // tag — and any non-`segment` extract — at read time in
+            // `prepare_document`; the nested tiers (X12 GS/ST, EDIFACT UNH, HL7
+            // BHS/MSH) surface as nested `$doc` levels rather than declared
+            // sections, and trailer segments are validated as they stream, not
+            // exposed as sections. Mirror that check here so the mistake fails
+            // on `--explain` rather than only when the reader opens the source.
+            if let Some(file_level_tag) = edi_file_level_segment(&input.format) {
+                for (section_name, section) in &envelope.sections {
+                    let extractable = matches!(
+                        &section.extract,
+                        clinker_format::EnvelopeExtract::Segment(tag) if tag == file_level_tag
+                    );
+                    if !extractable {
+                        let declared = match &section.extract {
+                            clinker_format::EnvelopeExtract::Segment(tag) => {
+                                format!("segment `{tag}`")
+                            }
+                            clinker_format::EnvelopeExtract::XmlPath(_) => {
+                                "an `xml_path` extract".to_string()
+                            }
+                            clinker_format::EnvelopeExtract::JsonPointer(_) => {
+                                "a `json_pointer` extract".to_string()
+                            }
+                            clinker_format::EnvelopeExtract::RecordType(_) => {
+                                "a `record_type` extract".to_string()
+                            }
+                        };
+                        return Err(ConfigError::Validation(format!(
+                            "[E357] source '{source}': envelope section '{section_name}' declares \
+                             {declared} on a {fmt} source, but only the file-level header segment \
+                             `{file_level_tag}` is extractable as a declared section — it is the \
+                             one segment the reader resolves from its bounded header pre-scan. \
+                             Nested tiers surface as nested `$doc` levels, not declared sections, \
+                             and trailer segments are validated by the reader, not exposed as \
+                             sections. Use `extract: {{ segment: {file_level_tag} }}`, or drop the \
+                             section",
+                            source = input.name,
+                            fmt = input.format.format_name(),
+                        )));
+                    }
                 }
             }
         }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -402,6 +402,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E354" => Some(include_str!("../../../../docs/explain/E354.md")),
         "E355" => Some(include_str!("../../../../docs/explain/E355.md")),
         "E356" => Some(include_str!("../../../../docs/explain/E356.md")),
+        "E357" => Some(include_str!("../../../../docs/explain/E357.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -620,8 +621,8 @@ mod tests {
             "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E324", "E325",
             "E326", "E327", "E330", "E331", "E332", "E333", "E334", "E335", "E336", "E337", "E338",
             "E339", "E340", "E341", "E342", "E343", "E344", "E345", "E346", "E347", "E348", "E349",
-            "E350", "E351", "E352", "E353", "E354", "E355", "E356", "E15Y", "W101", "W302", "W305",
-            "W306",
+            "E350", "E351", "E352", "E353", "E354", "E355", "E356", "E357", "E15Y", "W101", "W302",
+            "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -1535,3 +1535,134 @@ nodes:
 "#;
     parse_config(yaml).expect("the empty (whole-document) json_pointer must validate");
 }
+
+#[test]
+fn test_declared_section_colliding_with_synthesized_level_unions_field_views() {
+    // A declared `envelope.sections` name may collide with a synthesized level
+    // (the engine reserves no names). When it does, the reader exposes BOTH —
+    // the declared file-level section AND the synthesized positional level — so
+    // a `$doc` field valid under EITHER view must resolve. Resolving
+    // declared-first would let the closed declared view shadow the synthesized
+    // positional access and falsely reject a legitimate `eNN` element (#560).
+    fn compile(transform_cxl: &str) -> Result<crate::plan::CompiledPlan, Vec<Diagnostic>> {
+        let mut yaml = String::from(
+            r#"
+pipeline:
+  name: x12_section_name_collision
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      path: po.x12
+      envelope:
+        sections:
+          transaction_set:
+            extract: { segment: "ISA" }
+            fields:
+              note: string
+      schema:
+        - { name: seg_id, type: string }
+  - type: transform
+    name: t0
+    input: interchange
+    config:
+      cxl: |
+"#,
+        );
+        for line in transform_cxl.lines() {
+            yaml.push_str(&format!("        {line}\n"));
+        }
+        yaml.push_str(
+            "  - type: output\n    name: out\n    input: t0\n    config:\n      name: out\n      type: csv\n      path: out.csv\n",
+        );
+        let config = parse_config(&yaml).expect("parse x12 name-collision pipeline");
+        config.compile(&CompileContext::default())
+    }
+
+    // The declared field on the collided section resolves via the declared view.
+    compile("emit seg = seg_id\nemit n = $doc.transaction_set.note")
+        .expect("a declared field on the collided section must compile");
+
+    // A positional element the synthesized `transaction_set` level serves must
+    // compile via the union — declared-first shadowing would falsely reject it.
+    compile("emit seg = seg_id\nemit e = $doc.transaction_set.e02")
+        .expect("an in-range positional element on the collided level must compile via the union");
+
+    // A field served by NEITHER view (out-of-range positional, and not a
+    // declared field) is still a typo — the union does not weaken that check.
+    let err = compile("emit seg = seg_id\nemit e = $doc.transaction_set.e99")
+        .expect_err("a field served by neither view must still fail");
+    assert!(
+        err.iter().any(|d| d.code == "E348"),
+        "expected an E348 diagnostic for the field served by neither view, got: {err:?}"
+    );
+}
+
+#[test]
+fn test_edi_declared_section_wrong_tier_segment_rejected_e357() {
+    // Only the file-level header segment is extractable as a declared envelope
+    // section — X12 `ISA`, EDIFACT `UNB`, HL7 `FHS`. A declared section with any
+    // other `segment:` tag (or a non-`segment` extract) errors at read time;
+    // reject it at plan time so it fails on `--explain` instead (#561).
+    fn source_yaml(fmt: &str, extract: &str) -> String {
+        format!(
+            r#"
+pipeline:
+  name: edi_section_tier
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: {fmt}
+      path: in.edi
+      envelope:
+        sections:
+          sec:
+            extract: {extract}
+            fields:
+              a: string
+      schema:
+        - {{ name: seg_id, type: string }}
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#,
+        )
+    }
+
+    // A wrong-tier nested segment on each EDI format is rejected, and the
+    // format's own file-level header segment is accepted.
+    for (fmt, bad, good) in [
+        ("x12", r#"{ segment: "GS" }"#, r#"{ segment: "ISA" }"#),
+        ("edifact", r#"{ segment: "UNH" }"#, r#"{ segment: "UNB" }"#),
+        ("hl7", r#"{ segment: "MSH" }"#, r#"{ segment: "FHS" }"#),
+    ] {
+        let err = parse_config(&source_yaml(fmt, bad)).expect_err(&format!(
+            "a wrong-tier {fmt} segment section must be rejected"
+        ));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("E357"),
+            "expected E357 for {fmt} {bad}, got: {msg}"
+        );
+
+        parse_config(&source_yaml(fmt, good))
+            .unwrap_or_else(|e| panic!("the file-level {fmt} segment must validate: {e}"));
+    }
+
+    // A non-`segment` extract on an EDI source is rejected too — the reader
+    // serves the file-level header only through a `segment` extract.
+    let err = parse_config(&source_yaml("x12", r#"{ json_pointer: "/Head" }"#))
+        .expect_err("a non-segment extract on an X12 source must be rejected");
+    assert!(
+        err.to_string().contains("E357"),
+        "expected E357 for a non-segment extract, got: {err}"
+    );
+}

--- a/crates/clinker-plan/tests/envelope_doc_validation.rs
+++ b/crates/clinker-plan/tests/envelope_doc_validation.rs
@@ -1,0 +1,114 @@
+//! Plan-time output-envelope section-name validation (`E346`) across
+//! composition input ports.
+//!
+//! `E346` rejects a `reconstruct_envelope` Output whose `header_from_doc` /
+//! `footer_from_doc` names a section that no FEEDING source declares. The
+//! feeding-source set is traced upstream through the node graph; a
+//! `Composition` must be resolved through EVERY bound `inputs:` port, not just
+//! its primary port, so a section declared on a source bound to a non-primary
+//! port stays reachable and is not falsely rejected.
+
+use clinker_plan::config::parse_config;
+
+/// Two sources feed a composition on distinct input ports (`primary`,
+/// `reference`); a `concat` `envelope` node consolidates the composition output
+/// so the `reconstruct_envelope` Output reaches the E346 section-name check
+/// rather than the E347 lineage-stripper guard. `header_from_doc` names the
+/// caller-supplied section. The composition body file is never resolved —
+/// `parse_config` validates the top-level graph, where the port bindings live.
+fn multi_port_pipeline(header_section: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: comp_port_envelope
+nodes:
+  - type: source
+    name: src_primary
+    config:
+      name: src_primary
+      type: json
+      glob: ./p/*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          HeadPrimary:
+            extract: {{ json_pointer: "/HeadPrimary" }}
+            fields:
+              id: string
+      schema:
+        - {{ name: amount, type: int }}
+  - type: source
+    name: src_reference
+    config:
+      name: src_reference
+      type: json
+      glob: ./r/*.json
+      options:
+        record_path: records
+      envelope:
+        sections:
+          HeadReference:
+            extract: {{ json_pointer: "/HeadReference" }}
+            fields:
+              id: string
+      schema:
+        - {{ name: amount, type: int }}
+  - type: composition
+    name: enrich
+    input: src_primary
+    use: ./enrich.comp.yaml
+    inputs:
+      primary: src_primary
+      reference: src_reference
+  - type: envelope
+    name: framed
+    body: enrich
+    config: {{ strategy: concat }}
+  - type: output
+    name: out
+    input: framed
+    config:
+      name: out
+      type: csv
+      path: out.csv
+      reconstruct_envelope: true
+      options:
+        envelope:
+          header_from_doc: {header_section}
+"#,
+    )
+}
+
+#[test]
+fn envelope_section_on_non_primary_composition_port_is_accepted() {
+    // `HeadReference` is declared on `src_reference`, bound to the composition's
+    // NON-primary `reference` port. Scoping E346 to the composition's primary
+    // port alone (`header.input` = `src_primary`) would falsely reject it;
+    // unioning every bound port keeps it reachable.
+    parse_config(&multi_port_pipeline("HeadReference"))
+        .expect("a section on a non-primary composition port must not trip E346");
+}
+
+#[test]
+fn envelope_section_on_primary_composition_port_is_accepted() {
+    // The primary-port source's section stays reachable too — the fix widens
+    // the feeding-source set, it does not shift it off the primary port.
+    parse_config(&multi_port_pipeline("HeadPrimary"))
+        .expect("a section on the primary composition port must not trip E346");
+}
+
+#[test]
+fn envelope_section_declared_on_no_feeding_port_is_rejected_e346() {
+    // A genuinely-undeclared section (declared by no source on any bound port)
+    // is still rejected — widening the feeding-source scope does not disable the
+    // check.
+    let err = parse_config(&multi_port_pipeline("HeadMissing"))
+        .expect_err("an undeclared section must still trip E346");
+    let msg = err.to_string();
+    assert!(msg.contains("E346"), "expected E346, got: {msg}");
+    assert!(
+        msg.contains("HeadMissing"),
+        "message should name the undeclared section: {msg}"
+    );
+}

--- a/docs/explain/E357.md
+++ b/docs/explain/E357.md
@@ -1,0 +1,116 @@
+# Error E357: declared envelope section on an EDI source names a non-file-level segment
+
+## What it means
+
+An X12, EDIFACT, or HL7 source declares an `envelope.sections` entry whose
+`extract` is not the format's file-level header segment. Only the file-level
+header is extractable as a declared envelope section, because it is the one
+segment the reader resolves from its bounded header pre-scan:
+
+- **X12** — `ISA` (the interchange header)
+- **EDIFACT** — `UNB` (the interchange header)
+- **HL7** — `FHS` (the file header)
+
+Every other `extract.segment:` tag — and every non-`segment` extract (`xml_path`,
+`json_pointer`, `record_type`) — is rejected. The nested tiers (X12's `GS`
+functional group and `ST` transaction set, EDIFACT's `UNH` message, HL7's `BHS`
+batch and `MSH` message) surface as nested `$doc` levels, not declared sections,
+and trailer segments (`SE`/`GE`/`IEA`, `UNT`/`UNZ`, `BTS`/`FTS`) are validated by
+the reader as they stream, not exposed as `$doc` fields.
+
+Before this check, a declared section with a wrong-tier `segment:` tag passed
+compile and then failed at read time when the reader opened the source. This
+diagnostic moves the failure to plan time so it surfaces on `clinker explain`.
+
+```
+source 'interchange': envelope section 'group' declares segment `GS` on a x12
+source, but only the file-level header segment `ISA` is extractable as a
+declared section
+```
+
+## Example
+
+```yaml
+# Rejected: a declared section extracts `GS`, a nested functional-group segment
+# that the X12 reader does not serve as a declared envelope section.
+nodes:
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      path: po.x12
+      envelope:
+        sections:
+          group:
+            extract: { segment: "GS" }
+            fields:
+              e06: string
+      schema:
+        - { name: seg_id, type: string }
+```
+
+```yaml
+# Corrected (declare the file-level header): extract `ISA`, the one segment
+# available as a declared section.
+  - type: source
+    name: interchange
+    config:
+      name: interchange
+      type: x12
+      path: po.x12
+      envelope:
+        sections:
+          interchange:
+            extract: { segment: "ISA" }
+            fields:
+              e13: string
+      schema:
+        - { name: seg_id, type: string }
+```
+
+```yaml
+# Corrected (read the nested tier positionally): the functional-group level is a
+# synthesized nested section, addressed through `$doc` without a declared entry.
+  - type: transform
+    name: tag
+    input: interchange
+    config:
+      cxl: |
+        emit seg = seg_id
+        emit gs06 = $doc.functional_group.e06
+```
+
+## How to fix
+
+1. **Declare the file-level header segment** — `extract: { segment: ISA }` for
+   X12, `UNB` for EDIFACT, `FHS` for HL7 — if you want a typed, declared `$doc`
+   section for the interchange/file header.
+
+2. **Read a nested tier through its synthesized level** instead of declaring it.
+   The functional group / transaction set / batch / message tiers are exposed as
+   nested `$doc` levels keyed by positional `eNN` / `fNN` elements (see `E348`),
+   or by a typed schema via `group_section` / `set_section` on X12.
+
+3. **Drop the section** if it was declared by mistake.
+
+## Technical context
+
+Each EDI reader's `prepare_document` iterates the declared `envelope.sections`
+and extracts each one from the header material it retained during the bounded
+pre-scan. Only the file-level header is retained — the interchange/file envelope
+is a single structure whose header the reader can resolve before body streaming
+begins — so the reader rejects any section whose `extract` names a different
+segment or a non-`segment` extract kind. The planner now mirrors that check over
+every X12 / EDIFACT / HL7 source at validation time, so the mistake fails fast on
+`clinker explain` rather than surfacing only when the reader opens the source.
+SWIFT is exempt: its reader serves declared sections under user-chosen or default
+block labels, so it has no single file-level tag to enforce.
+
+## See also
+
+- "Envelopes & Document Context" in the pipeline reference
+- Error E348 — a `$doc` path against a segment/positional format names an unknown
+  section or out-of-range element
+- Error E356 — an `envelope:` block on a plain single-schema CSV / fixed-width
+  source


### PR DESCRIPTION
## Summary

Fixes three plan-time envelope / `$doc` validation defects in `clinker-plan`. Two are false positives that reject legitimate pipelines; one is a validation gap that lets a config compile and then fail at read time.

### 1. E346 scoped to a composition's primary port only (false positive)

The output-envelope section-name check (`E346`) traces an Output's feeding sources upstream through the node graph, but resolved a `Composition` through its primary input port only (`header.input`). An output-envelope `header_from_doc` / `footer_from_doc` naming a section declared on a source bound to a **non-primary** composition port was therefore falsely rejected, even though the section is genuinely reachable at run time — and the register/extraction pass, which walks all ports, disagreed with it.

Fix: resolve a composition through **every** bound `inputs:` port, matching the all-ports attribution the register and `E348` passes already use. A genuinely undeclared section is still rejected.

### 2. Declared section name colliding with a synthesized EDI level shadowed positional access (false positive)

`$doc` validation for X12 / EDIFACT / HL7 resolved a section declared-first: a declared `envelope.sections` name that happens to collide with a synthesized level (`functional_group` / `transaction_set` / `batch`) won and closed the section, shadowing the synthesized positional level. Reading a positional element the synthesized level would serve (e.g. `$doc.transaction_set.e05`) then produced a false `E348`.

Fix: union the two field views — a field valid under the declared closed view **or** the synthesized level view resolves. The declared view no longer shadows the synthesized positional access. A field served by neither view is still rejected.

### 3. Declared EDI section with a non-file-level segment tag passed compile, errored at read time (validation gap)

For X12 / EDIFACT / HL7, only the file-level header segment is extractable as a declared envelope section: `ISA` (X12), `UNB` (EDIFACT), `FHS` (HL7). The readers reject any other `extract.segment:` tag — and any non-`segment` extract — when they open the source. Plan-time validation accepted any declared section regardless of its tag, so a section declared with `extract: { segment: GS }` on an X12 source compiled and then failed at read time.

Fix: a new `E357` rejects, at plan time, a declared envelope section on an X12 / EDIFACT / HL7 source whose extract is not the format's file-level header segment — mirroring the readers' own check, so the mistake fails on `clinker explain` instead. Adds the `E357` explain doc.

## Tests

- `crates/clinker-plan/tests/envelope_doc_validation.rs` — E346 across composition ports: a section on a non-primary port is accepted, one on the primary port is accepted, and a genuinely undeclared section is still rejected.
- `crates/clinker-plan/src/plan/tests/doc_paths.rs` — the declared/synthesized name-collision union, and the `E357` wrong-tier / non-`segment` rejection with the file-level tag accepted, across all three EDI formats.

Each test was confirmed to fail before its fix and pass after.

## Validation

`cargo fmt --all --check`, both `clippy` passes (`-D warnings`), `cargo test -p clinker-plan` (686 tests), and `cargo check --benches --workspace` all pass. The existing EDI / envelope integration suites (`x12_pipeline`, `edifact_pipeline`, `hl7_pipeline`, `swift_pipeline`, `output_envelope_seam`, `envelope_node`) remain green — no existing fixture declares a non-file-level EDI segment section, so `E357` breaks nothing.

Closes #559, #560, #561

Closes #560
Closes #561
