### PR TITLE
fix(format): fail loud on undeclared repeated fields instead of dropping them

### DIFF
--- a/crates/clinker-exec/tests/format_dispatch.rs
+++ b/crates/clinker-exec/tests/format_dispatch.rs
@@ -284,6 +284,142 @@ nodes:
     );
 }
 
+/// The undeclared repeat in RECORD 1 must be dead-lettered, not aborted.
+/// Schema inference reads the first record eagerly during ingest setup, before
+/// the executor's record loop; if the loud error surfaced there it would bypass
+/// the document-DLQ reclassification and abort the run. The reader defers the
+/// fallible assembly to the loop so even a first-record repeat dead-letters.
+#[test]
+fn test_xml_undeclared_repeat_in_first_record_dead_letters() {
+    let yaml = r#"
+pipeline:
+  name: xml-first-record-repeat
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: xml
+    path: input.xml
+    dlq_granularity: document
+    options:
+      record_path: records/record
+    schema:
+      - { name: name, type: string }
+      - { name: age, type: string }
+- type: output
+  name: dest
+  input: src
+  config:
+    name: dest
+    type: csv
+    path: output.csv
+    include_unmapped: true
+"#;
+    // The very FIRST record repeats `<name>`, which is not declared `multiple:`.
+    let input_data = xml_input(
+        "records",
+        "record",
+        &[
+            vec![("name", "Alice"), ("name", "Ally"), ("age", "30")],
+            vec![("name", "Bob"), ("age", "25")],
+        ],
+    );
+    let (counters, dlq, output) = run_format_test(yaml, "src", input_data)
+        .expect("a first-record repeat must dead-letter, not abort the run");
+    assert!(
+        counters.dlq_count >= 1,
+        "the first-record repeat is dead-lettered, got dlq_count={}",
+        counters.dlq_count
+    );
+    assert_eq!(counters.ok_count, 0, "the condemned document emits nothing");
+    assert!(!dlq.is_empty());
+    let body: Vec<&str> = output.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert!(
+        body.is_empty(),
+        "no data row reaches the sink, got {body:?}"
+    );
+}
+
+/// A first-record repeat in one file dead-letters that file's document while a
+/// clean SECOND file streams through — proving the run continues past the
+/// condemned document rather than aborting.
+#[test]
+fn test_xml_undeclared_repeat_first_file_condemned_second_file_processes() {
+    let yaml = r#"
+pipeline:
+  name: xml-multi-file-repeat
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: xml
+    glob: ./*.xml
+    dlq_granularity: document
+    files:
+      on_no_match: skip
+    options:
+      record_path: records/record
+    schema:
+      - { name: name, type: string }
+      - { name: age, type: string }
+- type: output
+  name: dest
+  input: src
+  config:
+    name: dest
+    type: csv
+    path: output.csv
+    include_unmapped: true
+"#;
+    let config = clinker_plan::config::parse_config(yaml).unwrap();
+    // File a: record 1 repeats <name> → whole document condemned.
+    let file_a =
+        "<records><record><name>Alice</name><name>Ally</name><age>30</age></record></records>";
+    // File b: clean → streams through.
+    let file_b = "<records><record><name>Carol</name><age>40</age></record></records>";
+    let slots = vec![
+        clinker_exec::source::multi_file::FileSlot::new(
+            std::path::PathBuf::from("a.xml"),
+            Box::new(Cursor::new(file_a.as_bytes().to_vec())),
+        ),
+        clinker_exec::source::multi_file::FileSlot::new(
+            std::path::PathBuf::from("b.xml"),
+            Box::new(Cursor::new(file_b.as_bytes().to_vec())),
+        ),
+    ];
+    let readers: clinker_exec::executor::SourceReaders = HashMap::from([(
+        "src".to_string(),
+        clinker_exec::source::SourceInput::Files(slots),
+    )]);
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "dest".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    let params = test_params();
+    let report = common::run_config(&config, readers, writers, &params)
+        .expect("a condemned first file must not abort the run");
+    assert!(
+        report.counters.dlq_count >= 1,
+        "the first file's document is dead-lettered"
+    );
+    let output = buf.as_string();
+    assert!(
+        output.contains("Carol"),
+        "the clean second file still processes: {output}"
+    );
+    assert!(
+        !output.contains("Alice"),
+        "the condemned first file emits nothing: {output}"
+    );
+}
+
 /// JSON NDJSON output produces valid newline-delimited JSON.
 /// CSV input → NDJSON output, verify each line parses as JSON.
 #[test]

--- a/crates/clinker-exec/tests/format_dispatch.rs
+++ b/crates/clinker-exec/tests/format_dispatch.rs
@@ -176,6 +176,114 @@ nodes:
     assert!(output.contains("Bob"), "output missing Bob: {output}");
 }
 
+/// An XML element that repeats while its column is not declared `multiple: true`
+/// is a loud runtime error under the default fail-fast strategy — the run aborts
+/// with a diagnostic naming the remedy, rather than silently keeping the first
+/// value and dropping the rest.
+#[test]
+fn test_xml_undeclared_repeat_aborts_under_fail_fast() {
+    let yaml = r#"
+pipeline:
+  name: xml-undeclared-repeat
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: xml
+    path: input.xml
+    options:
+      record_path: records/record
+    schema:
+      - { name: name, type: string }
+      - { name: age, type: string }
+- type: output
+  name: dest
+  input: src
+  config:
+    name: dest
+    type: csv
+    path: output.csv
+    include_unmapped: true
+"#;
+    // The second record repeats `<name>`, which is not declared `multiple:`.
+    let input_data = xml_input(
+        "records",
+        "record",
+        &[
+            vec![("name", "Alice"), ("age", "30")],
+            vec![("name", "Bob"), ("name", "Bobby"), ("age", "25")],
+        ],
+    );
+    let err = run_format_test(yaml, "src", input_data)
+        .expect_err("undeclared repeat must abort the run, not drop silently");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("multiple: true") && msg.contains("name"),
+        "diagnostic names the field and remedy: {msg}"
+    );
+}
+
+/// Under `error_handling.strategy: continue` + `dlq_granularity: document`, the
+/// same undeclared repeat is dead-lettered rather than aborting the run: the
+/// offending document is routed to the DLQ and no record of it reaches the
+/// success sink.
+#[test]
+fn test_xml_undeclared_repeat_dead_letters_under_document_dlq() {
+    let yaml = r#"
+pipeline:
+  name: xml-undeclared-repeat-dlq
+error_handling:
+  strategy: continue
+nodes:
+- type: source
+  name: src
+  config:
+    name: src
+    type: xml
+    path: input.xml
+    dlq_granularity: document
+    options:
+      record_path: records/record
+    schema:
+      - { name: name, type: string }
+      - { name: age, type: string }
+- type: output
+  name: dest
+  input: src
+  config:
+    name: dest
+    type: csv
+    path: output.csv
+    include_unmapped: true
+"#;
+    let input_data = xml_input(
+        "records",
+        "record",
+        &[
+            vec![("name", "Alice"), ("age", "30")],
+            vec![("name", "Bob"), ("name", "Bobby"), ("age", "25")],
+        ],
+    );
+    let (counters, dlq, output) = run_format_test(yaml, "src", input_data)
+        .expect("document-granularity DLQ dead-letters rather than aborting");
+    assert!(
+        counters.dlq_count >= 1,
+        "the undeclared repeat is dead-lettered, got dlq_count={}",
+        counters.dlq_count
+    );
+    assert_eq!(
+        counters.ok_count, 0,
+        "no record of the condemned document reaches the success sink"
+    );
+    assert!(!dlq.is_empty(), "a DLQ entry is recorded");
+    let body: Vec<&str> = output.lines().skip(1).filter(|l| !l.is_empty()).collect();
+    assert!(
+        body.is_empty(),
+        "no data row reaches the success sink, got {body:?}"
+    );
+}
+
 /// JSON NDJSON output produces valid newline-delimited JSON.
 /// CSV input → NDJSON output, verify each line parses as JSON.
 #[test]

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -187,6 +187,33 @@ pub enum FormatError {
         /// The offending value — the one that contains the delimiter.
         value: String,
     },
+    /// A self-describing reader (XML, JSON) found more than one value landing on
+    /// one flattened field of a single record while that field's schema column is
+    /// NOT declared `multiple: true`. In XML this is a child element that repeats
+    /// (`<Tag>a</Tag><Tag>b</Tag>`); in JSON it is two keys that flatten to the
+    /// same dotted name (`{"a": {"b": 1}, "a.b": 2}`). Only a `multiple:` column
+    /// collects every occurrence into an array — for any other column the reader
+    /// would keep one value and silently discard the rest, the exact data loss
+    /// this variant refuses.
+    ///
+    /// Routed to the document-level DLQ under `dlq_granularity: document` (see
+    /// [`FormatError::is_document_structural`]) so one malformed document does not
+    /// abort the run when the author opted into continuing past bad data;
+    /// otherwise it aborts loudly rather than dropping values. `field` names the
+    /// offending flattened field.
+    ///
+    /// Routes to fix this at the user level:
+    ///
+    /// - Declare the column `multiple: true` so every occurrence collects into an
+    ///   array, in document order.
+    /// - Or add a `split_to_rows` entry so each occurrence fans out to its own
+    ///   record.
+    /// - In JSON, a genuine flattened-name clash between two distinct keys is
+    ///   resolved by renaming one so they no longer collide.
+    UndeclaredRepeatedField {
+        format: &'static str,
+        field: String,
+    },
 }
 
 impl fmt::Display for FormatError {
@@ -266,6 +293,15 @@ impl fmt::Display for FormatError {
                  field's `on_conflict` to `escape` or `encode_json` for a lossless join, or pick \
                  a `delimiter` the values never contain."
             ),
+            Self::UndeclaredRepeatedField { format, field } => write!(
+                f,
+                "{format} source: field {field:?} occurs more than once in a single record, but \
+                 its schema column is not declared `multiple: true`, so all but one value would \
+                 be silently dropped. Declare the column `multiple: true` to keep every \
+                 occurrence as an array (in document order), or add a `split_to_rows` entry to \
+                 fan each occurrence out to its own record. (In JSON this also fires when two \
+                 distinct keys flatten to the same dotted name — rename one to disambiguate.)"
+            ),
         }
     }
 }
@@ -330,14 +366,18 @@ impl FormatError {
 
     /// `true` for the error classes the executor reclassifies from
     /// run-aborting to document-DLQ under `dlq_granularity: document`: a
-    /// trailer count mismatch ([`FormatError::StructuralCount`]) or a
+    /// trailer count mismatch ([`FormatError::StructuralCount`]), a
     /// non-count structural failure of a multi-record document
-    /// ([`FormatError::StructuralValidation`]). Every other variant keeps
+    /// ([`FormatError::StructuralValidation`]), or an undeclared repeated
+    /// field a self-describing reader detected
+    /// ([`FormatError::UndeclaredRepeatedField`]). Every other variant keeps
     /// aborting the run.
     pub fn is_document_structural(&self) -> bool {
         matches!(
             self,
-            Self::StructuralCount { .. } | Self::StructuralValidation { .. }
+            Self::StructuralCount { .. }
+                | Self::StructuralValidation { .. }
+                | Self::UndeclaredRepeatedField { .. }
         )
     }
 
@@ -409,6 +449,39 @@ mod tests {
             column: "x".to_string(),
         };
         assert!(!e.is_document_structural());
+        assert!(!e.is_structural_count());
+    }
+
+    #[test]
+    fn undeclared_repeated_field_display_names_field_and_remedies() {
+        let e = FormatError::UndeclaredRepeatedField {
+            format: "XML",
+            field: "Tag".to_string(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("XML"), "names the format: {msg}");
+        assert!(msg.contains("\"Tag\""), "names the field: {msg}");
+        assert!(
+            msg.contains("multiple: true"),
+            "points to the collect remedy: {msg}"
+        );
+        assert!(
+            msg.contains("split_to_rows"),
+            "points to the fan-out remedy: {msg}"
+        );
+    }
+
+    #[test]
+    fn undeclared_repeated_field_is_document_structural() {
+        // Routed to the document-level DLQ under `dlq_granularity: document`
+        // (dead-lettered, not fatal), mirroring the other reader-detected
+        // structural failures; it aborts loudly otherwise rather than dropping
+        // values silently. It is not a trailer count claim.
+        let e = FormatError::UndeclaredRepeatedField {
+            format: "JSON",
+            field: "a.b".to_string(),
+        };
+        assert!(e.is_document_structural());
         assert!(!e.is_structural_count());
     }
 }

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -262,11 +262,23 @@ impl JsonReader {
         }
     }
 
+    /// Flatten a JSON value into dotted keys on `out`.
+    ///
+    /// When `collisions` is `Some`, a second value landing on a name already
+    /// present is treated as an undeclared repeat (the JSON analogue of a
+    /// repeated XML element): if the name is a `multiple:` column both values
+    /// collect into an array in document order, otherwise the name is recorded
+    /// so the caller can refuse the record loudly rather than silently keeping
+    /// one value. When `collisions` is `None` a later value overwrites an
+    /// earlier one (last-wins) — used by the fan-out element projection, whose
+    /// merge onto the already-populated parent record is deliberate.
     fn flatten_value(
         prefix: &str,
         value: &serde_json::Value,
         out: &mut serde_json::Map<String, serde_json::Value>,
         depth: usize,
+        mut collisions: Option<&mut Vec<String>>,
+        multi_value: &[String],
     ) {
         const MAX_DEPTH: usize = 64;
         if depth > MAX_DEPTH {
@@ -284,13 +296,67 @@ impl JsonReader {
                     } else {
                         format!("{prefix}.{key}")
                     };
-                    Self::flatten_value(&name, val, out, depth + 1);
+                    Self::flatten_value(
+                        &name,
+                        val,
+                        out,
+                        depth + 1,
+                        collisions.as_deref_mut(),
+                        multi_value,
+                    );
                 }
             }
-            other => {
-                out.insert(prefix.to_string(), other.clone());
-            }
+            other => match collisions {
+                Some(sink) if out.contains_key(prefix) => {
+                    if multi_value.iter().any(|f| f.as_str() == prefix) {
+                        // Declared `multiple:` — collect in document order.
+                        match out.get_mut(prefix).expect("contains_key just held") {
+                            serde_json::Value::Array(items) => items.push(other.clone()),
+                            slot => {
+                                let first = slot.take();
+                                *slot = serde_json::Value::Array(vec![first, other.clone()]);
+                            }
+                        }
+                    } else {
+                        // Undeclared flattened-name collision — the caller
+                        // turns this into a loud error. The overwrite is
+                        // immaterial because the record is never kept.
+                        sink.push(prefix.to_string());
+                        out.insert(prefix.to_string(), other.clone());
+                    }
+                }
+                _ => {
+                    out.insert(prefix.to_string(), other.clone());
+                }
+            },
         }
+    }
+
+    /// Flatten one raw JSON record into dotted keys, refusing a flattened-name
+    /// collision on a column not declared `multiple: true` — the JSON analogue
+    /// of an undeclared repeated XML element. A collision on a `multiple:`
+    /// column instead collects both values into an array, in document order.
+    fn flatten_record_body(
+        &self,
+        raw: &serde_json::Value,
+    ) -> Result<serde_json::Map<String, serde_json::Value>, FormatError> {
+        let mut flat = serde_json::Map::new();
+        let mut collisions: Vec<String> = Vec::new();
+        Self::flatten_value(
+            "",
+            raw,
+            &mut flat,
+            0,
+            Some(&mut collisions),
+            &self.config.multi_value_fields,
+        );
+        if let Some(field) = collisions.into_iter().next() {
+            return Err(FormatError::UndeclaredRepeatedField {
+                format: "JSON",
+                field,
+            });
+        }
+        Ok(flat)
     }
 
     /// Expand one flattened record through the declared `split_to_rows`
@@ -553,8 +619,7 @@ impl FormatReader for JsonReader {
                 self.inner = InnerReader::Done;
                 return Ok(s);
             };
-            let mut flat = serde_json::Map::new();
-            Self::flatten_value("", &raw, &mut flat, 0);
+            let flat = self.flatten_record_body(&raw)?;
             let expanded = self.apply_split_to_rows(flat);
             if !expanded.is_empty() {
                 break expanded;
@@ -588,8 +653,7 @@ impl FormatReader for JsonReader {
                 Some(v) => v,
                 None => return Ok(None),
             };
-            let mut flat = serde_json::Map::new();
-            Self::flatten_value("", &raw, &mut flat, 0);
+            let flat = self.flatten_record_body(&raw)?;
             let expanded = self.apply_split_to_rows(flat);
             if expanded.is_empty() {
                 continue;
@@ -649,7 +713,9 @@ fn project_element(
 ) {
     match (entry.mode, elem) {
         (SplitToRowsMode::Extract, serde_json::Value::Object(_)) => {
-            JsonReader::flatten_value("", elem, out, 0);
+            // Merge the occurrence's keys onto the already-populated parent
+            // record: a deliberate merge, so no collision detection (last-wins).
+            JsonReader::flatten_value("", elem, out, 0, None, &[]);
         }
         (SplitToRowsMode::Extract, other) => {
             let name = entry
@@ -660,7 +726,7 @@ fn project_element(
             out.insert(name.to_string(), other.clone());
         }
         (SplitToRowsMode::Split, _) => {
-            JsonReader::flatten_value(&entry.field, elem, out, 0);
+            JsonReader::flatten_value(&entry.field, elem, out, 0, None, &[]);
         }
     }
 }
@@ -1313,6 +1379,44 @@ mod tests {
         assert_eq!(
             r.next_record().unwrap().unwrap().get("tags"),
             Some(&Value::Array(vec![Value::String("solo".into())]))
+        );
+    }
+
+    #[test]
+    fn undeclared_flattened_name_collision_is_a_loud_error() {
+        // A literal dotted key and a nested object both flatten to `a.b`. Only
+        // one would survive last-write-wins; refuse loudly instead of silently
+        // dropping the other, matching the XML undeclared-repeat behavior.
+        let input = r#"[{"a":{"b":1},"a.b":2}]"#;
+        let mut r = reader_from_str(input, default_config());
+        let err = r
+            .schema()
+            .expect_err("flattened-name collision must fail loud");
+        assert!(
+            matches!(err, FormatError::UndeclaredRepeatedField { format: "JSON", ref field } if field == "a.b"),
+            "names the offending field: {err:?}"
+        );
+        assert!(
+            err.is_document_structural(),
+            "dead-letterable, not fatal-only"
+        );
+    }
+
+    #[test]
+    fn flattened_name_collision_on_a_multiple_column_collects() {
+        // The escape hatch, symmetric with XML: declaring the colliding name
+        // `multiple: true` collects both values into an array in document order
+        // rather than erroring.
+        let input = r#"[{"a":{"b":1},"a.b":2}]"#;
+        let config = JsonReaderConfig {
+            multi_value_fields: vec!["a.b".into()],
+            ..default_config()
+        };
+        let mut r = reader_from_str(input, config);
+        let _s = r.schema().unwrap();
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("a.b"),
+            Some(&Value::Array(vec![Value::Integer(1), Value::Integer(2)]))
         );
     }
 

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -87,6 +87,12 @@ pub struct JsonReader {
     schema: Option<Arc<Schema>>,
     config: JsonReaderConfig,
     pending: Vec<serde_json::Map<String, serde_json::Value>>,
+    /// The first raw record, read eagerly by schema inference and held UN-parsed
+    /// so its fallible flatten (which rejects an undeclared flattened-name
+    /// collision) runs in `next_record`, inside the executor's record loop,
+    /// rather than in the eager `schema` call the ingest setup makes before that
+    /// loop. `None` once consumed or when the source is empty.
+    deferred_first: Option<serde_json::Value>,
     /// The re-openable byte source. Body iteration and the envelope pre-scan
     /// each open their own fresh [`Read`] from it, so no whole-file buffer is
     /// held for a file-backed (`ReopenableSource::Path`) source.
@@ -139,6 +145,7 @@ impl JsonReader {
             schema: None,
             config,
             pending: Vec::new(),
+            deferred_first: None,
             source,
             body_identity,
         })
@@ -612,17 +619,27 @@ impl FormatReader for JsonReader {
         // `keep_empty: false` entry drops a record whose field is empty, and
         // inferring the schema from that dropped expansion would cache a
         // column-less schema for the whole source while records kept flowing.
-        let expanded = loop {
+        //
+        // Name inference flattens WITHOUT collision detection: it needs only the
+        // column names, which a flattened-name collision does not change. The
+        // fallible detecting flatten is deferred — the raw record is stashed in
+        // `deferred_first` and re-flattened in `next_record`, so an undeclared
+        // collision in the FIRST record surfaces through the executor's record
+        // loop (where it can be dead-lettered) rather than through this eager
+        // `schema` call, which the ingest setup makes before the loop begins and
+        // whose error would abort the whole run.
+        let (raw, expanded) = loop {
             let Some(raw) = self.next_raw()? else {
                 let s = SchemaBuilder::new().build();
                 self.schema = Some(Arc::clone(&s));
                 self.inner = InnerReader::Done;
                 return Ok(s);
             };
-            let flat = self.flatten_record_body(&raw)?;
+            let mut flat = serde_json::Map::new();
+            Self::flatten_value("", &raw, &mut flat, 0, None, &[]);
             let expanded = self.apply_split_to_rows(flat);
             if !expanded.is_empty() {
-                break expanded;
+                break (raw, expanded);
             }
         };
 
@@ -633,14 +650,29 @@ impl FormatReader for JsonReader {
             .map(|k| k.clone().into_boxed_str())
             .collect::<SchemaBuilder>()
             .build();
+        self.deferred_first = Some(raw);
         self.schema = Some(Arc::clone(&schema));
-        self.pending = expanded;
         Ok(schema)
     }
 
     fn next_record(&mut self) -> Result<Option<Record>, FormatError> {
         if self.schema.is_none() {
             self.schema()?;
+        }
+
+        // Assemble the record schema inference stashed, detecting an undeclared
+        // flattened-name collision here rather than in the eager `schema` call.
+        if let Some(raw) = self.deferred_first.take() {
+            let flat = self.flatten_record_body(&raw)?;
+            let mut expanded = self.apply_split_to_rows(flat).into_iter();
+            if let Some(first) = expanded.next() {
+                let record = self.map_to_record(first)?;
+                self.pending = expanded.collect();
+                return Ok(Some(record));
+            }
+            // The deferred record expanded to nothing after all (only reachable
+            // if detection changed the expansion, which it does not) — fall
+            // through to the pending/main-loop path.
         }
 
         if !self.pending.is_empty() {
@@ -714,7 +746,14 @@ fn project_element(
     match (entry.mode, elem) {
         (SplitToRowsMode::Extract, serde_json::Value::Object(_)) => {
             // Merge the occurrence's keys onto the already-populated parent
-            // record: a deliberate merge, so no collision detection (last-wins).
+            // record. Collision detection is off (`None`) here: an element key
+            // that clashes with a parent field, or with another element key,
+            // still resolves last-wins rather than raising
+            // `UndeclaredRepeatedField`. That element-internal / element-vs-parent
+            // collision under `extract` is the fan-out half of the read-side
+            // collision gap and is tracked separately by issue #920 — the
+            // top-level record collision this module now rejects does not cover
+            // it.
             JsonReader::flatten_value("", elem, out, 0, None, &[]);
         }
         (SplitToRowsMode::Extract, other) => {
@@ -726,6 +765,10 @@ fn project_element(
             out.insert(name.to_string(), other.clone());
         }
         (SplitToRowsMode::Split, _) => {
+            // Split mode re-nests the element under its own field name, so a
+            // clash with a parent field is possible but a within-element clash
+            // is not; collision detection stays off for the same #920 reason as
+            // the extract arm above.
             JsonReader::flatten_value(&entry.field, elem, out, 0, None, &[]);
         }
     }
@@ -1389,8 +1432,15 @@ mod tests {
         // dropping the other, matching the XML undeclared-repeat behavior.
         let input = r#"[{"a":{"b":1},"a.b":2}]"#;
         let mut r = reader_from_str(input, default_config());
-        let err = r
+        // Schema inference is infallible (names only), so the loud error is
+        // deferred to record assembly in `next_record` — this lets the executor
+        // dead-letter a first-record collision instead of aborting during its
+        // eager pre-loop `schema` call.
+        let _s = r
             .schema()
+            .expect("schema inference does not detect collisions");
+        let err = r
+            .next_record()
             .expect_err("flattened-name collision must fail loud");
         assert!(
             matches!(err, FormatError::UndeclaredRepeatedField { format: "JSON", ref field } if field == "a.b"),

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -612,6 +612,11 @@ impl XmlReader {
     /// `Arc<Schema>` reflects exactly the keys present in that XML
     /// element — the per-Source `OnUnmapped` policy at the dispatch
     /// layer reconciles records against the user-declared schema.
+    ///
+    /// A child element that repeats is collected into a `Value::Array` only
+    /// when its column is declared `multiple: true`; a repeat on any other
+    /// column returns [`FormatError::UndeclaredRepeatedField`] rather than
+    /// silently keeping the first occurrence and dropping the rest.
     fn fields_to_record(&self, fields: Vec<(String, String)>) -> Result<Record, FormatError> {
         // Keyed by the boxed column name so the slot map costs exactly one
         // clone per distinct field, the same as the `HashSet` first-wins dedup
@@ -624,14 +629,21 @@ impl XmlReader {
         for (key, val) in fields {
             let value = infer_value(&val);
             match slot.get(key.as_str()) {
-                // A repeated key on a `multiple:` column accumulates in
-                // document order; on any other column the first occurrence
-                // wins, which is the long-standing duplicate-key collapse.
-                Some(&i) => {
-                    if let Value::Array(items) = &mut values[i] {
-                        items.push(value);
+                Some(&i) => match &mut values[i] {
+                    // A repeated key on a `multiple:` column accumulates in
+                    // document order.
+                    Value::Array(items) => items.push(value),
+                    // A repeated key on any other column would keep the first
+                    // value and silently drop this one. Refuse loudly instead:
+                    // an undeclared repeat is a data-loss hazard, not a
+                    // first-wins convenience.
+                    _ => {
+                        return Err(FormatError::UndeclaredRepeatedField {
+                            format: "XML",
+                            field: key,
+                        });
                     }
-                }
+                },
                 None => {
                     let multiple = self.is_multi_value(&key);
                     let name = key.into_boxed_str();
@@ -1994,21 +2006,64 @@ mod tests {
     }
 
     #[test]
-    fn xml_unmatched_repeated_keys_keep_first_value() {
-        // Repeated keys named by neither a fan-out nor a `multiple:` column
-        // keep the existing duplicate-key collapse: the first value wins, on
-        // every fanned-out record.
+    fn xml_undeclared_repeated_element_is_a_loud_error() {
+        // A child element that repeats while its column is named by neither a
+        // fan-out nor a `multiple:` declaration is refused loudly: keeping the
+        // first value and dropping the rest is silent data loss. `<Dup>`
+        // repeats here; `<Tag>` is fanned out so it never repeats per record.
         let xml = r#"<Root><Row><Dup>x</Dup><Dup>y</Dup><Tag>a</Tag><Tag>b</Tag></Row></Root>"#;
         let config = split_config("Root/Row", vec![split("Tag")]);
         let mut r = reader_from_str(xml, config);
-        let _s = r.schema().unwrap();
 
-        let r1 = r.next_record().unwrap().unwrap();
-        assert_eq!(r1.get("Dup"), Some(&Value::String("x".into())));
-        assert_eq!(r1.get("Tag"), Some(&Value::String("a".into())));
-        let r2 = r.next_record().unwrap().unwrap();
-        assert_eq!(r2.get("Dup"), Some(&Value::String("x".into())));
-        assert_eq!(r2.get("Tag"), Some(&Value::String("b".into())));
+        // Schema inference buffers the first element through the same record
+        // assembly, so the loud error surfaces there too — inference and
+        // assembly agree instead of the inference quietly deduping the column.
+        let err = r.schema().expect_err("undeclared repeat must fail loud");
+        assert!(
+            matches!(err, FormatError::UndeclaredRepeatedField { format: "XML", ref field } if field == "Dup"),
+            "names the offending field: {err:?}"
+        );
+        assert!(
+            err.is_document_structural(),
+            "dead-letterable, not fatal-only"
+        );
+    }
+
+    #[test]
+    fn xml_undeclared_repeat_without_any_fan_out_is_a_loud_error() {
+        // A bare reproduction: no fan-out at all, a plainly repeated
+        // element on a column that is not `multiple:`. The first
+        // `next_record` surfaces the loud error rather than a first-wins record.
+        let xml = r#"<Root><Row><Dup>x</Dup><Dup>y</Dup></Row></Root>"#;
+        let config = XmlReaderConfig {
+            record_path: Some("Root/Row".into()),
+            ..Default::default()
+        };
+        let mut r = reader_from_str(xml, config);
+        let err = r
+            .next_record()
+            .expect_err("undeclared repeat must fail loud");
+        assert!(
+            matches!(err, FormatError::UndeclaredRepeatedField { format: "XML", ref field } if field == "Dup"),
+            "names the offending field: {err:?}"
+        );
+    }
+
+    #[test]
+    fn xml_declared_multiple_repeat_still_collects() {
+        // The escape hatch: declaring the column `multiple: true` collects
+        // every occurrence into an array, in document order — no error.
+        let xml = r#"<Root><Row><Dup>x</Dup><Dup>y</Dup></Row></Root>"#;
+        let config = multi_value_config("Root/Row", &["Dup"]);
+        let mut r = reader_from_str(xml, config);
+        let rec = r.next_record().unwrap().unwrap();
+        assert_eq!(
+            rec.get("Dup"),
+            Some(&Value::Array(vec![
+                Value::String("x".into()),
+                Value::String("y".into()),
+            ]))
+        );
         assert!(r.next_record().unwrap().is_none());
     }
 

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -186,11 +186,15 @@ pub struct XmlReader {
     matched_depth: usize,
     /// Current XML depth (incremented on Start, decremented on End).
     xml_depth: usize,
-    /// Expanded records awaiting emission: schema inference reads the first
-    /// record element eagerly, and a `split_to_rows` fan-out expands one
-    /// element into several records. Bounded by one element's expansion,
-    /// never the whole input.
-    pending: VecDeque<Record>,
+    /// Expanded field lists awaiting assembly into records: schema inference
+    /// reads the first record element eagerly, and a `split_to_rows` fan-out
+    /// expands one element into several. Held as RAW `(key, value)` lists —
+    /// not assembled `Record`s — so the fallible assembly step (which rejects
+    /// an undeclared repeated field) runs in `next_record`, inside the
+    /// executor's record loop, rather than in the eager `schema` call the
+    /// ingest setup makes before that loop. Bounded by one element's
+    /// expansion, never the whole input.
+    pending: VecDeque<Vec<(String, String)>>,
     /// Whether we've finished all records.
     done: bool,
 }
@@ -472,13 +476,21 @@ impl XmlReader {
                         format!("{}.{name}", element_stack.join("."))
                     };
                     let instance_from = fields.len();
-                    fields.push((prefix.clone(), String::new()));
+                    // A value-less self-closing element pushes no field of its
+                    // own, exactly as the empty-body form `<x></x>` does through
+                    // `flush_text_field`'s non-empty guard. Pushing an empty
+                    // leader here instead would make `<x/><x/>` look like a
+                    // repeated field and wrongly trip `UndeclaredRepeatedField`,
+                    // while the identical `<x></x><x></x>` passes — so only the
+                    // element's attributes (if any) are recorded.
                     let child_attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
                     for (key, val) in child_attrs {
                         fields.push((format!("{prefix}.{key}"), val));
                     }
                     // A self-closing element named by a declared fan-out field
-                    // is a complete occurrence on its own.
+                    // is a complete occurrence on its own; its range spans the
+                    // attributes pushed above, or is empty when it has none —
+                    // the same empty range the empty-body form contributes.
                     if open_instance.is_none()
                         && let Some(pi) = self.split_field_index(&prefix)
                     {
@@ -678,9 +690,17 @@ impl FormatReader for XmlReader {
             return Ok(Arc::clone(s));
         }
 
-        // Infer schema from the first expanded record's field names
+        // Infer the schema from the first expanded record's field NAMES
         // (preserving order). The fan-out applies before inference, so the
         // columns it lifts or synthesizes are what the schema reflects.
+        //
+        // Name inference is deliberately infallible. The per-record assembly
+        // that CAN fail — an undeclared repeated field on a non-`multiple:`
+        // column — is deferred to `next_record`, so a first-record repeat
+        // surfaces through the executor's record loop (where it can be
+        // dead-lettered under `dlq_granularity: document`) rather than through
+        // this eager `schema` call, which the ingest setup makes before the
+        // loop begins and whose error would abort the whole run.
         //
         // Read forward until a record element actually expands to something: a
         // `keep_empty: false` entry drops an element with no occurrence, and
@@ -713,13 +733,15 @@ impl FormatReader for XmlReader {
             })
             .collect::<SchemaBuilder>()
             .build();
-        self.schema = Some(Arc::clone(&schema));
 
-        // Buffer every record the first element expanded to.
+        // Buffer the first element's expansions as RAW field lists; the
+        // fallible `fields_to_record` assembly runs in `next_record`. Set the
+        // cached schema only after buffering so a caller never sees a schema
+        // paired with an unbuffered first record.
         for fields in expanded {
-            let record = self.fields_to_record(fields)?;
-            self.pending.push_back(record);
+            self.pending.push_back(fields);
         }
+        self.schema = Some(Arc::clone(&schema));
 
         Ok(schema)
     }
@@ -730,16 +752,15 @@ impl FormatReader for XmlReader {
         }
 
         loop {
-            if let Some(record) = self.pending.pop_front() {
-                return Ok(Some(record));
+            if let Some(fields) = self.pending.pop_front() {
+                return Ok(Some(self.fields_to_record(fields)?));
             }
             let raw = match self.read_next_record_raw()? {
                 Some(r) => r,
                 None => return Ok(None),
             };
             for fields in self.apply_split_to_rows(raw) {
-                let record = self.fields_to_record(fields)?;
-                self.pending.push_back(record);
+                self.pending.push_back(fields);
             }
         }
     }
@@ -975,9 +996,10 @@ fn strip_field_prefix<'a>(key: &'a str, path: &'a str) -> &'a str {
 /// `position_column: line_no`). The occurrence wins the first: it IS the record
 /// under `extract`. The synthesized position wins the second: it is what the
 /// author asked for by name, and the JSON reader resolves the same collision
-/// the same way. The displaced field is dropped rather than carried alongside,
-/// because the duplicate-key collapse downstream is first-wins and would
-/// otherwise silently keep the shadowed value.
+/// the same way. The displaced field is dropped here rather than carried
+/// alongside: two fields sharing one name would otherwise reach record assembly
+/// as a repeat and trip its loud `UndeclaredRepeatedField` error, turning this
+/// intended fan-out shadow into a spurious rejection.
 ///
 /// One pass over the record buckets every field, so the work is linear in the
 /// record's fields plus the fan-out it emits — a rescan per occurrence would
@@ -2015,10 +2037,16 @@ mod tests {
         let config = split_config("Root/Row", vec![split("Tag")]);
         let mut r = reader_from_str(xml, config);
 
-        // Schema inference buffers the first element through the same record
-        // assembly, so the loud error surfaces there too — inference and
-        // assembly agree instead of the inference quietly deduping the column.
-        let err = r.schema().expect_err("undeclared repeat must fail loud");
+        // Schema inference is infallible (it only reads the column names), so
+        // the loud error is deferred to record assembly in `next_record` — this
+        // is what lets the executor dead-letter a first-record repeat instead of
+        // aborting during its eager pre-loop `schema` call.
+        let _s = r
+            .schema()
+            .expect("schema inference does not assemble records");
+        let err = r
+            .next_record()
+            .expect_err("undeclared repeat must fail loud");
         assert!(
             matches!(err, FormatError::UndeclaredRepeatedField { format: "XML", ref field } if field == "Dup"),
             "names the offending field: {err:?}"
@@ -2027,6 +2055,29 @@ mod tests {
             err.is_document_structural(),
             "dead-letterable, not fatal-only"
         );
+    }
+
+    #[test]
+    fn xml_repeated_self_closing_empty_element_is_not_an_error() {
+        // Repeated value-less self-closing elements must behave exactly like
+        // their empty-body twins: they contribute no field, so a non-`multiple:`
+        // column that merely appears twice as `<x/>` is NOT a data-loss repeat
+        // and must not be rejected. (Regression guard for the self-closing /
+        // empty-body asymmetry adjacent to issue #920.)
+        let xml = r#"<Root><Row><id>1</id><middle_name/><middle_name/></Row></Root>"#;
+        let config = XmlReaderConfig {
+            record_path: Some("Root/Row".into()),
+            ..Default::default()
+        };
+        let mut r = reader_from_str(xml, config);
+        let rec = r
+            .next_record()
+            .expect("repeated empty self-closing element must not error")
+            .expect("one record");
+        assert_eq!(rec.get("id"), Some(&Value::Integer(1)));
+        // The value-less element yields no field at all, matching `<x></x>`.
+        assert_eq!(rec.get("middle_name"), None);
+        assert!(r.next_record().unwrap().is_none());
     }
 
     #[test]

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -84,6 +84,22 @@ level, which removes the `orders.items` path the inner entry addresses — so th
 pairing is rejected at compile (`E358`) rather than silently fanning out only
 one level. A duplicated field is rejected too.
 
+## Flattened-name collisions
+
+The reader dissolves nested objects into dotted keys, so `{"a": {"b": 1}}`
+becomes the field `a.b`. When two distinct keys flatten to the **same** name —
+for example a nested `{"a": {"b": 1}}` alongside a literal `{"a.b": 2}` in the
+same record — only one value could survive, and keeping one while dropping the
+other is silent data loss. The reader refuses the record instead, naming the
+colliding field. This mirrors the XML reader's treatment of a repeated element:
+both formats now fail loud on an undeclared collision rather than one keeping the
+first value and the other the last. If the collision is intentional (both values
+belong together), declare the column `multiple: true` to collect them into an
+array in document order; otherwise rename one of the source keys so they no
+longer collide. As with XML, detection is per document at read time, so the run
+aborts under `fail_fast` and dead-letters the document under `continue` /
+`best_effort` with `dlq_granularity: document`.
+
 ## Bounding envelope retention: `max_index_bytes`
 
 When a source declares an `envelope:` and a pipeline reads `$doc.*` paths

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -100,6 +100,12 @@ longer collide. As with XML, detection is per document at read time, so the run
 aborts under `fail_fast` and dead-letters the document under `continue` /
 `best_effort` with `dlq_granularity: document`.
 
+Detection covers collisions at the top level of a record. A collision *inside*
+an array element that a `split_to_rows: extract` fan-out lifts to the top level
+(one element key clashing with a parent field or with another element key) is
+not yet detected and still resolves last-wins — tracked by
+[issue 920](https://github.com/rustpunk/clinker/issues/920).
+
 ## Bounding envelope retention: `max_index_bytes`
 
 When a source declares an `envelope:` and a pipeline reads `$doc.*` paths

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -180,9 +180,17 @@ container (`Item.name`, `Item.qty`) collects each of them independently.
 A field cannot be both collected and fanned out: naming a `multiple: true`
 column in `split_to_rows` is rejected at compile (`E358`).
 
-Repeated fields named by neither a `split_to_rows` entry nor a `multiple:`
-column keep the default duplicate-key collapse: the first value wins and later
-repetitions are dropped.
+A repeated element named by neither a `split_to_rows` entry nor a `multiple:`
+column is a **loud error**, not a silent drop. Keeping the first occurrence and
+discarding the rest would lose data without warning, so the reader refuses the
+record and names the offending field, pointing at the two ways to handle a
+repeat on purpose: declare the column `multiple: true` to collect every
+occurrence into an array, or add a `split_to_rows` entry to fan each occurrence
+out to its own record. Detection is per document at read time — a plan cannot
+know in advance that a particular document repeats a field. Under the default
+`fail_fast` strategy the run aborts with the diagnostic; under `continue` /
+`best_effort` with `dlq_granularity: document` the offending document is routed
+to the dead-letter queue and the run continues.
 
 ### Delimited text in one element: `split_values`
 


### PR DESCRIPTION
## Problem

When an XML record element contained a repeated child element whose schema
column was **not** declared `multiple: true`, the reader kept the first
occurrence and silently discarded the rest — no warning, no log line, no
dead-letter entry. The raw extraction preserved every repeat in document order
and then threw the extras away.

The JSON reader had the mirror-image gap: when two keys flattened to the same
dotted name (for example a nested `{"a": {"b": 1}}` alongside a literal
`{"a.b": 2}`), the collision resolved **last**-write-wins — the opposite
precedence to XML's first-wins, and just as silent.

Repeated elements are ordinary, standard XML, and a flattened-name clash is
ordinary JSON. Requiring every such case to be pre-declared just to avoid silent
truncation inverts the safe default: the failure mode for an undeclared
collision should be loud, not lossy.

## What changed

Both readers now refuse an undeclared collision loudly instead of dropping data:

- A repeated XML element, or a JSON top-level flattened-name collision, on a
  column that is **not** declared `multiple: true` now returns a new
  `FormatError::UndeclaredRepeatedField` that names the offending field and
  points at the two ways to handle a repeat on purpose.
- The two formats agree **at the top level of a record**: declaring the column
  `multiple: true` collects every occurrence into an array (in document order)
  on both readers, and a `split_to_rows` entry fans each occurrence out to its
  own record. The previously divergent first-wins (XML) / last-wins (JSON)
  silent behavior at that level is gone.
- Documentation for both formats now describes the behavior, replacing the
  single XML sentence that recorded the silent drop as intended.

### Known residual (tracked separately)

Detection covers collisions at the top level of a record. A collision *inside*
an array element that a `split_to_rows: extract` fan-out lifts to the top level
(an element key clashing with a parent field or another element key) is **not
yet detected** and still resolves last-wins. That fan-out path is the read-side
collision gap tracked by #920; the parity claim above is deliberately scoped to
the top level, and the code and JSON docs point at #920 for the rest.

## Design decision: runtime dead-letter, not a plan-time check

Whether a field actually repeats is a property of a **document**, not of the
plan: every non-`multiple` field is nominally single-valued, so a plan-time
diagnostic cannot see that a given input repeats one. Detection is therefore
inherently at read time.

The new error is classified **document-structural**, so it flows through the
reader's existing structural-failure disposition rather than introducing a new
path:

- Under the default `fail_fast` strategy the run **aborts** with the diagnostic
  (loud, never lossy) — this is the core fix for the reported data loss.
- Under `continue` / `best_effort` with `dlq_granularity: document`, the
  offending document is **routed to the dead-letter queue** and the run
  continues past it.

This mirrors how the readers already treat other document-scoped structural
failures (envelope trailer count mismatches, unknown record-type
discriminators), so no new stream machinery or diagnostic code was needed.

To make that routing hold for a repeat in the **first** record, schema
inference is kept infallible: it reads only the column names and defers the
fallible record assembly (where the collision is detected) to the record loop.
Ingest triggers schema discovery eagerly during setup, before the loop, so if
the error surfaced there it would bypass the document-DLQ reclassification and
abort the run even under `continue`. Deferring assembly to the loop means a
first-record repeat dead-letters like any other.

A finer, per-record dead-letter for a mid-document reader failure would require
a new per-record reject seam threaded through the ingest-to-dispatch stream (the
current reader-error path is document-grained); that is a larger, separable
change and a reasonable follow-up, but it is not needed to close the data-loss
defect this PR targets.

## A self-closing consistency fix

A value-less self-closing element (`<x/>`) no longer contributes an empty field,
matching the empty-body form (`<x></x>`) it was already inconsistent with.
Without this, a repeated optional self-closing element
(`<middle_name/><middle_name/>`) would trip the new loud error while its
empty-body twin passed — a regression the new behavior would otherwise have
introduced.

## Tests

- XML: schema inference succeeds and the loud error surfaces at record assembly;
  an undeclared repeat (with and without a fan-out) is rejected; a declared
  `multiple: true` repeat still collects; a repeated self-closing empty element
  does **not** error and yields no field.
- JSON: an undeclared top-level flattened-name collision is rejected at record
  assembly; a collision on a `multiple:` column collects into the array; the
  fan-out element-merge path is unchanged.
- Error type: the new variant names the field and both remedies and is
  classified document-structural.
- End-to-end: an XML pipeline with an undeclared repeat aborts under fail-fast;
  a repeat in the **first** record dead-letters under `continue` +
  `dlq_granularity: document`; and a condemned first file does not stop a clean
  second file from streaming through.

Validation run locally: `cargo fmt --all --check`,
`cargo clippy --workspace --all-targets -- -D warnings`, and
`cargo test -p clinker-format -p clinker-exec` — all green.

Closes #913
