### PR TITLE
fix(exec): version-gate metrics spool parse and document per-source DLQ sum contract

### DIFF
--- a/crates/clinker-exec/src/executor/mod.rs
+++ b/crates/clinker-exec/src/executor/mod.rs
@@ -1532,18 +1532,10 @@ impl PipelineExecutor {
             .map(|(k, &v)| (k.as_ref().to_string(), v))
             .collect();
         let merged_key: &Arc<str> = &crate::executor::dispatch::MERGED_SOURCE_NAME;
-        let per_source_record_counts: BTreeMap<String, u64> = ctx
-            .source_count_per_source
-            .iter()
-            .filter(|(k, _)| !Arc::ptr_eq(k, merged_key))
-            .filter_map(|(k, v)| v.map(|n| (k.as_ref().to_string(), n)))
-            .collect();
-        let per_source_dlq_counts: BTreeMap<String, u64> = ctx
-            .dlq_per_source
-            .iter()
-            .filter(|(k, v)| !Arc::ptr_eq(k, merged_key) && **v > 0)
-            .map(|(k, v)| (k.as_ref().to_string(), *v))
-            .collect();
+        let per_source_record_counts =
+            project_declared_source_record_counts(&ctx.source_count_per_source, merged_key);
+        let per_source_dlq_counts =
+            project_declared_source_dlq_counts(&ctx.dlq_per_source, merged_key);
 
         let cumulative_spill_bytes = ctx.memory_budget.cumulative_spill_bytes();
         let per_stage_spill_bytes = ctx.memory_budget.per_stage_spill_bytes();
@@ -1595,6 +1587,41 @@ impl PipelineExecutor {
     }
 }
 
+/// Project the per-source finalized ingest counts into the report-facing map:
+/// drop the synthetic `<merged>` rollup slot (matched by pointer identity, so
+/// a user source literally named `<merged>` is not confused with it) and any
+/// source whose finalize slot is still `None` (never finalized), keying the
+/// survivors by declared source name. A source that finalized with zero
+/// records is kept as `Some(0)` — "stream closed empty" is distinct from
+/// "never finished".
+fn project_declared_source_record_counts(
+    source_count_per_source: &HashMap<Arc<str>, Option<u64>>,
+    merged_key: &Arc<str>,
+) -> BTreeMap<String, u64> {
+    source_count_per_source
+        .iter()
+        .filter(|(k, _)| !Arc::ptr_eq(k, merged_key))
+        .filter_map(|(k, v)| v.map(|n| (k.as_ref().to_string(), n)))
+        .collect()
+}
+
+/// Project the per-source DLQ counters into the report-facing map: drop the
+/// synthetic `<merged>` rollup slot (by pointer identity) and any source with
+/// zero entries, keying survivors by declared source name. The sum of the
+/// surfaced values is therefore `<= counters.dlq_count`; the remainder is the
+/// DLQ entries the executor attributed to `<merged>` — Combine emits and
+/// post-aggregate synthetic rows that carry no originating source stamp.
+fn project_declared_source_dlq_counts(
+    dlq_per_source: &HashMap<Arc<str>, u64>,
+    merged_key: &Arc<str>,
+) -> BTreeMap<String, u64> {
+    dlq_per_source
+        .iter()
+        .filter(|(k, v)| !Arc::ptr_eq(k, merged_key) && **v > 0)
+        .map(|(k, v)| (k.as_ref().to_string(), *v))
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     //! Executor white-box tests — submodules below each read a crate-private
@@ -1622,6 +1649,7 @@ mod tests {
     mod iejoin_pre_output_budget;
     mod multi_output;
     mod nested_composition_overshoot;
+    mod per_source_projection;
     mod resident_node_buffer_spill;
     mod scheduling;
     mod source_consumer_release;

--- a/crates/clinker-exec/src/executor/params.rs
+++ b/crates/clinker-exec/src/executor/params.rs
@@ -139,9 +139,17 @@ pub struct ExecutionReport {
     /// Per-source DLQ entry counts, keyed by Source-node name. A
     /// source with no DLQ entries is absent from the map, matching
     /// the "absent = none landed" precedent on
-    /// `per_source_rollback_cursors`. Sums across this map equal
-    /// `counters.dlq_count` minus any entries the executor failed to
-    /// attribute to a declared source.
+    /// `per_source_rollback_cursors`.
+    ///
+    /// Contract: the sum of the values is `<=` `counters.dlq_count`,
+    /// never `==` in general. The difference is the DLQ
+    /// entries the executor could not attribute to a single declared
+    /// source and stamped under the synthetic `<merged>` rollup —
+    /// Combine emits and post-aggregate synthetic rows carry no
+    /// originating source stamp, so a failure downstream of them is
+    /// counted in `dlq_count` but filtered out of this map. Equality
+    /// holds only for pipelines whose every DLQ entry traces to a
+    /// declared source (e.g. a Transform funnel over plain sources).
     pub per_source_dlq_counts: BTreeMap<String, u64>,
     /// Bytes committed to spill files across every spill site
     /// (`node_buffers` admission, grace-hash partition flush, sort-merge

--- a/crates/clinker-exec/src/executor/tests/per_source_projection.rs
+++ b/crates/clinker-exec/src/executor/tests/per_source_projection.rs
@@ -1,0 +1,87 @@
+//! Projection of the per-source count maps onto the report-facing view.
+//!
+//! `project_declared_source_dlq_counts` and
+//! `project_declared_source_record_counts` are the single point where the
+//! internal per-source counters (which include the synthetic `<merged>` rollup
+//! slot) are filtered down to the declared-source view the `ExecutionReport`
+//! surfaces. These white-box tests seed the raw maps directly so the
+//! `<merged>` filter and the zero-handling asymmetry are pinned without
+//! standing up a full pipeline — the integration counterparts in
+//! `tests/per_source_merged_dlq.rs` and `tests/per_source_record_counts.rs`
+//! prove the same contract end-to-end.
+
+use super::*;
+
+use crate::executor::dispatch::MERGED_SOURCE_NAME;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// A DLQ counter map keyed by the synthetic `<merged>` slot plus a declared
+/// source projects to the declared source alone: `<merged>` is dropped, so the
+/// surfaced sum is strictly below the aggregate that includes it.
+#[test]
+fn dlq_projection_drops_the_merged_rollup_slot() {
+    let merged_key: &Arc<str> = &MERGED_SOURCE_NAME;
+    let mut dlq_per_source: HashMap<Arc<str>, u64> = HashMap::new();
+    dlq_per_source.insert(Arc::from("src_a"), 3);
+    dlq_per_source.insert(Arc::clone(merged_key), 5);
+
+    let projected = project_declared_source_dlq_counts(&dlq_per_source, merged_key);
+
+    assert_eq!(
+        projected,
+        BTreeMap::from([("src_a".to_string(), 3)]),
+        "only the declared source surfaces; the <merged> slot is filtered out"
+    );
+    assert!(
+        !projected.contains_key("<merged>"),
+        "the synthetic rollup key never leaks into the report map"
+    );
+    let surfaced: u64 = projected.values().sum();
+    let total: u64 = dlq_per_source.values().sum();
+    assert!(
+        surfaced < total,
+        "the surfaced per-source sum ({surfaced}) is below the aggregate ({total}) \
+         once the <merged>-attributed entries are excluded"
+    );
+}
+
+/// A source with zero DLQ entries is absent from the projected DLQ map,
+/// matching the "absent = none landed" precedent.
+#[test]
+fn dlq_projection_drops_zero_count_sources() {
+    let merged_key: &Arc<str> = &MERGED_SOURCE_NAME;
+    let mut dlq_per_source: HashMap<Arc<str>, u64> = HashMap::new();
+    dlq_per_source.insert(Arc::from("src_clean"), 0);
+    dlq_per_source.insert(Arc::from("src_bad"), 2);
+
+    let projected = project_declared_source_dlq_counts(&dlq_per_source, merged_key);
+
+    assert_eq!(
+        projected,
+        BTreeMap::from([("src_bad".to_string(), 2)]),
+        "a zero-entry source is omitted from the DLQ map"
+    );
+}
+
+/// The record-count projection also drops `<merged>`, but keeps a source that
+/// finalized with zero records as `Some(0)` (distinct from "never finalized",
+/// which is `None` and omitted).
+#[test]
+fn record_projection_drops_merged_keeps_zero_and_omits_unfinalized() {
+    let merged_key: &Arc<str> = &MERGED_SOURCE_NAME;
+    let mut source_counts: HashMap<Arc<str>, Option<u64>> = HashMap::new();
+    source_counts.insert(Arc::from("src_rows"), Some(4));
+    source_counts.insert(Arc::from("src_empty"), Some(0));
+    source_counts.insert(Arc::from("src_unfinalized"), None);
+    source_counts.insert(Arc::clone(merged_key), Some(4));
+
+    let projected = project_declared_source_record_counts(&source_counts, merged_key);
+
+    assert_eq!(
+        projected,
+        BTreeMap::from([("src_rows".to_string(), 4), ("src_empty".to_string(), 0)]),
+        "the <merged> rollup and the unfinalized source are dropped; a source \
+         that finalized empty is kept as 0"
+    );
+}

--- a/crates/clinker-exec/src/metrics.rs
+++ b/crates/clinker-exec/src/metrics.rs
@@ -180,6 +180,43 @@ pub fn write_spool(metrics: &ExecutionMetrics, spool_dir: &Path) -> io::Result<(
     Ok(())
 }
 
+/// Schema version this collector accepts. Spool files stamped with any other
+/// integer `schema_version` are skipped as version-incompatible; files with no
+/// integer `schema_version` at all are treated as corrupt. Kept in sync with
+/// the version stamped by the run's metrics producer.
+const CURRENT_SCHEMA_VERSION: u32 = 3;
+
+/// Outcome of the pre-deserialize `schema_version` gate applied to a spool
+/// file's raw JSON.
+///
+/// The check runs against a `serde_json::Value` *before* the full
+/// [`ExecutionMetrics`] deserialize so a structurally-valid pre-v3 file (which
+/// lacks the v3-only per-source maps) surfaces as a version mismatch rather
+/// than the missing-field parse error a direct deserialize would raise.
+#[derive(Debug, PartialEq, Eq)]
+enum SchemaVersionGate {
+    /// `schema_version == CURRENT_SCHEMA_VERSION`; proceed to full deserialize.
+    Current,
+    /// A recognizable spool file written under a different, unsupported schema
+    /// version. Carries the observed version for the skip warning.
+    Unsupported(u64),
+    /// No integer `schema_version` field — not a recognizable spool file, so it
+    /// is routed to the corrupt/parse-error skip branch alongside malformed JSON.
+    Unrecognized,
+}
+
+/// Classify a spool file's `schema_version` from its raw JSON.
+fn classify_schema_version(raw: &serde_json::Value) -> SchemaVersionGate {
+    match raw
+        .get("schema_version")
+        .and_then(serde_json::Value::as_u64)
+    {
+        Some(v) if v == u64::from(CURRENT_SCHEMA_VERSION) => SchemaVersionGate::Current,
+        Some(v) => SchemaVersionGate::Unsupported(v),
+        None => SchemaVersionGate::Unrecognized,
+    }
+}
+
 /// One entry produced by `collect_spool` — a parsed file and its path.
 pub struct SpoolEntry {
     /// Path to the spool file (used for deletion by the caller if desired).
@@ -188,11 +225,22 @@ pub struct SpoolEntry {
     pub metrics: ExecutionMetrics,
 }
 
-/// Sweep `spool_dir` for completed `.json` files (skipping `.tmp`).
+/// Sweep `spool_dir` for completed `.json` files (skipping `.tmp`) and return
+/// the surviving [`ExecutionMetrics`] entries sorted by `execution_id`.
 ///
-/// Returns an iterator of `(path, ExecutionMetrics)` pairs. Files that fail
-/// to parse are skipped with a `tracing::warn!` — the collector never
-/// corrupts its output by writing a partially valid record.
+/// Each file is gated in two stages so a version mismatch is reported as such
+/// rather than as corruption. A file is skipped with a `tracing::warn!` when:
+///
+/// - it is not valid JSON (the raw parse fails), or has no integer
+///   `schema_version` field — reported as `failed to parse spool file`;
+/// - its `schema_version` is an integer other than
+///   [`CURRENT_SCHEMA_VERSION`] — reported as `unsupported schema_version`,
+///   the path a pre-v3 spool file (missing the per-source maps) takes; or
+/// - the version matches but the full [`ExecutionMetrics`] deserialize still
+///   fails — reported as `failed to parse spool file`.
+///
+/// Skipping never corrupts the collector's output: a file that cannot be
+/// parsed cleanly is dropped rather than partially collected.
 ///
 /// Caller is responsible for deletion after successful collection:
 /// ```rust,ignore
@@ -222,22 +270,47 @@ pub fn collect_spool(spool_dir: &Path) -> io::Result<impl Iterator<Item = SpoolE
             }
         };
 
-        let metrics: ExecutionMetrics = match serde_json::from_reader(file) {
-            Ok(m) => m,
+        // First pass: read the raw JSON so the `schema_version` guard fires
+        // before the full deserialize. A pre-v3 file is missing the v3-only
+        // per-source maps; deserializing it straight into `ExecutionMetrics`
+        // would fail with a missing-field error and mask a structurally-valid
+        // older file as corruption instead of a version mismatch.
+        let raw: serde_json::Value = match serde_json::from_reader(file) {
+            Ok(v) => v,
             Err(e) => {
                 tracing::warn!(path = %path.display(), error = %e, "metrics collect: failed to parse spool file — skipping");
                 continue;
             }
         };
 
-        if metrics.schema_version != 3 {
-            tracing::warn!(
-                path = %path.display(),
-                schema_version = metrics.schema_version,
-                "metrics collect: unsupported schema_version — skipping"
-            );
-            continue;
+        match classify_schema_version(&raw) {
+            SchemaVersionGate::Current => {}
+            SchemaVersionGate::Unsupported(version) => {
+                tracing::warn!(
+                    path = %path.display(),
+                    schema_version = version,
+                    "metrics collect: unsupported schema_version — skipping"
+                );
+                continue;
+            }
+            SchemaVersionGate::Unrecognized => {
+                tracing::warn!(
+                    path = %path.display(),
+                    reason = "missing schema_version",
+                    "metrics collect: failed to parse spool file — skipping"
+                );
+                continue;
+            }
         }
+
+        // Second pass: full deserialization, now guaranteed to be v3-shaped.
+        let metrics: ExecutionMetrics = match serde_json::from_value(raw) {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "metrics collect: failed to parse spool file — skipping");
+                continue;
+            }
+        };
 
         entries.push(SpoolEntry { path, metrics });
     }
@@ -447,5 +520,121 @@ mod tests {
         unsafe { std::env::remove_var("CLINKER_METRICS_SPOOL_DIR") };
         let result = resolve_spool_dir(None, None);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn classify_schema_version_gates_by_raw_version() {
+        let current: serde_json::Value =
+            serde_json::from_str(r#"{"schema_version": 3, "execution_id": "v3"}"#).unwrap();
+        assert_eq!(
+            classify_schema_version(&current),
+            SchemaVersionGate::Current,
+            "an exact v3 stamp proceeds to full deserialization"
+        );
+
+        let older: serde_json::Value =
+            serde_json::from_str(r#"{"schema_version": 2, "execution_id": "v2"}"#).unwrap();
+        assert_eq!(
+            classify_schema_version(&older),
+            SchemaVersionGate::Unsupported(2),
+            "a pre-v3 stamp is a version mismatch, not corruption"
+        );
+
+        let missing: serde_json::Value =
+            serde_json::from_str(r#"{"execution_id": "no-version"}"#).unwrap();
+        assert_eq!(
+            classify_schema_version(&missing),
+            SchemaVersionGate::Unrecognized,
+            "a valid JSON object with no schema_version is not a recognizable spool file"
+        );
+
+        let non_integer: serde_json::Value =
+            serde_json::from_str(r#"{"schema_version": "3"}"#).unwrap();
+        assert_eq!(
+            classify_schema_version(&non_integer),
+            SchemaVersionGate::Unrecognized,
+            "a non-integer schema_version does not satisfy the gate"
+        );
+    }
+
+    /// A synthetic pre-v3 spool file — structurally valid JSON stamped with an
+    /// older `schema_version` and lacking the v3-only per-source maps — is
+    /// skipped via the version-mismatch gate, before the deserialize step that
+    /// would otherwise raise a missing-field error and misreport it as
+    /// corruption. Genuinely-corrupt files (no `schema_version`, malformed
+    /// JSON) are also skipped, while a valid v3 file in the same directory is
+    /// still collected.
+    #[test]
+    fn collect_spool_skips_incompatible_files_and_keeps_v3() {
+        let dir = TempDir::new().unwrap();
+
+        // A pre-v3 file: the v2 shape omits `per_source_record_counts` /
+        // `per_source_dlq_counts`, so a direct `ExecutionMetrics` deserialize
+        // would fail on the missing fields.
+        fs::write(
+            dir.path().join("019571b2-0000-7000-0000-0000000000a2.json"),
+            br#"{"schema_version": 2, "execution_id": "019571b2-0000-7000-0000-0000000000a2", "records_ok": 5, "records_written": 5}"#,
+        )
+        .unwrap();
+
+        // A file with no `schema_version` at all — corrupt from the
+        // collector's view, routed to the parse-error branch.
+        fs::write(
+            dir.path().join("019571b2-0000-7000-0000-0000000000a3.json"),
+            br#"{"execution_id": "019571b2-0000-7000-0000-0000000000a3"}"#,
+        )
+        .unwrap();
+
+        // Malformed JSON — the raw parse itself fails.
+        fs::write(
+            dir.path().join("019571b2-0000-7000-0000-0000000000a4.json"),
+            b"{ this is not valid json",
+        )
+        .unwrap();
+
+        // A valid v3 file written by the real producer path.
+        let good_id = "019571b2-0000-7000-0000-0000000000a5";
+        write_spool(&sample_metrics(good_id), dir.path()).unwrap();
+
+        let entries: Vec<SpoolEntry> = collect_spool(dir.path()).unwrap().collect();
+        assert_eq!(
+            entries.len(),
+            1,
+            "only the v3 file survives; the pre-v3, missing-version, and \
+             malformed files are all skipped"
+        );
+        assert_eq!(
+            entries[0].metrics.execution_id, good_id,
+            "the surviving entry is the v3 file"
+        );
+        assert_eq!(entries[0].metrics.schema_version, CURRENT_SCHEMA_VERSION);
+    }
+
+    /// Populated per-source maps survive the write→read round-trip. The
+    /// `sample_metrics` helper seeds empty maps, so this test asserts the
+    /// non-empty case the spool actually carries in production.
+    #[test]
+    fn collect_spool_preserves_populated_per_source_maps() {
+        let dir = TempDir::new().unwrap();
+        let id = "019571b2-0000-7000-0000-0000000000b1";
+        let mut metrics = sample_metrics(id);
+        metrics.per_source_record_counts =
+            BTreeMap::from([("src_a".to_string(), 7), ("src_b".to_string(), 3)]);
+        metrics.per_source_dlq_counts = BTreeMap::from([("src_b".to_string(), 2)]);
+
+        write_spool(&metrics, dir.path()).unwrap();
+        let entries: Vec<SpoolEntry> = collect_spool(dir.path()).unwrap().collect();
+        assert_eq!(entries.len(), 1);
+        let round_tripped = &entries[0].metrics;
+        assert_eq!(
+            round_tripped.per_source_record_counts,
+            BTreeMap::from([("src_a".to_string(), 7), ("src_b".to_string(), 3)]),
+            "record-count map survives write→read with every entry intact"
+        );
+        assert_eq!(
+            round_tripped.per_source_dlq_counts,
+            BTreeMap::from([("src_b".to_string(), 2)]),
+            "dlq-count map survives write→read"
+        );
     }
 }

--- a/crates/clinker-exec/tests/per_source_dlq_counts.rs
+++ b/crates/clinker-exec/tests/per_source_dlq_counts.rs
@@ -123,9 +123,36 @@ nodes:
         "only the offending source surfaces; no synthetic '<merged>' key"
     );
 
+    // Per-source ingest counts are independent of DLQ outcome: every source's
+    // records still count at ingest even when all of them later DLQ. src_bad's
+    // two rows both DLQ but remain in the record-count map.
+    assert_eq!(
+        report.per_source_record_counts.get("src_good"),
+        Some(&3),
+        "src_good's three clean rows count at ingest"
+    );
+    assert_eq!(
+        report.per_source_record_counts.get("src_bad"),
+        Some(&2),
+        "src_bad's DLQ'd rows still count at ingest — record count is \
+         independent of DLQ outcome"
+    );
+
+    // The sum-<=-aggregate contract: for this Transform-funnel pipeline every
+    // DLQ entry traces to a declared source, so the surfaced sum reaches the
+    // aggregate. The invariant is `<=`, not `==`, because pipelines with
+    // Combine / post-aggregate synthetic emits attribute some entries to the
+    // filtered-out `<merged>` slot (see per_source_merged_dlq.rs).
     let attributed: u64 = report.per_source_dlq_counts.values().sum();
+    assert!(
+        attributed <= report.counters.dlq_count,
+        "per-source DLQ counts never exceed the aggregate dlq_count \
+         (attributed={attributed}, dlq_count={})",
+        report.counters.dlq_count
+    );
     assert_eq!(
         attributed, report.counters.dlq_count,
-        "per-source DLQ counts sum to the aggregate dlq_count"
+        "every DLQ entry in this plain-source funnel traces to a declared \
+         source, so the surfaced sum reaches the aggregate"
     );
 }

--- a/crates/clinker-exec/tests/per_source_merged_dlq.rs
+++ b/crates/clinker-exec/tests/per_source_merged_dlq.rs
@@ -1,0 +1,172 @@
+//! Regression coverage for the `per_source_dlq_counts` sum-<=-aggregate
+//! contract when the executor attributes DLQ entries to the synthetic
+//! `<merged>` rollup.
+//!
+//! Post-aggregate synthetic rows carry `source_row: 0` and no engine
+//! `SourceName` stamp, so a failure downstream of an Aggregate is attributed
+//! to `<merged>` at the DLQ funnel. That slot is filtered out of the
+//! report-facing `per_source_dlq_counts`, so its sum is strictly below
+//! `counters.dlq_count` — the inequality the report doc promises and the
+//! strict `assert_eq!` in `per_source_dlq_counts.rs` cannot express.
+
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::path::PathBuf;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineExecutor, PipelineRunParams, SourceReaders};
+use clinker_exec::source::multi_file::FileSlot;
+use clinker_plan::config::{CompileContext, parse_config};
+
+fn slot(name: &str, csv: &str) -> FileSlot {
+    FileSlot::new(
+        PathBuf::from(format!("{name}.csv")),
+        Box::new(Cursor::new(csv.as_bytes().to_vec())),
+    )
+}
+
+fn writer(buf: &SharedBuffer) -> Box<dyn std::io::Write + Send> {
+    Box::new(buf.clone())
+}
+
+fn run_params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "test".to_string(),
+        batch_id: "batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// A single source feeds a pre-aggregate Transform (which DLQs one row under
+/// the real source), an Aggregate, then a post-aggregate Transform that
+/// divides by zero on every group's synthetic output row (each DLQ'd under
+/// `<merged>`). The declared source's DLQ count still surfaces and is correct,
+/// but the `<merged>`-attributed group failures are excluded — so the surfaced
+/// sum is strictly below the aggregate `dlq_count`.
+#[test]
+fn merged_attributed_dlq_keeps_per_source_sum_below_aggregate() {
+    let yaml = r#"
+pipeline:
+  name: per_source_merged_dlq
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: category, type: string }
+        - { name: amount, type: int }
+  - type: transform
+    name: pre
+    input: src_a
+    config:
+      cxl: |
+        emit category = category
+        emit amount = if(amount < 0) then (1 / 0) else amount
+  - type: aggregate
+    name: agg
+    input: pre
+    config:
+      group_by:
+        - category
+      cxl: |
+        emit category = category
+        emit total = sum(amount)
+  - type: transform
+    name: post
+    input: agg
+    config:
+      cxl: |
+        emit category = category
+        emit ratio = total / (total - total)
+  - type: output
+    name: out
+    input: post
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    // Rows: category x (10, 5) and y (20) aggregate into two clean groups whose
+    // post-aggregate `total / (total - total)` divides by zero → two `<merged>`
+    // DLQ entries. The z row is negative, so the pre-aggregate Transform DLQs it
+    // under the real source src_a and it never reaches the aggregate.
+    let readers: SourceReaders = HashMap::from([(
+        "src_a".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![slot(
+            "a",
+            "category,amount\nx,10\nx,5\ny,20\nz,-1\n",
+        )]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    // Three DLQ entries total: one real-source (the z row at the pre-aggregate
+    // Transform) plus one per clean group (x, y) at the post-aggregate divide.
+    assert_eq!(
+        report.counters.dlq_count, 3,
+        "one pre-aggregate real-source failure plus two post-aggregate group \
+         failures"
+    );
+
+    // The synthetic rollup key never leaks into the surfaced map.
+    assert!(
+        !report.per_source_dlq_counts.contains_key("<merged>"),
+        "the '<merged>' rollup slot is filtered out of the per-source map: {:?}",
+        report.per_source_dlq_counts
+    );
+
+    // The one declared-source failure still surfaces, attributed correctly.
+    assert_eq!(
+        report.per_source_dlq_counts.get("src_a"),
+        Some(&1),
+        "the pre-aggregate failure is attributed to its real source src_a"
+    );
+    assert_eq!(
+        report.per_source_dlq_counts.len(),
+        1,
+        "only the declared source surfaces; the two '<merged>' group failures \
+         are excluded"
+    );
+
+    // The contract: the surfaced sum is strictly below the aggregate because
+    // the two post-aggregate failures are attributed to '<merged>'.
+    let attributed: u64 = report.per_source_dlq_counts.values().sum();
+    assert!(
+        attributed < report.counters.dlq_count,
+        "the surfaced per-source sum ({attributed}) is strictly below the \
+         aggregate dlq_count ({}) — the '<merged>'-attributed entries are \
+         excluded",
+        report.counters.dlq_count
+    );
+    assert_eq!(
+        attributed, 1,
+        "only the single declared-source failure is attributed in the map"
+    );
+
+    // Cross-check against the raw DLQ entries: exactly two entries carry the
+    // synthetic '<merged>' source name, confirming the gap is the merged
+    // rollup and not a dropped entry.
+    let merged_entries = report
+        .dlq_entries
+        .iter()
+        .filter(|e| e.source_name.as_ref() == "<merged>")
+        .count();
+    assert_eq!(
+        merged_entries, 2,
+        "the two post-aggregate group failures are stamped '<merged>'"
+    );
+}

--- a/crates/clinker-exec/tests/per_source_record_counts.rs
+++ b/crates/clinker-exec/tests/per_source_record_counts.rs
@@ -199,3 +199,173 @@ nodes:
         "per-source counts under fused Merge.interleave sum to the aggregate total"
     );
 }
+
+/// Single-source `Source -> Output` with no Merge: the plain Source dispatch
+/// arm finalizes the sole source's count. A regression in the `<merged>`
+/// filter that mis-applied to a single-source pipeline would drop the source
+/// from the surfaced map; a lone declared source must still surface with its
+/// exact row count and no synthetic key alongside it.
+#[test]
+fn single_source_per_source_count_surfaces() {
+    let yaml = r#"
+pipeline:
+  name: per_source_counts_single
+nodes:
+  - type: source
+    name: only
+    config:
+      name: only
+      type: csv
+      path: only.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: only
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let readers: SourceReaders = HashMap::from([(
+        "only".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![slot("only", "id\n1\n2\n3\n")]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    assert_eq!(
+        report.per_source_record_counts.get("only"),
+        Some(&3),
+        "the sole source's ingest count surfaces"
+    );
+    assert_eq!(
+        report.per_source_record_counts.len(),
+        1,
+        "no synthetic '<merged>' key leaks in the single-source case"
+    );
+    let sum: u64 = report.per_source_record_counts.values().sum();
+    assert_eq!(sum, report.counters.total_count);
+}
+
+/// A declared source whose input is empty (header only, zero data rows)
+/// finalizes with a count of zero. The record-count map keeps that `Some(0)`
+/// entry — "stream closed with zero records" is a distinct, reported state —
+/// while the DLQ map (which drops zero-entry sources) omits it.
+#[test]
+fn zero_row_source_surfaces_zero_in_record_map() {
+    let yaml = r#"
+pipeline:
+  name: per_source_counts_zero_row
+nodes:
+  - type: source
+    name: empty_src
+    config:
+      name: empty_src
+      type: csv
+      path: empty.csv
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: empty_src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let readers: SourceReaders = HashMap::from([(
+        "empty_src".to_string(),
+        // Header only, no data rows.
+        clinker_exec::executor::SourceInput::Files(vec![slot("empty", "id\n")]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    assert_eq!(
+        report.per_source_record_counts.get("empty_src"),
+        Some(&0),
+        "an empty source finalizes and surfaces Some(0) — the record map does \
+         not drop zero counts"
+    );
+    assert_eq!(report.counters.total_count, 0);
+    assert!(
+        !report.per_source_dlq_counts.contains_key("empty_src"),
+        "the DLQ map drops zero-entry sources, so an empty source is absent \
+         there"
+    );
+}
+
+/// `Source -> Transform -> Output` (single source): the executor pre-pass fuses
+/// the Transform directly onto the Source, draining the ingest receiver inside
+/// the Transform arm, which finalizes the source's count from that arm rather
+/// than the plain Source arm. The count must still land on the surfaced map.
+#[test]
+fn fused_transform_per_source_counts_finalize() {
+    let yaml = r#"
+pipeline:
+  name: per_source_counts_fused_transform
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: csv
+      path: events.csv
+      schema:
+        - { name: id, type: int }
+  - type: transform
+    name: shape
+    input: events
+    config:
+      cxl: |
+        emit id = id
+  - type: output
+    name: out
+    input: shape
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).unwrap();
+    let readers: SourceReaders = HashMap::from([(
+        "events".to_string(),
+        clinker_exec::executor::SourceInput::Files(vec![slot("events", "id\n1\n2\n3\n4\n5\n")]),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> =
+        HashMap::from([("out".to_string(), writer(&buf))]);
+
+    let plan = config.compile(&CompileContext::default()).unwrap();
+    let report =
+        PipelineExecutor::run_plan_with_readers_writers(&plan, readers, writers, &run_params())
+            .unwrap();
+
+    assert_eq!(
+        report.per_source_record_counts.get("events"),
+        Some(&5),
+        "the fused Source->Transform arm finalized the source's ingest count"
+    );
+    assert_eq!(
+        report.per_source_record_counts.len(),
+        1,
+        "no synthetic '<merged>' key leaks through the fused-Transform path"
+    );
+    let sum: u64 = report.per_source_record_counts.values().sum();
+    assert_eq!(sum, report.counters.total_count);
+}

--- a/crates/clinker/tests/metrics_spool_cli.rs
+++ b/crates/clinker/tests/metrics_spool_cli.rs
@@ -1,0 +1,144 @@
+//! End-to-end coverage that `clinker run --metrics-spool-dir <dir>` writes a
+//! v3 spool file whose per-source maps are actually populated.
+//!
+//! Every other per-source test drives `PipelineExecutor` in-process and never
+//! exercises the CLI's spool-write path, so nothing proves the v3 JSON on disk
+//! carries the `per_source_record_counts` / `per_source_dlq_counts` breakdowns.
+//! This test shells out to the compiled binary, runs a multi-source pipeline
+//! that also DLQs one row, and parses the produced JSON back through the typed
+//! `ExecutionMetrics` shape.
+
+use std::process::Command;
+
+use clinker_exec::metrics::ExecutionMetrics;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+/// Multi-source merge with a Transform that dead-letters any row whose
+/// `amount` is zero. `src_a` carries one such row (attributed to src_a at the
+/// DLQ funnel); `src_b` is clean. Both sources therefore surface in the
+/// record-count map, and `src_a` surfaces in the DLQ map.
+const PIPELINE: &str = r#"pipeline:
+  name: metrics_spool_cli
+error_handling:
+  strategy: continue
+nodes:
+  - type: source
+    name: src_a
+    config:
+      name: src_a
+      type: csv
+      path: a.csv
+      schema:
+        - { name: id, type: int }
+        - { name: amount, type: int }
+  - type: source
+    name: src_b
+    config:
+      name: src_b
+      type: csv
+      path: b.csv
+      schema:
+        - { name: id, type: int }
+        - { name: amount, type: int }
+  - type: merge
+    name: m
+    inputs: [src_a, src_b]
+  - type: transform
+    name: tfm
+    input: m
+    config:
+      cxl: |
+        emit id = id
+        emit v = if(amount == 0) then (1 / 0) else amount
+  - type: output
+    name: out
+    input: tfm
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+
+#[test]
+fn run_populates_per_source_maps_in_v3_spool_file() {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let root = tmp.path();
+
+    std::fs::write(root.join("pipeline.yaml"), PIPELINE).expect("write pipeline");
+    // src_a: three rows, the middle one (amount=0) dead-letters.
+    std::fs::write(root.join("a.csv"), "id,amount\n1,10\n2,0\n3,30\n").expect("write a.csv");
+    // src_b: two clean rows.
+    std::fs::write(root.join("b.csv"), "id,amount\n10,5\n20,7\n").expect("write b.csv");
+    // write_spool requires the target directory to exist.
+    std::fs::create_dir(root.join("spool")).expect("create spool dir");
+
+    let output = Command::new(clinker_bin())
+        .arg("run")
+        .arg("pipeline.yaml")
+        .arg("--metrics-spool-dir")
+        .arg("spool")
+        .current_dir(root)
+        .output()
+        .expect("spawn clinker");
+
+    // A DLQ'd row makes this a partial-success run (exit code 2); the spool is
+    // still written. Assert the run at least reached completion rather than
+    // erroring out before the spool write.
+    let code = output.status.code();
+    assert!(
+        matches!(code, Some(0) | Some(2)),
+        "run should complete (clean or partial), got {code:?}; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Exactly one spool file, named <execution_id>.json.
+    let spool_files: Vec<_> = std::fs::read_dir(root.join("spool"))
+        .expect("read spool dir")
+        .map(|e| e.expect("dir entry").path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("json"))
+        .collect();
+    assert_eq!(
+        spool_files.len(),
+        1,
+        "exactly one v3 spool file is written; found {spool_files:?}"
+    );
+
+    let json = std::fs::read_to_string(&spool_files[0]).expect("read spool file");
+    let metrics: ExecutionMetrics =
+        serde_json::from_str(&json).expect("spool file deserializes as v3 ExecutionMetrics");
+
+    assert_eq!(metrics.schema_version, 3, "spool file is stamped v3");
+
+    // Both declared sources surface in the ingest-count map with their row
+    // totals (the DLQ'd row still counts at ingest).
+    assert_eq!(
+        metrics.per_source_record_counts.get("src_a"),
+        Some(&3),
+        "src_a's three ingested rows surface in the spooled record-count map: {:?}",
+        metrics.per_source_record_counts
+    );
+    assert_eq!(
+        metrics.per_source_record_counts.get("src_b"),
+        Some(&2),
+        "src_b's two rows surface in the spooled record-count map"
+    );
+
+    // The DLQ map is populated with the attributed source.
+    assert_eq!(
+        metrics.per_source_dlq_counts.get("src_a"),
+        Some(&1),
+        "src_a's dead-lettered row surfaces in the spooled DLQ map: {:?}",
+        metrics.per_source_dlq_counts
+    );
+    assert!(
+        !metrics.per_source_dlq_counts.contains_key("src_b"),
+        "src_b has no DLQ entries and is absent from the spooled DLQ map"
+    );
+    assert_eq!(
+        metrics.records_dlq, 1,
+        "the aggregate DLQ count matches the single dead-lettered row"
+    );
+}

--- a/docs/user/src/ops/metrics.md
+++ b/docs/user/src/ops/metrics.md
@@ -93,8 +93,14 @@ schema bump means draining the spool first.
 | `dlq_path` | string/null | Path to the DLQ file, or null if none |
 | `error` | string/null | Error message on exit 1/3/4, or null on success (exit 0) and partial success (exit 2) |
 | `retraction` | object | Correlation-key retraction counters (see below). All-zero on strict pipelines, which never enter the relaxed loop |
-| `per_source_record_counts` | object | Ingest record count per Source node, keyed by node name |
-| `per_source_dlq_counts` | object | DLQ entry count per Source node; sources with zero DLQ entries are absent |
+| `per_source_record_counts` | object | Ingest record count per Source node, keyed by node name. A source that read zero records is present with a count of `0` |
+| `per_source_dlq_counts` | object | DLQ entry count per Source node; sources with zero DLQ entries are absent. The values sum to **at most** `records_dlq` — see the note below |
+
+The sum of `per_source_dlq_counts` values is at most `records_dlq`, and can
+be less: a failure in a Combine emit or a post-aggregate row is not traceable
+to a single declared source, so it is counted in `records_dlq` but not in this
+per-source breakdown. For pipelines whose dead-letters all originate at a
+declared source, the two match exactly.
 
 The `retraction` object carries the relaxed correlation-key retraction
 orchestrator's counters: `groups_recomputed`, `partitions_dispatched`,


### PR DESCRIPTION
## Summary

Three related fixes and test-coverage additions around execution metrics: the
spool-file version gate, the per-source DLQ sum contract, and per-source
coverage gaps.

## Spool parse: report a version mismatch, not corruption

The v3 metrics schema added `per_source_record_counts` / `per_source_dlq_counts`
as mandatory fields (no `#[serde(default)]`). As a result, `collect_spool`
deserialized a structurally-valid pre-v3 spool file straight into
`ExecutionMetrics`, hit a missing-field error, and logged it as a corrupt file —
before the `schema_version` guard the code relies on could run. Post-upgrade log
analysis then showed old-format files as corruption rather than an expected
version mismatch.

`collect_spool` now reads the raw JSON first and classifies `schema_version`
before the full deserialize:

- an integer `schema_version` other than the current one (e.g. a pre-v3 file) is
  reported as `unsupported schema_version`;
- malformed JSON, or valid JSON with no integer `schema_version`, is reported as
  a parse error;
- a matching version proceeds to the full deserialize.

The `collect_spool` doc comment now describes this gate precisely.

## Per-source DLQ sum contract

`ExecutionReport.per_source_dlq_counts` filters out the synthetic rollup slot the
executor uses for DLQ entries it cannot attribute to a single declared source
(Combine emits and post-aggregate synthetic rows carry no originating source
stamp). For such pipelines the sum of the per-source values is strictly below
`counters.dlq_count`.

- The field doc now states the sum-`<=`-`dlq_count` contract explicitly.
- A new regression test drives a pipeline that produces both a declared-source
  DLQ and merged-attributed DLQ entries, and asserts the strict inequality plus
  the filtered map.
- The existing per-source DLQ test's sum assertion is widened to the `<=`
  invariant (its exact-equality case still holds for that plain-source pipeline).
- The report-construction filters are extracted into two small, unit-tested
  helpers.

## Per-source coverage

Adds coverage for previously-untested branches:

- single-source and zero-row per-source record counts;
- the fused Source→Transform finalize path;
- a merged-attribution projection unit test;
- a non-empty per-source map write→read round-trip;
- a CLI end-to-end test that runs `clinker run --metrics-spool-dir <dir>` and
  verifies the spooled v3 JSON carries populated per-source maps.

User-facing metrics docs note the record-count zero behavior and the DLQ sum
bound.

## Testing

- `cargo fmt --all --check`
- `cargo clippy --workspace --locked -- -D warnings` (with and without
  `--all-targets`)
- `cargo test -p clinker-exec` (new and existing per-source, metrics, and
  projection tests)
- `cargo test -p clinker --test metrics_spool_cli`
- `cargo check --benches --workspace`

Closes #83, #84, #85


Closes #84
Closes #85
