### PR TITLE
fix(format): post-review correctness follow-ups for multi-value read/write

### DIFF
--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -22,6 +22,7 @@
 //! small `ReopenableSource::Buffered` — the honest one-shot fallback, bounded
 //! because such inputs are small by construction.
 
+use std::collections::HashSet;
 use std::io::{BufRead, BufReader, Read};
 use std::sync::Arc;
 
@@ -115,6 +116,20 @@ enum InnerReader {
     Array(JsonArrayStream),
     /// Exhausted (empty document).
     Done,
+}
+
+/// Collision-tracking state threaded through [`JsonReader::flatten_value`] for a
+/// single record.
+///
+/// `undeclared` collects flattened-name collisions on columns NOT declared
+/// `multiple:`, which the caller turns into a loud `UndeclaredRepeatedField`.
+/// `accumulated` records which `multiple:` keys have already been promoted to an
+/// occurrence-accumulator array; it is what lets the collector tell a slot that
+/// is accumulating several occurrences apart from a single first occurrence that
+/// is itself array-valued, so each distinct occurrence stays one element.
+struct CollisionSink<'a> {
+    undeclared: &'a mut Vec<String>,
+    accumulated: &'a mut HashSet<String>,
 }
 
 impl JsonReader {
@@ -284,7 +299,7 @@ impl JsonReader {
         value: &serde_json::Value,
         out: &mut serde_json::Map<String, serde_json::Value>,
         depth: usize,
-        mut collisions: Option<&mut Vec<String>>,
+        mut collisions: Option<&mut CollisionSink<'_>>,
         multi_value: &[String],
     ) {
         const MAX_DEPTH: usize = 64;
@@ -316,19 +331,34 @@ impl JsonReader {
             other => match collisions {
                 Some(sink) if out.contains_key(prefix) => {
                     if multi_value.iter().any(|f| f.as_str() == prefix) {
-                        // Declared `multiple:` — collect in document order.
-                        match out.get_mut(prefix).expect("contains_key just held") {
-                            serde_json::Value::Array(items) => items.push(other.clone()),
-                            slot => {
-                                let first = slot.take();
-                                *slot = serde_json::Value::Array(vec![first, other.clone()]);
+                        // Declared `multiple:` — collect one element per
+                        // occurrence, in document order. `accumulated` tells a
+                        // slot already holding several collected occurrences
+                        // apart from a single first occurrence that is itself
+                        // array-valued, so only a true accumulator is extended:
+                        // `{"a":{"b":[1,2]},"a.b":3}` collects `[[1,2], 3]`, not
+                        // the boundary-erasing `[1,2,3]`.
+                        let slot = out.get_mut(prefix).expect("contains_key just held");
+                        if sink.accumulated.contains(prefix) {
+                            match slot {
+                                serde_json::Value::Array(items) => items.push(other.clone()),
+                                // An accumulated key is always array-valued; wrap
+                                // rather than panic if that invariant ever breaks.
+                                lone => {
+                                    let first = lone.take();
+                                    *lone = serde_json::Value::Array(vec![first, other.clone()]);
+                                }
                             }
+                        } else {
+                            let first = slot.take();
+                            *slot = serde_json::Value::Array(vec![first, other.clone()]);
+                            sink.accumulated.insert(prefix.to_string());
                         }
                     } else {
                         // Undeclared flattened-name collision — the caller
                         // turns this into a loud error. The overwrite is
                         // immaterial because the record is never kept.
-                        sink.push(prefix.to_string());
+                        sink.undeclared.push(prefix.to_string());
                         out.insert(prefix.to_string(), other.clone());
                     }
                 }
@@ -348,16 +378,21 @@ impl JsonReader {
         raw: &serde_json::Value,
     ) -> Result<serde_json::Map<String, serde_json::Value>, FormatError> {
         let mut flat = serde_json::Map::new();
-        let mut collisions: Vec<String> = Vec::new();
+        let mut undeclared: Vec<String> = Vec::new();
+        let mut accumulated: HashSet<String> = HashSet::new();
+        let mut sink = CollisionSink {
+            undeclared: &mut undeclared,
+            accumulated: &mut accumulated,
+        };
         Self::flatten_value(
             "",
             raw,
             &mut flat,
             0,
-            Some(&mut collisions),
+            Some(&mut sink),
             &self.config.multi_value_fields,
         );
-        if let Some(field) = collisions.into_iter().next() {
+        if let Some(field) = undeclared.into_iter().next() {
             return Err(FormatError::UndeclaredRepeatedField {
                 format: "JSON",
                 field,
@@ -751,9 +786,9 @@ fn project_element(
             // still resolves last-wins rather than raising
             // `UndeclaredRepeatedField`. That element-internal / element-vs-parent
             // collision under `extract` is the fan-out half of the read-side
-            // collision gap and is tracked separately by issue #920 — the
-            // top-level record collision this module now rejects does not cover
-            // it.
+            // collision gap, tracked at
+            // https://github.com/rustpunk/clinker/issues/920 — the top-level
+            // record collision this module now rejects does not cover it.
             JsonReader::flatten_value("", elem, out, 0, None, &[]);
         }
         (SplitToRowsMode::Extract, other) => {
@@ -767,8 +802,9 @@ fn project_element(
         (SplitToRowsMode::Split, _) => {
             // Split mode re-nests the element under its own field name, so a
             // clash with a parent field is possible but a within-element clash
-            // is not; collision detection stays off for the same #920 reason as
-            // the extract arm above.
+            // is not; collision detection stays off for the same reason as the
+            // extract arm above — the element-internal collision gap tracked at
+            // https://github.com/rustpunk/clinker/issues/920.
             JsonReader::flatten_value(&entry.field, elem, out, 0, None, &[]);
         }
     }
@@ -1467,6 +1503,28 @@ mod tests {
         assert_eq!(
             r.next_record().unwrap().unwrap().get("a.b"),
             Some(&Value::Array(vec![Value::Integer(1), Value::Integer(2)]))
+        );
+    }
+
+    #[test]
+    fn multiple_column_collision_keeps_each_occurrence_a_distinct_element() {
+        // The first occurrence is itself array-valued (`a.b == [1,2]` from the
+        // nested object) and the second is a scalar (`a.b == 3`). Each distinct
+        // occurrence must be one element, so the array-valued first occurrence
+        // is wrapped rather than extended into: `[[1,2], 3]`, never `[1,2,3]`.
+        let input = r#"[{"a":{"b":[1,2]},"a.b":3}]"#;
+        let config = JsonReaderConfig {
+            multi_value_fields: vec!["a.b".into()],
+            ..default_config()
+        };
+        let mut r = reader_from_str(input, config);
+        let _s = r.schema().unwrap();
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("a.b"),
+            Some(&Value::Array(vec![
+                Value::Array(vec![Value::Integer(1), Value::Integer(2)]),
+                Value::Integer(3),
+            ]))
         );
     }
 

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -108,6 +108,13 @@ struct RawRecord {
     /// fields (`<Item></Item>`) contributes an empty range, so the fan-out
     /// still emits a record for it.
     split_instances: Vec<Vec<Range<usize>>>,
+    /// Dotted names of value-less, non-fan-out self-closing elements (`<x/>`)
+    /// that pushed no field of their own. These are recorded only so schema
+    /// inference can see the column — record assembly never reads them, which
+    /// is what keeps a repeated `<x/><x/>` on a non-`multiple:` column from
+    /// tripping the undeclared-repeat guard while a column appearing ONLY as
+    /// `<x/>` in the first record still surfaces in the inferred schema.
+    presence: Vec<String>,
 }
 
 impl RawRecord {
@@ -117,6 +124,7 @@ impl RawRecord {
         RawRecord {
             fields,
             split_instances: vec![Vec::new(); field_count],
+            presence: Vec::new(),
         }
     }
 }
@@ -407,6 +415,7 @@ impl XmlReader {
         let mut fields = start_attrs;
         let mut split_instances: Vec<Vec<Range<usize>>> =
             vec![Vec::new(); self.config.split_to_rows.len()];
+        let mut presence: Vec<String> = Vec::new();
         let mut open_instance: Option<OpenInstance> = None;
         let record_depth = self.xml_depth;
         let mut element_stack: Vec<String> = Vec::new();
@@ -428,7 +437,12 @@ impl XmlReader {
             // Any event other than a text fragment terminates the current text
             // node; resolve and push it before handling the structural event.
             if !matches!(&event, Event::Text(_) | Event::GeneralRef(_)) {
-                flush_text_field(&mut fields, &element_stack, &mut text_run)?;
+                flush_text_field(
+                    &mut fields,
+                    &element_stack,
+                    &mut text_run,
+                    &self.config.multi_value_fields,
+                )?;
             }
 
             match event {
@@ -476,17 +490,20 @@ impl XmlReader {
                         format!("{}.{name}", element_stack.join("."))
                     };
                     let instance_from = fields.len();
-                    // A value-less self-closing element pushes no field of its
-                    // own, exactly as the empty-body form `<x></x>` does through
-                    // `flush_text_field`'s non-empty guard. Pushing an empty
-                    // leader here instead would make `<x/><x/>` look like a
-                    // repeated field and wrongly trip `UndeclaredRepeatedField`,
-                    // while the identical `<x></x><x></x>` passes — so only the
-                    // element's attributes (if any) are recorded.
+                    // A value-less self-closing element mirrors the empty-body
+                    // form `<x></x>` (see `flush_text_field`): on a declared
+                    // `multiple:` column it is a real empty occurrence collected
+                    // into the array, and on any other column it pushes NO field
+                    // — so `<x/><x/>` on a non-`multiple:` column cannot look
+                    // like a repeated field and trip `UndeclaredRepeatedField`.
+                    // Only its attributes (if any) go into `fields` here; the
+                    // empty-occurrence push and schema-presence record happen
+                    // below.
                     let child_attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
                     for (key, val) in child_attrs {
                         fields.push((format!("{prefix}.{key}"), val));
                     }
+                    let is_split_field = self.split_field_index(&prefix).is_some();
                     // A self-closing element named by a declared fan-out field
                     // is a complete occurrence on its own; its range spans the
                     // attributes pushed above, or is empty when it has none —
@@ -495,6 +512,21 @@ impl XmlReader {
                         && let Some(pi) = self.split_field_index(&prefix)
                     {
                         split_instances[pi].push(instance_from..fields.len());
+                    }
+                    // A value-less, non-fan-out self-closing element: on a
+                    // declared `multiple:` column, push an empty occurrence
+                    // (collected as `Null`), preserving array position exactly as
+                    // the empty-body form does. On any other column, push no
+                    // field — keeping a repeated `<x/><x/>` from tripping the
+                    // undeclared-repeat guard — but record its bare column
+                    // presence so a column appearing ONLY as `<x/>` in the first
+                    // record does not vanish from the inferred schema.
+                    if !is_split_field && fields.len() == instance_from {
+                        if self.is_multi_value(&prefix) {
+                            fields.push((prefix, String::new()));
+                        } else if !presence.contains(&prefix) {
+                            presence.push(prefix);
+                        }
                     }
                 }
                 Event::Text(ref t) => {
@@ -534,6 +566,7 @@ impl XmlReader {
         Ok(RawRecord {
             fields,
             split_instances,
+            presence,
         })
     }
 
@@ -706,27 +739,35 @@ impl FormatReader for XmlReader {
         // `keep_empty: false` entry drops an element with no occurrence, and
         // inferring from that dropped expansion would cache a column-less
         // schema for the whole source while records kept flowing.
-        let expanded = loop {
+        let (expanded, presence) = loop {
             let Some(raw) = self.read_next_record_raw()? else {
                 let s = SchemaBuilder::new().build();
                 self.schema = Some(Arc::clone(&s));
                 self.done = true;
                 return Ok(s);
             };
+            // Value-less self-closing columns push no field, so they never reach
+            // the expansion; carry their names alongside so inference keeps them.
+            let presence = raw.presence.clone();
             let expanded = self.apply_split_to_rows(raw);
             if !expanded.is_empty() {
-                break expanded;
+                break (expanded, presence);
             }
         };
 
         let mut seen = std::collections::HashSet::new();
+        // Real field names first (in document order), then any value-less
+        // self-closing columns that contributed no field — so a column present
+        // only as `<x/>` in the first record is not silently absent.
         let schema = expanded
             .first()
             .expect("non-empty checked above")
             .iter()
-            .filter_map(|(k, _)| {
+            .map(|(k, _)| k.clone())
+            .chain(presence)
+            .filter_map(|k| {
                 if seen.insert(k.clone()) {
-                    Some(k.clone().into_boxed_str())
+                    Some(k.into_boxed_str())
                 } else {
                     None
                 }
@@ -1069,22 +1110,30 @@ fn split_field_to_rows(
     }
 }
 
-/// Resolve the current text run and push it, if non-empty, as a field keyed by
-/// the innermost open element's dotted path. Text directly under the record
-/// element (empty path) or an empty resolved value pushes nothing. Clears
+/// Resolve the current text run and push it as a field keyed by the innermost
+/// open element's dotted path. Text directly under the record element (empty
+/// path) pushes nothing. A non-empty value is always a field; an empty resolved
+/// value pushes nothing UNLESS its column is declared `multiple:`, where an
+/// empty repeated element is a real positional array element that must be
+/// preserved (`<tags>a</tags><tags></tags><tags>b</tags>` collects `[a, "", b]`,
+/// not `[a, b]`). For any other column an empty text node still pushes nothing,
+/// matching the value-less self-closing form and keeping `<x></x><x></x>` on a
+/// non-`multiple:` column from tripping the undeclared-repeat guard. Clears
 /// `text_run` for the next node.
 fn flush_text_field(
     fields: &mut Vec<(String, String)>,
     element_stack: &[String],
     text_run: &mut String,
+    multi_value_fields: &[String],
 ) -> Result<(), FormatError> {
     let value = finalize_text_run(text_run)?;
     text_run.clear();
-    if !value.is_empty() {
-        let field_name = element_stack.join(".");
-        if !field_name.is_empty() {
-            fields.push((field_name, value));
-        }
+    let field_name = element_stack.join(".");
+    if field_name.is_empty() {
+        return Ok(());
+    }
+    if !value.is_empty() || multi_value_fields.iter().any(|f| f == &field_name) {
+        fields.push((field_name, value));
     }
     Ok(())
 }
@@ -1817,7 +1866,10 @@ mod tests {
     #[test]
     fn multiple_on_an_empty_element_still_yields_an_array() {
         // `<Tag></Tag>` carries no text, so the collected array holds one
-        // empty value rather than the record losing the column.
+        // empty value rather than the record losing the column. An empty text
+        // node resolves to `Null` (the reader's empty-string rule), and a
+        // declared `multiple:` column preserves that occurrence instead of
+        // dropping it.
         let xml = r#"<Root><Row><id>1</id><Tag></Tag></Row></Root>"#;
         let config = multi_value_config("Root/Row", &["Tag"]);
         let mut r = reader_from_str(xml, config);
@@ -1825,7 +1877,51 @@ mod tests {
 
         let r1 = r.next_record().unwrap().unwrap();
         assert_eq!(r1.get("id"), Some(&Value::Integer(1)));
-        assert_eq!(r1.get("Tag"), None);
+        assert_eq!(r1.get("Tag"), Some(&Value::Array(vec![Value::Null])));
+    }
+
+    #[test]
+    fn multiple_preserves_an_empty_repeated_element_positionally() {
+        // `<Tag>a</Tag><Tag></Tag><Tag>b</Tag>` on a `multiple:` column must
+        // collect three occurrences in order — the empty middle element is a
+        // real array element, not a gap to be squeezed out. Dropping it would
+        // lose position and prevent a faithful round-trip.
+        let xml = r#"<Root><Row><Tag>a</Tag><Tag></Tag><Tag>b</Tag></Row></Root>"#;
+        let config = multi_value_config("Root/Row", &["Tag"]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(
+            r1.get("Tag"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::Null,
+                Value::String("b".into()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn multiple_preserves_an_empty_self_closing_element_positionally() {
+        // The self-closing empty form `<Tag/>` must behave exactly like the
+        // empty-body `<Tag></Tag>` on a `multiple:` column: a real empty
+        // occurrence collected in position, so the two forms stay symmetric and
+        // neither squeezes the empty middle out of `[a, "", b]`.
+        let xml = r#"<Root><Row><Tag>a</Tag><Tag/><Tag>b</Tag></Row></Root>"#;
+        let config = multi_value_config("Root/Row", &["Tag"]);
+        let mut r = reader_from_str(xml, config);
+        let _s = r.schema().unwrap();
+
+        let r1 = r.next_record().unwrap().unwrap();
+        assert_eq!(
+            r1.get("Tag"),
+            Some(&Value::Array(vec![
+                Value::String("a".into()),
+                Value::Null,
+                Value::String("b".into()),
+            ]))
+        );
     }
 
     #[test]
@@ -2078,6 +2174,49 @@ mod tests {
         // The value-less element yields no field at all, matching `<x></x>`.
         assert_eq!(rec.get("middle_name"), None);
         assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn self_closing_only_column_is_present_in_the_inferred_schema() {
+        // A column that appears ONLY as a value-less self-closing `<x/>` in the
+        // first record pushes no field, but it must not vanish from the inferred
+        // schema — otherwise the column is silently absent for the whole source.
+        // Its bare presence is recorded for schema inference without a repeated
+        // `<x/><x/>` tripping the undeclared-repeat guard.
+        let xml = r#"<Root><Row><id>1</id><middle_name/></Row></Root>"#;
+        let config = XmlReaderConfig {
+            record_path: Some("Root/Row".into()),
+            ..Default::default()
+        };
+        let mut r = reader_from_str(xml, config);
+        let s = r.schema().unwrap();
+        assert!(
+            s.columns().iter().any(|c| &**c == "middle_name"),
+            "self-closing-only column must stay in the schema: {:?}",
+            s.columns()
+        );
+        assert!(s.columns().iter().any(|c| &**c == "id"));
+    }
+
+    #[test]
+    fn repeated_self_closing_only_column_is_present_and_does_not_error() {
+        // The presence contribution must not resurrect the undeclared-repeat
+        // false positive: a column appearing only as a repeated `<x/><x/>` on a
+        // non-`multiple:` schema still surfaces in the inferred schema AND
+        // assembles a record without a loud error.
+        let xml = r#"<Root><Row><id>1</id><middle_name/><middle_name/></Row></Root>"#;
+        let config = XmlReaderConfig {
+            record_path: Some("Root/Row".into()),
+            ..Default::default()
+        };
+        let mut r = reader_from_str(xml, config);
+        let s = r.schema().unwrap();
+        assert!(s.columns().iter().any(|c| &**c == "middle_name"));
+        let rec = r
+            .next_record()
+            .expect("repeated self-closing must not error")
+            .expect("one record");
+        assert_eq!(rec.get("id"), Some(&Value::Integer(1)));
     }
 
     #[test]

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -419,6 +419,12 @@ impl XmlReader {
         let mut open_instance: Option<OpenInstance> = None;
         let record_depth = self.xml_depth;
         let mut element_stack: Vec<String> = Vec::new();
+        // Parallel to `element_stack`: whether each open element has yet
+        // contributed a child element or a non-empty text node. An element that
+        // closes with this still `false` is a value-less LEAF (`<x></x>` /
+        // `<x/>`, attributes aside), distinct from a branch like `<Tags>` whose
+        // only content is child elements.
+        let mut element_content: Vec<bool> = Vec::new();
         // Raw source form of the current text node, accumulated across the
         // `Text` + `GeneralRef` fragment run quick-xml splits a text node into.
         // Flushed — trimmed and reference-resolved — at the next structural
@@ -441,7 +447,7 @@ impl XmlReader {
                     &mut fields,
                     &element_stack,
                     &mut text_run,
-                    &self.config.multi_value_fields,
+                    &mut element_content,
                 )?;
             }
 
@@ -449,7 +455,13 @@ impl XmlReader {
                 Event::Start(ref e) => {
                     self.xml_depth += 1;
                     let name = elem_name_static(&self.config.namespace_handling, &e.name());
+                    // This element is a child of whatever is currently open, so
+                    // its parent is a branch, not a value-less leaf.
+                    if let Some(has_content) = element_content.last_mut() {
+                        *has_content = true;
+                    }
                     element_stack.push(name);
+                    element_content.push(false);
                     let prefix = element_stack.join(".");
                     // Opening an element named by a declared fan-out field
                     // starts a new occurrence; the attributes pushed below are
@@ -474,7 +486,24 @@ impl XmlReader {
                     if self.xml_depth < record_depth {
                         break;
                     }
+                    let had_content = element_content.pop().unwrap_or(true);
+                    // The element being closed is the innermost open one; capture
+                    // its column before popping the stack.
+                    let closed_prefix = element_stack.join(".");
                     element_stack.pop();
+                    // An empty-body leaf (`<x></x>`, attributes aside) contributed
+                    // no child and no text: value-less for its own column, handled
+                    // exactly like the self-closing `<x/>` form — collected as a
+                    // null occurrence on a `multiple:` column, recorded as schema
+                    // presence otherwise. A branch (`<Tags>` with children) has
+                    // content, so it is never mistaken for a leaf.
+                    if !had_content && !closed_prefix.is_empty() {
+                        self.record_value_less_occurrence(
+                            closed_prefix,
+                            &mut fields,
+                            &mut presence,
+                        );
+                    }
                     if let Some(ref open) = open_instance
                         && element_stack.len() < open.stack_len
                     {
@@ -483,6 +512,11 @@ impl XmlReader {
                     }
                 }
                 Event::Empty(ref e) => {
+                    // A self-closing element is a child of whatever is open, so
+                    // its parent is a branch, not a value-less leaf.
+                    if let Some(has_content) = element_content.last_mut() {
+                        *has_content = true;
+                    }
                     let name = elem_name_static(&self.config.namespace_handling, &e.name());
                     let prefix = if element_stack.is_empty() {
                         name.clone()
@@ -490,20 +524,18 @@ impl XmlReader {
                         format!("{}.{name}", element_stack.join("."))
                     };
                     let instance_from = fields.len();
-                    // A value-less self-closing element mirrors the empty-body
-                    // form `<x></x>` (see `flush_text_field`): on a declared
-                    // `multiple:` column it is a real empty occurrence collected
-                    // into the array, and on any other column it pushes NO field
-                    // — so `<x/><x/>` on a non-`multiple:` column cannot look
-                    // like a repeated field and trip `UndeclaredRepeatedField`.
-                    // Only its attributes (if any) go into `fields` here; the
-                    // empty-occurrence push and schema-presence record happen
-                    // below.
+                    // A self-closing element carries no text for its own column,
+                    // so it is value-less for that column whether or not it has
+                    // attributes. Its attributes (which key to `prefix.@attr`,
+                    // distinct columns) go into `fields`; its own value-less
+                    // occurrence is handled by `record_value_less_occurrence`
+                    // below, keyed on the element's column — NOT on whether the
+                    // element pushed any field at all, so an attribute push does
+                    // not mask the empty occurrence.
                     let child_attrs = extract_attributes_static(&self.config.attribute_prefix, e)?;
                     for (key, val) in child_attrs {
                         fields.push((format!("{prefix}.{key}"), val));
                     }
-                    let is_split_field = self.split_field_index(&prefix).is_some();
                     // A self-closing element named by a declared fan-out field
                     // is a complete occurrence on its own; its range spans the
                     // attributes pushed above, or is empty when it has none —
@@ -513,21 +545,10 @@ impl XmlReader {
                     {
                         split_instances[pi].push(instance_from..fields.len());
                     }
-                    // A value-less, non-fan-out self-closing element: on a
-                    // declared `multiple:` column, push an empty occurrence
-                    // (collected as `Null`), preserving array position exactly as
-                    // the empty-body form does. On any other column, push no
-                    // field — keeping a repeated `<x/><x/>` from tripping the
-                    // undeclared-repeat guard — but record its bare column
-                    // presence so a column appearing ONLY as `<x/>` in the first
-                    // record does not vanish from the inferred schema.
-                    if !is_split_field && fields.len() == instance_from {
-                        if self.is_multi_value(&prefix) {
-                            fields.push((prefix, String::new()));
-                        } else if !presence.contains(&prefix) {
-                            presence.push(prefix);
-                        }
-                    }
+                    // Collect the empty occurrence (`multiple:` column) or record
+                    // schema presence (any other non-fan-out column), exactly as
+                    // the empty-body `<x></x>` form does at its `End`.
+                    self.record_value_less_occurrence(prefix, &mut fields, &mut presence);
                 }
                 Event::Text(ref t) => {
                     text_run.push_str(&t.decode().map_err(|e| FormatError::Xml(e.to_string()))?);
@@ -541,6 +562,11 @@ impl XmlReader {
                         let field_name = element_stack.join(".");
                         if !field_name.is_empty() {
                             fields.push((field_name, text));
+                            // CDATA text is content, so its element is not a
+                            // value-less leaf.
+                            if let Some(has_content) = element_content.last_mut() {
+                                *has_content = true;
+                            }
                         }
                     }
                 }
@@ -714,6 +740,55 @@ impl XmlReader {
     /// Whether the source schema declares this flattened field `multiple: true`.
     fn is_multi_value(&self, key: &str) -> bool {
         self.config.multi_value_fields.iter().any(|f| f == key)
+    }
+
+    /// Record a value-less occurrence of the column named `name` — an empty-body
+    /// `<x></x>` or a self-closing `<x/>`, whether or not it carries attributes.
+    ///
+    /// The two empty forms behave identically: on a declared `multiple:` column
+    /// the occurrence is a real (null) array element, pushed into `fields` so it
+    /// keeps its array position and projects with every other field; on any other
+    /// column it pushes NO field — which keeps a repeated `<x/><x/>` (or
+    /// `<x></x><x></x>`) on a non-`multiple:` column from tripping the
+    /// undeclared-repeat guard — but records the column's projected presence so a
+    /// column appearing ONLY as an empty element in the first record still
+    /// surfaces in the inferred schema. A declared fan-out field is handled by
+    /// its occurrence range, not here.
+    fn record_value_less_occurrence(
+        &self,
+        name: String,
+        fields: &mut Vec<(String, String)>,
+        presence: &mut Vec<String>,
+    ) {
+        if self.is_multi_value(&name) {
+            fields.push((name, String::new()));
+        } else if self.split_field_index(&name).is_none() {
+            let projected = self.project_presence_name(&name);
+            if !presence.contains(&projected) {
+                presence.push(projected);
+            }
+        }
+    }
+
+    /// Project a value-less column's raw dotted name through the same
+    /// `split_to_rows` name transformation its valued sibling's field undergoes,
+    /// so the empty form contributes the SAME inferred-schema column name a valued
+    /// occurrence would (`Item.middle` inside an `Item` extract fan-out → `middle`)
+    /// rather than a phantom raw-prefix column. A name outside every fan-out group
+    /// is a head/tail field and keeps its raw name.
+    fn project_presence_name(&self, name: &str) -> String {
+        let mut current = name.to_string();
+        for entry in &self.config.split_to_rows {
+            // Only a strict descendant of the group is owned-and-renamed by an
+            // occurrence; a name merely sharing a prefix segment is not.
+            if current
+                .strip_prefix(entry.field.as_str())
+                .is_some_and(|rest| rest.starts_with('.'))
+            {
+                current = projected_key(&current, &entry.field, entry.mode);
+            }
+        }
+        current
     }
 }
 
@@ -1111,29 +1186,28 @@ fn split_field_to_rows(
 }
 
 /// Resolve the current text run and push it as a field keyed by the innermost
-/// open element's dotted path. Text directly under the record element (empty
-/// path) pushes nothing. A non-empty value is always a field; an empty resolved
-/// value pushes nothing UNLESS its column is declared `multiple:`, where an
-/// empty repeated element is a real positional array element that must be
-/// preserved (`<tags>a</tags><tags></tags><tags>b</tags>` collects `[a, "", b]`,
-/// not `[a, b]`). For any other column an empty text node still pushes nothing,
-/// matching the value-less self-closing form and keeping `<x></x><x></x>` on a
-/// non-`multiple:` column from tripping the undeclared-repeat guard. Clears
-/// `text_run` for the next node.
+/// open element's dotted path, marking that element as having contributed
+/// content. Text directly under the record element (empty path) and an empty
+/// resolved value push nothing. A value-less element is NOT handled here — it is
+/// resolved at its `End` (empty-body `<x></x>`) or in the `Event::Empty` arm
+/// (self-closing `<x/>`), where "value-less" means the element contributed no
+/// child element and no non-empty text, independent of any attributes it
+/// carries. Clears `text_run` for the next node.
 fn flush_text_field(
     fields: &mut Vec<(String, String)>,
     element_stack: &[String],
     text_run: &mut String,
-    multi_value_fields: &[String],
+    element_content: &mut [bool],
 ) -> Result<(), FormatError> {
     let value = finalize_text_run(text_run)?;
     text_run.clear();
     let field_name = element_stack.join(".");
-    if field_name.is_empty() {
+    if field_name.is_empty() || value.is_empty() {
         return Ok(());
     }
-    if !value.is_empty() || multi_value_fields.iter().any(|f| f == &field_name) {
-        fields.push((field_name, value));
+    fields.push((field_name, value));
+    if let Some(has_content) = element_content.last_mut() {
+        *has_content = true;
     }
     Ok(())
 }
@@ -1922,6 +1996,99 @@ mod tests {
                 Value::String("b".into()),
             ]))
         );
+    }
+
+    #[test]
+    fn multiple_preserves_an_empty_element_with_an_attribute_positionally() {
+        // A value-less element that carries an ATTRIBUTE is still value-less for
+        // its OWN column — the attribute keys to a distinct `Tag.@x` column. Both
+        // the self-closing `<Tag x="1"/>` and empty-body `<Tag x="1"></Tag>`
+        // forms must collect the empty (null) occurrence in position, so the
+        // attribute push does not mask it: `[a, null, b]`, never `[a, b]`.
+        for middle in [r#"<Tag x="1"/>"#, r#"<Tag x="1"></Tag>"#] {
+            let xml = format!("<Root><Row><Tag>a</Tag>{middle}<Tag>b</Tag></Row></Root>");
+            let config = multi_value_config("Root/Row", &["Tag"]);
+            let mut r = reader_from_str(&xml, config);
+            let _s = r.schema().unwrap();
+
+            let r1 = r.next_record().unwrap().unwrap();
+            assert_eq!(
+                r1.get("Tag"),
+                Some(&Value::Array(vec![
+                    Value::String("a".into()),
+                    Value::Null,
+                    Value::String("b".into()),
+                ])),
+                "middle form {middle:?}"
+            );
+            // The attribute still lands on its own (non-`multiple:`) column.
+            assert_eq!(
+                r1.get("Tag.@x"),
+                Some(&Value::Integer(1)),
+                "form {middle:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn attributed_self_closing_on_a_non_multiple_column_does_not_drop_or_misassemble() {
+        // The non-`multiple:` counterpart: a value-less self-closing element with
+        // an attribute must not error and must not invent a value for its own
+        // column — only the attribute column is populated.
+        let xml = r#"<Root><Row><id>1</id><middle x="9"/></Row></Root>"#;
+        let config = default_config_with_path("Root/Row");
+        let mut r = reader_from_str(xml, config);
+        let rec = r
+            .next_record()
+            .expect("value-less self-closing with an attribute must not error")
+            .expect("one record");
+        assert_eq!(rec.get("id"), Some(&Value::Integer(1)));
+        assert_eq!(rec.get("middle"), None, "own column stays value-less");
+        assert_eq!(rec.get("middle.@x"), Some(&Value::Integer(9)));
+    }
+
+    #[test]
+    fn self_closing_only_inside_extract_fan_out_uses_the_projected_schema_name() {
+        // Under `split_to_rows: extract`, a valued `<name>` inside `<Item>`
+        // projects to column `name` (the group prefix is lifted off). A
+        // self-closing-only `<middle/>` inside `<Item>` must contribute the SAME
+        // projected name `middle`, never a phantom raw `Item.middle` that no
+        // record carries.
+        let xml = r#"<Root><Row><Item><name>x</name><middle/></Item></Row></Root>"#;
+        let config = split_config("Root/Row", vec![extract("Item")]);
+        let mut r = reader_from_str(xml, config);
+        let s = r.schema().unwrap();
+        let cols = column_names(&s);
+        assert!(cols.contains(&"name"), "valued column projected: {cols:?}");
+        assert!(
+            cols.contains(&"middle"),
+            "self-closing column uses the projected name: {cols:?}"
+        );
+        assert!(
+            !cols.contains(&"Item.middle"),
+            "no phantom raw-prefix column: {cols:?}"
+        );
+    }
+
+    #[test]
+    fn empty_body_and_self_closing_only_columns_agree_in_the_inferred_schema() {
+        // Schema presence is consistent across the two empty forms: a column that
+        // appears only as an empty-body `<a></a>` and one only as a self-closing
+        // `<b/>` both surface in the inferred schema.
+        let xml = r#"<Root><Row><id>1</id><a></a><b/></Row></Root>"#;
+        let config = default_config_with_path("Root/Row");
+        let mut r = reader_from_str(xml, config);
+        let s = r.schema().unwrap();
+        let cols = column_names(&s);
+        assert!(
+            cols.contains(&"a"),
+            "empty-body-only column present: {cols:?}"
+        );
+        assert!(
+            cols.contains(&"b"),
+            "self-closing-only column present: {cols:?}"
+        );
+        assert!(cols.contains(&"id"));
     }
 
     #[test]

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -976,6 +976,19 @@ fn fill_slot(
     slot.part_count = 0;
     match val {
         Value::Array(items) if !is_attr => {
+            // BACKSTOP GAP: this treats ANY top-level array at an element field
+            // as a `multiple:` field and emits repeated elements, because the
+            // writer is not given the declared-`multiple:` column set — its
+            // config carries only the `join_values` override subset, not every
+            // declared-multiple field. A misrouted runtime array on a column
+            // that is NOT declared `multiple:` (e.g. a stray `match: collect`
+            // result) is therefore emitted as repeats rather than failing loud
+            // with `UnserializableArrayValue`. A NESTED array (array-inside-a-
+            // field) is still caught by `write_value_text` in `fill_parts`;
+            // only the top-level non-multiple case slips through. Restoring the
+            // loud backstop needs the plan to thread the declared-multiple set
+            // into `XmlWriterConfig` — the same missing plumbing the CSV writer
+            // has at https://github.com/rustpunk/clinker/issues/853.
             slot.is_array = true;
             slot.text.clear();
             fill_parts(slot, name, items)?;
@@ -1044,6 +1057,18 @@ fn emit_body<W: Write>(
                     continue;
                 }
                 let text = fill.text(*field);
+                // A scalar on a field carrying a `repeat_as` / `wrap_in` override
+                // is a one-element sequence: apply the same naming an array of
+                // length one would get, so the emitted shape does not depend on
+                // whether a lone value arrived wrapped (`[x]`) or bare (`x`) —
+                // symmetric with the reader normalizing a lone scalar to a
+                // one-element array. A field with no override (`repeat` is
+                // `None`) keeps the plain `<name>text</name>` rendering.
+                if repeat.is_some() {
+                    let one = [text.to_owned()];
+                    emit_repeated_leaf(writer, name, repeat, &one)?;
+                    continue;
+                }
                 if text.is_empty() {
                     writer
                         .write_event(Event::Empty(BytesStart::new(name.as_str())))
@@ -1529,6 +1554,36 @@ mod tests {
             output,
             "<Root><Record><id>7</id><Tags><Tag>a</Tag><Tag>b</Tag></Tags></Record></Root>"
         );
+    }
+
+    /// A SCALAR value on a field carrying `repeat_as` / `wrap_in` is treated as
+    /// a one-element sequence and gets the same container/item naming an array of
+    /// length one would — so the output shape does not depend on whether a lone
+    /// value arrived bare (`a`) or wrapped (`[a]`).
+    #[test]
+    fn test_xml_write_multi_value_scalar_applies_repeat_and_wrap() {
+        let schema = Arc::new(Schema::new(vec!["id".into(), "tags".into()]));
+        let scalar = Record::new(
+            Arc::clone(&schema),
+            vec![Value::Integer(7), Value::String("a".into())],
+        );
+        let scalar_out = write_records(
+            xml_join_config("tags", Some("Tag"), Some("Tags")),
+            &[scalar],
+            &schema,
+        );
+        assert_eq!(
+            scalar_out,
+            "<Root><Record><id>7</id><Tags><Tag>a</Tag></Tags></Record></Root>"
+        );
+        // Byte-identical to the same lone value delivered as a one-element array.
+        let array = record_with_tags(&schema, 7, vec![Value::String("a".into())]);
+        let array_out = write_records(
+            xml_join_config("tags", Some("Tag"), Some("Tags")),
+            &[array],
+            &schema,
+        );
+        assert_eq!(scalar_out, array_out);
     }
 
     /// An illegal `repeat_as` / `wrap_in` name fails the write with

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -9,7 +9,10 @@
 //!   declare `multiple: true`.
 //! - **E359** — a `multiple: true` column reaching an output whose format has
 //!   no multi-value encoding, which would degrade or reject the value at the
-//!   sink instead of at compile.
+//!   sink instead of at compile. The `xml` writer encodes a `multiple:` column
+//!   as repeated child ELEMENTS, so a `multiple:` column that maps to an XML
+//!   attribute (its name starts with the `attribute_prefix`) is rejected here
+//!   too — an attribute holds a single value and cannot repeat.
 //! - **E361** — a `multiple: true` column on a source whose format has no way
 //!   to PRODUCE one, which would bind the column as an array and then hand
 //!   CXL a scalar.
@@ -27,10 +30,10 @@ use std::collections::{BTreeSet, HashMap};
 
 use clinker_format::{Column, OnConflict, SourceSchema, SplitToRowsMode, under_field_path};
 
-use crate::config::OutputConfig;
 use crate::config::format::{InputFormat, OutputFormat};
 use crate::config::pipeline_node::PipelineNode;
 use crate::config::source::SourceConfig;
+use crate::config::{OutputConfig, XmlOutputOptions};
 use crate::yaml::Spanned;
 
 /// Whether an output format can encode a `multiple: true` field.
@@ -62,6 +65,27 @@ fn output_encodes_multi_value(format: &OutputFormat) -> bool {
         | OutputFormat::Hl7(_)
         | OutputFormat::Swift(_) => false,
     }
+}
+
+/// The `attribute_prefix` an XML output resolves to: the declared value, or the
+/// writer default `@` when unset — matching `build_xml_writer_config`, so the
+/// plan-time attribute classification and the runtime writer agree.
+fn xml_output_attribute_prefix(opts: Option<&XmlOutputOptions>) -> String {
+    opts.and_then(|o| o.attribute_prefix.clone())
+        .unwrap_or_else(|| "@".to_string())
+}
+
+/// Whether a flattened column name maps to an XML attribute rather than a child
+/// element: its last dotted segment starts with `attribute_prefix`. Mirrors the
+/// XML writer's classification (a top-level `@id` on the record element, a
+/// nested `Address.@type` on the `<Address>` branch). An empty prefix disables
+/// attribute classification, so no column is an attribute — matching the writer.
+fn column_maps_to_xml_attribute(column: &str, attribute_prefix: &str) -> bool {
+    if attribute_prefix.is_empty() {
+        return false;
+    }
+    let last_segment = column.rsplit('.').next().unwrap_or(column);
+    last_segment.starts_with(attribute_prefix)
 }
 
 /// How an input format can carry a column declared `multiple: true`.
@@ -942,8 +966,14 @@ fn validate_join_declarations(output: &OutputConfig) -> Vec<DeclarationFault> {
         }
     }
     // The delimiter / escape shape checks below are the CSV writer's; the XML
-    // writer ignores delimiter / on_conflict / escape, so an XML entry's
-    // defaulted values are not faults.
+    // writer ignores delimiter / on_conflict / escape. Unlike `repeat_as` /
+    // `wrap_in` — faulted on a CSV output above because they are `Option`, so an
+    // explicit value is distinguishable from the default — `delimiter` and
+    // `escape` are defaulted `String`s (default `;` and `\`), so a set value
+    // cannot be told from the default. A CSV-only shape knob on an XML entry is
+    // therefore left inert rather than faulted: the alternative would be a
+    // non-default heuristic that the module's Option-based detectability rule
+    // deliberately avoids, and it would fault `delimiter` and `escape` alike.
     if !matches!(output.format, OutputFormat::Csv(_)) {
         return faults;
     }
@@ -1103,6 +1133,58 @@ pub fn output_node_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
                 message: fault.message,
                 help: fault.help,
             });
+        }
+        // E359 (XML attribute variant): the XML writer encodes a `multiple:`
+        // column as repeated child ELEMENTS, never as an attribute — an XML
+        // attribute holds one value and cannot repeat. `output_encodes_multi_value`
+        // answers `true` for `xml` (it encodes via elements), so without this a
+        // `multiple:` column whose name maps to an attribute (its last dotted
+        // segment starts with the output's `attribute_prefix`) would compile
+        // clean and then abort at write on every record with a non-dead-letterable
+        // error. Catch it here instead.
+        if let OutputFormat::Xml(opts) = &output.format {
+            let prefix = xml_output_attribute_prefix(opts.as_ref());
+            let mut attr_cols: Vec<String> = Vec::new();
+            let mut consider = |column: &str| {
+                if column_maps_to_xml_attribute(column, &prefix)
+                    && !attr_cols.iter().any(|c| c == column)
+                {
+                    attr_cols.push(column.to_string());
+                }
+            };
+            if let Some(declared) = output.schema.as_ref().map(multi_value_columns) {
+                for column in &declared {
+                    consider(column);
+                }
+            }
+            if let Some(feeding) = reachability.get(header.name.as_str()) {
+                for source_name in feeding {
+                    if let Some(columns) = multi_value_by_source.get(source_name.as_str()) {
+                        for column in columns {
+                            consider(column);
+                        }
+                    }
+                }
+            }
+            if !attr_cols.is_empty() {
+                faults.push(NodeFault {
+                    node_index,
+                    code: "E359",
+                    message: format!(
+                        "output '{out}': the multi-value column(s) {columns} (`multiple: true`) \
+                         map to XML attribute(s) — the name's last segment starts with the \
+                         attribute prefix '{prefix}' — and the XML writer encodes a `multiple:` \
+                         field as repeated child elements, which an attribute cannot hold",
+                        out = header.name,
+                        columns = quoted_list(&attr_cols),
+                    ),
+                    help: format!(
+                        "emit the repeating field as a child element by removing the '{prefix}' \
+                         attribute prefix from the column name, or collapse it to a single value \
+                         in a transform before the sink"
+                    ),
+                });
+            }
         }
         if output_encodes_multi_value(&output.format) {
             continue;

--- a/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/multi_value_validation.rs
@@ -268,6 +268,41 @@ fn multi_value_column_into_a_non_encoding_output_is_rejected_with_a_span() {
 }
 
 #[test]
+fn multi_value_column_mapping_to_an_xml_attribute_is_rejected() {
+    // XML encodes a `multiple:` column as repeated child ELEMENTS. A column whose
+    // name maps to an XML attribute (its last dotted segment starts with the
+    // attribute prefix `@`) cannot repeat, so — unlike an element-mapped
+    // `multiple:` column, which XML encodes fine — it must be caught at plan time
+    // (E359) rather than aborting at write for every record.
+    let yaml = pipeline(
+        r#"      schema:
+        - { name: "@tags", type: string, multiple: true }"#,
+        "xml",
+    );
+    let found = coded(&compile_err(&yaml), "E359");
+    assert_eq!(found.len(), 1, "expected one E359: {found:?}");
+    assert!(
+        found[0].0.contains("@tags") && found[0].0.contains("attribute"),
+        "{}",
+        found[0].0
+    );
+    assert!(found[0].1, "E359 must carry a source span");
+}
+
+#[test]
+fn multi_value_column_mapping_to_an_xml_element_still_compiles() {
+    // The complement of the attribute rejection: an element-mapped `multiple:`
+    // column (no attribute prefix) is exactly what XML encodes as repeated child
+    // elements, so it must NOT be faulted.
+    let yaml = pipeline(
+        r#"      schema:
+        - { name: tags, type: string, multiple: true }"#,
+        "xml",
+    );
+    compile_ok(&yaml);
+}
+
+#[test]
 fn empty_split_values_delimiter_is_rejected() {
     let yaml = pipeline(
         r#"      split_values:
@@ -1221,14 +1256,20 @@ fn join_values_repeat_and_wrap_on_an_xml_output_compiles() {
 #[test]
 fn join_values_csv_shape_knobs_on_an_xml_output_are_not_faults() {
     // The delimiter / escape shape checks are the CSV writer's alone; the XML
-    // writer ignores them, so a multi-character delimiter that E362 would reject
-    // on a CSV output is simply inert on an XML output.
-    let yaml = join_pipeline(
-        "xml",
-        r#"      join_values:
-        - { field: tags, delimiter: "::" }"#,
-    );
-    compile_ok(&yaml);
+    // writer ignores them, so a multi-character delimiter — and an `escape`,
+    // which is a defaulted `String` like `delimiter` and cannot be told set from
+    // unset — that E362 would constrain on a CSV output is simply inert on an XML
+    // output. (`escape` is NOT an `Option`, so there is no clean way to fault a
+    // set-vs-defaulted escape; the asymmetry with the Option-typed `repeat_as` /
+    // `wrap_in` is intentional, not an oversight.)
+    for knob in [
+        r#"{ field: tags, delimiter: "::" }"#,
+        r#"{ field: tags, escape: "|" }"#,
+        r#"{ field: tags, delimiter: "::", escape: "|" }"#,
+    ] {
+        let yaml = join_pipeline("xml", &format!("      join_values:\n        - {knob}"));
+        compile_ok(&yaml);
+    }
 }
 
 #[test]

--- a/docs/explain/E359.md
+++ b/docs/explain/E359.md
@@ -23,6 +23,14 @@ XML format reference). The `fixed_width` writer has a well-established conventio
 for it that is not implemented yet; the segment formats (`edifact`, `x12`, `hl7`,
 `swift`) emit a fixed positional grammar with no repetition slot.
 
+One more case is specific to `xml`: the writer encodes a `multiple:` column as
+repeated child **elements**, never as an attribute. A `multiple:` column whose
+name maps to an XML attribute — its last dotted segment starts with the output's
+`attribute_prefix` (default `@`, so `@tags` or `Order.@tags`) — is rejected here
+too, because an attribute holds a single value and cannot repeat. Emit the
+repeating field as a child element (drop the attribute prefix) or collapse it to
+a single value before the sink.
+
 ```
 output 'report': source 'orders' declares the multi-value column(s) 'tags'
 (`multiple: true`), and a `fixed_width` output has no encoding for a field
@@ -136,6 +144,12 @@ nodes:
 
 2. **Fan the values out to rows** with `split_to_rows` on the source, so each
    output record carries one value and the column is no longer multi-value.
+
+3. **On an `xml` output, emit the repeating field as an element, not an
+   attribute.** A `multiple:` column whose name maps to an XML attribute (its
+   last dotted segment starts with the `attribute_prefix`) cannot repeat — drop
+   the prefix so it emits as a repeated child element, or collapse it to a single
+   value before the sink.
 
 3. **Collapse the column to a single value** in a transform before the sink.
 

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -100,10 +100,15 @@ longer collide. As with XML, detection is per document at read time, so the run
 aborts under `fail_fast` and dead-letters the document under `continue` /
 `best_effort` with `dlq_granularity: document`.
 
-Detection covers collisions at the top level of a record. A collision *inside*
-an array element that a `split_to_rows: extract` fan-out lifts to the top level
-(one element key clashing with a parent field or with another element key) is
-not yet detected and still resolves last-wins — tracked by
+Detection covers two **distinct** source keys that flatten to the same dotted
+name — the nested `{"a": {"b": 1}}` plus literal `{"a.b": 2}` case above. It does
+**not** cover a key that is *literally duplicated* within one JSON object
+(`{"tags": "x", "tags": "y"}`): the JSON parser collapses such duplicates
+last-wins (keeping `"y"`) before the record reaches collision detection, so that
+repeat is silently dropped rather than reported. A collision *inside* an array
+element that a `split_to_rows: extract` fan-out lifts to the top level (one
+element key clashing with a parent field or with another element key) is
+likewise not yet detected and still resolves last-wins — tracked by
 [issue 920](https://github.com/rustpunk/clinker/issues/920).
 
 ## Bounding envelope retention: `max_index_bytes`

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -113,8 +113,11 @@ field with an empty array emits **nothing** (no element, and no container even
 when one is configured); an empty-string value emits a self-closing item element
 (`<tags/>`).
 
-An array reaching an **attribute** field (`@tags` declared `multiple: true`) is
-rejected — an XML attribute holds a single value and cannot repeat.
+A `multiple:` column that maps to an **attribute** field (a column whose name
+maps to an XML attribute, e.g. `@tags`, declared `multiple: true`) is rejected at
+compile with [E359](../../explain/E359.md) — an XML attribute holds a single
+value and cannot repeat, and the writer emits repetition only as child elements.
+A runtime array reaching an attribute field is likewise rejected by the writer.
 
 To rename the elements, add a `join_values` entry — the same block the CSV writer
 reads, sharing the `field` key. The XML writer reads two keys from it and ignores
@@ -138,6 +141,13 @@ the CSV-only `delimiter` / `on_conflict` / `escape`:
   own element name.
 - **`wrap_in`** — a container element bracketing the repeated items. Omit it for
   bare repeats with no container.
+
+A **scalar** value on a field that carries a `join_values` entry is treated as a
+one-element sequence: it receives the same `repeat_as` / `wrap_in` naming an
+array of length one would, so the emitted shape does not depend on whether a lone
+value arrived wrapped (`[a]`) or bare (`a`) — mirroring how the reader normalizes
+a lone scalar into a one-element array. A field with no entry emits the plain
+`<field>value</field>` element.
 
 The two combine into the four arrangements, with no other key:
 
@@ -241,6 +251,13 @@ first:
 `<Tag>a</Tag><Tag>b</Tag>` yields `["a", "b"]`, and a single `<Tag>` still
 yields a one-element array. Declaring the flattened children of a repeated
 container (`Item.name`, `Item.qty`) collects each of them independently.
+
+An empty occurrence — an empty-body `<Tag></Tag>` or a self-closing `<Tag/>` — is
+a real array element, collected in position as a null:
+`<Tag>a</Tag><Tag></Tag><Tag>b</Tag>` yields `["a", null, "b"]` rather than
+squeezing the empty element out, so the array round-trips its per-item shape. (An
+empty text value reads as null, the same rule the reader applies elsewhere; the
+self-closing and empty-body forms behave identically.)
 
 A field cannot be both collected and fanned out: naming a `multiple: true`
 column in `split_to_rows` is rejected at compile (`E358`).


### PR DESCRIPTION
## Post-review correctness follow-ups for multi-value read/write

Follow-up corrections to the multi-value read/write paths (JSON/XML readers, the
XML writer, and the plan-time multi-value gate). Each item below fixes a distinct
review finding; every fix carries a focused test.

### Fixed

1. **JSON collision collection erased array boundaries.** When collecting a
   colliding occurrence into a `multiple:` column, a first occurrence that was
   itself an array was extended into rather than kept as one element, so
   `{"a":{"b":[1,2]},"a.b":3}` (column `a.b` declared `multiple: true`) collected
   `[1,2,3]` instead of `[[1,2], 3]`. Occurrence boundaries are now preserved: a
   per-record accumulator set distinguishes a slot that is accumulating several
   occurrences from a single first occurrence that happens to be array-valued.

2. **XML dropped an empty repeated element from a `multiple:` array.** The
   text-flush guard skipped empty text, so `<tags>a</tags><tags></tags><tags>b</tags>`
   collected `[a, b]` — losing the empty middle occurrence and its position. An
   empty occurrence on a declared-`multiple:` column is now a real (null) array
   element, so the array reads `[a, null, b]` and round-trips its shape. The
   self-closing form `<tags/>` and the empty-body form `<tags></tags>` now behave
   identically.

3. **A self-closing-only column was dropped from the inferred schema.** A
   value-less self-closing `<x/>` contributes no field (so a repeated `<x/><x/>`
   on a non-`multiple:` column does not falsely error), but combined with
   first-record schema inference a column appearing *only* as `<x/>` in the first
   record vanished from the schema entirely. A bare-presence contribution is now
   recorded for schema inference — the column stays in the schema — without
   reintroducing the repeated-element false positive.

4. **The multi-value output gate was not XML-attribute-aware.** The XML writer
   encodes a `multiple:` column as repeated child *elements*, never as an
   attribute, but a `multiple:` column mapping to an XML attribute (its name
   starts with the `attribute_prefix`) compiled clean and then aborted at write
   for every record. It is now rejected at plan time (E359) with a clear message,
   and an element-mapped `multiple:` column still compiles.

7. **The XML writer ignored `repeat_as` / `wrap_in` for a scalar value.** A
   scalar on a field carrying a `join_values` override now gets the same
   container/item naming an array of length one would, so the emitted shape does
   not depend on whether a lone value arrived wrapped (`[a]`) or bare (`a`) —
   symmetric with the reader normalizing a lone scalar into a one-element array.

9. **Two source comments cited a bare ticket id;** reworded to describe the
   behavior and link the full issue URL.

### Documentation

6a. The JSON format reference's collision-detection claim is narrowed: detection
    covers two *distinct* keys that flatten to the same dotted name; a *literally
    duplicated* JSON key (`{"tags":"x","tags":"y"}`) is collapsed last-wins by the
    JSON parser before detection runs and is **not** currently detected.

8. **E362 asymmetry clarified (no behavior change).** The reported asymmetry rests
   on `escape` being an `Option`; it is in fact a defaulted `String`, exactly like
   `delimiter`, so a set-vs-default `escape` on an XML output cannot be cleanly
   distinguished. Faulting it would require a non-default heuristic that the gate's
   Option-based detectability rule deliberately avoids (and would then apply to
   `delimiter` too). The intentional inertness is documented and the existing
   regression test extended to pin `escape` explicitly.

### Surfaced as follow-ups (not fixed here)

5. **XML writer array-misroute backstop.** The writer emits repeated elements for
   any runtime array at an element field, so a misrouted runtime array on a column
   that is *not* declared `multiple:` is emitted as repeats rather than failing
   loud. Restoring the loud backstop needs the plan to thread the declared-multiple
   column set into the writer config — the same missing plumbing the CSV writer has
   (issues/853). A nested array inside a field is still rejected; only the
   top-level non-multiple case slips through. Documented in a code comment.

6b. **Literal duplicate JSON key detection.** Catching `{"tags":"x","tags":"y"}`
    requires either reimplementing the JSON value parse to reject duplicate keys or
    double-parsing every record, so it is documented as a known limitation rather
    than forced here.

### Validation

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test -p clinker-format -p clinker-plan -p clinker-exec` all pass.
