### PR TITLE
docs: add a user-facing surface contract to the agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,17 @@ bench, socket, and file-descriptor caveats.
 - Never push to main directly; push only feature branches created for an explicitly requested task.
 - If a term, architecture rule, or behavior is unclear, record it in [docs/ai/80_OPEN_QUESTIONS.md](docs/ai/80_OPEN_QUESTIONS.md) instead of guessing.
 
+## User-Facing Surface
+
+Anything a pipeline author writes by hand — a YAML key, a CXL construct, a CLI flag, an option value — is a user interface. Changing it is a design decision, not an implementation detail.
+
+- Ground surface decisions in patterns config authors have already met and that demonstrably work in tools of this shape, rather than in a spelling that only makes sense from inside the engine. Where an established convention exists, follow it; where this project departs from one, say so in the PR and give the reason.
+- One concept, one spelling. A second syntax for something the surface already expresses is a defect, not a convenience.
+- The common case is the short case; the general form stays reachable without rewriting the simple one.
+- Engine vocabulary stays out of author vocabulary — internal identifiers and namespaced machinery are not things a user should have to type.
+- Errors are part of the surface: a diagnostic names the offending input, the rule it broke, and a corrected form the author can paste.
+- User documentation ships in the same PR as the surface change.
+
 ## Rust Conventions
 
 - Prefer existing local patterns over new abstractions.

--- a/docs/ai/30_DESIGN_RULES.md
+++ b/docs/ai/30_DESIGN_RULES.md
@@ -123,6 +123,11 @@ Existing files under `docs/*` may be stale. Treat them as secondary context only
 
 ## Configuration And Format Rules
 
+These rules govern how config is parsed and modeled. What a surface should
+*look like* to the author who types it is a separate question, answered by the
+User-Facing Surface contract in [AGENTS.md](../../AGENTS.md); consult it before
+adding, renaming, or narrowing anything a pipeline author writes by hand.
+
 - YAML parsing must go through `clinker_plan::yaml`. The module states it is
   the single YAML parser chokepoint and the only place that should call
   `serde_saphyr::from_str*` or construct a serde-saphyr budget. It enforces a


### PR DESCRIPTION
The agent guide covers how config is parsed and how Rust in this workspace should be written, but it says nothing about how a surface should look to the person typing it. Config and expression syntax has therefore been designed case by case, and the recurring failure mode is a spelling that reads naturally from inside the engine and not at all from outside it — an option named after the component that consumes it, a second syntax for something already expressible, an error that states what the parser wanted rather than what the author should write instead.

This adds that missing contract to `AGENTS.md`, the file a contributor reads first.

## The contract

Anything a pipeline author writes by hand — a YAML key, a CXL construct, a CLI flag, an option value — is a user interface, and changing it is a design decision rather than an implementation detail. Six rules follow from that:

- Ground the decision in patterns config authors have already met and that demonstrably work in tools of this shape, instead of inventing one. Where an established convention exists, follow it; where this project departs from one, say so and give the reason.
- One concept, one spelling. A second syntax for something the surface already expresses is a defect, not a convenience.
- The common case is the short case, and the general form stays reachable without rewriting the simple one.
- Engine vocabulary stays out of author vocabulary — internal identifiers and namespaced machinery are not things a user should have to type.
- Errors are part of the surface: a diagnostic names the offending input, the rule it broke, and a corrected form the author can paste.
- User documentation ships in the same PR as the surface change.

The "say so and give the reason" clause is the load-bearing one. The contract is not a claim that convention always wins — it is a requirement that departing from convention be a stated, argued choice rather than an unexamined default.

## One home, not three

The design-rules page already has a configuration section, but it is about *mechanism*: which parser to route through, which serde attributes to keep, where the pre-parse limits live. Surface shape is a different question and was genuinely absent.

Rather than restate the rules there and create a second copy to drift, that section now opens by naming the split and pointing at the contract. The normative text exists in exactly one place.

## Validation

Documentation-only; no Rust source touched. `git diff --check` clean. The relative link from the design-rules page to the guide resolves from `docs/ai/` to the repository root.
