### PR TITLE
docs: strip internal planning references from diagnostic pages and fixtures

### DIFF
--- a/crates/clinker-exec/tests/fixtures/channels/acme_prod.channel.yaml
+++ b/crates/clinker-exec/tests/fixtures/channels/acme_prod.channel.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Binds to channel_target_pipeline, fixed + default overrides.
 channel:
   name: acme_prod

--- a/crates/clinker-exec/tests/fixtures/channels/acme_staging.channel.yaml
+++ b/crates/clinker-exec/tests/fixtures/channels/acme_staging.channel.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Same pipeline as acme_prod, different bindings for staging.
 channel:
   name: acme_staging

--- a/crates/clinker-exec/tests/fixtures/channels/beta_prod.channel.yaml
+++ b/crates/clinker-exec/tests/fixtures/channels/beta_prod.channel.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Second pipeline target, production bindings.
 channel:
   name: beta_prod

--- a/crates/clinker-exec/tests/fixtures/channels/beta_staging.channel.yaml
+++ b/crates/clinker-exec/tests/fixtures/channels/beta_staging.channel.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Second pipeline, staging bindings.
 channel:
   name: beta_staging

--- a/crates/clinker-exec/tests/fixtures/channels/comp_direct.channel.yaml
+++ b/crates/clinker-exec/tests/fixtures/channels/comp_direct.channel.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Targets a composition directly (tests ChannelTarget::Composition).
 # Uses config.fixed only — binding cannot be overridden.
 channel:

--- a/crates/clinker-exec/tests/fixtures/channels/empty_defaults.channel.yaml
+++ b/crates/clinker-exec/tests/fixtures/channels/empty_defaults.channel.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Minimal channel with only default bindings (no fixed key).
 channel:
   name: empty_defaults

--- a/crates/clinker-exec/tests/fixtures/combine/two_input_mixed.yaml
+++ b/crates/clinker-exec/tests/fixtures/combine/two_input_mixed.yaml
@@ -37,8 +37,7 @@ nodes:
       orders: orders
       products: products
     config:
-      # 1 equi + 2 range — exercises the full DecomposedPredicate shape
-      # called out in phase-c1 §RESOLUTION T-8. The strengthened
+      # 1 equi + 2 range — exercises the full DecomposedPredicate shape.
       # `test_combine_decompose_mixed` asserts `ranges[0].op ==
       # RangeOp::Ge` and `ranges[0].left_input == "orders"`
       # (source-order-preserving split_conjunction).

--- a/crates/clinker-exec/tests/fixtures/compositions/address_normalize.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/address_normalize.comp.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # 1 input, 2 outputs (normalized, rejected), 1 config param.
 # Normalizes addresses; routes invalid ones to rejected output.
 _compose:

--- a/crates/clinker-exec/tests/fixtures/compositions/customer_enrich.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/customer_enrich.comp.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # 2 inputs (customers, addresses), 1 output, 2 config params.
 # Enriches customer records by joining with address data.
 _compose:

--- a/crates/clinker-exec/tests/fixtures/compositions/dlq_shape.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/dlq_shape.comp.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # 1 input, 1 output, 3 config params. Models DLQ reshaping pattern.
 _compose:
   name: dlq_shape

--- a/crates/clinker-exec/tests/fixtures/compositions/nested_caller.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/nested_caller.comp.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Uses another composition internally (tests recursive expansion).
 _compose:
   name: nested_caller

--- a/crates/clinker-exec/tests/fixtures/compositions/passthrough_check.comp.yaml
+++ b/crates/clinker-exec/tests/fixtures/compositions/passthrough_check.comp.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Minimal composition for testing pass-through column behavior and W101 trigger.
 _compose:
   name: passthrough_check

--- a/crates/clinker-exec/tests/fixtures/pipelines/channel_target_pipeline.yaml
+++ b/crates/clinker-exec/tests/fixtures/pipelines/channel_target_pipeline.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Target of acme_prod, acme_staging, and empty_defaults channels.
 pipeline:
   name: channel_target_pipeline

--- a/crates/clinker-exec/tests/fixtures/pipelines/composition_pipeline.yaml
+++ b/crates/clinker-exec/tests/fixtures/pipelines/composition_pipeline.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Uses customer_enrich and address_normalize compositions.
 pipeline:
   name: composition_pipeline

--- a/crates/clinker-exec/tests/fixtures/pipelines/nested_composition_pipeline.yaml
+++ b/crates/clinker-exec/tests/fixtures/pipelines/nested_composition_pipeline.yaml
@@ -1,5 +1,3 @@
-# FORWARD-ONLY: baseline captured in Task 16c.2.4
-#
 # Uses nested_caller (which uses address_normalize internally).
 pipeline:
   name: nested_composition_pipeline

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_channel_target_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_channel_target_pipeline.snap
@@ -62,6 +62,6 @@ Worker threads: 4
 
 === DAG Topology ===
 
-  ● [source] ingest_src (line:7)
-  │ [composition:body=<ID>] enrich1 (line:18)
-  │ [output] sink (line:28)
+  ● [source] ingest_src (line:5)
+  │ [composition:body=<ID>] enrich1 (line:16)
+  │ [output] sink (line:26)

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_composition_pipeline.snap
@@ -86,8 +86,8 @@ Worker threads: 4
 
 === DAG Topology ===
 
-  ● [source] addresses_src (line:17)
-  │ [composition:body=<ID>] addr_norm (line:40)
-  ● [source] customers_src (line:7)
-  │ [composition:body=<ID>] enrich1 (line:29)
-  │ [output] enriched_out (line:49)
+  ● [source] addresses_src (line:15)
+  │ [composition:body=<ID>] addr_norm (line:38)
+  ● [source] customers_src (line:5)
+  │ [composition:body=<ID>] enrich1 (line:27)
+  │ [output] enriched_out (line:47)

--- a/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_nested_composition_pipeline.snap
+++ b/crates/clinker-exec/tests/snapshots/pre_lift_baselines__explain_nested_composition_pipeline.snap
@@ -62,6 +62,6 @@ Worker threads: 4
 
 === DAG Topology ===
 
-  ● [source] raw_src (line:7)
-  │ [composition:body=<ID>] nested_process (line:20)
-  │ [output] final_out (line:29)
+  ● [source] raw_src (line:5)
+  │ [composition:body=<ID>] nested_process (line:18)
+  │ [output] final_out (line:27)

--- a/crates/clinker/tests/explain_no_ephemeral_refs.rs
+++ b/crates/clinker/tests/explain_no_ephemeral_refs.rs
@@ -1,0 +1,170 @@
+//! Regression guard: user-facing diagnostic pages and shared test fixtures must
+//! not carry internal planning pointers — milestone/phase labels, task ids,
+//! locked-decision codes, or resolution/decision-letter codes.
+//!
+//! The `docs/explain/*.md` pages are embedded into the binary via `include_str!`
+//! in `clinker_plan` and printed verbatim by `clinker explain --code <CODE>`, so
+//! a stray planning label is shipped straight to a user landing on the page from
+//! a CLI error. The `clinker-exec` fixtures are shared test inputs. Both must
+//! read as self-contained to an outside reader.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Workspace root, two levels above this crate's manifest (`crates/clinker`).
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("workspace root is two levels above the clinker crate manifest")
+        .to_path_buf()
+}
+
+/// Finds `prefix` at a word boundary (not preceded by an ASCII alphanumeric)
+/// immediately followed by an ASCII digit — e.g. `LD-16`, `Phase 16`, `D57`.
+/// The digit anchor keeps the compiler's real `Phase 1`/`Phase 2` stages and
+/// fixed-width sample data like `D000000100` from matching.
+fn boundary_prefix_then_digit(line: &str, prefix: &str) -> Option<String> {
+    let mut search_from = 0;
+    while let Some(rel) = line[search_from..].find(prefix) {
+        let start = search_from + rel;
+        let preceded_ok = match line[..start].chars().next_back() {
+            Some(c) => !c.is_ascii_alphanumeric(),
+            None => true,
+        };
+        if let Some(next) = line[start + prefix.len()..].chars().next()
+            && preceded_ok
+            && next.is_ascii_digit()
+        {
+            return Some(format!("{prefix}{next}"));
+        }
+        search_from = start + prefix.len();
+    }
+    None
+}
+
+/// Matches `RESOLUTION <UPPERCASE>-` decision-letter codes such as
+/// `RESOLUTION W-18` or `RESOLUTION B-6`.
+fn resolution_code(line: &str) -> Option<String> {
+    const KEY: &str = "RESOLUTION ";
+    let mut search_from = 0;
+    while let Some(rel) = line[search_from..].find(KEY) {
+        let start = search_from + rel;
+        let mut after = line[start + KEY.len()..].chars();
+        if let (Some(letter), Some(dash)) = (after.next(), after.next())
+            && letter.is_ascii_uppercase()
+            && dash == '-'
+        {
+            return Some(format!("RESOLUTION {letter}-"));
+        }
+        search_from = start + KEY.len();
+    }
+    None
+}
+
+/// Returns the first ephemeral internal-reference token found on `line`.
+fn ephemeral_token(line: &str) -> Option<String> {
+    for literal in ["Task 16", "FORWARD-ONLY", "phase-c"] {
+        if line.contains(literal) {
+            return Some(literal.to_string());
+        }
+    }
+    for prefix in ["LD-", "Phase 1", "D5"] {
+        if let Some(token) = boundary_prefix_then_digit(line, prefix) {
+            return Some(token);
+        }
+    }
+    resolution_code(line)
+}
+
+/// Collects every file under `dir` (recursively) whose extension is `ext`.
+fn collect_files(dir: &Path, ext: &str, out: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {}: {e}", dir.display()));
+    for entry in entries {
+        let path = entry.expect("directory entry").path();
+        if path.is_dir() {
+            collect_files(&path, ext, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some(ext) {
+            out.push(path);
+        }
+    }
+}
+
+/// Scans `files`, returning `<repo-relative path>:<line>: <token>` for every
+/// ephemeral reference found.
+fn scan(files: &[PathBuf], root: &Path) -> Vec<String> {
+    let mut violations = Vec::new();
+    for path in files {
+        let content =
+            fs::read_to_string(path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        for (idx, line) in content.lines().enumerate() {
+            if let Some(token) = ephemeral_token(line) {
+                let rel = path.strip_prefix(root).unwrap_or(path);
+                violations.push(format!("{}:{}: {token}", rel.display(), idx + 1));
+            }
+        }
+    }
+    violations
+}
+
+#[test]
+fn explain_pages_have_no_ephemeral_internal_references() {
+    let root = repo_root();
+    let explain_dir = root.join("docs/explain");
+    let mut files = Vec::new();
+    collect_files(&explain_dir, "md", &mut files);
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "no explain pages found under {}",
+        explain_dir.display()
+    );
+
+    let violations = scan(&files, &root);
+    assert!(
+        violations.is_empty(),
+        "explain pages carry internal planning references (these are shipped \
+         verbatim by `clinker explain --code`):\n{}",
+        violations.join("\n")
+    );
+
+    // Assert the bytes the registry actually serves are clean too, for every
+    // page reachable through `clinker explain --code <CODE>`.
+    for path in &files {
+        let code = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .expect("explain page has a UTF-8 file stem");
+        if let Some(shipped) = clinker_plan::plan::explain_provenance::explain_code(code) {
+            for (idx, line) in shipped.lines().enumerate() {
+                assert!(
+                    ephemeral_token(line).is_none(),
+                    "explain_code({code}) served an internal reference on line {}: {line}",
+                    idx + 1
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn exec_fixtures_have_no_ephemeral_internal_references() {
+    let root = repo_root();
+    let fixtures_dir = root.join("crates/clinker-exec/tests/fixtures");
+    let mut files = Vec::new();
+    collect_files(&fixtures_dir, "yaml", &mut files);
+    collect_files(&fixtures_dir, "yml", &mut files);
+    files.sort();
+    assert!(
+        !files.is_empty(),
+        "no YAML fixtures found under {}",
+        fixtures_dir.display()
+    );
+
+    let violations = scan(&files, &root);
+    assert!(
+        violations.is_empty(),
+        "exec test fixtures carry internal planning references:\n{}",
+        violations.join("\n")
+    );
+}

--- a/docs/explain/E101.md
+++ b/docs/explain/E101.md
@@ -28,12 +28,12 @@ use valid types.
 ## Technical context
 
 Composition signatures are parsed during Phase 1 of the two-phase compile
-process (LD-16c-5: workspace-wide scan). The `_compose:` header declares
-`inputs:`, `outputs:`, `config_schema:`, and `resources_schema:` — these
-two separate axes are mandated by LD-16c-1 (config vs resources: two
-slots). A parse failure here blocks the entire Phase 1 symbol table build
-because downstream call sites and channels cannot resolve against a
-malformed signature.
+process — a workspace-wide scan that builds the symbol table. The
+`_compose:` header declares `inputs:`, `outputs:`, `config_schema:`, and
+`resources_schema:`; config and resources are two separate axes, so they
+occupy two distinct slots rather than a single merged map. A parse failure
+here blocks the entire Phase 1 symbol table build because downstream call
+sites and channels cannot resolve against a malformed signature.
 
 ## See also
 

--- a/docs/explain/E102.md
+++ b/docs/explain/E102.md
@@ -35,8 +35,8 @@ or correct the `input:` reference to match an existing declared port name.
 
 ## Technical context
 
-Composition bodies are sealed from above (IsolatedFromAbove contract,
-LD-16c-6). All data flowing into or out of the body must pass through
+Composition bodies are sealed from above (the IsolatedFromAbove contract).
+All data flowing into or out of the body must pass through
 declared ports. When a node's `input:` field names a port that was never
 declared in `_compose.inputs:` or `_compose.outputs:`, the compiler
 cannot wire the dataflow edge. This check runs during Phase 2 body

--- a/docs/explain/E103.md
+++ b/docs/explain/E103.md
@@ -48,11 +48,11 @@ only declared parameter names.
 ## Technical context
 
 Call-site bindings are validated against the composition's declared
-signature during Phase 2 resolution. Per LD-16c-1, `config:` and
-`resources:` are separate axes — binding a config key under `resources:`
-(or vice versa) also triggers E103. Per LD-16c-2, port schemas enforce
-minimum-required contracts: extra upstream columns pass through, but
-explicitly binding a non-existent port name is an error.
+signature during Phase 2 resolution. `config:` and `resources:` are
+separate axes — binding a config key under `resources:` (or vice versa)
+also triggers E103. Port schemas enforce minimum-required contracts: extra
+upstream columns pass through, but explicitly binding a non-existent port
+name is an error.
 
 ## See also
 

--- a/docs/explain/E104.md
+++ b/docs/explain/E104.md
@@ -26,7 +26,7 @@ Add the missing required parameter to the call site's `config:`,
 
 ## Technical context
 
-Per LD-16c-1, composition parameters are declared in `config_schema:` with
+Composition parameters are declared in `config_schema:` with
 `required: true|false` and optional `default:` values. A parameter marked
 `required: true` with no default must be supplied at every call site and
 cannot be deferred to channel overlays. This ensures that a composition

--- a/docs/explain/E107.md
+++ b/docs/explain/E107.md
@@ -32,7 +32,7 @@ restructuring the pipeline to avoid circular dependencies.
 
 ## Technical context
 
-Per LD-16c-6, cycle detection runs on the flat post-expansion graph, not
+Cycle detection runs on the flat post-expansion graph, not
 the hierarchical representation. `PipelineNode::Composition` boundary
 markers are retained as structural no-ops but elided during cycle
 analysis. This avoids the false positives and false negatives that arise

--- a/docs/explain/E307.md
+++ b/docs/explain/E307.md
@@ -59,7 +59,7 @@ when `resolve_any_node()` cannot match the input value against any
 declared producer. Unlike transform's single-input `input:` field
 (which uses `resolve_input_reference` — transform-like prefixes
 only), combine's multi-input map accepts any node type as a producer,
-so a broader resolver is needed (RESOLUTION W-2).
+so a broader resolver is needed.
 
 The diagnostic's primary span points at the offending value in the
 `input:` map; secondary spans list the closest name matches in the

--- a/docs/explain/E310.md
+++ b/docs/explain/E310.md
@@ -56,7 +56,7 @@ Pick one of these remediations, in rough order of cost-to-apply:
 
 ## Technical context
 
-Combine uses a dual-threshold memory budget (RESOLUTION B-6, D57/D58):
+Combine uses a dual-threshold memory budget: a soft/hard envelope where
 `soft_limit()` (0.80 of total) triggers spill-to-disk for the
 GraceHash strategy, `hard_limit()` aborts the run, and a separate
 `spike_allowance()` tolerates brief fan-out bursts. E310 fires only

--- a/docs/explain/W101.md
+++ b/docs/explain/W101.md
@@ -24,7 +24,7 @@ takes precedence.
 
 ## Technical context
 
-Per LD-16c-2 (port schema: minimum-required + body-wins), upstream rows
+Port schemas are minimum-required and body-wins: upstream rows
 may carry additional columns beyond the declared port schema. These
 extras pass through the composition boundary. When the body creates a
 column with the same name as a pass-through column, the body column wins.

--- a/docs/explain/W302.md
+++ b/docs/explain/W302.md
@@ -61,10 +61,10 @@ plumbing, overflow partitions, and the memory-budget integration
 required by GraceHash. It is sound only when every input fits
 entirely in memory and the predicate is pure equality. W302 flags
 the pattern where the user could safely opt in but the planner
-defaults to HashBuildProbe for broad applicability. Per
-RESOLUTION W-18, this is distinct from W305/W306 (which flag
-planner-hint gaps) — W302 is specifically about pinning in-memory
-vs spillable strategies when cardinality makes spill unnecessary.
+defaults to HashBuildProbe for broad applicability. This is distinct
+from W305/W306 (which flag planner-hint gaps) — W302 is specifically
+about pinning in-memory vs spillable strategies when cardinality makes
+spill unnecessary.
 
 ## See also
 

--- a/docs/explain/W305.md
+++ b/docs/explain/W305.md
@@ -74,10 +74,9 @@ and at least one `range_conjunct` or residual cross-input predicate
 exists. Contrast with E305 (no cross-input predicates at all — not
 a warning, an error).
 
-Per RESOLUTION W-18, W305 is the "no equality conjuncts" warning;
-the original overloaded W305 was split into W305 (this warning)
-and W306 (ambiguous driving input) so each is independently
-user-actionable.
+W305 is the "no equality conjuncts" warning; it and W306 (ambiguous
+driving input) are separate codes so each carries one independently
+user-actionable remedy.
 
 ## See also
 

--- a/docs/explain/W306.md
+++ b/docs/explain/W306.md
@@ -69,7 +69,7 @@ can swing runtime by orders of magnitude for skewed cardinalities.
 When the planner has no cardinality signal, any choice is a guess —
 W306 surfaces the guess so users can confirm or override.
 
-Per RESOLUTION W-18, W306 is distinct from W305 (no equality
+W306 is distinct from W305 (no equality
 conjuncts) because the two remediations are different: W305 asks for
 a predicate change; W306 asks for a cardinality hint or a `drive:`
 field. Splitting them lets each warning carry one clear action.


### PR DESCRIPTION
## What

The `docs/explain/*.md` diagnostic pages are compiled into the binary and
printed verbatim by `clinker explain --code <CODE>`, so anything they contain
reaches a user who lands on the page straight from a CLI error. Several of those
pages — and a set of shared `clinker-exec` test fixtures — still carried internal
decision codes and baseline-capture labels that mean nothing to an outside
reader and drift out of date as the code changes.

This sweep rewrites each site around the behavior the code encoded, keeping the
reasoning and dropping the opaque label.

## Changes

**Explain pages** (`docs/explain/`): E101–E104, E107, E307, E310, W101, W302,
W305, W306 — replaced bracketed decision-code references with the plain-language
rationale they stood for:

- signature parsing is a workspace-wide scan that builds the symbol table;
- `config:` and `resources:` are two separate axes (two slots, not one merged map);
- combine's memory budget is a dual soft/hard envelope — spill triggers at the
  0.80 soft threshold, abort when the hard limit is crossed;
- port schemas are minimum-required with body-wins shadowing;
- W302/W305/W306 are distinct warnings so each carries one clear remedy.

**Fixtures** (`crates/clinker-exec/tests/fixtures/`): removed the baseline-capture
header line (and its `#` separator) from 14 channel/composition/pipeline YAML
files, keeping the one-line description of what each fixture exercises; removed a
stray decision-code pointer from a combine fixture comment. These are
comment-only edits — pipeline parsing and behavior are unchanged.

**Guard test** (`crates/clinker/tests/explain_no_ephemeral_refs.rs`): a new test
that scans the embedded explain pages (through the same `explain_code` registry
`clinker explain` serves) and the exec YAML fixtures, and fails if an internal
planning reference reappears. It fails on the pre-sweep tree and passes after.

## Deliberately left intact

- The real two-phase compiler stages `Phase 1` / `Phase 2` — these describe the
  compiler, not an internal milestone.
- Fixed-width flat-file sample data such as `D000000100` in `E345.md`, which is a
  detail-record example, not a decision code.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked --offline -- -D warnings`
- `cargo test -p clinker --locked --offline` (all green, including the new guard test)

Closes #166
