### PR TITLE
build: ignore generated mdBook output at any depth under docs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,12 @@
 !.claude/skills/post-impl-followup/
 lancedb/
 docs/internal/
-docs/*/book/
+# Generated mdBook output. `**` rather than `*` so this covers a build at any
+# depth: the two books default to docs/user/book/ and docs/engine/book/, but an
+# ad-hoc `mdbook build docs/user -d docs/book` lands one directory higher, which
+# a single-segment glob misses. That gap left several MB of stale generated HTML
+# untracked-but-committable in the working tree.
+docs/**/book/
 !docs/ai/
 !docs/ai/**
 target/


### PR DESCRIPTION
## Problem

The ignore rule for generated mdBook output was `docs/*/book/` — a single-segment glob.

Both books default to `<root>/book/`, so `docs/user/book/` and `docs/engine/book/` were covered. But an ad-hoc build that redirects output, e.g. `mdbook build docs/user -d docs/book`, lands one directory higher, and a single `*` does not reach there.

That gap is not hypothetical. `docs/book/` currently holds several MB of stale generated HTML — untracked, and because nothing ignored it, one `git add .` away from being committed. Its contents are a build of the user guide against an older chapter layout (its table of contents links a flat `pipeline/` structure that predates the current `pipelines/` + `nodes/` split), so it would have landed as a large, wrong, generated artifact in a repository that tracks no other build output.

## Change

One rule, widened:

```diff
-docs/*/book/
+docs/**/book/
```

`**` matches zero or more path segments, so this covers `docs/book/` as well as both default locations and any future book added under `docs/`.

## Verification

Pattern behaviour was checked against a scratch repository before the edit and re-checked in place afterwards:

| path | `docs/*/book/` | `docs/**/book/` |
|---|---|---|
| `docs/book/index.html` | not ignored | ignored |
| `docs/user/book/index.html` | ignored | ignored |
| `docs/engine/book/index.html` | ignored | ignored |

Also confirmed:

- the `!docs/ai/` / `!docs/ai/**` negations still expose the AI docs;
- no source under `docs/user/src`, `docs/engine/src`, `docs/explain`, nor either `book.toml`, is affected;
- **no tracked file is shadowed** — the tracked-file count is unchanged at 1094, and no tracked path contains a `book/` segment;
- `git diff --check` is clean.

No test or build gate is affected: nothing in CI builds either book, and an ignore rule cannot change tracked-file behaviour.

## Note

This only stops the directory being committable. The existing `docs/book/` tree stays on disk until someone removes it; it is safe to delete, since it is generated output with no tracked files and neither book builds to that path.
