### PR TITLE
docs: correct stale endpoint status lines and raise the file-descriptor floor to a measured value

### DIFF
--- a/crates/clinker-exec/AGENTS.md
+++ b/crates/clinker-exec/AGENTS.md
@@ -93,11 +93,11 @@ Existing normal dependencies are intentional evidence:
 - **Inferred:** `cargo check -p clinker-exec --features bench-alloc --locked --offline`
 - **Inferred:** `cargo check --benches -p clinker-exec --locked --offline`
 - **Inferred:** `cargo test -p clinker-exec --locked --offline <test_name>`
-- **Inferred:** `cargo test -p clinker-exec --locked --offline` (needs a soft `ulimit -n` of at least 65536 — see `docs/ai/50_TESTING_AND_COMMANDS.md` section 4 for the raise-only snippet)
+- **Inferred:** `cargo test -p clinker-exec --locked --offline` (needs a soft `ulimit -n` of at least the 65536 floor — see `docs/ai/50_TESTING_AND_COMMANDS.md` section 4 for the measurement behind it and the raise-only snippet)
 
 For Rust source changes, also run the workspace gates from the root
 `AGENTS.md` unless the user explicitly scopes validation narrower.
-Spill-heavy tests need a soft `ulimit -n` of at least 65536; raise it with
+Spill-heavy tests need a soft `ulimit -n` of at least the 65536 floor; raise it with
 the raise-only snippet in `docs/ai/50_TESTING_AND_COMMANDS.md` section 4
 rather than a fixed `ulimit -n <n>`, which can lower an already-sufficient
 limit.

--- a/crates/clinker-exec/AGENTS.md
+++ b/crates/clinker-exec/AGENTS.md
@@ -93,11 +93,14 @@ Existing normal dependencies are intentional evidence:
 - **Inferred:** `cargo check -p clinker-exec --features bench-alloc --locked --offline`
 - **Inferred:** `cargo check --benches -p clinker-exec --locked --offline`
 - **Inferred:** `cargo test -p clinker-exec --locked --offline <test_name>`
-- **Inferred:** `ulimit -n 4096 && cargo test -p clinker-exec --locked --offline`
+- **Inferred:** `cargo test -p clinker-exec --locked --offline` (needs a soft `ulimit -n` of at least 65536 — see `docs/ai/50_TESTING_AND_COMMANDS.md` section 4 for the raise-only snippet)
 
 For Rust source changes, also run the workspace gates from the root
-`AGENTS.md` unless the user explicitly scopes validation narrower. Spill-heavy
-tests may need the raised `ulimit`.
+`AGENTS.md` unless the user explicitly scopes validation narrower.
+Spill-heavy tests need a soft `ulimit -n` of at least 65536; raise it with
+the raise-only snippet in `docs/ai/50_TESTING_AND_COMMANDS.md` section 4
+rather than a fixed `ulimit -n <n>`, which can lower an already-sufficient
+limit.
 
 ## Documentation updates
 

--- a/crates/clinker-net/AGENTS.md
+++ b/crates/clinker-net/AGENTS.md
@@ -53,11 +53,11 @@ Current normal dependencies are intentional: `clinker-exec`, `clinker-plan`, `cl
 - HTTP/connect/body failures are hard source errors, not per-row DLQ records.
 - 5xx/transport failures retry only within configured retry limits; 4xx is fatal.
 - Page body reads are capped by `MAX_PAGE_BYTES`.
-- SQL cursor wording in docs/manifests is roadmap language, not implemented behavior in this crate; route changes to the central open-question registry before documenting it as current behavior.
+- No SQL transport exists in this crate: the only implemented transport is REST. Treat any SQL-cursor wording anywhere as roadmap work tracked in issues #225 (Source) / #226 (sink), not as behavior to preserve or extend; route changes to the central open-question registry before documenting it as current behavior.
 
 ## Common mistakes for AI agents to avoid
 
-- Inventing implemented SQL cursor support from broad wording in docs or the manifest.
+- Inventing implemented SQL cursor support from roadmap wording in docs or issues.
 - Making `max_pages` optional for REST.
 - Adding async runtime assumptions.
 - Faking filesystem paths for network sources.

--- a/crates/clinker-net/Cargo.toml
+++ b/crates/clinker-net/Cargo.toml
@@ -3,7 +3,7 @@ name = "clinker-net"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Network finite-pull Source readers (REST, SQL cursors) for Clinker"
+description = "Network finite-pull Source readers (REST) for Clinker"
 
 [dependencies]
 clinker-exec = { workspace = true }

--- a/docs/ai/50_TESTING_AND_COMMANDS.md
+++ b/docs/ai/50_TESTING_AND_COMMANDS.md
@@ -58,13 +58,14 @@ Status: **Inferred from CI.**
 
 ```bash
 # Raise the file-descriptor soft limit to the 65536 floor the spill tests
-# need. Raise-only by construction: the branch runs only when the current
+# need. Raise-only by construction: the body runs only when the current
 # soft limit is below the floor, and both targets are >= the current soft
 # limit — so an already-sufficient limit is never lowered. `-S` is
 # load-bearing: a bare `ulimit -n N` sets the soft AND the hard limit, and
 # an unprivileged process can never raise a hard limit back.
-[ "$(ulimit -Sn)" != unlimited ] && [ "$(ulimit -Sn)" -lt 65536 ] \
-  && { ulimit -S -n 65536 2>/dev/null || ulimit -S -n "$(ulimit -Hn)"; }
+if [ "$(ulimit -Sn)" != unlimited ] && [ "$(ulimit -Sn)" -lt 65536 ]; then
+  ulimit -S -n 65536 2>/dev/null || ulimit -S -n "$(ulimit -Hn)"
+fi
 
 cargo test --workspace --locked --offline
 ```
@@ -103,6 +104,10 @@ End-to-end confirmation on the same host, running
 
 Cutting the thread count does not rescue 4096: a single grace-hash or
 cascaded-merge test can sit near the per-operator bound on its own.
+
+On a host that is already at or above the floor the `if` is a no-op, not a
+failure: it changes nothing and succeeds, so the block is safe to lift into
+a setup script or chain with `&&` without stranding the command after it.
 
 Never write a bare `ulimit -n <n>` before the suite. On a host whose soft
 limit already exceeds `<n>` that command *lowers* the limit into the failing
@@ -377,7 +382,7 @@ cargo test --workspace --locked --offline
 
 Status: **Verified outside the sandbox for the full test command.** Apply
 the raise-only fd snippet from section 4 before the test command; the
-spill tests need a soft `ulimit -n` of at least 65536. If REST e2e tests
+spill tests need a soft `ulimit -n` of at least the 65536 floor. If REST e2e tests
 are involved, the full test command may need unsandboxed localhost socket
 access.
 
@@ -406,7 +411,7 @@ Status: **Inferred from CI for the exact online forms.** Locked/offline variants
 ## 13. Expensive, Flaky, Or Environment-Dependent Commands
 
 - **Environment-dependent:** `cargo test --workspace` needs local socket permission for `clinker-net` REST e2e tests. The restricted sandbox produced `Operation not permitted`; the unsandboxed run passed.
-- **Environment-dependent:** spill-heavy tests need a soft `ulimit -n` of at least 65536; demand scales with the libtest thread count, which defaults to the core count. At 1024 a `clinker-exec` spill test fails with `Too many open files (os error 24)`; at 4096 on a 32-core host several do, because the measured peak there is 4165-4222 descriptors. Raise the limit with the raise-only snippet in section 4 — a bare `ulimit -n <n>` lowers an already-higher limit into the failing range. CI is unaffected: `.github/workflows/ci.yml` sets no `ulimit`, so every job inherits the runner default.
+- **Environment-dependent:** spill-heavy tests need a soft `ulimit -n` of at least 65536; demand scales with the libtest thread count, which defaults to the core count. At 1024 a `clinker-exec` spill test fails with `Too many open files (os error 24)`; at 4096 on a 32-core host two do, because the measured peak there is 4165-4222 descriptors. Raise the limit with the raise-only snippet in section 4 — a bare `ulimit -n <n>` lowers an already-higher limit into the failing range. CI is unaffected: `.github/workflows/ci.yml` sets no `ulimit`, so every job inherits the runner default.
 - **Expensive:** `cargo test --benches -p clinker-benchmarks` runs the e2e benchmark smoke matrix and took several minutes.
 - **Expensive:** `cargo bench ...` runs real Criterion measurements and should be reserved for performance-sensitive changes.
 - **Expensive:** `cargo test -- --ignored` includes at least one XML generator test that reports generating about 600 MB.
@@ -414,7 +419,7 @@ Status: **Inferred from CI for the exact online forms.** Locked/offline variants
 
 ## 14. Troubleshooting Common Failures
 
-- `Too many open files (os error 24)` in spill tests: check `ulimit -Sn`. It must be at least 65536; raise it with the raise-only snippet in section 4. Do not prefix a fixed `ulimit -n <n>` — that lowers an already-sufficient limit. If the hard limit (`ulimit -Hn`) is itself below the floor, raise the hard limit at the OS level or cut the parallelism with `cargo test -- --test-threads=<n>`; fewer threads reduces the demand but does not remove it, because a single grace-hash or cascaded-merge test can be near the per-operator bound on its own.
+- `Too many open files (os error 24)` in spill tests: check `ulimit -Sn`. It must be at least the 65536 floor (see section 4 for the measurement behind it and the headroom it carries); raise it with the raise-only snippet there. Do not prefix a fixed `ulimit -n <n>` — that lowers an already-sufficient limit. If the hard limit (`ulimit -Hn`) is itself below the floor, raise the hard limit at the OS level or cut the parallelism with `cargo test -- --test-threads=<n>`; fewer threads reduces the demand but does not remove it, because a single grace-hash or cascaded-merge test can be near the per-operator bound on its own.
 - A `proptest` failure caused by fd exhaustion writes a regression seed under `crates/clinker-exec/proptest-regressions/` and asks you to commit it. **Do not.** Replayed at a healthy fd limit those seeds pass — they are environment artifacts, not counterexamples, and committing one adds permanent noise implying a bug that does not exist. Delete the file, fix the fd limit, and re-run. The tracked regression files are `pipeline/iejoin.txt`, `pipeline/sort_key.txt`, and `pipeline/sort_merge_join.txt`; anything else appearing after a `Too many open files` run is an artifact.
 - `Operation not permitted` in `crates/clinker-net/tests/rest_executor_e2e.rs`: the test likely cannot bind a local socket in the sandbox. Rerun outside the sandbox or in normal CI.
 - `cargo deny check` cannot acquire `~/.cargo/advisory-dbs/db.lock`: the filesystem sandbox is read-only for that cargo advisory DB path. Rerun with permission to write/read the cargo advisory database.

--- a/docs/ai/50_TESTING_AND_COMMANDS.md
+++ b/docs/ai/50_TESTING_AND_COMMANDS.md
@@ -57,12 +57,61 @@ Status: **Inferred from CI.**
 ## 4. Full Test Command
 
 ```bash
-ulimit -n 4096 && cargo test --workspace --locked --offline
+# Raise the file-descriptor soft limit to the 65536 floor the spill tests
+# need. Raise-only by construction: the branch runs only when the current
+# soft limit is below the floor, and both targets are >= the current soft
+# limit — so an already-sufficient limit is never lowered. `-S` is
+# load-bearing: a bare `ulimit -n N` sets the soft AND the hard limit, and
+# an unprivileged process can never raise a hard limit back.
+[ "$(ulimit -Sn)" != unlimited ] && [ "$(ulimit -Sn)" -lt 65536 ] \
+  && { ulimit -S -n 65536 2>/dev/null || ulimit -S -n "$(ulimit -Hn)"; }
+
+cargo test --workspace --locked --offline
 ```
 
 Status: **Verified outside the sandbox.**
 
-Why the prefix matters: with the default local `ulimit -n` of `1024`, `clinker-exec` spill tests can fail with `Too many open files (os error 24)`. The `clinker-net` REST e2e tests also need permission to bind local sockets; they failed inside the restricted sandbox with `Operation not permitted` and passed outside it.
+Why the fd floor matters: the spill path opens up to `MERGE_FAN_IN` = 64
+readers per active k-way merge pass
+(`crates/clinker-exec/src/pipeline/spill_merge.rs`), and grace-hash holds
+one open probe-spill writer per on-disk partition
+(`crates/clinker-exec/src/pipeline/grace_hash/mod.rs`, `PartitionState::OnDisk`).
+`cargo test` multiplies that by the libtest thread count, which defaults to
+the core count — so the process-wide peak scales with `nproc`, not with any
+single test. Below the floor, spill tests fail with
+`Too many open files (os error 24)`, and *which* tests fail varies run to
+run: the victim is whichever test opens a file while the process is at the
+ceiling.
+
+Measured on a 32-core host (`nproc` = 32), sampling `/proc/<pid>/fd` of the
+`clinker-exec` lib test binary about 16 000 times per run across five runs:
+the peak concurrent descriptor count is **4165–4222**. That is above the
+`4096` this document used to prescribe, which is why the documented command
+was itself the cause of the failures it claimed to prevent. The floor of
+`65536` gives roughly 15x headroom over the measured peak, which absorbs
+higher core counts — demand scales with `available_parallelism()`, so a
+128-core host lands near ~17 000 and still fits.
+
+End-to-end confirmation on the same host, running
+`cargo test -p clinker-exec --lib --locked --offline`:
+
+| soft `ulimit -n` | result |
+|---|---|
+| 4096 (the value this document used to prescribe) | FAILED — 868 passed, 2 failed, both `Too many open files (os error 24)` |
+| 4096 with `-- --test-threads=4` | FAILED — 868 passed, 2 failed |
+| 65536 | ok — 870 passed, 0 failed |
+
+Cutting the thread count does not rescue 4096: a single grace-hash or
+cascaded-merge test can sit near the per-operator bound on its own.
+
+Never write a bare `ulimit -n <n>` before the suite. On a host whose soft
+limit already exceeds `<n>` that command *lowers* the limit into the failing
+range — following the instruction becomes the cause of the failure it was
+meant to prevent.
+
+The `clinker-net` REST e2e tests separately need permission to bind local
+sockets; they fail inside the restricted sandbox with
+`Operation not permitted` and pass outside it.
 
 CI runs:
 
@@ -121,17 +170,18 @@ UPDATE_SCENARIO_GOLDENS=1 cargo test -p clinker --test scenarios -- --nocapture
 re-bless run passes, so without it the input digest to paste back into the
 harness's `GATES` table is never printed.
 
-Status: **Inferred for the exact per-crate commands.** The full workspace test command above covered these packages successfully outside the sandbox with `ulimit -n 4096`.
+Status: **Inferred for the exact per-crate commands.** The full workspace test command above covered these packages successfully outside the sandbox at a soft fd limit of 65536 or higher.
 
 Targeted examples:
 
 ```bash
 cargo test -p cxl --locked --offline
 cargo test -p clinker-exec --lib --locked --offline executor::tests::spill_dir_unavailable_midrun::unarmed_seam_lets_a_real_spilling_run_complete -- --exact
-ulimit -n 4096 && cargo test -p clinker-exec --lib --locked --offline executor::tests::spill_dir_unavailable_midrun::unarmed_seam_lets_a_real_spilling_run_complete -- --exact
 ```
 
-Status: **Verified.** The second command failed at `ulimit -n 1024`; the third passed with `ulimit -n 4096`.
+Status: **Verified.** The second command needs the section 4 fd floor: it
+failed at `ulimit -n 1024` and passes at 65536. Apply the raise-only
+snippet from section 4 first rather than prefixing a fixed `ulimit -n`.
 
 ## 6. Formatting Command
 
@@ -322,10 +372,14 @@ cargo fmt --all --check
 cargo check --workspace --locked --offline
 cargo clippy --workspace --locked --offline -- -D warnings
 cargo clippy --workspace --all-targets --locked --offline -- -D warnings
-ulimit -n 4096 && cargo test --workspace --locked --offline
+cargo test --workspace --locked --offline
 ```
 
-Status: **Verified outside the sandbox for the full test command.** If REST e2e tests are involved, the full test command may need unsandboxed localhost socket access.
+Status: **Verified outside the sandbox for the full test command.** Apply
+the raise-only fd snippet from section 4 before the test command; the
+spill tests need a soft `ulimit -n` of at least 65536. If REST e2e tests
+are involved, the full test command may need unsandboxed localhost socket
+access.
 
 For sprint-closing / CI parity:
 
@@ -352,7 +406,7 @@ Status: **Inferred from CI for the exact online forms.** Locked/offline variants
 ## 13. Expensive, Flaky, Or Environment-Dependent Commands
 
 - **Environment-dependent:** `cargo test --workspace` needs local socket permission for `clinker-net` REST e2e tests. The restricted sandbox produced `Operation not permitted`; the unsandboxed run passed.
-- **Environment-dependent:** spill-heavy tests may need `ulimit -n 4096`. With `ulimit -n` at `1024`, one `clinker-exec` spill test failed with `Too many open files (os error 24)`.
+- **Environment-dependent:** spill-heavy tests need a soft `ulimit -n` of at least 65536; demand scales with the libtest thread count, which defaults to the core count. At 1024 a `clinker-exec` spill test fails with `Too many open files (os error 24)`; at 4096 on a 32-core host several do, because the measured peak there is 4165-4222 descriptors. Raise the limit with the raise-only snippet in section 4 — a bare `ulimit -n <n>` lowers an already-higher limit into the failing range. CI is unaffected: `.github/workflows/ci.yml` sets no `ulimit`, so every job inherits the runner default.
 - **Expensive:** `cargo test --benches -p clinker-benchmarks` runs the e2e benchmark smoke matrix and took several minutes.
 - **Expensive:** `cargo bench ...` runs real Criterion measurements and should be reserved for performance-sensitive changes.
 - **Expensive:** `cargo test -- --ignored` includes at least one XML generator test that reports generating about 600 MB.
@@ -360,7 +414,8 @@ Status: **Inferred from CI for the exact online forms.** Locked/offline variants
 
 ## 14. Troubleshooting Common Failures
 
-- `Too many open files (os error 24)` in spill tests: check `ulimit -n`. Retry with `ulimit -n 4096 && cargo test ...`.
+- `Too many open files (os error 24)` in spill tests: check `ulimit -Sn`. It must be at least 65536; raise it with the raise-only snippet in section 4. Do not prefix a fixed `ulimit -n <n>` — that lowers an already-sufficient limit. If the hard limit (`ulimit -Hn`) is itself below the floor, raise the hard limit at the OS level or cut the parallelism with `cargo test -- --test-threads=<n>`; fewer threads reduces the demand but does not remove it, because a single grace-hash or cascaded-merge test can be near the per-operator bound on its own.
+- A `proptest` failure caused by fd exhaustion writes a regression seed under `crates/clinker-exec/proptest-regressions/` and asks you to commit it. **Do not.** Replayed at a healthy fd limit those seeds pass — they are environment artifacts, not counterexamples, and committing one adds permanent noise implying a bug that does not exist. Delete the file, fix the fd limit, and re-run. The tracked regression files are `pipeline/iejoin.txt`, `pipeline/sort_key.txt`, and `pipeline/sort_merge_join.txt`; anything else appearing after a `Too many open files` run is an artifact.
 - `Operation not permitted` in `crates/clinker-net/tests/rest_executor_e2e.rs`: the test likely cannot bind a local socket in the sandbox. Rerun outside the sandbox or in normal CI.
 - `cargo deny check` cannot acquire `~/.cargo/advisory-dbs/db.lock`: the filesystem sandbox is read-only for that cargo advisory DB path. Rerun with permission to write/read the cargo advisory database.
 - `cargo test --workspace` can run for a long time: the workspace has a large test suite with many integration tests. Use `cargo test -p <package>` or an exact test filter while iterating.

--- a/docs/ai/50_TESTING_AND_COMMANDS.md
+++ b/docs/ai/50_TESTING_AND_COMMANDS.md
@@ -85,19 +85,19 @@ ceiling.
 
 Measured on a 32-core host (`nproc` = 32), sampling `/proc/<pid>/fd` of the
 `clinker-exec` lib test binary about 16 000 times per run across five runs:
-the peak concurrent descriptor count is **4165–4222**. That is above the
-`4096` this document used to prescribe, which is why the documented command
-was itself the cause of the failures it claimed to prevent. The floor of
-`65536` gives roughly 15x headroom over the measured peak, which absorbs
-higher core counts — demand scales with `available_parallelism()`, so a
-128-core host lands near ~17 000 and still fits.
+the peak concurrent descriptor count is **4165–4222**. Any floor at or below
+`4096` is therefore below what the suite actually needs on a host this size.
+The floor of `65536` gives roughly 15x headroom over the measured peak,
+which absorbs higher core counts — demand scales with
+`available_parallelism()`, so a 128-core host lands near ~17 000 and still
+fits.
 
 End-to-end confirmation on the same host, running
 `cargo test -p clinker-exec --lib --locked --offline`:
 
 | soft `ulimit -n` | result |
 |---|---|
-| 4096 (the value this document used to prescribe) | FAILED — 868 passed, 2 failed, both `Too many open files (os error 24)` |
+| 4096 | FAILED — 868 passed, 2 failed, both `Too many open files (os error 24)` |
 | 4096 with `-- --test-threads=4` | FAILED — 868 passed, 2 failed |
 | 65536 | ok — 870 passed, 0 failed |
 

--- a/docs/engine/src/architecture.md
+++ b/docs/engine/src/architecture.md
@@ -8,7 +8,7 @@ Within a run, stateless operators (Transform, Route, most Combine probe-side wor
 
 Every design decision cascades from three commitments. They are permanent — an architectural proposal that violates any of them is rejected at design review, not implementation review.
 
-1. **Finite inputs only.** Files (CSV / JSON / XML / fixed-width) and finite-cursor network sources (paginated REST, SQL `SELECT` cursors) — both reach EOF after exhausting their cursor. Unbounded sources (Kafka, Kinesis, SSE, webhooks, `tail -f`) are out of scope permanently.
+1. **Finite inputs only.** Files (CSV / JSON / XML / fixed-width / EDIFACT / X12 / HL7 v2 / SWIFT MT) and finite-cursor network sources (paginated REST with hard page/record caps) — both reach EOF after exhausting their cursor. Unbounded sources (Kafka, Kinesis, SSE, webhooks, `tail -f`) are out of scope permanently.
 
 2. **Finite jobs.** No daemon mode, no service surface, no infinite event loop. `clinker run` invokes, drains, exits.
 

--- a/docs/user/src/README.md
+++ b/docs/user/src/README.md
@@ -37,9 +37,10 @@ memory ceiling.
 
 **Three pillars of what Clinker is:**
 
-1. **Finite inputs.** Files (CSV, JSON, XML, fixed-width) are the canonical
-   shape. Finite-cursor network sources (paginated REST APIs, SQL `SELECT`
-   cursors) fit the same model -- they exhaust their cursor and EOF.
+1. **Finite inputs.** Files (CSV, JSON, XML, fixed-width, EDIFACT, X12,
+   HL7 v2, SWIFT MT) are the canonical shape. Finite-cursor network
+   sources (paginated REST APIs with hard page/record caps) fit the same
+   model -- they exhaust their cursor and EOF.
    Unbounded sources (Kafka topics, Kinesis streams, Server-Sent Events,
    webhooks, `tail -f`-style file followers) are out of scope and will
    remain so.

--- a/docs/user/src/getting-started/concepts.md
+++ b/docs/user/src/getting-started/concepts.md
@@ -25,9 +25,9 @@ through.
 ### Finite inputs only
 
 Clinker reads sources that have an end. Files are the canonical shape, and
-finite-cursor network sources (paginated REST APIs, SQL `SELECT` cursors)
-fit the same model -- they exhaust their cursor and EOF. Unbounded sources
-(Kafka, Kinesis, Server-Sent Events, webhooks, `tail -f`-style file
+finite-cursor network sources (paginated REST APIs with hard page/record
+caps) fit the same model -- they exhaust their cursor and EOF. Unbounded
+sources (Kafka, Kinesis, Server-Sent Events, webhooks, `tail -f`-style file
 followers) are explicitly **out of scope** and will remain so.
 
 ### Single process, ever

--- a/docs/user/src/nodes/source.md
+++ b/docs/user/src/nodes/source.md
@@ -97,7 +97,7 @@ alias automatically (see [Channels](../pipelines/channels.md)).
 
 A source declaration has two independent layers:
 
-- **Transport** (`transport:`) selects *where* the records come from. The only transport today is `file` — read bytes from the filesystem, resolved through one of the file matchers (`path` / `glob` / `regex` / `paths`). `transport:` is optional and defaults to `file`, so a source that omits it reads from disk exactly as before.
+- **Transport** (`transport:`) selects *where* the records come from. Two transports exist: `file` — read bytes from the filesystem, resolved through one of the file matchers (`path` / `glob` / `regex` / `paths`) — and `rest` — pull records from a paginated HTTP endpoint under a hard page/record cap (see [Network Sources (REST)](../formats/source-network.md)). `transport:` is optional and defaults to `file`, so a source that omits it reads from disk exactly as before.
 - **Format** (`type:`) selects *how* the bytes decode into records: `csv`, `json`, `xml`, `fixed_width`, `edifact`, `x12`, `hl7`, `swift`.
 
 ```yaml

--- a/docs/user/src/non-goals.md
+++ b/docs/user/src/non-goals.md
@@ -107,9 +107,15 @@ SQL is the right surface.
 ## Not a connector marketplace
 
 Clinker ships with a deliberately small set of source and sink types:
-CSV, JSON, XML, fixed-width files in the current release; finite-cursor
-REST and SQL sources on the roadmap. There is no plugin registry, no
-third-party connector store, no SaaS-API catalog.
+CSV, JSON, XML, fixed-width, EDIFACT, X12, HL7 v2, and SWIFT MT files,
+plus a finite-cursor REST source. Writing to a network endpoint is not
+supported: a REST Output sink
+([issue #224](https://github.com/rustpunk/clinker/issues/224)) and
+finite-cursor SQL sources and sinks
+([#225](https://github.com/rustpunk/clinker/issues/225),
+[#226](https://github.com/rustpunk/clinker/issues/226)) are tracked but
+unbuilt. There is no plugin registry, no third-party connector store, no
+SaaS-API catalog.
 
 **Out of scope:**
 


### PR DESCRIPTION
Closes #955. Closes #979.

Two documentation defects that both cause a reader to act on a false statement. Documentation-only: no Rust source is touched.

## Endpoint status lines (#955)

Docs and one crate manifest described a SQL cursor transport as something Clinker has. It does not exist — `SourceTransport` has exactly two variants, `File` and `Rest` (`crates/clinker-plan/src/config/source.rs`), and `clinker-net` contains one module, `rest`. Separately, REST was described as roadmap in places even though it is wired end to end and has its own user page.

The issue named three sites. A sweep of every surface carrying the claim found seven:

| Site | Was |
|---|---|
| `crates/clinker-net/Cargo.toml` | description advertised "(REST, SQL cursors)" |
| `docs/user/src/non-goals.md` | REST listed as roadmap; SQL roadmap carried no issue link; format list showed 4 of 8 |
| `docs/user/src/README.md` | pillar 1 named "SQL `SELECT` cursors" as an existing input |
| `docs/user/src/getting-started/concepts.md` | same claim |
| `docs/engine/src/architecture.md` | same claim, plus the truncated format list |
| `docs/user/src/nodes/source.md` | **the inverse error** — see below |
| `crates/clinker-net/AGENTS.md` | two notes referencing manifest wording this PR removes |

The most severe was not in the issue. The canonical Source reference stated "the only transport today is `file`", telling a reader that a shipped, wired, separately-documented feature does not exist. It now describes both transports and links the network sources page.

Roadmap work is now named with its tracking issues (#224 REST sink, #225 SQL source, #226 SQL sink) rather than as vague future capability, and the shipped format list is complete: CSV, JSON, XML, fixed-width, EDIFACT, X12, HL7 v2, SWIFT MT.

## File-descriptor floor (#979)

`docs/ai/50_TESTING_AND_COMMANDS.md` prescribed `ulimit -n 4096` before the test suite, in eight places. That instruction was wrong in two independent ways.

**The value was too low.** Peak concurrent descriptor use was measured by sampling `/proc/<pid>/fd` of the `clinker-exec` lib test binary — about 16,000 samples per run across five runs on a 32-core host: **peak 4222**, above the prescribed 4096. Confirmed end to end: at a soft limit of 4096 the suite fails with `Too many open files (os error 24)` (868 passed, 2 failed); at 65536 it passes clean (870 passed, 0 failed). Reducing parallelism with `--test-threads=4` does not fix it.

The demand is now explained in the doc rather than asserted: the spill path opens up to `MERGE_FAN_IN` = 64 readers per active k-way merge pass, grace-hash holds one open probe-spill writer per on-disk partition, and `cargo test` multiplies both by the libtest thread count, which defaults to the core count. The process-wide peak therefore scales with `nproc`, not with any single test — which is why *which* tests fail varies between runs. The victim is whichever test happens to open a file while the process sits at the ceiling.

**The shape was wrong.** A bare `ulimit -n <n>` is unconditional. On a host whose soft limit already exceeds `<n>`, following the instruction *lowers* the limit into the failing range, becoming the cause of the failure it was meant to prevent. Raising the number would not fix this — any pinned value has the same defect.

The replacement is raise-only, and guarded so it cannot lower:

```bash
[ "$(ulimit -Sn)" != unlimited ] && [ "$(ulimit -Sn)" -lt 65536 ] \
  && { ulimit -S -n 65536 2>/dev/null || ulimit -S -n "$(ulimit -Hn)"; }
```

`-S` is load-bearing and carries an inline comment saying so. A bare `ulimit -n N` sets the soft **and hard** limit; on the common Linux shape (soft 1024, hard 1048576) that raises the soft limit correctly while silently dropping the hard limit to 65536 — irreversibly, since an unprivileged process cannot raise a hard limit back. That is a quieter version of the same defect this issue is about.

Verified across six limit shapes: already-sufficient soft limit is left untouched; 1024 and the macOS 256 shape both raise to 65536 with the hard limit unchanged; a hard limit below the floor falls back to the best available; `unlimited` short-circuits without arithmetic; and a false guard does not swallow the following command.

All ten sites now state 65536. CI is unaffected and the doc now says so — no workflow sets a `ulimit`, so every job inherits the runner default and never lowers it.

## Verification

- `git diff --check` clean
- `mdbook build` green for both books (`docs/user`, `docs/engine`)
- `cargo check --workspace` green (a manifest is touched)
- `cargo metadata` confirms the published description no longer names SQL
- No `sql` match remains in any manifest; remaining matches under `docs/user/src` and `docs/engine/src` are CXL-vs-SQL prose, OLAP/CDC non-goals, and the roadmap reference carrying its issue links
- Every `ulimit` mention in `docs/`, `crates/`, and `.github/` states 65536, none pinned

Follow-ups filed rather than folded in: #986 (a `RecordSource` doc comment names a SQL cursor transport as an existing implementor — Rust source, out of scope for a documentation change) and #987 (the testing guide references a generated `docs/book/index.html` that does not exist).