### PR TITLE
fix(plan): guarantee the case-sensitivity probe cleans up its temp file

### DIFF
--- a/crates/clinker-plan/src/config/fs_type.rs
+++ b/crates/clinker-plan/src/config/fs_type.rs
@@ -160,10 +160,37 @@ fn nearest_existing_dir(path: &Path) -> Option<std::path::PathBuf> {
     }
 }
 
+/// Removes a probe file when it goes out of scope, so the case-sensitivity
+/// probe leaves no residue on **any** return path — the normal one, an early
+/// `?` bubble, or an unwinding panic between creating the file and reading the
+/// result.
+///
+/// The probe cannot be relocated to an OS temp dir to sidestep the residue
+/// concern: it must be created in the very directory being classified, because
+/// case-sensitivity is a per-*filesystem* (and, on Windows, a per-*directory*)
+/// property that only a file created on that exact target reveals. Since the
+/// target is frequently a tracked directory (the collision-detection path
+/// probes the current working directory for a bare output filename), guaranteed
+/// cleanup is the mechanism that keeps a probe from ever littering the working
+/// tree.
+struct ProbeFile {
+    path: std::path::PathBuf,
+}
+
+impl Drop for ProbeFile {
+    fn drop(&mut self) {
+        // Best-effort: a genuine OS unlink failure is outside our control, and a
+        // removal error must never mask the probe result the caller is after.
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
 /// Create a uniquely-named lowercase probe file in `dir` and report whether its
 /// uppercased name resolves to the same file. OS-agnostic: it measures the
 /// filesystem's actual behavior rather than inferring it from a type table, so
-/// no `#[cfg]` arm is needed.
+/// no `#[cfg]` arm is needed. The probe file is registered with a [`ProbeFile`]
+/// guard the instant it exists, so it is removed on every exit path rather than
+/// only on the success path.
 fn probe_case_sensitive(dir: &Path) -> io::Result<bool> {
     // A lowercase, process+time-unique stem so two concurrent probes in one
     // directory never clash. The extension stays lowercase; only the stem case
@@ -183,17 +210,17 @@ fn probe_case_sensitive(dir: &Path) -> io::Result<bool> {
         .write(true)
         .create_new(true)
         .open(&lower)?;
+    // Adopt the probe into an RAII guard the moment it exists on disk, so any
+    // subsequent early return or panic still removes it. The binding is named
+    // (`_probe`, not `_`) so it lives to the end of the scope rather than being
+    // dropped immediately.
+    let _probe = ProbeFile { path: lower };
     drop(file);
 
     let upper = dir.join(format!("{}.TMP", stem.to_ascii_uppercase()));
     // If the uppercased name resolves to a file, the filesystem folded the case
     // back onto the lowercase probe we just created — it is case-insensitive.
     let insensitive = upper.exists();
-
-    // Best-effort cleanup; a leaked probe file is harmless and the temp dir is
-    // the writer's own output directory, but removal failure must not mask the
-    // probe result.
-    let _ = std::fs::remove_file(&lower);
 
     Ok(!insensitive)
 }
@@ -552,5 +579,41 @@ mod tests {
         // Case-insensitive filesystem ⇔ the uppercase twin folded onto the
         // lowercase file.
         assert_eq!(sensitive, !folded);
+    }
+
+    #[test]
+    fn probe_file_guard_removes_its_file_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("residue.tmp");
+        std::fs::write(&p, b"x").unwrap();
+        assert!(p.exists());
+        {
+            let _guard = ProbeFile { path: p.clone() };
+        }
+        assert!(!p.exists(), "ProbeFile must remove its file on drop");
+    }
+
+    #[test]
+    fn probe_file_guard_removes_its_file_even_when_unwinding() {
+        // A probe file created against a tracked directory must not survive a
+        // panic between creation and the point where it would otherwise be
+        // cleaned up. A plain best-effort `remove_file` at the end of the
+        // function would leak here; the RAII guard removes the file while the
+        // stack unwinds.
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("residue-panic.tmp");
+        std::fs::write(&p, b"x").unwrap();
+        let path_for_closure = p.clone();
+        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = ProbeFile {
+                path: path_for_closure,
+            };
+            panic!("boom");
+        }));
+        assert!(caught.is_err(), "the closure was expected to panic");
+        assert!(
+            !p.exists(),
+            "ProbeFile must remove its file even while the stack unwinds"
+        );
     }
 }

--- a/crates/clinker-plan/tests/case_probe_no_leak.rs
+++ b/crates/clinker-plan/tests/case_probe_no_leak.rs
@@ -1,0 +1,66 @@
+//! The case-sensitivity probe must never leave a stray file in the directory it
+//! classifies. It creates a real probe file there (case-sensitivity can only be
+//! measured on the target filesystem itself), so cleanup on every exit path is
+//! the guarantee that keeps the working tree clean.
+
+use clinker_plan::config::{case_sensitive_dir, collision_key};
+
+/// Count `clinker-case-probe-*` entries left in `dir`.
+fn probe_residue(dir: &std::path::Path) -> Vec<std::ffi::OsString> {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(Result::ok)
+        .map(|e| e.file_name())
+        .filter(|name| name.to_string_lossy().starts_with("clinker-case-probe-"))
+        .collect()
+}
+
+#[test]
+fn case_sensitive_dir_leaves_no_probe_file_behind() {
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("errors.csv");
+
+    // The probe runs (and must clean up) even though the target file itself is
+    // never created.
+    let _ = case_sensitive_dir(&target).unwrap();
+
+    assert!(
+        !target.exists(),
+        "probe must not create the real output path"
+    );
+    let residue = probe_residue(dir.path());
+    assert!(
+        residue.is_empty(),
+        "case_sensitive_dir left probe residue behind: {residue:?}"
+    );
+}
+
+#[test]
+fn repeated_probes_leave_no_residue() {
+    // Even under many back-to-back probes in one directory, nothing accumulates.
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("out.csv");
+    for _ in 0..16 {
+        let _ = case_sensitive_dir(&target).unwrap();
+    }
+    let residue = probe_residue(dir.path());
+    assert!(
+        residue.is_empty(),
+        "repeated probes accumulated residue: {residue:?}"
+    );
+}
+
+#[test]
+fn collision_key_probes_target_dir_without_residue() {
+    // `collision_key` classifies via the same probe; a stray temp file must not
+    // survive computing a key against a real directory.
+    let dir = tempfile::tempdir().unwrap();
+    let target = dir.path().join("dlq.csv");
+    let key = collision_key(target.to_str().unwrap());
+    assert!(!key.is_empty());
+    let residue = probe_residue(dir.path());
+    assert!(
+        residue.is_empty(),
+        "collision_key left probe residue behind: {residue:?}"
+    );
+}


### PR DESCRIPTION
## Problem

The case-sensitivity probe in `clinker-plan`'s `config::fs_type` module classifies whether a directory's filesystem folds filename case (e.g. `errors.csv` vs `Errors.csv` naming the same physical file). It does this by an **active probe**: it creates a short-lived file named `clinker-case-probe-*.tmp` in the directory being classified, then checks whether the uppercased name resolves back to the same file.

Cleanup of that probe file was a best-effort `remove_file` placed only on the function's success path. If a return or panic occurred between creating the file and the cleanup line, the probe file leaked. Because the probe must run in the directory being classified, and that directory is frequently a tracked one — for a bare output filename the probe runs against the current working directory — a leaked probe could land in the working tree, which is how it was first noticed (a stray `clinker-case-probe-*.tmp` after a test run).

## Why not just probe a temp directory

Relocating the probe to the OS temp dir would sidestep the residue concern but silently break correctness: case-sensitivity is a **per-filesystem** property — and on Windows a **per-directory** attribute — that only a file created on that exact target reveals. Probing a different directory can return the wrong answer whenever the output directory and the temp directory differ in case behavior (a case-sensitive output volume vs a case-insensitive temp volume, or vice versa). The probe must stay in the directory being classified.

## Fix

Register the probe file with a small RAII guard the instant it exists on disk, and move removal into the guard's `Drop`. Cleanup now runs on **every** exit path — the normal return, an early `?` bubble, or an unwinding panic — while the probe file stays in the target directory, so the classification result is unchanged. Removal remains best-effort inside `Drop` (a genuine OS unlink failure is outside our control and must not mask the probe result).

## Tests

- Unit tests for the guard: removal on scope exit, and removal while the stack unwinds through a panic (the exact leak mechanism).
- Integration tests (`crates/clinker-plan/tests/case_probe_no_leak.rs`) asserting the public probe entry points (`case_sensitive_dir`, `collision_key`) leave no `clinker-case-probe-*` residue behind, including under repeated back-to-back probes.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --locked -- -D warnings` and `--all-targets`
- `cargo test -p clinker-plan --locked` (683 unit + 3 integration + 2 doc, all pass)
- `cargo check --benches --workspace --locked`

No dependency changes.

Closes #391