### PR TITLE
test(format): depth-limit + entity-expansion reader tests; drop per-document envelope section clone

### DIFF
--- a/crates/clinker-format/src/fixed_width/writer.rs
+++ b/crates/clinker-format/src/fixed_width/writer.rs
@@ -170,17 +170,18 @@ impl<W: Write> FixedWidthWriter<W> {
     /// carries (a missing section emits no line). A computed footer count is
     /// rejected at plan time for fixed-width (E346).
     fn write_section_line(
-        &mut self,
+        writer: &mut W,
+        config: &FixedWidthWriterConfig,
         fields: &indexmap::IndexMap<Box<str>, Value>,
     ) -> Result<(), FormatError> {
         let mut line = String::new();
         for value in fields.values() {
             line.push_str(&value_to_envelope_cell(value));
         }
-        self.writer.write_all(line.as_bytes())?;
-        match self.config.line_separator {
-            LineSeparator::Lf => self.writer.write_all(b"\n")?,
-            LineSeparator::CrLf => self.writer.write_all(b"\r\n")?,
+        writer.write_all(line.as_bytes())?;
+        match config.line_separator {
+            LineSeparator::Lf => writer.write_all(b"\n")?,
+            LineSeparator::CrLf => writer.write_all(b"\r\n")?,
             LineSeparator::None => {}
         }
         Ok(())
@@ -369,12 +370,12 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
             return Ok(());
         };
         framer.begin();
-        // Clone the header fields out so the immutable framer borrow ends
-        // before the `&mut self` write below; `None` (document lacks the
-        // configured section) emits no header line.
-        let header = framer.header_fields(doc).cloned();
-        if let Some(fields) = header.as_ref() {
-            self.write_section_line(fields)?;
+        // Render the header directly off the framer's borrow into the
+        // DocumentContext: `write_section_line` takes the disjoint `writer`
+        // field, so it runs while the framer borrow is live. `None` (document
+        // lacks the configured section) emits no header line.
+        if let Some(fields) = framer.header_fields(doc) {
+            Self::write_section_line(&mut self.writer, &self.config, fields)?;
         }
         Ok(())
     }
@@ -383,9 +384,8 @@ impl<W: Write + Send> FormatWriter for FixedWidthWriter<W> {
         let Some(framer) = self.framer.as_ref() else {
             return Ok(());
         };
-        let footer = framer.footer_fields(doc).cloned();
-        if let Some(fields) = footer.as_ref() {
-            self.write_section_line(fields)?;
+        if let Some(fields) = framer.footer_fields(doc) {
+            Self::write_section_line(&mut self.writer, &self.config, fields)?;
         }
         Ok(())
     }
@@ -1283,5 +1283,49 @@ mod tests {
         }
         let out = String::from_utf8(buf).unwrap();
         assert_eq!(out, "HDR\n00007\nTRL\n", "got: {out}");
+    }
+
+    #[test]
+    fn fixed_width_envelope_two_documents_each_reframed() {
+        // Two documents in one stream each get their own header/footer line
+        // rendered from their own `$doc` sections. Exercises the per-document
+        // framing across `begin_document` / `end_document` more than once — the
+        // section maps are rendered in place off the framer's borrow.
+        let mut amount = field("amount");
+        amount.ty = Type::Int;
+        amount.width = Some(5);
+        amount.justify = Some(Justify::Right);
+        amount.pad = Some("0".into());
+        let config = FixedWidthWriterConfig {
+            line_separator: LineSeparator::Lf,
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: None,
+            }),
+        };
+        let doc1 = doc_with_sections(&[
+            ("Head", &[("tag", Value::String("H1".into()))]),
+            ("Foot", &[("tag", Value::String("T1".into()))]),
+        ]);
+        let doc2 = doc_with_sections(&[
+            ("Head", &[("tag", Value::String("H2".into()))]),
+            ("Foot", &[("tag", Value::String("T2".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let mut w = FixedWidthWriter::new(&mut buf, vec![amount], config).unwrap();
+            w.begin_document(&doc1).unwrap();
+            w.write_record(&make_record(&["amount"], vec![Value::Integer(7)]))
+                .unwrap();
+            w.end_document(&doc1).unwrap();
+            w.begin_document(&doc2).unwrap();
+            w.write_record(&make_record(&["amount"], vec![Value::Integer(8)]))
+                .unwrap();
+            w.end_document(&doc2).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out, "H1\n00007\nT1\nH2\n00008\nT2\n", "got: {out}");
     }
 }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -153,7 +153,8 @@ impl<W: Write> XmlWriter<W> {
     /// for a section the document actually carries (a missing section emits no
     /// wrapper at all).
     fn write_section_element(
-        &mut self,
+        writer: &mut XmlEmitter<W>,
+        config: &XmlWriterConfig,
         wrapper: &str,
         fields: &indexmap::IndexMap<Box<str>, Value>,
         count: Option<(&str, i64)>,
@@ -168,19 +169,15 @@ impl<W: Write> XmlWriter<W> {
         if let Some((field, ref v)) = count_value {
             pairs.push((field, v));
         }
-        let tree = build_field_tree(
-            &pairs,
-            self.config.preserve_nulls,
-            &self.config.attribute_prefix,
-        )?;
+        let tree = build_field_tree(&pairs, config.preserve_nulls, &config.attribute_prefix)?;
         let mut start = BytesStart::new(wrapper);
         push_attributes(&mut start, &tree.attrs);
-        self.writer
+        writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
-        self.write_field_tree(&tree.children)?;
+        write_field_tree(writer, &tree.children)?;
         let end = BytesEnd::new(wrapper);
-        self.writer
+        writer
             .write_event(Event::End(end))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
         Ok(())
@@ -203,57 +200,62 @@ impl<W: Write> XmlWriter<W> {
         }
         Ok(())
     }
+}
 
-    /// Recursively write a field tree as nested XML elements.
-    fn write_field_tree(&mut self, nodes: &[FieldNode]) -> Result<(), FormatError> {
-        for node in nodes {
-            match node {
-                FieldNode::Leaf { name, text } => {
-                    if text.is_empty() {
-                        // Self-closing empty element (for preserve_nulls: true)
-                        let elem = BytesStart::new(name.as_str());
-                        self.writer
-                            .write_event(Event::Empty(elem))
-                            .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    } else {
-                        let start = BytesStart::new(name.as_str());
-                        self.writer
-                            .write_event(Event::Start(start))
-                            .map_err(|e| FormatError::Xml(e.to_string()))?;
-                        let text_event = BytesText::new(text);
-                        self.writer
-                            .write_event(Event::Text(text_event))
-                            .map_err(|e| FormatError::Xml(e.to_string()))?;
-                        let end = BytesEnd::new(name.as_str());
-                        self.writer
-                            .write_event(Event::End(end))
-                            .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    }
+/// Recursively write a field tree as nested XML elements. Takes the emitter
+/// directly rather than `&mut self`, so a caller can render an envelope section
+/// while holding a disjoint borrow of the framer.
+fn write_field_tree<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    nodes: &[FieldNode],
+) -> Result<(), FormatError> {
+    for node in nodes {
+        match node {
+            FieldNode::Leaf { name, text } => {
+                if text.is_empty() {
+                    // Self-closing empty element (for preserve_nulls: true)
+                    let elem = BytesStart::new(name.as_str());
+                    writer
+                        .write_event(Event::Empty(elem))
+                        .map_err(|e| FormatError::Xml(e.to_string()))?;
+                } else {
+                    let start = BytesStart::new(name.as_str());
+                    writer
+                        .write_event(Event::Start(start))
+                        .map_err(|e| FormatError::Xml(e.to_string()))?;
+                    let text_event = BytesText::new(text);
+                    writer
+                        .write_event(Event::Text(text_event))
+                        .map_err(|e| FormatError::Xml(e.to_string()))?;
+                    let end = BytesEnd::new(name.as_str());
+                    writer
+                        .write_event(Event::End(end))
+                        .map_err(|e| FormatError::Xml(e.to_string()))?;
                 }
-                FieldNode::Branch { name, body } => {
-                    let mut start = BytesStart::new(name.as_str());
-                    push_attributes(&mut start, &body.attrs);
-                    if body.children.is_empty() {
-                        // Attribute-only branch: nothing nests inside, so the
-                        // element self-closes carrying its attributes.
-                        self.writer
-                            .write_event(Event::Empty(start))
-                            .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    } else {
-                        self.writer
-                            .write_event(Event::Start(start))
-                            .map_err(|e| FormatError::Xml(e.to_string()))?;
-                        self.write_field_tree(&body.children)?;
-                        let end = BytesEnd::new(name.as_str());
-                        self.writer
-                            .write_event(Event::End(end))
-                            .map_err(|e| FormatError::Xml(e.to_string()))?;
-                    }
+            }
+            FieldNode::Branch { name, body } => {
+                let mut start = BytesStart::new(name.as_str());
+                push_attributes(&mut start, &body.attrs);
+                if body.children.is_empty() {
+                    // Attribute-only branch: nothing nests inside, so the
+                    // element self-closes carrying its attributes.
+                    writer
+                        .write_event(Event::Empty(start))
+                        .map_err(|e| FormatError::Xml(e.to_string()))?;
+                } else {
+                    writer
+                        .write_event(Event::Start(start))
+                        .map_err(|e| FormatError::Xml(e.to_string()))?;
+                    write_field_tree(writer, &body.children)?;
+                    let end = BytesEnd::new(name.as_str());
+                    writer
+                        .write_event(Event::End(end))
+                        .map_err(|e| FormatError::Xml(e.to_string()))?;
                 }
             }
         }
-        Ok(())
     }
+    Ok(())
 }
 
 impl<W: Write + Send> FormatWriter for XmlWriter<W> {
@@ -328,17 +330,15 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         self.writer
             .write_event(Event::Start(start))
             .map_err(|e| FormatError::Xml(e.to_string()))?;
-        // Reset the per-document counter and clone the header section's fields
-        // out (so the immutable framer borrow ends before the `&mut self`
-        // write below). `None` when the document lacks the configured section
-        // — then no `<header>` is emitted.
-        let header_owned: Option<indexmap::IndexMap<Box<str>, Value>> = {
-            let framer = self.framer.as_mut().expect("framer checked above");
-            framer.begin();
-            framer.header_fields(doc).cloned()
-        };
-        if let Some(fields) = header_owned.as_ref() {
-            self.write_section_element("header", fields, None)?;
+        // Reset the per-document counter, then render the header directly off
+        // the framer's borrow into the DocumentContext. `write_section_element`
+        // takes the disjoint `writer` field, so it runs while the framer borrow
+        // is live. `None` (the document lacks the configured section) emits no
+        // `<header>`.
+        let framer = self.framer.as_mut().expect("framer checked above");
+        framer.begin();
+        if let Some(fields) = framer.header_fields(doc) {
+            Self::write_section_element(&mut self.writer, &self.config, "header", fields, None)?;
         }
         Ok(())
     }
@@ -347,16 +347,13 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
         let Some(framer) = self.framer.as_ref() else {
             return Ok(());
         };
-        // `None` when the document lacks the configured footer section — then
-        // no `<footer>` is emitted (the count rides the present section only).
-        let footer_owned: Option<indexmap::IndexMap<Box<str>, Value>> =
-            framer.footer_fields(doc).cloned();
-        let count_owned: Option<(String, i64)> = framer
-            .footer_count()
-            .map(|(field, n)| (field.to_string(), n));
-        if let Some(fields) = footer_owned.as_ref() {
-            let count_ref = count_owned.as_ref().map(|(f, n)| (f.as_str(), *n));
-            self.write_section_element("footer", fields, count_ref)?;
+        // Render the footer directly off the framer's borrow: the section map
+        // and the computed count stay borrowed while the disjoint `writer` field
+        // is written. `None` (the document lacks the configured footer section)
+        // emits no `<footer>` — the count rides a present section only.
+        if let Some(fields) = framer.footer_fields(doc) {
+            let count = framer.footer_count();
+            Self::write_section_element(&mut self.writer, &self.config, "footer", fields, count)?;
         }
         let end = BytesEnd::new("Document");
         self.writer
@@ -1845,6 +1842,60 @@ mod tests {
         assert!(
             out.contains(r#"<header version="1.1"><batch_id>A</batch_id></header>"#),
             "got: {out}"
+        );
+    }
+
+    #[test]
+    fn xml_envelope_two_documents_each_reframed_with_reset_count() {
+        // Two documents in one stream: each carries its own header/footer
+        // rendered from its own `$doc` sections, and the streaming record count
+        // resets per document (1, then 2). Exercises the per-document framing
+        // across `begin_document` / `end_document` more than once — the section
+        // maps are rendered in place off the framer's borrow into each
+        // DocumentContext.
+        let schema = Arc::new(Schema::new(vec!["amount".into()]));
+        let config = XmlWriterConfig {
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: Some("count".into()),
+            }),
+            ..Default::default()
+        };
+        let doc1 = doc_with_sections(&[
+            ("Head", &[("batch_id", Value::String("A".into()))]),
+            ("Foot", &[("checksum", Value::String("S1".into()))]),
+        ]);
+        let doc2 = doc_with_sections(&[
+            ("Head", &[("batch_id", Value::String("B".into()))]),
+            ("Foot", &[("checksum", Value::String("S2".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let mut w = XmlWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc1).unwrap();
+            w.write_record(&Record::new(Arc::clone(&schema), vec![Value::Integer(10)]))
+                .unwrap();
+            w.end_document(&doc1).unwrap();
+            w.begin_document(&doc2).unwrap();
+            w.write_record(&Record::new(Arc::clone(&schema), vec![Value::Integer(20)]))
+                .unwrap();
+            w.write_record(&Record::new(Arc::clone(&schema), vec![Value::Integer(30)]))
+                .unwrap();
+            w.end_document(&doc2).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            out,
+            "<Root>\
+             <Document><header><batch_id>A</batch_id></header>\
+             <Record><amount>10</amount></Record>\
+             <footer><checksum>S1</checksum><count>1</count></footer></Document>\
+             <Document><header><batch_id>B</batch_id></header>\
+             <Record><amount>20</amount></Record><Record><amount>30</amount></Record>\
+             <footer><checksum>S2</checksum><count>2</count></footer></Document>\
+             </Root>"
         );
     }
 }

--- a/crates/clinker-format/tests/reader_dos_json.rs
+++ b/crates/clinker-format/tests/reader_dos_json.rs
@@ -1,0 +1,121 @@
+//! Pathological-JSON safety tests for the streaming JSON reader.
+//!
+//! These pin the reader's behavior on the malformed/adversarial inputs a
+//! DoS-minded producer emits — deeply nested structures, truncated documents —
+//! so a dependency-default change (serde_json's parse recursion limit) or a
+//! regression in the reader's own flatten cap surfaces as a failing test rather
+//! than a stack overflow or silent wrong result. Companion to the XML suite in
+//! `reader_dos_xml.rs` and the YAML DoS suite in `clinker-plan`.
+
+use std::io::Cursor;
+
+use clinker_format::FormatReader;
+use clinker_format::error::FormatError;
+use clinker_format::json::reader::{JsonReader, JsonReaderConfig};
+use clinker_record::Value;
+
+/// A single-line JSON object nested `depth` levels deep under the key `k`:
+/// `{"k":{"k":…{"k":1}…}}`. Read as one NDJSON line.
+fn nested_object_line(depth: usize) -> String {
+    let mut s = String::with_capacity(depth * 6 + 2);
+    for _ in 0..depth {
+        s.push_str("{\"k\":");
+    }
+    s.push('1');
+    for _ in 0..depth {
+        s.push('}');
+    }
+    s
+}
+
+fn reader(bytes: Vec<u8>) -> JsonReader {
+    JsonReader::from_reader(Cursor::new(bytes), JsonReaderConfig::default())
+        .expect("reader construction reads only the first structural byte")
+}
+
+/// Drive `schema()` then drain every record, returning the first error the
+/// reader surfaces (or `Ok(count)` when the whole document reads cleanly).
+/// Returning at all proves the reader did not overflow the stack.
+fn drain(r: &mut JsonReader) -> Result<usize, FormatError> {
+    r.schema()?;
+    let mut n = 0;
+    while r.next_record()?.is_some() {
+        n += 1;
+    }
+    Ok(n)
+}
+
+#[test]
+fn deeply_nested_object_is_rejected_not_stack_overflow() {
+    // 3000 levels is well past serde_json's default parse recursion limit
+    // (128). The NDJSON path parses each line with `serde_json::from_str`,
+    // whose recursion guard returns a clean error rather than recursing into a
+    // stack overflow. If a future serde_json disabled that guard by default,
+    // this reader would regress to overflowing — so the test both pins the
+    // guarantee and proves the process survives (it returns an error value).
+    let mut r = reader(nested_object_line(3000).into_bytes());
+    match r.schema() {
+        Err(FormatError::Json(_)) => {}
+        other => panic!("expected a Json parse error for over-deep nesting, got {other:?}"),
+    }
+}
+
+#[test]
+fn deeply_nested_top_level_array_element_is_rejected() {
+    // A top-level array routes through the streaming element scanner, which
+    // owns its own iterative nesting bound (never the call stack). A single
+    // element nested 3000 deep is rejected cleanly instead of overflowing.
+    let mut r = reader(format!("[{}]", nested_object_line(3000)).into_bytes());
+    match drain(&mut r) {
+        Err(FormatError::Json(_)) => {}
+        other => panic!("expected a Json error draining an over-deep array element, got {other:?}"),
+    }
+}
+
+#[test]
+fn flatten_sentinel_marks_objects_deeper_than_the_flatten_cap() {
+    // 100 levels sits within serde_json's 128 parse limit but past the reader's
+    // 64-level flatten cap, so the flattener stops descending and records its
+    // "[max depth]" sentinel rather than recursing without bound. Pins the cap
+    // as observable behavior at the reader boundary.
+    let mut r = reader(nested_object_line(100).into_bytes());
+    let rec = r
+        .next_record()
+        .expect("a 100-deep object parses within serde's limit")
+        .expect("one record");
+    let has_sentinel = rec
+        .iter_all_fields()
+        .any(|(_, v)| v == &Value::String("[max depth]".into()));
+    assert!(
+        has_sentinel,
+        "flatten cap must surface a `[max depth]` sentinel value; fields: {:?}",
+        rec.iter_all_fields().collect::<Vec<_>>()
+    );
+    assert!(r.next_record().unwrap().is_none());
+}
+
+#[test]
+fn ndjson_truncated_object_errors_cleanly() {
+    // A line cut off mid-value is a parse error, not a panic or a silent
+    // empty record.
+    let mut r = reader(br#"{"a":1,"b":"#.to_vec());
+    match r.schema() {
+        Err(FormatError::Json(_)) => {}
+        other => panic!("expected a Json error for a truncated object, got {other:?}"),
+    }
+}
+
+#[test]
+fn unterminated_top_level_array_errors_on_drain() {
+    // The first element parses; the missing closing `]` surfaces as an error
+    // when the stream reaches for the next element — never a silent truncation
+    // that would drop the rest of a real document.
+    let mut r = reader(br#"[{"a":1}"#.to_vec());
+    let _ = r.schema().expect("first element parses");
+    let first = r.next_record().expect("first record").expect("one element");
+    assert_eq!(first.get("a"), Some(&Value::Integer(1)));
+    match r.next_record() {
+        Err(FormatError::Json(_)) => {}
+        other => panic!("expected a Json error for an unterminated array, got {other:?}"),
+    }
+}

--- a/crates/clinker-format/tests/reader_dos_xml.rs
+++ b/crates/clinker-format/tests/reader_dos_xml.rs
@@ -1,0 +1,128 @@
+//! Pathological-XML safety tests for the streaming XML reader.
+//!
+//! These pin the guarantees on adversarial XML the reader must never inflate or
+//! resolve unsafely:
+//!
+//! * Entity-expansion (billion-laughs) and external-entity (XXE) payloads stay
+//!   inert — quick-xml does not expand DTD-declared or SYSTEM entities, and the
+//!   reader surfaces the unresolved reference as a clean error rather than
+//!   materializing an exponential string or fetching a file.
+//! * A deeply nested sibling that the reader *skips* (`skip_subtree`) is walked
+//!   iteratively (an integer depth counter, not the call stack), so a
+//!   pathological nesting depth in a skipped subtree cannot overflow the stack.
+//!   (The record-extraction path's deep-nesting guarantee is pinned by
+//!   `streaming_doc_index_xml::deeply_nested_document_streams_without_stack_overflow`.)
+//!
+//! Companion to the JSON suite in `reader_dos_json.rs`.
+
+use std::io::Cursor;
+
+use clinker_format::FormatReader;
+use clinker_format::error::FormatError;
+use clinker_format::xml::reader::{XmlReader, XmlReaderConfig};
+use clinker_record::Value;
+
+fn reader(xml: String, record_path: &str) -> XmlReader {
+    XmlReader::from_reader(
+        Cursor::new(xml.into_bytes()),
+        XmlReaderConfig {
+            record_path: Some(record_path.into()),
+            ..Default::default()
+        },
+    )
+    .expect("XML buffer read")
+}
+
+/// Drive `schema()` then drain every record, returning the first error the
+/// reader surfaces (or `Ok(count)` when the whole document reads cleanly).
+/// Returning at all proves the reader did not overflow the stack.
+fn drain(r: &mut XmlReader) -> Result<usize, FormatError> {
+    r.schema()?;
+    let mut n = 0;
+    while r.next_record()?.is_some() {
+        n += 1;
+    }
+    Ok(n)
+}
+
+#[test]
+fn billion_laughs_entities_do_not_expand() {
+    // Classic entity-expansion bomb. The DOCTYPE's <!ENTITY> declarations are
+    // inert: quick-xml never expands `&lol4;`, so the reader meets an
+    // unresolved general entity and errors instead of inflating an exponential
+    // string. Memory/time cannot blow up because no expansion ever happens.
+    let xml = concat!(
+        "<?xml version=\"1.0\"?>\n",
+        "<!DOCTYPE root [\n",
+        "  <!ENTITY lol \"lol\">\n",
+        "  <!ENTITY lol1 \"&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;\">\n",
+        "  <!ENTITY lol2 \"&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;\">\n",
+        "  <!ENTITY lol3 \"&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;\">\n",
+        "  <!ENTITY lol4 \"&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;\">\n",
+        "]>\n",
+        "<root><record><v>&lol4;</v></record></root>",
+    )
+    .to_string();
+    let mut r = reader(xml, "root/record");
+    let err = drain(&mut r).expect_err("billion-laughs entity must error, never expand");
+    match err {
+        // The error names the unresolved entity — proving the reader met the
+        // `&lol4;` reference and rejected it, rather than expanding it into a
+        // string of `lol`s.
+        FormatError::Xml(msg) => assert!(
+            msg.contains("lol4"),
+            "error must name the unresolved entity: {msg}"
+        ),
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
+#[test]
+fn external_system_entity_is_not_resolved() {
+    // An external (SYSTEM) entity must never be fetched. quick-xml does not
+    // resolve it, so the reader meets an unresolved entity and errors — it
+    // never touches the filesystem or network.
+    let xml = concat!(
+        "<?xml version=\"1.0\"?>\n",
+        "<!DOCTYPE root [ <!ENTITY xxe SYSTEM \"file:///etc/passwd\"> ]>\n",
+        "<root><record><v>&xxe;</v></record></root>",
+    )
+    .to_string();
+    let mut r = reader(xml, "root/record");
+    let err = drain(&mut r).expect_err("external entity must not resolve");
+    match err {
+        // The error names the unresolved entity — the SYSTEM entity was never
+        // fetched; the reader simply met an entity it does not resolve.
+        FormatError::Xml(msg) => assert!(
+            msg.contains("xxe"),
+            "error must name the unresolved external entity: {msg}"
+        ),
+        other => panic!("expected FormatError::Xml, got {other:?}"),
+    }
+}
+
+#[test]
+fn deeply_nested_skipped_sibling_does_not_overflow_the_stack() {
+    // A deeply nested sibling BEFORE the record element is skipped iteratively
+    // (`skip_subtree` tracks depth with a counter, never a recursive call), so
+    // it cannot overflow the stack. The record that follows the skipped subtree
+    // still reads correctly.
+    let depth = 5_000;
+    let mut xml = String::with_capacity(depth * 7 + 48);
+    xml.push_str("<root><skip>");
+    for _ in 0..depth {
+        xml.push_str("<n>");
+    }
+    for _ in 0..depth {
+        xml.push_str("</n>");
+    }
+    xml.push_str("</skip><rec><x>1</x></rec></root>");
+
+    let mut r = reader(xml, "root/rec");
+    let rec = r
+        .next_record()
+        .expect("the record after a deep skipped sibling is reached, not crashed")
+        .expect("one record");
+    assert_eq!(rec.get("x"), Some(&Value::Integer(1)));
+    assert!(r.next_record().unwrap().is_none());
+}


### PR DESCRIPTION
## Summary

Two focused changes in `clinker-format`, both low-risk:

1. **Reader safety tests (#460)** — the JSON and XML readers relied on parser
   defaults for malformed and adversarial input without any asserting tests.
   This adds crate-boundary tests that pin the guarantees so a dependency-default
   change or a reader regression fails a test instead of shipping a stack
   overflow, an unbounded expansion, or a silent wrong result.

2. **Drop the per-document envelope section clone (#556)** — the XML and
   fixed-width writers cloned the header/footer section map once per document to
   satisfy the borrow checker. That clone is unnecessary and is now removed.

## Reader safety tests (#460)

Added `crates/clinker-format/tests/reader_dos_json.rs` and
`crates/clinker-format/tests/reader_dos_xml.rs`:

- **Deep nesting is rejected, not crashed.** A JSON object read as NDJSON and a
  top-level JSON array element, each nested far past the parser's limit, are
  rejected with a clean error rather than overflowing the stack (the NDJSON path
  leans on `serde_json`'s recursion limit; the array path on the streaming
  element scanner's own iterative nesting bound).
- **The flatten cap is observable.** An object nested past the reader's 64-level
  flatten cap but within the parse limit surfaces the `[max depth]` sentinel.
- **Truncated / unterminated JSON errors** instead of silently truncating.
- **XML entity payloads stay inert.** A billion-laughs entity-expansion bomb and
  an external `SYSTEM` entity (XXE) are never expanded or fetched — the reader
  reports the unresolved entity by name. This matches quick-xml's default of not
  resolving DTD-declared or external entities.
- **Deeply nested skipped XML subtrees** are walked iteratively, so a
  pathological depth in a skipped sibling cannot overflow the stack. (The
  record-extraction deep-nesting path is already covered by
  `streaming_doc_index_xml::deeply_nested_document_streams_without_stack_overflow`.)

## Envelope writer clone removal (#556)

`begin_document` / `end_document` in the XML and fixed-width writers rendered the
header/footer section by `.cloned()`-ing its `IndexMap<Box<str>, Value>` out of
the `DocumentContext` to release the immutable framer borrow before the
`&mut self` write. The section-render helpers now take the disjoint `writer`
field directly (the pattern the CSV writer already uses), so the section renders
in place with no clone. The section fields are borrowed straight from the
`DocumentContext`, which outlives the call.

This is a per-document (not per-record) allocation, so the change is a small
efficiency and clarity win, not a hot-path fix. Output is byte-identical, pinned
by the existing golden tests plus new multi-document tests that also verify the
per-document record-count reset.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --locked -- -D warnings` and
  `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p clinker-format --locked` (all green, including the new tests)
- `cargo check --benches --workspace --locked`

No dependency, config, or public-API changes; the touched writer helpers are
private to their modules.

Closes #460, #556


Closes #556
