### PR TITLE
refactor(exec): infallible GraceHash ctor, one spill-cap accessor, structured dispatch args

### DIFF
--- a/crates/clinker-exec/src/executor/aggregate_dispatch.rs
+++ b/crates/clinker-exec/src/executor/aggregate_dispatch.rs
@@ -48,6 +48,22 @@ fn aggregate_spill_schema(compiled: &cxl::plan::CompiledAggregate) -> Arc<Schema
         .build()
 }
 
+/// Compiled identity of an `aggregate:` node — its name plus the typed and
+/// compiled programs, output schema, strategy, and distinct-ness the dispatch
+/// arm reads off [`PlanNode::Aggregation`]. Bundling the six fields lets
+/// [`dispatch_aggregation`] thread one value into both the per-document
+/// factory ([`DocAggregatorFactory::from_ctx`]) and the streaming-ingest
+/// helper ([`run_streaming_aggregate_ingest`]) instead of re-passing the same
+/// list to each.
+struct AggregateSpec<'a> {
+    name: &'a str,
+    typed: &'a Arc<cxl::typecheck::TypedProgram>,
+    compiled: &'a Arc<cxl::plan::CompiledAggregate>,
+    output_schema: &'a Arc<Schema>,
+    strategy: AggregateStrategy,
+    has_distinct: bool,
+}
+
 /// Execute the `Aggregation` arm for `node_idx`: select hash or streaming
 /// strategy, ingest the predecessor's records (per-record for hash, sorted
 /// for streaming), trip soft/hard spill thresholds inside the RSS budget,
@@ -72,6 +88,14 @@ pub(crate) fn dispatch_aggregation(
     } = *node
     else {
         unreachable!("dispatch_aggregation called with non-Aggregation node");
+    };
+    let spec = AggregateSpec {
+        name: name.as_str(),
+        typed,
+        compiled,
+        output_schema,
+        strategy: agg_strategy,
+        has_distinct,
     };
     // Whether this aggregate participates in retraction-mode
     // commit is fully determined by the planner-set
@@ -128,28 +152,9 @@ pub(crate) fn dispatch_aggregation(
     let agg_timer = stage_metrics::StageTimer::new(stage_metrics::StageName::Sort);
 
     if let Some(producer_idx) = streaming_ingest_producer {
-        let ingest = run_streaming_aggregate_ingest(
-            ctx,
-            current_dag,
-            node_idx,
-            producer_idx,
-            name,
-            typed,
-            has_distinct,
-            agg_strategy,
-            compiled,
-            output_schema,
-        )?;
-        return finalize_aggregate_emit(
-            ctx,
-            current_dag,
-            node_idx,
-            name,
-            agg_timer,
-            ingest.input_count,
-            ingest.out_rows,
-            ingest.puncts,
-        );
+        let ingest =
+            run_streaming_aggregate_ingest(ctx, current_dag, node_idx, producer_idx, &spec)?;
+        return finalize_aggregate_emit(ctx, current_dag, node_idx, name, agg_timer, ingest);
     }
 
     let (input, input_puncts): (
@@ -376,15 +381,7 @@ pub(crate) fn dispatch_aggregation(
         // Builds nothing in the prelude: each document's table derives its
         // own evaluator + spill schema through the `ctx`-free factory, so a
         // strict run allocates no throwaway evaluator or spill schema here.
-        let factory = DocAggregatorFactory::from_ctx(
-            ctx,
-            name,
-            typed,
-            has_distinct,
-            agg_strategy,
-            compiled,
-            output_schema,
-        )?;
+        let factory = DocAggregatorFactory::from_ctx(ctx, &spec)?;
         run_strict_aggregate_per_document(ctx, factory, name, output_schema, &input, &input_puncts)?
     };
 
@@ -394,9 +391,11 @@ pub(crate) fn dispatch_aggregation(
         node_idx,
         name,
         agg_timer,
-        input_count,
-        out_rows,
-        input_puncts,
+        AggregateEmit {
+            input_count,
+            out_rows,
+            input_puncts,
+        },
     )
 }
 
@@ -406,17 +405,19 @@ pub(crate) fn dispatch_aggregation(
 /// the output tail. Shared by the materialized ingest path and the
 /// streaming-ingest path ([`run_streaming_aggregate_ingest`]) — both
 /// produce the same finalized `out_rows`, so the emit half is identical.
-#[allow(clippy::too_many_arguments)]
 fn finalize_aggregate_emit(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
     name: &str,
     agg_timer: stage_metrics::StageTimer,
-    input_count: u64,
-    out_rows: Vec<crate::aggregation::SortRow>,
-    input_puncts: Vec<crate::executor::stream_event::Punctuation>,
+    emit: AggregateEmit,
 ) -> Result<(), PipelineError> {
+    let AggregateEmit {
+        input_count,
+        out_rows,
+        input_puncts,
+    } = emit;
     ctx.collector
         .record(agg_timer.finish(input_count, out_rows.len() as u64));
     if let Some(region) = current_dag.deferred_region_at_producer(node_idx) {
@@ -558,34 +559,29 @@ impl DocAggregatorFactory {
     /// aggregate's fan-out ceiling is always [`cxl::eval::DEFAULT_MAX_EXPANSION`].
     fn from_ctx(
         ctx: &ExecutorContext<'_>,
-        node_name: &str,
-        typed: &Arc<cxl::typecheck::TypedProgram>,
-        has_distinct: bool,
-        strategy: AggregateStrategy,
-        compiled: &Arc<cxl::plan::CompiledAggregate>,
-        output_schema: &Arc<Schema>,
+        spec: &AggregateSpec<'_>,
     ) -> Result<Self, PipelineError> {
         // The compression mode resolves against the output-schema width and
         // batch size so a spilled table's on-disk format matches what
         // `--explain` reports.
-        let spill_schema = aggregate_spill_schema(compiled);
+        let spill_schema = aggregate_spill_schema(spec.compiled);
         let spill_compress = ctx
             .spill_compress
-            .resolve_for_schema(output_schema.column_count(), ctx.batch_size as u64);
+            .resolve_for_schema(spec.output_schema.column_count(), ctx.batch_size as u64);
         Ok(Self {
-            strategy,
-            compiled: Arc::clone(compiled),
-            typed: Arc::clone(typed),
-            has_distinct,
+            strategy: spec.strategy,
+            compiled: Arc::clone(spec.compiled),
+            typed: Arc::clone(spec.typed),
+            has_distinct: spec.has_distinct,
             max_expansion: cxl::eval::DEFAULT_MAX_EXPANSION,
-            output_schema: Arc::clone(output_schema),
+            output_schema: Arc::clone(spec.output_schema),
             spill_schema,
             mem_limit: parse_memory_limit(ctx.config),
             spill_dir: ctx.spill_root_path.to_path_buf(),
             spill_compress,
-            transform_name: node_name.to_string(),
+            transform_name: spec.name.to_string(),
             arbitrator: Arc::clone(&ctx.memory_budget),
-            is_global_fold: compiled.group_by_fields.is_empty(),
+            is_global_fold: spec.compiled.group_by_fields.is_empty(),
         })
     }
 
@@ -1055,13 +1051,15 @@ struct StreamingIngestEffects {
     add_errors: Vec<(Record, u64, String)>,
 }
 
-/// Streaming-ingest result handed back to [`dispatch_aggregation`]: the
-/// finalized group rows, the document-boundary punctuations forwarded at
-/// the output tail, and the count of records the producer fed in.
-struct StreamingIngestOutput {
-    out_rows: Vec<crate::aggregation::SortRow>,
-    puncts: Vec<crate::executor::stream_event::Punctuation>,
+/// Finalized aggregate output handed to [`finalize_aggregate_emit`]: the
+/// finalized group rows, the document-boundary punctuations forwarded at the
+/// output tail, and the count of records ingested. Produced identically by the
+/// materialized drain path and the streaming-ingest path
+/// ([`run_streaming_aggregate_ingest`]), so both feed the same emit half.
+struct AggregateEmit {
     input_count: u64,
+    out_rows: Vec<crate::aggregation::SortRow>,
+    input_puncts: Vec<crate::executor::stream_event::Punctuation>,
 }
 
 /// Drive a strict (non-relaxed, non-time-windowed) Aggregate's ingest off
@@ -1111,21 +1109,17 @@ struct StreamingIngestOutput {
 /// streaming finalize path, matching the prior behavior). Spill stays
 /// RSS-triggered inside `add_record` / `finalize`, never
 /// channel-depth-triggered.
-#[allow(clippy::too_many_arguments)]
 fn run_streaming_aggregate_ingest(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
     node_idx: NodeIndex,
     producer_idx: NodeIndex,
-    name: &str,
-    typed: &Arc<cxl::typecheck::TypedProgram>,
-    has_distinct: bool,
-    agg_strategy: AggregateStrategy,
-    compiled: &Arc<cxl::plan::CompiledAggregate>,
-    output_schema: &Arc<Schema>,
-) -> Result<StreamingIngestOutput, PipelineError> {
+    spec: &AggregateSpec<'_>,
+) -> Result<AggregateEmit, PipelineError> {
     use crate::aggregation::SortRow as AggSortRow;
     use crate::executor::stream_event::StreamEvent;
+
+    let name = spec.name;
 
     let expected_input = current_dag.graph[node_idx]
         .expected_input_schema_in(current_dag)
@@ -1140,15 +1134,7 @@ fn run_streaming_aggregate_ingest(
     // `sum_consumer_usage` while live, and is unregistered when that
     // document flushes (on its `DocumentClose`, or at disconnect for the
     // document left open).
-    let factory = DocAggregatorFactory::from_ctx(
-        ctx,
-        name,
-        typed,
-        has_distinct,
-        agg_strategy,
-        compiled,
-        output_schema,
-    )?;
+    let factory = DocAggregatorFactory::from_ctx(ctx, spec)?;
 
     // Install the bounded streaming-ingest channel keyed by the producer's
     // index, so its dispatch arm streams into it with no producer-side
@@ -1408,10 +1394,10 @@ fn run_streaming_aggregate_ingest(
         }
     }
 
-    Ok(StreamingIngestOutput {
-        out_rows,
-        puncts,
+    Ok(AggregateEmit {
         input_count,
+        out_rows,
+        input_puncts: puncts,
     })
 }
 

--- a/crates/clinker-exec/src/executor/combine_dispatch.rs
+++ b/crates/clinker-exec/src/executor/combine_dispatch.rs
@@ -1232,7 +1232,6 @@ struct StreamingProbeEffects {
 /// sequencing match the drain-to-`Vec` path exactly. Mid-stream
 /// `$source.count` is `None` (the driver total is unknown until disconnect),
 /// the same defer-emit semantic the streaming Aggregate ingest uses.
-#[allow(clippy::too_many_arguments)]
 fn run_streaming_combine_probe(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,

--- a/crates/clinker-exec/src/executor/dispatch.rs
+++ b/crates/clinker-exec/src/executor/dispatch.rs
@@ -2894,16 +2894,42 @@ fn service_node_buffer_spill_requests(
     ctx: &mut ExecutorContext<'_>,
     current_dag: &ExecutionPlanDag,
 ) -> Result<(), PipelineError> {
+    let is_spill_allowed = |idx: NodeIndex| node_buffer_spill_allowed(current_dag, idx);
+    let node_name = |idx: NodeIndex| current_dag.graph[idx].name().to_string();
     service_pending_node_buffer_spills(
         &mut ctx.node_buffers,
-        &ctx.node_buffer_consumer_ids,
-        &ctx.memory_budget,
-        ctx.spill_root_path.as_ref(),
-        ctx.spill_compress,
-        ctx.batch_size,
-        |idx| node_buffer_spill_allowed(current_dag, idx),
-        |idx| current_dag.graph[idx].name().to_string(),
+        &NodeBufferSpillSweep {
+            consumer_ids: &ctx.node_buffer_consumer_ids,
+            arbitrator: &ctx.memory_budget,
+            spill_root: ctx.spill_root_path.as_ref(),
+            spill_compress: ctx.spill_compress,
+            batch_size: ctx.batch_size,
+            is_spill_allowed: &is_spill_allowed,
+            node_name: &node_name,
+        },
     )
+}
+
+/// Non-buffer inputs to [`service_pending_node_buffer_spills`]: the per-slot
+/// consumer registry, the arbitrator, the run's spill settings, and the
+/// `is_spill_allowed` / `node_name` resolvers the caller derives from the live
+/// DAG. Bundling them keeps the sweep's signature within clippy's argument
+/// budget and gives the thin [`service_node_buffer_spill_requests`] adapter
+/// and the white-box test one shape to construct.
+pub(crate) struct NodeBufferSpillSweep<'a> {
+    pub(crate) consumer_ids: &'a HashMap<
+        NodeBufferKey,
+        (
+            crate::pipeline::memory::ConsumerId,
+            Arc<crate::pipeline::memory::ConsumerHandle>,
+        ),
+    >,
+    pub(crate) arbitrator: &'a crate::pipeline::memory::MemoryArbitrator,
+    pub(crate) spill_root: &'a std::path::Path,
+    pub(crate) spill_compress: clinker_plan::config::CompressMode,
+    pub(crate) batch_size: usize,
+    pub(crate) is_spill_allowed: &'a dyn Fn(NodeIndex) -> bool,
+    pub(crate) node_name: &'a dyn Fn(NodeIndex) -> String,
 }
 
 /// Spill every resident `node_buffers` slot whose consumer flagged a
@@ -2911,39 +2937,26 @@ fn service_node_buffer_spill_requests(
 /// file against the arbitrator's disk quota.
 ///
 /// The `ExecutorContext`-free core of [`service_node_buffer_spill_requests`]:
-/// it takes the slot map, the per-slot consumer registry, the arbitrator,
-/// and the run's spill settings directly, plus `is_spill_allowed` /
-/// `node_name` resolvers the caller derives from the live DAG. Splitting it
-/// out lets a white-box test drive the resident-slot spill path
-/// deterministically — a live pipeline run cannot, because the RSS-vs-
+/// it takes the slot map plus a [`NodeBufferSpillSweep`] carrying the per-slot
+/// consumer registry, the arbitrator, the run's spill settings, and the
+/// `is_spill_allowed` / `node_name` resolvers the caller derives from the live
+/// DAG. Splitting it out lets a white-box test drive the resident-slot spill
+/// path deterministically — a live pipeline run cannot, because the RSS-vs-
 /// charged arms of `should_spill` cannot be made to transition false→true
 /// between two admissions with real record footprints.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn service_pending_node_buffer_spills(
     node_buffers: &mut HashMap<NodeBufferKey, NodeBuffer>,
-    consumer_ids: &HashMap<
-        NodeBufferKey,
-        (
-            crate::pipeline::memory::ConsumerId,
-            Arc<crate::pipeline::memory::ConsumerHandle>,
-        ),
-    >,
-    arbitrator: &crate::pipeline::memory::MemoryArbitrator,
-    spill_root: &std::path::Path,
-    spill_compress: clinker_plan::config::CompressMode,
-    batch_size: usize,
-    is_spill_allowed: impl Fn(NodeIndex) -> bool,
-    node_name: impl Fn(NodeIndex) -> String,
+    sweep: &NodeBufferSpillSweep<'_>,
 ) -> Result<(), PipelineError> {
     // Phase 1: collect the slots whose consumer flagged a spill request and
     // that are eligible to spill (resident `Memory` + single-drain
     // topology). `take_spill_request` read-and-clears the flag for every
     // flagged slot, spillable or not, so a non-spillable flag does not spin.
     let mut to_spill: Vec<NodeBufferKey> = Vec::new();
-    for (key, (_id, handle)) in consumer_ids {
+    for (key, (_id, handle)) in sweep.consumer_ids {
         if handle.take_spill_request()
             && matches!(node_buffers.get(key), Some(NodeBuffer::Memory(_)))
-            && is_spill_allowed(key.node)
+            && (sweep.is_spill_allowed)(key.node)
         {
             to_spill.push(key.clone());
         }
@@ -2952,7 +2965,8 @@ pub(crate) fn service_pending_node_buffer_spills(
     // nothing mutated the slot between the two phases, so it is still the
     // `Memory` variant Phase 1 saw.
     for key in to_spill {
-        let Some(handle) = consumer_ids
+        let Some(handle) = sweep
+            .consumer_ids
             .get(&key)
             .map(|(_id, handle)| Arc::clone(handle))
         else {
@@ -2961,23 +2975,26 @@ pub(crate) fn service_pending_node_buffer_spills(
         let Some(buffer) = node_buffers.remove(&key) else {
             continue;
         };
-        let name = node_name(key.node);
+        let name = (sweep.node_name)(key.node);
         // Resolve the compression mode against this slot's schema width and
         // the run's batch size, matching the admission path so the on-disk
         // format agrees with what `--explain` projects.
         let column_count = buffer.first_record_column_count();
-        let compress = spill_compress.resolve_for_schema(column_count, batch_size as u64);
-        let (spilled, file_bytes) = buffer.spill_resident_memory(Some(spill_root), compress)?;
+        let compress = sweep
+            .spill_compress
+            .resolve_for_schema(column_count, sweep.batch_size as u64);
+        let (spilled, file_bytes) =
+            buffer.spill_resident_memory(Some(sweep.spill_root), compress)?;
         node_buffers.insert(key, spilled);
         if file_bytes > 0 {
             // Rows are on disk now; the slot's in-memory charge is zero.
             handle.set_bytes(0);
-            if arbitrator.record_spill_bytes(&name, file_bytes) {
+            if sweep.arbitrator.record_spill_bytes(&name, file_bytes) {
                 return Err(PipelineError::spill_cap_exceeded(
                     name,
-                    arbitrator.max_spill_bytes(),
+                    sweep.arbitrator.max_spill_bytes(),
                     file_bytes,
-                    arbitrator.cumulative_spill_bytes(),
+                    sweep.arbitrator.cumulative_spill_bytes(),
                 ));
             }
         }

--- a/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
+++ b/crates/clinker-exec/src/executor/tests/resident_node_buffer_spill.rs
@@ -21,7 +21,9 @@ use std::sync::Arc;
 use clinker_record::{Record, Schema, Value};
 use petgraph::graph::NodeIndex;
 
-use crate::executor::dispatch::{NodeBufferKey, service_pending_node_buffer_spills};
+use crate::executor::dispatch::{
+    NodeBufferKey, NodeBufferSpillSweep, service_pending_node_buffer_spills,
+};
 use crate::executor::node_buffer::{NodeBuffer, NodeBufferConsumer, record_byte_cost};
 use crate::pipeline::memory::{ConsumerHandle, ConsumerId, MemoryArbitrator, NoOpPolicy};
 
@@ -86,18 +88,20 @@ fn flagged_resident_memory_slot_spills_and_discharges_via_sweep() {
 
     service_pending_node_buffer_spills(
         &mut node_buffers,
-        &consumer_ids,
-        &arb,
-        spill_dir.path(),
-        clinker_plan::config::CompressMode::On,
-        2048,
-        |_idx| true,
-        |idx| {
-            if idx == idx_a {
-                "stage_a".to_string()
-            } else {
-                "stage_b".to_string()
-            }
+        &NodeBufferSpillSweep {
+            consumer_ids: &consumer_ids,
+            arbitrator: &arb,
+            spill_root: spill_dir.path(),
+            spill_compress: clinker_plan::config::CompressMode::On,
+            batch_size: 2048,
+            is_spill_allowed: &|_idx| true,
+            node_name: &|idx| {
+                if idx == idx_a {
+                    "stage_a".to_string()
+                } else {
+                    "stage_b".to_string()
+                }
+            },
         },
     )
     .expect("resident-slot spill sweep");
@@ -177,13 +181,15 @@ fn flagged_non_spillable_slot_is_skipped_by_sweep() {
 
     service_pending_node_buffer_spills(
         &mut node_buffers,
-        &consumer_ids,
-        &arb,
-        spill_dir.path(),
-        clinker_plan::config::CompressMode::On,
-        2048,
-        |_idx| false,
-        |_idx| "fanout".to_string(),
+        &NodeBufferSpillSweep {
+            consumer_ids: &consumer_ids,
+            arbitrator: &arb,
+            spill_root: spill_dir.path(),
+            spill_compress: clinker_plan::config::CompressMode::On,
+            batch_size: 2048,
+            is_spill_allowed: &|_idx| false,
+            node_name: &|_idx| "fanout".to_string(),
+        },
     )
     .expect("sweep skips non-spillable slots without error");
 

--- a/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/mod.rs
@@ -298,7 +298,7 @@ fn charge_grace_spill(
     if budget.record_spill_bytes(name, written) {
         return Err(GraceSpillError::CapExceeded {
             attempted: written,
-            cap: budget.disk_quota(),
+            cap: budget.max_spill_bytes(),
             cumulative: budget.cumulative_spill_bytes(),
         });
     }
@@ -317,7 +317,7 @@ impl GraceHashExecutor {
         consumer_handle: std::sync::Arc<crate::pipeline::memory::ConsumerHandle>,
         spill_compress: bool,
         name: &str,
-    ) -> std::io::Result<Self> {
+    ) -> Self {
         let assigner = PartitionAssigner::new(partition_bits.max(1));
         let n = assigner.num_partitions();
         let mut partitions = Vec::with_capacity(n);
@@ -328,7 +328,7 @@ impl GraceHashExecutor {
                 distinct_sketch: GraceHll::new(),
             });
         }
-        Ok(Self {
+        Self {
             assigner,
             partitions,
             spill_dir: spill_dir.to_path_buf(),
@@ -336,7 +336,7 @@ impl GraceHashExecutor {
             name: name.to_string(),
             consumer_handle,
             spill_compress,
-        })
+        }
     }
 
     /// Path of the spill directory hosting per-partition files.
@@ -784,12 +784,7 @@ pub(crate) fn execute_combine_grace_hash(
         consumer_handle,
         spill_compress,
         name,
-    )
-    .map_err(|e| PipelineError::Internal {
-        op: "combine",
-        node: name.to_string(),
-        detail: format!("grace hash spill dir bind failed: {e}"),
-    })?;
+    );
 
     // ── Build phase ────────────────────────────────────────────────────
     //

--- a/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/spill.rs
@@ -286,7 +286,7 @@ pub(super) fn process_spilled_partition(
             if budget.record_spill_bytes(name, b_written) {
                 return Err(PipelineError::spill_cap_exceeded(
                     name,
-                    budget.disk_quota(),
+                    budget.max_spill_bytes(),
                     b_written,
                     budget.cumulative_spill_bytes(),
                 ));
@@ -310,7 +310,7 @@ pub(super) fn process_spilled_partition(
                 if budget.record_spill_bytes(name, p_written) {
                     return Err(PipelineError::spill_cap_exceeded(
                         name,
-                        budget.disk_quota(),
+                        budget.max_spill_bytes(),
                         p_written,
                         budget.cumulative_spill_bytes(),
                     ));

--- a/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
+++ b/crates/clinker-exec/src/pipeline/grace_hash/tests.rs
@@ -148,8 +148,7 @@ fn pipeline_temp_dir_owns_spill_files_on_drop() {
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
         "grace_test",
-    )
-    .unwrap();
+    );
     let schema = schema_with(&["k"]);
     // Deposit a record and force a spill so a file actually exists.
     let rec = record_for(&schema, vec![Value::Integer(7)]);
@@ -188,8 +187,7 @@ fn pipeline_temp_dir_cleans_on_panic_unwind() {
             crate::pipeline::memory::ConsumerHandle::new(),
             true,
             "grace_test",
-        )
-        .unwrap();
+        );
         let schema = schema_with(&["k"]);
         let rec = record_for(&schema, vec![Value::Integer(99)]);
         let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy));
@@ -220,8 +218,7 @@ fn spill_activates_under_tiny_budget() {
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
         "grace_test",
-    )
-    .unwrap();
+    );
     let budget = tiny_budget();
     for i in 0..256i64 {
         let rec = record_for(
@@ -262,7 +259,7 @@ fn spill_activates_on_charged_bytes_without_rss() {
         .unwrap();
     let consumer_handle = crate::pipeline::memory::ConsumerHandle::new();
     let mut exec =
-        GraceHashExecutor::new(4, dir.path(), consumer_handle.clone(), true, "grace_test").unwrap();
+        GraceHashExecutor::new(4, dir.path(), consumer_handle.clone(), true, "grace_test");
 
     // 1 GiB hard limit → 800 MiB soft limit, above any host's test RSS,
     // so the RSS arm of `should_spill` cannot trip. Register the handle so
@@ -316,8 +313,7 @@ fn lazy_probe_spill_routes_to_partition_file() {
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
         "grace_test",
-    )
-    .unwrap();
+    );
     let budget = tiny_budget();
 
     // Send 64 records all to partition 0 (top 4 bits = 0). Use a
@@ -1029,8 +1025,7 @@ fn build_eviction_spill_commit_trips_disk_cap_mid_stream() {
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
         "join_build",
-    )
-    .unwrap();
+    );
 
     // Tiny soft limit so `should_spill` fires continuously; 1-byte cap so
     // the first eviction commit overshoots; hard limit huge so
@@ -1139,8 +1134,7 @@ fn build_ondisk_immediate_write_commit_trips_disk_cap() {
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
         "join_ondisk",
-    )
-    .unwrap();
+    );
 
     // A budget that does NOT auto-spill (soft limit ~8 GiB) so the test
     // controls exactly when a commit happens; the cap starts unlimited so
@@ -1254,8 +1248,7 @@ fn probe_finalize_spill_commit_trips_disk_cap_per_partition() {
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
         "join_probe",
-    )
-    .unwrap();
+    );
     let budget =
         MemoryArbitrator::with_policy(10 * 1024 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
 
@@ -1395,8 +1388,7 @@ fn build_spill_reload_records_match() {
         crate::pipeline::memory::ConsumerHandle::new(),
         true,
         "grace_test",
-    )
-    .unwrap();
+    );
     let budget = MemoryArbitrator::with_policy(u64::MAX, 0.80, 0.70, Box::new(NoOpPolicy)); // never spills via budget
     let originals: Vec<Record> = (0..16i64)
         .map(|i| {

--- a/crates/clinker-exec/src/pipeline/iejoin.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin.rs
@@ -1192,7 +1192,7 @@ impl EmitSink<'_> {
             if written > 0 && self.budget.record_spill_bytes(self.name, written) {
                 return Err(PipelineError::spill_cap_exceeded(
                     self.name,
-                    self.budget.disk_quota(),
+                    self.budget.max_spill_bytes(),
                     written,
                     self.budget.cumulative_spill_bytes(),
                 ));

--- a/crates/clinker-exec/src/pipeline/iejoin/block.rs
+++ b/crates/clinker-exec/src/pipeline/iejoin/block.rs
@@ -1372,7 +1372,7 @@ pub(super) fn execute_block_band(
     if residue > 0 && budget.record_spill_bytes(name, residue) {
         return Err(PipelineError::spill_cap_exceeded(
             name,
-            budget.disk_quota(),
+            budget.max_spill_bytes(),
             residue,
             budget.cumulative_spill_bytes(),
         ));
@@ -1617,7 +1617,7 @@ fn charge_block_spill(ctx: &DrainCtx<'_>, written: u64) -> Result<(), PipelineEr
     if written > 0 && ctx.budget.record_spill_bytes(ctx.name, written) {
         return Err(PipelineError::spill_cap_exceeded(
             ctx.name,
-            ctx.budget.disk_quota(),
+            ctx.budget.max_spill_bytes(),
             written,
             ctx.budget.cumulative_spill_bytes(),
         ));

--- a/crates/clinker-exec/src/pipeline/memory.rs
+++ b/crates/clinker-exec/src/pipeline/memory.rs
@@ -1118,12 +1118,7 @@ impl MemoryArbitrator {
         self.peak_rss.store(n, Ordering::Relaxed);
     }
 
-    /// Disk-spill quota in bytes. `u64::MAX` = unlimited.
-    pub fn disk_quota(&self) -> u64 {
-        self.max_spill_bytes.load(Ordering::Relaxed)
-    }
-
-    /// Configured disk-spill quota in bytes.
+    /// Configured disk-spill quota in bytes. `u64::MAX` = unlimited.
     pub fn max_spill_bytes(&self) -> u64 {
         self.max_spill_bytes.load(Ordering::Relaxed)
     }
@@ -2264,10 +2259,10 @@ mod tests {
     }
 
     #[test]
-    fn test_disk_quota_default_unlimited() {
+    fn test_max_spill_bytes_default_unlimited() {
         let arbitrator =
             MemoryArbitrator::with_policy(512 * 1024 * 1024, 0.80, 0.70, Box::new(NoOpPolicy));
-        assert_eq!(arbitrator.disk_quota(), u64::MAX);
+        assert_eq!(arbitrator.max_spill_bytes(), u64::MAX);
         assert_eq!(arbitrator.cumulative_spill_bytes(), 0);
     }
 

--- a/crates/clinker-exec/src/pipeline/sort_merge_join.rs
+++ b/crates/clinker-exec/src/pipeline/sort_merge_join.rs
@@ -291,7 +291,7 @@ impl MatchWindow {
         if written > 0 && ctx.budget.record_spill_bytes(ctx.name, written) {
             return Err(PipelineError::spill_cap_exceeded(
                 ctx.name,
-                ctx.budget.disk_quota(),
+                ctx.budget.max_spill_bytes(),
                 written,
                 ctx.budget.cumulative_spill_bytes(),
             ));
@@ -1144,7 +1144,7 @@ fn execute_combine_sort_merge_with_stats(
     if residue > 0 && budget.record_spill_bytes(name, residue) {
         return Err(PipelineError::spill_cap_exceeded(
             name,
-            budget.disk_quota(),
+            budget.max_spill_bytes(),
             residue,
             budget.cumulative_spill_bytes(),
         ));
@@ -1358,7 +1358,7 @@ where
             if written > 0 && budget.record_spill_bytes(name, written) {
                 return Err(PipelineError::spill_cap_exceeded(
                     name,
-                    budget.disk_quota(),
+                    budget.max_spill_bytes(),
                     written,
                     budget.cumulative_spill_bytes(),
                 ));
@@ -1372,7 +1372,7 @@ where
     if residue > 0 && budget.record_spill_bytes(name, residue) {
         return Err(PipelineError::spill_cap_exceeded(
             name,
-            budget.disk_quota(),
+            budget.max_spill_bytes(),
             residue,
             budget.cumulative_spill_bytes(),
         ));
@@ -1507,7 +1507,7 @@ fn push_output_row(
         if written > 0 && mspill.budget.record_spill_bytes(mspill.name, written) {
             return Err(PipelineError::spill_cap_exceeded(
                 mspill.name,
-                mspill.budget.disk_quota(),
+                mspill.budget.max_spill_bytes(),
                 written,
                 mspill.budget.cumulative_spill_bytes(),
             ));

--- a/crates/clinker-exec/src/pipeline/spill_merge.rs
+++ b/crates/clinker-exec/src/pipeline/spill_merge.rs
@@ -438,7 +438,7 @@ fn merge_group<P: Serialize + DeserializeOwned + Ord>(
     if written > 0 && budget.budget.record_spill_bytes(budget.node, written) {
         return Err(PipelineError::spill_cap_exceeded(
             budget.node,
-            budget.budget.disk_quota(),
+            budget.budget.max_spill_bytes(),
             written,
             budget.budget.cumulative_spill_bytes(),
         ));


### PR DESCRIPTION
## Summary

Four behavior-preserving tech-debt cleanups in `clinker-exec`, all confined to the executor dispatch and pipeline spill code.

### 1. Infallible `GraceHashExecutor::new` (#323)

`GraceHashExecutor::new` returned `std::io::Result<Self>` but performed no I/O — it allocated the partition vector and initialized in-memory state, then unconditionally returned `Ok(..)`. Actual spill-file creation happens lazily in the build/probe/spill paths, which classify their own failures. The constructor is now infallible (`-> Self`), and the single production call site drops the impossible `.map_err(|e| PipelineError::Internal { .. "grace hash spill dir bind failed" .. })?` wrapper. Test constructors drop their `.unwrap()`.

### 2. One disk-spill-cap accessor (#326)

`MemoryArbitrator` exposed both `disk_quota()` and `max_spill_bytes()`, which read the same `max_spill_bytes` atomic and returned identical values. Having two names for one value invited call-site drift — the grace-hash and sort-merge paths reported the cap via `disk_quota()`, while the node-buffer and streaming-handoff paths used `max_spill_bytes()`. `max_spill_bytes()` is kept (it reads clearly alongside `set_max_spill_bytes()` / `cumulative_spill_bytes()`), the duplicate is deleted rather than aliased, and every call site is routed to the survivor.

### 3. Structured spill-servicing arguments (#843)

`service_pending_node_buffer_spills` carried an 8-argument signature behind a `#[allow(clippy::too_many_arguments)]`. Its non-buffer inputs — the consumer registry, arbitrator, spill settings, and the `is_spill_allowed` / `node_name` DAG resolvers — are bundled into a new `NodeBufferSpillSweep` context struct, so the function takes the mutable slot map plus one context. The suppression is removed.

### 4. Structured aggregate/combine dispatch arguments (#419)

- `AggregateSpec` bundles an aggregate node's compiled identity (name, typed/compiled programs, output schema, strategy, distinct-ness) and threads it through both `DocAggregatorFactory::from_ctx` and `run_streaming_aggregate_ingest`, removing the duplication those two sites previously re-passed field-by-field.
- `AggregateEmit` carries the finalized rows / document punctuations / input count into `finalize_aggregate_emit`, replacing the streaming-only `StreamingIngestOutput` so the materialized and streaming paths feed one shared emit shape.
- These retire the `too_many_arguments` suppressions on `finalize_aggregate_emit` and `run_streaming_aggregate_ingest`, and the now-stale suppression on `run_streaming_combine_probe` (already within the argument threshold).

## Notes

No new lint suppressions are introduced. No public cross-crate API changes (the collapsed accessor and all restructured functions have callers only within `clinker-exec`).

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --locked -- -D warnings` and `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p clinker-exec` (856 lib tests + integration + doctests)
- `cargo check --benches --workspace`

Closes #323, #326, #843, #419

Closes #326
Closes #843
Closes #419
