### PR TITLE
Follow-up: harden config --resolved canonicalizer, tighten explain-doc harness, read config once

### DIFF
--- a/crates/clinker-plan/src/config/canonical.rs
+++ b/crates/clinker-plan/src/config/canonical.rs
@@ -138,6 +138,7 @@ pub fn expand_multi_value_shorthand(raw: &str) -> Result<String, CanonicalError>
 
 /// Where a shorthand sequence's real opening token lives, relative to the
 /// offset the parser reported for its value.
+#[derive(Debug)]
 enum SequenceStart {
     /// Splice the region beginning at this byte — guaranteed to be `-` or `[`.
     Splice(usize),
@@ -154,6 +155,10 @@ enum SequenceStart {
 ///
 /// - a flow sequence reports the `[` itself (inline or on its own line);
 /// - a YAML alias reports the `*anchor` use-site token;
+/// - an anchored sequence definition (`key: &anchor` then the sequence) reports
+///   its content token in this parser version, but the reported offset landing
+///   on the `&anchor` token is handled defensively — the anchor is skipped to
+///   the real `-` / `[` so a valid anchored config is never refused;
 /// - a block sequence reports the `-` when the item is indented deeper than its
 ///   key, but the first item's *value* (two bytes past `- `) when the dash sits
 ///   at the key's own indent — the common `key:\n- item` form.
@@ -165,6 +170,7 @@ fn resolve_sequence_start(raw: &str, reported: usize) -> SequenceStart {
     match bytes[reported] {
         b'[' => SequenceStart::Splice(reported),
         b'*' => SequenceStart::PassThrough,
+        b'&' => resolve_anchor_start(raw, reported),
         _ => {
             let line_start = raw[..reported].rfind('\n').map(|i| i + 1).unwrap_or(0);
             let after = &raw[line_start..];
@@ -184,6 +190,45 @@ fn resolve_sequence_start(raw: &str, reported: usize) -> SequenceStart {
                 ))
             }
         }
+    }
+}
+
+/// Resolve a reported offset that lands on an anchor token (`&anchor`) to the
+/// sequence's real opening `-` / `[`.
+///
+/// Skips the anchor name and the whitespace / line break that separates it from
+/// the value, then reports the sequence token that follows. A shape with no
+/// `-` / `[` after the anchor is passed through byte-identical rather than
+/// erroring: an anchored value that already parsed is never corrupted, and the
+/// unexpanded sequence still re-parses as authored.
+fn resolve_anchor_start(raw: &str, anchor_at: usize) -> SequenceStart {
+    let bytes = raw.as_bytes();
+    // Skip `&` and the anchor name. A YAML anchor name runs until whitespace,
+    // a line break, or a flow indicator.
+    let mut i = anchor_at + 1;
+    while i < bytes.len()
+        && !matches!(
+            bytes[i],
+            b' ' | b'\t' | b'\r' | b'\n' | b'[' | b']' | b'{' | b'}' | b','
+        )
+    {
+        i += 1;
+    }
+    // Skip the whitespace / newline between the anchor and its value.
+    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\r' | b'\n') {
+        i += 1;
+    }
+    match bytes.get(i) {
+        Some(b'[') => SequenceStart::Splice(i),
+        Some(b'-')
+            if matches!(
+                bytes.get(i + 1).copied(),
+                None | Some(b' ') | Some(b'\t') | Some(b'\n') | Some(b'\r')
+            ) =>
+        {
+            SequenceStart::Splice(i)
+        }
+        _ => SequenceStart::PassThrough,
     }
 }
 
@@ -266,14 +311,72 @@ fn push_edit<T: Serialize>(
 }
 
 /// Whether a sequence's byte range carries a comment or blank line that
-/// regenerating it would drop. Any line whose trimmed form is empty or opens a
-/// comment, and any line carrying a trailing ` #` comment, counts — erring
-/// toward leaving the sequence untouched so no author comment is ever lost.
+/// regenerating it would drop. A blank line, or any line carrying a YAML
+/// comment, counts — erring toward leaving the sequence untouched so no author
+/// comment is ever lost.
 fn region_has_interior_noise(region: &str) -> bool {
-    region.split('\n').any(|line| {
-        let trimmed = line.trim();
-        trimmed.is_empty() || trimmed.starts_with('#') || line.contains(" #")
-    })
+    region
+        .split('\n')
+        .any(|line| line.trim().is_empty() || line_has_comment(line))
+}
+
+/// Whether `line` carries a YAML comment: an unquoted `#` at the line start
+/// (after indentation) or preceded by whitespace — a space **or a tab** — and
+/// not inside a single- or double-quoted scalar.
+///
+/// This is stricter than a plain `" #"` substring on two axes: a tab-separated
+/// comment (`- item\t# note`) is recognized so regenerating the sequence never
+/// silently drops it, and a literal `#` inside a quoted value (e.g. a delimiter
+/// spelled `" #"`) is *not* mistaken for a comment, so a sequence carrying one
+/// still expands.
+fn line_has_comment(line: &str) -> bool {
+    let bytes = line.as_bytes();
+    let mut in_single = false;
+    let mut in_double = false;
+    // The start of a line counts as "preceded by whitespace", so a comment-only
+    // line is detected even with no leading space.
+    let mut prev_ws = true;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if in_single {
+            // A doubled `''` is an escaped quote, not a close.
+            if c == b'\'' {
+                if bytes.get(i + 1) == Some(&b'\'') {
+                    i += 2;
+                    continue;
+                }
+                in_single = false;
+            }
+            prev_ws = false;
+        } else if in_double {
+            if c == b'\\' {
+                i += 2;
+                prev_ws = false;
+                continue;
+            }
+            if c == b'"' {
+                in_double = false;
+            }
+            prev_ws = false;
+        } else {
+            match c {
+                b'#' if prev_ws => return true,
+                b'\'' => {
+                    in_single = true;
+                    prev_ws = false;
+                }
+                b'"' => {
+                    in_double = true;
+                    prev_ws = false;
+                }
+                b' ' | b'\t' => prev_ws = true,
+                _ => prev_ws = false,
+            }
+        }
+        i += 1;
+    }
+    false
 }
 
 /// End (exclusive) of the flow sequence that opens at `raw[start] == '['`.
@@ -921,6 +1024,138 @@ nodes:
             "a sequence with an interior comment is left untouched"
         );
         assert!(out.contains("# keep this comment"), "\n{out}");
+    }
+
+    #[test]
+    fn anchored_block_same_indent_single_item_expands_and_reparses() {
+        // An anchor on the sequence definition, with the block at the key's own
+        // indent (`key: &sv\n- item`). The definition must expand — never error
+        // — and the anchor must survive so a later alias still resolves.
+        let raw = "\
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: csv
+      path: in.csv
+      split_values: &sv
+      - tags
+      schema:
+        - { name: tags, type: string, multiple: true }
+";
+        let out = expand_multi_value_shorthand(raw).unwrap();
+        assert!(!out.contains("- - "), "no doubled dash corruption:\n{out}");
+        assert!(out.contains("field: tags"), "\n{out}");
+        assert!(out.contains("delimiter:"), "defaults materialized:\n{out}");
+        assert!(
+            out.contains("split_values: &sv"),
+            "anchor must be preserved:\n{out}"
+        );
+        assert_parse_identity(raw, &out);
+        assert_idempotent(raw);
+    }
+
+    #[test]
+    fn anchored_block_deeper_multi_item_expands_and_reparses() {
+        // An anchor on the sequence definition, with a deeper-indented block of
+        // several items. All items expand and the anchor is preserved.
+        let raw = "\
+nodes:
+  - type: source
+    name: s
+    config:
+      name: s
+      type: csv
+      path: in.csv
+      split_values: &sv
+        - tags
+        - codes
+      schema:
+        - { name: tags, type: string, multiple: true }
+        - { name: codes, type: string, multiple: true }
+";
+        let out = expand_multi_value_shorthand(raw).unwrap();
+        assert!(!out.contains("- - "), "no doubled dash corruption:\n{out}");
+        assert!(out.contains("field: tags"), "\n{out}");
+        assert!(out.contains("field: codes"), "\n{out}");
+        assert!(
+            out.contains("split_values: &sv"),
+            "anchor must be preserved:\n{out}"
+        );
+        assert_parse_identity(raw, &out);
+        assert_idempotent(raw);
+    }
+
+    #[test]
+    fn resolve_sequence_start_skips_anchor_at_reported_offset() {
+        // Defensive contract: if the parser ever reports the `&anchor` token as
+        // the sequence value's offset, the resolver skips it to the real
+        // `-` / `[` rather than classifying the region `Unexpected` (which
+        // would hard-error on a valid anchored config).
+        for (src, want_byte) in [
+            ("key: &sv\n  - a\n", b'-'),
+            ("key: &sv\n- a\n", b'-'),
+            ("key: &sv [a]\n", b'['),
+            ("key: &longer_name\n  - a\n", b'-'),
+        ] {
+            let amp = src.find('&').expect("anchor token");
+            match resolve_sequence_start(src, amp) {
+                SequenceStart::Splice(pos) => assert_eq!(
+                    src.as_bytes()[pos],
+                    want_byte,
+                    "resolved to {:?}, want {:?} in {src:?}",
+                    src.as_bytes()[pos] as char,
+                    want_byte as char
+                ),
+                other => panic!("expected Splice for {src:?}, got {other:?}"),
+            }
+        }
+
+        // An anchor with no sequence token after it is passed through, not
+        // errored — a valid document is never corrupted.
+        match resolve_sequence_start("key: &sv scalar\n", 5) {
+            SequenceStart::PassThrough => {}
+            other => panic!("expected PassThrough for a scalar anchor, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tab_preceded_comment_is_preserved() {
+        // A shorthand item ending in a TAB-separated comment must not be
+        // dropped: the sequence is passed through byte-identical rather than
+        // regenerated (which would discard the comment).
+        let raw = "nodes:\n  - type: source\n    name: s\n    config:\n      name: s\n      \
+                   type: csv\n      path: in.csv\n      split_values:\n        \
+                   - tags\t# keep this\n      schema:\n        \
+                   - { name: tags, type: string, multiple: true }\n";
+        let out = expand_multi_value_shorthand(raw).unwrap();
+        assert_eq!(
+            raw, out,
+            "a tab-preceded comment must leave the sequence untouched:\n{out}"
+        );
+        assert!(out.contains("# keep this"), "\n{out}");
+        assert_parse_identity(raw, &out);
+        assert_idempotent(raw);
+    }
+
+    #[test]
+    fn quoted_hash_value_still_expands() {
+        // A value containing `" #"` inside a quoted scalar must not be mistaken
+        // for a comment: the sequence still expands, materializing the bare
+        // item's defaults while the quoted value is preserved verbatim.
+        let raw = "nodes:\n  - type: source\n    name: s\n    config:\n      name: s\n      \
+                   type: csv\n      path: in.csv\n      split_values:\n        \
+                   - field: notes\n          delimiter: \" #\"\n        - tags\n      \
+                   schema:\n        - { name: notes, type: string, multiple: true }\n        \
+                   - { name: tags, type: string, multiple: true }\n";
+        let out = expand_multi_value_shorthand(raw).unwrap();
+        // The bare `- tags` gained its default delimiter — the block expanded.
+        assert!(out.contains("field: tags"), "block should expand:\n{out}");
+        assert!(out.contains("field: notes"), "\n{out}");
+        // `assert_parse_identity` guarantees the quoted `#` delimiter survived.
+        assert_parse_identity(raw, &out);
+        assert_idempotent(raw);
     }
 
     #[test]

--- a/crates/clinker-plan/src/config/canonical.rs
+++ b/crates/clinker-plan/src/config/canonical.rs
@@ -329,6 +329,15 @@ fn region_has_interior_noise(region: &str) -> bool {
 /// silently drops it, and a literal `#` inside a quoted value (e.g. a delimiter
 /// spelled `" #"`) is *not* mistaken for a comment, so a sequence carrying one
 /// still expands.
+///
+/// A line that ends still "inside" a quote had an unbalanced quote — a bare `'`
+/// or `"` in a plain scalar (`it's`, `5" nail`) rather than a real quoted
+/// region. The scanner cannot then trust its position, so it conservatively
+/// counts the line as noise: the sequence is passed through unexpanded (valid
+/// YAML, re-parses identically) rather than regenerated, which could drop a
+/// genuine trailing comment the runaway quote skipped over. The only cost is
+/// that a quote-bearing bare item with no comment stops expanding — the safe
+/// direction for a canonicalizer whose first duty is to never lose a comment.
 fn line_has_comment(line: &str) -> bool {
     let bytes = line.as_bytes();
     let mut in_single = false;
@@ -376,7 +385,10 @@ fn line_has_comment(line: &str) -> bool {
         }
         i += 1;
     }
-    false
+    // An unbalanced quote (a bare `'`/`"` in a plain scalar) leaves the scanner
+    // "inside" a quote at end of line, having skipped past any real comment.
+    // Bail conservatively: treat the line as noise so the comment is preserved.
+    in_single || in_double
 }
 
 /// End (exclusive) of the flow sequence that opens at `raw[start] == '['`.
@@ -1154,6 +1166,44 @@ nodes:
         assert!(out.contains("field: tags"), "block should expand:\n{out}");
         assert!(out.contains("field: notes"), "\n{out}");
         // `assert_parse_identity` guarantees the quoted `#` delimiter survived.
+        assert_parse_identity(raw, &out);
+        assert_idempotent(raw);
+    }
+
+    #[test]
+    fn bare_apostrophe_item_with_comment_is_preserved() {
+        // A plain scalar containing a bare apostrophe (`it's`) has an odd quote
+        // count. The comment scanner must not run away into quote-mode past the
+        // trailing comment and let the block be regenerated (which would drop
+        // the comment) — the sequence is passed through byte-identical instead.
+        let raw = "nodes:\n  - type: source\n    name: s\n    config:\n      name: s\n      \
+                   type: csv\n      path: in.csv\n      split_values:\n        \
+                   - it's  # KEEP THIS COMMENT\n      schema:\n        \
+                   - { name: order_id, type: string }\n";
+        let out = expand_multi_value_shorthand(raw).unwrap();
+        assert_eq!(
+            raw, out,
+            "an apostrophe-bearing bare item with a comment must be left untouched:\n{out}"
+        );
+        assert!(out.contains("# KEEP THIS COMMENT"), "\n{out}");
+        assert_parse_identity(raw, &out);
+        assert_idempotent(raw);
+    }
+
+    #[test]
+    fn bare_double_quote_item_with_comment_is_preserved() {
+        // The double-quote variant of the odd-quote case (`5" nail`, inches):
+        // same conservative bail keeps the trailing comment.
+        let raw = "nodes:\n  - type: source\n    name: s\n    config:\n      name: s\n      \
+                   type: csv\n      path: in.csv\n      split_values:\n        \
+                   - 5\" nail  # KEEP THIS COMMENT\n      schema:\n        \
+                   - { name: order_id, type: string }\n";
+        let out = expand_multi_value_shorthand(raw).unwrap();
+        assert_eq!(
+            raw, out,
+            "an inch-quote-bearing bare item with a comment must be left untouched:\n{out}"
+        );
+        assert!(out.contains("# KEEP THIS COMMENT"), "\n{out}");
         assert_parse_identity(raw, &out);
         assert_idempotent(raw);
     }

--- a/crates/clinker-plan/src/config/error.rs
+++ b/crates/clinker-plan/src/config/error.rs
@@ -156,7 +156,18 @@ pub fn parse_config_with_vars(
     extra_vars: &[(&str, &str)],
 ) -> Result<PipelineConfig, ConfigError> {
     let yaml = std::fs::read_to_string(path)?;
-    let interpolated = interpolate_env_vars(&yaml, extra_vars)?;
+    parse_config_source(&yaml, extra_vars)
+}
+
+/// Interpolate, parse, and external-schema-resolve a config from an
+/// already-read YAML string, stamping `source_hash` — the file-independent core
+/// of [`parse_config_with_vars`]. Callers that already hold the source bytes use
+/// this to avoid re-reading (and re-`stat`-ing) the file.
+fn parse_config_source(
+    yaml: &str,
+    extra_vars: &[(&str, &str)],
+) -> Result<PipelineConfig, ConfigError> {
+    let interpolated = interpolate_env_vars(yaml, extra_vars)?;
     let mut config: PipelineConfig = crate::yaml::from_str(&interpolated)?;
     config.source_hash = *blake3::hash(interpolated.as_bytes()).as_bytes();
     // Resolve any external `.schema.yaml` (`SourceSchema::File`) references to
@@ -304,6 +315,20 @@ pub fn load_config_with_vars_and_patches(
 /// Load and parse a pipeline config from a YAML file path.
 pub fn load_config(path: &std::path::Path) -> Result<PipelineConfig, ConfigError> {
     load_config_with_vars(path, &[])
+}
+
+/// Load and validate a pipeline config from an already-read YAML string,
+/// running the same interpolation, external-schema resolution, and validation
+/// as [`load_config`].
+///
+/// Exists so a caller holding the source bytes — e.g. `clinker config
+/// --resolved`, which both validates and then rewrites the same text — validates
+/// without a second read of the file. Reading once removes the TOCTOU window in
+/// which the file could change between validation and the rewrite.
+pub fn load_config_from_str(yaml: &str) -> Result<PipelineConfig, ConfigError> {
+    let config = parse_config_source(yaml, &[])?;
+    validate_config(&config)?;
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -459,6 +484,45 @@ mod external_schema_tests {
             config.source_hash,
             *blake3::hash(interpolated.as_bytes()).as_bytes(),
             "an inline-schema config hashes to exactly the YAML-text BLAKE3"
+        );
+    }
+
+    /// `load_config_from_str` validates the same YAML the path loader does,
+    /// producing an identical config — the property that lets `config
+    /// --resolved` validate the bytes it already read instead of re-reading the
+    /// file (closing the TOCTOU window between validation and the rewrite).
+    #[test]
+    fn load_config_from_str_matches_path_loader_and_validates() {
+        let yaml = "pipeline:\n  name: read_once\n\
+             nodes:\n  - type: source\n    name: src\n    config:\n      \
+             name: src\n      type: csv\n      path: /tmp/in.csv\n      \
+             schema:\n        - { name: amount, type: int }\n  - type: output\n    \
+             name: out\n    input: src\n    config:\n      name: out\n      \
+             type: csv\n      path: /tmp/out.csv\n";
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("pipeline.yaml");
+        std::fs::write(&p, yaml).unwrap();
+
+        let from_path = load_config(&p).expect("path loader");
+        let from_str = load_config_from_str(yaml).expect("string loader");
+        assert_eq!(
+            from_path.source_hash, from_str.source_hash,
+            "reading once must produce the same pipeline identity as the path loader"
+        );
+        assert_eq!(from_path.nodes.len(), from_str.nodes.len());
+
+        // Validation still runs: a config that parses but is out of range is
+        // rejected (here an out-of-band `resume_threshold`, [E324]).
+        let invalid = "pipeline:\n  name: bad\n  memory:\n    resume_threshold: 2.0\n\
+             nodes:\n  - type: source\n    name: src\n    config:\n      \
+             name: src\n      type: csv\n      path: /tmp/in.csv\n      \
+             schema:\n        - { name: amount, type: int }\n";
+        assert!(
+            matches!(
+                load_config_from_str(invalid),
+                Err(ConfigError::Validation(_))
+            ),
+            "load_config_from_str must run validate_config, not just parse"
         );
     }
 }

--- a/crates/clinker-plan/src/plan/tests/explain_examples.rs
+++ b/crates/clinker-plan/src/plan/tests/explain_examples.rs
@@ -269,9 +269,13 @@ fn check(block: &MarkedBlock, eval: &Evaluation) -> Option<String> {
     match &block.expectation {
         Expectation::Code(code) => {
             let matched = match eval {
-                // Parse-time validation embeds the code in its message text,
-                // e.g. `[E357] source '...'`.
-                Evaluation::ParseRejected(msg) => msg.contains(code.as_str()),
+                // Parse-time validation embeds the code as a bracketed token,
+                // e.g. `[E357] source '...'`. Match that whole token rather than
+                // a bare substring, so a coincidental substring (a shorter code
+                // that is a prefix of the real one, or the code text appearing
+                // in prose) cannot pass a block spuriously — as precise as the
+                // compile-time `c == code` check below.
+                Evaluation::ParseRejected(msg) => msg.contains(&format!("[{code}]")),
                 Evaluation::CompileErrors(codes) | Evaluation::Compiled(codes) => {
                     codes.iter().any(|c| c == code)
                 }
@@ -318,6 +322,40 @@ fn describe(eval: &Evaluation) -> String {
             }
         }
     }
+}
+
+#[test]
+fn parse_rejected_expect_code_matches_bracketed_token_not_substring() {
+    // A parse-time rejection carries its code as a bracketed token, e.g.
+    // `[E357] source '...'`. The harness must require that exact token, not a
+    // bare substring, so a wrong expected code cannot ride on a coincidence.
+    let rejected = Evaluation::ParseRejected(
+        "[E357] source 'x': envelope section 'a' declares ...".to_string(),
+    );
+
+    let exact = MarkedBlock {
+        page: "E357.md".to_string(),
+        marker_line: 1,
+        expectation: Expectation::Code("E357".to_string()),
+        yaml: String::new(),
+    };
+    assert!(
+        check(&exact, &rejected).is_none(),
+        "the documented code must match its own parse-time rejection"
+    );
+
+    // `E35` is a substring of the emitted `E357`; a bare-substring check passed
+    // this spuriously. The tightened token match must report it as a mismatch.
+    let wrong = MarkedBlock {
+        page: "E357.md".to_string(),
+        marker_line: 1,
+        expectation: Expectation::Code("E35".to_string()),
+        yaml: String::new(),
+    };
+    assert!(
+        check(&wrong, &rejected).is_some(),
+        "a wrong expected code must fail even when it is a substring of the real one"
+    );
 }
 
 #[test]

--- a/crates/clinker/src/main.rs
+++ b/crates/clinker/src/main.rs
@@ -2563,13 +2563,18 @@ fn run_config(args: &ConfigArgs) -> Result<u8, Box<dyn std::error::Error>> {
         );
     }
 
-    // Validate before rewriting: a parse or schema error surfaces here rather
-    // than producing a document that no longer matches a loadable plan.
-    clinker_plan::config::load_config(&args.config)
-        .map_err(|e| format!("{}: {e}", args.config.display()))?;
-
+    // Read the source once and reuse it for both validation and the rewrite.
+    // A second read would reopen the file after validation, leaving a TOCTOU
+    // window in which the resolved output could reflect different bytes than the
+    // ones just validated.
     let raw = std::fs::read_to_string(&args.config)
         .map_err(|e| format!("{}: {e}", args.config.display()))?;
+
+    // Validate before rewriting: a parse or schema error surfaces here rather
+    // than producing a document that no longer matches a loadable plan.
+    clinker_plan::config::load_config_from_str(&raw)
+        .map_err(|e| format!("{}: {e}", args.config.display()))?;
+
     let resolved = clinker_plan::config::expand_multi_value_shorthand(&raw)
         .map_err(|e| format!("{}: {e}", args.config.display()))?;
     print!("{resolved}");


### PR DESCRIPTION
## Summary

Post-review follow-up addressing four findings in the `config --resolved`
canonicalizer, the explain-doc marked-example test harness, and the `config`
CLI. Each fix is scoped and independently tested; behavior for every existing
case is preserved.

`config --resolved` prints a pipeline config with the multi-value shorthand
(`split_to_rows` / `split_values` / `join_values`) expanded to full canonical
form while leaving the rest of the document byte-for-byte intact. Its guiding
invariant is that it must **never emit non-parseable YAML** and must always be
idempotent — resolving an already-resolved config is a no-op.

## Fixes

### 1. Anchored shorthand sequences are never refused

The resolver that locates a shorthand sequence's opening token (`-` for a block
sequence, `[` for a flow one) had no handling for a YAML **anchor** placed on
the sequence definition (`split_values: &sv` followed by the items). If the
parser reported the anchor token as the value's offset, the region was
classified as an unexpected shape and the command failed with a hard internal
error on a config that parses and validates cleanly.

The resolver now recognizes an anchor token, skips the anchor name and the
whitespace before the value, and splices from the real `-` / `[`. A shape with
no sequence token after the anchor is passed through byte-identical rather than
errored, so an anchored config is always either expanded or left unchanged —
never rejected. New tests cover anchored block sequences at the key's own indent
(single item) and at a deeper indent (multiple items), asserting each resolves,
re-parses, stays idempotent, and preserves the anchor; a direct resolver unit
test covers the anchor-token offset itself. The existing alias use-site
(`*sv`) and inline-flow-anchor cases stay green.

### 2. Comment detection preserves tab-separated comments and ignores quoted `#`

Regenerating a shorthand sequence would discard any comment interleaved among
its items, so a sequence carrying an interior comment is passed through
unchanged instead. The check for "does this region carry a comment" used a
`" #"` (space-then-hash) substring, which had two defects:

- A shorthand item ending in a **tab-separated** comment (`- item⇥# note`) was
  not detected, so the region was regenerated and the comment silently dropped.
- A value legitimately containing `" #"` inside a **quoted scalar** (e.g. a
  delimiter spelled `" #"`) was mistaken for a comment, needlessly leaving the
  block un-expanded.

The substring check is replaced with a quote-aware scanner that recognizes a
YAML comment as an unquoted `#` at line start or preceded by whitespace — a
space **or a tab** — and not inside a single- or double-quoted scalar. Tab-
preceded comments are now preserved (block passed through byte-identical), and a
shorthand whose value contains a quoted `#` still expands. Both are tested.

### 3. Explain-doc harness matches diagnostic codes as whole tokens

The marked-example harness checks that a documented block surfaces its declared
diagnostic. On the compile-time path it required exact code equality, but on the
parse-time (validation) path it matched by bare substring — so a marked block
could pass on a coincidental substring (a shorter code that is a prefix of the
real one, or the code text appearing in prose) rather than on the documented
diagnostic actually firing.

The parse-time path now matches the bracketed token the validation messages emit
(`[EXXX]`), making it as precise as the compile path. A new test proves a wrong
expected code on a parse-time-rejecting block is reported. All currently-marked
example pages remain green.

### 4. `config --resolved` reads the config file once

`run_config` loaded and validated the config (one file read) and then read the
file a second time for the byte-level rewrite, leaving a time-of-check /
time-of-use window in which the two reads could observe different bytes. The
command now reads the source once and reuses it: validation runs through a new
`load_config_from_str` that performs the same env-var interpolation, external-
schema resolution, and validation as the path loader, and the same bytes are
then rewritten. Behavior is otherwise identical — the config is still fully
validated before anything is printed. A parity test confirms the string loader
matches the path loader and still runs validation.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p clinker -p clinker-plan` — all pass

For every canonicalizer change, the resolved output is re-parsed and re-resolved
in tests to confirm it stays parseable and idempotent; the anchor and comment
cases are covered specifically.
