### PR TITLE
feat(format): parse delimited cells into multi-value fields on read (#930)

### DIFF
--- a/crates/clinker-exec/src/executor/ingest.rs
+++ b/crates/clinker-exec/src/executor/ingest.rs
@@ -60,7 +60,11 @@ fn build_format_reader(
                 open_one_shot(&source)?,
             ),
             _ => {
-                let config = build_csv_reader_config(opts.as_ref())?;
+                let mut config = build_csv_reader_config(opts.as_ref())?;
+                // `split_values` is applied only on the single-schema CSV
+                // reader. The multi-record backend does not consume it, and the
+                // plan-time gate rejects a multi-record source that declares it.
+                config.split_values = input.split_values.clone().unwrap_or_default();
                 Ok(Box::new(CsvReader::from_reader(
                     open_one_shot(&source)?,
                     config,
@@ -85,7 +89,11 @@ fn build_format_reader(
                 open_one_shot(&source)?,
             ),
             SourceSchema::Columns(cols) => {
-                let config = build_fw_reader_config(opts.as_ref());
+                let mut config = build_fw_reader_config(opts.as_ref());
+                // Single-layout fixed-width only; the multi-record backend does
+                // not consume `split_values` and the plan-time gate rejects a
+                // multi-record source that declares it.
+                config.split_values = input.split_values.clone().unwrap_or_default();
                 Ok(Box::new(FixedWidthReader::new(
                     open_one_shot(&source)?,
                     cols.clone(),

--- a/crates/clinker-exec/tests/csv_split_values_e2e.rs
+++ b/crates/clinker-exec/tests/csv_split_values_e2e.rs
@@ -1,0 +1,99 @@
+//! End-to-end proof that a CSV source's `split_values` declaration is threaded
+//! through ingest and materializes as a `Value::Array` in the output.
+//!
+//! The reader-level split is unit-tested in `clinker-format`; this guards the
+//! executor wiring (`build_csv_reader_config` copying `split_values` onto the
+//! single-schema CSV reader) that the unit tests cannot see.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+
+const PIPELINE: &str = r#"
+pipeline:
+  name: csv_split_values_e2e
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./in.csv
+      split_values:
+        - { field: tags, delimiter: ";" }
+      schema:
+        - { name: order_id, type: string }
+        - { name: tags, type: string, multiple: true }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: json
+      path: ./out.json
+"#;
+
+/// Parse the JSON output into one `serde_json::Value` per record, tolerating
+/// either a top-level array or newline-delimited objects.
+fn records(output: &str) -> Vec<serde_json::Value> {
+    let trimmed = output.trim();
+    if let Ok(serde_json::Value::Array(items)) = serde_json::from_str(trimmed) {
+        return items;
+    }
+    trimmed
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str(l).expect("each output line is a JSON object"))
+        .collect()
+}
+
+#[test]
+fn csv_split_values_reads_delimited_cells_as_arrays() {
+    let config = clinker_plan::config::parse_config(PIPELINE).expect("pipeline parses");
+    let params = PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    };
+
+    // Row 1: three values. Row 2: an empty cell (zero values). Row 3: one value.
+    let csv_input = "order_id,tags\n1,a;b;c\n2,\n3,solo\n";
+    let readers: SourceReaders = HashMap::from([(
+        "orders".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.csv",
+            Box::new(std::io::Cursor::new(csv_input.as_bytes().to_vec())),
+        ),
+    )]);
+
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+
+    common::run_config(&config, readers, writers, &params).expect("run succeeds");
+
+    let output = String::from_utf8(buf.contents()).expect("utf-8 output");
+    let recs = records(&output);
+    assert_eq!(recs.len(), 3, "one record per input row: {output}");
+
+    let tags = |i: usize| {
+        recs[i]
+            .get("tags")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null)
+    };
+    assert_eq!(tags(0), serde_json::json!(["a", "b", "c"]), "{output}");
+    assert_eq!(
+        tags(1),
+        serde_json::json!([]),
+        "empty cell → empty array: {output}"
+    );
+    assert_eq!(tags(2), serde_json::json!(["solo"]), "{output}");
+}

--- a/crates/clinker-format/src/csv/reader.rs
+++ b/crates/clinker-format/src/csv/reader.rs
@@ -6,6 +6,7 @@ use clinker_record::{Record, Schema, SchemaBuilder, Value};
 use crate::bom::SkipBom;
 use crate::charset::Charset;
 use crate::error::FormatError;
+use crate::multi_value::{SplitValues, split_text_value};
 use crate::traits::FormatReader;
 
 /// Configuration for the CSV reader.
@@ -18,6 +19,10 @@ pub struct CsvReaderConfig {
     /// `iso-8859-1`) decodes high bytes correctly instead of failing UTF-8
     /// validation or silently corrupting them.
     pub charset: Charset,
+    /// In-cell parse declarations: a column's cell text is split on its
+    /// delimiter into the several values a `multiple: true` column holds.
+    /// Empty by default; populated from the source's `split_values`.
+    pub split_values: Vec<SplitValues>,
 }
 
 impl Default for CsvReaderConfig {
@@ -27,6 +32,7 @@ impl Default for CsvReaderConfig {
             quote_char: b'"',
             has_header: true,
             charset: Charset::default(),
+            split_values: Vec::new(),
         }
     }
 }
@@ -51,6 +57,12 @@ pub struct CsvReader<R: Read> {
     inner: csv::Reader<SkipBom<R>>,
     schema: Option<Arc<Schema>>,
     config: CsvReaderConfig,
+    /// Per-column split delimiter, index-aligned to the schema columns:
+    /// `Some(delim)` for a column a `split_values` entry covers, `None`
+    /// otherwise. Built once alongside the schema so per-record decoding is a
+    /// positional lookup rather than a name scan. Empty until the schema is
+    /// resolved and when no `split_values` are declared.
+    split_delims: Vec<Option<String>>,
     row_count: u64,
     record_buf: csv::ByteRecord,
 }
@@ -66,6 +78,7 @@ impl<R: Read> CsvReader<R> {
             inner,
             schema: None,
             config,
+            split_delims: Vec::new(),
             row_count: 0,
             record_buf: csv::ByteRecord::new(),
         }
@@ -101,6 +114,26 @@ impl<R: Read> CsvReader<R> {
                 .build()
         };
 
+        // Build the index-aligned split map: for each column a `split_values`
+        // entry names, record its delimiter at that column's position. The
+        // entry's `field` is the document field name, which for CSV is the
+        // column (header) name. E358 has already checked, at plan time, that
+        // every entry names a real `multiple: true` column; an entry that
+        // matches no column here is simply inert.
+        if !self.config.split_values.is_empty() {
+            self.split_delims = schema
+                .columns()
+                .iter()
+                .map(|name| {
+                    self.config
+                        .split_values
+                        .iter()
+                        .find(|e| e.field.as_str() == name.as_ref())
+                        .map(|e| e.delimiter.clone())
+                })
+                .collect();
+        }
+
         self.schema = Some(Arc::clone(&schema));
         Ok(schema)
     }
@@ -118,7 +151,7 @@ impl<R: Read + Send> FormatReader for CsvReader<R> {
         // If we peeked a record during no-header schema inference, consume it first
         if !self.config.has_header && self.row_count == 0 && !self.record_buf.is_empty() {
             self.row_count += 1;
-            let values = decode_record(&self.record_buf, charset)?;
+            let values = decode_record(&self.record_buf, charset, &self.split_delims)?;
             return Ok(Some(Record::new(schema, values)));
         }
 
@@ -127,18 +160,38 @@ impl<R: Read + Send> FormatReader for CsvReader<R> {
         }
 
         self.row_count += 1;
-        let values = decode_record(&self.record_buf, charset)?;
+        let values = decode_record(&self.record_buf, charset, &self.split_delims)?;
         Ok(Some(Record::new(schema, values)))
     }
 }
 
 /// Decode every field of a raw [`csv::ByteRecord`] through `charset` into a
-/// `Value::String` column vector. A field that is not valid in the configured
-/// charset (only possible under [`Charset::Utf8`]) fails the record loudly
-/// rather than substituting replacement bytes.
-fn decode_record(rec: &csv::ByteRecord, charset: Charset) -> Result<Vec<Value>, FormatError> {
+/// column vector. A field that is not valid in the configured charset (only
+/// possible under [`Charset::Utf8`]) fails the record loudly rather than
+/// substituting replacement bytes.
+///
+/// A column carrying a `Some(delimiter)` in `split_delims` — a `multiple: true`
+/// column a `split_values` entry covers — materializes as a `Value::Array` of
+/// the cell's delimiter-separated parts. An empty cell yields an empty array
+/// (zero values), not a one-element array holding an empty string: a blank CSV
+/// cell means the column has no values, whereas an author who wrote a delimiter
+/// between two empties meant those empties. Every other column stays a scalar
+/// `Value::String`; element typing is CXL's responsibility downstream.
+fn decode_record(
+    rec: &csv::ByteRecord,
+    charset: Charset,
+    split_delims: &[Option<String>],
+) -> Result<Vec<Value>, FormatError> {
     rec.iter()
-        .map(|f| charset.decode(f.to_vec()).map(|s| Value::String(s.into())))
+        .enumerate()
+        .map(|(i, f)| {
+            let s = charset.decode(f.to_vec())?;
+            Ok(match split_delims.get(i).and_then(Option::as_deref) {
+                Some(_) if s.is_empty() => Value::Array(Vec::new()),
+                Some(delim) => split_text_value(&Value::String(s.into()), delim),
+                None => Value::String(s.into()),
+            })
+        })
         .collect()
 }
 
@@ -170,6 +223,109 @@ mod tests {
         assert_eq!(
             schema.columns().iter().map(|c| &**c).collect::<Vec<_>>(),
             vec!["first_name", "last_name", "email"]
+        );
+    }
+
+    /// A config whose `tags` column is split on the given delimiter.
+    fn split_config(field: &str, delimiter: &str) -> CsvReaderConfig {
+        CsvReaderConfig {
+            split_values: vec![SplitValues {
+                field: field.to_string(),
+                delimiter: delimiter.to_string(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn split_values_parses_cell_into_array() {
+        let csv = "order_id,tags\n1,a;b;c";
+        let mut reader = CsvReader::from_reader(csv.as_bytes(), split_config("tags", ";"));
+        reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(record.get("order_id"), Some(&Value::String("1".into())));
+        assert_eq!(
+            record.get("tags"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+                Value::String("c".into()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn split_values_empty_cell_yields_empty_array() {
+        let csv = "order_id,tags\n1,";
+        let mut reader = CsvReader::from_reader(csv.as_bytes(), split_config("tags", ";"));
+        reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(record.get("tags"), Some(&Value::Array(Vec::new())));
+    }
+
+    #[test]
+    fn split_values_single_value_yields_one_element_array() {
+        let csv = "order_id,tags\n1,solo";
+        let mut reader = CsvReader::from_reader(csv.as_bytes(), split_config("tags", ";"));
+        reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(
+            record.get("tags"),
+            Some(&Value::Array(vec![Value::String("solo".into())]))
+        );
+    }
+
+    #[test]
+    fn split_values_preserves_interior_empty_parts() {
+        // Only a *fully* empty cell collapses to `[]`; a delimiter written
+        // between two empties is the author declaring those empties.
+        let csv = "order_id,tags\n1,a;;c";
+        let mut reader = CsvReader::from_reader(csv.as_bytes(), split_config("tags", ";"));
+        reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(
+            record.get("tags"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("".into()),
+                Value::String("c".into()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn split_values_only_touches_covered_columns() {
+        // `notes` is not declared for splitting, so it stays a scalar even
+        // though it contains the delimiter.
+        let csv = "order_id,tags,notes\n1,a;b,x;y";
+        let mut reader = CsvReader::from_reader(csv.as_bytes(), split_config("tags", ";"));
+        reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(
+            record.get("tags"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+            ]))
+        );
+        assert_eq!(record.get("notes"), Some(&Value::String("x;y".into())));
+    }
+
+    #[test]
+    fn split_values_splits_a_quoted_cell_after_csv_unquoting() {
+        // A quoted cell containing the CSV field delimiter is unquoted by the
+        // csv parser first; the intra-cell split then runs on the recovered
+        // text, so the field delimiter inside the quotes is not a boundary.
+        let csv = "order_id,tags\n1,\"a,b;c\"";
+        let mut reader = CsvReader::from_reader(csv.as_bytes(), split_config("tags", ";"));
+        reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(
+            record.get("tags"),
+            Some(&Value::Array(vec![
+                Value::String("a,b".into()),
+                Value::String("c".into()),
+            ]))
         );
     }
 

--- a/crates/clinker-format/src/fixed_width/field.rs
+++ b/crates/clinker-format/src/fixed_width/field.rs
@@ -262,6 +262,46 @@ pub fn extract_value(field: &ResolvedField, line: &[u8], row: u64) -> Result<Val
     parse_field_value(field, &raw, row)
 }
 
+/// Extract a field a `split_values` entry covers as a `Value::Array` of typed
+/// elements: strip the field's padding, split the text on `delimiter`, and
+/// coerce each part to the declared type.
+///
+/// Unlike CSV — where cells stay `Value::String` and downstream coercion types
+/// them — the fixed-width read path is the sole coercion pass, so each element
+/// is typed here. An absent or blank field yields an empty array (zero values),
+/// mirroring the CSV reader; a field with no delimiter yields a one-element
+/// array. Each part is coerced independently, so an interior empty part fails
+/// the same way an empty scalar of that type would (`""` is a valid `string`,
+/// not a valid `int`).
+///
+/// # Errors
+///
+/// Returns [`FormatError::InvalidRecord`] at `row` when the field is truncated,
+/// not valid UTF-8, or any part fails to parse as the declared type.
+pub fn extract_split_value(
+    field: &ResolvedField,
+    line: &[u8],
+    row: u64,
+    delimiter: &str,
+) -> Result<Value, FormatError> {
+    let raw = field_text(field, line, row)?;
+    if raw.is_empty() {
+        return Ok(Value::Array(Vec::new()));
+    }
+    let parts = raw
+        .split(delimiter)
+        .map(|part| {
+            coerce_scalar(&field.ty, field.format.as_deref(), field.scale, part).map_err(
+                |message| FormatError::InvalidRecord {
+                    row,
+                    message: with_field(&field.name, &message),
+                },
+            )
+        })
+        .collect::<Result<Vec<Value>, _>>()?;
+    Ok(Value::Array(parts))
+}
+
 /// Borrow a field's raw (un-coerced) text from a record line, stripped of
 /// padding per the field's justification and `trim` policy.
 ///

--- a/crates/clinker-format/src/fixed_width/reader.rs
+++ b/crates/clinker-format/src/fixed_width/reader.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 
 use crate::bom::SkipBom;
 use crate::fixed_width::field::{self, ResolvedField};
+use crate::multi_value::SplitValues;
 use crate::schema::Column;
 use clinker_record::schema_def::LineSeparator;
 use clinker_record::{Record, Schema, SchemaBuilder};
@@ -32,12 +33,17 @@ use crate::traits::FormatReader;
 /// Configuration for the fixed-width reader.
 pub struct FixedWidthReaderConfig {
     pub line_separator: LineSeparator,
+    /// In-cell parse declarations: a field's text is split on its delimiter
+    /// into the several values a `multiple: true` column holds. Empty by
+    /// default; populated from the source's `split_values`.
+    pub split_values: Vec<SplitValues>,
 }
 
 impl Default for FixedWidthReaderConfig {
     fn default() -> Self {
         Self {
             line_separator: LineSeparator::Lf,
+            split_values: Vec::new(),
         }
     }
 }
@@ -51,6 +57,10 @@ pub struct FixedWidthReader<R: Read> {
     // otherwise shift every field of the first record.
     reader: BufReader<SkipBom<R>>,
     fields: Vec<ResolvedField>,
+    /// Per-field split delimiter, index-aligned to `fields`: `Some(delim)` for
+    /// a field a `split_values` entry covers, `None` otherwise. Built once at
+    /// construction so per-record extraction is a positional lookup.
+    split_delims: Vec<Option<String>>,
     schema: Arc<Schema>,
     config: FixedWidthReaderConfig,
     record_length: usize,
@@ -76,9 +86,29 @@ impl<R: Read> FixedWidthReader<R> {
             .build();
         let record_length = resolved.iter().map(ResolvedField::end).max().unwrap_or(0);
 
+        // Map each field to its split delimiter, if any. The entry's `field` is
+        // the document field name, which for fixed-width is the column name.
+        // E358 has already verified at plan time that every entry names a real
+        // `multiple: true` column; an unmatched entry is inert.
+        let split_delims: Vec<Option<String>> = if config.split_values.is_empty() {
+            Vec::new()
+        } else {
+            resolved
+                .iter()
+                .map(|f| {
+                    config
+                        .split_values
+                        .iter()
+                        .find(|e| e.field == f.name)
+                        .map(|e| e.delimiter.clone())
+                })
+                .collect()
+        };
+
         Ok(Self {
             reader: BufReader::new(SkipBom::new(reader)),
             fields: resolved,
+            split_delims,
             schema,
             config,
             record_length,
@@ -106,8 +136,14 @@ impl<R: Read + Send> FormatReader for FixedWidthReader<R> {
         self.row_number += 1;
 
         let mut values = Vec::with_capacity(self.fields.len());
-        for f in &self.fields {
-            values.push(field::extract_value(f, &self.line_buf, self.row_number)?);
+        for (i, f) in self.fields.iter().enumerate() {
+            let value = match self.split_delims.get(i).and_then(Option::as_deref) {
+                Some(delim) => {
+                    field::extract_split_value(f, &self.line_buf, self.row_number, delim)?
+                }
+                None => field::extract_value(f, &self.line_buf, self.row_number)?,
+            };
+            values.push(value);
         }
 
         Ok(Some(Record::new(Arc::clone(&self.schema), values)))
@@ -124,6 +160,104 @@ mod tests {
 
     fn field(name: &str) -> Column {
         Column::bare(name, Type::String)
+    }
+
+    fn split_config(field: &str, delimiter: &str) -> FixedWidthReaderConfig {
+        FixedWidthReaderConfig {
+            split_values: vec![SplitValues {
+                field: field.to_string(),
+                delimiter: delimiter.to_string(),
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// A `tags` string field over a fixed byte range parses into a string array.
+    #[test]
+    fn split_values_parses_fixed_field_into_string_array() {
+        // "01" id (0..2 int), "a;b;c     " tags (2..12 string, space-padded)
+        let data = b"01a;b;c     \n";
+        let fields = vec![
+            {
+                let mut f = field("id");
+                f.ty = Type::Int;
+                f.start = Some(0);
+                f.width = Some(2);
+                f
+            },
+            {
+                let mut f = field("tags");
+                f.ty = Type::String;
+                f.start = Some(2);
+                f.width = Some(10);
+                f
+            },
+        ];
+        let mut reader =
+            FixedWidthReader::new(&data[..], fields, split_config("tags", ";")).unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(record.get("id"), Some(&Value::Integer(1)));
+        assert_eq!(
+            record.get("tags"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+                Value::String("c".into()),
+            ]))
+        );
+    }
+
+    /// Fixed-width types each element itself (it is the sole coercion pass), so
+    /// an `int` multiple field materializes as an array of integers.
+    #[test]
+    fn split_values_types_each_element_for_numeric_field() {
+        // "1;2;3     " codes (0..10 int, space-padded)
+        let data = b"1;2;3     \n";
+        let fields = vec![{
+            let mut f = field("codes");
+            f.ty = Type::Int;
+            f.start = Some(0);
+            f.width = Some(10);
+            f
+        }];
+        let mut reader =
+            FixedWidthReader::new(&data[..], fields, split_config("codes", ";")).unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(
+            record.get("codes"),
+            Some(&Value::Array(vec![
+                Value::Integer(1),
+                Value::Integer(2),
+                Value::Integer(3),
+            ]))
+        );
+    }
+
+    /// A blank field (all padding) yields an empty array, not one empty value.
+    #[test]
+    fn split_values_blank_fixed_field_yields_empty_array() {
+        // id "01", tags all spaces over 2..12
+        let data = b"01          \n";
+        let fields = vec![
+            {
+                let mut f = field("id");
+                f.ty = Type::Int;
+                f.start = Some(0);
+                f.width = Some(2);
+                f
+            },
+            {
+                let mut f = field("tags");
+                f.ty = Type::String;
+                f.start = Some(2);
+                f.width = Some(10);
+                f
+            },
+        ];
+        let mut reader =
+            FixedWidthReader::new(&data[..], fields, split_config("tags", ";")).unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert_eq!(record.get("tags"), Some(&Value::Array(Vec::new())));
     }
 
     #[test]
@@ -369,6 +503,7 @@ mod tests {
 
         let config = FixedWidthReaderConfig {
             line_separator: LineSeparator::CrLf,
+            ..Default::default()
         };
         let mut reader = FixedWidthReader::new(&data[..], fields, config).unwrap();
 
@@ -407,6 +542,7 @@ mod tests {
 
         let config = FixedWidthReaderConfig {
             line_separator: LineSeparator::None,
+            ..Default::default()
         };
         let mut reader = FixedWidthReader::new(&data[..], fields, config).unwrap();
 

--- a/crates/clinker-format/src/multi_value.rs
+++ b/crates/clinker-format/src/multi_value.rs
@@ -14,6 +14,7 @@
 //! every mistake into one message naming neither the offending key nor the
 //! accepted forms.
 
+use clinker_record::Value;
 use serde::de::{self};
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -116,6 +117,39 @@ impl SplitValues {
 pub fn under_field_path(key: &str, path: &str) -> bool {
     key.strip_prefix(path)
         .is_some_and(|rest| rest.is_empty() || rest.starts_with('.'))
+}
+
+/// Parse a delimited cell into the several values a `multiple:` column holds.
+///
+/// A scalar becomes an array of its delimiter-separated parts; an array (a
+/// field that both repeats and carries delimited text) splits each element and
+/// flattens the result, so the two declarations compose instead of fighting.
+/// Empty parts are preserved — an author who declared the delimiter is the
+/// authority on what sits between two of them. A fully empty cell is the
+/// reader's own decision (a CSV blank means zero values, an XML empty element
+/// means one), so callers special-case it before reaching here.
+///
+/// Format-agnostic over [`clinker_record::Value`]: the XML, CSV, and
+/// fixed-width readers all share this one implementation.
+pub(crate) fn split_text_value(value: &Value, delimiter: &str) -> Value {
+    fn parts(text: &str, delimiter: &str) -> Vec<Value> {
+        text.split(delimiter)
+            .map(|p| Value::String(p.into()))
+            .collect()
+    }
+    match value {
+        Value::String(s) => Value::Array(parts(s.as_str(), delimiter)),
+        Value::Array(items) => Value::Array(
+            items
+                .iter()
+                .flat_map(|item| match item {
+                    Value::String(s) => parts(s.as_str(), delimiter),
+                    other => vec![other.clone()],
+                })
+                .collect(),
+        ),
+        other => Value::Array(vec![other.clone()]),
+    }
 }
 
 /// `keep_empty`'s default. Named rather than inlined so the inverted-industry

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -43,7 +43,7 @@ use crate::bom::UTF8_BOM;
 use crate::doc_index::DocArenaIndex;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
-use crate::multi_value::{SplitToRows, SplitToRowsMode, SplitValues};
+use crate::multi_value::{SplitToRows, SplitToRowsMode, SplitValues, split_text_value};
 use crate::source::{ReopenableSource, SourceIdentity};
 use crate::traits::FormatReader;
 use crate::xml::streaming::{SectionTarget, extract_sections};
@@ -922,34 +922,6 @@ pub(crate) fn finalize_text_run(raw: &str) -> Result<String, FormatError> {
     let trimmed = raw.trim_matches(is_xml_whitespace);
     let value = escape::unescape(trimmed).map_err(|e| FormatError::Xml(e.to_string()))?;
     Ok(value.into_owned())
-}
-
-/// Parse a delimited cell into the several values a `multiple:` column holds.
-///
-/// A scalar becomes an array of its delimiter-separated parts; an array (a
-/// field that both repeats and carries delimited text) splits each element and
-/// flattens the result, so the two declarations compose instead of fighting.
-/// Empty parts are preserved — an author who declared the delimiter is the
-/// authority on what sits between two of them.
-pub(crate) fn split_text_value(value: &Value, delimiter: &str) -> Value {
-    fn parts(text: &str, delimiter: &str) -> Vec<Value> {
-        text.split(delimiter)
-            .map(|p| Value::String(p.into()))
-            .collect()
-    }
-    match value {
-        Value::String(s) => Value::Array(parts(s.as_str(), delimiter)),
-        Value::Array(items) => Value::Array(
-            items
-                .iter()
-                .flat_map(|item| match item {
-                    Value::String(s) => parts(s.as_str(), delimiter),
-                    other => vec![other.clone()],
-                })
-                .collect(),
-        ),
-        other => Value::Array(vec![other.clone()]),
-    }
 }
 
 /// The name an occurrence's field carries on the output record.

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -68,14 +68,15 @@ enum MultiValueInput {
     /// a bare `multiple: true` is enough.
     Native,
     /// The format carries one value per field, but a field's text can hold
-    /// several separated by a delimiter, so the shape is expressible once a
-    /// `split_values` entry says what that delimiter is. Rejected all the same
-    /// until that entry reaches the reader: no CSV or fixed-width reader is
-    /// given the source's `split_values` today, so the column would bind as an
-    /// array and receive the raw cell. This verdict records that the format
-    /// CAN support the declaration, which is what separates it from
-    /// [`MultiValueInput::PositionalAxis`]; only the remediation differs while
-    /// the wiring is outstanding.
+    /// several separated by a delimiter. A `multiple: true` column is supplied
+    /// once a `split_values` entry says what that delimiter is: the
+    /// single-schema CSV and fixed-width readers then parse the cell into the
+    /// array the column holds. A column no entry covers — or any such column on
+    /// a multi-record source, whose backend never receives the block — is
+    /// rejected all the same, since it would bind as an array and receive the
+    /// raw cell. This verdict records that the format CAN support the
+    /// declaration, which is what separates it from
+    /// [`MultiValueInput::PositionalAxis`]; only the remediation differs.
     InCell,
     /// Repetition is a positional coordinate, not a list. A repeated composite
     /// serializes as two axes interleaved in one element (`11:B:1^12:B:2`),
@@ -94,9 +95,9 @@ enum MultiValueInput {
 /// - `json` — a JSON array is the format's own native shape.
 /// - `xml` — repeated child elements, collected in document order.
 /// - `csv` / `fixed_width` — one value per cell on the wire, but
-///   delimited-in-cell text is a long-standing convention for both. Reading it
-///   is a `split_values` entry, whose wiring into these two readers is tracked
-///   at https://github.com/rustpunk/clinker/issues/930.
+///   delimited-in-cell text is a long-standing convention for both. A
+///   `split_values` entry declares the delimiter, and the single-schema readers
+///   parse the cell into the array a `multiple: true` column holds (#930).
 /// - `edifact` / `x12` / `hl7` / `swift` — positional segment grammars.
 fn input_multi_value_support(format: &InputFormat) -> MultiValueInput {
     match format {
@@ -111,18 +112,30 @@ fn input_multi_value_support(format: &InputFormat) -> MultiValueInput {
     }
 }
 
-/// Whether a format's reader is handed the source's `split_to_rows` and
-/// `split_values` declarations at all.
+/// Whether a format's reader is handed the source's `split_to_rows`
+/// declarations. A declaration a reader never receives is a silent no-op — the
+/// same failure `E360` exists to stop for the retired `array_paths:` key — so
+/// each declaration kind carries its own capability. Only the JSON and XML
+/// readers fan a repeated field out to rows (over a file, and for both formats
+/// over a REST response body); the delimited-cell formats do not.
+fn format_reads_split_to_rows(format: &InputFormat) -> bool {
+    matches!(format, InputFormat::Json(_) | InputFormat::Xml(_))
+}
+
+/// Whether a format's reader is handed the source's `split_values` declarations.
 ///
-/// The third per-format capability table, and the one that keeps the other two
-/// honest: a declaration a reader never receives is a silent no-op, which is
-/// the same failure `E360` exists to stop for the retired `array_paths:` key.
-/// Only the JSON and XML readers are given these two blocks — over a file, and
-/// (for both formats) over a REST response body.
-fn format_reads_multi_value_declarations(format: &InputFormat) -> bool {
+/// JSON and XML always are. The delimited-cell formats (`csv`, `fixed_width`)
+/// are too — a `split_values` entry parses a cell into the array a
+/// `multiple: true` column holds — but only on their single-schema reader: the
+/// multi-record backend does not consume the block, so declaring it on a
+/// multi-record source of either format is a no-op the gate rejects. Segment
+/// grammars never carry the block.
+fn format_reads_split_values(format: &InputFormat, schema: &SourceSchema) -> bool {
     match format {
         InputFormat::Json(_) | InputFormat::Xml(_) => true,
-        InputFormat::Csv(_) | InputFormat::FixedWidth(_) => false,
+        InputFormat::Csv(_) | InputFormat::FixedWidth(_) => {
+            !matches!(schema, SourceSchema::MultiRecord { .. })
+        }
         InputFormat::Edifact(_)
         | InputFormat::X12(_)
         | InputFormat::Hl7(_)
@@ -169,43 +182,48 @@ fn validate_source_declarations(
     let in_cell = source.split_values.as_deref().unwrap_or(&[]);
 
     // A declaration the format's reader is never handed does nothing at all,
-    // and nothing downstream reports it: the run emits one record per input row
-    // where the author asked for one per occurrence. Reject the block itself
-    // rather than only its contents, so the no-op fails at compile the way the
-    // retired `array_paths:` key does under E360. Every check below inspects
-    // the contents of these same two blocks, so a source that must delete them
-    // returns here rather than also being told what is wrong inside them.
-    if !format_reads_multi_value_declarations(&source.format) {
-        let format = source.format.format_name();
-        for (key, declared, remedy) in [
-            (
-                "split_to_rows",
-                !fan_out.is_empty(),
-                "fanning a repeated field out to one record per occurrence is read by the `json` \
-                 and `xml` readers",
-            ),
-            (
-                "split_values",
-                !in_cell.is_empty(),
-                "parsing a delimited cell into several values is read by the `json` and `xml` \
-                 readers; support for the delimited-cell formats is tracked at \
-                 https://github.com/rustpunk/clinker/issues/930",
-            ),
-        ] {
-            if !declared {
-                continue;
-            }
-            faults.push(DeclarationFault {
-                message: format!(
-                    "source '{}': `{key}` is declared on a `{format}` source, whose reader is \
-                     never handed it — the declaration would be a silent no-op",
-                    source.name
-                ),
-                help: format!("remove the `{key}` block from this source: {remedy}"),
-            });
+    // and nothing downstream reports it. Reject the block itself rather than
+    // only its contents, so the no-op fails at compile the way the retired
+    // `array_paths:` key does under E360. Each declaration kind has its own
+    // per-format capability: the delimited-cell formats read `split_values` but
+    // not `split_to_rows`, so a source can legitimately carry one block and be
+    // told to delete the other.
+    let reads_fan_out = format_reads_split_to_rows(&source.format);
+    let reads_in_cell = format_reads_split_values(&source.format, schema);
+    let format = source.format.format_name();
+    for (key, unread, remedy) in [
+        (
+            "split_to_rows",
+            !reads_fan_out && !fan_out.is_empty(),
+            "fanning a repeated field out to one record per occurrence is read by the `json` \
+             and `xml` readers",
+        ),
+        (
+            "split_values",
+            !reads_in_cell && !in_cell.is_empty(),
+            "parsing a delimited cell into several values is read by the `json`, `xml`, and — on \
+             a single-schema source — `csv` and `fixed_width` readers",
+        ),
+    ] {
+        if !unread {
+            continue;
         }
-        return faults;
+        faults.push(DeclarationFault {
+            message: format!(
+                "source '{}': `{key}` is declared on a `{format}` source, whose reader is \
+                 never handed it — the declaration would be a silent no-op",
+                source.name
+            ),
+            help: format!("remove the `{key}` block from this source: {remedy}"),
+        });
     }
+
+    // The content checks below run only against declarations the reader
+    // actually consumes; a block rejected above as an unread no-op is treated as
+    // empty here, so the author is told to delete it rather than also what is
+    // wrong inside it.
+    let fan_out: &[clinker_format::SplitToRows] = if reads_fan_out { fan_out } else { &[] };
+    let in_cell: &[clinker_format::SplitValues] = if reads_in_cell { in_cell } else { &[] };
 
     // Whether the reader assigns each extracted field to at most one declared
     // group by document position. The XML reader does — it records one index
@@ -440,13 +458,16 @@ fn validate_source_declarations(
 /// A per-source check, not a reachability walk: the mismatch is between one
 /// source's schema and its own format, with no path through the DAG involved.
 ///
-/// A delimited-cell format is rejected together with the segment formats, and a
-/// `split_values` entry does not excuse it: no CSV or fixed-width reader is
-/// handed that block today (see [`format_reads_multi_value_declarations`]), so
-/// accepting the pair would bind the column as an array and then deliver the
-/// raw cell — the exact disagreement this gate exists to prevent. Only the
-/// remediation differs between the two verdicts. Reported per source, listing
-/// every column the format cannot supply, so one source yields one diagnostic.
+/// A delimited-cell format supplies the column only when a `split_values` entry
+/// names its input field: the single-schema CSV and fixed-width readers then
+/// parse the cell into the array the column holds (see
+/// [`format_reads_split_values`]). A `multiple: true` column no entry covers —
+/// or any such column on a multi-record source, whose backend never receives
+/// the block — is rejected together with the segment formats, since accepting
+/// it would bind the column as an array and then deliver the raw cell, the exact
+/// disagreement this gate exists to prevent. Only the remediation differs
+/// between the verdicts. Reported per source, listing every column the format
+/// cannot supply, so one source yields one diagnostic.
 fn validate_multi_value_input(
     source: &SourceConfig,
     schema: &SourceSchema,
@@ -456,7 +477,21 @@ fn validate_multi_value_input(
         return None;
     }
     let columns = schema.bound_columns()?;
-    let unsupplied: Vec<&Column> = columns.iter().filter(|c| c.is_multiple()).collect();
+    // A delimited-cell format supplies a `multiple: true` column when a
+    // `split_values` entry names its input field: the reader parses the cell
+    // into the array the column holds. That excuse applies only where the reader
+    // consumes the block (single-schema csv / fixed_width — json/xml are Native
+    // and never reach here); a column no entry covers stays unsupplied and
+    // still faults.
+    let reads_in_cell = format_reads_split_values(&source.format, schema);
+    let declared = source.split_values.as_deref().unwrap_or(&[]);
+    let unsupplied: Vec<&Column> = columns
+        .iter()
+        .filter(|c| {
+            c.is_multiple()
+                && !(reads_in_cell && declared.iter().any(|e| e.field == c.physical_name()))
+        })
+        .collect();
     if unsupplied.is_empty() {
         return None;
     }
@@ -472,13 +507,13 @@ fn validate_multi_value_input(
     let help = match support {
         MultiValueInput::Native => None,
         MultiValueInput::InCell => Some(format!(
-            "drop `multiple: true` from the column — the cell arrives as one string, and a \
-             transform can split it where the parts are needed (`{field}.split(\";\")`). \
-             Declaring the split at the source is a `split_values` entry, whose wiring into the \
-             {format} reader is not implemented yet and is tracked at \
-             https://github.com/rustpunk/clinker/issues/930; a `json` or `xml` source carries \
-             that declaration today",
-            field = unsupplied[0].name
+            "declare a `split_values` entry so the {format} reader parses the cell into the \
+             array the column holds (`split_values:` `- {{ field: {phys}, delimiter: \";\" }}`), \
+             naming the column's input field and the delimiter its text uses; or drop \
+             `multiple: true` and split the cell in a transform where the parts are needed \
+             (`{col}.split(\";\")`)",
+            phys = unsupplied[0].physical_name(),
+            col = unsupplied[0].name,
         )),
         // HL7 exposes the positional axes as its own declaration; the other
         // three segment formats do not, so promising one would dangle.

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -506,13 +506,24 @@ fn validate_multi_value_input(
     // whole function rather than asserting it cannot be reached.
     let help = match support {
         MultiValueInput::Native => None,
-        MultiValueInput::InCell => Some(format!(
+        // A single-schema delimited-cell reader consumes `split_values`, so
+        // declaring one is the fix. A multi-record reader does not (E358 rejects
+        // the block as a no-op on the same source), so recommending it here would
+        // contradict that gate — point only at the transform route instead.
+        MultiValueInput::InCell if reads_in_cell => Some(format!(
             "declare a `split_values` entry so the {format} reader parses the cell into the \
              array the column holds (`split_values:` `- {{ field: {phys}, delimiter: \";\" }}`), \
              naming the column's input field and the delimiter its text uses; or drop \
              `multiple: true` and split the cell in a transform where the parts are needed \
              (`{col}.split(\";\")`)",
             phys = unsupplied[0].physical_name(),
+            col = unsupplied[0].name,
+        )),
+        MultiValueInput::InCell => Some(format!(
+            "this multi-record {format} source's reader does not consume `split_values`, so \
+             declaring the split there is a no-op — drop `multiple: true` and split the cell in a \
+             transform where the parts are needed (`{col}.split(\";\")`), or restructure the \
+             source as a single-schema {format} where a `split_values` entry is read",
             col = unsupplied[0].name,
         )),
         // HL7 exposes the positional axes as its own declaration; the other

--- a/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
@@ -876,45 +876,40 @@ fn e361_fires_on_a_csv_source_with_a_bare_multi_value_column() {
     assert!(found[0].1, "E361 must carry a source span");
 }
 
-/// A `split_values` entry does not rescue the declaration on a delimited-cell
-/// format. No CSV or fixed-width reader is handed that block — only the JSON
-/// and XML readers are — so accepting the pair would bind the column as an
-/// array and then deliver the raw cell, which is precisely what E361 exists to
-/// stop. The gate has to reject what the runtime cannot honor, not what the
-/// format could honor once the wiring lands.
+/// A `split_values` entry now rescues a `multiple: true` column on a
+/// single-schema delimited-cell source: the CSV and fixed-width readers parse
+/// the cell into the array the column holds (#930), so the pair that used to
+/// fault E361 compiles clean. The JSON output encodes the resulting array.
 #[test]
-fn e361_fires_on_a_delimited_cell_format_even_with_a_split_values_entry() {
-    for format in ["csv", "fixed_width"] {
-        let yaml = source_format_pipeline(
-            format,
-            r#"      split_values:
+fn e361_accepts_a_delimited_cell_column_a_split_values_entry_covers() {
+    let csv = source_format_pipeline(
+        "csv",
+        r#"      split_values:
         - field: tags
           delimiter: ";"
       schema:
         - { name: order_id, type: string }
         - { name: tags, type: string, multiple: true }"#,
-        );
-        let diags = compile_err(&yaml);
-        let found = coded(&diags, "E361");
-        assert_eq!(found.len(), 1, "expected one E361 for {format}: {found:?}");
-        assert!(found[0].0.contains("'tags'"), "{format}: {}", found[0].0);
-        let help = diags
-            .iter()
-            .find(|d| d.code == "E361")
-            .and_then(|d| d.help.clone())
-            .unwrap_or_default();
-        assert!(
-            help.contains("917") && help.contains("not implemented yet"),
-            "the help must name the outstanding wiring rather than prescribe \
-             `split_values`: {help}"
-        );
-    }
+    );
+    compile_ok(&csv);
+
+    let fixed_width = source_format_pipeline(
+        "fixed_width",
+        r#"      split_values:
+        - field: tags
+          delimiter: ";"
+      schema:
+        - { name: order_id, type: string, start: 0, width: 4 }
+        - { name: tags, type: string, start: 4, width: 20, multiple: true }"#,
+    );
+    compile_ok(&fixed_width);
 }
 
-/// Every declared column is reported, not just the ones no `split_values` entry
-/// names: the entry has no bearing on the verdict.
+/// Coverage is per column: an entry rescues the column it names and no other.
+/// A source with two `multiple: true` columns and one `split_values` entry
+/// accepts the covered column and still faults the uncovered one.
 #[test]
-fn e361_reports_every_multi_value_column_on_a_delimited_cell_format() {
+fn e361_faults_only_the_delimited_cell_columns_no_split_values_entry_covers() {
     let yaml = source_format_pipeline(
         "csv",
         r#"      split_values:
@@ -926,24 +921,34 @@ fn e361_reports_every_multi_value_column_on_a_delimited_cell_format() {
     );
     let found = coded(&compile_err(&yaml), "E361");
     assert_eq!(found.len(), 1, "expected one E361: {found:?}");
-    assert!(found[0].0.contains("'codes'"), "{}", found[0].0);
-    assert!(found[0].0.contains("'tags'"), "{}", found[0].0);
+    assert!(
+        found[0].0.contains("'codes'"),
+        "the uncovered column must fault: {}",
+        found[0].0
+    );
+    assert!(
+        !found[0].0.contains("'tags'"),
+        "the covered column must not fault: {}",
+        found[0].0
+    );
 }
 
-/// The other half of the same hole: a `split_values` block on a format whose
-/// reader never receives it is a silent no-op, reported on its own rather than
-/// left to be inferred from the E361 above.
+/// The other half of the same hole: a declaration a format's reader never
+/// receives is a silent no-op, reported on its own rather than left to be
+/// inferred from the E361 above. Each declaration kind has its own capability —
+/// the delimited-cell formats read `split_values` but not `split_to_rows`, so a
+/// `split_to_rows` block on `csv` is the no-op here even though `split_values`
+/// is not.
 #[test]
 fn e358_rejects_multi_value_declarations_a_format_never_receives() {
     for (format, key, body) in [
         (
             "csv",
-            "split_values",
-            r#"      split_values:
-        - field: tags
-          delimiter: ";"
+            "split_to_rows",
+            r#"      split_to_rows:
+        - line_items
       schema:
-        - { name: tags, type: string }"#,
+        - { name: sku, type: string }"#,
         ),
         (
             "fixed_width",
@@ -972,6 +977,55 @@ fn e358_rejects_multi_value_declarations_a_format_never_receives() {
         );
         assert!(found[0].1, "{format}: E358 must carry a source span");
     }
+}
+
+/// `split_values` is consumed only by the single-schema CSV and fixed-width
+/// readers; a multi-record source of either format runs a different backend that
+/// never receives the block, so declaring it there is the same silent no-op E358
+/// rejects on any other unreading format. The guard keeps the gate flip from
+/// opening a hole the multi-record path cannot honor.
+#[test]
+fn split_values_on_a_multi_record_csv_source_is_a_no_op() {
+    let yaml = r#"
+pipeline:
+  name: multi_record_split_values
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: csv
+      path: ./in.csv
+      split_values:
+        - field: tags
+          delimiter: ";"
+      schema:
+        discriminator: { field: kind }
+        records:
+          - id: header
+            tag: H
+            columns:
+              - { name: kind, type: string }
+          - id: detail
+            tag: D
+            columns:
+              - { name: kind, type: string }
+              - { name: tags, type: string, multiple: true }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: json
+      path: out.json
+"#;
+    let found = coded(&compile_err(yaml), "E358");
+    assert_eq!(found.len(), 1, "expected one E358 no-op: {found:?}");
+    assert!(
+        found[0].0.contains("split_values") && found[0].0.contains("silent no-op"),
+        "{}",
+        found[0].0
+    );
 }
 
 /// Repetition in a segment format is a positional coordinate, not a list, so no

--- a/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
@@ -1019,12 +1019,32 @@ nodes:
       type: json
       path: out.json
 "#;
-    let found = coded(&compile_err(yaml), "E358");
+    let diags = compile_err(yaml);
+    let found = coded(&diags, "E358");
     assert_eq!(found.len(), 1, "expected one E358 no-op: {found:?}");
     assert!(
         found[0].0.contains("split_values") && found[0].0.contains("silent no-op"),
         "{}",
         found[0].0
+    );
+
+    // E361 fires on the same source (`tags` is `multiple: true` and the
+    // multi-record reader cannot produce it). Its remediation must AGREE with
+    // E358's "remove the `split_values` block": it must not tell the author to
+    // declare the very block E358 rejects.
+    let e361_help = diags
+        .iter()
+        .find(|d| d.code == "E361")
+        .and_then(|d| d.help.clone())
+        .expect("E361 also fires on the multi-record source");
+    assert!(
+        e361_help.contains("does not consume `split_values`")
+            && e361_help.contains("drop `multiple: true`"),
+        "E361 help must point at the transform route, not contradict E358: {e361_help}"
+    );
+    assert!(
+        !e361_help.contains("declare a `split_values`"),
+        "E361 must not recommend the block E358 just rejected: {e361_help}"
     );
 }
 

--- a/docs/explain/E361.md
+++ b/docs/explain/E361.md
@@ -18,11 +18,15 @@ Where each input format stands:
   its own.
 - **`xml`** — repeated child elements are collected into one array, in document
   order. `multiple: true` works on its own.
-- **`csv` / `fixed_width`** — one value per cell on the wire. A cell's text may
-  hold several values separated by a delimiter, and a `split_values` entry is
-  meant to declare that, but neither reader is handed the entry yet
-  ([issue 930](https://github.com/rustpunk/clinker/issues/930)). Rejected until
-  it is — a pending no, not a permanent one.
+- **`csv` / `fixed_width`** — one value per cell on the wire, but a cell's text
+  may hold several values separated by a delimiter. Declare that with a
+  [`split_values`](https://github.com/rustpunk/clinker/issues/930) entry naming
+  the column's input field and its delimiter, and the reader parses the cell
+  into the array the column holds. A `multiple: true` column **no `split_values`
+  entry covers** is rejected — there is nothing to tell the reader how to split
+  it. The declaration is read only on a single-schema source; a multi-record
+  source of either format runs a backend that does not consume it, so it is
+  rejected there too.
 - **`edifact` / `x12` / `hl7` / `swift`** — repetition in these formats is a
   positional coordinate, not a list, and no `split_values` entry changes that.
   See the technical context below.
@@ -36,7 +40,8 @@ more than one value
 ## Example
 
 ```yaml
-# Rejected: a CSV source declares a multi-value column with nothing to make it.
+# Accepted: a `split_values` entry declares the delimiter, so the CSV reader
+# parses each cell into an array (`1,a;b;c` reads `tags` as ["a", "b", "c"]).
 nodes:
   - type: source
     name: orders
@@ -44,44 +49,46 @@ nodes:
       name: orders
       type: csv
       path: ./orders.csv
+      split_values:
+        - { field: tags, delimiter: ";" }
       schema:
         - { name: order_id, type: string }
         - { name: tags, type: string, multiple: true }
 ```
 
 ```yaml
-# Corrected: the column is single-valued, and the split happens downstream.
+# Rejected: `tags` is `multiple: true` but no `split_values` entry covers it,
+# so the reader has no delimiter and would deliver the raw cell.
       schema:
         - { name: order_id, type: string }
-        - { name: tags, type: string }
-```
-
-```yaml
-# ... with a transform reading the parts where they are needed.
-  - type: transform
-    name: parse_tags
-    input: orders
-    config:
-      cxl: |
-        emit tag_list = tags.split(";")
+        - { name: tags, type: string, multiple: true }
 ```
 
 ## How to fix
 
-1. **On a `csv` or `fixed_width` source, drop `multiple: true`.** The cell
-   arrives as one string; split it in a transform (`tags.split(";")`) where the
-   parts are needed. Declaring the split at the source is a `split_values`
-   entry, which neither reader is handed yet — that wiring is
-   [issue 930](https://github.com/rustpunk/clinker/issues/930). A `json` or
-   `xml` source carries the declaration today.
+1. **On a `csv` or `fixed_width` source, declare a `split_values` entry** naming
+   the column's input field and the delimiter its text uses, so the reader
+   parses the cell into the array the column holds:
 
-2. **On a segment format, drop `multiple: true`.** For an HL7 source, declare
+   ```yaml
+   split_values:
+     - { field: tags, delimiter: ";" }
+   ```
+
+   Name the input field — the column's `source_name` when it aliases a
+   differently-named field, since the split runs against the names the document
+   carries. The entry is read only on a single-schema source; on a multi-record
+   source, split the cell in a transform instead (next option).
+
+2. **Or drop `multiple: true`** and split the cell in a transform where the
+   parts are needed: the cell arrives as one string, and
+   `emit tag_list = tags.split(";")` produces the list downstream.
+
+3. **On a segment format, drop `multiple: true`.** For an HL7 source, declare
    the field under `options.split_fields` with its repetition and component
    counts instead: that produces one column per occurrence, which is the shape
    the wire really has. For `edifact`, `x12`, and `swift` there is no such
    declaration today, and each occurrence arrives verbatim in the element text.
-
-3. **Drop `multiple: true`** if the field never actually repeats.
 
 4. **If the schema is shared across sources** and only some of them repeat the
    field, clear it for this one with a channel source patch
@@ -99,19 +106,23 @@ one-element array rather than erroring, so an ungated declaration produces no
 error anywhere — just a one-element array nothing actually collected, where the
 reader delivered a raw cell.
 
-The one-element-array normalization the JSON and XML readers apply is
-deliberately not generalized to the other formats. Those two have a genuine
-ambiguity — XML cannot distinguish a collection of one from a scalar, so the
-declaration is what disambiguates. A CSV cell is always exactly one string, so
-the same normalization would wrap `a;b;c` into `["a;b;c"]` and make
-`size(tags)` return 1 on every row forever: a loud authoring error converted
-into a quiet permanent wrong answer.
+A `split_values` entry is what supplies the delimited-cell formats: the
+single-schema CSV and fixed-width readers split the cell on the declared
+delimiter into the several values the column holds. CSV keeps each element as a
+string and lets the downstream coercion layer type it; fixed-width, whose reader
+is the sole coercion pass, types each element itself. An empty cell yields an
+empty array (zero values), and a cell with no delimiter yields a one-element
+array. A `multiple: true` column with no covering entry stays rejected: the
+reader has no delimiter, so accepting it would bind an array and deliver the raw
+cell — the exact disagreement this gate exists to prevent.
 
-The gate rejects what the runtime cannot honor, not what the format could
-honor in principle. `csv` and `fixed_width` are recorded internally as formats
-that CAN carry the declaration — which is what separates them from the segment
-formats below — but until the reader receives the `split_values` entry, an
-accepted declaration is indistinguishable from a wrong one at run time.
+The one-element-array normalization the JSON and XML readers apply is
+deliberately not generalized to the delimited-cell formats. Those two have a
+genuine ambiguity — XML cannot distinguish a collection of one from a scalar, so
+the declaration is what disambiguates. A CSV cell is always exactly one string;
+the `split_values` entry, not a blanket normalization, is what turns it into the
+array the column holds, so `a;b;c` reads as three values rather than being
+wrapped whole into `["a;b;c"]`.
 
 The segment formats are marked permanent rather than pending. A repeated
 composite serializes as two structural axes interleaved in one element —

--- a/docs/user/src/formats/csv.md
+++ b/docs/user/src/formats/csv.md
@@ -74,6 +74,36 @@ Input columns the schema does not name are governed by the source's
 [`on_unmapped`](../formats/auto-widen.md) policy, the same as every other
 format.
 
+## Multi-value cells (`split_values`)
+
+A CSV cell holds one string, but that string may pack several values behind a
+delimiter (`1,a;b;c`). Declare the column `multiple: true` and add a
+`split_values` entry naming the field and its delimiter, and the reader parses
+the cell into an array:
+
+```yaml
+- type: source
+  name: orders
+  config:
+    name: orders
+    type: csv
+    path: ./orders.csv
+    split_values:
+      - { field: tags, delimiter: ";" }
+    schema:
+      - { name: order_id, type: string }
+      - { name: tags, type: string, multiple: true }
+```
+
+`tags` reads as `["a", "b", "c"]`. An empty cell is an empty array; a cell with
+no delimiter is a one-element array; each element is coerced to the column's
+declared `type:`. A quoted cell is unquoted first, so a delimiter inside the
+quotes is not a boundary. A `multiple: true` column with no covering
+`split_values` entry is rejected at compile ([E361](../../explain/E361.md)). The
+entry is read only on a single-schema source, not the multi-record reader below.
+See [`split_values`](../nodes/source.md#several-values-in-one-cell-split_values)
+in the Source reference for the full grammar.
+
 ## Writing CSV
 
 On output, the writer emits one row per record with cells in the

--- a/docs/user/src/formats/fixed-width.md
+++ b/docs/user/src/formats/fixed-width.md
@@ -87,6 +87,28 @@ cannot grow a single record until end of input: memory stays bounded regardless
 of how long the physical line runs. A final line with no trailing newline reads
 normally as long as its declared fields fit within the width.
 
+## Multi-value cells (`split_values`)
+
+A fixed-width field holds one value, but its text may pack several behind a
+delimiter within the field's byte range. Declare the column `multiple: true`
+and add a `split_values` entry, and the reader splits the (padding-stripped)
+field text and coerces each part to the column's declared type:
+
+```yaml
+    split_values:
+      - { field: tags, delimiter: ";" }
+    schema:
+      - { name: order_id, type: string, start: 0, width: 4 }
+      - { name: tags, type: string, start: 4, width: 20, multiple: true }
+```
+
+Because the fixed-width reader is the sole coercion pass, each element is typed
+here — a `multiple: true` `int` field over `1;2;3` reads as `[1, 2, 3]`. A blank
+field is an empty array; a field with no delimiter is a one-element array. A
+`multiple: true` column with no covering `split_values` entry is rejected at
+compile ([E361](../../explain/E361.md)). The entry is read only on a
+single-schema source, not the multi-record reader below.
+
 ## Schema drift
 
 Fixed-width is **inert** with respect to

--- a/docs/user/src/nodes/source.md
+++ b/docs/user/src/nodes/source.md
@@ -280,8 +280,8 @@ cannot carry fails before a run starts rather than mid-stream:
 |---|---|---|
 | `json` | native — an array | native — an array |
 | `xml` | native — repeated child elements | not yet ([issue 916](https://github.com/rustpunk/clinker/issues/916)) |
-| `csv` | not yet ([issue 917](https://github.com/rustpunk/clinker/issues/917)) | not yet ([issue 917](https://github.com/rustpunk/clinker/issues/917)) |
-| `fixed_width` | not yet ([issue 917](https://github.com/rustpunk/clinker/issues/917)) | not yet ([issue 918](https://github.com/rustpunk/clinker/issues/918)) |
+| `csv` | delimited cell via `split_values` | not yet ([issue 917](https://github.com/rustpunk/clinker/issues/917)) |
+| `fixed_width` | delimited cell via `split_values` | not yet ([issue 918](https://github.com/rustpunk/clinker/issues/918)) |
 | `edifact`, `x12`, `hl7`, `swift` | no — repetition is positional | no — repetition is positional |
 
 A `multiple: true` column reaching an output that cannot encode it is `E359`; one
@@ -290,15 +290,19 @@ on a source that cannot produce it is `E361`. `E359` covers an output's own
 repetition yet, so declaring it on a sink would be accepted and ignored. Run
 `clinker explain --code E361` for the full remediation of either.
 
-**`csv` and `fixed_width` are a pending no, not a permanent one.** Neither wire
-format repeats a field, but a cell's text may hold several values separated by a
-delimiter — the shape a `split_values` entry is meant to declare. No CSV or
-fixed-width reader is handed that entry yet
-([issue 917](https://github.com/rustpunk/clinker/issues/917)), so a
-`multiple: true` column on one of these formats would bind as an array and then
-receive the raw cell. `E361` rejects it until the reader can honor it. In the
-meantime, leave the column single-valued and split it where the parts are
-needed: `tags.split(";")` in a transform.
+**`csv` and `fixed_width` read a `multiple: true` column through a
+`split_values` entry.** Neither wire format repeats a field, but a cell's text
+may hold several values separated by a delimiter. Declare that delimiter with a
+[`split_values`](#several-values-in-one-cell-split_values) entry and the reader
+parses the cell into the array the column holds. A `multiple: true` column no
+entry covers is rejected by `E361` — the reader would have no delimiter and
+deliver the raw cell; either add the entry or leave the column single-valued and
+split it in a transform (`tags.split(";")`). The entry is read only on a
+single-schema source: a multi-record source of either format runs a backend that
+does not consume it. The **output** side is still pending
+([csv #917](https://github.com/rustpunk/clinker/issues/917),
+[fixed_width #918](https://github.com/rustpunk/clinker/issues/918)) — no writer
+encodes repetition yet.
 
 **The segment formats are a permanent no**, not a pending one. Repetition there
 is a positional coordinate rather than a list: a repeated composite is written
@@ -406,9 +410,11 @@ naming a column's exposed name when that column reads a differently-named input
 field — the split runs against the document's own field names, so name the
 `source_name`.
 
-The entry is read by the **JSON** and **XML** readers. Declaring it on any other
-format is rejected (`E358`) rather than silently ignored: those readers are
-never handed it, so the cell would arrive unsplit with nothing to say so.
+The entry is read by the **JSON** and **XML** readers, and — on a single-schema
+source — by the **CSV** and **fixed-width** readers. On a multi-record CSV or
+fixed-width source, or on any segment format, declaring it is rejected (`E358`)
+rather than silently ignored: those readers are never handed it, so the cell
+would arrive unsplit with nothing to say so.
 
 ### Migrating from `array_paths`
 
@@ -426,11 +432,13 @@ unset. Add `keep_empty: false` to the entry to migrate row-for-row.
 
 ### Format notes
 
-Both knobs are honored by the **JSON** and **XML** readers, over a file path and
-over a `rest` response body alike. Declaring either on a format whose reader is
-never handed it — `csv`, `fixed_width`, or any segment format — is rejected at
-compile (`E358`) rather than accepted and inert, and a `multiple: true` column on
-such a source is rejected by `E361`.
+`split_to_rows` is honored by the **JSON** and **XML** readers, over a file path
+and over a `rest` response body alike. `split_values` is honored by those two and
+also by the single-schema **CSV** and **fixed-width** readers. Declaring a knob on
+a reader that is never handed it — `split_to_rows` on any delimited-cell or
+segment format, `split_values` on a multi-record or segment source — is rejected
+at compile (`E358`) rather than accepted and inert, and a `multiple: true` column
+no `split_values` entry can cover is rejected by `E361`.
 
 Composition body files are gated by the same four checks as the pipeline that
 calls them.

--- a/examples/pipelines/data/orders_tags.csv
+++ b/examples/pipelines/data/orders_tags.csv
@@ -1,0 +1,4 @@
+order_id,tags
+1,electronics;sale;featured
+2,
+3,clearance

--- a/examples/pipelines/multi_value_split_values_csv.yaml
+++ b/examples/pipelines/multi_value_split_values_csv.yaml
@@ -1,0 +1,43 @@
+pipeline:
+  name: multi_value_split_values_csv
+
+# A CSV cell holds one string, but that string can pack several values behind a
+# delimiter. Declaring the column `multiple: true` and adding a `split_values`
+# entry parses each `tags` cell into an array on the way in:
+#
+#   1,electronics;sale;featured  ->  tags = ["electronics", "sale", "featured"]
+#   2,                           ->  tags = []            (empty cell → zero values)
+#   3,clearance                  ->  tags = ["clearance"] (no delimiter → one value)
+#
+# Each element is coerced to the column's declared `type:`. A `multiple: true`
+# column with no covering `split_values` entry is rejected at compile
+# (`clinker explain --code E361`).
+#
+# The sink is JSON because that is the one output format that can encode a
+# multi-value field today (`clinker explain --code E359`). The reverse
+# direction — joining an array back into a delimited CSV cell — is tracked
+# separately (issue 917).
+
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: csv
+      path: ./data/orders_tags.csv
+      split_values:
+        - { field: tags, delimiter: ";" }
+      schema:
+        - { name: order_id, type: string }
+        - { name: tags, type: string, multiple: true }
+
+  - type: output
+    name: tagged_orders
+    input: orders
+    config:
+      name: tagged_orders
+      type: json
+      path: ./output/tagged_orders.json
+
+error_handling:
+  strategy: fail_fast


### PR DESCRIPTION
## What

Parse a delimited CSV or fixed-width cell into a multi-value field on read. A
column declared `multiple: true` with a `split_values` entry now materialises as
an array:

```yaml
sources:
  - name: orders
    type: csv
    split_values:
      - { field: tags, delimiter: ";" }
    schema:
      - { name: order_id, type: string }
      - { name: tags, type: string, multiple: true }
```

reads `1,a;b;c` as `tags = ["a", "b", "c"]`.

This is the read-side counterpart to the CSV writer's `join_values` (#917) —
opposite direction, independent config surface. It closes #930.

## Why

The multi-value schema surface already declared `multiple: true` and wired
`split_values` into the JSON and XML readers, but the CSV and fixed-width readers
were stubbed: a `multiple: true` column on either format was rejected at compile
(E361) because the reader could not produce an array. This adds the missing
reader wiring and flips that gate.

## How

- **Shared helper.** The delimited-cell split logic (`split_text_value`) was
  duplicated in the XML reader; it moves to the format crate's multi-value module
  and the XML, CSV, and fixed-width readers all share it.
- **CSV** keeps each element a string and lets the existing downstream coercion
  layer type it. **Fixed-width** types each element itself, since its reader is
  the sole coercion pass.
- **Empty-cell semantics.** A blank cell yields an empty array (zero values); a
  cell with no delimiter yields a one-element array. Interior empty parts between
  delimiters are preserved.
- **Single-schema only.** `split_values` is threaded onto the single-schema
  readers; the multi-record backend does not consume it, so declaring it on a
  multi-record source is rejected as a no-op rather than silently dropped.
- **Per-kind capability.** The single "reader is handed the declarations"
  capability is split in two, so a format can read `split_values` without reading
  `split_to_rows` (which CSV/fixed-width still do not).
- **E361** accepts a `multiple: true` column a `split_values` entry covers, and
  still rejects an uncovered column (or any such column on a multi-record
  source). The gate help and the explain page now point at the read-side issue.

## Tests

- Reader unit tests (CSV and fixed-width): three-value split, empty → `[]`,
  no-delimiter → one element, covered-columns-only, quoted-cell interaction, and
  per-element typing for a numeric fixed-width field.
- Plan-time gate suite: accept-when-covered, fault-only-the-uncovered-column, the
  multi-record no-op guard, and the delimited-cell block still rejecting
  `split_to_rows`.
- An end-to-end executor test running a CSV `split_values` pipeline to JSON.
- A runnable example (`examples/pipelines/multi_value_split_values_csv.yaml`),
  covered by the `--explain` smoke guard.

User docs (source reference, CSV and fixed-width format pages) and the E361
explain page are updated in the same change.

## Follow-ups

- Multi-record CSV/fixed-width `split_values` support (kept rejecting here).
- A read↔write round-trip test once the CSV writer's `join_values` (#917) lands.
