### PR TITLE
feat(format): write repeated XML child elements for multi-value fields

### DIFF
--- a/crates/clinker-exec/src/executor/registry.rs
+++ b/crates/clinker-exec/src/executor/registry.rs
@@ -327,6 +327,11 @@ fn build_writer_factory(
         OutputFormat::Xml(opts) => {
             let mut xml_config = build_xml_writer_config(opts.as_ref());
             xml_config.include_engine_stamped = include_engine_stamped;
+            // Per-field repeated-element overrides (`repeat_as` / `wrap_in`); a
+            // `multiple:` field with no entry emits bare repeats named after the
+            // field. The plan-time E362 gate has already validated the block, so
+            // the XML and CSV arms each consume the sub-vocabulary they read.
+            xml_config.join_values = join_values;
             xml_config.envelope = resolve_envelope_spec(
                 reconstruct_envelope,
                 opts.as_ref().and_then(|o| o.envelope.as_ref()),

--- a/crates/clinker-exec/tests/xml_multi_value_e2e.rs
+++ b/crates/clinker-exec/tests/xml_multi_value_e2e.rs
@@ -1,0 +1,118 @@
+//! End-to-end proof that a `multiple:` field reaches an XML sink and is written
+//! as repeated child elements, and that a `join_values` `repeat_as` / `wrap_in`
+//! override renames the item and adds a container — the central acceptance
+//! criterion of #916.
+//!
+//! The repeated-element emission is unit-tested in `clinker-format`; this guards
+//! the executor wiring the unit tests cannot see: the writer factory threading
+//! the output's `join_values` into the XML writer config.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+
+fn params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+/// A JSON source (native arrays) with a two-value `tags` column on one record.
+const JSON_INPUT: &str = r#"[{"order_id":"1","tags":["a","b"]}]"#;
+
+fn json_reader() -> SourceReaders {
+    HashMap::from([(
+        "orders".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.json",
+            Box::new(std::io::Cursor::new(JSON_INPUT.as_bytes().to_vec())),
+        ),
+    )])
+}
+
+fn run(pipeline: &str) -> String {
+    let config = clinker_plan::config::parse_config(pipeline).expect("pipeline parses");
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    common::run_config(&config, json_reader(), writers, &params())
+        .expect("run succeeds — the array encodes as repeated elements");
+    String::from_utf8(buf.contents()).expect("utf-8 output")
+}
+
+/// With no `join_values` config the values emit as bare repeated elements named
+/// after the field — the write side of the read-side `multiple: true` collect.
+#[test]
+fn xml_multi_value_default_emits_repeated_elements() {
+    const PIPELINE: &str = r#"
+pipeline:
+  name: xml_multi_value_default
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: json
+      path: ./in.json
+      schema:
+        - { name: order_id, type: string }
+        - { name: tags, type: string, multiple: true }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: xml
+      path: ./out.xml
+"#;
+    let output = run(PIPELINE);
+    assert_eq!(
+        output, "<Root><Record><order_id>1</order_id><tags>a</tags><tags>b</tags></Record></Root>",
+        "got: {output}"
+    );
+}
+
+/// A `join_values` entry with `repeat_as` and `wrap_in` renames the item element
+/// and wraps the run in a container — proving the override flows from YAML,
+/// through the writer factory, into the XML writer config.
+#[test]
+fn xml_multi_value_repeat_as_and_wrap_in_flow_through_the_factory() {
+    const PIPELINE: &str = r#"
+pipeline:
+  name: xml_multi_value_wrapped
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: json
+      path: ./in.json
+      schema:
+        - { name: order_id, type: string }
+        - { name: tags, type: string, multiple: true }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: xml
+      path: ./out.xml
+      join_values:
+        - { field: tags, repeat_as: Tag, wrap_in: Tags }
+"#;
+    let output = run(PIPELINE);
+    assert_eq!(
+        output,
+        "<Root><Record><order_id>1</order_id><Tags><Tag>a</Tag><Tag>b</Tag></Tags></Record></Root>",
+        "got: {output}"
+    );
+}

--- a/crates/clinker-format/src/csv/writer.rs
+++ b/crates/clinker-format/src/csv/writer.rs
@@ -993,6 +993,8 @@ mod tests {
             delimiter: "|".into(),
             on_conflict: OnConflict::Error,
             escape: "\\".into(),
+            repeat_as: None,
+            wrap_in: None,
         }]);
         let output = write_to_string(&schema, config, &[record]);
         assert_eq!(output, "codes\nx|y\n");
@@ -1052,6 +1054,8 @@ mod tests {
             delimiter: ";".into(),
             on_conflict: OnConflict::Escape,
             escape: "\\".into(),
+            repeat_as: None,
+            wrap_in: None,
         }]);
         let output = write_to_string(&schema, config, &[record]);
 
@@ -1086,6 +1090,8 @@ mod tests {
             delimiter: ";".into(),
             on_conflict: OnConflict::EncodeJson,
             escape: "\\".into(),
+            repeat_as: None,
+            wrap_in: None,
         }]);
         let output = write_to_string(&schema, config, &[record]);
 
@@ -1124,6 +1130,8 @@ mod tests {
             delimiter: ";".into(),
             on_conflict: OnConflict::Escape,
             escape: "\\".into(),
+            repeat_as: None,
+            wrap_in: None,
         }]);
         let out = write_to_string(&schema, config, &[record]);
         let read_config = CsvReaderConfig {
@@ -1169,6 +1177,8 @@ mod tests {
             delimiter: ";".into(),
             on_conflict: OnConflict::EncodeJson,
             escape: "\\".into(),
+            repeat_as: None,
+            wrap_in: None,
         }]);
         let json = write_to_string(&schema, json_cfg, &[record]);
         assert_eq!(json, "id,tags\n1,\"[\"\"\"\"]\"\n");

--- a/crates/clinker-format/src/multi_value.rs
+++ b/crates/clinker-format/src/multi_value.rs
@@ -161,42 +161,68 @@ pub enum OnConflict {
     EncodeJson,
 }
 
-/// One `join_values` entry: collapse a `multiple:` field into one delimited
-/// CSV cell on write. The write-side inverse of [`SplitValues`].
+/// One `join_values` entry: the write-side declaration for a `multiple:` field,
+/// the inverse of [`SplitValues`]. Each writer reads the sub-vocabulary that
+/// applies to it:
+///
+/// - The **CSV** writer collapses the values into one delimited cell, honoring
+///   `delimiter` / `on_conflict` / `escape`.
+/// - The **XML** writer emits the values as repeated child elements, honoring
+///   `repeat_as` (the per-item element name) and `wrap_in` (an optional
+///   container). It ignores `delimiter` / `on_conflict` / `escape`, which have no
+///   meaning for repeated elements; the CSV writer likewise ignores
+///   `repeat_as` / `wrap_in`.
 ///
 /// Two accepted YAML shapes, freely mixable in one sequence:
 ///
 /// ```yaml
 /// join_values:
 ///   - tags                          # shorthand: delimiter ";", on_conflict: error
-///   - field: notes                  # full form
+///   - field: notes                  # full form (CSV)
 ///     delimiter: "|"
 ///     on_conflict: escape           # error | escape | encode_json
 ///     escape: "\\"                  # only meaningful with on_conflict: escape
+///   - field: tags                   # full form (XML)
+///     repeat_as: Tag                # per-item element name; defaults to the field
+///     wrap_in: Tags                 # optional container; omit for bare repeats
 /// ```
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct JoinValues {
     /// Flattened field name whose values are joined into one cell.
     pub field: String,
     /// Separator written between values. Defaults to
-    /// [`crate::schema::DEFAULT_VALUE_DELIMITER`].
+    /// [`crate::schema::DEFAULT_VALUE_DELIMITER`]. CSV output only.
     pub delimiter: String,
-    /// What to do when a value being joined contains the delimiter.
+    /// What to do when a value being joined contains the delimiter. CSV output
+    /// only.
     pub on_conflict: OnConflict,
     /// Escape character used under [`OnConflict::Escape`]. Defaults to a
-    /// backslash. Ignored by the other policies.
+    /// backslash. Ignored by the other policies. CSV output only.
     pub escape: String,
+    /// XML output only: the element name emitted per array item. `None` (the
+    /// default) names each item after the field's own element. Ignored by the
+    /// CSV writer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repeat_as: Option<String>,
+    /// XML output only: a container element wrapping the repeated items. `None`
+    /// (the default) emits bare repeats with no container. Ignored by the CSV
+    /// writer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wrap_in: Option<String>,
 }
 
 impl JoinValues {
     /// A `join_values` entry using the default delimiter, `on_conflict: error`,
-    /// and the default escape — what the bare-scalar shorthand deserializes to.
+    /// the default escape, and no XML repeat/wrap overrides — what the
+    /// bare-scalar shorthand deserializes to.
     pub fn bare(field: impl Into<String>) -> Self {
         JoinValues {
             field: field.into(),
             delimiter: crate::schema::DEFAULT_VALUE_DELIMITER.to_string(),
             on_conflict: OnConflict::default(),
             escape: default_escape(),
+            repeat_as: None,
+            wrap_in: None,
         }
     }
 }
@@ -423,6 +449,10 @@ impl<'de> Deserialize<'de> for JoinValues {
             on_conflict: OnConflict,
             #[serde(default = "default_escape")]
             escape: String,
+            #[serde(default)]
+            repeat_as: Option<String>,
+            #[serde(default)]
+            wrap_in: Option<String>,
         }
 
         struct V;
@@ -433,7 +463,7 @@ impl<'de> Deserialize<'de> for JoinValues {
                 f.write_str(
                     "a `join_values` entry: either a field name (`tags`) or a map \
                      `{ field: <name>, delimiter: <str>, on_conflict: error|escape|encode_json, \
-                     escape: <str> }`",
+                     escape: <str>, repeat_as: <name>, wrap_in: <name> }`",
                 )
             }
 
@@ -448,6 +478,8 @@ impl<'de> Deserialize<'de> for JoinValues {
                     delimiter: full.delimiter,
                     on_conflict: full.on_conflict,
                     escape: full.escape,
+                    repeat_as: full.repeat_as,
+                    wrap_in: full.wrap_in,
                 })
             }
         }

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -21,6 +21,7 @@ use clinker_record::{DocumentContext, Record, Schema, Value};
 
 use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
 use crate::error::FormatError;
+use crate::multi_value::JoinValues;
 use crate::traits::FormatWriter;
 
 #[derive(Clone)]
@@ -45,6 +46,14 @@ pub struct XmlWriterConfig {
     /// the executor under `reconstruct_envelope: true` and wraps each document
     /// in a `<Document>` frame with header/footer elements.
     pub envelope: Option<OutputEnvelopeSpec>,
+    /// Per-field overrides for how a `multiple:` field's values are emitted as
+    /// repeated child elements. A `Value::Array` at any element field emits one
+    /// child element per value, named after the field, unless an entry here
+    /// names the field and sets `repeat_as` (the per-item element name) and/or
+    /// `wrap_in` (a container element). Empty by default; populated from the
+    /// output's `join_values`. Mirrors the CSV writer's `join_values` field —
+    /// the two writers read disjoint sub-vocabularies of the same declaration.
+    pub join_values: Vec<JoinValues>,
 }
 
 impl Default for XmlWriterConfig {
@@ -56,6 +65,7 @@ impl Default for XmlWriterConfig {
             attribute_prefix: "@".into(),
             include_engine_stamped: false,
             envelope: None,
+            join_values: Vec::new(),
         }
     }
 }
@@ -609,15 +619,18 @@ fn insert_field(
 
 /// Convert a clinker Value to XML text content.
 ///
-/// `Value::Map` and `Value::Array` have no canonical scalar serialization
-/// for an XML element body (silently JSON-encoding a map, or comma-joining
-/// an array, hides routing bugs — e.g. a `$widened` sidecar reaching the
-/// writer without `include_unmapped: true` expansion for a map, or a
-/// `match: collect` combine output misrouted to XML for an array), so this
-/// returns `FormatError::UnserializableMapValue` /
-/// `FormatError::UnserializableArrayValue` carrying the offending column.
-/// XML is the single point of truth for collection rejection on this path;
-/// there is no upstream pre-walk.
+/// This renders a single scalar into one element body. A top-level
+/// `Value::Array` at a record element field is a `multiple:` field, emitted as
+/// repeated child elements before reaching here (see [`fill_slot`] and
+/// [`emit_repeated_leaf`]) — so an array reaching this scalar renderer is a
+/// NESTED collection (an array or map inside a `multiple:` field), which has no
+/// element-body serialization. A `Value::Map` likewise has none. Both return
+/// `FormatError::UnserializableMapValue` / `FormatError::UnserializableArrayValue`
+/// carrying the offending column rather than being silently flattened, which
+/// would hide a routing bug (e.g. a `$widened` sidecar reaching the writer
+/// without `include_unmapped: true` expansion). The envelope-section path also
+/// renders through here, so a section field carrying a collection is rejected
+/// the same way.
 fn value_to_text(col: &str, val: &Value) -> Result<String, FormatError> {
     let mut buf = String::new();
     write_value_text(&mut buf, col, val)?;
@@ -694,8 +707,32 @@ struct PlanAttr {
 
 /// A precompiled child node: a leaf element or a nested branch.
 enum PlanNode {
-    Leaf { name: String, field: usize },
-    Branch { name: String, body: PlanBody },
+    Leaf {
+        name: String,
+        field: usize,
+        /// Per-item naming when this leaf's value is a `Value::Array`. `None`
+        /// emits bare repeats named after the leaf; `Some` carries the
+        /// `repeat_as` / `wrap_in` overrides from the field's `join_values`
+        /// entry (validated at plan build). A scalar value ignores this.
+        repeat: Option<XmlRepeat>,
+    },
+    Branch {
+        name: String,
+        body: PlanBody,
+    },
+}
+
+/// How a `multiple:` field's repeated child elements are named, resolved from a
+/// `join_values` entry at plan build. Both names are validated as legal XML
+/// names when the plan is built, so a malformed override fails the write cleanly
+/// before any byte is emitted — the same point the element/attribute names are
+/// checked.
+struct XmlRepeat {
+    /// Element name emitted per array item (a `repeat_as`, or the leaf's own
+    /// element name when the entry did not set one).
+    item_name: String,
+    /// Optional container element wrapping the repeated items (`wrap_in`).
+    wrap_in: Option<String>,
 }
 
 /// The memoized plan plus the identity it was built for. `field_is_attr` marks,
@@ -727,6 +764,7 @@ fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCac
             name,
             name,
             &config.attribute_prefix,
+            &config.join_values,
             &mut field_is_attr,
         )?;
     }
@@ -747,6 +785,7 @@ fn plan_insert_field(
     field: &str,
     path: &str,
     attribute_prefix: &str,
+    join_values: &[JoinValues],
     field_is_attr: &mut [bool],
 ) -> Result<(), FormatError> {
     if let Some((first, rest)) = path.split_once('.') {
@@ -771,6 +810,7 @@ fn plan_insert_field(
                 field,
                 rest,
                 attribute_prefix,
+                join_values,
                 field_is_attr,
             )
         } else {
@@ -781,6 +821,7 @@ fn plan_insert_field(
                 field,
                 rest,
                 attribute_prefix,
+                join_values,
                 field_is_attr,
             )?;
             body.children.push(PlanNode::Branch {
@@ -811,12 +852,50 @@ fn plan_insert_field(
         Ok(())
     } else {
         check_xml_name(path, &format!("field '{field}': element"))?;
+        let repeat = build_repeat_spec(field, path, join_values)?;
         body.children.push(PlanNode::Leaf {
             name: path.to_string(),
             field: field_index,
+            repeat,
         });
         Ok(())
     }
+}
+
+/// Resolve a leaf's repeated-element naming from the output's `join_values`.
+///
+/// The entry is matched by the leaf's full flattened field name (the same
+/// name the CSV writer matches on). Returns `None` when no entry names the field
+/// or the entry carries neither XML override — the array then emits bare repeats
+/// named after the leaf. When an override is present, `repeat_as` / `wrap_in` are
+/// validated as legal XML names here, before any byte is written, so a malformed
+/// name fails the write cleanly the same way an illegal element name does.
+fn build_repeat_spec(
+    field: &str,
+    leaf_name: &str,
+    join_values: &[JoinValues],
+) -> Result<Option<XmlRepeat>, FormatError> {
+    let Some(entry) = join_values.iter().find(|j| j.field == field) else {
+        return Ok(None);
+    };
+    if entry.repeat_as.is_none() && entry.wrap_in.is_none() {
+        return Ok(None);
+    }
+    let item_name = match &entry.repeat_as {
+        Some(name) => {
+            check_xml_name(name, &format!("field '{field}': `repeat_as` element"))?;
+            name.clone()
+        }
+        None => leaf_name.to_string(),
+    };
+    let wrap_in = match &entry.wrap_in {
+        Some(name) => {
+            check_xml_name(name, &format!("field '{field}': `wrap_in` element"))?;
+            Some(name.clone())
+        }
+        None => None,
+    };
+    Ok(Some(XmlRepeat { item_name, wrap_in }))
 }
 
 /// Per-record scratch, one slot per field in iterator order. Slot `String`
@@ -829,7 +908,16 @@ struct FillBuf {
 
 #[derive(Default)]
 struct FillSlot {
+    /// Scalar rendering. Empty when the field is null-dropped or holds an array.
     text: String,
+    /// Per-element renderings when the field's value is a `Value::Array`. The
+    /// live entries are `parts[..part_count]`; the `Vec` and each inner `String`
+    /// retain their capacity across records, like `text` does.
+    parts: Vec<String>,
+    part_count: usize,
+    /// True when this slot holds an array — the repeated-element emit path reads
+    /// `parts` rather than `text`.
+    is_array: bool,
     emits: bool,
 }
 
@@ -855,12 +943,28 @@ impl FillBuf {
     fn text(&self, field: usize) -> &str {
         &self.slots[field].text
     }
+
+    /// The per-element renderings for an array field, or `None` for a scalar.
+    /// A returned slice is always non-empty: an empty array sets `emits = false`,
+    /// so callers gate on `emits` before reaching here.
+    fn parts(&self, field: usize) -> Option<&[String]> {
+        let slot = &self.slots[field];
+        slot.is_array.then_some(&slot.parts[..slot.part_count])
+    }
 }
 
-/// Fill a single slot with a field's presence and rendered text. A field is
-/// dropped (`emits = false`) when it is a null attribute, or a null element
-/// under `preserve_nulls: false`; otherwise its text is rendered (a preserved
-/// null element renders to the empty string, emitted as a self-closing tag).
+/// Fill a single slot with a field's presence and rendered value(s).
+///
+/// A scalar field is dropped (`emits = false`) when it is a null attribute, or a
+/// null element under `preserve_nulls: false`; otherwise its text is rendered (a
+/// preserved null element renders to the empty string, emitted as a self-closing
+/// tag).
+///
+/// A `Value::Array` at an ELEMENT field is a `multiple:` field: each element is
+/// rendered into `parts` for the repeated-element emit path, and an empty array
+/// drops the field (`emits = false`) so it emits nothing. An array at an
+/// ATTRIBUTE field is rejected — an XML attribute holds a single value and
+/// cannot repeat.
 fn fill_slot(
     slot: &mut FillSlot,
     is_attr: bool,
@@ -868,16 +972,50 @@ fn fill_slot(
     name: &str,
     val: &Value,
 ) -> Result<(), FormatError> {
-    let skip = if is_attr {
-        val.is_null()
-    } else {
-        val.is_null() && !preserve_nulls
-    };
-    slot.emits = !skip;
-    slot.text.clear();
-    if !skip {
-        write_value_text(&mut slot.text, name, val)?;
+    slot.is_array = false;
+    slot.part_count = 0;
+    match val {
+        Value::Array(items) if !is_attr => {
+            slot.is_array = true;
+            slot.text.clear();
+            fill_parts(slot, name, items)?;
+            slot.emits = !items.is_empty();
+        }
+        Value::Array(_) => {
+            return Err(FormatError::Xml(format!(
+                "field '{name}': an XML attribute cannot hold multiple values — a \
+                 `multiple:` field maps to repeated elements, not an attribute"
+            )));
+        }
+        _ => {
+            let skip = if is_attr {
+                val.is_null()
+            } else {
+                val.is_null() && !preserve_nulls
+            };
+            slot.emits = !skip;
+            slot.text.clear();
+            if !skip {
+                write_value_text(&mut slot.text, name, val)?;
+            }
+        }
     }
+    Ok(())
+}
+
+/// Render each element of a `multiple:` field's array into the slot's `parts`,
+/// reusing the existing `String` capacity. A nested collection element (an array
+/// or map inside the field) has no element body and is rejected by
+/// [`write_value_text`], the same misroute detection the scalar path applies.
+fn fill_parts(slot: &mut FillSlot, name: &str, items: &[Value]) -> Result<(), FormatError> {
+    if slot.parts.len() < items.len() {
+        slot.parts.resize_with(items.len(), String::new);
+    }
+    for (i, item) in items.iter().enumerate() {
+        slot.parts[i].clear();
+        write_value_text(&mut slot.parts[i], name, item)?;
+    }
+    slot.part_count = items.len();
     Ok(())
 }
 
@@ -893,8 +1031,16 @@ fn emit_body<W: Write>(
 ) -> Result<(), FormatError> {
     for child in &body.children {
         match child {
-            PlanNode::Leaf { name, field } => {
+            PlanNode::Leaf {
+                name,
+                field,
+                repeat,
+            } => {
                 if !fill.emits(*field) {
+                    continue;
+                }
+                if let Some(parts) = fill.parts(*field) {
+                    emit_repeated_leaf(writer, name, repeat, parts)?;
                     continue;
                 }
                 let text = fill.text(*field);
@@ -937,6 +1083,52 @@ fn emit_body<W: Write>(
                 }
             }
         }
+    }
+    Ok(())
+}
+
+/// Emit a `multiple:` field's values as repeated child elements. `parts` holds
+/// the per-element rendered text and is non-empty (an empty array sets
+/// `emits = false`, so the caller skips it). Each item is
+/// `<item_name>text</item_name>`, or a self-closing `<item_name/>` when its text
+/// is empty; a `wrap_in` container, when set, brackets the whole run.
+///
+/// `item_name` and any `wrap_in` were validated as legal XML names at plan build
+/// ([`build_repeat_spec`]), so no per-record name check is needed here.
+fn emit_repeated_leaf<W: Write>(
+    writer: &mut XmlEmitter<W>,
+    leaf_name: &str,
+    repeat: &Option<XmlRepeat>,
+    parts: &[String],
+) -> Result<(), FormatError> {
+    let item_name = repeat.as_ref().map_or(leaf_name, |r| r.item_name.as_str());
+    let wrap_in = repeat.as_ref().and_then(|r| r.wrap_in.as_deref());
+    if let Some(container) = wrap_in {
+        writer
+            .write_event(Event::Start(BytesStart::new(container)))
+            .map_err(xml_err)?;
+    }
+    for part in parts {
+        if part.is_empty() {
+            writer
+                .write_event(Event::Empty(BytesStart::new(item_name)))
+                .map_err(xml_err)?;
+        } else {
+            writer
+                .write_event(Event::Start(BytesStart::new(item_name)))
+                .map_err(xml_err)?;
+            writer
+                .write_event(Event::Text(BytesText::new(part)))
+                .map_err(xml_err)?;
+            writer
+                .write_event(Event::End(BytesEnd::new(item_name)))
+                .map_err(xml_err)?;
+        }
+    }
+    if let Some(container) = wrap_in {
+        writer
+            .write_event(Event::End(BytesEnd::new(container)))
+            .map_err(xml_err)?;
     }
     Ok(())
 }
@@ -1177,37 +1369,285 @@ mod tests {
         }
     }
 
-    /// XML writer rejects `Value::Array` payloads with
-    /// `FormatError::UnserializableArrayValue`, parallel to the map
-    /// rejection. The prior behavior comma-joined the array's elements
-    /// inside a single element, silently hiding a misroute (e.g. a
-    /// `match: collect` combine output sent to XML). `fill_values` runs
-    /// before any bytes, so the rejected record leaves no partial output.
+    /// Build a `[id, tags]` record whose `tags` field carries `values`.
+    fn record_with_tags(schema: &Arc<Schema>, id: i64, values: Vec<Value>) -> Record {
+        Record::new(
+            Arc::clone(schema),
+            vec![Value::Integer(id), Value::Array(values)],
+        )
+    }
+
+    /// A `join_values` config naming one field with the given XML overrides.
+    fn xml_join_config(
+        field: &str,
+        repeat_as: Option<&str>,
+        wrap_in: Option<&str>,
+    ) -> XmlWriterConfig {
+        XmlWriterConfig {
+            join_values: vec![JoinValues {
+                field: field.into(),
+                repeat_as: repeat_as.map(str::to_string),
+                wrap_in: wrap_in.map(str::to_string),
+                ..JoinValues::bare(field)
+            }],
+            ..Default::default()
+        }
+    }
+
+    /// A `multiple:` field emits one child element per value, in order, named
+    /// after the field — the XML counterpart to CSV's delimited join (#916).
     #[test]
-    fn test_xml_writer_rejects_array_value() {
+    fn test_xml_write_multi_value_emits_repeated_elements() {
         let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = record_with_tags(
+            &schema,
+            7,
+            vec![Value::String("a".into()), Value::String("b".into())],
+        );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            "<Root><Record><id>7</id><tags>a</tags><tags>b</tags></Record></Root>"
+        );
+    }
+
+    /// A single-element array yields exactly one element, byte-identical to a
+    /// scalar field's output (criterion 3).
+    #[test]
+    fn test_xml_write_multi_value_single_element_matches_scalar() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let array = record_with_tags(&schema, 7, vec![Value::String("a".into())]);
+        let array_out = write_records(XmlWriterConfig::default(), &[array], &schema);
+        let scalar = Record::new(
+            Arc::clone(&schema),
+            vec![Value::Integer(7), Value::String("a".into())],
+        );
+        let scalar_out = write_records(XmlWriterConfig::default(), &[scalar], &schema);
+        assert_eq!(array_out, scalar_out);
+        assert_eq!(
+            array_out,
+            "<Root><Record><id>7</id><tags>a</tags></Record></Root>"
+        );
+    }
+
+    /// An empty multi-value field emits nothing — no items and, with `wrap_in`
+    /// set, no container either (criterion 3).
+    #[test]
+    fn test_xml_write_multi_value_empty_array_emits_nothing() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let bare = record_with_tags(&schema, 7, vec![]);
+        assert_eq!(
+            write_records(XmlWriterConfig::default(), &[bare], &schema),
+            "<Root><Record><id>7</id></Record></Root>"
+        );
+        let wrapped = record_with_tags(&schema, 7, vec![]);
+        assert_eq!(
+            write_records(
+                xml_join_config("tags", Some("Tag"), Some("Tags")),
+                &[wrapped],
+                &schema
+            ),
+            "<Root><Record><id>7</id></Record></Root>",
+            "an empty array emits no container even when wrap_in is set"
+        );
+    }
+
+    /// An empty-string value renders to a self-closing item element, so a run of
+    /// mixed present/empty values round-trips its per-item shape.
+    #[test]
+    fn test_xml_write_multi_value_empty_string_value_self_closes() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = record_with_tags(
+            &schema,
+            7,
+            vec![Value::String("a".into()), Value::String("".into())],
+        );
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert_eq!(
+            output,
+            "<Root><Record><id>7</id><tags>a</tags><tags/></Record></Root>"
+        );
+    }
+
+    /// `repeat_as` renames the per-item element; the field name is no longer the
+    /// element name.
+    #[test]
+    fn test_xml_write_multi_value_repeat_as_renames_item() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = record_with_tags(
+            &schema,
+            7,
+            vec![Value::String("a".into()), Value::String("b".into())],
+        );
+        let output = write_records(
+            xml_join_config("tags", Some("Tag"), None),
+            &[record],
+            &schema,
+        );
+        assert_eq!(
+            output,
+            "<Root><Record><id>7</id><Tag>a</Tag><Tag>b</Tag></Record></Root>"
+        );
+    }
+
+    /// `wrap_in` alone adds a container around items still named after the field.
+    #[test]
+    fn test_xml_write_multi_value_wrap_in_adds_container() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = record_with_tags(
+            &schema,
+            7,
+            vec![Value::String("a".into()), Value::String("b".into())],
+        );
+        let output = write_records(
+            xml_join_config("tags", None, Some("Tags")),
+            &[record],
+            &schema,
+        );
+        assert_eq!(
+            output,
+            "<Root><Record><id>7</id><Tags><tags>a</tags><tags>b</tags></Tags></Record></Root>"
+        );
+    }
+
+    /// `repeat_as` and `wrap_in` together produce a named container with named
+    /// items (criterion 2).
+    #[test]
+    fn test_xml_write_multi_value_repeat_as_and_wrap_in_together() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = record_with_tags(
+            &schema,
+            7,
+            vec![Value::String("a".into()), Value::String("b".into())],
+        );
+        let output = write_records(
+            xml_join_config("tags", Some("Tag"), Some("Tags")),
+            &[record],
+            &schema,
+        );
+        assert_eq!(
+            output,
+            "<Root><Record><id>7</id><Tags><Tag>a</Tag><Tag>b</Tag></Tags></Record></Root>"
+        );
+    }
+
+    /// An illegal `repeat_as` / `wrap_in` name fails the write with
+    /// `FormatError::Xml`, leaving no partial output — element names are
+    /// validated as legal XML names (criterion 5), like the record/root names.
+    #[test]
+    fn test_xml_write_multi_value_invalid_override_name_rejected() {
+        for (repeat_as, wrap_in, bad) in [(Some("1bad"), None, "1bad"), (None, Some("a b"), "a b")]
+        {
+            let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+            let record = record_with_tags(&schema, 7, vec![Value::String("a".into())]);
+            let mut buf = Vec::new();
+            let mut writer = XmlWriter::new(
+                &mut buf,
+                Arc::clone(&schema),
+                xml_join_config("tags", repeat_as, wrap_in),
+            );
+            let err = writer.write_record(&record).unwrap_err();
+            match err {
+                FormatError::Xml(msg) => {
+                    assert!(msg.contains(bad), "message names the bad name: {msg}");
+                    assert!(
+                        msg.contains("well-formed XML name"),
+                        "message explains the malformed name: {msg}"
+                    );
+                }
+                other => panic!("expected FormatError::Xml, got {other:?}"),
+            }
+            drop(writer);
+            assert!(
+                buf.is_empty(),
+                "no partial output before a rejected override name"
+            );
+        }
+    }
+
+    /// An array reaching an attribute-classified field is rejected — an XML
+    /// attribute holds a single value and cannot repeat.
+    #[test]
+    fn test_xml_write_multi_value_array_on_attribute_rejected() {
+        let schema = Arc::new(Schema::new(vec!["@tags".into()]));
         let record = Record::new(
             Arc::clone(&schema),
-            vec![
-                Value::Integer(7),
-                Value::Array(vec![Value::String("a".into()), Value::String("b".into())]),
-            ],
+            vec![Value::Array(vec![Value::String("a".into())])],
         );
         let mut buf = Vec::new();
         let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
         let err = writer.write_record(&record).unwrap_err();
         match err {
-            FormatError::UnserializableArrayValue { format, column } => {
-                assert_eq!(format, "XML");
-                assert_eq!(column, "tags");
+            FormatError::Xml(msg) => {
+                assert!(
+                    msg.contains("@tags") && msg.contains("cannot hold multiple values"),
+                    "message names the field and the reason: {msg}"
+                );
             }
-            other => panic!("expected UnserializableArrayValue, got {other:?}"),
+            other => panic!("expected FormatError::Xml, got {other:?}"),
         }
         drop(writer);
         assert!(
             buf.is_empty(),
-            "rejected record must not leave partial output behind"
+            "no partial output before a rejected attribute array"
         );
+    }
+
+    /// A nested collection inside a `multiple:` field (an array element that is
+    /// itself an array) has no element body and is still rejected.
+    #[test]
+    fn test_xml_write_multi_value_nested_collection_element_rejected() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let record = record_with_tags(
+            &schema,
+            7,
+            vec![Value::Array(vec![Value::String("a".into())])],
+        );
+        let mut buf = Vec::new();
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = writer.write_record(&record).unwrap_err();
+        assert!(
+            matches!(&err, FormatError::UnserializableArrayValue { column, .. } if column == "tags"),
+            "expected UnserializableArrayValue for the nested array, got {err:?}"
+        );
+    }
+
+    /// Read a document with repeated child elements into a `multiple:` column and
+    /// write it back to XML: the repeated elements reappear byte-identically
+    /// (criterion 4).
+    #[test]
+    fn test_xml_write_multi_value_read_write_round_trip() {
+        let input = "<Root><Order><id>1</id><tags>a</tags><tags>b</tags></Order></Root>";
+        let cursor = std::io::Cursor::new(input.as_bytes().to_vec());
+        let mut reader = XmlReader::from_reader(
+            cursor,
+            XmlReaderConfig {
+                record_path: Some("Root/Order".into()),
+                multi_value_fields: vec!["tags".into()],
+                ..Default::default()
+            },
+        )
+        .expect("XML buffer read");
+        let schema = reader.schema().unwrap();
+        let record = reader.next_record().unwrap().unwrap();
+        assert!(reader.next_record().unwrap().is_none());
+        assert_eq!(
+            record.get("tags"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::String("b".into()),
+            ]))
+        );
+
+        let output = write_records(
+            XmlWriterConfig {
+                record_element: "Order".into(),
+                ..Default::default()
+            },
+            &[record],
+            &schema,
+        );
+        assert_eq!(output, input, "repeated elements round-trip byte-for-byte");
     }
 
     /// Assert that writing a single record whose only field is `field`

--- a/crates/clinker-format/tests/writer_array_rejection.rs
+++ b/crates/clinker-format/tests/writer_array_rejection.rs
@@ -1,13 +1,13 @@
-//! Crate-boundary handling of `Value::Array` payloads in the non-JSON writers.
+//! Crate-boundary handling of `Value::Array` payloads across the writers.
 //!
-//! The XML and fixed-width writers still reject a stray array — most often a
+//! The fixed-width writer still rejects a stray array — most often a
 //! `match: collect` combine output misrouted to a positional format — as an
 //! explicit `FormatError::UnserializableArrayValue` naming the offending column,
 //! listing the two remedies (coerce to a scalar in CXL, or route to JSON). The
-//! CSV writer instead JOINS an array into one delimited cell (#917): with
-//! multi-value CSV output a supported shape, an array is expected there, so it
-//! is encoded rather than rejected. JSON output serializes arrays natively.
-//! See #46, #917.
+//! CSV writer JOINS an array into one delimited cell (#917), and the XML writer
+//! emits it as repeated child elements (#916): with multi-value output a
+//! supported shape for both, an array is expected there, so it is encoded rather
+//! than rejected. JSON output serializes arrays natively. See #46, #917, #916.
 
 use std::sync::Arc;
 
@@ -65,24 +65,25 @@ fn csv_writer_joins_array_into_delimited_cell() {
     assert_eq!(out, "id,tags\n7,a;b\n");
 }
 
+/// The XML writer now emits an array as repeated child elements (#916) rather
+/// than rejecting it: with `multiple:` XML output supported, a repeated element
+/// is the expected shape. The default (no `join_values` config) names each
+/// element after the field.
 #[test]
-fn xml_writer_rejects_array_payload() {
+fn xml_writer_emits_repeated_elements_for_array() {
     let (schema, record) = record_with_array();
     let mut buf = Vec::new();
-    let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
-    let err = writer.write_record(&record).unwrap_err();
-    assert!(
-        matches!(&err, FormatError::UnserializableArrayValue { format, column }
-            if *format == "XML" && column == "tags"),
-        "expected UnserializableArrayValue for XML/tags, got {err:?}"
-    );
-    assert_lists_remedies(&err);
-    // The XML writer fills and validates every value before emitting any byte,
-    // so a rejected record leaves no partial output.
-    drop(writer);
-    assert!(
-        buf.is_empty(),
-        "rejected record leaves no partial XML output"
+    {
+        let mut writer = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        writer
+            .write_record(&record)
+            .expect("XML writer emits repeated elements for a scalar array");
+        writer.flush().expect("flush succeeds");
+    }
+    let out = String::from_utf8(buf).expect("XML output is UTF-8");
+    assert_eq!(
+        out,
+        "<Root><Record><id>7</id><tags>a</tags><tags>b</tags></Record></Root>"
     );
 }
 

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -14,9 +14,10 @@
 //!   to PRODUCE one, which would bind the column as an array and then hand
 //!   CXL a scalar.
 //! - **E362** — a malformed `join_values` declaration on an output: declared on
-//!   a format whose writer never consumes it, a duplicate field, an empty
-//!   delimiter, or an escape/delimiter that is not a single character under
-//!   `on_conflict: escape`. The write-side mirror of E358.
+//!   a format whose writer never consumes it (only `csv` and `xml` do), a
+//!   duplicate field, or — on a CSV output — an empty delimiter or an
+//!   escape/delimiter that is not a single character under `on_conflict: escape`.
+//!   The write-side mirror of E358.
 //!
 //! E359 and E361 are the two arrows of the same rule, and each reads its own
 //! per-format capability table: [`output_encodes_multi_value`] for the write
@@ -43,8 +44,9 @@ use crate::yaml::Spanned;
 ///   `;` with `on_conflict: error`; `join_values` overrides the policy per
 ///   field (#917). No multi-record CSV writer exists, so the answer is
 ///   unconditional.
-/// - `xml` — repeated child elements: tracked at
-///   https://github.com/rustpunk/clinker/issues/916.
+/// - `xml` — repeated child elements, one per array value, named after the
+///   field; `join_values` `repeat_as` / `wrap_in` override the item and
+///   container element names.
 /// - `fixed_width` — repeating field groups: tracked at
 ///   https://github.com/rustpunk/clinker/issues/918.
 /// - `edifact` / `x12` / `hl7` / `swift` — these writers emit a fixed
@@ -53,7 +55,7 @@ fn output_encodes_multi_value(format: &OutputFormat) -> bool {
     match format {
         OutputFormat::Json(_) => true,
         OutputFormat::Csv(_) => true,
-        OutputFormat::Xml(_) => false,
+        OutputFormat::Xml(_) => true,
         OutputFormat::FixedWidth(_) => false,
         OutputFormat::Edifact(_)
         | OutputFormat::X12(_)
@@ -880,12 +882,18 @@ pub fn source_node_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
 /// Validate an output's `join_values` declarations (E362), the write-side
 /// mirror of E358's source-declaration checks.
 ///
-/// The block is consumed by the CSV writer only, so declaring it on any other
-/// output format is a silent no-op the gate rejects — the same LD-011 spirit as
-/// E358's "reader never handed it". On a CSV output each entry is checked: no
-/// duplicate field, a non-empty delimiter, and — under `on_conflict: escape`,
-/// whose invertible escaping is defined char-wise — a single-character delimiter
-/// and escape.
+/// The block is consumed by two writers: the CSV writer joins the values into
+/// one delimited cell, and the XML writer emits them as repeated child elements.
+/// Declaring it on any other output format is a silent no-op the gate rejects —
+/// the same no-op-rejection principle as E358's "reader never handed it".
+///
+/// The duplicate-field check applies to both consumers. The delimiter / escape
+/// shape checks are the CSV writer's alone — a non-empty delimiter, and under
+/// `on_conflict: escape` (whose invertible escaping is defined char-wise) a
+/// single-character delimiter and escape. The XML writer reads only `repeat_as`
+/// and `wrap_in`, validated as legal XML names at write time (consistent with
+/// the configured root / record element names), so those shape checks would
+/// wrongly fault an XML entry's defaulted delimiter.
 ///
 /// Deliberately does NOT require the field to be a statically-declared
 /// `multiple:` column, unlike E358's `split_values` check. A write-side array
@@ -899,23 +907,26 @@ fn validate_join_declarations(output: &OutputConfig) -> Vec<DeclarationFault> {
         return faults;
     }
     let format = output.format.format_name();
-    if !matches!(output.format, OutputFormat::Csv(_)) {
+    let consumes = matches!(output.format, OutputFormat::Csv(_) | OutputFormat::Xml(_));
+    if !consumes {
         faults.push(DeclarationFault {
             message: format!(
                 "output '{}': `join_values` is declared on a `{format}` output, whose writer \
                  never consumes it — the declaration would be a silent no-op",
                 output.name
             ),
-            help: "remove the `join_values` block: joining several values into one delimited \
-                   cell is written by the `csv` writer only. A `json` output emits a native \
-                   array, and the `xml` / `fixed_width` / segment writers have no delimited-cell \
-                   join."
+            help: "remove the `join_values` block: the `csv` writer joins several values into \
+                   one delimited cell, and the `xml` writer emits them as repeated child \
+                   elements. A `json` output emits a native array, and the `fixed_width` / \
+                   segment writers have no multi-value encoding to configure."
                 .to_string(),
         });
         // Once the format cannot consume the block at all, the per-entry checks
         // are moot — the author is told to delete the whole block.
         return faults;
     }
+    // Two entries for one field leave its encoding ambiguous, whichever writer
+    // consumes it.
     for (i, entry) in entries.iter().enumerate() {
         if entries[i + 1..].iter().any(|o| o.field == entry.field) {
             faults.push(DeclarationFault {
@@ -923,10 +934,17 @@ fn validate_join_declarations(output: &OutputConfig) -> Vec<DeclarationFault> {
                     "output '{}': `join_values` declares the field '{}' more than once",
                     output.name, entry.field
                 ),
-                help: "declare each field once, with the delimiter and policy it should join with"
-                    .to_string(),
+                help: "declare each field once, with the encoding it should use".to_string(),
             });
         }
+    }
+    // The delimiter / escape shape checks below are the CSV writer's; the XML
+    // writer ignores delimiter / on_conflict / escape, so an XML entry's
+    // defaulted values are not faults.
+    if !matches!(output.format, OutputFormat::Csv(_)) {
+        return faults;
+    }
+    for entry in entries {
         // The delimiter matters only for the delimited policies (`error`,
         // `escape`); `encode_json` ignores it, so an empty or multi-character
         // delimiter under `encode_json` is harmless and exempt.
@@ -1151,13 +1169,14 @@ mod tests {
     }
 
     #[test]
-    fn json_and_csv_encode_multi_value_today() {
-        // `json` (native arrays) and `csv` (join into a delimited cell, #917)
-        // encode a `multiple:` field; the remaining writers do not yet.
+    fn json_csv_and_xml_encode_multi_value_today() {
+        // `json` (native arrays), `csv` (join into a delimited cell, #917), and
+        // `xml` (repeated child elements, #916) encode a `multiple:` field; the
+        // remaining writers do not yet.
         assert!(output_encodes_multi_value(&OutputFormat::Json(None)));
         assert!(output_encodes_multi_value(&OutputFormat::Csv(None)));
+        assert!(output_encodes_multi_value(&OutputFormat::Xml(None)));
         for format in [
-            OutputFormat::Xml(None),
             OutputFormat::FixedWidth(None),
             OutputFormat::Edifact(None),
             OutputFormat::X12(None),

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -887,13 +887,16 @@ pub fn source_node_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
 /// Declaring it on any other output format is a silent no-op the gate rejects —
 /// the same no-op-rejection principle as E358's "reader never handed it".
 ///
-/// The duplicate-field check applies to both consumers. The delimiter / escape
-/// shape checks are the CSV writer's alone — a non-empty delimiter, and under
-/// `on_conflict: escape` (whose invertible escaping is defined char-wise) a
-/// single-character delimiter and escape. The XML writer reads only `repeat_as`
-/// and `wrap_in`, validated as legal XML names at write time (consistent with
-/// the configured root / record element names), so those shape checks would
-/// wrongly fault an XML entry's defaulted delimiter.
+/// The duplicate-field check applies to both consumers. Each writer reads a
+/// disjoint subset of the remaining keys, so a key aimed at the other writer is a
+/// silent no-op the gate rejects: `repeat_as` / `wrap_in` on a CSV output (the
+/// CSV writer never reads them, and they are `Option` so an explicit value is
+/// detectable). The delimiter / escape shape checks are the CSV writer's alone —
+/// a non-empty delimiter, and under `on_conflict: escape` (whose invertible
+/// escaping is defined char-wise) a single-character delimiter and escape. The
+/// XML writer reads only `repeat_as` and `wrap_in`, validated as legal XML names
+/// at write time (consistent with the configured root / record element names),
+/// so a defaulted `delimiter` on an XML entry is inert rather than faulted.
 ///
 /// Deliberately does NOT require the field to be a statically-declared
 /// `multiple:` column, unlike E358's `split_values` check. A write-side array
@@ -945,6 +948,30 @@ fn validate_join_declarations(output: &OutputConfig) -> Vec<DeclarationFault> {
         return faults;
     }
     for entry in entries {
+        // `repeat_as` / `wrap_in` name the repeated-element and container of the
+        // XML writer's output; the CSV writer never reads them, so setting one on
+        // a CSV output is a silent no-op — the values would join into one cell
+        // with the author's naming intent discarded. Unlike a defaulted
+        // `delimiter` (which cannot be told set-from-unset), these are `Option`
+        // fields, so an explicit value is detectable and faulted here.
+        if entry.repeat_as.is_some() || entry.wrap_in.is_some() {
+            let knob = if entry.repeat_as.is_some() {
+                "repeat_as"
+            } else {
+                "wrap_in"
+            };
+            faults.push(DeclarationFault {
+                message: format!(
+                    "output '{}': `join_values` on field '{}' sets `{knob}`, which only the `xml` \
+                     writer honors — a `csv` output joins the values into one delimited cell and \
+                     never reads it",
+                    output.name, entry.field
+                ),
+                help: "drop `repeat_as` / `wrap_in` on a CSV output (they name XML repeated \
+                       elements), or write this stream to an `xml` output where they take effect"
+                    .to_string(),
+            });
+        }
         // The delimiter matters only for the delimited policies (`error`,
         // `escape`); `encode_json` ignores it, so an empty or multi-character
         // delimiter under `encode_json` is harmless and exempt.

--- a/crates/clinker-plan/src/config/output.rs
+++ b/crates/clinker-plan/src/config/output.rs
@@ -80,12 +80,15 @@ pub struct OutputConfig {
     /// format implements `begin_document` / `end_document`.
     #[serde(default, skip_serializing_if = "is_false_bool")]
     pub reconstruct_envelope: bool,
-    /// In-cell join declarations: each names a `multiple:` field whose values a
-    /// CSV writer collapses into one delimited cell, with a per-field delimiter
-    /// and collision policy. The write-side inverse of `split_values`. Empty by
-    /// default; a `multiple:` field with no entry joins with the default `;` and
-    /// `on_conflict: error`. Consumed by the CSV writer only — declaring it on
-    /// another output format is rejected (E362).
+    /// Write-side multi-value declarations: each names a `multiple:` field and
+    /// says how the writer encodes it. The CSV writer collapses the values into
+    /// one delimited cell (`delimiter` / `on_conflict` / `escape`); the XML
+    /// writer emits them as repeated child elements (`repeat_as` for the per-item
+    /// element name, `wrap_in` for an optional container). The write-side inverse
+    /// of `split_values`. Empty by default; a `multiple:` field with no entry
+    /// takes each writer's default (CSV joins with `;` / `on_conflict: error`,
+    /// XML repeats elements named after the field). Consumed by the CSV and XML
+    /// writers only — declaring it on another output format is rejected (E362).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub join_values: Option<Vec<JoinValues>>,
     #[serde(flatten)]

--- a/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
@@ -7,8 +7,9 @@
 //! at reader construction (XML only) or nothing at all, so these pin the move to
 //! compile time with a diagnostic code and a source span.
 //!
-//! CSV now encodes a multi-value field (it joins into a delimited cell, #917),
-//! so the E359 reachability tests below drive a still-non-encoding sink (`xml`).
+//! CSV and XML now encode a multi-value field (a delimited cell, #917; repeated
+//! child elements, #916), so the E359 reachability tests below drive a
+//! still-non-encoding sink (`fixed_width`).
 
 use clinker_core_types::Diagnostic;
 
@@ -232,11 +233,11 @@ fn duplicate_split_values_field_is_rejected() {
 }
 
 #[test]
-fn multi_value_column_into_a_json_or_csv_output_compiles() {
-    // JSON (native arrays) and CSV (join into a delimited cell, #917) both
-    // encode a multi-value field, so the E359 capability table lets them
-    // through — the join defaults to `;` / `on_conflict: error`, no config.
-    for format in ["json", "csv"] {
+fn multi_value_column_into_a_json_csv_or_xml_output_compiles() {
+    // JSON (native arrays), CSV (join into a delimited cell, #917), and XML
+    // (repeated child elements, #916) all encode a multi-value field, so the
+    // E359 capability table lets them through with no per-field config.
+    for format in ["json", "csv", "xml"] {
         let yaml = pipeline(
             r#"      schema:
         - { name: tags, type: string, multiple: true }"#,
@@ -248,22 +249,22 @@ fn multi_value_column_into_a_json_or_csv_output_compiles() {
 
 #[test]
 fn multi_value_column_into_a_non_encoding_output_is_rejected_with_a_span() {
-    // CSV now encodes (#917); XML and fixed-width still have no writer for it.
-    for format in ["xml", "fixed_width"] {
-        let yaml = pipeline(
-            r#"      schema:
+    // CSV (#917) and XML (#916) now encode; fixed-width still has no writer for
+    // a `multiple:` field.
+    let format = "fixed_width";
+    let yaml = pipeline(
+        r#"      schema:
         - { name: tags, type: string, multiple: true }"#,
-            format,
-        );
-        let found = coded(&compile_err(&yaml), "E359");
-        assert_eq!(found.len(), 1, "expected one E359 for {format}");
-        assert!(
-            found[0].0.contains("'tags'") && found[0].0.contains(format),
-            "{format}: {}",
-            found[0].0
-        );
-        assert!(found[0].1, "E359 must carry a source span for {format}");
-    }
+        format,
+    );
+    let found = coded(&compile_err(&yaml), "E359");
+    assert_eq!(found.len(), 1, "expected one E359 for {format}");
+    assert!(
+        found[0].0.contains("'tags'") && found[0].0.contains(format),
+        "{format}: {}",
+        found[0].0
+    );
+    assert!(found[0].1, "E359 must carry a source span for {format}");
 }
 
 #[test]
@@ -375,8 +376,8 @@ nodes:
     input: pick
     config:
       name: out
-      type: xml
-      path: out.xml
+      type: fixed_width
+      path: out.fw
 "#;
     let found = coded(&compile_err(yaml), "E359");
     assert_eq!(found.len(), 1, "expected one E359 through the transform");
@@ -406,8 +407,8 @@ nodes:
     input: pick
     config:
       name: out
-      type: xml
-      path: out.xml
+      type: fixed_width
+      path: out.fw
   - type: transform
     name: pick
     input: src
@@ -448,8 +449,8 @@ nodes:
     input: src
     config:
       name: out
-      type: xml
-      path: out.xml
+      type: fixed_width
+      path: out.fw
       schema:
         - { name: id, type: string }
         - { name: codes, type: string, multiple: true }
@@ -538,8 +539,8 @@ nodes:
     input: enriched
     config:
       name: report
-      type: xml
-      path: out.xml
+      type: fixed_width
+      path: out.fw
 "#;
     let found = coded(&compile_err(yaml), "E359");
     assert_eq!(
@@ -582,8 +583,8 @@ nodes:
     input: src
     config:
       name: out
-      type: xml
-      path: out.xml
+      type: fixed_width
+      path: out.fw
 "#;
     let found = coded(&compile_err(yaml), "E359");
     assert_eq!(
@@ -627,8 +628,8 @@ nodes:
     input: orders_src
     config:
       name: report
-      type: xml
-      path: out.xml
+      type: fixed_width
+      path: out.fw
 "#;
     let found = coded(&compile_err(yaml), "E359");
     assert_eq!(found.len(), 1, "expected one E359: {found:?}");
@@ -665,8 +666,8 @@ nodes:
     input: src
     config:
       name: out
-      type: xml
-      path: out.xml
+      type: fixed_width
+      path: out.fw
 "#,
         schema_path.display()
     );
@@ -1203,6 +1204,46 @@ fn join_values_on_a_non_csv_output_is_rejected() {
         found[0].0
     );
     assert!(found[0].1, "E362 must carry a source span");
+}
+
+#[test]
+fn join_values_repeat_and_wrap_on_an_xml_output_compiles() {
+    // The XML writer consumes `join_values` for repeated-element naming (#916),
+    // so `repeat_as` / `wrap_in` on an XML sink is a valid override, not a no-op.
+    let yaml = join_pipeline(
+        "xml",
+        r#"      join_values:
+        - { field: tags, repeat_as: Tag, wrap_in: Tags }"#,
+    );
+    compile_ok(&yaml);
+}
+
+#[test]
+fn join_values_csv_shape_knobs_on_an_xml_output_are_not_faults() {
+    // The delimiter / escape shape checks are the CSV writer's alone; the XML
+    // writer ignores them, so a multi-character delimiter that E362 would reject
+    // on a CSV output is simply inert on an XML output.
+    let yaml = join_pipeline(
+        "xml",
+        r#"      join_values:
+        - { field: tags, delimiter: "::" }"#,
+    );
+    compile_ok(&yaml);
+}
+
+#[test]
+fn join_values_duplicate_field_on_an_xml_output_is_rejected() {
+    // The duplicate-field check applies to every consumer of the block, XML
+    // included — two entries for one field leave its encoding ambiguous.
+    let yaml = join_pipeline(
+        "xml",
+        r#"      join_values:
+        - { field: tags, repeat_as: Tag }
+        - { field: tags, wrap_in: Tags }"#,
+    );
+    let found = coded(&compile_err(&yaml), "E362");
+    assert_eq!(found.len(), 1, "expected one E362: {found:?}");
+    assert!(found[0].0.contains("more than once"), "{}", found[0].0);
 }
 
 #[test]

--- a/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
@@ -1232,6 +1232,28 @@ fn join_values_csv_shape_knobs_on_an_xml_output_are_not_faults() {
 }
 
 #[test]
+fn join_values_xml_knobs_on_a_csv_output_are_rejected() {
+    // The reverse of `join_values_csv_shape_knobs_on_an_xml_output_are_not_faults`:
+    // `repeat_as` / `wrap_in` are XML-output-only. The CSV writer never reads
+    // them, so setting one on a CSV output is a silent no-op E362 rejects — these
+    // are `Option` fields, so an explicit value is detectable.
+    for knob in [
+        r#"{ field: tags, repeat_as: Tag }"#,
+        r#"{ field: tags, wrap_in: Tags }"#,
+    ] {
+        let yaml = join_pipeline("csv", &format!("      join_values:\n        - {knob}"));
+        let found = coded(&compile_err(&yaml), "E362");
+        assert_eq!(found.len(), 1, "expected one E362 for {knob}: {found:?}");
+        assert!(
+            found[0].0.contains("only the `xml` writer honors"),
+            "{}",
+            found[0].0
+        );
+        assert!(found[0].1, "E362 must carry a source span");
+    }
+}
+
+#[test]
 fn join_values_duplicate_field_on_an_xml_output_is_rejected() {
     // The duplicate-field check applies to every consumer of the block, XML
     // included — two entries for one field leave its encoding ambiguous.

--- a/docs/explain/E359.md
+++ b/docs/explain/E359.md
@@ -16,24 +16,25 @@ the same declaration — but the remaining writers do not encode it, and the
 fixed-width writer's column conversion drops the attribute outright. Declaring it
 there would be accepted and quietly ignored.
 
-The `json` output encodes a multi-value field as a JSON array, and the `csv`
-output joins it into one delimited cell (`join_values`, see the CSV format
-reference). The `xml` and `fixed_width` writers each have a well-established
-convention for it that is not implemented yet; the segment formats (`edifact`,
-`x12`, `hl7`, `swift`) emit a fixed positional grammar with no repetition slot.
+The `json` output encodes a multi-value field as a JSON array, the `csv` output
+joins it into one delimited cell (`join_values`, see the CSV format reference),
+and the `xml` output emits it as repeated child elements (`join_values`, see the
+XML format reference). The `fixed_width` writer has a well-established convention
+for it that is not implemented yet; the segment formats (`edifact`, `x12`, `hl7`,
+`swift`) emit a fixed positional grammar with no repetition slot.
 
 ```
 output 'report': source 'orders' declares the multi-value column(s) 'tags'
-(`multiple: true`), and a `xml` output has no encoding for a field holding more
-than one value
+(`multiple: true`), and a `fixed_width` output has no encoding for a field
+holding more than one value
 ```
 
 ## Example
 
 <!-- explain-test: expect-code=E359 -->
 ```yaml
-# Rejected: a multi-value column flows into an XML output, which has no
-# repeated-element writer yet.
+# Rejected: a multi-value column flows into a fixed-width output, which has no
+# writer for a multi-value field yet.
 nodes:
   - type: source
     name: orders
@@ -52,8 +53,10 @@ nodes:
     input: orders
     config:
       name: report
-      type: xml
-      path: ./out/report.xml
+      type: fixed_width
+      path: ./out/report.txt
+      schema:
+        - { name: order_id, type: string, start: 0, width: 10 }
 ```
 
 ```yaml
@@ -77,6 +80,18 @@ nodes:
       name: report
       type: json
       path: ./out/report.json
+```
+
+```yaml
+# Corrected (write XML): the values emit as repeated child elements, one per
+# value. See `join_values` in the XML format reference to rename them.
+  - type: output
+    name: report
+    input: orders
+    config:
+      name: report
+      type: xml
+      path: ./out/report.xml
 ```
 
 ```yaml
@@ -114,9 +129,10 @@ nodes:
 
 ## How to fix
 
-1. **Write the stream to a `json` or `csv` output.** JSON emits a native array;
-   CSV joins the values into one delimited cell (`join_values`, defaulting to
-   `;` with `on_conflict: error`).
+1. **Write the stream to a `json`, `csv`, or `xml` output.** JSON emits a native
+   array; CSV joins the values into one delimited cell (`join_values`, defaulting
+   to `;` with `on_conflict: error`); XML emits them as repeated child elements
+   (`join_values` `repeat_as` / `wrap_in` rename them).
 
 2. **Fan the values out to rows** with `split_to_rows` on the source, so each
    output record carries one value and the column is no longer multi-value.
@@ -152,9 +168,8 @@ Which formats qualify lives in one per-format capability table, so a writer
 gaining multi-value support relaxes exactly one entry and nothing else in the
 gate changes. The read side has its own table and its own diagnostic (`E361`);
 the two are the same rule pointed in opposite directions, and neither consults
-the other. `json` and `csv` encode a multi-value field today; the remaining
-writer-side support is tracked per format:
-[XML](https://github.com/rustpunk/clinker/issues/916) and
+the other. `json`, `csv`, and `xml` encode a multi-value field today; the
+remaining writer-side support is tracked per format:
 [fixed-width](https://github.com/rustpunk/clinker/issues/918).
 
 ## See also

--- a/docs/explain/E362.md
+++ b/docs/explain/E362.md
@@ -2,18 +2,26 @@
 
 ## What it means
 
-`join_values` tells a CSV sink how to collapse a `multiple:` field into one
-delimited cell — the write-side inverse of a source's `split_values`. This
+`join_values` is the write-side multi-value declaration — the inverse of a
+source's `split_values`. Two writers consume it: the CSV writer collapses the
+values into one delimited cell (`delimiter` / `on_conflict` / `escape`), and the
+XML writer emits them as repeated child elements (`repeat_as` / `wrap_in`). This
 diagnostic fires when the declaration itself is malformed, before any record is
 written:
 
-- **Declared on a non-CSV output.** Only the `csv` writer consumes `join_values`.
-  A `json` output already emits a native array, and the `xml` / `fixed_width` /
-  segment writers have no delimited-cell join, so declaring the block there is a
-  silent no-op — rejected the same way an unread `split_values` block is on a
-  source (`E358`).
-- **A duplicate `field`.** Two entries for the same field leave it ambiguous
-  which delimiter and policy win.
+- **Declared on an output that consumes it neither way.** Only the `csv` and
+  `xml` writers read `join_values`. A `json` output already emits a native array,
+  and the `fixed_width` / segment writers have no multi-value encoding to
+  configure, so declaring the block there is a silent no-op — rejected the same
+  way an unread `split_values` block is on a source (`E358`).
+- **A duplicate `field`.** Two entries for the same field leave its encoding
+  ambiguous. This applies to both consumers.
+
+The remaining checks are the CSV writer's — the XML writer reads only `repeat_as`
+and `wrap_in` (validated as legal XML names when the record is written) and
+ignores `delimiter` / `on_conflict` / `escape`, so a defaulted delimiter on an
+XML entry is not a fault:
+
 - **An empty `delimiter`.** There would be nothing to separate the joined values.
 - **A multi-character `delimiter` under `on_conflict: error` or `escape`.** Under
   `error` the collision check tests whether a value contains the delimiter, which
@@ -69,14 +77,27 @@ never consumes it — the declaration would be a silent no-op
         - { field: notes, delimiter: "|", on_conflict: escape, escape: "\\" }
 ```
 
+```yaml
+# Accepted: an XML join renaming the repeated element and adding a container. A
+# multi-value field with no entry emits bare repeats named after the field.
+  - type: output
+    name: report
+    input: orders
+    config:
+      name: report
+      type: xml
+      path: ./out/report.xml
+      join_values:
+        - { field: tags, repeat_as: Tag, wrap_in: Tags }
+```
+
 ## How to fix
 
-1. **On a non-CSV output, remove the `join_values` block.** A `json` output emits
-   a native array with no configuration; the `xml` / `fixed_width` / segment
-   writers have no delimited-cell join.
+1. **On an output that is neither `csv` nor `xml`, remove the `join_values`
+   block.** A `json` output emits a native array with no configuration; the
+   `fixed_width` / segment writers have no multi-value encoding to configure.
 
-2. **Declare each field once**, with the delimiter and policy it should join
-   with.
+2. **Declare each field once**, with the encoding it should use.
 
 3. **Give a non-empty delimiter** (the default is `;`).
 
@@ -105,7 +126,8 @@ would split back wrongly downstream.
 
 ## See also
 
-- `join_values` in the CSV format reference
+- `join_values` in the CSV format reference — joining into a delimited cell
+- Writing multi-value fields in the XML format reference — repeated child elements
 - Error E358 — a malformed `split_to_rows` / `split_values` declaration on a source
 - Error E359 — a `multiple:` column reaching an output that cannot encode it
 - Error E361 — a `multiple:` column on a source that cannot produce one

--- a/docs/explain/E362.md
+++ b/docs/explain/E362.md
@@ -17,6 +17,16 @@ written:
 - **A duplicate `field`.** Two entries for the same field leave its encoding
   ambiguous. This applies to both consumers.
 
+Each writer reads a disjoint subset of the keys, so a key aimed at the other
+writer is a silent no-op that this gate rejects:
+
+- **`repeat_as` or `wrap_in` on a CSV output.** These name the XML writer's
+  repeated element and container; the CSV writer never reads them, so the values
+  would join into one delimited cell with the author's naming intent discarded.
+  Because they are optional keys, an explicitly-set value is detectable and
+  faulted (unlike a defaulted `delimiter` on an XML output, which cannot be told
+  set-from-unset and stays inert).
+
 The remaining checks are the CSV writer's — the XML writer reads only `repeat_as`
 and `wrap_in` (validated as legal XML names when the record is written) and
 ignores `delimiter` / `on_conflict` / `escape`, so a defaulted delimiter on an

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -94,6 +94,71 @@ Attribute handling details:
 - An element with only attribute fields and no children self-closes:
   `Address.@type` alone emits `<Address type="home"/>`.
 
+### Writing multi-value fields (repeated elements)
+
+A `multiple:` field is written as **repeated child elements**, one per value, in
+order — the XML counterpart to the CSV writer's delimited
+[`join_values`](csv.md#writing-multi-value-cells-join_values) cell, and the
+write-side inverse of reading [`multiple: true`](#all-occurrences-in-one-field-multiple-true).
+The default needs no configuration:
+
+```xml
+<Order><id>1</id><tags>a</tags><tags>b</tags></Order>
+```
+
+The value itself carries whether it repeats, so no per-field declaration is
+needed to decide *whether* to repeat — only to rename the elements. A field with
+one value emits exactly one element, byte-identical to a scalar field's output; a
+field with an empty array emits **nothing** (no element, and no container even
+when one is configured); an empty-string value emits a self-closing item element
+(`<tags/>`).
+
+An array reaching an **attribute** field (`@tags` declared `multiple: true`) is
+rejected — an XML attribute holds a single value and cannot repeat.
+
+To rename the elements, add a `join_values` entry — the same block the CSV writer
+reads, sharing the `field` key. The XML writer reads two keys from it and ignores
+the CSV-only `delimiter` / `on_conflict` / `escape`:
+
+```yaml
+- type: output
+  name: xml_out
+  input: processed
+  config:
+    name: xml_out
+    type: xml
+    path: "./output/result.xml"
+    join_values:
+      - field: tags
+        repeat_as: Tag      # per-item element name; defaults to the field name
+        wrap_in: Tags       # optional container; omit for bare repeats
+```
+
+- **`repeat_as`** — the element name emitted per item. Defaults to the field's
+  own element name.
+- **`wrap_in`** — a container element bracketing the repeated items. Omit it for
+  bare repeats with no container.
+
+The two combine into the four arrangements, with no other key:
+
+| `repeat_as` | `wrap_in` | Output for `tags = [a, b]` |
+|-------------|-----------|-----------------------------|
+| —           | —         | `<tags>a</tags><tags>b</tags>` |
+| `Tag`       | —         | `<Tag>a</Tag><Tag>b</Tag>` |
+| —           | `Tags`    | `<Tags><tags>a</tags><tags>b</tags></Tags>` |
+| `Tag`       | `Tags`    | `<Tags><Tag>a</Tag><Tag>b</Tag></Tags>` |
+
+`repeat_as` and `wrap_in` must each be a well-formed XML name, validated the same
+way as the `root_element` / `record_element` names. Declaring `join_values` on an
+output format that is neither `csv` nor `xml` is rejected at compile
+([E362](../../explain/E362.md)).
+
+**Round trip.** A document read into a `multiple: true` column with the default
+naming writes back to the identical repeated elements — reading
+`<Order><id>1</id><tags>a</tags><tags>b</tags></Order>` into a `tags` column and
+writing it to an XML output with `record_element: Order` reproduces the input
+byte-for-byte.
+
 ## Repeated elements
 
 When a record element contains repeated child elements, two source-level


### PR DESCRIPTION
## Summary

The XML writer now emits a multi-value (`multiple: true` / array-valued) field as **repeated child elements**, one per value in document order — the XML counterpart to the CSV writer's delimited `join_values` cell. A `multiple: true` column bound to an XML output is now accepted at plan time and written losslessly, so reading a document's repeated elements into a `multiple: true` column and writing it back to XML reproduces the input.

Previously the XML writer rejected any array value (`UnserializableArrayValue`) and the plan-time capability table rated XML as having no multi-value encoding, so a `multiple: true` column bound to an XML output was rejected at compile.

## Behavior

- **Default (no configuration):** bare repeated elements named after the field.
  `tags = ["a", "b"]` → `<tags>a</tags><tags>b</tags>`.
  - A single-element array emits exactly one element, byte-identical to a scalar field.
  - An **empty array emits nothing** — no items, and no container even when one is configured. (An empty-string value emits a self-closing item, e.g. `<tags/>`.)
  - The value itself carries whether it repeats, so no per-field declaration is needed to decide *whether* to repeat — only to rename the elements.
- **Overrides** live in the existing `join_values` block, shared with the CSV writer (the two writers read disjoint sub-vocabularies of the same declaration):

  ```yaml
  join_values:
    - field: tags
      repeat_as: Tag      # per-item element name; defaults to the field name
      wrap_in: Tags       # optional container element; omit for bare repeats
  ```

  | `repeat_as` | `wrap_in` | Output for `tags = [a, b]` |
  |-------------|-----------|-----------------------------|
  | —           | —         | `<tags>a</tags><tags>b</tags>` |
  | `Tag`       | —         | `<Tag>a</Tag><Tag>b</Tag>` |
  | —           | `Tags`    | `<Tags><tags>a</tags><tags>b</tags></Tags>` |
  | `Tag`       | `Tags`    | `<Tags><Tag>a</Tag><Tag>b</Tag></Tags>` |

  The XML writer ignores the CSV-only `delimiter` / `on_conflict` / `escape` keys.
- An array reaching an **attribute-classified** field is rejected — an XML attribute holds a single value and cannot repeat. `repeat_as` / `wrap_in` are validated as legal XML names before any byte is written, consistent with the configured root/record element-name validation.

## Plan-time gates

- **E359** (output capability): XML now rates as encoding a multi-value field, so a `multiple: true` column reaching an XML output compiles.
- **E362** (`join_values` shape): now accepts the block on an XML output, validating the shared duplicate-field rule. The delimiter/escape shape checks remain CSV-only, since the XML writer ignores those keys.

## Tests

- Repeated-element output; single-element array byte-identical to a scalar; empty array emits nothing; empty-string value self-closes.
- `repeat_as`, `wrap_in`, and both together; invalid override name rejected; array-on-attribute rejected; nested-collection element still rejected.
- Read → write round-trip: a document with repeated elements read into a `multiple: true` column writes back byte-for-byte.
- Plan gates: `multiple: true` into an XML output compiles; `join_values` `repeat_as`/`wrap_in` on an XML output compiles; duplicate field still rejected.
- End-to-end: a JSON source with a `multiple:` column feeding an XML sink emits repeated elements, with and without `repeat_as`/`wrap_in`, proving the override flows from YAML through the writer factory.

## Docs

- `docs/user/src/formats/xml.md`: new "Writing multi-value fields (repeated elements)" section.
- `docs/explain/E359.md` and `docs/explain/E362.md`: updated to reflect XML as a multi-value encoder / `join_values` consumer.

## Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p clinker-format -p clinker-plan` all pass; the new end-to-end tests in `clinker-exec` pass.

Closes #916
