### PR TITLE
fix(examples): repair two stale example pipelines and add an --explain CI smoke check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,29 @@ jobs:
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo test --workspace
 
+      # Example pipelines double as runnable documentation and a smoke-test
+      # surface, so every top-level pipeline under examples/pipelines/ must at
+      # least compile through the plan-only `--explain` path. This catches
+      # config-schema and CXL-grammar drift at the boundary instead of leaving a
+      # reader to trip over a stale example. `cargo test` above already exercises
+      # the same gate via crates/clinker/tests/examples_explain.rs; this step is
+      # the fast, explicit signal and keeps the smoke command discoverable.
+      - name: Smoke-check example pipelines (--explain)
+        run: |
+          cargo build --locked -p clinker
+          bin="$PWD/target/debug/clinker"
+          cd examples/pipelines
+          rc=0
+          for f in *.yaml; do
+            if "$bin" run "$f" --explain >/dev/null; then
+              echo "ok: $f"
+            else
+              echo "FAIL: $f did not pass --explain"
+              rc=1
+            fi
+          done
+          exit $rc
+
       # Bench infrastructure CI gate (compile + smoke)
       - run: cargo check --benches --workspace
       - run: cargo check --features bench-alloc -p clinker-benchmarks

--- a/crates/clinker/tests/examples_explain.rs
+++ b/crates/clinker/tests/examples_explain.rs
@@ -1,0 +1,96 @@
+//! Every runnable example pipeline under `examples/pipelines/` must compile
+//! through the plan-only `--explain` path.
+//!
+//! The examples double as runnable documentation and as a smoke-test surface.
+//! A stale example silently rots — it keeps sitting in the tree until a reader
+//! tries to run it and hits a config-schema or CXL-grammar drift the engine has
+//! since moved past. This guard shells out to the compiled CLI (the surface an
+//! operator actually invokes) and fails the moment any example stops parsing or
+//! type-checking. `--explain` is plan-only: it resolves, compiles, and plans the
+//! pipeline without ingesting records, so the check stays fast and needs no
+//! fixture data beyond what the examples already carry.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn clinker_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_clinker")
+}
+
+/// Workspace-root `examples/pipelines` directory, resolved from this crate's
+/// manifest dir (`crates/clinker`). Canonicalized so the spawned CLI gets an
+/// unambiguous working directory regardless of where the test runner sits.
+fn examples_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../examples/pipelines")
+        .canonicalize()
+        .expect("examples/pipelines directory must exist")
+}
+
+/// Top-level `*.yaml` files under `examples/pipelines`, sorted for a
+/// deterministic report order.
+///
+/// The check covers only the directory's direct entries. Subdirectories hold
+/// composition fragments (`*.comp.yaml`), per-source schema files
+/// (`*.schema.yaml`), and fixture CSVs — none of which are standalone
+/// pipelines, so `clinker run` on them would fail by design.
+fn example_pipelines() -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = std::fs::read_dir(examples_dir())
+        .expect("read examples/pipelines")
+        .map(|entry| entry.expect("read dir entry").path())
+        .filter(|path| path.is_file() && path.extension().is_some_and(|ext| ext == "yaml"))
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn every_example_pipeline_passes_explain() {
+    let dir = examples_dir();
+    let pipelines = example_pipelines();
+    assert!(
+        !pipelines.is_empty(),
+        "expected at least one example pipeline under {}",
+        dir.display()
+    );
+
+    // The examples reference their inputs and outputs with paths relative to
+    // this directory (e.g. `./data/invoices.csv`), so run each from here — the
+    // same working directory a reader following the docs would use.
+    let mut failures = Vec::new();
+    for path in &pipelines {
+        let name = path
+            .file_name()
+            .expect("example path has a file name")
+            .to_string_lossy()
+            .into_owned();
+
+        let output = Command::new(clinker_bin())
+            .arg("run")
+            .arg(&name)
+            .arg("--explain")
+            .current_dir(&dir)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to spawn clinker for {name}: {e}"));
+
+        if !output.status.success() {
+            failures.push(format!(
+                "{name} (exit {}):\n{}",
+                output
+                    .status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string()),
+                String::from_utf8_lossy(&output.stderr).trim_end(),
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} example pipeline(s) failed `run --explain`:\n\n{}",
+        failures.len(),
+        pipelines.len(),
+        failures.join("\n\n---\n\n"),
+    );
+}

--- a/examples/pipelines/invoices.yaml
+++ b/examples/pipelines/invoices.yaml
@@ -14,7 +14,7 @@ nodes:
         - { name: invoice_id, type: string }
         - { name: invoice_date, type: string }
         - { name: customer_id, type: string }
-        - { name: amount, type: string }
+        - { name: amount, type: float }
 
   - type: source
     name: customers
@@ -35,18 +35,18 @@ nodes:
     input: invoices
     config:
       cxl: |
-        emit _include = days_since(invoice_date) < 90
+        emit _include = now.diff_days(invoice_date.to_date()) < 90
 
-  # TODO(16c compositions): fiscal_date composition import was stripped during 16b fixture migration.
-
-  - type: transform
+  - type: aggregate
     name: totals
     description: Sum by customer
     input: recent_only
     config:
+      group_by: [customer_id]
       cxl: |
+        emit customer_id = customer_id
         emit total_amount = sum(amount)
-        emit invoice_count = count(invoice_id)
+        emit invoice_count = count(*)
 
   - type: output
     name: rollup

--- a/examples/pipelines/multi_file_orders.yaml
+++ b/examples/pipelines/multi_file_orders.yaml
@@ -1,12 +1,12 @@
 pipeline:
   name: multi_file_orders
-  description: |
-    Demo of flexible-file-matching: glob, modified_after, sort_by + take_first.
-    `glob: ./data/orders_*.csv` matches every shard at runtime; the executor's
-    MultiFileFormatReader concatenates them into one record stream and stamps
-    `$source.file` per record. Downstream `group_by` operates per-file by
-    default thanks to plan-time `FilePartitioned` lineage; insert a `merge:`
-    node before the aggregate to roll up across files.
+
+# Demo of flexible-file-matching: glob, modified_after, sort_by + take_first.
+# `glob: ./data/orders_*.csv` matches every shard at runtime; the executor's
+# MultiFileFormatReader concatenates them into one record stream and stamps
+# `$source.file` per record. Downstream `group_by` operates per-file by
+# default thanks to plan-time `FilePartitioned` lineage; insert a `merge:`
+# node before the aggregate to roll up across files.
 nodes:
   - type: source
     name: orders


### PR DESCRIPTION
## Problem

Two pipelines under `examples/pipelines/` no longer parsed or compiled against the current engine, so `clinker run <file> --explain` failed on each. Because the examples double as runnable documentation and as a smoke-test surface, the breakage sat unnoticed until someone tried to run them.

### `multi_file_orders.yaml`
Declared a top-level `pipeline.description`, a key the pipeline config schema no longer accepts:

```
YAML parse error: unknown field `description`, expected one of name, memory, ...
```

Fix: move the prose into YAML comments (no schema change needed).

### `invoices.yaml`
Three independent drifts each blocked `--explain`; only the first surfaces until it is fixed, then the next appears:

1. `days_since(invoice_date)` referenced a CXL builtin that no longer exists — `unresolved identifier 'days_since'`. Replaced with the documented `now.diff_days(...)` idiom, parsing the string `invoice_date` with `.to_date()`.
2. `amount` was typed `string` but fed `sum(amount)`, which requires a numeric argument. Typed it `float`, matching the sibling examples (`multi_file_orders`, `audit_join`).
3. The per-customer rollup ran `sum`/`count` inside a row-level `transform`, which the engine rejects (`aggregate function 'sum' is not allowed in a row-level transform`). Converted it to an `aggregate` node grouped by `customer_id`, counting rows with `count(*)`.

Also dropped a stale internal TODO comment from `invoices.yaml`.

## Regression guard

So this rot is caught at the boundary next time rather than by a confused reader:

- **`crates/clinker/tests/examples_explain.rs`** — shells out to the compiled CLI and asserts every top-level `examples/pipelines/*.yaml` passes plan-only `--explain`. Runs as part of `cargo test --workspace` on all CI targets. Fails before this change (two examples broken), passes after.
- **CI step in the `check` job** — an explicit, fast smoke check running the same `--explain` sweep over the examples, keeping the command discoverable.

Both derive the file list dynamically, so new examples are covered automatically. The check targets the directory's direct `*.yaml` entries; subdirectories hold composition fragments (`*.comp.yaml`), source schema files (`*.schema.yaml`), and fixture data, none of which are standalone pipelines.

## Validation

- All 11 top-level example pipelines pass `clinker run <file> --explain`.
- `cargo fmt --all --check`, both `cargo clippy --workspace [--all-targets] -- -D warnings` passes, and `cargo test -p clinker` are green locally.

## Follow-up (out of scope)

`now.diff_days(<date>)` — the documented "age in days" idiom — type-checks but evaluates to `null` because the runtime `diff_days` only accepts a `Date` receiver, while `now` is a `DateTime`. That is a pre-existing engine/doc inconsistency affecting the documented example too; worth a separate issue to let `diff_days` accept a `DateTime` receiver.

Closes #397