### PR TITLE
format(json): expand dotted column names into nested objects on write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,40 @@ All notable changes to Clinker are tracked here.
 
 ## Unreleased
 
+### Changed — JSON output expands dotted column names into nested objects
+
+**Behaviour change.** A JSON output previously emitted every column name
+verbatim, so a column named `customer.name` became the literal key
+`"customer.name"`. It now expands into `{"customer": {"name": …}}`, matching
+what the XML writer has always done with the same column set — so a pipeline
+that reads nested JSON and writes JSON reproduces its input shape. This applies
+unconditionally; there is no option to keep the old output, because a per-output
+flag would mean the same column name meant different things at different
+outputs.
+
+Any pipeline whose output schema carries a dotted column name emits a different
+JSON shape than before. This includes columns produced by the JSON and XML
+readers' flattening, and — under `include_correlation_keys: true` — the
+engine-stamped `$ck.<field>` columns, which now nest under a `"$ck"` object.
+
+- To emit a key that genuinely contains a `.`, escape the separator in the
+  column name: a column declared `a\.b` writes the single key `"a.b"`. The full
+  grammar, including the reserved `[`, is documented at
+  `docs/user/src/cxl/field-paths.md`.
+- Two column names that cannot both be expanded — a column `a` holding a value
+  alongside a column `a.b` needing `a` to be a container, or two spellings of
+  the same path — are now refused before any byte is written, naming both
+  columns, on the JSON **and** XML writers. The XML writer previously emitted
+  two sibling elements for that column set, which its own reader then rejected
+  on the way back in.
+- A column name carrying a malformed escape (a `\` not part of `\.`, `\[`, or
+  `\\`, as in a column literally named `C:\temp`) is likewise refused, with the
+  corrected spelling in the message.
+
+Known gap: the readers still join flattened path segments without escaping them,
+so a source key that literally contains a `.` arrives as an unescaped column
+name and writes back nested. Tracked separately.
+
 ### Added — scoped variables and the `state` node
 
 - Three-scope variable system: `pipeline`, `source`, and `record`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@ engine-stamped `$ck.<field>` columns, which now nest under a `"$ck"` object.
 
 Known gap: the readers still join flattened path segments without escaping them,
 so a source key that literally contains a `.` arrives as an unescaped column
-name and writes back nested. Tracked separately.
+name and writes back nested. The read-side inverse is tracked at
+<https://github.com/rustpunk/clinker/issues/920>.
 
 ### Added — scoped variables and the `state` node
 

--- a/crates/clinker-exec/tests/json_nested_write_e2e.rs
+++ b/crates/clinker-exec/tests/json_nested_write_e2e.rs
@@ -1,0 +1,85 @@
+//! End-to-end proof that a JSON source read with nested objects and written
+//! back with no intervening transform reproduces the input nesting.
+//!
+//! The expansion itself is unit-tested in `clinker-format`; what this guards is
+//! the executor wiring those tests cannot see — a real pipeline routing a
+//! source's inferred dotted columns through the writer factory into the JSON
+//! writer.
+
+mod common;
+
+use std::collections::HashMap;
+
+use clinker_bench_support::io::SharedBuffer;
+use clinker_exec::executor::{PipelineRunParams, SourceReaders};
+
+fn params() -> PipelineRunParams {
+    PipelineRunParams {
+        execution_id: "test-exec".to_string(),
+        batch_id: "test-batch".to_string(),
+        pipeline_vars: indexmap::IndexMap::new(),
+        shutdown_token: None,
+        ..Default::default()
+    }
+}
+
+fn json_reader(input: &str) -> SourceReaders {
+    HashMap::from([(
+        "orders".to_string(),
+        clinker_exec::executor::single_file_reader(
+            "in.json",
+            Box::new(std::io::Cursor::new(input.as_bytes().to_vec())),
+        ),
+    )])
+}
+
+fn run(pipeline: &str, input: &str) -> String {
+    let config = clinker_plan::config::parse_config(pipeline).expect("pipeline parses");
+    let buf = SharedBuffer::new();
+    let writers: HashMap<String, Box<dyn std::io::Write + Send>> = HashMap::from([(
+        "out".to_string(),
+        Box::new(buf.clone()) as Box<dyn std::io::Write + Send>,
+    )]);
+    common::run_config(&config, json_reader(input), writers, &params()).expect("run succeeds");
+    String::from_utf8(buf.contents()).expect("utf-8 output")
+}
+
+const PIPELINE: &str = r#"
+pipeline:
+  name: json_nested_passthrough
+nodes:
+  - type: source
+    name: orders
+    config:
+      name: orders
+      type: json
+      path: ./in.json
+      schema:
+        - { name: order_id, type: string }
+        - { name: customer.name, type: string }
+        - { name: customer.email, type: string }
+        - { name: customer.address.city, type: string }
+  - type: output
+    name: out
+    input: orders
+    config:
+      name: out
+      type: json
+      path: ./out.json
+      options:
+        format: ndjson
+"#;
+
+#[test]
+fn nested_json_read_and_written_back_keeps_its_shape() {
+    const INPUT: &str = r#"[{"order_id":"1","customer":{"name":"Ada","email":"ada@example.com","address":{"city":"Boston"}}}]"#;
+    let output = run(PIPELINE, INPUT);
+    let written: serde_json::Value =
+        serde_json::from_str(output.trim_end()).expect("valid JSON output");
+    let source: serde_json::Value = serde_json::from_str(INPUT).expect("valid JSON input");
+    assert_eq!(
+        written,
+        source.as_array().expect("input array")[0],
+        "got: {output}"
+    );
+}

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -214,6 +214,20 @@ pub enum FormatError {
         format: &'static str,
         field: String,
     },
+    /// A writer that expands dotted column names into nested output (JSON
+    /// objects, XML elements) was handed a column set it cannot expand: a
+    /// malformed escape in one name, a name nesting past the depth cap, or
+    /// two names that would occupy the same place in the tree.
+    ///
+    /// Raised when the writer builds its plan for a schema, before any byte of
+    /// the first record is written, so a rejected column set leaves no partial
+    /// output. The grammar and the remedies live in
+    /// [`clinker_record::field_path`]; the inner error carries the offending
+    /// names and the escaped spelling that resolves a clash.
+    FieldPath {
+        format: &'static str,
+        source: clinker_record::field_path::FieldPathError,
+    },
 }
 
 impl fmt::Display for FormatError {
@@ -301,6 +315,11 @@ impl fmt::Display for FormatError {
                  occurrence as an array (in document order), or add a `split_to_rows` entry to \
                  fan each occurrence out to its own record. (In JSON this also fires when two \
                  distinct keys flatten to the same dotted name — rename one to disambiguate.)"
+            ),
+            Self::FieldPath { format, source } => write!(
+                f,
+                "{format} writer cannot expand this output's column names into nested output: \
+                 {source}"
             ),
         }
     }
@@ -399,6 +418,7 @@ impl std::error::Error for FormatError {
         match self {
             Self::Io(e) => Some(e),
             Self::Csv(e) => Some(e),
+            Self::FieldPath { source, .. } => Some(source),
             _ => None,
         }
     }

--- a/crates/clinker-format/src/error.rs
+++ b/crates/clinker-format/src/error.rs
@@ -344,6 +344,16 @@ impl FormatError {
         }
     }
 
+    /// Build a [`FormatError::FieldPath`] for a writer that could not expand
+    /// its output's column names into nested output. `format` names the writer
+    /// for the diagnostic; the grammar failure itself is format-independent.
+    pub fn field_path(
+        format: &'static str,
+        source: clinker_record::field_path::FieldPathError,
+    ) -> Self {
+        Self::FieldPath { format, source }
+    }
+
     /// Build a [`FormatError::StructuralCount`] for an HL7 batch/file
     /// envelope count mismatch (`BTS`/`FTS`).
     pub fn hl7_structural_count(message: impl Into<String>) -> Self {

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -491,10 +491,7 @@ pub(crate) fn clinker_to_json(val: &Value) -> Result<serde_json::Value, FormatEr
 
 /// Wrap a field-name grammar failure as this writer's error.
 fn field_path_error(source: FieldPathError) -> FormatError {
-    FormatError::FieldPath {
-        format: "JSON",
-        source,
-    }
+    FormatError::field_path("JSON", source)
 }
 
 // ── Column name → nested object expansion ────────────────────────────
@@ -508,10 +505,7 @@ struct PlanCache {
 /// One object's contents: the ordered keys it emits. Key order is
 /// first-insertion order, so columns sharing a prefix group at the position
 /// where that prefix first appeared even when the schema interleaves them.
-#[derive(Default)]
-struct PlanBody {
-    children: Vec<PlanNode>,
-}
+type PlanBody = Vec<PlanNode>;
 
 enum PlanNode {
     /// A key holding a column's value, addressed by its schema position.
@@ -535,47 +529,44 @@ fn build_plan_cache(
     schema: &Arc<Schema>,
     include_engine_stamped: bool,
 ) -> Result<PlanCache, FormatError> {
-    let emitted = || {
-        (0..schema.column_count())
-            .filter(move |&i| include_engine_stamped || !schema.is_engine_stamped(i))
-    };
-    field_path::check_expandable(emitted().map(|i| schema.columns()[i].as_ref()))
+    let emitted: Vec<(usize, &str)> = (0..schema.column_count())
+        .filter(|&i| include_engine_stamped || !schema.is_engine_stamped(i))
+        .map(|i| (i, schema.columns()[i].as_ref()))
+        .collect();
+    field_path::check_expandable(emitted.iter().map(|&(_, name)| name))
         .map_err(field_path_error)?;
 
     let mut root = PlanBody::default();
-    for i in emitted() {
-        let name = schema.columns()[i].as_ref();
+    for &(field, name) in &emitted {
+        let path = field_path::decode(name).map_err(field_path_error)?;
+        let (leaf, branches) = path
+            .split_last()
+            .expect("decoding yields at least one segment");
         let mut body = &mut root;
-        let mut path = field_path::segments(name).peekable();
-        while let Some(segment) = path.next() {
-            let segment = segment.map_err(field_path_error)?;
-            if path.peek().is_none() {
-                body.children.push(PlanNode::Leaf {
-                    name: segment.into_owned(),
-                    field: i,
-                });
-                break;
-            }
+        for segment in branches {
             // Descend into the branch this segment already opened, so a shared
             // prefix groups at the position where it first appeared.
             let at = body
-                .children
                 .iter()
-                .position(|n| matches!(n, PlanNode::Branch { name, .. } if *name == *segment))
+                .position(|n| matches!(n, PlanNode::Branch { name, .. } if *name == **segment))
                 .unwrap_or_else(|| {
-                    body.children.push(PlanNode::Branch {
-                        name: segment.into_owned(),
+                    body.push(PlanNode::Branch {
+                        name: segment.to_string(),
                         body: PlanBody::default(),
                     });
-                    body.children.len() - 1
+                    body.len() - 1
                 });
-            body = match &mut body.children[at] {
+            body = match &mut body[at] {
                 PlanNode::Branch { body, .. } => body,
                 PlanNode::Leaf { .. } => {
                     unreachable!("check_expandable rejects a column nesting under a value column")
                 }
             };
         }
+        body.push(PlanNode::Leaf {
+            name: leaf.to_string(),
+            field,
+        });
     }
     Ok(PlanCache {
         schema: Arc::clone(schema),
@@ -623,7 +614,7 @@ impl serde::Serialize for PlanBodySer<'_> {
         // `None` length hint: serde_json ignores it, and the exact post-null-
         // skip entry count would need a second pass over the plan.
         let mut map = serializer.serialize_map(None)?;
-        for node in &self.body.children {
+        for node in self.body {
             match node {
                 PlanNode::Leaf { name, field } => {
                     let value = &self.values[*field];
@@ -635,8 +626,9 @@ impl serde::Serialize for PlanBodySer<'_> {
                 PlanNode::Branch { name, body } => {
                     // An object whose every descendant is omitted emits no key
                     // at all rather than an empty object, so it reads back as
-                    // the absent column it stands for.
-                    if !body_emits(body, self.values, self.preserve_nulls) {
+                    // the absent column it stands for. Under `preserve_nulls`
+                    // every leaf emits, so no subtree can be empty.
+                    if !self.preserve_nulls && !has_present_leaf(body, self.values) {
                         continue;
                     }
                     map.serialize_entry(
@@ -654,17 +646,18 @@ impl serde::Serialize for PlanBodySer<'_> {
     }
 }
 
-/// Whether any leaf under `body` contributes a key for this record.
+/// Whether any leaf under `body` holds a non-null value. Only meaningful under
+/// `preserve_nulls: false`, the one mode in which a subtree can go unemitted.
 ///
 /// Re-walks the subtree rather than caching per-record presence flags: the walk
 /// is bounded by the plan, which is already retained, while a presence buffer
-/// would be per-record state proportional to record width.
-fn body_emits(body: &PlanBody, values: &[Value], preserve_nulls: bool) -> bool {
-    preserve_nulls
-        || body.children.iter().any(|node| match node {
-            PlanNode::Leaf { field, .. } => !values[*field].is_null(),
-            PlanNode::Branch { body, .. } => body_emits(body, values, preserve_nulls),
-        })
+/// would be per-record state proportional to record width. It short-circuits on
+/// the first present leaf, so the cost is paid only by sparse records.
+fn has_present_leaf(body: &PlanBody, values: &[Value]) -> bool {
+    body.iter().any(|node| match node {
+        PlanNode::Leaf { field, .. } => !values[*field].is_null(),
+        PlanNode::Branch { body, .. } => has_present_leaf(body, values),
+    })
 }
 
 /// Borrows a clinker [`Value`] and serializes it directly, mirroring

--- a/crates/clinker-format/src/json/writer.rs
+++ b/crates/clinker-format/src/json/writer.rs
@@ -1,6 +1,13 @@
 //! JSON writer supporting array mode, NDJSON mode, pretty-printing,
 //! and null omission. Implements `FormatWriter`.
 //!
+//! Dotted column names expand back into nested objects on the way out —
+//! `Address.City` and `Address.State` become one `"Address"` object with two
+//! keys — so a document read from nested JSON writes back with its shape
+//! intact. The names are decoded with the shared record-space grammar in
+//! [`clinker_record::field_path`], the same grammar the XML writer expands
+//! elements with, so one column set produces the same tree in both formats.
+//!
 //! Under `reconstruct_envelope` the whole-stream array framing is REPLACED by
 //! per-document object framing: each enveloped document becomes one JSON
 //! object `{ "<header>": {...}, "body": [ ... ], "<footer>": {...} }`, with the
@@ -13,6 +20,7 @@
 use std::io::Write;
 use std::sync::Arc;
 
+use clinker_record::field_path::{self, FieldPathError};
 use clinker_record::{DocumentContext, Record, Schema, Value};
 
 use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
@@ -59,16 +67,21 @@ impl Default for JsonWriterConfig {
 
 pub struct JsonWriter<W: Write> {
     writer: W,
-    /// Schema held for the writer's lifetime. Post-rip the writer emits
-    /// records via `Record::iter_all_fields` (schema-positional) so the
-    /// field is not read per-record, but keeping the `Arc` pins the
-    /// schema against unintended drop by factory callers.
+    /// Schema held for the writer's lifetime. The writer emits records against
+    /// the plan built from `Record::schema`, so the field is not read
+    /// per-record, but keeping the `Arc` pins the schema against unintended
+    /// drop by factory callers.
     _schema: Arc<Schema>,
     config: JsonWriterConfig,
     records_written: u64,
     /// Per-document envelope framer + state machine, present only when
     /// `config.envelope` is. Drives the per-document-object reframe.
     envelope: Option<EnvelopeState>,
+    /// Precompiled name→object-tree expansion, rebuilt only when the schema
+    /// identity changes. Holds one `String` per distinct path segment plus one
+    /// column index per leaf — bounded by the schema's column names, never by
+    /// record count.
+    plan_cache: Option<PlanCache>,
     /// Reusable serialization buffer. Each record is serialized straight into
     /// this `Vec` (via a borrowing `serde::Serialize` impl, no intermediate
     /// `serde_json::Value` tree) and then written to the sink; the allocation
@@ -108,16 +121,38 @@ impl<W: Write> JsonWriter<W> {
             config,
             records_written: 0,
             envelope,
+            plan_cache: None,
             scratch: Vec::new(),
         }
     }
 
-    /// Serialize a record as a JSON object into the reusable `scratch` buffer
-    /// in schema-column order. `preserve_nulls: false` omits keys with Null
-    /// values. Engine-stamped columns are stripped from the default output;
-    /// callers opt in via `include_engine_stamped`. Keys borrow the schema's
-    /// column names and values borrow the record's [`Value`]s, so no
-    /// intermediate `serde_json::Value` tree is built.
+    /// Ensure `plan_cache` holds an expansion plan for this record's schema,
+    /// rebuilding only when the schema identity changes (`Arc::ptr_eq`), so a
+    /// single-schema stream builds it once. Name decoding and collision
+    /// detection happen here, before any byte of the record is written, so an
+    /// unexpandable column set fails `write_record` cleanly.
+    fn ensure_plan(&mut self, record: &Record) -> Result<(), FormatError> {
+        let current = self
+            .plan_cache
+            .as_ref()
+            .is_some_and(|c| Arc::ptr_eq(&c.schema, record.schema()));
+        if !current {
+            self.plan_cache = Some(build_plan_cache(
+                record.schema(),
+                self.config.include_engine_stamped,
+            )?);
+        }
+        Ok(())
+    }
+
+    /// Serialize a record as a JSON object into the reusable `scratch` buffer,
+    /// walking the expansion plan so dotted column names emit as nested
+    /// objects. `preserve_nulls: false` omits null leaves, and an object whose
+    /// every descendant is omitted emits no key at all. Engine-stamped columns
+    /// are stripped from the default output; callers opt in via
+    /// `include_engine_stamped`. Keys borrow the plan's segment names and
+    /// values borrow the record's [`Value`]s, so no intermediate
+    /// `serde_json::Value` tree is built.
     ///
     /// The buffer is cleared first, and the sink is written only by the caller
     /// on success, so a mid-record error (non-finite float) leaves no partial
@@ -125,20 +160,30 @@ impl<W: Write> JsonWriter<W> {
     ///
     /// # Errors
     ///
-    /// Returns [`FormatError::Json`] when a field holds a non-finite float
-    /// (NaN or an infinity), which JSON cannot represent.
+    /// Returns [`FormatError::FieldPath`] when the schema's column names cannot
+    /// be expanded, and [`FormatError::Json`] when a field holds a non-finite
+    /// float (NaN or an infinity), which JSON cannot represent.
     fn serialize_record(&mut self, record: &Record) -> Result<(), FormatError> {
         use serde::Serialize as _;
-        self.scratch.clear();
-        let obj = RecordObjectSer {
-            record,
-            preserve_nulls: self.config.preserve_nulls,
-            include_engine_stamped: self.config.include_engine_stamped,
+        self.ensure_plan(record)?;
+        // Disjoint field borrows: serializing reads the plan (`plan_cache`)
+        // while writing into `scratch`.
+        let Self {
+            plan_cache,
+            scratch,
+            config,
+            ..
+        } = self;
+        scratch.clear();
+        let obj = PlanBodySer {
+            body: &plan_cache.as_ref().expect("plan built above").root,
+            values: record.values(),
+            preserve_nulls: config.preserve_nulls,
         };
-        let result = if self.config.pretty {
-            obj.serialize(&mut serde_json::Serializer::pretty(&mut self.scratch))
+        let result = if config.pretty {
+            obj.serialize(&mut serde_json::Serializer::pretty(&mut *scratch))
         } else {
-            obj.serialize(&mut serde_json::Serializer::new(&mut self.scratch))
+            obj.serialize(&mut serde_json::Serializer::new(&mut *scratch))
         };
         result.map_err(|e| FormatError::Json(e.to_string()))
     }
@@ -155,27 +200,41 @@ impl<W: Write> JsonWriter<W> {
     }
 
     /// Build a JSON object from an envelope section's ordered fields, plus an
-    /// optional trailing computed-count entry. `null` is always emitted for a
-    /// section (envelope sections are small typed metadata, not body records),
-    /// so the round-trip stays faithful regardless of `preserve_nulls`.
+    /// optional trailing computed-count entry. Section field names expand into
+    /// nested objects by the same rule body records use, and the count entry
+    /// rides that expansion too — matching the XML writer, which passes the
+    /// count through the same field tree its section fields go through.
+    /// `null` is always emitted for a section (envelope sections are small
+    /// typed metadata, not body records), so the round-trip stays faithful
+    /// regardless of `preserve_nulls`.
+    ///
+    /// Unlike the body path this materializes an owned `serde_json::Map`: a
+    /// section is bounded `$doc` metadata already held in memory under
+    /// `max_index_bytes`, not a streamed record.
     ///
     /// # Errors
     ///
-    /// Returns [`FormatError::Json`] when a section field holds a non-finite
-    /// float (NaN or an infinity), which JSON cannot represent.
+    /// Returns [`FormatError::FieldPath`] when the section's field names cannot
+    /// be expanded, and [`FormatError::Json`] when a section field holds a
+    /// non-finite float (NaN or an infinity), which JSON cannot represent.
     fn section_object(
         fields: &indexmap::IndexMap<Box<str>, Value>,
         count: Option<(&str, i64)>,
     ) -> Result<serde_json::Value, FormatError> {
         use serde_json::{Map, Value as Jv};
-        let mut obj = Map::new();
+        let names = fields
+            .keys()
+            .map(|k| k.as_ref())
+            .chain(count.map(|(field, _)| field));
+        field_path::check_expandable(names).map_err(field_path_error)?;
+        let mut root = Map::new();
         for (name, value) in fields {
-            obj.insert(name.to_string(), clinker_to_json(value)?);
+            insert_section_field(&mut root, name, clinker_to_json(value)?)?;
         }
         if let Some((field, n)) = count {
-            obj.insert(field.to_string(), Jv::Number(n.into()));
+            insert_section_field(&mut root, field, Jv::Number(n.into()))?;
         }
-        Ok(Jv::Object(obj))
+        Ok(Jv::Object(root))
     }
 
     /// Append one body record to the currently-open document object's `body`
@@ -430,42 +489,182 @@ pub(crate) fn clinker_to_json(val: &Value) -> Result<serde_json::Value, FormatEr
     })
 }
 
-/// Borrows a record and serializes its fields as a JSON object directly to the
-/// target serializer, with no intermediate `serde_json::Value` tree. Keys
-/// borrow the schema's column names; values borrow the record's [`Value`]s via
-/// [`ValueSer`]. Mirrors the field selection of the (removed) `record_to_json`:
-/// honors `preserve_nulls` (skips null fields when false) and
-/// `include_engine_stamped` (whether `$`-namespaced correlation columns
-/// appear).
-struct RecordObjectSer<'a> {
-    record: &'a Record,
-    preserve_nulls: bool,
-    include_engine_stamped: bool,
+/// Wrap a field-name grammar failure as this writer's error.
+fn field_path_error(source: FieldPathError) -> FormatError {
+    FormatError::FieldPath {
+        format: "JSON",
+        source,
+    }
 }
 
-impl serde::Serialize for RecordObjectSer<'_> {
+// ── Column name → nested object expansion ────────────────────────────
+
+/// The expansion plan plus the schema identity it was built for.
+struct PlanCache {
+    schema: Arc<Schema>,
+    root: PlanBody,
+}
+
+/// One object's contents: the ordered keys it emits. Key order is
+/// first-insertion order, so columns sharing a prefix group at the position
+/// where that prefix first appeared even when the schema interleaves them.
+#[derive(Default)]
+struct PlanBody {
+    children: Vec<PlanNode>,
+}
+
+enum PlanNode {
+    /// A key holding a column's value, addressed by its schema position.
+    Leaf { name: String, field: usize },
+    /// A key holding a nested object.
+    Branch { name: String, body: PlanBody },
+}
+
+/// Build the expansion plan for a schema: decode every emitted column name and
+/// place its index at the leaf its path addresses.
+///
+/// The whole column set is checked before the first placement, so a set that
+/// cannot be expanded is refused as a set rather than discovered halfway
+/// through building a tree.
+///
+/// # Errors
+///
+/// Returns [`FormatError::FieldPath`] for a malformed escape, a name past the
+/// depth cap, or two columns that would occupy the same place in the tree.
+fn build_plan_cache(
+    schema: &Arc<Schema>,
+    include_engine_stamped: bool,
+) -> Result<PlanCache, FormatError> {
+    let emitted = || {
+        (0..schema.column_count())
+            .filter(move |&i| include_engine_stamped || !schema.is_engine_stamped(i))
+    };
+    field_path::check_expandable(emitted().map(|i| schema.columns()[i].as_ref()))
+        .map_err(field_path_error)?;
+
+    let mut root = PlanBody::default();
+    for i in emitted() {
+        let name = schema.columns()[i].as_ref();
+        let mut body = &mut root;
+        let mut path = field_path::segments(name).peekable();
+        while let Some(segment) = path.next() {
+            let segment = segment.map_err(field_path_error)?;
+            if path.peek().is_none() {
+                body.children.push(PlanNode::Leaf {
+                    name: segment.into_owned(),
+                    field: i,
+                });
+                break;
+            }
+            // Descend into the branch this segment already opened, so a shared
+            // prefix groups at the position where it first appeared.
+            let at = body
+                .children
+                .iter()
+                .position(|n| matches!(n, PlanNode::Branch { name, .. } if *name == *segment))
+                .unwrap_or_else(|| {
+                    body.children.push(PlanNode::Branch {
+                        name: segment.into_owned(),
+                        body: PlanBody::default(),
+                    });
+                    body.children.len() - 1
+                });
+            body = match &mut body.children[at] {
+                PlanNode::Branch { body, .. } => body,
+                PlanNode::Leaf { .. } => {
+                    unreachable!("check_expandable rejects a column nesting under a value column")
+                }
+            };
+        }
+    }
+    Ok(PlanCache {
+        schema: Arc::clone(schema),
+        root,
+    })
+}
+
+/// Place one already-materialized section value at the path its field name
+/// addresses, creating intermediate objects as it descends.
+fn insert_section_field(
+    root: &mut serde_json::Map<String, serde_json::Value>,
+    name: &str,
+    value: serde_json::Value,
+) -> Result<(), FormatError> {
+    let path = field_path::decode(name).map_err(field_path_error)?;
+    let (leaf, branches) = path
+        .split_last()
+        .expect("decoding yields at least one segment");
+    let mut object = root;
+    for segment in branches {
+        object = object
+            .entry(segment.as_ref())
+            .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()))
+            .as_object_mut()
+            .expect("check_expandable rejects a field nesting under a value field");
+    }
+    object.insert(leaf.to_string(), value);
+    Ok(())
+}
+
+/// Borrows one object's plan and the record's values, serializing the object
+/// directly to the target serializer with no intermediate `serde_json::Value`
+/// tree. Keys borrow the plan's segment names; values borrow the record's
+/// [`Value`]s via [`ValueSer`]. Nested objects recurse through this same impl,
+/// bounded by [`clinker_record::field_path::MAX_FIELD_PATH_DEPTH`].
+struct PlanBodySer<'a> {
+    body: &'a PlanBody,
+    values: &'a [Value],
+    preserve_nulls: bool,
+}
+
+impl serde::Serialize for PlanBodySer<'_> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap;
         // `None` length hint: serde_json ignores it, and the exact post-null-
-        // skip entry count would need a second pass over the fields.
+        // skip entry count would need a second pass over the plan.
         let mut map = serializer.serialize_map(None)?;
-        if self.include_engine_stamped {
-            for (col, val) in self.record.iter_all_fields() {
-                if !self.preserve_nulls && val.is_null() {
-                    continue;
+        for node in &self.body.children {
+            match node {
+                PlanNode::Leaf { name, field } => {
+                    let value = &self.values[*field];
+                    if !self.preserve_nulls && value.is_null() {
+                        continue;
+                    }
+                    map.serialize_entry(name.as_str(), &ValueSer(value))?;
                 }
-                map.serialize_entry(col, &ValueSer(val))?;
-            }
-        } else {
-            for (col, val) in self.record.iter_user_fields() {
-                if !self.preserve_nulls && val.is_null() {
-                    continue;
+                PlanNode::Branch { name, body } => {
+                    // An object whose every descendant is omitted emits no key
+                    // at all rather than an empty object, so it reads back as
+                    // the absent column it stands for.
+                    if !body_emits(body, self.values, self.preserve_nulls) {
+                        continue;
+                    }
+                    map.serialize_entry(
+                        name.as_str(),
+                        &PlanBodySer {
+                            body,
+                            values: self.values,
+                            preserve_nulls: self.preserve_nulls,
+                        },
+                    )?;
                 }
-                map.serialize_entry(col, &ValueSer(val))?;
             }
         }
         map.end()
     }
+}
+
+/// Whether any leaf under `body` contributes a key for this record.
+///
+/// Re-walks the subtree rather than caching per-record presence flags: the walk
+/// is bounded by the plan, which is already retained, while a presence buffer
+/// would be per-record state proportional to record width.
+fn body_emits(body: &PlanBody, values: &[Value], preserve_nulls: bool) -> bool {
+    preserve_nulls
+        || body.children.iter().any(|node| match node {
+            PlanNode::Leaf { field, .. } => !values[*field].is_null(),
+            PlanNode::Branch { body, .. } => body_emits(body, values, preserve_nulls),
+        })
 }
 
 /// Borrows a clinker [`Value`] and serializes it directly, mirroring
@@ -523,6 +722,7 @@ mod tests {
     use super::*;
     use crate::json::reader::{JsonReader, JsonReaderConfig};
     use crate::traits::FormatReader;
+    use clinker_record::schema::{FieldMetadata, SchemaBuilder};
 
     fn test_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
@@ -553,6 +753,47 @@ mod tests {
         String::from_utf8(buf).unwrap()
     }
 
+    /// Build a record over a schema of plain columns, one value per column.
+    fn record_of(schema: &Arc<Schema>, values: Vec<Value>) -> Record {
+        Record::new(Arc::clone(schema), values)
+    }
+
+    fn schema_of(columns: &[&str]) -> Arc<Schema> {
+        columns.iter().copied().collect::<SchemaBuilder>().build()
+    }
+
+    /// Write one record as a single NDJSON line, so assertions can pin the
+    /// exact bytes rather than a reparsed tree.
+    fn write_one_line(
+        config: JsonWriterConfig,
+        schema: &Arc<Schema>,
+        values: Vec<Value>,
+    ) -> String {
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            ..config
+        };
+        write_records(config, &[record_of(schema, values)], schema)
+            .trim_end()
+            .to_string()
+    }
+
+    /// Write one record and return the writer error plus everything that
+    /// reached the sink, so a rejection can be checked to have emitted nothing.
+    fn write_one_expecting_error(
+        config: JsonWriterConfig,
+        schema: &Arc<Schema>,
+        values: Vec<Value>,
+    ) -> (FormatError, Vec<u8>) {
+        let mut buf = Vec::new();
+        let mut w = JsonWriter::new(&mut buf, Arc::clone(schema), config);
+        let err = w
+            .write_record(&record_of(schema, values))
+            .expect_err("expected the record to be refused");
+        drop(w);
+        (err, buf)
+    }
+
     #[test]
     fn test_json_write_array_mode() {
         let schema = test_schema();
@@ -562,12 +803,14 @@ mod tests {
             make_record(&schema, "Carol", 35, true),
         ];
         let output = write_records(JsonWriterConfig::default(), &records, &schema);
-        let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
-        let arr = parsed.as_array().unwrap();
-        assert_eq!(arr.len(), 3);
-        assert_eq!(arr[0]["name"], "Alice");
-        assert_eq!(arr[1]["age"], 25);
-        assert_eq!(arr[2]["active"], true);
+        // Exact bytes: a flat schema must emit exactly what it did before
+        // dotted names started expanding.
+        assert_eq!(
+            output,
+            "[\n{\"name\":\"Alice\",\"age\":30,\"active\":true},\n\
+             {\"name\":\"Bob\",\"age\":25,\"active\":false},\n\
+             {\"name\":\"Carol\",\"age\":35,\"active\":true}\n]\n"
+        );
     }
 
     #[test]
@@ -977,6 +1220,320 @@ mod tests {
             ),
             other => panic!("expected FormatError::Json, got {other:?}"),
         }
+    }
+
+    // ── Dotted column name → nested object expansion ─────────────────
+
+    #[test]
+    fn dotted_columns_expand_into_one_nested_object() {
+        let schema = schema_of(&["Address.City", "Address.State", "name"]);
+        let out = write_one_line(
+            JsonWriterConfig::default(),
+            &schema,
+            vec![
+                Value::String("Boston".into()),
+                Value::String("MA".into()),
+                Value::String("Ada".into()),
+            ],
+        );
+        assert_eq!(
+            out,
+            r#"{"Address":{"City":"Boston","State":"MA"},"name":"Ada"}"#
+        );
+    }
+
+    #[test]
+    fn a_shared_prefix_groups_at_its_first_occurrence() {
+        // Interleaved in the schema, grouped in the output, hoisted to where
+        // the prefix first appeared — the same shape the XML writer produces.
+        let schema = schema_of(&["A.x", "n", "A.y"]);
+        let out = write_one_line(
+            JsonWriterConfig::default(),
+            &schema,
+            vec![Value::Integer(1), Value::Integer(2), Value::Integer(3)],
+        );
+        assert_eq!(out, r#"{"A":{"x":1,"y":3},"n":2}"#);
+    }
+
+    #[test]
+    fn expansion_nests_to_arbitrary_depth() {
+        let schema = schema_of(&["a.b.c", "a.b.d", "a.e"]);
+        let out = write_one_line(
+            JsonWriterConfig::default(),
+            &schema,
+            vec![Value::Integer(1), Value::Integer(2), Value::Integer(3)],
+        );
+        assert_eq!(out, r#"{"a":{"b":{"c":1,"d":2},"e":3}}"#);
+    }
+
+    #[test]
+    fn an_object_with_no_emitted_children_emits_no_key() {
+        let schema = schema_of(&["a.b", "a.c", "d"]);
+        let config = JsonWriterConfig {
+            preserve_nulls: false,
+            ..Default::default()
+        };
+        // Every descendant null: the parent key is absent, not `{}` — so it
+        // reads back as the absent column it stands for.
+        let all_null = write_one_line(
+            config.clone(),
+            &schema,
+            vec![Value::Null, Value::Null, Value::Integer(9)],
+        );
+        assert_eq!(all_null, r#"{"d":9}"#);
+        // One descendant present: the parent appears with only that child.
+        let one_present = write_one_line(
+            config,
+            &schema,
+            vec![Value::Null, Value::Integer(7), Value::Integer(9)],
+        );
+        assert_eq!(one_present, r#"{"a":{"c":7},"d":9}"#);
+    }
+
+    #[test]
+    fn preserved_nulls_keep_the_nested_object() {
+        let schema = schema_of(&["a.b"]);
+        let config = JsonWriterConfig {
+            preserve_nulls: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            write_one_line(config, &schema, vec![Value::Null]),
+            r#"{"a":{"b":null}}"#
+        );
+    }
+
+    #[test]
+    fn pretty_mode_indents_the_nested_object() {
+        let schema = schema_of(&["Address.City", "name"]);
+        let config = JsonWriterConfig {
+            pretty: true,
+            ..Default::default()
+        };
+        let out = write_one_line(
+            config,
+            &schema,
+            vec![Value::String("Boston".into()), Value::String("Ada".into())],
+        );
+        assert_eq!(
+            out,
+            "{\n  \"Address\": {\n    \"City\": \"Boston\"\n  },\n  \"name\": \"Ada\"\n}"
+        );
+    }
+
+    #[test]
+    fn a_structured_value_nests_below_the_expanded_leaf() {
+        // Expansion adds structure above the leaf; the value model supplies
+        // structure below it. The two never interact.
+        let schema = schema_of(&["Items.Item", "meta.tags"]);
+        let out = write_one_line(
+            JsonWriterConfig::default(),
+            &schema,
+            vec![
+                Value::Array(vec![Value::Integer(1), Value::Integer(2)]),
+                Value::Map(Box::new(
+                    [("k".into(), Value::String("v".into()))]
+                        .into_iter()
+                        .collect(),
+                )),
+            ],
+        );
+        assert_eq!(out, r#"{"Items":{"Item":[1,2]},"meta":{"tags":{"k":"v"}}}"#);
+    }
+
+    #[test]
+    fn a_column_that_is_also_a_container_is_refused_before_any_byte() {
+        for columns in [
+            // A value column and a container of the same name, either order.
+            ["a", "a.b"],
+            ["a.b", "a"],
+            // The same clash one level deeper.
+            ["a.b", "a.b.c"],
+            ["a.b.c", "a.b"],
+            // Two distinct spellings addressing the identical path.
+            ["a[b", "a\\[b"],
+        ] {
+            let schema = schema_of(&columns);
+            let (err, buf) = write_one_expecting_error(
+                JsonWriterConfig::default(),
+                &schema,
+                vec![Value::Integer(1); columns.len()],
+            );
+            let FormatError::FieldPath { format, .. } = &err else {
+                panic!("expected a field-path error for {columns:?}, got {err:?}");
+            };
+            assert_eq!(*format, "JSON");
+            let msg = err.to_string();
+            for column in columns {
+                assert!(msg.contains(column), "{msg} should name {column}");
+            }
+            assert!(
+                buf.is_empty(),
+                "a refused column set must emit no bytes, got: {:?}",
+                String::from_utf8_lossy(&buf)
+            );
+        }
+    }
+
+    #[test]
+    fn an_escaped_separator_keeps_the_dot_in_the_key() {
+        // The replacement for the literal dotted key unconditional expansion
+        // takes away: declare the column with the separator escaped.
+        let schema = schema_of(&["a\\.b", "a"]);
+        let out = write_one_line(
+            JsonWriterConfig::default(),
+            &schema,
+            vec![Value::Integer(1), Value::Integer(2)],
+        );
+        assert_eq!(out, r#"{"a.b":1,"a":2}"#);
+
+        // An escaped and an unescaped separator address different paths, so
+        // the two coexist rather than colliding.
+        let schema = schema_of(&["a.b", "a\\.b"]);
+        let out = write_one_line(
+            JsonWriterConfig::default(),
+            &schema,
+            vec![Value::Integer(1), Value::Integer(2)],
+        );
+        assert_eq!(out, r#"{"a":{"b":1},"a.b":2}"#);
+    }
+
+    #[test]
+    fn a_malformed_escape_is_refused_before_any_byte() {
+        let schema = schema_of(&["C:\\temp"]);
+        let (err, buf) = write_one_expecting_error(
+            JsonWriterConfig::default(),
+            &schema,
+            vec![Value::Integer(1)],
+        );
+        assert!(
+            matches!(
+                err,
+                FormatError::FieldPath {
+                    source: clinker_record::field_path::FieldPathError::UnknownEscape { .. },
+                    ..
+                }
+            ),
+            "got {err:?}"
+        );
+        // The message must carry the spelling that fixes it.
+        assert!(err.to_string().contains("C:\\\\temp"), "{err}");
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn engine_stamped_columns_expand_by_the_same_rule() {
+        // The rule is a function of the column-name string alone, with no
+        // carve-out for engine-stamped namespaces.
+        let schema = SchemaBuilder::new()
+            .with_field("amount")
+            .with_field_meta(
+                "$ck.customer_id",
+                FieldMetadata::source_correlation("customer_id"),
+            )
+            .build();
+        let values = vec![Value::Integer(5), Value::String("C-1".into())];
+
+        let stripped = write_one_line(JsonWriterConfig::default(), &schema, values.clone());
+        assert_eq!(stripped, r#"{"amount":5}"#);
+
+        let config = JsonWriterConfig {
+            include_engine_stamped: true,
+            ..Default::default()
+        };
+        let included = write_one_line(config, &schema, values);
+        assert_eq!(included, r#"{"amount":5,"$ck":{"customer_id":"C-1"}}"#);
+    }
+
+    #[test]
+    fn a_new_schema_identity_rebuilds_the_plan() {
+        let flat = schema_of(&["a"]);
+        let nested = schema_of(&["a.b"]);
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            ..Default::default()
+        };
+        let mut buf = Vec::new();
+        {
+            let mut w = JsonWriter::new(&mut buf, Arc::clone(&flat), config);
+            w.write_record(&record_of(&flat, vec![Value::Integer(1)]))
+                .unwrap();
+            w.write_record(&record_of(&nested, vec![Value::Integer(2)]))
+                .unwrap();
+            w.write_record(&record_of(&flat, vec![Value::Integer(3)]))
+                .unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        assert_eq!(out.trim_end(), "{\"a\":1}\n{\"a\":{\"b\":2}}\n{\"a\":3}");
+    }
+
+    #[test]
+    fn a_nested_schema_reuses_the_scratch_buffer_without_bleed() {
+        // The nested walk writes into the same retained buffer every record;
+        // a wide schema with a long value would surface any stale tail.
+        let columns: Vec<String> = (0..40).map(|i| format!("g{}.c{i}", i % 4)).collect();
+        let schema = schema_of(&columns.iter().map(String::as_str).collect::<Vec<_>>());
+        let long = "x".repeat(500);
+        let mk = |seed: i64, tail: &str| {
+            let mut values: Vec<Value> = (0..40).map(|i| Value::Integer(seed + i)).collect();
+            values[17] = Value::String(format!("{long}-{tail}").into());
+            record_of(&schema, values)
+        };
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            ..Default::default()
+        };
+        let written = write_records(config, &[mk(0, "first"), mk(100, "second")], &schema);
+        let lines: Vec<&str> = written.trim_end().split('\n').collect();
+        assert_eq!(lines.len(), 2);
+        for (line, (seed, tail)) in lines.iter().zip([(0, "first"), (100, "second")]) {
+            let v: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert_eq!(v["g0"]["c0"], seed);
+            assert_eq!(v["g3"]["c39"], seed + 39);
+            assert_eq!(v["g1"]["c17"], format!("{long}-{tail}"));
+        }
+    }
+
+    #[test]
+    fn envelope_section_fields_expand_too() {
+        let schema = schema_of(&["amount"]);
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            envelope: Some(crate::envelope_writer::OutputEnvelopeSpec {
+                header_from_doc: Some("Head".into()),
+                footer_from_doc: Some("Foot".into()),
+                footer_record_count_field: Some("totals.count".into()),
+            }),
+            ..Default::default()
+        };
+        let doc = doc_with_sections(&[
+            (
+                "Head",
+                &[
+                    ("batch.id", Value::String("B-1".into())),
+                    ("batch.source", Value::String("ftp".into())),
+                ],
+            ),
+            ("Foot", &[("totals.checksum", Value::String("S".into()))]),
+        ]);
+        let mut buf = Vec::new();
+        {
+            let mut w = JsonWriter::new(&mut buf, Arc::clone(&schema), config);
+            w.begin_document(&doc).unwrap();
+            w.write_record(&record_of(&schema, vec![Value::Integer(1)]))
+                .unwrap();
+            w.end_document(&doc).unwrap();
+            w.flush().unwrap();
+        }
+        let out = String::from_utf8(buf).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(out.trim_end()).unwrap();
+        assert_eq!(parsed["header"]["batch"]["id"], "B-1");
+        assert_eq!(parsed["header"]["batch"]["source"], "ftp");
+        // The computed count rides the same expansion, joining the section
+        // field that shares its prefix.
+        assert_eq!(parsed["footer"]["totals"]["checksum"], "S");
+        assert_eq!(parsed["footer"]["totals"]["count"], 1);
     }
 
     #[test]

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -2,6 +2,13 @@
 //! to nested elements, attribute-prefixed fields emitted as XML attributes,
 //! null handling, and proper escaping.
 //!
+//! Column names are decoded with the shared record-space grammar in
+//! [`clinker_record::field_path`] — the same grammar the JSON writer expands
+//! objects with — so one column set produces the same tree in both formats.
+//! What stays XML-specific is everything below the decode: attribute
+//! classification against `attribute_prefix`, repeated-element naming, and
+//! rejecting a segment that is not a well-formed XML `Name`.
+//!
 //! Under `reconstruct_envelope`, each document is wrapped in a `<Document>`
 //! element inside the root: `begin_document` opens `<Document>` and emits the
 //! header section as a `<header>` element; the body `<Record>` elements stream
@@ -17,6 +24,7 @@ use quick_xml::events::attributes::Attribute;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::name::QName;
 
+use clinker_record::field_path::{self, FieldPathError};
 use clinker_record::{DocumentContext, Record, Schema, Value};
 
 use crate::envelope_writer::{EnvelopeFramer, OutputEnvelopeSpec};
@@ -375,6 +383,14 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
 
 // ── Field tree for dotted name → nested element expansion ────────────
 
+/// Wrap a field-name grammar failure as this writer's error.
+fn field_path_error(source: FieldPathError) -> FormatError {
+    FormatError::FieldPath {
+        format: "XML",
+        source,
+    }
+}
+
 /// One element's content: the attributes attached to its start tag plus its
 /// child nodes. The whole body is materialized before the element's start
 /// tag is emitted, because attributes have to be known at that point.
@@ -412,14 +428,16 @@ fn build_field_tree(
     preserve_nulls: bool,
     attribute_prefix: &str,
 ) -> Result<ElementBody, FormatError> {
+    field_path::check_expandable(fields.iter().map(|&(name, _)| name)).map_err(field_path_error)?;
     let mut root = ElementBody::default();
 
     for &(name, val) in fields {
-        if val.is_null() && (!preserve_nulls || is_attribute_path(name, attribute_prefix)) {
+        let path = field_path::decode(name).map_err(field_path_error)?;
+        if val.is_null() && (!preserve_nulls || is_attribute_path(&path, attribute_prefix)) {
             continue;
         }
         let text = value_to_text(name, val)?;
-        insert_field(&mut root, name, name, &text, attribute_prefix)?;
+        insert_field(&mut root, name, &path, &text, attribute_prefix)?;
     }
 
     Ok(root)
@@ -478,11 +496,10 @@ fn escape_attribute_value(raw: &str) -> String {
 
 /// True when the path's final segment is attribute-classified — i.e. a
 /// non-empty prefix marks it as an attribute of its enclosing element.
-fn is_attribute_path(path: &str, attribute_prefix: &str) -> bool {
+fn is_attribute_path(path: &[Cow<'_, str>], attribute_prefix: &str) -> bool {
     !attribute_prefix.is_empty()
         && path
-            .rsplit('.')
-            .next()
+            .last()
             .is_some_and(|segment| segment.starts_with(attribute_prefix))
 }
 
@@ -553,30 +570,32 @@ fn check_xml_name(name: &str, context: &str) -> Result<(), FormatError> {
     }
 }
 
-/// Insert a dotted field name into the tree, creating branches as needed.
+/// Insert a decoded field path into the tree, creating branches as needed.
 /// An attribute-prefixed segment must be the path's final segment (an
 /// attribute is a leaf — nothing can nest under it); `field` is the full
 /// original field name, carried for error messages.
 fn insert_field(
     body: &mut ElementBody,
     field: &str,
-    path: &str,
+    path: &[Cow<'_, str>],
     text: &str,
     attribute_prefix: &str,
 ) -> Result<(), FormatError> {
-    if let Some((first, rest)) = path.split_once('.') {
-        if !attribute_prefix.is_empty() && first.starts_with(attribute_prefix) {
+    let (segment, rest) = path
+        .split_first()
+        .expect("a decoded field path has at least one segment");
+    if !rest.is_empty() {
+        if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
             return Err(FormatError::Xml(format!(
-                "field '{field}': attribute-prefixed segment '{first}' \
+                "field '{field}': attribute-prefixed segment '{segment}' \
                  cannot have fields nested under it — an XML attribute is a leaf"
             )));
         }
-        check_xml_name(first, &format!("field '{field}': element"))?;
-        // Find or create a branch for `first`
-        let branch = body
-            .children
-            .iter_mut()
-            .find(|n| matches!(n, FieldNode::Branch { name, .. } if name == first));
+        check_xml_name(segment, &format!("field '{field}': element"))?;
+        // Find or create a branch for `segment`
+        let branch = body.children.iter_mut().find(
+            |n| matches!(n, FieldNode::Branch { name, .. } if name.as_str() == segment.as_ref()),
+        );
         if let Some(FieldNode::Branch {
             body: branch_body, ..
         }) = branch
@@ -586,13 +605,13 @@ fn insert_field(
             let mut branch_body = ElementBody::default();
             insert_field(&mut branch_body, field, rest, text, attribute_prefix)?;
             body.children.push(FieldNode::Branch {
-                name: first.to_string(),
+                name: segment.to_string(),
                 body: branch_body,
             });
             Ok(())
         }
-    } else if !attribute_prefix.is_empty() && path.starts_with(attribute_prefix) {
-        let attr_name = &path[attribute_prefix.len()..];
+    } else if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
+        let attr_name = &segment[attribute_prefix.len()..];
         if attr_name.is_empty() {
             return Err(FormatError::Xml(format!(
                 "field '{field}': attribute prefix '{attribute_prefix}' \
@@ -608,9 +627,9 @@ fn insert_field(
         body.attrs.push((attr_name.to_string(), text.to_string()));
         Ok(())
     } else {
-        check_xml_name(path, &format!("field '{field}': element"))?;
+        check_xml_name(segment, &format!("field '{field}': element"))?;
         body.children.push(FieldNode::Leaf {
-            name: path.to_string(),
+            name: segment.to_string(),
             text: text.to_string(),
         });
         Ok(())
@@ -755,14 +774,16 @@ fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCac
     } else {
         record.iter_user_fields().map(|(name, _)| name).collect()
     };
+    field_path::check_expandable(names.iter().copied()).map_err(field_path_error)?;
     let mut root = PlanBody::default();
     let mut field_is_attr = vec![false; names.len()];
     for (i, name) in names.iter().enumerate() {
+        let path = field_path::decode(name).map_err(field_path_error)?;
         plan_insert_field(
             &mut root,
             i,
             name,
-            name,
+            &path,
             &config.attribute_prefix,
             &config.join_values,
             &mut field_is_attr,
@@ -775,7 +796,7 @@ fn build_plan_cache(record: &Record, config: &XmlWriterConfig) -> Result<PlanCac
     })
 }
 
-/// Insert a dotted field name into the plan, creating branches as needed —
+/// Insert a decoded field path into the plan, creating branches as needed —
 /// the plan-time twin of [`insert_field`], storing the field index in place of
 /// a rendered value. Attribute-prefixed segments must be terminal, and
 /// attribute names are validated here (once) rather than per record.
@@ -783,23 +804,25 @@ fn plan_insert_field(
     body: &mut PlanBody,
     field_index: usize,
     field: &str,
-    path: &str,
+    path: &[Cow<'_, str>],
     attribute_prefix: &str,
     join_values: &[JoinValues],
     field_is_attr: &mut [bool],
 ) -> Result<(), FormatError> {
-    if let Some((first, rest)) = path.split_once('.') {
-        if !attribute_prefix.is_empty() && first.starts_with(attribute_prefix) {
+    let (segment, rest) = path
+        .split_first()
+        .expect("a decoded field path has at least one segment");
+    if !rest.is_empty() {
+        if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
             return Err(FormatError::Xml(format!(
-                "field '{field}': attribute-prefixed segment '{first}' \
+                "field '{field}': attribute-prefixed segment '{segment}' \
                  cannot have fields nested under it — an XML attribute is a leaf"
             )));
         }
-        check_xml_name(first, &format!("field '{field}': element"))?;
-        let branch = body
-            .children
-            .iter_mut()
-            .find(|n| matches!(n, PlanNode::Branch { name, .. } if name == first));
+        check_xml_name(segment, &format!("field '{field}': element"))?;
+        let branch = body.children.iter_mut().find(
+            |n| matches!(n, PlanNode::Branch { name, .. } if name.as_str() == segment.as_ref()),
+        );
         if let Some(PlanNode::Branch {
             body: branch_body, ..
         }) = branch
@@ -825,13 +848,13 @@ fn plan_insert_field(
                 field_is_attr,
             )?;
             body.children.push(PlanNode::Branch {
-                name: first.to_string(),
+                name: segment.to_string(),
                 body: branch_body,
             });
             Ok(())
         }
-    } else if !attribute_prefix.is_empty() && path.starts_with(attribute_prefix) {
-        let attr_name = &path[attribute_prefix.len()..];
+    } else if !attribute_prefix.is_empty() && segment.starts_with(attribute_prefix) {
+        let attr_name = &segment[attribute_prefix.len()..];
         if attr_name.is_empty() {
             return Err(FormatError::Xml(format!(
                 "field '{field}': attribute prefix '{attribute_prefix}' \
@@ -851,10 +874,10 @@ fn plan_insert_field(
         });
         Ok(())
     } else {
-        check_xml_name(path, &format!("field '{field}': element"))?;
-        let repeat = build_repeat_spec(field, path, join_values)?;
+        check_xml_name(segment, &format!("field '{field}': element"))?;
+        let repeat = build_repeat_spec(field, segment, join_values)?;
         body.children.push(PlanNode::Leaf {
-            name: path.to_string(),
+            name: segment.to_string(),
             field: field_index,
             repeat,
         });
@@ -1242,6 +1265,58 @@ mod tests {
         assert!(
             output.contains("<Address><City>NYC</City></Address>"),
             "Dotted field should expand to nested elements: {output}"
+        );
+    }
+
+    #[test]
+    fn an_escaped_separator_stays_inside_one_element_name() {
+        // `.` is a legal XML NameChar, so an escaped separator produces one
+        // element rather than a nesting level. This is the replacement for the
+        // literal dotted name that unconditional expansion takes away.
+        let schema = Arc::new(Schema::new(vec![r"a\.b".into()]));
+        let record = Record::new(Arc::clone(&schema), vec![Value::String("v".into())]);
+        let output = write_records(XmlWriterConfig::default(), &[record], &schema);
+        assert!(output.contains("<a.b>v</a.b>"), "{output}");
+
+        // The reader flattens `<a.b>` back to the column `a.b` — unescaped, so
+        // the name it hands back would nest on a second write. Closing that is
+        // the read side's half of the grammar, tracked by
+        // https://github.com/rustpunk/clinker/issues/920; pinned here so the
+        // flip is deliberate.
+        let mut reader = XmlReader::from_reader(
+            std::io::Cursor::new(output.into_bytes()),
+            XmlReaderConfig {
+                record_path: Some("Root/Record".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let _s = reader.schema().unwrap();
+        let back = reader.next_record().unwrap().unwrap();
+        assert_eq!(back.get("a.b"), Some(&Value::String("v".into())));
+    }
+
+    #[test]
+    fn a_column_that_is_also_a_container_is_refused() {
+        // Previously emitted two sibling `<a>` elements, which this crate's own
+        // reader then refused on the way back in.
+        let schema = Arc::new(Schema::new(vec!["a".into(), "a.b".into()]));
+        let record = Record::new(
+            Arc::clone(&schema),
+            vec![Value::Integer(1), Value::Integer(2)],
+        );
+        let mut buf = Vec::new();
+        let mut w = XmlWriter::new(&mut buf, Arc::clone(&schema), XmlWriterConfig::default());
+        let err = w.write_record(&record).unwrap_err();
+        assert!(
+            matches!(err, FormatError::FieldPath { format: "XML", .. }),
+            "{err:?}"
+        );
+        drop(w);
+        assert!(
+            buf.is_empty(),
+            "a refused column set emits no bytes, got: {:?}",
+            String::from_utf8_lossy(&buf)
         );
     }
 

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -385,10 +385,7 @@ impl<W: Write + Send> FormatWriter for XmlWriter<W> {
 
 /// Wrap a field-name grammar failure as this writer's error.
 fn field_path_error(source: FieldPathError) -> FormatError {
-    FormatError::FieldPath {
-        format: "XML",
-        source,
-    }
+    FormatError::field_path("XML", source)
 }
 
 /// One element's content: the attributes attached to its start tag plus its

--- a/crates/clinker-format/tests/json_nested_roundtrip.rs
+++ b/crates/clinker-format/tests/json_nested_roundtrip.rs
@@ -1,0 +1,100 @@
+//! Nested JSON survives a read followed by a write with no transform between.
+//!
+//! The reader flattens nested objects into dotted column names and the writer
+//! expands them back, so the two are inverses over the whole shape a JSON
+//! document can carry: objects to any depth, arrays of objects, arrays of
+//! scalars, and nulls.
+
+use clinker_format::json::reader::{JsonReader, JsonReaderConfig};
+use clinker_format::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
+use clinker_format::{FormatReader, FormatWriter};
+
+/// Read `input` as a single-record NDJSON document and write it straight back,
+/// with no transform between, returning the emitted JSON.
+fn read_then_write(input: &str) -> serde_json::Value {
+    let mut reader = JsonReader::from_reader(
+        std::io::Cursor::new(input.as_bytes().to_vec()),
+        JsonReaderConfig::default(),
+    )
+    .expect("reader opens");
+    let schema = reader.schema().expect("schema inferred");
+
+    let mut buf = Vec::new();
+    {
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            // The reader emits an explicit null for a source null, so keeping
+            // nulls is what makes the round trip lossless.
+            preserve_nulls: true,
+            ..Default::default()
+        };
+        let mut writer = JsonWriter::new(&mut buf, schema, config);
+        while let Some(record) = reader.next_record().expect("record reads") {
+            writer.write_record(&record).expect("record writes");
+        }
+        writer.flush().expect("writer flushes");
+    }
+    let out = String::from_utf8(buf).expect("utf-8 output");
+    serde_json::from_str(out.trim_end()).expect("valid JSON output")
+}
+
+fn assert_round_trips(input: &str) {
+    let expected: serde_json::Value = serde_json::from_str(input).expect("valid JSON input");
+    assert_eq!(read_then_write(input), expected, "input: {input}");
+}
+
+#[test]
+fn nested_objects_round_trip_to_any_depth() {
+    assert_round_trips(r#"{"customer":{"name":"Ada","email":"ada@example.com"},"id":7}"#);
+    assert_round_trips(r#"{"a":{"b":{"c":{"d":1}}},"top":2}"#);
+}
+
+#[test]
+fn a_prefix_shared_by_interleaved_keys_regroups() {
+    // The reader flattens depth-first, so the writer sees `a.x`, `n`, `a.y`
+    // only when the source itself interleaved them — which JSON cannot express
+    // for one object. What it can express is two sibling objects, and both come
+    // back whole.
+    assert_round_trips(r#"{"a":{"x":1},"n":2,"b":{"y":3}}"#);
+}
+
+#[test]
+fn arrays_survive_whole() {
+    // The reader does not flatten arrays: an array stays one column's value and
+    // the writer serializes it natively, so its interior shape is untouched.
+    assert_round_trips(r#"{"items":[{"sku":"A","qty":1},{"sku":"B","qty":2}]}"#);
+    assert_round_trips(r#"{"tags":["x","y","z"],"id":1}"#);
+    assert_round_trips(r#"{"order":{"lines":[{"n":1}]},"id":2}"#);
+}
+
+#[test]
+fn nulls_survive_when_preserved() {
+    assert_round_trips(r#"{"a":{"b":null},"c":null}"#);
+}
+
+#[test]
+fn an_empty_nested_object_contributes_no_column() {
+    // `{"a":{}}` flattens to no column at all, so nothing comes back for it —
+    // the writer's own rule that an object with no emitted descendants emits no
+    // key keeps the two ends agreeing.
+    assert_eq!(
+        read_then_write(r#"{"a":{},"b":1}"#),
+        serde_json::json!({"b":1})
+    );
+}
+
+#[test]
+fn a_literal_dotted_source_key_comes_back_nested() {
+    // A source key that literally contains `.` reaches the writer as the column
+    // `a.b`, indistinguishable from a nested `{"a":{"b":…}}`, because the
+    // reader joins path segments without escaping them. The writer then nests
+    // it. Closing this gap is the read side's half of the grammar, tracked by
+    // https://github.com/rustpunk/clinker/issues/920 — the reader's join has to
+    // escape each key the way `field_path::encode_segment` does. Pinned here so
+    // that flip is a deliberate change to this expectation rather than a
+    // silent one.
+    assert_eq!(
+        read_then_write(r#"{"a.b":1}"#),
+        serde_json::json!({"a":{"b":1}})
+    );
+}

--- a/crates/clinker-format/tests/nested_write_symmetry.rs
+++ b/crates/clinker-format/tests/nested_write_symmetry.rs
@@ -1,0 +1,214 @@
+//! The JSON and XML writers expand one column set the same way.
+//!
+//! Both decode column names with the shared record-space grammar, so grouping,
+//! key order, null pruning, escaping, and the rejection of an unexpandable
+//! column set are properties of the grammar rather than of either writer. A
+//! change that made one writer disagree with the other would fail here.
+
+use std::sync::Arc;
+
+use clinker_format::json::writer::{JsonOutputMode, JsonWriter, JsonWriterConfig};
+use clinker_format::xml::writer::{XmlWriter, XmlWriterConfig};
+use clinker_format::{FormatError, FormatWriter};
+use clinker_record::schema::FieldMetadata;
+use clinker_record::{Record, Schema, SchemaBuilder, Value};
+
+fn schema_of(columns: &[&str]) -> Arc<Schema> {
+    columns.iter().copied().collect::<SchemaBuilder>().build()
+}
+
+fn write_json(schema: &Arc<Schema>, values: Vec<Value>, preserve_nulls: bool) -> String {
+    let config = JsonWriterConfig {
+        format: JsonOutputMode::Ndjson,
+        preserve_nulls,
+        ..Default::default()
+    };
+    let mut buf = Vec::new();
+    {
+        let mut w = JsonWriter::new(&mut buf, Arc::clone(schema), config);
+        w.write_record(&Record::new(Arc::clone(schema), values))
+            .expect("json record writes");
+        w.flush().expect("json writer flushes");
+    }
+    String::from_utf8(buf)
+        .expect("utf-8")
+        .trim_end()
+        .to_string()
+}
+
+fn write_xml(schema: &Arc<Schema>, values: Vec<Value>, preserve_nulls: bool) -> String {
+    let config = XmlWriterConfig {
+        preserve_nulls,
+        ..Default::default()
+    };
+    let mut buf = Vec::new();
+    {
+        let mut w = XmlWriter::new(&mut buf, Arc::clone(schema), config);
+        w.write_record(&Record::new(Arc::clone(schema), values))
+            .expect("xml record writes");
+        w.flush().expect("xml writer flushes");
+    }
+    String::from_utf8(buf).expect("utf-8")
+}
+
+/// The error each writer raises for the same column set, or `None` when it
+/// accepted the set.
+fn refusal(schema: &Arc<Schema>, values: Vec<Value>) -> (Option<FormatError>, Option<FormatError>) {
+    let mut json_buf = Vec::new();
+    let json = {
+        let mut w = JsonWriter::new(
+            &mut json_buf,
+            Arc::clone(schema),
+            JsonWriterConfig::default(),
+        );
+        w.write_record(&Record::new(Arc::clone(schema), values.clone()))
+            .err()
+    };
+    let mut xml_buf = Vec::new();
+    let xml = {
+        let mut w = XmlWriter::new(&mut xml_buf, Arc::clone(schema), XmlWriterConfig::default());
+        w.write_record(&Record::new(Arc::clone(schema), values))
+            .err()
+    };
+    (json, xml)
+}
+
+#[test]
+fn both_writers_group_a_shared_prefix_at_its_first_occurrence() {
+    let schema = schema_of(&["A.x", "n", "A.y"]);
+    let values = vec![Value::Integer(1), Value::Integer(2), Value::Integer(3)];
+    assert_eq!(
+        write_json(&schema, values.clone(), false),
+        r#"{"A":{"x":1,"y":3},"n":2}"#
+    );
+    assert!(
+        write_xml(&schema, values, false).contains("<A><x>1</x><y>3</y></A><n>2</n>"),
+        "XML groups and hoists the same way"
+    );
+}
+
+#[test]
+fn both_writers_nest_to_the_same_depth() {
+    let schema = schema_of(&["a.b.c", "a.b.d"]);
+    let values = vec![Value::Integer(1), Value::Integer(2)];
+    assert_eq!(
+        write_json(&schema, values.clone(), false),
+        r#"{"a":{"b":{"c":1,"d":2}}}"#
+    );
+    assert!(write_xml(&schema, values, false).contains("<a><b><c>1</c><d>2</d></b></a>"));
+}
+
+#[test]
+fn both_writers_omit_a_container_whose_children_are_all_absent() {
+    let schema = schema_of(&["a.b", "a.c", "d"]);
+    let values = vec![Value::Null, Value::Null, Value::Integer(9)];
+    assert_eq!(write_json(&schema, values.clone(), false), r#"{"d":9}"#);
+    let xml = write_xml(&schema, values, false);
+    assert!(
+        !xml.contains("<a"),
+        "XML omits the empty container too: {xml}"
+    );
+    assert!(xml.contains("<d>9</d>"));
+}
+
+#[test]
+fn both_writers_keep_an_escaped_separator_in_the_name() {
+    // `.` is a legal XML NameChar, so the escaped column lands as one element
+    // named `a.b` — the same single key JSON emits.
+    let schema = schema_of(&["a\\.b"]);
+    let values = vec![Value::Integer(1)];
+    assert_eq!(write_json(&schema, values.clone(), false), r#"{"a.b":1}"#);
+    assert!(write_xml(&schema, values, false).contains("<a.b>1</a.b>"));
+}
+
+#[test]
+fn both_writers_refuse_a_column_set_that_cannot_be_expanded() {
+    // Before the shared grammar the XML writer silently emitted two sibling
+    // `<a>` elements for this set, which its own reader then refused on the way
+    // back in. Both writers now refuse it up front, with the same error.
+    for columns in [["a", "a.b"], ["a.b", "a"], ["a.b", "a.b.c"]] {
+        let schema = schema_of(&columns);
+        let values = vec![Value::Integer(1); columns.len()];
+        let (json, xml) = refusal(&schema, values);
+        let (Some(json), Some(xml)) = (json, xml) else {
+            panic!("both writers must refuse {columns:?}");
+        };
+        assert!(
+            matches!(json, FormatError::FieldPath { format: "JSON", .. }),
+            "JSON: {json:?}"
+        );
+        assert!(
+            matches!(xml, FormatError::FieldPath { format: "XML", .. }),
+            "XML: {xml:?}"
+        );
+        // Only the format label differs — the diagnostic itself is the
+        // grammar's, so both name the same two columns and the same remedy.
+        assert_eq!(
+            json.to_string().replace("JSON", ""),
+            xml.to_string().replace("XML", "")
+        );
+    }
+}
+
+#[test]
+fn an_engine_stamped_column_expands_by_the_same_rule() {
+    // The rule reads the column-name string and nothing else, so it applies to
+    // engine-stamped columns with no carve-out. JSON nests `$ck.customer_id`
+    // and reads back cleanly.
+    //
+    // XML cannot follow it here, and did not before this rule either: `$` is
+    // not a legal XML name start character, so the segment `$ck` is refused at
+    // the format boundary — after the shared decode, not instead of it. That is
+    // a format constraint rather than a second grammar, and it means enabling
+    // correlation-key output on an XML sink fails outright. Pinned so the
+    // divergence stays a known, located fact.
+    let schema = SchemaBuilder::new()
+        .with_field("amount")
+        .with_field_meta(
+            "$ck.customer_id",
+            FieldMetadata::source_correlation("customer_id"),
+        )
+        .build();
+    let values = vec![Value::Integer(5), Value::String("C-1".into())];
+    let record = || Record::new(Arc::clone(&schema), values.clone());
+
+    let mut json_buf = Vec::new();
+    {
+        let config = JsonWriterConfig {
+            format: JsonOutputMode::Ndjson,
+            include_engine_stamped: true,
+            ..Default::default()
+        };
+        let mut w = JsonWriter::new(&mut json_buf, Arc::clone(&schema), config);
+        w.write_record(&record()).expect("json accepts `$ck`");
+        w.flush().expect("json flushes");
+    }
+    assert_eq!(
+        String::from_utf8(json_buf).expect("utf-8").trim_end(),
+        r#"{"amount":5,"$ck":{"customer_id":"C-1"}}"#
+    );
+
+    let mut xml_buf = Vec::new();
+    let config = XmlWriterConfig {
+        include_engine_stamped: true,
+        ..Default::default()
+    };
+    let mut w = XmlWriter::new(&mut xml_buf, Arc::clone(&schema), config);
+    let err = w
+        .write_record(&record())
+        .expect_err("XML has no well-formed name for `$ck`");
+    assert!(
+        matches!(err, FormatError::Xml(ref m) if m.contains("not a well-formed XML name")),
+        "{err:?}"
+    );
+}
+
+#[test]
+fn both_writers_refuse_a_malformed_escape() {
+    let schema = schema_of(&["C:\\temp"]);
+    let (json, xml) = refusal(&schema, vec![Value::Integer(1)]);
+    for err in [json, xml] {
+        let err = err.expect("a malformed escape is refused by both writers");
+        assert!(matches!(err, FormatError::FieldPath { .. }), "{err:?}");
+    }
+}

--- a/crates/clinker-plan/src/config/multi_value.rs
+++ b/crates/clinker-plan/src/config/multi_value.rs
@@ -84,8 +84,15 @@ fn column_maps_to_xml_attribute(column: &str, attribute_prefix: &str) -> bool {
     if attribute_prefix.is_empty() {
         return false;
     }
-    let last_segment = column.rsplit('.').next().unwrap_or(column);
-    last_segment.starts_with(attribute_prefix)
+    // Decoded with the shared field-path grammar, so an escaped separator is
+    // classified the way the writer will classify it: `a\.@x` is one segment
+    // named `a.@x`, an element, not an `@x` attribute of `a`. A name the
+    // grammar rejects outright is not an attribute either — the writer raises
+    // the grammar error itself, with the remedy.
+    clinker_record::field_path::decode(column)
+        .ok()
+        .and_then(|path| path.last().map(|s| s.starts_with(attribute_prefix)))
+        .unwrap_or(false)
 }
 
 /// How an input format can carry a column declared `multiple: true`.
@@ -1161,8 +1168,8 @@ pub fn output_node_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
             // attribute-vs-element is a SINK-side property, because the only
             // name transforms between source and this sink cannot change a
             // column's attribute status. That status is a LEAF-only property —
-            // `column_maps_to_xml_attribute` reads `rsplit('.').next()`, the same
-            // last-segment rule the XML writer's `is_attribute_path` uses — and:
+            // `column_maps_to_xml_attribute` reads the last decoded segment, the
+            // same rule the XML writer's `is_attribute_path` uses — and:
             //   * `multi_value_columns` yields the EXPOSED `Column::name` (what
             //     downstream CXL and the output see), not the physical
             //     `source_name`, so a straight source→output path already carries

--- a/crates/clinker-record/src/field_path.rs
+++ b/crates/clinker-record/src/field_path.rs
@@ -1,0 +1,571 @@
+//! The record-space field-path grammar: how a flat column-name string encodes
+//! an ordered sequence of path segments.
+//!
+//! A record-space field name is the string a [`Schema`](crate::Schema) column
+//! carries. It is not opaque: an unescaped `.` separates segments, so the
+//! column `Address.City` addresses the path `["Address", "City"]`. Readers
+//! produce such names when they flatten nested input, writers expand them back
+//! into nested output, and CXL addresses them from expressions. All three must
+//! agree on one grammar or the same name means different things at different
+//! ends of a pipeline.
+//!
+//! This module lives in `clinker-record` — the format-neutral value-model
+//! vocabulary crate — rather than in `clinker-format`, because `cxl` depends on
+//! `clinker-record` and not on `clinker-format`. The grammar has to be reachable
+//! from the expression language as well as from every reader and writer; hosting
+//! it in a format crate would put it out of CXL's reach and force a second
+//! implementation there.
+//!
+//! The user-facing statement of this grammar is `docs/user/src/cxl/field-paths.md`.
+//!
+//! # Grammar
+//!
+//! Decoding scans left to right over Unicode scalar values:
+//!
+//! 1. `\` introduces an escape and must be followed by exactly one of `.`, `[`,
+//!    or `\`. The pair contributes that one literal character to the current
+//!    segment.
+//! 2. A `\` at end of name, or before any other character, is an error. A
+//!    silently passed-through `C:\temp` would decode to `C:temp`, changing a
+//!    field name without saying so.
+//! 3. An unescaped `.` ends the current segment and starts the next.
+//! 4. Every other character — including an unescaped `[`, and `]`, `@`, `$`,
+//!    `/`, whitespace — is a literal character of the current segment.
+//! 5. `[` is reserved. It decodes as a literal today, but `\[` is the form that
+//!    keeps meaning "a literal `[`" if bracket indexing is ever given meaning in
+//!    a flat name; a bare `[` is not forward-compatible.
+//! 6. Empty segments are legal: `a..b` is `["a", "", "b"]`, `""` is `[""]`. An
+//!    empty map key is a real key in the value model, and the grammar does not
+//!    reject what the value model can hold.
+//! 7. More than [`MAX_FIELD_PATH_DEPTH`] segments is an error, so a pathological
+//!    name cannot drive unbounded recursion in a tree-building writer.
+//!
+//! [`encode_segment`] is the inverse: it escapes `\`, `.`, and `[` so an
+//! arbitrary literal survives as one segment. Decoding is deliberately more
+//! permissive than encoding is productive — a bare `[` decodes but is never
+//! produced — which is what leaves rule 5's seam open.
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fmt;
+
+/// Maximum number of segments a single field name may decode to.
+///
+/// Matches the JSON reader's nesting cap, so a name the reader can produce is
+/// always a name a writer can expand.
+pub const MAX_FIELD_PATH_DEPTH: usize = 64;
+
+/// Characters that carry structural meaning in a field name and therefore need
+/// escaping to appear literally in a segment.
+const RESERVED: [char; 3] = ['\\', '.', '['];
+
+/// A field name that cannot be decoded, or a set of names that cannot all be
+/// expanded into one object tree.
+///
+/// Every message renders names verbatim between backticks rather than through
+/// `{:?}`. The subject of these diagnostics is backslash escaping, and Debug
+/// quoting would escape the escapes — a remedy printed as `a\\.b` is a
+/// different name from the `a\.b` the author needs to write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FieldPathError {
+    /// The name ends with a `\` that escapes nothing.
+    TrailingEscape { name: String },
+    /// The name contains `\` followed by a character that is not `.`, `[`, or `\`.
+    UnknownEscape { name: String, escape: char },
+    /// The name decodes to more than `limit` segments.
+    TooDeep { name: String, limit: usize },
+    /// `first` terminates at a path `second` continues through — `a` alongside
+    /// `a.b`, at any depth. `first` is always the shorter of the two.
+    ///
+    /// `literal_form` carries the all-literal spelling of `first` when writing
+    /// it that way resolves the clash, and is `None` when `first` has no
+    /// separator to escape and only a rename will.
+    NestedUnderValue {
+        first: String,
+        second: String,
+        literal_form: Option<String>,
+    },
+    /// Two names decode to the identical path, so only one could be written.
+    DuplicatePath { first: String, second: String },
+}
+
+impl fmt::Display for FieldPathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TrailingEscape { name } => write!(
+                f,
+                "field name `{name}` ends with a `\\` that escapes nothing — a `\\` must be \
+                 followed by `.`, `[`, or `\\`. Write `\\\\` for a literal backslash."
+            ),
+            Self::UnknownEscape { name, escape } => write!(
+                f,
+                "field name `{name}` contains the escape `\\{escape}`, which has no meaning — a \
+                 `\\` must be followed by `.`, `[`, or `\\`. Write `\\\\` for a literal backslash: \
+                 a Windows path column is declared as `C:\\\\temp`."
+            ),
+            Self::TooDeep { name, limit } => write!(
+                f,
+                "field name `{name}` nests more than {limit} levels deep — flatten the name so it \
+                 addresses at most {limit} path segments."
+            ),
+            Self::NestedUnderValue {
+                first,
+                second,
+                literal_form,
+            } => {
+                write!(
+                    f,
+                    "field names `{first}` and `{second}` cannot both be written: `{first}` holds \
+                     a value and is also the container `{second}` nests inside. Rename one of them"
+                )?;
+                match literal_form {
+                    Some(literal) => write!(
+                        f,
+                        ", or — if the `.` in `{first}` is part of the name rather than a nesting \
+                         separator — declare it as `{literal}`."
+                    ),
+                    None => write!(f, "."),
+                }
+            }
+            Self::DuplicatePath { first, second } => write!(
+                f,
+                "field names `{first}` and `{second}` address the same field path, so only one \
+                 could be written. Rename one of them."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FieldPathError {}
+
+/// Decode a field name into its segments, lazily.
+///
+/// Every segment that carries no escape borrows from `name`; only a segment
+/// with an escape allocates. The iterator always yields at least one item (the
+/// empty name decodes to one empty segment) and stops at the first error.
+pub fn segments(name: &str) -> Segments<'_> {
+    Segments {
+        name,
+        pos: 0,
+        emitted: 0,
+        done: false,
+    }
+}
+
+/// Decode a field name into an owned segment vector, surfacing the first error.
+///
+/// The convenience form of [`segments`] for callers that build a tree and need
+/// the whole path in hand. Bounded by [`MAX_FIELD_PATH_DEPTH`] entries.
+pub fn decode(name: &str) -> Result<Vec<Cow<'_, str>>, FieldPathError> {
+    segments(name).collect()
+}
+
+/// Encode one literal segment so it survives [`decode`] as exactly itself,
+/// escaping `\`, `.`, and `[`.
+///
+/// Borrows unchanged when the literal contains none of them.
+pub fn encode_segment(literal: &str) -> Cow<'_, str> {
+    if !literal.contains(RESERVED) {
+        return Cow::Borrowed(literal);
+    }
+    let mut out = String::with_capacity(literal.len() + 8);
+    for ch in literal.chars() {
+        if RESERVED.contains(&ch) {
+            out.push('\\');
+        }
+        out.push(ch);
+    }
+    Cow::Owned(out)
+}
+
+/// Verify that every name in `names` decodes, and that the whole set can be
+/// expanded into one object tree.
+///
+/// Rejects a name that terminates at a path another name continues through
+/// (`a` alongside `a.b`, in either order, at any depth) and two names that
+/// decode to the same path. Both cases would otherwise resolve last-wins,
+/// dropping a column without saying so. `a.b` and `a\.b` do not collide: they
+/// decode to `["a", "b"]` and `["a.b"]`.
+///
+/// Order-independent: the same name set produces the same verdict whatever
+/// order it arrives in. Callers run this over the full emitted column set
+/// before writing any bytes, so a rejected set leaves no partial output.
+///
+/// The trie built here borrows from `names` and is dropped on return; nothing
+/// is retained.
+pub fn check_expandable<'a>(
+    names: impl IntoIterator<Item = &'a str>,
+) -> Result<(), FieldPathError> {
+    let mut root = TrieNode::default();
+    for name in names {
+        let mut node = &mut root;
+        let mut path = segments(name).peekable();
+        while let Some(seg) = path.next() {
+            let seg = seg?;
+            let last = path.peek().is_none();
+            node = node.children.entry(seg).or_default();
+            match (last, node.terminal, node.interior) {
+                // A shorter name already ends where this one keeps descending.
+                (false, Some(shorter), _) => return Err(nesting_clash(shorter, name)),
+                // A longer name already descends through where this one ends.
+                (true, None, Some(longer)) => return Err(nesting_clash(name, longer)),
+                (true, Some(other), _) => {
+                    return Err(FieldPathError::DuplicatePath {
+                        first: other.to_string(),
+                        second: name.to_string(),
+                    });
+                }
+                (false, None, _) => {
+                    node.interior.get_or_insert(name);
+                }
+                (true, None, None) => node.terminal = Some(name),
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Build the clash between a terminal name and the longer name nesting under
+/// it, offering the terminal's all-literal encoding when that would resolve it.
+fn nesting_clash(terminal: &str, nested: &str) -> FieldPathError {
+    let literal_form = decode(terminal)
+        .ok()
+        // Rejoined with plain `.` and re-escaped: the spelling that keeps the
+        // whole name as one literal key.
+        .map(|segs| encode_segment(&segs.join(".")).into_owned())
+        .filter(|literal| literal != terminal);
+    FieldPathError::NestedUnderValue {
+        first: terminal.to_string(),
+        second: nested.to_string(),
+        literal_form,
+    }
+}
+
+/// One node of the transient prefix trie [`check_expandable`] walks. `terminal`
+/// names the column that ends here; `interior` names a column that passes
+/// through on its way deeper. A node carrying both is the collision.
+#[derive(Default)]
+struct TrieNode<'a> {
+    terminal: Option<&'a str>,
+    interior: Option<&'a str>,
+    children: HashMap<Cow<'a, str>, TrieNode<'a>>,
+}
+
+/// Lazy decoder over a field name, yielding one segment per unescaped `.`-
+/// separated run. See [`segments`].
+pub struct Segments<'a> {
+    name: &'a str,
+    /// Byte offset where the next segment starts.
+    pos: usize,
+    emitted: usize,
+    done: bool,
+}
+
+impl<'a> Iterator for Segments<'a> {
+    type Item = Result<Cow<'a, str>, FieldPathError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        if self.emitted >= MAX_FIELD_PATH_DEPTH {
+            self.done = true;
+            return Some(Err(FieldPathError::TooDeep {
+                name: self.name.to_string(),
+                limit: MAX_FIELD_PATH_DEPTH,
+            }));
+        }
+        let bytes = self.name.as_bytes();
+        // `decoded` stays `None` while the segment is escape-free, so the
+        // common case borrows straight out of `name`. `chunk` marks the start
+        // of the verbatim run not yet copied into it.
+        let mut decoded: Option<String> = None;
+        let mut chunk = self.pos;
+        let mut i = self.pos;
+        loop {
+            // `.`, `\` and `[` are ASCII and cannot occur inside a multi-byte
+            // UTF-8 sequence, so scanning by byte never splits a character.
+            match bytes.get(i) {
+                None => {
+                    self.done = true;
+                    self.emitted += 1;
+                    return Some(Ok(finish(self.name, decoded, chunk, i)));
+                }
+                Some(b'.') => {
+                    self.pos = i + 1;
+                    self.emitted += 1;
+                    return Some(Ok(finish(self.name, decoded, chunk, i)));
+                }
+                Some(b'\\') => {
+                    let Some(&esc) = bytes.get(i + 1) else {
+                        self.done = true;
+                        return Some(Err(FieldPathError::TrailingEscape {
+                            name: self.name.to_string(),
+                        }));
+                    };
+                    if !matches!(esc, b'.' | b'[' | b'\\') {
+                        self.done = true;
+                        let escape = self.name[i + 1..]
+                            .chars()
+                            .next()
+                            .expect("a byte past the backslash implies a character");
+                        return Some(Err(FieldPathError::UnknownEscape {
+                            name: self.name.to_string(),
+                            escape,
+                        }));
+                    }
+                    let buf = decoded.get_or_insert_with(String::new);
+                    buf.push_str(&self.name[chunk..i]);
+                    buf.push(char::from(esc));
+                    i += 2;
+                    chunk = i;
+                }
+                Some(_) => i += 1,
+            }
+        }
+    }
+}
+
+/// Close a segment: borrow it whole when nothing was escaped, otherwise append
+/// the trailing verbatim run to the decoded buffer.
+fn finish(name: &str, decoded: Option<String>, chunk: usize, end: usize) -> Cow<'_, str> {
+    match decoded {
+        None => Cow::Borrowed(&name[chunk..end]),
+        Some(mut buf) => {
+            buf.push_str(&name[chunk..end]);
+            Cow::Owned(buf)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn segs(name: &str) -> Vec<String> {
+        decode(name)
+            .unwrap_or_else(|e| panic!("{name:?} should decode, got: {e}"))
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn err(name: &str) -> FieldPathError {
+        decode(name).unwrap_err()
+    }
+
+    /// The canonical name for a path: every segment escaped, joined with `.`.
+    /// The inverse of [`decode`], used here to exercise the round trip in both
+    /// directions.
+    fn encode_path<S: AsRef<str>>(path: &[S]) -> String {
+        path.iter()
+            .map(|seg| encode_segment(seg.as_ref()))
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+
+    #[test]
+    fn plain_names_split_on_unescaped_dots() {
+        assert_eq!(segs("a.b.c"), ["a", "b", "c"]);
+        assert_eq!(segs("a"), ["a"]);
+        assert_eq!(segs("Address.City"), ["Address", "City"]);
+    }
+
+    #[test]
+    fn empty_segments_are_real_segments() {
+        assert_eq!(segs(""), [""]);
+        assert_eq!(segs("a..b"), ["a", "", "b"]);
+        assert_eq!(segs(".a"), ["", "a"]);
+        assert_eq!(segs("a."), ["a", ""]);
+        assert_eq!(segs("."), ["", ""]);
+    }
+
+    #[test]
+    fn escapes_decode_to_one_literal_character() {
+        assert_eq!(segs(r"a\.b"), ["a.b"]);
+        assert_eq!(segs(r"a\.b.c"), ["a.b", "c"]);
+        assert_eq!(segs(r"a\\b"), [r"a\b"]);
+        assert_eq!(segs(r"a\[0]"), ["a[0]"]);
+        assert_eq!(segs(r"\."), ["."]);
+    }
+
+    #[test]
+    fn unescaped_bracket_stays_literal() {
+        // Pins the reserved-`[` seam: a bare `[` decodes as a literal today, so
+        // giving bracket indexing meaning in a flat name is a visible change to
+        // this expectation, and `\[` is the forward-compatible spelling.
+        assert_eq!(segs("a[0]"), ["a[0]"]);
+        assert_eq!(segs("a[0].b"), ["a[0]", "b"]);
+        assert_eq!(segs("]"), ["]"]);
+    }
+
+    #[test]
+    fn other_punctuation_is_literal() {
+        assert_eq!(segs("$ck.customer_id"), ["$ck", "customer_id"]);
+        assert_eq!(segs("@id"), ["@id"]);
+        assert_eq!(segs("a b/c"), ["a b/c"]);
+        assert_eq!(segs("héllo.wörld"), ["héllo", "wörld"]);
+    }
+
+    #[test]
+    fn dangling_escape_is_rejected() {
+        assert_eq!(
+            err(r"a\"),
+            FieldPathError::TrailingEscape {
+                name: r"a\".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn unknown_escape_is_rejected_naming_the_character() {
+        assert_eq!(
+            err(r"a\tb"),
+            FieldPathError::UnknownEscape {
+                name: r"a\tb".to_string(),
+                escape: 't',
+            }
+        );
+        // A Windows path column: loud, with the remedy in the message, rather
+        // than silently decoding to `C:temp`.
+        let e = err(r"C:\temp");
+        assert!(matches!(
+            e,
+            FieldPathError::UnknownEscape { ref escape, .. } if *escape == 't'
+        ));
+        assert!(e.to_string().contains(r"C:\\temp"), "{e}");
+        assert_eq!(
+            err(r"a\]"),
+            FieldPathError::UnknownEscape {
+                name: r"a\]".to_string(),
+                escape: ']',
+            }
+        );
+    }
+
+    #[test]
+    fn depth_is_capped() {
+        let ok = vec!["a"; MAX_FIELD_PATH_DEPTH].join(".");
+        assert_eq!(segs(&ok).len(), MAX_FIELD_PATH_DEPTH);
+        let too_deep = vec!["a"; MAX_FIELD_PATH_DEPTH + 1].join(".");
+        assert_eq!(
+            err(&too_deep),
+            FieldPathError::TooDeep {
+                name: too_deep.clone(),
+                limit: MAX_FIELD_PATH_DEPTH,
+            }
+        );
+    }
+
+    #[test]
+    fn encode_segment_escapes_only_the_reserved_characters() {
+        assert_eq!(encode_segment("a.b"), r"a\.b");
+        assert_eq!(encode_segment(r"a\b"), r"a\\b");
+        assert_eq!(encode_segment("a[0]"), r"a\[0]");
+        assert_eq!(encode_segment("plain"), "plain");
+        assert!(matches!(encode_segment("plain"), Cow::Borrowed(_)));
+        assert!(matches!(encode_segment("@id"), Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn encoding_round_trips_through_decoding() {
+        let corpus = [
+            vec!["a"],
+            vec!["a", "b", "c"],
+            vec!["a.b"],
+            vec![r"a\b"],
+            vec!["a[0]", "b"],
+            vec![""],
+            vec!["a", "", "b"],
+            vec![r"C:\temp", "size"],
+            vec!["héllo.wörld"],
+            vec!["$ck", "customer_id"],
+        ];
+        for path in corpus {
+            let name = encode_path(&path);
+            assert_eq!(segs(&name), path, "round trip through {name:?}");
+        }
+    }
+
+    #[test]
+    fn canonical_names_re_encode_to_themselves() {
+        for name in ["a", "a.b.c", r"a\.b", r"a\\b", "", "a..b", "@id", "$ck.x"] {
+            assert_eq!(encode_path(&decode(name).unwrap()), name);
+        }
+    }
+
+    #[test]
+    fn disjoint_names_expand() {
+        assert!(check_expandable(["a", "b.c", "b.d", "e.f.g"]).is_ok());
+        assert!(check_expandable(std::iter::empty()).is_ok());
+    }
+
+    #[test]
+    fn a_value_that_is_also_a_container_is_rejected_in_either_order() {
+        for names in [["a", "a.b"], ["a.b", "a"]] {
+            let e = check_expandable(names).unwrap_err();
+            assert_eq!(
+                e,
+                FieldPathError::NestedUnderValue {
+                    first: "a".to_string(),
+                    second: "a.b".to_string(),
+                    // Escaping `a` changes nothing, so only a rename resolves it.
+                    literal_form: None,
+                },
+                "the shorter name is reported first whatever order they arrive in"
+            );
+            let msg = e.to_string();
+            assert!(msg.contains("`a`") && msg.contains("`a.b`"), "{msg}");
+        }
+    }
+
+    #[test]
+    fn a_deeper_clash_suggests_the_literal_spelling() {
+        for names in [["a.b", "a.b.c"], ["a.b.c", "a.b"]] {
+            let e = check_expandable(names).unwrap_err();
+            assert_eq!(
+                e,
+                FieldPathError::NestedUnderValue {
+                    first: "a.b".to_string(),
+                    second: "a.b.c".to_string(),
+                    literal_form: Some(r"a\.b".to_string()),
+                }
+            );
+            // The remedy must survive rendering as the exact name to type.
+            assert!(e.to_string().contains(r"`a\.b`"), "{e}");
+        }
+    }
+
+    #[test]
+    fn two_names_for_the_same_path_are_rejected() {
+        assert_eq!(
+            check_expandable(["a.b", "a.b"]).unwrap_err(),
+            FieldPathError::DuplicatePath {
+                first: "a.b".to_string(),
+                second: "a.b".to_string(),
+            }
+        );
+        // Distinct spellings of one path collide too: `[` is literal either way.
+        assert_eq!(
+            check_expandable(["a[b", r"a\[b"]).unwrap_err(),
+            FieldPathError::DuplicatePath {
+                first: "a[b".to_string(),
+                second: r"a\[b".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn escaping_the_separator_avoids_the_collision() {
+        assert!(check_expandable(["a.b", r"a\.b"]).is_ok());
+        assert!(check_expandable([r"a\.b", "a", "a.b"]).is_err());
+    }
+
+    #[test]
+    fn a_malformed_name_is_reported_by_the_expansion_check() {
+        assert!(matches!(
+            check_expandable(["ok", r"C:\temp"]).unwrap_err(),
+            FieldPathError::UnknownEscape { .. }
+        ));
+    }
+}

--- a/crates/clinker-record/src/field_path.rs
+++ b/crates/clinker-record/src/field_path.rs
@@ -51,8 +51,11 @@ use std::fmt;
 
 /// Maximum number of segments a single field name may decode to.
 ///
-/// Matches the JSON reader's nesting cap, so a name the reader can produce is
-/// always a name a writer can expand.
+/// Chosen to match the depth at which the JSON reader stops flattening, so a
+/// name that reader produces is always a name a writer can expand. The XML
+/// reader flattens with no depth bound, so a pathologically deep document can
+/// still produce a name past this cap — the writer refuses it rather than
+/// recursing without limit, which is the point of having the cap at all.
 pub const MAX_FIELD_PATH_DEPTH: usize = 64;
 
 /// Characters that carry structural meaning in a field name and therefore need
@@ -138,26 +141,79 @@ impl fmt::Display for FieldPathError {
 
 impl std::error::Error for FieldPathError {}
 
-/// Decode a field name into its segments, lazily.
+/// Decode a field name into its ordered segments.
 ///
-/// Every segment that carries no escape borrows from `name`; only a segment
-/// with an escape allocates. The iterator always yields at least one item (the
-/// empty name decodes to one empty segment) and stops at the first error.
-pub fn segments(name: &str) -> Segments<'_> {
-    Segments {
-        name,
-        pos: 0,
-        emitted: 0,
-        done: false,
+/// A segment carrying no escape borrows from `name`; only a segment with an
+/// escape allocates, so an ordinary name costs one `Vec` and no string copies.
+/// Always yields at least one segment: the empty name decodes to one empty
+/// segment. Bounded by [`MAX_FIELD_PATH_DEPTH`] entries.
+///
+/// Callers decode once per schema (a writer building its expansion plan) or per
+/// document (an envelope section), never per record.
+pub fn decode(name: &str) -> Result<Vec<Cow<'_, str>>, FieldPathError> {
+    let mut out: Vec<Cow<'_, str>> = Vec::new();
+    // `decoded` stays `None` while the current segment is escape-free, so the
+    // common case borrows straight out of `name`. `chunk` marks the start of the
+    // verbatim run not yet copied into it.
+    let mut decoded: Option<String> = None;
+    let mut chunk = 0;
+    let mut i = 0;
+    let bytes = name.as_bytes();
+    loop {
+        if out.len() == MAX_FIELD_PATH_DEPTH {
+            return Err(FieldPathError::TooDeep {
+                name: name.to_string(),
+                limit: MAX_FIELD_PATH_DEPTH,
+            });
+        }
+        // `.`, `\` and `[` are ASCII and cannot occur inside a multi-byte UTF-8
+        // sequence, so scanning by byte never splits a character.
+        match bytes.get(i) {
+            None => {
+                out.push(close_segment(name, decoded, chunk, i));
+                return Ok(out);
+            }
+            Some(b'.') => {
+                out.push(close_segment(name, decoded.take(), chunk, i));
+                i += 1;
+                chunk = i;
+            }
+            Some(b'\\') => {
+                let Some(&escape) = bytes.get(i + 1) else {
+                    return Err(FieldPathError::TrailingEscape {
+                        name: name.to_string(),
+                    });
+                };
+                if !matches!(escape, b'.' | b'[' | b'\\') {
+                    return Err(FieldPathError::UnknownEscape {
+                        name: name.to_string(),
+                        escape: name[i + 1..]
+                            .chars()
+                            .next()
+                            .expect("a byte past the backslash implies a character"),
+                    });
+                }
+                let buf = decoded.get_or_insert_with(String::new);
+                buf.push_str(&name[chunk..i]);
+                buf.push(char::from(escape));
+                i += 2;
+                chunk = i;
+            }
+            Some(_) => i += 1,
+        }
     }
 }
 
-/// Decode a field name into an owned segment vector, surfacing the first error.
-///
-/// The convenience form of [`segments`] for callers that build a tree and need
-/// the whole path in hand. Bounded by [`MAX_FIELD_PATH_DEPTH`] entries.
-pub fn decode(name: &str) -> Result<Vec<Cow<'_, str>>, FieldPathError> {
-    segments(name).collect()
+/// Close a segment: borrow it whole when nothing was escaped, otherwise append
+/// the trailing verbatim run to the buffer the escapes were decoded into.
+fn close_segment(name: &str, decoded: Option<String>, chunk: usize, end: usize) -> Cow<'_, str> {
+    match decoded {
+        None => Cow::Borrowed(&name[chunk..end]),
+        Some(mut buf) => {
+            buf.push_str(&name[chunk..end]);
+            Cow::Owned(buf)
+        }
+    }
 }
 
 /// Encode one literal segment so it survives [`decode`] as exactly itself,
@@ -198,12 +254,12 @@ pub fn check_expandable<'a>(
 ) -> Result<(), FieldPathError> {
     let mut root = TrieNode::default();
     for name in names {
+        let path = decode(name)?;
+        let depth = path.len();
         let mut node = &mut root;
-        let mut path = segments(name).peekable();
-        while let Some(seg) = path.next() {
-            let seg = seg?;
-            let last = path.peek().is_none();
-            node = node.children.entry(seg).or_default();
+        for (at, segment) in path.into_iter().enumerate() {
+            let last = at + 1 == depth;
+            node = node.children.entry(segment).or_default();
             match (last, node.terminal, node.interior) {
                 // A shorter name already ends where this one keeps descending.
                 (false, Some(shorter), _) => return Err(nesting_clash(shorter, name)),
@@ -249,93 +305,6 @@ struct TrieNode<'a> {
     terminal: Option<&'a str>,
     interior: Option<&'a str>,
     children: HashMap<Cow<'a, str>, TrieNode<'a>>,
-}
-
-/// Lazy decoder over a field name, yielding one segment per unescaped `.`-
-/// separated run. See [`segments`].
-pub struct Segments<'a> {
-    name: &'a str,
-    /// Byte offset where the next segment starts.
-    pos: usize,
-    emitted: usize,
-    done: bool,
-}
-
-impl<'a> Iterator for Segments<'a> {
-    type Item = Result<Cow<'a, str>, FieldPathError>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
-            return None;
-        }
-        if self.emitted >= MAX_FIELD_PATH_DEPTH {
-            self.done = true;
-            return Some(Err(FieldPathError::TooDeep {
-                name: self.name.to_string(),
-                limit: MAX_FIELD_PATH_DEPTH,
-            }));
-        }
-        let bytes = self.name.as_bytes();
-        // `decoded` stays `None` while the segment is escape-free, so the
-        // common case borrows straight out of `name`. `chunk` marks the start
-        // of the verbatim run not yet copied into it.
-        let mut decoded: Option<String> = None;
-        let mut chunk = self.pos;
-        let mut i = self.pos;
-        loop {
-            // `.`, `\` and `[` are ASCII and cannot occur inside a multi-byte
-            // UTF-8 sequence, so scanning by byte never splits a character.
-            match bytes.get(i) {
-                None => {
-                    self.done = true;
-                    self.emitted += 1;
-                    return Some(Ok(finish(self.name, decoded, chunk, i)));
-                }
-                Some(b'.') => {
-                    self.pos = i + 1;
-                    self.emitted += 1;
-                    return Some(Ok(finish(self.name, decoded, chunk, i)));
-                }
-                Some(b'\\') => {
-                    let Some(&esc) = bytes.get(i + 1) else {
-                        self.done = true;
-                        return Some(Err(FieldPathError::TrailingEscape {
-                            name: self.name.to_string(),
-                        }));
-                    };
-                    if !matches!(esc, b'.' | b'[' | b'\\') {
-                        self.done = true;
-                        let escape = self.name[i + 1..]
-                            .chars()
-                            .next()
-                            .expect("a byte past the backslash implies a character");
-                        return Some(Err(FieldPathError::UnknownEscape {
-                            name: self.name.to_string(),
-                            escape,
-                        }));
-                    }
-                    let buf = decoded.get_or_insert_with(String::new);
-                    buf.push_str(&self.name[chunk..i]);
-                    buf.push(char::from(esc));
-                    i += 2;
-                    chunk = i;
-                }
-                Some(_) => i += 1,
-            }
-        }
-    }
-}
-
-/// Close a segment: borrow it whole when nothing was escaped, otherwise append
-/// the trailing verbatim run to the decoded buffer.
-fn finish(name: &str, decoded: Option<String>, chunk: usize, end: usize) -> Cow<'_, str> {
-    match decoded {
-        None => Cow::Borrowed(&name[chunk..end]),
-        Some(mut buf) => {
-            buf.push_str(&name[chunk..end]);
-            Cow::Owned(buf)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/crates/clinker-record/src/lib.rs
+++ b/crates/clinker-record/src/lib.rs
@@ -3,6 +3,7 @@ pub mod coercion;
 pub mod counters;
 pub mod decimal_serde;
 pub mod document_context;
+pub mod field_path;
 pub mod field_str;
 pub mod group_key;
 pub mod minimal;
@@ -26,6 +27,7 @@ pub use document_context::{
     DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, synthetic_document_context,
     synthetic_document_context_ref,
 };
+pub use field_path::{FieldPathError, MAX_FIELD_PATH_DEPTH};
 pub use field_str::FieldStr;
 pub use group_key::{GroupByKey, GroupKeyError, value_to_group_key};
 pub use minimal::MinimalRecord;

--- a/crates/clinker-record/src/lib.rs
+++ b/crates/clinker-record/src/lib.rs
@@ -27,7 +27,6 @@ pub use document_context::{
     DocumentContext, DocumentGrain, DocumentId, EnvelopeRecord, synthetic_document_context,
     synthetic_document_context_ref,
 };
-pub use field_path::{FieldPathError, MAX_FIELD_PATH_DEPTH};
 pub use field_str::FieldStr;
 pub use group_key::{GroupByKey, GroupKeyError, value_to_group_key};
 pub use minimal::MinimalRecord;

--- a/crates/clinker-record/src/record/mod.rs
+++ b/crates/clinker-record/src/record/mod.rs
@@ -257,11 +257,7 @@ impl Record {
             .columns()
             .iter()
             .enumerate()
-            .filter(|(i, _)| {
-                self.schema
-                    .field_metadata(*i)
-                    .is_none_or(|m| !m.is_engine_stamped())
-            })
+            .filter(|(i, _)| !self.schema.is_engine_stamped(*i))
             .map(|(i, name)| (name.as_ref(), &self.values[i]))
     }
 

--- a/crates/clinker-record/src/schema.rs
+++ b/crates/clinker-record/src/schema.rs
@@ -244,11 +244,13 @@ impl Schema {
     }
 
     /// Whether column `idx` is engine-stamped rather than user-declared — the
-    /// predicate that decides what the default writer surface emits.
+    /// predicate deciding what the default writer surface and the default
+    /// projection path emit.
     ///
-    /// The by-index form exists for callers that must keep the column's schema
-    /// position (a writer precompiling a plan against `Record::values`), which
-    /// the field iterators do not hand back.
+    /// The by-index form serves callers that must keep the column's schema
+    /// position, which the field iterators on [`Record`](crate::Record) do not
+    /// hand back — a writer precompiling a plan against `Record::values`, or
+    /// any pass building a positional column map.
     pub fn is_engine_stamped(&self, idx: usize) -> bool {
         self.field_metadata(idx)
             .is_some_and(FieldMetadata::is_engine_stamped)

--- a/crates/clinker-record/src/schema.rs
+++ b/crates/clinker-record/src/schema.rs
@@ -242,6 +242,17 @@ impl Schema {
     pub fn field_metadata_by_name(&self, name: &str) -> Option<&FieldMetadata> {
         self.index(name).and_then(|i| self.field_metadata(i))
     }
+
+    /// Whether column `idx` is engine-stamped rather than user-declared — the
+    /// predicate that decides what the default writer surface emits.
+    ///
+    /// The by-index form exists for callers that must keep the column's schema
+    /// position (a writer precompiling a plan against `Record::values`), which
+    /// the field iterators do not hand back.
+    pub fn is_engine_stamped(&self, idx: usize) -> bool {
+        self.field_metadata(idx)
+            .is_some_and(FieldMetadata::is_engine_stamped)
+    }
 }
 
 /// Fluent builder for `Arc<Schema>` construction.

--- a/docs/user/src/SUMMARY.md
+++ b/docs/user/src/SUMMARY.md
@@ -66,6 +66,7 @@
 - [Aggregate Functions](cxl/aggregates.md)
 - [Closures](cxl/closures.md)
 - [Nested Paths](cxl/nested-paths.md)
+- [Field Paths](cxl/field-paths.md)
 - [Emit Each](cxl/emit-each.md)
 - [System Variables](cxl/system-variables.md)
 - [Null Handling](cxl/nulls.md)

--- a/docs/user/src/cxl/builtins-map.md
+++ b/docs/user/src/cxl/builtins-map.md
@@ -75,7 +75,7 @@ Returns a new map with `key` set to `value`. If the key was already present, its
 
 For `profile = {"name":"Alice","address":{"city":"LA"}}`, `profile.set("address.city", "NYC")` is `{"name":"Alice","address":{"city":"NYC"}}` -- the sibling `name` and any other `address` keys are preserved.
 
-> **Known limitation.** Because `.` and `[` are path syntax, `set` cannot target a key whose name *literally* contains a `.` or `[` (for example a JSON field literally named `"a.b"`). To write such a key, build it with [`merge`](#mergeother-map---map) and a map literal; to remove it, use [`remove_field`](#remove_fieldkey-string---map), which matches the exact key string.
+> **Known limitation.** Because `.` and `[` are path syntax, `set` cannot yet target a key whose name *literally* contains a `.` or `[` (for example a JSON field literally named `"a.b"`). Column names solve this with a backslash escape — `a\.b` is one segment named `a.b`, per [Field Paths](field-paths.md) — and the decided direction is for `set` / `unset` keys to read that same grammar, since both are flat strings addressing a path. Until they do: to write such a key, build it with [`merge`](#mergeother-map---map) and a map literal; to remove it, use [`remove_field`](#remove_fieldkey-string---map), which matches the exact key string.
 
 ### remove_field(key: String) -> Map
 

--- a/docs/user/src/cxl/field-paths.md
+++ b/docs/user/src/cxl/field-paths.md
@@ -33,16 +33,19 @@ Reading a name left to right:
 | `\.` | A literal `.` inside the current segment. |
 | `\\` | A literal `\`. |
 | `\[` | A literal `[`. |
-| Anything else | A literal character of the current segment. |
+| `\` before anything else | **An error.** `\]`, `\t`, and a name ending in `\` are all rejected. |
+| Any other character | A literal character of the current segment — including a bare `[`, and `]`, `@`, `$`, `/`, and whitespace. |
 
 So `Address.City` is two segments, and `a\.b` is one segment named `a.b`.
 
 Three consequences worth stating outright:
 
-- **A lone `\` is an error, never a literal.** `C:\temp` is rejected, because
-  silently treating `\t` as the two characters `\` and `t` would make the
-  encoding ambiguous, and silently *dropping* the `\` would rename the column
-  without saying so. Write `C:\\temp`.
+- **An unrecognized escape is an error, never a literal.** A `\` must be
+  followed by `.`, `[`, or `\` — nothing else, and not the end of the name.
+  `C:\temp` is rejected, because silently treating `\t` as the two characters
+  `\` and `t` would make the encoding ambiguous, and silently *dropping* the
+  `\` would rename the column without saying so. Write `C:\\temp`. The same
+  applies to `\]`, which is covered below.
 - **Empty segments are real.** `a..b` is three segments — `a`, the empty name,
   and `b`. An empty key is a value a document can genuinely carry, so the
   grammar does not reject it.
@@ -59,6 +62,25 @@ nonetheless **reserved**: bracket indexing may later be given meaning inside a
 flat name, matching the `[n]` form CXL expressions already use. Writing `\[`
 means "a literal `[`" today and will keep meaning exactly that. A bare `[` is
 not guaranteed to.
+
+So the column `a[0]` future-proofs as `a\[0]` — escaping only the opening
+bracket:
+
+| Spelling | Result |
+|----------|--------|
+| `a\[0]` | One segment named `a[0]`. Correct, and stable across the reserved-`[` change. |
+| `a\[0\]` | **Rejected** — `\]` is not an escape. |
+| `a[0]` | One segment named `a[0]` today, but a bare `[` is the form that is not guaranteed to keep that meaning. |
+
+**Only the opening bracket is ever escaped.** `]` is never escaped and never
+needs to be: it would carry meaning only as the close of an unescaped `[`, so a
+literal `]` standing on its own is already unambiguous. Escaping it would add
+noise without removing any ambiguity.
+
+Writing `\]` is an error rather than a silently-accepted no-op, for the same
+reason `C:\temp` is: an escape that quietly meant nothing would let two
+different names decode to the same path, and one of them would be dropped. The
+error names the offending escape and the rule.
 
 If a column name of yours contains `[`, escaping it now costs nothing and makes
 it future-proof.

--- a/docs/user/src/cxl/field-paths.md
+++ b/docs/user/src/cxl/field-paths.md
@@ -47,8 +47,10 @@ Three consequences worth stating outright:
   and `b`. An empty key is a value a document can genuinely carry, so the
   grammar does not reject it.
 - **A name may nest at most 64 levels deep.** This matches the depth at which
-  the JSON reader stops flattening, so any name a reader can produce is a name a
-  writer can expand.
+  the JSON reader stops flattening, so any name that reader produces is a name a
+  writer can expand. The XML reader flattens with no depth bound, so an
+  extraordinarily deep XML document can produce a name past the cap; writing it
+  back out fails with a clear error rather than recursing without limit.
 
 ### Writing a literal bracket
 

--- a/docs/user/src/cxl/field-paths.md
+++ b/docs/user/src/cxl/field-paths.md
@@ -1,0 +1,144 @@
+# Field Paths
+
+A column name is not opaque. An unescaped `.` inside it separates **path
+segments**, so the column `Address.City` addresses the path `Address` → `City`.
+Readers produce such names when they flatten nested input, writers expand them
+back into nested output, and the rule for reading them is the same everywhere in
+Clinker — one grammar, not one per format.
+
+This page is the reference for that grammar. The places it applies:
+
+- Column names declared in a source or output `schema:`.
+- Column names a self-describing reader infers (the JSON reader flattens
+  `{"a":{"b":1}}` to the column `a.b`; the XML reader flattens
+  `<a><b>1</b></a>` the same way).
+- Column names a writer expands back into nesting — see
+  [Writing JSON](../formats/json.md#writing-json) and
+  [Writing XML](../formats/xml.md#writing-xml).
+
+It does **not** cover CXL expressions. Reaching into a *value* — a map or array
+held in one column — uses the expression forms on
+[Nested Paths](nested-paths.md) (`profile.city`, `profile["a.b"]`, `items[0]`).
+The two are different surfaces over the same idea: a path is an ordered list of
+segments either way, but a column name spells it with `.` and a backslash
+escape, while an expression spells it with dots and brackets.
+
+## The rule
+
+Reading a name left to right:
+
+| Input | Meaning |
+|-------|---------|
+| `.` | Ends the current segment, starts the next. |
+| `\.` | A literal `.` inside the current segment. |
+| `\\` | A literal `\`. |
+| `\[` | A literal `[`. |
+| Anything else | A literal character of the current segment. |
+
+So `Address.City` is two segments, and `a\.b` is one segment named `a.b`.
+
+Three consequences worth stating outright:
+
+- **A lone `\` is an error, never a literal.** `C:\temp` is rejected, because
+  silently treating `\t` as the two characters `\` and `t` would make the
+  encoding ambiguous, and silently *dropping* the `\` would rename the column
+  without saying so. Write `C:\\temp`.
+- **Empty segments are real.** `a..b` is three segments — `a`, the empty name,
+  and `b`. An empty key is a value a document can genuinely carry, so the
+  grammar does not reject it.
+- **A name may nest at most 64 levels deep.** This matches the depth at which
+  the JSON reader stops flattening, so any name a reader can produce is a name a
+  writer can expand.
+
+### Writing a literal bracket
+
+`[` is currently a literal character, so a column named `a[0]` works. It is
+nonetheless **reserved**: bracket indexing may later be given meaning inside a
+flat name, matching the `[n]` form CXL expressions already use. Writing `\[`
+means "a literal `[`" today and will keep meaning exactly that. A bare `[` is
+not guaranteed to.
+
+If a column name of yours contains `[`, escaping it now costs nothing and makes
+it future-proof.
+
+## Expansion on write
+
+A writer that can express nesting rebuilds it from the decoded paths.
+
+**Grouping.** Columns sharing a prefix collect into one container, positioned
+where that prefix first appeared — even when the schema interleaves them.
+Columns `Address.City`, `name`, `Address.State` write as:
+
+```json
+{"Address":{"City":"Boston","State":"MA"},"name":"Ada"}
+```
+
+**Absent children.** A column omitted for a record (a null under
+`preserve_nulls: false`) contributes nothing, and a container whose every
+descendant is omitted emits no key at all rather than an empty object. That
+keeps the round trip honest: reading `{"a":{}}` produces no column, so writing
+no column must produce no `"a"`.
+
+**Values are untouched.** Expansion adds structure *above* a column's value; a
+`Value::Map` or array held *in* that column still serializes as itself. A column
+`Items.Item` holding `[1,2]` writes as `{"Items":{"Item":[1,2]}}`.
+
+**No carve-outs.** The rule reads the column-name string and nothing else, so it
+applies identically to engine-stamped columns. Under
+`include_correlation_keys: true` the column `$ck.customer_id` writes as
+`{"$ck":{"customer_id":…}}`.
+
+## When two names clash
+
+Two columns can describe places that cannot both exist. The writer refuses the
+whole column set before writing a single byte, naming both columns — it never
+silently keeps one.
+
+| Columns | Why |
+|---------|-----|
+| `a` and `a.b` | `a` holds a value and is also the container `a.b` sits inside. |
+| `a.b` and `a.b.c` | The same clash, one level down. |
+| `a[b` and `a\[b` | Two spellings of the identical path. |
+
+`a.b` and `a\.b` do **not** clash: they address `a` → `b` and the single
+segment `a.b`. That is what the escape is for.
+
+When a clash comes from a `.` you meant literally, the diagnostic offers the
+escaped spelling:
+
+```
+XML writer cannot expand this output's column names into nested output: field
+names `a.b` and `a.b.c` cannot both be written: `a.b` holds a value and is also
+the container `a.b.c` nests inside. Rename one of them, or — if the `.` in `a.b`
+is part of the name rather than a nesting separator — declare it as `a\.b`.
+```
+
+## Where the grammar does not reach yet
+
+Two surfaces read column names without this grammar. Both are tracked, and both
+are stated here so the current behavior is a known position rather than a
+surprise:
+
+- **Flat writers emit the raw name.** CSV and fixed-width have no nesting to
+  expand into, so they write the column name verbatim — a column declared
+  `a\.b` appears as the literal CSV header `a\.b`, backslash included. Whether
+  flat writers should emit the *decoded* name instead is a separate decision.
+- **Readers join without escaping.** The JSON and XML readers join flattened
+  path segments with a plain `.`, so a source key that literally contains a `.`
+  (`{"a.b": 1}`) arrives as the column `a.b` — indistinguishable from a nested
+  `{"a":{"b":1}}`, and it writes back nested. Closing that means escaping each
+  key as the reader joins it, tracked by
+  [issue 920](https://github.com/rustpunk/clinker/issues/920).
+
+`set` and `unset` in CXL also use a path grammar of their own that does not yet
+support escaping — see the known limitation on
+[Map Methods](builtins-map.md#setkey-string-value-any---map).
+
+## See also
+
+- [Nested Paths](nested-paths.md) — the expression-side forms for reaching into
+  a value.
+- [Writing JSON](../formats/json.md#writing-json) — expansion on the JSON write
+  side.
+- [Writing XML](../formats/xml.md#writing-xml) — expansion on the XML write
+  side, plus the attribute convention layered over it.

--- a/docs/user/src/cxl/nested-paths.md
+++ b/docs/user/src/cxl/nested-paths.md
@@ -101,6 +101,7 @@ The first chain reads a string out of nested structure and uppercases it. The se
 
 ## See also
 
+- [Field Paths](field-paths.md) -- the other surface for the same idea: how a flat column-name string spells a path, with a backslash escape instead of brackets.
 - [Closures](closures.md) -- closures over arrays of maps typically use bracket-index on the `it` binding.
 - [Array Methods](builtins-array.md) -- traversal builtins that consume nested arrays.
 - [Map Methods](builtins-map.md) -- builders and accessors for map values.

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -138,3 +138,85 @@ JSON output fails with a JSON error naming the value, rather than silently
 substituting `null` — a substituted `null` would be indistinguishable from
 a genuine source null on read-back. Filter such records or replace the
 value in a transform before the JSON output.
+
+## Writing JSON
+
+A JSON output writes one object per record, in schema-column order, either as a
+single array (`format: array`, the default) or one object per line
+(`format: ndjson`).
+
+```yaml
+- type: output
+  name: enriched
+  input: processed
+  config:
+    name: enriched
+    type: json
+    path: "./output/enriched.json"
+    options:
+      format: ndjson     # array | ndjson
+      pretty: false      # indent the emitted objects
+```
+
+### Dotted column names become nested objects
+
+A column name containing a `.` expands back into nesting, the same way the
+[XML writer](xml.md#writing-xml) expands one into nested elements. Columns
+`Address.City` and `Address.State` write as one object:
+
+```json
+{"Address":{"City":"Boston","State":"MA"},"name":"Ada"}
+```
+
+This is what makes a JSON-in / JSON-out pipeline reproduce its input shape: the
+reader flattened `{"Address":{"City":…}}` into the column `Address.City`, and
+the writer puts it back. It applies to every JSON output, with no option to turn
+it off — a flag would mean the same column name meant different things at
+different outputs.
+
+Three points follow from the rule, all shared with the XML writer and specified
+in full on [Field Paths](../cxl/field-paths.md):
+
+- **Grouping.** Columns sharing a prefix collect into one object, positioned
+  where that prefix first appeared, even when the schema interleaves them.
+- **Absent children.** Under `preserve_nulls: false` a null column emits no key,
+  and an object whose every descendant is absent emits no key at all rather than
+  an empty `{}` — so it reads back as the absent column it stands for.
+- **Values are untouched.** A column holding a map or an array still serializes
+  as that map or array. Expansion adds structure above the value, never inside
+  it.
+
+### Keeping a literal `.` in a key
+
+To emit a key that genuinely contains a `.`, escape the separator in the column
+name. The column `a\.b` writes the single key `"a.b"`:
+
+```yaml
+      schema:
+        - { name: "a\\.b", type: string }   # emits {"a.b": …}
+        - { name: "a.b",   type: string }   # emits {"a": {"b": …}}
+```
+
+A `[` in a column name is currently literal but reserved; write `\[` if you want
+it to stay literal indefinitely. See
+[Field Paths](../cxl/field-paths.md#writing-a-literal-bracket) for why.
+
+Note that this is a **write-side** escape. A source key that literally contains
+a `.` still arrives from the reader as an unescaped column name (the
+[Flattened-name collisions](#flattened-name-collisions) section above covers
+what the reader does), so `{"a.b": 1}` read and written back comes out as
+`{"a": {"b": 1}}`. Closing that is tracked by
+[issue 920](https://github.com/rustpunk/clinker/issues/920).
+
+### Column names that cannot both be written
+
+Two columns can describe places that cannot both exist in one object — a column
+`a` holding a value alongside a column `a.b` that needs `a` to be an object.
+Rather than keep one and drop the other, the writer refuses the whole column set
+before emitting a byte, naming both columns and, where escaping would resolve
+it, the escaped spelling to use. [Field Paths](../cxl/field-paths.md#when-two-names-clash)
+lists every clashing shape.
+
+A column name carrying a malformed escape — a `\` that is not part of `\.`,
+`\[`, or `\\`, as in a column literally named `C:\temp` — is refused the same
+way, with the corrected spelling (`C:\\temp`) in the message.

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -47,14 +47,30 @@ rather than silently dropping data.
 
 ## Writing XML
 
-The XML writer expands dotted field names to nested elements and applies
-the same `attribute_prefix` convention in reverse: a field whose final
-path segment carries the prefix is emitted as an XML **attribute** of its
-enclosing element instead of a child element. A top-level `@id` attaches
-to the record element's start tag; a nested `Address.@type` attaches to
-the `<Address>` element. Records read from an XML source therefore
-round-trip — `<Record id="7"><name>A</name></Record>` reads and writes
-back unchanged, and the writer never emits an `@`-named element.
+The XML writer expands dotted field names to nested elements, by the same rule
+the [JSON writer](json.md#writing-json) expands them into nested objects —
+grouping, ordering, absent-child pruning, and the `\.` escape for a literal dot
+are all specified once on [Field Paths](../cxl/field-paths.md). What is specific
+to XML is layered on top of that decoding, not instead of it.
+
+The `attribute_prefix` convention applies in reverse: a field whose final path
+segment carries the prefix is emitted as an XML **attribute** of its enclosing
+element instead of a child element. A top-level `@id` attaches to the record
+element's start tag; a nested `Address.@type` attaches to the `<Address>`
+element. Records read from an XML source therefore round-trip —
+`<Record id="7"><name>A</name></Record>` reads and writes back unchanged, and
+the writer never emits an `@`-named element.
+
+Each decoded segment must also be a well-formed XML `Name`, so a segment that
+begins with a digit or contains a space is rejected. A literal dot survives —
+`.` is a legal XML name character, so a column declared `a\.b` emits the single
+element `<a.b>` rather than nesting.
+
+Two column names that cannot both be expanded — a column `a` holding a value
+alongside a column `a.b` needing `a` to be a container — are refused before any
+byte of the record is written, naming both columns. Earlier versions emitted two
+sibling `<a>` elements for that column set, which this reader then refused on
+the way back in.
 
 ```yaml
 - type: output


### PR DESCRIPTION
Closes #970.

The readers flatten nested JSON and XML into dotted column names, and the XML writer expands those names back into nested elements. The JSON writer did not — it emitted the dotted name as a literal key. Reading nested JSON and writing it straight back out produced a flat document with keys like `"Address.City"`, so the format could not round-trip its own input.

This closes that asymmetry, and in doing so settles the field-path grammar that #400 and #920 both need.

## The grammar is shared, and it lives in `clinker-record`

The obvious implementation — teach the JSON writer to split on `.` — would have produced a second, silently diverging copy of a rule the XML writer already implements twice. Instead the rule is extracted once into `clinker_record::field_path` and consumed by all three expansion sites.

`clinker-record` rather than `clinker-format` is deliberate and load-bearing. `cxl` depends on `clinker-record` but not on `clinker-format`, and #400 must implement this identical grammar inside the CXL evaluator. Had the grammar landed in `clinker-format`, #400 could not have reached it and would have been forced to fork the rule — the exact outcome the one-syntax principle exists to prevent.

## The grammar

A column name encodes a path of segments. `.` separates segments; `\` escapes, with exactly three valid sequences — `\\`, `\.`, `\[`. Anything else after a backslash is an error rather than a silent passthrough, because silently decoding `C:\temp` to `C:temp` would be the same class of silent-wrong-output this milestone exists to remove. Depth is capped at 64, matching the JSON reader, so a pathological name cannot drive unbounded recursion into a stack overflow.

`[` is reserved but not yet meaningful: it is a literal today, and `\[` already decodes to a literal `[`, so an author who escapes it now stays correct after #400 gives brackets array-index meaning. `]` is deliberately **not** escapable — it has no standalone significance, only meaning following an unescaped `[`, so `a\[0]` round-trips unambiguously and always will.

Expansion groups columns sharing a prefix at the position where that prefix first appeared, matching the XML writer exactly. Collisions are a hard error, never last-wins: a path may not be both a leaf and a branch (`a` and `a.b`), and two columns may not terminate at the same path. Detection runs over the whole column set before any byte is written, so a rejected schema never leaves a half-written record. The error names both offending columns and prints the escaped form that would fix it.

Note `a.b` and `a\.b` do not collide — they are different paths. That is the point of the escape, and it is what preserves the ability to emit a literal dotted key, which unconditional expansion would otherwise have deleted outright.

## Breaking change

JSON output for any schema carrying a dotted column now nests. That is the issue premise rather than a side effect, but it is a real behaviour change and is flagged in the changelog. A schema that genuinely wants a literal dotted key declares the column as `a\.b`.

The XML writer also now rejects the collision cases it previously resolved by silently emitting duplicate sibling elements — which the reader then rejected as an undeclared repeated field. That failure mode is gone from both writers.

## Bounded memory

Per record, zero new bytes. There is no intermediate `serde_json::Value` tree: serialization recurses through nested `SerializeMap`, borrowing plan segment names and record values straight into the writer scratch buffer that already existed. There is no per-record presence buffer either — whether a container emits is a short-circuiting recursive walk over its leaves, costing a re-walk instead of an allocation. That trade is deliberate: memory wins over throughput.

Retained per schema identity is one plan — one `Arc<Schema>` clone, one string per distinct path segment, one index per leaf — rebuilt only when schema identity changes, and never growing with record count. The collision-check trie borrows the caller name bytes rather than copying them and is freed before the first record.

## Verification

Full gauntlet green: `cargo fmt --all --check`; both clippy passes with `-D warnings`; `cargo test --workspace` 4679 passed / 0 failed; `cargo check --benches --workspace`; `cargo check --features bench-alloc`; `cargo test --benches -p clinker-benchmarks` 147 scenarios / 14 passed / 0 failed; `mdbook build docs/user`; `git diff --check`.

Tests worth calling out:
- **Round-trip** (`json_nested_roundtrip.rs`) — nested JSON in, nested JSON out, compared as parsed values. Covers three levels, arrays of objects, arrays of scalars, nulls, and empty nested objects.
- **Cross-writer symmetry** (`nested_write_symmetry.rs`) — one column set through both writers, asserting identical shape, grouping, ordering, null-pruning, and the identical error on the same colliding set. This is the test that would catch a future fork of the rule.
- **Executor wiring** (`json_nested_write_e2e.rs`) — a real pipeline through the JSON writer registry arm, not just the writer in isolation.
- Flat-schema output is pinned byte-for-byte, so the plan rewrite cannot silently perturb existing pipelines.
- A negative test pins the currently-wrong behaviour for a literal-dot key arriving *from* a source document, naming #920 as its owner, so that gap is tracked rather than silently regressed.

Collision-free with concurrent work: no file under the JSON/XML reader surface is touched.

## Follow-ups filed

#993 (XML output fails outright on engine-stamped columns under `include_correlation_keys` — pre-existing, now pinned by a test), #994, #998, #999, #1000. All are tracked separately rather than widening this change.

One item is flagged for maintainer ratification in the #400 comment: the answer that there is one path *model* with two surface encodings — backslash for flat strings, brackets for CXL expressions — since that is the substance of the #400 gate.