### PR TITLE
fix(format): EDIFACT UNH round-trip fidelity, chunked UNA detection, SWIFT block-id interning

### DIFF
--- a/crates/clinker-format/src/edifact/reader.rs
+++ b/crates/clinker-format/src/edifact/reader.rs
@@ -979,6 +979,80 @@ mod tests {
         assert_eq!(recs2[1].get("e01"), Some(&Value::String("O'BRIEN".into())));
     }
 
+    /// Full reader → `$doc` → writer → reader round-trip of a UNH that carries
+    /// a data element past the message type (a common access reference in the
+    /// third element). The writer must reconstruct the full UNH rather than
+    /// collapsing it to a two-element header, so the extra element survives.
+    #[test]
+    fn reader_writer_round_trip_preserves_unh_element_past_message_type() {
+        use crate::edifact::writer::{EdifactWriter, EdifactWriterConfig};
+        use crate::envelope::EnvelopeFieldType;
+        use crate::traits::FormatWriter;
+        use clinker_record::{DocumentContext, DocumentId, EnvelopeRecord};
+
+        // The UNH carries a third element "CAR-ACCESS-REF" after the message
+        // reference and the message-type composite; UNT counts UNH+BGM+UNT=3.
+        let input = "UNB+UNOA:1+SENDER+RECEIVER+240101:1200+REF1'\
+            UNH+M1+ORDERS:D:96A:UN+CAR-ACCESS-REF'BGM+220'UNT+3+M1'UNZ+1+REF1'";
+
+        // 1. Read: the UNH body record exposes the extra element in e03.
+        let cfg = unb_section(&[("e05", EnvelopeFieldType::String)]);
+        let mut r = reader(input);
+        let sections = r.prepare_document(&cfg).unwrap();
+        let body_recs: Vec<Record> = std::iter::from_fn(|| r.next_record().unwrap()).collect();
+        assert_eq!(body_recs.len(), 2); // UNH, BGM
+        assert_eq!(
+            body_recs[0].get("seg_id"),
+            Some(&Value::String("UNH".into()))
+        );
+        assert_eq!(
+            body_recs[0].get("e03"),
+            Some(&Value::String("CAR-ACCESS-REF".into())),
+            "reader dropped the UNH element past the message type"
+        );
+
+        // 2. Re-emit through the writer.
+        let ctx = Arc::new(DocumentContext::new(
+            DocumentId::next(),
+            Arc::from("orders.edi"),
+            EnvelopeRecord::from_sections(sections),
+        ));
+        let schema = r.schema().unwrap();
+        let out = {
+            let mut buf = Vec::new();
+            let mut w = EdifactWriter::new(
+                std::io::Cursor::new(&mut buf),
+                Arc::clone(&schema),
+                EdifactWriterConfig {
+                    interchange_from_doc: Some("interchange".into()),
+                    segment_newline: false,
+                    ..Default::default()
+                },
+            );
+            for rec in &body_recs {
+                let mut rec = rec.clone();
+                rec.set_doc_ctx(Arc::clone(&ctx));
+                w.write_record(&rec).unwrap();
+            }
+            w.flush().unwrap();
+            String::from_utf8(buf).unwrap()
+        };
+
+        // The reconstructed UNH keeps all three elements verbatim.
+        assert!(
+            out.contains("UNH+M1+ORDERS:D:96A:UN+CAR-ACCESS-REF'"),
+            "UNH not reconstructed with its third element: {out}"
+        );
+
+        // 3. Re-read: the extra element still round-trips.
+        let recs2 = collect(&out);
+        assert_eq!(recs2[0].get("seg_id"), Some(&Value::String("UNH".into())));
+        assert_eq!(
+            recs2[0].get("e03"),
+            Some(&Value::String("CAR-ACCESS-REF".into()))
+        );
+    }
+
     /// Collect every body record from a raw byte interchange — the
     /// Latin-1 path carries high bytes that are not valid UTF-8, so the
     /// fixture cannot be a `&str`.

--- a/crates/clinker-format/src/edifact/tokenizer.rs
+++ b/crates/clinker-format/src/edifact/tokenizer.rs
@@ -13,7 +13,7 @@
 //! byte cap turns a missing terminator (truncated / corrupt input)
 //! into an error rather than letting the buffer grow without limit.
 
-use std::io::{BufRead, Read};
+use std::io::{self, BufRead, Read};
 
 use crate::edifact::charset::Charset;
 use crate::error::FormatError;
@@ -26,6 +26,90 @@ use crate::segment_tokenizer::{
 /// with no terminator byte fails fast instead of buffering the whole
 /// file into one "segment".
 pub(crate) const MAX_SEGMENT_BYTES: usize = 64 * 1024;
+
+/// The three-byte tag that introduces a `UNA` service-string advice.
+const UNA_TAG: &[u8] = b"UNA";
+
+/// Total byte length of a `UNA` service string: the `UNA` tag plus the six
+/// service characters. `UNA` is not terminator-delimited, so its length is
+/// fixed rather than discovered.
+const UNA_LEN: usize = 9;
+
+/// A [`BufRead`] that yields a small stashed prefix before delegating to an
+/// inner buffered reader.
+///
+/// The EDIFACT tokenizer must peek up to the nine `UNA` bytes to discover the
+/// delimiter set, but a chunking, non-file source can deliver those bytes
+/// across several reads and [`BufRead::fill_buf`] on a `BufReader` never grows
+/// a partially-filled buffer. Peeking therefore has to *consume* bytes to
+/// accumulate them. When the stream turns out to carry no `UNA`, the consumed
+/// bytes belong to the first real segment, so they are restored here via
+/// [`Self::push_front`] and re-yielded ahead of the inner reader on the next
+/// read. A present `UNA` is consumed outright and never pushed back.
+struct PrefixedReader<R> {
+    /// Bytes to re-yield before the inner reader; empty once fully drained.
+    prefix: Vec<u8>,
+    /// Consumed offset into `prefix`.
+    pos: usize,
+    inner: R,
+}
+
+impl<R> PrefixedReader<R> {
+    fn new(inner: R) -> Self {
+        Self {
+            prefix: Vec::new(),
+            pos: 0,
+            inner,
+        }
+    }
+
+    /// Stash `bytes` to be re-yielded ahead of the inner reader. Only called
+    /// while no prefix is pending (a single push during `UNA` resolution),
+    /// so it replaces rather than accumulates.
+    fn push_front(&mut self, bytes: &[u8]) {
+        self.prefix = bytes.to_vec();
+        self.pos = 0;
+    }
+}
+
+impl<R: Read> Read for PrefixedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.pos < self.prefix.len() {
+            let n = (&self.prefix[self.pos..]).read(buf)?;
+            self.pos += n;
+            if self.pos >= self.prefix.len() {
+                self.prefix.clear();
+                self.pos = 0;
+            }
+            return Ok(n);
+        }
+        self.inner.read(buf)
+    }
+}
+
+impl<R: BufRead> BufRead for PrefixedReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        if self.pos < self.prefix.len() {
+            return Ok(&self.prefix[self.pos..]);
+        }
+        self.inner.fill_buf()
+    }
+
+    fn consume(&mut self, amt: usize) {
+        // Per the `BufRead` contract `amt` never exceeds the last `fill_buf`
+        // slice, which is the prefix alone while one is pending, so a single
+        // `consume` stays within whichever source `fill_buf` returned.
+        if self.pos < self.prefix.len() {
+            self.pos += amt;
+            if self.pos >= self.prefix.len() {
+                self.prefix.clear();
+                self.pos = 0;
+            }
+        } else {
+            self.inner.consume(amt);
+        }
+    }
+}
 
 /// The six EDIFACT service characters discovered from `UNA` (or the
 /// Level-A defaults when `UNA` is absent).
@@ -75,7 +159,7 @@ impl Delimiters {
 /// is therefore set before any byte is interpreted, so no element is ever
 /// decoded under a wrong repertoire.
 pub(crate) struct SegmentTokenizer<R: Read> {
-    reader: R,
+    reader: PrefixedReader<R>,
     delimiters: Delimiters,
     charset: Charset,
     initialized: bool,
@@ -93,7 +177,7 @@ impl<R: BufRead> SegmentTokenizer<R> {
     /// decoded, so the placeholder is never used to interpret bytes.
     pub(crate) fn new(reader: R) -> Self {
         Self {
-            reader,
+            reader: PrefixedReader::new(reader),
             delimiters: Delimiters::level_a(),
             charset: Charset::default(),
             initialized: false,
@@ -128,41 +212,77 @@ impl<R: BufRead> SegmentTokenizer<R> {
         self.charset.decode(raw)
     }
 
-    /// Resolve the optional `UNA` prefix. Peeks the first bytes of the
-    /// stream: a `UNA` tag consumes the 9-byte service string and the
-    /// (optional) single separator byte that follows it; otherwise the
-    /// Level-A defaults stand and no bytes are consumed.
+    /// Resolve the optional `UNA` prefix. A `UNA` tag consumes the 9-byte
+    /// service string and any single separator byte that follows it and
+    /// overrides the delimiter set; otherwise the Level-A defaults stand and
+    /// no bytes are consumed by the interchange.
+    ///
+    /// The `UNA` bytes can arrive across several reads from a chunking,
+    /// non-file source, and `BufRead::fill_buf` never grows a partially-filled
+    /// buffer, so the scan accumulates by consuming: it peeks the three-byte
+    /// tag first (enough to decide `UNA`-vs-not), then, only for a `UNA`, the
+    /// remaining service bytes — looping until nine bytes are gathered or the
+    /// stream genuinely ends, mirroring the X12 `ISA` header accumulation. A
+    /// present `UNA` is consumed outright; when no `UNA` is present the peeked
+    /// tag bytes belong to the first real segment and are pushed back for the
+    /// segment read.
     fn initialize(&mut self) -> Result<(), FormatError> {
         if self.initialized {
             return Ok(());
         }
         self.initialized = true;
 
-        let head = self.reader.fill_buf()?;
-        if head.starts_with(b"UNA") {
-            if head.len() < 9 {
-                // A truncated UNA is unrecoverable — the delimiter set is
-                // undefined, so nothing downstream can be tokenized.
-                return Err(FormatError::Edifact(
-                    "truncated UNA service string: need 9 bytes after the stream start, \
-                     the interchange is corrupt or truncated"
-                        .into(),
-                ));
+        // Phase 1: peek the three-byte tag (or fewer, at a genuine EOF).
+        let mut peeked: Vec<u8> = Vec::with_capacity(UNA_LEN);
+        self.accumulate_up_to(&mut peeked, UNA_TAG.len())?;
+
+        if !peeked.starts_with(UNA_TAG) {
+            // No `UNA`: the Level-A defaults stand, and the tag bytes peeked
+            // to decide that belong to the first real segment, so restore them
+            // ahead of the inner reader for the segment read.
+            self.reader.push_front(&peeked);
+            return Ok(());
+        }
+
+        // Phase 2: a `UNA` is present — gather the remaining service bytes.
+        self.accumulate_up_to(&mut peeked, UNA_LEN)?;
+        if peeked.len() < UNA_LEN {
+            // A truncated UNA is unrecoverable — the delimiter set is
+            // undefined, so nothing downstream can be tokenized.
+            return Err(FormatError::Edifact(
+                "truncated UNA service string: need 9 bytes after the stream start, \
+                 the interchange is corrupt or truncated"
+                    .into(),
+            ));
+        }
+        // UNA layout: bytes 3..9 are component, element, decimal, release,
+        // repetition, terminator in that fixed order.
+        let una = &peeked[3..9];
+        self.delimiters = Delimiters {
+            component: una[0],
+            element: una[1],
+            decimal: una[2],
+            release: una[3],
+            repetition: una[4],
+            terminator: una[5],
+        };
+        skip_inter_segment_whitespace(&mut self.reader)?;
+        Ok(())
+    }
+
+    /// Consume bytes from the reader into `buf` until it holds `target` bytes
+    /// or the stream ends, returning early on a genuine EOF. A single
+    /// `fill_buf` may return fewer bytes than requested when a non-file source
+    /// chunks its reads, so this loops rather than trusting one fill.
+    fn accumulate_up_to(&mut self, buf: &mut Vec<u8>, target: usize) -> Result<(), FormatError> {
+        while buf.len() < target {
+            let chunk = self.reader.fill_buf()?;
+            if chunk.is_empty() {
+                break;
             }
-            // UNA layout: bytes 3..9 are component, element, decimal,
-            // release, repetition, terminator in that fixed order.
-            let una = &head[3..9];
-            let delimiters = Delimiters {
-                component: una[0],
-                element: una[1],
-                decimal: una[2],
-                release: una[3],
-                repetition: una[4],
-                terminator: una[5],
-            };
-            self.delimiters = delimiters;
-            self.reader.consume(9);
-            skip_inter_segment_whitespace(&mut self.reader)?;
+            let take = (target - buf.len()).min(chunk.len());
+            buf.extend_from_slice(&chunk[..take]);
+            self.reader.consume(take);
         }
         Ok(())
     }
@@ -318,10 +438,44 @@ fn bytes_to_string(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::Cursor;
+    use std::io::{BufReader, Cursor};
 
     fn tok(data: &[u8]) -> SegmentTokenizer<Cursor<Vec<u8>>> {
         SegmentTokenizer::new(Cursor::new(data.to_vec()))
+    }
+
+    /// A `Read` source that hands out at most `chunk` bytes per `read` call,
+    /// modelling a network/pipe reader whose first fills fall short of the
+    /// nine `UNA` bytes. Wrapped in a `BufReader` (as the source ingest path
+    /// wraps a file), each `fill_buf` then returns only that short chunk.
+    struct ChunkedReader {
+        data: Vec<u8>,
+        pos: usize,
+        chunk: usize,
+    }
+
+    impl ChunkedReader {
+        fn new(data: &[u8], chunk: usize) -> Self {
+            Self {
+                data: data.to_vec(),
+                pos: 0,
+                chunk,
+            }
+        }
+    }
+
+    impl Read for ChunkedReader {
+        fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+            let remaining = &self.data[self.pos..];
+            let n = remaining.len().min(self.chunk).min(buf.len());
+            buf[..n].copy_from_slice(&remaining[..n]);
+            self.pos += n;
+            Ok(n)
+        }
+    }
+
+    fn chunked_tok(data: &[u8], chunk: usize) -> SegmentTokenizer<BufReader<ChunkedReader>> {
+        SegmentTokenizer::new(BufReader::new(ChunkedReader::new(data, chunk)))
     }
 
     #[test]
@@ -436,6 +590,56 @@ mod tests {
     #[test]
     fn truncated_una_errors() {
         let mut t = tok(b"UNA:+");
+        let err = t.next_segment().unwrap_err();
+        assert!(matches!(err, FormatError::Edifact(msg) if msg.contains("UNA")));
+    }
+
+    #[test]
+    fn chunked_una_is_not_misread_as_truncated() {
+        // A valid UNA delivered across reads that each fall short of the nine
+        // service-string bytes must still resolve the delimiters, not be
+        // rejected as a truncated UNA. The custom UNA declares component '|',
+        // element '*', decimal ',', release '#', repetition ' ', terminator
+        // '~'. A four-byte chunk splits the service string mid-way.
+        for chunk in [1usize, 2, 3, 4, 5] {
+            let mut t = chunked_tok(b"UNA|*,# ~UNB*UNOA|1~", chunk);
+            let first = t.next_segment().unwrap().unwrap();
+            let d = t.delimiters();
+            assert_eq!(d.component, b'|', "chunk={chunk}");
+            assert_eq!(d.element, b'*', "chunk={chunk}");
+            assert_eq!(d.terminator, b'~', "chunk={chunk}");
+            assert_eq!(first, "UNB*UNOA|1", "chunk={chunk}");
+        }
+    }
+
+    #[test]
+    fn chunked_absent_una_keeps_first_segment_bytes() {
+        // With no UNA, the tag bytes peeked to decide that must be restored so
+        // the first real segment is read whole — a chunked source that splits
+        // the leading "UNB" must not lose those bytes to the UNA probe.
+        for chunk in [1usize, 2, 3, 4] {
+            let mut t = chunked_tok(b"UNB+UNOA:1'BGM+220'", chunk);
+            assert_eq!(t.delimiters(), Delimiters::level_a(), "chunk={chunk}");
+            assert_eq!(
+                t.next_segment().unwrap().unwrap(),
+                "UNB+UNOA:1",
+                "chunk={chunk}"
+            );
+            assert_eq!(
+                t.next_segment().unwrap().unwrap(),
+                "BGM+220",
+                "chunk={chunk}"
+            );
+            assert!(t.next_segment().unwrap().is_none(), "chunk={chunk}");
+        }
+    }
+
+    #[test]
+    fn chunked_truncated_una_still_errors() {
+        // A genuinely truncated UNA (fewer than nine bytes, then EOF)
+        // delivered in small chunks is still an error — the accumulate loop
+        // stops at real EOF, not at a short fill.
+        let mut t = chunked_tok(b"UNA:+", 2);
         let err = t.next_segment().unwrap_err();
         assert!(matches!(err, FormatError::Edifact(msg) if msg.contains("UNA")));
     }

--- a/crates/clinker-format/src/edifact/writer.rs
+++ b/crates/clinker-format/src/edifact/writer.rs
@@ -283,9 +283,23 @@ impl<W: Write> EdifactWriter<W> {
             None => String::new(),
         };
 
-        if matches!(seg_id.as_str(), "UNB" | "UNZ" | "UNH" | "UNT") {
-            // Drive message grouping from the UNH record's identity but
-            // never echo the service segment verbatim.
+        if seg_id == "UNH" {
+            // An explicit UNH record opens (or re-drives) a message.
+            // Reconstruct the header from the record's positional columns so
+            // elements past the message type — a common access reference, a
+            // message subset identification, and so on — survive the
+            // round-trip rather than collapsing to a two-element UNH. The
+            // reader stamps element 1 into `msg_ref`/`e01` and element 2 into
+            // `msg_type`/`e02`, so elements 3 onward are `record_elements`
+            // past the second slot.
+            let header = self.record_elements(record)?;
+            let header_tail = header.get(2..).unwrap_or(&[]);
+            self.transition_message_with_header(&msg_ref, &msg_type, header_tail)?;
+            return Ok(());
+        }
+        if matches!(seg_id.as_str(), "UNB" | "UNZ" | "UNT") {
+            // Drive message grouping from the service segment's identity but
+            // never echo it verbatim — the writer reconstructs envelopes.
             self.transition_message(&msg_ref, &msg_type)?;
             return Ok(());
         }
@@ -304,7 +318,31 @@ impl<W: Write> EdifactWriter<W> {
     /// `msg_ref` changes, or open the first message. A record with an
     /// empty `msg_ref` joins the current message; if none is open, it
     /// opens an anonymous single message.
+    ///
+    /// The auto-open path (a body record with no preceding explicit `UNH`
+    /// record) has only the reference and type, so it emits a two-element
+    /// `UNH`; [`Self::transition_message_with_header`] carries a header tail
+    /// for the explicit-`UNH`-record path.
     fn transition_message(&mut self, msg_ref: &str, msg_type: &str) -> Result<(), FormatError> {
+        self.transition_message_with_header(msg_ref, msg_type, &[])
+    }
+
+    /// Open a new `UNH` message as [`Self::transition_message`] does, but
+    /// reconstruct the header with `header_tail` appended after the reference
+    /// and message type — the `UNH` data elements past element 2 (a common
+    /// access reference, a message subset identification, and so on) that an
+    /// explicit `UNH` record carries in its `e03`, `e04`, … columns.
+    ///
+    /// Element 1 (the reference) and element 2 (the message type) always come
+    /// from the resolved `msg_ref`/`msg_type`, never the tail, so element 1
+    /// stays identical to the reference the `UNT`/`UNZ` echo checks use; the
+    /// tail contributes only elements 3 onward.
+    fn transition_message_with_header(
+        &mut self,
+        msg_ref: &str,
+        msg_type: &str,
+        header_tail: &[String],
+    ) -> Result<(), FormatError> {
         let need_new = match &self.open_message {
             None => true,
             Some(open) => !msg_ref.is_empty() && open.reference != *msg_ref,
@@ -330,7 +368,18 @@ impl<W: Write> EdifactWriter<W> {
         } else {
             msg_ref.to_string()
         };
-        self.write_segment("UNH", &[reference.clone(), resolved_type])?;
+        let mut unh_elements = Vec::with_capacity(2 + header_tail.len());
+        unh_elements.push(reference.clone());
+        unh_elements.push(resolved_type);
+        unh_elements.extend_from_slice(header_tail);
+        // Trim trailing empty elements past the mandatory reference+type pair
+        // so a tail padded with empties does not fabricate spurious element
+        // separators; the pair itself is always emitted (never trimmed below
+        // two elements), keeping a plain two-element UNH byte-identical.
+        while unh_elements.len() > 2 && unh_elements.last().is_some_and(|s| s.is_empty()) {
+            unh_elements.pop();
+        }
+        self.write_segment("UNH", &unh_elements)?;
         self.message_count += 1;
         self.open_message = Some(OpenMessage {
             reference,
@@ -860,6 +909,58 @@ mod tests {
             &s,
         );
         assert!(out.contains("UNZ+2+REF1'"), "output was: {out}");
+    }
+
+    #[test]
+    fn explicit_unh_record_reconstructs_elements_past_message_type() {
+        // A UNH record carrying a third element (a common access reference in
+        // e03) must reconstruct that element on the wire, not collapse to a
+        // two-element UNH. Element 1/2 stay the resolved reference and type.
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(
+                    &s,
+                    "UNH",
+                    "M1",
+                    "ORDERS:D:96A:UN",
+                    &["M1", "ORDERS:D:96A:UN", "CAR-ACCESS-REF"],
+                ),
+                body(&s, "BGM", "M1", "ORDERS:D:96A:UN", &["220"]),
+            ],
+            &s,
+        );
+        assert!(
+            out.contains("UNH+M1+ORDERS:D:96A:UN+CAR-ACCESS-REF'"),
+            "UNH lost the element past the message type: {out}"
+        );
+    }
+
+    #[test]
+    fn explicit_unh_record_without_extras_stays_two_element() {
+        // A UNH record whose only elements are the reference and type must
+        // still emit a plain two-element UNH — no fabricated empty tail.
+        let s = schema();
+        let out = write_all(
+            literal_config(),
+            &[
+                body(
+                    &s,
+                    "UNH",
+                    "M1",
+                    "ORDERS:D:96A:UN",
+                    &["M1", "ORDERS:D:96A:UN"],
+                ),
+                body(&s, "BGM", "M1", "ORDERS:D:96A:UN", &["220"]),
+            ],
+            &s,
+        );
+        assert!(out.contains("UNH+M1+ORDERS:D:96A:UN'"), "{out}");
+        assert!(
+            !out.contains("UNH+M1+ORDERS:D:96A:UN+'"),
+            "spurious trailing element: {out}"
+        );
     }
 
     #[test]

--- a/crates/clinker-format/src/swift/reader.rs
+++ b/crates/clinker-format/src/swift/reader.rs
@@ -85,6 +85,10 @@ pub struct SwiftReader<R: Read> {
     /// The block-4 field lines, framed at first body pull and drained one
     /// record per `next_record`.
     body_lines: std::collections::VecDeque<ParsedBlock4Line>,
+    /// The constant block-4 discriminator (`TEXT_BLOCK_ID`) as a `Value`,
+    /// interned once so every body record clones the cheap shared handle
+    /// instead of re-rendering the constant to a fresh `String` per record.
+    block_value: Value,
     /// `true` once the message-level `OpenLevel` has been queued, so the
     /// matching `CloseLevel` is queued exactly once at end-of-message.
     level_open: bool,
@@ -108,6 +112,7 @@ impl<R: Read> SwiftReader<R> {
             user_header: None,
             trailer: None,
             body_lines: std::collections::VecDeque::new(),
+            block_value: Value::String(TEXT_BLOCK_ID.to_string().as_str().into()),
             level_open: false,
             pending_events: Vec::new(),
             done: false,
@@ -218,7 +223,7 @@ impl<R: Read> SwiftReader<R> {
     /// distinguish body lines from any future block-keyed record shape.
     fn body_record(&self, line: &ParsedBlock4Line) -> Record {
         let values = vec![
-            Value::String(TEXT_BLOCK_ID.to_string().as_str().into()),
+            self.block_value.clone(),
             Value::String(line.tag.as_str().into()),
             string_or_null(&line.value),
         ];

--- a/docs/user/src/formats/edifact.md
+++ b/docs/user/src/formats/edifact.md
@@ -79,7 +79,12 @@ schema:
 Service segments (`UNB`, `UNZ`, `UNH`, `UNT`) are consumed by the reader
 to drive envelope state and validation — they are never emitted as body
 records. The `UNH` segment that opens a message **is** emitted as a body
-record (its `seg_id` is `UNH`), carrying the message reference and type.
+record (its `seg_id` is `UNH`), carrying the message reference in `msg_ref`
+and the message-type composite in `msg_type`, with its full positional
+element list also stamped onto `e01`, `e02`, … — so any `UNH` element past
+the message type (a common access reference, a message subset
+identification, and so on) is available as `e03` onward and is
+reconstructed on write.
 
 The number of `eNN` columns is controlled by the source `max_elements`
 option (default 32). A segment carrying more data elements than that is
@@ -258,10 +263,6 @@ represent (a non-ASCII character under `UNOA`/`UNOB`, or a codepoint above
 - **Functional groups.** A single `UNB..UNZ` interchange is supported;
   `UNG`/`UNE` functional-group segments are rejected with a precise
   error.
-- **UNH composite fidelity.** The reader stamps the `UNH` reference
-  (element 1) and the full message-type composite (element 2). A `UNH`
-  carrying additional elements (e.g. a common access reference) is
-  reconstructed as a two-element `UNH` on round-trip.
 - **Output splitting.** An interchange is a single `UNB..UNZ` envelope and
   cannot be divided across files. An `edifact` output combined with a
   `split:` block is rejected at config-validation time (diagnostic


### PR DESCRIPTION
## Summary

Three fidelity/robustness fixes to the EDI-format readers and writer in `clinker-format`.

### EDIFACT: preserve UNH elements past the message type (writer)

A `UNH` message header may carry data elements beyond the message reference (element 1) and the message-type composite (element 2) — a common access reference, a transfer status, a message subset/implementation identification, a scenario identification. The reader already stamps a message's full `UNH` element list onto the emitted `UNH` body record (`msg_ref`/`e01`, `msg_type`/`e02`, then `e03` onward), but the writer reconstructed each `UNH` from the reference and type only, so those additional elements were dropped on a reader → writer → reader round-trip.

The writer now rebuilds the `UNH` from the record's positional element columns:

- Elements 1 and 2 stay pinned to the resolved reference and message type, so element 1 remains identical to the reference the `UNT`/`UNZ` echo checks use.
- Elements 3 onward are carried through verbatim.
- A plain two-element `UNH` is byte-identical to before (the reference+type pair is never trimmed; only a padded tail is trimmed).

### EDIFACT: detect UNA across chunked reads (tokenizer)

`UNA` service-string detection read from a single `fill_buf()` and treated a short first fill as a truncated `UNA`. `BufRead::fill_buf` never grows a partially-filled buffer, so a chunking, non-file `Read` source (a network or pipe reader) whose first fill returns fewer than nine bytes would mis-reject a perfectly valid `UNA`. File sources fill in one shot, so this never manifested for them.

Detection now accumulates the three-byte tag, then — only for a `UNA` — the remaining service bytes, looping `fill_buf`/`consume` until the nine bytes are gathered or the stream genuinely ends. This mirrors the accumulate-then-inspect pattern the X12 `ISA` reader already uses. A present `UNA` is consumed outright; when no `UNA` is present the peeked tag bytes belong to the first real segment and are restored ahead of the reader through a small `BufRead` prefix wrapper, so no segment bytes are lost.

### SWIFT: intern the block-4 discriminator (reader)

The MT reader rendered the constant block-4 id to a fresh `String` on every block-4 field line — a redundant per-record heap allocation on the read hot path. The constant is now interned once at reader construction and the cheap shared handle cloned per record. The emitted value is byte-identical; no behavior change.

## Tests

- Chunked-`UNA` cases at the tokenizer boundary: a valid `UNA` split across 1–5-byte reads still resolves the delimiters; an absent `UNA` split across reads keeps the first segment's bytes; a genuinely truncated `UNA` in small chunks still errors.
- A full reader → writer → reader round-trip preserving a `UNH` element past the message type, plus a writer unit test that a plain two-element `UNH` is unchanged.
- The existing SWIFT test already pins the block-4 discriminator value, so the interning change is covered there.
- Format reference docs updated: the `UNH` composite-fidelity limitation note is removed, and the reader schema section now documents that a `UNH` body record carries its full positional element list.

## Validation

`cargo fmt --all --check`, both `cargo clippy --workspace [--all-targets] -- -D warnings` passes, `cargo test -p clinker-format`, and `cargo check --benches --workspace` all pass locally.

Closes #402, #458, #501


Closes #458
Closes #501
