### PR TITLE
ci: allow the gauntlet to be started manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Auto-update PR branches rebases open PRs with the default GITHUB_TOKEN, and
+  # pushes made with that token never start a workflow run. Manual dispatch is
+  # therefore the only way to re-validate a rebased branch without pushing to it.
+  # Dispatched runs report against the selected branch rather than the PR's merge
+  # ref, so they appear in the Actions tab instead of the PR's check list.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Problem

The `Auto-update PR branches` workflow rebases every open pull request onto `main` after each merge, pushing with the default `GITHUB_TOKEN`. Pushes made with that token deliberately do not start workflow runs, which keeps a single squash-merge from fanning the full CI gauntlet across every open PR.

The trade-off is that a rebased branch keeps the check results from its pre-rebase commit. Re-validating one currently requires pushing something to the branch — an empty commit or a force-push — because `ci.yml` only responds to `push` and `pull_request`.

## Change

Add a `workflow_dispatch` trigger to `ci.yml` so the gauntlet can be started against any branch from the Actions tab.

Nothing else changes: the existing `push` and `pull_request` triggers, the job graph, and the toolchain are untouched.

## Note on where dispatched runs appear

A dispatched run is evaluated against the selected branch rather than the pull request's merge ref, so it is reported in the Actions tab and not in the pull request's check list. That is sufficient for confirming a rebased branch still builds and tests clean, but a reviewer looking only at the PR's checks will not see it.

## Verification

- `ci.yml` parses as valid YAML and exposes exactly three triggers: `push`, `pull_request`, `workflow_dispatch`.
- `git diff --check` is clean.
- The trigger itself becomes exercisable once this lands on the default branch, since GitHub only offers manual dispatch for workflows present on the default branch.