### PR TITLE
plan,format: reject XPath/JSONPath-style record_path with a diagnostic

### DIFF
--- a/crates/clinker-core-types/src/diagnostic.rs
+++ b/crates/clinker-core-types/src/diagnostic.rs
@@ -93,6 +93,7 @@
 //! | `E348`      | error    | A `$doc.<section>.<field>` access against a segment/positional source (X12 / EDIFACT / HL7) names a section the format does not synthesize, or a positional element outside the `e`/`f`-prefix pattern or beyond the configured `max_elements` / `max_fields` |
 //! | `E349`      | error    | A `$doc.<section>.<field>` access is attributed to a `rest` source (or a `rest` source declares an `envelope:` block) — a REST pull buffers no document, so the access can never resolve |
 //! | `E356`      | error    | A plain single-schema CSV / fixed-width source declares an `envelope:` block — a plain flat file carries no header/trailer structure to extract, so the declared sections are inert (a multi-record source declaring `discriminator:` + `records:` is unaffected) |
+//! | `E363`      | error    | A source's `record_path` is not a path in its format's grammar — an XPath descendant step (`//`), a JSONPath root marker (`$.`), a leading `/`, an empty segment, or an XML segment no element can be named |
 
 use crate::span::{FileId, Span};
 

--- a/crates/clinker-format/src/json/reader.rs
+++ b/crates/clinker-format/src/json/reader.rs
@@ -42,6 +42,7 @@ use crate::error::FormatError;
 use crate::json::body_stream::{JsonArrayStream, is_json_ws};
 use crate::json::streaming::{SectionTarget, extract_sections};
 use crate::multi_value::{SplitToRows, SplitToRowsMode, SplitValues};
+use crate::record_path::{RecordPath, RecordPathSyntax};
 use crate::source::{ReopenableSource, SourceIdentity};
 use crate::traits::FormatReader;
 
@@ -210,10 +211,11 @@ impl JsonReader {
     ) -> Result<(InnerReader, SourceIdentity), FormatError> {
         // record_path → navigate then stream the named array lazily.
         if let Some(ref rp) = config.record_path {
-            let path_segments: Vec<String> = rp.split('.').map(String::from).collect();
+            let path = RecordPath::parse(RecordPathSyntax::Json, rp)
+                .map_err(|e| FormatError::Json(e.to_string()))?;
             let (buf, identity) = Self::open_buf(source)?;
             return Ok((
-                InnerReader::Array(JsonArrayStream::at_path(buf, &path_segments)?),
+                InnerReader::Array(JsonArrayStream::at_path(buf, path.segments())?),
                 identity,
             ));
         }
@@ -1340,6 +1342,52 @@ mod tests {
         let mut r = reader_from_str(input, config);
         let s = r.schema().unwrap();
         assert_eq!(&*s.columns()[0], "x");
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("x"),
+            Some(&Value::Integer(1))
+        );
+        assert_eq!(
+            r.next_record().unwrap().unwrap().get("x"),
+            Some(&Value::Integer(2))
+        );
+        assert!(r.next_record().unwrap().is_none());
+    }
+
+    #[test]
+    fn jsonpath_shaped_record_path_fails_at_construction() {
+        // `$.data` used to reach the body stream and surface as
+        // `record_path: key '$' not found in object` — a message about the
+        // document rather than about the path the author wrote.
+        let input = r#"{"data":{"rows":[{"x":1}]}}"#;
+        for raw in ["$.data", "/data", ".data", "data..rows", "data.", ""] {
+            let Err(err) = JsonReader::from_reader(
+                std::io::Cursor::new(input.as_bytes().to_vec()),
+                JsonReaderConfig {
+                    record_path: Some(raw.into()),
+                    ..default_config()
+                },
+            ) else {
+                panic!("{raw:?}: must be rejected at construction");
+            };
+            let msg = match err {
+                FormatError::Json(m) => m,
+                other => panic!("{raw:?}: expected FormatError::Json, got {other:?}"),
+            };
+            assert!(msg.contains("record_path"), "{raw:?}: {msg}");
+            if raw == "$.data" {
+                assert!(msg.contains("JSONPath"), "{msg}");
+            }
+        }
+    }
+
+    #[test]
+    fn the_corrected_json_record_path_still_streams_every_record() {
+        let input = r#"{"data":{"rows":[{"x":1},{"x":2}]}}"#;
+        let config = JsonReaderConfig {
+            record_path: Some("data.rows".into()),
+            ..default_config()
+        };
+        let mut r = reader_from_str(input, config);
         assert_eq!(
             r.next_record().unwrap().unwrap().get("x"),
             Some(&Value::Integer(1))

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -12,6 +12,7 @@ pub mod hl7;
 pub mod json;
 pub mod multi_record;
 pub mod multi_value;
+pub mod record_path;
 pub mod schema;
 pub(crate) mod segment_tokenizer;
 pub mod source;
@@ -33,6 +34,7 @@ pub use error::FormatError;
 pub use multi_value::{
     JoinValues, OnConflict, SplitToRows, SplitToRowsMode, SplitValues, under_field_path,
 };
+pub use record_path::{RecordPath, RecordPathError, RecordPathErrorKind, RecordPathSyntax};
 pub use schema::{
     Column, DEFAULT_VALUE_DELIMITER, Discriminator, GeneratedSchema, RECORD_TYPE_COLUMN,
     RecordType, SourceSchema, StructureConstraint, multi_record_superset,

--- a/crates/clinker-format/src/lib.rs
+++ b/crates/clinker-format/src/lib.rs
@@ -34,7 +34,7 @@ pub use error::FormatError;
 pub use multi_value::{
     JoinValues, OnConflict, SplitToRows, SplitToRowsMode, SplitValues, under_field_path,
 };
-pub use record_path::{RecordPath, RecordPathError, RecordPathErrorKind, RecordPathSyntax};
+pub use record_path::{RecordPath, RecordPathError, RecordPathSyntax};
 pub use schema::{
     Column, DEFAULT_VALUE_DELIMITER, Discriminator, GeneratedSchema, RECORD_TYPE_COLUMN,
     RecordType, SourceSchema, StructureConstraint, multi_record_superset,

--- a/crates/clinker-format/src/record_path.rs
+++ b/crates/clinker-format/src/record_path.rs
@@ -1,0 +1,461 @@
+//! The `record_path` grammar shared by the XML and JSON readers.
+//!
+//! `record_path` names the element (XML) or object key (JSON) whose contents
+//! become one record each. Both readers used to build their segment list with a
+//! bare `split`, which accepted anything: an XPath-shaped `//product` produced a
+//! leading empty segment that no element name can equal, so the run completed
+//! with zero records and no error. Parsing the string through one grammar makes
+//! every unsupported form fail loud at the boundary that first sees it.
+//!
+//! The two grammars are deliberately separate types of path, not dialects of
+//! one: XML segments are element names matched level by level from the document
+//! element, JSON segments are object keys descended from the document root.
+//!
+//! Bounded work: one pass over a config string, allocating only the segment
+//! vector the readers already built.
+
+use std::fmt;
+
+use crate::xml::writer::is_valid_xml_name;
+
+/// Which of the two `record_path` grammars a string is written in.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RecordPathSyntax {
+    /// Slash-separated XML element names, rooted at the document element.
+    Xml,
+    /// Dot-separated JSON object keys, descended from the document root.
+    Json,
+}
+
+impl RecordPathSyntax {
+    /// The separator between segments.
+    fn separator(self) -> char {
+        match self {
+            RecordPathSyntax::Xml => '/',
+            RecordPathSyntax::Json => '.',
+        }
+    }
+
+    /// One sentence naming the grammar, used to open every diagnostic.
+    fn grammar(self) -> &'static str {
+        match self {
+            RecordPathSyntax::Xml => {
+                "a slash-separated path of XML element names, matched level by level from the \
+                 document element (for example `catalog/product`)"
+            }
+            RecordPathSyntax::Json => {
+                "a dot-separated path of object keys, descended from the document root (for \
+                 example `data.rows`)"
+            }
+        }
+    }
+
+    /// What omitting the key entirely does, so a diagnostic can distinguish
+    /// "omitted" from "present but empty".
+    fn omission(self) -> &'static str {
+        match self {
+            RecordPathSyntax::Xml => "every top-level element becomes one record",
+            RecordPathSyntax::Json => "the reader auto-detects the document shape",
+        }
+    }
+
+    /// The full guidance paragraph a plan-time diagnostic attaches as help.
+    pub fn help(self) -> String {
+        match self {
+            RecordPathSyntax::Xml => "`record_path` on an `xml` source is a slash-separated path \
+                                      of XML element names, matched level by level from the \
+                                      document element: no leading or doubled `/`, no empty \
+                                      segments, and no XPath axes, predicates, or wildcards. \
+                                      Every segment must be a legal XML element name; a namespace \
+                                      prefix (`ns:Order`) is allowed and matches under \
+                                      `namespace_handling: qualify`. Omit `record_path` entirely \
+                                      and every top-level element becomes one record. Run \
+                                      `clinker explain --code E363` for the full grammar."
+                .to_string(),
+            RecordPathSyntax::Json => "`record_path` on a `json` source is a dot-separated path \
+                                       of object keys descended from the document root: no `$.` \
+                                       JSONPath root marker, no leading `/`, and no empty \
+                                       segments. It takes precedence over `format:`, so pair it \
+                                       with `format: object` or leave `format:` off. Omit \
+                                       `record_path` entirely and the reader auto-detects the \
+                                       document shape. Run `clinker explain --code E363` for the \
+                                       full grammar."
+                .to_string(),
+        }
+    }
+}
+
+/// Why a `record_path` string is not a path in its declared grammar.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RecordPathErrorKind {
+    /// The string is present but empty — distinct from omitting the key.
+    Empty,
+    /// An XPath descendant-or-self step (`//`), which matches at any depth.
+    XPathDescendant,
+    /// A leading separator, as an absolute XPath or JSON Pointer would carry.
+    Rooted,
+    /// A leading `$.`, the JSONPath root marker.
+    JsonPathRoot,
+    /// A separator with nothing between it and the next one, or the end.
+    EmptySegment { index: usize },
+    /// A segment no XML element can be named, so it can never match.
+    NotAnXmlName { index: usize, segment: String },
+}
+
+/// A `record_path` string rejected by its grammar, carrying enough context to
+/// render a message that names the actual grammar and a corrected path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordPathError {
+    pub syntax: RecordPathSyntax,
+    pub raw: String,
+    pub kind: RecordPathErrorKind,
+}
+
+impl RecordPathError {
+    /// The guidance paragraph a plan-time diagnostic attaches as help.
+    pub fn help(&self) -> String {
+        self.syntax.help()
+    }
+
+    /// The nearest string in the grammar, when mechanically stripping the
+    /// offending syntax yields one. Offered as a corrected example only — none
+    /// of these forms is accepted as an alias, because `//product` in real
+    /// XPath descends any number of levels and silently accepting it would
+    /// promise a match the reader cannot make.
+    fn corrected(&self) -> Option<String> {
+        let sep = self.syntax.separator();
+        let doubled = format!("{sep}{sep}");
+        let mut s = match self.syntax {
+            RecordPathSyntax::Xml => self.raw.clone(),
+            RecordPathSyntax::Json => self
+                .raw
+                .strip_prefix("$.")
+                .unwrap_or(&self.raw)
+                .trim_start_matches('/')
+                .to_string(),
+        };
+        // Each pass strictly shortens the string, so this terminates.
+        while s.contains(&doubled) {
+            s = s.replace(&doubled, &sep.to_string());
+        }
+        let s = s.trim_matches(sep).to_string();
+        RecordPath::parse(self.syntax, &s).ok().map(|_| s)
+    }
+}
+
+impl fmt::Display for RecordPathError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let raw = &self.raw;
+        let grammar = self.syntax.grammar();
+        match &self.kind {
+            RecordPathErrorKind::Empty => {
+                write!(
+                    f,
+                    "`record_path` is empty; it must be {grammar}. Omit the key entirely and {}",
+                    self.syntax.omission()
+                )?;
+            }
+            RecordPathErrorKind::XPathDescendant => {
+                write!(
+                    f,
+                    "`record_path` {raw:?} uses the XPath descendant step `//`, which matches at \
+                     any depth; `record_path` is {grammar}, so name every enclosing element"
+                )?;
+            }
+            RecordPathErrorKind::Rooted => {
+                write!(
+                    f,
+                    "`record_path` {raw:?} starts with `/`, as an absolute XPath or JSON Pointer \
+                     would; `record_path` is {grammar} and is already anchored there"
+                )?;
+            }
+            RecordPathErrorKind::JsonPathRoot => {
+                write!(
+                    f,
+                    "`record_path` {raw:?} starts with the JSONPath root marker `$.`, which is \
+                     not part of the grammar; `record_path` is {grammar}"
+                )?;
+            }
+            RecordPathErrorKind::EmptySegment { index } => {
+                write!(
+                    f,
+                    "`record_path` {raw:?} has an empty segment at position {}; it must be \
+                     {grammar}",
+                    index + 1
+                )?;
+            }
+            RecordPathErrorKind::NotAnXmlName { index, segment } => {
+                write!(
+                    f,
+                    "`record_path` {raw:?} segment {} ({segment:?}) is not an XML element name, \
+                     so no element can ever match it; `record_path` is {grammar} — XPath axes, \
+                     predicates, and wildcards are not supported",
+                    index + 1
+                )?;
+            }
+        }
+        if let Some(fixed) = self.corrected() {
+            write!(f, ". Write {fixed:?} instead")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for RecordPathError {}
+
+/// A validated `record_path`: the segments the reader descends, in order.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RecordPath(Vec<String>);
+
+impl RecordPath {
+    /// Parse `raw` in `syntax`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RecordPathError`] for any string that is not a path in the
+    /// declared grammar. Every rejected form either matches nothing (yielding a
+    /// silent empty run) or fails obscurely deeper in the reader.
+    pub fn parse(syntax: RecordPathSyntax, raw: &str) -> Result<Self, RecordPathError> {
+        let err = |kind| RecordPathError {
+            syntax,
+            raw: raw.to_string(),
+            kind,
+        };
+        if raw.is_empty() {
+            return Err(err(RecordPathErrorKind::Empty));
+        }
+        // Checked ahead of the separator rules for both grammars: `$` cannot
+        // start an XML name either, so an XML path written as JSONPath gets the
+        // message that names what it actually is.
+        if raw.starts_with("$.") {
+            return Err(err(RecordPathErrorKind::JsonPathRoot));
+        }
+        if syntax == RecordPathSyntax::Xml && raw.contains("//") {
+            // Ahead of the rooted check so `//product` is reported as the XPath
+            // descendant step it is rather than as a stray leading slash.
+            return Err(err(RecordPathErrorKind::XPathDescendant));
+        }
+        // Rejected for JSON too, though `/` is a legal character inside an
+        // object key: a leading `/` reads as a JSON Pointer, and a top-level key
+        // whose name genuinely starts with `/` is not reachable through
+        // `record_path`.
+        if raw.starts_with('/') {
+            return Err(err(RecordPathErrorKind::Rooted));
+        }
+
+        let mut segments = Vec::new();
+        for (index, segment) in raw.split(syntax.separator()).enumerate() {
+            if segment.is_empty() {
+                return Err(err(RecordPathErrorKind::EmptySegment { index }));
+            }
+            if syntax == RecordPathSyntax::Xml && !is_xml_element_name(segment) {
+                return Err(err(RecordPathErrorKind::NotAnXmlName {
+                    index,
+                    segment: segment.to_string(),
+                }));
+            }
+            segments.push(segment.to_string());
+        }
+        Ok(RecordPath(segments))
+    }
+
+    /// The segments to descend, outermost first.
+    pub fn segments(&self) -> &[String] {
+        &self.0
+    }
+
+    /// Consume the path, yielding the segments a reader keeps for matching.
+    pub fn into_segments(self) -> Vec<String> {
+        self.0
+    }
+}
+
+/// True when `segment` can name an XML element the reader will meet.
+///
+/// Namespaces in XML narrows an element name from the XML 1.0 `Name`
+/// production to a `QName`: an optional prefix and a local part, each an
+/// `NCName`. Splitting on `:` and checking each part with the writer's `Name`
+/// predicate gives exactly that — and rejects an XPath axis step
+/// (`child::product`), whose two colons no namespace-well-formed document can
+/// carry.
+fn is_xml_element_name(segment: &str) -> bool {
+    let part_ok = |p: &str| !p.is_empty() && is_valid_xml_name(p);
+    let mut parts = segment.split(':');
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(local), None, _) => part_ok(local),
+        (Some(prefix), Some(local), None) => part_ok(prefix) && part_ok(local),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use RecordPathErrorKind as Kind;
+    use RecordPathSyntax::{Json, Xml};
+
+    fn parse_err(syntax: RecordPathSyntax, raw: &str) -> RecordPathError {
+        RecordPath::parse(syntax, raw).expect_err("must be rejected")
+    }
+
+    fn segments(syntax: RecordPathSyntax, raw: &str) -> Vec<String> {
+        RecordPath::parse(syntax, raw)
+            .unwrap_or_else(|e| panic!("{raw:?} must parse, got: {e}"))
+            .into_segments()
+    }
+
+    #[test]
+    fn accepted_paths_split_exactly_as_the_readers_used_to() {
+        // Round-trip against the ad-hoc `split` both readers ran before the
+        // grammar existed: every currently-valid path must keep its segments.
+        for raw in [
+            "records/record",
+            "Orders/Order",
+            "doc/records/record",
+            "PurchaseOrders/Order",
+            "root/data/record",
+            "records",
+            "ns:Root/ns:Item",
+            "Item-2/Order.v1",
+        ] {
+            let old: Vec<String> = raw.split('/').map(String::from).collect();
+            assert_eq!(segments(Xml, raw), old, "xml {raw:?}");
+        }
+        for raw in [
+            "data.rows",
+            "data.records",
+            "batch_records",
+            "records",
+            "$schema.rows",
+            "a/b.rows",
+        ] {
+            let old: Vec<String> = raw.split('.').map(String::from).collect();
+            assert_eq!(segments(Json, raw), old, "json {raw:?}");
+        }
+    }
+
+    #[test]
+    fn rejected_xml_paths_name_their_violation() {
+        let cases: &[(&str, Kind)] = &[
+            ("", Kind::Empty),
+            ("//product", Kind::XPathDescendant),
+            ("Orders//Order", Kind::XPathDescendant),
+            ("/Orders/Order", Kind::Rooted),
+            ("Orders/", Kind::EmptySegment { index: 1 }),
+            (
+                "//product[@id]",
+                // The descendant step is found before the predicate.
+                Kind::XPathDescendant,
+            ),
+            (
+                "product[@id]",
+                Kind::NotAnXmlName {
+                    index: 0,
+                    segment: "product[@id]".into(),
+                },
+            ),
+            (
+                "child::product",
+                Kind::NotAnXmlName {
+                    index: 0,
+                    segment: "child::product".into(),
+                },
+            ),
+            (
+                "*",
+                Kind::NotAnXmlName {
+                    index: 0,
+                    segment: "*".into(),
+                },
+            ),
+            (
+                "catalog/pro duct",
+                Kind::NotAnXmlName {
+                    index: 1,
+                    segment: "pro duct".into(),
+                },
+            ),
+            (
+                "$.data",
+                // The JSONPath marker is named even on an XML source.
+                Kind::JsonPathRoot,
+            ),
+        ];
+        for (raw, kind) in cases {
+            assert_eq!(parse_err(Xml, raw).kind, *kind, "xml {raw:?}");
+        }
+    }
+
+    #[test]
+    fn rejected_json_paths_name_their_violation() {
+        let cases: &[(&str, Kind)] = &[
+            ("", Kind::Empty),
+            ("$.data", Kind::JsonPathRoot),
+            ("$.a.b", Kind::JsonPathRoot),
+            ("/data", Kind::Rooted),
+            ("//data", Kind::Rooted),
+            (".data", Kind::EmptySegment { index: 0 }),
+            ("data..rows", Kind::EmptySegment { index: 1 }),
+            ("data.", Kind::EmptySegment { index: 1 }),
+        ];
+        for (raw, kind) in cases {
+            assert_eq!(parse_err(Json, raw).kind, *kind, "json {raw:?}");
+        }
+    }
+
+    #[test]
+    fn only_the_exact_jsonpath_prefix_is_rejected() {
+        // Narrowing the `$.` marker costs a top-level key literally named `$`
+        // followed by a dot; a `$`-prefixed key stays addressable.
+        assert_eq!(segments(Json, "$"), vec!["$".to_string()]);
+        assert_eq!(
+            segments(Json, "$schema.rows"),
+            vec!["$schema".to_string(), "rows".to_string()]
+        );
+    }
+
+    #[test]
+    fn messages_carry_the_corrected_path() {
+        let cases = [
+            (Xml, "//product", "\"product\""),
+            (Xml, "/Orders/Order", "\"Orders/Order\""),
+            (Xml, "Orders//Order", "\"Orders/Order\""),
+            (Xml, "Orders/", "\"Orders\""),
+            (Json, "$.data", "\"data\""),
+            (Json, "/data", "\"data\""),
+            (Json, "data..rows", "\"data.rows\""),
+            (Json, "data.", "\"data\""),
+        ];
+        for (syntax, raw, fixed) in cases {
+            let msg = parse_err(syntax, raw).to_string();
+            assert!(
+                msg.contains(&format!("Write {fixed} instead")),
+                "{raw:?}: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn messages_omit_a_correction_that_is_still_invalid() {
+        for (syntax, raw) in [(Xml, "child::product"), (Xml, "//product[@id]"), (Xml, "")] {
+            let msg = parse_err(syntax, raw).to_string();
+            assert!(!msg.contains("Write "), "{raw:?}: {msg}");
+        }
+    }
+
+    #[test]
+    fn messages_name_the_grammar_the_author_reached_for() {
+        assert!(parse_err(Xml, "//product").to_string().contains("XPath"));
+        assert!(parse_err(Json, "$.data").to_string().contains("JSONPath"));
+        assert!(
+            parse_err(Xml, "")
+                .to_string()
+                .contains("every top-level element becomes one record")
+        );
+        assert!(
+            parse_err(Json, "")
+                .to_string()
+                .contains("auto-detects the document shape")
+        );
+    }
+}

--- a/crates/clinker-format/src/record_path.rs
+++ b/crates/clinker-format/src/record_path.rs
@@ -60,7 +60,7 @@ impl RecordPathSyntax {
     }
 
     /// The full guidance paragraph a plan-time diagnostic attaches as help.
-    pub fn help(self) -> String {
+    fn help(self) -> String {
         match self {
             RecordPathSyntax::Xml => "`record_path` on an `xml` source is a slash-separated path \
                                       of XML element names, matched level by level from the \
@@ -85,9 +85,11 @@ impl RecordPathSyntax {
     }
 }
 
-/// Why a `record_path` string is not a path in its declared grammar.
+/// Why a `record_path` string is not a path in its declared grammar. Selects
+/// the message [`RecordPathError`] renders; callers act on the message, not on
+/// the taxonomy, so it stays inside the module.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub enum RecordPathErrorKind {
+enum RecordPathErrorKind {
     /// The string is present but empty — distinct from omitting the key.
     Empty,
     /// An XPath descendant-or-self step (`//`), which matches at any depth.
@@ -106,9 +108,9 @@ pub enum RecordPathErrorKind {
 /// render a message that names the actual grammar and a corrected path.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RecordPathError {
-    pub syntax: RecordPathSyntax,
-    pub raw: String,
-    pub kind: RecordPathErrorKind,
+    syntax: RecordPathSyntax,
+    raw: String,
+    kind: RecordPathErrorKind,
 }
 
 impl RecordPathError {

--- a/crates/clinker-format/src/xml/reader.rs
+++ b/crates/clinker-format/src/xml/reader.rs
@@ -44,6 +44,7 @@ use crate::doc_index::DocArenaIndex;
 use crate::envelope::{EnvelopeConfig, EnvelopeExtract, coerce_section_fields};
 use crate::error::FormatError;
 use crate::multi_value::{SplitToRows, SplitToRowsMode, SplitValues, split_text_value};
+use crate::record_path::{RecordPath, RecordPathSyntax};
 use crate::source::{ReopenableSource, SourceIdentity};
 use crate::traits::FormatReader;
 use crate::xml::streaming::{SectionTarget, extract_sections};
@@ -230,11 +231,12 @@ impl XmlReader {
         let source = source.into_reopenable().map_err(FormatError::Io)?;
         let (parser, body_identity) = Self::open_body(&source)?;
 
-        let path_segments: Vec<String> = config
-            .record_path
-            .as_deref()
-            .map(|p| p.split('/').map(String::from).collect())
-            .unwrap_or_default();
+        let path_segments = match config.record_path.as_deref() {
+            Some(raw) => RecordPath::parse(RecordPathSyntax::Xml, raw)
+                .map_err(|e| FormatError::Xml(e.to_string()))?
+                .into_segments(),
+            None => Vec::new(),
+        };
 
         Ok(XmlReader {
             source,
@@ -1320,6 +1322,59 @@ mod tests {
             }],
             ..Default::default()
         }
+    }
+
+    /// A catalogue the rejected paths below all *look* like they would match,
+    /// so a test that reads zero records is reading zero from a real document.
+    const CATALOG: &str = r#"<catalog>
+        <product><product_id>1</product_id><name>A</name></product>
+        <product><product_id>2</product_id><name>B</name></product>
+    </catalog>"#;
+
+    #[test]
+    fn xpath_shaped_record_path_fails_at_construction() {
+        // Every form here used to build a segment list containing an empty
+        // string, which no element name equals: the reader ran to EOF and the
+        // pipeline reported success over zero records.
+        for raw in ["//product", "/catalog/product", "catalog//product", ""] {
+            let Err(err) = XmlReader::from_reader(
+                Cursor::new(CATALOG.as_bytes().to_vec()),
+                default_config_with_path(raw),
+            ) else {
+                panic!("{raw:?}: must be rejected at construction");
+            };
+            let msg = match err {
+                FormatError::Xml(m) => m,
+                other => panic!("{raw:?}: expected FormatError::Xml, got {other:?}"),
+            };
+            assert!(msg.contains("record_path"), "{raw:?}: {msg}");
+        }
+    }
+
+    #[test]
+    fn jsonpath_shaped_record_path_on_an_xml_source_fails_at_construction() {
+        let Err(err) = XmlReader::from_reader(
+            Cursor::new(CATALOG.as_bytes().to_vec()),
+            default_config_with_path("$.product"),
+        ) else {
+            panic!("must be rejected at construction");
+        };
+        match err {
+            FormatError::Xml(m) => assert!(m.contains("JSONPath"), "{m}"),
+            other => panic!("expected FormatError::Xml, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn the_corrected_record_path_still_streams_every_record() {
+        // The positive twin of the rejections above: the XML-name segment rule
+        // must not over-reject a path that matches.
+        let mut reader = reader_from_str(CATALOG, default_config_with_path("catalog/product"));
+        let first = reader.next_record().expect("record").expect("first");
+        assert_eq!(first.get("product_id"), Some(&Value::Integer(1)));
+        let second = reader.next_record().expect("record").expect("second");
+        assert_eq!(second.get("product_id"), Some(&Value::Integer(2)));
+        assert!(reader.next_record().expect("eof").is_none());
     }
 
     fn envelope_config(sections: &[SectionSpec]) -> EnvelopeConfig {

--- a/crates/clinker-format/src/xml/writer.rs
+++ b/crates/clinker-format/src/xml/writer.rs
@@ -541,7 +541,10 @@ fn is_xml_name_char(c: char) -> bool {
 /// well-formedness check, so an illegal name (e.g. one containing a space
 /// or `=`) would otherwise be written verbatim into the start tag and
 /// corrupt the document.
-fn is_valid_xml_name(name: &str) -> bool {
+///
+/// Shared with the `record_path` grammar, which needs the same predicate to
+/// reject a path segment no element can be named.
+pub(crate) fn is_valid_xml_name(name: &str) -> bool {
     let mut chars = name.chars();
     match chars.next() {
         Some(first) if is_xml_name_start_char(first) => {}

--- a/crates/clinker-plan/src/config/mod.rs
+++ b/crates/clinker-plan/src/config/mod.rs
@@ -13,6 +13,7 @@ pub mod patch;
 pub mod path_template;
 pub mod pipeline;
 pub mod pipeline_node;
+pub mod record_path;
 pub mod route;
 pub mod scoped_var;
 pub mod sort;

--- a/crates/clinker-plan/src/config/pipeline.rs
+++ b/crates/clinker-plan/src/config/pipeline.rs
@@ -1202,15 +1202,16 @@ impl PipelineConfig {
                 );
             }
         }
-        // Every per-source multi-value gate (E360, E361, E358) and the
-        // source-to-output E359 gate, run over this pipeline's own nodes. The
-        // same two passes run again inside `bind_composition` over each
-        // composition body's node list, which never appears here: the body file
-        // is re-read and bound separately, so a body source gated only from
-        // this loop would be gated by nothing at all.
+        // Every per-source multi-value gate (E360, E361, E358), the
+        // source-to-output E359 gate, and the E363 `record_path` grammar gate,
+        // run over this pipeline's own nodes. The same passes run again inside
+        // `bind_composition` over each composition body's node list, which never
+        // appears here: the body file is re-read and bound separately, so a body
+        // source gated only from this loop would be gated by nothing at all.
         for fault in crate::config::multi_value::source_node_faults(&self.nodes)
             .into_iter()
             .chain(crate::config::multi_value::output_node_faults(&self.nodes))
+            .chain(crate::config::record_path::record_path_faults(&self.nodes))
         {
             let primary = doc_node_line_by_name
                 .get(self.nodes[fault.node_index].value.name())

--- a/crates/clinker-plan/src/config/record_path.rs
+++ b/crates/clinker-plan/src/config/record_path.rs
@@ -1,0 +1,55 @@
+//! Plan-time gate on a source's `record_path` option (E363).
+//!
+//! The XML and JSON readers reject a malformed `record_path` at construction,
+//! which closes the hole for every caller that builds a reader config directly.
+//! This gate is what gives a pipeline author the diagnostic instead: a code, a
+//! source span, and a corrected path, reported before any input is opened —
+//! rather than an unspanned format error from the middle of a run.
+
+use clinker_format::{RecordPath, RecordPathSyntax};
+
+use crate::config::multi_value::NodeFault;
+use crate::config::pipeline_node::PipelineNode;
+use crate::config::{InputFormat, JsonInputOptions, XmlInputOptions};
+use crate::yaml::Spanned;
+
+/// Every source whose `record_path` is not a path in its format's grammar.
+///
+/// Takes a node LIST rather than the pipeline, for the same reason the
+/// multi-value gates do: a composition body's nodes need the identical check
+/// and never appear in the call-site pipeline's `nodes:`.
+pub fn record_path_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
+    let mut faults = Vec::new();
+    for (node_index, spanned) in nodes.iter().enumerate() {
+        let PipelineNode::Source {
+            header,
+            config: body,
+        } = &spanned.value
+        else {
+            continue;
+        };
+        let declared = match &body.source.format {
+            InputFormat::Json(opts) => opts.as_ref().and_then(|o: &JsonInputOptions| {
+                o.record_path
+                    .as_deref()
+                    .map(|p| (RecordPathSyntax::Json, p))
+            }),
+            InputFormat::Xml(opts) => opts.as_ref().and_then(|o: &XmlInputOptions| {
+                o.record_path.as_deref().map(|p| (RecordPathSyntax::Xml, p))
+            }),
+            _ => None,
+        };
+        let Some((syntax, raw)) = declared else {
+            continue;
+        };
+        if let Err(e) = RecordPath::parse(syntax, raw) {
+            faults.push(NodeFault {
+                node_index,
+                code: "E363",
+                message: format!("source '{}': {e}", header.name),
+                help: e.help(),
+            });
+        }
+    }
+    faults
+}

--- a/crates/clinker-plan/src/config/record_path.rs
+++ b/crates/clinker-plan/src/config/record_path.rs
@@ -8,9 +8,9 @@
 
 use clinker_format::{RecordPath, RecordPathSyntax};
 
+use crate::config::InputFormat;
 use crate::config::multi_value::NodeFault;
 use crate::config::pipeline_node::PipelineNode;
-use crate::config::{InputFormat, JsonInputOptions, XmlInputOptions};
 use crate::yaml::Spanned;
 
 /// Every source whose `record_path` is not a path in its format's grammar.
@@ -29,14 +29,14 @@ pub fn record_path_faults(nodes: &[Spanned<PipelineNode>]) -> Vec<NodeFault> {
             continue;
         };
         let declared = match &body.source.format {
-            InputFormat::Json(opts) => opts.as_ref().and_then(|o: &JsonInputOptions| {
-                o.record_path
-                    .as_deref()
-                    .map(|p| (RecordPathSyntax::Json, p))
-            }),
-            InputFormat::Xml(opts) => opts.as_ref().and_then(|o: &XmlInputOptions| {
-                o.record_path.as_deref().map(|p| (RecordPathSyntax::Xml, p))
-            }),
+            InputFormat::Json(opts) => opts
+                .as_ref()
+                .and_then(|o| o.record_path.as_deref())
+                .map(|p| (RecordPathSyntax::Json, p)),
+            InputFormat::Xml(opts) => opts
+                .as_ref()
+                .and_then(|o| o.record_path.as_deref())
+                .map(|p| (RecordPathSyntax::Xml, p)),
             _ => None,
         };
         let Some((syntax, raw)) = declared else {

--- a/crates/clinker-plan/src/config/source.rs
+++ b/crates/clinker-plan/src/config/source.rs
@@ -503,6 +503,11 @@ pub struct CsvInputOptions {
 pub struct JsonInputOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<JsonFormat>,
+    /// Dot-separated object keys locating the records array, descended from
+    /// the document root (`data.rows`). Not JSONPath: a `$.` root marker, a
+    /// leading `/`, and an empty segment are all rejected at compile time
+    /// (E363). Takes precedence over `format:`. Omitted, the reader
+    /// auto-detects the document shape.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_path: Option<String>,
     /// Hard cap on the bytes the envelope pre-scan's path-pruned document
@@ -520,6 +525,12 @@ pub struct JsonInputOptions {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct XmlInputOptions {
+    /// Slash-separated XML element names locating the record elements,
+    /// matched level by level from the document element (`catalog/product`).
+    /// Not XPath: a `//` descendant step, a leading `/`, an empty segment, and
+    /// a segment that is not a legal XML element name are all rejected at
+    /// compile time (E363). Omitted, every top-level element becomes one
+    /// record.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub record_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/clinker-plan/src/plan/bind_schema.rs
+++ b/crates/clinker-plan/src/plan/bind_schema.rs
@@ -3037,25 +3037,29 @@ fn bind_composition(
         }
     }
 
-    // 7e. The multi-value gates (E358 / E359 / E360 / E361), which the
-    // call-site pipeline runs over its OWN `nodes:` — a list that never
-    // contains a body's nodes. Without this pass a body source declaring the
-    // retired `array_paths:`, a `multiple: true` column its format cannot
-    // produce, or a malformed `split_to_rows` block reaches the executor
-    // ungated and emits one record per document where the author asked for one
-    // per element. The XML reader's construction-time nesting/duplicate
-    // rejection used to catch part of that for body sources and was replaced by
-    // the plan-time gate, so running the gate here is what keeps the
-    // replacement whole. Runs after 7d so an external `.schema.yaml` is already
-    // folded inline and the gates see its columns. Collect every finding, then
-    // abandon the body, mirroring the passes above.
+    // 7e. The multi-value gates (E358 / E359 / E360 / E361) and the E363
+    // `record_path` grammar gate, which the call-site pipeline runs over its
+    // OWN `nodes:` — a list that never contains a body's nodes. Without this
+    // pass a body source declaring the retired `array_paths:`, a `multiple:
+    // true` column its format cannot produce, a malformed `split_to_rows`
+    // block, or an XPath-shaped `record_path` reaches the executor ungated and
+    // emits one record per document — or none at all — where the author asked
+    // for one per element. The XML reader's construction-time
+    // nesting/duplicate rejection used to catch part of that for body sources
+    // and was replaced by the plan-time gate, so running the gate here is what
+    // keeps the replacement whole. Runs after 7d so an external `.schema.yaml`
+    // is already folded inline and the gates see its columns. Collect every
+    // finding, then abandon the body, mirroring the passes above.
     {
         let faults = crate::config::multi_value::source_node_faults(&body_file.nodes)
             .into_iter()
             .chain(crate::config::multi_value::output_node_faults(
                 &body_file.nodes,
+            ))
+            .chain(crate::config::record_path::record_path_faults(
+                &body_file.nodes,
             ));
-        let mut has_multi_value_violation = false;
+        let mut has_node_config_violation = false;
         for fault in faults {
             diags.push(
                 Diagnostic::error(
@@ -3072,9 +3076,9 @@ fn bind_composition(
                 )
                 .with_help(fault.help),
             );
-            has_multi_value_violation = true;
+            has_node_config_violation = true;
         }
-        if has_multi_value_violation {
+        if has_node_config_violation {
             return;
         }
     }

--- a/crates/clinker-plan/src/plan/explain_provenance.rs
+++ b/crates/clinker-plan/src/plan/explain_provenance.rs
@@ -411,6 +411,7 @@ pub fn explain_code(code: &str) -> Option<&'static str> {
         "E360" => Some(include_str!("../../../../docs/explain/E360.md")),
         "E361" => Some(include_str!("../../../../docs/explain/E361.md")),
         "E362" => Some(include_str!("../../../../docs/explain/E362.md")),
+        "E363" => Some(include_str!("../../../../docs/explain/E363.md")),
         "E323" => Some(include_str!("../../../../docs/explain/E323.md")),
         "E150b" => Some(include_str!("../../../../docs/explain/E150b.md")),
         "E150c" => Some(include_str!("../../../../docs/explain/E150c.md")),
@@ -617,6 +618,17 @@ mod tests {
     }
 
     #[test]
+    fn test_explain_code_e363_record_path_syntax() {
+        let doc = explain_code("E363").unwrap();
+        assert!(doc.contains("E363"));
+        assert!(doc.contains("record_path"));
+        // Both grammars an author is likely to reach for must be named, so the
+        // page answers "why was mine rejected" for either.
+        assert!(doc.contains("XPath"));
+        assert!(doc.contains("JSONPath"));
+    }
+
+    #[test]
     fn test_explain_code_unknown() {
         assert!(explain_code("E999").is_none());
     }
@@ -630,7 +642,7 @@ mod tests {
             "E324", "E325", "E326", "E327", "E330", "E331", "E332", "E333", "E334", "E335", "E336",
             "E337", "E338", "E339", "E340", "E341", "E342", "E343", "E344", "E345", "E346", "E347",
             "E348", "E349", "E350", "E351", "E352", "E353", "E354", "E355", "E356", "E357", "E358",
-            "E359", "E360", "E361", "E362", "E15Y", "W101", "W302", "W305", "W306",
+            "E359", "E360", "E361", "E362", "E363", "E15Y", "W101", "W302", "W305", "W306",
         ];
         let required_sections = [
             "## What it means",

--- a/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
@@ -18,7 +18,8 @@
 //! resolved to its inline columns relative to the composition file's own
 //! directory (so a body Output's declared-decimal `scale` reaches the write
 //! boundary and a body Source's file schema resolves from the right base);
-//! and the multi-value gates (E358 / E359 / E360 / E361) run over body nodes,
+//! and the per-source config gates — the multi-value family (E358 / E359 /
+//! E360 / E361) and the `record_path` grammar (E363) — run over body nodes,
 //! which the call-site pipeline's own `nodes:` walk never sees.
 
 use std::path::PathBuf;

--- a/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/body_node_config_validation.rs
@@ -531,6 +531,35 @@ fn body_source_unproducible_multi_value_column_rejected_with_e361() {
     );
 }
 
+/// A JSONPath-shaped `record_path` on a body source. Without the body walk the
+/// grammar gate would exist for top-level sources only, and a body source would
+/// keep failing obscurely from inside the reader — or, for the XPath-shaped
+/// forms, reading zero records with no error at all.
+#[test]
+fn body_source_jsonpath_record_path_rejected_with_e363() {
+    let diags = compile_body_source(
+        r#"  - type: source
+    name: body_src
+    config:
+      name: body_src
+      type: json
+      path: body_src.json
+      options:
+        record_path: "$.data"
+      schema:
+        - { name: sku, type: string }"#,
+    );
+    let diag = diags
+        .iter()
+        .find(|d| d.code == "E363")
+        .unwrap_or_else(|| panic!("expected an E363 for the body source; got: {diags:?}"));
+    assert!(
+        diag.message.contains("JSONPath") && diag.message.contains("mv_body.comp.yaml"),
+        "the diagnostic must name the grammar and the body file: {:?}",
+        diag.message
+    );
+}
+
 /// A body Output whose `schema:` names an external `.schema.yaml` with a
 /// scaled `decimal` column resolves to inline columns at bind time. The
 /// resolved schema yields `as_columns() == Some`, which is the exact

--- a/crates/clinker-plan/src/plan/tests/mod.rs
+++ b/crates/clinker-plan/src/plan/tests/mod.rs
@@ -22,6 +22,7 @@ mod multi_value_validation;
 mod overlay_compile;
 mod plan_time_window_root;
 mod predicate_support;
+mod record_path_validation;
 mod reshape_validation;
 mod route_ports;
 mod typed_scoped_key;

--- a/crates/clinker-plan/src/plan/tests/record_path_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/record_path_validation.rs
@@ -1,0 +1,289 @@
+//! The plan-time `record_path` grammar gate (E363).
+//!
+//! `record_path` used to be an unvalidated `Option<String>` copied verbatim
+//! into reader config. An XPath-shaped value (`//product`) split into a segment
+//! list whose first entry no element name can equal, so the run finished with
+//! zero records and reported success. These tests pin every rejected form to a
+//! spanned compile-time diagnostic, and pin the accepted forms so the grammar
+//! does not over-reject.
+
+use clinker_core_types::Diagnostic;
+
+use crate::config::{CompileContext, parse_config};
+
+/// A single-source XML pipeline declaring `record_path: raw`. `raw` is written
+/// through `{:?}` so a value containing YAML-significant characters (`*`, a
+/// leading `/`, the empty string) reaches the parser intact.
+fn xml_pipeline(raw: &str) -> String {
+    xml_pipeline_with(raw, "")
+}
+
+/// [`xml_pipeline`] plus extra lines spliced into the source's `options:`
+/// block, for the namespace-qualified case.
+fn xml_pipeline_with(raw: &str, extra_options: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: record_path_gate
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: xml
+      path: ./in.xml
+      options:
+        record_path: {raw:?}
+{extra_options}
+      schema:
+        - {{ name: id, type: int }}
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+/// An XML pipeline that declares no `record_path` at all — the supported form
+/// an empty string is NOT equivalent to.
+fn xml_pipeline_without_record_path() -> String {
+    r#"
+pipeline:
+  name: record_path_gate
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: xml
+      path: ./in.xml
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    .to_string()
+}
+
+/// The JSON twin of [`xml_pipeline`].
+fn json_pipeline(raw: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: record_path_gate
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: json
+      path: ./in.json
+      options:
+        record_path: {raw:?}
+      schema:
+        - {{ name: id, type: int }}
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+fn json_pipeline_without_record_path() -> String {
+    r#"
+pipeline:
+  name: record_path_gate
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: json
+      path: ./in.json
+      schema:
+        - { name: id, type: int }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    .to_string()
+}
+
+fn compile_err(yaml: &str) -> Vec<Diagnostic> {
+    let config = parse_config(yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .expect_err("compile must fail")
+}
+
+fn compile_ok(yaml: &str) {
+    let config = parse_config(yaml).expect("pipeline parses");
+    config
+        .compile(&CompileContext::default())
+        .unwrap_or_else(|d| panic!("compile must succeed, got: {d:?}"));
+}
+
+/// Every diagnostic carrying `code`, as `(message, has_span)`.
+fn coded(diags: &[Diagnostic], code: &str) -> Vec<(String, bool)> {
+    diags
+        .iter()
+        .filter(|d| d.code == code)
+        .map(|d| {
+            (
+                d.message.clone(),
+                d.primary.span != clinker_core_types::span::Span::SYNTHETIC,
+            )
+        })
+        .collect()
+}
+
+/// The single E363 a pipeline must produce, asserting it carries a span.
+fn sole_e363(yaml: &str) -> String {
+    let diags = compile_err(yaml);
+    let found = coded(&diags, "E363");
+    assert_eq!(found.len(), 1, "expected exactly one E363, got: {diags:?}");
+    assert!(found[0].1, "E363 must carry a source span: {}", found[0].0);
+    found[0].0.clone()
+}
+
+#[test]
+fn xpath_descendant_step_is_rejected() {
+    let msg = sole_e363(&xml_pipeline("//product"));
+    assert!(msg.contains("src"), "{msg}");
+    assert!(msg.contains("XPath"), "{msg}");
+    // The message must show the shape the author should have written.
+    assert!(msg.contains("Write \"product\" instead"), "{msg}");
+}
+
+#[test]
+fn rooted_xml_path_is_rejected() {
+    let msg = sole_e363(&xml_pipeline("/Orders/Order"));
+    assert!(msg.contains("already anchored"), "{msg}");
+    assert!(msg.contains("Write \"Orders/Order\" instead"), "{msg}");
+}
+
+#[test]
+fn doubled_separator_inside_an_xml_path_is_rejected() {
+    let msg = sole_e363(&xml_pipeline("Orders//Order"));
+    assert!(msg.contains("Write \"Orders/Order\" instead"), "{msg}");
+}
+
+#[test]
+fn trailing_separator_on_an_xml_path_is_rejected() {
+    let msg = sole_e363(&xml_pipeline("Orders/"));
+    assert!(msg.contains("empty segment"), "{msg}");
+    assert!(msg.contains("Write \"Orders\" instead"), "{msg}");
+}
+
+#[test]
+fn an_empty_xml_record_path_is_rejected_though_omitting_it_is_fine() {
+    // `record_path: ""` is not the same as leaving the key out: the empty
+    // string is a one-segment path naming an element called "", which reads
+    // zero records. Omitting the key makes every top-level element a record.
+    let msg = sole_e363(&xml_pipeline(""));
+    assert!(msg.contains("empty"), "{msg}");
+    assert!(
+        msg.contains("every top-level element becomes one record"),
+        "{msg}"
+    );
+    compile_ok(&xml_pipeline_without_record_path());
+}
+
+#[test]
+fn xpath_predicates_and_axes_are_rejected() {
+    for (raw, needle) in [
+        ("//product[@id]", "XPath"),
+        ("product[@id]", "not an XML element name"),
+        ("child::product", "not an XML element name"),
+        ("*", "not an XML element name"),
+    ] {
+        let msg = sole_e363(&xml_pipeline(raw));
+        assert!(msg.contains(needle), "{raw:?}: {msg}");
+    }
+}
+
+#[test]
+fn jsonpath_root_marker_is_rejected_on_a_json_source() {
+    let msg = sole_e363(&json_pipeline("$.data"));
+    assert!(msg.contains("JSONPath"), "{msg}");
+    assert!(msg.contains("Write \"data\" instead"), "{msg}");
+}
+
+#[test]
+fn rooted_and_empty_segment_json_paths_are_rejected() {
+    for (raw, needle) in [
+        ("/data", "already anchored"),
+        ("//data", "already anchored"),
+        (".data", "empty segment"),
+        ("data..rows", "empty segment"),
+        ("data.", "empty segment"),
+    ] {
+        let msg = sole_e363(&json_pipeline(raw));
+        assert!(msg.contains(needle), "{raw:?}: {msg}");
+    }
+}
+
+#[test]
+fn an_empty_json_record_path_is_rejected_though_omitting_it_is_fine() {
+    let msg = sole_e363(&json_pipeline(""));
+    assert!(msg.contains("empty"), "{msg}");
+    compile_ok(&json_pipeline_without_record_path());
+}
+
+#[test]
+fn accepted_xml_paths_still_compile() {
+    for raw in [
+        "records/record",
+        "Orders/Order",
+        "doc/records/record",
+        "PurchaseOrders/Order",
+        "root/data/record",
+        "records",
+    ] {
+        compile_ok(&xml_pipeline(raw));
+    }
+}
+
+#[test]
+fn a_namespace_qualified_xml_path_still_compiles() {
+    // `:` is a legal XML NameChar and `namespace_handling: qualify` keeps the
+    // prefix on every element name, so a qualified path must survive the
+    // XML-name segment rule.
+    compile_ok(&xml_pipeline_with(
+        "ns:Orders/ns:Order",
+        "        namespace_handling: qualify",
+    ));
+}
+
+#[test]
+fn accepted_json_paths_still_compile() {
+    for raw in [
+        "data.rows",
+        "data.records",
+        "batch_records",
+        "records",
+        // Only the exact `$.` prefix is a JSONPath marker, so a `$`-prefixed
+        // key stays addressable.
+        "$schema.rows",
+        "$",
+    ] {
+        compile_ok(&json_pipeline(raw));
+    }
+}

--- a/crates/clinker-plan/src/plan/tests/record_path_validation.rs
+++ b/crates/clinker-plan/src/plan/tests/record_path_validation.rs
@@ -11,119 +11,46 @@ use clinker_core_types::Diagnostic;
 
 use crate::config::{CompileContext, parse_config};
 
-/// A single-source XML pipeline declaring `record_path: raw`. `raw` is written
-/// through `{:?}` so a value containing YAML-significant characters (`*`, a
-/// leading `/`, the empty string) reaches the parser intact.
+/// A single-source pipeline over `format`, with `options` (already indented,
+/// empty for a source that declares none) spliced under the source's `config:`.
+fn pipeline(format: &str, options: &str) -> String {
+    format!(
+        r#"
+pipeline:
+  name: record_path_gate
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: {format}
+      path: ./in.{format}
+{options}      schema:
+        - {{ name: id, type: int }}
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+"#
+    )
+}
+
+/// An `options:` block declaring `record_path: raw`, plus any extra option
+/// lines. `raw` is written through `{:?}` so a value carrying YAML-significant
+/// characters (`*`, a leading `/`, the empty string) reaches the parser intact.
+fn record_path_options(raw: &str, extra: &str) -> String {
+    format!("      options:\n        record_path: {raw:?}\n{extra}")
+}
+
 fn xml_pipeline(raw: &str) -> String {
-    xml_pipeline_with(raw, "")
+    pipeline("xml", &record_path_options(raw, ""))
 }
 
-/// [`xml_pipeline`] plus extra lines spliced into the source's `options:`
-/// block, for the namespace-qualified case.
-fn xml_pipeline_with(raw: &str, extra_options: &str) -> String {
-    format!(
-        r#"
-pipeline:
-  name: record_path_gate
-nodes:
-  - type: source
-    name: src
-    config:
-      name: src
-      type: xml
-      path: ./in.xml
-      options:
-        record_path: {raw:?}
-{extra_options}
-      schema:
-        - {{ name: id, type: int }}
-  - type: output
-    name: out
-    input: src
-    config:
-      name: out
-      type: csv
-      path: out.csv
-"#
-    )
-}
-
-/// An XML pipeline that declares no `record_path` at all — the supported form
-/// an empty string is NOT equivalent to.
-fn xml_pipeline_without_record_path() -> String {
-    r#"
-pipeline:
-  name: record_path_gate
-nodes:
-  - type: source
-    name: src
-    config:
-      name: src
-      type: xml
-      path: ./in.xml
-      schema:
-        - { name: id, type: int }
-  - type: output
-    name: out
-    input: src
-    config:
-      name: out
-      type: csv
-      path: out.csv
-"#
-    .to_string()
-}
-
-/// The JSON twin of [`xml_pipeline`].
 fn json_pipeline(raw: &str) -> String {
-    format!(
-        r#"
-pipeline:
-  name: record_path_gate
-nodes:
-  - type: source
-    name: src
-    config:
-      name: src
-      type: json
-      path: ./in.json
-      options:
-        record_path: {raw:?}
-      schema:
-        - {{ name: id, type: int }}
-  - type: output
-    name: out
-    input: src
-    config:
-      name: out
-      type: csv
-      path: out.csv
-"#
-    )
-}
-
-fn json_pipeline_without_record_path() -> String {
-    r#"
-pipeline:
-  name: record_path_gate
-nodes:
-  - type: source
-    name: src
-    config:
-      name: src
-      type: json
-      path: ./in.json
-      schema:
-        - { name: id, type: int }
-  - type: output
-    name: out
-    input: src
-    config:
-      name: out
-      type: csv
-      path: out.csv
-"#
-    .to_string()
+    pipeline("json", &record_path_options(raw, ""))
 }
 
 fn compile_err(yaml: &str) -> Vec<Diagnostic> {
@@ -203,7 +130,7 @@ fn an_empty_xml_record_path_is_rejected_though_omitting_it_is_fine() {
         msg.contains("every top-level element becomes one record"),
         "{msg}"
     );
-    compile_ok(&xml_pipeline_without_record_path());
+    compile_ok(&pipeline("xml", ""));
 }
 
 #[test]
@@ -244,7 +171,7 @@ fn rooted_and_empty_segment_json_paths_are_rejected() {
 fn an_empty_json_record_path_is_rejected_though_omitting_it_is_fine() {
     let msg = sole_e363(&json_pipeline(""));
     assert!(msg.contains("empty"), "{msg}");
-    compile_ok(&json_pipeline_without_record_path());
+    compile_ok(&pipeline("json", ""));
 }
 
 #[test]
@@ -266,9 +193,12 @@ fn a_namespace_qualified_xml_path_still_compiles() {
     // `:` is a legal XML NameChar and `namespace_handling: qualify` keeps the
     // prefix on every element name, so a qualified path must survive the
     // XML-name segment rule.
-    compile_ok(&xml_pipeline_with(
-        "ns:Orders/ns:Order",
-        "        namespace_handling: qualify",
+    compile_ok(&pipeline(
+        "xml",
+        &record_path_options(
+            "ns:Orders/ns:Order",
+            "        namespace_handling: qualify\n",
+        ),
     ));
 }
 

--- a/crates/clinker/tests/channel_source_patch.rs
+++ b/crates/clinker/tests/channel_source_patch.rs
@@ -472,6 +472,72 @@ sources:
     assert!(stderr.contains("E231"), "stderr:\n{stderr}");
 }
 
+/// A channel `options:` patch is applied before validation, so a patched
+/// `record_path` is subject to the same grammar gate a hand-written one is. The
+/// base pipeline's `small.rows` is valid; only the overlay's JSONPath-shaped
+/// value is not.
+///
+/// Asserted on the diagnostic text rather than its code: the run path renders
+/// compile diagnostics through `PipelineError::Compilation`, which carries only
+/// their messages — the same for every plan-time gate, not this one.
+#[test]
+fn patched_jsonpath_record_path_fails_at_compile() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let p = dir.path();
+    write(
+        p,
+        "in.json",
+        "{ \"small\": { \"rows\": [ {\"id\":\"1\"} ] } }\n",
+    );
+    write(
+        p,
+        "pipe.yaml",
+        "\
+pipeline:
+  name: json_record_path_patch
+nodes:
+  - type: source
+    name: src
+    config:
+      name: src
+      type: json
+      path: in.json
+      options:
+        record_path: small.rows
+      schema:
+        - { name: id, type: string }
+  - type: output
+    name: out
+    input: src
+    config:
+      name: out
+      type: csv
+      path: out.csv
+",
+    );
+    // The unpatched pipeline runs, so the failure below is the patch's.
+    assert!(run_in(p, &[]).status.success(), "base json run failed");
+
+    write_channel(
+        p,
+        "badpath",
+        "\
+sources:
+  src:
+    options:
+      record_path: \"$.rows\"
+",
+    );
+    let out = run_in(p, &["--channel", "badpath"]);
+    assert!(
+        !out.status.success(),
+        "a patched JSONPath-shaped record_path must fail at compile"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("JSONPath"), "stderr:\n{stderr}");
+    assert!(stderr.contains("record_path"), "stderr:\n{stderr}");
+}
+
 /// Pipeline whose output path carries the `{pipeline_hash}` token, so the
 /// effective pipeline identity is observable as the output filename.
 const HASH_PIPELINE: &str = "\

--- a/docs/ai/AI_CHANGELOG.md
+++ b/docs/ai/AI_CHANGELOG.md
@@ -39,6 +39,22 @@ Representative code and manifest evidence cited by those docs includes:
 
 ## Entries
 
+### 2026-07-25: `record_path` Has One Grammar, Enforced at Both Layers
+
+Type: Source-backed fact (issue #949).
+
+Summary: A source's `record_path` is parsed through a single grammar rather than
+split ad hoc by each reader. XML takes a slash-separated path of XML element
+names rooted at the document element; JSON takes a dot-separated path of object
+keys from the document root. XPath and JSONPath shapes (`//product`, `$.data`, a
+leading `/`, empty segments) are rejected — an XPath-shaped value used to split
+into a segment no element name can equal, so the run emitted zero records and
+reported success. Rejection happens at plan time with E363 (over the call-site
+pipeline's nodes and each composition body's nodes) and again at reader
+construction, which covers callers that build a reader config directly.
+Evidence: `crates/clinker-format/src/record_path.rs`;
+`crates/clinker-plan/src/config/record_path.rs`; `docs/explain/E363.md`.
+
 ### 2026-07-24: Multi-Value Fields Replace `array_paths`
 
 Type: Source-backed fact (PRs #925, #930-#932, #934, #935, #938, #939,

--- a/docs/explain/E363.md
+++ b/docs/explain/E363.md
@@ -1,0 +1,191 @@
+# Error E363: `record_path` is not a path in its format's grammar
+
+## What it means
+
+A source's `record_path` option is written in a syntax the reader does not
+implement. `record_path` is a plain path, not a query language:
+
+- On an **`xml`** source it is a **slash-separated path of XML element names**,
+  matched level by level starting at the document element — `catalog/product`
+  selects `<product>` children of the document element `<catalog>`. Every
+  segment must be a legal XML element name; a namespace prefix (`ns:Order`) is
+  allowed and matches when `namespace_handling: qualify` is set.
+- On a **`json`** source it is a **dot-separated path of object keys**,
+  descended from the document root — `data.rows` selects the array at
+  `{"data": {"rows": [...]}}`.
+
+These are rejected:
+
+| Written | Why it is rejected |
+|---------|--------------------|
+| `//product` | The XPath descendant step `//` matches at any depth. The reader matches level by level, so it would never find the element. |
+| `/Orders/Order` | A leading `/` is how an absolute XPath or a JSON Pointer is anchored. `record_path` is already anchored at the document element / root. |
+| `Orders//Order`, `data..rows` | An empty segment between two separators. No element or key is named "". |
+| `Orders/`, `data.` | A trailing separator, leaving a final empty segment. |
+| `$.data` | `$.` is the JSONPath root marker. The grammar has no root marker. |
+| `""` (empty string) | An empty path is not the same as omitting the key — see below. |
+| `//product[@id]`, `child::product`, `*` | XPath predicates, axes, and wildcards. |
+
+Omitting `record_path` entirely is a distinct, supported thing: on an `xml`
+source every top-level element becomes one record, and on a `json` source the
+reader auto-detects the document shape. An empty string is not that — it is a
+path with one empty segment.
+
+```
+source 'catalog': `record_path` "//product" uses the XPath descendant step `//`,
+which matches at any depth; `record_path` is a slash-separated path of XML
+element names, matched level by level from the document element (for example
+`catalog/product`), so name every enclosing element. Write "product" instead
+```
+
+## Example
+
+<!-- explain-test: expect-code=E363 -->
+```yaml
+# Rejected: `//product` is XPath. The reader matches element names level by
+# level, so this would descend nothing and the run would produce no records.
+nodes:
+  - type: source
+    name: catalog
+    config:
+      name: catalog
+      type: xml
+      path: ./catalog.xml
+      options:
+        record_path: "//product"
+      schema:
+        - { name: product_id, type: int }
+        - { name: name, type: string }
+```
+
+<!-- explain-test: expect-code=E363 -->
+```yaml
+# Rejected: `$.` is the JSONPath root marker, which is not part of the grammar.
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: json
+      path: ./events.json
+      options:
+        record_path: "$.data"
+      schema:
+        - { name: event_id, type: string }
+```
+
+<!-- explain-test: expect-clean -->
+```yaml
+# Corrected: name every enclosing element, starting at the document element.
+nodes:
+  - type: source
+    name: catalog
+    config:
+      name: catalog
+      type: xml
+      path: ./catalog.xml
+      options:
+        record_path: "catalog/product"
+      schema:
+        - { name: product_id, type: int }
+        - { name: name, type: string }
+```
+
+<!-- explain-test: expect-clean -->
+```yaml
+# Corrected: dot-separated object keys, and `format: object` states the wrapper
+# shape the path descends.
+nodes:
+  - type: source
+    name: events
+    config:
+      name: events
+      type: json
+      path: ./events.json
+      options:
+        format: object
+        record_path: "data"
+      schema:
+        - { name: event_id, type: string }
+```
+
+## How to fix
+
+1. **Drop an XPath or JSON Pointer anchor.** `/Orders/Order` becomes
+   `Orders/Order`; `/data` becomes `data`. The path already starts at the
+   document element (XML) or document root (JSON).
+
+2. **Replace a `//` descendant step with the elements it skipped.** `//product`
+   becomes `catalog/product` — write out each enclosing element. If the record
+   elements really are the document element's direct children and you do not
+   want to name it, omit `record_path` entirely: every top-level element then
+   becomes one record.
+
+3. **Drop the JSONPath `$.` marker.** `$.data.rows` becomes `data.rows`.
+
+4. **Remove a doubled or trailing separator.** `Orders//Order` becomes
+   `Orders/Order`; `data.` becomes `data`.
+
+5. **Rewrite a predicate, axis, or wildcard as a plain path.** There is no
+   `record_path` equivalent for `[@id='7']`, `child::`, or `*`. Select the
+   element by path and filter the records in a transform:
+   `where product_id == 7`.
+
+6. **On a `json` source, pair the path with `format: object`** (or leave
+   `format:` off). `record_path` takes precedence over `format:`, so
+   `format: ndjson` combined with a `record_path` silently ignores the declared
+   `ndjson` shape.
+
+The message names the corrected path whenever stripping the offending syntax
+yields a valid one.
+
+## Technical context
+
+Both readers used to build their segment list with a bare `split` on the
+separator, which accepted every string. `//product` split into
+`["", "product"]`, and no element name equals the empty string — so the XML
+reader ran to end-of-input, emitted zero records, and the pipeline reported
+success. That silent-empty outcome is what this diagnostic removes: the failure
+is now reported at compile time, before any input is opened.
+
+The rejected forms are not silently rewritten into the ones they resemble.
+`//product` in real XPath descends any number of levels; accepting it as
+`catalog/product` would promise a match the reader cannot make, and a document
+that nests `<product>` one level deeper would then read as zero records again
+with no warning.
+
+Two narrow addressing capabilities are given up deliberately, both on JSON,
+where an object key may legally contain any character:
+
+- A path is rejected only for the **exact** leading two bytes `$.`, so a
+  top-level key named `$` (`record_path: "$"`) and a key merely starting with
+  `$` (`record_path: "$schema.rows"`) both stay addressable. A key literally
+  named `$` followed by a nested key does not.
+- A **leading** `/` is rejected, so a top-level key whose name starts with `/`
+  is not addressable. A `/` elsewhere in a key (`a/b.rows`) is fine.
+
+The XML segment rule is the same XML 1.0 `Name` predicate the XML writer uses to
+validate element names, narrowed to a namespace-well-formed `QName` (at most one
+colon, separating a prefix from a local part). Any path that can match a real
+element is by construction a sequence of such names, so the rule rejects only
+paths that could never match — including an XPath axis step like
+`child::product`, whose two colons no namespace-well-formed document carries.
+
+The neighbouring envelope option `extract: { xml_path: … }` has a **different**
+rooting convention: it tolerates a leading `/` (`/doc/Head` is its documented
+form). The two are separate grammars addressing different things — `xml_path`
+locates one envelope section in the document, `record_path` locates the record
+elements — and they are not being aligned.
+
+The gate runs over the call-site pipeline's nodes and again over each
+composition body's nodes, so a source declared inside a composition body cannot
+bypass it. The readers additionally reject a malformed path at construction, so
+a caller that builds a reader config directly — the REST transport, or a
+library embedding — fails loud too.
+
+## See also
+
+- "XML Format → `record_path`" in the format reference
+- "JSON Format → `record_path`" in the format reference
+- Error E358 — a malformed `split_to_rows` / `split_values` declaration
+- Error E361 — a source format that cannot produce the multi-value column it declares

--- a/docs/user/src/formats/json.md
+++ b/docs/user/src/formats/json.md
@@ -20,8 +20,8 @@ rules.
       - { name: timestamp, type: date_time }
       - { name: payload, type: string }
     options:
-      format: ndjson          # array | ndjson | object (auto-detect if omitted)
-      record_path: "$.data"   # JSONPath to the records array (object format)
+      format: object          # array | ndjson | object (auto-detect if omitted)
+      record_path: "data"     # dot-separated keys to the records array
       max_index_bytes: 64MB   # cap on retained envelope sections (optional)
 ```
 
@@ -31,11 +31,46 @@ rules.
 |----------|--------|
 | `array` | The file is a single JSON array of objects. |
 | `ndjson` | One JSON object per line (newline-delimited JSON). |
-| `object` | A single top-level object; `record_path` locates the records array within it. |
+| `object` | A single top-level object; [`record_path`](#record_path) locates the records array within it. |
 
 If `format` is omitted, Clinker auto-detects the shape from the file
 content. Declare it explicitly when the file is large enough that you want
-to skip detection, or when an `object` wrapper needs a `record_path`.
+to skip detection, or when an `object` wrapper needs a
+[`record_path`](#record_path).
+
+## `record_path`
+
+`record_path` is a **dot-separated path of object keys**, descended from the
+document root. `data.rows` selects the array at `{"data": {"rows": [ … ]}}`, and
+each of its elements becomes one record. This is the canonical statement of the
+grammar; other pages link here rather than restate it.
+
+The rules, in full:
+
+- **No `$.` root marker.** It is not JSONPath. Write `data.rows`, not
+  `$.data.rows`. Only the exact leading `$.` is rejected, so a key that merely
+  starts with `$` (`$schema.rows`) is still addressable.
+- **No leading `/`.** A leading slash is how a JSON Pointer is anchored;
+  `record_path` is already anchored at the document root.
+- **No empty segments** — no doubled separator (`data..rows`) and no trailing
+  one (`data.`).
+- **Omitting `record_path` entirely** lets the reader auto-detect the document
+  shape. That is not the same as `record_path: ""`, which is a path naming a key
+  called "" and is rejected.
+
+A value breaking any of these fails at compile time with
+[E363](../../explain/E363.md), before any input is opened. The diagnostic names
+the corrected path where one can be derived.
+
+**`record_path` takes precedence over `format:`.** When both are declared the
+reader navigates the path and streams the array it finds, whatever `format:`
+says — so pair `record_path` with `format: object` (or leave `format:` off).
+Declaring `format: ndjson` alongside a `record_path` does not read NDJSON.
+
+Because a JSON key may contain any character, the two rejected prefixes give up
+a sliver of addressing: a top-level key literally named `$` followed by a nested
+key, and a top-level key whose name starts with `/`, are not reachable through
+`record_path`.
 
 ## Nested arrays
 

--- a/docs/user/src/formats/xml.md
+++ b/docs/user/src/formats/xml.md
@@ -1,9 +1,9 @@
 # XML Format
 
-The XML reader selects record elements by XPath and maps each one onto the
-source's declared `schema:`. Child elements bind to fields by name;
-attributes bind under a configurable prefix. Namespaces are stripped by
-default so schema field names stay clean. See
+The XML reader selects record elements by a slash-separated path of element
+names and maps each one onto the source's declared `schema:`. Child elements
+bind to fields by name; attributes bind under a configurable prefix. Namespaces
+are stripped by default so schema field names stay clean. See
 [Source Nodes](../nodes/source.md) for the shared schema and transport
 rules.
 
@@ -19,7 +19,7 @@ rules.
       - { name: name, type: string }
       - { name: price, type: float }
     options:
-      record_path: "//product"          # XPath to record elements
+      record_path: "catalog/product"    # slash-separated element path
       attribute_prefix: "@"             # prefix for XML attribute fields
       namespace_handling: strip         # strip | qualify
       max_index_bytes: 64MB             # cap on retained envelope sections (optional)
@@ -29,10 +29,54 @@ rules.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `record_path` | — | XPath selecting the elements that each become one record. |
+| `record_path` | — | Slash-separated path of element names selecting the elements that each become one record — see [`record_path`](#record_path). Omitted, every top-level element becomes one record. |
 | `attribute_prefix` | `@` | Prefix that distinguishes an element's attributes from its child elements when both map to schema fields. |
 | `namespace_handling` | `strip` | `strip` removes namespace prefixes from element and attribute names; `qualify` preserves the namespace-qualified names. |
 | `max_index_bytes` | `64MB` | Cap on the bytes the envelope pre-scan retains while extracting declared `$doc.*` sections. |
+
+## `record_path`
+
+`record_path` is a **slash-separated path of XML element names**, matched level
+by level starting at the document element. `catalog/product` selects every
+`<product>` that is a child of the document element `<catalog>`. This is the
+canonical statement of the grammar; other pages link here rather than restate
+it.
+
+The rules, in full:
+
+- The path is already anchored at the document element, so it carries **no
+  leading `/`**. Write `Orders/Order`, not `/Orders/Order`.
+- **No `//`.** It is not XPath: there is no descendant-or-any-depth step. Name
+  every enclosing element.
+- **No empty segments** — no doubled separator (`Orders//Order`) and no trailing
+  one (`Orders/`).
+- **No XPath predicates, axes, or wildcards** (`product[@id='7']`,
+  `child::product`, `*`). Select the elements by path and filter the records in
+  a transform.
+- Every segment must be a **legal XML element name**. Under
+  `namespace_handling: qualify` element names keep their prefix, so a qualified
+  segment (`ns:Order`) is allowed and is what matches; under the default
+  `strip` the prefix is gone and the segment is the local name.
+- **Omitting `record_path` entirely** makes every top-level element one record.
+  That is not the same as `record_path: ""`, which is a path naming an element
+  called "" and is rejected.
+
+A value breaking any of these fails at compile time with
+[E363](../../explain/E363.md), before any input is opened. The diagnostic names
+the corrected path where one can be derived.
+
+### `record_path` and `xml_path` root differently
+
+The envelope option
+[`extract: { xml_path: … }`](../pipelines/envelope-and-doc-context.md#extract-rules-per-format)
+is also a slash-path over XML, but it **tolerates a leading `/`** — `/doc/Head`
+is its documented form. `record_path` rejects one.
+
+The two are separate grammars addressing separate things: `xml_path` locates a
+single envelope section anywhere in the document, `record_path` locates the
+record elements the body streams. They are deliberately not aligned — writing
+`record_path: "/catalog/product"` is an error, and writing
+`xml_path: "/doc/Head"` is correct.
 
 ## Truncated input
 

--- a/docs/user/src/nodes/source.md
+++ b/docs/user/src/nodes/source.md
@@ -123,7 +123,7 @@ has its own reference page covering its options and decoding model:
 |---------|--------|-----------|
 | `csv` | Delimited text (RFC 4180) | [CSV Format](../formats/csv.md) |
 | `json` | Array / NDJSON / wrapper object | [JSON Format](../formats/json.md) |
-| `xml` | XPath-selected record elements | [XML Format](../formats/xml.md) |
+| `xml` | Element-path-selected record elements | [XML Format](../formats/xml.md) |
 | `fixed_width` | Column-positioned legacy extracts | [Fixed-Width Format](../formats/fixed-width.md) |
 | `edifact` | UN/EDIFACT interchanges | [EDIFACT Format](../formats/edifact.md) |
 | `x12` | ANSI ASC X12 interchanges | [X12 Format](../formats/x12.md) |

--- a/docs/user/src/pipelines/envelope-and-doc-context.md
+++ b/docs/user/src/pipelines/envelope-and-doc-context.md
@@ -147,6 +147,12 @@ Each section declares how the reader locates its payload:
 | HL7 v2  | `segment`        | A header-segment tag — only `FHS` (BHS/MSH surface as nested levels) |
 | Multi-record CSV / fixed-width | `record_type` | A header record-type tag, e.g. `H` |
 
+`xml_path` and the source-level `record_path` option are both slash-paths over
+XML but root differently: `xml_path` tolerates a leading `/` (`/doc/Head` is its
+documented form), while `record_path` rejects one. They locate different things
+and are deliberately not aligned — see
+[XML Format → `record_path` and `xml_path` root differently](../formats/xml.md#record_path-and-xml_path-root-differently).
+
 Declaring an `xml_path` section against a JSON source (or vice versa),
 a `segment` extract against XML/JSON, a `record_type` extract against
 any format other than multi-record CSV / fixed-width, or any `envelope:`


### PR DESCRIPTION
Closes #949.

Both readers built their `record_path` segment list with a bare `split` on the separator, which accepted every string. The failure that motivated the issue is silent: `record_path: "//product"` split into `["", "product"]`, no element name can equal the empty string, the XML reader ran to end-of-input, and the pipeline **reported success over zero records**. `/Orders/Order` failed the same way. The JSON side failed loud but pointed at the wrong thing — `key '$' not found in object` blames the document for a mistake in the path.

## One grammar, parsed once

`RecordPath::parse` takes the syntax the source's format implies and returns the segments, or an error naming the violation and — where stripping the offending syntax yields a valid path — the corrected form. XML segments are element names matched level by level from the document element; JSON segments are object keys descended from the document root.

Both ad-hoc splits are replaced by that call, and no second splitting path remains. The readers reject at construction rather than only at plan time, which covers callers that build a reader config directly — the REST transport, or a library embedding the crate. A plan-time gate supplies the spanned diagnostic, **E363**, and runs over the call-site pipeline's nodes *and* each composition body's nodes, so a body-declared source and a channel-patched one are both covered.

The XML segment rule reuses the writer's existing XML 1.0 `Name` predicate, narrowed to a namespace-well-formed `QName`. That narrowing is load-bearing: `:` is a legal `NameStartChar`, so a bare `Name` check accepts the XPath axis step `child::product`. Splitting on `:` and requiring at most a prefix and a local part rejects it, because no namespace-well-formed document can carry two colons in one element name.

## Two JSON forms are given up, deliberately

Per the issue's decision — reject loud, do not alias — some previously-accepted strings now error. A JSON key may contain any character, so rejecting JSONPath costs real addressing range:

- a top-level key named exactly `$` **followed by** a nested key
- a top-level key whose name starts with `/`

The blast radius is held as small as the decision allows: only the exact `$.` prefix is treated as the JSONPath marker, so `$schema.rows` and a bare `$` both stay addressable. There is no escape spelling that recovers the two lost forms today; #1003 tracks that, since adopting the record-space escape grammar here would restore them as `\$.foo` and `\/name`.

## Rooting conventions stay different

`record_path` and the envelope option `xml_path` keep their divergent rooting rules — `xml_path` tolerates a leading `/`, `record_path` rejects one. They locate different things, and aligning them in either direction would break a documented, tested form. The divergence was previously undocumented; it is now stated once in the XML format reference and cross-referenced from the envelope page.

## Documentation

Both format reference pages carried an unsupported form as their canonical *first* example — `//product` and `$.data` — so the most likely thing for a reader to copy was the exact input that fails silently. The JSON snippet additionally combined `format: ndjson` with a `record_path`, which is not a runnable combination. Each page now states its grammar once under a `record_path` heading, with examples in accepted syntax, and `E363` gets a full explain document.

## Second commit

A follow-up cleanup narrows `RecordPathError`'s fields, the `RecordPathErrorKind` taxonomy, and `RecordPathSyntax::help` to private — none had a consumer outside the module — and collapses five near-identical pipeline builders in the gate's tests into one parameterized helper.

## Verification

Full gauntlet green against the current main: `cargo fmt --all --check`; `cargo clippy --workspace --all-targets --locked -D warnings`; `cargo test --workspace --locked`; `git diff --check`.

Targeted coverage: each rejected form and its diagnostic text (`record_path_validation.rs`, 219 lines), composition-body and channel-patched sources (`channel_source_patch.rs`), and a round-trip test asserting every *accepted* path splits into exactly the segments the previous ad-hoc split produced — so this is validation added, not addressing behaviour changed.

All four `record_path` values under `examples/pipelines/` and `benches/pipelines/` are accepted forms and validate unchanged.
