### PR TITLE
plan: validate $doc paths against multi-record CSV/fixed-width record_type schema

### DIFF
--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -1083,15 +1083,29 @@ impl PipelineConfig {
         //   any user-declared section/field, so a typo or out-of-range
         //   positional element is caught without false-positiving on a
         //   legitimate wire path.
-        // - Unvalidated: CSV, fixed-width, SWIFT (see `doc_schema_for`).
+        // - Closed (E341) for a multi-record CSV/fixed-width source: a
+        //   `discriminator:` + `records:` schema exposes each `record_type`
+        //   envelope section, and the reader serves exactly that section's
+        //   declared `fields:` (coerced from the matched header record), so
+        //   the same closed-schema check applies.
+        // - Unvalidated: plain (single-record) CSV/fixed-width, SWIFT (see
+        //   `doc_schema_for`).
         //
         // `doc_schema_for` is keyed once per source here, not rebuilt on
         // every (path × node × source) iteration of the loop below — a
         // `SegmentPositional` schema allocates its synthesized-section
-        // vector, so recomputing it per reference would be wasteful.
-        let doc_schema_by_source: HashMap<&str, DocSchema> = source_configs
-            .iter()
-            .map(|s| (s.name.as_str(), doc_schema_for(s)))
+        // vector, so recomputing it per reference would be wasteful. Keyed
+        // off `source_bodies()` rather than `source_configs` because the
+        // multi-record classification needs the resolved `SourceSchema`,
+        // which lives on the body, not the format-layer `SourceConfig`.
+        let doc_schema_by_source: HashMap<&str, DocSchema> = self
+            .source_bodies()
+            .map(|body| {
+                (
+                    body.source.name.as_str(),
+                    doc_schema_for(&body.source, &body.schema),
+                )
+            })
             .collect();
         // E349 — a `rest` source that declares an `envelope:` block. The
         // declaration is always inert (a REST pull buffers no document), so
@@ -2709,15 +2723,19 @@ fn resolve_all_input_references(
 ///   user-declared section/field, so a typo (`$doc.functonal_group.e06`)
 ///   or an out-of-range positional element (`$doc.transaction_set.e99`) is
 ///   caught (`E348`) without false-positiving on a legitimate wire path.
-/// - **Unvalidated** (CSV, fixed-width, SWIFT): not statically checked. A
-///   plain flat file synthesizes no `$doc` sections (a `$doc` read against
-///   one is inert but harmless), a multi-record flat file's `record_type`
-///   sections are author-declared but the section vocabulary the reader
-///   serves is not statically reconstructible here without resolving the
-///   `format_schema`, and SWIFT serves declared sections under user-chosen
-///   *or* stable default block labels — none fits the closed or positional
-///   model cleanly, so each is left unchecked rather than risk a false
-///   positive.
+/// - **Multi-record flat file** (CSV / fixed-width with a `discriminator:` +
+///   `records:` schema): each `record_type` envelope section is served as a
+///   **closed** schema — the reader coerces the matched header record's
+///   columns through the section's declared `fields:`, serving exactly those
+///   fields, so a `$doc.<section>.<field>` naming an undeclared section or
+///   field resolves null at run time. Validated by the closed arm (`E341`),
+///   the same one XML/JSON use.
+/// - **Unvalidated** (plain single-record CSV / fixed-width, SWIFT): not
+///   statically checked. A plain flat file synthesizes no `$doc` sections
+///   (declaring an `envelope:` on one is rejected by `E356`), and SWIFT
+///   serves declared sections under user-chosen *or* stable default block
+///   labels — neither fits the closed or positional model cleanly, so each
+///   is left unchecked rather than risk a false positive.
 ///
 /// REST sources are handled before this classification: a `rest` transport
 /// buffers no document, so any `$doc` access against one can never resolve
@@ -2728,7 +2746,7 @@ enum DocSchema {
     /// Validate against the format's synthesized section/positional-element
     /// vocabulary plus any user-declared section/field.
     SegmentPositional(SegmentPositionalSchema),
-    /// Not statically validated (CSV, fixed-width, SWIFT).
+    /// Not statically validated (plain single-record CSV, fixed-width, SWIFT).
     Unvalidated,
 }
 
@@ -3103,16 +3121,23 @@ fn synthesized_section(
     }
 }
 
-/// Classify how a source's `$doc` references are validated, from its
-/// format. The REST transport is checked by the caller before this is
-/// consulted, so this maps purely on `InputFormat`.
+/// Classify how a source's `$doc` references are validated, from its format
+/// and resolved schema shape. The REST transport is checked by the caller
+/// before this is consulted, so this maps on `InputFormat` plus — for the
+/// flat-file formats — the resolved [`SourceSchema`](clinker_format::SourceSchema)
+/// cardinality: a multi-record CSV/fixed-width schema (`discriminator:` +
+/// `records:`) is closed over its declared `record_type` section fields,
+/// while a plain single-record one is unvalidated.
 ///
 /// The positional bound is the reader's body-segment ceiling, not the
 /// header segment's precise arity (see [`SegmentPositionalSchema`]). A
 /// tighter per-segment-arity bound — to catch a mid-range positional typo
 /// on a short header segment — is tracked at
 /// <https://github.com/rustpunk/clinker/issues/558>.
-fn doc_schema_for(source: &crate::config::SourceConfig) -> DocSchema {
+fn doc_schema_for(
+    source: &crate::config::SourceConfig,
+    schema: &clinker_format::SourceSchema,
+) -> DocSchema {
     match &source.format {
         InputFormat::Xml(_) | InputFormat::Json(_) => DocSchema::Closed,
         InputFormat::X12(opts) => {
@@ -3165,6 +3190,26 @@ fn doc_schema_for(source: &crate::config::SourceConfig) -> DocSchema {
                 .and_then(|o| o.max_fields)
                 .unwrap_or(HL7_DEFAULT_MAX_FIELDS),
         }),
+        // A multi-record flat file (`discriminator:` + `records:`) exposes
+        // each declared `record_type` envelope section as a CLOSED schema:
+        // the reader coerces the matched header record's columns through the
+        // section's declared `fields:` and serves exactly those fields (a
+        // field the section does not declare is never served), so a
+        // `$doc.<section>.<field>` naming an undeclared section or field is a
+        // genuine typo that resolves null at run time — validated by the same
+        // closed-schema arm XML/JSON use (`E341`).
+        InputFormat::Csv(_) | InputFormat::FixedWidth(_)
+            if matches!(schema, clinker_format::SourceSchema::MultiRecord { .. }) =>
+        {
+            DocSchema::Closed
+        }
+        // Plain single-record CSV / fixed-width synthesize no `$doc` sections
+        // (declaring an `envelope:` on one is rejected by `E356`), and an
+        // as-yet-unresolved external `File` schema (which may itself be
+        // multi-record) is left unvalidated rather than risk a false positive
+        // — the same resolved-shape gate the `E356` guard applies. SWIFT
+        // serves sections under user-chosen or default block labels and is
+        // likewise unvalidated.
         InputFormat::Csv(_) | InputFormat::FixedWidth(_) | InputFormat::Swift(_) => {
             DocSchema::Unvalidated
         }

--- a/crates/clinker-plan/src/plan/tests/doc_paths.rs
+++ b/crates/clinker-plan/src/plan/tests/doc_paths.rs
@@ -914,6 +914,185 @@ nodes:
 }
 
 #[test]
+fn test_multi_record_csv_doc_field_typo_aborts_with_e341() {
+    // A multi-record CSV source exposes its `head` (record type `H`) section
+    // with a single declared field, `batch_id`. A `$doc.head.<typo>` against
+    // it names a field the section never serves — the reader coerces only the
+    // section's declared fields from the matched header record, so the typo
+    // resolves null at run time. Before this validation it compiled silently;
+    // now the closed-schema arm rejects it with E341, the same code XML/JSON
+    // typos raise.
+    let yaml = r#"
+pipeline:
+  name: multi_record_csv_doc_field_typo
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: csv
+      path: ./payments.csv
+      schema:
+        discriminator: { field: record_type }
+        records:
+          - { id: header, tag: H, columns: [ { name: record_type, type: string }, { name: batch_id, type: string } ] }
+          - { id: detail, tag: D, columns: [ { name: record_type, type: string }, { name: amount, type: int } ] }
+      envelope:
+        sections:
+          head:
+            extract: { record_type: H }
+            fields:
+              batch_id: string
+  - type: transform
+    name: tag
+    input: payments
+    config:
+      cxl: |
+        emit kind = record_type
+        emit batch = $doc.head.bath_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse multi-record csv typo pipeline");
+    let err = config
+        .compile(&CompileContext::default())
+        .expect_err("a `$doc` field typo against a multi-record csv source must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E341")
+        .unwrap_or_else(|| panic!("expected an E341 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("bath_id") && diag.message.contains("head"),
+        "E341 message must name the undeclared field and its section: {}",
+        diag.message
+    );
+    assert!(diag.help.is_some(), "E341 must carry help text");
+}
+
+#[test]
+fn test_multi_record_csv_doc_section_typo_aborts_with_e341() {
+    // A `$doc.<typo-section>.<field>` names a section that no `envelope.sections`
+    // key declares. The multi-record source's closed schema rejects the unknown
+    // section with E341 rather than resolving it to null.
+    let yaml = r#"
+pipeline:
+  name: multi_record_csv_doc_section_typo
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: csv
+      path: ./payments.csv
+      schema:
+        discriminator: { field: record_type }
+        records:
+          - { id: header, tag: H, columns: [ { name: record_type, type: string }, { name: batch_id, type: string } ] }
+          - { id: detail, tag: D, columns: [ { name: record_type, type: string }, { name: amount, type: int } ] }
+      envelope:
+        sections:
+          head:
+            extract: { record_type: H }
+            fields:
+              batch_id: string
+  - type: transform
+    name: tag
+    input: payments
+    config:
+      cxl: |
+        emit kind = record_type
+        emit batch = $doc.hed.batch_id
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse multi-record csv section-typo pipeline");
+    let err = config
+        .compile(&CompileContext::default())
+        .expect_err("a `$doc` section typo against a multi-record csv source must fail to compile");
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E341")
+        .unwrap_or_else(|| panic!("expected an E341 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("hed"),
+        "E341 message must name the undeclared section: {}",
+        diag.message
+    );
+    assert!(diag.help.is_some(), "E341 must carry help text");
+}
+
+#[test]
+fn test_multi_record_fixed_width_doc_field_typo_aborts_with_e341() {
+    // The same closed-schema check applies to a multi-record fixed-width
+    // source: a `$doc.head.<typo>` naming a field the `head` section does not
+    // declare fails the compile with E341.
+    let yaml = r#"
+pipeline:
+  name: multi_record_fixed_width_doc_field_typo
+nodes:
+  - type: source
+    name: payments
+    config:
+      name: payments
+      type: fixed_width
+      path: ./payments.txt
+      schema:
+        discriminator: { start: 0, width: 1 }
+        structure:
+          - { record: trailer, count: count }
+        records:
+          - { id: header,  tag: H, columns: [ { name: batch_id, type: string, start: 1, width: 9 } ] }
+          - { id: detail,  tag: D, columns: [ { name: id, type: int, start: 1, width: 5 }, { name: amount, type: int, start: 6, width: 4 } ] }
+          - { id: trailer, tag: T, columns: [ { name: count, type: int, start: 1, width: 5 } ] }
+      envelope:
+        sections:
+          head:
+            extract: { record_type: H }
+            fields:
+              batch_id: string
+  - type: transform
+    name: tag
+    input: payments
+    config:
+      cxl: |
+        emit kind = record_type
+        emit amount = amount
+        emit batch = $doc.head.batch_di
+  - type: output
+    name: out
+    input: tag
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#;
+    let config = parse_config(yaml).expect("parse multi-record fixed-width typo pipeline");
+    let err = config.compile(&CompileContext::default()).expect_err(
+        "a `$doc` field typo against a multi-record fixed-width source must fail to compile",
+    );
+    let diag = err
+        .iter()
+        .find(|d| d.code == "E341")
+        .unwrap_or_else(|| panic!("expected an E341 diagnostic, got: {err:?}"));
+    assert!(
+        diag.message.contains("batch_di") && diag.message.contains("head"),
+        "E341 message must name the undeclared field and its section: {}",
+        diag.message
+    );
+    assert!(diag.help.is_some(), "E341 must carry help text");
+}
+
+#[test]
 fn test_plain_csv_without_envelope_compiles() {
     // The guard fires only on a declared envelope: a plain CSV source with no
     // `envelope:` block is unaffected.

--- a/docs/explain/E341.md
+++ b/docs/explain/E341.md
@@ -16,9 +16,13 @@ schema. Without this check, an undeclared path compiles silently and resolves to
 
 This check applies to **XML** and **JSON** sources, whose readers extract exactly
 the sections and fields the `envelope:` block declares — the declaration is the
-complete, closed schema. Segment- and positional-based formats (X12, EDIFACT,
-HL7, fixed-width) synthesize extra envelope levels and positional fields beyond
-the declared config, so their envelope is open and is not checked this way.
+complete, closed schema. It also applies to a **multi-record CSV / fixed-width**
+source (one whose schema declares `discriminator:` + `records:`): each
+`record_type` envelope section serves exactly the section's declared `fields:`
+(coerced from the matched header record), so that envelope is closed too.
+Segment- and positional-based formats (X12, EDIFACT, HL7) synthesize extra
+envelope levels and positional fields beyond the declared config, so their
+envelope is open and is checked differently (see E348).
 
 ```
 `$doc.Summry.total` references envelope section 'Summry', but source 'payments'
@@ -82,10 +86,14 @@ planner closes that gap: it collects every `$doc` path the pipeline's programs
 reference (Transform, Aggregate, Route conditions, Combine predicates and bodies,
 and composition bodies), traces each referencing node back through the DAG to the
 source(s) feeding it, and validates each path against that source's declared
-envelope. The check runs only for XML and JSON sources, because their readers
-extract exactly the declared sections and fields; for those formats the
+envelope. The check runs for XML and JSON sources, and for a multi-record CSV /
+fixed-width source (`discriminator:` + `records:`), because each of these readers
+extracts exactly the declared sections and fields; for those formats the
 `envelope:` declaration is authoritative, so a path it omits is a genuine typo
-rather than a wire-derived section the config legitimately leaves untyped.
+rather than a wire-derived section the config legitimately leaves untyped. A
+multi-record source's `record_type` section serves only the fields the section
+itself declares, so an undeclared field on it resolves null just as an undeclared
+XML/JSON field would.
 
 ## See also
 

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -310,6 +310,16 @@ field the declared section does not declare, is rejected with error `E341`
 (`$doc.Summry.total` against a declared `Summary`). Run
 `clinker explain --code E341` for the full write-up.
 
+**Multi-record CSV / fixed-width sources** — a source whose schema declares
+`discriminator:` + `records:` exposes a header record type as a `$doc`
+section through the `record_type` extract. The reader coerces the matched
+header record's columns through the section's declared `fields:` and serves
+exactly those fields, so the section is closed just like an XML/JSON one: a
+reference naming an undeclared section, or a field the section does not
+declare, is rejected with error `E341`. (A plain single-schema CSV /
+fixed-width source has no such structure — declaring an `envelope:` on one
+is rejected with error `E356`.)
+
 **Segment/positional sources (X12, EDIFACT, HL7)** — the file-level header
 (`ISA`/`UNB`/`FHS`) is declared through `envelope:` and is closed, but the
 reader *also* synthesizes nested envelope levels the config never names —
@@ -326,12 +336,11 @@ positional element (`$doc.transaction_set.e99`) is rejected with error
 [Network (REST) sources carry no `$doc` context](#network-rest-sources-carry-no-doc-context)
 above (`E349`).
 
-CSV, fixed-width, and SWIFT MT sources are not statically checked. A plain
-flat file synthesizes no `$doc` sections; a multi-record flat file's
-`record_type` sections are author-declared but their served vocabulary is
-not reconstructed at this layer; and SWIFT serves declared sections under
-user-chosen *or* default block labels — none fits the closed or positional
-model cleanly.
+Plain (single-schema) CSV / fixed-width and SWIFT MT sources are not
+statically checked. A plain flat file synthesizes no `$doc` sections, and
+SWIFT serves declared sections under user-chosen *or* default block labels —
+neither fits the closed or positional model cleanly. (A *multi-record* CSV /
+fixed-width source is checked — see above.)
 
 ## Indexed `$doc` access
 


### PR DESCRIPTION
## Summary

Compile-time `$doc.<section>.<field>` validation already covers XML/JSON (closed schema, `E341`), X12/EDIFACT/HL7 (segment/positional, `E348`), and REST (rejected outright, `E349`) — but CSV and fixed-width were left unchecked.

A **multi-record** CSV/fixed-width source (one whose schema declares `discriminator:` + `records:`) exposes a header record type as a `$doc` section through the `record_type` extract. At run time the reader coerces the matched header record's columns through the section's declared `fields:` and serves exactly those fields, so that section is a genuine **closed** schema. A typo — a `$doc` path naming a section or field the declaration does not carry — compiled silently and resolved to `null` at run time, the same failure mode `E341`/`E348` prevent for other formats.

## Change

- Classify a multi-record CSV/fixed-width source as a closed-schema source, so its `$doc` paths flow through the existing `E341` arm, which validates each path against the section's declared fields. No new diagnostic code — the record-type indirection produces the same "undeclared section/field" message a closed schema does.
- The gate keys strictly on the **resolved multi-record schema shape**:
  - A plain single-record (`Columns`) source stays unvalidated — declaring an `envelope:` on one is already rejected by `E356`.
  - An as-yet-unresolved external `File` schema (which may itself be multi-record) is left alone rather than risk a false positive — the same resolved-shape gate `E356` applies.
  - SWIFT remains unchecked (its sections resolve under user-chosen or default block labels).
- This gating also keeps the scripted-reader pattern (a pathless single-schema `csv` source with no envelope, used to drive the executor's document-boundary handling) unaffected.

## Tests

New plan-crate tests: a field typo and a section typo against multi-record CSV, and a field typo against multi-record fixed-width — each now aborts the compile with `E341`. The existing controls confirm a legitimate declared path still compiles, and the plain-source `E356` and scripted-reader paths are untouched.

## Docs

Updated the `E341` explain doc and the envelope/document-context user guide to describe the new multi-record coverage.

Closes #552