### PR TITLE
build: ignore isolated target-verify build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@ docs/**/book/
 !docs/ai/
 !docs/ai/**
 target/
+# Isolated build target used when a checkout must not share the workspace
+# `target/` — concurrent builds in sibling checkouts otherwise race on the
+# shared directory and can link a stale rlib. Deliberately unanchored so it
+# matches at any depth: inside a linked worktree this directory is top-level
+# relative to that worktree's root, so an anchored pattern would miss it and
+# leave a multi-GB build tree untracked-but-committable.
+target-verify/
 bench-data/
 examples/pipelines/output/
 examples/pipelines/retract-demo/output/


### PR DESCRIPTION
A checkout that must not share the workspace `target/` points cargo at a local `target-verify/` instead. Concurrent builds in sibling checkouts otherwise race on the shared directory and can link a stale rlib — a sibling's version of a type leaking into the build.

That directory was untracked and unignored, so a multi-gigabyte build tree sat one `git add -A` away from being committed. This closes that.

## Why the pattern is unanchored

`target-verify/` carries no leading slash, so it matches at any depth. That is deliberate rather than incidental.

Inside a linked worktree, the build directory is top-level *relative to that worktree's own root*. An anchored `/target-verify/` would match in the primary checkout and silently miss it in every worktree — which is precisely where the isolated builds actually happen. This mirrors the reasoning already recorded for `docs/**/book/` a few lines above.

## Verification

`git check-ignore -v` confirms the rule fires at top level, one level down (`crates/clinker-format/target-verify/x`), and arbitrarily deep (`deep/nested/target-verify/y`), all attributed to this pattern.

It does not over-match: a hypothetical source file named `target_verify.rs` is correctly left tracked, since the pattern requires the hyphen and a trailing slash.

`git diff --check` clean. One line of pattern plus its rationale comment; no other file touched.