### PR TITLE
plan: split overloaded E200 into distinct parse / resolve / type diagnostic codes

### DIFF
--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -29,6 +29,8 @@
 //! | `E115`      | error    | Composition body node fails node-scoped config validation (same checks as top-level nodes) |
 //! | `E200`      | error    | CXL type error (compile-time typecheck failure)      |
 //! | `E201`      | error    | Source declaration missing required `schema:` field  |
+//! | `E202`      | error    | CXL parse error (compile-time CXL syntax failure)    |
+//! | `E203`      | error    | CXL name-resolution error (unresolved field / variable / module reference) |
 //! | `E210`      | error    | Source declares more than one of `{path,glob,regex,paths}` |
 //! | `E211`      | error    | Source declares none of `{path,glob,regex,paths}`    |
 //! | `E212`      | error    | Invalid glob pattern in source matcher               |

--- a/crates/clinker-exec/tests/combine_test.rs
+++ b/crates/clinker-exec/tests/combine_test.rs
@@ -1907,9 +1907,9 @@ nodes:
     /// sibling node would have triggered a CXL error in bind_schema.
     ///
     /// Previously combine undeclared-input emission lived in stage-5
-    /// edge wiring AFTER bind_schema. A fixture with both an E200 (CXL)
+    /// edge wiring AFTER bind_schema. A fixture with both a CXL error
     /// on one node and a combine-undeclared on another would surface
-    /// ONLY the E200; the combine typo was invisible until the user
+    /// ONLY the CXL error; the combine typo was invisible until the user
     /// fixed the unrelated CXL error first. The unified
     /// `resolve_all_input_references` pass moves combine-undeclared
     /// forward to the structural stage so it fires regardless of what
@@ -1917,8 +1917,8 @@ nodes:
     ///
     /// `compile_topology_only`'s early return still short-circuits
     /// bind_schema once any structural-stage E004 exists, so this
-    /// fixture surfaces ONLY E004 (not both E200 and E004 in the same
-    /// pass). The load-bearing user-facing fix — combine typo no
+    /// fixture surfaces ONLY E004 (not both the CXL error and E004 in
+    /// the same pass). The load-bearing user-facing fix — combine typo no
     /// longer hidden by a sibling CXL error — is what this regression
     /// locks in.
     #[test]
@@ -1960,8 +1960,8 @@ nodes:
         // The load-bearing assertion: combine-undeclared is visible
         // here, with the structured payload identifying the broken
         // qualifier. Pre-remediation this combine typo would have been
-        // hidden behind cxl_broken's sibling E200 (because E307 lived
-        // in stage-5 Phase-2 after bind_schema's early return).
+        // hidden behind cxl_broken's sibling CXL error (because E307
+        // lived in stage-5 Phase-2 after bind_schema's early return).
         let combine_e004 = diags
             .iter()
             .find(|d| {
@@ -1971,7 +1971,7 @@ nodes:
                 panic!(
                     "expected an E004 with combine-arm payload from \
                      broken_combine.products → nowhere even though \
-                     cxl_broken would have triggered an E200 in bind_schema. \
+                     cxl_broken would have triggered a CXL error in bind_schema. \
                      The unified input-reference pass at stage 3.5 must \
                      fire BEFORE bind_schema. got: {diags:#?}"
                 )

--- a/crates/clinker-exec/tests/node_taxonomy_lift_test.rs
+++ b/crates/clinker-exec/tests/node_taxonomy_lift_test.rs
@@ -761,10 +761,10 @@ nodes:
 // ---------------------------------------------------------------------
 
 #[test]
-fn test_compile_surfaces_cxl_type_error() {
+fn test_compile_surfaces_cxl_name_resolution_error() {
     // A transform that references a column absent from the upstream
-    // source schema must produce an E200 diagnostic during `compile()`,
-    // BEFORE any I/O occurs.
+    // source schema fails CXL name resolution, producing an E203
+    // diagnostic during `compile()`, BEFORE any I/O occurs.
     let yaml = r#"
 pipeline:
   name: bad_ref
@@ -792,11 +792,11 @@ nodes:
 "#;
     let cfg = parse_pipeline(yaml);
     let res = cfg.compile(&clinker_plan::config::CompileContext::default());
-    assert!(res.is_err(), "compile must fail on CXL type error");
+    assert!(res.is_err(), "compile must fail on unresolved CXL column");
     let diags = res.err().unwrap();
     assert!(
-        diags.iter().any(|d| d.code == "E200"),
-        "expected E200, got: {:?}",
+        diags.iter().any(|d| d.code == "E203"),
+        "expected E203, got: {:?}",
         diags.iter().map(|d| &d.code).collect::<Vec<_>>()
     );
 }

--- a/crates/clinker-exec/tests/snapshots/state_node_diagnostics__snapshot_e173_composition_body_reads_undeclared_parent_var.snap
+++ b/crates/clinker-exec/tests/snapshots/state_node_diagnostics__snapshot_e173_composition_body_reads_undeclared_parent_var.snap
@@ -2,4 +2,4 @@
 source: crates/clinker-exec/tests/state_node_diagnostics.rs
 expression: render_diags(&diags)
 ---
-E200: CXL name resolution failed in "read_var": [E173] composition body references parent-scope variable '$pipeline.cutoff' which is not opted into the body's `_compose.scoped_vars.pipeline` schema
+E203: CXL name resolution failed in "read_var": [E173] composition body references parent-scope variable '$pipeline.cutoff' which is not opted into the body's `_compose.scoped_vars.pipeline` schema

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -730,9 +730,10 @@ impl PipelineConfig {
         // per stage-3 validation), seeds each source's schema from its
         // author-declared `schema:` block, and typechecks every
         // CXL-bearing node against the propagated upstream schema.
-        // E200 diagnostics surface here with per-node spans. Also
-        // recurses into composition bodies via bind_composition,
-        // populating CompileArtifacts.composition_bodies.
+        // CXL compile diagnostics (E202 parse / E203 name-resolution /
+        // E200 type) surface here with per-node spans. Also recurses into
+        // composition bodies via bind_composition, populating
+        // CompileArtifacts.composition_bodies.
         let scoped_vars_registry =
             build_scoped_vars_registry(self.pipeline.vars.as_ref(), &self.nodes);
         // Channel `sources:` patches addressed at a source inside a composition
@@ -770,8 +771,9 @@ impl PipelineConfig {
             &mut diags,
         );
 
-        // Early-abort optimization: CXL type errors (E200/E201), source-CK
-        // validation errors (E153), and DLQ/output-path errors
+        // Early-abort optimization: CXL compile errors (parse E202,
+        // name-resolution E203, type E200), source-schema errors (E201),
+        // source-CK validation errors (E153), and DLQ/output-path errors
         // (E317/E318) make per-variant lowering meaningless, so stop here
         // rather than lowering a plan that cannot run. Every other
         // error-severity diagnostic — composition-binding errors
@@ -779,7 +781,10 @@ impl PipelineConfig {
         // which lets lowering accumulate the full diagnostic set first.
         let has_cxl_errors = diags.iter().any(|d| {
             matches!(d.severity, clinker_core_types::Severity::Error)
-                && matches!(d.code.as_str(), "E200" | "E201" | "E153" | "E317" | "E318")
+                && matches!(
+                    d.code.as_str(),
+                    "E200" | "E202" | "E203" | "E201" | "E153" | "E317" | "E318"
+                )
         });
         if has_cxl_errors {
             return Err(diags);

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -11,9 +11,10 @@
 //! binds the composition body at the call-site boundary using
 //! row-polymorphic type propagation (Leijen 2005).
 //!
-//! Errors surface as E200 diagnostics (CXL type error), E201
-//! diagnostics (missing source schema), and E102–E109 / W101
-//! diagnostics for composition binding.
+//! A CXL body's own compilation surfaces one of three codes by failure
+//! class: E202 (parse), E203 (name resolution), E200 (type check). Other
+//! errors surface as E201 (missing source schema) and E102–E109 / W101
+//! (composition binding).
 
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroU32;
@@ -1438,7 +1439,8 @@ struct ReshapeNodeBinding<'a> {
 /// CXL against that schema, enforce the group-identity and synthesis
 /// invariants, and publish the audit-widened output row.
 ///
-/// Validation enforced here (compile errors, code E200):
+/// Validation enforced here (structural checks use code E200; a rule
+/// expression's own CXL compilation uses E202/E203/E200 by failure class):
 /// - every `partition_by` field exists upstream;
 /// - each rule's `when` predicate and every `set` / `overrides` value
 ///   expression typechecks against the upstream row;
@@ -1789,7 +1791,8 @@ struct CullNodeBinding<'a> {
 /// predicate in aggregate context, validate the `removed_to` port name,
 /// and publish the (unchanged) upstream row as the node's output.
 ///
-/// Validation enforced here (compile errors, code E200):
+/// Validation enforced here (structural checks use code E200; a rule
+/// predicate's own CXL compilation uses E202/E203/E200 by failure class):
 /// - every `partition_by` and `order_by` field exists upstream;
 /// - at least one removal rule is declared;
 /// - each rule's `drop_group_when` predicate typechecks against the
@@ -4319,7 +4322,7 @@ fn typecheck_cxl(
             .map(|e| e.message.clone())
             .collect();
         return Err(Diagnostic::error(
-            "E200",
+            "E202",
             format!("CXL parse error in {node_name:?}: {}", messages.join("; ")),
             LabeledSpan::primary(span, String::new()),
         ));
@@ -4379,7 +4382,7 @@ fn typecheck_parsed_program(
     )
     .map_err(|diags| {
         Diagnostic::error(
-            "E200",
+            "E203",
             format!(
                 "CXL name resolution failed in {node_name:?}: {}",
                 diags
@@ -4438,7 +4441,7 @@ const CULL_RULE_PARSE_PREFIX: &str = "emit __cull_pred = ";
 /// stay in this wrapper's coordinate space; the caller rebases them into
 /// the reconstructed decision source via [`cxl::ast::rebase_expr_spans`].
 /// Returns the relocated predicate and the rule program's node count (the
-/// id span the caller must skip). `Err` is an E200 parse diagnostic
+/// id span the caller must skip). `Err` is an E202 parse diagnostic
 /// already attributed to `node_name`.
 #[allow(clippy::result_large_err)]
 fn parse_cull_rule_predicate(
@@ -4451,7 +4454,7 @@ fn parse_cull_rule_predicate(
     if !parsed.errors.is_empty() {
         let messages: Vec<String> = parsed.errors.iter().map(|e| e.message.clone()).collect();
         return Err(Diagnostic::error(
-            "E200",
+            "E202",
             format!("CXL parse error in {node_name:?}: {}", messages.join("; ")),
             LabeledSpan::primary(span, String::new()),
         ));
@@ -4469,7 +4472,7 @@ fn parse_cull_rule_predicate(
         }) => expr,
         _ => {
             return Err(Diagnostic::error(
-                "E200",
+                "E202",
                 format!(
                     "CXL parse error in {node_name:?}: drop_group_when must be a single \
                      expression"
@@ -5533,7 +5536,8 @@ fn walk_expr_for_qualified_refs(
 ///
 /// Wraps the source as `"filter {where_src}"` so the CXL parser
 /// produces a `Statement::Filter`. Routes diagnostics by category:
-/// - Parse / name-resolution failures → E200 (general compile error)
+/// - Parse failures → E202
+/// - Name-resolution failures → E203
 /// - Typecheck "filter predicate must be type Bool" → E303
 /// - Other typecheck errors → E200
 fn typecheck_combine_where(
@@ -5553,7 +5557,7 @@ fn typecheck_combine_where(
             .collect::<Vec<_>>()
             .join("; ");
         return Err(vec![Diagnostic::error(
-            "E200",
+            "E202",
             format!("combine {combine_name:?} where-clause parse error: {msg}"),
             LabeledSpan::primary(span, String::new()),
         )]);
@@ -5578,7 +5582,7 @@ fn typecheck_combine_where(
                 .collect::<Vec<_>>()
                 .join("; ");
             return Err(vec![Diagnostic::error(
-                "E200",
+                "E203",
                 format!("combine {combine_name:?} where-clause name resolution: {msg}"),
                 LabeledSpan::primary(span, String::new()),
             )]);

--- a/crates/clinker-plan/src/plan/execution/mod.rs
+++ b/crates/clinker-plan/src/plan/execution/mod.rs
@@ -640,9 +640,10 @@ pub struct PlanTransformPayload {
     pub dlq_node: Option<NodeIndex>,
     /// Compile-time-typechecked CXL program. Populated by
     /// `PipelineConfig::compile` via `bind_schema::bind_schema` and
-    /// NEVER `None`: a transform whose CXL fails to typecheck surfaces
-    /// as a compile-time E200 diagnostic and the enclosing `compile()`
-    /// call returns `Err` before this payload is built.
+    /// NEVER `None`: a transform whose CXL fails to compile surfaces as a
+    /// compile-time diagnostic (E202 parse / E203 name-resolution / E200
+    /// type) and the enclosing `compile()` call returns `Err` before this
+    /// payload is built.
     pub typed: Arc<TypedProgram>,
     /// Producer-declared scoped variables this transform writes via
     /// `emit $<scope>.<key>`. Empty list means no scope writes.

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -347,6 +347,9 @@ fn parse_dotted_path(path: &str) -> Result<(&str, &str), ProvenanceExplainError>
 /// contract is enforced by `test_explain_docs_all_have_required_sections`.
 pub fn explain_code(code: &str) -> Option<&'static str> {
     match code {
+        "E200" => Some(include_str!("../../../../docs/explain/E200.md")),
+        "E202" => Some(include_str!("../../../../docs/explain/E202.md")),
+        "E203" => Some(include_str!("../../../../docs/explain/E203.md")),
         "E101" => Some(include_str!("../../../../docs/explain/E101.md")),
         "E102" => Some(include_str!("../../../../docs/explain/E102.md")),
         "E103" => Some(include_str!("../../../../docs/explain/E103.md")),
@@ -616,13 +619,13 @@ mod tests {
     #[test]
     fn test_explain_docs_all_have_required_sections() {
         let codes = [
-            "E101", "E102", "E103", "E104", "E106", "E107", "E108", "E115", "E150b", "E150c",
-            "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306", "E307", "E308",
-            "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323", "E324", "E325",
-            "E326", "E327", "E330", "E331", "E332", "E333", "E334", "E335", "E336", "E337", "E338",
-            "E339", "E340", "E341", "E342", "E343", "E344", "E345", "E346", "E347", "E348", "E349",
-            "E350", "E351", "E352", "E353", "E354", "E355", "E356", "E357", "E15Y", "W101", "W302",
-            "W305", "W306",
+            "E200", "E202", "E203", "E101", "E102", "E103", "E104", "E106", "E107", "E108", "E115",
+            "E150b", "E150c", "E150d", "E150e", "E300", "E301", "E303", "E304", "E305", "E306",
+            "E307", "E308", "E309", "E310", "E311", "E312", "E313", "E319", "E320", "E321", "E323",
+            "E324", "E325", "E326", "E327", "E330", "E331", "E332", "E333", "E334", "E335", "E336",
+            "E337", "E338", "E339", "E340", "E341", "E342", "E343", "E344", "E345", "E346", "E347",
+            "E348", "E349", "E350", "E351", "E352", "E353", "E354", "E355", "E356", "E357", "E15Y",
+            "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_reshape_compiled_on_node.rs
@@ -349,12 +349,13 @@ nodes:
         .expect_err("a predicate referencing an unknown column must fail to compile");
     // The diagnostic names both the offending rule (only the per-rule
     // attribution path, which is comment-tolerant, adds the rule name) and
-    // the unknown column.
+    // the unknown column. An unknown column is a CXL name-resolution
+    // failure, so the code is E203.
     assert!(
-        diags.iter().any(|d| d.code == "E200"
+        diags.iter().any(|d| d.code == "E203"
             && d.message.contains("bad_rule")
             && d.message.contains("nonexistent")),
-        "expected an E200 naming rule `bad_rule` and the unknown column, got {:?}",
+        "expected an E203 naming rule `bad_rule` and the unknown column, got {:?}",
         diags
             .iter()
             .map(|d| (d.code.clone(), d.message.clone()))

--- a/crates/clinker-plan/src/plan/tests/cull_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/cull_validation.rs
@@ -175,14 +175,15 @@ fn drop_group_when_unknown_field_rejected() {
           drop_group_when: "sum(nonexistent) > 0""#,
     );
     let diags = compile_diagnostics(&yaml);
-    // The typecheck reports the unknown field; the exact wording comes from
-    // the CXL resolver, so pin the field name and the node label.
+    // The CXL resolver reports the unknown field, so this is a
+    // name-resolution failure (E203), not a type error. Pin the field
+    // name and the node label.
     let found = diags
         .iter()
-        .any(|(code, msg)| code == "E200" && msg.contains("nonexistent"));
+        .any(|(code, msg)| code == "E203" && msg.contains("nonexistent"));
     assert!(
         found,
-        "expected an E200 naming the unknown field `nonexistent`, got {diags:?}"
+        "expected an E203 naming the unknown field `nonexistent`, got {diags:?}"
     );
 }
 

--- a/crates/clinker-plan/src/plan/tests/envelope_synthesis.rs
+++ b/crates/clinker-plan/src/plan/tests/envelope_synthesis.rs
@@ -124,10 +124,10 @@ fn footer_collect_is_e354() {
 
 #[test]
 fn footer_median_is_a_compile_error() {
-    // `median` is not a CXL aggregate function at all, so it fails typechecking
-    // as an unknown function (surfaced as E200) — a compile error either way,
-    // satisfying the "median(x) is a compile error" acceptance without a
-    // special case in the allow-list.
+    // `median` is not a CXL aggregate function at all, so it fails name
+    // resolution as an unresolved identifier (surfaced as E203) — a compile
+    // error either way, satisfying the "median(x) is a compile error"
+    // acceptance without a special case in the allow-list.
     let yaml = pipeline_with_envelope_config(
         "strategy: concat\nfooter:\n  interchange:\n    mid: median(amount)",
     );
@@ -136,7 +136,7 @@ fn footer_median_is_a_compile_error() {
         .compile(&CompileContext::default())
         .expect_err("median is not a CXL aggregate and must fail to compile");
     assert!(
-        err.iter().any(|d| d.code == "E200" || d.code == "E354"),
+        err.iter().any(|d| d.code == "E203" || d.code == "E354"),
         "median must surface a compile diagnostic (unknown function), got: {err:?}"
     );
 }

--- a/crates/clinker-plan/src/plan/tests/overlay_compile.rs
+++ b/crates/clinker-plan/src/plan/tests/overlay_compile.rs
@@ -204,8 +204,9 @@ target: normalize
 fn spliced_bad_cxl_errors_anchored_to_op() {
     // The op engine does not typecheck CXL, so a spliced node with a bad body
     // applies structurally and then fails in the ordinary `bind_schema` pass.
-    // Because the engine stamps the injected node with the op's location, that
-    // typecheck diagnostic (E200) still points at the op, not the base.
+    // The body references an unknown column, so it fails name resolution
+    // (E203). Because the engine stamps the injected node with the op's
+    // location, that diagnostic still points at the op, not the base.
     let op = parse_op(
         r#"
 op: add
@@ -226,7 +227,7 @@ after: normalize
 
     let cxl_err = diags
         .iter()
-        .find(|d| d.code == "E200" && d.primary.span.synthetic_line_number() == Some(op_line))
+        .find(|d| d.code == "E203" && d.primary.span.synthetic_line_number() == Some(op_line))
         .unwrap_or_else(|| {
             panic!("expected an op-spanned CXL diagnostic at line {op_line}, got: {diags:?}")
         });

--- a/crates/clinker-plan/tests/e200_split_diagnostics.rs
+++ b/crates/clinker-plan/tests/e200_split_diagnostics.rs
@@ -1,0 +1,117 @@
+//! Boundary tests for the CXL-compile diagnostic split (#461).
+//!
+//! `typecheck_cxl` once collapsed CXL parse, name-resolution, and type
+//! failures under one `E200` code. Each class now carries its own code:
+//! parse → E202, name-resolution → E203, type → E200. These tests compile a
+//! pipeline through the public `PipelineConfig::compile` boundary and pin the
+//! code each failure class produces, so the three stay distinguishable by
+//! code (not just by message prefix).
+
+use clinker_plan::config::{CompileContext, parse_config};
+
+/// A source → transform → output pipeline whose transform body is `cxl`.
+/// The upstream schema is `amount: int, label: string`, so a well-formed
+/// body has real columns to reference and mistype.
+fn pipeline_with_transform_cxl(cxl: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: e200_split
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - {{ name: amount, type: int }}
+        - {{ name: label, type: string }}
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "{cxl}"
+  - type: output
+    name: out
+    input: t
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+/// Compile the fixture, expect failure, and return every `(code, message)`.
+fn compile_diagnostics(yaml: &str) -> Vec<(String, String)> {
+    let config = parse_config(yaml).expect("fixture must parse as YAML");
+    let diags = config
+        .compile(&CompileContext::default())
+        .expect_err("fixture is expected to fail compilation");
+    diags
+        .into_iter()
+        .map(|d| (d.code.clone(), d.message.clone()))
+        .collect()
+}
+
+fn codes(diags: &[(String, String)]) -> Vec<&str> {
+    diags.iter().map(|(c, _)| c.as_str()).collect()
+}
+
+#[test]
+fn cxl_parse_error_is_e202() {
+    // A trailing binary operator with no right operand is a syntax error.
+    let diags = compile_diagnostics(&pipeline_with_transform_cxl("emit total = amount *"));
+    assert!(
+        diags.iter().any(|(code, _)| code == "E202"),
+        "expected a parse error coded E202, got {:?}",
+        codes(&diags)
+    );
+    // A parse failure short-circuits resolution and type checking, so it
+    // must not masquerade as a name-resolution (E203) or type (E200) error.
+    assert!(
+        !diags
+            .iter()
+            .any(|(code, _)| code == "E200" || code == "E203"),
+        "a CXL parse error must not surface as E200/E203, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn cxl_name_resolution_error_is_e203() {
+    // `subtotal` is not a column of the upstream schema.
+    let diags = compile_diagnostics(&pipeline_with_transform_cxl("emit total = subtotal + 1"));
+    assert!(
+        diags
+            .iter()
+            .any(|(code, msg)| code == "E203" && msg.contains("subtotal")),
+        "expected a name-resolution error coded E203 naming `subtotal`, got {diags:?}"
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|(code, _)| code == "E200" || code == "E202"),
+        "a CXL name-resolution error must not surface as E200/E202, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn cxl_type_error_is_e200() {
+    // `amount` is Int and `label` is String; adding them does not type-check.
+    let diags = compile_diagnostics(&pipeline_with_transform_cxl("emit total = amount + label"));
+    assert!(
+        diags.iter().any(|(code, _)| code == "E200"),
+        "expected a type error coded E200, got {:?}",
+        codes(&diags)
+    );
+    assert!(
+        !diags
+            .iter()
+            .any(|(code, _)| code == "E202" || code == "E203"),
+        "a CXL type error must not surface as E202/E203, got {:?}",
+        codes(&diags)
+    );
+}

--- a/crates/clinker-plan/tests/route_condition_diagnostics.rs
+++ b/crates/clinker-plan/tests/route_condition_diagnostics.rs
@@ -129,14 +129,14 @@ nodes:
 fn route_condition_parse_error_is_diagnosed_at_bind_time() {
     // A syntactically invalid condition (`amount >` has no right operand) is a
     // valid YAML scalar but not a valid CXL predicate. The binder must reject
-    // it at compile time with a branch-qualified E200 anchored at the Route
+    // it at compile time with a branch-qualified E202 anchored at the Route
     // node's source line — not defer it to run start.
     let err = compile_route_condition("amount >")
         .expect_err("a route condition that fails to parse must fail the compile");
     let diag = err
         .iter()
-        .find(|d| d.code == "E200" && d.message.contains("parse error"))
-        .unwrap_or_else(|| panic!("expected an E200 parse-error diagnostic, got: {err:?}"));
+        .find(|d| d.code == "E202" && d.message.contains("parse error"))
+        .unwrap_or_else(|| panic!("expected an E202 parse-error diagnostic, got: {err:?}"));
     assert!(
         diag.message.contains("branch big"),
         "the diagnostic must name the offending branch, got: {}",
@@ -152,13 +152,13 @@ fn route_condition_parse_error_is_diagnosed_at_bind_time() {
 fn route_condition_unknown_field_is_diagnosed_at_bind_time() {
     // A condition that references a field the upstream schema does not declare
     // fails name resolution. The binder must surface that as a branch-qualified
-    // E200 naming the unresolved identifier, anchored at the Route node.
+    // E203 naming the unresolved identifier, anchored at the Route node.
     let err = compile_route_condition("nonexistent_field > 100")
         .expect_err("a route condition referencing an unknown field must fail the compile");
     let diag = err
         .iter()
-        .find(|d| d.code == "E200" && d.message.contains("name resolution"))
-        .unwrap_or_else(|| panic!("expected an E200 name-resolution diagnostic, got: {err:?}"));
+        .find(|d| d.code == "E203" && d.message.contains("name resolution"))
+        .unwrap_or_else(|| panic!("expected an E203 name-resolution diagnostic, got: {err:?}"));
     assert!(
         diag.message.contains("nonexistent_field") && diag.message.contains("branch big"),
         "the diagnostic must name the unresolved field and the offending branch, got: {}",

--- a/docs/explain/E200.md
+++ b/docs/explain/E200.md
@@ -1,0 +1,82 @@
+# Error E200: CXL type error
+
+## What it means
+
+A CXL expression parsed and every name in it resolved, but the expression
+does not type-check against the upstream schema. The operand types do not
+fit the operator or function applied to them — for example adding a number
+to a string, comparing incompatible types, calling an aggregate on a
+non-numeric column, or using a function that is not a known CXL builtin.
+
+This is a *type* failure, the last of the three CXL compile passes. A
+syntax failure is reported as E202 and an unresolved-name failure as E203;
+E200 is reserved for expressions that are well-formed and fully resolved
+but ill-typed.
+
+## Example
+
+```yaml
+# Invalid: `amount` is an int; `+` on int and string does not type-check
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: amount, type: int }
+        - { name: label, type: string }
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit total = amount + label"   # ERROR: Int + String
+```
+
+```yaml
+# Invalid: `median` is not a CXL aggregate function
+nodes:
+  - type: aggregate
+    name: agg
+    input: src
+    config:
+      group_by: [label]
+      cxl: |
+        emit label = label
+        emit mid = median(amount)          # ERROR: unknown aggregate function
+```
+
+```yaml
+# Corrected: operands and functions match their types
+nodes:
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit total = amount + 1"
+```
+
+## How to fix
+
+Read the type the checker reports for each operand and make the operation
+consistent. Convert a value with `.to_int()` / `.to_float()` /
+`.to_decimal()` / `.to_string()` where a cast is intended, compare like
+with like, and use a supported builtin. For a combine `where:` clause that
+must return `Bool` specifically, see the combine-specific refinement E303.
+
+## Technical context
+
+Type checking is the third compile-time CXL pass — after parsing (E202)
+and name resolution (E203) — run against the propagated upstream Row; the
+same pass `clinker run --dry-run` exercises. A type error short-circuits
+lowering for that node: compilation returns the error rather than
+producing a runnable plan, so an ill-typed body never reaches the
+executor. The diagnostic's primary span points at the node whose body
+failed to type-check.
+
+## See also
+
+- E202 (CXL parse error — the first CXL compile pass)
+- E203 (CXL name-resolution error — the second CXL compile pass)
+- E303 (combine where-clause is not boolean — a combine-specific type error)

--- a/docs/explain/E202.md
+++ b/docs/explain/E202.md
@@ -1,0 +1,69 @@
+# Error E202: CXL parse error
+
+## What it means
+
+A CXL expression could not be parsed. The compiler reached a token it did
+not expect (or ran out of input mid-expression) before it could build a
+syntax tree, so the node body, route branch condition, combine
+`where:` clause, or Cull `drop_group_when` predicate is not valid CXL.
+
+This is a *syntax* failure. It is reported before name resolution (E203)
+and type checking (E200) run, because those passes need a well-formed
+syntax tree to operate on.
+
+## Example
+
+```yaml
+# Invalid: the emit has no right-hand side
+nodes:
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit total ="          # ERROR: expression expected after `=`
+```
+
+```yaml
+# Invalid: unbalanced parenthesis
+nodes:
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit total = (amount + tax"   # ERROR: `)` expected
+```
+
+```yaml
+# Corrected
+nodes:
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit total = amount + tax"
+```
+
+## How to fix
+
+Read the parser message: it names the token it expected and the position
+it stopped at. Common causes are a dangling operator or `=`, an unbalanced
+`(` / `)` / `[` / `]`, a missing statement separator, or a stray
+character. Fix the syntax so the expression is complete, then recompile —
+a name-resolution (E203) or type (E200) error may surface next once the
+body parses.
+
+## Technical context
+
+Every CXL-bearing surface — Transform / Aggregate / Route bodies, Route
+branch conditions, Combine `where:` clauses, and Cull `drop_group_when`
+predicates — is parsed during compile time (`clinker run --dry-run`
+exercises the same pass) before schema binding. A parse failure short-
+circuits that node's remaining CXL passes, and the plan is not lowered:
+compilation returns the error rather than producing a runnable plan. The
+diagnostic's primary span points at the node whose body failed to parse.
+
+## See also
+
+- E203 (CXL name-resolution error — the next pass after parsing)
+- E200 (CXL type error — runs once a body parses and resolves)
+- E303 (combine where-clause is not boolean — a combine-specific type error)

--- a/docs/explain/E203.md
+++ b/docs/explain/E203.md
@@ -1,0 +1,79 @@
+# Error E203: CXL name-resolution error
+
+## What it means
+
+A CXL expression parsed cleanly but referenced a name the resolver could
+not bind: a column that is not present in the upstream schema, a scoped
+variable (`$pipeline.*` / `$source.*` / `$record.*`) that was never
+declared, or a module member that the imported module does not export.
+
+This is a *name-resolution* failure. It is reported after parsing
+succeeds (E202) but before type checking (E200), because an unresolved
+name has no type to check.
+
+## Example
+
+```yaml
+# Invalid: `subtotal` is not a column of the upstream schema
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: in.csv
+      schema:
+        - { name: amount, type: int }
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit total = subtotal + 1"   # ERROR: unresolved identifier `subtotal`
+```
+
+```yaml
+# Invalid: reading a scoped variable that no Transform declares
+nodes:
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit flagged = amount > $pipeline.cutoff"   # ERROR: `$pipeline.cutoff` undeclared
+```
+
+```yaml
+# Corrected: reference a declared column
+nodes:
+  - type: transform
+    name: t
+    input: src
+    config:
+      cxl: "emit total = amount + 1"
+```
+
+## How to fix
+
+Check the spelling of the referenced name against the upstream schema.
+For a column, declare it in the feeding source's `schema:` block or emit
+it from an upstream Transform first. For a scoped variable, declare it on
+the Transform that writes it (`declares:` plus `emit $<scope>.<name>`)
+before any reader references it. For a module member, confirm the module
+exports it. The resolver emits a "did you mean" suggestion when a close
+match exists in the declared registry.
+
+## Technical context
+
+Name resolution runs against the propagated upstream Row during compile
+time — the same pass `clinker run --dry-run` exercises — after the body
+parses and before type checking. An unresolved name short-circuits the
+node's type-check pass, and the plan is not lowered: compilation returns
+the error rather than producing a runnable plan. The diagnostic's primary
+span points at the node whose body failed to resolve; the message carries
+the resolver's own sub-diagnostic (which may itself name a more specific
+scoped-variable code such as E173).
+
+## See also
+
+- E202 (CXL parse error — the pass before name resolution)
+- E200 (CXL type error — the pass after name resolution)
+- E109 (ambiguous column reference in an open row)

--- a/docs/user/src/nodes/route.md
+++ b/docs/user/src/nodes/route.md
@@ -36,7 +36,7 @@ Condition keys become the port names used in downstream `input:` wiring.
 
 Branch conditions are typechecked when the pipeline is compiled -- the same plan-building pass you trigger with `clinker run pipeline.yaml --dry-run` (see [Validation & Dry Run](../ops/validation.md)). Each condition is checked against the concrete column types of the route's input, so a condition that references an unknown column or compares incompatible types fails at compile time rather than partway through a run.
 
-Compile failures surface as an **E200** diagnostic (the shared CXL resolution/type-error code) and name the offending branch -- for example `split_by_value (branch high)` -- so in a multi-branch route the error points at the specific branch rather than just the route node.
+Compile failures surface as a CXL diagnostic keyed to the failure class -- **E202** for a branch condition that does not parse, **E203** for one that references an unknown column, and **E200** for one that compares incompatible types -- and name the offending branch, for example `split_by_value (branch high)`, so in a multi-branch route the error points at the specific branch rather than just the route node.
 
 ## Default branch
 

--- a/docs/user/src/pipelines/variables.md
+++ b/docs/user/src/pipelines/variables.md
@@ -101,7 +101,7 @@ CXL access is identical for declared and built-in keys:
       emit confidence = $record.fuzzy_score
 ```
 
-Reads of undeclared keys are rejected with **E200** (CXL name
+Reads of undeclared keys are rejected with **E203** (CXL name
 resolution failed) at compile time, with a "did you mean" suggestion
 that scans the declared registry.
 
@@ -200,7 +200,7 @@ checked against the pipeline. Each code below tells you what to fix.
 | E173 | Composition body reads a parent scoped var without opting in.          |
 | E174 | Composition `_compose.scoped_vars` declares a different type than the parent. |
 | E175 | An init-phase node reads a runtime-only writer's variable.             |
-| E200 | A reference to an undeclared scoped variable (resolver-level failure). |
+| E203 | A reference to an undeclared scoped variable (resolver-level failure). |
 
 Cross-Transform duplicate `declares:` (the same `(scope, name)` declared
 on two Transforms) is rejected before the run starts. `$pipeline`,


### PR DESCRIPTION
## Problem

CXL compilation runs three passes — parse, name resolution, type check — but every failure surfaced under a single `E200` code. A user could only tell the classes apart by the message prefix (`CXL parse error` vs `CXL name resolution failed` vs `CXL type error`), not by code. That also meant `clinker explain --code E200` would have had to cover all three at once; in practice it had no page at all.

## Change

Each failure class now carries its own code across the whole CXL-compile surface in `bind_schema` — node bodies, route branch conditions, combine `where:` clauses, and Cull `drop_group_when` predicates:

- **E202** — CXL parse error (syntax failure)
- **E203** — CXL name-resolution error (unresolved field / variable / module reference)
- **E200** — CXL type error (now exclusively type-check failures)

Supporting changes:

- The plan-time early-abort set that stops lowering on a CXL failure now matches `E202`/`E203` as well as `E200`, so a parse or name-resolution error still halts compilation before lowering rather than falling through to produce a plan that cannot run.
- New `docs/explain/E200.md`, `E202.md`, `E203.md`, each registered with `explain_code`, so `clinker explain --code <E200|E202|E203>` renders a page with the standard sections.
- The diagnostic-code registry, the affected diagnostics assertions, the E173 composition snapshot, and the user docs (scoped variables, route) are updated to the new codes.

Structural reshape / cull / aggregate guards that reused `E200` (for example "partition_by field not present in the upstream schema") are intentionally left on `E200`. Those are plan-structural checks, not the CXL parse/resolve/type pipeline, and are out of scope for this split.

## Tests

- New boundary test `crates/clinker-plan/tests/e200_split_diagnostics.rs` compiles a pipeline through the public `PipelineConfig::compile` entry point and pins one code per failure class (parse → E202, name-resolution → E203, type → E200), asserting each class does not leak into the others' codes.
- Existing diagnostics tests and the E173 snapshot updated to the new, more specific codes.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --locked -- -D warnings` and the `--all-targets` pass
- `cargo test -p clinker-plan`, plus `clinker-exec`, `clinker`, and `clinker-lineage` (the crates whose tests reference these codes)
- `cargo check --benches --workspace`

Closes #461