### PR TITLE
ci: require manual CI for auto-rebased PRs (drop the CI-triggering PAT)

### DIFF
--- a/.github/workflows/pr-auto-update-branches.yml
+++ b/.github/workflows/pr-auto-update-branches.yml
@@ -17,8 +17,12 @@ concurrency:
 
 jobs:
   update:
+    # No PR_BRANCH_UPDATE_TOKEN is passed on purpose. Without a PAT the reusable
+    # workflow pushes rebases with the default GITHUB_TOKEN, and pushes made with
+    # GITHUB_TOKEN do not trigger new workflow runs. A squash-merge therefore
+    # still auto-rebases every open PR, but those rebases no longer auto-start the
+    # CI gauntlet — a maintainer runs CI manually when they choose to validate a
+    # rebased PR.
     uses: rustpunk/github-workflows/.github/workflows/pr-auto-update-branches.yml@main
     with:
       base: main
-    secrets:
-      PR_BRANCH_UPDATE_TOKEN: ${{ secrets.PR_BRANCH_UPDATE_TOKEN }}


### PR DESCRIPTION
## What

Stop the auto-rebase-on-merge workflow from automatically starting the full CI gauntlet on every open PR.

## Why

When a PR is squash-merged, **Auto-update PR branches** rebases every other open PR onto `main`. It passed a PAT (`PR_BRANCH_UPDATE_TOKEN`) to the reusable rebase workflow, and a PAT-authenticated force-push triggers CI. So one merge fans out into a full CI run on every open PR at once — expensive and rarely wanted for all of them simultaneously.

## Change

Drop the `PR_BRANCH_UPDATE_TOKEN` secret from the caller. The reusable workflow's token input is optional and falls back to the default `GITHUB_TOKEN`. Pushes authenticated with `GITHUB_TOKEN` do not start new workflow runs (GitHub's built-in loop protection), so:

- Open PRs are still auto-rebased onto `main` after a merge (unchanged).
- Those rebases no longer auto-start CI.
- A maintainer runs CI manually when they choose to validate a rebased PR.

## Running CI manually after a rebase

`ci.yml` currently triggers on `push` to `main` and on `pull_request`. To run it on a rebased PR head today, push any commit or close/reopen the PR. If a one-click manual trigger is preferred, adding `workflow_dispatch` to `ci.yml` would let CI be dispatched on a branch from the Actions tab — can follow up separately.
